### PR TITLE
fix(llama): apply Llama 3 RoPE scaling

### DIFF
--- a/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -415,10 +415,12 @@ def build_dual_profile_decoder_engine(
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
         cos_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"))
         sin_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"))
         cos_half_table = _const_in_work_dtype(
             network, cos_half_np.shape, cos_half_np,
             work_np_dtype, work_trt_dtype)

--- a/python/tensorrt_model_connect/families/llama/graph_ops.py
+++ b/python/tensorrt_model_connect/families/llama/graph_ops.py
@@ -8,6 +8,9 @@ Tensor names and shapes must stay compatible with the C++ bundle runtime.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
@@ -447,6 +450,7 @@ def make_rope_table_half_dim(
     cosine: bool,
     partial_rotary_factor: float = 1.0,
     interleaved: bool = False,
+    rope_scaling: Mapping[str, Any] | None = None,
 ) -> np.ndarray:
     """Build a RoPE cos/sin table of shape [max_cache_length, rotary_ndims // 2].
 
@@ -463,6 +467,7 @@ def make_rope_table_half_dim(
         partial_rotary_factor: Fraction of head dims that rotate (default 1.0).
         interleaved:      If True, adjacent-pair frequencies (CodeGen/GPT-J).
                           If False, half-split frequencies (LLaMA/Qwen).
+        rope_scaling:     Optional Hugging Face RoPE scaling configuration.
 
     Returns:
         Float32 array [max_cache_length, rotary_ndims // 2].
@@ -474,17 +479,71 @@ def make_rope_table_half_dim(
     if max_cache_length <= 0 or rope_theta <= 0.0:
         return np.full((max(max_cache_length, 1), max(half, 1)),
                        default, dtype=np.float32)
-    table = np.full((max_cache_length, half), default, dtype=np.float32)
-    for pos in range(max_cache_length):
-        for d in range(half):
-            # For both interleaved and rotate-half the frequency index is d
-            # (the distinction only affects which input pair is rotated; the
-            # freq assignment per half-dim is the same).
-            exponent = (2.0 * d) / rotary_ndims
-            inv_freq = rope_theta ** (-exponent)
-            angle = pos * inv_freq
-            table[pos, d] = np.cos(angle) if cosine else np.sin(angle)
-    return table
+    if not rope_scaling:
+        table = np.full(
+            (max_cache_length, half),
+            default,
+            dtype=np.float32,
+        )
+        for pos in range(max_cache_length):
+            for dimension in range(half):
+                exponent = (2.0 * dimension) / rotary_ndims
+                inverse_frequency = rope_theta ** (-exponent)
+                angle = pos * inverse_frequency
+                table[pos, dimension] = (
+                    np.cos(angle) if cosine else np.sin(angle)
+                )
+        return table
+
+    exponents = np.arange(0, rotary_ndims, 2, dtype=np.float64) / rotary_ndims
+    inverse_frequencies = np.power(float(rope_theta), -exponents)
+    rope_type = str(
+        rope_scaling.get("rope_type")
+        or rope_scaling.get("type")
+        or ""
+    ).lower()
+    if rope_type != "llama3":
+        raise NotImplementedError(
+            f"Unsupported Llama RoPE scaling type: {rope_type or '<missing>'}"
+        )
+    factor = float(rope_scaling["factor"])
+    low_freq_factor = float(rope_scaling["low_freq_factor"])
+    high_freq_factor = float(rope_scaling["high_freq_factor"])
+    original_context = float(
+        rope_scaling["original_max_position_embeddings"]
+    )
+    if (
+        factor <= 0.0
+        or low_freq_factor <= 0.0
+        or high_freq_factor <= low_freq_factor
+        or original_context <= 0.0
+    ):
+        raise ValueError(f"Invalid Llama 3 RoPE scaling: {dict(rope_scaling)}")
+
+    wavelengths = 2.0 * np.pi / inverse_frequencies
+    low_freq_wavelength = original_context / low_freq_factor
+    high_freq_wavelength = original_context / high_freq_factor
+    scaled = np.where(
+        wavelengths > low_freq_wavelength,
+        inverse_frequencies / factor,
+        inverse_frequencies,
+    )
+    smooth = (
+        original_context / wavelengths - low_freq_factor
+    ) / (high_freq_factor - low_freq_factor)
+    interpolated = (1.0 - smooth) * scaled / factor + smooth * scaled
+    medium = (
+        (wavelengths >= high_freq_wavelength)
+        & (wavelengths <= low_freq_wavelength)
+    )
+    inverse_frequencies = np.where(medium, interpolated, scaled)
+
+    angles = np.outer(
+        np.arange(max_cache_length, dtype=np.float64),
+        inverse_frequencies,
+    )
+    values = np.cos(angles) if cosine else np.sin(angles)
+    return values.astype(np.float32)
 
 
 def reshape_rows_to_heads_4d(

--- a/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
@@ -314,10 +314,12 @@ def build_standard_decoder_engine(
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
         cos_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"))
         sin_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"))
         cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
         cos_half_tensor = _cast_work_dtype(cos_half_tensor)

--- a/tests/e2e/models/llama/test_llama_rope_scaling.py
+++ b/tests/e2e/models/llama/test_llama_rope_scaling.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Llama 3.1 RoPE scaling tests for Minitron."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tensorrt_model_connect.families.llama import graph_ops
+
+
+LLAMA3_SCALING = {
+    "factor": 8.0,
+    "high_freq_factor": 4.0,
+    "low_freq_factor": 1.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3",
+}
+
+
+def _llama3_inverse_frequencies(head_dim: int, rope_theta: float) -> np.ndarray:
+    inverse = 1.0 / (
+        rope_theta
+        ** (np.arange(0, head_dim, 2, dtype=np.float64) / head_dim)
+    )
+    wavelength = 2.0 * np.pi / inverse
+    low_wavelength = 8192.0
+    high_wavelength = 8192.0 / 4.0
+    scaled = np.where(wavelength > low_wavelength, inverse / 8.0, inverse)
+    smooth = (8192.0 / wavelength - 1.0) / 3.0
+    interpolated = (1.0 - smooth) * scaled / 8.0 + smooth * scaled
+    medium = (wavelength >= high_wavelength) & (wavelength <= low_wavelength)
+    return np.where(medium, interpolated, scaled)
+
+
+def test_half_dim_table_matches_llama3_reference_formula() -> None:
+    positions = 32
+    head_dim = 128
+    rope_theta = 500000.0
+    inverse = _llama3_inverse_frequencies(head_dim, rope_theta)
+    angles = np.outer(np.arange(positions, dtype=np.float64), inverse)
+
+    cosine = graph_ops.make_rope_table_half_dim(
+        positions,
+        head_dim,
+        rope_theta,
+        True,
+        rope_scaling=LLAMA3_SCALING,
+    )
+    sine = graph_ops.make_rope_table_half_dim(
+        positions,
+        head_dim,
+        rope_theta,
+        False,
+        rope_scaling=LLAMA3_SCALING,
+    )
+
+    np.testing.assert_allclose(cosine, np.cos(angles), atol=1e-7)
+    np.testing.assert_allclose(sine, np.sin(angles), atol=1e-7)


### PR DESCRIPTION
## Summary

- implement the Hugging Face Llama 3.1 RoPE frequency scaling contract
- feed scaled tables to standard and dual-profile Llama decoder engines
- preserve the existing unscaled path and reject unknown scaling types instead of silently ignoring them

## Validation

- 17 non-GPU Llama tests passed; 3 GPU-marked tests deselected locally
- 675 builder tests passed; 89 skipped
- Ruff, legal-header, and diff checks passed
- GB300 Minitron depth improved from 16.72% to 92.81% token-prefix agreement (9/10 exact)
- GB300 Minitron width improved from 45.62% to 96.88% token-prefix agreement (9/10 exact)
- paired BF16 engine/reference was worse than paired FP16, so model precision remains FP16

The remaining one-sample FP16 divergences are not waived and accuracy thresholds are unchanged.

Closes #661