### PR TITLE
fix(qwen): honor all configured EOS tokens

### DIFF
--- a/include/trtmc/runtime/pipeline_plugin.h
+++ b/include/trtmc/runtime/pipeline_plugin.h
@@ -55,6 +55,7 @@ struct BaseConfig {
     bool tokenizer_add_special_tokens{false};
     bool tokenizer_add_special_tokens_present{false};
     IoMap io_map;
+    std::vector<int32_t> id_eos_ids;
 };
 
 // Parse universal base config from config.json text.

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -627,6 +627,16 @@ def _get_gpu_name() -> str:
     return ""
 
 
+def _apply_generation_config_eos(model_dir: Path, config: dict) -> None:
+    """Apply Hugging Face generation-config EOS precedence to runtime config."""
+    generation_config_path = model_dir / "generation_config.json"
+    if not generation_config_path.exists():
+        return
+    generation_config = json.loads(generation_config_path.read_text(encoding="utf-8"))
+    if "eos_token_id" in generation_config:
+        config["eos_token_id"] = generation_config["eos_token_id"]
+
+
 def _detect_tokenizer_add_special_tokens(model_dir: Path) -> bool:
     """Detect whether the HF tokenizer adds special tokens (BOS/EOS) by default.
 
@@ -1289,6 +1299,7 @@ def build_bundle(
 
     def make_runtime_config_json(source: bytes | None) -> bytes:
         cfg_dict = json.loads(source) if source is not None else dict(config.raw)
+        _apply_generation_config_eos(model_dir_path, cfg_dict)
         runtime_strategy = getattr(plugin, "runtime_strategy", None)
         if runtime_strategy:
             cfg_dict["runtime_strategy"] = runtime_strategy

--- a/src/runtime/models/qwen/MODEL.toml
+++ b/src/runtime/models/qwen/MODEL.toml
@@ -7,6 +7,7 @@ runtime_plugins = ["plugin.cpp|register_qwen_plugin"]
 runtime_strategies = ["qwen_decoder_kv_cache"]
 runtime_tests = [
   "test_qwen_tensor_names|test_qwen_tensor_names.cpp|_|_|_",
+  "test_qwen_sampler|test_qwen_sampler.cpp|trtmc_model_qwen|_|_",
 ]
 [validation_profiles]
 decoder_debug = ["qwen_decoder_kv_cache"]

--- a/src/runtime/models/qwen/pipeline.cpp
+++ b/src/runtime/models/qwen/pipeline.cpp
@@ -150,6 +150,14 @@ single_decoder_context(std::unique_ptr<TrtModule> decoder) {
     return decoders;
 }
 
+QwenTextGenConfig normalize_eos_token_ids(QwenTextGenConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
 std::string normalize_generation_mode(std::string mode) {
     std::transform(mode.begin(), mode.end(), mode.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -291,8 +299,8 @@ QwenTextGenerationPipeline::QwenTextGenerationPipeline(
     std::shared_ptr<void> distributed_owner)
     : distributed_owner_(std::move(distributed_owner)), decoders_(std::move(decoders)),
       prefill_(std::move(prefill)), linear_spec_lora_prefill_(std::move(linear_spec_lora_prefill)),
-      state_(std::move(state)), config_(std::move(config)), stream_(stream),
-      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      state_(std::move(state)), config_(normalize_eos_token_ids(std::move(config))),
+      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       sampler_(std::move(sampler)), logits_output_name_(config_.logits_output_name) {
     if (decoders_.empty()) {
         throw std::runtime_error("QwenTextGenerationPipeline: no decoder modules");
@@ -350,9 +358,8 @@ TextResult QwenTextGenerationPipeline::generate(const std::string& prompt,
 
     auto input_ids = encode_prompt(*tokenizer_, config_, prompt, cfg);
     int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
-    auto sp = qwen_sampling_params_from_config(cfg, eos);
+    auto sp = qwen_sampling_params_from_config(cfg, config_.id_eos_ids);
     last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
@@ -372,8 +379,7 @@ QwenTextGenerationPipeline::GenerationResult
 QwenTextGenerationPipeline::generate_ids(const std::vector<int32_t>& input_ids,
                                          const GenerateConfig& cfg) {
     int32_t max_new = cfg.max_new_tokens; // honour exact value (0 = no generation)
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    auto sp = qwen_sampling_params_from_config(cfg, eos);
+    auto sp = qwen_sampling_params_from_config(cfg, config_.id_eos_ids);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp, cfg).token_ids};
 }
 
@@ -676,7 +682,7 @@ bool QwenTextGenerationPipeline::append_tokens_until_eos(const std::vector<int32
                                                          const QwenSamplingParams& params) const {
     for (int32_t token : tokens) {
         output.push_back(token);
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (qwen_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -747,7 +753,7 @@ bool QwenTextGenerationPipeline::append_linear_spec_tokens(const std::vector<int
         const int32_t token = ar_tokens[static_cast<std::size_t>(i)];
         output.push_back(token);
         ++generated;
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (qwen_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -875,7 +881,7 @@ QwenTextGenerationPipeline::generate_linear_spec_from_ids(const std::vector<int3
 
     std::vector<int32_t> output = input_ids;
     output.push_back(next_token);
-    if (params.eos_token_id >= 0 && next_token == params.eos_token_id) {
+    if (qwen_is_eos_token(params, next_token)) {
         return TimedGenResult{std::move(output),
                               std::chrono::duration<double, std::milli>(t1 - t0).count(), 0.0};
     }
@@ -949,12 +955,12 @@ int32_t QwenTextGenerationPipeline::run_decode_loop(
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         const float* sample_ptr = gpu_sampling ? d_logits_ptr_ : logits.data();
         const QwenSampleResult result = sampler->sample(sample_ptr, vocab_size, params);
+        const bool is_eos = result.is_eos || qwen_is_eos_token(params, result.token_id);
         output.push_back(result.token_id);
         ++steps;
-        if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval,
-                                  result.is_eos))
+        if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval, is_eos))
             break;
-        if (result.is_eos)
+        if (is_eos)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/qwen/pipeline.h
+++ b/src/runtime/models/qwen/pipeline.h
@@ -30,6 +30,7 @@ struct QwenTextGenConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
     int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
     bool has_position_input{true};
     std::string chat_template_format{};
     std::string token_id_name{"token_id"};

--- a/src/runtime/models/qwen/plugin.cpp
+++ b/src/runtime/models/qwen/plugin.cpp
@@ -522,6 +522,7 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
         tgc.vocab_size = ctx.config.vocab_size;
         tgc.id_bos = ctx.config.id_bos;
         tgc.id_eos = ctx.config.id_eos;
+        tgc.id_eos_ids = ctx.config.id_eos_ids;
         tgc.has_position_input = first_dec.module->has_input(io.position_id);
         tgc.token_id_name = io.token_id;
         tgc.logits_output_name = io.logits;

--- a/src/runtime/models/qwen/sampler.cpp
+++ b/src/runtime/models/qwen/sampler.cpp
@@ -30,9 +30,17 @@
 
 namespace trtmc {
 
+bool qwen_is_eos_token(const QwenSamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
 // Shared argmax helper — returns {token_id, logprob} for the highest logit.
 static QwenSampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
-                                           int32_t eos_token_id) {
+                                           const QwenSamplingParams& params) {
     QwenSampleResult result;
     const float* best = logits;
     for (int32_t i = 1; i < vocab_size; ++i) {
@@ -41,7 +49,7 @@ static QwenSampleResult argmax_over_logits(const float* logits, int32_t vocab_si
     }
     result.token_id = static_cast<int32_t>(best - logits);
     result.logprob = *best;
-    result.is_eos = (result.token_id == eos_token_id);
+    result.is_eos = qwen_is_eos_token(params, result.token_id);
     return result;
 }
 
@@ -182,11 +190,11 @@ class GreedySampler final : public QwenISampler {
         if (vocab_size <= 0 || logits == nullptr) {
             QwenSampleResult result;
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_is_eos_token(params, 0);
             return result;
         }
 
-        return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+        return argmax_over_logits(logits, vocab_size, params);
     }
 
     QwenLogitsLocation logits_location() const override { return QwenLogitsLocation::HOST; }
@@ -210,12 +218,12 @@ class TopKSampler final : public QwenISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
 
@@ -233,7 +241,7 @@ class TopKSampler final : public QwenISampler {
                 result.token_id = dist.indices[static_cast<std::size_t>(i)];
                 result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(i)],
                                                    std::numeric_limits<float>::min()));
-                result.is_eos = (result.token_id == params.eos_token_id);
+                result.is_eos = qwen_is_eos_token(params, result.token_id);
                 return result;
             }
         }
@@ -241,7 +249,7 @@ class TopKSampler final : public QwenISampler {
         result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
         result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(dist.keep - 1)],
                                            std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -278,12 +286,12 @@ class TorchCudaMultinomialSampler final : public QwenISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
         ensure_execution_policy(vocab_size);
@@ -312,7 +320,7 @@ class TorchCudaMultinomialSampler final : public QwenISampler {
             }
         }
         result.logprob = std::log(std::max(picked_prob, std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -381,7 +389,7 @@ class GpuGreedySampler final : public QwenISampler {
         QwenSampleResult result;
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_is_eos_token(params, 0);
             return result;
         }
 
@@ -397,7 +405,7 @@ class GpuGreedySampler final : public QwenISampler {
 
         result.token_id = h_token_id_;
         result.logprob = h_logit_val_;
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -417,16 +425,26 @@ class GpuGreedySampler final : public QwenISampler {
 // Factory
 // ─────────────────────────────────────────────────────────────
 
-QwenSamplingParams qwen_sampling_params_from_config(const GenerateConfig& cfg,
-                                                    int32_t default_eos) {
+QwenSamplingParams
+qwen_sampling_params_from_config(const GenerateConfig& cfg,
+                                 const std::vector<int32_t>& default_eos_token_ids) {
     QwenSamplingParams p;
     p.temperature = cfg.temperature;
     p.top_k = cfg.top_k;
     p.top_p = cfg.top_p;
     p.min_p = cfg.min_p;
     p.seed = cfg.seed;
-    p.eos_token_id = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : default_eos;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
     return p;
+}
+
+QwenSamplingParams qwen_sampling_params_from_config(const GenerateConfig& cfg,
+                                                    int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return qwen_sampling_params_from_config(cfg, defaults);
 }
 
 std::unique_ptr<QwenISampler>

--- a/src/runtime/models/qwen/sampler.h
+++ b/src/runtime/models/qwen/sampler.h
@@ -30,6 +30,7 @@ struct QwenSamplingParams {
     float repetition_penalty{1.0f};
     int32_t seed{-1}; // -1 = deterministic (argmax)
     int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
 };
 
 /// Factory options for choosing concrete sampler implementations.
@@ -78,8 +79,14 @@ class QwenISampler {
 /// Forward-declared here; defined in sampler.cpp alongside the factory.
 struct GenerateConfig; // defined in trtmc/pipeline.h
 
+QwenSamplingParams
+qwen_sampling_params_from_config(const GenerateConfig& cfg,
+                                 const std::vector<int32_t>& default_eos_token_ids);
 QwenSamplingParams qwen_sampling_params_from_config(const GenerateConfig& cfg,
                                                     int32_t default_eos = -1);
+
+/// Return true when token_id matches any effective EOS token.
+bool qwen_is_eos_token(const QwenSamplingParams& params, int32_t token_id);
 
 /// Factory: create sampler from QwenSamplingParams.
 /// - top_k <= 1 && top_p/min_p disabled && seed == -1 => GreedySampler

--- a/src/runtime/registry/pipeline_plugin.cpp
+++ b/src/runtime/registry/pipeline_plugin.cpp
@@ -59,6 +59,9 @@ void parse_cache_and_tokens(const std::string& config_text, int32_t max_cache_le
     }
     cfg.id_bos = extract_json_int_or_first_array(config_text, "bos_token_id", -1);
     cfg.id_eos = extract_json_int_or_first_array(config_text, "eos_token_id", -1);
+    cfg.id_eos_ids = extract_json_int_array(config_text, "eos_token_id", 256);
+    if (cfg.id_eos_ids.empty() && cfg.id_eos >= 0)
+        cfg.id_eos_ids.push_back(cfg.id_eos);
 }
 
 void parse_strategy_and_tokenizer_flags(const std::string& config_text, BaseConfig& cfg) {

--- a/src/utils/json_helpers.cpp
+++ b/src/utils/json_helpers.cpp
@@ -72,8 +72,8 @@ bool find_key_colon(const std::string& text, const std::string& key, std::size_t
 }
 
 bool find_array_start(const std::string& text, std::size_t colon, std::size_t& open_bracket) {
-    open_bracket = text.find('[', colon + 1);
-    return open_bracket != std::string::npos;
+    open_bracket = skip_whitespace(text, colon + 1);
+    return open_bracket < text.size() && text[open_bracket] == '[';
 }
 
 std::size_t scan_while(const std::string& text, std::size_t pos, bool (*is_allowed)(char)) {

--- a/tests/builder/test_generation_config_eos.py
+++ b/tests/builder/test_generation_config_eos.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for effective EOS defaults embedded in engine bundles."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensorrt_model_connect.engine_builder import build_bundle
+
+
+@pytest.mark.parametrize(
+    ("model_eos", "generation_eos"),
+    [
+        (5, [5, 7]),
+        ([5, 7], 3),
+    ],
+)
+def test_generation_config_eos_overrides_model_config_in_bundle(
+    tmp_path,
+    model_eos,
+    generation_eos,
+):
+    """generation_config.json supplies the effective scalar/list EOS defaults."""
+    model_config = {
+        "model_type": "example_decoder",
+        "architectures": ["ExampleDecoderForCausalLM"],
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "eos_token_id": model_eos,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(model_config))
+    (tmp_path / "generation_config.json").write_text(json.dumps({"eos_token_id": generation_eos}))
+
+    mock_plugin = MagicMock()
+    mock_plugin.name = "example_family"
+    mock_plugin.runtime_strategy = ""
+    mock_plugin.load_weights.return_value = {}
+    mock_plugin.build_engine.return_value = b"PLAN"
+
+    del mock_plugin.build_vision_engine
+    del mock_plugin.build_extra_engines
+    del mock_plugin.embed_input
+    del mock_plugin.get_vl_config
+    del mock_plugin.get_segmentation_config
+    del mock_plugin.get_audio_config
+    del mock_plugin.get_bundle_config_overrides
+
+    with patch(
+        "tensorrt_model_connect.engine_builder.find_plugin",
+        return_value=mock_plugin,
+    ):
+        with patch(
+            "tensorrt_model_connect.engine_builder._get_trt_version",
+            return_value="10.0",
+        ):
+            with patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="",
+            ):
+                with patch("tensorrt_model_connect.engine_builder._ensure_tokenizer_json"):
+                    with patch("tensorrt_model_connect.engine_builder.write_bundle") as mock_write:
+                        build_bundle(
+                            str(tmp_path),
+                            str(tmp_path / "output.trtfb"),
+                        )
+
+    sections = mock_write.call_args[0][2]
+    config_section = next(s for s in sections if s.name == "config.json")
+    bundled_config = json.loads(config_section.data)
+    assert bundled_config["eos_token_id"] == generation_eos

--- a/tests/cpp/models/qwen/test_qwen_sampler.cpp
+++ b/tests/cpp/models/qwen/test_qwen_sampler.cpp
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// =============================================================================
+// test_qwen_sampler.cpp -- CPU tests for Qwen EOS sampling behavior
+// =============================================================================
+
+#include "runtime/models/qwen/sampler.h"
+#include "trtmc/pipeline.h"
+
+#include <iostream>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static trtmc::QwenSampleResult greedy_sample(const trtmc::QwenSamplingParams& params,
+                                             int32_t winning_token) {
+    std::vector<float> logits(8, 0.0F);
+    logits[static_cast<std::size_t>(winning_token)] = 1.0F;
+    auto sampler = trtmc::create_qwen_sampler(params);
+    return sampler->sample(logits.data(), static_cast<int32_t>(logits.size()), params);
+}
+
+static void test_any_default_eos_stops_generation() {
+    trtmc::GenerateConfig config;
+    const std::vector<int32_t> defaults{5, 7};
+    const auto params = trtmc::qwen_sampling_params_from_config(config, defaults);
+
+    check(params.eos_token_ids == defaults, "sampler: preserves all default EOS IDs");
+    check(greedy_sample(params, 7).is_eos, "sampler: second default EOS stops generation");
+}
+
+static void test_request_eos_overrides_model_defaults() {
+    trtmc::GenerateConfig config;
+    config.eos_token_id = 3;
+    const auto params = trtmc::qwen_sampling_params_from_config(config, std::vector<int32_t>{5, 7});
+
+    check(params.eos_token_ids == std::vector<int32_t>({3}),
+          "sampler: request EOS replaces model defaults");
+    check(!greedy_sample(params, 7).is_eos,
+          "sampler: overridden model EOS no longer stops generation");
+    check(greedy_sample(params, 3).is_eos, "sampler: explicit request EOS stops generation");
+}
+
+int main() {
+    test_any_default_eos_stops_generation();
+    test_request_eos_overrides_model_defaults();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All Qwen sampler tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/test_decoder_config.cpp
+++ b/tests/cpp/test_decoder_config.cpp
@@ -145,6 +145,28 @@ static void test_decoder_tokenizer_config() {
           "decoder: tokenizer_add_special_tokens_present = true");
     check(cfg.id_bos == 151643, "decoder: bos_token_id");
     check(cfg.id_eos == 151645, "decoder: eos_token_id from array");
+    check(cfg.id_eos_ids == std::vector<int32_t>({151645, 151643}),
+          "decoder: all eos_token_id values from array");
+}
+
+// -----------------------------------------------------------------------------
+// Intention: Verify scalar EOS remains compatible with legacy model configs.
+// Setup:     Config with a scalar eos_token_id.
+// Mechanism: Assert both the legacy scalar and effective EOS list are populated.
+// -----------------------------------------------------------------------------
+static void test_decoder_scalar_eos_config() {
+    const std::string config = R"({
+        "vocab_size": 32000,
+        "hidden_size": 1024,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 8,
+        "eos_token_id": 2
+    })";
+
+    const auto cfg = trtmc::parse_base_config(config, 128);
+    check(cfg.id_eos == 2, "decoder: scalar eos_token_id");
+    check(cfg.id_eos_ids == std::vector<int32_t>({2}),
+          "decoder: scalar eos_token_id becomes one-element list");
 }
 
 // -----------------------------------------------------------------------------
@@ -212,6 +234,7 @@ int main() {
     test_decoder_gqa_attention_size();
     test_decoder_mha();
     test_decoder_tokenizer_config();
+    test_decoder_scalar_eos_config();
     test_decoder_cache_length_override();
     test_decoder_cache_length_cap();
     test_missing_runtime_strategy_stays_empty();

--- a/tests/cpp/test_json_helpers.cpp
+++ b/tests/cpp/test_json_helpers.cpp
@@ -419,6 +419,19 @@ bool test_extract_json_int_array_basic() {
     return true;
 }
 
+// Intention: Verify a scalar value is not confused with a later array.
+// Setup:     Scalar EOS followed by an unrelated integer array.
+// Mechanism: Calls extract_json_int_array for EOS and expects no array values.
+bool test_extract_json_int_array_rejects_scalar() {
+    const std::string json = R"({"eos_token_id": 2, "other_ids": [5, 7]})";
+    const auto values = trtmc::extract_json_int_array(json, "eos_token_id", 8);
+    if (!values.empty()) {
+        std::cerr << "extract_json_int_array_rejects_scalar: unexpected values" << std::endl;
+        return false;
+    }
+    return true;
+}
+
 // Intention: Verify invalid int token stops array parsing.
 // Setup:     JSON with malformed middle element.
 // Mechanism: Calls extract_json_int_array and checks prefix-only behavior.
@@ -480,6 +493,7 @@ int main() {
     run("extract_json_float_array_max_count", test_extract_json_float_array_max_count);
     run("extract_json_float_array_invalid", test_extract_json_float_array_stops_on_invalid_token);
     run("extract_json_int_array_basic", test_extract_json_int_array_basic);
+    run("extract_json_int_array_rejects_scalar", test_extract_json_int_array_rejects_scalar);
     run("extract_json_int_array_invalid", test_extract_json_int_array_stops_on_invalid_token);
     run("string_array_basic", test_extract_json_string_array_basic);
     run("string_array_empty", test_extract_json_string_array_empty);


### PR DESCRIPTION
## Background

Qwen3 4B Instruct declares more than one valid end-of-sequence token in
`generation_config.json`, but TRTMC embedded only the scalar value from
`config.json`. The runtime therefore continued decoding after the alternate EOS
token and diverged from Transformers.

Fixes #640.

## Exit Criteria

- Preserve scalar and list-valued EOS defaults with Transformers
  `generation_config.json` precedence.
- Stop Qwen generation on any effective EOS token.
- Preserve explicit request-level EOS overrides and legacy scalar configs.
- Match the Transformers token sequence for the reported Qwen3 workload.

## Implementation

- Apply `generation_config.json` EOS precedence while embedding the effective
  runtime config in a bundle.
- Parse every configured EOS ID and propagate the list through the Qwen
  pipeline and all sampler implementations.
- Treat an explicit request EOS as a singleton override of model defaults.
- Tighten integer-array parsing so a scalar value cannot be confused with a
  later unrelated JSON array.
- Add bundle, config-parser, and Qwen sampler regression coverage.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/builder/test_generation_config_eos.py`:
  2 passed.
- `PYTHONPATH=python python3 -m pytest tests/builder -q`: 677 passed,
  89 skipped.
- `ctest --test-dir /tmp/trtmc-qwen3-multi-eos-build --output-on-failure -R 'test_qwen_sampler|test_decoder_config|test_json_helpers'`:
  3 passed.
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`:
  complexity, changed-file lint, and 158 architecture tests passed.
- `python3 tools/model_ci.py validate`: all 78 model manifests passed.
- `python3 tools/legal_headers.py --check`: passed with 0 findings.
- Fresh GB300 bundle with TensorRT 11.2 and CUDA 13.3: TRTMC and
  Transformers both produced token IDs `[26194, 13, 151643]` and text
  ` Tokyo.` for the reported prompt.
- `PYTHONPATH=python python3 -m pytest tests/tools -q`: 2230 passed; one
  unrelated proof-runner test could not use `cp --reflink` on the local
  filesystem. GitHub CI remains the authoritative run for that test.

## Notes For Future Readers

- Review the effective bundle-config precedence first, then the shared config
  parser, and finally the Qwen sampling and pipeline propagation.
- The legacy scalar EOS fields and overload remain intentionally supported for
  existing model bundles and callers.
