### PR TITLE
perf(wan): offload preprocessing matmuls

### DIFF
--- a/src/runtime/models/wan/MODEL.toml
+++ b/src/runtime/models/wan/MODEL.toml
@@ -7,10 +7,12 @@ runtime_plugins = ["plugin.cpp|register_wan_plugin"]
 runtime_strategies = ["diffusion_wan"]
 legacy_runtime_strategy_aliases = ["diffusion|default|_|_|diffusion_wan"]
 gnu_warning_suppressed_sources = ["pipeline.cpp"]
+runtime_link_libraries = ["cublas"]
 runtime_tests = [
   "test_wan_pipeline|test_wan_pipeline.cpp|trtmc_model_wan|_|_",
   "test_wan_c_abi_runtime_regression|test_wan_c_abi_runtime_regression.cpp|trtmc_model_wan|_|_",
   "test_wan_generation_plan|test_wan_generation_plan.cpp|_|_|_",
   "test_wan_generation_conditioning|test_wan_generation_conditioning.cpp|_|_|_",
   "test_wan_denoising_step_seam|test_wan_denoising_step_seam.cpp|_|_|_",
+  "test_wan_gpu_matmul|test_wan_gpu_matmul.cpp|trtmc_model_wan|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/wan/gpu_matmul.cpp
+++ b/src/runtime/models/wan/gpu_matmul.cpp
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan/gpu_matmul.h"
+
+#include <cstddef>
+#include <cublas_v2.h>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+namespace {
+
+struct DeviceBuffer {
+    float* data{nullptr};
+    std::size_t bytes{0};
+};
+
+bool ensure_capacity(DeviceBuffer& buffer, std::size_t required) {
+    if (buffer.bytes >= required)
+        return true;
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer.data = nullptr;
+    buffer.bytes = 0;
+    if (cudaMalloc(reinterpret_cast<void**>(&buffer.data), required) != cudaSuccess)
+        return false;
+    buffer.bytes = required;
+    return true;
+}
+
+void release(DeviceBuffer& buffer) {
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer = {};
+}
+
+bool request_is_valid(const float* lhs, const float* rhs, const float* output, int32_t rows,
+                      int32_t inner, int32_t columns) {
+    return lhs != nullptr && rhs != nullptr && output != nullptr && rows > 0 && inner > 0 &&
+           columns > 0;
+}
+
+void add_bias(float* output, const float* bias, int32_t rows, int32_t columns) {
+    if (bias == nullptr)
+        return;
+    for (int32_t row = 0; row < rows; ++row) {
+        float* output_row =
+            output + static_cast<std::size_t>(row) * static_cast<std::size_t>(columns);
+        for (int32_t column = 0; column < columns; ++column)
+            output_row[column] += bias[column];
+    }
+}
+
+} // namespace
+
+struct WanGpuMatmul::Impl {
+    cublasHandle_t handle{nullptr};
+    cudaStream_t stream{nullptr};
+    DeviceBuffer lhs;
+    DeviceBuffer rhs;
+    DeviceBuffer output;
+    bool ready{false};
+
+    bool prepare(const float* lhs_data, const float* rhs_data, std::size_t lhs_bytes,
+                 std::size_t rhs_bytes, std::size_t output_bytes) {
+        if (!ensure_capacity(lhs, lhs_bytes) || !ensure_capacity(rhs, rhs_bytes) ||
+            !ensure_capacity(output, output_bytes)) {
+            return false;
+        }
+        if (cudaMemcpyAsync(lhs.data, lhs_data, lhs_bytes, cudaMemcpyHostToDevice, stream) !=
+            cudaSuccess) {
+            return false;
+        }
+        if (cudaMemcpyAsync(rhs.data, rhs_data, rhs_bytes, cudaMemcpyHostToDevice, stream) ==
+            cudaSuccess) {
+            return true;
+        }
+        cudaStreamSynchronize(stream);
+        return false;
+    }
+
+    bool multiply(int32_t rows, int32_t inner, int32_t columns) {
+        constexpr float alpha = 1.0F;
+        constexpr float beta = 0.0F;
+        return cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, columns, rows, inner, &alpha, rhs.data,
+                           columns, lhs.data, inner, &beta, output.data,
+                           columns) == CUBLAS_STATUS_SUCCESS;
+    }
+
+    bool download(float* host_output, std::size_t output_bytes) {
+        const auto copy_status =
+            cudaMemcpyAsync(host_output, output.data, output_bytes, cudaMemcpyDeviceToHost, stream);
+        const auto sync_status = cudaStreamSynchronize(stream);
+        return copy_status == cudaSuccess && sync_status == cudaSuccess;
+    }
+};
+
+WanGpuMatmul::WanGpuMatmul() : impl_(std::make_unique<Impl>()) {
+    if (cudaStreamCreate(&impl_->stream) != cudaSuccess)
+        return;
+    if (cublasCreate(&impl_->handle) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetStream(impl_->handle, impl_->stream) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetMathMode(impl_->handle, CUBLAS_PEDANTIC_MATH) != CUBLAS_STATUS_SUCCESS)
+        return;
+    impl_->ready = true;
+}
+
+WanGpuMatmul::~WanGpuMatmul() {
+    release(impl_->lhs);
+    release(impl_->rhs);
+    release(impl_->output);
+    if (impl_->handle != nullptr)
+        cublasDestroy(impl_->handle);
+    if (impl_->stream != nullptr)
+        cudaStreamDestroy(impl_->stream);
+}
+
+bool WanGpuMatmul::run(const float* lhs, const float* rhs, const float* bias, float* output,
+                       int32_t rows, int32_t inner, int32_t columns) {
+    if (!impl_->ready || !request_is_valid(lhs, rhs, output, rows, inner, columns))
+        return false;
+
+    const auto lhs_bytes =
+        static_cast<std::size_t>(rows) * static_cast<std::size_t>(inner) * sizeof(float);
+    const auto rhs_bytes =
+        static_cast<std::size_t>(inner) * static_cast<std::size_t>(columns) * sizeof(float);
+    const auto output_count = static_cast<std::size_t>(rows) * static_cast<std::size_t>(columns);
+    const auto output_bytes = output_count * sizeof(float);
+    if (!impl_->prepare(lhs, rhs, lhs_bytes, rhs_bytes, output_bytes))
+        return false;
+    if (!impl_->multiply(rows, inner, columns)) {
+        cudaStreamSynchronize(impl_->stream);
+        return false;
+    }
+    if (!impl_->download(output, output_bytes))
+        return false;
+
+    add_bias(output, bias, rows, columns);
+    return true;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/wan/gpu_matmul.h
+++ b/src/runtime/models/wan/gpu_matmul.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace trtmc {
+
+class WanGpuMatmul {
+  public:
+    WanGpuMatmul();
+    ~WanGpuMatmul();
+
+    WanGpuMatmul(const WanGpuMatmul&) = delete;
+    WanGpuMatmul& operator=(const WanGpuMatmul&) = delete;
+
+    bool run(const float* lhs, const float* rhs, const float* bias, float* output, int32_t rows,
+             int32_t inner, int32_t columns);
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/wan/pipeline.cpp
+++ b/src/runtime/models/wan/pipeline.cpp
@@ -5,14 +5,16 @@
 
 // WanPipeline — TrtModule-based Wan2.1 diffusion pipeline.
 // Ports WanDiffusionBackend to use TrtModule::forward() for all GPU work.
-// All CPU math (timestep embedding, RoPE, patchify, unpatchify, text projection)
-// is kept identical. Raw TRT calls replaced with TrtModule::forward(TensorMap).
+// Large preprocessing projections use cuBLAS with the exact CPU implementation
+// retained as a fallback. Raw TRT calls use TrtModule::forward(TensorMap).
 
 #include "runtime/models/wan/pipeline.h"
 
+#include "runtime/models/wan/gpu_matmul.h"
 #include "runtime/models/wan/wan_denoising_step_seam.h"
 #include "runtime/models/wan/wan_generation_conditioning.h"
 #include "runtime/models/wan/wan_generation_plan.h"
+#include "runtime/models/wan/wan_matmul_policy.h"
 
 #include <algorithm>
 #include <cmath>
@@ -562,9 +564,18 @@ WanPipeline::WanPipeline(std::unique_ptr<TrtModule> text_encoder,
       denoiser_(std::move(denoiser)), vae_(std::move(vae)),
       vae_first_frame_(std::move(vae_first_frame)), config_(std::move(config)),
       weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)) {}
+      model_id_(std::move(model_id_str)), gpu_matmul_(std::make_unique<WanGpuMatmul>()) {}
 
 WanPipeline::~WanPipeline() = default;
+
+void WanPipeline::matmul_bias(const float* lhs, const float* rhs, const float* bias, float* output,
+                              int32_t rows, int32_t inner, int32_t columns) const {
+    if (wan_should_use_gpu_matmul(rows, inner, columns) && gpu_matmul_ != nullptr &&
+        gpu_matmul_->run(lhs, rhs, bias, output, rows, inner, columns)) {
+        return;
+    }
+    cpu_matmul_bias(lhs, rhs, bias, output, rows, inner, columns);
+}
 
 // ---------------------------------------------------------------------------
 // T5 encoder via TrtModule::forward()
@@ -681,7 +692,7 @@ bool WanPipeline::run_denoiser(const std::vector<float>& hidden, const std::vect
 }
 
 // ---------------------------------------------------------------------------
-// Timestep embedding (CPU math — identical to old backend)
+// Timestep embedding
 // ---------------------------------------------------------------------------
 
 void WanPipeline::compute_timestep_embedding(float timestep, std::vector<float>& temb_6d,
@@ -700,24 +711,24 @@ void WanPipeline::compute_timestep_embedding(float timestep, std::vector<float>&
     }
 
     std::vector<float> hidden_1(static_cast<std::size_t>(dim));
-    cpu_matmul_bias(sinusoidal.data(), weights_.time_emb_0_weight.data(),
-                    weights_.time_emb_0_bias.data(), hidden_1.data(), 1, freq_dim, dim);
+    matmul_bias(sinusoidal.data(), weights_.time_emb_0_weight.data(),
+                weights_.time_emb_0_bias.data(), hidden_1.data(), 1, freq_dim, dim);
     cpu_silu_inplace(hidden_1.data(), static_cast<std::size_t>(dim));
 
     time_embed.resize(static_cast<std::size_t>(dim));
-    cpu_matmul_bias(hidden_1.data(), weights_.time_emb_2_weight.data(),
-                    weights_.time_emb_2_bias.data(), time_embed.data(), 1, dim, dim);
+    matmul_bias(hidden_1.data(), weights_.time_emb_2_weight.data(), weights_.time_emb_2_bias.data(),
+                time_embed.data(), 1, dim, dim);
 
     std::vector<float> silu_te(time_embed.begin(), time_embed.end());
     cpu_silu_inplace(silu_te.data(), static_cast<std::size_t>(dim));
 
     temb_6d.resize(static_cast<std::size_t>(6 * dim));
-    cpu_matmul_bias(silu_te.data(), weights_.time_proj_weight.data(),
-                    weights_.time_proj_bias.data(), temb_6d.data(), 1, dim, 6 * dim);
+    matmul_bias(silu_te.data(), weights_.time_proj_weight.data(), weights_.time_proj_bias.data(),
+                temb_6d.data(), 1, dim, 6 * dim);
 }
 
 // ---------------------------------------------------------------------------
-// Text projection (CPU math — identical to old backend)
+// Text projection
 // ---------------------------------------------------------------------------
 
 void WanPipeline::project_text(const std::vector<float>& in, int32_t seq_len,
@@ -726,15 +737,15 @@ void WanPipeline::project_text(const std::vector<float>& in, int32_t seq_len,
     const int32_t dim = config_.dit_dim;
 
     out.resize(static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(dim));
-    cpu_matmul_bias(in.data(), weights_.text_proj_weight.data(), weights_.text_proj_bias.data(),
-                    out.data(), seq_len, te_dim, dim);
+    matmul_bias(in.data(), weights_.text_proj_weight.data(), weights_.text_proj_bias.data(),
+                out.data(), seq_len, te_dim, dim);
 
     if (!weights_.text_proj_2_weight.empty()) {
         cpu_gelu_tanh_inplace(out.data(),
                               static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(dim));
         std::vector<float> tmp(out.size());
-        cpu_matmul_bias(out.data(), weights_.text_proj_2_weight.data(),
-                        weights_.text_proj_2_bias.data(), tmp.data(), seq_len, dim, dim);
+        matmul_bias(out.data(), weights_.text_proj_2_weight.data(),
+                    weights_.text_proj_2_bias.data(), tmp.data(), seq_len, dim, dim);
         out = std::move(tmp);
     }
 }
@@ -1292,9 +1303,9 @@ ImageResult WanPipeline::generate_image(const std::string& prompt, const Generat
     };
     const auto embed_hidden = [this, &layout](const std::vector<float>& patches,
                                               std::vector<float>& hidden) {
-        cpu_matmul_bias(patches.data(), weights_.patch_embed_weight.data(),
-                        weights_.patch_embed_bias.data(), hidden.data(), layout.num_patches,
-                        layout.patch_dim, layout.dim);
+        matmul_bias(patches.data(), weights_.patch_embed_weight.data(),
+                    weights_.patch_embed_bias.data(), hidden.data(), layout.num_patches,
+                    layout.patch_dim, layout.dim);
     };
     const auto unpatchify_fn = [this, &layout](const std::vector<float>& patches,
                                                std::vector<float>& out) {

--- a/src/runtime/models/wan/pipeline.h
+++ b/src/runtime/models/wan/pipeline.h
@@ -21,6 +21,8 @@
 
 namespace trtmc {
 
+class WanGpuMatmul;
+
 class WanPipeline final : public IPipeline {
   public:
     WanPipeline(std::unique_ptr<TrtModule> text_encoder, std::unique_ptr<TrtModule> denoiser,
@@ -49,6 +51,8 @@ class WanPipeline final : public IPipeline {
     void compute_timestep_embedding(float timestep, std::vector<float>& temb_6d,
                                     std::vector<float>& time_embed) const;
     void project_text(const std::vector<float>& in, int32_t seq_len, std::vector<float>& out) const;
+    void matmul_bias(const float* lhs, const float* rhs, const float* bias, float* output,
+                     int32_t rows, int32_t inner, int32_t columns) const;
     void patchify(const std::vector<float>& latents, int32_t c, int32_t t, int32_t h, int32_t w,
                   std::vector<float>& patches) const;
     void unpatchify(const std::vector<float>& patches, int32_t c, int32_t t, int32_t h, int32_t w,
@@ -90,6 +94,7 @@ class WanPipeline final : public IPipeline {
     WanPreprocessorWeights weights_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
+    std::unique_ptr<WanGpuMatmul> gpu_matmul_;
 
     std::vector<DeviceTensor> vae_cache_in_;
     std::vector<DeviceTensor> vae_cache_out_;

--- a/src/runtime/models/wan/plugin.cpp
+++ b/src/runtime/models/wan/plugin.cpp
@@ -62,6 +62,15 @@ class WanPlugin final : public IPipelinePlugin {
         auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
                                           denoiser_section_name, denoiser_options);
 
+        if (ctx.cuda_graphs) {
+            parts.denoiser.module->enable_cuda_graph();
+            parts.vae.module->enable_cuda_graph();
+            if (parts.vae_first_frame.module)
+                parts.vae_first_frame.module->enable_cuda_graph();
+            for (auto& text_encoder : parts.text_encoders)
+                text_encoder.module->enable_cuda_graph();
+        }
+
         // Extract first text encoder
         std::unique_ptr<TrtModule> te_module;
         if (!parts.text_encoders.empty())

--- a/src/runtime/models/wan/wan_matmul_policy.h
+++ b/src/runtime/models/wan/wan_matmul_policy.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace trtmc {
+
+inline bool wan_should_use_gpu_matmul(int32_t rows, int32_t inner, int32_t columns) {
+    if (rows <= 0 || inner <= 0 || columns <= 0)
+        return false;
+    constexpr int64_t kGpuOperationThreshold = 1'000'000;
+    return static_cast<int64_t>(rows) * inner * columns > kGpuOperationThreshold;
+}
+
+} // namespace trtmc

--- a/tests/cpp/models/wan/test_wan_denoising_step_seam.cpp
+++ b/tests/cpp/models/wan/test_wan_denoising_step_seam.cpp
@@ -15,6 +15,7 @@
 // =============================================================================
 
 #include "runtime/models/wan/wan_denoising_step_seam.h"
+#include "runtime/models/wan/wan_matmul_policy.h"
 
 #include <cstdint>
 #include <iostream>
@@ -148,11 +149,23 @@ void test_wan_step_runner_handles_zero_steps_and_success() {
           "wan seam applies scheduler updates on success");
 }
 
+void test_wan_large_preprocessing_matmuls_use_gpu() {
+    check(trtmc::wan_should_use_gpu_matmul(7800, 64, 1536),
+          "wan routes the release patch projection to GPU");
+    check(trtmc::wan_should_use_gpu_matmul(226, 4096, 1536), "wan routes text projection to GPU");
+    check(trtmc::wan_should_use_gpu_matmul(1, 1536, 9216),
+          "wan routes large timestep projection to GPU");
+    check(!trtmc::wan_should_use_gpu_matmul(1, 256, 1536),
+          "wan keeps small timestep projection on CPU");
+    check(!trtmc::wan_should_use_gpu_matmul(0, 64, 1536), "wan rejects invalid matrix dimensions");
+}
+
 } // namespace
 
 int main() {
     test_wan_step_runner_updates_latents_and_handles_failure();
     test_wan_step_runner_handles_zero_steps_and_success();
+    test_wan_large_preprocessing_matmuls_use_gpu();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " Wan denoising seam test(s) failed\n";

--- a/tests/cpp/models/wan/test_wan_gpu_matmul.cpp
+++ b/tests/cpp/models/wan/test_wan_gpu_matmul.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan/gpu_matmul.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (condition)
+        return;
+    std::cerr << "FAIL: " << name << '\n';
+    ++g_failures;
+}
+
+void test_gpu_matmul_matches_fp32_contract() {
+    constexpr int32_t rows = 17;
+    constexpr int32_t inner = 13;
+    constexpr int32_t columns = 19;
+    std::vector<float> lhs(static_cast<std::size_t>(rows * inner));
+    std::vector<float> rhs(static_cast<std::size_t>(inner * columns));
+    std::vector<float> bias(static_cast<std::size_t>(columns));
+    for (std::size_t i = 0; i < lhs.size(); ++i)
+        lhs[i] = static_cast<float>(static_cast<int32_t>(i % 11) - 5) * 0.125F;
+    for (std::size_t i = 0; i < rhs.size(); ++i)
+        rhs[i] = static_cast<float>(static_cast<int32_t>(i % 7) - 3) * 0.0625F;
+    for (int32_t column = 0; column < columns; ++column)
+        bias[static_cast<std::size_t>(column)] = static_cast<float>(column - 9) * 0.03125F;
+
+    std::vector<float> expected(static_cast<std::size_t>(rows * columns));
+    for (int32_t row = 0; row < rows; ++row) {
+        for (int32_t column = 0; column < columns; ++column) {
+            double value = bias[static_cast<std::size_t>(column)];
+            for (int32_t k = 0; k < inner; ++k) {
+                value += static_cast<double>(lhs[static_cast<std::size_t>(row * inner + k)]) *
+                         static_cast<double>(rhs[static_cast<std::size_t>(k * columns + column)]);
+            }
+            expected[static_cast<std::size_t>(row * columns + column)] = static_cast<float>(value);
+        }
+    }
+
+    trtmc::WanGpuMatmul matmul;
+    std::vector<float> actual(expected.size());
+    check(matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), rows, inner, columns),
+          "Wan GPU matmul executes");
+    float max_error = 0.0F;
+    for (std::size_t i = 0; i < actual.size(); ++i)
+        max_error = std::max(max_error, std::abs(actual[i] - expected[i]));
+    check(max_error <= 1.0e-5F, "Wan GPU matmul matches FP32 CPU accumulation");
+    check(!matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), 0, inner, columns),
+          "Wan GPU matmul rejects invalid dimensions");
+}
+
+} // namespace
+
+int main() {
+    test_gpu_matmul_matches_fp32_contract();
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

The GB300 release comparison reported Wan2.1 T2V at 22535.561 ms p50 versus a 3713.853 ms Diffusers reference. A fresh isolated run on the current branch reproduced the regression at 22451.805 ms p50.

The dominant cost was not TensorRT inference. Each FP16, 832x480, 17-frame, 30-step request performed the 7800x64x1536 patch projection on the CPU for every denoising step. Large text and timestep projections used the same serialized CPU helper.

Fixes #638.

## Exit Criteria

- Preserve the FP16, 832x480, 17-frame, 30-step workload.
- Remove the dominant per-step CPU matrix multiply.
- Do not relax media thresholds, change precision, or change the legacy bundle contract.
- Restore performance to within the release comparison margin.

## Implementation

- Add a per-pipeline cuBLAS helper for large patch, text, and timestep projections.
- Use pedantic FP32 math to preserve the existing preprocessing numerical contract.
- Retain the exact CPU implementation as the fallback for small matrices and GPU failures.
- Honor requested CUDA graph settings for the Wan denoiser, VAE engines, and text encoder.
- Add focused routing-policy and GPU numerical tests.

## Validation

Validated on GB300 with TensorRT 11.2 and CUDA 13.3:

- Fresh baseline, 1 warmup + 2 measured: 22451.805 ms p50, 22452.425 ms p95.
- Fixed build, 3 warmups + 10 measured: 2160.239 ms p50, 2166.731 ms p95.
- The fixed p50 is 90.4% below the fresh baseline and 41.8% faster than the 3713.853 ms reference.
- A CUDA-graph smoke measured 2139.399 ms p50 with 1 warmup + 2 measured.
- Full model-owned external Diffusers E2E passed for the FP16, 832x480, 17-frame, 30-step workload.
- Both TRT and reference produced 17 frames; TRT pixel mean 0.516849 and pixel standard deviation 0.284496 passed the unchanged media contract.
- Independent frame diagnostics measured mean PSNR 11.608, mean SSIM 0.5358, TRT temporal consistency 0.99956, and reference temporal consistency 0.99966.
- All six Wan C++ tests passed, including the GPU numerical comparison.
- Legal, clang-format, CCN, 158 architecture, 675 builder, 22 Wan Python, family coverage, and test-impact checks passed.

## Notes For Future Readers

The legacy denoiser plan has a fixed unbatched tensor contract, so classifier-free guidance remains two engine invocations per step. This change removes the dominant CPU serialization and honors CUDA graphs to reduce repeated launch overhead without requiring a bundle rebuild. Since the complete pipeline is already faster than the reference, changing the denoiser batch contract is deferred.
