### PR TITLE
feat(validation): show task types in reports

### DIFF
--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -93,6 +93,16 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     assert catalog["sample_limits"]["gedit_bench_image_edit"] == 5
 
 
+def test_standard_validation_suites_have_report_task_types():
+    missing = [
+        suite["id"]
+        for suite in task_eval.load_suites()
+        if not trtmc_validate._suite_task_metadata(suite)[0]
+    ]
+
+    assert not missing
+
+
 def test_every_dataset_backed_validation_binding_has_native_reference_runner():
     catalog = trtmc_validate.load_catalog()
     suites = {suite["id"]: suite for suite in task_eval.load_suites()}
@@ -996,6 +1006,8 @@ def test_write_report_links_each_comparison(tmp_path):
             {
                 "model": "model-a",
                 "workload": "workload-a",
+                "task_type": "Text → Audio",
+                "user_contract": "tts_audio",
                 "status": "passed",
                 "reference_environment": [
                     {"name": "reference_common", "python": "/profiles/python"}
@@ -1043,6 +1055,9 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "🟢 1 &nbsp; 🟡 0 &nbsp;" in document
     assert "🔴 0 &nbsp; ⚪ 0" in document
     assert "Vanilla reproduction" in document
+    assert "<th>Task type</th>" in document
+    assert "Text → Audio" in document
+    assert "tts_audio" in document
     assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
     assert "Dataset slice (500 samples)" in document
     assert "<th>Samples</th>" in document
@@ -1093,6 +1108,37 @@ def test_write_report_surfaces_quantized_reference_precision_contract(
     document = html_path.read_text(encoding="utf-8")
     assert "TRTMC FP8 (BF16 base) vs HF BF16" in document
     assert "Quantized candidate vs unquantized reference" in document
+
+
+def test_report_infers_task_type_for_legacy_standard_result(tmp_path):
+    case_dir = tmp_path / "bark-large" / "seedtts_en_tts_intelligibility"
+    case_dir.mkdir(parents=True)
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "bark-large",
+                "workload": "seedtts_en_tts_intelligibility",
+                "status": "passed",
+                "reproduce": {
+                    "dataset": {
+                        "command": "python tools/trtmc_validate.py bark-large",
+                        "sample_limit": 3,
+                        "prepared_input_count": 3,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    result = report["results"][0]
+    assert result["task_type"] == "Text → Audio"
+    assert result["user_contract"] == "tts_audio"
+    document = html_path.read_text(encoding="utf-8")
+    assert "<strong>Text → Audio</strong>" in document
+    assert '<div class="detail">tts_audio</div>' in document
 
 
 def test_traffic_light_counts_are_mutually_exclusive():

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -10,6 +10,7 @@ import argparse
 import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import cache
 import html
 import json
 import os
@@ -52,6 +53,27 @@ NOT_COMPARED_DIRECTORY = "not-compared"
 LEGACY_E2E_REASON = (
     "E2E execution does not compare aligned reference and TRTMC outputs."
 )
+_TASK_TYPE_BY_USER_CONTRACT = {
+    "multiple_choice_qa": "Text → Choice",
+    "continuation_parity": "Text → Text",
+    "code_completion": "Text → Code",
+    "translation": "Text → Text",
+    "seq2seq_output": "Text → Text",
+    "vl_answer": "Image + Text → Text",
+    "ocr_text": "Image → Text",
+    "exact_transcript": "Audio → Text",
+    "tts_audio": "Text → Audio",
+    "diffusion_image": "Text → Image",
+    "diffusion_video": "Text → Video",
+    "image-to-image": "Image + Text → Image",
+    "image_classification": "Image → Class",
+    "segmentation_mask": "Image → Mask",
+    "prompted_mask": "Image + Prompt → Mask",
+    "time_series_prediction_parity": "Time Series → Time Series",
+    "encoder_embedding_parity": "Text → Embedding",
+    "ranking_order": "Query + Documents → Ranking",
+    "diffusion_text_generation": "Text → Text",
+}
 
 
 class ValidationError(RuntimeError):
@@ -186,6 +208,31 @@ def load_catalog(path: Path = DEFAULT_CATALOG) -> dict[str, Any]:
     for name, spec in models.items():
         _validate_model_spec(path, name, spec)
     return raw
+
+
+def _suite_task_metadata(suite: Mapping[str, Any]) -> tuple[str, str]:
+    user_contract = str(suite.get("user_contract", "") or "")
+    task_type = str(suite.get("task_type", "") or "")
+    if not task_type:
+        task_type = _TASK_TYPE_BY_USER_CONTRACT.get(user_contract, "")
+    return task_type, user_contract
+
+
+@cache
+def _default_suite_task_metadata() -> dict[str, tuple[str, str]]:
+    return {
+        str(suite["id"]): _suite_task_metadata(suite)
+        for suite in task_eval.load_suites(DEFAULT_SUITES)
+    }
+
+
+def _result_task_metadata(result: Mapping[str, Any]) -> tuple[str, str]:
+    task_type = str(result.get("task_type", "") or "")
+    user_contract = str(result.get("user_contract", "") or "")
+    if task_type:
+        return task_type, user_contract
+    workload = str(result.get("workload", "") or "")
+    return _default_suite_task_metadata().get(workload, ("", user_contract))
 
 
 def ready_model_names(models_root: Path = DEFAULT_MODELS) -> tuple[str, ...]:
@@ -1143,9 +1190,12 @@ def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(precision_contract, dict):
         candidate = raw_result.get("precision_contract")
         precision_contract = dict(candidate) if isinstance(candidate, dict) else {}
+    task_type, user_contract = _result_task_metadata(normalized)
     normalized.update(
         {
             "schema_version": "trtmc.validation-result/v2",
+            "task_type": task_type,
+            "user_contract": user_contract,
             "execution": execution,
             "comparison": comparison,
             "validation": validation,
@@ -1205,6 +1255,8 @@ def _comparison_result(
     reference_environment: EnvironmentSelection,
     dataset_command: str,
     sample_limit: int = 0,
+    task_type: str = "",
+    user_contract: str = "",
 ) -> dict[str, Any]:
     workload = _required_workload(binding)
     summary_path = case_dir / "validation" / workload / "eval_summary.json"
@@ -1238,6 +1290,8 @@ def _comparison_result(
         "schema_version": "trtmc.validation-result/v2",
         "model": binding.model,
         "workload": binding.workload,
+        "task_type": task_type,
+        "user_contract": user_contract,
         "executor": "trtmc_compare",
         "status": status,
         "returncode": returncode,
@@ -1282,6 +1336,7 @@ def run_binding(
     dataset_command = shlex.join([sys.executable, *sys.argv])
 
     suite = suites[workload]
+    task_type, user_contract = _suite_task_metadata(suite)
     dataset = (
         Path(arguments.dataset)
         if arguments.dataset
@@ -1303,6 +1358,8 @@ def run_binding(
         reference_environment=environment,
         dataset_command=dataset_command,
         sample_limit=int(arguments.limit or 0),
+        task_type=task_type,
+        user_contract=user_contract,
     )
 
     comparison = case_dir / "comparison.json"
@@ -1947,6 +2004,7 @@ def _report_rows(
         rows.append(
             "<tr>"
             f"<td>{html.escape(str(result.get('model', '')))}</td>"
+            f"<td>{_render_task_type(result)}</td>"
             f"<td>{html.escape(str(result.get('workload') or '—'))}</td>"
             f"<td>{_render_samples(result)}</td>"
             f"<td>{_render_execution(result)}</td>"
@@ -1959,6 +2017,18 @@ def _report_rows(
             "</tr>"
         )
     return "".join(rows)
+
+
+def _render_task_type(result: Mapping[str, Any]) -> str:
+    task_type, user_contract = _result_task_metadata(result)
+    if not task_type:
+        return "—"
+    contract = (
+        f'<div class="detail">{html.escape(user_contract)}</div>'
+        if user_contract
+        else ""
+    )
+    return f"<strong>{html.escape(task_type)}</strong>{contract}"
 
 
 def _report_document(
@@ -2039,7 +2109,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 {execution_errors} execution errors ·
 {report["summary"]["selected_samples"]} samples{duration_summary}<br>
 {html.escape(provenance)}</div>
-<table><thead><tr><th>Model</th><th>Workload</th><th>Samples</th><th>Execution</th>
+<table><thead><tr><th>Model</th><th>Task type</th><th>Workload</th><th>Samples</th><th>Execution</th>
 <th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
 <th>Validation</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
 <tbody>{rows}</tbody></table>


### PR DESCRIPTION
## Background
Validation reports identify the model and suite but do not explain the task in user-facing terms. This is especially confusing for media models such as Bark, where generated audio can be mistaken for an input artifact.

## Exit Criteria
- Every standard validation suite has a concise input-to-output task type.
- Bark is reported as `Text → Audio`.
- Existing standard-suite results can gain task types when a report is regenerated, without rerunning model validation.

## Implementation
- Maps suite `user_contract` values to user-facing task types while allowing a suite to provide an explicit override.
- Stores task type and contract in new comparison results.
- Adds a `Task type` column to HTML reports and infers metadata for legacy standard-suite artifacts.

## Validation
- `ruff check tools/trtmc_validate.py tests/tools/test_trtmc_validate.py`: passed.
- `python3 -m py_compile tools/trtmc_validate.py`: passed.
- `python3 -m pytest tests/tools/test_trtmc_validate.py -q -k 'standard_validation_suites_have_report_task_types or write_report_links_each_comparison or report_infers_task_type_for_legacy_standard_result'`: 3 passed.
- `python3 -m pytest tests/tools/test_trtmc_validate.py -q`: 62 passed and 1 pre-existing ELF reference-profile assertion failed; the same assertion fails on unmodified `github/main`.

## Notes For Future Readers
- Add a mapping for a new `user_contract`, or set `task_type` explicitly on a suite when its input/output modalities differ from the shared contract.
