### PR TITLE
fix(bart): align masking and validation semantics

### DIFF
--- a/python/tensorrt_model_connect/families/bart/debug_runner.py
+++ b/python/tensorrt_model_connect/families/bart/debug_runner.py
@@ -49,6 +49,18 @@ def _require_trt_runtime() -> None:
     if cudart is None:
         raise ImportError("cuda-python is required for family debug_runner execution")
 
+
+def _decoder_cross_attention_mask_name(engine) -> str | None:
+    tensor_names = {
+        engine.get_tensor_name(index)
+        for index in range(engine.num_io_tensors)
+    }
+    for name in ("cross_attention_mask", "encoder_mask"):
+        if name in tensor_names:
+            return name
+    return None
+
+
 def load_vision_engine_from_bundle(bundle_path: str) -> tuple[bytes | None, dict]:
     """Load vision engine plan bytes from this family's .trtfb bundle."""
     import json
@@ -175,9 +187,8 @@ class Seq2SeqTrtRunner:
         # Auto-detect dimensions from decoder engine
         cache_shape = tuple(self.dec_engine.get_tensor_shape("cache_k_0"))
         self.attention_size = cache_shape[1]
-        self._decoder_has_encoder_mask = any(
-            self.dec_engine.get_tensor_name(i) == "encoder_mask"
-            for i in range(self.dec_engine.num_io_tensors)
+        self._decoder_cross_attention_mask_name = (
+            _decoder_cross_attention_mask_name(self.dec_engine)
         )
         if hidden_size is None:
             cross_shape = tuple(self.dec_engine.get_tensor_shape("cross_k_0"))
@@ -234,6 +245,24 @@ class Seq2SeqTrtRunner:
         self._h_logits = np.zeros(logits_shape, dtype=np.float32)
         err, self._d_logits = cudart.cudaMalloc(self._logits_numel * 4)
         _check_cuda(err)
+
+        self._debug_output_names = []
+        self._h_debug = {}
+        self._d_debug = {}
+        for index in range(self.dec_engine.num_io_tensors):
+            name = self.dec_engine.get_tensor_name(index)
+            if not name.startswith("debug_"):
+                continue
+            if self.dec_engine.get_tensor_mode(name) != trt.TensorIOMode.OUTPUT:
+                continue
+            shape = tuple(self.dec_engine.get_tensor_shape(name))
+            dtype = _trt_nptype_safe(self.dec_engine.get_tensor_dtype(name))
+            host = np.zeros(shape, dtype=dtype)
+            err, device = cudart.cudaMalloc(host.nbytes)
+            _check_cuda(err)
+            self._debug_output_names.append(name)
+            self._h_debug[name] = host
+            self._d_debug[name] = device
 
         # ----- Encoder device buffers -----
         enc_input_bytes = max_source_positions * 4  # int32 tokens
@@ -320,6 +349,8 @@ class Seq2SeqTrtRunner:
         self.dec_context.set_tensor_address("position_id", self._d_position_id)
         self.dec_context.set_tensor_address("attention_mask", self._d_mask)
         self.dec_context.set_tensor_address("logits", self._d_logits)
+        for name in self._debug_output_names:
+            self.dec_context.set_tensor_address(name, self._d_debug[name])
 
         for i in range(self.num_layers):
             self.dec_context.set_tensor_address(f"cache_k_{i}", self._d_cache_k[i])
@@ -328,8 +359,9 @@ class Seq2SeqTrtRunner:
             self.dec_context.set_tensor_address(f"present_v_{i}", self._d_present_v[i])
             self.dec_context.set_tensor_address(f"cross_k_{i}", self._d_cross_k[i])
             self.dec_context.set_tensor_address(f"cross_v_{i}", self._d_cross_v[i])
-        if self._decoder_has_encoder_mask:
-            self.dec_context.set_tensor_address("encoder_mask", self._d_enc_mask)
+        if self._decoder_cross_attention_mask_name is not None:
+            self.dec_context.set_tensor_address(
+                self._decoder_cross_attention_mask_name, self._d_enc_mask)
 
         self.dec_context.execute_async_v3(stream)
 
@@ -351,10 +383,19 @@ class Seq2SeqTrtRunner:
 
         cudart.cudaMemcpyAsync(self._h_logits.ctypes.data, self._d_logits,
             self._logits_numel * 4, D2H, stream)
+        for name in self._debug_output_names:
+            host = self._h_debug[name]
+            cudart.cudaMemcpyAsync(
+                host.ctypes.data, self._d_debug[name], host.nbytes, D2H, stream)
         cudart.cudaStreamSynchronize(stream)
         self.cache_length = min(self.cache_length + 1, self.max_cache_length)
 
-        return {"logits": self._h_logits.copy()}
+        outputs = {"logits": self._h_logits.copy()}
+        outputs.update({
+            name: self._h_debug[name].copy()
+            for name in self._debug_output_names
+        })
+        return outputs
 
     def reset(self):
         cache_bytes = self.max_cache_length * self.attention_size * self._cache_elem_bytes
@@ -393,6 +434,7 @@ class Seq2SeqTrtRunner:
         bufs.extend(self._d_present_v)
         bufs.extend(self._d_cross_k)
         bufs.extend(self._d_cross_v)
+        bufs.extend(self._d_debug.values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
@@ -156,6 +156,7 @@ def _add_bart_tp_decoder_layer(
     max_cache_length: int,
     max_enc_seq: int,
     tp_size: int,
+    activation_function: str = "gelu",
 ):
     attention_window = max_cache_length + 1
 
@@ -259,7 +260,7 @@ def _add_bart_tp_decoder_layer(
         local_ffn_dim,
         weights[f"{prefix}.fc1_bias"],
     )
-    act = graph_ops.add_activation(network, fc1, "gelu_new")
+    act = graph_ops.add_activation(network, fc1, activation_function)
     fc2 = graph_ops.add_matmul_rhs_constant(
         network, act, local_ffn_dim, hidden_size, weights[f"{prefix}.w_fc2"])
     fc2 = _add_row_parallel_bias(
@@ -303,6 +304,7 @@ def build_bart_tp_decoder_engine(
     local_ffn_dim = dec_ffn // parallel.tp_size
     attention_window = max_cache_length + 1
     max_enc_seq = max_cache_length
+    activation_function = config.hidden_act or "gelu"
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -383,6 +385,7 @@ def build_bart_tp_decoder_engine(
             max_cache_length=max_cache_length,
             max_enc_seq=max_enc_seq,
             tp_size=parallel.tp_size,
+            activation_function=activation_function,
         )
         hidden_state = result["hidden"]
         present_k_outputs.append(result["present_k"])

--- a/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
@@ -144,6 +144,7 @@ def _add_bart_tp_decoder_layer(
     cross_k,
     cross_v,
     attention_mask,
+    cross_attention_mask,
     eps,
     weights,
     prefix: str,
@@ -233,10 +234,13 @@ def _add_bart_tp_decoder_layer(
         weights[f"{prefix}.cross_b_v"],
     )
 
+    cross_mask_4d = network.add_shuffle(cross_attention_mask)
+    cross_mask_4d.reshape_dims = (1, 1, 1, max_enc_seq)
     ccf = graph_ops.add_attention_from_rows(
         network, cq, ck_proj, cv_proj,
         num_heads=local_heads, head_dim=head_dim,
-        q_seq=1, kv_seq=max_enc_seq)
+        q_seq=1, kv_seq=max_enc_seq,
+        mask=cross_mask_4d.get_output(0))
     ca = graph_ops.add_matmul_rhs_constant(
         network, ccf, local_attention_size, hidden_size, weights[f"{prefix}.cross_w_o"])
     ca = _add_row_parallel_bias(
@@ -311,6 +315,8 @@ def build_bart_tp_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (attention_window,))
+    cross_attention_mask = network.add_input(
+        "cross_attention_mask", trt.float32, (max_enc_seq,))
 
     cache_k_inputs, cache_v_inputs = [], []
     for layer_idx in range(dec_layers):
@@ -365,6 +371,7 @@ def build_bart_tp_decoder_engine(
             cross_k=cross_k_inputs[layer_idx],
             cross_v=cross_v_inputs[layer_idx],
             attention_mask=attention_mask,
+            cross_attention_mask=cross_attention_mask,
             eps=config.rms_norm_eps,
             weights=rank_weights,
             prefix=prefix,

--- a/python/tensorrt_model_connect/families/bart/graph_ops.py
+++ b/python/tensorrt_model_connect/families/bart/graph_ops.py
@@ -140,6 +140,41 @@ def add_gelu_new(
     return result.get_output(0)
 
 
+def add_gelu_erf(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """GELU (exact, erf-based): 0.5*x*(1+erf(x/sqrt(2)))."""
+    target_dtype = inp.dtype
+    const_shape = (1,) * max(1, len(tuple(inp.shape)))
+
+    def _const(value):
+        constant = add_constant(
+            network,
+            const_shape,
+            np.array([value], dtype=np.float32),
+            dtype=dtype,
+        )
+        return _cast_back_to_trt_dtype(network, constant, target_dtype)
+
+    inv_sqrt2 = _const(1.0 / np.sqrt(2.0))
+    scaled = network.add_elementwise(
+        inp, inv_sqrt2, trt.ElementWiseOperation.PROD)
+    erf = network.add_unary(
+        scaled.get_output(0), trt.UnaryOperation.ERF)
+    one_plus_erf = network.add_elementwise(
+        _const(1.0), erf.get_output(0), trt.ElementWiseOperation.SUM)
+    half_x = network.add_elementwise(
+        _const(0.5), inp, trt.ElementWiseOperation.PROD)
+    result = network.add_elementwise(
+        half_x.get_output(0),
+        one_plus_erf.get_output(0),
+        trt.ElementWiseOperation.PROD,
+    )
+    return result.get_output(0)
+
+
 def add_activation(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
@@ -147,7 +182,9 @@ def add_activation(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Dispatch activation by name: 'silu', 'gelu_new', 'gelu', 'relu', 'relu2'/'squared_relu'."""
-    if activation_type in ("gelu_new", "gelu"):
+    if activation_type == "gelu":
+        return add_gelu_erf(network, inp, dtype=dtype)
+    elif activation_type in ("gelu_new", "gelu_fast", "gelu_pytorch_tanh"):
         return add_gelu_new(network, inp, dtype=dtype)
     elif activation_type == "relu":
         act = network.add_activation(inp, trt.ActivationType.RELU)

--- a/python/tensorrt_model_connect/families/bart/plugin.py
+++ b/python/tensorrt_model_connect/families/bart/plugin.py
@@ -215,6 +215,8 @@ class BartPlugin:
         token_id = network.add_input("token_id", trt.int32, (1,))
         position_id = network.add_input("position_id", trt.int32, (1,))
         attention_mask = network.add_input("attention_mask", trt.float32, (attention_window,))
+        cross_attention_mask = network.add_input(
+            "cross_attention_mask", trt.float32, (max_enc_seq,))
 
         cache_k_inputs, cache_v_inputs = [], []
         for i in range(dec_layers):
@@ -272,6 +274,10 @@ class BartPlugin:
             network.add_cast(attention_mask, work_trt_dtype).get_output(0)
             if attention_mask.dtype != work_trt_dtype else attention_mask
         )
+        cross_attention_mask_work = (
+            network.add_cast(cross_attention_mask, work_trt_dtype).get_output(0)
+            if cross_attention_mask.dtype != work_trt_dtype else cross_attention_mask
+        )
 
         if debug_layer_outputs:
             _mark_debug_output(network, hidden_state, "debug_embed")
@@ -283,7 +289,9 @@ class BartPlugin:
                 network=network, hidden=hidden_state,
                 cache_k=cache_k_work[layer_idx], cache_v=cache_v_work[layer_idx],
                 cross_k=cross_k_work[layer_idx], cross_v=cross_v_work[layer_idx],
-                attention_mask=attention_mask_work, eps=config.rms_norm_eps,
+                attention_mask=attention_mask_work,
+                cross_attention_mask=cross_attention_mask_work,
+                eps=config.rms_norm_eps,
                 weights=weights, prefix=prefix,
                 hidden_size=hidden, num_heads=dec_heads, head_dim=head_dim,
                 ffn_dim=dec_ffn, max_cache_length=max_cache_length,
@@ -457,7 +465,7 @@ def _build_bart_encoder(
 
 
 def _add_bart_decoder_layer(*, network, hidden, cache_k, cache_v, cross_k, cross_v,
-    attention_mask, eps, weights, prefix,
+    attention_mask, cross_attention_mask, eps, weights, prefix,
     hidden_size, num_heads, head_dim, ffn_dim, max_cache_length, max_enc_seq,
     dtype=np.float32):
     attention_size = hidden_size
@@ -498,10 +506,13 @@ def _add_bart_decoder_layer(*, network, hidden, cache_k, cache_v, cross_k, cross
     ck_proj = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, cross_k, hidden_size, attention_size, weights[f"{prefix}.cross_w_k"], dtype=dtype), attention_size, weights[f"{prefix}.cross_b_k"], dtype=dtype)
     cv_proj = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, cross_v, hidden_size, attention_size, weights[f"{prefix}.cross_w_v"], dtype=dtype), attention_size, weights[f"{prefix}.cross_b_v"], dtype=dtype)
 
+    cross_mask_4d = network.add_shuffle(cross_attention_mask)
+    cross_mask_4d.reshape_dims = (1, 1, 1, max_enc_seq)
     ccf = graph_ops.add_attention_from_rows(
         network, cq, ck_proj, cv_proj,
         num_heads=num_heads, head_dim=head_dim,
-        q_seq=1, kv_seq=max_enc_seq)
+        q_seq=1, kv_seq=max_enc_seq,
+        mask=cross_mask_4d.get_output(0))
     ca = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, ccf, attention_size, hidden_size, weights[f"{prefix}.cross_w_o"], dtype=dtype), hidden_size, weights[f"{prefix}.cross_b_o"], dtype=dtype)
     # Residual + post-norm
     pca = network.add_elementwise(psa, ca, trt.ElementWiseOperation.SUM).get_output(0)

--- a/python/tensorrt_model_connect/families/bart/plugin.py
+++ b/python/tensorrt_model_connect/families/bart/plugin.py
@@ -197,6 +197,7 @@ class BartPlugin:
         head_dim = hidden // dec_heads
         attention_window = max_cache_length + 1
         max_enc_seq = max_cache_length
+        activation_function = config.hidden_act or "gelu"
         if precision == "fp16":
             work_np_dtype, work_trt_dtype = np.float16, trt.float16
         elif precision == "fp32":
@@ -295,7 +296,8 @@ class BartPlugin:
                 weights=weights, prefix=prefix,
                 hidden_size=hidden, num_heads=dec_heads, head_dim=head_dim,
                 ffn_dim=dec_ffn, max_cache_length=max_cache_length,
-                max_enc_seq=max_enc_seq, dtype=work_np_dtype)
+                max_enc_seq=max_enc_seq, activation_function=activation_function,
+                dtype=work_np_dtype)
             hidden_state = result["hidden"]
             present_k_outputs.append(result["present_k"])
             present_v_outputs.append(result["present_v"])
@@ -421,6 +423,7 @@ def _build_bart_encoder(
     if enc_mask.dtype != work_trt_dtype:
         enc_mask = network.add_cast(enc_mask, work_trt_dtype).get_output(0)
     head_dim = hidden // enc_heads
+    activation_function = config.hidden_act or "gelu"
 
     for li in range(enc_layers):
         pfx = f"enc_layer.{li}"
@@ -442,7 +445,7 @@ def _build_bart_encoder(
 
         fc1 = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, hs, hidden, enc_ffn, weights[f"{pfx}.w_fc1"], dtype=work_np_dtype), enc_ffn, weights[f"{pfx}.b_fc1"], dtype=work_np_dtype)
         act = graph_ops.add_activation(
-            network, fc1, "gelu_new", dtype=work_np_dtype)
+            network, fc1, activation_function, dtype=work_np_dtype)
         fc2 = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, act, enc_ffn, hidden, weights[f"{pfx}.w_fc2"], dtype=work_np_dtype), hidden, weights[f"{pfx}.b_fc2"], dtype=work_np_dtype)
         hs = network.add_elementwise(hs, fc2, trt.ElementWiseOperation.SUM).get_output(0)
         hs = graph_ops.add_layer_norm_native(
@@ -467,7 +470,7 @@ def _build_bart_encoder(
 def _add_bart_decoder_layer(*, network, hidden, cache_k, cache_v, cross_k, cross_v,
     attention_mask, cross_attention_mask, eps, weights, prefix,
     hidden_size, num_heads, head_dim, ffn_dim, max_cache_length, max_enc_seq,
-    dtype=np.float32):
+    activation_function="gelu", dtype=np.float32):
     attention_size = hidden_size
     attention_window = max_cache_length + 1
 
@@ -523,7 +526,8 @@ def _add_bart_decoder_layer(*, network, hidden, cache_k, cache_v, cross_k, cross
 
     # MLP (no pre-norm, GELU)
     fc1 = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, pca, hidden_size, ffn_dim, weights[f"{prefix}.w_fc1"], dtype=dtype), ffn_dim, weights[f"{prefix}.fc1_bias"], dtype=dtype)
-    act = graph_ops.add_activation(network, fc1, "gelu_new", dtype=dtype)
+    act = graph_ops.add_activation(
+        network, fc1, activation_function, dtype=dtype)
     fc2 = graph_ops.add_bias_sum(network, graph_ops.add_matmul_rhs_constant(network, act, ffn_dim, hidden_size, weights[f"{prefix}.w_fc2"], dtype=dtype), hidden_size, weights[f"{prefix}.fc2_bias"], dtype=dtype)
     # Residual + post-norm
     out = network.add_elementwise(pca, fc2, trt.ElementWiseOperation.SUM).get_output(0)

--- a/src/runtime/models/bart/plugin.cpp
+++ b/src/runtime/models/bart/plugin.cpp
@@ -147,9 +147,9 @@ class BartPipeline final : public IPipeline {
         actual_enc_len_ = actual_len;
 
         // Build attention mask: 0.0 for valid positions, -1e9 for padding
-        std::vector<float> enc_mask(static_cast<std::size_t>(max_source_length_), -1e9f);
+        encoder_attention_mask_.assign(static_cast<std::size_t>(max_source_length_), -1e9f);
         for (int32_t i = 0; i < actual_len; ++i)
-            enc_mask[static_cast<std::size_t>(i)] = 0.0f;
+            encoder_attention_mask_[static_cast<std::size_t>(i)] = 0.0f;
 
         TensorMap inputs;
         Tensor ids_tensor;
@@ -161,7 +161,7 @@ class BartPipeline final : public IPipeline {
         // Provide attention mask if the encoder expects it
         Tensor mask_tensor;
         if (encoder_->has_input("attention_mask")) {
-            mask_tensor.data = enc_mask.data();
+            mask_tensor.data = encoder_attention_mask_.data();
             mask_tensor.shape = {max_source_length_};
             mask_tensor.dtype = DType::kFloat32;
             inputs["attention_mask"] = mask_tensor;
@@ -211,6 +211,13 @@ class BartPipeline final : public IPipeline {
         token_tensor.dtype = DType::kInt32;
         TensorMap inputs;
         inputs["token_id"] = token_tensor;
+        Tensor cross_mask_tensor;
+        if (decoder_->has_input("cross_attention_mask")) {
+            cross_mask_tensor.data = encoder_attention_mask_.data();
+            cross_mask_tensor.shape = {max_source_length_};
+            cross_mask_tensor.dtype = DType::kFloat32;
+            inputs["cross_attention_mask"] = cross_mask_tensor;
+        }
         state_->prepare_step(inputs);
         TensorMap outputs = decoder_->forward(inputs);
         auto it = outputs.find("logits");
@@ -238,6 +245,7 @@ class BartPipeline final : public IPipeline {
     std::string model_id_;
     std::vector<void*> cross_k_ptrs_;
     std::vector<void*> cross_v_ptrs_;
+    std::vector<float> encoder_attention_mask_;
     std::size_t cross_kv_bytes_{0};
 };
 

--- a/tests/e2e/models/bart/test_bart_build_engine_integration.py
+++ b/tests/e2e/models/bart/test_bart_build_engine_integration.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
@@ -125,3 +127,91 @@ class TestBartBuildEngine:
         weights = plugin.load_weights(str(tmp_path), cfg)
         engine = plugin.build_engine(cfg, weights, max_cache_length=32, verbose=False)
         assert isinstance(engine, bytes) and len(engine) > 0
+
+        import tensorrt as trt
+
+        runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+        deserialized = runtime.deserialize_cuda_engine(engine)
+        assert deserialized is not None
+        input_names = {
+            deserialized.get_tensor_name(index)
+            for index in range(deserialized.num_io_tensors)
+            if deserialized.get_tensor_mode(deserialized.get_tensor_name(index))
+            == trt.TensorIOMode.INPUT
+        }
+        assert "cross_attention_mask" in input_names
+
+    def test_decoder_cross_attention_uses_source_padding_mask(self, monkeypatch):
+        plugin_module = importlib.import_module(
+            "tensorrt_model_connect.families.bart.plugin"
+        )
+
+        class FakeLayer:
+            def __init__(self, output):
+                self.output = output
+                self.reshape_dims = None
+                self.axis = None
+
+            def get_output(self, index):
+                assert index == 0
+                return self.output
+
+        class FakeNetwork:
+            def add_shuffle(self, tensor):
+                return FakeLayer(("shuffle", tensor))
+
+            def add_concatenation(self, tensors):
+                return FakeLayer(("concatenation", tuple(tensors)))
+
+            def add_elementwise(self, left, right, operation):
+                return FakeLayer(("elementwise", left, right, operation))
+
+        def passthrough(_network, tensor, *_args, **_kwargs):
+            return tensor
+
+        attention_masks = []
+
+        def capture_attention(
+            _network, query, _key, _value, *, mask=None, **_kwargs
+        ):
+            attention_masks.append(mask)
+            return query
+
+        monkeypatch.setattr(
+            plugin_module.graph_ops, "add_matmul_rhs_constant", passthrough
+        )
+        monkeypatch.setattr(plugin_module.graph_ops, "add_bias_sum", passthrough)
+        monkeypatch.setattr(
+            plugin_module.graph_ops, "add_layer_norm_native", passthrough
+        )
+        monkeypatch.setattr(plugin_module.graph_ops, "add_activation", passthrough)
+        monkeypatch.setattr(
+            plugin_module.graph_ops, "add_attention_from_rows", capture_attention
+        )
+
+        self_attention_mask = object()
+        cross_attention_mask = object()
+        plugin_module._add_bart_decoder_layer(
+            network=FakeNetwork(),
+            hidden=object(),
+            cache_k=object(),
+            cache_v=object(),
+            cross_k=object(),
+            cross_v=object(),
+            attention_mask=self_attention_mask,
+            cross_attention_mask=cross_attention_mask,
+            eps=1e-5,
+            weights=defaultdict(lambda: np.zeros(1, dtype=np.float32)),
+            prefix="layer.0",
+            hidden_size=16,
+            num_heads=4,
+            head_dim=4,
+            ffn_dim=32,
+            max_cache_length=8,
+            max_enc_seq=8,
+        )
+
+        assert attention_masks == [
+            ("shuffle", self_attention_mask),
+            ("shuffle", cross_attention_mask),
+        ]

--- a/tests/e2e/models/bart/test_bart_build_engine_integration.py
+++ b/tests/e2e/models/bart/test_bart_build_engine_integration.py
@@ -215,3 +215,23 @@ class TestBartBuildEngine:
             ("shuffle", self_attention_mask),
             ("shuffle", cross_attention_mask),
         ]
+
+    def test_bart_gelu_dispatch_matches_checkpoint_variants(self, monkeypatch):
+        graph_ops = importlib.import_module(
+            "tensorrt_model_connect.families.bart.graph_ops"
+        )
+        exact = object()
+        approximate = object()
+        monkeypatch.setattr(
+            graph_ops, "add_gelu_erf", lambda *_args, **_kwargs: exact
+        )
+        monkeypatch.setattr(
+            graph_ops, "add_gelu_new", lambda *_args, **_kwargs: approximate
+        )
+
+        assert graph_ops.add_activation(None, object(), "gelu") is exact
+        assert graph_ops.add_activation(None, object(), "gelu_new") is approximate
+        assert (
+            graph_ops.add_activation(None, object(), "gelu_pytorch_tanh")
+            is approximate
+        )

--- a/tests/e2e/models/bart/test_bart_builder_tp.py
+++ b/tests/e2e/models/bart/test_bart_builder_tp.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 import importlib
 from types import SimpleNamespace
 
@@ -131,3 +132,88 @@ def test_bart_plugin_routes_parallel_builds(monkeypatch):
     assert kwargs["parallel_config"] == parallel
     assert kwargs["verbose"] is True
     assert kwargs["debug_layer_outputs"] is True
+
+
+def test_bart_tp_cross_attention_uses_source_padding_mask(monkeypatch):
+    class FakeLayer:
+        def __init__(self, output):
+            self.output = output
+            self.reshape_dims = None
+            self.axis = None
+
+        def get_output(self, index):
+            assert index == 0
+            return self.output
+
+    class FakeNetwork:
+        def add_shuffle(self, tensor):
+            return FakeLayer(("shuffle", tensor))
+
+        def add_concatenation(self, tensors):
+            return FakeLayer(("concatenation", tuple(tensors)))
+
+        def add_elementwise(self, left, right, operation):
+            return FakeLayer(("elementwise", left, right, operation))
+
+    def passthrough(_network, tensor, *_args, **_kwargs):
+        return tensor
+
+    attention_masks = []
+
+    def capture_attention(
+        _network, query, _key, _value, *, mask=None, **_kwargs
+    ):
+        attention_masks.append(mask)
+        return query
+
+    monkeypatch.setattr(
+        decoder_tp_builder.graph_ops, "add_matmul_rhs_constant", passthrough
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder.graph_ops, "add_bias_sum", passthrough
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder.graph_ops, "add_layer_norm_native", passthrough
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder.graph_ops, "add_activation", passthrough
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder.graph_ops,
+        "add_attention_from_rows",
+        capture_attention,
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder,
+        "add_all_reduce_sum",
+        lambda _network, tensor, _tp_size: tensor,
+    )
+
+    self_attention_mask = object()
+    cross_attention_mask = object()
+    decoder_tp_builder._add_bart_tp_decoder_layer(
+        network=FakeNetwork(),
+        hidden=object(),
+        cache_k=object(),
+        cache_v=object(),
+        cross_k=object(),
+        cross_v=object(),
+        attention_mask=self_attention_mask,
+        cross_attention_mask=cross_attention_mask,
+        eps=1e-5,
+        weights=defaultdict(lambda: np.zeros(1, dtype=np.float32)),
+        prefix="layer.0",
+        hidden_size=16,
+        local_attention_size=8,
+        local_heads=2,
+        head_dim=4,
+        local_ffn_dim=16,
+        max_cache_length=8,
+        max_enc_seq=8,
+        tp_size=2,
+    )
+
+    assert attention_masks == [
+        ("shuffle", self_attention_mask),
+        ("shuffle", cross_attention_mask),
+    ]

--- a/tests/e2e/models/bart/test_bart_debug_runner.py
+++ b/tests/e2e/models/bart/test_bart_debug_runner.py
@@ -11,6 +11,39 @@ from unittest.mock import patch
 from tests.builder.debug_runner_test_support import make_bundle_bytes
 
 
+def test_bart_debug_runner_prefers_current_cross_attention_mask_name() -> None:
+    from tensorrt_model_connect.families.bart.debug_runner import (
+        _decoder_cross_attention_mask_name,
+    )
+
+    class FakeEngine:
+        names = ("token_id", "encoder_mask", "cross_attention_mask", "logits")
+        num_io_tensors = len(names)
+
+        def get_tensor_name(self, index):
+            return self.names[index]
+
+    assert (
+        _decoder_cross_attention_mask_name(FakeEngine())
+        == "cross_attention_mask"
+    )
+
+
+def test_bart_debug_runner_accepts_legacy_encoder_mask_name() -> None:
+    from tensorrt_model_connect.families.bart.debug_runner import (
+        _decoder_cross_attention_mask_name,
+    )
+
+    class FakeEngine:
+        names = ("token_id", "encoder_mask", "logits")
+        num_io_tensors = len(names)
+
+        def get_tensor_name(self, index):
+            return self.names[index]
+
+    assert _decoder_cross_attention_mask_name(FakeEngine()) == "encoder_mask"
+
+
 def test_bart_seq2seq_engine_section_and_communicator_forwarded(tmp_path) -> None:
     from tensorrt_model_connect.families.bart.debug_runner import (
         load_config_from_bundle,

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -142,6 +142,13 @@ suites:
           # the causal BART path's 1024-position table.
           prompt_token_limit: 958
           prompt_truncation_side: left
+          # Compare raw greedy logits with TRTMC. The checkpoint's generation
+          # defaults otherwise inject a 3-gram repetition ban and force BOS/EOS
+          # tokens that the native runtime does not apply.
+          hf_generation_overrides:
+            no_repeat_ngram_size: 0
+            forced_bos_token_id: null
+            forced_eos_token_id: null
         gpt2-125m:
           # Reserve the suite's 64 generated tokens inside GPT-2's 1024 limit.
           prompt_token_limit: 960

--- a/tests/tools/test_transformers_text_reference.py
+++ b/tests/tools/test_transformers_text_reference.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_reference_module():
+    path = REPO_ROOT / "tools" / "reference" / "transformers_text.py"
+    spec = importlib.util.spec_from_file_location(
+        "transformers_text_reference_under_test", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _arguments() -> argparse.Namespace:
+    return argparse.Namespace(
+        max_new_tokens=None,
+        temperature=None,
+        top_k=None,
+        top_p=None,
+        seed=None,
+        do_sample=False,
+        apply_chat_template=False,
+    )
+
+
+def test_generation_settings_apply_explicit_hf_overrides() -> None:
+    module = _load_reference_module()
+    settings = module._generation_settings(
+        _arguments(),
+        {
+            "generation": {"max_new_tokens": 64},
+            "task_eval": {
+                "hf_use_cache": False,
+                "hf_generation_overrides": {
+                    "no_repeat_ngram_size": 0,
+                    "forced_bos_token_id": None,
+                    "forced_eos_token_id": None,
+                },
+            },
+        },
+        {},
+    )
+
+    assert settings["generation_overrides"] == {
+        "use_cache": False,
+        "no_repeat_ngram_size": 0,
+        "forced_bos_token_id": None,
+        "forced_eos_token_id": None,
+    }
+
+
+def test_generation_settings_reject_non_mapping_hf_overrides() -> None:
+    module = _load_reference_module()
+    with pytest.raises(
+        ValueError, match="task_eval.hf_generation_overrides must be a mapping"
+    ):
+        module._generation_settings(
+            _arguments(),
+            {"task_eval": {"hf_generation_overrides": ["not", "a", "mapping"]}},
+            {},
+        )

--- a/tools/reference/transformers_text.py
+++ b/tools/reference/transformers_text.py
@@ -224,6 +224,10 @@ def _generation_settings(
         settings["generation_overrides"]["use_cache"] = bool(
             task_config["hf_use_cache"]
         )
+    hf_generation_overrides = task_config.get("hf_generation_overrides", {})
+    if not isinstance(hf_generation_overrides, dict):
+        raise ValueError("task_eval.hf_generation_overrides must be a mapping")
+    settings["generation_overrides"].update(hf_generation_overrides)
     return settings
 
 


### PR DESCRIPTION
## Background

`bart-base` disagreed with the Hugging Face reference on every
`mmlu_continuation_parity` sample for two independent reasons:

1. Decoder cross-attention consumed padded encoder rows because the encoder
   padding mask was not connected to the decoder.
2. The reference inherited BART's checkpoint generation defaults
   (`no_repeat_ngram_size=3` and forced BOS/EOS), while TRTMC performed the raw
   greedy generation declared by the validation suite.

The graph also hardcoded tanh-approximate GELU even though BART configures exact
erf GELU.

## Exit Criteria

- BART decoder cross-attention excludes padded encoder states.
- Single-device and tensor-parallel builders share the same mask and activation
  behavior.
- The C++ runtime binds the prepared encoder mask during every decode step.
- The HF reference compares raw greedy generation without checkpoint-specific
  output processors for this BART workload.
- Focused and real-model validation prove token-level agreement.

## Implementation

- Add a `cross_attention_mask` input to both BART decoder builders and pass it
  into every decoder cross-attention layer.
- Retain the encoder additive mask in the BART runtime and bind it to new
  bundles while keeping older bundles loadable.
- Respect the checkpoint activation setting and distinguish exact `gelu` from
  tanh-based GELU variants.
- Add explicit, workload-scoped HF generation overrides so BART validation
  compares the same raw greedy contract as TRTMC.
- Update the BART debug runner to bind the current mask input and return marked
  per-layer outputs.

## Validation

- Source headers, Ruff, and diff whitespace checks pass.
- Focused local suites: 199 passed, with the GPU-only engine construction case
  excluded locally.
- GB300 BART builder, tensor-parallel, and debug-runner suites: 11 passed.
- Reference override tests: 2 passed.
- FP32 layer diagnosis over the first 20 decoder steps matched HF at every
  embedding, decoder layer, logit argmax, and raw generated token.
- Fresh FP16 bundle validation on 10 MMLU samples passed with:
  - token prefix agreement: `1.0`
  - exact match rate: `1.0`
  - divergence rate: `0.0`
  - execution retries: `0`

## Notes For Future Readers

- The BART checkpoint's `generate()` defaults are not equivalent to raw greedy
  logits. Keep validation-suite generation settings authoritative.
- The encoder and decoder use the same additive `0.0`/`-1e9` padding-mask
  representation.

Closes #658