### PR TITLE
fix(bloom): align tokenizer and FP32 math

### DIFF
--- a/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
@@ -346,6 +346,7 @@ def build_dual_profile_decoder_engine(
         work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
     else:
         work_np_dtype, work_trt_dtype = np.float32, trt.float32
+        trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_tp_builder.py
@@ -311,6 +311,7 @@ def build_dual_profile_tp_decoder_engine(
         work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
     else:
         work_np_dtype, work_trt_dtype = np.float32, trt.float32
+        trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
@@ -197,6 +197,7 @@ def build_standard_decoder_engine(
     else:
         work_np_dtype = np.float32
         work_trt_dtype = trt.float32
+        trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     if dynamic_kv_cache and position_type == "alibi":
         raise ValueError("dynamic_kv_cache is not supported for ALiBi decoder builds")

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -254,7 +254,9 @@ inline bool is_prefix(char32_t cp, Variant v) {
 
 // BLOOM word char: not whitespace and not BLOOM punctuation
 inline bool is_bloom_word_char(char32_t cp) {
-    return !is_whitespace(cp) && !is_bloom_punct(cp);
+    // The serialized regex is `[^(\s|[.,!?…。，、।۔،])]`. Parentheses and
+    // the pipe are literal members of that negated character class.
+    return !is_whitespace(cp) && !is_bloom_punct(cp) && cp != '(' && cp != ')' && cp != '|';
 }
 
 // ── Scanning helpers (advance pointer past matching chars) ──
@@ -528,32 +530,30 @@ std::vector<std::string> pre_tokenize(const std::string& text, Variant variant,
     return result;
 }
 
-// ── BLOOM pre-tokenize helpers ──
-
-// Handle optional leading space + word chars for BLOOM
-inline bool try_bloom_space_word(char32_t cp, const char*& p, const char* end, const char* start,
-                                 std::vector<std::string>& result) {
-    if (cp != ' ')
-        return false;
-    if (p >= end) {
-        result.emplace_back(start, p);
-        return true;
+// Return the end of a BLOOM Split-regex match beginning at `start`.
+// The regex is " ?[^(\s|[.,!?...])]+": an optional ASCII space followed by
+// one or more non-whitespace, non-punctuation characters.
+const char* bloom_match_end(const char* start, const char* end) {
+    const char* p = start;
+    char32_t cp = read_utf8(p, end);
+    if (cp == ' ') {
+        if (p >= end)
+            return nullptr;
+        cp = read_utf8(p, end);
+        if (!is_bloom_word_char(cp))
+            return nullptr;
+    } else if (!is_bloom_word_char(cp)) {
+        return nullptr;
     }
-    const char* after_space = p;
-    char32_t next_cp = read_utf8(p, end);
-    if (is_bloom_word_char(next_cp)) {
-        scan_bloom_words(p, end);
-        result.emplace_back(start, p);
-        return true;
-    }
-    // Space followed by whitespace or punctuation — back up
-    p = after_space;
-    return false;
+    scan_bloom_words(p, end);
+    return p;
 }
 
-// BLOOM pre-tokenizer: " ?[^(\s|[.,!?...])]+".
-// Simpler than GPT-2: optional space + non-whitespace-non-punct chars.
-// Punctuation chars become individual tokens.
+// BLOOM uses Split(..., behavior="Isolated", invert=false) followed by
+// ByteLevel(use_regex=false). Regex matches are isolated, while every
+// contiguous unmatched span remains a single pre-token. In particular,
+// punctuation and adjacent newlines must stay together so BPE can merge
+// strings such as ".\n\n".
 std::vector<std::string> bloom_pre_tokenize(const std::string& text) {
     std::vector<std::string> result;
     if (text.empty())
@@ -564,33 +564,16 @@ std::vector<std::string> bloom_pre_tokenize(const std::string& text) {
 
     while (p < end) {
         const char* start = p;
-        char32_t cp = read_utf8(p, end);
-
-        if (try_bloom_space_word(cp, p, end, start, result))
-            continue;
-
-        if (is_whitespace(cp)) {
-            emit_whitespace_leave_last(p, end, start, result);
+        if (const char* match_end = bloom_match_end(start, end)) {
+            result.emplace_back(start, match_end);
+            p = match_end;
             continue;
         }
 
-        if (is_bloom_punct(cp)) {
-            // Keep consecutive non-word chars together (Split "Isolated" behavior:
-            // unmatched text stays as one segment for BPE to merge)
-            while (p < end) {
-                const char* next_start = p;
-                char32_t next_cp = read_utf8(p, end);
-                if (!is_bloom_punct(next_cp) || is_whitespace(next_cp)) {
-                    p = next_start;
-                    break;
-                }
-            }
-            result.emplace_back(start, p);
-            continue;
-        }
-
-        // Word chars (no leading space)
-        scan_bloom_words(p, end);
+        // Preserve one contiguous unmatched span until the next regex match.
+        read_utf8(p, end);
+        while (p < end && bloom_match_end(p, end) == nullptr)
+            read_utf8(p, end);
         result.emplace_back(start, p);
     }
 

--- a/tests/builder/test_split_decoder_builder_contract.py
+++ b/tests/builder/test_split_decoder_builder_contract.py
@@ -21,6 +21,12 @@ REMOVED_SHARED_BUILDER_MODULES = (
     BUILDERS_DIR / "utils.py",
 )
 
+BLOOM_FP32_BUILDERS = (
+    FAMILIES_DIR / "bloom" / "standard_decoder_builder.py",
+    FAMILIES_DIR / "bloom" / "dual_profile_decoder_builder.py",
+    FAMILIES_DIR / "bloom" / "dual_profile_decoder_tp_builder.py",
+)
+
 
 def _family_files(name: str) -> list[Path]:
     return sorted(FAMILIES_DIR.glob(f"*/{name}"))
@@ -103,3 +109,15 @@ def test_family_code_does_not_import_shared_builder_package() -> None:
             violations.append(str(path.relative_to(ROOT)))
 
     assert not violations
+
+
+def test_bloom_fp32_builders_disable_tf32() -> None:
+    """BLOOM FP32 must not silently use lower-precision TF32 matmuls."""
+    missing = [
+        str(path.relative_to(ROOT))
+        for path in BLOOM_FP32_BUILDERS
+        if "trt_config.clear_flag(trt.BuilderFlag.TF32)"
+        not in path.read_text(encoding="utf-8")
+    ]
+
+    assert not missing

--- a/tests/cpp/test_bpe_tokenizer.cpp
+++ b/tests/cpp/test_bpe_tokenizer.cpp
@@ -732,12 +732,15 @@ int main() {
               "\u0120": 7, "!": 8, ".": 9, ",": 10,
               "he": 11, "ll": 12, "lo": 13, "hell": 19, "hel": 20,
               "\u0120w": 14, "or": 15, "ld": 16, "orld": 21,
-              "hello": 17, "\u0120world": 18
+              "hello": 17, "\u0120world": 18,
+              "\u010a": 22, "\u010a\u010a": 23, ".\u010a\u010a": 24,
+              "|": 25, "|.": 26
             },
             "merges": [
               "h e", "l l", "l o", "he ll", "hel lo",
               "\u0120 w", "o r", "l d", "or ld",
-              "\u0120w orld", "hello \u0120world"
+              "\u0120w orld", "hello \u0120world",
+              "\u010a \u010a", ". \u010a\u010a", "| ."
             ]
           },
           "pre_tokenizer": {
@@ -786,6 +789,19 @@ int main() {
             check(ids.size() == 5, "word_separator_punct_split_dot_size");
             check(ids[0] == 19 && ids[1] == 3, "word_separator_punct_split_dot_hello");
             check(ids[2] == 9, "word_separator_punct_split_dot_period");
+        }
+
+        // Split(Isolated) preserves the unmatched ".\n\n" span, allowing
+        // BLOOM's BPE merge across punctuation and adjacent newlines.
+        {
+            auto ids = tok->encode(".\n\nworld");
+            check(ids.size() == 3 && ids[0] == 24 && ids[1] == 4 && ids[2] == 21,
+                  "word_separator_preserves_unmatched_punctuation_newlines");
+        }
+        {
+            auto ids = tok->encode("|.world");
+            check(ids.size() == 3 && ids[0] == 26 && ids[1] == 4 && ids[2] == 21,
+                  "word_separator_preserves_unmatched_regex_literals");
         }
 
         // Round-trip: "hell" + "o" → byte_decode → "hello"


### PR DESCRIPTION
## Summary

- preserve unmatched spans in the BLOOM Split pre-tokenizer so native token IDs match Hugging Face around punctuation and newlines
- disable TensorRT TF32 in BLOOM FP32 standard, prefill, and tensor-parallel decoder builders
- add tokenizer and builder-contract regression coverage

## Root cause

The native BLOOM tokenizer split unmatched punctuation and newline spans even though the serialized Hugging Face tokenizer uses Split with Isolated behavior. For example, a prompt encoded as 312 tokens in Hugging Face was executed as 328 tokens in TRTMC.

After token alignment, one near-tie still diverged during batched prefill because BLOOM FP32 builders left TensorRT's TF32 flag enabled. The top two logits differed by roughly 0.003, and TF32 reversed their order.

## Validation

- `python -m pytest -q tests/builder/test_split_decoder_builder_contract.py` — 5 passed
- `test_bpe_tokenizer` on GB300-2 — all tests passed
- `clang-format --dry-run --Werror` on changed C++ files
- latest `tools/trtmc_validate.py` on GB300-2, `bloom-560m / mmlu_continuation_parity`, 10 samples, forced clean build — exact match 1.0, token-prefix agreement 1.0, 0 divergences

Closes #659