### PR TITLE
fix(qwen3-omni): align Thinker and Talker stopping

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
@@ -17,7 +17,7 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass
-from typing import BinaryIO, Callable, Protocol
+from typing import Any, BinaryIO, Callable, Protocol
 
 import numpy as np
 
@@ -74,8 +74,13 @@ def _chatml(request: TalkerRequest) -> str:
     return (
         f"<|im_start|>system\n{_SYSTEM_PROMPT}<|im_end|>\n"
         f"<|im_start|>user\n{request.prompt}<|im_end|>\n"
-        f"<|im_start|>assistant\n{request.assistant_text}<|im_end|>\n"
+        f"<|im_start|>assistant\n{request.assistant_text}<|im_end|>"
     )
+
+
+def _thinker_forward_input_ids(sequence_ids: Any) -> Any:
+    """Exclude the selected EOS, which Transformers does not forward."""
+    return sequence_ids[..., :-1]
 
 
 class _OfficialTalker:
@@ -148,7 +153,9 @@ class _OfficialTalker:
             input_ids = self._tokenizer(
                 _chatml(request), add_special_tokens=False, return_tensors="pt"
             ).input_ids
-            thinker_embed = self._thinker_embedding(input_ids).to(self._device)
+            thinker_embed = self._thinker_embedding(
+                _thinker_forward_input_ids(input_ids)
+            ).to(self._device)
             thinker_hidden = torch.zeros_like(thinker_embed)
             input_ids = input_ids.to(self._device)
 

--- a/src/runtime/models/qwen3_omni/omni_thinker_plan.h
+++ b/src/runtime/models/qwen3_omni/omni_thinker_plan.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace trtmc {
+
+inline bool omni_thinker_should_stop(int32_t token_id, int32_t eos_token_id) {
+    return eos_token_id >= 0 && token_id == eos_token_id;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/qwen3_omni/pipeline.cpp
+++ b/src/runtime/models/qwen3_omni/pipeline.cpp
@@ -7,6 +7,7 @@
 
 #include "runtime/models/qwen3_omni/argmax_kernel.h"
 #include "runtime/models/qwen3_omni/omni_audio_plan.h"
+#include "runtime/models/qwen3_omni/omni_thinker_plan.h"
 #include "runtime/models/qwen3_omni/talker_runtime.h"
 #include "trtmc/tokenizer.h"
 
@@ -238,7 +239,7 @@ std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input
 
     for (int32_t step = 0; step < max_tokens; ++step) {
         const int32_t token = next_token;
-        if (token == 0 || token == config_->thinker_eos_token_id)
+        if (omni_thinker_should_stop(token, config_->thinker_eos_token_id))
             break;
         output_ids.push_back(token);
         if (step + 1 < max_tokens)

--- a/src/runtime/models/qwen3_omni/plugin.cpp
+++ b/src/runtime/models/qwen3_omni/plugin.cpp
@@ -58,6 +58,7 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
         omni_cfg.thinker_vocab_size = ctx.config.vocab_size;
         omni_cfg.thinker_num_layers = ctx.config.num_layers;
         omni_cfg.thinker_num_heads = ctx.config.num_heads;
+        omni_cfg.thinker_eos_token_id = extract_json_int(json, "im_end_token_id", 151645);
         omni_cfg.num_experts = extract_json_int(json, "num_local_experts", 8);
         omni_cfg.num_experts_per_tok = extract_json_int(json, "num_experts_per_tok", 2);
         omni_cfg.talker_hidden_size = extract_json_int(json, "omni_talker_hidden_size", 0);

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_audio_plan.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_audio_plan.cpp
@@ -15,6 +15,7 @@
 // =============================================================================
 
 #include "runtime/models/qwen3_omni/omni_audio_plan.h"
+#include "runtime/models/qwen3_omni/omni_thinker_plan.h"
 
 #include <cstdint>
 #include <iostream>
@@ -99,6 +100,13 @@ void test_code2wav_output_uses_official_stride_and_causal_delay() {
           "omni code2wav output rejects zero frames");
 }
 
+void test_thinker_stops_only_on_configured_eos() {
+    check(!trtmc::omni_thinker_should_stop(0, 151645),
+          "omni thinker preserves token zero as ordinary text");
+    check(trtmc::omni_thinker_should_stop(151645, 151645),
+          "omni thinker stops on configured im_end token");
+}
+
 } // namespace
 
 int main() {
@@ -107,6 +115,7 @@ int main() {
     test_codec_plan_derives_official_frame_shape();
     test_code2wav_input_builder_transposes_frame_major_tokens();
     test_code2wav_output_uses_official_stride_and_causal_delay();
+    test_thinker_stops_only_on_configured_eos();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " omni audio plan test(s) failed\n";

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
@@ -132,7 +132,7 @@ void test_omni_pipeline_construction() {
 }
 
 void test_omni_generate_audio() {
-    const std::vector<float> thinker_logits = {1.0F, 0.1F, 0.1F, 0.1F};
+    const std::vector<float> thinker_logits = {0.1F, 0.1F, 0.1F, 1.0F};
     auto thinker_engine = trtmc::test::build_mock_step_engine(9, 4, thinker_logits);
     if (!thinker_engine) {
         std::cerr << "WARNING: Could not build thinker engine for omni_generate, skipping\n";
@@ -147,6 +147,7 @@ void test_omni_generate_audio() {
     auto thinker_cache = std::make_unique<trtmc::Qwen3OmniKvCache>(0, 8, 0, stream);
 
     trtmc::OmniConfig cfg;
+    cfg.thinker_eos_token_id = 3;
     trtmc::OmniPipeline pipeline(std::move(thinker), std::move(thinker_cache), nullptr, cfg, stream,
                                  std::make_shared<OmniFixedTokenizer>(), "test-omni-gen");
 

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/comparators/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/comparators/omni.py
@@ -372,6 +372,18 @@ class OmniComparator:
                 note="Code2Wav synthetic fallback must never certify",
             )
 
+            ref_thinker_text = str((ref.data or {}).get("decoded_text", "") or "")
+            if ref_thinker_text:
+                trt_thinker_text = str((trt.data or {}).get("thinker_text", "") or "")
+                thinker_text_matches = trt_thinker_text == ref_thinker_text
+                metrics["thinker_text_exact"] = MetricResult(
+                    value=1.0 if thinker_text_matches else 0.0,
+                    threshold=1.0,
+                    operator="==",
+                    passed=thinker_text_matches,
+                    note="must exactly match the pinned official-HF Thinker response",
+                )
+
             if wav_evidence:
                 channels = int(wav_evidence.get("channels", 0))
                 encoding = str(wav_evidence.get("encoding", ""))
@@ -421,6 +433,13 @@ class OmniComparator:
                             operator=">=",
                             passed=duration_ratio >= duration_ratio_min,
                             note=f"TRT samples={num_samples}, HF samples={ref_num_samples}",
+                        ),
+                        "audio_num_samples_exact": MetricResult(
+                            value=float(num_samples),
+                            threshold=float(ref_num_samples),
+                            operator="==",
+                            passed=ref_num_samples > 0 and num_samples == ref_num_samples,
+                            note="must exactly match the pinned official-HF audio shape",
                         ),
                         "audio_rms": MetricResult(
                             value=rms,

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_RUNTIME_TIMEOUT_S = 600
 _MAX_RUNTIME_TIMEOUT_S = 3600
 _SIMPLE_WAVEFORM_FALLBACK = "no Code2Wav engine, generating simple waveform"
+_THINKER_TEXT_PREFIX = "[trtmc] Omni Thinker text: "
 
 
 def _runtime_timeout_s(case: E2ECase) -> int:
@@ -136,6 +137,9 @@ class OmniMultimodalRunner:
             )
 
         data = _parse_stage_output(result.stdout.strip(), stage_name)
+        thinker_text = _parse_thinker_text(result.stderr or "")
+        if thinker_text:
+            data["thinker_text"] = thinker_text
 
         return StageOutput(
             stage_name=stage_name,
@@ -381,6 +385,15 @@ def _parse_stage_output(stdout: str, stage_name: str) -> dict[str, Any]:
             continue
 
     return {"raw_output": stdout}
+
+
+def _parse_thinker_text(stderr: str) -> str:
+    """Extract the final Thinker response reported by the C++ runtime."""
+    for line in reversed(stderr.splitlines()):
+        line = line.strip()
+        if line.startswith(_THINKER_TEXT_PREFIX):
+            return line[len(_THINKER_TEXT_PREFIX) :].strip()
+    return ""
 
 
 # Primary plugin for auto-discovery

--- a/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
+++ b/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
@@ -20,7 +20,7 @@ def test_qwen3_omni_runtime_feeds_generated_text_to_official_talker() -> None:
     assert "tokenizer_->decode(text_tokens)" in source
     assert "talker_runtime_->run(prompt, assistant_text)" in source
     assert "format_omni_chat_prompt(prompt)" in source
-    assert "token == config_->thinker_eos_token_id" in source
+    assert "omni_thinker_should_stop(token, config_->thinker_eos_token_id)" in source
     assert 'outputs.find("hidden_state")' not in source
 
 

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -21,6 +21,7 @@ from tensorrt_model_connect.families.qwen3_omni.audio_runtime import (
     _chatml,
     _read_request,
     _serve_worker,
+    _thinker_forward_input_ids,
 )
 from tensorrt_model_connect.config import ModelConfig
 from tensorrt_model_connect.families.qwen3_omni.plugin import (
@@ -80,6 +81,13 @@ def test_talker_chatml_contains_model_roles_and_exact_text() -> None:
     assert "<|im_start|>system\n" in rendered
     assert "<|im_start|>user\nquestion<|im_end|>" in rendered
     assert "<|im_start|>assistant\nanswer<|im_end|>" in rendered
+    assert rendered.endswith("answer<|im_end|>")
+
+
+def test_talker_does_not_forward_selected_thinker_eos() -> None:
+    sequence_ids = np.array([[10, 11, 151645]])
+
+    assert _thinker_forward_input_ids(sequence_ids).tolist() == [[10, 11]]
 
 
 def test_persistent_talker_worker_initializes_once_for_multiple_requests() -> None:

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_comparator.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_comparator.py
@@ -18,13 +18,13 @@ from tests.e2e_harness.contracts import (
 )
 
 
-def _invariant_ref(stage_name: str) -> StageOutput:
+def _invariant_ref(stage_name: str, *, num_samples: int = 37_845) -> StageOutput:
     return StageOutput(
         stage_name=stage_name,
         data={
             "_invariant_only": True,
             "sample_rate": 24_000,
-            "num_samples": 37_845,
+            "num_samples": num_samples,
         },
         metadata={"source": "invariant_only"},
     )
@@ -76,7 +76,7 @@ def _threshold() -> ThresholdProfile:
 def test_omni_invariant_talker_requires_meaningful_audio(tmp_path) -> None:
     audio = tmp_path / "talker.wav"
     _write_wav(audio, num_samples=24_000)
-    reference = _invariant_ref("talker_decode")
+    reference = _invariant_ref("talker_decode", num_samples=24_000)
     reference.data["wav_path"] = str(audio)
 
     result = OmniComparator().compare(
@@ -101,7 +101,7 @@ def test_omni_invariant_talker_accepts_product_float32_wav(tmp_path) -> None:
     reference_audio = tmp_path / "reference.wav"
     _write_float32_wav(audio, num_samples=24_000)
     _write_wav(reference_audio, num_samples=24_000)
-    reference = _invariant_ref("talker_decode")
+    reference = _invariant_ref("talker_decode", num_samples=24_000)
     reference.data["wav_path"] = str(reference_audio)
 
     result = OmniComparator().compare(
@@ -114,6 +114,57 @@ def test_omni_invariant_talker_accepts_product_float32_wav(tmp_path) -> None:
     assert result.status == StageStatus.PASSED.value
     assert result.metrics["audio_wav_valid"].passed is True
     assert result.metrics["audio_encoding_supported"].passed is True
+
+
+def test_omni_talker_requires_exact_thinker_text_and_audio_shape(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    short_audio = tmp_path / "short.wav"
+    _write_float32_wav(audio, num_samples=37_845)
+    _write_float32_wav(short_audio, num_samples=35_925)
+    reference = _invariant_ref("talker_decode")
+    reference.data.update(
+        {
+            "decoded_text": "Hello from Qwen-Omni!",
+            "wav_path": str(audio),
+        }
+    )
+
+    matching = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            data={"thinker_text": "Hello from Qwen-Omni!"},
+            metadata={"audio_output_path": str(audio)},
+        ),
+        reference,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+    wrong_text = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            data={"thinker_text": "Hello from Qwen-Omni"},
+            metadata={"audio_output_path": str(audio)},
+        ),
+        reference,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+    wrong_shape = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            data={"thinker_text": "Hello from Qwen-Omni!"},
+            metadata={"audio_output_path": str(short_audio)},
+        ),
+        reference,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert matching.status == StageStatus.PASSED.value
+    assert matching.metrics["thinker_text_exact"].passed is True
+    assert matching.metrics["audio_num_samples_exact"].passed is True
+    assert wrong_text.metrics["thinker_text_exact"].passed is False
+    assert wrong_shape.metrics["audio_num_samples_exact"].passed is False
 
 
 def test_omni_waveform_oracle_fails_closed_without_reference_audio(tmp_path) -> None:
@@ -221,7 +272,7 @@ def test_omni_invariant_talker_compares_pinned_reference_waveform(tmp_path) -> N
         )
         wav_file.writeframes(b"".join(struct.pack("<h", sample) for sample in samples))
 
-    reference_output = _invariant_ref("talker_decode")
+    reference_output = _invariant_ref("talker_decode", num_samples=24_000)
     reference_output.data["wav_path"] = str(reference)
     matching_result = OmniComparator().compare(
         StageOutput(stage_name="talker_decode", metadata={"audio_output_path": str(matching)}),

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
@@ -117,6 +117,25 @@ def test_omni_runner_uses_model_owned_runtime_budget(monkeypatch, tmp_path) -> N
     assert captured["timeout"] == 900
 
 
+def test_talker_runner_captures_thinker_text(monkeypatch, tmp_path) -> None:
+    case = _make_case(inputs={"prompt": "hello", "max_new_tokens": 16})
+    ctx = _make_ctx(case, tmp_path)
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="Generated 37845 audio samples\n",
+            stderr="[trtmc] Omni Thinker text: Hello from Qwen-Omni!\n",
+        )
+
+    monkeypatch.setattr(omni.subprocess, "run", _fake_run)
+
+    out = omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="talker_decode"), ctx)
+
+    assert out.data["thinker_text"] == "Hello from Qwen-Omni!"
+
+
 def test_omni_timeout_preserves_partial_stderr(monkeypatch, tmp_path) -> None:
     case = _make_case(
         inputs={


### PR DESCRIPTION
## Background

Qwen3-Omni generated `Hello from Qwen-Omni` and 58,965 audio samples while the pinned official-HF reference generated `Hello from Qwen-Omni!` and 37,845 samples.

Three boundary mismatches caused the drift:

- the Thinker treated token ID 0 as EOS even though this tokenizer maps it to `!`;
- the Talker ChatML bridge appended an extra newline after the final `<|im_end|>`;
- the Talker bridge reconstructed an embedding for the selected Thinker EOS even though Transformers includes EOS in the returned sequence without forwarding it through the model.

## Exit Criteria

- Stop Thinker generation only on the configured `im_end_token_id`.
- Match the official Talker prompt boundary and forwarded embedding sequence.
- Require exact pinned Thinker text and audio sample shape in the E2E oracle.
- Produce deterministic reference-aligned output on GB300.

## Implementation

- Load the Thinker EOS token from the model config and remove the token-zero sentinel.
- Remove the trailing ChatML newline and exclude the selected Thinker EOS from reconstructed Talker embeddings.
- Capture the Thinker response from the runtime and compare it exactly with the pinned reference.
- Add exact audio sample-count validation and focused C++/Python regressions.

## Validation

- GB300, TensorRT 11.2, CUDA 13.3:
  - Thinker text: `Hello from Qwen-Omni!`
  - Talker output: 20 frames across 16 codebooks
  - Code2Wav output: 37,845 samples at 24 kHz
  - two independent runs produced byte-identical WAV output
- Qwen3-Omni Python tests: 44 passed
- Focused Qwen3-Omni C++ tests: 2 passed
- Builder tests: 675 passed, 89 skipped
- Source-quality architecture tests: 158 passed
- Cyclomatic-complexity, Ruff, clang-format, and legal checks passed

## Notes For Future Readers

Token ID 0 is ordinary tokenizer content for this model and must not be used as a universal generation sentinel. The pinned E2E oracle now couples Talker audio certification to both the exact Thinker response and exact reference audio shape.

Fixes #641
