### PR TITLE
fix(gpt-neo): honor local attention layers

### DIFF
--- a/python/tensorrt_model_connect/families/gpt_neo/attention_contract.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/attention_contract.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve GPT-Neo's Hugging Face local/global attention contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def resolve_attention_layer_types(
+    raw_config: Mapping[str, Any],
+    *,
+    num_layers: int,
+) -> tuple[str, ...]:
+    """Return one validated attention type for every decoder layer."""
+
+    configured = raw_config.get("attention_layers")
+    if configured is not None:
+        layer_types = list(configured)
+    else:
+        layer_types = []
+        for entry in raw_config.get("attention_types") or []:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                raise ValueError(
+                    "GPT-Neo attention_types entries must be [pattern, repeats]"
+                )
+            pattern, repeats = entry
+            if not isinstance(pattern, (list, tuple)):
+                raise ValueError("GPT-Neo attention pattern must be a sequence")
+            layer_types.extend(list(pattern) * int(repeats))
+
+    if not layer_types:
+        layer_types = ["global"] * num_layers
+    if len(layer_types) != num_layers:
+        raise ValueError(
+            "GPT-Neo attention pattern length does not match num_hidden_layers: "
+            f"{len(layer_types)} != {num_layers}"
+        )
+
+    normalized = tuple(str(layer_type).lower() for layer_type in layer_types)
+    unsupported = sorted(set(normalized) - {"global", "local"})
+    if unsupported:
+        raise ValueError(
+            f"Unsupported GPT-Neo attention layer types: {unsupported}"
+        )
+    return normalized
+
+
+def resolve_local_attention_window(
+    raw_config: Mapping[str, Any],
+    layer_types: tuple[str, ...],
+) -> int:
+    """Return and validate the local attention window."""
+
+    window = int(raw_config.get("window_size") or 0)
+    if "local" in layer_types and window <= 0:
+        raise ValueError(
+            "GPT-Neo local attention layers require a positive window_size"
+        )
+    return window

--- a/python/tensorrt_model_connect/families/gpt_neo/default_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_decoder.py
@@ -19,6 +19,7 @@ Tensor names MUST match what the C++ runtime expects:
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -65,6 +66,8 @@ def build_standard_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    attention_layer_types: Sequence[str] | None = None,
+    local_attention_window: int = 0,
     embed_input: bool = False,
     verbose: bool = False,
     debug_layer_outputs: bool = False,
@@ -147,6 +150,8 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            attention_layer_types=attention_layer_types,
+            local_attention_window=local_attention_window,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
@@ -272,6 +277,19 @@ def build_standard_decoder_engine(
     if work_trt_dtype != trt.float32:
         mask_cast = network.add_cast(attention_mask, work_trt_dtype)
         attention_mask = mask_cast.get_output(0)
+    local_attention_mask = None
+    if (
+        attention_layer_types
+        and "local" in attention_layer_types
+        and local_attention_window > 0
+    ):
+        local_attention_mask = graph_ops.add_local_attention_mask_2d(
+            network,
+            attention_mask,
+            position_id,
+            max_cache_length=max_cache_length,
+            window_size=local_attention_window,
+        )
 
     def _cast_work_dtype(tensor: trt.ITensor) -> trt.ITensor:
         if tensor.dtype == work_trt_dtype:
@@ -410,13 +428,22 @@ def build_standard_decoder_engine(
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        layer_attention_mask = (
+            local_attention_mask
+            if (
+                local_attention_mask is not None
+                and layer_idx < len(attention_layer_types or ())
+                and attention_layer_types[layer_idx] == "local"
+            )
+            else attention_mask
+        )
 
         result = _add_decoder_layer(
             network=network,
             hidden=hidden_state,
             cache_k=cache_k_inputs[layer_idx],
             cache_v=cache_v_inputs[layer_idx],
-            attention_mask=attention_mask,
+            attention_mask=layer_attention_mask,
             position_id=position_id,
             attention_scale=attn_scale,
             eps_tensor=eps_tensor,

--- a/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder.py
@@ -43,6 +43,7 @@ Tensor contract (matches the C++ runtime KvCache naming):
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -161,6 +162,8 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    attention_layer_types: Sequence[str] | None = None,
+    local_attention_window: int = 0,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -439,12 +442,35 @@ def build_dual_profile_decoder_engine(
             num_heads, target_dtype=work_trt_dtype)
     else:
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
+    local_mask_4d = None
+    if (
+        attention_layer_types
+        and "local" in attention_layer_types
+        and local_attention_window > 0
+    ):
+        local_mask_2d = graph_ops.add_local_attention_mask_2d(
+            network,
+            attention_mask_work,
+            position_id,
+            max_cache_length=max_cache_length,
+            window_size=local_attention_window,
+        )
+        local_mask_4d = graph_ops.add_2d_mask_to_4d(network, local_mask_2d)
 
     present_k_outs: list[trt.ITensor] = []
     present_v_outs: list[trt.ITensor] = []
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        layer_mask_4d = (
+            local_mask_4d
+            if (
+                local_mask_4d is not None
+                and layer_idx < len(attention_layer_types or ())
+                and attention_layer_types[layer_idx] == "local"
+            )
+            else mask_4d
+        )
 
         # Pre-attention norm.
         normed = _norm_multi(
@@ -517,7 +543,7 @@ def build_dual_profile_decoder_engine(
             network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
+            q_seq=None, kv_seq=None, causal=False, mask=layer_mask_4d,
             scale=attn_scale, tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,

--- a/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder_tp.py
@@ -44,6 +44,7 @@ Tensor contract (matches the C++ runtime KvCache naming):
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -172,6 +173,8 @@ def build_dual_profile_tp_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    attention_layer_types: Sequence[str] | None = None,
+    local_attention_window: int = 0,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     parallel_config=None,
@@ -423,12 +426,35 @@ def build_dual_profile_tp_decoder_engine(
             num_heads, target_dtype=work_trt_dtype)
     else:
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
+    local_mask_4d = None
+    if (
+        attention_layer_types
+        and "local" in attention_layer_types
+        and local_attention_window > 0
+    ):
+        local_mask_2d = graph_ops.add_local_attention_mask_2d(
+            network,
+            attention_mask_work,
+            position_id,
+            max_cache_length=max_cache_length,
+            window_size=local_attention_window,
+        )
+        local_mask_4d = graph_ops.add_2d_mask_to_4d(network, local_mask_2d)
 
     present_k_outs: list[trt.ITensor] = []
     present_v_outs: list[trt.ITensor] = []
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        layer_mask_4d = (
+            local_mask_4d
+            if (
+                local_mask_4d is not None
+                and layer_idx < len(attention_layer_types or ())
+                and attention_layer_types[layer_idx] == "local"
+            )
+            else mask_4d
+        )
 
         # Pre-attention norm.
         normed = _norm_multi(
@@ -501,7 +527,7 @@ def build_dual_profile_tp_decoder_engine(
             network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
+            q_seq=None, kv_seq=None, causal=False, mask=layer_mask_4d,
             scale=attn_scale, tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,

--- a/python/tensorrt_model_connect/families/gpt_neo/graph_ops.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/graph_ops.py
@@ -523,6 +523,77 @@ def add_2d_mask_to_4d(
     return mask_4d.get_output(0)
 
 
+def add_local_attention_mask_2d(
+    network: trt.INetworkDefinition,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    *,
+    max_cache_length: int,
+    window_size: int,
+) -> trt.ITensor:
+    """Add GPT-Neo's local-window restriction to a runtime causal mask."""
+
+    if window_size <= 0:
+        raise ValueError("window_size must be positive")
+    cache_positions = add_constant(
+        network,
+        (max_cache_length,),
+        np.arange(max_cache_length, dtype=np.int32),
+        dtype=np.int32,
+    )
+    key_positions = network.add_concatenation([cache_positions, position_id])
+    key_positions.axis = 0
+    key_2d = network.add_shuffle(key_positions.get_output(0))
+    key_2d.reshape_dims = (1, -1)
+
+    query_2d = network.add_shuffle(position_id)
+    query_2d.reshape_dims = (-1, 1)
+    window_span = add_constant(
+        network,
+        (1, 1),
+        np.array([[window_size - 1]], dtype=np.int32),
+        dtype=np.int32,
+    )
+    oldest_visible = network.add_elementwise(
+        query_2d.get_output(0),
+        window_span,
+        trt.ElementWiseOperation.SUB,
+    ).get_output(0)
+    out_of_window = network.add_elementwise(
+        key_2d.get_output(0),
+        oldest_visible,
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+
+    penalty = add_constant(
+        network,
+        (1, 1),
+        np.array([[-1e9]], dtype=np.float32),
+        dtype=np.float32,
+    )
+    zero = add_constant(
+        network,
+        (1, 1),
+        np.array([[0.0]], dtype=np.float32),
+        dtype=np.float32,
+    )
+    local_penalty = network.add_select(
+        out_of_window,
+        penalty,
+        zero,
+    ).get_output(0)
+    if local_penalty.dtype != attention_mask.dtype:
+        local_penalty = network.add_cast(
+            local_penalty,
+            attention_mask.dtype,
+        ).get_output(0)
+    return network.add_elementwise(
+        attention_mask,
+        local_penalty,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+
+
 def add_alibi_mask_4d(
     network: trt.INetworkDefinition,
     mask_2d: trt.ITensor,

--- a/python/tensorrt_model_connect/families/gpt_neo/plugin.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/plugin.py
@@ -10,7 +10,7 @@ GPT-Neo (EleutherAI) uses:
   - Separate Q/K/V Linear projections (NOT fused, NOT Conv1D)
   - Output projection with bias
   - Tied word embeddings (wte == lm_head)
-  - Local/global attention alternation (ignored — our causal mask handles it)
+  - Alternating local/global attention from the Hugging Face config
 """
 
 from __future__ import annotations
@@ -30,6 +30,10 @@ from .checkpoint_mapper import (
 from ...parallel_config import normalize_parallel_config
 from .standard_decoder_builder import build_standard_decoder_engine
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
+from .attention_contract import (
+    resolve_attention_layer_types,
+    resolve_local_attention_window,
+)
 
 
 class GPTNeoPlugin:
@@ -154,6 +158,14 @@ class GPTNeoPlugin:
         parallel_config=None,
     ) -> bytes:
         parallel = normalize_parallel_config(parallel_config)
+        attention_layer_types = resolve_attention_layer_types(
+            config.raw,
+            num_layers=config.num_hidden_layers,
+        )
+        local_attention_window = resolve_local_attention_window(
+            config.raw,
+            attention_layer_types,
+        )
         if parallel.enabled:
             return build_dual_profile_tp_decoder_engine(
                 config, weights, max_cache_length,
@@ -163,6 +175,8 @@ class GPTNeoPlugin:
                 position_type="learned",
                 activation="gelu_new",
                 scale_attn_weights=False,
+                attention_layer_types=attention_layer_types,
+                local_attention_window=local_attention_window,
                 verbose=verbose,
                 parallel_config=parallel)
         return build_standard_decoder_engine(
@@ -173,6 +187,8 @@ class GPTNeoPlugin:
             position_type="learned",
             activation="gelu_new",
             scale_attn_weights=False,
+            attention_layer_types=attention_layer_types,
+            local_attention_window=local_attention_window,
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/tests/e2e/models/gpt_neo/test_gpt_neo_attention_contract.py
+++ b/tests/e2e/models/gpt_neo/test_gpt_neo_attention_contract.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPT-Neo local/global attention contract tests."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+
+def test_plugin_forwards_hf_attention_pattern_to_decoder_builder(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.gpt_neo.plugin"
+    )
+
+    captured = {}
+
+    def fake_build(*args, **kwargs):
+        captured.update(kwargs)
+        return b"engine"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        fake_build,
+    )
+    config = SimpleNamespace(
+        num_hidden_layers=4,
+        raw={
+            "attention_layers": ["global", "local", "global", "local"],
+            "window_size": 256,
+        },
+    )
+
+    result = plugin_module.GPTNeoPlugin().build_engine(
+        config,
+        {},
+        max_cache_length=512,
+    )
+
+    assert result == b"engine"
+    assert captured["attention_layer_types"] == (
+        "global",
+        "local",
+        "global",
+        "local",
+    )
+    assert captured["local_attention_window"] == 256
+
+
+def test_attention_types_expand_to_all_layers() -> None:
+    from tensorrt_model_connect.families.gpt_neo.attention_contract import (
+        resolve_attention_layer_types,
+    )
+
+    assert resolve_attention_layer_types(
+        {"attention_types": [[["global", "local"], 3]]},
+        num_layers=6,
+    ) == (
+        "global",
+        "local",
+        "global",
+        "local",
+        "global",
+        "local",
+    )


### PR DESCRIPTION
## Summary

- expand GPT-Neo attention_types into one validated local/global type per decoder layer
- add the configured sliding-window mask only to local layers
- preserve the existing causal mask for global layers across standard, dual-profile, and tensor-parallel builders

## Validation

- 17 non-GPU GPT-Neo and split-builder tests passed; 3 GPU-marked tests deselected locally
- Ruff, legal-header, and diff checks passed
- GB300 gpt-neo-125m validation passed twice: 10/10 exact matches, token-prefix agreement 1.0

Accuracy thresholds are unchanged.

Closes #660