### PR TITLE
perf(z-image): offload preprocessing matmuls

### DIFF
--- a/src/runtime/models/z_image/MODEL.toml
+++ b/src/runtime/models/z_image/MODEL.toml
@@ -6,7 +6,9 @@ runtime_library = "libtrtmc_model_z_image.so"
 runtime_plugins = ["plugin.cpp|register_zimage_plugin"]
 runtime_strategies = ["diffusion_zimage"]
 legacy_runtime_strategy_aliases = ["diffusion|contains|diffusion_backend_type|z_image|diffusion_zimage"]
+runtime_link_libraries = ["cublas"]
 runtime_tests = [
   "test_z_image_pipeline|test_z_image_pipeline.cpp|trtmc_model_z_image|_|_",
   "test_z_image_batch_utils|test_z_image_batch_utils.cpp|_|_|_",
+  "test_z_image_gpu_matmul|test_z_image_gpu_matmul.cpp|trtmc_model_z_image|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/z_image/gpu_matmul.cpp
+++ b/src/runtime/models/z_image/gpu_matmul.cpp
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/z_image/gpu_matmul.h"
+
+#include <cstddef>
+#include <cublas_v2.h>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int64_t kGpuMatmulMinimumOperations = 1'000'000;
+
+struct DeviceBuffer {
+    float* data{nullptr};
+    std::size_t bytes{0};
+};
+
+bool ensure_capacity(DeviceBuffer& buffer, std::size_t required) {
+    if (buffer.bytes >= required)
+        return true;
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer = {};
+    if (cudaMalloc(reinterpret_cast<void**>(&buffer.data), required) != cudaSuccess)
+        return false;
+    buffer.bytes = required;
+    return true;
+}
+
+void release(DeviceBuffer& buffer) {
+    if (buffer.data != nullptr)
+        cudaFree(buffer.data);
+    buffer = {};
+}
+
+bool request_is_valid(const float* lhs, const float* rhs, const float* output, int32_t rows,
+                      int32_t inner, int32_t columns) {
+    return lhs != nullptr && rhs != nullptr && output != nullptr && rows > 0 && inner > 0 &&
+           columns > 0;
+}
+
+void add_bias(float* output, const float* bias, int32_t rows, int32_t columns) {
+    if (bias == nullptr)
+        return;
+    for (int32_t row = 0; row < rows; ++row) {
+        float* output_row =
+            output + static_cast<std::size_t>(row) * static_cast<std::size_t>(columns);
+        for (int32_t column = 0; column < columns; ++column)
+            output_row[column] += bias[column];
+    }
+}
+
+} // namespace
+
+bool z_image_should_use_gpu_matmul(int32_t rows, int32_t inner, int32_t columns) {
+    if (rows <= 0 || inner <= 0 || columns <= 0)
+        return false;
+    const auto operations =
+        static_cast<int64_t>(rows) * static_cast<int64_t>(inner) * static_cast<int64_t>(columns);
+    return operations >= kGpuMatmulMinimumOperations;
+}
+
+struct ZImageGpuMatmul::Impl {
+    cublasHandle_t handle{nullptr};
+    cudaStream_t stream{nullptr};
+    DeviceBuffer lhs;
+    DeviceBuffer rhs;
+    DeviceBuffer output;
+    bool ready{false};
+
+    bool prepare(const float* lhs_data, const float* rhs_data, std::size_t lhs_bytes,
+                 std::size_t rhs_bytes, std::size_t output_bytes) {
+        if (!ensure_capacity(lhs, lhs_bytes) || !ensure_capacity(rhs, rhs_bytes) ||
+            !ensure_capacity(output, output_bytes)) {
+            return false;
+        }
+        if (cudaMemcpyAsync(lhs.data, lhs_data, lhs_bytes, cudaMemcpyHostToDevice, stream) !=
+            cudaSuccess) {
+            return false;
+        }
+        if (cudaMemcpyAsync(rhs.data, rhs_data, rhs_bytes, cudaMemcpyHostToDevice, stream) ==
+            cudaSuccess) {
+            return true;
+        }
+        cudaStreamSynchronize(stream);
+        return false;
+    }
+
+    bool multiply(int32_t rows, int32_t inner, int32_t columns) {
+        constexpr float alpha = 1.0F;
+        constexpr float beta = 0.0F;
+        return cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, columns, rows, inner, &alpha, rhs.data,
+                           columns, lhs.data, inner, &beta, output.data,
+                           columns) == CUBLAS_STATUS_SUCCESS;
+    }
+
+    bool download(float* host_output, std::size_t output_bytes) {
+        const auto copy_status =
+            cudaMemcpyAsync(host_output, output.data, output_bytes, cudaMemcpyDeviceToHost, stream);
+        const auto sync_status = cudaStreamSynchronize(stream);
+        return copy_status == cudaSuccess && sync_status == cudaSuccess;
+    }
+};
+
+ZImageGpuMatmul::ZImageGpuMatmul() : impl_(std::make_unique<Impl>()) {
+    if (cudaStreamCreate(&impl_->stream) != cudaSuccess)
+        return;
+    if (cublasCreate(&impl_->handle) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetStream(impl_->handle, impl_->stream) != CUBLAS_STATUS_SUCCESS)
+        return;
+    if (cublasSetMathMode(impl_->handle, CUBLAS_PEDANTIC_MATH) != CUBLAS_STATUS_SUCCESS)
+        return;
+    impl_->ready = true;
+}
+
+ZImageGpuMatmul::~ZImageGpuMatmul() {
+    release(impl_->lhs);
+    release(impl_->rhs);
+    release(impl_->output);
+    if (impl_->handle != nullptr)
+        cublasDestroy(impl_->handle);
+    if (impl_->stream != nullptr)
+        cudaStreamDestroy(impl_->stream);
+}
+
+bool ZImageGpuMatmul::run(const float* lhs, const float* rhs, const float* bias, float* output,
+                          int32_t rows, int32_t inner, int32_t columns) {
+    if (!impl_->ready || !request_is_valid(lhs, rhs, output, rows, inner, columns))
+        return false;
+
+    const auto lhs_bytes =
+        static_cast<std::size_t>(rows) * static_cast<std::size_t>(inner) * sizeof(float);
+    const auto rhs_bytes =
+        static_cast<std::size_t>(inner) * static_cast<std::size_t>(columns) * sizeof(float);
+    const auto output_count = static_cast<std::size_t>(rows) * static_cast<std::size_t>(columns);
+    const auto output_bytes = output_count * sizeof(float);
+    if (!impl_->prepare(lhs, rhs, lhs_bytes, rhs_bytes, output_bytes))
+        return false;
+    if (!impl_->multiply(rows, inner, columns)) {
+        cudaStreamSynchronize(impl_->stream);
+        return false;
+    }
+    if (!impl_->download(output, output_bytes))
+        return false;
+
+    add_bias(output, bias, rows, columns);
+    return true;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/z_image/gpu_matmul.h
+++ b/src/runtime/models/z_image/gpu_matmul.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+namespace trtmc {
+
+bool z_image_should_use_gpu_matmul(int32_t rows, int32_t inner, int32_t columns);
+
+class ZImageGpuMatmul {
+  public:
+    ZImageGpuMatmul();
+    ~ZImageGpuMatmul();
+
+    ZImageGpuMatmul(const ZImageGpuMatmul&) = delete;
+    ZImageGpuMatmul& operator=(const ZImageGpuMatmul&) = delete;
+
+    bool run(const float* lhs, const float* rhs, const float* bias, float* output, int32_t rows,
+             int32_t inner, int32_t columns);
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -6,10 +6,12 @@
 #include "runtime/models/z_image/pipeline.h"
 
 #include "runtime/domains/diffusion/diffusion_math.h"
+#include "runtime/models/z_image/gpu_matmul.h"
 #include "runtime/models/z_image/z_image_batch_utils.h"
 #include "runtime/models/z_image/z_image_scheduler_helpers.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -44,6 +46,15 @@ constexpr float kRopeTheta = 256.0F;
 constexpr int32_t kRopeDimT = 32;
 constexpr int32_t kRopeDimH = 48;
 constexpr int32_t kRopeDimW = 48;
+
+void run_preprocessor_matmul(ZImageGpuMatmul* gpu_matmul, const float* lhs, const float* rhs,
+                             const float* bias, float* output, int32_t rows, int32_t inner,
+                             int32_t columns, bool& used_gpu) {
+    used_gpu = z_image_should_use_gpu_matmul(rows, inner, columns) && gpu_matmul != nullptr &&
+               gpu_matmul->run(lhs, rhs, bias, output, rows, inner, columns);
+    if (!used_gpu)
+        cpu_matmul_bias(lhs, rhs, bias, output, rows, inner, columns);
+}
 
 // ---------------------------------------------------------------------------
 // Layout helper (``ZImageLayout`` is declared in pipeline.h so private
@@ -198,7 +209,8 @@ ZImagePipeline::ZImagePipeline(std::unique_ptr<TrtModule> text_encoder,
                                int32_t tensor_parallel_rank, int32_t tensor_parallel_size)
     : distributed_owner_(std::move(distributed_owner)), tensor_parallel_rank_(tensor_parallel_rank),
       tensor_parallel_size_(tensor_parallel_size), text_encoder_(std::move(text_encoder)),
-      denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
+      denoiser_(std::move(denoiser)), vae_(std::move(vae)),
+      gpu_matmul_(std::make_unique<ZImageGpuMatmul>()), config_(std::move(config)),
       weights_(std::move(weights)), z_weights_(std::move(z_weights)),
       tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       bundle_path_(std::move(bundle_path)) {
@@ -388,6 +400,7 @@ bool ZImagePipeline::run_denoiser_batched(
 
 void ZImagePipeline::project_caption(const std::vector<float>& text_emb, int32_t actual_len,
                                      int32_t padded_len, std::vector<float>& projected) const {
+    const auto timing_start = std::chrono::steady_clock::now();
     const int32_t te_dim = config_.text_encoder_dim;
     const int32_t dit_dim = config_.dit_dim;
     const int32_t text_seq = config_.text_seq_len;
@@ -415,8 +428,10 @@ void ZImagePipeline::project_caption(const std::vector<float>& text_emb, int32_t
 
     // Linear(te_dim, dit_dim) + bias
     projected.resize(static_cast<std::size_t>(text_seq) * static_cast<std::size_t>(dit_dim));
-    cpu_matmul_bias(normed.data(), z_weights_.cap_proj_weight.data(),
-                    z_weights_.cap_proj_bias.data(), projected.data(), text_seq, te_dim, dit_dim);
+    bool used_gpu = false;
+    run_preprocessor_matmul(gpu_matmul_.get(), normed.data(), z_weights_.cap_proj_weight.data(),
+                            z_weights_.cap_proj_bias.data(), projected.data(), text_seq, te_dim,
+                            dit_dim, used_gpu);
 
     // Fill padding positions (actual_len..text_seq) with cap_pad_token
     if (!z_weights_.cap_pad_token.empty()) {
@@ -431,6 +446,11 @@ void ZImagePipeline::project_caption(const std::vector<float>& text_emb, int32_t
     }
 
     (void)padded_len; // padded_len used for RoPE, not projection
+    const auto elapsed =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - timing_start)
+            .count();
+    std::cerr << "[trtmc.preprocess_timing] label=\"z_image_caption_projection\" execute_ms="
+              << elapsed << " launches=1 implementation=\"" << (used_gpu ? "gpu" : "cpu") << "\"\n";
 }
 
 // ---------------------------------------------------------------------------
@@ -644,8 +664,9 @@ ImageResult ZImagePipeline::decode_z_image_result(int32_t z_dim, int32_t h_lat, 
 
 namespace {
 
-void compute_timestep_embedding(const ZImagePreprocessorWeights& z_weights, int32_t freq_dim,
-                                float raw_timestep, std::vector<float>& temb_out) {
+int32_t compute_timestep_embedding(ZImageGpuMatmul* gpu_matmul,
+                                   const ZImagePreprocessorWeights& z_weights, int32_t freq_dim,
+                                   float raw_timestep, std::vector<float>& temb_out) {
     const float t_for_embedding = 1000.0F - raw_timestep;
     const int32_t half = freq_dim / 2;
     std::vector<float> sinusoidal(static_cast<std::size_t>(freq_dim));
@@ -658,13 +679,20 @@ void compute_timestep_embedding(const ZImagePreprocessorWeights& z_weights, int3
 
     const int32_t mid_dim = static_cast<int32_t>(z_weights.t_embedder_mlp_0_bias.size());
     std::vector<float> h1(static_cast<std::size_t>(mid_dim));
-    cpu_matmul_bias(sinusoidal.data(), z_weights.t_embedder_mlp_0_weight.data(),
-                    z_weights.t_embedder_mlp_0_bias.data(), h1.data(), 1, freq_dim, mid_dim);
+    int32_t gpu_launches = 0;
+    bool used_gpu = false;
+    run_preprocessor_matmul(gpu_matmul, sinusoidal.data(), z_weights.t_embedder_mlp_0_weight.data(),
+                            z_weights.t_embedder_mlp_0_bias.data(), h1.data(), 1, freq_dim, mid_dim,
+                            used_gpu);
+    gpu_launches += used_gpu ? 1 : 0;
     cpu_silu_inplace(h1.data(), static_cast<std::size_t>(mid_dim));
 
     temb_out.resize(static_cast<std::size_t>(freq_dim));
-    cpu_matmul_bias(h1.data(), z_weights.t_embedder_mlp_2_weight.data(),
-                    z_weights.t_embedder_mlp_2_bias.data(), temb_out.data(), 1, mid_dim, freq_dim);
+    run_preprocessor_matmul(gpu_matmul, h1.data(), z_weights.t_embedder_mlp_2_weight.data(),
+                            z_weights.t_embedder_mlp_2_bias.data(), temb_out.data(), 1, mid_dim,
+                            freq_dim, used_gpu);
+    gpu_launches += used_gpu ? 1 : 0;
+    return gpu_launches;
 }
 
 std::vector<std::uint32_t> resolve_batch_seeds(const std::vector<std::string>& prompts,
@@ -974,27 +1002,43 @@ bool ZImagePipeline::run_denoise_loop_for_chunk(
     std::vector<float> denoiser_output;
     std::vector<float> sample_noise_pred;
     std::vector<float> noise_pred(static_cast<std::size_t>(batch) * latent_size);
+    double patch_embedding_ms = 0.0;
+    double timestep_embedding_ms = 0.0;
+    int32_t patch_gpu_launches = 0;
+    int32_t timestep_gpu_launches = 0;
 
     for (int32_t step = 0; step < num_inference_steps; ++step) {
         const float raw_timestep = scheduler.timesteps[static_cast<std::size_t>(step)];
 
-        compute_timestep_embedding(z_weights_, freq_dim, raw_timestep, temb_one);
+        auto timing_start = std::chrono::steady_clock::now();
+        timestep_gpu_launches += compute_timestep_embedding(gpu_matmul_.get(), z_weights_, freq_dim,
+                                                            raw_timestep, temb_one);
+        timestep_embedding_ms += std::chrono::duration<double, std::milli>(
+                                     std::chrono::steady_clock::now() - timing_start)
+                                     .count();
         for (int32_t b = 0; b < batch; ++b) {
             std::copy(temb_one.begin(), temb_one.end(),
                       temb_b.begin() +
                           static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(freq_dim));
         }
 
+        timing_start = std::chrono::steady_clock::now();
         for (int32_t b = 0; b < batch; ++b) {
             const auto* sample_latents_ptr =
                 latents.data() + static_cast<std::size_t>(b) * latent_size;
             sample_latents.assign(sample_latents_ptr, sample_latents_ptr + latent_size);
             patchify_2d(sample_latents, layout.z_dim, layout.h_lat, layout.w_lat, patches);
-            cpu_matmul_bias(patches.data(), z_weights_.x_embed_weight.data(),
-                            z_weights_.x_embed_bias.data(),
-                            hidden_b.data() + static_cast<std::size_t>(b) * hidden_size,
-                            layout.num_patches, layout.patch_dim, layout.dit_dim);
+            bool used_gpu = false;
+            run_preprocessor_matmul(gpu_matmul_.get(), patches.data(),
+                                    z_weights_.x_embed_weight.data(),
+                                    z_weights_.x_embed_bias.data(),
+                                    hidden_b.data() + static_cast<std::size_t>(b) * hidden_size,
+                                    layout.num_patches, layout.patch_dim, layout.dit_dim, used_gpu);
+            patch_gpu_launches += used_gpu ? 1 : 0;
         }
+        patch_embedding_ms += std::chrono::duration<double, std::milli>(
+                                  std::chrono::steady_clock::now() - timing_start)
+                                  .count();
 
         if (engine_is_batched) {
             if (!run_denoiser_batched(hidden_b, caption_projected_b, temb_b, rope_cos_b, rope_sin_b,
@@ -1027,6 +1071,12 @@ bool ZImagePipeline::run_denoise_loop_for_chunk(
         scheduler.step(noise_pred.data(), latents.data(), latents.data(), latents.size(), step);
         log_step_stats(step, num_inference_steps, raw_timestep, latents);
     }
+    std::cerr << "[trtmc.preprocess_timing] label=\"z_image_patch_embedding\" execute_ms="
+              << patch_embedding_ms << " launches=" << (num_inference_steps * batch)
+              << " gpu_launches=" << patch_gpu_launches << "\n";
+    std::cerr << "[trtmc.preprocess_timing] label=\"z_image_timestep_embedding\" execute_ms="
+              << timestep_embedding_ms << " launches=" << (num_inference_steps * 2)
+              << " gpu_launches=" << timestep_gpu_launches << "\n";
     return true;
 }
 

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -20,6 +20,8 @@
 
 namespace trtmc {
 
+class ZImageGpuMatmul;
+
 /// Internal layout descriptor for Z-Image (latent grid, patches, dims).
 /// Declared here so that ``ZImagePipeline`` private helpers can refer to it
 /// without dragging the full pipeline body into the header.
@@ -177,6 +179,7 @@ class ZImagePipeline final : public IPipeline {
     std::unique_ptr<TrtModule> text_encoder_;
     std::unique_ptr<TrtModule> denoiser_;
     std::unique_ptr<TrtModule> vae_;
+    std::unique_ptr<ZImageGpuMatmul> gpu_matmul_;
     ZImageDiffusionConfig config_;
     ZImageCommonPreprocessorWeights weights_;
     ZImagePreprocessorWeights z_weights_;

--- a/tests/cpp/models/z_image/test_z_image_gpu_matmul.cpp
+++ b/tests/cpp/models/z_image/test_z_image_gpu_matmul.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/z_image/gpu_matmul.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (condition)
+        return;
+    std::cerr << "FAIL: " << name << '\n';
+    ++failures;
+}
+
+void test_gpu_matmul_matches_fp32_contract() {
+    constexpr int32_t rows = 17;
+    constexpr int32_t inner = 13;
+    constexpr int32_t columns = 19;
+    std::vector<float> lhs(static_cast<std::size_t>(rows * inner));
+    std::vector<float> rhs(static_cast<std::size_t>(inner * columns));
+    std::vector<float> bias(static_cast<std::size_t>(columns));
+    for (std::size_t i = 0; i < lhs.size(); ++i)
+        lhs[i] = static_cast<float>(static_cast<int32_t>(i % 11) - 5) * 0.125F;
+    for (std::size_t i = 0; i < rhs.size(); ++i)
+        rhs[i] = static_cast<float>(static_cast<int32_t>(i % 7) - 3) * 0.0625F;
+    for (int32_t column = 0; column < columns; ++column)
+        bias[static_cast<std::size_t>(column)] = static_cast<float>(column - 9) * 0.03125F;
+
+    std::vector<float> expected(static_cast<std::size_t>(rows * columns));
+    for (int32_t row = 0; row < rows; ++row) {
+        for (int32_t column = 0; column < columns; ++column) {
+            double value = bias[static_cast<std::size_t>(column)];
+            for (int32_t k = 0; k < inner; ++k) {
+                value += static_cast<double>(lhs[static_cast<std::size_t>(row * inner + k)]) *
+                         static_cast<double>(rhs[static_cast<std::size_t>(k * columns + column)]);
+            }
+            expected[static_cast<std::size_t>(row * columns + column)] = static_cast<float>(value);
+        }
+    }
+
+    trtmc::ZImageGpuMatmul matmul;
+    std::vector<float> actual(expected.size());
+    check(matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), rows, inner, columns),
+          "Z-Image GPU matmul executes");
+    float max_error = 0.0F;
+    for (std::size_t i = 0; i < actual.size(); ++i)
+        max_error = std::max(max_error, std::abs(actual[i] - expected[i]));
+    check(max_error <= 1.0e-5F, "Z-Image GPU matmul matches FP32 CPU accumulation");
+    check(!matmul.run(lhs.data(), rhs.data(), bias.data(), actual.data(), 0, inner, columns),
+          "Z-Image GPU matmul rejects invalid dimensions");
+}
+
+} // namespace
+
+int main() {
+    test_gpu_matmul_matches_fp32_contract();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/cpp/models/z_image/test_z_image_pipeline.cpp
+++ b/tests/cpp/models/z_image/test_z_image_pipeline.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "runtime/models/z_image/gpu_matmul.h"
 #include "runtime/models/z_image/pipeline.h"
 
 #include <iostream>
@@ -60,6 +61,16 @@ void test_zimage_attention_mask() {
           "Z-Image attention mask hides unused fixed caption slots");
 }
 
+void test_zimage_gpu_matmul_policy() {
+    check(trtmc::z_image_should_use_gpu_matmul(4096, 64, 3840),
+          "Z-Image 1024px patch embedding uses GPU matmul");
+    check(trtmc::z_image_should_use_gpu_matmul(512, 2560, 3840),
+          "Z-Image caption projection uses GPU matmul");
+    check(!trtmc::z_image_should_use_gpu_matmul(1, 256, 3840),
+          "Z-Image timestep projection stays on CPU below threshold");
+    check(!trtmc::z_image_should_use_gpu_matmul(1, 16, 16), "Z-Image tiny projections stay on CPU");
+}
+
 } // namespace
 
 int main() {
@@ -67,6 +78,7 @@ int main() {
     test_zimage_initial_latent_contract();
     test_zimage_text_encoder_input_shape();
     test_zimage_attention_mask();
+    test_zimage_gpu_matmul_policy();
     if (failures > 0) {
         std::cerr << failures << " z-image pipeline test(s) FAILED\n";
     }


### PR DESCRIPTION
## Background

Z-Image-Turbo performed its patch embedding on the CPU for every denoising step. At the release workload (FP16, 1024x1024, batch 1, 9 steps), this repeatedly evaluated a `4096 x 64 x 3840` matrix multiply on the host. Caption projection also used a large host matrix multiply.

On GB300 with TensorRT 11.2.0.113, the current `main` baseline measured 10834.445 ms p50 and 10845.892 ms p95.

Fixes #639.

## Exit Criteria

- Preserve the existing FP16 bundle, prompt, resolution, seed, guidance, and 9-step workload.
- Remove the per-step CPU patch-embedding bottleneck without weakening validation.
- Keep a CPU fallback for unsupported or small matrix multiplies.
- Expose preprocessing timing separately from TensorRT engine timing.
- Preserve the model-owned external Diffusers image contract.

## Implementation

- Add a reusable Z-Image cuBLAS SGEMM helper with pedantic FP32 math and reusable device buffers.
- Route release-size patch embedding and caption projection through the GPU helper.
- Retain CPU execution below a tested operation threshold and on any GPU-helper failure.
- Add `trtmc.preprocess_timing` records for caption projection, patch embedding, and timestep embedding.
- Add GPU numerical-contract coverage and release-dimension routing tests.

## Validation

- Formal benchmark, same workload, 3 warmups + 10 measured iterations:
  - Before: p50 10834.445 ms, p95 10845.892 ms.
  - After: p50 1162.030 ms, p95 1163.079 ms.
  - p50 reduction: 89.3%.
- Model-owned 1024x1024 external Diffusers E2E: passed.
- Independent generated-frame comparison using the shared initial latent:
  - PSNR: 33.614 dB.
  - SSIM: 0.9717.
  - TRT pixel mean/std: 0.365651 / 0.304372.
- Z-Image C++ tests: 3 passed, including GPU numerical parity.
- Model encapsulation architecture tests: 158 passed.
- Builder tests: 675 passed, 1 skipped.
- Family coverage: 78/78 covered.
- Test-impact validation, model ownership, clang-format, legal headers, and CCN gate: passed.

## Notes For Future Readers

The remaining request time is dominated by the TensorRT denoiser itself (about 991 ms across nine launches), not Z-Image host preprocessing. The timestep projections remain on CPU because their actual release dimensions are below the offload threshold and take only about 6.5 ms across all nine steps.
