### PR TITLE
perf(pixart): offload preprocessing matmuls

### DIFF
--- a/src/runtime/models/pixart/MODEL.toml
+++ b/src/runtime/models/pixart/MODEL.toml
@@ -7,6 +7,8 @@ runtime_plugins = ["plugin.cpp|register_pixart_plugin"]
 runtime_strategies = ["diffusion_pixart"]
 legacy_runtime_strategy_aliases = ["diffusion|contains|diffusion_backend_type|pixart|diffusion_pixart"]
 gnu_warning_suppressed_sources = ["pipeline.cpp"]
+runtime_link_libraries = ["cublas"]
 runtime_tests = [
   "test_pixart_denoising_step_seam|test_pixart_denoising_step_seam.cpp|_|_|_",
+  "test_pixart_gpu_matmul|test_pixart_gpu_matmul.cpp|trtmc_model_pixart|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/pixart/gpu_matmul.cpp
+++ b/src/runtime/models/pixart/gpu_matmul.cpp
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/pixart/gpu_matmul.h"
+
+#include <cstddef>
+#include <cublas_v2.h>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+namespace {
+
+struct DeviceBuffer {
+    float* data{nullptr};
+    std::size_t bytes{0};
+};
+
+bool ensure_capacity(DeviceBuffer& buffer, std::size_t required) {
+    if (buffer.bytes >= required)
+        return true;
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer.data = nullptr;
+    buffer.bytes = 0;
+    if (cudaMalloc(reinterpret_cast<void**>(&buffer.data), required) != cudaSuccess)
+        return false;
+    buffer.bytes = required;
+    return true;
+}
+
+void release(DeviceBuffer& buffer) {
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer = {};
+}
+
+bool request_is_valid(const float* lhs, const float* rhs, const float* output, int32_t rows,
+                      int32_t inner, int32_t columns) {
+    return lhs != nullptr && rhs != nullptr && output != nullptr && rows > 0 && inner > 0 &&
+           columns > 0;
+}
+
+void add_bias(float* output, const float* bias, int32_t rows, int32_t columns) {
+    if (bias == nullptr)
+        return;
+    for (int32_t row = 0; row < rows; ++row) {
+        float* output_row =
+            output + static_cast<std::size_t>(row) * static_cast<std::size_t>(columns);
+        for (int32_t column = 0; column < columns; ++column)
+            output_row[column] += bias[column];
+    }
+}
+
+} // namespace
+
+struct PixArtGpuMatmul::Impl {
+    cublasHandle_t handle{nullptr};
+    cudaStream_t stream{nullptr};
+    DeviceBuffer lhs;
+    DeviceBuffer rhs;
+    DeviceBuffer output;
+    bool ready{false};
+
+    bool prepare(const float* lhs_data, const float* rhs_data, std::size_t lhs_bytes,
+                 std::size_t rhs_bytes, std::size_t output_bytes) {
+        if (!ensure_capacity(lhs, lhs_bytes) || !ensure_capacity(rhs, rhs_bytes) ||
+            !ensure_capacity(output, output_bytes)) {
+            return false;
+        }
+        if (cudaMemcpyAsync(lhs.data, lhs_data, lhs_bytes, cudaMemcpyHostToDevice, stream) !=
+            cudaSuccess) {
+            return false;
+        }
+        if (cudaMemcpyAsync(rhs.data, rhs_data, rhs_bytes, cudaMemcpyHostToDevice, stream) ==
+            cudaSuccess) {
+            return true;
+        }
+        cudaStreamSynchronize(stream);
+        return false;
+    }
+
+    bool multiply(int32_t rows, int32_t inner, int32_t columns) {
+        constexpr float alpha = 1.0F;
+        constexpr float beta = 0.0F;
+        return cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, columns, rows, inner, &alpha, rhs.data,
+                           columns, lhs.data, inner, &beta, output.data,
+                           columns) == CUBLAS_STATUS_SUCCESS;
+    }
+
+    bool download(float* host_output, std::size_t output_bytes) {
+        const auto copy_status =
+            cudaMemcpyAsync(host_output, output.data, output_bytes, cudaMemcpyDeviceToHost, stream);
+        const auto sync_status = cudaStreamSynchronize(stream);
+        return copy_status == cudaSuccess && sync_status == cudaSuccess;
+    }
+};
+
+PixArtGpuMatmul::PixArtGpuMatmul() : impl_(std::make_unique<Impl>()) {
+    if (cudaStreamCreate(&impl_->stream) != cudaSuccess)
+        return;
+    if (cublasCreate(&impl_->handle) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetStream(impl_->handle, impl_->stream) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetMathMode(impl_->handle, CUBLAS_PEDANTIC_MATH) != CUBLAS_STATUS_SUCCESS)
+        return;
+    impl_->ready = true;
+}
+
+PixArtGpuMatmul::~PixArtGpuMatmul() {
+    release(impl_->lhs);
+    release(impl_->rhs);
+    release(impl_->output);
+    if (impl_->handle != nullptr)
+        cublasDestroy(impl_->handle);
+    if (impl_->stream != nullptr)
+        cudaStreamDestroy(impl_->stream);
+}
+
+bool PixArtGpuMatmul::run(const float* lhs, const float* rhs, const float* bias, float* output,
+                          int32_t rows, int32_t inner, int32_t columns) {
+    if (!impl_->ready || !request_is_valid(lhs, rhs, output, rows, inner, columns))
+        return false;
+
+    const auto lhs_bytes =
+        static_cast<std::size_t>(rows) * static_cast<std::size_t>(inner) * sizeof(float);
+    const auto rhs_bytes =
+        static_cast<std::size_t>(inner) * static_cast<std::size_t>(columns) * sizeof(float);
+    const auto output_count = static_cast<std::size_t>(rows) * static_cast<std::size_t>(columns);
+    const auto output_bytes = output_count * sizeof(float);
+    if (!impl_->prepare(lhs, rhs, lhs_bytes, rhs_bytes, output_bytes))
+        return false;
+    if (!impl_->multiply(rows, inner, columns)) {
+        cudaStreamSynchronize(impl_->stream);
+        return false;
+    }
+    if (!impl_->download(output, output_bytes))
+        return false;
+
+    add_bias(output, bias, rows, columns);
+    return true;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/pixart/gpu_matmul.h
+++ b/src/runtime/models/pixart/gpu_matmul.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace trtmc {
+
+class PixArtGpuMatmul {
+  public:
+    PixArtGpuMatmul();
+    ~PixArtGpuMatmul();
+
+    PixArtGpuMatmul(const PixArtGpuMatmul&) = delete;
+    PixArtGpuMatmul& operator=(const PixArtGpuMatmul&) = delete;
+
+    bool run(const float* lhs, const float* rhs, const float* bias, float* output, int32_t rows,
+             int32_t inner, int32_t columns);
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/pixart/pipeline.cpp
+++ b/src/runtime/models/pixart/pipeline.cpp
@@ -5,15 +5,17 @@
 
 // PixArtPipeline - TrtModule-based PixArt diffusion pipeline.
 // PixArt bundles use T5 + DiT + VAE engines.
-// All CPU math (timestep embedding, RoPE, patchify, unpatchify, text projection)
-// is kept identical. Raw TRT calls replaced with TrtModule::forward(TensorMap).
+// Large projection matmuls use a model-owned cuBLAS helper with an exact CPU fallback.
+// Remaining preprocessing math stays on the host, and TrtModule owns engine transfers.
 
 #include "runtime/models/pixart/pipeline.h"
 
+#include "runtime/models/pixart/gpu_matmul.h"
 #include "runtime/models/pixart/pixart_denoising_step_seam.h"
 #include "runtime/models/pixart/pixart_dpmsolver.h"
 #include "runtime/models/pixart/pixart_generation_conditioning.h"
 #include "runtime/models/pixart/pixart_generation_plan.h"
+#include "runtime/models/pixart/pixart_matmul_policy.h"
 
 #include <algorithm>
 #include <cmath>
@@ -446,9 +448,19 @@ PixArtPipeline::PixArtPipeline(std::unique_ptr<TrtModule> text_encoder,
       tensor_parallel_size_(tensor_parallel_size), text_encoder_(std::move(text_encoder)),
       denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
       weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)) {}
+      model_id_(std::move(model_id_str)), gpu_matmul_(std::make_unique<PixArtGpuMatmul>()) {}
 
 PixArtPipeline::~PixArtPipeline() = default;
+
+void PixArtPipeline::matmul_bias(const float* lhs, const float* rhs, const float* bias,
+                                 float* output, int32_t rows, int32_t inner,
+                                 int32_t columns) const {
+    if (pixart_should_use_gpu_matmul(rows, inner, columns) && gpu_matmul_ != nullptr &&
+        gpu_matmul_->run(lhs, rhs, bias, output, rows, inner, columns)) {
+        return;
+    }
+    cpu_matmul_bias(lhs, rhs, bias, output, rows, inner, columns);
+}
 
 // ---------------------------------------------------------------------------
 // T5 encoder via TrtModule::forward()
@@ -585,20 +597,20 @@ void PixArtPipeline::compute_timestep_embedding(float timestep, std::vector<floa
     }
 
     std::vector<float> hidden_1(static_cast<std::size_t>(dim));
-    cpu_matmul_bias(sinusoidal.data(), weights_.time_emb_0_weight.data(),
-                    weights_.time_emb_0_bias.data(), hidden_1.data(), 1, freq_dim, dim);
+    matmul_bias(sinusoidal.data(), weights_.time_emb_0_weight.data(),
+                weights_.time_emb_0_bias.data(), hidden_1.data(), 1, freq_dim, dim);
     cpu_silu_inplace(hidden_1.data(), static_cast<std::size_t>(dim));
 
     time_embed.resize(static_cast<std::size_t>(dim));
-    cpu_matmul_bias(hidden_1.data(), weights_.time_emb_2_weight.data(),
-                    weights_.time_emb_2_bias.data(), time_embed.data(), 1, dim, dim);
+    matmul_bias(hidden_1.data(), weights_.time_emb_2_weight.data(), weights_.time_emb_2_bias.data(),
+                time_embed.data(), 1, dim, dim);
 
     std::vector<float> silu_te(time_embed.begin(), time_embed.end());
     cpu_silu_inplace(silu_te.data(), static_cast<std::size_t>(dim));
 
     temb_6d.resize(static_cast<std::size_t>(6 * dim));
-    cpu_matmul_bias(silu_te.data(), weights_.time_proj_weight.data(),
-                    weights_.time_proj_bias.data(), temb_6d.data(), 1, dim, 6 * dim);
+    matmul_bias(silu_te.data(), weights_.time_proj_weight.data(), weights_.time_proj_bias.data(),
+                temb_6d.data(), 1, dim, 6 * dim);
 }
 
 // ---------------------------------------------------------------------------
@@ -611,15 +623,15 @@ void PixArtPipeline::project_text(const std::vector<float>& in, int32_t seq_len,
     const int32_t dim = config_.dit_dim;
 
     out.resize(static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(dim));
-    cpu_matmul_bias(in.data(), weights_.text_proj_weight.data(), weights_.text_proj_bias.data(),
-                    out.data(), seq_len, te_dim, dim);
+    matmul_bias(in.data(), weights_.text_proj_weight.data(), weights_.text_proj_bias.data(),
+                out.data(), seq_len, te_dim, dim);
 
     if (!weights_.text_proj_2_weight.empty()) {
         cpu_gelu_tanh_inplace(out.data(),
                               static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(dim));
         std::vector<float> tmp(out.size());
-        cpu_matmul_bias(out.data(), weights_.text_proj_2_weight.data(),
-                        weights_.text_proj_2_bias.data(), tmp.data(), seq_len, dim, dim);
+        matmul_bias(out.data(), weights_.text_proj_2_weight.data(),
+                    weights_.text_proj_2_bias.data(), tmp.data(), seq_len, dim, dim);
         out = std::move(tmp);
     }
 }
@@ -1158,9 +1170,9 @@ ImageResult PixArtPipeline::generate_image(const std::string& prompt, const Gene
     };
     const auto embed_hidden = [this, &layout](const std::vector<float>& patches,
                                               std::vector<float>& hidden) {
-        cpu_matmul_bias(patches.data(), weights_.patch_embed_weight.data(),
-                        weights_.patch_embed_bias.data(), hidden.data(), layout.num_patches,
-                        layout.patch_dim, layout.dim);
+        matmul_bias(patches.data(), weights_.patch_embed_weight.data(),
+                    weights_.patch_embed_bias.data(), hidden.data(), layout.num_patches,
+                    layout.patch_dim, layout.dim);
     };
     const auto unpatchify_fn = [this, &layout](const std::vector<float>& patches,
                                                std::vector<float>& out) {

--- a/src/runtime/models/pixart/pipeline.h
+++ b/src/runtime/models/pixart/pipeline.h
@@ -21,6 +21,8 @@
 
 namespace trtmc {
 
+class PixArtGpuMatmul;
+
 class PixArtPipeline final : public IPipeline {
   public:
     PixArtPipeline(std::unique_ptr<TrtModule> text_encoder, std::unique_ptr<TrtModule> denoiser,
@@ -48,6 +50,8 @@ class PixArtPipeline final : public IPipeline {
     void compute_timestep_embedding(float timestep, std::vector<float>& temb_6d,
                                     std::vector<float>& time_embed) const;
     void project_text(const std::vector<float>& in, int32_t seq_len, std::vector<float>& out) const;
+    void matmul_bias(const float* lhs, const float* rhs, const float* bias, float* output,
+                     int32_t rows, int32_t inner, int32_t columns) const;
     void patchify(const std::vector<float>& latents, int32_t c, int32_t t, int32_t h, int32_t w,
                   std::vector<float>& patches) const;
     void unpatchify(const std::vector<float>& patches, int32_t c, int32_t t, int32_t h, int32_t w,
@@ -85,6 +89,7 @@ class PixArtPipeline final : public IPipeline {
     PixArtPreprocessorWeights weights_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
+    std::unique_ptr<PixArtGpuMatmul> gpu_matmul_;
 
     std::vector<DeviceTensor> vae_cache_in_;
     std::vector<DeviceTensor> vae_cache_out_;

--- a/src/runtime/models/pixart/pixart_matmul_policy.h
+++ b/src/runtime/models/pixart/pixart_matmul_policy.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace trtmc {
+
+inline bool pixart_should_use_gpu_matmul(int32_t rows, int32_t inner, int32_t columns) {
+    if (rows <= 0 || inner <= 0 || columns <= 0)
+        return false;
+    constexpr int64_t kGpuOperationThreshold = 1'000'000;
+    return static_cast<int64_t>(rows) * inner * columns > kGpuOperationThreshold;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/pixart/plugin.cpp
+++ b/src/runtime/models/pixart/plugin.cpp
@@ -62,6 +62,13 @@ class PixArtPlugin final : public IPipelinePlugin {
         auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
                                           denoiser_section_name, denoiser_options);
 
+        if (ctx.cuda_graphs) {
+            parts.denoiser.module->enable_cuda_graph();
+            parts.vae.module->enable_cuda_graph();
+            for (auto& text_encoder : parts.text_encoders)
+                text_encoder.module->enable_cuda_graph();
+        }
+
         // Extract first text encoder
         std::unique_ptr<TrtModule> te_module;
         if (!parts.text_encoders.empty())

--- a/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
+++ b/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
@@ -18,6 +18,7 @@
 #include "runtime/models/pixart/pixart_dpmsolver.h"
 #include "runtime/models/pixart/pixart_generation_conditioning.h"
 #include "runtime/models/pixart/pixart_generation_plan.h"
+#include "runtime/models/pixart/pixart_matmul_policy.h"
 
 #include <algorithm>
 #include <cmath>
@@ -213,6 +214,17 @@ void test_pixart_initial_latents_honor_override_and_requested_seed() {
     check(seed_one != seed_two, "PixArt requested seed changes generated initial latents");
 }
 
+void test_pixart_large_matmuls_use_gpu_policy() {
+    check(trtmc::pixart_should_use_gpu_matmul(4096, 64, 1152),
+          "PixArt patch projection uses GPU matmul");
+    check(trtmc::pixart_should_use_gpu_matmul(120, 4096, 1152),
+          "PixArt text projection uses GPU matmul");
+    check(!trtmc::pixart_should_use_gpu_matmul(1, 256, 1152),
+          "PixArt small timestep projection stays on CPU");
+    check(!trtmc::pixart_should_use_gpu_matmul(0, 4096, 1152),
+          "PixArt invalid matmul dimensions stay on CPU");
+}
+
 } // namespace
 
 int main() {
@@ -222,6 +234,7 @@ int main() {
     test_pixart_dpmsolver_matches_diffusers_order_two_golden();
     test_pixart_null_attention_mask_only_keeps_eos_token();
     test_pixart_initial_latents_honor_override_and_requested_seed();
+    test_pixart_large_matmuls_use_gpu_policy();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " PixArt denoising seam test(s) failed\n";

--- a/tests/cpp/models/pixart/test_pixart_gpu_matmul.cpp
+++ b/tests/cpp/models/pixart/test_pixart_gpu_matmul.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/pixart/gpu_matmul.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (condition)
+        return;
+    std::cerr << "FAIL: " << name << '\n';
+    ++g_failures;
+}
+
+void test_gpu_matmul_matches_fp32_contract() {
+    constexpr int32_t rows = 17;
+    constexpr int32_t inner = 13;
+    constexpr int32_t columns = 19;
+    std::vector<float> lhs(static_cast<std::size_t>(rows * inner));
+    std::vector<float> rhs(static_cast<std::size_t>(inner * columns));
+    std::vector<float> bias(static_cast<std::size_t>(columns));
+    for (std::size_t i = 0; i < lhs.size(); ++i)
+        lhs[i] = static_cast<float>(static_cast<int32_t>(i % 11) - 5) * 0.125F;
+    for (std::size_t i = 0; i < rhs.size(); ++i)
+        rhs[i] = static_cast<float>(static_cast<int32_t>(i % 7) - 3) * 0.0625F;
+    for (int32_t column = 0; column < columns; ++column)
+        bias[static_cast<std::size_t>(column)] = static_cast<float>(column - 9) * 0.03125F;
+
+    std::vector<float> expected(static_cast<std::size_t>(rows * columns));
+    for (int32_t row = 0; row < rows; ++row) {
+        for (int32_t column = 0; column < columns; ++column) {
+            double value = bias[static_cast<std::size_t>(column)];
+            for (int32_t k = 0; k < inner; ++k) {
+                value += static_cast<double>(lhs[static_cast<std::size_t>(row * inner + k)]) *
+                         static_cast<double>(rhs[static_cast<std::size_t>(k * columns + column)]);
+            }
+            expected[static_cast<std::size_t>(row * columns + column)] = static_cast<float>(value);
+        }
+    }
+
+    trtmc::PixArtGpuMatmul matmul;
+    std::vector<float> actual(expected.size());
+    check(matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), rows, inner, columns),
+          "PixArt GPU matmul executes");
+    float max_error = 0.0F;
+    for (std::size_t i = 0; i < actual.size(); ++i)
+        max_error = std::max(max_error, std::abs(actual[i] - expected[i]));
+    check(max_error <= 1.0e-5F, "PixArt GPU matmul matches FP32 CPU accumulation");
+    check(!matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), 0, inner, columns),
+          "PixArt GPU matmul rejects invalid dimensions");
+}
+
+} // namespace
+
+int main() {
+    test_gpu_matmul_matches_fp32_contract();
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

The GB300 release comparison reported PixArt-Sigma at 2698.437 ms p50 versus a 728.264 ms reference. A fresh isolated run on the current branch reproduced the regression at 2665.152 ms p50.

The dominant cost was not TensorRT inference. Each 1024x1024, 20-step request performed the large patch embedding projection on the CPU for every denoising step. The text and timestep projections used the same serialized CPU helper.

Fixes #636.

## Exit Criteria

- Preserve the FP16 engine and 1024x1024, 20-step workload.
- Remove the dominant CPU-side large-matrix projection cost.
- Do not relax correctness thresholds or change the legacy model bundle contract.
- Restore performance to within the release comparison margin.

## Implementation

- Add a per-pipeline cuBLAS helper for large patch, text, and timestep projections.
- Use pedantic FP32 math to preserve the existing numerical contract.
- Retain the exact CPU implementation as the fallback for small matrices and GPU failures.
- Honor requested CUDA graph settings for the PixArt denoiser, VAE, and text encoders.
- Add focused policy and GPU numerical tests.

## Validation

Validated on GB300 with TensorRT 11.2 and CUDA 13.3:

- Fresh baseline, 1 warmup + 2 measured: 2665.152 ms p50, 2673.486 ms p95.
- Fixed build, 3 warmups + 10 measured: 422.465 ms p50, 423.218 ms p95.
- The fixed p50 is 84.1% below the fresh baseline and 42.0% faster than the 728.264 ms reference.
- Full model-owned external Diffusers E2E passed for FP16, 1024x1024, 20 steps.
- Output contract passed with one frame, pixel mean 0.3209678829, and pixel standard deviation 0.3365905881.
- Focused C++ policy and GPU numerical tests passed.
- Legal, clang-format, CCN, architecture, builder, PixArt Python, family coverage, and test-impact checks passed.

## Notes For Future Readers

This change removes the dominant CPU serialization. Requested CUDA graphs now reduce repeated launch overhead without changing the engine contract. Classifier-free guidance remains two engine invocations per step; the complete pipeline is already faster than the reference, so changing engine batch semantics is deferred.
