### PR TITLE
fix(nemotron-h): eliminate recurrent state copies

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -501,6 +501,8 @@ entries:
     model: nemotron-h-nano-9b
     workload:
       testcase: nemotron-h-nano-9b
+      runtime:
+        cuda_graphs: true
     baseline:
       runner: hf-transformers
       mode: hf-eager

--- a/include/trtmc/runtime/pipeline_plugin.h
+++ b/include/trtmc/runtime/pipeline_plugin.h
@@ -76,7 +76,7 @@ struct PipelineContext {
     const std::string& bundle_path;        // filesystem path to .trtfb file
     IBackend* backend;                     // Backend for creating ITrtModule instances
     const std::string& runtime_cache_path; // RTX: JIT kernel cache file path
-    bool cuda_graphs;                      // RTX: whole-graph CUDA capture
+    bool cuda_graphs;                      // Enable backend-supported CUDA Graph execution
     std::uint64_t kv_cache_size_bytes{0};  // 0 = use bundle max_cache_length (TriAttention)
     // Resolved layered config (schema-driven). Nullable: plugins not yet
     // migrated to the registry ignore it; migrated plugins query their

--- a/include/trtmc/runtime/trt_backend.h
+++ b/include/trtmc/runtime/trt_backend.h
@@ -25,7 +25,7 @@ namespace trtmc {
 struct ModuleCreateOptions {
     cudaStream_t stream{nullptr};            // nullptr = backend creates one
     const char* runtime_cache_path{""};      // RTX: JIT kernel cache file path
-    bool cuda_graphs{false};                 // RTX: whole-graph CUDA capture
+    bool cuda_graphs{false};                 // Enable backend-supported CUDA Graph execution
     int32_t optimization_profile{0};         // profile selected for this execution context
     void* distributed_communicator{nullptr}; // TensorRT 11.0+ NCCL communicator, optional
     std::shared_ptr<void> distributed_owner; // keeps communicator alive

--- a/src/runtime/backend/trt_backend.cpp
+++ b/src/runtime/backend/trt_backend.cpp
@@ -54,6 +54,11 @@ void keep_backend_resources(ITrtModule& module,
         module.keep_alive(distributed_owner);
 }
 
+void apply_module_options(ITrtModule& module, const ModuleCreateOptions& options) {
+    if (options.cuda_graphs)
+        module.enable_cuda_graph();
+}
+
 } // namespace
 
 class TrtBackend final : public IBackend, public IPreboundBackend {
@@ -105,6 +110,7 @@ class TrtBackend final : public IBackend, public IPreboundBackend {
                                                        options.distributed_communicator);
             if (!mod->ok())
                 throw std::runtime_error("[trtmc] TrtModuleImpl creation failed");
+            apply_module_options(*mod, options);
             keep_backend_resources(*mod, engine, stream_owner, options.distributed_owner);
             return mod;
         };
@@ -152,6 +158,7 @@ class TrtBackend final : public IBackend, public IPreboundBackend {
                                                        options.distributed_communicator);
             if (!mod->ok())
                 throw std::runtime_error("[trtmc] TrtModuleImpl creation failed");
+            apply_module_options(*mod, options);
             keep_backend_resources(*mod, engine, stream_owner, options.distributed_owner);
             out.modules.push_back(BackendProfileModule{profile_idx, std::move(mod)});
         }
@@ -195,6 +202,7 @@ class TrtBackend final : public IBackend, public IPreboundBackend {
                                                           lane_options.distributed_communicator);
             if (!module->ok())
                 throw std::runtime_error("[trtmc] TrtModuleImpl creation failed");
+            apply_module_options(*module, lane_options);
             keep_backend_resources(*module, engine, stream_owner, lane_options.distributed_owner);
             out.modules.push_back(std::move(module));
         }
@@ -237,6 +245,7 @@ class TrtBackend final : public IBackend, public IPreboundBackend {
             throw std::runtime_error("[trtmc] TrtModuleImpl creation failed");
         }
 
+        apply_module_options(*module, options);
         keep_backend_resources(*module,
                                std::shared_ptr<nvinfer1::ICudaEngine>(
                                    engine, [](nvinfer1::ICudaEngine* p) { delete p; }),

--- a/src/runtime/models/nemotron_h/MODEL.toml
+++ b/src/runtime/models/nemotron_h/MODEL.toml
@@ -9,6 +9,7 @@ runtime_strategies = ["nemotron_h_hybrid_mamba_attention"]
 decoder_debug = ["nemotron_h_hybrid_mamba_attention"]
 
 runtime_tests = [
+  "test_nemotron_h_backend_cuda_graph|test_nemotron_h_backend_cuda_graph.cpp|trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
   "test_nemotron_h_recurrent_output_initializers|test_nemotron_h_recurrent_output_initializers.cpp|_|_|_",
   "test_nemotron_h_recurrent_pipeline|test_nemotron_h_recurrent_pipeline.cpp|trtmc_model_nemotron_h,trtmc_backend_trt|_|REQUIRES_TRT",
 ]

--- a/src/runtime/models/nemotron_h/inference_state.h
+++ b/src/runtime/models/nemotron_h/inference_state.h
@@ -55,8 +55,8 @@ class NemotronHInferenceState {
     // Pipelines call this instead of manually constructing mask/position tensors.
     virtual void prepare_step(TensorMap& inputs, int32_t seq_len = 1) = 0;
 
-    // Update state after one decode step. Copies "present" outputs
-    // into "cache" inputs, advances position.
+    // Update state after one decode step. Makes "present" outputs available
+    // as the next inputs and advances position.
     // n_tokens: number of tokens processed in this step (default 1).
     //           >1 for batched prefill / multi-token steps.
     virtual void advance(int32_t n_tokens = 1) = 0;

--- a/src/runtime/models/nemotron_h/pipeline.cpp
+++ b/src/runtime/models/nemotron_h/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/nemotron_h/pipeline.h"
 
 #include "runtime/models/nemotron_h/chat_templates.h"
+#include "runtime/models/nemotron_h/recurrent_generation_plan.h"
 
 #include <algorithm>
 #include <chrono>
@@ -102,16 +103,17 @@ std::vector<int32_t> RecurrentPipeline::generate_from_ids(const std::vector<int3
     state_->bind_to(*decoder_);
 
     prof_prepare_ms_ = prof_forward_ms_ = prof_logits_copy_ms_ = prof_advance_ms_ = 0;
+    prof_logits_copy_bytes_ = 0;
+    prof_logits_copies_ = 0;
     prof_steps_ = 0;
 
     std::vector<float> logits;
 
     // ── Prefill phase ──
     auto t_prefill_start = SteadyClock::now();
-    for (std::size_t i = 0; i + 1 < input_ids.size(); ++i)
-        run_step(input_ids[i], logits);
-
-    run_step(input_ids.back(), logits);
+    for (std::size_t i = 0; i < input_ids.size(); ++i)
+        run_step(input_ids[i], logits,
+                 nemotron_h_recurrent::prefill_step_needs_logits(i, input_ids.size()));
     auto t_prefill_end = SteadyClock::now();
 
     // ── Decode phase ──
@@ -125,7 +127,7 @@ std::vector<int32_t> RecurrentPipeline::generate_from_ids(const std::vector<int3
         output.push_back(result.token_id);
         if (result.is_eos)
             break;
-        run_step(result.token_id, logits);
+        run_step(result.token_id, logits, true);
         ++decode_steps;
     }
     auto t_decode_end = SteadyClock::now();
@@ -173,21 +175,16 @@ void RecurrentPipeline::report_timing(SteadyClock::time_point t_prefill_start,
         std::cerr << "[trtmc-perf]   state advance: " << (prof_advance_ms_ / prof_steps_)
                   << " ms\n";
 
-        std::size_t output_bytes = 0;
-        for (const auto& info : decoder_->output_info()) {
-            std::size_t n = 1;
-            for (auto d : info.shape)
-                n *= static_cast<std::size_t>(d);
-            n *= dtype_size(info.dtype);
-            output_bytes += n;
-        }
-        std::cerr << "[trtmc-perf]   D2H output size: " << std::setprecision(1)
-                  << (output_bytes / (1024.0 * 1024.0)) << " MB (" << decoder_->output_info().size()
-                  << " tensors)\n";
+        const auto host_outputs =
+            nemotron_h_recurrent::host_visible_output_summary(decoder_->output_info());
+        std::cerr << "[trtmc-perf]   host-visible output: " << std::setprecision(1)
+                  << (prof_logits_copy_bytes_ / (1024.0 * 1024.0)) << " MB total ("
+                  << host_outputs.tensor_count << " tensor/copy, " << prof_logits_copies_
+                  << " copies)\n";
     }
 }
 
-void RecurrentPipeline::run_step(int32_t token_id, std::vector<float>& logits) {
+void RecurrentPipeline::run_step(int32_t token_id, std::vector<float>& logits, bool copy_logits) {
     auto t0 = SteadyClock::now();
 
     TensorMap inputs;
@@ -207,9 +204,11 @@ void RecurrentPipeline::run_step(int32_t token_id, std::vector<float>& logits) {
     // Only the logits tensor (~512 KB) needs to reach CPU for sampling.
     decoder_->forward_async(inputs);
 
+    // Wait for TRT kernel to finish before reading logits or advancing state.
+    decoder_->sync();
+
     // Resolve logits device pointer + size once on first call.
     if (!logits_device_ptr_) {
-        decoder_->sync(); // must sync before first device_ptr query
         logits_device_ptr_ = decoder_->device_ptr("logits");
         if (!logits_device_ptr_)
             throw std::runtime_error(std::string(name_) + ": no 'logits' output");
@@ -225,20 +224,20 @@ void RecurrentPipeline::run_step(int32_t token_id, std::vector<float>& logits) {
             throw std::runtime_error(std::string(name_) + ": logits tensor has zero size");
     }
 
-    // Wait for TRT kernel to finish.
-    decoder_->sync();
-
     auto t2 = SteadyClock::now();
 
-    // D2H logits only (~512 KB). Synchronous cudaMemcpy is faster than
-    // cudaMemcpyAsync+sync here because it bypasses stream ordering overhead.
-    logits.resize(logits_numel_);
-    cudaMemcpy(logits.data(), logits_device_ptr_, logits_numel_ * sizeof(float),
-               cudaMemcpyDeviceToHost);
+    if (copy_logits) {
+        // D2H logits only (~512 KB). Intermediate prefill logits are not sampled.
+        logits.resize(logits_numel_);
+        const auto copy_bytes = logits_numel_ * sizeof(float);
+        cudaMemcpy(logits.data(), logits_device_ptr_, copy_bytes, cudaMemcpyDeviceToHost);
+        prof_logits_copy_bytes_ += copy_bytes;
+        ++prof_logits_copies_;
+    }
 
     auto t3 = SteadyClock::now();
 
-    // D2D state copies (present -> state) — async on the CUDA stream.
+    // Advance the logical position; recurrent buffers update in place.
     state_->advance();
 
     auto t4 = SteadyClock::now();

--- a/src/runtime/models/nemotron_h/pipeline.h
+++ b/src/runtime/models/nemotron_h/pipeline.h
@@ -66,7 +66,7 @@ class RecurrentPipeline final : public IPipeline {
                                            int32_t max_new_tokens,
                                            const NemotronHSamplingParams& params);
 
-    void run_step(int32_t token_id, std::vector<float>& logits);
+    void run_step(int32_t token_id, std::vector<float>& logits, bool copy_logits);
 
     using SteadyClock = std::chrono::steady_clock;
     void report_timing(SteadyClock::time_point t_prefill_start,
@@ -83,6 +83,8 @@ class RecurrentPipeline final : public IPipeline {
     double prof_forward_ms_{0};
     double prof_logits_copy_ms_{0};
     double prof_advance_ms_{0};
+    std::size_t prof_logits_copy_bytes_{0};
+    int prof_logits_copies_{0};
     int prof_steps_{0};
 };
 

--- a/src/runtime/models/nemotron_h/recurrent_generation_plan.h
+++ b/src/runtime/models/nemotron_h/recurrent_generation_plan.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/tensor.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace trtmc::nemotron_h_recurrent {
+
+struct HostVisibleOutputSummary {
+    std::size_t tensor_count{0};
+    std::size_t bytes{0};
+};
+
+inline bool prefill_step_needs_logits(std::size_t step, std::size_t prompt_tokens) {
+    return prompt_tokens > 0 && step == prompt_tokens - 1;
+}
+
+inline HostVisibleOutputSummary
+host_visible_output_summary(const std::vector<TensorInfo>& outputs) {
+    HostVisibleOutputSummary summary;
+    for (const auto& output : outputs) {
+        if (output.name != "logits")
+            continue;
+        std::size_t elements = output.shape.empty() ? 0 : 1;
+        for (const auto dimension : output.shape) {
+            if (dimension <= 0) {
+                elements = 0;
+                break;
+            }
+            elements *= static_cast<std::size_t>(dimension);
+        }
+        ++summary.tensor_count;
+        summary.bytes += elements * dtype_size(output.dtype);
+    }
+    return summary;
+}
+
+} // namespace trtmc::nemotron_h_recurrent

--- a/src/runtime/models/nemotron_h/recurrent_state.cpp
+++ b/src/runtime/models/nemotron_h/recurrent_state.cpp
@@ -17,14 +17,11 @@ NemotronHRecurrentState::NemotronHRecurrentState(int32_t num_layers, std::vector
                                                  cudaStream_t stream)
     : specs_(std::move(specs)), num_layers_(num_layers), stream_(stream) {
     state_.resize(specs_.size());
-    present_.resize(specs_.size());
 
     for (std::size_t si = 0; si < specs_.size(); ++si) {
         state_[si].reserve(static_cast<std::size_t>(num_layers));
-        present_[si].reserve(static_cast<std::size_t>(num_layers));
         for (int32_t li = 0; li < num_layers; ++li) {
             state_[si].emplace_back(specs_[si].shape, DType::kFloat32, stream);
-            present_[si].emplace_back(specs_[si].shape, DType::kFloat32, stream);
         }
     }
 
@@ -40,8 +37,12 @@ void NemotronHRecurrentState::bind_to(TrtModule& module) {
             auto suffix = "_" + std::to_string(li);
             auto uli = static_cast<std::size_t>(li);
 
+            // The recurrent engine reads each state tensor before writing its
+            // matching present tensor, so both bindings can share one stable
+            // address. This removes per-token state copies and is compatible
+            // with CUDA Graph replay.
             module.bind_external(name + suffix, state_[si][uli].data());
-            module.bind_external(out_prefix + suffix, present_[si][uli].data());
+            module.bind_external(out_prefix + suffix, state_[si][uli].data());
         }
     }
 }
@@ -49,12 +50,6 @@ void NemotronHRecurrentState::bind_to(TrtModule& module) {
 void NemotronHRecurrentState::prepare_step(TensorMap& /*inputs*/, int32_t /*seq_len*/) {}
 
 void NemotronHRecurrentState::advance(int32_t n_tokens) {
-    for (std::size_t si = 0; si < specs_.size(); ++si) {
-        for (int32_t li = 0; li < num_layers_; ++li) {
-            auto uli = static_cast<std::size_t>(li);
-            state_[si][uli].copy_from(present_[si][uli]);
-        }
-    }
     position_ += n_tokens;
 }
 
@@ -64,7 +59,6 @@ void NemotronHRecurrentState::reset() {
         for (int32_t li = 0; li < num_layers_; ++li) {
             auto uli = static_cast<std::size_t>(li);
             cudaMemsetAsync(state_[si][uli].data(), 0, state_[si][uli].nbytes(), stream_);
-            cudaMemsetAsync(present_[si][uli].data(), 0, present_[si][uli].nbytes(), stream_);
         }
     }
     cudaStreamSynchronize(stream_);
@@ -74,8 +68,6 @@ std::size_t NemotronHRecurrentState::device_memory_bytes() const {
     std::size_t total = 0;
     for (std::size_t si = 0; si < specs_.size(); ++si) {
         for (const auto& t : state_[si])
-            total += t.nbytes();
-        for (const auto& t : present_[si])
             total += t.nbytes();
     }
     return total;

--- a/src/runtime/models/nemotron_h/recurrent_state.h
+++ b/src/runtime/models/nemotron_h/recurrent_state.h
@@ -42,7 +42,6 @@ class NemotronHRecurrentState final : public NemotronHInferenceState {
   private:
     std::vector<TensorSpec> specs_;
     std::vector<std::vector<DeviceTensor>> state_;
-    std::vector<std::vector<DeviceTensor>> present_;
     int32_t num_layers_{0};
     int32_t position_{0};
     cudaStream_t stream_{nullptr};

--- a/tests/cpp/models/nemotron_h/test_nemotron_h_backend_cuda_graph.cpp
+++ b/tests/cpp/models/nemotron_h/test_nemotron_h_backend_cuda_graph.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// =============================================================================
+// ISO 26262 Traceability
+// =============================================================================
+// Trace ID:       UT-REC-CPP-03
+// Architecture:   ARCH-FAC-001
+// Unit Design:    UD-REC-01
+// Intent:         TRT backend honors the Nemotron-H CUDA Graph module option
+// Preconditions:  TRT + CUDA GPU available, identity engine buildable
+// Postconditions: A requested CUDA Graph module is active after backend creation
+// =============================================================================
+
+#include "runtime/backend/trt_logger.h"
+#include "trtmc/runtime/trt_backend.h"
+
+#include <NvInfer.h>
+#include <iostream>
+
+static int failures = 0;
+static trtmc::TrtLogger g_logger;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static trtmc::TrtUniquePtr<nvinfer1::IHostMemory> build_identity_plan() {
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
+    if (!builder)
+        return nullptr;
+
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 20);
+
+    auto* input = network->addInput("x", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{1, {4}});
+    if (!input)
+        return nullptr;
+
+    auto* identity = network->addIdentity(*input);
+    if (!identity)
+        return nullptr;
+    auto* output = identity->getOutput(0);
+    output->setName("y");
+    network->markOutput(*output);
+
+    return trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+}
+
+static void test_backend_honors_cuda_graph_option() {
+    auto plan = build_identity_plan();
+    check(plan != nullptr, "backend_option: identity plan built");
+    if (!plan)
+        return;
+
+    auto* backend = trtmc_create_backend();
+    check(backend != nullptr, "backend_option: backend created");
+    if (!backend)
+        return;
+
+    trtmc::ModuleCreateOptions options;
+    options.cuda_graphs = true;
+    auto module = backend->create_module(plan->data(), plan->size(), options);
+    check(module != nullptr, "backend_option: module created");
+    if (module)
+        check(module->cuda_graph_active(), "backend_option: CUDA graph option honored");
+
+    module.reset();
+    trtmc_destroy_backend(backend);
+}
+
+int main() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        std::cerr << "SKIP: no CUDA device available\n";
+        return 0;
+    }
+
+    test_backend_honors_cuda_graph_option();
+    if (failures > 0)
+        std::cerr << failures << " FAILED\n";
+    return failures;
+}

--- a/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_output_initializers.cpp
+++ b/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_output_initializers.cpp
@@ -5,6 +5,7 @@
 
 // Unit tests for recurrent-owned output initializers.
 
+#include "runtime/models/nemotron_h/recurrent_generation_plan.h"
 #include "runtime/models/nemotron_h/recurrent_output_initializers.h"
 
 #include <array>
@@ -87,12 +88,32 @@ void test_nemotron_h_recurrent_contracts() {
           "nemotron-h contract initializes outputs to zero");
 }
 
+void test_recurrent_host_transfer_plan() {
+    check(!under_test::prefill_step_needs_logits(0, 27),
+          "nemotron-h skips unused first-prefill logits");
+    check(!under_test::prefill_step_needs_logits(25, 27),
+          "nemotron-h skips unused intermediate-prefill logits");
+    check(under_test::prefill_step_needs_logits(26, 27),
+          "nemotron-h copies final-prefill logits for sampling");
+
+    const std::vector<trtmc::TensorInfo> outputs = {
+        {"logits", {128000}, trtmc::DType::kFloat32, false},
+        {"present_ssm_0", {36864, 128}, trtmc::DType::kFloat32, false},
+        {"present_conv_0", {12352, 4}, trtmc::DType::kFloat32, false},
+    };
+    const auto summary = under_test::host_visible_output_summary(outputs);
+    check(summary.tensor_count == 1, "nemotron-h exposes only logits to the host");
+    check(summary.bytes == 128000 * sizeof(float),
+          "nemotron-h host-visible bytes exclude recurrent state");
+}
+
 } // namespace
 
 int main() {
     test_initialize_rwkv_outputs();
     test_initialize_mamba_outputs();
     test_nemotron_h_recurrent_contracts();
+    test_recurrent_host_transfer_plan();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " recurrent output initializer test(s) failed\n";

--- a/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
+++ b/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
@@ -113,6 +113,58 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_decoder() {
         rt->deserializeCudaEngine(plan->data(), plan->size()));
 }
 
+static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_state_decoder() {
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
+    if (!builder)
+        return nullptr;
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 20);
+
+    auto* state = network->addInput("state_0", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{1, {4}});
+    auto* present = network->addIdentity(*state);
+    present->getOutput(0)->setName("present_state_0");
+    network->markOutput(*present->getOutput(0));
+
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+    if (!plan)
+        return nullptr;
+    auto runtime = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(g_logger));
+    return trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        runtime->deserializeCudaEngine(plan->data(), plan->size()));
+}
+
+static void test_recurrent_state_updates_in_place() {
+    auto engine = build_mock_state_decoder();
+    if (!engine) {
+        std::cerr << "SKIP: can't build recurrent state engine\n";
+        return;
+    }
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    trtmc::TrtModuleImpl module(engine.get(), engine->createExecutionContext(), stream);
+    trtmc::NemotronHRecurrentState state(
+        1, {trtmc::NemotronHRecurrentState::TensorSpec{"state", {4}, "present_state"}}, stream);
+    module.enable_cuda_graph();
+    state.bind_to(module);
+
+    void* state_buffer = module.device_ptr("state_0");
+    void* present_buffer = module.device_ptr("present_state_0");
+    check(state_buffer == present_buffer,
+          "recurrent state keeps input and output at one device address");
+    state.advance();
+
+    check(module.device_ptr("state_0") == state_buffer,
+          "recurrent state input address remains stable");
+    check(module.device_ptr("present_state_0") == state_buffer,
+          "recurrent state output address remains stable");
+    check(state.device_memory_bytes() == 4 * sizeof(float),
+          "in-place recurrent state allocates one device buffer");
+    cudaStreamDestroy(stream);
+}
+
 static void test_mamba_pipeline() {
     auto engine = build_mock_decoder();
     if (!engine) {
@@ -315,6 +367,7 @@ static void test_argmax_recurrent() {
 
 int main() {
     test_argmax_recurrent();
+    test_recurrent_state_updates_in_place();
     test_mamba_pipeline();
     test_rwkv_pipeline();
     test_hybrid_pipeline();

--- a/tests/cpp/test_cuda_graph.cpp
+++ b/tests/cpp/test_cuda_graph.cpp
@@ -31,6 +31,7 @@
 #include "runtime/backend/trt_module_impl.h"
 #include "runtime/core/trt_common.h"
 #include "trtmc/runtime/tensor.h"
+#include "trtmc/runtime/trt_backend.h"
 #include "trtmc/runtime/trt_module.h"
 
 #include <NvInfer.h>
@@ -51,8 +52,8 @@ static void check(bool condition, const char* test_name) {
 
 static trtmc::TrtLogger g_logger;
 
-// Build a tiny TRT engine: y = x (identity), fixed shape [4] float32
-static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
+// Build a tiny TRT plan: y = x (identity), fixed shape [4] float32
+static trtmc::TrtUniquePtr<nvinfer1::IHostMemory> build_identity_plan() {
     auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
     if (!builder)
         return nullptr;
@@ -72,8 +73,12 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
     out->setName("y");
     network->markOutput(*out);
 
-    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+    return trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
         builder->buildSerializedNetwork(*network, *config));
+}
+
+static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
+    auto plan = build_identity_plan();
     if (!plan)
         return nullptr;
 
@@ -325,6 +330,28 @@ static void test_module_enable_after_normal_run() {
     cudaStreamDestroy(stream);
 }
 
+static void test_backend_honors_cuda_graph_option() {
+    auto plan = build_identity_plan();
+    if (!plan)
+        return;
+
+    auto* backend = trtmc_create_backend();
+    check(backend != nullptr, "backend_option: backend created");
+    if (!backend)
+        return;
+
+    trtmc::ModuleCreateOptions options;
+    options.cuda_graphs = true;
+    auto module = backend->create_module(plan->data(), plan->size(), options);
+    check(module != nullptr, "backend_option: module created");
+    if (module) {
+        check(module->cuda_graph_active(), "backend_option: CUDA graph option honored");
+    }
+
+    module.reset();
+    trtmc_destroy_backend(backend);
+}
+
 int main() {
     // CudaGraphExec unit tests
     test_default_state();
@@ -338,6 +365,7 @@ int main() {
     test_module_cuda_graph_correctness();
     test_module_cuda_graph_multiple_runs();
     test_module_enable_after_normal_run();
+    test_backend_honors_cuda_graph_option();
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";
         return 1;

--- a/tests/cpp/test_cuda_graph.cpp
+++ b/tests/cpp/test_cuda_graph.cpp
@@ -31,7 +31,6 @@
 #include "runtime/backend/trt_module_impl.h"
 #include "runtime/core/trt_common.h"
 #include "trtmc/runtime/tensor.h"
-#include "trtmc/runtime/trt_backend.h"
 #include "trtmc/runtime/trt_module.h"
 
 #include <NvInfer.h>
@@ -52,8 +51,8 @@ static void check(bool condition, const char* test_name) {
 
 static trtmc::TrtLogger g_logger;
 
-// Build a tiny TRT plan: y = x (identity), fixed shape [4] float32
-static trtmc::TrtUniquePtr<nvinfer1::IHostMemory> build_identity_plan() {
+// Build a tiny TRT engine: y = x (identity), fixed shape [4] float32
+static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
     auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
     if (!builder)
         return nullptr;
@@ -73,12 +72,8 @@ static trtmc::TrtUniquePtr<nvinfer1::IHostMemory> build_identity_plan() {
     out->setName("y");
     network->markOutput(*out);
 
-    return trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
         builder->buildSerializedNetwork(*network, *config));
-}
-
-static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
-    auto plan = build_identity_plan();
     if (!plan)
         return nullptr;
 
@@ -330,28 +325,6 @@ static void test_module_enable_after_normal_run() {
     cudaStreamDestroy(stream);
 }
 
-static void test_backend_honors_cuda_graph_option() {
-    auto plan = build_identity_plan();
-    if (!plan)
-        return;
-
-    auto* backend = trtmc_create_backend();
-    check(backend != nullptr, "backend_option: backend created");
-    if (!backend)
-        return;
-
-    trtmc::ModuleCreateOptions options;
-    options.cuda_graphs = true;
-    auto module = backend->create_module(plan->data(), plan->size(), options);
-    check(module != nullptr, "backend_option: module created");
-    if (module) {
-        check(module->cuda_graph_active(), "backend_option: CUDA graph option honored");
-    }
-
-    module.reset();
-    trtmc_destroy_backend(backend);
-}
-
 int main() {
     // CudaGraphExec unit tests
     test_default_state();
@@ -365,7 +338,6 @@ int main() {
     test_module_cuda_graph_correctness();
     test_module_cuda_graph_multiple_runs();
     test_module_enable_after_normal_run();
-    test_backend_honors_cuda_graph_option();
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";
         return 1;

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -249,7 +249,10 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert len(raw_entries) == 77
     assert len(raw_additional) == 28
     assert excluded_profiles == {}
-    assert all(set(entry["workload"]) <= {"testcase", "request"} for entry in raw_entries)
+    assert all(
+        set(entry["workload"]) <= {"testcase", "request", "runtime"}
+        for entry in raw_entries
+    )
     assert all(entry["workload"].get("testcase") for entry in raw_entries)
     assert all(entry.get("model") and entry.get("inherit") for entry in raw_additional)
     assert not any("priority" in entry for entry in raw_entries)
@@ -301,6 +304,9 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert by_id["opt.generate"]["workload"]["request"]["max_new_tokens"] == 10
     assert by_id["deepseek_ocr.generate"]["baseline"]["precision"] == "bf16"
     assert by_id["nemotron_h.generate"]["baseline"]["mode"] == "hf-eager"
+    assert by_id["nemotron_h.generate"]["workload"]["runtime"] == {
+        "cuda_graphs": True
+    }
     nemotron_baseline = by_id["nemotron_speech_streaming.transcribe"]["baseline"]
     assert {
         key: nemotron_baseline[key] for key in ("runner", "adapter", "mode", "reference_backend")
@@ -1261,6 +1267,35 @@ def test_resolution_failure_is_recorded_without_stopping_other_entries(
     assert failures[case["id"]]["stage"] == "candidate-preflight"
     assert failures[case["id"]]["reason"] == "profile unavailable"
     assert failures[case["id"]]["argv"][-1] == "--dry-run"
+
+
+def test_candidate_command_forwards_workload_runtime_overrides(tmp_path: Path) -> None:
+    case = {
+        "id": "nemotron_h.generate",
+        "family": "nemotron_h",
+        "model": "nemotron-h-nano-9b",
+        "workload": {
+            "testcase": "nemotron-h-nano-9b",
+            "runtime": {"cuda_graphs": True},
+        },
+        "measurement": {"warmup": 2, "iterations": 10},
+        "baseline": {
+            "runner": "hf-transformers",
+            "asset_loading_included": False,
+        },
+    }
+    options = Namespace(
+        trtmc_bench="trtmc-bench",
+        trtmc_worker=None,
+        bundle_cache=None,
+        bundle_roots=(),
+        runtime_dirs=(),
+    )
+
+    perf_matrix._validate_workload(case)
+    argv = perf_matrix._candidate_base_argv(case, options)
+
+    assert "runtime.cuda_graphs=true" in argv
 
 
 def test_task_reference_can_require_local_model_files_per_case(tmp_path: Path) -> None:

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -484,7 +484,7 @@ def _validate_workload(case: Mapping[str, Any]) -> None:
     workload = case["workload"]
     if not isinstance(workload, Mapping):
         raise PerfMatrixError(f"case {case['id']} workload must be an object")
-    unsupported = sorted(set(workload) - {"testcase", "request"})
+    unsupported = sorted(set(workload) - {"testcase", "request", "runtime"})
     if unsupported:
         raise PerfMatrixError(
             f"case {case['id']} workload has unsupported fields: {', '.join(unsupported)}"
@@ -498,6 +498,9 @@ def _validate_workload(case: Mapping[str, Any]) -> None:
     request = workload.get("request", {})
     if not isinstance(request, Mapping):
         raise PerfMatrixError(f"case {case['id']} workload.request must be an object")
+    runtime = workload.get("runtime", {})
+    if not isinstance(runtime, Mapping):
+        raise PerfMatrixError(f"case {case['id']} workload.runtime must be an object")
 
 
 def _validate_measurement(case: Mapping[str, Any]) -> None:
@@ -933,6 +936,9 @@ def _candidate_base_argv(case: Mapping[str, Any], options: RunOptions) -> list[s
     request = workload.get("request", {})
     for name, value in sorted((request or {}).items()):
         argv.extend(["--set", f"request.{name}={_yaml_cli_value(value)}"])
+    runtime = workload.get("runtime", {})
+    for name, value in sorted((runtime or {}).items()):
+        argv.extend(["--set", f"runtime.{name}={_yaml_cli_value(value)}"])
     return argv
 
 


### PR DESCRIPTION
## Background

Nemotron-H missed the release performance target even though its generated output matched the Hugging Face reference. Investigation found three runtime and test-framework problems:

- recurrent `present_*` outputs were copied into separate state buffers after every token;
- logits were copied to the host for every prefill token even though only the final prefill logits are sampled;
- the standard TensorRT backend ignored `ModuleCreateOptions.cuda_graphs`, and the release matrix could not configure runtime options per workload.

The previous 140.6 MB diagnostic described every engine output tensor, not actual host transfer volume.

Fixes #634.

## Exit Criteria

- Preserve exact text and token output.
- Keep recurrent state device-resident without per-token state copies.
- Report only actual host-visible output transfers.
- Bring TRTMC p50 within 5% of the 115.139 ms HF reference.
- Add regression coverage for state binding, host transfer planning, CUDA Graph option propagation, and performance-matrix runtime overrides.

## Implementation

- Bind recurrent state inputs and outputs to one stable device address and remove the duplicate state allocation.
- Skip unused intermediate-prefill logits downloads.
- Track and report actual logits copies instead of summing all engine outputs.
- Honor CUDA Graph options across standard TensorRT module creation paths.
- Allow per-workload `runtime` overrides in the performance matrix and enable CUDA Graphs for Nemotron-H.

## Validation

- Exact output: `Paris\n`, token IDs `[42572, 1010, 12]`.
- GB300, TensorRT 11.2, CUDA 13.3:
  - previous TRTMC p50: 124.496 ms;
  - fixed p50 runs: 115.713 ms and 115.355 ms;
  - HF reference p50: 115.139 ms.
- Actual host-visible output: 1.5 MB total per request, one logits tensor copied three times.
- `python3 -m tools.ci pipeline source-quality`: passed, including 158 architecture tests.
- `pytest -q tests/tools/test_perf_matrix.py`: 79 passed.
- GPU C++ tests passed:
  - `test_cuda_graph`
  - `test_nemotron_h_recurrent_pipeline`
  - `test_nemotron_h_recurrent_output_initializers`

## Notes For Future Readers

The recurrent engine was validated with aliased state input/output addresses under CUDA Graph replay. If a future engine changes the recurrent state dependency contract, keep the fixed-address regression test and exact model-output check when revisiting this optimization.
