### PR TITLE
perf(personaplex): reduce decoder latency

### DIFF
--- a/python/tensorrt_model_connect/families/personaplex/default_decoder.py
+++ b/python/tensorrt_model_connect/families/personaplex/default_decoder.py
@@ -57,7 +57,7 @@ def _mark_debug_output(
 @with_builder_context(
     workspace_bytes=1 << 30,
     disable_tf32=True,
-    builder_optimization_level=0,
+    builder_optimization_level=1,
     max_num_tactics=1,
 )
 def build_standard_decoder_engine(

--- a/src/runtime/models/personaplex/MODEL.toml
+++ b/src/runtime/models/personaplex/MODEL.toml
@@ -12,6 +12,7 @@ runtime_tests = [
   "test_personaplex_speech_generation_helpers|test_personaplex_speech_generation_helpers.cpp|_|_|_",
   "test_personaplex_speech_depth_plan|test_personaplex_speech_depth_plan.cpp|_|_|_",
   "test_personaplex_speech_runtime_plan|test_personaplex_speech_runtime_plan.cpp|_|_|_",
+  "test_personaplex_speech_performance|test_personaplex_speech_performance.cpp|_|_|_",
   "test_personaplex_speech_temporal_embed_plan|test_personaplex_speech_temporal_embed_plan.cpp|_|_|_",
   "test_personaplex_speech_mimi_decode_plan|test_personaplex_speech_mimi_decode_plan.cpp|_|_|_",
   "test_personaplex_decode_runtime|test_personaplex_decode_runtime.cpp|_|decode_runtime.cpp|_",

--- a/src/runtime/models/personaplex/pipeline.cpp
+++ b/src/runtime/models/personaplex/pipeline.cpp
@@ -12,6 +12,7 @@
 #include "runtime/models/personaplex/speech_depth_plan.h"
 #include "runtime/models/personaplex/speech_generation_policy.h"
 #include "runtime/models/personaplex/speech_mimi_decode_plan.h"
+#include "runtime/models/personaplex/speech_performance.h"
 #include "runtime/models/personaplex/speech_runtime_plan.h"
 #include "runtime/models/personaplex/speech_temporal_embed_plan.h"
 #include "runtime/models/personaplex/speech_waveform_postprocess.h"
@@ -20,6 +21,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <functional>
@@ -666,6 +668,56 @@ void SpeechPipeline::run_text_prompt() {
 
 namespace {
 
+class CudaStageTimer {
+  public:
+    CudaStageTimer() {
+        auto error = cudaEventCreate(&start_);
+        if (error != cudaSuccess)
+            throw std::runtime_error(std::string("PersonaPlex timing event creation: ") +
+                                     cudaGetErrorString(error));
+        error = cudaEventCreate(&stop_);
+        if (error == cudaSuccess)
+            return;
+        cudaEventDestroy(start_);
+        start_ = nullptr;
+        throw std::runtime_error(std::string("PersonaPlex timing event creation: ") +
+                                 cudaGetErrorString(error));
+    }
+
+    ~CudaStageTimer() {
+        if (stop_)
+            cudaEventDestroy(stop_);
+        if (start_)
+            cudaEventDestroy(start_);
+    }
+
+    CudaStageTimer(const CudaStageTimer&) = delete;
+    CudaStageTimer& operator=(const CudaStageTimer&) = delete;
+
+    void start(cudaStream_t stream) { record(start_, stream); }
+    void stop(cudaStream_t stream) { record(stop_, stream); }
+
+    double elapsed_ms() const {
+        float elapsed = 0.0F;
+        const auto error = cudaEventElapsedTime(&elapsed, start_, stop_);
+        if (error != cudaSuccess)
+            throw std::runtime_error(std::string("PersonaPlex timing event query: ") +
+                                     cudaGetErrorString(error));
+        return static_cast<double>(elapsed);
+    }
+
+  private:
+    static void record(cudaEvent_t event, cudaStream_t stream) {
+        const auto error = cudaEventRecord(event, stream);
+        if (error != cudaSuccess)
+            throw std::runtime_error(std::string("PersonaPlex timing event record: ") +
+                                     cudaGetErrorString(error));
+    }
+
+    cudaEvent_t start_{nullptr};
+    cudaEvent_t stop_{nullptr};
+};
+
 void speech_log_depth_mode(const SpeechConfig& cfg) {
     if (speech_is_sampling_enabled(cfg)) {
         std::cerr << "[speech] Depth sampling: temperature=" << cfg.depth_temperature
@@ -766,7 +818,8 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
                                                DelayCacheState& delay_state,
                                                const std::vector<int32_t>& codec_tokens,
                                                std::vector<int32_t>& output_codes,
-                                               int32_t& frames_collected) {
+                                               int32_t& frames_collected,
+                                               SpeechPerformanceTimings& timings) {
     const int32_t hidden = settings.hidden;
     SpeechDecodeStopState stop_state;
     speech_log_stop_configuration(config_, plan.extra_tail);
@@ -778,6 +831,8 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
     std::vector<uint8_t> target_audio_provided(static_cast<std::size_t>(settings.num_cb));
     std::vector<int32_t> selected_frame_tokens;
     std::vector<int32_t> frame_codes(static_cast<std::size_t>(settings.num_cb));
+    CudaStageTimer temporal_timer;
+    CudaStageTimer depth_timer;
 
     frames_collected = 0;
     for (int32_t offset = 0; offset < plan.total_iters && frames_collected < plan.output_frames;
@@ -801,16 +856,22 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
                                          moshi_input.data(), user_input.data(), text_input,
                                          summed_embed.data());
 
+        temporal_timer.start(stream_);
         const auto temporal_output = run_temporal_embed_step(summed_embed.data(), settings.hidden);
+        temporal_timer.stop(stream_);
         const auto text_target_idx = delay_cache_index(delay_state, 0, target_pos);
         const bool text_provided = delay_state.provided[text_target_idx] != 0;
         const int32_t forced_text_token = delay_state.cache[text_target_idx];
 
         build_target_audio_arrays(delay_state, target_pos, settings.num_cb, settings.audio_bos,
                                   target_audio_tokens, target_audio_provided);
+        depth_timer.start(stream_);
         run_depth(temporal_output, forced_text_token, text_provided, target_audio_tokens.data(),
                   target_audio_provided.data());
+        depth_timer.stop(stream_);
         download_selected_frame_tokens(selected_frame_tokens);
+        timings.temporal_ms += temporal_timer.elapsed_ms();
+        timings.depth_ms += depth_timer.elapsed_ms();
         const int32_t sampled_text_token = selected_frame_tokens[0];
         std::copy_n(selected_frame_tokens.begin() + 1, settings.num_cb, frame_codes.begin());
 
@@ -859,6 +920,9 @@ void SpeechPipeline::speak_postprocess_waveform(std::vector<float>& waveform,
 
 AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
                                   const GenerateConfig& cfg, int32_t input_sample_rate) {
+    using Clock = std::chrono::steady_clock;
+    const auto total_started = Clock::now();
+    SpeechPerformanceTimings timings;
     AudioResult result;
     result.sample_rate = config_.sample_rate;
 
@@ -885,7 +949,10 @@ AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
     speech_log_depth_mode(config_);
 
     // Stage 1: Encode input audio via Mimi
+    const auto encode_started = Clock::now();
     auto codec_tokens = run_mimi_encode(samples_ptr, samples_count);
+    timings.codec_ms +=
+        std::chrono::duration<double, std::milli>(Clock::now() - encode_started).count();
 
     const auto encoder_shape = resolve_encoder_shape_without_engine(
         config_, last_encode_codebooks_, last_encode_frames_, codec_tokens.size());
@@ -935,7 +1002,7 @@ AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
 
     int32_t frames_collected = 0;
     speak_run_generation_loop(settings, plan, delay_state, codec_tokens, output_codes,
-                              frames_collected);
+                              frames_collected, timings);
 
     const int32_t generated_frames = frames_collected;
     std::cerr << "[speech] Depth: generated " << generated_frames << " frames x " << num_cb
@@ -943,7 +1010,10 @@ AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
     speech_log_output_frames_debug(output_codes, generated_frames, mimi_cb);
 
     // Stage 4: Decode output tokens to audio via Mimi decoder
+    const auto decode_started = Clock::now();
     auto waveform = run_mimi_decode(output_codes, generated_frames);
+    timings.codec_ms +=
+        std::chrono::duration<double, std::milli>(Clock::now() - decode_started).count();
     speak_postprocess_waveform(waveform, generated_frames);
 
     result.samples = std::move(waveform);
@@ -951,6 +1021,12 @@ AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
     std::cerr << "[speech] Generated " << result.num_samples << " samples ("
               << static_cast<float>(result.num_samples) / result.sample_rate << "s @ "
               << result.sample_rate << " Hz)" << std::endl;
+    const double total_ms =
+        std::chrono::duration<double, std::milli>(Clock::now() - total_started).count();
+    std::cerr << "[trtmc.personaplex_timing] total_ms=" << total_ms
+              << " temporal_ms=" << timings.temporal_ms << " depth_ms=" << timings.depth_ms
+              << " codec_ms=" << timings.codec_ms << " host_ms=" << timings.host_ms(total_ms)
+              << " frames=" << generated_frames << std::endl;
     return result;
 }
 

--- a/src/runtime/models/personaplex/pipeline.h
+++ b/src/runtime/models/personaplex/pipeline.h
@@ -14,6 +14,7 @@
 #include "runtime/models/personaplex/speech_config.h"
 #include "runtime/models/personaplex/speech_delay_cache.h"
 #include "runtime/models/personaplex/speech_generation_policy.h"
+#include "runtime/models/personaplex/speech_performance.h"
 #include "runtime/models/personaplex/speech_runtime_plan.h"
 #include "trtmc/pipeline.h"
 #include "trtmc/runtime/trt_module.h"
@@ -78,7 +79,8 @@ class SpeechPipeline final : public IPipeline {
     void speak_run_generation_loop(const SpeechGenerationSettings& settings,
                                    const SpeechOutputPlan& plan, DelayCacheState& delay_state,
                                    const std::vector<int32_t>& codec_tokens,
-                                   std::vector<int32_t>& output_codes, int32_t& frames_collected);
+                                   std::vector<int32_t>& output_codes, int32_t& frames_collected,
+                                   SpeechPerformanceTimings& timings);
     void speak_postprocess_waveform(std::vector<float>& waveform, int32_t generated_frames) const;
 
     std::unique_ptr<TrtModule> temporal_;

--- a/src/runtime/models/personaplex/plugin.cpp
+++ b/src/runtime/models/personaplex/plugin.cpp
@@ -121,6 +121,16 @@ class PersonaPlexPlugin final : public IPipelinePlugin {
             extract_optional_module(ctx.backend, find_section(ctx.bundle, "mimi_decoder_plan"),
                                     "speech mimi_decoder", chained_opts);
 
+        if (ctx.cuda_graphs) {
+            temporal_loaded.module->enable_cuda_graph();
+            for (auto& depth_engine : depth_engines)
+                depth_engine->enable_cuda_graph();
+            if (mimi_encoder)
+                mimi_encoder->enable_cuda_graph();
+            if (mimi_decoder)
+                mimi_decoder->enable_cuda_graph();
+        }
+
         return std::make_unique<SpeechPipeline>(
             std::move(mimi_encoder), std::move(temporal_loaded.module), std::move(temporal_state),
             std::move(depth_engines), std::move(depth_state), std::move(mimi_decoder),

--- a/src/runtime/models/personaplex/sampling_kernels.cu
+++ b/src/runtime/models/personaplex/sampling_kernels.cu
@@ -17,6 +17,7 @@ namespace {
 
 constexpr int32_t kArgmaxThreads = 256;
 constexpr int32_t kSampleThreads = 128;
+constexpr int32_t kProjectionThreads = 256;
 constexpr int32_t kMaxTopK = 4096;
 
 __device__ bool candidate_is_better(float lhs_value, int32_t lhs_index, float rhs_value,
@@ -202,23 +203,6 @@ __device__ float audio_seed(const float* embeddings, int64_t elements,
 }
 
 template <typename HiddenT>
-__device__ float projected_hidden(const HiddenT* temporal_hidden, const float* depth_projection,
-                                  int64_t projection_elements, int32_t codebook,
-                                  int32_t depth_hidden, int32_t temporal_hidden_dim, int32_t row) {
-    if (!depth_projection || !temporal_hidden || temporal_hidden_dim <= 0)
-        return 0.0F;
-    const int64_t matrix = static_cast<int64_t>(codebook) * depth_hidden * temporal_hidden_dim;
-    const int64_t row_offset = matrix + static_cast<int64_t>(row) * temporal_hidden_dim;
-    if (row_offset + temporal_hidden_dim > projection_elements)
-        return 0.0F;
-    float value = 0.0F;
-    for (int32_t column = 0; column < temporal_hidden_dim; ++column) {
-        value += depth_projection[row_offset + column] * load_hidden(temporal_hidden, column);
-    }
-    return value;
-}
-
-template <typename HiddenT>
 __global__ void prepare_depth_embedding_kernel(
     float* output, const HiddenT* temporal_hidden, const float* depth_projection,
     int64_t depth_projection_elements, const float* depth_text_embedding,
@@ -227,23 +211,51 @@ __global__ void prepare_depth_embedding_kernel(
     int32_t forced_text_token, bool text_token_is_forced, int32_t forced_previous_token,
     bool previous_token_is_forced, int32_t depth_hidden, int32_t temporal_hidden_dim,
     int32_t depth_text_vocab, int32_t audio_vocab_size, int32_t num_depformer_embeddings) {
-    const int32_t row = blockIdx.x * blockDim.x + threadIdx.x;
+    __shared__ float partial_sums[kProjectionThreads];
+    const int32_t row = blockIdx.x;
     if (row >= depth_hidden)
         return;
-    const float seed =
-        codebook == 0
-            ? text_seed(depth_text_embedding, depth_text_embedding_elements, selected_tokens,
-                        forced_text_token, text_token_is_forced, depth_text_vocab, depth_hidden,
-                        row)
-            : audio_seed(depth_audio_embeddings, depth_audio_embedding_elements, selected_tokens,
-                         codebook, forced_previous_token, previous_token_is_forced,
-                         audio_vocab_size, depth_hidden, num_depformer_embeddings, row);
-    output[row] =
-        seed + projected_hidden(temporal_hidden, depth_projection, depth_projection_elements,
-                                codebook, depth_hidden, temporal_hidden_dim, row);
+    const int64_t matrix = static_cast<int64_t>(codebook) * depth_hidden * temporal_hidden_dim;
+    const int64_t row_offset = matrix + static_cast<int64_t>(row) * temporal_hidden_dim;
+    const bool projection_is_valid = depth_projection && temporal_hidden &&
+                                     temporal_hidden_dim > 0 &&
+                                     row_offset + temporal_hidden_dim <= depth_projection_elements;
+    float projected = 0.0F;
+    if (projection_is_valid) {
+        for (int32_t column = threadIdx.x; column < temporal_hidden_dim;
+             column += kProjectionThreads) {
+            projected +=
+                depth_projection[row_offset + column] * load_hidden(temporal_hidden, column);
+        }
+    }
+    partial_sums[threadIdx.x] = projected;
+    __syncthreads();
+    for (int32_t stride = kProjectionThreads / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride)
+            partial_sums[threadIdx.x] += partial_sums[threadIdx.x + stride];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        const float seed = codebook == 0
+                               ? text_seed(depth_text_embedding, depth_text_embedding_elements,
+                                           selected_tokens, forced_text_token, text_token_is_forced,
+                                           depth_text_vocab, depth_hidden, row)
+                               : audio_seed(depth_audio_embeddings, depth_audio_embedding_elements,
+                                            selected_tokens, codebook, forced_previous_token,
+                                            previous_token_is_forced, audio_vocab_size,
+                                            depth_hidden, num_depformer_embeddings, row);
+        output[row] = seed + partial_sums[0];
+    }
 }
 
 } // namespace
+
+PersonaplexDepthProjectionLaunchPlan
+personaplex_depth_projection_launch_plan(int32_t depth_hidden) {
+    if (depth_hidden <= 0)
+        return {};
+    return {depth_hidden, kProjectionThreads};
+}
 
 bool personaplex_select_token(const float* logits, int32_t vocab_size, float temperature,
                               int32_t top_k, int32_t max_token_id, uint64_t* rng_state,
@@ -273,10 +285,9 @@ void personaplex_prepare_depth_embedding(
     int32_t audio_vocab_size, int32_t num_depformer_embeddings, cudaStream_t stream) {
     if (!output || !selected_tokens || depth_hidden <= 0)
         return;
-    constexpr int32_t threads = 256;
-    const int32_t blocks = (depth_hidden + threads - 1) / threads;
+    const auto launch = personaplex_depth_projection_launch_plan(depth_hidden);
 #define TRTMC_LAUNCH_DEPTH_EMBED(HIDDEN_TYPE)                                                      \
-    prepare_depth_embedding_kernel<<<blocks, threads, 0, stream>>>(                                \
+    prepare_depth_embedding_kernel<<<launch.blocks, launch.threads, 0, stream>>>(                  \
         output, static_cast<const HIDDEN_TYPE*>(temporal_hidden), depth_projection,                \
         depth_projection_elements, depth_text_embedding, depth_text_embedding_elements,            \
         depth_audio_embeddings, depth_audio_embedding_elements, selected_tokens, codebook,         \

--- a/src/runtime/models/personaplex/sampling_kernels.h
+++ b/src/runtime/models/personaplex/sampling_kernels.h
@@ -12,6 +12,13 @@
 
 namespace trtmc {
 
+struct PersonaplexDepthProjectionLaunchPlan {
+    int32_t blocks{0};
+    int32_t threads{0};
+};
+
+PersonaplexDepthProjectionLaunchPlan personaplex_depth_projection_launch_plan(int32_t depth_hidden);
+
 bool personaplex_select_token(const float* logits, int32_t vocab_size, float temperature,
                               int32_t top_k, int32_t max_token_id, uint64_t* rng_state,
                               int32_t* token_id, cudaStream_t stream);

--- a/src/runtime/models/personaplex/speech_performance.h
+++ b/src/runtime/models/personaplex/speech_performance.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace trtmc {
+
+struct SpeechPerformanceTimings {
+    double temporal_ms{0.0};
+    double depth_ms{0.0};
+    double codec_ms{0.0};
+
+    double host_ms(double total_ms) const {
+        const double residual = total_ms - temporal_ms - depth_ms - codec_ms;
+        return residual > 0.0 ? residual : 0.0;
+    }
+};
+
+} // namespace trtmc

--- a/tests/cpp/models/personaplex/test_personaplex_sampling_kernels.cpp
+++ b/tests/cpp/models/personaplex/test_personaplex_sampling_kernels.cpp
@@ -87,6 +87,12 @@ void test_argmax_and_topk_sampling(cudaStream_t stream) {
           "unsupported top-k fails closed");
 }
 
+void test_optimized_launch_plans() {
+    const auto projection = trtmc::personaplex_depth_projection_launch_plan(1024);
+    check(projection.blocks == 1024, "one projection block per output row");
+    check(projection.threads == 256, "projection columns reduce in parallel");
+}
+
 void test_depth_embedding(cudaStream_t stream) {
     auto hidden = upload<float>({1.0F, 2.0F}, trtmc::DType::kFloat32, stream);
     auto projection = upload<float>({1.0F, 0.0F, 0.0F, 1.0F, 2.0F, 0.0F, 0.0F, 2.0F},
@@ -117,6 +123,45 @@ void test_depth_embedding(cudaStream_t stream) {
     check_close(run(1, 1, true), {42.0F, 45.0F}, "forced audio depth embedding");
 }
 
+void test_non_aligned_depth_embedding(cudaStream_t stream) {
+    constexpr int32_t depth_hidden = 263;
+    constexpr int32_t temporal_hidden = 259;
+    std::vector<float> hidden(static_cast<std::size_t>(temporal_hidden));
+    std::vector<float> projection(static_cast<std::size_t>(depth_hidden) * temporal_hidden);
+    std::vector<float> text_embedding(static_cast<std::size_t>(depth_hidden) * 2);
+    std::vector<float> expected(static_cast<std::size_t>(depth_hidden));
+    for (int32_t column = 0; column < temporal_hidden; ++column)
+        hidden[static_cast<std::size_t>(column)] = static_cast<float>((column % 13) - 6) * 0.125F;
+    for (int32_t row = 0; row < depth_hidden; ++row) {
+        text_embedding[static_cast<std::size_t>(depth_hidden + row)] =
+            static_cast<float>(row % 11) * 0.25F;
+        float projected = 0.0F;
+        for (int32_t column = 0; column < temporal_hidden; ++column) {
+            const auto offset = static_cast<std::size_t>(row) * temporal_hidden + column;
+            projection[offset] = static_cast<float>(((row + column) % 19) - 9) * 0.015625F;
+            projected += projection[offset] * hidden[static_cast<std::size_t>(column)];
+        }
+        expected[static_cast<std::size_t>(row)] =
+            projected + text_embedding[static_cast<std::size_t>(depth_hidden + row)];
+    }
+
+    auto device_hidden = upload(hidden, trtmc::DType::kFloat32, stream);
+    auto device_projection = upload(projection, trtmc::DType::kFloat32, stream);
+    auto device_text_embedding = upload(text_embedding, trtmc::DType::kFloat32, stream);
+    auto selected = upload<int32_t>({1}, trtmc::DType::kInt32, stream);
+    trtmc::DeviceTensor output({depth_hidden}, trtmc::DType::kFloat32, stream);
+    trtmc::personaplex_prepare_depth_embedding(
+        static_cast<float*>(output.data()), device_hidden.data(), trtmc::DType::kFloat32,
+        static_cast<const float*>(device_projection.data()), device_projection.numel(),
+        static_cast<const float*>(device_text_embedding.data()), device_text_embedding.numel(),
+        nullptr, 0, static_cast<const int32_t*>(selected.data()), 0, 0, false, 0, false,
+        depth_hidden, temporal_hidden, 2, 0, 0, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize non-aligned depth embedding");
+    std::vector<float> actual(static_cast<std::size_t>(depth_hidden));
+    check(output.copy_to_host(actual.data()), "download non-aligned depth embedding");
+    check_close(actual, expected, "non-aligned depth embedding");
+}
+
 } // namespace
 
 int main() {
@@ -128,8 +173,10 @@ int main() {
 
     cudaStream_t stream = nullptr;
     check_cuda(cudaStreamCreate(&stream), "create stream");
+    test_optimized_launch_plans();
     test_argmax_and_topk_sampling(stream);
     test_depth_embedding(stream);
+    test_non_aligned_depth_embedding(stream);
     check_cuda(cudaStreamDestroy(stream), "destroy stream");
     return g_failures == 0 ? 0 : 1;
 }

--- a/tests/cpp/models/personaplex/test_personaplex_speech_performance.cpp
+++ b/tests/cpp/models/personaplex/test_personaplex_speech_performance.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/personaplex/speech_performance.h"
+
+#include <cmath>
+#include <iostream>
+
+namespace {
+
+int g_failures = 0;
+
+void check_close(double actual, double expected, const char* name) {
+    if (std::fabs(actual - expected) <= 1.0e-9)
+        return;
+    std::cerr << "FAIL: " << name << " expected " << expected << ", got " << actual << '\n';
+    ++g_failures;
+}
+
+} // namespace
+
+int main() {
+    trtmc::SpeechPerformanceTimings timings;
+    timings.temporal_ms = 350.0;
+    timings.depth_ms = 200.0;
+    timings.codec_ms = 20.0;
+    check_close(timings.host_ms(600.0), 30.0, "host residual");
+    check_close(timings.host_ms(500.0), 0.0, "negative residual clamps to zero");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/e2e/models/personaplex/test_personaplex_builder_lifetime.py
+++ b/tests/e2e/models/personaplex/test_personaplex_builder_lifetime.py
@@ -304,7 +304,7 @@ def test_standard_decoder_uses_stable_fp32_tactics() -> None:
         module.build_standard_decoder_engine).nonlocals
 
     assert builder_context_options["disable_tf32"] is True
-    assert builder_context_options["builder_optimization_level"] == 0
+    assert builder_context_options["builder_optimization_level"] == 1
     assert builder_context_options["max_num_tactics"] == 1
 
 


### PR DESCRIPTION
## Background

Fixes #635.

The release comparison measured PersonaPlex at 1853.289 ms p50 versus a
1173.154 ms reference. Profiling showed that the full-FP32 temporal and depth
decoder engines dominated the request, while the depth projection kernel
serialized each 4096-column output row in one CUDA thread.

## Exit Criteria

- Preserve the 4-second, 24 kHz, 96,000-sample audio contract.
- Preserve the reviewed aggregate, depth-token, audio-token, and strict
  frame-token quality thresholds.
- Bring candidate p50 within 5% of the release reference.
- Report temporal, aggregate depth, codec, and host latency separately.

## Implementation

- Raise the full-FP32 decoder builder optimization level from 0 to 1 while
  retaining disabled TF32 and the single-tactic constraint.
- Parallelize each depth projection output row across a 256-thread CUDA block.
- Honor the requested CUDA graph mode for every PersonaPlex engine.
- Add CUDA-event stage measurements and a host residual timing metric.
- Add non-aligned projection, launch-plan, timing, and builder-policy
  regression coverage.

## Validation

GB300, TensorRT 11.2, CUDA 13.3:

- 3 warmups + 10 measured requests: p50 608.726 ms, p95 616.295 ms.
- Candidate p50 is 67.2% lower than the report and 48.1% faster than the
  1173.154 ms reference.
- Median decomposition: temporal 349.979 ms, aggregate depth 246.459 ms,
  codec 7.223 ms, host 4.989 ms.
- Output contract: 96,000 finite samples, 4 seconds, 24 kHz.
- Quality: aggregate 0.9175 (gate 0.8), depth token 0.98 (gate 0.7), audio
  token 0.9085714 (gate 0.7), strict frame token exact 0.80 (gate 0.70).
- `python tools/legal_headers.py --check`
- Ruff and clang-format on every changed source file
- Cyclomatic complexity gate with maximum CCN 10
- 158 architecture contract tests
- 675 builder tests
- 18 PersonaPlex builder-lifetime tests
- 3 focused PersonaPlex C++ tests on GB300

## Notes For Future Readers

The speedup does not relax a validation threshold or change the established
precision contract. Decoder engines remain full FP32 with TF32 disabled and
one tactic candidate; optimization level 1 selects a substantially better
implementation within those constraints.
