### PR TITLE
feat(graph): add safe semantic region rewiring core

### DIFF
--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -366,7 +366,6 @@ jobs:
       TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT: "2m"
       TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT: "2m"
       TRTMC_GRAPH_PATCH_TEST_TIMEOUT: "10m"
-      GRAPH_PATCH_OUTPUT_DIR: ${{ runner.temp }}/trtmc-graph-patch-real-trt-${{ github.run_id }}-${{ github.run_attempt }}
       PYTHONHASHSEED: "0"
 
     steps:
@@ -401,6 +400,7 @@ jobs:
         timeout-minutes: 40
         env:
           TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
+          GRAPH_PATCH_OUTPUT_DIR: ${{ runner.temp }}/trtmc-graph-patch-real-trt-${{ github.run_id }}-${{ github.run_attempt }}
         run: >-
           python3 -m tools.ci graph-patch-real-trt
           --revision "${{ needs.legal.outputs.tested_sha }}"
@@ -409,6 +409,8 @@ jobs:
       - name: Upload graph-patch gate evidence
         if: ${{ always() && steps.gate.outcome != 'skipped' }}
         uses: actions/upload-artifact@v4
+        env:
+          GRAPH_PATCH_OUTPUT_DIR: ${{ runner.temp }}/trtmc-graph-patch-real-trt-${{ github.run_id }}-${{ github.run_attempt }}
         with:
           name: graph-patch-real-trt-${{ needs.legal.outputs.tested_sha }}-${{ github.run_attempt }}
           path: ${{ env.GRAPH_PATCH_OUTPUT_DIR }}

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -177,6 +177,7 @@ jobs:
       mode: ${{ steps.impact.outputs.mode }}
       run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
       unit_scope: ${{ steps.impact.outputs.unit_scope }}
+      run_graph_patch_trt: ${{ steps.impact.outputs.run_graph_patch_trt }}
 
     steps:
       - name: Check out pinned merge snapshot
@@ -215,6 +216,7 @@ jobs:
           MODE: ${{ steps.impact.outputs.mode }}
           RUN_UNIT_TESTS: ${{ steps.impact.outputs.run_unit_tests }}
           UNIT_SCOPE: ${{ steps.impact.outputs.unit_scope }}
+          RUN_GRAPH_PATCH_TRT: ${{ steps.impact.outputs.run_graph_patch_trt }}
         run: |
           {
             echo "### Model impact"
@@ -225,6 +227,7 @@ jobs:
             echo "- Representative fallback models: \`$FALLBACK_MODELS\`"
             echo "- Run source-only units: \`$RUN_UNIT_TESTS\`"
             echo "- Unit scope: \`$UNIT_SCOPE\`"
+            echo "- Run real-TensorRT graph-patch gate: \`$RUN_GRAPH_PATCH_TRT\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   source-quality:
@@ -333,12 +336,99 @@ jobs:
             rm -rf "$DOCKER_CONFIG"
           fi
 
+  graph-patch-real-trt:
+    name: 4 / Graph patch / Real TensorRT
+    needs:
+      - legal
+      - impact
+      - source-quality
+      - unit-tests
+    if: >-
+      ${{
+        always() &&
+        needs.legal.outputs.authorized == 'true' &&
+        needs.impact.outputs.run_graph_patch_trt == 'true' &&
+        needs.source-quality.result == 'success' &&
+        needs.impact.outputs.run_unit_tests == 'true' &&
+        needs.unit-tests.result == 'success'
+      }}
+    runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
+    # 150m > 90m image setup + 40m gate + 10m upload/cleanup reserve.
+    timeout-minutes: 150
+    permissions:
+      contents: read
+      packages: read
+    env:
+      TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
+      TRTMC_MODEL_PROOF_SLOTS_PER_GPU: ${{ vars.TRTMC_MODEL_PROOF_SLOTS_PER_GPU || '4' }}
+      TRTMC_MODEL_PROOF_GPU_LOCK_DIR: ${{ vars.TRTMC_MODEL_PROOF_GPU_LOCK_DIR || '/tmp/trtmc-model-proof-gpu-locks' }}
+      TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: "600"
+      TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT: "2m"
+      TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT: "2m"
+      TRTMC_GRAPH_PATCH_TEST_TIMEOUT: "10m"
+      GRAPH_PATCH_OUTPUT_DIR: ${{ runner.temp }}/trtmc-graph-patch-real-trt-${{ github.run_id }}-${{ github.run_attempt }}
+      PYTHONHASHSEED: "0"
+
+    steps:
+      - name: Check out pinned merge snapshot
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.legal.outputs.tested_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+          lfs: false
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          docker_config="${RUNNER_TEMP}/trtmc-docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-graph-patch"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
+          printf '%s' "$GHCR_TOKEN" | DOCKER_CONFIG="$docker_config" docker login ghcr.io \
+            --username "$GITHUB_ACTOR" --password-stdin
+
+      - name: Ensure CI Docker image
+        id: ci_image
+        timeout-minutes: 90
+        run: python3 -m tools.ci image ensure
+
+      - name: Run leased real-TensorRT graph-patch gate
+        id: gate
+        # 40m > 10m lease + 14m commands + 6m timeout kill grace + 5m cleanup.
+        timeout-minutes: 40
+        env:
+          TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
+        run: >-
+          python3 -m tools.ci graph-patch-real-trt
+          --revision "${{ needs.legal.outputs.tested_sha }}"
+          --output-dir "$GRAPH_PATCH_OUTPUT_DIR"
+
+      - name: Upload graph-patch gate evidence
+        if: ${{ always() && steps.gate.outcome != 'skipped' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: graph-patch-real-trt-${{ needs.legal.outputs.tested_sha }}-${{ github.run_attempt }}
+          path: ${{ env.GRAPH_PATCH_OUTPUT_DIR }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Clean graph-patch gate state
+        if: ${{ always() }}
+        run: |
+          if [ -n "${DOCKER_CONFIG:-}" ]; then
+            rm -rf "$DOCKER_CONFIG"
+          fi
+
   model-proof:
-    name: 4 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]
+    name: 5 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]
     needs:
       - legal
       - impact
       - unit-tests
+      - graph-patch-real-trt
     if: >-
       ${{
         always() &&
@@ -349,6 +439,12 @@ jobs:
            needs.unit-tests.result == 'success') ||
           (needs.impact.outputs.run_unit_tests == 'false' &&
            needs.unit-tests.result == 'skipped')
+        ) &&
+        (
+          (needs.impact.outputs.run_graph_patch_trt == 'true' &&
+           needs.graph-patch-real-trt.result == 'success') ||
+          (needs.impact.outputs.run_graph_patch_trt == 'false' &&
+           needs.graph-patch-real-trt.result == 'skipped')
         )
       }}
     strategy:
@@ -365,11 +461,12 @@ jobs:
     secrets: inherit
 
   no-model:
-    name: 4 / No model changes
+    name: 5 / No model changes
     needs:
       - legal
       - impact
       - unit-tests
+      - graph-patch-real-trt
     if: >-
       ${{
         always() &&
@@ -380,6 +477,12 @@ jobs:
            needs.unit-tests.result == 'success') ||
           (needs.impact.outputs.run_unit_tests == 'false' &&
            needs.unit-tests.result == 'skipped')
+        ) &&
+        (
+          (needs.impact.outputs.run_graph_patch_trt == 'true' &&
+           needs.graph-patch-real-trt.result == 'success') ||
+          (needs.impact.outputs.run_graph_patch_trt == 'false' &&
+           needs.graph-patch-real-trt.result == 'skipped')
         )
       }}
     runs-on: ubuntu-latest
@@ -398,7 +501,7 @@ jobs:
           esac >> "$GITHUB_STEP_SUMMARY"
 
   report:
-    name: 5 / Combined HTML report
+    name: 6 / Combined HTML report
     needs:
       - legal
       - impact
@@ -662,6 +765,7 @@ jobs:
       - impact
       - source-quality
       - unit-tests
+      - graph-patch-real-trt
       - model-proof
       - no-model
       - report
@@ -680,6 +784,8 @@ jobs:
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
           UNIT_RESULT: ${{ needs.unit-tests.result }}
           RUN_UNIT_TESTS: ${{ needs.impact.outputs.run_unit_tests }}
+          GRAPH_PATCH_TRT_RESULT: ${{ needs.graph-patch-real-trt.result }}
+          RUN_GRAPH_PATCH_TRT: ${{ needs.impact.outputs.run_graph_patch_trt }}
           MODEL_RESULT: ${{ needs.model-proof.result }}
           NO_MODEL_RESULT: ${{ needs.no-model.result }}
           REPORT_RESULT: ${{ needs.report.result }}
@@ -726,6 +832,28 @@ jobs:
               ;;
             *)
               echo "::error::Invalid run_unit_tests output: $RUN_UNIT_TESTS"
+              exit 1
+              ;;
+          esac
+          case "$RUN_GRAPH_PATCH_TRT" in
+            true)
+              test "$RUN_UNIT_TESTS" = "true" || {
+                echo "::error::The real-TensorRT graph-patch gate requires source units"
+                exit 1
+              }
+              test "$GRAPH_PATCH_TRT_RESULT" = "success" || {
+                echo "::error::Real-TensorRT graph-patch result: $GRAPH_PATCH_TRT_RESULT"
+                exit 1
+              }
+              ;;
+            false)
+              test "$GRAPH_PATCH_TRT_RESULT" = "skipped" || {
+                echo "::error::Real-TensorRT graph-patch gate ran unexpectedly: $GRAPH_PATCH_TRT_RESULT"
+                exit 1
+              }
+              ;;
+            *)
+              echo "::error::Invalid run_graph_patch_trt output: $RUN_GRAPH_PATCH_TRT"
               exit 1
               ;;
           esac

--- a/python/tensorrt_model_connect/graph_patch.py
+++ b/python/tensorrt_model_connect/graph_patch.py
@@ -60,7 +60,13 @@ class GraphPatchError(ValueError):
 def _json_value(value: Any) -> Any:
     """Convert metadata and backend values into deterministic JSON values."""
 
-    if value is None or isinstance(value, (str, bool, int)):
+    if isinstance(value, str):
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise GraphPatchError("Graph metadata strings must be valid UTF-8") from exc
+        return value
+    if value is None or isinstance(value, (bool, int)):
         return value
     if isinstance(value, float):
         if not math.isfinite(value):
@@ -93,10 +99,118 @@ def _fingerprint(payload: Mapping[str, Any]) -> str:
 
 
 def _validate_fingerprint(expected: Any, actual: str, artifact: str) -> None:
-    if expected is not None and expected != actual:
+    if (
+        not isinstance(expected, str)
+        or len(expected) != 64
+        or any(character not in "0123456789abcdef" for character in expected)
+    ):
+        raise GraphPatchError(
+            f"{artifact} fingerprint must be a 64-character lowercase SHA-256 digest"
+        )
+    if expected != actual:
         raise GraphPatchError(
             f"{artifact} fingerprint mismatch: expected {expected}, computed {actual}"
         )
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, Any],
+    allowed: set[str],
+    where: str,
+) -> None:
+    if not isinstance(value, Mapping):
+        raise GraphPatchError(f"{where} must be a JSON object")
+    non_string_keys = [key for key in value if not isinstance(key, str)]
+    if non_string_keys:
+        raise GraphPatchError(f"{where} object keys must be strings")
+    unknown = set(value) - allowed
+    if unknown:
+        raise GraphPatchError(f"Unknown {where} fields: {sorted(unknown)}")
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any],
+    expected: set[str],
+    where: str,
+) -> None:
+    _reject_unknown_fields(value, expected, where)
+    missing = expected - set(value)
+    if missing:
+        raise GraphPatchError(f"Missing {where} fields: {sorted(missing)}")
+
+
+def _require_string(value: Any, where: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        qualifier = "a string" if allow_empty else "a non-empty string"
+        raise GraphPatchError(f"{where} must be {qualifier}")
+    return value
+
+
+def _require_optional_string(value: Any, where: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, where)
+
+
+def _require_array(value: Any, where: str) -> list[Any]:
+    if type(value) is not list:
+        raise GraphPatchError(f"{where} must be a JSON array")
+    return value
+
+
+def _require_string_array(
+    value: Any,
+    where: str,
+    *,
+    allow_null: bool = False,
+) -> tuple[str | None, ...]:
+    raw = _require_array(value, where)
+    result: list[str | None] = []
+    for index, item in enumerate(raw):
+        if item is None and allow_null:
+            result.append(None)
+            continue
+        result.append(_require_string(item, f"{where}[{index}]"))
+    return tuple(result)
+
+
+def _load_json_object(value: str | bytes, where: str) -> Mapping[str, Any]:
+    """Decode one strict JSON object without silently collapsing duplicate keys."""
+
+    if isinstance(value, bytes):
+        try:
+            text = value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GraphPatchError(f"{where} must be valid UTF-8: {exc}") from exc
+    elif isinstance(value, str):
+        text = value
+    else:
+        raise GraphPatchError(f"{where} must be a string or UTF-8 bytes")
+
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise GraphPatchError(f"{where} contains duplicate object key {key!r}")
+            result[key] = item
+        return result
+
+    def reject_constant(constant: str) -> None:
+        raise GraphPatchError(f"{where} contains non-finite number {constant}")
+
+    try:
+        decoded = json.loads(
+            text,
+            object_pairs_hook=object_pairs,
+            parse_constant=reject_constant,
+        )
+    except GraphPatchError:
+        raise
+    except (json.JSONDecodeError, RecursionError, TypeError, ValueError) as exc:
+        raise GraphPatchError(f"{where} is not valid JSON: {exc}") from exc
+    if not isinstance(decoded, Mapping):
+        raise GraphPatchError(f"{where} JSON must contain an object")
+    return decoded
 
 
 @dataclass(frozen=True)
@@ -126,14 +240,17 @@ class LayerIdentityContract:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "LayerIdentityContract":
-        unknown = set(value) - {"provider_id", "schema_version"}
-        if unknown:
-            raise GraphPatchError(
-                f"Unknown layer identity contract fields: {sorted(str(item) for item in unknown)}"
-            )
+        _require_exact_fields(
+            value,
+            {"provider_id", "schema_version"},
+            "layer identity contract",
+        )
         contract = cls(
-            provider_id=value.get("provider_id"),
-            schema_version=value.get("schema_version"),
+            provider_id=_require_string(
+                value["provider_id"],
+                "Layer identity contract provider_id",
+            ),
+            schema_version=value["schema_version"],
         )
         contract.validate()
         return contract
@@ -166,17 +283,39 @@ class Tensor:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "Tensor":
+        _require_exact_fields(
+            value,
+            {
+                "id",
+                "name",
+                "dtype",
+                "shape",
+                "producer",
+                "consumers",
+                "is_shape_tensor",
+                "location",
+            },
+            "tensor",
+        )
+        shape = _require_array(value["shape"], "Tensor shape")
+        for index, dimension in enumerate(shape):
+            try:
+                _json_value(dimension)
+            except GraphPatchError as exc:
+                raise GraphPatchError(f"Tensor shape[{index}] is invalid: {exc}") from exc
+        consumers = _require_string_array(value["consumers"], "Tensor consumers")
+        is_shape_tensor = value["is_shape_tensor"]
+        if is_shape_tensor is not None and type(is_shape_tensor) is not bool:
+            raise GraphPatchError("Tensor is_shape_tensor must be a boolean or null")
         return cls(
-            id=str(value["id"]),
-            name=str(value.get("name", "")),
-            dtype=(None if value.get("dtype") is None else str(value.get("dtype"))),
-            shape=tuple(value.get("shape", ())),
-            producer=(None if value.get("producer") is None else str(value.get("producer"))),
-            consumers=tuple(str(item) for item in value.get("consumers", ())),
-            is_shape_tensor=(
-                None if value.get("is_shape_tensor") is None else bool(value.get("is_shape_tensor"))
-            ),
-            location=(None if value.get("location") is None else str(value.get("location"))),
+            id=_require_string(value["id"], "Tensor id"),
+            name=_require_string(value["name"], "Tensor name", allow_empty=True),
+            dtype=_require_optional_string(value["dtype"], "Tensor dtype"),
+            shape=tuple(shape),
+            producer=_require_optional_string(value["producer"], "Tensor producer"),
+            consumers=consumers,
+            is_shape_tensor=is_shape_tensor,
+            location=_require_optional_string(value["location"], "Tensor location"),
         )
 
 
@@ -209,29 +348,50 @@ class Node:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "Node":
+        _require_exact_fields(
+            value,
+            {
+                "id",
+                "name",
+                "op",
+                "inputs",
+                "outputs",
+                "identity",
+                "provenance",
+            },
+            "node",
+        )
         raw_identity = value.get("identity", {})
         raw_provenance = value.get("provenance", {})
         if not isinstance(raw_identity, Mapping):
             raise GraphPatchError("Node identity must be a JSON object")
-        unknown_identity = set(raw_identity) - {"attributes", "complete"}
-        if unknown_identity:
-            raise GraphPatchError(
-                f"Unknown node identity fields: {sorted(str(item) for item in unknown_identity)}"
-            )
-        raw_identity_attributes = raw_identity.get("attributes", {})
+        _require_exact_fields(
+            raw_identity,
+            {"attributes", "complete"},
+            "node identity",
+        )
+        raw_identity_attributes = raw_identity["attributes"]
         if not isinstance(raw_identity_attributes, Mapping):
             raise GraphPatchError("Node identity attributes must be a JSON object")
-        identity_complete = raw_identity.get("complete", False)
+        identity_complete = raw_identity["complete"]
         if type(identity_complete) is not bool:
             raise GraphPatchError("Node identity complete must be a boolean")
         if not isinstance(raw_provenance, Mapping):
             raise GraphPatchError("Node provenance must be a JSON object")
         return cls(
-            id=str(value["id"]),
-            name=str(value.get("name", "")),
-            op=str(value.get("op", "")),
-            inputs=tuple(None if item is None else str(item) for item in value.get("inputs", ())),
-            outputs=tuple(None if item is None else str(item) for item in value.get("outputs", ())),
+            id=_require_string(value["id"], "Node id"),
+            name=_require_string(value["name"], "Node name", allow_empty=True),
+            op=_require_string(value["op"], "Node op"),
+            inputs=_require_string_array(
+                value["inputs"],
+                "Node inputs",
+                allow_null=True,
+            ),
+            outputs=_require_string_array(
+                value["outputs"],
+                "Node outputs",
+                allow_null=True,
+            ),
             identity_attributes=_json_value(raw_identity_attributes),
             identity_complete=identity_complete,
             provenance=_json_value(raw_provenance),
@@ -331,30 +491,60 @@ class GraphSnapshot:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "GraphSnapshot":
+        _require_exact_fields(
+            value,
+            {
+                "schema_version",
+                "name",
+                "nodes",
+                "tensors",
+                "inputs",
+                "outputs",
+                "metadata",
+                "identity",
+                "fingerprint",
+            },
+            "graph snapshot",
+        )
         raw_metadata = value.get("metadata", {})
         raw_identity = value.get("identity", {})
         if not isinstance(raw_metadata, Mapping):
             raise GraphPatchError("Graph metadata must be a JSON object")
         if not isinstance(raw_identity, Mapping):
             raise GraphPatchError("Graph identity must be a JSON object")
-        unknown_identity = set(raw_identity) - {"contract", "complete"}
-        if unknown_identity:
-            raise GraphPatchError(
-                f"Unknown graph identity fields: {sorted(str(item) for item in unknown_identity)}"
-            )
-        raw_contract = raw_identity.get("contract")
+        _require_exact_fields(
+            raw_identity,
+            {"contract", "complete"},
+            "graph identity",
+        )
+        raw_contract = raw_identity["contract"]
         if raw_contract is not None and not isinstance(raw_contract, Mapping):
             raise GraphPatchError("Graph identity contract must be a JSON object or null")
-        identity_complete = raw_identity.get("complete", False)
+        identity_complete = raw_identity["complete"]
         if type(identity_complete) is not bool:
             raise GraphPatchError("Graph identity complete must be a boolean")
+        schema_version = value["schema_version"]
+        if type(schema_version) is not int:
+            raise GraphPatchError("Graph snapshot schema_version must be an integer")
+        raw_nodes = _require_array(value["nodes"], "Graph snapshot nodes")
+        raw_tensors = _require_array(value["tensors"], "Graph snapshot tensors")
         snapshot = cls(
-            schema_version=int(value.get("schema_version", GRAPH_SNAPSHOT_SCHEMA_VERSION)),
-            name=str(value.get("name", "")),
-            nodes=tuple(Node.from_dict(node) for node in value.get("nodes", ())),
-            tensors=tuple(Tensor.from_dict(tensor) for tensor in value.get("tensors", ())),
-            inputs=tuple(str(item) for item in value.get("inputs", ())),
-            outputs=tuple(str(item) for item in value.get("outputs", ())),
+            schema_version=schema_version,
+            name=_require_string(
+                value["name"],
+                "Graph snapshot name",
+                allow_empty=True,
+            ),
+            nodes=tuple(Node.from_dict(node) for node in raw_nodes),
+            tensors=tuple(Tensor.from_dict(tensor) for tensor in raw_tensors),
+            inputs=_require_string_array(
+                value["inputs"],
+                "Graph snapshot inputs",
+            ),
+            outputs=_require_string_array(
+                value["outputs"],
+                "Graph snapshot outputs",
+            ),
             metadata=_json_value(raw_metadata),
             identity_contract=(
                 None if raw_contract is None else LayerIdentityContract.from_dict(raw_contract)
@@ -381,10 +571,7 @@ class GraphSnapshot:
 
     @classmethod
     def from_json(cls, value: str | bytes) -> "GraphSnapshot":
-        decoded = json.loads(value)
-        if not isinstance(decoded, Mapping):
-            raise GraphPatchError("Graph snapshot JSON must contain an object")
-        return cls.from_dict(decoded)
+        return cls.from_dict(_load_json_object(value, "Graph snapshot"))
 
     def _validate_references(self) -> None:
         node_ids = [node.id for node in self.nodes]
@@ -422,6 +609,40 @@ class GraphSnapshot:
                 "Graph inputs/outputs reference unknown tensors: "
                 f"{sorted(unknown_inputs | unknown_outputs)}"
             )
+        if len(self.inputs) != len(set(self.inputs)):
+            raise GraphPatchError("Graph snapshot contains duplicate graph input tensor IDs")
+        if len(self.outputs) != len(set(self.outputs)):
+            raise GraphPatchError("Graph snapshot contains duplicate graph output tensor IDs")
+
+        node_by_id = {node.id: node for node in self.nodes}
+        tensor_by_id = {tensor.id: tensor for tensor in self.tensors}
+        for node in self.nodes:
+            for tensor_id in {item for item in node.inputs if item is not None}:
+                expected_uses = sum(item == tensor_id for item in node.inputs)
+                actual_uses = tensor_by_id[tensor_id].consumers.count(node.id)
+                if actual_uses != expected_uses:
+                    raise GraphPatchError(
+                        f"Node {node.id} input references and tensor {tensor_id} "
+                        "consumer references disagree"
+                    )
+            for tensor_id in {item for item in node.outputs if item is not None}:
+                if tensor_by_id[tensor_id].producer != node.id:
+                    raise GraphPatchError(
+                        f"Node {node.id} output and tensor {tensor_id} producer disagree"
+                    )
+        for tensor in self.tensors:
+            if tensor.producer is not None:
+                producer = node_by_id[tensor.producer]
+                if producer.outputs.count(tensor.id) != 1:
+                    raise GraphPatchError(
+                        f"Tensor {tensor.id} producer and node {producer.id} outputs disagree"
+                    )
+            for consumer_id in set(tensor.consumers):
+                consumer = node_by_id[consumer_id]
+                if consumer.inputs.count(tensor.id) != tensor.consumers.count(consumer_id):
+                    raise GraphPatchError(
+                        f"Tensor {tensor.id} consumers and node {consumer_id} inputs disagree"
+                    )
 
     def _validate_identity(self) -> None:
         if self.identity_contract is not None:
@@ -503,22 +724,67 @@ class RegionArtifact:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "RegionArtifact":
-        graph = value.get("graph", {})
-        selection = value.get("selection", {})
-        boundary = value.get("boundary", {})
-        metadata = value.get("metadata", {})
+        _require_exact_fields(
+            value,
+            {
+                "schema_version",
+                "graph",
+                "selection",
+                "boundary",
+                "nodes",
+                "tensors",
+                "metadata",
+                "region_fingerprint",
+            },
+            "region artifact",
+        )
+        graph = value["graph"]
+        selection = value["selection"]
+        boundary = value["boundary"]
+        metadata = value["metadata"]
         if not all(isinstance(item, Mapping) for item in (graph, selection, boundary, metadata)):
             raise GraphPatchError("Region graph, selection, boundary, and metadata must be objects")
+        _require_exact_fields(graph, {"name", "fingerprint"}, "region graph")
+        _require_exact_fields(selection, {"nodes"}, "region selection")
+        _require_exact_fields(
+            boundary,
+            {"inputs", "outputs", "internal"},
+            "region boundary",
+        )
+        schema_version = value["schema_version"]
+        if type(schema_version) is not int:
+            raise GraphPatchError("Region artifact schema_version must be an integer")
+        raw_nodes = _require_array(value["nodes"], "Region artifact nodes")
+        raw_tensors = _require_array(value["tensors"], "Region artifact tensors")
         artifact = cls(
-            schema_version=int(value.get("schema_version", REGION_ARTIFACT_SCHEMA_VERSION)),
-            graph_name=str(graph.get("name", "")),
-            graph_fingerprint=str(graph.get("fingerprint", "")),
-            selected_node_ids=tuple(str(item) for item in selection.get("nodes", ())),
-            nodes=tuple(Node.from_dict(node) for node in value.get("nodes", ())),
-            tensors=tuple(Tensor.from_dict(tensor) for tensor in value.get("tensors", ())),
-            input_tensor_ids=tuple(str(item) for item in boundary.get("inputs", ())),
-            output_tensor_ids=tuple(str(item) for item in boundary.get("outputs", ())),
-            internal_tensor_ids=tuple(str(item) for item in boundary.get("internal", ())),
+            schema_version=schema_version,
+            graph_name=_require_string(
+                graph["name"],
+                "Region graph name",
+                allow_empty=True,
+            ),
+            graph_fingerprint=_require_string(
+                graph["fingerprint"],
+                "Region graph fingerprint",
+            ),
+            selected_node_ids=_require_string_array(
+                selection["nodes"],
+                "Region selected nodes",
+            ),
+            nodes=tuple(Node.from_dict(node) for node in raw_nodes),
+            tensors=tuple(Tensor.from_dict(tensor) for tensor in raw_tensors),
+            input_tensor_ids=_require_string_array(
+                boundary["inputs"],
+                "Region boundary inputs",
+            ),
+            output_tensor_ids=_require_string_array(
+                boundary["outputs"],
+                "Region boundary outputs",
+            ),
+            internal_tensor_ids=_require_string_array(
+                boundary["internal"],
+                "Region boundary internal tensors",
+            ),
             metadata=_json_value(metadata),
         )
         if artifact.schema_version != REGION_ARTIFACT_SCHEMA_VERSION:
@@ -528,7 +794,7 @@ class RegionArtifact:
                 f"{REGION_ARTIFACT_SCHEMA_VERSION}"
             )
         _validate_fingerprint(
-            value.get("region_fingerprint"),
+            value["region_fingerprint"],
             artifact.fingerprint,
             "Region artifact",
         )
@@ -536,10 +802,7 @@ class RegionArtifact:
 
     @classmethod
     def from_json(cls, value: str | bytes) -> "RegionArtifact":
-        decoded = json.loads(value)
-        if not isinstance(decoded, Mapping):
-            raise GraphPatchError("Region artifact JSON must contain an object")
-        return cls.from_dict(decoded)
+        return cls.from_dict(_load_json_object(value, "Region artifact"))
 
 
 @dataclass(frozen=True)
@@ -558,7 +821,7 @@ class GraphRegionSelection:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "GraphRegionSelection":
-        unknown = set(value) - {
+        allowed = {
             "schema_version",
             "kind",
             "graph",
@@ -566,25 +829,30 @@ class GraphRegionSelection:
             "boundary",
             "instance",
         }
-        if unknown:
-            raise GraphPatchError(
-                f"Unknown graph-region fields: {sorted(str(item) for item in unknown)}"
-            )
-        graph = value.get("graph", {})
-        selection = value.get("selection", {})
-        boundary = value.get("boundary", {})
+        _reject_unknown_fields(value, allowed, "graph-region")
+        missing = {"schema_version", "kind", "graph", "selection", "boundary"} - set(value)
+        if missing:
+            raise GraphPatchError(f"Missing graph-region fields: {sorted(missing)}")
+        graph = value["graph"]
+        selection = value["selection"]
+        boundary = value["boundary"]
         if not all(isinstance(item, Mapping) for item in (graph, selection, boundary)):
             raise GraphPatchError("Region graph, selection, and boundary must be JSON objects")
-        for where, item, allowed in (
-            ("graph", graph, {"model", "stage", "fingerprint"}),
-            ("selection", selection, {"node_ids"}),
-            ("boundary", boundary, {"inputs", "outputs"}),
-        ):
-            extra = set(item) - allowed
-            if extra:
-                raise GraphPatchError(
-                    f"Unknown {where} fields: {sorted(str(key) for key in extra)}"
-                )
+        _require_exact_fields(
+            graph,
+            {"model", "stage", "fingerprint"},
+            "graph-region graph",
+        )
+        _require_exact_fields(
+            selection,
+            {"node_ids"},
+            "graph-region selection",
+        )
+        _require_exact_fields(
+            boundary,
+            {"inputs", "outputs"},
+            "graph-region boundary",
+        )
 
         def parse_tensor_refs(
             raw: Any,
@@ -597,12 +865,12 @@ class GraphRegionSelection:
             for index, reference in enumerate(raw):
                 if not isinstance(reference, Mapping):
                     raise GraphPatchError(f"{where}[{index}] must be a JSON object")
-                extra = set(reference) - {"tensor_id"}
-                if extra:
-                    raise GraphPatchError(
-                        f"Unknown {where}[{index}] fields: {sorted(str(key) for key in extra)}"
-                    )
-                tensor_id = reference.get("tensor_id")
+                _require_exact_fields(
+                    reference,
+                    {"tensor_id"},
+                    f"{where}[{index}]",
+                )
+                tensor_id = reference["tensor_id"]
                 if not isinstance(tensor_id, str) or not tensor_id:
                     raise GraphPatchError(f"{where}[{index}].tensor_id must be a non-empty string")
                 if tensor_id in seen:
@@ -611,7 +879,7 @@ class GraphRegionSelection:
                 ordered.append(tensor_id)
             return tuple(ordered)
 
-        raw_node_ids = selection.get("node_ids", ())
+        raw_node_ids = selection["node_ids"]
         if not isinstance(raw_node_ids, Sequence) or isinstance(
             raw_node_ids, (str, bytes, bytearray)
         ):
@@ -624,7 +892,7 @@ class GraphRegionSelection:
         if len(selected_node_ids) != len(set(selected_node_ids)):
             raise GraphPatchError("selection.node_ids contains duplicate node IDs")
 
-        fingerprint = graph.get("fingerprint")
+        fingerprint = graph["fingerprint"]
         if not isinstance(fingerprint, str) or not fingerprint:
             raise GraphPatchError("graph.fingerprint must be a non-empty string")
         schema_version = value.get("schema_version")
@@ -644,18 +912,18 @@ class GraphRegionSelection:
         instance = value.get("instance", {})
         if not isinstance(instance, Mapping):
             raise GraphPatchError("instance must be a JSON object")
-        model = graph.get("model", "")
-        stage = graph.get("stage", "")
+        model = graph["model"]
+        stage = graph["stage"]
         if not isinstance(model, str):
             raise GraphPatchError("graph.model must be a string")
         if not isinstance(stage, str):
             raise GraphPatchError("graph.stage must be a string")
         input_tensor_ids = parse_tensor_refs(
-            boundary.get("inputs", ()),
+            boundary["inputs"],
             "boundary.inputs",
         )
         output_tensor_ids = parse_tensor_refs(
-            boundary.get("outputs", ()),
+            boundary["outputs"],
             "boundary.outputs",
         )
 
@@ -673,10 +941,7 @@ class GraphRegionSelection:
 
     @classmethod
     def from_json(cls, value: str | bytes) -> "GraphRegionSelection":
-        decoded = json.loads(value)
-        if not isinstance(decoded, Mapping):
-            raise GraphPatchError("Graph-region JSON must contain an object")
-        return cls.from_dict(decoded)
+        return cls.from_dict(_load_json_object(value, "Graph-region"))
 
     def to_dict(self) -> dict[str, Any]:
         value: dict[str, Any] = {
@@ -796,16 +1061,11 @@ class GraphRegionSelectionSet:
                 model=selection.model,
                 stage=selection.stage,
             )
-        unknown = set(value) - {
-            "schema_version",
-            "kind",
-            "graph",
-            "regions",
-        }
-        if unknown:
-            raise GraphPatchError(
-                f"Unknown graph-region-set fields: {sorted(str(item) for item in unknown)}"
-            )
+        _require_exact_fields(
+            value,
+            {"schema_version", "kind", "graph", "regions"},
+            "graph-region-set",
+        )
         if kind != GRAPH_REGION_SELECTION_SET_KIND:
             raise GraphPatchError(
                 "Unsupported graph-region-set kind "
@@ -822,19 +1082,22 @@ class GraphRegionSelectionSet:
                 f"{GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION}"
             )
 
-        graph = value.get("graph", {})
+        graph = value["graph"]
         if not isinstance(graph, Mapping):
             raise GraphPatchError("Region-set graph must be a JSON object")
-        unknown_graph = set(graph) - {"model", "stage", "fingerprint", "build"}
-        if unknown_graph:
-            raise GraphPatchError(
-                f"Unknown graph fields: {sorted(str(item) for item in unknown_graph)}"
-            )
-        fingerprint = graph.get("fingerprint")
+        _reject_unknown_fields(
+            graph,
+            {"model", "stage", "fingerprint", "build"},
+            "graph-region-set graph",
+        )
+        missing_graph = {"model", "stage", "fingerprint"} - set(graph)
+        if missing_graph:
+            raise GraphPatchError(f"Missing graph-region-set graph fields: {sorted(missing_graph)}")
+        fingerprint = graph["fingerprint"]
         if not isinstance(fingerprint, str) or not fingerprint:
             raise GraphPatchError("graph.fingerprint must be a non-empty string")
-        model = graph.get("model", "")
-        stage = graph.get("stage", "")
+        model = graph["model"]
+        stage = graph["stage"]
         if not isinstance(model, str):
             raise GraphPatchError("graph.model must be a string")
         if not isinstance(stage, str):
@@ -843,7 +1106,7 @@ class GraphRegionSelectionSet:
         if not isinstance(build, Mapping):
             raise GraphPatchError("graph.build must be a JSON object")
 
-        raw_regions = value.get("regions")
+        raw_regions = value["regions"]
         if not isinstance(raw_regions, Sequence) or isinstance(
             raw_regions,
             (str, bytes, bytearray),
@@ -856,16 +1119,14 @@ class GraphRegionSelectionSet:
         for index, raw_region in enumerate(raw_regions):
             if not isinstance(raw_region, Mapping):
                 raise GraphPatchError(f"regions[{index}] must be a JSON object")
-            unknown_region = set(raw_region) - {
-                "selection",
-                "boundary",
-                "instance",
-            }
-            if unknown_region:
-                raise GraphPatchError(
-                    f"Unknown regions[{index}] fields: "
-                    f"{sorted(str(item) for item in unknown_region)}"
-                )
+            _reject_unknown_fields(
+                raw_region,
+                {"selection", "boundary", "instance"},
+                f"regions[{index}]",
+            )
+            missing_region = {"selection", "boundary"} - set(raw_region)
+            if missing_region:
+                raise GraphPatchError(f"Missing regions[{index}] fields: {sorted(missing_region)}")
             region_document = {
                 "schema_version": GRAPH_REGION_SELECTION_SCHEMA_VERSION,
                 "kind": GRAPH_REGION_SELECTION_KIND,
@@ -874,8 +1135,8 @@ class GraphRegionSelectionSet:
                     "stage": stage,
                     "fingerprint": fingerprint,
                 },
-                "selection": raw_region.get("selection", {}),
-                "boundary": raw_region.get("boundary", {}),
+                "selection": raw_region["selection"],
+                "boundary": raw_region["boundary"],
                 "instance": raw_region.get("instance", {}),
             }
             selection = GraphRegionSelection.from_dict(region_document)
@@ -907,10 +1168,7 @@ class GraphRegionSelectionSet:
 
     @classmethod
     def from_json(cls, value: str | bytes) -> "GraphRegionSelectionSet":
-        decoded = json.loads(value)
-        if not isinstance(decoded, Mapping):
-            raise GraphPatchError("Graph-region-set JSON must contain an object")
-        return cls.from_dict(decoded)
+        return cls.from_dict(_load_json_object(value, "Graph-region-set"))
 
     def to_dict(self) -> dict[str, Any]:
         graph: dict[str, Any] = {

--- a/python/tensorrt_model_connect/graph_patch.py
+++ b/python/tensorrt_model_connect/graph_patch.py
@@ -46,6 +46,7 @@ GRAPH_REGION_SET_KIND = GRAPH_REGION_SELECTION_SET_KIND
 ProvenanceProvider = (
     Mapping[Any, Mapping[str, Any]] | Callable[[Any, int], Mapping[str, Any] | None]
 )
+LayerIdentityProvider = Callable[[Any, int], Mapping[str, Any] | None]
 ReplacementCallback = Callable[
     [Any, tuple[Any, ...], "RegionArtifact"],
     Sequence[Any],
@@ -66,13 +67,18 @@ def _json_value(value: Any) -> Any:
             raise GraphPatchError("Graph metadata cannot contain NaN or infinity")
         return value
     if isinstance(value, Mapping):
+        non_string_keys = [key for key in value if not isinstance(key, str)]
+        if non_string_keys:
+            raise GraphPatchError("Graph metadata object keys must be strings")
         return {
-            str(key): _json_value(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            key: _json_value(item) for key, item in sorted(value.items(), key=lambda pair: pair[0])
         }
     if isinstance(value, (list, tuple)):
         return [_json_value(item) for item in value]
-    return str(value)
+    raise GraphPatchError(
+        "Graph metadata values must use JSON scalars, arrays, or objects; "
+        f"got {type(value).__name__}"
+    )
 
 
 def _fingerprint(payload: Mapping[str, Any]) -> str:
@@ -91,6 +97,46 @@ def _validate_fingerprint(expected: Any, actual: str, artifact: str) -> None:
         raise GraphPatchError(
             f"{artifact} fingerprint mismatch: expected {expected}, computed {actual}"
         )
+
+
+@dataclass(frozen=True)
+class LayerIdentityContract:
+    """Versioned model-owned meaning of per-layer identity attributes.
+
+    ``provider_id`` identifies the model/family-owned provider implementation.
+    Its owner must increment ``schema_version`` whenever the meaning or coverage
+    of the returned attributes changes.
+    """
+
+    provider_id: str
+    schema_version: int
+
+    def validate(self) -> None:
+        if not isinstance(self.provider_id, str) or not self.provider_id:
+            raise GraphPatchError("Layer identity provider_id must be a non-empty string")
+        if type(self.schema_version) is not int or self.schema_version < 1:
+            raise GraphPatchError("Layer identity schema_version must be a positive integer")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "provider_id": self.provider_id,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "LayerIdentityContract":
+        unknown = set(value) - {"provider_id", "schema_version"}
+        if unknown:
+            raise GraphPatchError(
+                f"Unknown layer identity contract fields: {sorted(str(item) for item in unknown)}"
+            )
+        contract = cls(
+            provider_id=value.get("provider_id"),
+            schema_version=value.get("schema_version"),
+        )
+        contract.validate()
+        return contract
 
 
 @dataclass(frozen=True)
@@ -143,6 +189,8 @@ class Node:
     op: str
     inputs: tuple[str | None, ...] = ()
     outputs: tuple[str | None, ...] = ()
+    identity_attributes: Mapping[str, Any] = field(default_factory=dict)
+    identity_complete: bool = False
     provenance: Mapping[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -152,12 +200,30 @@ class Node:
             "op": self.op,
             "inputs": list(self.inputs),
             "outputs": list(self.outputs),
+            "identity": {
+                "attributes": _json_value(self.identity_attributes),
+                "complete": self.identity_complete,
+            },
             "provenance": _json_value(self.provenance),
         }
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "Node":
+        raw_identity = value.get("identity", {})
         raw_provenance = value.get("provenance", {})
+        if not isinstance(raw_identity, Mapping):
+            raise GraphPatchError("Node identity must be a JSON object")
+        unknown_identity = set(raw_identity) - {"attributes", "complete"}
+        if unknown_identity:
+            raise GraphPatchError(
+                f"Unknown node identity fields: {sorted(str(item) for item in unknown_identity)}"
+            )
+        raw_identity_attributes = raw_identity.get("attributes", {})
+        if not isinstance(raw_identity_attributes, Mapping):
+            raise GraphPatchError("Node identity attributes must be a JSON object")
+        identity_complete = raw_identity.get("complete", False)
+        if type(identity_complete) is not bool:
+            raise GraphPatchError("Node identity complete must be a boolean")
         if not isinstance(raw_provenance, Mapping):
             raise GraphPatchError("Node provenance must be a JSON object")
         return cls(
@@ -166,6 +232,8 @@ class Node:
             op=str(value.get("op", "")),
             inputs=tuple(None if item is None else str(item) for item in value.get("inputs", ())),
             outputs=tuple(None if item is None else str(item) for item in value.get("outputs", ())),
+            identity_attributes=_json_value(raw_identity_attributes),
+            identity_complete=identity_complete,
             provenance=_json_value(raw_provenance),
         )
 
@@ -180,7 +248,22 @@ class GraphSnapshot:
     inputs: tuple[str, ...] = ()
     outputs: tuple[str, ...] = ()
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    identity_contract: LayerIdentityContract | None = None
     schema_version: int = GRAPH_SNAPSHOT_SCHEMA_VERSION
+
+    @property
+    def identity_complete(self) -> bool:
+        return self.identity_contract is not None and all(
+            node.identity_complete for node in self.nodes
+        )
+
+    def _identity_dict(self) -> dict[str, Any]:
+        return {
+            "contract": (
+                None if self.identity_contract is None else self.identity_contract.to_dict()
+            ),
+            "complete": self.identity_complete,
+        }
 
     def _payload_dict(self) -> dict[str, Any]:
         return {
@@ -191,6 +274,7 @@ class GraphSnapshot:
             "inputs": list(self.inputs),
             "outputs": list(self.outputs),
             "metadata": _json_value(self.metadata),
+            "identity": self._identity_dict(),
         }
 
     def _fingerprint_payload_dict(self) -> dict[str, Any]:
@@ -213,6 +297,10 @@ class GraphSnapshot:
                     "op": node.op,
                     "inputs": list(node.inputs),
                     "outputs": list(node.outputs),
+                    "identity": {
+                        "attributes": _json_value(node.identity_attributes),
+                        "complete": node.identity_complete,
+                    },
                 }
                 for node in self.nodes
             ],
@@ -220,6 +308,7 @@ class GraphSnapshot:
             "inputs": list(self.inputs),
             "outputs": list(self.outputs),
             "metadata": _json_value(self.metadata),
+            "identity": self._identity_dict(),
         }
 
     @property
@@ -243,8 +332,22 @@ class GraphSnapshot:
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "GraphSnapshot":
         raw_metadata = value.get("metadata", {})
+        raw_identity = value.get("identity", {})
         if not isinstance(raw_metadata, Mapping):
             raise GraphPatchError("Graph metadata must be a JSON object")
+        if not isinstance(raw_identity, Mapping):
+            raise GraphPatchError("Graph identity must be a JSON object")
+        unknown_identity = set(raw_identity) - {"contract", "complete"}
+        if unknown_identity:
+            raise GraphPatchError(
+                f"Unknown graph identity fields: {sorted(str(item) for item in unknown_identity)}"
+            )
+        raw_contract = raw_identity.get("contract")
+        if raw_contract is not None and not isinstance(raw_contract, Mapping):
+            raise GraphPatchError("Graph identity contract must be a JSON object or null")
+        identity_complete = raw_identity.get("complete", False)
+        if type(identity_complete) is not bool:
+            raise GraphPatchError("Graph identity complete must be a boolean")
         snapshot = cls(
             schema_version=int(value.get("schema_version", GRAPH_SNAPSHOT_SCHEMA_VERSION)),
             name=str(value.get("name", "")),
@@ -253,12 +356,20 @@ class GraphSnapshot:
             inputs=tuple(str(item) for item in value.get("inputs", ())),
             outputs=tuple(str(item) for item in value.get("outputs", ())),
             metadata=_json_value(raw_metadata),
+            identity_contract=(
+                None if raw_contract is None else LayerIdentityContract.from_dict(raw_contract)
+            ),
         )
         if snapshot.schema_version != GRAPH_SNAPSHOT_SCHEMA_VERSION:
             raise GraphPatchError(
                 "Unsupported graph snapshot schema_version "
                 f"{snapshot.schema_version}; expected "
                 f"{GRAPH_SNAPSHOT_SCHEMA_VERSION}"
+            )
+        snapshot._validate_identity()
+        if identity_complete != snapshot.identity_complete:
+            raise GraphPatchError(
+                "Graph identity completeness does not match its node identity records"
             )
         _validate_fingerprint(
             value.get("fingerprint"),
@@ -311,6 +422,20 @@ class GraphSnapshot:
                 "Graph inputs/outputs reference unknown tensors: "
                 f"{sorted(unknown_inputs | unknown_outputs)}"
             )
+
+    def _validate_identity(self) -> None:
+        if self.identity_contract is not None:
+            self.identity_contract.validate()
+        elif any(node.identity_complete for node in self.nodes):
+            raise GraphPatchError(
+                "Complete node identity records require a layer identity contract"
+            )
+        for node in self.nodes:
+            if type(node.identity_complete) is not bool:
+                raise GraphPatchError(f"Node {node.id} identity completeness must be a boolean")
+            if not isinstance(node.identity_attributes, Mapping):
+                raise GraphPatchError(f"Node {node.id} identity attributes must be a mapping")
+            _json_value(node.identity_attributes)
 
 
 @dataclass(frozen=True)
@@ -1297,14 +1422,54 @@ def _node_provenance(
     return _json_value(raw)
 
 
+def _node_identity(
+    provider: LayerIdentityProvider | None,
+    layer: Any,
+    index: int,
+    node_id: str,
+) -> tuple[Mapping[str, Any], bool]:
+    if provider is None:
+        return {}, False
+    raw = provider(layer, index)
+    if raw is None:
+        return {}, False
+    if not isinstance(raw, Mapping):
+        raise GraphPatchError(
+            f"Layer identity for {node_id} must be a mapping or None, got {type(raw).__name__}"
+        )
+    return _json_value(raw), True
+
+
 def capture_network(
     network: Any,
     *,
     name: str | None = None,
     metadata: Mapping[str, Any] | None = None,
     provenance: ProvenanceProvider | None = None,
+    identity_provider: LayerIdentityProvider | None = None,
+    identity_contract: LayerIdentityContract | None = None,
 ) -> CapturedGraph:
-    """Capture a graph and retain live object-to-ID bindings by identity."""
+    """Capture a graph and retain live object-to-ID bindings by identity.
+
+    The model builder owns ``identity_provider``.  For every layer it must
+    return a deterministic JSON object covering every layer-specific setting
+    that can change execution semantics.  TensorRT's generic layer wrapper may
+    hide subtype attributes, so providers may need to record those settings
+    when the model creates the layer.  Returning ``None`` marks that layer's
+    identity incomplete: the snapshot remains inspectable but cannot be used
+    for rewiring.
+    """
+    if (identity_provider is None) != (identity_contract is None):
+        raise GraphPatchError(
+            "Layer identity provider and contract must either both be present or both be absent"
+        )
+    if identity_provider is not None and not callable(identity_provider):
+        raise GraphPatchError("Layer identity provider must be callable")
+    if identity_contract is not None:
+        if not isinstance(identity_contract, LayerIdentityContract):
+            raise GraphPatchError("Layer identity contract has the wrong type")
+        identity_contract.validate()
+
     layer_count = _count(network, "num_layers", required=True)
     layers = [network.get_layer(index) for index in range(layer_count)]
     registry = _TensorRegistry()
@@ -1354,6 +1519,12 @@ def capture_network(
         raw_op = getattr(layer, "type", None)
         if raw_op is None:
             raw_op = getattr(layer, "op", type(layer).__name__)
+        identity_attributes, identity_complete = _node_identity(
+            identity_provider,
+            layer,
+            index,
+            node_id,
+        )
         nodes.append(
             Node(
                 id=node_id,
@@ -1361,6 +1532,8 @@ def capture_network(
                 op=str(raw_op),
                 inputs=tuple(input_ids),
                 outputs=layer_output_ids[index],
+                identity_attributes=identity_attributes,
+                identity_complete=identity_complete,
                 provenance=_node_provenance(
                     provenance,
                     layer,
@@ -1397,8 +1570,10 @@ def capture_network(
         inputs=tuple(graph_inputs),
         outputs=tuple(graph_outputs),
         metadata=_json_value(metadata or {}),
+        identity_contract=identity_contract,
     )
     snapshot._validate_references()
+    snapshot._validate_identity()
     tensor_bindings = {draft.id: draft.value for draft in registry.drafts}
     tensor_ids_by_identity = {
         id(tensor): tensor_id for tensor_id, tensor in tensor_bindings.items()
@@ -1447,6 +1622,8 @@ def snapshot_network(
     name: str | None = None,
     metadata: Mapping[str, Any] | None = None,
     provenance: ProvenanceProvider | None = None,
+    identity_provider: LayerIdentityProvider | None = None,
+    identity_contract: LayerIdentityContract | None = None,
 ) -> GraphSnapshot:
     """Snapshot an ``INetworkDefinition``-like object without importing TRT.
 
@@ -1454,6 +1631,11 @@ def snapshot_network(
     mapping keyed by node ID, layer name, integer index, or string index.  This
     is the hook through which builder scopes/source locations can later be
     attached to diagnostic graph artifacts.
+
+    ``identity_provider`` and ``identity_contract`` are an all-or-nothing,
+    model-owned pair.  See :func:`capture_network` for their completeness
+    contract.  Omitting them intentionally produces a structural-only snapshot
+    suitable for inspection and selection, but not rewiring.
     """
 
     return capture_network(
@@ -1461,6 +1643,8 @@ def snapshot_network(
         name=name,
         metadata=metadata,
         provenance=provenance,
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
     ).snapshot
 
 
@@ -1552,12 +1736,68 @@ def create_region_artifact(
     )
 
 
+def _capture_live_for_rewire(
+    network: Any,
+    snapshot: GraphSnapshot,
+    *,
+    current_name: str,
+    current_metadata: Mapping[str, Any],
+    identity_provider: LayerIdentityProvider,
+    identity_contract: LayerIdentityContract,
+    provenance: ProvenanceProvider | None,
+) -> CapturedGraph:
+    """Recapture independently supplied current identity before any callback."""
+
+    snapshot._validate_identity()
+    if not snapshot.identity_complete:
+        raise GraphPatchError(
+            "Graph rewiring requires a complete model-owned layer identity provider; "
+            "the selected snapshot is structural-only or incomplete"
+        )
+    if not isinstance(current_name, str):
+        raise GraphPatchError("Current graph name must be a string")
+    if not isinstance(current_metadata, Mapping):
+        raise GraphPatchError("Current graph metadata must be a mapping")
+    if not isinstance(identity_contract, LayerIdentityContract):
+        raise GraphPatchError("Current layer identity contract has the wrong type")
+    identity_contract.validate()
+    if identity_contract != snapshot.identity_contract:
+        raise GraphPatchError(
+            "Current layer identity contract does not match the selected graph snapshot"
+        )
+    if not callable(identity_provider):
+        raise GraphPatchError("Current layer identity provider must be callable")
+
+    live = capture_network(
+        network,
+        name=current_name,
+        metadata=current_metadata,
+        provenance=provenance,
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
+    )
+    if not live.snapshot.identity_complete:
+        raise GraphPatchError(
+            "Current layer identity provider did not completely describe every live layer"
+        )
+    if live.snapshot.fingerprint != snapshot.fingerprint:
+        raise GraphPatchError(
+            "Live graph no longer matches the selected graph snapshot: "
+            f"expected {snapshot.fingerprint}, got {live.snapshot.fingerprint}"
+        )
+    return live
+
+
 def rewire_region(
     network: Any,
     snapshot: GraphSnapshot,
     selected_node_ids: Sequence[str],
     replacement: ReplacementCallback,
     *,
+    current_name: str,
+    current_metadata: Mapping[str, Any],
+    identity_provider: LayerIdentityProvider,
+    identity_contract: LayerIdentityContract,
     provenance: ProvenanceProvider | None = None,
 ) -> RewireResult:
     """Replace a selected region by rewiring all of its external uses.
@@ -1569,21 +1809,24 @@ def rewire_region(
     all external consumer slots with ``set_input``, and updates marked network
     outputs through ``unmark_output``/``mark_output`` when needed.
 
+    ``current_name``, ``current_metadata``, and the identity provider/contract
+    must describe the current build independently.  They are never replayed
+    from ``snapshot``.  A structural-only or incompletely identified snapshot
+    is rejected before ``replacement`` is called.
+
     If this function raises after invoking ``replacement``, discard ``network``;
     callback-created layers cannot be rolled back generically.
     """
 
-    live = capture_network(
+    live = _capture_live_for_rewire(
         network,
-        name=snapshot.name,
-        metadata=snapshot.metadata,
+        snapshot,
+        current_name=current_name,
+        current_metadata=current_metadata,
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
         provenance=provenance,
     )
-    if live.snapshot.fingerprint != snapshot.fingerprint:
-        raise GraphPatchError(
-            "Live graph no longer matches the selected graph snapshot: "
-            f"expected {snapshot.fingerprint}, got {live.snapshot.fingerprint}"
-        )
 
     validate_region(snapshot, selected_node_ids)
     artifact = create_region_artifact(snapshot, selected_node_ids)
@@ -1846,9 +2089,17 @@ def rewire_selection(
     selection: GraphRegionSelection,
     replacement: ReplacementCallback,
     *,
+    current_name: str,
+    current_metadata: Mapping[str, Any],
+    identity_provider: LayerIdentityProvider,
+    identity_contract: LayerIdentityContract,
     provenance: ProvenanceProvider | None = None,
 ) -> RewireResult:
-    """Validate and replace one selection with newly created output tensors."""
+    """Validate and replace one fully identified selection.
+
+    Current graph identity is recaptured from the explicit ``current_*`` and
+    identity arguments before ``replacement`` can run.
+    """
 
     selection.validate(snapshot)
     return rewire_selection_set(
@@ -1856,6 +2107,10 @@ def rewire_selection(
         snapshot,
         coerce_region_selection_set(selection),
         replacement,
+        current_name=current_name,
+        current_metadata=current_metadata,
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
         provenance=provenance,
     ).results[0]
 
@@ -1866,6 +2121,10 @@ def rewire_selection_set(
     selection_set: GraphRegionSelectionSet,
     replacement: ReplacementCallback,
     *,
+    current_name: str,
+    current_metadata: Mapping[str, Any],
+    identity_provider: LayerIdentityProvider,
+    identity_contract: LayerIdentityContract,
     provenance: ProvenanceProvider | None = None,
 ) -> RewireBatchResult:
     """Replace every independent region against the same original snapshot.
@@ -1874,23 +2133,24 @@ def rewire_selection_set(
     tensors; aliases to the original graph or another region output are
     rejected before consumer rewiring.
 
+    Current graph identity is recaptured from the explicit ``current_*`` and
+    identity arguments.  A structural-only or incompletely identified snapshot
+    is rejected before ``replacement`` is called.
+
     If this function raises after invoking ``replacement``, discard ``network``;
     callback-created layers cannot be rolled back generically.
     """
 
     selection_set.validate(snapshot)
-    live = capture_network(
+    live = _capture_live_for_rewire(
         network,
-        name=snapshot.name,
-        metadata=snapshot.metadata,
+        snapshot,
+        current_name=current_name,
+        current_metadata=current_metadata,
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
         provenance=provenance,
     )
-    if live.snapshot.fingerprint != snapshot.fingerprint:
-        raise GraphPatchError(
-            "Live graph no longer matches the selected graph snapshot: "
-            f"expected {snapshot.fingerprint}, got "
-            f"{live.snapshot.fingerprint}"
-        )
     artifacts = tuple(
         create_region_artifact(
             snapshot,

--- a/python/tensorrt_model_connect/graph_patch.py
+++ b/python/tensorrt_model_connect/graph_patch.py
@@ -1,0 +1,1593 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-independent graph snapshots and subgraph replacement helpers.
+
+The objects consumed here deliberately use a small duck-typed surface:
+
+* a network exposes ``num_layers``/``get_layer`` and, optionally,
+  ``num_inputs``/``get_input`` plus ``num_outputs``/``get_output``;
+* a layer exposes ``num_inputs``/``get_input``, ``num_outputs``/``get_output``,
+  and ``set_input`` when it is rewired;
+* a tensor may expose ``name``, ``dtype``, and ``shape``.
+
+This makes the graph-selection prototype unit-testable without importing
+TensorRT and keeps the eventual UI artifact independent of a TensorRT version.
+The helper intentionally does not try to delete the selected layers.  It
+rewires every consumer outside the selected region, leaving the old region
+unreachable for the backend to prune.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+
+GRAPH_SNAPSHOT_SCHEMA_VERSION = 1
+REGION_ARTIFACT_SCHEMA_VERSION = 1
+GRAPH_REGION_SELECTION_SCHEMA_VERSION = 1
+GRAPH_REGION_SELECTION_KIND = "tensorrt_model_connect.graph_region"
+GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION = 1
+GRAPH_REGION_SELECTION_SET_KIND = "tensorrt_model_connect.graph_region_set"
+# Short aliases for callers that treat the set as the primary region artifact.
+GRAPH_REGION_SET_SCHEMA_VERSION = GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION
+GRAPH_REGION_SET_KIND = GRAPH_REGION_SELECTION_SET_KIND
+
+ProvenanceProvider = (
+    Mapping[Any, Mapping[str, Any]] | Callable[[Any, int], Mapping[str, Any] | None]
+)
+ReplacementCallback = Callable[
+    [Any, tuple[Any, ...], "RegionArtifact"],
+    Sequence[Any],
+]
+
+
+class GraphPatchError(ValueError):
+    """A graph cannot be snapshotted or safely patched."""
+
+
+def _json_value(value: Any) -> Any:
+    """Convert metadata and backend values into deterministic JSON values."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise GraphPatchError("Graph metadata cannot contain NaN or infinity")
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return str(value)
+
+
+def _fingerprint(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _json_value(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_fingerprint(expected: Any, actual: str, artifact: str) -> None:
+    if expected is not None and expected != actual:
+        raise GraphPatchError(
+            f"{artifact} fingerprint mismatch: expected {expected}, computed {actual}"
+        )
+
+
+@dataclass(frozen=True)
+class Tensor:
+    """One tensor in a backend-neutral graph snapshot."""
+
+    id: str
+    name: str
+    dtype: str | None = None
+    shape: tuple[Any, ...] = ()
+    producer: str | None = None
+    consumers: tuple[str, ...] = ()
+    is_shape_tensor: bool | None = None
+    location: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "dtype": self.dtype,
+            "shape": _json_value(self.shape),
+            "producer": self.producer,
+            "consumers": list(self.consumers),
+            "is_shape_tensor": self.is_shape_tensor,
+            "location": self.location,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "Tensor":
+        return cls(
+            id=str(value["id"]),
+            name=str(value.get("name", "")),
+            dtype=(None if value.get("dtype") is None else str(value.get("dtype"))),
+            shape=tuple(value.get("shape", ())),
+            producer=(None if value.get("producer") is None else str(value.get("producer"))),
+            consumers=tuple(str(item) for item in value.get("consumers", ())),
+            is_shape_tensor=(
+                None if value.get("is_shape_tensor") is None else bool(value.get("is_shape_tensor"))
+            ),
+            location=(None if value.get("location") is None else str(value.get("location"))),
+        )
+
+
+@dataclass(frozen=True)
+class Node:
+    """One layer/op in a backend-neutral graph snapshot."""
+
+    id: str
+    name: str
+    op: str
+    inputs: tuple[str | None, ...] = ()
+    outputs: tuple[str | None, ...] = ()
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "op": self.op,
+            "inputs": list(self.inputs),
+            "outputs": list(self.outputs),
+            "provenance": _json_value(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "Node":
+        raw_provenance = value.get("provenance", {})
+        if not isinstance(raw_provenance, Mapping):
+            raise GraphPatchError("Node provenance must be a JSON object")
+        return cls(
+            id=str(value["id"]),
+            name=str(value.get("name", "")),
+            op=str(value.get("op", "")),
+            inputs=tuple(None if item is None else str(item) for item in value.get("inputs", ())),
+            outputs=tuple(None if item is None else str(item) for item in value.get("outputs", ())),
+            provenance=_json_value(raw_provenance),
+        )
+
+
+@dataclass(frozen=True)
+class GraphSnapshot:
+    """A serializable, fingerprinted view of a network definition."""
+
+    name: str
+    nodes: tuple[Node, ...]
+    tensors: tuple[Tensor, ...]
+    inputs: tuple[str, ...] = ()
+    outputs: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = GRAPH_SNAPSHOT_SCHEMA_VERSION
+
+    def _payload_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "nodes": [node.to_dict() for node in self.nodes],
+            "tensors": [tensor.to_dict() for tensor in self.tensors],
+            "inputs": list(self.inputs),
+            "outputs": list(self.outputs),
+            "metadata": _json_value(self.metadata),
+        }
+
+    def _fingerprint_payload_dict(self) -> dict[str, Any]:
+        """Return graph identity without presentation-only provenance.
+
+        Source frames are useful UI breadcrumbs, but the outer call site is
+        necessarily different between ``graph inspect`` and a patched build.
+        Structural identity therefore includes node names/types/connectivity,
+        tensor contracts, graph I/O, and build metadata while excluding source
+        files, functions, and line numbers.
+        """
+
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "nodes": [
+                {
+                    "id": node.id,
+                    "name": node.name,
+                    "op": node.op,
+                    "inputs": list(node.inputs),
+                    "outputs": list(node.outputs),
+                }
+                for node in self.nodes
+            ],
+            "tensors": [tensor.to_dict() for tensor in self.tensors],
+            "inputs": list(self.inputs),
+            "outputs": list(self.outputs),
+            "metadata": _json_value(self.metadata),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(self._fingerprint_payload_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload_dict()
+        payload["fingerprint"] = self.fingerprint
+        return payload
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(
+            self.to_dict(),
+            indent=indent,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "GraphSnapshot":
+        raw_metadata = value.get("metadata", {})
+        if not isinstance(raw_metadata, Mapping):
+            raise GraphPatchError("Graph metadata must be a JSON object")
+        snapshot = cls(
+            schema_version=int(value.get("schema_version", GRAPH_SNAPSHOT_SCHEMA_VERSION)),
+            name=str(value.get("name", "")),
+            nodes=tuple(Node.from_dict(node) for node in value.get("nodes", ())),
+            tensors=tuple(Tensor.from_dict(tensor) for tensor in value.get("tensors", ())),
+            inputs=tuple(str(item) for item in value.get("inputs", ())),
+            outputs=tuple(str(item) for item in value.get("outputs", ())),
+            metadata=_json_value(raw_metadata),
+        )
+        if snapshot.schema_version != GRAPH_SNAPSHOT_SCHEMA_VERSION:
+            raise GraphPatchError(
+                "Unsupported graph snapshot schema_version "
+                f"{snapshot.schema_version}; expected "
+                f"{GRAPH_SNAPSHOT_SCHEMA_VERSION}"
+            )
+        _validate_fingerprint(
+            value.get("fingerprint"),
+            snapshot.fingerprint,
+            "Graph snapshot",
+        )
+        snapshot._validate_references()
+        return snapshot
+
+    @classmethod
+    def from_json(cls, value: str | bytes) -> "GraphSnapshot":
+        decoded = json.loads(value)
+        if not isinstance(decoded, Mapping):
+            raise GraphPatchError("Graph snapshot JSON must contain an object")
+        return cls.from_dict(decoded)
+
+    def _validate_references(self) -> None:
+        node_ids = [node.id for node in self.nodes]
+        tensor_ids = [tensor.id for tensor in self.tensors]
+        if len(node_ids) != len(set(node_ids)):
+            raise GraphPatchError("Graph snapshot contains duplicate node IDs")
+        if len(tensor_ids) != len(set(tensor_ids)):
+            raise GraphPatchError("Graph snapshot contains duplicate tensor IDs")
+
+        node_set = set(node_ids)
+        tensor_set = set(tensor_ids)
+        for node in self.nodes:
+            unknown = {
+                item
+                for item in (*node.inputs, *node.outputs)
+                if item is not None and item not in tensor_set
+            }
+            if unknown:
+                raise GraphPatchError(
+                    f"Node {node.id} references unknown tensors: {sorted(unknown)}"
+                )
+        for tensor in self.tensors:
+            references = set(tensor.consumers)
+            if tensor.producer is not None:
+                references.add(tensor.producer)
+            unknown = references - node_set
+            if unknown:
+                raise GraphPatchError(
+                    f"Tensor {tensor.id} references unknown nodes: {sorted(unknown)}"
+                )
+        unknown_inputs = set(self.inputs) - tensor_set
+        unknown_outputs = set(self.outputs) - tensor_set
+        if unknown_inputs or unknown_outputs:
+            raise GraphPatchError(
+                "Graph inputs/outputs reference unknown tensors: "
+                f"{sorted(unknown_inputs | unknown_outputs)}"
+            )
+
+
+@dataclass(frozen=True)
+class RegionBoundary:
+    """The automatically inferred cut around selected nodes."""
+
+    selected_node_ids: tuple[str, ...]
+    input_tensor_ids: tuple[str, ...]
+    output_tensor_ids: tuple[str, ...]
+    internal_tensor_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RegionArtifact:
+    """Portable contract produced by selecting a region in a graph snapshot."""
+
+    graph_name: str
+    graph_fingerprint: str
+    selected_node_ids: tuple[str, ...]
+    nodes: tuple[Node, ...]
+    tensors: tuple[Tensor, ...]
+    input_tensor_ids: tuple[str, ...]
+    output_tensor_ids: tuple[str, ...]
+    internal_tensor_ids: tuple[str, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = REGION_ARTIFACT_SCHEMA_VERSION
+
+    def _payload_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "graph": {
+                "name": self.graph_name,
+                "fingerprint": self.graph_fingerprint,
+            },
+            "selection": {
+                "nodes": list(self.selected_node_ids),
+            },
+            "boundary": {
+                "inputs": list(self.input_tensor_ids),
+                "outputs": list(self.output_tensor_ids),
+                "internal": list(self.internal_tensor_ids),
+            },
+            "nodes": [node.to_dict() for node in self.nodes],
+            "tensors": [tensor.to_dict() for tensor in self.tensors],
+            "metadata": _json_value(self.metadata),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(self._payload_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload_dict()
+        payload["region_fingerprint"] = self.fingerprint
+        return payload
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(
+            self.to_dict(),
+            indent=indent,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "RegionArtifact":
+        graph = value.get("graph", {})
+        selection = value.get("selection", {})
+        boundary = value.get("boundary", {})
+        metadata = value.get("metadata", {})
+        if not all(isinstance(item, Mapping) for item in (graph, selection, boundary, metadata)):
+            raise GraphPatchError("Region graph, selection, boundary, and metadata must be objects")
+        artifact = cls(
+            schema_version=int(value.get("schema_version", REGION_ARTIFACT_SCHEMA_VERSION)),
+            graph_name=str(graph.get("name", "")),
+            graph_fingerprint=str(graph.get("fingerprint", "")),
+            selected_node_ids=tuple(str(item) for item in selection.get("nodes", ())),
+            nodes=tuple(Node.from_dict(node) for node in value.get("nodes", ())),
+            tensors=tuple(Tensor.from_dict(tensor) for tensor in value.get("tensors", ())),
+            input_tensor_ids=tuple(str(item) for item in boundary.get("inputs", ())),
+            output_tensor_ids=tuple(str(item) for item in boundary.get("outputs", ())),
+            internal_tensor_ids=tuple(str(item) for item in boundary.get("internal", ())),
+            metadata=_json_value(metadata),
+        )
+        if artifact.schema_version != REGION_ARTIFACT_SCHEMA_VERSION:
+            raise GraphPatchError(
+                "Unsupported region artifact schema_version "
+                f"{artifact.schema_version}; expected "
+                f"{REGION_ARTIFACT_SCHEMA_VERSION}"
+            )
+        _validate_fingerprint(
+            value.get("region_fingerprint"),
+            artifact.fingerprint,
+            "Region artifact",
+        )
+        return artifact
+
+    @classmethod
+    def from_json(cls, value: str | bytes) -> "RegionArtifact":
+        decoded = json.loads(value)
+        if not isinstance(decoded, Mapping):
+            raise GraphPatchError("Region artifact JSON must contain an object")
+        return cls.from_dict(decoded)
+
+
+@dataclass(frozen=True)
+class GraphRegionSelection:
+    """Small region document downloaded by the interactive graph viewer.
+
+    The viewer stores node IDs plus boundary tensor contracts instead of a
+    second copy of the full graph.  Older programmatic callers may construct a
+    selection with tensor IDs alone; rich contracts are optional here, but are
+    preserved when a viewer document is parsed and serialized again.  At build
+    time the graph snapshot is reconstructed, its fingerprint is checked, and
+    the boundary is derived again.
+    """
+
+    graph_fingerprint: str
+    selected_node_ids: tuple[str, ...]
+    input_tensor_ids: tuple[str, ...]
+    output_tensor_ids: tuple[str, ...]
+    model: str = ""
+    stage: str = ""
+    instance: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = GRAPH_REGION_SELECTION_SCHEMA_VERSION
+    kind: str = GRAPH_REGION_SELECTION_KIND
+    input_contracts: tuple[Mapping[str, Any], ...] = ()
+    output_contracts: tuple[Mapping[str, Any], ...] = ()
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "GraphRegionSelection":
+        graph = value.get("graph", {})
+        selection = value.get("selection", {})
+        boundary = value.get("boundary", {})
+        if not all(isinstance(item, Mapping) for item in (graph, selection, boundary)):
+            raise GraphPatchError("Region graph, selection, and boundary must be JSON objects")
+
+        def parse_contracts(
+            raw: Any,
+            where: str,
+        ) -> tuple[tuple[str, ...], tuple[Mapping[str, Any], ...]]:
+            if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+                raise GraphPatchError(f"{where} must be a JSON array")
+            ordered: list[str] = []
+            contracts: list[Mapping[str, Any]] = []
+            seen: set[str] = set()
+            for index, contract in enumerate(raw):
+                if not isinstance(contract, Mapping):
+                    raise GraphPatchError(f"{where}[{index}] must be a JSON object")
+                tensor_id = contract.get("tensor_id")
+                if not isinstance(tensor_id, str) or not tensor_id:
+                    raise GraphPatchError(f"{where}[{index}].tensor_id must be a non-empty string")
+                if tensor_id not in seen:
+                    seen.add(tensor_id)
+                    ordered.append(tensor_id)
+                    contracts.append(_json_value(contract))
+            return tuple(ordered), tuple(contracts)
+
+        raw_node_ids = selection.get("node_ids", ())
+        if not isinstance(raw_node_ids, Sequence) or isinstance(
+            raw_node_ids, (str, bytes, bytearray)
+        ):
+            raise GraphPatchError("selection.node_ids must be a JSON array")
+        selected_node_ids = tuple(str(item) for item in raw_node_ids)
+        if not selected_node_ids or any(not item for item in selected_node_ids):
+            raise GraphPatchError("selection.node_ids must contain at least one non-empty node ID")
+        if len(selected_node_ids) != len(set(selected_node_ids)):
+            raise GraphPatchError("selection.node_ids contains duplicate node IDs")
+
+        fingerprint = graph.get("fingerprint")
+        if not isinstance(fingerprint, str) or not fingerprint:
+            raise GraphPatchError("graph.fingerprint must be a non-empty string")
+        schema_version = value.get(
+            "schema_version",
+            GRAPH_REGION_SELECTION_SCHEMA_VERSION,
+        )
+        if type(schema_version) is not int or (
+            schema_version != GRAPH_REGION_SELECTION_SCHEMA_VERSION
+        ):
+            raise GraphPatchError(
+                "Unsupported graph-region schema_version "
+                f"{schema_version!r}; expected "
+                f"{GRAPH_REGION_SELECTION_SCHEMA_VERSION}"
+            )
+        kind = value.get("kind", GRAPH_REGION_SELECTION_KIND)
+        if kind != GRAPH_REGION_SELECTION_KIND:
+            raise GraphPatchError(
+                f"Unsupported graph-region kind {kind!r}; expected {GRAPH_REGION_SELECTION_KIND!r}"
+            )
+        instance = value.get("instance", {})
+        if not isinstance(instance, Mapping):
+            raise GraphPatchError("instance must be a JSON object")
+        input_tensor_ids, input_contracts = parse_contracts(
+            boundary.get("inputs", ()),
+            "boundary.inputs",
+        )
+        output_tensor_ids, output_contracts = parse_contracts(
+            boundary.get("outputs", ()),
+            "boundary.outputs",
+        )
+
+        return cls(
+            schema_version=schema_version,
+            kind=kind,
+            graph_fingerprint=fingerprint,
+            selected_node_ids=selected_node_ids,
+            input_tensor_ids=input_tensor_ids,
+            output_tensor_ids=output_tensor_ids,
+            input_contracts=input_contracts,
+            output_contracts=output_contracts,
+            model=str(graph.get("model", "")),
+            stage=str(graph.get("stage", "")),
+            instance=_json_value(instance),
+        )
+
+    @classmethod
+    def from_json(cls, value: str | bytes) -> "GraphRegionSelection":
+        decoded = json.loads(value)
+        if not isinstance(decoded, Mapping):
+            raise GraphPatchError("Graph-region JSON must contain an object")
+        return cls.from_dict(decoded)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the viewer interchange document.
+
+        Parsed rich boundary contracts round-trip unchanged.  Selections
+        created by legacy callers with tensor IDs alone retain the compact
+        tensor-ID representation.
+        """
+
+        inputs = (
+            [_json_value(contract) for contract in self.input_contracts]
+            if self.input_contracts
+            else [{"tensor_id": tensor_id} for tensor_id in self.input_tensor_ids]
+        )
+        outputs = (
+            [_json_value(contract) for contract in self.output_contracts]
+            if self.output_contracts
+            else [{"tensor_id": tensor_id} for tensor_id in self.output_tensor_ids]
+        )
+
+        value: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "graph": {
+                "model": self.model,
+                "stage": self.stage,
+                "fingerprint": self.graph_fingerprint,
+            },
+            "selection": {
+                "node_ids": list(self.selected_node_ids),
+            },
+            "boundary": {
+                "inputs": inputs,
+                "outputs": outputs,
+            },
+        }
+        if self.instance:
+            value["instance"] = _json_value(self.instance)
+        return value
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(
+            self.to_dict(),
+            indent=indent,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+
+    def validate(self, snapshot: GraphSnapshot) -> RegionBoundary:
+        """Recompute and validate the selected cut against ``snapshot``."""
+
+        if snapshot.fingerprint != self.graph_fingerprint:
+            raise GraphPatchError(
+                "Selected graph fingerprint no longer matches the build graph: "
+                f"expected {self.graph_fingerprint}, got {snapshot.fingerprint}"
+            )
+        boundary = compute_region_boundary(snapshot, self.selected_node_ids)
+        if boundary.input_tensor_ids != self.input_tensor_ids:
+            raise GraphPatchError(
+                "Selected region input boundary no longer matches the build graph: "
+                f"expected {self.input_tensor_ids}, got "
+                f"{boundary.input_tensor_ids}"
+            )
+        if boundary.output_tensor_ids != self.output_tensor_ids:
+            raise GraphPatchError(
+                "Selected region output boundary no longer matches the build graph: "
+                f"expected {self.output_tensor_ids}, got "
+                f"{boundary.output_tensor_ids}"
+            )
+        _validate_selected_region(snapshot, boundary)
+        return boundary
+
+
+@dataclass(frozen=True)
+class GraphRegionSelectionSet:
+    """A set of independent region instances from one inspected graph.
+
+    Repeated transformer blocks are represented as separate regions instead of
+    one disconnected selection.  Every region is validated against the same
+    immutable graph snapshot and invokes the replacement callback once.
+
+    ``from_dict`` and ``from_json`` also accept the original single-region
+    document, preserving the existing viewer and YAML contract.
+    """
+
+    graph_fingerprint: str
+    selections: tuple[GraphRegionSelection, ...]
+    model: str = ""
+    stage: str = ""
+    build: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION
+    kind: str = GRAPH_REGION_SELECTION_SET_KIND
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "GraphRegionSelectionSet":
+        kind = value.get("kind")
+        if kind in (None, GRAPH_REGION_SELECTION_KIND) and "selection" in value:
+            selection = GraphRegionSelection.from_dict(value)
+            return cls(
+                graph_fingerprint=selection.graph_fingerprint,
+                selections=(selection,),
+                model=selection.model,
+                stage=selection.stage,
+            )
+        if kind != GRAPH_REGION_SELECTION_SET_KIND:
+            raise GraphPatchError(
+                "Unsupported graph-region-set kind "
+                f"{kind!r}; expected {GRAPH_REGION_SELECTION_SET_KIND!r}"
+            )
+
+        schema_version = value.get(
+            "schema_version",
+            GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION,
+        )
+        if type(schema_version) is not int or (
+            schema_version != GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION
+        ):
+            raise GraphPatchError(
+                "Unsupported graph-region-set schema_version "
+                f"{schema_version!r}; expected "
+                f"{GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION}"
+            )
+
+        graph = value.get("graph", {})
+        if not isinstance(graph, Mapping):
+            raise GraphPatchError("Region-set graph must be a JSON object")
+        fingerprint = graph.get("fingerprint")
+        if not isinstance(fingerprint, str) or not fingerprint:
+            raise GraphPatchError("graph.fingerprint must be a non-empty string")
+        model = str(graph.get("model", ""))
+        stage = str(graph.get("stage", ""))
+        build = graph.get("build", {})
+        if not isinstance(build, Mapping):
+            raise GraphPatchError("graph.build must be a JSON object")
+
+        raw_regions = value.get("regions")
+        if not isinstance(raw_regions, Sequence) or isinstance(
+            raw_regions,
+            (str, bytes, bytearray),
+        ):
+            raise GraphPatchError("regions must be a JSON array")
+        if not raw_regions:
+            raise GraphPatchError("regions must contain at least one region")
+
+        selections: list[GraphRegionSelection] = []
+        for index, raw_region in enumerate(raw_regions):
+            if not isinstance(raw_region, Mapping):
+                raise GraphPatchError(f"regions[{index}] must be a JSON object")
+            region_value: Mapping[str, Any] = raw_region
+            nested = raw_region.get("region")
+            if nested is not None:
+                if not isinstance(nested, Mapping):
+                    raise GraphPatchError(f"regions[{index}].region must be a JSON object")
+                region_value = nested
+
+            if "graph" in region_value or "kind" in region_value:
+                region_document = dict(region_value)
+                if "instance" not in region_document and isinstance(
+                    raw_region.get("instance"), Mapping
+                ):
+                    region_document["instance"] = raw_region["instance"]
+            else:
+                region_document = {
+                    "schema_version": GRAPH_REGION_SELECTION_SCHEMA_VERSION,
+                    "kind": GRAPH_REGION_SELECTION_KIND,
+                    "graph": {
+                        "model": model,
+                        "stage": stage,
+                        "fingerprint": fingerprint,
+                    },
+                    "selection": region_value.get("selection", {}),
+                    "boundary": region_value.get("boundary", {}),
+                    "instance": region_value.get(
+                        "instance",
+                        raw_region.get("instance", {}),
+                    ),
+                }
+            selection = GraphRegionSelection.from_dict(region_document)
+            if selection.graph_fingerprint != fingerprint:
+                raise GraphPatchError(
+                    f"regions[{index}] fingerprint does not match the region-set graph fingerprint"
+                )
+            if selection.model and model and selection.model != model:
+                raise GraphPatchError(
+                    f"regions[{index}] model does not match the region-set graph model"
+                )
+            if selection.stage and stage and selection.stage != stage:
+                raise GraphPatchError(
+                    f"regions[{index}] stage does not match the region-set graph stage"
+                )
+            selections.append(selection)
+
+        result = cls(
+            schema_version=schema_version,
+            kind=kind,
+            graph_fingerprint=fingerprint,
+            selections=tuple(selections),
+            model=model,
+            stage=stage,
+            build=_json_value(build),
+        )
+        result._validate_static_independence()
+        return result
+
+    @classmethod
+    def from_json(cls, value: str | bytes) -> "GraphRegionSelectionSet":
+        decoded = json.loads(value)
+        if not isinstance(decoded, Mapping):
+            raise GraphPatchError("Graph-region-set JSON must contain an object")
+        return cls.from_dict(decoded)
+
+    def to_dict(self) -> dict[str, Any]:
+        graph: dict[str, Any] = {
+            "model": self.model,
+            "stage": self.stage,
+            "fingerprint": self.graph_fingerprint,
+        }
+        if self.build:
+            graph["build"] = _json_value(self.build)
+        regions: list[dict[str, Any]] = []
+        for selection in self.selections:
+            region = selection.to_dict()
+            regions.append(
+                {
+                    "selection": region["selection"],
+                    "boundary": region["boundary"],
+                    **({"instance": region["instance"]} if "instance" in region else {}),
+                }
+            )
+        return {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "graph": graph,
+            "regions": regions,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(
+            self.to_dict(),
+            indent=indent,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+
+    def _validate_static_independence(self) -> None:
+        if type(self.schema_version) is not int or (
+            self.schema_version != GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION
+        ):
+            raise GraphPatchError(
+                "Unsupported graph-region-set schema_version "
+                f"{self.schema_version!r}; expected "
+                f"{GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION}"
+            )
+        if self.kind != GRAPH_REGION_SELECTION_SET_KIND:
+            raise GraphPatchError(
+                "Unsupported graph-region-set kind "
+                f"{self.kind!r}; expected "
+                f"{GRAPH_REGION_SELECTION_SET_KIND!r}"
+            )
+        if not isinstance(self.graph_fingerprint, str) or not self.graph_fingerprint:
+            raise GraphPatchError("A graph region set requires a non-empty graph fingerprint")
+        if not isinstance(self.build, Mapping):
+            raise GraphPatchError("Graph region-set build metadata must be a mapping")
+        if not self.selections:
+            raise GraphPatchError("A graph region set must contain at least one region")
+        owner: dict[str, int] = {}
+        for region_index, selection in enumerate(self.selections):
+            if not isinstance(selection, GraphRegionSelection):
+                raise GraphPatchError(f"Region {region_index} must be a GraphRegionSelection")
+            if (
+                selection.schema_version != GRAPH_REGION_SELECTION_SCHEMA_VERSION
+                or selection.kind != GRAPH_REGION_SELECTION_KIND
+            ):
+                raise GraphPatchError(f"Region {region_index} has an unsupported schema or kind")
+            if selection.graph_fingerprint != self.graph_fingerprint:
+                raise GraphPatchError(
+                    f"Region {region_index} fingerprint does not match "
+                    "the region-set graph fingerprint"
+                )
+            if selection.model and self.model and selection.model != self.model:
+                raise GraphPatchError(
+                    f"Region {region_index} model does not match the region-set graph model"
+                )
+            if selection.stage and self.stage and selection.stage != self.stage:
+                raise GraphPatchError(
+                    f"Region {region_index} stage does not match the region-set graph stage"
+                )
+            for node_id in selection.selected_node_ids:
+                previous = owner.get(node_id)
+                if previous is not None:
+                    raise GraphPatchError(
+                        "Graph region-set instances must not overlap: "
+                        f"node {node_id} appears in regions {previous} and "
+                        f"{region_index}"
+                    )
+                owner[node_id] = region_index
+
+    def validate(
+        self,
+        snapshot: GraphSnapshot,
+    ) -> tuple[RegionBoundary, ...]:
+        """Validate every independent instance against one original snapshot."""
+
+        self._validate_static_independence()
+        if snapshot.fingerprint != self.graph_fingerprint:
+            raise GraphPatchError(
+                "Selected graph fingerprint no longer matches the build graph: "
+                f"expected {self.graph_fingerprint}, got {snapshot.fingerprint}"
+            )
+
+        boundaries = tuple(selection.validate(snapshot) for selection in self.selections)
+        owner = {
+            node_id: region_index
+            for region_index, boundary in enumerate(boundaries)
+            for node_id in boundary.selected_node_ids
+        }
+        for tensor in snapshot.tensors:
+            producer_region = owner.get(tensor.producer)
+            if producer_region is None:
+                continue
+            for consumer in tensor.consumers:
+                consumer_region = owner.get(consumer)
+                if consumer_region is not None and consumer_region != producer_region:
+                    raise GraphPatchError(
+                        "Graph region-set instances must not directly depend "
+                        "on each other: "
+                        f"{tensor.id} connects region {producer_region} "
+                        f"to region {consumer_region}"
+                    )
+        return boundaries
+
+
+def coerce_region_selection_set(
+    selection: GraphRegionSelection | GraphRegionSelectionSet,
+) -> GraphRegionSelectionSet:
+    """Wrap the legacy single-region selection in a one-instance set."""
+
+    if isinstance(selection, GraphRegionSelectionSet):
+        return selection
+    if not isinstance(selection, GraphRegionSelection):
+        raise GraphPatchError(
+            "Graph patch selection must be a GraphRegionSelection or GraphRegionSelectionSet"
+        )
+    return GraphRegionSelectionSet(
+        graph_fingerprint=selection.graph_fingerprint,
+        selections=(selection,),
+        model=selection.model,
+        stage=selection.stage,
+    )
+
+
+def _validate_selected_region(
+    snapshot: GraphSnapshot,
+    boundary: RegionBoundary,
+) -> None:
+    """Reject disconnected or stateful regions in the first prototype."""
+
+    selected = set(boundary.selected_node_ids)
+    adjacency = {node_id: set() for node_id in selected}
+    for tensor in snapshot.tensors:
+        if tensor.producer not in selected:
+            continue
+        for consumer in tensor.consumers:
+            if consumer in selected:
+                adjacency[tensor.producer].add(consumer)
+                adjacency[consumer].add(tensor.producer)
+
+    pending = [boundary.selected_node_ids[0]]
+    visited: set[str] = set()
+    while pending:
+        node_id = pending.pop()
+        if node_id in visited:
+            continue
+        visited.add(node_id)
+        pending.extend(adjacency[node_id] - visited)
+    if visited != selected:
+        raise GraphPatchError(
+            "The graph-patch prototype requires one connected region; "
+            f"disconnected nodes: {sorted(selected - visited)}"
+        )
+
+    successors = {node.id: set() for node in snapshot.nodes}
+    for tensor in snapshot.tensors:
+        if tensor.producer is None:
+            continue
+        successors[tensor.producer].update(tensor.consumers)
+    for start in boundary.selected_node_ids:
+        pending_outside = [node_id for node_id in successors[start] if node_id not in selected]
+        visited_outside: set[str] = set()
+        while pending_outside:
+            node_id = pending_outside.pop()
+            if node_id in visited_outside:
+                continue
+            visited_outside.add(node_id)
+            for successor in successors.get(node_id, ()):
+                if successor in selected:
+                    raise GraphPatchError(
+                        "The graph-patch prototype requires a convex region; "
+                        f"an unselected path connects {start} back to {successor}"
+                    )
+                if successor not in visited_outside:
+                    pending_outside.append(successor)
+
+    unsafe_tokens = (
+        "ASSERTION",
+        "CONDITION",
+        "CONDITIONAL",
+        "DIST_COLLECTIVE",
+        "ITERATOR",
+        "KV_CACHE_UPDATE",
+        "LOOP",
+        "PLUGIN",
+        "RECURRENCE",
+    )
+    node_by_id = {node.id: node for node in snapshot.nodes}
+    unsafe = [
+        f"{node_id}:{node_by_id[node_id].op}"
+        for node_id in boundary.selected_node_ids
+        if any(token in node_by_id[node_id].op.upper() for token in unsafe_tokens)
+    ]
+    if unsafe:
+        raise GraphPatchError(
+            "The graph-patch prototype cannot replace stateful, control-flow, "
+            f"collective, or existing plugin layers: {unsafe}"
+        )
+
+
+@dataclass(frozen=True)
+class RewireResult:
+    """Receipt for a successful region replacement."""
+
+    artifact: RegionArtifact
+    replacement_outputs: tuple[Any, ...]
+    rewired_consumer_inputs: int
+    rewired_network_outputs: int
+
+
+@dataclass(frozen=True)
+class RewireBatchResult:
+    """Aggregate receipt for replacing independent region instances."""
+
+    results: tuple[RewireResult, ...]
+
+    @property
+    def region_count(self) -> int:
+        return len(self.results)
+
+    @property
+    def selected_node_count(self) -> int:
+        return sum(len(result.artifact.selected_node_ids) for result in self.results)
+
+    @property
+    def rewired_consumer_inputs(self) -> int:
+        return sum(result.rewired_consumer_inputs for result in self.results)
+
+    @property
+    def rewired_network_outputs(self) -> int:
+        return sum(result.rewired_network_outputs for result in self.results)
+
+    @property
+    def artifacts(self) -> tuple[RegionArtifact, ...]:
+        return tuple(result.artifact for result in self.results)
+
+    @property
+    def artifact(self) -> RegionArtifact:
+        """Preserve the historical accessor for one-region callers."""
+
+        if len(self.results) != 1:
+            raise GraphPatchError("A multi-region result has no single artifact; use artifacts")
+        return self.results[0].artifact
+
+
+@dataclass
+class _TensorDraft:
+    id: str
+    value: Any
+    name: str
+    dtype: str | None
+    shape: tuple[Any, ...]
+    is_shape_tensor: bool | None
+    location: str | None
+    producer: str | None = None
+    consumers: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _Capture:
+    snapshot: GraphSnapshot
+    layers: Mapping[str, Any]
+    tensors: Mapping[str, Any]
+
+
+class _TensorRegistry:
+    """Give repeated backend tensor handles deterministic snapshot IDs."""
+
+    def __init__(self) -> None:
+        self._by_object: dict[Any, str] = {}
+        self._by_identity: dict[int, str] = {}
+        self._values: list[Any] = []
+        self.drafts: list[_TensorDraft] = []
+
+    def register(self, tensor: Any) -> str:
+        try:
+            known = self._by_object.get(tensor)
+        except (TypeError, ValueError):
+            known = self._by_identity.get(id(tensor))
+        if known is not None:
+            return known
+
+        tensor_id = f"tensor:{len(self.drafts)}"
+        self._values.append(tensor)
+        try:
+            self._by_object[tensor] = tensor_id
+        except (TypeError, ValueError):
+            self._by_identity[id(tensor)] = tensor_id
+        self.drafts.append(
+            _TensorDraft(
+                id=tensor_id,
+                value=tensor,
+                name=_object_name(tensor, tensor_id),
+                dtype=_tensor_dtype(tensor),
+                shape=_tensor_shape(tensor),
+                is_shape_tensor=_optional_tensor_bool(
+                    tensor,
+                    "is_shape_tensor",
+                ),
+                location=_tensor_location(tensor),
+            )
+        )
+        return tensor_id
+
+    def draft(self, tensor_id: str) -> _TensorDraft:
+        return self.drafts[int(tensor_id.split(":", 1)[1])]
+
+
+def _count(value: Any, attribute: str, *, required: bool = False) -> int:
+    raw = getattr(value, attribute, None)
+    if raw is None:
+        if required:
+            raise GraphPatchError(f"Object does not expose required {attribute}")
+        return 0
+    if callable(raw):
+        raw = raw()
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise GraphPatchError(f"{attribute} must be an integer, got {raw!r}") from exc
+
+
+def _object_name(value: Any, fallback: str) -> str:
+    name = getattr(value, "name", None)
+    if name is None:
+        return fallback
+    text = str(name)
+    return text if text else fallback
+
+
+def _tensor_dtype(tensor: Any) -> str | None:
+    dtype = getattr(tensor, "dtype", None)
+    if dtype is None:
+        return None
+    text = str(dtype)
+    normalized = text.lower().replace("_", "")
+    if normalized in {"float16", "half", "datatype.half"}:
+        return "float16"
+    if normalized in {"bfloat16", "bf16", "datatype.bf16"}:
+        return "bfloat16"
+    if normalized in {"float32", "float", "datatype.float"}:
+        return "float32"
+    return text
+
+
+def _tensor_shape(tensor: Any) -> tuple[Any, ...]:
+    shape = getattr(tensor, "shape", None)
+    if shape is None:
+        return ()
+    try:
+        return tuple(_json_value(dimension) for dimension in shape)
+    except TypeError:
+        return (str(shape),)
+
+
+def _optional_tensor_bool(tensor: Any, attribute: str) -> bool | None:
+    try:
+        value = getattr(tensor, attribute)
+    except (AttributeError, RuntimeError):
+        return None
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _tensor_location(tensor: Any) -> str | None:
+    try:
+        value = getattr(tensor, "location")
+    except (AttributeError, RuntimeError):
+        return None
+    return None if value is None else str(value)
+
+
+def _node_provenance(
+    provider: ProvenanceProvider | None,
+    layer: Any,
+    index: int,
+    node_id: str,
+    node_name: str,
+) -> Mapping[str, Any]:
+    if provider is None:
+        return {}
+    if callable(provider):
+        raw = provider(layer, index)
+    else:
+        raw = None
+        for key in (node_id, node_name, index, str(index)):
+            if key in provider:
+                raw = provider[key]
+                break
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise GraphPatchError(
+            f"Provenance for {node_id} must be a mapping, got {type(raw).__name__}"
+        )
+    return _json_value(raw)
+
+
+def _capture_network(
+    network: Any,
+    *,
+    name: str | None,
+    metadata: Mapping[str, Any] | None,
+    provenance: ProvenanceProvider | None,
+) -> _Capture:
+    layer_count = _count(network, "num_layers", required=True)
+    layers = [network.get_layer(index) for index in range(layer_count)]
+    registry = _TensorRegistry()
+
+    graph_inputs: list[str] = []
+    for index in range(_count(network, "num_inputs")):
+        tensor = network.get_input(index)
+        if tensor is not None:
+            graph_inputs.append(registry.register(tensor))
+
+    # Register outputs in graph order first so tensor IDs are stable by producer.
+    layer_output_ids: list[tuple[str | None, ...]] = []
+    for index, layer in enumerate(layers):
+        node_id = f"node:{index}"
+        output_ids: list[str | None] = []
+        for output_index in range(_count(layer, "num_outputs")):
+            tensor = layer.get_output(output_index)
+            if tensor is None:
+                output_ids.append(None)
+                continue
+            tensor_id = registry.register(tensor)
+            draft = registry.draft(tensor_id)
+            if draft.producer is not None and draft.producer != node_id:
+                raise GraphPatchError(
+                    f"Tensor {tensor_id} has multiple producers: {draft.producer} and {node_id}"
+                )
+            draft.producer = node_id
+            output_ids.append(tensor_id)
+        layer_output_ids.append(tuple(output_ids))
+
+    nodes: list[Node] = []
+    layer_bindings: dict[str, Any] = {}
+    for index, layer in enumerate(layers):
+        node_id = f"node:{index}"
+        layer_bindings[node_id] = layer
+        input_ids: list[str | None] = []
+        for input_index in range(_count(layer, "num_inputs")):
+            tensor = layer.get_input(input_index)
+            if tensor is None:
+                input_ids.append(None)
+                continue
+            tensor_id = registry.register(tensor)
+            registry.draft(tensor_id).consumers.append(node_id)
+            input_ids.append(tensor_id)
+
+        node_name = _object_name(layer, node_id)
+        raw_op = getattr(layer, "type", None)
+        if raw_op is None:
+            raw_op = getattr(layer, "op", type(layer).__name__)
+        nodes.append(
+            Node(
+                id=node_id,
+                name=node_name,
+                op=str(raw_op),
+                inputs=tuple(input_ids),
+                outputs=layer_output_ids[index],
+                provenance=_node_provenance(
+                    provenance,
+                    layer,
+                    index,
+                    node_id,
+                    node_name,
+                ),
+            )
+        )
+
+    graph_outputs: list[str] = []
+    for index in range(_count(network, "num_outputs")):
+        tensor = network.get_output(index)
+        if tensor is not None:
+            graph_outputs.append(registry.register(tensor))
+
+    tensors = tuple(
+        Tensor(
+            id=draft.id,
+            name=draft.name,
+            dtype=draft.dtype,
+            shape=draft.shape,
+            producer=draft.producer,
+            consumers=tuple(draft.consumers),
+            is_shape_tensor=draft.is_shape_tensor,
+            location=draft.location,
+        )
+        for draft in registry.drafts
+    )
+    snapshot = GraphSnapshot(
+        name=(str(name) if name is not None else _object_name(network, "forward")),
+        nodes=tuple(nodes),
+        tensors=tensors,
+        inputs=tuple(graph_inputs),
+        outputs=tuple(graph_outputs),
+        metadata=_json_value(metadata or {}),
+    )
+    snapshot._validate_references()
+    return _Capture(
+        snapshot=snapshot,
+        layers=layer_bindings,
+        tensors={draft.id: draft.value for draft in registry.drafts},
+    )
+
+
+def snapshot_network(
+    network: Any,
+    *,
+    name: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    provenance: ProvenanceProvider | None = None,
+) -> GraphSnapshot:
+    """Snapshot an ``INetworkDefinition``-like object without importing TRT.
+
+    ``provenance`` can be either a ``(layer, index) -> mapping`` callback or a
+    mapping keyed by node ID, layer name, integer index, or string index.  This
+    is the hook through which builder scopes/source locations can later be
+    attached to the graph viewer.
+    """
+
+    return _capture_network(
+        network,
+        name=name,
+        metadata=metadata,
+        provenance=provenance,
+    ).snapshot
+
+
+def compute_region_boundary(
+    snapshot: GraphSnapshot,
+    selected_node_ids: Sequence[str],
+) -> RegionBoundary:
+    """Infer the ordered graph cut around ``selected_node_ids``."""
+
+    selected_requested = set(selected_node_ids)
+    if not selected_requested:
+        raise GraphPatchError("A graph region must select at least one node")
+    all_node_ids = {node.id for node in snapshot.nodes}
+    unknown = selected_requested - all_node_ids
+    if unknown:
+        raise GraphPatchError(f"Selected unknown node IDs: {sorted(unknown)}")
+
+    selected_nodes = tuple(node for node in snapshot.nodes if node.id in selected_requested)
+    selected = {node.id for node in selected_nodes}
+    tensor_by_id = {tensor.id: tensor for tensor in snapshot.tensors}
+    graph_outputs = set(snapshot.outputs)
+
+    input_ids: list[str] = []
+    output_ids: list[str] = []
+    internal_ids: list[str] = []
+    seen_inputs: set[str] = set()
+    seen_outputs: set[str] = set()
+    seen_internal: set[str] = set()
+
+    for node in selected_nodes:
+        for tensor_id in node.inputs:
+            if tensor_id is None or tensor_id in seen_inputs:
+                continue
+            if tensor_by_id[tensor_id].producer not in selected:
+                seen_inputs.add(tensor_id)
+                input_ids.append(tensor_id)
+
+    for node in selected_nodes:
+        for tensor_id in node.outputs:
+            if tensor_id is None:
+                continue
+            tensor = tensor_by_id[tensor_id]
+            is_output = tensor_id in graph_outputs or any(
+                consumer not in selected for consumer in tensor.consumers
+            )
+            if is_output and tensor_id not in seen_outputs:
+                seen_outputs.add(tensor_id)
+                output_ids.append(tensor_id)
+            elif not is_output and tensor_id not in seen_internal:
+                seen_internal.add(tensor_id)
+                internal_ids.append(tensor_id)
+
+    return RegionBoundary(
+        selected_node_ids=tuple(node.id for node in selected_nodes),
+        input_tensor_ids=tuple(input_ids),
+        output_tensor_ids=tuple(output_ids),
+        internal_tensor_ids=tuple(internal_ids),
+    )
+
+
+def create_region_artifact(
+    snapshot: GraphSnapshot,
+    selected_node_ids: Sequence[str],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> RegionArtifact:
+    """Create the portable contract a graph-selection UI would save."""
+
+    boundary = compute_region_boundary(snapshot, selected_node_ids)
+    selected = set(boundary.selected_node_ids)
+    nodes = tuple(node for node in snapshot.nodes if node.id in selected)
+    relevant_tensor_ids = {
+        tensor_id
+        for node in nodes
+        for tensor_id in (*node.inputs, *node.outputs)
+        if tensor_id is not None
+    }
+    tensors = tuple(tensor for tensor in snapshot.tensors if tensor.id in relevant_tensor_ids)
+    return RegionArtifact(
+        graph_name=snapshot.name,
+        graph_fingerprint=snapshot.fingerprint,
+        selected_node_ids=boundary.selected_node_ids,
+        nodes=nodes,
+        tensors=tensors,
+        input_tensor_ids=boundary.input_tensor_ids,
+        output_tensor_ids=boundary.output_tensor_ids,
+        internal_tensor_ids=boundary.internal_tensor_ids,
+        metadata=_json_value(metadata or {}),
+    )
+
+
+def rewire_region(
+    network: Any,
+    snapshot: GraphSnapshot,
+    selected_node_ids: Sequence[str],
+    replacement: ReplacementCallback,
+    *,
+    provenance: ProvenanceProvider | None = None,
+) -> RewireResult:
+    """Replace a selected region by rewiring all of its external uses.
+
+    The callback receives ``(network, boundary_inputs, region_artifact)`` and
+    returns one live backend tensor per ordered boundary output.  The helper
+    validates the snapshot against the live network before calling it, rewires
+    all external consumer slots with ``set_input``, and updates marked network
+    outputs through ``unmark_output``/``mark_output`` when needed.
+    """
+
+    live = _capture_network(
+        network,
+        name=snapshot.name,
+        metadata=snapshot.metadata,
+        provenance=provenance,
+    )
+    if live.snapshot.fingerprint != snapshot.fingerprint:
+        raise GraphPatchError(
+            "Live graph no longer matches the selected graph snapshot: "
+            f"expected {snapshot.fingerprint}, got {live.snapshot.fingerprint}"
+        )
+
+    artifact = create_region_artifact(snapshot, selected_node_ids)
+    return _rewire_captured_regions(
+        network,
+        snapshot,
+        live,
+        (artifact,),
+        replacement,
+    ).results[0]
+
+
+@dataclass(frozen=True)
+class _RewirePlan:
+    artifact: RegionArtifact
+    boundary_inputs: tuple[Any, ...]
+    external_slots: tuple[tuple[Any, int, int], ...]
+    marked_output_ids: frozenset[str]
+
+
+def _rewire_captured_regions(
+    network: Any,
+    snapshot: GraphSnapshot,
+    live: _Capture,
+    artifacts: Sequence[RegionArtifact],
+    replacement: ReplacementCallback,
+) -> RewireBatchResult:
+    """Plan and apply all rewires against one pre-callback live capture."""
+
+    plans: list[_RewirePlan] = []
+    for artifact in artifacts:
+        selected = set(artifact.selected_node_ids)
+        output_index_by_id = {
+            tensor_id: index for index, tensor_id in enumerate(artifact.output_tensor_ids)
+        }
+        external_slots: list[tuple[Any, int, int]] = []
+        for node in snapshot.nodes:
+            if node.id in selected:
+                continue
+            for input_index, input_tensor_id in enumerate(node.inputs):
+                output_index = output_index_by_id.get(input_tensor_id)
+                if output_index is None:
+                    continue
+                layer = live.layers[node.id]
+                if not callable(getattr(layer, "set_input", None)):
+                    raise GraphPatchError(f"External consumer {node.id} does not expose set_input")
+                external_slots.append((layer, input_index, output_index))
+
+        marked_output_ids = frozenset(snapshot.outputs) & frozenset(artifact.output_tensor_ids)
+        if marked_output_ids and (
+            not callable(getattr(network, "unmark_output", None))
+            or not callable(getattr(network, "mark_output", None))
+        ):
+            raise GraphPatchError(
+                "Selected region feeds a network output, but the network does "
+                "not expose unmark_output/mark_output"
+            )
+        plans.append(
+            _RewirePlan(
+                artifact=artifact,
+                boundary_inputs=tuple(
+                    live.tensors[tensor_id] for tensor_id in artifact.input_tensor_ids
+                ),
+                external_slots=tuple(external_slots),
+                marked_output_ids=marked_output_ids,
+            )
+        )
+
+    # Invoke every replacement and validate every output contract before
+    # rewiring the original graph.  A failing callback therefore cannot leave
+    # only a prefix of consumer slots rewired.
+    outputs_by_plan: list[tuple[Any, ...]] = []
+    for region_index, plan in enumerate(plans):
+        raw_outputs = replacement(
+            network,
+            plan.boundary_inputs,
+            plan.artifact,
+        )
+        try:
+            replacement_outputs = tuple(raw_outputs)
+        except TypeError as exc:
+            raise GraphPatchError(
+                f"Replacement for region {region_index} did not return an output sequence"
+            ) from exc
+        if len(replacement_outputs) != len(plan.artifact.output_tensor_ids):
+            raise GraphPatchError(
+                "Replacement returned "
+                f"{len(replacement_outputs)} outputs for region "
+                f"{region_index}, which has "
+                f"{len(plan.artifact.output_tensor_ids)} boundary outputs"
+            )
+        if any(output is None for output in replacement_outputs):
+            raise GraphPatchError(
+                f"Replacement outputs for region {region_index} cannot contain None"
+            )
+        outputs_by_plan.append(replacement_outputs)
+
+    results: list[RewireResult] = []
+    for plan, replacement_outputs in zip(plans, outputs_by_plan):
+        for layer, input_index, output_index in plan.external_slots:
+            layer.set_input(input_index, replacement_outputs[output_index])
+
+        rewired_network_outputs = 0
+        replacement_by_id = dict(zip(plan.artifact.output_tensor_ids, replacement_outputs))
+        for tensor_id in snapshot.outputs:
+            if tensor_id not in plan.marked_output_ids:
+                continue
+            old_output = live.tensors[tensor_id]
+            new_output = replacement_by_id[tensor_id]
+            old_name = getattr(old_output, "name", None)
+            network.unmark_output(old_output)
+            if old_name is not None and hasattr(new_output, "name"):
+                try:
+                    new_output.name = old_name
+                except (AttributeError, TypeError):
+                    pass
+            network.mark_output(new_output)
+            rewired_network_outputs += 1
+
+        results.append(
+            RewireResult(
+                artifact=plan.artifact,
+                replacement_outputs=replacement_outputs,
+                rewired_consumer_inputs=len(plan.external_slots),
+                rewired_network_outputs=rewired_network_outputs,
+            )
+        )
+    return RewireBatchResult(results=tuple(results))
+
+
+def rewire_selection(
+    network: Any,
+    snapshot: GraphSnapshot,
+    selection: GraphRegionSelection,
+    replacement: ReplacementCallback,
+    *,
+    provenance: ProvenanceProvider | None = None,
+) -> RewireResult:
+    """Validate a viewer-downloaded selection and replace that exact region."""
+
+    selection.validate(snapshot)
+    return rewire_selection_set(
+        network,
+        snapshot,
+        coerce_region_selection_set(selection),
+        replacement,
+        provenance=provenance,
+    ).results[0]
+
+
+def rewire_selection_set(
+    network: Any,
+    snapshot: GraphSnapshot,
+    selection_set: GraphRegionSelectionSet,
+    replacement: ReplacementCallback,
+    *,
+    provenance: ProvenanceProvider | None = None,
+) -> RewireBatchResult:
+    """Replace every independent region against the same original snapshot."""
+
+    selection_set.validate(snapshot)
+    live = _capture_network(
+        network,
+        name=snapshot.name,
+        metadata=snapshot.metadata,
+        provenance=provenance,
+    )
+    if live.snapshot.fingerprint != snapshot.fingerprint:
+        raise GraphPatchError(
+            "Live graph no longer matches the selected graph snapshot: "
+            f"expected {snapshot.fingerprint}, got "
+            f"{live.snapshot.fingerprint}"
+        )
+    artifacts = tuple(
+        create_region_artifact(
+            snapshot,
+            selection.selected_node_ids,
+            metadata=(
+                {"instance": _json_value(selection.instance)} if selection.instance else None
+            ),
+        )
+        for selection in selection_set.selections
+    )
+    return _rewire_captured_regions(
+        network,
+        snapshot,
+        live,
+        artifacts,
+        replacement,
+    )

--- a/python/tensorrt_model_connect/graph_patch.py
+++ b/python/tensorrt_model_connect/graph_patch.py
@@ -11,11 +11,17 @@ The objects consumed here deliberately use a small duck-typed surface:
   and ``set_input`` when it is rewired;
 * a tensor may expose ``name``, ``dtype``, and ``shape``.
 
-This makes the graph-selection prototype unit-testable without importing
-TensorRT and keeps the eventual UI artifact independent of a TensorRT version.
+This makes graph selection unit-testable without importing TensorRT and keeps
+selection artifacts independent of a TensorRT version.
 The helper intentionally does not try to delete the selected layers.  It
 rewires every consumer outside the selected region, leaving the old region
 unreachable for the backend to prune.
+
+Replacement callbacks may add backend layers while producing their outputs.
+TensorRT does not expose a general rollback API, so callers must discard the
+entire network if a callback or later validation raises.  The helper delays
+consumer rewiring until every callback output has passed its ABI checks, but
+does not claim transactional rollback of layers created by callbacks.
 """
 
 from __future__ import annotations
@@ -413,15 +419,7 @@ class RegionArtifact:
 
 @dataclass(frozen=True)
 class GraphRegionSelection:
-    """Small region document downloaded by the interactive graph viewer.
-
-    The viewer stores node IDs plus boundary tensor contracts instead of a
-    second copy of the full graph.  Older programmatic callers may construct a
-    selection with tensor IDs alone; rich contracts are optional here, but are
-    preserved when a viewer document is parsed and serialized again.  At build
-    time the graph snapshot is reconstructed, its fingerprint is checked, and
-    the boundary is derived again.
-    """
+    """Exact structural region selection pinned to one graph fingerprint."""
 
     graph_fingerprint: str
     selected_node_ids: tuple[str, ...]
@@ -432,45 +430,71 @@ class GraphRegionSelection:
     instance: Mapping[str, Any] = field(default_factory=dict)
     schema_version: int = GRAPH_REGION_SELECTION_SCHEMA_VERSION
     kind: str = GRAPH_REGION_SELECTION_KIND
-    input_contracts: tuple[Mapping[str, Any], ...] = ()
-    output_contracts: tuple[Mapping[str, Any], ...] = ()
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "GraphRegionSelection":
+        unknown = set(value) - {
+            "schema_version",
+            "kind",
+            "graph",
+            "selection",
+            "boundary",
+            "instance",
+        }
+        if unknown:
+            raise GraphPatchError(
+                f"Unknown graph-region fields: {sorted(str(item) for item in unknown)}"
+            )
         graph = value.get("graph", {})
         selection = value.get("selection", {})
         boundary = value.get("boundary", {})
         if not all(isinstance(item, Mapping) for item in (graph, selection, boundary)):
             raise GraphPatchError("Region graph, selection, and boundary must be JSON objects")
+        for where, item, allowed in (
+            ("graph", graph, {"model", "stage", "fingerprint"}),
+            ("selection", selection, {"node_ids"}),
+            ("boundary", boundary, {"inputs", "outputs"}),
+        ):
+            extra = set(item) - allowed
+            if extra:
+                raise GraphPatchError(
+                    f"Unknown {where} fields: {sorted(str(key) for key in extra)}"
+                )
 
-        def parse_contracts(
+        def parse_tensor_refs(
             raw: Any,
             where: str,
-        ) -> tuple[tuple[str, ...], tuple[Mapping[str, Any], ...]]:
+        ) -> tuple[str, ...]:
             if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
                 raise GraphPatchError(f"{where} must be a JSON array")
             ordered: list[str] = []
-            contracts: list[Mapping[str, Any]] = []
             seen: set[str] = set()
-            for index, contract in enumerate(raw):
-                if not isinstance(contract, Mapping):
+            for index, reference in enumerate(raw):
+                if not isinstance(reference, Mapping):
                     raise GraphPatchError(f"{where}[{index}] must be a JSON object")
-                tensor_id = contract.get("tensor_id")
+                extra = set(reference) - {"tensor_id"}
+                if extra:
+                    raise GraphPatchError(
+                        f"Unknown {where}[{index}] fields: {sorted(str(key) for key in extra)}"
+                    )
+                tensor_id = reference.get("tensor_id")
                 if not isinstance(tensor_id, str) or not tensor_id:
                     raise GraphPatchError(f"{where}[{index}].tensor_id must be a non-empty string")
-                if tensor_id not in seen:
-                    seen.add(tensor_id)
-                    ordered.append(tensor_id)
-                    contracts.append(_json_value(contract))
-            return tuple(ordered), tuple(contracts)
+                if tensor_id in seen:
+                    raise GraphPatchError(f"{where} contains duplicate tensor ID {tensor_id}")
+                seen.add(tensor_id)
+                ordered.append(tensor_id)
+            return tuple(ordered)
 
         raw_node_ids = selection.get("node_ids", ())
         if not isinstance(raw_node_ids, Sequence) or isinstance(
             raw_node_ids, (str, bytes, bytearray)
         ):
             raise GraphPatchError("selection.node_ids must be a JSON array")
-        selected_node_ids = tuple(str(item) for item in raw_node_ids)
-        if not selected_node_ids or any(not item for item in selected_node_ids):
+        if any(not isinstance(item, str) or not item for item in raw_node_ids):
+            raise GraphPatchError("selection.node_ids must contain at least one non-empty node ID")
+        selected_node_ids = tuple(raw_node_ids)
+        if not selected_node_ids:
             raise GraphPatchError("selection.node_ids must contain at least one non-empty node ID")
         if len(selected_node_ids) != len(set(selected_node_ids)):
             raise GraphPatchError("selection.node_ids contains duplicate node IDs")
@@ -478,10 +502,7 @@ class GraphRegionSelection:
         fingerprint = graph.get("fingerprint")
         if not isinstance(fingerprint, str) or not fingerprint:
             raise GraphPatchError("graph.fingerprint must be a non-empty string")
-        schema_version = value.get(
-            "schema_version",
-            GRAPH_REGION_SELECTION_SCHEMA_VERSION,
-        )
+        schema_version = value.get("schema_version")
         if type(schema_version) is not int or (
             schema_version != GRAPH_REGION_SELECTION_SCHEMA_VERSION
         ):
@@ -490,7 +511,7 @@ class GraphRegionSelection:
                 f"{schema_version!r}; expected "
                 f"{GRAPH_REGION_SELECTION_SCHEMA_VERSION}"
             )
-        kind = value.get("kind", GRAPH_REGION_SELECTION_KIND)
+        kind = value.get("kind")
         if kind != GRAPH_REGION_SELECTION_KIND:
             raise GraphPatchError(
                 f"Unsupported graph-region kind {kind!r}; expected {GRAPH_REGION_SELECTION_KIND!r}"
@@ -498,11 +519,17 @@ class GraphRegionSelection:
         instance = value.get("instance", {})
         if not isinstance(instance, Mapping):
             raise GraphPatchError("instance must be a JSON object")
-        input_tensor_ids, input_contracts = parse_contracts(
+        model = graph.get("model", "")
+        stage = graph.get("stage", "")
+        if not isinstance(model, str):
+            raise GraphPatchError("graph.model must be a string")
+        if not isinstance(stage, str):
+            raise GraphPatchError("graph.stage must be a string")
+        input_tensor_ids = parse_tensor_refs(
             boundary.get("inputs", ()),
             "boundary.inputs",
         )
-        output_tensor_ids, output_contracts = parse_contracts(
+        output_tensor_ids = parse_tensor_refs(
             boundary.get("outputs", ()),
             "boundary.outputs",
         )
@@ -514,10 +541,8 @@ class GraphRegionSelection:
             selected_node_ids=selected_node_ids,
             input_tensor_ids=input_tensor_ids,
             output_tensor_ids=output_tensor_ids,
-            input_contracts=input_contracts,
-            output_contracts=output_contracts,
-            model=str(graph.get("model", "")),
-            stage=str(graph.get("stage", "")),
+            model=model,
+            stage=stage,
             instance=_json_value(instance),
         )
 
@@ -529,24 +554,6 @@ class GraphRegionSelection:
         return cls.from_dict(decoded)
 
     def to_dict(self) -> dict[str, Any]:
-        """Return the viewer interchange document.
-
-        Parsed rich boundary contracts round-trip unchanged.  Selections
-        created by legacy callers with tensor IDs alone retain the compact
-        tensor-ID representation.
-        """
-
-        inputs = (
-            [_json_value(contract) for contract in self.input_contracts]
-            if self.input_contracts
-            else [{"tensor_id": tensor_id} for tensor_id in self.input_tensor_ids]
-        )
-        outputs = (
-            [_json_value(contract) for contract in self.output_contracts]
-            if self.output_contracts
-            else [{"tensor_id": tensor_id} for tensor_id in self.output_tensor_ids]
-        )
-
         value: dict[str, Any] = {
             "schema_version": self.schema_version,
             "kind": self.kind,
@@ -559,8 +566,8 @@ class GraphRegionSelection:
                 "node_ids": list(self.selected_node_ids),
             },
             "boundary": {
-                "inputs": inputs,
-                "outputs": outputs,
+                "inputs": [{"tensor_id": tensor_id} for tensor_id in self.input_tensor_ids],
+                "outputs": [{"tensor_id": tensor_id} for tensor_id in self.output_tensor_ids],
             },
         }
         if self.instance:
@@ -579,12 +586,45 @@ class GraphRegionSelection:
     def validate(self, snapshot: GraphSnapshot) -> RegionBoundary:
         """Recompute and validate the selected cut against ``snapshot``."""
 
+        if type(self.schema_version) is not int or (
+            self.schema_version != GRAPH_REGION_SELECTION_SCHEMA_VERSION
+        ):
+            raise GraphPatchError(
+                "Unsupported graph-region schema_version "
+                f"{self.schema_version!r}; expected "
+                f"{GRAPH_REGION_SELECTION_SCHEMA_VERSION}"
+            )
+        if self.kind != GRAPH_REGION_SELECTION_KIND:
+            raise GraphPatchError(
+                f"Unsupported graph-region kind {self.kind!r}; "
+                f"expected {GRAPH_REGION_SELECTION_KIND!r}"
+            )
+        if not isinstance(self.graph_fingerprint, str) or not self.graph_fingerprint:
+            raise GraphPatchError("graph.fingerprint must be a non-empty string")
+        if not isinstance(self.instance, Mapping):
+            raise GraphPatchError("instance must be a mapping")
+        if not isinstance(self.model, str) or not isinstance(self.stage, str):
+            raise GraphPatchError("Region model and stage must be strings")
+        if not self.selected_node_ids or len(self.selected_node_ids) != len(
+            set(self.selected_node_ids)
+        ):
+            raise GraphPatchError("selection.node_ids must contain unique, non-empty node IDs")
+        if any(not item for item in self.selected_node_ids):
+            raise GraphPatchError("selection.node_ids must contain unique, non-empty node IDs")
+        if len(self.input_tensor_ids) != len(set(self.input_tensor_ids)):
+            raise GraphPatchError("Region input boundary contains duplicate tensor IDs")
+        if len(self.output_tensor_ids) != len(set(self.output_tensor_ids)):
+            raise GraphPatchError("Region output boundary contains duplicate tensor IDs")
+        if any(not item for item in self.input_tensor_ids):
+            raise GraphPatchError("Region input boundary contains an empty tensor ID")
+        if any(not item for item in self.output_tensor_ids):
+            raise GraphPatchError("Region output boundary contains an empty tensor ID")
         if snapshot.fingerprint != self.graph_fingerprint:
             raise GraphPatchError(
                 "Selected graph fingerprint no longer matches the build graph: "
                 f"expected {self.graph_fingerprint}, got {snapshot.fingerprint}"
             )
-        boundary = compute_region_boundary(snapshot, self.selected_node_ids)
+        boundary = validate_region(snapshot, self.selected_node_ids)
         if boundary.input_tensor_ids != self.input_tensor_ids:
             raise GraphPatchError(
                 "Selected region input boundary no longer matches the build graph: "
@@ -597,20 +637,19 @@ class GraphRegionSelection:
                 f"expected {self.output_tensor_ids}, got "
                 f"{boundary.output_tensor_ids}"
             )
-        _validate_selected_region(snapshot, boundary)
         return boundary
 
 
 @dataclass(frozen=True)
 class GraphRegionSelectionSet:
-    """A set of independent region instances from one inspected graph.
+    """A set of independent region instances from one graph snapshot.
 
     Repeated transformer blocks are represented as separate regions instead of
     one disconnected selection.  Every region is validated against the same
     immutable graph snapshot and invokes the replacement callback once.
 
     ``from_dict`` and ``from_json`` also accept the original single-region
-    document, preserving the existing viewer and YAML contract.
+    structural document.
     """
 
     graph_fingerprint: str
@@ -624,7 +663,7 @@ class GraphRegionSelectionSet:
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "GraphRegionSelectionSet":
         kind = value.get("kind")
-        if kind in (None, GRAPH_REGION_SELECTION_KIND) and "selection" in value:
+        if kind == GRAPH_REGION_SELECTION_KIND and "selection" in value:
             selection = GraphRegionSelection.from_dict(value)
             return cls(
                 graph_fingerprint=selection.graph_fingerprint,
@@ -632,16 +671,23 @@ class GraphRegionSelectionSet:
                 model=selection.model,
                 stage=selection.stage,
             )
+        unknown = set(value) - {
+            "schema_version",
+            "kind",
+            "graph",
+            "regions",
+        }
+        if unknown:
+            raise GraphPatchError(
+                f"Unknown graph-region-set fields: {sorted(str(item) for item in unknown)}"
+            )
         if kind != GRAPH_REGION_SELECTION_SET_KIND:
             raise GraphPatchError(
                 "Unsupported graph-region-set kind "
                 f"{kind!r}; expected {GRAPH_REGION_SELECTION_SET_KIND!r}"
             )
 
-        schema_version = value.get(
-            "schema_version",
-            GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION,
-        )
+        schema_version = value.get("schema_version")
         if type(schema_version) is not int or (
             schema_version != GRAPH_REGION_SELECTION_SET_SCHEMA_VERSION
         ):
@@ -654,11 +700,20 @@ class GraphRegionSelectionSet:
         graph = value.get("graph", {})
         if not isinstance(graph, Mapping):
             raise GraphPatchError("Region-set graph must be a JSON object")
+        unknown_graph = set(graph) - {"model", "stage", "fingerprint", "build"}
+        if unknown_graph:
+            raise GraphPatchError(
+                f"Unknown graph fields: {sorted(str(item) for item in unknown_graph)}"
+            )
         fingerprint = graph.get("fingerprint")
         if not isinstance(fingerprint, str) or not fingerprint:
             raise GraphPatchError("graph.fingerprint must be a non-empty string")
-        model = str(graph.get("model", ""))
-        stage = str(graph.get("stage", ""))
+        model = graph.get("model", "")
+        stage = graph.get("stage", "")
+        if not isinstance(model, str):
+            raise GraphPatchError("graph.model must be a string")
+        if not isinstance(stage, str):
+            raise GraphPatchError("graph.stage must be a string")
         build = graph.get("build", {})
         if not isinstance(build, Mapping):
             raise GraphPatchError("graph.build must be a JSON object")
@@ -676,35 +731,28 @@ class GraphRegionSelectionSet:
         for index, raw_region in enumerate(raw_regions):
             if not isinstance(raw_region, Mapping):
                 raise GraphPatchError(f"regions[{index}] must be a JSON object")
-            region_value: Mapping[str, Any] = raw_region
-            nested = raw_region.get("region")
-            if nested is not None:
-                if not isinstance(nested, Mapping):
-                    raise GraphPatchError(f"regions[{index}].region must be a JSON object")
-                region_value = nested
-
-            if "graph" in region_value or "kind" in region_value:
-                region_document = dict(region_value)
-                if "instance" not in region_document and isinstance(
-                    raw_region.get("instance"), Mapping
-                ):
-                    region_document["instance"] = raw_region["instance"]
-            else:
-                region_document = {
-                    "schema_version": GRAPH_REGION_SELECTION_SCHEMA_VERSION,
-                    "kind": GRAPH_REGION_SELECTION_KIND,
-                    "graph": {
-                        "model": model,
-                        "stage": stage,
-                        "fingerprint": fingerprint,
-                    },
-                    "selection": region_value.get("selection", {}),
-                    "boundary": region_value.get("boundary", {}),
-                    "instance": region_value.get(
-                        "instance",
-                        raw_region.get("instance", {}),
-                    ),
-                }
+            unknown_region = set(raw_region) - {
+                "selection",
+                "boundary",
+                "instance",
+            }
+            if unknown_region:
+                raise GraphPatchError(
+                    f"Unknown regions[{index}] fields: "
+                    f"{sorted(str(item) for item in unknown_region)}"
+                )
+            region_document = {
+                "schema_version": GRAPH_REGION_SELECTION_SCHEMA_VERSION,
+                "kind": GRAPH_REGION_SELECTION_KIND,
+                "graph": {
+                    "model": model,
+                    "stage": stage,
+                    "fingerprint": fingerprint,
+                },
+                "selection": raw_region.get("selection", {}),
+                "boundary": raw_region.get("boundary", {}),
+                "instance": raw_region.get("instance", {}),
+            }
             selection = GraphRegionSelection.from_dict(region_document)
             if selection.graph_fingerprint != fingerprint:
                 raise GraphPatchError(
@@ -792,6 +840,8 @@ class GraphRegionSelectionSet:
             raise GraphPatchError("A graph region set requires a non-empty graph fingerprint")
         if not isinstance(self.build, Mapping):
             raise GraphPatchError("Graph region-set build metadata must be a mapping")
+        if not isinstance(self.model, str) or not isinstance(self.stage, str):
+            raise GraphPatchError("Graph region-set model and stage must be strings")
         if not self.selections:
             raise GraphPatchError("A graph region set must contain at least one region")
         owner: dict[str, int] = {}
@@ -942,6 +992,7 @@ def _validate_selected_region(
         "LOOP",
         "PLUGIN",
         "RECURRENCE",
+        "TRIP_LIMIT",
     )
     node_by_id = {node.id: node for node in snapshot.nodes}
     unsafe = [
@@ -954,6 +1005,17 @@ def _validate_selected_region(
             "The graph-patch prototype cannot replace stateful, control-flow, "
             f"collective, or existing plugin layers: {unsafe}"
         )
+
+
+def validate_region(
+    snapshot: GraphSnapshot,
+    selected_node_ids: Sequence[str],
+) -> RegionBoundary:
+    """Derive a boundary and enforce structural replacement safety."""
+
+    boundary = compute_region_boundary(snapshot, selected_node_ids)
+    _validate_selected_region(snapshot, boundary)
+    return boundary
 
 
 @dataclass(frozen=True)
@@ -1015,35 +1077,82 @@ class _TensorDraft:
 
 
 @dataclass(frozen=True)
-class _Capture:
+class CapturedGraph:
+    """One graph snapshot plus identity-safe live-handle lookup."""
+
     snapshot: GraphSnapshot
-    layers: Mapping[str, Any]
-    tensors: Mapping[str, Any]
+    _layers: Mapping[str, Any] = field(repr=False)
+    _tensors: Mapping[str, Any] = field(repr=False)
+    _node_ids_by_identity: Mapping[int, tuple[str, ...]] = field(repr=False)
+    _tensor_ids_by_identity: Mapping[int, str] = field(repr=False)
+    _node_ids_by_signature: Mapping[
+        tuple[
+            str,
+            str,
+            tuple[str | None, ...],
+            tuple[str | None, ...],
+        ],
+        tuple[str, ...],
+    ] = field(repr=False)
+
+    def node_id_for(self, layer: Any) -> str:
+        identity_candidates = self._node_ids_by_identity.get(id(layer), ())
+        if len(identity_candidates) == 1 and self._layers[identity_candidates[0]] is layer:
+            return identity_candidates[0]
+        # TensorRT can expose one C++ layer through a typed wrapper returned by
+        # add_*() and a distinct generic ILayer wrapper from get_layer().  Its
+        # ordered tensor handles are stable across those wrappers.
+        try:
+            signature = _layer_signature(layer, self.tensor_id_for)
+        except (
+            AttributeError,
+            GraphPatchError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ):
+            signature = None
+        candidates = () if signature is None else self._node_ids_by_signature.get(signature, ())
+        if len(candidates) != 1:
+            raise GraphPatchError("Layer handle does not belong to this captured graph")
+        return candidates[0]
+
+    def tensor_id_for(self, tensor: Any) -> str:
+        tensor_id = self._tensor_ids_by_identity.get(id(tensor))
+        if tensor_id is None or self._tensors[tensor_id] is not tensor:
+            raise GraphPatchError("Tensor handle does not belong to this captured graph")
+        return tensor_id
+
+    def _layer_for(self, node_id: str) -> Any:
+        return self._layers[node_id]
+
+    def _tensor_for(self, tensor_id: str) -> Any:
+        return self._tensors[tensor_id]
+
+    def _original_tensor_id(self, tensor: Any) -> str | None:
+        tensor_id = self._tensor_ids_by_identity.get(id(tensor))
+        if tensor_id is None or self._tensors[tensor_id] is not tensor:
+            return None
+        return tensor_id
 
 
 class _TensorRegistry:
     """Give repeated backend tensor handles deterministic snapshot IDs."""
 
     def __init__(self) -> None:
-        self._by_object: dict[Any, str] = {}
         self._by_identity: dict[int, str] = {}
+        # Strong references prevent object-id reuse during one capture.
         self._values: list[Any] = []
         self.drafts: list[_TensorDraft] = []
 
     def register(self, tensor: Any) -> str:
-        try:
-            known = self._by_object.get(tensor)
-        except (TypeError, ValueError):
-            known = self._by_identity.get(id(tensor))
+        known = self._by_identity.get(id(tensor))
         if known is not None:
             return known
 
         tensor_id = f"tensor:{len(self.drafts)}"
         self._values.append(tensor)
-        try:
-            self._by_object[tensor] = tensor_id
-        except (TypeError, ValueError):
-            self._by_identity[id(tensor)] = tensor_id
+        self._by_identity[id(tensor)] = tensor_id
         self.drafts.append(
             _TensorDraft(
                 id=tensor_id,
@@ -1076,6 +1185,39 @@ def _count(value: Any, attribute: str, *, required: bool = False) -> int:
         return int(raw)
     except (TypeError, ValueError) as exc:
         raise GraphPatchError(f"{attribute} must be an integer, got {raw!r}") from exc
+
+
+def _layer_signature(
+    layer: Any,
+    tensor_id_for: Callable[[Any], str],
+) -> tuple[
+    str,
+    str,
+    tuple[str | None, ...],
+    tuple[str | None, ...],
+]:
+    name = getattr(layer, "name", None)
+    raw_op = getattr(layer, "type", None)
+    if raw_op is None:
+        raw_op = getattr(layer, "op", type(layer).__name__)
+
+    def ids(method_name: str, count_name: str) -> tuple[str | None, ...]:
+        method = getattr(layer, method_name, None)
+        count = _count(layer, count_name, required=True)
+        if not callable(method):
+            raise GraphPatchError(f"Layer does not expose required {method_name}")
+        result: list[str | None] = []
+        for index in range(count):
+            tensor = method(index)
+            result.append(None if tensor is None else tensor_id_for(tensor))
+        return tuple(result)
+
+    return (
+        "" if name is None else str(name),
+        str(raw_op),
+        ids("get_input", "num_inputs"),
+        ids("get_output", "num_outputs"),
+    )
 
 
 def _object_name(value: Any, fallback: str) -> str:
@@ -1155,13 +1297,14 @@ def _node_provenance(
     return _json_value(raw)
 
 
-def _capture_network(
+def capture_network(
     network: Any,
     *,
-    name: str | None,
-    metadata: Mapping[str, Any] | None,
-    provenance: ProvenanceProvider | None,
-) -> _Capture:
+    name: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    provenance: ProvenanceProvider | None = None,
+) -> CapturedGraph:
+    """Capture a graph and retain live object-to-ID bindings by identity."""
     layer_count = _count(network, "num_layers", required=True)
     layers = [network.get_layer(index) for index in range(layer_count)]
     registry = _TensorRegistry()
@@ -1256,10 +1399,45 @@ def _capture_network(
         metadata=_json_value(metadata or {}),
     )
     snapshot._validate_references()
-    return _Capture(
+    tensor_bindings = {draft.id: draft.value for draft in registry.drafts}
+    tensor_ids_by_identity = {
+        id(tensor): tensor_id for tensor_id, tensor in tensor_bindings.items()
+    }
+
+    def captured_tensor_id(tensor: Any) -> str:
+        tensor_id = tensor_ids_by_identity.get(id(tensor))
+        if tensor_id is None or tensor_bindings[tensor_id] is not tensor:
+            raise GraphPatchError("Layer signature references an uncaptured tensor")
+        return tensor_id
+
+    signature_owners: dict[
+        tuple[
+            str,
+            str,
+            tuple[str | None, ...],
+            tuple[str | None, ...],
+        ],
+        list[str],
+    ] = {}
+    for node_id, layer in layer_bindings.items():
+        signature = _layer_signature(layer, captured_tensor_id)
+        signature_owners.setdefault(signature, []).append(node_id)
+
+    identity_owners: dict[int, list[str]] = {}
+    for node_id, layer in layer_bindings.items():
+        identity_owners.setdefault(id(layer), []).append(node_id)
+
+    return CapturedGraph(
         snapshot=snapshot,
-        layers=layer_bindings,
-        tensors={draft.id: draft.value for draft in registry.drafts},
+        _layers=layer_bindings,
+        _tensors=tensor_bindings,
+        _node_ids_by_identity={
+            identity: tuple(node_ids) for identity, node_ids in identity_owners.items()
+        },
+        _tensor_ids_by_identity=tensor_ids_by_identity,
+        _node_ids_by_signature={
+            signature: tuple(node_ids) for signature, node_ids in signature_owners.items()
+        },
     )
 
 
@@ -1275,10 +1453,10 @@ def snapshot_network(
     ``provenance`` can be either a ``(layer, index) -> mapping`` callback or a
     mapping keyed by node ID, layer name, integer index, or string index.  This
     is the hook through which builder scopes/source locations can later be
-    attached to the graph viewer.
+    attached to diagnostic graph artifacts.
     """
 
-    return _capture_network(
+    return capture_network(
         network,
         name=name,
         metadata=metadata,
@@ -1349,9 +1527,9 @@ def create_region_artifact(
     *,
     metadata: Mapping[str, Any] | None = None,
 ) -> RegionArtifact:
-    """Create the portable contract a graph-selection UI would save."""
+    """Create a portable contract for a structurally safe region."""
 
-    boundary = compute_region_boundary(snapshot, selected_node_ids)
+    boundary = validate_region(snapshot, selected_node_ids)
     selected = set(boundary.selected_node_ids)
     nodes = tuple(node for node in snapshot.nodes if node.id in selected)
     relevant_tensor_ids = {
@@ -1385,13 +1563,17 @@ def rewire_region(
     """Replace a selected region by rewiring all of its external uses.
 
     The callback receives ``(network, boundary_inputs, region_artifact)`` and
-    returns one live backend tensor per ordered boundary output.  The helper
+    returns one newly created live backend tensor per ordered boundary output;
+    returning a tensor from the original graph is rejected.  The helper
     validates the snapshot against the live network before calling it, rewires
     all external consumer slots with ``set_input``, and updates marked network
     outputs through ``unmark_output``/``mark_output`` when needed.
+
+    If this function raises after invoking ``replacement``, discard ``network``;
+    callback-created layers cannot be rolled back generically.
     """
 
-    live = _capture_network(
+    live = capture_network(
         network,
         name=snapshot.name,
         metadata=snapshot.metadata,
@@ -1403,6 +1585,7 @@ def rewire_region(
             f"expected {snapshot.fingerprint}, got {live.snapshot.fingerprint}"
         )
 
+    validate_region(snapshot, selected_node_ids)
     artifact = create_region_artifact(snapshot, selected_node_ids)
     return _rewire_captured_regions(
         network,
@@ -1421,10 +1604,95 @@ class _RewirePlan:
     marked_output_ids: frozenset[str]
 
 
+def _try_set_tensor_name(tensor: Any, name: str) -> bool:
+    try:
+        tensor.name = name
+    except (AttributeError, TypeError, ValueError, RuntimeError):
+        return False
+    return getattr(tensor, "name", None) == name
+
+
+def _preserve_replaced_output_name(
+    snapshot: GraphSnapshot,
+    tensor_id: str,
+    old_output: Any,
+    new_output: Any,
+) -> None:
+    """Move a public output name off the old tensor before reusing it."""
+
+    old_name = getattr(old_output, "name", None)
+    if old_output is new_output or old_name is None:
+        return
+    if not hasattr(new_output, "name"):
+        raise GraphPatchError(
+            f"Replacement for network output {tensor_id} does not expose a writable name"
+        )
+
+    stem = f"__trtmc_replaced_{snapshot.fingerprint[:12]}_{tensor_id.replace(':', '_')}"
+    for suffix in range(100):
+        temporary_name = stem if suffix == 0 else f"{stem}_{suffix}"
+        if _try_set_tensor_name(old_output, temporary_name):
+            break
+    else:
+        raise GraphPatchError(f"Could not reserve the public name of network output {tensor_id}")
+
+    # Some bindings can return two Python wrappers for one backend tensor.
+    # In that case the temporary rename is visible through both wrappers.
+    if getattr(new_output, "name", None) == temporary_name:
+        if not _try_set_tensor_name(new_output, old_name):
+            raise GraphPatchError(
+                f"Could not restore the public name of network output {tensor_id}"
+            )
+        return
+
+    if _try_set_tensor_name(new_output, old_name):
+        return
+
+    restored = _try_set_tensor_name(old_output, old_name)
+    suffix = "" if restored else "; the original name could not be restored"
+    raise GraphPatchError(
+        f"Could not preserve the public name of network output {tensor_id}{suffix}"
+    )
+
+
+def _validate_replacement_output(
+    artifact: RegionArtifact,
+    output_index: int,
+    output: Any,
+    *,
+    region_index: int,
+) -> None:
+    contract_by_id = {tensor.id: tensor for tensor in artifact.tensors}
+    tensor_id = artifact.output_tensor_ids[output_index]
+    contract = contract_by_id[tensor_id]
+    actual = {
+        "dtype": _tensor_dtype(output),
+        "shape": _tensor_shape(output),
+        "location": _tensor_location(output),
+        "is_shape_tensor": _optional_tensor_bool(output, "is_shape_tensor"),
+    }
+    expected = {
+        "dtype": contract.dtype,
+        "shape": contract.shape,
+        "location": contract.location,
+        "is_shape_tensor": contract.is_shape_tensor,
+    }
+    mismatches = [
+        f"{field}: expected {wanted!r}, got {actual[field]!r}"
+        for field, wanted in expected.items()
+        if wanted is not None and actual[field] != wanted
+    ]
+    if mismatches:
+        raise GraphPatchError(
+            "Replacement output ABI mismatch for "
+            f"region {region_index} output {output_index} ({tensor_id}): " + "; ".join(mismatches)
+        )
+
+
 def _rewire_captured_regions(
     network: Any,
     snapshot: GraphSnapshot,
-    live: _Capture,
+    live: CapturedGraph,
     artifacts: Sequence[RegionArtifact],
     replacement: ReplacementCallback,
 ) -> RewireBatchResult:
@@ -1444,7 +1712,7 @@ def _rewire_captured_regions(
                 output_index = output_index_by_id.get(input_tensor_id)
                 if output_index is None:
                     continue
-                layer = live.layers[node.id]
+                layer = live._layer_for(node.id)
                 if not callable(getattr(layer, "set_input", None)):
                     raise GraphPatchError(f"External consumer {node.id} does not expose set_input")
                 external_slots.append((layer, input_index, output_index))
@@ -1462,7 +1730,7 @@ def _rewire_captured_regions(
             _RewirePlan(
                 artifact=artifact,
                 boundary_inputs=tuple(
-                    live.tensors[tensor_id] for tensor_id in artifact.input_tensor_ids
+                    live._tensor_for(tensor_id) for tensor_id in artifact.input_tensor_ids
                 ),
                 external_slots=tuple(external_slots),
                 marked_output_ids=marked_output_ids,
@@ -1496,36 +1764,77 @@ def _rewire_captured_regions(
             raise GraphPatchError(
                 f"Replacement outputs for region {region_index} cannot contain None"
             )
+        for output_index, output in enumerate(replacement_outputs):
+            existing_tensor_id = live._original_tensor_id(output)
+            if existing_tensor_id is not None:
+                raise GraphPatchError(
+                    "Replacement outputs must be newly created backend tensors; "
+                    f"region {region_index} output {output_index} aliases "
+                    f"original tensor {existing_tensor_id}"
+                )
+            _validate_replacement_output(
+                plan.artifact,
+                output_index,
+                output,
+                region_index=region_index,
+            )
         outputs_by_plan.append(replacement_outputs)
 
-    results: list[RewireResult] = []
+    replacement_output_owners: dict[int, tuple[int, int]] = {}
+    for region_index, replacement_outputs in enumerate(outputs_by_plan):
+        for output_index, replacement_output in enumerate(replacement_outputs):
+            previous = replacement_output_owners.get(id(replacement_output))
+            if previous is not None:
+                raise GraphPatchError(
+                    "One replacement tensor cannot satisfy two region outputs: "
+                    f"region {previous[0]} output {previous[1]} and "
+                    f"region {region_index} output {output_index}"
+                )
+            replacement_output_owners[id(replacement_output)] = (
+                region_index,
+                output_index,
+            )
+
+    replacement_by_output_id: dict[str, Any] = {}
+    for plan, replacement_outputs in zip(plans, outputs_by_plan):
+        for tensor_id, replacement_output in zip(
+            plan.artifact.output_tensor_ids,
+            replacement_outputs,
+        ):
+            if tensor_id in plan.marked_output_ids:
+                replacement_by_output_id[tensor_id] = replacement_output
+
+    for tensor_id, replacement_output in replacement_by_output_id.items():
+        _preserve_replaced_output_name(
+            snapshot,
+            tensor_id,
+            live._tensor_for(tensor_id),
+            replacement_output,
+        )
+
     for plan, replacement_outputs in zip(plans, outputs_by_plan):
         for layer, input_index, output_index in plan.external_slots:
             layer.set_input(input_index, replacement_outputs[output_index])
 
-        rewired_network_outputs = 0
-        replacement_by_id = dict(zip(plan.artifact.output_tensor_ids, replacement_outputs))
+    # TensorRT only exposes append-style mark_output(). Preserve binding order
+    # by rebuilding the complete output list whenever one selected region
+    # replaces a marked graph output.
+    if replacement_by_output_id:
         for tensor_id in snapshot.outputs:
-            if tensor_id not in plan.marked_output_ids:
-                continue
-            old_output = live.tensors[tensor_id]
-            new_output = replacement_by_id[tensor_id]
-            old_name = getattr(old_output, "name", None)
-            network.unmark_output(old_output)
-            if old_name is not None and hasattr(new_output, "name"):
-                try:
-                    new_output.name = old_name
-                except (AttributeError, TypeError):
-                    pass
+            network.unmark_output(live._tensor_for(tensor_id))
+        for tensor_id in snapshot.outputs:
+            old_output = live._tensor_for(tensor_id)
+            new_output = replacement_by_output_id.get(tensor_id, old_output)
             network.mark_output(new_output)
-            rewired_network_outputs += 1
 
+    results: list[RewireResult] = []
+    for plan, replacement_outputs in zip(plans, outputs_by_plan):
         results.append(
             RewireResult(
                 artifact=plan.artifact,
                 replacement_outputs=replacement_outputs,
                 rewired_consumer_inputs=len(plan.external_slots),
-                rewired_network_outputs=rewired_network_outputs,
+                rewired_network_outputs=len(plan.marked_output_ids),
             )
         )
     return RewireBatchResult(results=tuple(results))
@@ -1539,7 +1848,7 @@ def rewire_selection(
     *,
     provenance: ProvenanceProvider | None = None,
 ) -> RewireResult:
-    """Validate a viewer-downloaded selection and replace that exact region."""
+    """Validate and replace one selection with newly created output tensors."""
 
     selection.validate(snapshot)
     return rewire_selection_set(
@@ -1559,10 +1868,18 @@ def rewire_selection_set(
     *,
     provenance: ProvenanceProvider | None = None,
 ) -> RewireBatchResult:
-    """Replace every independent region against the same original snapshot."""
+    """Replace every independent region against the same original snapshot.
+
+    Each callback result must contain newly created, mutually distinct backend
+    tensors; aliases to the original graph or another region output are
+    rejected before consumer rewiring.
+
+    If this function raises after invoking ``replacement``, discard ``network``;
+    callback-created layers cannot be rolled back generically.
+    """
 
     selection_set.validate(snapshot)
-    live = _capture_network(
+    live = capture_network(
         network,
         name=snapshot.name,
         metadata=snapshot.metadata,

--- a/tests/builder/test_graph_patch.py
+++ b/tests/builder/test_graph_patch.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+import tensorrt_model_connect.graph_patch as graph_patch_module
 from tensorrt_model_connect.graph_patch import (
     GraphPatchError,
     GraphRegionSelection,
@@ -272,6 +274,112 @@ def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
     )
     assert moved_source_line.nodes[2].provenance != snapshot.nodes[2].provenance
     assert moved_source_line.fingerprint == snapshot.fingerprint
+
+
+def test_snapshot_json_rejects_unknown_fields_at_every_record_level() -> None:
+    network, _ = _attention_network()
+    snapshot = _complete_snapshot(network)
+
+    top_level = snapshot.to_dict()
+    top_level["semantic_mapping"] = {}
+    with pytest.raises(GraphPatchError, match="Unknown graph snapshot fields"):
+        GraphSnapshot.from_dict(top_level)
+
+    node_level = snapshot.to_dict()
+    node_level["nodes"][0]["semantic_mapping"] = {}
+    with pytest.raises(GraphPatchError, match="Unknown node fields"):
+        GraphSnapshot.from_dict(node_level)
+
+    tensor_level = snapshot.to_dict()
+    tensor_level["tensors"][0]["semantic_mapping"] = {}
+    with pytest.raises(GraphPatchError, match="Unknown tensor fields"):
+        GraphSnapshot.from_dict(tensor_level)
+
+
+@pytest.mark.parametrize(
+    "mutate,message",
+    [
+        (lambda value: value.pop("fingerprint"), "Missing graph snapshot fields"),
+        (
+            lambda value: value.__setitem__("schema_version", "1"),
+            "schema_version must be an integer",
+        ),
+        (
+            lambda value: value.__setitem__("name", 7),
+            "Graph snapshot name must be a string",
+        ),
+        (
+            lambda value: value["nodes"][0].__setitem__("id", 7),
+            "Node id must be a non-empty string",
+        ),
+        (
+            lambda value: value["tensors"][0].__setitem__("is_shape_tensor", 1),
+            "is_shape_tensor must be a boolean or null",
+        ),
+        (
+            lambda value: value["identity"].pop("complete"),
+            "Missing graph identity fields",
+        ),
+        (
+            lambda value: value["metadata"].__setitem__("bad", "\ud800"),
+            "valid UTF-8",
+        ),
+    ],
+)
+def test_snapshot_dict_rejects_missing_fields_and_type_coercion(
+    mutate: Any,
+    message: str,
+) -> None:
+    network, _ = _attention_network()
+    value = _complete_snapshot(network).to_dict()
+    mutate(value)
+
+    with pytest.raises(GraphPatchError, match=message):
+        GraphSnapshot.from_dict(value)
+
+
+def test_snapshot_rejects_disagreement_between_node_and_tensor_edges() -> None:
+    network, _ = _attention_network()
+    snapshot = _complete_snapshot(network)
+    consumer = snapshot.nodes[2]
+    changed_consumer = replace(
+        consumer,
+        inputs=(snapshot.inputs[0], *consumer.inputs[1:]),
+    )
+    inconsistent = replace(
+        snapshot,
+        nodes=(*snapshot.nodes[:2], changed_consumer, *snapshot.nodes[3:]),
+    )
+
+    with pytest.raises(GraphPatchError, match="consumer references disagree"):
+        GraphSnapshot.from_dict(inconsistent.to_dict())
+
+
+@pytest.mark.parametrize(
+    "document,message",
+    [
+        ('{"name":"first","name":"second"}', "duplicate object key 'name'"),
+        ('{"metadata":{"value":NaN}}', "non-finite number NaN"),
+    ],
+)
+def test_snapshot_json_decoder_rejects_ambiguous_values(
+    document: str,
+    message: str,
+) -> None:
+    with pytest.raises(GraphPatchError, match=message):
+        GraphSnapshot.from_json(document)
+
+
+def test_snapshot_json_decoder_normalizes_recursion_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_with_recursion(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise RecursionError("artifact nesting is too deep")
+
+    monkeypatch.setattr(graph_patch_module.json, "loads", fail_with_recursion)
+    with pytest.raises(GraphPatchError, match="not valid JSON"):
+        GraphSnapshot.from_json("{}")
 
 
 def test_complete_identity_round_trip_and_operation_drift_changes_fingerprint() -> None:
@@ -1008,7 +1116,7 @@ def test_selection_document_requires_kind_and_schema_version(field: str) -> None
     value = _selection_document(snapshot)
     value.pop(field)
 
-    with pytest.raises(GraphPatchError, match="Unsupported"):
+    with pytest.raises(GraphPatchError, match="Missing graph-region fields"):
         GraphRegionSelection.from_dict(value)
 
 

--- a/tests/builder/test_graph_patch.py
+++ b/tests/builder/test_graph_patch.py
@@ -1,0 +1,623 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.graph_patch import (
+    GraphPatchError,
+    GraphRegionSelection,
+    GraphRegionSelectionSet,
+    GraphSnapshot,
+    RegionArtifact,
+    coerce_region_selection_set,
+    compute_region_boundary,
+    create_region_artifact,
+    rewire_region,
+    rewire_selection,
+    rewire_selection_set,
+    snapshot_network,
+)
+
+
+class FakeTensor:
+    def __init__(
+        self,
+        name: str,
+        shape: tuple[int, ...] = (1, 8, 128),
+        dtype: str = "float16",
+    ):
+        self.name = name
+        self.shape = shape
+        self.dtype = dtype
+
+
+class FakeLayer:
+    def __init__(
+        self,
+        name: str,
+        op: str,
+        inputs: list[FakeTensor],
+        outputs: list[FakeTensor],
+    ):
+        self.name = name
+        self.type = op
+        self.inputs = list(inputs)
+        self.outputs = list(outputs)
+        self.set_input_calls: list[tuple[int, FakeTensor]] = []
+
+    @property
+    def num_inputs(self) -> int:
+        return len(self.inputs)
+
+    @property
+    def num_outputs(self) -> int:
+        return len(self.outputs)
+
+    def get_input(self, index: int) -> FakeTensor:
+        return self.inputs[index]
+
+    def get_output(self, index: int) -> FakeTensor:
+        return self.outputs[index]
+
+    def set_input(self, index: int, value: FakeTensor) -> None:
+        self.set_input_calls.append((index, value))
+        self.inputs[index] = value
+
+
+class FakeNetwork:
+    def __init__(
+        self,
+        inputs: list[FakeTensor],
+        layers: list[FakeLayer],
+        outputs: list[FakeTensor],
+        name: str = "qwen3_decode",
+    ):
+        self.name = name
+        self.inputs = list(inputs)
+        self.layers = list(layers)
+        self.outputs = list(outputs)
+        self.output_calls: list[tuple[str, FakeTensor]] = []
+
+    @property
+    def num_inputs(self) -> int:
+        return len(self.inputs)
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layers)
+
+    @property
+    def num_outputs(self) -> int:
+        return len(self.outputs)
+
+    def get_input(self, index: int) -> FakeTensor:
+        return self.inputs[index]
+
+    def get_layer(self, index: int) -> FakeLayer:
+        return self.layers[index]
+
+    def get_output(self, index: int) -> FakeTensor:
+        return self.outputs[index]
+
+    def unmark_output(self, tensor: FakeTensor) -> None:
+        self.output_calls.append(("unmark", tensor))
+        self.outputs.remove(tensor)
+
+    def mark_output(self, tensor: FakeTensor) -> None:
+        self.output_calls.append(("mark", tensor))
+        self.outputs.append(tensor)
+
+
+def _attention_network() -> tuple[FakeNetwork, dict[str, FakeTensor]]:
+    tensors = {
+        name: FakeTensor(name) for name in ("hidden", "q", "k", "context", "residual", "tap")
+    }
+    layers = [
+        FakeLayer(
+            "model.layers.0.self_attn.q_proj",
+            "MATRIX_MULTIPLY",
+            [tensors["hidden"]],
+            [tensors["q"]],
+        ),
+        FakeLayer(
+            "model.layers.0.self_attn.k_proj",
+            "MATRIX_MULTIPLY",
+            [tensors["hidden"]],
+            [tensors["k"]],
+        ),
+        FakeLayer(
+            "model.layers.0.self_attn.core",
+            "SCALED_DOT_PRODUCT_ATTENTION",
+            [tensors["q"], tensors["k"]],
+            [tensors["context"]],
+        ),
+        FakeLayer(
+            "model.layers.0.residual",
+            "ELEMENTWISE",
+            [tensors["context"], tensors["hidden"]],
+            [tensors["residual"]],
+        ),
+        FakeLayer(
+            "debug.attention_tap",
+            "IDENTITY",
+            [tensors["context"]],
+            [tensors["tap"]],
+        ),
+    ]
+    network = FakeNetwork(
+        [tensors["hidden"]],
+        layers,
+        [tensors["residual"], tensors["context"]],
+    )
+    return network, tensors
+
+
+def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
+    network, _ = _attention_network()
+
+    def provenance(layer: FakeLayer, index: int) -> dict:
+        return {
+            "module_path": layer.name.rsplit(".", 1)[0],
+            "source": {"file": "graph_blocks.py", "line": 200 + index},
+        }
+
+    snapshot = snapshot_network(
+        network,
+        metadata={"stage": "decode", "model": "Qwen/Qwen3-8B"},
+        provenance=provenance,
+    )
+    restored = GraphSnapshot.from_json(snapshot.to_json())
+
+    assert restored == snapshot
+    assert restored.fingerprint == snapshot.fingerprint
+    assert len(snapshot.fingerprint) == 64
+    assert snapshot.nodes[2].provenance == {
+        "module_path": "model.layers.0.self_attn",
+        "source": {"file": "graph_blocks.py", "line": 202},
+    }
+
+    changed = snapshot_network(
+        network,
+        metadata={"stage": "prefill", "model": "Qwen/Qwen3-8B"},
+        provenance=provenance,
+    )
+    assert changed.fingerprint != snapshot.fingerprint
+
+    moved_source_line = snapshot_network(
+        network,
+        metadata={"stage": "decode", "model": "Qwen/Qwen3-8B"},
+        provenance=lambda layer, index: {
+            "module_path": layer.name.rsplit(".", 1)[0],
+            "source": {"file": "graph_blocks.py", "line": 900 + index},
+        },
+    )
+    assert moved_source_line.nodes[2].provenance != snapshot.nodes[2].provenance
+    assert moved_source_line.fingerprint == snapshot.fingerprint
+
+
+def test_boundary_and_region_artifact_are_derived_from_selection() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+
+    boundary = compute_region_boundary(snapshot, ["node:2"])
+
+    assert boundary.selected_node_ids == ("node:2",)
+    assert boundary.input_tensor_ids == ("tensor:1", "tensor:2")
+    assert boundary.output_tensor_ids == ("tensor:3",)
+    assert boundary.internal_tensor_ids == ()
+
+    artifact = create_region_artifact(
+        snapshot,
+        ["node:2"],
+        metadata={"requested_replacement": "tvm_ffi"},
+    )
+    restored = RegionArtifact.from_json(artifact.to_json())
+    assert restored == artifact
+    assert restored.graph_fingerprint == snapshot.fingerprint
+    assert restored.input_tensor_ids == ("tensor:1", "tensor:2")
+    assert restored.output_tensor_ids == ("tensor:3",)
+    assert {tensor.name for tensor in restored.tensors} == {"q", "k", "context"}
+    assert len(restored.fingerprint) == 64
+
+
+def test_multi_node_region_records_internal_tensor() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+
+    boundary = compute_region_boundary(snapshot, ["node:0", "node:2"])
+
+    assert boundary.selected_node_ids == ("node:0", "node:2")
+    assert boundary.input_tensor_ids == ("tensor:0", "tensor:2")
+    assert boundary.output_tensor_ids == ("tensor:3",)
+    assert boundary.internal_tensor_ids == ("tensor:1",)
+
+
+def test_rewire_region_updates_all_external_consumers_and_network_output() -> None:
+    network, tensors = _attention_network()
+
+    def provenance(layer: FakeLayer, _index: int) -> dict:
+        return {"module_path": layer.name}
+
+    snapshot = snapshot_network(network, provenance=provenance)
+    new_context = FakeTensor("ffi_context")
+    callback_receipt: dict[str, object] = {}
+
+    def replacement(
+        received_network: FakeNetwork,
+        inputs: tuple[FakeTensor, ...],
+        artifact: RegionArtifact,
+    ) -> list[FakeTensor]:
+        callback_receipt["network"] = received_network
+        callback_receipt["inputs"] = inputs
+        callback_receipt["artifact"] = artifact
+        return [new_context]
+
+    result = rewire_region(
+        network,
+        snapshot,
+        ["node:2"],
+        replacement,
+        provenance=provenance,
+    )
+
+    assert callback_receipt["network"] is network
+    assert callback_receipt["inputs"] == (tensors["q"], tensors["k"])
+    assert callback_receipt["artifact"].selected_node_ids == ("node:2",)
+    assert network.layers[3].inputs[0] is new_context
+    assert network.layers[4].inputs[0] is new_context
+    assert network.layers[2].outputs[0] is tensors["context"]
+    assert result.rewired_consumer_inputs == 2
+    assert result.rewired_network_outputs == 1
+    assert result.replacement_outputs == (new_context,)
+    assert network.output_calls == [
+        ("unmark", tensors["context"]),
+        ("mark", new_context),
+    ]
+    assert new_context.name == "context"
+    assert set(network.outputs) == {tensors["residual"], new_context}
+
+
+def test_rewire_fails_closed_when_graph_drifted() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    network.layers[2].name = "model.layers.0.self_attn.changed"
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return []
+
+    with pytest.raises(GraphPatchError, match="no longer matches"):
+        rewire_region(network, snapshot, ["node:2"], replacement)
+
+    assert called is False
+
+
+def test_invalid_selection_and_output_count_are_rejected() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+
+    with pytest.raises(GraphPatchError, match="at least one"):
+        compute_region_boundary(snapshot, [])
+    with pytest.raises(GraphPatchError, match="unknown node"):
+        compute_region_boundary(snapshot, ["node:99"])
+    with pytest.raises(GraphPatchError, match="returned 0 outputs"):
+        rewire_region(network, snapshot, ["node:2"], lambda *_args: [])
+
+
+def _viewer_selection(snapshot: GraphSnapshot) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "tensorrt_model_connect.graph_region",
+        "graph": {
+            "model": "Qwen/Qwen3-8B",
+            "stage": "decode",
+            "fingerprint": snapshot.fingerprint,
+        },
+        "selection": {
+            "node_ids": ["node:2"],
+            "semantic_paths": [],
+        },
+        "boundary": {
+            "inputs": [
+                {"tensor_id": "tensor:1", "consumer": "node:2"},
+                {"tensor_id": "tensor:2", "consumer": "node:2"},
+            ],
+            # The viewer has one edge per external consumer. Repeated tensor
+            # IDs are deliberately accepted and collapsed by the loader.
+            "outputs": [
+                {"tensor_id": "tensor:3", "consumer": "node:3"},
+                {"tensor_id": "tensor:3", "consumer": "node:4"},
+            ],
+        },
+    }
+
+
+def _selection_for_nodes(
+    snapshot: GraphSnapshot,
+    node_ids: list[str],
+) -> GraphRegionSelection:
+    boundary = compute_region_boundary(snapshot, node_ids)
+    return GraphRegionSelection(
+        graph_fingerprint=snapshot.fingerprint,
+        selected_node_ids=boundary.selected_node_ids,
+        input_tensor_ids=boundary.input_tensor_ids,
+        output_tensor_ids=boundary.output_tensor_ids,
+    )
+
+
+def _repeated_regions_network() -> tuple[FakeNetwork, dict[str, FakeTensor]]:
+    tensors = {
+        name: FakeTensor(name)
+        for name in (
+            "hidden",
+            "context_0",
+            "hidden_1",
+            "context_1",
+            "output",
+        )
+    }
+    network = FakeNetwork(
+        [tensors["hidden"]],
+        [
+            FakeLayer(
+                "model.layers.0.self_attn.core",
+                "SCALED_DOT_PRODUCT_ATTENTION",
+                [tensors["hidden"]],
+                [tensors["context_0"]],
+            ),
+            FakeLayer(
+                "model.layers.0.residual",
+                "ELEMENTWISE",
+                [tensors["context_0"], tensors["hidden"]],
+                [tensors["hidden_1"]],
+            ),
+            FakeLayer(
+                "model.layers.1.self_attn.core",
+                "SCALED_DOT_PRODUCT_ATTENTION",
+                [tensors["hidden_1"]],
+                [tensors["context_1"]],
+            ),
+            FakeLayer(
+                "model.layers.1.residual",
+                "ELEMENTWISE",
+                [tensors["context_1"], tensors["hidden_1"]],
+                [tensors["output"]],
+            ),
+        ],
+        [tensors["output"]],
+    )
+    return network, tensors
+
+
+def _selection_set_document(snapshot: GraphSnapshot) -> dict:
+    region_0 = compute_region_boundary(snapshot, ["node:0"])
+    region_1 = compute_region_boundary(snapshot, ["node:2"])
+
+    def region(boundary, layer_index):
+        return {
+            "instance": {
+                "layer_index": layer_index,
+                "layer_prefix": f"model.layers.{layer_index}.self_attn",
+            },
+            "selection": {"node_ids": list(boundary.selected_node_ids)},
+            "boundary": {
+                "inputs": [{"tensor_id": tensor_id} for tensor_id in boundary.input_tensor_ids],
+                "outputs": [{"tensor_id": tensor_id} for tensor_id in boundary.output_tensor_ids],
+            },
+        }
+
+    return {
+        "schema_version": 1,
+        "kind": "tensorrt_model_connect.graph_region_set",
+        "graph": {
+            "model": "Qwen/Qwen3-8B",
+            "stage": "decode",
+            "fingerprint": snapshot.fingerprint,
+            "build": {"precision": "fp16"},
+        },
+        "regions": [
+            region(region_0, 0),
+            region(region_1, 1),
+        ],
+    }
+
+
+def test_viewer_selection_drives_exact_rewire() -> None:
+    network, tensors = _attention_network()
+    snapshot = snapshot_network(network)
+    selection = GraphRegionSelection.from_dict(_viewer_selection(snapshot))
+    replacement_output = FakeTensor("ffi_context")
+
+    result = rewire_selection(
+        network,
+        snapshot,
+        selection,
+        lambda _network, inputs, _artifact: (
+            [replacement_output] if inputs == (tensors["q"], tensors["k"]) else []
+        ),
+    )
+
+    assert selection.input_tensor_ids == ("tensor:1", "tensor:2")
+    assert selection.output_tensor_ids == ("tensor:3",)
+    assert result.rewired_consumer_inputs == 2
+    assert network.layers[3].inputs[0] is replacement_output
+    assert network.layers[4].inputs[0] is replacement_output
+
+
+def test_region_set_parses_legacy_single_region_and_round_trips() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    legacy = GraphRegionSelection.from_dict(_viewer_selection(snapshot))
+
+    wrapped = GraphRegionSelectionSet.from_dict(_viewer_selection(snapshot))
+    assert wrapped == coerce_region_selection_set(legacy)
+    assert wrapped.selections == (legacy,)
+    assert legacy.input_contracts == (
+        {"consumer": "node:2", "tensor_id": "tensor:1"},
+        {"consumer": "node:2", "tensor_id": "tensor:2"},
+    )
+    assert legacy.output_contracts == ({"consumer": "node:3", "tensor_id": "tensor:3"},)
+    assert GraphRegionSelection.from_json(legacy.to_json()) == legacy
+
+    repeated_network, _ = _repeated_regions_network()
+    repeated_snapshot = snapshot_network(repeated_network)
+    selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(repeated_snapshot))
+    restored = GraphRegionSelectionSet.from_json(selection_set.to_json())
+
+    assert restored == selection_set
+    assert len(restored.selections) == 2
+    assert restored.selections[1].instance["layer_index"] == 1
+    assert restored.build == {"precision": "fp16"}
+
+
+def test_region_set_replaces_each_independent_instance_once() -> None:
+    network, tensors = _repeated_regions_network()
+    snapshot = snapshot_network(network)
+    selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
+    replacements = [
+        FakeTensor("ffi_context_0"),
+        FakeTensor("ffi_context_1"),
+    ]
+    calls = []
+
+    def replacement(received_network, inputs, artifact):
+        calls.append((received_network, inputs, artifact))
+        return [replacements[len(calls) - 1]]
+
+    result = rewire_selection_set(
+        network,
+        snapshot,
+        selection_set,
+        replacement,
+    )
+
+    assert len(calls) == 2
+    assert calls[0][1] == (tensors["hidden"],)
+    assert calls[1][1] == (tensors["hidden_1"],)
+    assert calls[0][2].metadata["instance"]["layer_index"] == 0
+    assert calls[1][2].metadata["instance"]["layer_index"] == 1
+    assert network.layers[1].inputs[0] is replacements[0]
+    assert network.layers[3].inputs[0] is replacements[1]
+    assert result.region_count == 2
+    assert result.selected_node_count == 2
+    assert result.rewired_consumer_inputs == 2
+    assert result.rewired_network_outputs == 0
+    assert result.artifacts == tuple(call[2] for call in calls)
+    with pytest.raises(GraphPatchError, match="no single artifact"):
+        _ = result.artifact
+
+
+def test_region_set_rejects_overlap_and_direct_dependencies() -> None:
+    network, _ = _repeated_regions_network()
+    snapshot = snapshot_network(network)
+    value = _selection_set_document(snapshot)
+    value["regions"][1] = value["regions"][0]
+    with pytest.raises(GraphPatchError, match="must not overlap"):
+        GraphRegionSelectionSet.from_dict(value)
+
+    first = _selection_for_nodes(snapshot, ["node:0"])
+    directly_dependent = _selection_for_nodes(snapshot, ["node:1"])
+    selection_set = GraphRegionSelectionSet(
+        graph_fingerprint=snapshot.fingerprint,
+        selections=(first, directly_dependent),
+    )
+    with pytest.raises(GraphPatchError, match="directly depend"):
+        selection_set.validate(snapshot)
+
+
+def test_region_set_validates_all_outputs_before_rewiring() -> None:
+    network, tensors = _repeated_regions_network()
+    snapshot = snapshot_network(network)
+    selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
+    calls = 0
+
+    def replacement(_network, _inputs, _artifact):
+        nonlocal calls
+        calls += 1
+        return [FakeTensor("first")] if calls == 1 else []
+
+    with pytest.raises(GraphPatchError, match="region 1"):
+        rewire_selection_set(
+            network,
+            snapshot,
+            selection_set,
+            replacement,
+        )
+
+    assert calls == 2
+    assert network.layers[1].inputs[0] is tensors["context_0"]
+    assert network.layers[3].inputs[0] is tensors["context_1"]
+
+
+def test_viewer_selection_fails_closed_on_fingerprint_or_boundary_drift() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    value = _viewer_selection(snapshot)
+    value["graph"]["fingerprint"] = "stale"
+    with pytest.raises(GraphPatchError, match="fingerprint"):
+        GraphRegionSelection.from_dict(value).validate(snapshot)
+
+    value = _viewer_selection(snapshot)
+    value["boundary"]["outputs"] = [{"tensor_id": "tensor:4"}]
+    with pytest.raises(GraphPatchError, match="output boundary"):
+        GraphRegionSelection.from_dict(value).validate(snapshot)
+
+
+def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    with pytest.raises(GraphPatchError, match="connected region"):
+        _selection_for_nodes(snapshot, ["node:0", "node:1"]).validate(snapshot)
+
+    hidden = FakeTensor("hidden")
+    direct = FakeTensor("direct")
+    detour = FakeTensor("detour")
+    output = FakeTensor("output")
+    nonconvex = FakeNetwork(
+        [hidden],
+        [
+            FakeLayer("a", "IDENTITY", [hidden], [direct]),
+            FakeLayer("b", "IDENTITY", [direct], [detour]),
+            FakeLayer("c", "ELEMENTWISE", [direct, detour], [output]),
+        ],
+        [output],
+    )
+    nonconvex_snapshot = snapshot_network(nonconvex)
+    with pytest.raises(GraphPatchError, match="convex region"):
+        _selection_for_nodes(
+            nonconvex_snapshot,
+            ["node:0", "node:2"],
+        ).validate(nonconvex_snapshot)
+
+    network.layers[2].type = "PLUGIN_V3"
+    plugin_snapshot = snapshot_network(network)
+    with pytest.raises(GraphPatchError, match="existing plugin"):
+        _selection_for_nodes(plugin_snapshot, ["node:2"]).validate(plugin_snapshot)
+
+
+def test_graph_patch_module_has_no_tensorrt_import() -> None:
+    path = (
+        Path(__file__).resolve().parents[2] / "python" / "tensorrt_model_connect" / "graph_patch.py"
+    )
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_modules.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
+    assert "tensorrt" not in imported_modules
+    assert "tensorrt_rtx" not in imported_modules

--- a/tests/builder/test_graph_patch.py
+++ b/tests/builder/test_graph_patch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -13,6 +14,7 @@ from tensorrt_model_connect.graph_patch import (
     GraphRegionSelection,
     GraphRegionSelectionSet,
     GraphSnapshot,
+    LayerIdentityContract,
     RegionArtifact,
     capture_network,
     coerce_region_selection_set,
@@ -139,6 +141,41 @@ class FakeNetwork:
         self.outputs.append(tensor)
 
 
+FAKE_IDENTITY_CONTRACT = LayerIdentityContract(
+    provider_id="tests.fake_layer_identity",
+    schema_version=1,
+)
+
+
+def _fake_layer_identity(layer: FakeLayer, _index: int) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    if hasattr(layer, "operation"):
+        attributes["operation"] = str(layer.operation)
+    return attributes
+
+
+def _complete_snapshot(network: FakeNetwork, **kwargs: Any) -> GraphSnapshot:
+    return snapshot_network(
+        network,
+        identity_provider=_fake_layer_identity,
+        identity_contract=FAKE_IDENTITY_CONTRACT,
+        **kwargs,
+    )
+
+
+def _current_identity(
+    network: FakeNetwork,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "current_name": network.name,
+        "current_metadata": {} if metadata is None else metadata,
+        "identity_provider": _fake_layer_identity,
+        "identity_contract": FAKE_IDENTITY_CONTRACT,
+    }
+
+
 def _attention_network() -> tuple[FakeNetwork, dict[str, FakeTensor]]:
     tensors = {
         name: FakeTensor(name) for name in ("hidden", "q", "k", "context", "residual", "tap")
@@ -183,6 +220,14 @@ def _attention_network() -> tuple[FakeNetwork, dict[str, FakeTensor]]:
     return network, tensors
 
 
+def _elementwise_network(operation: str) -> FakeNetwork:
+    value = FakeTensor("value")
+    output = FakeTensor("output")
+    layer = FakeLayer("combine", "ELEMENTWISE", [value, value], [output])
+    layer.operation = operation
+    return FakeNetwork([value], [layer], [output], name="elementwise")
+
+
 def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
     network, _ = _attention_network()
 
@@ -201,6 +246,9 @@ def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
 
     assert restored == snapshot
     assert restored.fingerprint == snapshot.fingerprint
+    assert restored.identity_contract is None
+    assert restored.identity_complete is False
+    assert all(node.identity_complete is False for node in restored.nodes)
     assert len(snapshot.fingerprint) == 64
     assert snapshot.nodes[2].provenance == {
         "module_path": "model.layers.0.self_attn",
@@ -224,6 +272,81 @@ def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
     )
     assert moved_source_line.nodes[2].provenance != snapshot.nodes[2].provenance
     assert moved_source_line.fingerprint == snapshot.fingerprint
+
+
+def test_complete_identity_round_trip_and_operation_drift_changes_fingerprint() -> None:
+    summed = _complete_snapshot(_elementwise_network("SUM"))
+    multiplied = _complete_snapshot(_elementwise_network("PROD"))
+    restored = GraphSnapshot.from_json(summed.to_json())
+
+    assert restored == summed
+    assert restored.identity_contract == FAKE_IDENTITY_CONTRACT
+    assert restored.identity_complete is True
+    assert restored.nodes[0].identity_attributes == {"operation": "SUM"}
+    assert summed.fingerprint != multiplied.fingerprint
+
+
+def test_complete_identity_serialization_rejects_tampering() -> None:
+    snapshot = _complete_snapshot(_elementwise_network("SUM"))
+
+    changed_attributes = snapshot.to_dict()
+    changed_attributes["nodes"][0]["identity"]["attributes"]["operation"] = "PROD"
+    with pytest.raises(GraphPatchError, match="fingerprint mismatch"):
+        GraphSnapshot.from_dict(changed_attributes)
+
+    changed_completeness = snapshot.to_dict()
+    changed_completeness["identity"]["complete"] = False
+    with pytest.raises(GraphPatchError, match="completeness does not match"):
+        GraphSnapshot.from_dict(changed_completeness)
+
+
+def test_identity_provider_requires_contract_and_canonical_json() -> None:
+    network, _ = _attention_network()
+
+    with pytest.raises(GraphPatchError, match="both be present"):
+        snapshot_network(network, identity_provider=_fake_layer_identity)
+    with pytest.raises(GraphPatchError, match="both be present"):
+        snapshot_network(network, identity_contract=FAKE_IDENTITY_CONTRACT)
+    with pytest.raises(GraphPatchError, match="contract has the wrong type"):
+        snapshot_network(
+            network,
+            identity_provider=_fake_layer_identity,
+            identity_contract={  # type: ignore[arg-type]
+                "provider_id": "tests.fake_layer_identity",
+                "schema_version": 1,
+            },
+        )
+    with pytest.raises(GraphPatchError, match="JSON scalars"):
+        snapshot_network(
+            network,
+            identity_provider=lambda _layer, _index: {"unstable": {"q", "k"}},
+            identity_contract=FAKE_IDENTITY_CONTRACT,
+        )
+
+    partial = snapshot_network(
+        network,
+        identity_provider=lambda _layer, index: None if index == 2 else {},
+        identity_contract=FAKE_IDENTITY_CONTRACT,
+    )
+    assert partial.identity_complete is False
+    assert partial.nodes[2].identity_complete is False
+
+
+def test_snapshot_rejects_non_json_metadata_values() -> None:
+    network, _ = _attention_network()
+
+    with pytest.raises(GraphPatchError, match="JSON scalars"):
+        snapshot_network(network, metadata={"unstable": {"q", "k"}})
+
+
+def test_snapshot_rejects_non_string_metadata_keys_before_normalization() -> None:
+    network, _ = _attention_network()
+
+    with pytest.raises(GraphPatchError, match="keys must be strings"):
+        snapshot_network(
+            network,
+            metadata={"collision": {1: "integer", "1": "string"}},
+        )
 
 
 def test_snapshot_tracks_tensor_handles_by_identity_not_equality() -> None:
@@ -349,7 +472,7 @@ def test_rewire_region_updates_all_external_consumers_and_network_output() -> No
     def provenance(layer: FakeLayer, _index: int) -> dict:
         return {"module_path": layer.name}
 
-    snapshot = snapshot_network(network, provenance=provenance)
+    snapshot = _complete_snapshot(network, provenance=provenance)
     new_context = FakeTensor("ffi_context")
     callback_receipt: dict[str, object] = {}
 
@@ -369,6 +492,7 @@ def test_rewire_region_updates_all_external_consumers_and_network_output() -> No
         ["node:2"],
         replacement,
         provenance=provenance,
+        **_current_identity(network),
     )
 
     assert callback_receipt["network"] is network
@@ -393,7 +517,7 @@ def test_rewire_region_updates_all_external_consumers_and_network_output() -> No
 def test_rewire_region_preserves_network_output_order() -> None:
     network, tensors = _attention_network()
     network.outputs = [tensors["context"], tensors["residual"]]
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     new_context = FakeTensor("ffi_context")
 
     rewire_region(
@@ -401,6 +525,7 @@ def test_rewire_region_preserves_network_output_order() -> None:
         snapshot,
         ["node:2"],
         lambda *_args: [new_context],
+        **_current_identity(network),
     )
 
     assert network.outputs == [new_context, tensors["residual"]]
@@ -409,7 +534,7 @@ def test_rewire_region_preserves_network_output_order() -> None:
 
 def test_rewire_region_fails_before_mutation_when_output_name_cannot_be_preserved() -> None:
     network, tensors = _attention_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     replacement = ReadOnlyNameFakeTensor("ffi_context")
 
     with pytest.raises(GraphPatchError, match="preserve the public name"):
@@ -418,6 +543,7 @@ def test_rewire_region_fails_before_mutation_when_output_name_cannot_be_preserve
             snapshot,
             ["node:2"],
             lambda *_args: [replacement],
+            **_current_identity(network),
         )
 
     assert network.layers[3].inputs[0] is tensors["context"]
@@ -443,7 +569,7 @@ def test_rewire_region_rejects_output_abi_mismatch_before_mutation(
 ) -> None:
     network, tensors = _attention_network()
     setattr(tensors["context"], field, expected)
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     replacement = FakeTensor("ffi_context")
     setattr(replacement, field, actual)
 
@@ -453,6 +579,7 @@ def test_rewire_region_rejects_output_abi_mismatch_before_mutation(
             snapshot,
             ["node:2"],
             lambda *_args: [replacement],
+            **_current_identity(network),
         )
 
     assert network.layers[3].inputs[0] is tensors["context"]
@@ -466,7 +593,7 @@ def test_rewire_region_rejects_original_tensor_as_replacement_output(
     tensor_name: str,
 ) -> None:
     network, tensors = _attention_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     original_names = {name: tensor.name for name, tensor in tensors.items()}
 
     with pytest.raises(GraphPatchError, match="newly created backend tensors"):
@@ -475,6 +602,7 @@ def test_rewire_region_rejects_original_tensor_as_replacement_output(
             snapshot,
             ["node:2"],
             lambda *_args: [tensors[tensor_name]],
+            **_current_identity(network),
         )
 
     assert network.layers[3].inputs[0] is tensors["context"]
@@ -486,7 +614,7 @@ def test_rewire_region_rejects_original_tensor_as_replacement_output(
 
 def test_rewire_fails_closed_when_graph_drifted() -> None:
     network, _ = _attention_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     network.layers[2].name = "model.layers.0.self_attn.changed"
     called = False
 
@@ -496,21 +624,186 @@ def test_rewire_fails_closed_when_graph_drifted() -> None:
         return []
 
     with pytest.raises(GraphPatchError, match="no longer matches"):
-        rewire_region(network, snapshot, ["node:2"], replacement)
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            replacement,
+            **_current_identity(network),
+        )
+
+    assert called is False
+
+
+@pytest.mark.parametrize("entrypoint", ["region", "selection", "selection_set"])
+def test_all_rewire_entrypoints_reject_structural_only_snapshot(
+    entrypoint: str,
+) -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    boundary = compute_region_boundary(snapshot, ["node:2"])
+    selection = GraphRegionSelection(
+        graph_fingerprint=snapshot.fingerprint,
+        selected_node_ids=boundary.selected_node_ids,
+        input_tensor_ids=boundary.input_tensor_ids,
+        output_tensor_ids=boundary.output_tensor_ids,
+    )
+    selection_set = GraphRegionSelectionSet(
+        graph_fingerprint=snapshot.fingerprint,
+        selections=(selection,),
+    )
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="structural-only or incomplete"):
+        if entrypoint == "region":
+            rewire_region(
+                network,
+                snapshot,
+                ["node:2"],
+                replacement,
+                **_current_identity(network),
+            )
+        elif entrypoint == "selection":
+            rewire_selection(
+                network,
+                snapshot,
+                selection,
+                replacement,
+                **_current_identity(network),
+            )
+        else:
+            rewire_selection_set(
+                network,
+                snapshot,
+                selection_set,
+                replacement,
+                **_current_identity(network),
+            )
+
+    assert called is False
+    assert network.output_calls == []
+
+
+def test_rewire_rejects_layer_identity_operation_drift_before_callback() -> None:
+    network = _elementwise_network("SUM")
+    snapshot = _complete_snapshot(network)
+    network.layers[0].operation = "PROD"
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="no longer matches"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:0"],
+            replacement,
+            **_current_identity(network),
+        )
+
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    ("current_name", "current_metadata"),
+    [
+        ("other-graph", {"precision": "fp16"}),
+        ("qwen3_decode", {"precision": "bf16"}),
+    ],
+)
+def test_rewire_validates_current_name_and_metadata_instead_of_replaying_snapshot(
+    current_name: str,
+    current_metadata: dict[str, str],
+) -> None:
+    network, _ = _attention_network()
+    expected_metadata = {"precision": "fp16"}
+    snapshot = _complete_snapshot(network, metadata=expected_metadata)
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="no longer matches"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            replacement,
+            current_name=current_name,
+            current_metadata=current_metadata,
+            identity_provider=_fake_layer_identity,
+            identity_contract=FAKE_IDENTITY_CONTRACT,
+        )
+
+    assert called is False
+
+
+def test_rewire_rejects_contract_mismatch_or_incomplete_current_provider() -> None:
+    network, _ = _attention_network()
+    snapshot = _complete_snapshot(network)
+    selection = _selection_for_nodes(snapshot, ["node:2"])
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="contract does not match"):
+        rewire_selection(
+            network,
+            snapshot,
+            selection,
+            replacement,
+            current_name=network.name,
+            current_metadata={},
+            identity_provider=_fake_layer_identity,
+            identity_contract=LayerIdentityContract(
+                provider_id="tests.other_identity",
+                schema_version=1,
+            ),
+        )
+    with pytest.raises(GraphPatchError, match="did not completely describe"):
+        rewire_selection(
+            network,
+            snapshot,
+            selection,
+            replacement,
+            current_name=network.name,
+            current_metadata={},
+            identity_provider=lambda _layer, index: None if index == 2 else {},
+            identity_contract=FAKE_IDENTITY_CONTRACT,
+        )
 
     assert called is False
 
 
 def test_invalid_selection_and_output_count_are_rejected() -> None:
     network, _ = _attention_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
 
     with pytest.raises(GraphPatchError, match="at least one"):
         compute_region_boundary(snapshot, [])
     with pytest.raises(GraphPatchError, match="unknown node"):
         compute_region_boundary(snapshot, ["node:99"])
     with pytest.raises(GraphPatchError, match="returned 0 outputs"):
-        rewire_region(network, snapshot, ["node:2"], lambda *_args: [])
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            lambda *_args: [],
+            **_current_identity(network),
+        )
 
 
 def _selection_document(snapshot: GraphSnapshot) -> dict:
@@ -627,9 +920,9 @@ def _selection_set_document(snapshot: GraphSnapshot) -> dict:
     }
 
 
-def test_structural_selection_document_drives_exact_rewire() -> None:
+def test_complete_selection_document_drives_exact_rewire() -> None:
     network, tensors = _attention_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     selection = GraphRegionSelection.from_dict(_selection_document(snapshot))
     replacement_output = FakeTensor("ffi_context")
 
@@ -640,6 +933,7 @@ def test_structural_selection_document_drives_exact_rewire() -> None:
         lambda _network, inputs, _artifact: (
             [replacement_output] if inputs == (tensors["q"], tensors["k"]) else []
         ),
+        **_current_identity(network),
     )
 
     assert selection.input_tensor_ids == ("tensor:1", "tensor:2")
@@ -720,7 +1014,7 @@ def test_selection_document_requires_kind_and_schema_version(field: str) -> None
 
 def test_region_set_replaces_each_independent_instance_once() -> None:
     network, tensors = _repeated_regions_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
     replacements = [
         FakeTensor("ffi_context_0"),
@@ -737,6 +1031,7 @@ def test_region_set_replaces_each_independent_instance_once() -> None:
         snapshot,
         selection_set,
         replacement,
+        **_current_identity(network),
     )
 
     assert len(calls) == 2
@@ -775,7 +1070,7 @@ def test_region_set_rejects_overlap_and_direct_dependencies() -> None:
 
 def test_region_set_validates_all_outputs_before_rewiring() -> None:
     network, tensors = _repeated_regions_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
     calls = 0
 
@@ -790,6 +1085,7 @@ def test_region_set_validates_all_outputs_before_rewiring() -> None:
             snapshot,
             selection_set,
             replacement,
+            **_current_identity(network),
         )
 
     assert calls == 2
@@ -799,7 +1095,7 @@ def test_region_set_validates_all_outputs_before_rewiring() -> None:
 
 def test_region_set_rejects_one_tensor_for_two_region_outputs_before_rewiring() -> None:
     network, tensors = _repeated_regions_network()
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
     shared = FakeTensor("shared")
     original_output_names = [tensor.name for tensor in network.outputs]
@@ -810,6 +1106,7 @@ def test_region_set_rejects_one_tensor_for_two_region_outputs_before_rewiring() 
             snapshot,
             selection_set,
             lambda *_args: [shared],
+            **_current_identity(network),
         )
 
     assert network.layers[1].inputs[0] is tensors["context_0"]
@@ -852,7 +1149,7 @@ def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
         ],
         [output],
     )
-    nonconvex_snapshot = snapshot_network(nonconvex)
+    nonconvex_snapshot = _complete_snapshot(nonconvex)
     with pytest.raises(GraphPatchError, match="convex region"):
         _selection_for_nodes(
             nonconvex_snapshot,
@@ -871,11 +1168,12 @@ def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
             nonconvex_snapshot,
             ["node:0", "node:2"],
             replacement,
+            **_current_identity(nonconvex),
         )
     assert called is False
 
     network.layers[2].type = "PLUGIN_V3"
-    plugin_snapshot = snapshot_network(network)
+    plugin_snapshot = _complete_snapshot(network)
     with pytest.raises(GraphPatchError, match="existing plugin"):
         _selection_for_nodes(plugin_snapshot, ["node:2"]).validate(plugin_snapshot)
     with pytest.raises(GraphPatchError, match="existing plugin"):
@@ -884,6 +1182,7 @@ def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
             plugin_snapshot,
             ["node:2"],
             replacement,
+            **_current_identity(network),
         )
     assert called is False
 
@@ -901,7 +1200,7 @@ def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
 def test_rewire_region_rejects_control_flow_layers(unsafe_op: str) -> None:
     network, _ = _attention_network()
     network.layers[2].type = unsafe_op
-    snapshot = snapshot_network(network)
+    snapshot = _complete_snapshot(network)
     called = False
 
     def replacement(*_args):
@@ -917,6 +1216,7 @@ def test_rewire_region_rejects_control_flow_layers(unsafe_op: str) -> None:
             snapshot,
             ["node:2"],
             replacement,
+            **_current_identity(network),
         )
     assert called is False
 

--- a/tests/builder/test_graph_patch.py
+++ b/tests/builder/test_graph_patch.py
@@ -14,6 +14,7 @@ from tensorrt_model_connect.graph_patch import (
     GraphRegionSelectionSet,
     GraphSnapshot,
     RegionArtifact,
+    capture_network,
     coerce_region_selection_set,
     compute_region_boundary,
     create_region_artifact,
@@ -34,6 +35,31 @@ class FakeTensor:
         self.name = name
         self.shape = shape
         self.dtype = dtype
+
+
+class EqualFakeTensor(FakeTensor):
+    """Distinct backend handles that intentionally compare equal."""
+
+    def __hash__(self) -> int:
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, EqualFakeTensor)
+
+
+class ReadOnlyNameFakeTensor:
+    def __init__(self, name: str):
+        self._name = name
+        self.shape = (1, 8, 128)
+        self.dtype = "float16"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, _value: str) -> None:
+        raise AttributeError("name is read-only")
 
 
 class FakeLayer:
@@ -200,6 +226,86 @@ def test_snapshot_json_round_trip_and_structural_fingerprint() -> None:
     assert moved_source_line.fingerprint == snapshot.fingerprint
 
 
+def test_snapshot_tracks_tensor_handles_by_identity_not_equality() -> None:
+    graph_input = EqualFakeTensor("input")
+    first_output = EqualFakeTensor("first")
+    second_output = EqualFakeTensor("second")
+    network = FakeNetwork(
+        [graph_input],
+        [
+            FakeLayer("first", "IDENTITY", [graph_input], [first_output]),
+            FakeLayer("second", "IDENTITY", [first_output], [second_output]),
+        ],
+        [second_output],
+    )
+
+    captured = capture_network(network)
+    snapshot = captured.snapshot
+
+    assert len(snapshot.tensors) == 3
+    assert snapshot.nodes[0].outputs == ("tensor:1",)
+    assert snapshot.nodes[1].inputs == ("tensor:1",)
+    assert snapshot.nodes[1].outputs == ("tensor:2",)
+    assert captured.node_id_for(network.layers[0]) == "node:0"
+    equivalent_wrapper = FakeLayer(
+        "first",
+        "IDENTITY",
+        [graph_input],
+        [first_output],
+    )
+    assert captured.node_id_for(equivalent_wrapper) == "node:0"
+    assert captured.tensor_id_for(first_output) == "tensor:1"
+    with pytest.raises(GraphPatchError, match="does not belong"):
+        captured.tensor_id_for(EqualFakeTensor("unknown"))
+
+
+def test_captured_graph_resolves_unique_no_output_layer_proxy() -> None:
+    graph_input = FakeTensor("input")
+    network = FakeNetwork(
+        [graph_input],
+        [FakeLayer("sink", "ASSERTION", [graph_input], [])],
+        [graph_input],
+    )
+
+    captured = capture_network(network)
+    equivalent_wrapper = FakeLayer("sink", "ASSERTION", [graph_input], [])
+
+    assert captured.node_id_for(equivalent_wrapper) == "node:0"
+
+
+def test_captured_graph_rejects_ambiguous_no_output_layer_proxy() -> None:
+    graph_input = FakeTensor("input")
+    network = FakeNetwork(
+        [graph_input],
+        [
+            FakeLayer("sink", "ASSERTION", [graph_input], []),
+            FakeLayer("sink", "ASSERTION", [graph_input], []),
+        ],
+        [graph_input],
+    )
+
+    captured = capture_network(network)
+    equivalent_wrapper = FakeLayer("sink", "ASSERTION", [graph_input], [])
+
+    with pytest.raises(GraphPatchError, match="does not belong"):
+        captured.node_id_for(equivalent_wrapper)
+
+
+def test_captured_graph_rejects_one_layer_handle_used_for_two_nodes() -> None:
+    graph_input = FakeTensor("input")
+    shared_layer = FakeLayer("sink", "ASSERTION", [graph_input], [])
+    network = FakeNetwork(
+        [graph_input],
+        [shared_layer, shared_layer],
+        [graph_input],
+    )
+
+    captured = capture_network(network)
+
+    with pytest.raises(GraphPatchError, match="does not belong"):
+        captured.node_id_for(shared_layer)
+
+
 def test_boundary_and_region_artifact_are_derived_from_selection() -> None:
     network, _ = _attention_network()
     snapshot = snapshot_network(network)
@@ -275,11 +381,107 @@ def test_rewire_region_updates_all_external_consumers_and_network_output() -> No
     assert result.rewired_network_outputs == 1
     assert result.replacement_outputs == (new_context,)
     assert network.output_calls == [
+        ("unmark", tensors["residual"]),
         ("unmark", tensors["context"]),
+        ("mark", tensors["residual"]),
         ("mark", new_context),
     ]
     assert new_context.name == "context"
-    assert set(network.outputs) == {tensors["residual"], new_context}
+    assert network.outputs == [tensors["residual"], new_context]
+
+
+def test_rewire_region_preserves_network_output_order() -> None:
+    network, tensors = _attention_network()
+    network.outputs = [tensors["context"], tensors["residual"]]
+    snapshot = snapshot_network(network)
+    new_context = FakeTensor("ffi_context")
+
+    rewire_region(
+        network,
+        snapshot,
+        ["node:2"],
+        lambda *_args: [new_context],
+    )
+
+    assert network.outputs == [new_context, tensors["residual"]]
+    assert new_context.name == "context"
+
+
+def test_rewire_region_fails_before_mutation_when_output_name_cannot_be_preserved() -> None:
+    network, tensors = _attention_network()
+    snapshot = snapshot_network(network)
+    replacement = ReadOnlyNameFakeTensor("ffi_context")
+
+    with pytest.raises(GraphPatchError, match="preserve the public name"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            lambda *_args: [replacement],
+        )
+
+    assert network.layers[3].inputs[0] is tensors["context"]
+    assert network.layers[4].inputs[0] is tensors["context"]
+    assert network.outputs == [tensors["residual"], tensors["context"]]
+    assert network.output_calls == []
+    assert tensors["context"].name == "context"
+
+
+@pytest.mark.parametrize(
+    ("field", "expected", "actual"),
+    [
+        ("dtype", "float32", "int8"),
+        ("shape", (1,), (99,)),
+        ("location", "DEVICE", "HOST"),
+        ("is_shape_tensor", False, True),
+    ],
+)
+def test_rewire_region_rejects_output_abi_mismatch_before_mutation(
+    field: str,
+    expected: object,
+    actual: object,
+) -> None:
+    network, tensors = _attention_network()
+    setattr(tensors["context"], field, expected)
+    snapshot = snapshot_network(network)
+    replacement = FakeTensor("ffi_context")
+    setattr(replacement, field, actual)
+
+    with pytest.raises(GraphPatchError, match=rf"ABI mismatch.*{field}"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            lambda *_args: [replacement],
+        )
+
+    assert network.layers[3].inputs[0] is tensors["context"]
+    assert network.layers[4].inputs[0] is tensors["context"]
+    assert network.outputs == [tensors["residual"], tensors["context"]]
+    assert network.output_calls == []
+
+
+@pytest.mark.parametrize("tensor_name", ["hidden", "residual", "context"])
+def test_rewire_region_rejects_original_tensor_as_replacement_output(
+    tensor_name: str,
+) -> None:
+    network, tensors = _attention_network()
+    snapshot = snapshot_network(network)
+    original_names = {name: tensor.name for name, tensor in tensors.items()}
+
+    with pytest.raises(GraphPatchError, match="newly created backend tensors"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            lambda *_args: [tensors[tensor_name]],
+        )
+
+    assert network.layers[3].inputs[0] is tensors["context"]
+    assert network.layers[4].inputs[0] is tensors["context"]
+    assert network.outputs == [tensors["residual"], tensors["context"]]
+    assert network.output_calls == []
+    assert {name: tensor.name for name, tensor in tensors.items()} == original_names
 
 
 def test_rewire_fails_closed_when_graph_drifted() -> None:
@@ -311,7 +513,7 @@ def test_invalid_selection_and_output_count_are_rejected() -> None:
         rewire_region(network, snapshot, ["node:2"], lambda *_args: [])
 
 
-def _viewer_selection(snapshot: GraphSnapshot) -> dict:
+def _selection_document(snapshot: GraphSnapshot) -> dict:
     return {
         "schema_version": 1,
         "kind": "tensorrt_model_connect.graph_region",
@@ -322,18 +524,14 @@ def _viewer_selection(snapshot: GraphSnapshot) -> dict:
         },
         "selection": {
             "node_ids": ["node:2"],
-            "semantic_paths": [],
         },
         "boundary": {
             "inputs": [
-                {"tensor_id": "tensor:1", "consumer": "node:2"},
-                {"tensor_id": "tensor:2", "consumer": "node:2"},
+                {"tensor_id": "tensor:1"},
+                {"tensor_id": "tensor:2"},
             ],
-            # The viewer has one edge per external consumer. Repeated tensor
-            # IDs are deliberately accepted and collapsed by the loader.
             "outputs": [
-                {"tensor_id": "tensor:3", "consumer": "node:3"},
-                {"tensor_id": "tensor:3", "consumer": "node:4"},
+                {"tensor_id": "tensor:3"},
             ],
         },
     }
@@ -429,10 +627,10 @@ def _selection_set_document(snapshot: GraphSnapshot) -> dict:
     }
 
 
-def test_viewer_selection_drives_exact_rewire() -> None:
+def test_structural_selection_document_drives_exact_rewire() -> None:
     network, tensors = _attention_network()
     snapshot = snapshot_network(network)
-    selection = GraphRegionSelection.from_dict(_viewer_selection(snapshot))
+    selection = GraphRegionSelection.from_dict(_selection_document(snapshot))
     replacement_output = FakeTensor("ffi_context")
 
     result = rewire_selection(
@@ -451,20 +649,15 @@ def test_viewer_selection_drives_exact_rewire() -> None:
     assert network.layers[4].inputs[0] is replacement_output
 
 
-def test_region_set_parses_legacy_single_region_and_round_trips() -> None:
+def test_region_set_parses_single_region_and_round_trips() -> None:
     network, _ = _attention_network()
     snapshot = snapshot_network(network)
-    legacy = GraphRegionSelection.from_dict(_viewer_selection(snapshot))
+    selection = GraphRegionSelection.from_dict(_selection_document(snapshot))
 
-    wrapped = GraphRegionSelectionSet.from_dict(_viewer_selection(snapshot))
-    assert wrapped == coerce_region_selection_set(legacy)
-    assert wrapped.selections == (legacy,)
-    assert legacy.input_contracts == (
-        {"consumer": "node:2", "tensor_id": "tensor:1"},
-        {"consumer": "node:2", "tensor_id": "tensor:2"},
-    )
-    assert legacy.output_contracts == ({"consumer": "node:3", "tensor_id": "tensor:3"},)
-    assert GraphRegionSelection.from_json(legacy.to_json()) == legacy
+    wrapped = GraphRegionSelectionSet.from_dict(_selection_document(snapshot))
+    assert wrapped == coerce_region_selection_set(selection)
+    assert wrapped.selections == (selection,)
+    assert GraphRegionSelection.from_json(selection.to_json()) == selection
 
     repeated_network, _ = _repeated_regions_network()
     repeated_snapshot = snapshot_network(repeated_network)
@@ -475,6 +668,54 @@ def test_region_set_parses_legacy_single_region_and_round_trips() -> None:
     assert len(restored.selections) == 2
     assert restored.selections[1].instance["layer_index"] == 1
     assert restored.build == {"precision": "fp16"}
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["selection"].update({"semantic_paths": []}),
+        lambda value: value["boundary"]["outputs"][0].update({"consumer": "node:3"}),
+        lambda value: value["boundary"]["outputs"].append({"tensor_id": "tensor:3"}),
+    ],
+)
+def test_selection_document_rejects_unknown_or_duplicate_boundary_data(
+    mutation,
+) -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    value = _selection_document(snapshot)
+    mutation(value)
+
+    with pytest.raises(GraphPatchError, match="Unknown|duplicate"):
+        GraphRegionSelection.from_dict(value)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["node_id", "model", "stage"],
+)
+def test_selection_document_rejects_non_string_fields(field: str) -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    value = _selection_document(snapshot)
+    if field == "node_id":
+        value["selection"]["node_ids"] = [2]
+    else:
+        value["graph"][field] = {"not": "a string"}
+
+    with pytest.raises(GraphPatchError, match="string|node ID"):
+        GraphRegionSelection.from_dict(value)
+
+
+@pytest.mark.parametrize("field", ["kind", "schema_version"])
+def test_selection_document_requires_kind_and_schema_version(field: str) -> None:
+    network, _ = _attention_network()
+    snapshot = snapshot_network(network)
+    value = _selection_document(snapshot)
+    value.pop(field)
+
+    with pytest.raises(GraphPatchError, match="Unsupported"):
+        GraphRegionSelection.from_dict(value)
 
 
 def test_region_set_replaces_each_independent_instance_once() -> None:
@@ -556,15 +797,37 @@ def test_region_set_validates_all_outputs_before_rewiring() -> None:
     assert network.layers[3].inputs[0] is tensors["context_1"]
 
 
-def test_viewer_selection_fails_closed_on_fingerprint_or_boundary_drift() -> None:
+def test_region_set_rejects_one_tensor_for_two_region_outputs_before_rewiring() -> None:
+    network, tensors = _repeated_regions_network()
+    snapshot = snapshot_network(network)
+    selection_set = GraphRegionSelectionSet.from_dict(_selection_set_document(snapshot))
+    shared = FakeTensor("shared")
+    original_output_names = [tensor.name for tensor in network.outputs]
+
+    with pytest.raises(GraphPatchError, match="two region outputs"):
+        rewire_selection_set(
+            network,
+            snapshot,
+            selection_set,
+            lambda *_args: [shared],
+        )
+
+    assert network.layers[1].inputs[0] is tensors["context_0"]
+    assert network.layers[3].inputs[0] is tensors["context_1"]
+    assert network.outputs == [tensors["output"]]
+    assert [tensor.name for tensor in network.outputs] == original_output_names
+    assert shared.name == "shared"
+
+
+def test_selection_document_fails_closed_on_fingerprint_or_boundary_drift() -> None:
     network, _ = _attention_network()
     snapshot = snapshot_network(network)
-    value = _viewer_selection(snapshot)
+    value = _selection_document(snapshot)
     value["graph"]["fingerprint"] = "stale"
     with pytest.raises(GraphPatchError, match="fingerprint"):
         GraphRegionSelection.from_dict(value).validate(snapshot)
 
-    value = _viewer_selection(snapshot)
+    value = _selection_document(snapshot)
     value["boundary"]["outputs"] = [{"tensor_id": "tensor:4"}]
     with pytest.raises(GraphPatchError, match="output boundary"):
         GraphRegionSelection.from_dict(value).validate(snapshot)
@@ -595,11 +858,67 @@ def test_selection_rejects_disconnected_nonconvex_and_plugin_regions() -> None:
             nonconvex_snapshot,
             ["node:0", "node:2"],
         ).validate(nonconvex_snapshot)
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="convex region"):
+        rewire_region(
+            nonconvex,
+            nonconvex_snapshot,
+            ["node:0", "node:2"],
+            replacement,
+        )
+    assert called is False
 
     network.layers[2].type = "PLUGIN_V3"
     plugin_snapshot = snapshot_network(network)
     with pytest.raises(GraphPatchError, match="existing plugin"):
         _selection_for_nodes(plugin_snapshot, ["node:2"]).validate(plugin_snapshot)
+    with pytest.raises(GraphPatchError, match="existing plugin"):
+        rewire_region(
+            network,
+            plugin_snapshot,
+            ["node:2"],
+            replacement,
+        )
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    "unsafe_op",
+    [
+        "CONDITIONAL_INPUT",
+        "ITERATOR",
+        "LOOP_OUTPUT",
+        "RECURRENCE",
+        "TRIP_LIMIT",
+    ],
+)
+def test_rewire_region_rejects_control_flow_layers(unsafe_op: str) -> None:
+    network, _ = _attention_network()
+    network.layers[2].type = unsafe_op
+    snapshot = snapshot_network(network)
+    called = False
+
+    def replacement(*_args):
+        nonlocal called
+        called = True
+        return [FakeTensor("replacement")]
+
+    with pytest.raises(GraphPatchError, match="control-flow"):
+        create_region_artifact(snapshot, ["node:2"])
+    with pytest.raises(GraphPatchError, match="control-flow"):
+        rewire_region(
+            network,
+            snapshot,
+            ["node:2"],
+            replacement,
+        )
+    assert called is False
 
 
 def test_graph_patch_module_has_no_tensorrt_import() -> None:

--- a/tests/builder/test_graph_patch_real_trt.py
+++ b/tests/builder/test_graph_patch_real_trt.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-TensorRT smoke coverage for multi-instance graph rewiring."""
+
+from __future__ import annotations
+
+from tests.builder.conftest import requires_trt
+
+from tensorrt_model_connect.graph_patch import (
+    GraphRegionSelection,
+    GraphRegionSelectionSet,
+    LayerIdentityContract,
+    capture_network,
+    compute_region_boundary,
+    rewire_selection_set,
+)
+
+
+@requires_trt
+def test_multi_instance_rewire_compiles_real_tensorrt_network() -> None:
+    import tensorrt as trt
+
+    logger = trt.Logger(trt.Logger.ERROR)
+    builder = trt.Builder(logger)
+    identity_contract = LayerIdentityContract(
+        provider_id="tests.real_trt_layer_identity",
+        schema_version=1,
+    )
+
+    # Model builders must record subtype settings at layer construction time:
+    # TensorRT's generic ILayer wrapper does not expose every subtype attribute.
+    def identity_provider_for(operations_by_name):
+        def provide(layer, _index):
+            operation = operations_by_name.get(layer.name)
+            return {} if operation is None else {"operation": operation}
+
+        return provide
+
+    def elementwise_fingerprint(operation):
+        candidate = builder.create_network(
+            1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+        )
+        candidate_input = candidate.add_input("value", trt.float32, (1, 4))
+        candidate_layer = candidate.add_elementwise(
+            candidate_input,
+            candidate_input,
+            operation,
+        )
+        candidate_layer.name = "combine"
+        candidate_layer.get_output(0).name = "combined"
+        candidate.mark_output(candidate_layer.get_output(0))
+        identity_provider = identity_provider_for({"combine": str(operation)})
+        return capture_network(
+            candidate,
+            name="real-trt-elementwise",
+            metadata={"engine_role": "identity-regression"},
+            identity_provider=identity_provider,
+            identity_contract=identity_contract,
+        ).snapshot.fingerprint
+
+    assert elementwise_fingerprint(trt.ElementWiseOperation.SUM) != elementwise_fingerprint(
+        trt.ElementWiseOperation.PROD
+    )
+
+    identity_provider = identity_provider_for({})
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    value = network.add_input("value", trt.float32, (1, 4))
+
+    first = network.add_identity(value)
+    first.name = "layer.0.replace_me"
+    first.get_output(0).name = "first_output"
+    network.mark_output(first.get_output(0))
+    bridge = network.add_identity(first.get_output(0))
+    bridge.name = "layer.0.bridge"
+    second = network.add_identity(bridge.get_output(0))
+    second.name = "layer.1.replace_me"
+    consumer = network.add_identity(second.get_output(0))
+    consumer.name = "consumer"
+    consumer.get_output(0).name = "output"
+    network.mark_output(consumer.get_output(0))
+
+    captured = capture_network(
+        network,
+        name="real-trt-multi-instance",
+        metadata={"engine_role": "decode"},
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
+    )
+    snapshot = captured.snapshot
+    assert captured.node_id_for(first) == "node:0"
+    assert captured.tensor_id_for(first.get_output(0)) == snapshot.nodes[0].outputs[0]
+    selections = []
+    for layer_index, node_id in enumerate(("node:0", "node:2")):
+        boundary = compute_region_boundary(snapshot, (node_id,))
+        selections.append(
+            GraphRegionSelection(
+                graph_fingerprint=snapshot.fingerprint,
+                selected_node_ids=boundary.selected_node_ids,
+                input_tensor_ids=boundary.input_tensor_ids,
+                output_tensor_ids=boundary.output_tensor_ids,
+                stage="decode",
+                instance={"layer_index": layer_index},
+            )
+        )
+    selection_set = GraphRegionSelectionSet(
+        graph_fingerprint=snapshot.fingerprint,
+        selections=tuple(selections),
+        stage="decode",
+    )
+
+    replacement_outputs = []
+
+    def replacement(live_network, inputs, _artifact):
+        layer = live_network.add_identity(inputs[0])
+        layer.name = f"external.replacement.{len(replacement_outputs)}"
+        output = layer.get_output(0)
+        replacement_outputs.append(output)
+        return (output,)
+
+    result = rewire_selection_set(
+        network,
+        snapshot,
+        selection_set,
+        replacement,
+        current_name="real-trt-multi-instance",
+        current_metadata={"engine_role": "decode"},
+        identity_provider=identity_provider,
+        identity_contract=identity_contract,
+    )
+
+    assert result.region_count == 2
+    assert result.rewired_consumer_inputs == 2
+    assert bridge.get_input(0) is replacement_outputs[0]
+    assert consumer.get_input(0) is replacement_outputs[1]
+    assert [network.get_output(index).name for index in range(network.num_outputs)] == [
+        "first_output",
+        "output",
+    ]
+
+    plan = builder.build_serialized_network(
+        network,
+        builder.create_builder_config(),
+    )
+    assert plan is not None
+    assert len(bytes(plan)) > 0

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -692,6 +692,13 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert '--revision "${{ needs.legal.outputs.tested_sha }}"' in graph_patch
     assert "actions/upload-artifact@v4" in graph_patch
     assert "if-no-files-found: error" in graph_patch
+    job_environment = graph_patch.split("    env:", maxsplit=1)[1].split(
+        "\n\n    steps:", maxsplit=1
+    )[0]
+    assert "runner.temp" not in job_environment
+    assert graph_patch.count(
+        "GRAPH_PATCH_OUTPUT_DIR: ${{ runner.temp }}/trtmc-graph-patch-real-trt-"
+    ) == 2
 
     assert "- legal" in model_proof
     assert "- impact" in model_proof

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -62,6 +62,7 @@ def test_ci_orchestration_uses_the_class_based_python_entrypoint() -> None:
         "coverage.py",
         "docker_image.py",
         "e2e_scheduler.py",
+        "graph_patch.py",
         "model_proof.py",
         "pipeline.py",
         "stage.py",
@@ -71,6 +72,8 @@ def test_ci_orchestration_uses_the_class_based_python_entrypoint() -> None:
         "CoverageRunner",
         "DockerImageManager",
         "E2EParallelRunner",
+        "GraphPatchRealTrtRunner",
+        "GraphPatchRealTrtGate",
         "ModelProofRunner",
         "CiPipeline",
         "ContainerStageRunner",
@@ -511,7 +514,7 @@ def test_github_workflows_publish_html_reports_for_nightly_and_model_proof() -> 
 
     premerge = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
     assert "model-proof.yml" in premerge
-    assert "5 / Combined HTML report" in premerge
+    assert "6 / Combined HTML report" in premerge
     assert "Download isolated model proof artifacts" in premerge
     assert "merge-multiple: false" in premerge
     assert (
@@ -621,9 +624,12 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
 
     legal = text.split("\n  legal:", maxsplit=1)[1].split("\n  impact:", maxsplit=1)[0]
     impact = text.split("\n  impact:", maxsplit=1)[1].split("\n  unit-tests:", maxsplit=1)[0]
-    unit_tests = text.split("\n  unit-tests:", maxsplit=1)[1].split("\n  model-proof:", maxsplit=1)[
-        0
-    ]
+    unit_tests = text.split("\n  unit-tests:", maxsplit=1)[1].split(
+        "\n  graph-patch-real-trt:", maxsplit=1
+    )[0]
+    graph_patch = text.split("\n  graph-patch-real-trt:", maxsplit=1)[1].split(
+        "\n  model-proof:", maxsplit=1
+    )[0]
     model_proof = text.split("\n  model-proof:", maxsplit=1)[1].split("\n  no-model:", maxsplit=1)[
         0
     ]
@@ -647,6 +653,7 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "fallback_models: ${{ steps.impact.outputs.fallback_models }}" in impact
     assert "run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}" in impact
     assert "unit_scope: ${{ steps.impact.outputs.unit_scope }}" in impact
+    assert "run_graph_patch_trt: ${{ steps.impact.outputs.run_graph_patch_trt }}" in impact
     assert "Directly affected models" in impact
     assert "Representative fallback models" in impact
 
@@ -670,17 +677,38 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert 'unit_scratch="${RUNNER_TEMP}/trtmc-premerge-unit-' in unit_tests
     assert 'rm -rf -- "$unit_scratch"' in unit_tests
 
+    for dependency in ("legal", "impact", "source-quality", "unit-tests"):
+        assert f"- {dependency}" in graph_patch
+    assert "name: 4 / Graph patch / Real TensorRT" in graph_patch
+    assert "needs.impact.outputs.run_graph_patch_trt == 'true'" in graph_patch
+    assert "needs.source-quality.result == 'success'" in graph_patch
+    assert "needs.unit-tests.result == 'success'" in graph_patch
+    assert (
+        "runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || "
+        "vars.TRTMC_RUNNER_LABELS" in graph_patch
+    )
+    assert "python3 -m tools.ci image ensure" in graph_patch
+    assert "python3 -m tools.ci graph-patch-real-trt" in graph_patch
+    assert '--revision "${{ needs.legal.outputs.tested_sha }}"' in graph_patch
+    assert "actions/upload-artifact@v4" in graph_patch
+    assert "if-no-files-found: error" in graph_patch
+
     assert "- legal" in model_proof
     assert "- impact" in model_proof
     assert "- unit-tests" in model_proof
+    assert "- graph-patch-real-trt" in model_proof
     assert "needs.legal.outputs.authorized == 'true'" in model_proof
     assert "needs.impact.outputs.has_models == 'true'" in model_proof
     assert "needs.impact.outputs.run_unit_tests == 'true'" in model_proof
     assert "needs.impact.outputs.run_unit_tests == 'false'" in model_proof
     assert "needs.unit-tests.result == 'success'" in model_proof
     assert "needs.unit-tests.result == 'skipped'" in model_proof
+    assert "needs.impact.outputs.run_graph_patch_trt == 'true'" in model_proof
+    assert "needs.impact.outputs.run_graph_patch_trt == 'false'" in model_proof
+    assert "needs.graph-patch-real-trt.result == 'success'" in model_proof
+    assert "needs.graph-patch-real-trt.result == 'skipped'" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
-    assert "name: 4 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]" in model_proof
+    assert "name: 5 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]" in model_proof
     assert "fail-fast: true" in model_proof
     assert "continue-on-error" not in model_proof
     assert "max-parallel:" not in model_proof
@@ -692,14 +720,17 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "- legal" in no_model
     assert "- impact" in no_model
     assert "- unit-tests" in no_model
+    assert "- graph-patch-real-trt" in no_model
     assert "needs.legal.outputs.authorized == 'true'" in no_model
     assert "needs.impact.outputs.has_models == 'false'" in no_model
+    assert "needs.graph-patch-real-trt.result == 'success'" in no_model
+    assert "needs.graph-patch-real-trt.result == 'skipped'" in no_model
     assert 'none) echo "No model-owned, platform, or unit inputs changed."' in no_model
     assert 'unit) echo "Unit tests cover this change; no model proof is required."' in no_model
 
     for dependency in ("legal", "impact", "unit-tests", "model-proof", "no-model"):
         assert f"- {dependency}" in report
-    assert "5 / Combined HTML report" in report
+    assert "6 / Combined HTML report" in report
     assert "always()" in report
     assert "github.event.label.name == 'run-ci'" in report
     assert "needs.legal.outputs.authorized == 'true'" not in report
@@ -720,13 +751,80 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "Upload combined model proof HTML report" in report
     assert "Enforce combined report certification" in report
 
-    for dependency in ("legal", "impact", "unit-tests", "model-proof", "no-model", "report"):
+    for dependency in (
+        "legal",
+        "impact",
+        "unit-tests",
+        "graph-patch-real-trt",
+        "model-proof",
+        "no-model",
+        "report",
+    ):
         assert f"- {dependency}" in required
     assert "'Premerge CI' || 'Ignored label / Premerge CI'" in required
     assert "always()" in required
     assert 'test "$MODEL_RESULT" = "success"' in required
     assert 'test "$UNIT_RESULT" = "success"' in required
+    assert 'test "$GRAPH_PATCH_TRT_RESULT" = "success"' in required
+    assert 'test "$GRAPH_PATCH_TRT_RESULT" = "skipped"' in required
     assert 'test "$REPORT_RESULT" = "success"' in required
+
+
+def test_graph_patch_timeout_hierarchy_and_cleanup_ownership_are_fail_closed() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
+    graph_patch = workflow.split("\n  graph-patch-real-trt:", maxsplit=1)[1].split(
+        "\n  model-proof:", maxsplit=1
+    )[0]
+
+    job_timeout = int(
+        re.search(r"(?m)^    timeout-minutes: ([0-9]+)$", graph_patch).group(1)  # type: ignore[union-attr]
+    )
+    image_step = graph_patch.split("      - name: Ensure CI Docker image", maxsplit=1)[1].split(
+        "      - name:", maxsplit=1
+    )[0]
+    gate_step = graph_patch.split(
+        "      - name: Run leased real-TensorRT graph-patch gate", maxsplit=1
+    )[1].split("      - name:", maxsplit=1)[0]
+    image_timeout = int(
+        re.search(r"timeout-minutes: ([0-9]+)", image_step).group(1)  # type: ignore[union-attr]
+    )
+    gate_timeout = int(
+        re.search(r"timeout-minutes: ([0-9]+)", gate_step).group(1)  # type: ignore[union-attr]
+    )
+
+    def duration_seconds(name: str) -> int:
+        match = re.search(rf'(?m)^      {name}: "([0-9]+)([smh])"$', graph_patch)
+        assert match, name
+        multiplier = {"s": 1, "m": 60, "h": 3600}[match.group(2)]
+        return int(match.group(1)) * multiplier
+
+    lease_match = re.search(
+        r'(?m)^      TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: "([0-9]+)"$',
+        graph_patch,
+    )
+    assert lease_match
+    lease_seconds = int(lease_match.group(1))
+    inner_seconds = sum(
+        duration_seconds(name)
+        for name in (
+            "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT",
+            "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT",
+            "TRTMC_GRAPH_PATCH_TEST_TIMEOUT",
+        )
+    )
+    command_kill_grace_seconds = 3 * 2 * 60
+    cleanup_reserve_seconds = 5 * 60
+    upload_and_job_cleanup_reserve_seconds = 10 * 60
+
+    assert gate_timeout * 60 > (
+        lease_seconds + inner_seconds + command_kill_grace_seconds + cleanup_reserve_seconds
+    )
+    assert job_timeout * 60 > (
+        image_timeout * 60 + gate_timeout * 60 + upload_and_job_cleanup_reserve_seconds
+    )
+    assert lease_seconds == 600
+    assert '"timeout", "--kill-after=2m"' in _ci_source("context.py")
+    assert "docker rm -f" not in graph_patch
 
 
 def test_premerge_ci_requires_gpu_free_source_quality() -> None:
@@ -1631,7 +1729,7 @@ def test_premerge_unit_container_is_unprivileged_offline_and_cpu_only() -> None:
     start = _ci_source("container.py", "environment.py")
     workflow = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
     unit_tests = workflow.split("\n  unit-tests:", maxsplit=1)[1].split(
-        "\n  model-proof:", maxsplit=1
+        "\n  graph-patch-real-trt:", maxsplit=1
     )[0]
 
     for option in (

--- a/tests/tools/test_graph_patch_ci.py
+++ b/tests/tools/test_graph_patch_ci.py
@@ -1,0 +1,1011 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the conditional real-TensorRT graph-patch CI gate."""
+
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.ci import graph_patch as graph_patch_ci
+from tools.ci.graph_patch import GraphPatchRealTrtGate, GraphPatchRealTrtRunner
+from tools.ci.process import CiError
+
+
+def _write_junit(
+    path: Path,
+    *,
+    tests: int = 1,
+    failures: int = 0,
+    errors: int = 0,
+    skipped: int = 0,
+) -> None:
+    if failures:
+        outcome = "<failure />"
+    elif errors:
+        outcome = "<error />"
+    elif skipped:
+        outcome = "<skipped />"
+    else:
+        outcome = ""
+    cases = "".join(f'<testcase name="case-{index}">{outcome}</testcase>' for index in range(tests))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "<testsuites>"
+        f'<testsuite tests="{tests}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}">'
+        f"{cases}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+
+def _write_preflight(path: Path, revision: str = "b" * 40) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source_revision": revision,
+                "tensorrt_version": "11.2.0.113",
+                "cuda_status": 0,
+                "visible_device_count": 1,
+                "builder_created": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _container_metadata(
+    labels: dict[str, str],
+    *,
+    container_id: str,
+) -> dict[str, object]:
+    return {
+        "Id": container_id,
+        "Config": {"Labels": labels},
+    }
+
+
+def _orphan_labels(
+    *,
+    owner_token: str = "b" * 32,
+    gpu: str = "2",
+    lock_namespace: str = "c" * 64,
+    slots: str = "1",
+) -> dict[str, str]:
+    return {
+        "com.nvidia.trtmc.model-proof": "1",
+        "com.nvidia.trtmc.graph-patch-real-trt": "1",
+        "com.nvidia.trtmc.model-proof.gpu": gpu,
+        "com.nvidia.trtmc.model-proof.lock-namespace": lock_namespace,
+        "com.nvidia.trtmc.model-proof.slots": slots,
+        "com.nvidia.trtmc.graph-patch.owner-token": owner_token,
+    }
+
+
+def test_graph_patch_preflight_requires_one_gpu_and_pinned_revision(
+    tmp_path: Path,
+) -> None:
+    evidence = tmp_path / "preflight.json"
+    revision = "b" * 40
+    _write_preflight(evidence, revision)
+
+    assert (
+        GraphPatchRealTrtGate.certify_preflight(
+            evidence,
+            expected_revision=revision,
+        )["visible_device_count"]
+        == 1
+    )
+
+    payload = json.loads(evidence.read_text(encoding="utf-8"))
+    payload["visible_device_count"] = 2
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(CiError, match="visible_device_count"):
+        GraphPatchRealTrtGate.certify_preflight(
+            evidence,
+            expected_revision=revision,
+        )
+
+
+def test_graph_patch_junit_requires_one_fully_passing_test(tmp_path: Path) -> None:
+    junit = tmp_path / "junit.xml"
+    _write_junit(junit)
+
+    assert GraphPatchRealTrtGate.certify_junit(junit) == {
+        "tests": 1,
+        "failures": 0,
+        "errors": 0,
+        "skipped": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("tests", "failures", "errors", "skipped"),
+    (
+        (0, 0, 0, 0),
+        (1, 1, 0, 0),
+        (1, 0, 1, 0),
+        (1, 0, 0, 1),
+    ),
+)
+def test_graph_patch_junit_rejects_empty_or_nonpassing_results(
+    tmp_path: Path,
+    tests: int,
+    failures: int,
+    errors: int,
+    skipped: int,
+) -> None:
+    junit = tmp_path / "junit.xml"
+    _write_junit(
+        junit,
+        tests=tests,
+        failures=failures,
+        errors=errors,
+        skipped=skipped,
+    )
+
+    with pytest.raises(CiError):
+        GraphPatchRealTrtGate.certify_junit(junit)
+
+
+@pytest.mark.parametrize("content", ("", "<not-closed>", "<other />"))
+def test_graph_patch_junit_rejects_missing_or_malformed_evidence(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    junit = tmp_path / "junit.xml"
+    if content:
+        junit.write_text(content, encoding="utf-8")
+
+    with pytest.raises(CiError):
+        GraphPatchRealTrtGate.certify_junit(junit)
+
+
+def test_graph_patch_inner_gate_runs_only_the_exact_real_trt_target(
+    tmp_path: Path,
+) -> None:
+    class RecordingContext:
+        repository = tmp_path
+        env = {"TRTMC_GRAPH_PATCH_JUNIT": str(tmp_path / "junit.xml")}
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def run(
+            self,
+            command: list[str],
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.calls.append((command, kwargs))
+            return subprocess.CompletedProcess(command, 0)
+
+    context = RecordingContext()
+    gate = GraphPatchRealTrtGate(context)  # type: ignore[arg-type]
+    gate.run_test()
+
+    command, options = context.calls[-1]
+    assert command[:3] == ["python3", "-m", "pytest"]
+    assert command.count(GraphPatchRealTrtGate.TEST_PATH) == 1
+    assert GraphPatchRealTrtGate.TEST_PATH.endswith(
+        "::test_multi_instance_rewire_compiles_real_tensorrt_network"
+    )
+    assert not any(character in GraphPatchRealTrtGate.TEST_PATH for character in "*?[")
+    assert f"--junitxml={tmp_path / 'junit.xml'}" in command
+    assert options["check"] is False
+    assert options["limit"] == "10m"
+    assert options["updates"] == {"PYTHONPATH": f"{tmp_path / 'python'}:{tmp_path}"}
+
+
+def test_graph_patch_host_runner_uses_shared_lease_and_isolated_gpu_container(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    output = tmp_path / "gate-output"
+
+    class RecordingContext:
+        env = {
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_RUN_ID": "42",
+            "GITHUB_RUN_ATTEMPT": "3",
+            "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
+            "TRTMC_CI_IMAGE": "trtmc:test",
+            "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
+            "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT": "2m",
+            "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT": "2m",
+            "TRTMC_GRAPH_PATCH_TEST_TIMEOUT": "10m",
+        }
+
+        def __init__(self) -> None:
+            self.repository = repository
+            self.commands: list[list[str]] = []
+
+        def executable(self, name: str) -> str:
+            return f"/usr/bin/{name}"
+
+        def output(self, command: list[str]) -> str:
+            self.commands.append(command)
+            if command[:2] == ["git", "rev-parse"]:
+                return "b" * 40
+            if command[:3] == ["git", "status", "--porcelain=v1"]:
+                return ""
+            if command[:3] == ["docker", "image", "inspect"]:
+                return "sha256:" + "a" * 64
+            if command[:3] == ["docker", "ps", "--no-trunc"]:
+                return ""
+            raise AssertionError(command)
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            if command[:3] == ["docker", "container", "inspect"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    stdout="",
+                    stderr=f"Error: No such object: {command[-1]}",
+                )
+            if command[:2] == ["docker", "run"]:
+                _write_preflight(output / "preflight.json")
+                _write_junit(output / "junit.xml")
+            return subprocess.CompletedProcess(command, 0)
+
+    leases: list[object] = []
+
+    class FakeLease:
+        def __init__(
+            self,
+            _context: object,
+            model: str,
+            resource_class: str,
+            artifacts: Path,
+        ):
+            assert model == "graph-patch-real-trt"
+            assert resource_class == "shared"
+            assert artifacts == output
+            self.gpu_id = 2
+            self.slot_ids = [1]
+            self.slots_per_gpu = 4
+            self.lock_namespace = "c" * 64
+            self.released = False
+            leases.append(self)
+
+        def acquire(self) -> None:
+            return None
+
+        def evidence(self, revision: str) -> dict[str, object]:
+            return {
+                "schema_version": 1,
+                "model": "graph-patch-real-trt",
+                "source_revision": revision,
+                "gpu_id": "2",
+                "gpu_slot_ids": [1],
+                "resource_class": "shared",
+            }
+
+        def release(self) -> None:
+            self.released = True
+
+    monkeypatch.setattr(graph_patch_ci, "GpuLease", FakeLease)
+    context = RecordingContext()
+    GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+        context,
+        output_dir=output,
+        revision="b" * 40,
+        owner_token="d" * 32,
+    ).run_host()
+
+    lease = leases[0]
+    assert lease.released is True  # type: ignore[attr-defined]
+    docker_run = next(command for command in context.commands if command[:2] == ["docker", "run"])
+    assert docker_run[docker_run.index("--gpus") + 1] == "device=2"
+    assert "com.nvidia.trtmc.model-proof.slots=1" in docker_run
+    assert "com.nvidia.trtmc.graph-patch.owner-token=" + "d" * 32 in docker_run
+    assert "com.nvidia.trtmc.graph-patch.run-id=42" in docker_run
+    assert "com.nvidia.trtmc.graph-patch.run-attempt=3" in docker_run
+    assert "com.nvidia.trtmc.graph-patch.repository=NVIDIA/TensorRT-Model-Connect" in docker_run
+    assert "--read-only" in docker_run
+    assert docker_run[docker_run.index("--network") + 1] == "none"
+    assert f"type=bind,src={repository},dst=/src,readonly" in docker_run
+    assert f"type=bind,src={output},dst=/artifacts" in docker_run
+    assert "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT=2m" in docker_run
+    assert "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT=2m" in docker_run
+    assert "TRTMC_GRAPH_PATCH_TEST_TIMEOUT=10m" in docker_run
+    assert docker_run[-5:] == [
+        "python3",
+        "-m",
+        "tools.ci",
+        "pipeline",
+        "graph-patch-real-trt",
+    ]
+    assert docker_run[-6] == "sha256:" + "a" * 64
+    assert (output / "gpu-lease.json").is_file()
+    assert (output / "source-revision.txt").read_text(encoding="utf-8") == "b" * 40 + "\n"
+    runner_evidence = json.loads((output / "runner-evidence.json").read_text(encoding="utf-8"))
+    assert runner_evidence["source_revision"] == "b" * 40
+    assert runner_evidence["requested_image"] == "trtmc:test"
+    assert runner_evidence["immutable_image_id"] == "sha256:" + "a" * 64
+    assert runner_evidence["gpu_lock_namespace"] == "c" * 64
+    assert runner_evidence["owner_labels"]["com.nvidia.trtmc.graph-patch.owner-token"] == "d" * 32
+    assert (
+        sum(command[:3] == ["docker", "container", "inspect"] for command in context.commands) == 2
+    )
+
+
+def test_graph_patch_host_runner_rejects_dirty_checkout(tmp_path: Path) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+
+    class DirtyContext:
+        env = {
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_RUN_ID": "42",
+            "GITHUB_RUN_ATTEMPT": "3",
+        }
+
+        def __init__(self) -> None:
+            self.repository = repository
+            self.commands: list[list[str]] = []
+
+        def executable(self, name: str) -> str:
+            return f"/usr/bin/{name}"
+
+        def output(self, command: list[str]) -> str:
+            self.commands.append(command)
+            if command[:2] == ["git", "rev-parse"]:
+                return "b" * 40
+            if command[:3] == ["git", "status", "--porcelain=v1"]:
+                return " M python/tensorrt_model_connect/graph_patch.py"
+            raise AssertionError(command)
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    context = DirtyContext()
+    with pytest.raises(CiError, match="outside the pinned revision"):
+        GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+            context,
+            revision="b" * 40,
+        ).run_host()
+    assert not [command for command in context.commands if command[:2] == ["docker", "rm"]]
+
+
+def test_graph_patch_host_runner_revision_mismatch_makes_no_destructive_call(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+
+    class MismatchContext:
+        env = {"RUNNER_TEMP": str(tmp_path)}
+
+        def __init__(self) -> None:
+            self.repository = repository
+            self.commands: list[list[str]] = []
+            self.revision_calls = 0
+
+        def executable(self, name: str) -> str:
+            return f"/usr/bin/{name}"
+
+        def output(self, command: list[str]) -> str:
+            self.commands.append(command)
+            if command[:2] == ["git", "rev-parse"]:
+                self.revision_calls += 1
+                return ("b" if self.revision_calls == 1 else "c") * 40
+            raise AssertionError(command)
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    context = MismatchContext()
+    with pytest.raises(CiError, match="does not match the pinned tested revision"):
+        GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+            context,
+            revision="b" * 40,
+        ).run_host()
+
+    assert not [command for command in context.commands if command[:2] == ["docker", "rm"]]
+
+
+def test_graph_patch_cleanup_refuses_foreign_same_name_without_removal(
+    tmp_path: Path,
+) -> None:
+    class InventoryContext:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.containers: dict[str, dict[str, object]] = {}
+            self.commands: list[list[str]] = []
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            if command[:3] == ["docker", "container", "inspect"]:
+                name = command[-1]
+                if name not in self.containers:
+                    return subprocess.CompletedProcess(
+                        command,
+                        1,
+                        stdout="",
+                        stderr=f"Error: No such object: {name}",
+                    )
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(self.containers[name]),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                self.containers.pop(command[-1])
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    context = InventoryContext()
+    owner = GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+        context,
+        owner_token="a" * 32,
+    )
+    foreign = GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+        context,
+        owner_token="b" * 32,
+    )
+    context.containers[owner.container_name] = _container_metadata(
+        foreign._ownership_labels(),
+        container_id="1" * 64,
+    )
+
+    with pytest.raises(CiError, match="refusing to remove foreign"):
+        owner._remove_owned_container(reason="before launch")
+
+    assert owner.container_name in context.containers
+    assert not [command for command in context.commands if command[:3] == ["docker", "rm", "-f"]]
+
+
+def test_default_local_runners_use_unique_names_and_scoped_cleanup(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+
+    class InventoryContext:
+        env = {"RUNNER_TEMP": str(tmp_path)}
+
+        def __init__(self) -> None:
+            self.repository = repository
+            self.containers: dict[str, dict[str, object]] = {}
+            self.removed: list[str] = []
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:3] == ["docker", "container", "inspect"]:
+                name = command[-1]
+                if name not in self.containers:
+                    return subprocess.CompletedProcess(
+                        command,
+                        1,
+                        stdout="",
+                        stderr=f"Error: No such object: {name}",
+                    )
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(self.containers[name]),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                container_id = command[-1]
+                name = next(
+                    name
+                    for name, metadata in self.containers.items()
+                    if metadata["Id"] == container_id
+                )
+                self.removed.append(container_id)
+                self.containers.pop(name)
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    context = InventoryContext()
+    first = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    second = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+
+    assert first.owner_token != second.owner_token
+    assert first.container_name != second.container_name
+    assert first._prepare_output() != second._prepare_output()
+    context.containers = {
+        first.container_name: _container_metadata(
+            first._ownership_labels(),
+            container_id="2" * 64,
+        ),
+        second.container_name: _container_metadata(
+            second._ownership_labels(),
+            container_id="3" * 64,
+        ),
+    }
+    first.container_launch_attempted = True
+    first._cleanup()
+
+    assert context.removed == ["2" * 64]
+    assert second.container_name in context.containers
+
+
+def test_orphan_reclaim_removes_old_owner_on_the_acquired_slot(tmp_path: Path) -> None:
+    candidate_id = "5" * 64
+
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+
+        def output(self, command: list[str]) -> str:
+            assert command[:3] == ["docker", "ps", "--no-trunc"]
+            assert "label=com.nvidia.trtmc.model-proof=1" in command
+            assert "label=com.nvidia.trtmc.graph-patch-real-trt=1" not in command
+            assert "label=com.nvidia.trtmc.model-proof.gpu=2" in command
+            assert "label=com.nvidia.trtmc.model-proof.lock-namespace=" + "c" * 64 in command
+            return candidate_id
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:3] == ["docker", "container", "inspect"]:
+                assert command[-1] == candidate_id
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(
+                        _container_metadata(
+                            _orphan_labels(owner_token="b" * 32),
+                            container_id=candidate_id,
+                        )
+                    ),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                self.removed.append(command[-1])
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+        context,
+        owner_token="a" * 32,
+    )
+    runner.lease = Lease()  # type: ignore[assignment]
+    runner._reclaim_orphans()
+
+    assert context.removed == [candidate_id]
+
+
+def test_orphan_reclaim_removes_ordinary_model_proof_on_acquired_slot(
+    tmp_path: Path,
+) -> None:
+    candidate_id = "a" * 64
+    labels = _orphan_labels()
+    labels.pop("com.nvidia.trtmc.graph-patch-real-trt")
+    labels.pop("com.nvidia.trtmc.graph-patch.owner-token")
+
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+
+        def output(self, _command: list[str]) -> str:
+            return candidate_id
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:3] == ["docker", "container", "inspect"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(_container_metadata(labels, container_id=candidate_id)),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                self.removed.append(command[-1])
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+    runner._reclaim_orphans()
+
+    assert context.removed == [candidate_id]
+
+
+@pytest.mark.parametrize(
+    ("gpu", "lock_namespace", "slots"),
+    (
+        ("2", "c" * 64, "2"),
+        ("2", "d" * 64, "1"),
+        ("3", "c" * 64, "1"),
+    ),
+)
+def test_orphan_reclaim_preserves_nonoverlapping_or_foreign_leases(
+    tmp_path: Path,
+    gpu: str,
+    lock_namespace: str,
+    slots: str,
+) -> None:
+    candidate_id = "6" * 64
+
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+
+        def output(self, _command: list[str]) -> str:
+            return candidate_id
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:3] == ["docker", "container", "inspect"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(
+                        _container_metadata(
+                            _orphan_labels(
+                                owner_token="b" * 32,
+                                gpu=gpu,
+                                lock_namespace=lock_namespace,
+                                slots=slots,
+                            ),
+                            container_id=candidate_id,
+                        )
+                    ),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                self.removed.append(command[-1])
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+    runner._reclaim_orphans()
+
+    assert context.removed == []
+
+
+@pytest.mark.parametrize("slots", ("1,999", "1,1", "4"))
+def test_orphan_reclaim_rejects_invalid_slot_sets_without_deletion(
+    tmp_path: Path,
+    slots: str,
+) -> None:
+    candidate_id = "b" * 64
+
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def output(self, _command: list[str]) -> str:
+            return candidate_id
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            if command[:3] == ["docker", "container", "inspect"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(
+                        _container_metadata(
+                            _orphan_labels(slots=slots),
+                            container_id=candidate_id,
+                        )
+                    ),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+
+    with pytest.raises(CiError, match="invalid GPU slot labels"):
+        runner._reclaim_orphans()
+    assert not [command for command in context.commands if command[:3] == ["docker", "rm", "-f"]]
+
+
+@pytest.mark.parametrize("inventory", ("unsafe-id", "7" * 64 + "\n" + "7" * 64))
+def test_orphan_reclaim_rejects_malformed_inventory_without_deletion(
+    tmp_path: Path,
+    inventory: str,
+) -> None:
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def output(self, _command: list[str]) -> str:
+            return inventory
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+
+    with pytest.raises(CiError, match="orphan inventory"):
+        runner._reclaim_orphans()
+    assert not [command for command in context.commands if command[:3] == ["docker", "rm", "-f"]]
+
+
+def test_orphan_reclaim_inventory_error_makes_no_destructive_call(tmp_path: Path) -> None:
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def output(self, _command: list[str]) -> str:
+            raise CiError("Docker inventory failed")
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+
+    with pytest.raises(CiError, match="inventory failed"):
+        runner._reclaim_orphans()
+    assert not [command for command in context.commands if command[:3] == ["docker", "rm", "-f"]]
+
+
+@pytest.mark.parametrize("failure", ("error", "malformed"))
+def test_orphan_reclaim_inspect_failure_is_transactional(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    first_id = "8" * 64
+    second_id = "9" * 64
+
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def output(self, _command: list[str]) -> str:
+            return f"{first_id}\n{second_id}"
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            self.commands.append(command)
+            if command[:3] == ["docker", "container", "inspect"]:
+                if command[-1] == first_id:
+                    return subprocess.CompletedProcess(
+                        command,
+                        0,
+                        stdout=json.dumps(
+                            _container_metadata(
+                                _orphan_labels(),
+                                container_id=first_id,
+                            )
+                        ),
+                        stderr="",
+                    )
+                if failure == "error":
+                    return subprocess.CompletedProcess(
+                        command,
+                        2,
+                        stdout="",
+                        stderr="Docker daemon unavailable",
+                    )
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout="{}",
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    class Lease:
+        gpu_id = 2
+        slot_ids = [1]
+        slots_per_gpu = 4
+        lock_namespace = "c" * 64
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(context)  # type: ignore[arg-type]
+    runner.lease = Lease()  # type: ignore[assignment]
+
+    with pytest.raises(CiError, match="inspect|metadata"):
+        runner._reclaim_orphans()
+    assert not [command for command in context.commands if command[:3] == ["docker", "rm", "-f"]]
+
+
+def test_signal_path_validates_same_owner_before_finally_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Context:
+        repository = tmp_path
+        env: dict[str, str] = {}
+
+        def __init__(self) -> None:
+            self.metadata: dict[str, object] = {}
+            self.removed: list[str] = []
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:3] == ["docker", "container", "inspect"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout=json.dumps(self.metadata),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "rm", "-f"]:
+                self.removed.append(command[-1])
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(command)
+
+    context = Context()
+    runner = GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+        context,
+        owner_token="e" * 32,
+    )
+    context.metadata = _container_metadata(
+        runner._ownership_labels(),
+        container_id="4" * 64,
+    )
+    runner.container_launch_attempted = True
+    monkeypatch.setattr(
+        runner,
+        "_run_host",
+        lambda: runner._signal(signal.SIGTERM, None),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        runner.run_host()
+
+    assert exit_info.value.code == 143
+    assert context.removed == ["4" * 64]
+
+
+def test_graph_patch_inner_timeout_cannot_exceed_outer_budget(
+    tmp_path: Path,
+) -> None:
+    class Context:
+        repository = tmp_path
+        env = {
+            "TRTMC_GRAPH_PATCH_JUNIT": str(tmp_path / "junit.xml"),
+            "TRTMC_GRAPH_PATCH_TEST_TIMEOUT": "11m",
+        }
+
+        def run(
+            self,
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            raise AssertionError(command)
+
+    with pytest.raises(CiError, match="must not exceed 600 seconds"):
+        GraphPatchRealTrtGate(Context()).run_test()  # type: ignore[arg-type]
+
+
+def test_graph_patch_host_runner_rejects_non_pinned_revision(tmp_path: Path) -> None:
+    class Context:
+        repository = tmp_path
+        env = {"RUNNER_TEMP": str(tmp_path)}
+
+    with pytest.raises(CiError, match="full Git object ID"):
+        GraphPatchRealTrtRunner(  # type: ignore[arg-type]
+            Context(),
+            revision="feature/graph-patch",
+        )

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -217,7 +217,7 @@ def test_validate_and_all_emit_deterministic_matrix_and_github_outputs(
     )
 
     assert validated["models"] == ["model_a", "model_b"]
-    assert result["schema_version"] == 3
+    assert result["schema_version"] == 4
     assert result["direct_models"] == ["model_a", "model_b"]
     assert result["fallback_models"] == []
     assert result["matrix"] == {
@@ -242,6 +242,7 @@ def test_validate_and_all_emit_deterministic_matrix_and_github_outputs(
         "mode=all",
         "run_unit_tests=false",
         "unit_scope=none",
+        "run_graph_patch_trt=false",
         'expected_cases_by_model={"model_a":["model_a"],"model_b":["model_b"]}',
         "expected_result_count=2",
     ]
@@ -576,6 +577,7 @@ def test_impact_treats_legal_and_docs_as_no_model_change(tmp_path: Path) -> None
     assert result["matrix"] == {"include": []}
     assert result["run_unit_tests"] is False
     assert result["unit_scope"] == "none"
+    assert result["run_graph_patch_trt"] is False
 
 
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
@@ -637,6 +639,160 @@ def test_cli_and_unit_test_changes_run_units_without_model_proofs(
     assert result["matrix"] == {"include": []}
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == expected_scope
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_scope"),
+    (
+        ("python/tensorrt_model_connect/graph_patch.py", "builder"),
+        ("tests/builder/test_graph_patch_real_trt.py", "builder"),
+        ("tools/ci/graph_patch.py", "all"),
+    ),
+)
+def test_graph_patch_contract_runs_units_and_real_trt_without_model_proofs(
+    tmp_path: Path,
+    path: str,
+    expected_scope: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# changed graph-patch contract\n")
+    head = _commit(repo, "change graph-patch contract")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == expected_scope
+    assert result["run_graph_patch_trt"] is True
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {"graph_patch_trt"}
+
+
+def test_graph_patch_contract_mixed_with_model_change_preserves_model_proof(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "python/tensorrt_model_connect/graph_patch.py",
+        "# changed graph-patch contract\n",
+    )
+    _write(
+        repo,
+        "python/tensorrt_model_connect/families/model_b/graph_ops.py",
+        "# changed model graph\n",
+    )
+    head = _commit(repo, "change graph-patch contract and model")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_b"]
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == []
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "builder"
+    assert result["run_graph_patch_trt"] is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        ".github/workflows/trtmc-ci.yml",
+        "tools/ci/__main__.py",
+        "tools/ci/pipeline.py",
+    ),
+)
+def test_graph_patch_shared_wiring_adds_gate_without_narrowing_broad_impact(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# changed shared graph-patch wiring\n")
+    head = _commit(repo, "change shared graph-patch wiring")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {"include": [{"model": "model_a", "selection_kind": "fallback"}]}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+    assert result["run_graph_patch_trt"] is True
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {"ci_tooling"}
+
+
+def test_unrelated_ci_wiring_does_not_trigger_graph_patch_gate(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "tools/ci/context.py", "# changed unrelated CI wiring\n")
+    head = _commit(repo, "change unrelated CI wiring")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["unit_scope"] == "all"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_graph_patch_trt"] is False
+
+
+def test_graph_patch_impact_exports_real_trt_gate_decision(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "python/tensorrt_model_connect/graph_patch.py",
+        "# changed graph-patch contract\n",
+    )
+    head = _commit(repo, "change graph-patch contract")
+    output = tmp_path / "github-output"
+
+    result = _run(
+        repo,
+        "impact",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--platform-change-policy",
+        "fallback",
+        "--fallback-model",
+        "model_a",
+        "--github-output",
+        str(output),
+    )
+
+    assert json.loads(result.stdout)["run_graph_patch_trt"] is True
+    assert "run_graph_patch_trt=true" in output.read_text(encoding="utf-8").splitlines()
+
+
+def test_deleting_graph_patch_contract_still_requires_real_trt_gate(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _make_repo(tmp_path)
+    path = repo / "python/tensorrt_model_connect/graph_patch.py"
+    _write(repo, path.relative_to(repo).as_posix(), "# graph-patch contract\n")
+    base = _commit(repo, "add graph-patch contract")
+    path.unlink()
+    head = _commit(repo, "delete graph-patch contract")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["unit_scope"] == "builder"
+    assert result["run_graph_patch_trt"] is True
 
 
 @pytest.mark.parametrize("path", ("src/cli/main.cpp", "src/cli/args.h"))

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1040,6 +1040,15 @@ class TestSharedModules:
         assert match.unit_tiers == ["builder", "tools"]
         assert match.rebuild_cpp is False
 
+    def test_future_graph_module_remains_broad_impact(self, imap):
+        """A naming coincidence must not silently bypass model validation."""
+        match = test_impact.classify_file(
+            "python/tensorrt_model_connect/graph_future_runtime.py",
+            imap,
+        )
+        assert match.rule == "shared_builder_module"
+        assert sorted(match.models) == sorted(imap.all_model_names)
+
     def test_shared_module_all_models(self, imap):
         """checkpoint_mapper.py -> all models (no escalation)."""
         match = test_impact.classify_file(

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1029,6 +1029,17 @@ class TestFamilyPlugin:
 
 
 class TestSharedModules:
+    def test_graph_tooling_triggers_owned_units(self, imap):
+        """Opt-in graph tooling runs its focused builder and tools suites."""
+        match = test_impact.classify_file(
+            "python/tensorrt_model_connect/graph_patch.py",
+            imap,
+        )
+        assert match.rule == "graph_tooling"
+        assert match.models == []
+        assert match.unit_tiers == ["builder", "tools"]
+        assert match.rebuild_cpp is False
+
     def test_shared_module_all_models(self, imap):
         """checkpoint_mapper.py -> all models (no escalation)."""
         match = test_impact.classify_file(

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -19,9 +19,12 @@ flowchart LR
     B --> C[Ownership and impact]
     B --> D[Source quality]
     C --> E[C++ and Python units]
-    E --> F1[Model A proof]
-    E --> F2[Model B proof]
-    E --> FN[Model N proof]
+    E --> GP{Graph-patch paths changed?}
+    GP -->|yes| GT[Leased real-TensorRT gate]
+    GP -->|no| F1[Model A proof]
+    GT --> F1
+    GT --> F2[Model B proof]
+    GT --> FN[Model N proof]
     F1 --> G[Combined HTML report]
     F2 --> G
     FN --> G
@@ -43,6 +46,7 @@ python3 -m tools.ci pipeline source-quality
 python3 -m tools.ci image ensure
 python3 -m tools.ci container start
 python3 -m tools.ci stage premerge-unit
+python3 -m tools.ci graph-patch-real-trt
 python3 -m tools.ci model-proof --model patchtsmixer --suite premerge
 ```
 
@@ -104,7 +108,26 @@ actual unit work to `UnitTestRunner` and `CoverageRunner`.
 The unit gate admits the model matrix. Source Quality joins the final required
 `Premerge CI` check, so it cannot be bypassed even though it runs in parallel.
 
-### 4. Prove each affected model in isolation
+### 4. Prove graph-patch rewiring in real TensorRT when required
+
+An exact change to `python/tensorrt_model_connect/graph_patch.py`, its real-TRT
+test, or the gate runner selects source units plus one conditional GPU job; it
+does not select a model proof on its own. The host-side runner acquires a shared
+slot through the same `GpuLease` protocol as model proofs, then starts the
+immutable CI image with only the leased GPU visible. Inside that container the
+gate checks NVIDIA/CUDA/TensorRT availability, builds the real TensorRT smoke
+network, and emits JUnit. Certification requires at least one test and exactly
+zero failures, errors, and skips.
+
+Changes to the shared workflow or its `tools.ci` command/pipeline dispatch keep
+their ordinary full-unit plus representative-model fallback and add this gate;
+the extra trigger never narrows their existing shared-platform coverage.
+
+When a diff also changes a model, that model keeps its ordinary proof. Its proof
+waits for this gate, avoiding same-PR GPU contention. A graph-patch-only diff
+continues through the no-model branch after the GPU gate passes.
+
+### 5. Prove each affected model in isolation
 
 Each matrix job runs:
 
@@ -148,7 +171,7 @@ phases may remain not-run when their required input could not be produced.
 The combined report and scheduled failure-issue reconciliation are still
 attempted, while publication remains gated on complete success.
 
-### 5. Compose one report
+### 6. Compose one report
 
 After every selected model passes, the Combined HTML Report job downloads all
 per-model artifacts and generates one report. Certification checks require:
@@ -184,6 +207,7 @@ selection and breadth differ.
 | `docker_image.py` | Fingerprint, build, cache, and verify the CI image | Host |
 | `container.py` | Construct trusted or hardened long-lived containers | Host |
 | `stage.py` | Enter a container and propagate cancellation | Host |
+| `graph_patch.py` | Lease a GPU and certify the real-TensorRT graph-patch smoke | Host and container |
 | `quality.py` | Run impact support, source quality, and unit tests | Container |
 | `coverage.py` | Select tests, collect coverage, and enforce thresholds | Container |
 | `package.py` | Build, validate, install, and smoke-test wheels | Container |
@@ -224,7 +248,7 @@ the producing class remains the source of truth for optional evidence fields.
 
 - **Functionality / units:** `CiCommand` defines the public command tree and
   creates exactly one owning class for `image`, `container`, `stage`,
-  `pipeline`, `e2e`, `coverage`, or `model-proof`.
+  `pipeline`, `e2e`, `coverage`, `graph-patch-real-trt`, or `model-proof`.
 - **Inputs:** `sys.argv` strings plus `os.environ`. A model-proof request, for
   example, is `{model: str, suite: "premerge"|"nightly", revision: str,
   output_dir: Path|None, inner: bool}`.
@@ -236,8 +260,8 @@ the producing class remains the source of truth for optional evidence fields.
 ### `pipeline.py`
 
 - **Functionality / units:** `CiPipeline` maps a stage name such as
-  `source-quality`, `premerge-unit`, `package`, or `full-e2e` to a short
-  ordered list of class methods.
+  `source-quality`, `premerge-unit`, `graph-patch-real-trt`, `package`, or
+  `full-e2e` to a short ordered list of class methods.
 - **Inputs:** A `CiContext` and one stage-name string from
   `python3 -m tools.ci pipeline <stage>`.
 - **Outputs:** The ordered operations' files and process side effects. If
@@ -326,6 +350,31 @@ the producing class remains the source of truth for optional evidence fields.
 - **Boundary:** It bridges host execution to
   `python3 -m tools.ci pipeline <stage>`; stage policy remains in
   `pipeline.py`.
+
+### `graph_patch.py`
+
+- **Functionality / units:** `GraphPatchRealTrtRunner` acquires one shared
+  `GpuLease`, runs the immutable CI image with only that GPU visible, and
+  cleans the exact run-owned container. Once it holds the lease, it also
+  reclaims a stale graph-gate or ordinary model-proof container only when
+  immutable-ID inspection confirms the same GPU, lock namespace, and an
+  overlapping valid slot set. `GraphPatchRealTrtGate` performs the
+  GPU/CUDA/TensorRT preflight, invokes only
+  `tests/builder/test_graph_patch_real_trt.py::test_multi_instance_rewire_compiles_real_tensorrt_network`,
+  and certifies its xUnit2 JUnit.
+- **Inputs:** The checked-out source, `TRTMC_CI_IMAGE`, the model-proof GPU
+  lease environment, pinned `--revision`, optional `--output-dir`, and the
+  pipeline-stage JUnit path `TRTMC_GRAPH_PATCH_JUNIT`.
+- **Outputs:** `junit.xml`, `preflight.json`, `gpu-lease.json`, and
+  `runner-evidence.json` in the run-owned artifact directory plus
+  `source-revision.txt`. Runner evidence records the immutable local image ID,
+  GPU lock namespace, unique container owner labels, and pinned source
+  revision. A passing status requires the checkout to match that revision,
+  exactly one leased GPU to be visible, TensorRT to create a builder, at least
+  one test, and exactly zero failures, errors, and skips.
+- **Boundary:** It owns this model-neutral hardware gate only. `model_ci.py`
+  decides when it is required, `docker_image.py` owns the image, `gpu_lease.py`
+  owns allocation fairness, and model-owned E2E remains in model proof.
 
 ### `quality.py`
 

--- a/tools/ci/__main__.py
+++ b/tools/ci/__main__.py
@@ -35,6 +35,12 @@ class CiCommand:
         commands.add_parser("e2e", help="Run the parallel E2E scheduler")
         coverage = commands.add_parser("coverage", help="Run a standalone coverage wrapper")
         coverage.add_argument("language", choices=("all", "cpp", "python"))
+        graph_patch = commands.add_parser(
+            "graph-patch-real-trt",
+            help="Run the leased real-TensorRT graph-patch gate",
+        )
+        graph_patch.add_argument("--output-dir", type=Path)
+        graph_patch.add_argument("--revision", default="HEAD")
         proof = commands.add_parser("model-proof", help="Run one hermetic model certification")
         proof.add_argument("--model", required=True)
         proof.add_argument("--suite", default="premerge")
@@ -101,6 +107,18 @@ class CiCommand:
                 if remaining:
                     self.parser.error(f"unrecognized combined coverage arguments: {remaining}")
                 coverage_runner.all_reports()
+            return 0
+        if arguments.command == "graph-patch-real-trt":
+            if remaining:
+                self.parser.error(f"unrecognized graph-patch arguments: {' '.join(remaining)}")
+            from .context import CiContext
+            from .graph_patch import GraphPatchRealTrtRunner
+
+            GraphPatchRealTrtRunner(
+                CiContext(env=dict(os.environ)),
+                output_dir=arguments.output_dir,
+                revision=arguments.revision,
+            ).run_host()
             return 0
         if (
             arguments.command == "model-reference-cache"

--- a/tools/ci/graph_patch.py
+++ b/tools/ci/graph_patch.py
@@ -1,0 +1,713 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the graph-patch smoke test on one leased GPU and certify its JUnit.
+
+Boundary: this module owns only the conditional real-TensorRT gate; model
+selection, generic container image management, and model proofs stay elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import signal
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from .context import CiContext
+from .gpu_lease import GpuLease
+from .process import CiError
+
+
+_NVIDIA_SMI_TIMEOUT = "2m"
+_TENSORRT_PREFLIGHT_TIMEOUT = "2m"
+_PYTEST_TIMEOUT = "10m"
+_MAX_GPU_LEASE_SECONDS = 600
+_OWNER_LABEL_PREFIX = "com.nvidia.trtmc.graph-patch"
+
+
+_PREFLIGHT = r"""
+import json
+import os
+from pathlib import Path
+
+import tensorrt as trt
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart
+
+status, count = cudart.cudaGetDeviceCount()
+if int(status) != 0 or int(count) != 1:
+    raise SystemExit(
+        f"CUDA preflight failed: cudaGetDeviceCount returned status={status!r}, count={count!r}"
+    )
+logger = trt.Logger(trt.Logger.ERROR)
+builder = trt.Builder(logger)
+if builder is None:
+    raise SystemExit("TensorRT preflight failed: trt.Builder returned None")
+evidence = {
+    "schema_version": 1,
+    "source_revision": os.environ["TRTMC_GRAPH_PATCH_SOURCE_REVISION"],
+    "tensorrt_version": trt.__version__,
+    "cuda_status": int(status),
+    "visible_device_count": int(count),
+    "builder_created": True,
+}
+Path(os.environ["TRTMC_GRAPH_PATCH_PREFLIGHT"]).write_text(
+    json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+print(f"TensorRT={trt.__version__} CUDA_devices={int(count)}")
+"""
+
+
+class GraphPatchRealTrtGate:
+    """Run and certify the single real-TensorRT graph-patch test in-container."""
+
+    TEST_PATH = (
+        "tests/builder/test_graph_patch_real_trt.py"
+        "::test_multi_instance_rewire_compiles_real_tensorrt_network"
+    )
+
+    def __init__(self, context: CiContext):
+        self.context = context
+        configured = context.env.get(
+            "TRTMC_GRAPH_PATCH_JUNIT",
+            ".ci/graph-patch-real-trt/junit.xml",
+        )
+        self.junit = Path(configured)
+        if not self.junit.is_absolute():
+            self.junit = context.repository / self.junit
+        configured_preflight = context.env.get(
+            "TRTMC_GRAPH_PATCH_PREFLIGHT",
+            str(self.junit.with_name("preflight.json")),
+        )
+        self.preflight_evidence = Path(configured_preflight)
+        if not self.preflight_evidence.is_absolute():
+            self.preflight_evidence = context.repository / self.preflight_evidence
+        self.pytest_returncode: int | None = None
+
+    def preflight(self) -> None:
+        """Require a visible NVIDIA GPU, CUDA runtime, and TensorRT builder."""
+        self.context.run(
+            ["nvidia-smi", "--query-gpu=index,name", "--format=csv,noheader"],
+            limit=self._bounded_timeout(
+                "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT",
+                _NVIDIA_SMI_TIMEOUT,
+                2 * 60,
+            ),
+        )
+        self.preflight_evidence.parent.mkdir(parents=True, exist_ok=True)
+        self.preflight_evidence.unlink(missing_ok=True)
+        self.context.run(
+            ["python3", "-c", _PREFLIGHT],
+            limit=self._bounded_timeout(
+                "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT",
+                _TENSORRT_PREFLIGHT_TIMEOUT,
+                2 * 60,
+            ),
+            updates={
+                "TRTMC_GRAPH_PATCH_PREFLIGHT": str(self.preflight_evidence),
+            },
+        )
+
+    def run_test(self) -> None:
+        """Run the exact smoke target and always leave certification to JUnit."""
+        self.junit.parent.mkdir(parents=True, exist_ok=True)
+        self.junit.unlink(missing_ok=True)
+        python_path = f"{self.context.repository / 'python'}:{self.context.repository}"
+        result = self.context.run(
+            [
+                "python3",
+                "-m",
+                "pytest",
+                self.TEST_PATH,
+                "-q",
+                "-x",
+                "-rA",
+                "--strict-markers",
+                "-p",
+                "no:cacheprovider",
+                "-o",
+                "junit_family=xunit2",
+                f"--junitxml={self.junit}",
+            ],
+            limit=self._bounded_timeout(
+                "TRTMC_GRAPH_PATCH_TEST_TIMEOUT",
+                _PYTEST_TIMEOUT,
+                10 * 60,
+            ),
+            updates={"PYTHONPATH": python_path},
+            check=False,
+        )
+        self.pytest_returncode = result.returncode
+
+    def enforce(self) -> None:
+        """Reject empty, failed, errored, skipped, or otherwise nonzero runs."""
+        preflight = self.certify_preflight(self.preflight_evidence)
+        summary = self.certify_junit(self.junit)
+        if self.pytest_returncode is None:
+            raise CiError("graph-patch pytest did not run")
+        if self.pytest_returncode:
+            raise CiError(
+                "graph-patch real-TensorRT pytest exited with "
+                f"{self.pytest_returncode} despite JUnit summary {summary}"
+            )
+        print(f"Certified graph-patch real-TensorRT gate: preflight={preflight} junit={summary}")
+
+    @staticmethod
+    def certify_preflight(
+        path: Path,
+        *,
+        expected_revision: str | None = None,
+    ) -> dict[str, object]:
+        """Require explicit evidence for one visible GPU and a TensorRT builder."""
+        if not path.is_file():
+            raise CiError(f"graph-patch TensorRT preflight evidence is missing: {path}")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise CiError(f"graph-patch TensorRT preflight evidence is invalid: {path}") from error
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            raise CiError("graph-patch TensorRT preflight has an unsupported schema")
+        required = {
+            "cuda_status": 0,
+            "visible_device_count": 1,
+            "builder_created": True,
+        }
+        mismatches = [
+            f"{name}={payload.get(name)!r}"
+            for name, expected in required.items()
+            if payload.get(name) != expected
+        ]
+        revision = payload.get("source_revision")
+        version = payload.get("tensorrt_version")
+        if not isinstance(revision, str) or not re.fullmatch(
+            r"(?:[a-f0-9]{40}|[a-f0-9]{64})", revision
+        ):
+            mismatches.append(f"source_revision={revision!r}")
+        if expected_revision is not None and revision != expected_revision:
+            mismatches.append(f"source_revision expected {expected_revision!r}, found {revision!r}")
+        if not isinstance(version, str) or not version:
+            mismatches.append(f"tensorrt_version={version!r}")
+        if mismatches:
+            raise CiError("graph-patch TensorRT preflight did not pass: " + ", ".join(mismatches))
+        return payload
+
+    @staticmethod
+    def certify_junit(path: Path) -> dict[str, int]:
+        """Return strict aggregate counts for one pytest xUnit2 document."""
+        if not path.is_file():
+            raise CiError(f"graph-patch real-TensorRT JUnit is missing: {path}")
+        try:
+            root = ET.parse(path).getroot()
+        except (OSError, ET.ParseError) as error:
+            raise CiError(f"graph-patch real-TensorRT JUnit is invalid: {path}") from error
+        if root.tag == "testsuite":
+            suites = (root,)
+        elif root.tag == "testsuites":
+            suites = tuple(child for child in root if child.tag == "testsuite")
+        else:
+            raise CiError(f"graph-patch JUnit has unsupported root element: {root.tag}")
+        if not suites:
+            raise CiError("graph-patch JUnit contains no test suites")
+
+        summary = {
+            name: sum(GraphPatchRealTrtGate._count(suite, name) for suite in suites)
+            for name in ("tests", "failures", "errors", "skipped")
+        }
+        cases = sum(len(suite.findall(".//testcase")) for suite in suites)
+        if summary["tests"] < 1 or cases < 1:
+            raise CiError("graph-patch real-TensorRT gate collected no tests")
+        if cases != summary["tests"]:
+            raise CiError(
+                "graph-patch JUnit test count is inconsistent: "
+                f"tests={summary['tests']} testcases={cases}"
+            )
+        rejected = {
+            name: value for name, value in summary.items() if name != "tests" and value != 0
+        }
+        if rejected:
+            detail = ", ".join(f"{name}={value}" for name, value in rejected.items())
+            raise CiError(f"graph-patch real-TensorRT gate did not fully pass: {detail}")
+        if root.findall(".//failure") or root.findall(".//error") or root.findall(".//skipped"):
+            raise CiError("graph-patch JUnit contains a non-passing testcase element")
+        return summary
+
+    @staticmethod
+    def _count(suite: ET.Element, name: str) -> int:
+        value = suite.get(name, "0")
+        if not value.isdigit():
+            raise CiError(f"graph-patch JUnit has invalid {name} count: {value!r}")
+        return int(value)
+
+    def _bounded_timeout(self, name: str, default: str, maximum_seconds: int) -> str:
+        value = self.context.env.get(name, default)
+        match = re.fullmatch(r"([1-9][0-9]*)([smh])", value)
+        if not match:
+            raise CiError(f"{name} must be a positive timeout with an s, m, or h suffix")
+        multiplier = {"s": 1, "m": 60, "h": 3600}[match.group(2)]
+        seconds = int(match.group(1)) * multiplier
+        if seconds > maximum_seconds:
+            raise CiError(f"{name} must not exceed {maximum_seconds} seconds")
+        return value
+
+
+class GraphPatchRealTrtRunner:
+    """Lease one shared GPU and run the gate in the immutable CI image."""
+
+    def __init__(
+        self,
+        context: CiContext,
+        output_dir: Path | None = None,
+        revision: str = "HEAD",
+        *,
+        owner_token: str | None = None,
+    ):
+        self.context = context
+        self.output_dir = output_dir
+        if revision != "HEAD" and not re.fullmatch(
+            r"(?:[a-f0-9]{40}|[a-f0-9]{64})",
+            revision,
+        ):
+            raise CiError("graph-patch revision must be HEAD or a full Git object ID")
+        self.revision = revision
+        self.owner_token = owner_token or secrets.token_hex(16)
+        if not re.fullmatch(r"[a-f0-9]{32}", self.owner_token):
+            raise CiError("graph-patch owner token must be 32 lowercase hexadecimal characters")
+        self.lease: GpuLease | None = None
+        self.owner_labels = self._build_ownership_labels()
+        self.container_name = self._build_container_name()
+        self.container_launch_attempted = False
+
+    def run_host(self) -> None:
+        previous = {
+            number: signal.signal(number, self._signal)
+            for number in (signal.SIGINT, signal.SIGTERM)
+        }
+        try:
+            try:
+                self._run_host()
+            finally:
+                self._cleanup()
+        finally:
+            for number, handler in previous.items():
+                signal.signal(number, handler)
+
+    def _run_host(self) -> None:
+        for executable in ("docker", "git", "nvidia-smi"):
+            self.context.executable(executable)
+        revision = self.context.output(["git", "rev-parse", f"{self.revision}^{{commit}}"])
+        checked_out = self.context.output(["git", "rev-parse", "HEAD^{commit}"])
+        if checked_out != revision:
+            raise CiError(
+                "graph-patch checkout does not match the pinned tested revision: "
+                f"expected {revision}, found {checked_out}"
+            )
+        dirty = self.context.output(["git", "status", "--porcelain=v1", "--untracked-files=all"])
+        if dirty:
+            raise CiError("graph-patch checkout contains changes outside the pinned revision")
+        artifacts = self._prepare_output()
+        (artifacts / "source-revision.txt").write_text(
+            revision + "\n",
+            encoding="utf-8",
+        )
+        image = self.context.env.get("TRTMC_CI_IMAGE", "")
+        if not image:
+            raise CiError("TRTMC_CI_IMAGE is not set")
+        try:
+            image_id = self.context.output(
+                ["docker", "image", "inspect", "--format", "{{.Id}}", image]
+            )
+        except CiError as error:
+            raise CiError(f"CI image is not present: {image}") from error
+        if not re.fullmatch(r"sha256:[a-f0-9]{64}", image_id):
+            raise CiError(f"CI image has an invalid immutable image ID: {image_id!r}")
+
+        lease_timeout = self.context.env.get(
+            "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS",
+            str(_MAX_GPU_LEASE_SECONDS),
+        )
+        if not lease_timeout.isdigit() or not 1 <= int(lease_timeout) <= _MAX_GPU_LEASE_SECONDS:
+            raise CiError(
+                "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS must be an integer "
+                f"from 1 to {_MAX_GPU_LEASE_SECONDS} for the graph-patch gate"
+            )
+        self.context.env["TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS"] = lease_timeout
+
+        self.lease = GpuLease(
+            self.context,
+            "graph-patch-real-trt",
+            "shared",
+            artifacts,
+        )
+        self.lease.acquire()
+        self._reclaim_orphans()
+        evidence = self.lease.evidence(revision)
+        (artifacts / "gpu-lease.json").write_text(
+            json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        runner_evidence = {
+            "schema_version": 1,
+            "source_revision": revision,
+            "requested_image": image,
+            "immutable_image_id": image_id,
+            "gpu_lock_namespace": self.lease.lock_namespace,
+            "container_name": self.container_name,
+            "owner_labels": self._ownership_labels(),
+        }
+        (artifacts / "runner-evidence.json").write_text(
+            json.dumps(runner_evidence, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        self._remove_owned_container(reason="before launch")
+        self.container_launch_attempted = True
+        result = self.context.run(
+            self._container_command(image_id, artifacts, revision),
+            check=False,
+        )
+        junit = artifacts / "junit.xml"
+        try:
+            preflight = GraphPatchRealTrtGate.certify_preflight(
+                artifacts / "preflight.json",
+                expected_revision=revision,
+            )
+            summary = GraphPatchRealTrtGate.certify_junit(junit)
+        except CiError as error:
+            if result.returncode:
+                raise CiError(
+                    f"graph-patch real-TensorRT container failed with {result.returncode}; {error}"
+                ) from error
+            raise
+        if result.returncode:
+            raise CiError(
+                "graph-patch real-TensorRT container failed with "
+                f"{result.returncode} despite preflight {preflight} and JUnit {summary}"
+            )
+        print(f"Graph-patch real-TensorRT artifacts: {artifacts}")
+
+    def _prepare_output(self) -> Path:
+        scratch_root = Path(self.context.env.get("RUNNER_TEMP", "/tmp")).resolve()
+        configured = self.output_dir or (
+            scratch_root
+            / (
+                "trtmc-graph-patch-real-trt-"
+                f"{self.context.env.get('GITHUB_RUN_ID', 'local')}-"
+                f"{self.context.env.get('GITHUB_RUN_ATTEMPT', '0')}-"
+                f"{self.owner_token[:12]}"
+            )
+        )
+        if configured.is_symlink():
+            raise CiError(f"graph-patch output must not be a symlink: {configured}")
+        output = configured.resolve()
+        if output in {
+            Path("/"),
+            scratch_root,
+            self.context.repository,
+        } or not output.is_relative_to(scratch_root):
+            raise CiError("unsafe graph-patch real-TensorRT output directory")
+        if output.exists():
+            raise CiError(f"graph-patch output already exists: {output}")
+        output.mkdir(parents=True)
+        return output
+
+    def _container_command(
+        self,
+        image: str,
+        artifacts: Path,
+        revision: str,
+    ) -> list[str]:
+        assert self.lease and self.lease.gpu_id is not None
+        slots = ",".join(map(str, self.lease.slot_ids))
+        labels: list[str] = []
+        all_labels = {
+            "com.nvidia.trtmc.model-proof": "1",
+            "com.nvidia.trtmc.graph-patch-real-trt": "1",
+            "com.nvidia.trtmc.model-proof.gpu": str(self.lease.gpu_id),
+            "com.nvidia.trtmc.model-proof.slots": slots,
+            "com.nvidia.trtmc.model-proof.lock-namespace": self.lease.lock_namespace,
+            **self._ownership_labels(),
+        }
+        for name, value in all_labels.items():
+            labels.extend(("--label", f"{name}={value}"))
+        timeouts = {
+            "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT": self.context.env.get(
+                "TRTMC_GRAPH_PATCH_NVIDIA_SMI_TIMEOUT",
+                _NVIDIA_SMI_TIMEOUT,
+            ),
+            "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT": self.context.env.get(
+                "TRTMC_GRAPH_PATCH_TRT_PREFLIGHT_TIMEOUT",
+                _TENSORRT_PREFLIGHT_TIMEOUT,
+            ),
+            "TRTMC_GRAPH_PATCH_TEST_TIMEOUT": self.context.env.get(
+                "TRTMC_GRAPH_PATCH_TEST_TIMEOUT",
+                _PYTEST_TIMEOUT,
+            ),
+        }
+        timeout_environment: list[str] = []
+        for name, value in timeouts.items():
+            timeout_environment.extend(("-e", f"{name}={value}"))
+        return [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            self.container_name,
+            "--read-only",
+            "--network",
+            "none",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--ipc",
+            "private",
+            "--gpus",
+            f"device={self.lease.gpu_id}",
+            *labels,
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--mount",
+            f"type=bind,src={self.context.repository},dst=/src,readonly",
+            "--mount",
+            f"type=bind,src={artifacts},dst=/artifacts",
+            "--workdir",
+            "/src",
+            "--tmpfs",
+            "/tmp:rw,exec,nosuid,nodev,size=2g",
+            "-e",
+            "HOME=/tmp",
+            "-e",
+            "USER=trtmc-ci",
+            "-e",
+            "LOGNAME=trtmc-ci",
+            "-e",
+            "PYTHONHASHSEED=0",
+            "-e",
+            "PYTHONPATH=/src/python:/src",
+            "-e",
+            "TRTMC_GRAPH_PATCH_JUNIT=/artifacts/junit.xml",
+            "-e",
+            "TRTMC_GRAPH_PATCH_PREFLIGHT=/artifacts/preflight.json",
+            "-e",
+            f"TRTMC_GRAPH_PATCH_SOURCE_REVISION={revision}",
+            *timeout_environment,
+            image,
+            "python3",
+            "-m",
+            "tools.ci",
+            "pipeline",
+            "graph-patch-real-trt",
+        ]
+
+    def _reclaim_orphans(self) -> None:
+        """Remove only stale GPU-proof containers covered by the held flock."""
+        assert self.lease and self.lease.gpu_id is not None
+        rows = self.context.output(
+            [
+                "docker",
+                "ps",
+                "--no-trunc",
+                "--filter",
+                "label=com.nvidia.trtmc.model-proof=1",
+                "--filter",
+                f"label=com.nvidia.trtmc.model-proof.gpu={self.lease.gpu_id}",
+                "--filter",
+                f"label=com.nvidia.trtmc.model-proof.lock-namespace={self.lease.lock_namespace}",
+                "--format",
+                "{{.ID}}",
+            ]
+        ).splitlines()
+        candidates: list[str] = []
+        for row in rows:
+            container_id = row.strip()
+            if row != container_id or not re.fullmatch(r"[a-f0-9]{64}", container_id):
+                raise CiError(f"graph-patch orphan inventory has an unsafe ID: {row!r}")
+            if container_id in candidates:
+                raise CiError(f"graph-patch orphan inventory has a duplicate ID: {container_id}")
+            candidates.append(container_id)
+
+        # Validate the complete inventory before deleting anything.  Acquiring
+        # an overlapping flock slot proves a matching leftover container has
+        # lost its host owner; non-overlapping runs remain untouched.
+        reclaimable: list[str] = []
+        for container_id in candidates:
+            inspected = self._inspect_container(container_id, allow_absent=False)
+            assert inspected is not None
+            inspected_id, labels = inspected
+            if inspected_id != container_id:
+                raise CiError(
+                    "graph-patch orphan inspect returned a different immutable ID: "
+                    f"expected {container_id}, found {inspected_id}"
+                )
+            if not self._orphan_matches_lease(labels):
+                continue
+            reclaimable.append(container_id)
+
+        for container_id in reclaimable:
+            removed = self.context.run(
+                ["docker", "rm", "-f", container_id],
+                check=False,
+                capture_output=True,
+            )
+            if removed.returncode:
+                detail = (removed.stderr or removed.stdout or "").strip()
+                raise CiError(
+                    f"could not remove orphaned graph-patch container {container_id}"
+                    + (f": {detail}" if detail else "")
+                )
+
+    def _orphan_matches_lease(self, labels: dict[str, str]) -> bool:
+        assert self.lease and self.lease.gpu_id is not None
+        required = {
+            "com.nvidia.trtmc.model-proof": "1",
+            "com.nvidia.trtmc.model-proof.gpu": str(self.lease.gpu_id),
+            "com.nvidia.trtmc.model-proof.lock-namespace": self.lease.lock_namespace,
+        }
+        if any(labels.get(name) != value for name, value in required.items()):
+            return False
+        slots = labels.get("com.nvidia.trtmc.model-proof.slots", "")
+        if not re.fullmatch(r"(?:0|[1-9][0-9]*)(?:,(?:0|[1-9][0-9]*))*", slots):
+            raise CiError("graph-patch orphan container has invalid GPU slot labels")
+        slot_ids = list(map(int, slots.split(",")))
+        if len(slot_ids) != len(set(slot_ids)) or any(
+            slot < 0 or slot >= self.lease.slots_per_gpu for slot in slot_ids
+        ):
+            raise CiError("graph-patch orphan container has invalid GPU slot labels")
+        graph_marker = labels.get("com.nvidia.trtmc.graph-patch-real-trt")
+        if graph_marker not in {None, "1"}:
+            raise CiError("graph-patch orphan container has an invalid graph marker label")
+        if graph_marker == "1":
+            owner_token = labels.get(f"{_OWNER_LABEL_PREFIX}.owner-token", "")
+            if not re.fullmatch(r"[a-f0-9]{32}", owner_token):
+                raise CiError("graph-patch orphan container has an invalid owner token label")
+        return bool(set(slot_ids).intersection(self.lease.slot_ids))
+
+    def _cleanup(self) -> None:
+        cleanup_error: CiError | None = None
+        try:
+            if self.container_launch_attempted:
+                self._remove_owned_container(reason="during cleanup")
+        except CiError as error:
+            cleanup_error = error
+        finally:
+            if self.lease:
+                self.lease.release()
+        if cleanup_error:
+            raise cleanup_error
+
+    def _ownership_labels(self) -> dict[str, str]:
+        return dict(self.owner_labels)
+
+    def _build_ownership_labels(self) -> dict[str, str]:
+        return {
+            f"{_OWNER_LABEL_PREFIX}.owner-token": self.owner_token,
+            f"{_OWNER_LABEL_PREFIX}.run-id": (
+                self.context.env.get("GITHUB_RUN_ID", "local") or "local"
+            ),
+            f"{_OWNER_LABEL_PREFIX}.run-attempt": (
+                self.context.env.get("GITHUB_RUN_ATTEMPT", "0") or "0"
+            ),
+            f"{_OWNER_LABEL_PREFIX}.repository": (
+                self.context.env.get("GITHUB_REPOSITORY", "local") or "local"
+            ),
+        }
+
+    def _inspect_container(
+        self,
+        target: str,
+        *,
+        allow_absent: bool = True,
+    ) -> tuple[str, dict[str, str]] | None:
+        result = self.context.run(
+            [
+                "docker",
+                "container",
+                "inspect",
+                "--format",
+                "{{json .}}",
+                target,
+            ],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "").strip()
+            if allow_absent and re.search(
+                r"No such (?:object|container)",
+                detail,
+                flags=re.IGNORECASE,
+            ):
+                return None
+            raise CiError(
+                f"could not inspect graph-patch container ownership for {target}"
+                + (f": {detail}" if detail else "")
+            )
+        try:
+            payload = json.loads(result.stdout)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise CiError("graph-patch container ownership metadata is invalid") from error
+        if not isinstance(payload, dict):
+            raise CiError("graph-patch container ownership metadata is invalid")
+        container_id = payload.get("Id")
+        config = payload.get("Config")
+        labels = config.get("Labels") if isinstance(config, dict) else None
+        if (
+            not isinstance(container_id, str)
+            or not re.fullmatch(r"[a-f0-9]{64}", container_id)
+            or not isinstance(labels, dict)
+            or not all(
+                isinstance(name, str) and isinstance(value, str) for name, value in labels.items()
+            )
+        ):
+            raise CiError("graph-patch container ownership metadata is invalid")
+        return container_id, labels
+
+    def _remove_owned_container(self, *, reason: str) -> bool:
+        inspected = self._inspect_container(self.container_name)
+        if inspected is None:
+            return False
+        container_id, labels = inspected
+        expected = self._ownership_labels()
+        mismatches = [
+            f"{name} expected {value!r}, found {labels.get(name)!r}"
+            for name, value in expected.items()
+            if labels.get(name) != value
+        ]
+        if mismatches:
+            raise CiError(
+                f"refusing to remove foreign graph-patch container {self.container_name} "
+                f"{reason}: " + ", ".join(mismatches)
+            )
+        removed = self.context.run(
+            ["docker", "rm", "-f", container_id],
+            check=False,
+            capture_output=True,
+        )
+        if removed.returncode:
+            detail = (removed.stderr or removed.stdout or "").strip()
+            raise CiError(
+                f"could not remove owned graph-patch container {self.container_name}"
+                + (f": {detail}" if detail else "")
+            )
+        return True
+
+    def _signal(self, number: int, _frame: object) -> None:
+        raise SystemExit(130 if number == signal.SIGINT else 143)
+
+    def _build_container_name(self) -> str:
+        run_id = self.owner_labels[f"{_OWNER_LABEL_PREFIX}.run-id"]
+        attempt = self.owner_labels[f"{_OWNER_LABEL_PREFIX}.run-attempt"]
+        name = (f"trtmc-graph-patch-real-trt-{run_id}-{attempt}-{self.owner_token[:12]}").replace(
+            "_", "-"
+        )
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", name):
+            raise CiError("unsafe graph-patch real-TensorRT container name")
+        return name

--- a/tools/ci/pipeline.py
+++ b/tools/ci/pipeline.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from .context import CiContext
 from .coverage import CoverageRunner
 from .e2e import E2ERunner
+from .graph_patch import GraphPatchRealTrtGate
 from .package import WheelPackageManager
 from .process import CiError
 from .quality import EnvironmentVerifier, ImpactAnalyzer, SourceQualityChecks, UnitTestRunner
@@ -30,6 +31,7 @@ class CiPipeline:
         self.package = WheelPackageManager(context)
         self.coverage = CoverageRunner(context)
         self.e2e = E2ERunner(context)
+        self.graph_patch = GraphPatchRealTrtGate(context)
         self.stages: dict[str, list[tuple[str, Callable[[], None]]]] = {
             "setup": [
                 ("Install trtmc pip package", self.package.install_once),
@@ -69,6 +71,11 @@ class CiPipeline:
             ],
             "premerge-unit": [
                 ("Source-only C++ and Python unit tests", self.units.premerge),
+            ],
+            "graph-patch-real-trt": [
+                ("GPU and TensorRT preflight", self.graph_patch.preflight),
+                ("Real TensorRT graph-patch test", self.graph_patch.run_test),
+                ("Certify graph-patch JUnit", self.graph_patch.enforce),
             ],
             "cpp-coverage": [
                 ("Setup TensorRT-Model-Connect source checks", self.environment.verify),

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -147,6 +147,33 @@ FULL_UNIT_TEST_ONLY_EXACT = frozenset(
         "tools/test_impact.py",
     }
 )
+
+# These three files define one self-contained graph-patch contract.  The core
+# and smoke test need builder units; the runner also needs the complete tools
+# suite.  All three require the dedicated real-TensorRT gate, but do not by
+# themselves change a model-owned implementation.  Keep this list exact: CI
+# wiring, generic tooling, and adjacent platform code remain broad changes and
+# continue to select representative model proofs.
+GRAPH_PATCH_TRT_EXACT = frozenset(
+    {
+        "python/tensorrt_model_connect/graph_patch.py",
+        "tests/builder/test_graph_patch_real_trt.py",
+        "tools/ci/graph_patch.py",
+    }
+)
+GRAPH_PATCH_TRT_FULL_UNIT_EXACT = frozenset({"tools/ci/graph_patch.py"})
+# These shared entrypoints wire the graph-patch gate into CI.  They retain
+# their ordinary broad CI/tooling classification (full units plus
+# representative model proof) and add the real-TensorRT gate; changing gate
+# wiring must never narrow their existing impact.
+GRAPH_PATCH_TRT_TRIGGER_EXACT = frozenset(
+    {
+        ".github/workflows/trtmc-ci.yml",
+        "tools/ci/__main__.py",
+        "tools/ci/pipeline.py",
+    }
+)
+
 UNIT_TEST_ONLY_PREFIXES = (
     "tests/builder/",
     "tests/cpp/",
@@ -628,6 +655,8 @@ def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | Non
             "model-coupled test has no isolated model owner; move it into a "
             f"MODEL.toml contract or use a synthetic plugin before changing it: {path}"
         )
+    if path in GRAPH_PATCH_TRT_EXACT:
+        return "graph_patch_trt", None
     if path in UNIT_TEST_ONLY_EXACT:
         return "unit_cli", None
     if path in FULL_UNIT_TEST_ONLY_EXACT or any(
@@ -728,6 +757,7 @@ def _result(
     fallback_models: Iterable[str] = (),
     run_unit_tests: bool = False,
     unit_scope: str = "none",
+    run_graph_patch_trt: bool = False,
 ) -> dict[str, object]:
     selected = sorted(set(models))
     direct = set(selected if direct_models is None else direct_models)
@@ -740,7 +770,7 @@ def _result(
     if len(scheduled) != len(set(scheduled)) or set(scheduled) != set(selected):
         raise ModelCIError("matrix model order must contain each affected model exactly once")
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "mode": mode,
         "has_models": bool(selected),
         "expected_count": len(selected),
@@ -758,6 +788,7 @@ def _result(
         },
         "run_unit_tests": run_unit_tests,
         "unit_scope": unit_scope,
+        "run_graph_patch_trt": run_graph_patch_trt,
         "changes": changes,
     }
 
@@ -933,6 +964,7 @@ def calculate_impact(
     fallback_selected: set[str] = set()
     broad_change = False
     unit_scope = "none"
+    run_graph_patch_trt = False
     pyproject_task_eval_only = _is_task_eval_optional_extra_only_change(
         repo_root,
         comparison_base,
@@ -951,6 +983,8 @@ def calculate_impact(
                 continue
             seen_path_revision.add((path, catalog.revision))
             kind, owner = _classify_path(path, catalog)
+            if path in GRAPH_PATCH_TRT_TRIGGER_EXACT:
+                run_graph_patch_trt = True
             if path == "pyproject.toml" and pyproject_task_eval_only:
                 kind = "unit_tests"
             item = {"path": path, "kind": kind}
@@ -958,6 +992,10 @@ def calculate_impact(
                 item["model"] = owner
                 affected.add(owner)
                 unit_scope = _merge_unit_scope(unit_scope, "builder")
+            elif kind == "graph_patch_trt":
+                run_graph_patch_trt = True
+                requested_scope = "all" if path in GRAPH_PATCH_TRT_FULL_UNIT_EXACT else "builder"
+                unit_scope = _merge_unit_scope(unit_scope, requested_scope)
             elif kind == "unit_cli":
                 unit_scope = _merge_unit_scope(unit_scope, "cli")
             elif kind == "unit_tests":
@@ -1026,6 +1064,7 @@ def calculate_impact(
         fallback_models=fallback_selected,
         run_unit_tests=unit_scope != "none" or broad_change,
         unit_scope="all" if broad_change else unit_scope,
+        run_graph_patch_trt=run_graph_patch_trt,
     )
     result["base_revision"] = base_catalog.revision
     result["head_revision"] = head_catalog.revision
@@ -1043,6 +1082,7 @@ def _write_github_output(path: Path, result: dict[str, object]) -> None:
         "mode": str(result["mode"]),
         "run_unit_tests": str(bool(result["run_unit_tests"])).lower(),
         "unit_scope": str(result["unit_scope"]),
+        "run_graph_patch_trt": str(bool(result["run_graph_patch_trt"])).lower(),
     }
     if "expected_cases_by_model" in result:
         outputs["expected_cases_by_model"] = json.dumps(

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1408,6 +1408,20 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestUnitTiers.test_benchmark_python_triggers_owned_units",),
         ),
         ClassificationRule(
+            priority=96,
+            name="graph_tooling",
+            matcher=_regex_rule(
+                r"python/tensorrt_model_connect/graph_[A-Za-z0-9_]+\.py$"
+            ),
+            resolver=_match_result(
+                "graph_tooling",
+                _no_models,
+                ["builder", "tools"],
+                False,
+            ),
+            covered_by=("TestSharedModules.test_graph_tooling_triggers_owned_units",),
+        ),
+        ClassificationRule(
             priority=100,
             name="shared_builder_module",
             matcher=_path_startswith("python/tensorrt_model_connect/"),

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1410,9 +1410,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ClassificationRule(
             priority=96,
             name="graph_tooling",
-            matcher=_regex_rule(
-                r"python/tensorrt_model_connect/graph_[A-Za-z0-9_]+\.py$"
-            ),
+            matcher=_path_equals("python/tensorrt_model_connect/graph_patch.py"),
             resolver=_match_result(
                 "graph_tooling",
                 _no_models,


### PR DESCRIPTION
## Background

Bring-your-own-kernel support needs a shared, backend-neutral graph surgery
primitive before model-owned semantic contracts, TVM-FFI adapters, or tutorials
can safely build on it. TensorRT networks are mutable and do not provide
rollback, so graph capture, drift detection, boundary validation, and
replacement-output validation must fail closed before existing consumers are
changed.

## Exit Criteria

- Capture a deterministic graph snapshot and selected-region boundary, including
  a versioned model/family-owned layer identity contract.
- Reject incomplete identity, live-graph drift, disconnected or non-convex
  selections, unsafe control-flow/plugin regions, overlapping multi-region
  replacements, and invalid replacement outputs before consumer mutation.
- Rewire both external consumers and TensorRT network outputs while preserving
  output order and names.
- Compile a rewritten network with real TensorRT in a required, isolated,
  exact-revision CI gate.
- Keep semantic contracts, SelectionLock artifacts, TVM-FFI invocation, and
  model-specific kernel integrations out of this foundational PR.

## Implementation

- Adds `GraphSnapshot`, stable node/tensor records, canonical JSON fingerprints,
  region boundaries, validation, and single- or multi-region rewiring in
  `tensorrt_model_connect.graph_patch`.
- Requires a typed and versioned `LayerIdentityContract` for mutation. The shared
  core records identity attributes supplied by the owning model/family and
  recaptures the live graph with the current provider before applying a patch.
- Validates replacement arity, dtype, exact shape, location,
  shape-tensor status, freshness, aliasing, and cross-region uniqueness before
  touching consumers. Callback failure requires discarding the network because
  TensorRT cannot roll back newly created layers.
- Adds a required real-TensorRT graph-patch CI job with immutable image/source
  evidence, a single leased GPU, network-disabled read-only execution, strict
  JUnit checks, and ownership-safe orphan cleanup.
- Tightens graph-tooling impact routing so future shared graph modules fall back
  to broad model coverage instead of silently selecting no models.

## Validation

- `python3 -m pytest -q tests/builder/test_graph_patch.py tests/builder/test_graph_patch_real_trt.py tests/tools/test_graph_patch_ci.py tests/tools/test_model_ci.py tests/tools/test_test_impact.py tests/tools/test_github_actions_ci.py`: passed with 508 tests and one expected host-side real-TensorRT skip.
- `TRTMC_CI_IMAGE=trtmc-dev-gb300:manylinux_2_39 python3 -m tools.ci graph-patch-real-trt --revision bc4cdb54e5c1edeec14e93ee8a33625f1b65c61b --output-dir /tmp/trtmc-graph-patch-pr-a-bc4cdb54`: passed on TensorRT 11.2.0.113; 1 test passed with zero failures, errors, or skips, and the rewritten network serialized successfully.
- `python3 tools/legal_headers.py --check`: passed with 4,799 managed
  files, zero changes, and zero findings.
- Workflow YAML parsing and `git diff --check github/main...HEAD`: passed.
- Production wheel build was not run locally because the offline CI image lacks
  `conan-py-build`, `build`, and `auditwheel`. Static wheel-root validation and
  an isolated zip import passed; the canonical package CI remains the
  production-wheel receipt.

## Notes For Future Readers

- Review order: public contracts and failure semantics in `graph_patch.py`, core
  unit tests, real-TensorRT integration test, then CI runner/workflow changes.
- `identity_complete` is a trusted declaration from the model/family-owned
  provider. The shared core verifies the declaration, schema, canonical
  serialization, and drift, but cannot prove that a provider enumerates every
  behavior-defining TensorRT subtype attribute. Provider exhaustiveness and
  schema-version changes require owner review.
- This is the first PR in a deliberately separated stack. Later PRs will add
  semantic capture and SelectionLock CLI artifacts, a generic TVM-FFI patch
  provider, and model-owned examples. This PR must remain useful without
  importing those higher layers.
