### PR TITLE
feat(wan2.2): replace tuning env vars with runtime config

### DIFF
--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/runtime_config_schema.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative runtime settings for the ``wan2_2_ti2v`` pipeline."""
+
+from __future__ import annotations
+
+import math
+
+from tensorrt_model_connect.runtime_config import (
+    ConfigField,
+    Layer,
+    Schema,
+    register_schema,
+)
+
+
+_SESSION = frozenset({Layer.SESSION_REQUEST, Layer.PLATFORM_PROFILE})
+_INT32_MAX = 2**31 - 1
+
+
+def _positive_finite(value: object) -> bool:
+    return (
+        isinstance(value, float)
+        and math.isfinite(value)
+        and value > 0.0
+    )
+
+
+def _nonnegative_int32(value: object) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 0 <= value <= _INT32_MAX
+    )
+
+
+def _positive_int32(value: object) -> bool:
+    return _nonnegative_int32(value) and value > 0
+
+
+SCHEMA = Schema(
+    namespace="wan2_2_ti2v",
+    fields=(
+        ConfigField(
+            name="easycache_enabled",
+            type_tag="bool",
+            default=False,
+            allowed_layers=_SESSION,
+        ),
+        ConfigField(
+            name="easycache_threshold",
+            type_tag="double",
+            default=0.02,
+            allowed_layers=_SESSION,
+            validator=_positive_finite,
+        ),
+        ConfigField(
+            name="easycache_first_exact_steps",
+            type_tag="int64",
+            default=7,
+            allowed_layers=_SESSION,
+            validator=_nonnegative_int32,
+        ),
+        ConfigField(
+            name="easycache_last_exact_steps",
+            type_tag="int64",
+            default=2,
+            allowed_layers=_SESSION,
+            validator=_nonnegative_int32,
+        ),
+        ConfigField(
+            name="easycache_max_consecutive_reuse",
+            type_tag="int64",
+            default=1,
+            allowed_layers=_SESSION,
+            validator=_positive_int32,
+        ),
+        ConfigField(
+            name="late_cfg_enabled",
+            type_tag="bool",
+            default=False,
+            allowed_layers=_SESSION,
+        ),
+    ),
+)
+
+
+register_schema(SCHEMA)

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_ownership.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_ownership.py
@@ -78,7 +78,6 @@ def test_wan22_runtime_settings_are_declarative_and_model_owned() -> None:
     checked_paths = [
         *RUNTIME_ROOT.glob("*.cpp"),
         *RUNTIME_ROOT.glob("*.h"),
-        REPO_ROOT / "website/docs/getting-started/quick-start.md",
     ]
     leftovers = [
         str(path.relative_to(REPO_ROOT))

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_ownership.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_ownership.py
@@ -13,6 +13,7 @@ import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 PRODUCTION_ROOT = REPO_ROOT / "python/tensorrt_model_connect/families/wan2_2_ti2v"
+RUNTIME_ROOT = REPO_ROOT / "src/runtime/models/wan2_2_ti2v"
 FORBIDDEN_WAN21 = re.compile(
     r"families[./]wan_t2v(?![A-Za-z0-9_])"
     r"|runtime/models/wan(?![A-Za-z0-9_])"
@@ -71,3 +72,23 @@ def test_wan22_torch_is_build_extra_not_global_runtime_dependency() -> None:
 
     assert "torch>=2.0" not in pyproject["project"]["dependencies"]
     assert pyproject["project"]["optional-dependencies"]["wan"] == ["torch>=2.0"]
+
+
+def test_wan22_runtime_settings_are_declarative_and_model_owned() -> None:
+    checked_paths = [
+        *RUNTIME_ROOT.glob("*.cpp"),
+        *RUNTIME_ROOT.glob("*.h"),
+        REPO_ROOT / "website/docs/getting-started/quick-start.md",
+    ]
+    leftovers = [
+        str(path.relative_to(REPO_ROOT))
+        for path in checked_paths
+        if "TRTMC_" "WAN22_" in path.read_text(encoding="utf-8")
+    ]
+    assert not leftovers
+
+    manifest = (RUNTIME_ROOT / "MODEL.toml").read_text(encoding="utf-8")
+    assert (
+        'runtime_config_schemas = '
+        '["config_schema.cpp|register_wan2_2_ti2v_schema"]'
+    ) in manifest

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_runtime_config_schema.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative Wan2.2 runtime-config contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import runpy
+
+import pytest
+
+import tensorrt_model_connect.runtime_config as runtime_config
+from tensorrt_model_connect.runtime_config import (
+    SchemaRegistry,
+    resolve_cli_config,
+)
+
+
+def _load_schema_without_global_registration():
+    captured = []
+    original = runtime_config.register_schema
+    runtime_config.register_schema = captured.append
+    try:
+        runpy.run_path(str(Path(__file__).parents[1] / "runtime_config_schema.py"))
+    finally:
+        runtime_config.register_schema = original
+    assert len(captured) == 1
+    return captured[0]
+
+
+SCHEMA = _load_schema_without_global_registration()
+
+
+def _registry() -> SchemaRegistry:
+    registry = SchemaRegistry()
+    registry.register_schema(SCHEMA)
+    return registry
+
+
+def test_defaults_are_portable_and_inert() -> None:
+    bundle = resolve_cli_config(registry=_registry())
+
+    assert bundle.get("wan2_2_ti2v", "easycache_enabled") is False
+    assert bundle.get("wan2_2_ti2v", "easycache_threshold") == 0.02
+    assert bundle.get("wan2_2_ti2v", "easycache_first_exact_steps") == 7
+    assert bundle.get("wan2_2_ti2v", "easycache_last_exact_steps") == 2
+    assert bundle.get("wan2_2_ti2v", "easycache_max_consecutive_reuse") == 1
+    assert bundle.get("wan2_2_ti2v", "late_cfg_enabled") is False
+
+
+def test_thor_receipt_values_resolve_through_set() -> None:
+    bundle = resolve_cli_config(
+        set_tokens=[
+            "wan2_2_ti2v.easycache_enabled=true",
+            "wan2_2_ti2v.easycache_threshold=1.0",
+            "wan2_2_ti2v.easycache_max_consecutive_reuse=4",
+            "wan2_2_ti2v.late_cfg_enabled=true",
+        ],
+        registry=_registry(),
+    )
+
+    assert bundle.get("wan2_2_ti2v", "easycache_enabled") is True
+    assert bundle.get("wan2_2_ti2v", "easycache_threshold") == 1.0
+    assert bundle.get("wan2_2_ti2v", "easycache_first_exact_steps") == 7
+    assert bundle.get("wan2_2_ti2v", "easycache_last_exact_steps") == 2
+    assert bundle.get("wan2_2_ti2v", "easycache_max_consecutive_reuse") == 4
+    assert bundle.get("wan2_2_ti2v", "late_cfg_enabled") is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "wan2_2_ti2v.easycache_threshold=0",
+        "wan2_2_ti2v.easycache_threshold=nan",
+        "wan2_2_ti2v.easycache_first_exact_steps=-1",
+        "wan2_2_ti2v.easycache_last_exact_steps=2147483648",
+        "wan2_2_ti2v.easycache_max_consecutive_reuse=0",
+    ],
+)
+def test_invalid_values_fail_before_pipeline_load(token: str) -> None:
+    with pytest.raises(ValueError, match="Validator rejected"):
+        resolve_cli_config(set_tokens=[token], registry=_registry())

--- a/src/runtime/models/wan2_2_ti2v/MODEL.toml
+++ b/src/runtime/models/wan2_2_ti2v/MODEL.toml
@@ -4,10 +4,11 @@
 id = "wan2_2_ti2v"
 runtime_library = "libtrtmc_model_wan2_2_ti2v.so"
 runtime_plugins = ["plugin.cpp|register_wan2_2_ti2v_plugin"]
+runtime_config_schemas = ["config_schema.cpp|register_wan2_2_ti2v_schema"]
 runtime_strategies = ["diffusion_wan2_2_ti2v"]
 runtime_tests = [
   "test_wan2_2_cuda_rng|test_wan2_2_cuda_rng.cpp|_|torch_cuda_normal.cu|REQUIRES_GPU",
-  "test_wan2_2_easycache|test_wan2_2_easycache.cpp|_|easycache.cpp|_",
+  "test_wan2_2_easycache|test_wan2_2_easycache.cpp|_|config_schema.cpp,easycache.cpp,runtime_config.cpp|_",
   "test_wan2_2_prompt_cleaner|test_wan2_2_prompt_cleaner.cpp|_|prompt_cleaner.cpp|_",
   "test_wan2_2_options|test_wan2_2_options.cpp|nlohmann_json::nlohmann_json|options.cpp|_",
   "test_wan2_2_staged_pipeline|test_wan2_2_staged_pipeline.cpp|trtmc_model_wan2_2_ti2v|_|REQUIRES_TRT,REQUIRES_GPU",

--- a/src/runtime/models/wan2_2_ti2v/config_schema.cpp
+++ b/src/runtime/models/wan2_2_ti2v/config_schema.cpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan2_2_ti2v/config_schema.h"
+
+#include <any>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <set>
+
+namespace trtmc::config::schemas {
+namespace {
+
+bool is_positive_double(const std::any& value) {
+    if (value.type() != typeid(double))
+        return false;
+    const double parsed = std::any_cast<double>(value);
+    return std::isfinite(parsed) && parsed > 0.0;
+}
+
+bool is_nonnegative_int32(const std::any& value) {
+    if (value.type() != typeid(std::int64_t))
+        return false;
+    const auto parsed = std::any_cast<std::int64_t>(value);
+    return parsed >= 0 && parsed <= std::numeric_limits<std::int32_t>::max();
+}
+
+bool is_positive_int32(const std::any& value) {
+    if (!is_nonnegative_int32(value))
+        return false;
+    return std::any_cast<std::int64_t>(value) > 0;
+}
+
+} // namespace
+
+Schema make_wan2_2_ti2v_schema() {
+    const std::set<Layer> session = {Layer::SessionRequest, Layer::PlatformProfile};
+    return Schema{
+        "wan2_2_ti2v",
+        {
+            ConfigField{"easycache_enabled", "bool", std::any{false}, session, nullptr},
+            ConfigField{"easycache_threshold", "double", std::any{0.02}, session,
+                        is_positive_double},
+            ConfigField{"easycache_first_exact_steps", "int64", std::any{std::int64_t{7}}, session,
+                        is_nonnegative_int32},
+            ConfigField{"easycache_last_exact_steps", "int64", std::any{std::int64_t{2}}, session,
+                        is_nonnegative_int32},
+            ConfigField{"easycache_max_consecutive_reuse", "int64", std::any{std::int64_t{1}},
+                        session, is_positive_int32},
+            ConfigField{"late_cfg_enabled", "bool", std::any{false}, session, nullptr},
+        },
+    };
+}
+
+REGISTER_CONFIG_SCHEMA_FACTORY_WITH_MANIFEST(register_wan2_2_ti2v_schema, make_wan2_2_ti2v_schema);
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/wan2_2_ti2v/config_schema.h
+++ b/src/runtime/models/wan2_2_ti2v/config_schema.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/config/schema_registry.h"
+
+namespace trtmc::config::schemas {
+
+Schema make_wan2_2_ti2v_schema();
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/wan2_2_ti2v/easycache.cpp
+++ b/src/runtime/models/wan2_2_ti2v/easycache.cpp
@@ -7,77 +7,16 @@
 
 #include "runtime/models/wan2_2_ti2v/options.h"
 
-#include <algorithm>
-#include <array>
-#include <cctype>
-#include <cerrno>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 
 namespace trtmc::wan2_2_ti2v {
 namespace {
 
-constexpr const char* kEnableEnvironment = "TRTMC_WAN22_EASYCACHE";
-constexpr const char* kThresholdEnvironment = "TRTMC_WAN22_EASYCACHE_THRESHOLD";
-constexpr const char* kFirstExactEnvironment = "TRTMC_WAN22_EASYCACHE_FIRST_EXACT_STEPS";
-constexpr const char* kLastExactEnvironment = "TRTMC_WAN22_EASYCACHE_LAST_EXACT_STEPS";
-constexpr const char* kMaxConsecutiveReuseEnvironment =
-    "TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE";
-constexpr const char* kLateCfgEnableEnvironment = "TRTMC_WAN22_EASYCACHE_LATE_CFG";
 constexpr double kMinimumNorm = 1.0e-8;
 constexpr double kMaximumTimestepExtrapolation = 2.0;
-
-std::string lowercase(std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
-        return static_cast<char>(std::tolower(character));
-    });
-    return value;
-}
-
-bool parse_enabled(const char* name) {
-    const char* value = std::getenv(name);
-    if (value == nullptr || *value == '\0')
-        return false;
-    const auto normalized = lowercase(value);
-    constexpr std::array<std::string_view, 4> enabled = {"1", "true", "yes", "on"};
-    constexpr std::array<std::string_view, 4> disabled = {"0", "false", "no", "off"};
-    if (std::find(enabled.begin(), enabled.end(), normalized) != enabled.end())
-        return true;
-    if (std::find(disabled.begin(), disabled.end(), normalized) != disabled.end())
-        return false;
-    throw std::invalid_argument(std::string(name) +
-                                " must be one of 0/1, false/true, no/yes, or off/on");
-}
-
-double parse_positive_double(const char* name, double default_value) {
-    const char* value = std::getenv(name);
-    if (value == nullptr || *value == '\0')
-        return default_value;
-    char* end = nullptr;
-    errno = 0;
-    const double parsed = std::strtod(value, &end);
-    if (errno != 0 || end == value || *end != '\0' || !std::isfinite(parsed) || parsed <= 0.0)
-        throw std::invalid_argument(std::string(name) + " must be a finite positive number");
-    return parsed;
-}
-
-int32_t parse_nonnegative_int(const char* name, int32_t default_value) {
-    const char* value = std::getenv(name);
-    if (value == nullptr || *value == '\0')
-        return default_value;
-    char* end = nullptr;
-    errno = 0;
-    const long parsed = std::strtol(value, &end, 10);
-    if (errno != 0 || end == value || *end != '\0' || parsed < 0 ||
-        parsed > std::numeric_limits<int32_t>::max()) {
-        throw std::invalid_argument(std::string(name) + " must be a non-negative integer");
-    }
-    return static_cast<int32_t>(parsed);
-}
 
 bool exact_windows_are_valid(const EasyCacheConfig& config) noexcept {
     return config.first_exact_steps >= 0 && config.last_exact_steps >= 0 &&
@@ -110,23 +49,6 @@ bool is_qualified_conservative_late_cfg_profile(const EasyCacheConfig& config) n
 
 } // namespace
 
-EasyCacheConfig easycache_config_from_environment(int32_t total_steps) {
-    EasyCacheConfig config;
-    config.total_steps = total_steps;
-    config.enabled = parse_enabled(kEnableEnvironment);
-    if (!config.enabled)
-        return config;
-
-    config.threshold = parse_positive_double(kThresholdEnvironment, config.threshold);
-    config.first_exact_steps =
-        parse_nonnegative_int(kFirstExactEnvironment, config.first_exact_steps);
-    config.last_exact_steps = parse_nonnegative_int(kLastExactEnvironment, config.last_exact_steps);
-    config.max_consecutive_reuse =
-        parse_nonnegative_int(kMaxConsecutiveReuseEnvironment, config.max_consecutive_reuse);
-    validate_config(config);
-    return config;
-}
-
 bool is_thor_performance_easycache_config(const EasyCacheConfig& easycache) noexcept {
     return easycache.enabled && easycache.threshold == kThorPerformanceEasyCacheThreshold &&
            easycache.first_exact_steps == kThorPerformanceEasyCacheFirstExactSteps &&
@@ -145,15 +67,15 @@ bool is_qualified_thor_performance_easycache_profile(
            runtime.compute_capability_major == 11 && runtime.compute_capability_minor == 0;
 }
 
-bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache,
-                                       bool thor_performance_profile_qualified) {
-    if (!parse_enabled(kLateCfgEnableEnvironment))
+bool validate_late_cfg_request(bool requested, const EasyCacheConfig& easycache,
+                               bool thor_performance_profile_qualified) {
+    if (!requested)
         return false;
     if (!is_qualified_conservative_late_cfg_profile(easycache) &&
         !(thor_performance_profile_qualified && is_thor_performance_easycache_config(easycache))) {
         throw std::invalid_argument(
-            "TRTMC_WAN22_EASYCACHE_LATE_CFG requires either the conservative 50-step "
-            "EasyCache profile (threshold=0.08, first_exact_steps=7, last_exact_steps=2, "
+            "wan2_2_ti2v.late_cfg_enabled requires either the conservative 50-step EasyCache "
+            "profile (threshold=0.08, first_exact_steps=7, last_exact_steps=2, "
             "max_consecutive_reuse=4) or its runtime-qualified Thor performance profile");
     }
     return true;

--- a/src/runtime/models/wan2_2_ti2v/easycache.h
+++ b/src/runtime/models/wan2_2_ti2v/easycache.h
@@ -49,12 +49,11 @@ struct EasyCacheRuntimeProfile {
     int32_t compute_capability_minor{0};
 };
 
-EasyCacheConfig easycache_config_from_environment(int32_t total_steps);
 bool is_thor_performance_easycache_config(const EasyCacheConfig& easycache) noexcept;
 bool is_qualified_thor_performance_easycache_profile(
     const EasyCacheConfig& easycache, const EasyCacheRuntimeProfile& runtime) noexcept;
-bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache,
-                                       bool thor_performance_profile_qualified = false);
+bool validate_late_cfg_request(bool requested, const EasyCacheConfig& easycache,
+                               bool thor_performance_profile_qualified = false);
 
 class EasyCacheController {
   public:

--- a/src/runtime/models/wan2_2_ti2v/pipeline.cpp
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.cpp
@@ -392,9 +392,12 @@ make_wan22_vae_cache_bindings(const std::vector<void*>& input_addresses,
 
 Wan22TI2VPipeline::Wan22TI2VPipeline(Wan22ModuleLoader module_loader,
                                      std::unique_ptr<ITokenizer> tokenizer,
-                                     Wan22TI2VOptions options, std::string model_id)
+                                     Wan22TI2VOptions options,
+                                     wan2_2_ti2v::RuntimeConfig runtime_config,
+                                     std::string model_id)
     : module_loader_(std::move(module_loader)), tokenizer_(std::move(tokenizer)),
-      options_(std::move(options)), model_id_(std::move(model_id)) {
+      options_(std::move(options)), runtime_config_(std::move(runtime_config)),
+      model_id_(std::move(model_id)) {
     if (!module_loader_ || !tokenizer_)
         throw std::invalid_argument("Wan2.2 requires a tokenizer and staged TensorRT loader");
     const auto status = cudaStreamCreate(&stream_);
@@ -512,8 +515,8 @@ void Wan22TI2VPipeline::run_denoising(std::vector<float>& latents,
     auto denoiser = load_module("denoiser_plan");
     validate_denoiser_contract(*denoiser, shape);
 
-    const auto easycache_config =
-        wan2_2_ti2v::easycache_config_from_environment(request.num_inference_steps);
+    auto easycache_config = runtime_config_.easycache;
+    easycache_config.total_steps = request.num_inference_steps;
     bool thor_performance_profile_qualified = false;
     if (wan2_2_ti2v::is_thor_performance_easycache_config(easycache_config)) {
         const auto runtime_profile = current_easycache_runtime_profile(request);
@@ -536,8 +539,8 @@ void Wan22TI2VPipeline::run_denoising(std::vector<float>& latents,
     }
 
     std::unique_ptr<wan2_2_ti2v::LateCfgController> late_cfg;
-    if (wan2_2_ti2v::late_cfg_enabled_from_environment(easycache_config,
-                                                       thor_performance_profile_qualified)) {
+    if (wan2_2_ti2v::validate_late_cfg_request(runtime_config_.late_cfg_enabled, easycache_config,
+                                               thor_performance_profile_qualified)) {
         late_cfg = std::make_unique<wan2_2_ti2v::LateCfgController>();
         std::cerr << "[wan2.2-ti2v.late_cfg] enabled=1 refresh_interval=2"
                   << " first_exact_steps=20 last_exact_steps=2"

--- a/src/runtime/models/wan2_2_ti2v/pipeline.h
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.h
@@ -7,6 +7,7 @@
 
 #include "runtime/backend/prebound_backend.h"
 #include "runtime/models/wan2_2_ti2v/options.h"
+#include "runtime/models/wan2_2_ti2v/runtime_config.h"
 #include "trtmc/pipeline.h"
 #include "trtmc/tokenizer.h"
 
@@ -43,7 +44,8 @@ make_wan22_vae_cache_bindings(const std::vector<void*>& input_addresses,
 class Wan22TI2VPipeline final : public IPipeline {
   public:
     Wan22TI2VPipeline(Wan22ModuleLoader module_loader, std::unique_ptr<ITokenizer> tokenizer,
-                      Wan22TI2VOptions options, std::string model_id);
+                      Wan22TI2VOptions options, wan2_2_ti2v::RuntimeConfig runtime_config,
+                      std::string model_id);
     ~Wan22TI2VPipeline() override;
 
     bool supports_image_generation() const override { return true; }
@@ -72,6 +74,7 @@ class Wan22TI2VPipeline final : public IPipeline {
     Wan22ModuleLoader module_loader_;
     std::unique_ptr<ITokenizer> tokenizer_;
     Wan22TI2VOptions options_;
+    wan2_2_ti2v::RuntimeConfig runtime_config_;
     std::string model_id_;
     cudaStream_t stream_{nullptr};
     std::mutex generation_mutex_;

--- a/src/runtime/models/wan2_2_ti2v/plugin.cpp
+++ b/src/runtime/models/wan2_2_ti2v/plugin.cpp
@@ -7,6 +7,7 @@
 #include "bundle/bundle_view.h"
 #include "runtime/backend/prebound_backend.h"
 #include "runtime/models/wan2_2_ti2v/pipeline.h"
+#include "runtime/models/wan2_2_ti2v/runtime_config.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "trtmc/runtime/trt_backend.h"
 #include "trtmc/tokenizer.h"
@@ -108,7 +109,8 @@ class Wan22TI2VPlugin final : public IPipelinePlugin {
         auto tokenizer = load_tokenizer(ctx.bundle);
         return std::make_unique<Wan22TI2VPipeline>(
             make_staged_module_loader(ctx, std::move(plan_sections)), std::move(tokenizer),
-            parse_wan22_options(ctx.config_json), ctx.bundle.info.model_id);
+            parse_wan22_options(ctx.config_json),
+            wan2_2_ti2v::resolve_runtime_config(ctx.runtime_config), ctx.bundle.info.model_id);
     }
 };
 

--- a/src/runtime/models/wan2_2_ti2v/runtime_config.cpp
+++ b/src/runtime/models/wan2_2_ti2v/runtime_config.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan2_2_ti2v/runtime_config.h"
+
+#include "trtmc/config/config_bundle.h"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc::wan2_2_ti2v {
+namespace {
+
+constexpr const char* kNamespace = "wan2_2_ti2v";
+
+int32_t checked_int32(std::int64_t value, const char* field) {
+    if (value < 0 || value > std::numeric_limits<int32_t>::max()) {
+        throw std::out_of_range(std::string(kNamespace) + "." + field +
+                                " is outside the non-negative int32 range");
+    }
+    return static_cast<int32_t>(value);
+}
+
+} // namespace
+
+RuntimeConfig resolve_runtime_config(const config::ConfigBundle* config) {
+    RuntimeConfig result;
+    if (config == nullptr)
+        return result;
+
+    try {
+        result.easycache.enabled = config->get<bool>(kNamespace, "easycache_enabled");
+        result.easycache.threshold = config->get<double>(kNamespace, "easycache_threshold");
+        result.easycache.first_exact_steps =
+            checked_int32(config->get<std::int64_t>(kNamespace, "easycache_first_exact_steps"),
+                          "easycache_first_exact_steps");
+        result.easycache.last_exact_steps =
+            checked_int32(config->get<std::int64_t>(kNamespace, "easycache_last_exact_steps"),
+                          "easycache_last_exact_steps");
+        result.easycache.max_consecutive_reuse =
+            checked_int32(config->get<std::int64_t>(kNamespace, "easycache_max_consecutive_reuse"),
+                          "easycache_max_consecutive_reuse");
+        result.late_cfg_enabled = config->get<bool>(kNamespace, "late_cfg_enabled");
+    } catch (const std::exception& error) {
+        throw std::runtime_error(std::string("Invalid Wan2.2 runtime config: ") + error.what());
+    }
+    return result;
+}
+
+} // namespace trtmc::wan2_2_ti2v

--- a/src/runtime/models/wan2_2_ti2v/runtime_config.h
+++ b/src/runtime/models/wan2_2_ti2v/runtime_config.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/wan2_2_ti2v/easycache.h"
+
+namespace trtmc::config {
+class ConfigBundle;
+}
+
+namespace trtmc::wan2_2_ti2v {
+
+struct RuntimeConfig {
+    EasyCacheConfig easycache;
+    bool late_cfg_enabled{false};
+};
+
+// Copy the immutable session config while PipelineContext is alive. The
+// pipeline owns the returned values and never retains ConfigBundle pointers.
+RuntimeConfig resolve_runtime_config(const config::ConfigBundle* config);
+
+} // namespace trtmc::wan2_2_ti2v

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "runtime/models/wan2_2_ti2v/config_schema.h"
 #include "runtime/models/wan2_2_ti2v/easycache.h"
+#include "runtime/models/wan2_2_ti2v/runtime_config.h"
+#include "trtmc/config/cli_support.h"
+#include "trtmc/config/schema_registry.h"
 
 #include <cmath>
-#include <cstdlib>
 #include <iostream>
 #include <optional>
 #include <stdexcept>
@@ -42,28 +45,6 @@ void check_throws(Callable&& callable, const char* label) {
     }
 }
 
-class ScopedEnvironment {
-  public:
-    explicit ScopedEnvironment(const char* name) : name_(name) {
-        if (const char* value = std::getenv(name))
-            original_ = value;
-    }
-
-    ~ScopedEnvironment() {
-        if (original_.has_value())
-            setenv(name_.c_str(), original_->c_str(), 1);
-        else
-            unsetenv(name_.c_str());
-    }
-
-    void set(const char* value) { setenv(name_.c_str(), value, 1); }
-    void unset() { unsetenv(name_.c_str()); }
-
-  private:
-    std::string name_;
-    std::optional<std::string> original_;
-};
-
 EasyCacheConfig qualified_config() {
     EasyCacheConfig config;
     config.enabled = true;
@@ -98,67 +79,77 @@ trtmc::wan2_2_ti2v::EasyCacheRuntimeProfile qualified_thor_runtime() {
     return runtime;
 }
 
-void test_defaults_are_inert() {
-    ScopedEnvironment easycache("TRTMC_WAN22_EASYCACHE");
-    ScopedEnvironment threshold("TRTMC_WAN22_EASYCACHE_THRESHOLD");
-    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
-    easycache.unset();
-    threshold.set("not-parsed-while-disabled");
-    late_cfg.unset();
+void register_runtime_schema() {
+    auto& registry = trtmc::config::SchemaRegistry::instance();
+    registry.clear_for_testing();
+    registry.register_schema(trtmc::config::schemas::make_wan2_2_ti2v_schema());
+}
 
-    const auto config = trtmc::wan2_2_ti2v::easycache_config_from_environment(50);
-    check(!config.enabled, "EasyCache is disabled by default");
-    check(!trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config),
+trtmc::wan2_2_ti2v::RuntimeConfig
+resolve_settings(const std::vector<std::string>& set_tokens = {}) {
+    const auto bundle = trtmc::config::resolve_cli_config("", set_tokens);
+    return trtmc::wan2_2_ti2v::resolve_runtime_config(&bundle);
+}
+
+void test_declarative_defaults_are_inert() {
+    register_runtime_schema();
+    const auto settings = resolve_settings();
+    check(!settings.easycache.enabled, "EasyCache is disabled by default");
+    check(close(settings.easycache.threshold, 0.02), "EasyCache threshold default is preserved");
+    check(settings.easycache.first_exact_steps == 7 && settings.easycache.last_exact_steps == 2 &&
+              settings.easycache.max_consecutive_reuse == 1,
+          "EasyCache integer defaults are preserved");
+    check(!trtmc::wan2_2_ti2v::validate_late_cfg_request(settings.late_cfg_enabled,
+                                                         settings.easycache),
           "late-CFG is disabled by default");
 }
 
-void test_qualified_profile_lock() {
-    ScopedEnvironment easycache("TRTMC_WAN22_EASYCACHE");
-    ScopedEnvironment threshold("TRTMC_WAN22_EASYCACHE_THRESHOLD");
-    ScopedEnvironment first("TRTMC_WAN22_EASYCACHE_FIRST_EXACT_STEPS");
-    ScopedEnvironment last("TRTMC_WAN22_EASYCACHE_LAST_EXACT_STEPS");
-    ScopedEnvironment maximum("TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE");
-    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
-    easycache.set("true");
-    threshold.set("0.08");
-    first.set("7");
-    last.set("2");
-    maximum.set("4");
-    late_cfg.set("true");
-
-    const auto parsed = trtmc::wan2_2_ti2v::easycache_config_from_environment(50);
-    check(trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(parsed),
+void test_declarative_values_reach_runtime_api() {
+    register_runtime_schema();
+    const auto settings = resolve_settings({
+        "wan2_2_ti2v.easycache_enabled=true",
+        "wan2_2_ti2v.easycache_threshold=0.08",
+        "wan2_2_ti2v.easycache_first_exact_steps=7",
+        "wan2_2_ti2v.easycache_last_exact_steps=2",
+        "wan2_2_ti2v.easycache_max_consecutive_reuse=4",
+        "wan2_2_ti2v.late_cfg_enabled=true",
+    });
+    auto parsed = settings.easycache;
+    parsed.total_steps = 50;
+    check(settings.late_cfg_enabled, "late-CFG declarative value reaches the runtime API");
+    check(parsed.enabled && close(parsed.threshold, 0.08) && parsed.first_exact_steps == 7 &&
+              parsed.last_exact_steps == 2 && parsed.max_consecutive_reuse == 4,
+          "EasyCache declarative values reach the runtime API");
+    check(trtmc::wan2_2_ti2v::validate_late_cfg_request(settings.late_cfg_enabled, parsed),
           "late-CFG accepts the qualified EasyCache profile");
 
     auto invalid = qualified_config();
     invalid.enabled = false;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects disabled EasyCache");
     invalid = qualified_config();
     invalid.threshold = 0.05;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects an unqualified threshold");
     invalid = qualified_config();
     invalid.first_exact_steps = 8;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects an unqualified prefix");
     invalid = qualified_config();
     invalid.last_exact_steps = 1;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects an unqualified suffix");
     invalid = qualified_config();
     invalid.max_consecutive_reuse = 3;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects an unqualified reuse cap");
     invalid = qualified_config();
     invalid.total_steps = 49;
-    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, invalid); },
                  "late-CFG rejects an unqualified step count");
 }
 
 void test_thor_performance_profile_scope() {
-    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
-    late_cfg.set("true");
     const auto config = thor_performance_config();
     const auto runtime = qualified_thor_runtime();
 
@@ -166,11 +157,10 @@ void test_thor_performance_profile_scope() {
           "Thor performance EasyCache config is exact");
     check(trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config, runtime),
           "Thor performance profile accepts official integrated SM110");
-    check(trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config, true),
+    check(trtmc::wan2_2_ti2v::validate_late_cfg_request(true, config, true),
           "late-CFG accepts runtime-qualified Thor performance profile");
-    check_throws(
-        [&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config, false); },
-        "late-CFG rejects an unqualified Thor performance profile");
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::validate_late_cfg_request(true, config, false); },
+                 "late-CFG rejects an unqualified Thor performance profile");
 
     auto invalid_runtime = runtime;
     invalid_runtime.video_height = 384;
@@ -217,6 +207,16 @@ void test_thor_performance_profile_scope() {
     invalid_config.total_steps = 49;
     check(!trtmc::wan2_2_ti2v::is_thor_performance_easycache_config(invalid_config),
           "Thor performance profile rejects non-qualified step count");
+}
+
+void test_schema_rejects_invalid_values() {
+    register_runtime_schema();
+    check_throws([] { (void)resolve_settings({"wan2_2_ti2v.easycache_threshold=0"}); },
+                 "schema rejects a non-positive threshold");
+    check_throws([] { (void)resolve_settings({"wan2_2_ti2v.easycache_first_exact_steps=-1"}); },
+                 "schema rejects a negative exact-step count");
+    check_throws([] { (void)resolve_settings({"wan2_2_ti2v.easycache_max_consecutive_reuse=0"}); },
+                 "schema rejects a zero reuse cap");
 }
 
 void test_easycache_exact_and_reuse_paths() {
@@ -382,9 +382,10 @@ void test_synthetic_unconditional_updates_easycache() {
 } // namespace
 
 int main() {
-    test_defaults_are_inert();
-    test_qualified_profile_lock();
+    test_declarative_defaults_are_inert();
+    test_declarative_values_reach_runtime_api();
     test_thor_performance_profile_scope();
+    test_schema_rejects_invalid_values();
     test_easycache_exact_and_reuse_paths();
     test_late_cfg_exact_windows_cadence_and_prediction();
     test_prediction_falls_back_to_actual();

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
@@ -400,7 +400,7 @@ int main() {
     };
     {
         auto tokenizer = std::make_unique<FakeTokenizer>();
-        trtmc::Wan22TI2VPipeline pipeline(std::move(loader), std::move(tokenizer), {},
+        trtmc::Wan22TI2VPipeline pipeline(std::move(loader), std::move(tokenizer), {}, {},
                                           "wan22-test");
         if (module_loads != 0) {
             std::cerr << "FAIL: pipeline construction eagerly loaded a TensorRT plan\n";

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -9076,6 +9076,15 @@ def test_audio_speech_comparator_sidecars_are_task_owned() -> None:
     assert not violations, _format_violations(violations)
 
 
+def test_wan22_quick_start_uses_declarative_runtime_settings() -> None:
+    """Keep the full-checkout Wan2.2 instructions free of tuning env vars."""
+
+    quick_start = REPO_ROOT / "website" / "docs" / "getting-started" / "quick-start.md"
+    text = quick_start.read_text(encoding="utf-8")
+
+    assert "TRTMC_" "WAN22_" not in text
+
+
 def test_generated_e2e_task_sidecars_are_task_owned() -> None:
     """Trace: ARCH-MODPLUG-001
     Intent: prevent generated E2E sidecars from carrying active behavior for

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -125,14 +125,14 @@ trtmc build Wan-AI/Wan2.2-TI2V-5B \
   --fp8 \
   -o wan22-thor.trtfb
 
-env TRTMC_WAN22_EASYCACHE=1 \
-    TRTMC_WAN22_EASYCACHE_THRESHOLD=1.0 \
-    TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE=4 \
-    TRTMC_WAN22_EASYCACHE_LATE_CFG=1 \
-  trtmc generate-video wan22-thor.trtfb \
-    --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
-    --output wan22-frames \
-    --seed 42
+trtmc generate-video wan22-thor.trtfb \
+  --set wan2_2_ti2v.easycache_enabled=true \
+  --set wan2_2_ti2v.easycache_threshold=1.0 \
+  --set wan2_2_ti2v.easycache_max_consecutive_reuse=4 \
+  --set wan2_2_ti2v.late_cfg_enabled=true \
+  --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
+  --output wan22-frames \
+  --seed 42
 ```
 
 The first command downloads the pinned checkpoint from Hugging Face, verifies
@@ -160,7 +160,7 @@ clocks, temperatures, or prompts.
 
 TensorRT plans must be built on the target Thor. Wan2.2 itself is not
 Thor-only: the packaged FP8 profile also supports GB300 SM 10.3, while other
-supported GPUs can omit `--fp8` and the four EasyCache environment variables
+supported GPUs can omit `--fp8` and the four EasyCache `--set` arguments
 to use the portable BF16 path.
 
 ## What To Read Next


### PR DESCRIPTION
## Summary

- register model-owned C++ and Python runtime schemas for all six Wan2.2 EasyCache and late-CFG settings
- route repeatable `--set wan2_2_ti2v.<key>=<value>` arguments through `LoadOptions` and `PipelineContext` into pipeline-owned typed configuration
- remove the Wan2.2 environment-variable parser while preserving exact-window, quality-profile, and Thor qualification guards
- update the Thor quick start to use the declarative settings

## Why

Process-global environment variables do not scale as the number of model-specific controls grows. Wan2.2 now uses the existing namespaced runtime-config API shared by the CLI and C++ callers, without changing the global CLI, bundle format, or other model ownership.

## Validation

- `25 passed`: Wan2.2 Python family, schema, and ownership tests
- `67 passed`: Python config CLI/schema tests in one process
- `161 passed`: model-plugin encapsulation plus Wan2.2 ownership tests after moving the docs assertion to the full-checkout gate
- `3 passed`: non-GPU Wan2.2 C++ unit tests
- `4 passed`: Thor CTest suite, including the staged GPU pipeline
- compiled `test_wan2_2_staged_pipeline` and `libtrtmc_model_wan2_2_ti2v.so` against TensorRT 11.2
- repo source, tests, and docs contain no legacy Wan2.2 environment-variable names

## Thor qualification

Jetson AGX Thor was held in MAXN with CPU, GPU, and EMC clocks fixed at their maximum frequencies. The build resolved `Wan-AI/Wan2.2-TI2V-5B` to checkpoint `921dbaf3f1674a56f47e83fb80a34bac8a8f203e`, verified the packaged 120-layer FP8 scale profile, and selected the qualified SM110 BF16 VAE convolution path.

- TensorRT: `11.2.0.113`
- bundle build wall time: `2053 s`
- bundle size: `20,613,214,463 bytes`
- bundle SHA256: `a922841a426592abe8454a33d1ab56cf67849a484bbea76b15685f8e0bf4df98`
- full generation: `1280x704`, 121 frames, 50 steps, CFG 5, seed 42
- generation wall time: `206 s`
- internal E2E: `202,163.702 ms`
- denoiser: 31 launches (`17` compute steps, `33` EasyCache reuse steps)
- output: 121 PNG files; representative first, middle, and last frames are visually aligned with the accepted 205-second Thor run, with no visible collapse or prompt-semantic drift

The effective-config receipt records the four explicit controls as `session_request` and the 7/2 exact windows as schema defaults. No `TRTMC_WAN22_*` variable was present.

The GPU build used production commit `3c1cdc0c`; current head `de271dbd` differs from it only by relocating one test assertion between two test files, with no production or documentation delta.
