### PR TITLE
perf(sana-wm): optimize stage-one kernels

### DIFF
--- a/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_gdn_plugin.cu
+++ b/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_gdn_plugin.cu
@@ -104,6 +104,50 @@ bool report_cublas_error(cublasStatus_t status, const char* op, const char* mode
     return true;
 }
 
+struct ThreadCublasHandles {
+    int32_t device{-1};
+    cublasHandle_t handle{nullptr};
+
+    ~ThreadCublasHandles() { reset(); }
+
+    void reset() {
+        if (handle == nullptr)
+            return;
+        int32_t current_device = -1;
+        const bool restore_device =
+            cudaGetDevice(&current_device) == cudaSuccess && current_device != device;
+        if (restore_device)
+            cudaSetDevice(device);
+        cublasDestroy(handle);
+        if (restore_device)
+            cudaSetDevice(current_device);
+        handle = nullptr;
+        device = -1;
+    }
+};
+
+bool get_thread_cublas_handle(cublasHandle_t& handle, cudaStream_t stream, const char* mode,
+                              SanaWmGdnShape shape) {
+    int32_t current_device = -1;
+    if (report_cuda_launch_error(cudaGetDevice(&current_device), "cudaGetDevice", mode, false,
+                                 shape)) {
+        return false;
+    }
+
+    thread_local ThreadCublasHandles handles;
+    if (handles.handle != nullptr && handles.device != current_device)
+        handles.reset();
+    if (handles.handle == nullptr) {
+        if (report_cublas_error(cublasCreate(&handles.handle), "create", mode, shape))
+            return false;
+        handles.device = current_device;
+    }
+    if (report_cublas_error(cublasSetStream(handles.handle, stream), "set_stream", mode, shape))
+        return false;
+    handle = handles.handle;
+    return true;
+}
+
 void clear_stale_cuda_error(const char* mode, bool reverse, SanaWmGdnShape shape) {
     const cudaError_t prior = cudaGetLastError();
     if (prior == cudaSuccess)
@@ -136,6 +180,7 @@ bool use_main_combined_cublas() {
 }
 
 constexpr int32_t kRawRmsThreads = 128;
+constexpr int32_t kRawBzThreadsPerOutput = 8;
 
 SanaWmGdnShape parse_shape(const nvinfer1::Dims& dims) {
     SanaWmGdnShape shape;
@@ -569,113 +614,162 @@ __global__ void cam_prep_inv_rms_kernel(float* q_inv, float* k_inv, const void* 
     }
 }
 
+struct CamPrepValues {
+    float q;
+    float k;
+    float v;
+    float k_pre_sq;
+};
+
 template <bool kRawBf16>
-__global__ void cam_prep_kernel(float* q_out, float* k_out, float* v_out, float* inflation_sq,
-                                const void* q_raw, const void* k_raw, const void* v_raw,
-                                const float* q_inv, const float* k_inv, const float* q_norm_weight,
-                                const float* k_norm_weight, const float* proj_q,
-                                const float* proj_kv, const float* rope_cos, const float* rope_sin,
-                                SanaWmCamPrepShape shape, float k_scale) {
+__device__ __forceinline__ CamPrepValues cam_prep_values(
+    const void* q_raw, const void* k_raw, const void* v_raw, const float* q_inv, const float* k_inv,
+    const float* q_norm_weight, const float* k_norm_weight, const float* proj_q,
+    const float* proj_kv, const float* rope_cos, const float* rope_sin, SanaWmCamPrepShape shape,
+    float k_scale, int32_t b, int32_t n, int32_t h, int32_t d) {
+    const int32_t half = shape.head_dim / 2;
+    const int32_t rope_pairs = half / 2;
+    CamPrepValues values{0.0F, 0.0F, 0.0F, 0.0F};
+    const int32_t bn = b * shape.tokens + n;
+    const float q_inv_value = q_inv[bn];
+    const float k_inv_value = k_inv[bn];
+    const int32_t norm_base = h * shape.head_dim;
+
+    if (d < half) {
+        const int32_t group = d / 4;
+        const int32_t row = d - group * 4;
+        const int32_t base_d = group * 4;
+        float q_acc = 0.0F;
+        float k_acc = 0.0F;
+        float v_terms[4];
+#pragma unroll
+        for (int32_t col = 0; col < 4; ++col) {
+            const int32_t src_d = base_d + col;
+            const int64_t raw_offset = cam_prep_raw_offset(shape, b, n, h, src_d);
+            float q_src = cam_prep_load_raw<kRawBf16>(q_raw, raw_offset) * q_inv_value *
+                          q_norm_weight[norm_base + src_d];
+            q_src = q_src > 0.0F ? q_src : 0.0F;
+            float k_src = cam_prep_load_raw<kRawBf16>(k_raw, raw_offset) * k_inv_value *
+                          k_norm_weight[norm_base + src_d];
+            k_src = (k_src > 0.0F ? k_src : 0.0F) * k_scale;
+            const float v_src = cam_prep_load_raw<kRawBf16>(v_raw, raw_offset);
+            const float q_m = proj_q[cam_prep_matrix_offset(shape, b, n, row, col)];
+            const float kv_m = proj_kv[cam_prep_matrix_offset(shape, b, n, row, col)];
+            q_acc += q_src * q_m;
+            k_acc += k_src * kv_m;
+            v_terms[col] = __fmul_rn(v_src, kv_m);
+            if (col == row) {
+                values.k_pre_sq = k_src * k_src;
+            }
+        }
+        values.q = q_acc;
+        values.k = k_acc;
+        values.v = __fadd_rn(__fadd_rn(v_terms[0], v_terms[2]), __fadd_rn(v_terms[1], v_terms[3]));
+    } else {
+        const int32_t rope_d = d - half;
+        const int32_t pair = rope_d / 2;
+        const int32_t even_d = half + pair * 2;
+        const int32_t odd_d = even_d + 1;
+        const int64_t even_offset = cam_prep_raw_offset(shape, b, n, h, even_d);
+        const int64_t odd_offset = cam_prep_raw_offset(shape, b, n, h, odd_d);
+        float q_even = cam_prep_load_raw<kRawBf16>(q_raw, even_offset) * q_inv_value *
+                       q_norm_weight[norm_base + even_d];
+        q_even = q_even > 0.0F ? q_even : 0.0F;
+        float q_odd = cam_prep_load_raw<kRawBf16>(q_raw, odd_offset) * q_inv_value *
+                      q_norm_weight[norm_base + odd_d];
+        q_odd = q_odd > 0.0F ? q_odd : 0.0F;
+        float k_even = cam_prep_load_raw<kRawBf16>(k_raw, even_offset) * k_inv_value *
+                       k_norm_weight[norm_base + even_d];
+        k_even = (k_even > 0.0F ? k_even : 0.0F) * k_scale;
+        float k_odd = cam_prep_load_raw<kRawBf16>(k_raw, odd_offset) * k_inv_value *
+                      k_norm_weight[norm_base + odd_d];
+        k_odd = (k_odd > 0.0F ? k_odd : 0.0F) * k_scale;
+        const float v_even = cam_prep_load_raw<kRawBf16>(v_raw, even_offset);
+        const float v_odd = cam_prep_load_raw<kRawBf16>(v_raw, odd_offset);
+        const float c = rope_cos[static_cast<int64_t>(n) * rope_pairs + pair];
+        const float s = rope_sin[static_cast<int64_t>(n) * rope_pairs + pair];
+        if ((rope_d & 1) == 0) {
+            values.q = q_even * c - q_odd * s;
+            values.k = k_even * c - k_odd * s;
+            values.v = v_even * c - v_odd * s;
+            values.k_pre_sq = k_even * k_even;
+        } else {
+            values.q = q_even * s + q_odd * c;
+            values.k = k_even * s + k_odd * c;
+            values.v = v_even * s + v_odd * c;
+            values.k_pre_sq = k_odd * k_odd;
+        }
+    }
+    return values;
+}
+
+template <bool kRawBf16>
+__global__ void cam_prep_output_tiled_kernel(
+    float* q_out, float* k_out, float* v_out, const void* q_raw, const void* k_raw,
+    const void* v_raw, const float* q_inv, const float* k_inv, const float* q_norm_weight,
+    const float* k_norm_weight, const float* proj_q, const float* proj_kv, const float* rope_cos,
+    const float* rope_sin, SanaWmCamPrepShape shape, float k_scale) {
+    __shared__ float q_tile[32][33];
+    __shared__ float k_tile[32][33];
+    __shared__ float v_tile[32][33];
+    const int32_t bh = static_cast<int32_t>(blockIdx.z);
+    const int32_t b = bh / shape.heads;
+    const int32_t h = bh - b * shape.heads;
+    const int32_t input_d = static_cast<int32_t>(blockIdx.y) * 32 + threadIdx.x;
+    const int32_t input_n_base = static_cast<int32_t>(blockIdx.x) * 32 + threadIdx.y;
+
+#pragma unroll
+    for (int32_t offset = 0; offset < 32; offset += 8) {
+        const int32_t input_n = input_n_base + offset;
+        if (input_n < shape.tokens && input_d < shape.head_dim) {
+            const auto values = cam_prep_values<kRawBf16>(
+                q_raw, k_raw, v_raw, q_inv, k_inv, q_norm_weight, k_norm_weight, proj_q, proj_kv,
+                rope_cos, rope_sin, shape, k_scale, b, input_n, h, input_d);
+            q_tile[threadIdx.y + offset][threadIdx.x] = values.q;
+            k_tile[threadIdx.y + offset][threadIdx.x] = values.k;
+            v_tile[threadIdx.y + offset][threadIdx.x] = values.v;
+        }
+    }
+    __syncthreads();
+
+    const int32_t output_n = static_cast<int32_t>(blockIdx.x) * 32 + threadIdx.x;
+    const int32_t output_d_base = static_cast<int32_t>(blockIdx.y) * 32 + threadIdx.y;
+#pragma unroll
+    for (int32_t offset = 0; offset < 32; offset += 8) {
+        const int32_t output_d = output_d_base + offset;
+        if (output_n < shape.tokens && output_d < shape.head_dim) {
+            const int64_t out_offset = cam_prep_bhdn_offset(shape, b, h, output_d, output_n);
+            q_out[out_offset] = q_tile[threadIdx.x][threadIdx.y + offset];
+            k_out[out_offset] = k_tile[threadIdx.x][threadIdx.y + offset];
+            v_out[out_offset] = v_tile[threadIdx.x][threadIdx.y + offset];
+        }
+    }
+}
+
+template <bool kRawBf16>
+__global__ void cam_prep_inflation_kernel(float* inflation_sq, const void* q_raw, const void* k_raw,
+                                          const void* v_raw, const float* q_inv, const float* k_inv,
+                                          const float* q_norm_weight, const float* k_norm_weight,
+                                          const float* proj_q, const float* proj_kv,
+                                          const float* rope_cos, const float* rope_sin,
+                                          SanaWmCamPrepShape shape, float k_scale) {
     __shared__ float k_pre_sums[256];
     __shared__ float k_post_sums[256];
-
     const int32_t pid = static_cast<int32_t>(blockIdx.x);
     const int32_t h = pid % shape.heads;
     const int32_t bn = pid / shape.heads;
     const int32_t b = bn / shape.tokens;
     const int32_t n = bn - b * shape.tokens;
     const int32_t d = threadIdx.x;
-    const int32_t half = shape.head_dim / 2;
-    const int32_t rope_pairs = half / 2;
-
-    float q_value = 0.0F;
-    float k_value = 0.0F;
-    float v_value = 0.0F;
-    float k_pre_sq = 0.0F;
-    float k_post_sq = 0.0F;
-
-    const float q_inv_value = q_inv[bn];
-    const float k_inv_value = k_inv[bn];
-    const int32_t norm_base = h * shape.head_dim;
-
+    CamPrepValues values{0.0F, 0.0F, 0.0F, 0.0F};
     if (d < shape.head_dim) {
-        if (d < half) {
-            const int32_t group = d / 4;
-            const int32_t row = d - group * 4;
-            const int32_t base_d = group * 4;
-            float q_acc = 0.0F;
-            float k_acc = 0.0F;
-            float v_terms[4];
-#pragma unroll
-            for (int32_t col = 0; col < 4; ++col) {
-                const int32_t src_d = base_d + col;
-                const int64_t raw_offset = cam_prep_raw_offset(shape, b, n, h, src_d);
-                float q_src = cam_prep_load_raw<kRawBf16>(q_raw, raw_offset) * q_inv_value *
-                              q_norm_weight[norm_base + src_d];
-                q_src = q_src > 0.0F ? q_src : 0.0F;
-                float k_src = cam_prep_load_raw<kRawBf16>(k_raw, raw_offset) * k_inv_value *
-                              k_norm_weight[norm_base + src_d];
-                k_src = (k_src > 0.0F ? k_src : 0.0F) * k_scale;
-                const float v_src = cam_prep_load_raw<kRawBf16>(v_raw, raw_offset);
-                const float q_m = proj_q[cam_prep_matrix_offset(shape, b, n, row, col)];
-                const float kv_m = proj_kv[cam_prep_matrix_offset(shape, b, n, row, col)];
-                q_acc += q_src * q_m;
-                k_acc += k_src * kv_m;
-                v_terms[col] = __fmul_rn(v_src, kv_m);
-                if (col == row) {
-                    k_pre_sq = k_src * k_src;
-                }
-            }
-            q_value = q_acc;
-            k_value = k_acc;
-            v_value =
-                __fadd_rn(__fadd_rn(v_terms[0], v_terms[2]), __fadd_rn(v_terms[1], v_terms[3]));
-        } else {
-            const int32_t rope_d = d - half;
-            const int32_t pair = rope_d / 2;
-            const int32_t even_d = half + pair * 2;
-            const int32_t odd_d = even_d + 1;
-            const int64_t even_offset = cam_prep_raw_offset(shape, b, n, h, even_d);
-            const int64_t odd_offset = cam_prep_raw_offset(shape, b, n, h, odd_d);
-            float q_even = cam_prep_load_raw<kRawBf16>(q_raw, even_offset) * q_inv_value *
-                           q_norm_weight[norm_base + even_d];
-            q_even = q_even > 0.0F ? q_even : 0.0F;
-            float q_odd = cam_prep_load_raw<kRawBf16>(q_raw, odd_offset) * q_inv_value *
-                          q_norm_weight[norm_base + odd_d];
-            q_odd = q_odd > 0.0F ? q_odd : 0.0F;
-            float k_even = cam_prep_load_raw<kRawBf16>(k_raw, even_offset) * k_inv_value *
-                           k_norm_weight[norm_base + even_d];
-            k_even = (k_even > 0.0F ? k_even : 0.0F) * k_scale;
-            float k_odd = cam_prep_load_raw<kRawBf16>(k_raw, odd_offset) * k_inv_value *
-                          k_norm_weight[norm_base + odd_d];
-            k_odd = (k_odd > 0.0F ? k_odd : 0.0F) * k_scale;
-            const float v_even = cam_prep_load_raw<kRawBf16>(v_raw, even_offset);
-            const float v_odd = cam_prep_load_raw<kRawBf16>(v_raw, odd_offset);
-            const float c = rope_cos[static_cast<int64_t>(n) * rope_pairs + pair];
-            const float s = rope_sin[static_cast<int64_t>(n) * rope_pairs + pair];
-            if ((rope_d & 1) == 0) {
-                q_value = q_even * c - q_odd * s;
-                k_value = k_even * c - k_odd * s;
-                v_value = v_even * c - v_odd * s;
-                k_pre_sq = k_even * k_even;
-            } else {
-                q_value = q_even * s + q_odd * c;
-                k_value = k_even * s + k_odd * c;
-                v_value = v_even * s + v_odd * c;
-                k_pre_sq = k_odd * k_odd;
-            }
-        }
-        const int64_t out_offset = cam_prep_bhdn_offset(shape, b, h, d, n);
-        q_out[out_offset] = q_value;
-        k_out[out_offset] = k_value;
-        v_out[out_offset] = v_value;
-        k_post_sq = k_value * k_value;
+        values = cam_prep_values<kRawBf16>(q_raw, k_raw, v_raw, q_inv, k_inv, q_norm_weight,
+                                           k_norm_weight, proj_q, proj_kv, rope_cos, rope_sin,
+                                           shape, k_scale, b, n, h, d);
     }
-
-    k_pre_sums[d] = d < shape.head_dim ? k_pre_sq : 0.0F;
-    k_post_sums[d] = d < shape.head_dim ? k_post_sq : 0.0F;
+    k_pre_sums[d] = values.k_pre_sq;
+    k_post_sums[d] = values.k * values.k;
     __syncthreads();
-
     for (int32_t stride = blockDim.x / 2; stride > 0; stride >>= 1) {
         if (d < stride) {
             k_pre_sums[d] += k_pre_sums[d + stride];
@@ -1420,7 +1514,10 @@ __global__ void raw_phase_a_bz_kernel(float* b_z, const float* k_raw, const floa
                                       const float* k_norm_weight, const float* beta,
                                       SanaWmGdnShape shape, int32_t t, float k_scale) {
     const int64_t total = static_cast<int64_t>(shape.batch) * shape.heads * shape.head_dim;
-    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int32_t outputs_per_block = blockDim.x / kRawBzThreadsPerOutput;
+    const int32_t output_in_block = threadIdx.x / kRawBzThreadsPerOutput;
+    const int32_t residue = threadIdx.x % kRawBzThreadsPerOutput;
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * outputs_per_block + output_in_block;
     if (idx >= total)
         return;
     const int32_t d = static_cast<int32_t>(idx % shape.head_dim);
@@ -1428,40 +1525,151 @@ __global__ void raw_phase_a_bz_kernel(float* b_z, const float* k_raw, const floa
     const int32_t b = static_cast<int32_t>(idx / (shape.head_dim * shape.heads));
     float accum = 0.0F;
     for (int32_t chunk = 0; chunk < shape.spatial; chunk += 64) {
-        float partial[8];
-#pragma unroll
-        for (int32_t residue = 0; residue < 8; ++residue) {
-            const int32_t first_s = chunk + residue;
-            float value = 0.0F;
-            if (first_s < shape.spatial) {
-                const float beta_s = beta[bht1s_offset(shape, b, h, t, first_s)];
-                const float k_value = raw_normed_relu(k_raw, k_inv, k_norm_weight, shape, b, t,
-                                                      first_s, h, d, k_scale);
-                value = __fmul_rn(beta_s, k_value);
-            }
-#pragma unroll
-            for (int32_t offset = 8; offset < 64; offset += 8) {
-                const int32_t s = first_s + offset;
-                float term = 0.0F;
-                if (s < shape.spatial) {
-                    const float beta_s = beta[bht1s_offset(shape, b, h, t, s)];
-                    const float k_value =
-                        raw_normed_relu(k_raw, k_inv, k_norm_weight, shape, b, t, s, h, d, k_scale);
-                    term = __fmul_rn(beta_s, k_value);
-                }
-                value = __fadd_rn(value, term);
-            }
-            partial[residue] = value;
+        const int32_t first_s = chunk + residue;
+        float value = 0.0F;
+        if (first_s < shape.spatial) {
+            const float beta_s = beta[bht1s_offset(shape, b, h, t, first_s)];
+            const float k_value =
+                raw_normed_relu(k_raw, k_inv, k_norm_weight, shape, b, t, first_s, h, d, k_scale);
+            value = __fmul_rn(beta_s, k_value);
         }
-        const float pair_0 = __fadd_rn(partial[0], partial[1]);
-        const float pair_1 = __fadd_rn(partial[2], partial[3]);
-        const float pair_2 = __fadd_rn(partial[4], partial[5]);
-        const float pair_3 = __fadd_rn(partial[6], partial[7]);
-        const float half_0 = __fadd_rn(pair_0, pair_2);
-        const float half_1 = __fadd_rn(pair_1, pair_3);
-        accum = __fadd_rn(accum, __fadd_rn(half_0, half_1));
+#pragma unroll
+        for (int32_t offset = 8; offset < 64; offset += 8) {
+            const int32_t s = first_s + offset;
+            float term = 0.0F;
+            if (s < shape.spatial) {
+                const float beta_s = beta[bht1s_offset(shape, b, h, t, s)];
+                const float k_value =
+                    raw_normed_relu(k_raw, k_inv, k_norm_weight, shape, b, t, s, h, d, k_scale);
+                term = __fmul_rn(beta_s, k_value);
+            }
+            value = __fadd_rn(value, term);
+        }
+        const uint32_t mask = __activemask();
+        const float adjacent = __shfl_down_sync(mask, value, 1, kRawBzThreadsPerOutput);
+        const float pair = (residue & 1) == 0 ? __fadd_rn(value, adjacent) : value;
+        const float pair_2 = __shfl_sync(mask, pair, 4, kRawBzThreadsPerOutput);
+        const float pair_3 = __shfl_sync(mask, pair, 6, kRawBzThreadsPerOutput);
+        const float half = residue == 0 ? __fadd_rn(pair, pair_2)
+                                        : (residue == 2 ? __fadd_rn(pair, pair_3) : pair);
+        const float half_1 = __shfl_sync(mask, half, 2, kRawBzThreadsPerOutput);
+        if (residue == 0)
+            accum = __fadd_rn(accum, __fadd_rn(half, half_1));
     }
-    b_z[frame_vector_offset(shape, b, h, t, d)] = accum;
+    if (residue == 0)
+        b_z[frame_vector_offset(shape, b, h, t, d)] = accum;
+}
+
+__global__ void sana_wm_short_conv_kernel(uint16_t* output, const uint16_t* input,
+                                          const uint16_t* weight, const uint16_t* bias,
+                                          int32_t batch, int32_t frames, int32_t spatial,
+                                          int32_t channels, int32_t kernel_size) {
+    const int64_t total =
+        static_cast<int64_t>(batch) * frames * spatial * static_cast<int64_t>(channels);
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+
+    const int32_t channel = static_cast<int32_t>(idx % channels);
+    int64_t token_index = idx / channels;
+    const int32_t spatial_index = static_cast<int32_t>(token_index % spatial);
+    token_index /= spatial;
+    const int32_t frame = static_cast<int32_t>(token_index % frames);
+    const int32_t batch_index = static_cast<int32_t>(token_index / frames);
+    const int32_t radius = kernel_size - 1;
+
+    float forward = 0.0F;
+    float backward = 0.0F;
+    for (int32_t tap = 0; tap < kernel_size; ++tap) {
+        const float weight_value = bf16_bits_to_float(weight[channel * kernel_size + tap]);
+        const int32_t forward_frame = frame - radius + tap;
+        if (forward_frame >= 0) {
+            const int64_t input_offset =
+                ((static_cast<int64_t>(batch_index) * frames + forward_frame) * spatial +
+                 spatial_index) *
+                    channels +
+                channel;
+            forward = __fmaf_rn(bf16_bits_to_float(input[input_offset]), weight_value, forward);
+        }
+        const int32_t backward_frame = frame + radius - tap;
+        if (backward_frame < frames) {
+            const int64_t input_offset =
+                ((static_cast<int64_t>(batch_index) * frames + backward_frame) * spatial +
+                 spatial_index) *
+                    channels +
+                channel;
+            backward = __fmaf_rn(bf16_bits_to_float(input[input_offset]), weight_value, backward);
+        }
+    }
+    if (bias != nullptr) {
+        const float bias_value = bf16_bits_to_float(bias[channel]);
+        forward = __fadd_rn(forward, bias_value);
+        backward = __fadd_rn(backward, bias_value);
+    }
+
+    const float forward_bf16 = bf16_bits_to_float(bf16_bits(forward));
+    const float backward_bf16 = bf16_bits_to_float(bf16_bits(backward));
+    const float combined_bf16 =
+        bf16_bits_to_float(bf16_bits(__fadd_rn(forward_bf16, backward_bf16)));
+    const float center_weight = bf16_bits_to_float(weight[channel * kernel_size + kernel_size - 1]);
+    const float center_product =
+        bf16_bits_to_float(bf16_bits(__fmul_rn(bf16_bits_to_float(input[idx]), center_weight)));
+    output[idx] = bf16_bits(__fsub_rn(combined_bf16, center_product));
+}
+
+__device__ __forceinline__ float sana_wm_silu_bf16(float value) {
+    return bf16_bits_to_float(bf16_bits(value / (1.0F + expf(-value))));
+}
+
+__device__ __forceinline__ float sana_wm_add_bias_bf16(float value, const uint16_t* bias,
+                                                       int32_t channel) {
+    if (bias == nullptr)
+        return value;
+    return bf16_bits_to_float(bf16_bits(__fadd_rn(value, bf16_bits_to_float(bias[channel]))));
+}
+
+__global__ void sana_wm_bias_silu_kernel(uint16_t* values, const uint16_t* bias, int64_t total,
+                                         int32_t channels) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+
+    const int32_t channel = static_cast<int32_t>(idx % channels);
+    const float value = sana_wm_add_bias_bf16(bf16_bits_to_float(values[idx]), bias, channel);
+    values[idx] = bf16_bits(sana_wm_silu_bf16(value));
+}
+
+__global__ void sana_wm_gated_silu_kernel(uint16_t* output, const uint16_t* input,
+                                          const uint16_t* bias, int64_t total, int32_t hidden) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+
+    const int32_t channel = static_cast<int32_t>(idx % hidden);
+    const int64_t row = idx / hidden;
+    const int64_t input_offset = row * (2 * hidden) + channel;
+    const float value =
+        sana_wm_add_bias_bf16(bf16_bits_to_float(input[input_offset]), bias, channel);
+    const float gate = sana_wm_silu_bf16(sana_wm_add_bias_bf16(
+        bf16_bits_to_float(input[input_offset + hidden]), bias, hidden + channel));
+    output[idx] = bf16_bits(__fmul_rn(value, gate));
+}
+
+__global__ void sana_wm_t2i_modulate_kernel(uint16_t* output, const uint16_t* input,
+                                            const uint16_t* shift, const uint16_t* scale,
+                                            int64_t total, int32_t tokens, int32_t hidden) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+
+    const int32_t channel = static_cast<int32_t>(idx % hidden);
+    const int64_t batch_frame = idx / (static_cast<int64_t>(tokens) * hidden);
+    const int64_t modulation_offset = batch_frame * hidden + channel;
+    const float scale_plus_one = bf16_bits_to_float(
+        bf16_bits(__fadd_rn(bf16_bits_to_float(scale[modulation_offset]), 1.0F)));
+    const float product =
+        bf16_bits_to_float(bf16_bits(__fmul_rn(bf16_bits_to_float(input[idx]), scale_plus_one)));
+    output[idx] = bf16_bits(__fadd_rn(product, bf16_bits_to_float(shift[modulation_offset])));
 }
 
 __global__ void prepare_phase_a_bf16_kernel(uint16_t* k_values, uint16_t* k_rot_values,
@@ -1714,6 +1922,35 @@ __global__ void phase_c_raw_cublas_output_kernel(float* out, const float* num,
     out[raw_output_offset(shape, b, t, s, h, d)] = num_bf16 / (den_bf16 + eps);
 }
 
+__global__ void phase_c_raw_cublas_output_vectorized_kernel(float* out, const float* num,
+                                                            const uint16_t* den_values,
+                                                            SanaWmGdnShape shape,
+                                                            int32_t padded_dim, int32_t t,
+                                                            float eps) {
+    const int32_t vectors_per_token = shape.head_dim / 4;
+    const int64_t total =
+        static_cast<int64_t>(shape.batch) * shape.heads * shape.spatial * vectors_per_token;
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= total)
+        return;
+    const int32_t vector_d = static_cast<int32_t>(idx % vectors_per_token);
+    const int32_t d = vector_d * 4;
+    const int32_t s = static_cast<int32_t>((idx / vectors_per_token) % shape.spatial);
+    const int32_t h =
+        static_cast<int32_t>((idx / (vectors_per_token * shape.spatial)) % shape.heads);
+    const int32_t b = static_cast<int32_t>(
+        idx / (static_cast<int64_t>(vectors_per_token) * shape.spatial * shape.heads));
+    const int64_t num_offset = frame_scratch_offset(shape, padded_dim, b, h, s, d);
+    const float4 raw = *reinterpret_cast<const float4*>(num + num_offset);
+    const float den_bf16 = bf16_bits_to_float(
+        den_values[(static_cast<int64_t>(b) * shape.heads + h) * shape.spatial + s]);
+    const float divisor = den_bf16 + eps;
+    const float4 result{round_bf16(raw.x) / divisor, round_bf16(raw.y) / divisor,
+                        round_bf16(raw.z) / divisor, round_bf16(raw.w) / divisor};
+    const int64_t out_offset = raw_output_offset(shape, b, t, s, h, d);
+    *reinterpret_cast<float4*>(out + out_offset) = result;
+}
+
 __global__ void copy_raw_phase_c_num_debug_kernel(float* out, const float* num,
                                                   SanaWmGdnShape shape, int32_t padded_dim,
                                                   int32_t t) {
@@ -1797,21 +2034,35 @@ __global__ void phase_c_den_bf16_kernel(uint16_t* den_values, const float* hist_
 __global__ void copy_phase_c_num_debug_kernel(float* out, const float* num, SanaWmGdnShape shape,
                                               int32_t padded_dim, int32_t t,
                                               bool camera_corrections) {
-    const int64_t total =
-        static_cast<int64_t>(shape.batch) * shape.heads * shape.spatial * shape.head_dim;
-    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (idx >= total)
-        return;
-    const int32_t d = static_cast<int32_t>(idx % shape.head_dim);
-    const int32_t s = static_cast<int32_t>((idx / shape.head_dim) % shape.spatial);
-    const int32_t h = static_cast<int32_t>((idx / (shape.head_dim * shape.spatial)) % shape.heads);
-    const int32_t b = static_cast<int32_t>(
-        idx / (static_cast<int64_t>(shape.head_dim) * shape.spatial * shape.heads));
-    const float raw = num[frame_scratch_offset(shape, padded_dim, b, h, s, d)];
-    const uint16_t bits =
-        camera_corrections ? camera_phase_c_num_bf16_bits(raw, h, t, s, d) : bf16_bits(raw);
-    const float value = bf16_bits_to_float(bits);
-    out[out_bhdn_offset(shape, b, h, d, t, s, false)] = value;
+    __shared__ uint16_t tile[32][33];
+    const int32_t bh = static_cast<int32_t>(blockIdx.z);
+    const int32_t b = bh / shape.heads;
+    const int32_t h = bh - b * shape.heads;
+    const int32_t input_d = static_cast<int32_t>(blockIdx.x) * 32 + threadIdx.x;
+    const int32_t input_s_base = static_cast<int32_t>(blockIdx.y) * 32 + threadIdx.y;
+
+#pragma unroll
+    for (int32_t offset = 0; offset < 32; offset += 8) {
+        const int32_t input_s = input_s_base + offset;
+        if (input_s < shape.spatial && input_d < shape.head_dim) {
+            const float raw = num[frame_scratch_offset(shape, padded_dim, b, h, input_s, input_d)];
+            tile[threadIdx.y + offset][threadIdx.x] =
+                camera_corrections ? camera_phase_c_num_bf16_bits(raw, h, t, input_s, input_d)
+                                   : bf16_bits(raw);
+        }
+    }
+    __syncthreads();
+
+    const int32_t output_s = static_cast<int32_t>(blockIdx.y) * 32 + threadIdx.x;
+    const int32_t output_d_base = static_cast<int32_t>(blockIdx.x) * 32 + threadIdx.y;
+#pragma unroll
+    for (int32_t offset = 0; offset < 32; offset += 8) {
+        const int32_t output_d = output_d_base + offset;
+        if (output_s < shape.spatial && output_d < shape.head_dim) {
+            const float value = bf16_bits_to_float(tile[threadIdx.x][threadIdx.y + offset]);
+            out[out_bhdn_offset(shape, b, h, output_d, t, output_s, false)] = value;
+        }
+    }
 }
 
 __global__ void copy_phase_c_den_debug_kernel(float* out, const uint16_t* den_values,
@@ -1994,9 +2245,8 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
         static_cast<int64_t>(shape.batch) * shape.heads * shape.spatial * shape.head_dim;
 
     cublasHandle_t handle = nullptr;
-    if (report_cublas_error(cublasCreate(&handle), "create", "camera_combined_cublas", shape))
+    if (!get_thread_cublas_handle(handle, stream, "camera_combined_cublas", shape))
         return 1;
-    cublasSetStream(handle, stream);
 
     const long long scratch_stride =
         static_cast<long long>(shape.spatial) * static_cast<long long>(padded_dim);
@@ -2012,7 +2262,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                              k, beta, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_a_bf16",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2025,7 +2274,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                 beta_v_values, padded_dim, scratch_stride, k_rot_values, padded_dim, scratch_stride,
                 gemm_b, padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_a_a",
                 "camera_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         finalize_raw_phase_a_bf16_kernel<<<
@@ -2033,7 +2281,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
             stream>>>(i_p_kv, a_t, i_p_z_unused, gemm_a, gemm_b, gemm_a, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "finalize_phase_a_bf16",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
     }
@@ -2048,7 +2295,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_fwd",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(t) * matrix_stride;
@@ -2057,7 +2303,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_fwd",
                 "camera_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2066,7 +2311,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                             shape, padded_dim, t, t, false);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_fwd_update",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp = state_kv;
@@ -2085,7 +2329,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_rev",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(f_src) * matrix_stride;
@@ -2094,7 +2337,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_rev",
                 "camera_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2103,7 +2345,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                             shape, padded_dim, f_src, f_dst, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_rev_update",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp = state_kv;
@@ -2111,6 +2352,9 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
         next_kv = tmp;
     }
 
+    dim3 phase_c_copy_threads(32, 8);
+    dim3 phase_c_copy_blocks((shape.head_dim + 31) / 32, (shape.spatial + 31) / 32,
+                             shape.batch * shape.heads);
     for (int32_t t = 0; t < shape.frames; ++t) {
         prepare_phase_c_qrot_bf16_kernel<<<static_cast<uint32_t>((scratch_elems + kThreads - 1) /
                                                                  kThreads),
@@ -2118,7 +2362,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                                                                   t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_c_q",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         convert_history_frame_to_bf16_kernel<<<
@@ -2126,7 +2369,6 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
             stream>>>(state_kv_bf16, hist_kv, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "hist_to_bf16_phase_c",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2134,21 +2376,15 @@ int32_t launch_camera_combined_cublas(SanaWmGdnShape shape, const void* const* i
                 state_kv_bf16, padded_dim, matrix_stride, q_values, padded_dim, scratch_stride,
                 phase_c_num, padded_dim, scratch_stride, static_cast<int32_t>(bh), "phase_c_num",
                 "camera_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
-        copy_phase_c_num_debug_kernel<<<static_cast<uint32_t>(
-                                            (output_elems_per_frame + kThreads - 1) / kThreads),
-                                        kThreads, 0, stream>>>(out, phase_c_num, shape, padded_dim,
-                                                               t, true);
+        copy_phase_c_num_debug_kernel<<<phase_c_copy_blocks, phase_c_copy_threads, 0, stream>>>(
+            out, phase_c_num, shape, padded_dim, t, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_num_copy",
                                      "camera_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
     }
-
-    cublasDestroy(handle);
     return 0;
 }
 
@@ -2207,9 +2443,8 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
     const int64_t output_elems = output_elems_per_frame * shape.frames;
 
     cublasHandle_t handle = nullptr;
-    if (report_cublas_error(cublasCreate(&handle), "create", "main_combined_cublas", shape))
+    if (!get_thread_cublas_handle(handle, stream, "main_combined_cublas", shape))
         return 1;
-    cublasSetStream(handle, stream);
 
     const long long scratch_stride =
         static_cast<long long>(shape.spatial) * static_cast<long long>(padded_dim);
@@ -2225,7 +2460,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                              k_rot, beta, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_a_bf16",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2233,7 +2467,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 beta_k_rot_values, padded_dim, scratch_stride, k_rot_values, padded_dim,
                 scratch_stride, gemm_a, padded_dim, matrix_stride, static_cast<int32_t>(bh),
                 "phase_a_pkv", "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2241,7 +2474,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 beta_v_values, padded_dim, scratch_stride, k_rot_values, padded_dim, scratch_stride,
                 gemm_b, padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_a_a",
                 "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2249,7 +2481,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 beta_k_values, padded_dim, scratch_stride, k_values, padded_dim, scratch_stride,
                 gemm_c, padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_a_pz",
                 "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         finalize_raw_phase_a_bf16_kernel<<<
@@ -2257,7 +2488,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
             stream>>>(i_p_kv, a_t, i_p_z, gemm_a, gemm_b, gemm_c, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "finalize_phase_a_bf16",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_a_bz_kernel<<<static_cast<uint32_t>((vector_elems_per_frame + kThreads - 1) /
@@ -2265,7 +2495,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                             kThreads, 0, stream>>>(b_z, k, beta, shape, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_a_bz", "main_combined_cublas",
                                      false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
     }
@@ -2283,7 +2512,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                              shape, stream)) {
         const bool failed = report_cuda_launch_error(cudaPeekAtLastError(), "debug_output",
                                                      "main_combined_cublas", false, shape);
-        cublasDestroy(handle);
         return failed ? 1 : 0;
     }
 
@@ -2300,7 +2528,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_fwd",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(t) * matrix_stride;
@@ -2309,7 +2536,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_fwd",
                 "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2318,14 +2544,12 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                             shape, padded_dim, t, t, false);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_fwd_update",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_b_z_bf16_kernel<<<static_cast<uint32_t>(vector_elems_per_frame), 32, 0, stream>>>(
             next_z, state_z, hist_z, i_p_z, b_z, decay, shape, padded_dim, t, t, false);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_z_fwd", "main_combined_cublas",
                                      false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp_kv = state_kv;
@@ -2350,7 +2574,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_rev",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(f_src) * matrix_stride;
@@ -2359,7 +2582,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_rev",
                 "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2368,14 +2590,12 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                             shape, padded_dim, f_src, f_dst, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_rev_update",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_b_z_bf16_kernel<<<static_cast<uint32_t>(vector_elems_per_frame), 32, 0, stream>>>(
             next_z, state_z, hist_z, i_p_z, b_z, decay, shape, padded_dim, f_src, f_dst, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_z_rev", "main_combined_cublas",
                                      false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp_kv = state_kv;
@@ -2393,7 +2613,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                              shape, stream)) {
         const bool failed = report_cuda_launch_error(cudaPeekAtLastError(), "debug_output",
                                                      "main_combined_cublas", false, shape);
-        cublasDestroy(handle);
         return failed ? 1 : 0;
     }
 
@@ -2406,7 +2625,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                                   padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_c_qrot",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         convert_history_frame_to_bf16_kernel<<<
@@ -2414,7 +2632,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
             stream>>>(state_kv_bf16, hist_kv, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "hist_to_bf16_phase_c",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2422,7 +2639,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                 state_kv_bf16, padded_dim, matrix_stride, q_rot_values, padded_dim, scratch_stride,
                 phase_c_num, padded_dim, scratch_stride, static_cast<int32_t>(bh), "phase_c_num",
                 "main_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (debug_phase_c_num) {
@@ -2432,7 +2648,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                                    padded_dim, t, false);
             if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_num_debug",
                                          "main_combined_cublas", false, shape)) {
-                cublasDestroy(handle);
                 return 1;
             }
             continue;
@@ -2443,7 +2658,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
             phase_c_den, hist_z, q, shape, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_den", "main_combined_cublas",
                                      false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (debug_phase_c_den) {
@@ -2452,7 +2666,6 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                             kThreads, 0, stream>>>(out, phase_c_den, shape, t);
             if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_den_debug",
                                          "main_combined_cublas", false, shape)) {
-                cublasDestroy(handle);
                 return 1;
             }
             continue;
@@ -2463,12 +2676,9 @@ int32_t launch_main_combined_cublas(SanaWmGdnShape shape, const void* const* inp
                                                               padded_dim, t, eps);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_output",
                                      "main_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
     }
-
-    cublasDestroy(handle);
     return 0;
 }
 
@@ -2669,9 +2879,8 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
     }
 
     cublasHandle_t handle = nullptr;
-    if (report_cublas_error(cublasCreate(&handle), "create", "main_raw_combined_cublas", shape))
+    if (!get_thread_cublas_handle(handle, stream, "main_raw_combined_cublas", shape))
         return 1;
-    cublasSetStream(handle, stream);
 
     const long long scratch_stride =
         static_cast<long long>(shape.spatial) * static_cast<long long>(padded_dim);
@@ -2687,7 +2896,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
             k_inv, k_norm_weight, rope_cos, rope_sin, beta, shape, padded_dim, t, k_scale);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_a_bf16",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2705,7 +2913,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 beta_k_values, padded_dim, scratch_stride, k_values, padded_dim, scratch_stride,
                 gemm_c, padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_a_pz",
                 "main_raw_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         finalize_raw_phase_a_bf16_kernel<<<
@@ -2713,16 +2920,14 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
             stream>>>(i_p_kv, a_t, i_p_z, gemm_a, gemm_b, gemm_c, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "finalize_phase_a_bf16",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
-        raw_phase_a_bz_kernel<<<static_cast<uint32_t>((vector_elems_per_frame + kThreads - 1) /
-                                                      kThreads),
-                                kThreads, 0, stream>>>(b_z, k_raw, k_inv, k_norm_weight, beta,
-                                                       shape, t, k_scale);
+        raw_phase_a_bz_kernel<<<
+            static_cast<uint32_t>((vector_elems_per_frame * kRawBzThreadsPerOutput + kThreads - 1) /
+                                  kThreads),
+            kThreads, 0, stream>>>(b_z, k_raw, k_inv, k_norm_weight, beta, shape, t, k_scale);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_a_bz",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
     }
@@ -2741,7 +2946,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                              shape, stream)) {
         const bool failed = report_cuda_launch_error(cudaPeekAtLastError(), "debug_output",
                                                      "main_raw_combined_cublas", false, shape);
-        cublasDestroy(handle);
         return failed ? 1 : 0;
     }
 
@@ -2758,7 +2962,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_fwd",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(t) * matrix_stride;
@@ -2767,7 +2970,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_fwd",
                 "main_raw_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2776,14 +2978,12 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                                             shape, padded_dim, t, t, false);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_fwd_update",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_b_z_bf16_kernel<<<static_cast<uint32_t>(vector_elems_per_frame), 32, 0, stream>>>(
             next_z, state_z, hist_z, i_p_z, b_z, decay, shape, padded_dim, t, t, false);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_z_fwd",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp_kv = state_kv;
@@ -2808,7 +3008,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                                               padded_dim);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "state_to_bf16_rev",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         const auto* i_p_frame = i_p_kv + static_cast<std::size_t>(f_src) * matrix_stride;
@@ -2817,7 +3016,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 padded_dim, matrix_stride, i_p_frame, padded_dim, frame_matrix_stride, gemm_a,
                 padded_dim, matrix_stride, static_cast<int32_t>(bh), "phase_b_rev",
                 "main_raw_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         update_padded_state_kernel<<<static_cast<uint32_t>((matrix_elems_per_frame + kThreads - 1) /
@@ -2826,14 +3024,12 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                                             shape, padded_dim, f_src, f_dst, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_kv_rev_update",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_b_z_bf16_kernel<<<static_cast<uint32_t>(vector_elems_per_frame), 32, 0, stream>>>(
             next_z, state_z, hist_z, i_p_z, b_z, decay, shape, padded_dim, f_src, f_dst, true);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_b_z_rev",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         float* tmp_kv = state_kv;
@@ -2852,7 +3048,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                                              shape, stream)) {
         const bool failed = report_cuda_launch_error(cudaPeekAtLastError(), "debug_output",
                                                      "main_raw_combined_cublas", false, shape);
-        cublasDestroy(handle);
         return failed ? 1 : 0;
     }
 
@@ -2866,10 +3061,8 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
             padded_dim, eps);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_scalar_output",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
-        cublasDestroy(handle);
         return 0;
     }
     for (int32_t t = 0; t < shape.frames; ++t) {
@@ -2879,7 +3072,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
             q_rot_values, q_raw, q_inv, q_norm_weight, rope_cos, rope_sin, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "prepare_phase_c_qrot",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         convert_history_frame_to_bf16_kernel<<<
@@ -2887,7 +3079,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
             stream>>>(state_kv_bf16, hist_kv, shape, padded_dim, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "hist_to_bf16_phase_c",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (!cublas_bf16_gemm_strided_batched(
@@ -2895,14 +3086,12 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 state_kv_bf16, padded_dim, matrix_stride, q_rot_values, padded_dim, scratch_stride,
                 phase_c_num, padded_dim, scratch_stride, static_cast<int32_t>(bh), "phase_c_num",
                 "main_raw_combined_cublas", shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         phase_c_raw_den_bf16_kernel<<<static_cast<uint32_t>(bh * shape.spatial), 32, 0, stream>>>(
             phase_c_den, hist_z, q_raw, q_inv, q_norm_weight, shape, t);
         if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_den",
                                      "main_raw_combined_cublas", false, shape)) {
-            cublasDestroy(handle);
             return 1;
         }
         if (debug_phase_c_num) {
@@ -2911,7 +3100,6 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 0, stream>>>(out, phase_c_num, shape, padded_dim, t);
             if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_num_debug",
                                          "main_raw_combined_cublas", false, shape)) {
-                cublasDestroy(handle);
                 return 1;
             }
         } else if (debug_phase_c_den) {
@@ -2920,22 +3108,26 @@ int32_t launch_main_raw_combined_cublas(SanaWmGdnShape shape, const void* const*
                 0, stream>>>(out, phase_c_den, shape, t);
             if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_den_debug",
                                          "main_raw_combined_cublas", false, shape)) {
-                cublasDestroy(handle);
                 return 1;
             }
         } else {
-            phase_c_raw_cublas_output_kernel<<<
-                static_cast<uint32_t>((output_elems_per_frame + kThreads - 1) / kThreads), kThreads,
-                0, stream>>>(out, phase_c_num, phase_c_den, shape, padded_dim, t, eps);
+            if (shape.head_dim % 4 == 0) {
+                const int64_t output_vectors = output_elems_per_frame / 4;
+                phase_c_raw_cublas_output_vectorized_kernel<<<
+                    static_cast<uint32_t>((output_vectors + kThreads - 1) / kThreads), kThreads, 0,
+                    stream>>>(out, phase_c_num, phase_c_den, shape, padded_dim, t, eps);
+            } else {
+                phase_c_raw_cublas_output_kernel<<<
+                    static_cast<uint32_t>((output_elems_per_frame + kThreads - 1) / kThreads),
+                    kThreads, 0, stream>>>(out, phase_c_num, phase_c_den, shape, padded_dim, t,
+                                           eps);
+            }
             if (report_cuda_launch_error(cudaPeekAtLastError(), "phase_c_output",
                                          "main_raw_combined_cublas", false, shape)) {
-                cublasDestroy(handle);
                 return 1;
             }
         }
     }
-
-    cublasDestroy(handle);
     return 0;
 }
 
@@ -3115,6 +3307,67 @@ int32_t launch_main_raw_combined(SanaWmGdnShape shape, const void* const* inputs
 }
 
 } // namespace
+
+int32_t launch_sana_wm_short_conv(void* output, const void* input, const void* weight,
+                                  const void* bias, int32_t batch, int32_t frames, int32_t spatial,
+                                  int32_t channels, int32_t kernel_size,
+                                  cudaStream_t stream) noexcept {
+    if (output == nullptr || input == nullptr || weight == nullptr || batch <= 0 || frames <= 0 ||
+        spatial <= 0 || channels <= 0 || kernel_size <= 0) {
+        return 1;
+    }
+    constexpr int32_t kThreads = 256;
+    const int64_t total =
+        static_cast<int64_t>(batch) * frames * spatial * static_cast<int64_t>(channels);
+    sana_wm_short_conv_kernel<<<static_cast<uint32_t>((total + kThreads - 1) / kThreads), kThreads,
+                                0, stream>>>(
+        static_cast<uint16_t*>(output), static_cast<const uint16_t*>(input),
+        static_cast<const uint16_t*>(weight), static_cast<const uint16_t*>(bias), batch, frames,
+        spatial, channels, kernel_size);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_sana_wm_bias_silu(void* values, const void* bias, int32_t rows, int32_t spatial,
+                                 int32_t channels, cudaStream_t stream) noexcept {
+    if (values == nullptr || rows <= 0 || spatial <= 0 || channels <= 0)
+        return 1;
+    constexpr int32_t kThreads = 256;
+    const int64_t total = static_cast<int64_t>(rows) * spatial * channels;
+    sana_wm_bias_silu_kernel<<<static_cast<uint32_t>((total + kThreads - 1) / kThreads), kThreads,
+                               0, stream>>>(static_cast<uint16_t*>(values),
+                                            static_cast<const uint16_t*>(bias), total, channels);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_sana_wm_gated_silu(void* output, const void* input, const void* bias, int32_t rows,
+                                  int32_t spatial, int32_t hidden, cudaStream_t stream) noexcept {
+    if (output == nullptr || input == nullptr || rows <= 0 || spatial <= 0 || hidden <= 0)
+        return 1;
+    constexpr int32_t kThreads = 256;
+    const int64_t total = static_cast<int64_t>(rows) * spatial * hidden;
+    sana_wm_gated_silu_kernel<<<static_cast<uint32_t>((total + kThreads - 1) / kThreads), kThreads,
+                                0, stream>>>(static_cast<uint16_t*>(output),
+                                             static_cast<const uint16_t*>(input),
+                                             static_cast<const uint16_t*>(bias), total, hidden);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_sana_wm_t2i_modulate(void* output, const void* input, const void* shift,
+                                    const void* scale, int32_t batch, int32_t frames,
+                                    int32_t tokens, int32_t hidden, cudaStream_t stream) noexcept {
+    if (output == nullptr || input == nullptr || shift == nullptr || scale == nullptr ||
+        batch <= 0 || frames <= 0 || tokens <= 0 || hidden <= 0) {
+        return 1;
+    }
+    constexpr int32_t kThreads = 256;
+    const int64_t total = static_cast<int64_t>(batch) * frames * tokens * hidden;
+    sana_wm_t2i_modulate_kernel<<<static_cast<uint32_t>((total + kThreads - 1) / kThreads),
+                                  kThreads, 0, stream>>>(
+        static_cast<uint16_t*>(output), static_cast<const uint16_t*>(input),
+        static_cast<const uint16_t*>(shift), static_cast<const uint16_t*>(scale), total, tokens,
+        hidden);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
 
 SanaWmUcpePlugin::SanaWmUcpePlugin(int32_t frames, int32_t spatial, int32_t heads, int32_t head_dim,
                                    bool inverse, bool tree_reduce, bool downscale, bool double_rope,
@@ -3434,18 +3687,39 @@ int32_t SanaWmCamPrepPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc
         return 1;
     }
     const int32_t prep_blocks = shape.batch * shape.tokens * shape.heads;
+    dim3 output_threads(32, 8);
+    dim3 output_blocks((shape.tokens + 31) / 32, (shape.head_dim + 31) / 32,
+                       shape.batch * shape.heads);
     const float k_scale = 1.0F / std::sqrt(static_cast<float>(shape.head_dim)) *
                           (1.0F / std::sqrt(static_cast<float>(spatial_)));
     if (raw_type == nvinfer1::DataType::kBF16) {
-        cam_prep_kernel<true><<<prep_blocks, prep_threads, 0, stream>>>(
-            q_out, k_out, v_out, inflation_sq, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
+        cam_prep_output_tiled_kernel<true><<<output_blocks, output_threads, 0, stream>>>(
+            q_out, k_out, v_out, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
+            static_cast<const float*>(inputs[7]), static_cast<const float*>(inputs[8]),
+            static_cast<const float*>(inputs[3]), static_cast<const float*>(inputs[4]),
+            static_cast<const float*>(inputs[5]), static_cast<const float*>(inputs[6]), shape,
+            k_scale);
+        if (cudaPeekAtLastError() != cudaSuccess) {
+            return 1;
+        }
+        cam_prep_inflation_kernel<true><<<prep_blocks, prep_threads, 0, stream>>>(
+            inflation_sq, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
             static_cast<const float*>(inputs[7]), static_cast<const float*>(inputs[8]),
             static_cast<const float*>(inputs[3]), static_cast<const float*>(inputs[4]),
             static_cast<const float*>(inputs[5]), static_cast<const float*>(inputs[6]), shape,
             k_scale);
     } else {
-        cam_prep_kernel<false><<<prep_blocks, prep_threads, 0, stream>>>(
-            q_out, k_out, v_out, inflation_sq, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
+        cam_prep_output_tiled_kernel<false><<<output_blocks, output_threads, 0, stream>>>(
+            q_out, k_out, v_out, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
+            static_cast<const float*>(inputs[7]), static_cast<const float*>(inputs[8]),
+            static_cast<const float*>(inputs[3]), static_cast<const float*>(inputs[4]),
+            static_cast<const float*>(inputs[5]), static_cast<const float*>(inputs[6]), shape,
+            k_scale);
+        if (cudaPeekAtLastError() != cudaSuccess) {
+            return 1;
+        }
+        cam_prep_inflation_kernel<false><<<prep_blocks, prep_threads, 0, stream>>>(
+            inflation_sq, inputs[0], inputs[1], inputs[2], q_inv, k_inv,
             static_cast<const float*>(inputs[7]), static_cast<const float*>(inputs[8]),
             static_cast<const float*>(inputs[3]), static_cast<const float*>(inputs[4]),
             static_cast<const float*>(inputs[5]), static_cast<const float*>(inputs[6]), shape,

--- a/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_gdn_plugin.h
+++ b/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_gdn_plugin.h
@@ -183,6 +183,18 @@ class SanaWmCamPrepPlugin : public nvinfer1::IPluginV2DynamicExt {
 };
 
 #if TRTMC_HAS_LIBTORCH_CONV
+int32_t launch_sana_wm_short_conv(void* output, const void* input, const void* weight,
+                                  const void* bias, int32_t batch, int32_t frames, int32_t spatial,
+                                  int32_t channels, int32_t kernel_size,
+                                  cudaStream_t stream) noexcept;
+int32_t launch_sana_wm_bias_silu(void* values, const void* bias, int32_t rows, int32_t spatial,
+                                 int32_t channels, cudaStream_t stream) noexcept;
+int32_t launch_sana_wm_gated_silu(void* output, const void* input, const void* bias, int32_t rows,
+                                  int32_t spatial, int32_t hidden, cudaStream_t stream) noexcept;
+int32_t launch_sana_wm_t2i_modulate(void* output, const void* input, const void* shift,
+                                    const void* scale, int32_t batch, int32_t frames,
+                                    int32_t tokens, int32_t hidden, cudaStream_t stream) noexcept;
+
 class SanaWmTorchConv2dPlugin : public nvinfer1::IPluginV2DynamicExt {
   public:
     SanaWmTorchConv2dPlugin() = default;

--- a/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_torch_conv2d_plugin.cpp
+++ b/python/tensorrt_model_connect/families/sana_wm/native_plugins/sana_wm_torch_conv2d_plugin.cpp
@@ -14,7 +14,6 @@
 #include <ATen/ops/amin.h>
 #include <ATen/ops/cat.h>
 #include <ATen/ops/constant_pad_nd.h>
-#include <ATen/ops/conv1d.h>
 #include <ATen/ops/conv2d.h>
 #include <ATen/ops/conv3d.h>
 #include <ATen/ops/cos.h>
@@ -154,11 +153,6 @@ bool report_timestep_error(const char* op, const char* detail) {
     return true;
 }
 
-bool report_t2i_error(const char* op, const char* detail) {
-    std::fprintf(stderr, "[trtmc.sana_wm_t2i_modulate] %s failed: %s\n", op, detail);
-    return true;
-}
-
 bool report_frame_gate_error(const char* op, const char* detail) {
     std::fprintf(stderr, "[trtmc.sana_wm_frame_gate] %s failed: %s\n", op, detail);
     return true;
@@ -196,11 +190,6 @@ bool report_frame_mean_error(const char* op, const char* detail) {
 
 bool report_layer_norm_error(const char* op, const char* detail) {
     std::fprintf(stderr, "[trtmc.sana_wm_layer_norm] %s failed: %s\n", op, detail);
-    return true;
-}
-
-bool report_short_conv_error(const char* op, const char* detail) {
-    std::fprintf(stderr, "[trtmc.sana_wm_short_conv] %s failed: %s\n", op, detail);
     return true;
 }
 
@@ -470,8 +459,6 @@ int32_t SanaWmTorchConv2dPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
         auto output_view = at::from_blob(
             outputs[0], {shape.batch, out_channels_, shape.height, shape.width}, options);
         output_view.copy_(output);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_torch_conv_error("aten conv2d", e.what());
@@ -760,8 +747,6 @@ int32_t SanaWmTorchConv3dPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
         auto output_view = at::from_blob(
             outputs[0], {shape.batch, out_channels_, output_t_, output_h_, output_w_}, options);
         output_view.copy_(output);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_torch_conv3d_error("aten conv3d", e.what());
@@ -880,8 +865,6 @@ int32_t SanaWmVaeRmsSiluPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputD
         auto output = at::silu(at::div(input, rms));
         auto output_view = at::from_blob(outputs[0], dimensions, options);
         output_view.copy_(output);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_vae_rms_silu_error("aten rms norm + silu", e.what());
@@ -1044,8 +1027,6 @@ int32_t SanaWmVaeDenormalizePlugin::enqueue(nvinfer1::PluginTensorDesc const* in
         auto result = input * std / scaling_factor_ + mean;
         auto output = at::from_blob(outputs[0], dimensions, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         report_vae_rms_silu_error("aten VAE denormalize", error.what());
@@ -1212,8 +1193,6 @@ int32_t SanaWmVaeLayerNormPlugin::enqueue(nvinfer1::PluginTensorDesc const* inpu
                           .movedim(-1, 1);
         auto output = at::from_blob(outputs[0], dimensions, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         report_layer_norm_error("aten VAE channel layer_norm", error.what());
@@ -1494,32 +1473,30 @@ int32_t SanaWmGlumbconvTempPlugin::enqueue(nvinfer1::PluginTensorDesc const* inp
         auto t_weight =
             at::from_blob(t_weight_device_, {channels_, channels_, t_kernel_, 1}, options);
 
-        std::optional<at::Tensor> inverted_bias;
-        if (inverted_bias_device_ != nullptr)
-            inverted_bias = at::from_blob(inverted_bias_device_, {expanded}, options);
-        std::optional<at::Tensor> depth_bias;
-        if (depth_bias_device_ != nullptr)
-            depth_bias = at::from_blob(depth_bias_device_, {expanded}, options);
-
         const std::array<int64_t, 2> stride{1, 1};
         const std::array<int64_t, 2> dilation{1, 1};
         const std::array<int64_t, 2> pad_none{0, 0};
         const std::array<int64_t, 2> pad_depth{1, 1};
         const std::array<int64_t, 2> pad_temporal{t_kernel_ / 2, 0};
+        const int32_t rows = batch_ * frames_;
+        const int32_t spatial = height_ * width_;
 
         auto x =
             input.reshape({batch_ * frames_, height_, width_, channels_}).permute({0, 3, 1, 2});
-        auto inverted =
-            at::conv2d(x, inverted_weight, inverted_bias, stride, pad_none, dilation, 1);
-        inverted = at::silu(inverted);
-        auto depth =
-            at::conv2d(inverted, depth_weight, depth_bias, stride, pad_depth, dilation, expanded);
-        auto chunks = depth.chunk(2, 1);
-        if (chunks.size() != 2)
+        auto inverted = at::conv2d(x, inverted_weight, std::nullopt, stride, pad_none, dilation, 1);
+        if (launch_sana_wm_bias_silu(inverted.data_ptr(), inverted_bias_device_, rows, spatial,
+                                     expanded, stream) != 0) {
             return 1;
-        auto gated = chunks[0] * at::silu(chunks[1]);
+        }
+        auto depth =
+            at::conv2d(inverted, depth_weight, std::nullopt, stride, pad_depth, dilation, expanded);
+        auto gated =
+            at::empty({rows, hidden_, height_, width_}, options, at::MemoryFormat::ChannelsLast);
+        if (launch_sana_wm_gated_silu(gated.data_ptr(), depth.data_ptr(), depth_bias_device_, rows,
+                                      spatial, hidden_, stream) != 0) {
+            return 1;
+        }
         auto point = at::conv2d(gated, point_weight, std::nullopt, stride, pad_none, dilation, 1);
-        const int32_t spatial = height_ * width_;
         auto point_bcts = point.view({batch_, frames_, channels_, spatial}).permute({0, 2, 1, 3});
         auto temporal =
             at::conv2d(point_bcts, t_weight, std::nullopt, stride, pad_temporal, dilation, 1);
@@ -1527,8 +1504,6 @@ int32_t SanaWmGlumbconvTempPlugin::enqueue(nvinfer1::PluginTensorDesc const* inp
             (point_bcts + temporal).permute({0, 2, 3, 1}).reshape({batch_, token_count, channels_});
         auto output_view = at::from_blob(outputs[0], {batch_, token_count, channels_}, options);
         output_view.copy_(out);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_glumbconvtemp_error("aten glumbconvtemp", e.what());
@@ -1819,8 +1794,6 @@ int32_t SanaWmTimestepEmbedPlugin::enqueue(nvinfer1::PluginTensorDesc const* inp
         auto output_t0 =
             at::from_blob(outputs[1], {batch, 1, frames, 6 * hidden_size_}, bf16_options);
         output_t0.copy_(t0.reshape({batch, 1, frames, 6 * hidden_size_}));
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_timestep_error("aten timestep embed", e.what());
@@ -1909,50 +1882,24 @@ int32_t SanaWmT2IModulatePlugin::enqueue(nvinfer1::PluginTensorDesc const* input
                                          nvinfer1::PluginTensorDesc const*,
                                          void const* const* inputs, void* const* outputs, void*,
                                          cudaStream_t stream) noexcept {
-    try {
-        const auto x_dims = inputDesc[0].dims;
-        const auto shift_dims = inputDesc[1].dims;
-        const auto scale_dims = inputDesc[2].dims;
-        if (x_dims.nbDims != 4 || shift_dims.nbDims != 4 || scale_dims.nbDims != 4)
-            return 1;
-        const int32_t batch = x_dims.d[0];
-        const int32_t frames = x_dims.d[1];
-        const int32_t tokens = x_dims.d[2];
-        const int32_t hidden = x_dims.d[3];
-        if (batch <= 0 || frames <= 0 || tokens <= 0 || hidden <= 0)
-            return 1;
-        if (shift_dims.d[0] != batch || shift_dims.d[1] != frames || shift_dims.d[2] != 1 ||
-            shift_dims.d[3] != hidden || scale_dims.d[0] != batch || scale_dims.d[1] != frames ||
-            scale_dims.d[2] != 1 || scale_dims.d[3] != hidden) {
-            return 1;
-        }
-
-        int device_index = 0;
-        if (cudaGetDevice(&device_index) != cudaSuccess)
-            return 1;
-        const auto torch_stream = c10::cuda::getStreamFromExternal(stream, device_index);
-        c10::cuda::CUDAStreamGuard guard(torch_stream);
-        const auto options =
-            at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, device_index);
-        auto x =
-            at::from_blob(const_cast<void*>(inputs[0]), {batch, frames, tokens, hidden}, options);
-        auto shift =
-            at::from_blob(const_cast<void*>(inputs[1]), {batch, frames, 1, hidden}, options);
-        auto scale =
-            at::from_blob(const_cast<void*>(inputs[2]), {batch, frames, 1, hidden}, options);
-        auto result = x * (scale + 1) + shift;
-        auto output = at::from_blob(outputs[0], {batch, frames, tokens, hidden}, options);
-        output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
-        return 0;
-    } catch (const c10::Error& e) {
-        report_t2i_error("aten t2i_modulate", e.what());
+    const auto x_dims = inputDesc[0].dims;
+    const auto shift_dims = inputDesc[1].dims;
+    const auto scale_dims = inputDesc[2].dims;
+    if (x_dims.nbDims != 4 || shift_dims.nbDims != 4 || scale_dims.nbDims != 4)
         return 1;
-    } catch (const std::exception& e) {
-        report_t2i_error("aten t2i_modulate", e.what());
+    const int32_t batch = x_dims.d[0];
+    const int32_t frames = x_dims.d[1];
+    const int32_t tokens = x_dims.d[2];
+    const int32_t hidden = x_dims.d[3];
+    if (batch <= 0 || frames <= 0 || tokens <= 0 || hidden <= 0)
+        return 1;
+    if (shift_dims.d[0] != batch || shift_dims.d[1] != frames || shift_dims.d[2] != 1 ||
+        shift_dims.d[3] != hidden || scale_dims.d[0] != batch || scale_dims.d[1] != frames ||
+        scale_dims.d[2] != 1 || scale_dims.d[3] != hidden) {
         return 1;
     }
+    return launch_sana_wm_t2i_modulate(outputs[0], inputs[0], inputs[1], inputs[2], batch, frames,
+                                       tokens, hidden, stream);
 }
 
 SanaWmCaptionEmbedPlugin::SanaWmCaptionEmbedPlugin(int32_t hidden_size)
@@ -2090,8 +2037,6 @@ int32_t SanaWmCaptionEmbedPlugin::enqueue(nvinfer1::PluginTensorDesc const* inpu
 
         auto output = at::from_blob(outputs[0], {batch, groups, length, hidden_size_}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_caption_embed_error("aten caption embed", e.what());
@@ -2275,8 +2220,6 @@ int32_t SanaWmCrossAttentionPlugin::enqueue(nvinfer1::PluginTensorDesc const* in
 
         auto output = at::from_blob(outputs[0], {batch, token_count, hidden}, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_cross_attention_error("aten cross attention", e.what());
@@ -2553,29 +2496,18 @@ int32_t SanaWmSoftmaxAttentionPlugin::enqueue(nvinfer1::PluginTensorDesc const* 
                 return at::cat({geometric, rope}, -1);
             };
 
-            auto q_bhdn = rms_norm(q_raw, q_weight)
+            auto q_bhnd = rms_norm(q_raw, q_weight)
                               .reshape({batch, tokens, heads_, head_dim_})
-                              .permute({0, 2, 3, 1})
-                              .contiguous();
-            auto k_bhdn = rms_norm(k_raw, k_weight)
+                              .permute({0, 2, 1, 3});
+            auto k_bhnd = rms_norm(k_raw, k_weight)
                               .reshape({batch, tokens, heads_, head_dim_})
-                              .permute({0, 2, 3, 1})
-                              .contiguous();
-            auto v_bhdn = v_raw.reshape({batch, tokens, heads_, head_dim_})
-                              .permute({0, 2, 3, 1})
-                              .contiguous();
-            auto q_trans =
-                apply_camera(q_bhdn.transpose(-1, -2), p_t, false).transpose(-1, -2).contiguous();
-            auto kv_bhdn = at::cat({k_bhdn, v_bhdn}, 1);
-            auto kv_trans = apply_camera(kv_bhdn.transpose(-1, -2), p_inv, false)
-                                .transpose(-1, -2)
-                                .contiguous();
-            auto k_trans = kv_trans.slice(1, 0, heads_);
-            auto v_trans = kv_trans.slice(1, heads_, 2 * heads_);
-
-            auto q = q_trans.transpose(-1, -2);
-            auto k = k_trans.transpose(-1, -2);
-            auto v = v_trans.transpose(-1, -2);
+                              .permute({0, 2, 1, 3});
+            auto v_bhnd = v_raw.reshape({batch, tokens, heads_, head_dim_}).permute({0, 2, 1, 3});
+            auto q = apply_camera(q_bhnd, p_t, false);
+            auto kv_bhnd = at::cat({k_bhnd, v_bhnd}, 1);
+            auto kv_trans = apply_camera(kv_bhnd, p_inv, false);
+            auto k = kv_trans.slice(1, 0, heads_);
+            auto v = kv_trans.slice(1, heads_, 2 * heads_);
             const int32_t padded_dim = head_dim_ == 32 || head_dim_ == 64 || head_dim_ == 128 ||
                                                head_dim_ == 256 || head_dim_ >= 256
                                            ? head_dim_
@@ -2589,16 +2521,15 @@ int32_t SanaWmSoftmaxAttentionPlugin::enqueue(nvinfer1::PluginTensorDesc const* 
             auto out = at::scaled_dot_product_attention(q, k, v, std::nullopt, 0.0, false);
             if (padded_dim != head_dim_)
                 out = out.slice(-1, 0, head_dim_);
-            out = out.transpose(-1, -2);
-            auto out_trans =
-                apply_camera(out.transpose(-1, -2), p, true).transpose(-1, -2).contiguous();
-            result = out_trans.reshape({batch, channels, tokens}).permute({0, 2, 1});
+            auto out_trans = apply_camera(out, p, true);
+            auto output =
+                at::from_blob(outputs[0], {batch, tokens, heads_, head_dim_}, bf16_options);
+            output.copy_(out_trans.permute({0, 2, 1, 3}));
+            return 0;
         }
 
         auto output = at::from_blob(outputs[0], {batch, tokens, channels}, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_softmax_attention_error("aten softmax attention", e.what());
@@ -2891,8 +2822,6 @@ int32_t SanaWmTorchCamPrepPlugin::enqueue(nvinfer1::PluginTensorDesc const* inpu
         at::from_blob(outputs[1], qkv_shape, float_options).copy_(k_out.to(at::kFloat));
         at::from_blob(outputs[2], qkv_shape, float_options).copy_(v_out.to(at::kFloat));
         at::from_blob(outputs[3], {batch, heads_, tokens}, float_options).copy_(inflation);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_torch_cam_prep_error("aten camera prep", e.what());
@@ -3034,8 +2963,6 @@ int32_t SanaWmCameraBetaDiscountPlugin::enqueue(nvinfer1::PluginTensorDesc const
         auto discounted = beta.to(at::kFloat) / frame_inflation.unsqueeze(-1);
         at::from_blob(outputs[0], {batch, heads_, frames_, spatial_}, float_options)
             .copy_(discounted);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_camera_beta_discount_error("aten beta discount", e.what());
@@ -3152,8 +3079,6 @@ int32_t SanaWmFrameGatePlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDe
         auto result = (tokens * gate).reshape({batch, token_count, hidden});
         auto output = at::from_blob(outputs[0], {batch, token_count, hidden}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_frame_gate_error("aten frame gate", e.what());
@@ -3280,8 +3205,6 @@ int32_t SanaWmFrameMeanPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDe
         auto result = x.mean(2);
         auto output = at::from_blob(outputs[0], {batch, frames_, hidden}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_frame_mean_error("aten mean", e.what());
@@ -3402,8 +3325,6 @@ int32_t SanaWmLayerNormPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDe
         auto result = at::layer_norm(x, {hidden}, {}, {}, static_cast<double>(eps_), true);
         auto output = at::from_blob(outputs[0], shape, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         (void)count;
         return 0;
     } catch (const c10::Error& e) {
@@ -3579,65 +3500,20 @@ bool SanaWmShortConvPlugin::ensureDeviceCache(cudaStream_t stream, int32_t devic
 int32_t SanaWmShortConvPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc,
                                        nvinfer1::PluginTensorDesc const*, void const* const* inputs,
                                        void* const* outputs, void*, cudaStream_t stream) noexcept {
-    try {
-        const auto dims = inputDesc[0].dims;
-        const int32_t expected_weight = channels_ * kernel_size_;
-        if (dims.nbDims != 3 || dims.d[0] <= 0 || dims.d[1] != frames_ * spatial_ ||
-            dims.d[2] != channels_ || frames_ <= 0 || spatial_ <= 0 || channels_ <= 0 ||
-            kernel_size_ <= 0 || static_cast<int32_t>(weight_.size()) != expected_weight) {
-            return 1;
-        }
-        const int32_t batch = dims.d[0];
-        int device_index = 0;
-        if (cudaGetDevice(&device_index) != cudaSuccess)
-            return 1;
-        if (!ensureDeviceCache(stream, device_index))
-            return 1;
-        const auto torch_stream = c10::cuda::getStreamFromExternal(stream, device_index);
-        c10::cuda::CUDAStreamGuard guard(torch_stream);
-        const auto options =
-            at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, device_index);
-        auto x = at::from_blob(const_cast<void*>(inputs[0]), {batch, frames_ * spatial_, channels_},
-                               options);
-        auto temporal = x.reshape({batch, frames_, spatial_, channels_})
-                            .permute({0, 2, 1, 3})
-                            .contiguous()
-                            .reshape({batch * spatial_, frames_, channels_});
-        auto weight = at::from_blob(weight_device_, {channels_, 1, kernel_size_}, options);
-        std::optional<at::Tensor> bias;
-        if (bias_device_ != nullptr)
-            bias = at::from_blob(bias_device_, {channels_}, options);
-        const std::array<int64_t, 1> stride{1};
-        const std::array<int64_t, 1> padding{0};
-        const std::array<int64_t, 1> dilation{1};
-
-        auto causal = [&](const at::Tensor& btc) {
-            auto bct = btc.transpose(1, 2).contiguous();
-            auto padded = at::constant_pad_nd(bct, {kernel_size_ - 1, 0}, 0);
-            auto y = at::conv1d(padded, weight, bias, stride, padding, dilation, channels_);
-            return y.transpose(1, 2).contiguous();
-        };
-
-        auto y_fwd = causal(temporal);
-        auto y_bwd = causal(temporal.flip({1})).flip({1});
-        auto center = weight.select(2, kernel_size_ - 1).reshape({1, 1, channels_});
-        auto combined = y_fwd + y_bwd - temporal * center;
-        auto restored = combined.reshape({batch, spatial_, frames_, channels_})
-                            .permute({0, 2, 1, 3})
-                            .contiguous()
-                            .reshape({batch, frames_ * spatial_, channels_});
-        auto output = at::from_blob(outputs[0], {batch, frames_ * spatial_, channels_}, options);
-        output.copy_(restored);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
-        return 0;
-    } catch (const c10::Error& e) {
-        report_short_conv_error("aten short conv", e.what());
-        return 1;
-    } catch (const std::exception& e) {
-        report_short_conv_error("aten short conv", e.what());
+    const auto dims = inputDesc[0].dims;
+    const int32_t expected_weight = channels_ * kernel_size_;
+    if (dims.nbDims != 3 || dims.d[0] <= 0 || dims.d[1] != frames_ * spatial_ ||
+        dims.d[2] != channels_ || frames_ <= 0 || spatial_ <= 0 || channels_ <= 0 ||
+        kernel_size_ <= 0 || static_cast<int32_t>(weight_.size()) != expected_weight) {
         return 1;
     }
+    int32_t device_index = 0;
+    if (cudaGetDevice(&device_index) != cudaSuccess)
+        return 1;
+    if (!ensureDeviceCache(stream, device_index))
+        return 1;
+    return launch_sana_wm_short_conv(outputs[0], inputs[0], weight_device_, bias_device_, dims.d[0],
+                                     frames_, spatial_, channels_, kernel_size_, stream);
 }
 
 SanaWmGateProjPlugin::SanaWmGateProjPlugin(int32_t input_dim, int32_t output_dim,
@@ -3892,8 +3768,6 @@ int32_t SanaWmGateProjPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDes
         const auto output_options = activation_ == 2 ? options.dtype(at::kFloat) : options;
         auto output = at::from_blob(outputs[0], output_shape, output_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_gate_proj_error("aten linear", e.what());
@@ -4059,8 +3933,6 @@ int32_t SanaWmDecayPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc,
         auto result = at::exp(-(a * at::softplus(gate_dt, 1.0, 20.0)));
         auto output = at::from_blob(outputs[0], {batch, frames, heads_}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_decay_error("aten decay", e.what());
@@ -4191,8 +4063,6 @@ int32_t SanaWmGemmaRmsNormPlugin::enqueue(nvinfer1::PluginTensorDesc const* inpu
         auto result = (normalized * weight).to(at::kBFloat16);
         auto output = at::from_blob(outputs[0], shape, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_gemma_rms_norm_error("aten rms norm", e.what());
@@ -4306,8 +4176,6 @@ int32_t SanaWmGemmaGatedGeluPlugin::enqueue(nvinfer1::PluginTensorDesc const* in
         auto result = at::gelu(gate, "tanh") * up;
         auto output = at::from_blob(outputs[0], shape, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_gemma_gated_gelu_error("aten gated gelu", e.what());
@@ -4466,8 +4334,6 @@ int32_t SanaWmGemmaRopePlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDe
             result = at::cat({result, q.slice(-1, rotary_dim_, head_dim_)}, -1);
         auto output = at::from_blob(outputs[0], {rows, heads_, head_dim_}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_gemma_rope_error("aten rope", e.what());
@@ -4656,8 +4522,6 @@ int32_t SanaWmGemmaAttentionPlugin::enqueue(nvinfer1::PluginTensorDesc const* in
         auto result = context.transpose(1, 2).reshape({query_rows, heads_ * head_dim_});
         auto output = at::from_blob(outputs[0], {query_rows, heads_ * head_dim_}, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& e) {
         report_gemma_attention_error("aten scaled_dot_product_attention", e.what());
@@ -4812,8 +4676,6 @@ int32_t SanaWmLtxTextNormalizePlugin::enqueue(nvinfer1::PluginTensorDesc const* 
 
         auto output = at::from_blob(outputs[0], {batch, seq_len, packed_dim}, bf16_options);
         output.copy_(normalized);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_text_normalize] %s\n", error.what());
@@ -4982,8 +4844,6 @@ int32_t SanaWmLtxRegisterPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
         auto result = flipped * padded + (1 - flipped) * registers;
         auto output = at::from_blob(outputs[0], {1, seq_len, hidden_dim_}, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_register] %s\n", error.what());
@@ -5263,8 +5123,6 @@ int32_t SanaWmLtxConnectorBlockPlugin::enqueue(nvinfer1::PluginTensorDesc const*
 
         auto output = at::from_blob(outputs[0], {1, seq_len, hidden_dim_}, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_connector_block] %s\n", error.what());
@@ -5366,8 +5224,6 @@ int32_t SanaWmLtxRmsNormPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputD
         auto result = at::rms_norm(input, normalized_shape, std::nullopt, eps_);
         auto output = at::from_blob(outputs[0], shape, options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_rms_norm] %s\n", error.what());
@@ -5485,8 +5341,6 @@ int32_t SanaWmLtxTimestepFrequencyPlugin::enqueue(nvinfer1::PluginTensorDesc con
         auto result = at::cat({at::cos(args), at::sin(args)}, -1).to(at::kBFloat16);
         auto output = at::from_blob(outputs[0], {rows, frequency_dim_}, bf16_options);
         output.copy_(result);
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_timestep_frequency] %s\n", error.what());
@@ -5801,8 +5655,6 @@ int32_t SanaWmLtxVideoBlockPlugin::enqueue(nvinfer1::PluginTensorDesc const* inp
             for (int32_t i = 0; i < static_cast<int32_t>(debug_values.size()); ++i)
                 write(i + 1, debug_values[static_cast<size_t>(i)]);
         }
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_video_block] %s\n", error.what());
@@ -5993,8 +5845,6 @@ int32_t SanaWmLtxVideoOutputPlugin::enqueue(nvinfer1::PluginTensorDesc const* in
             (latent.to(at::kFloat) - velocity.to(at::kFloat) * raw_timestep).to(at::kBFloat16);
         auto output = at::from_blob(outputs[0], {tokens, output_dim_}, bf16_options);
         output.copy_(denoised.reshape({tokens, output_dim_}));
-        if (cudaStreamSynchronize(stream) != cudaSuccess)
-            return 1;
         return 0;
     } catch (const c10::Error& error) {
         std::fprintf(stderr, "[trtmc.sana_wm_ltx_video_output] %s\n", error.what());

--- a/tests/builder/test_sana_wm_builder_performance_contract.py
+++ b/tests/builder/test_sana_wm_builder_performance_contract.py
@@ -35,3 +35,118 @@ def test_production_builders_do_not_suppress_tensorrt_search(relative_path: str)
     )
     for assignment in forbidden_assignments:
         assert assignment not in source
+
+
+def test_gdn_enqueue_paths_reuse_cublas_handles() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_gdn_plugin.cu").read_text(encoding="utf-8")
+
+    assert "thread_local ThreadCublasHandles" in source
+    for function_name in (
+        "launch_camera_combined_cublas",
+        "launch_main_combined_cublas",
+        "launch_main_raw_combined_cublas",
+    ):
+        body = source.split(f"int32_t {function_name}", maxsplit=1)[1].split(
+            "\nint32_t ", maxsplit=1
+        )[0]
+        assert "cublasCreate(" not in body
+        assert "cublasDestroy(" not in body
+
+
+def test_aten_plugins_do_not_synchronize_the_tensorrt_stream() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_torch_conv2d_plugin.cpp").read_text(
+        encoding="utf-8"
+    )
+
+    assert "cudaStreamSynchronize(stream)" not in source
+
+
+def test_raw_gdn_bz_reduction_parallelizes_each_output() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_gdn_plugin.cu").read_text(encoding="utf-8")
+
+    assert "constexpr int32_t kRawBzThreadsPerOutput = 8;" in source
+    assert "threadIdx.x / kRawBzThreadsPerOutput" in source
+    assert "vector_elems_per_frame * kRawBzThreadsPerOutput" in source
+
+
+def test_short_conv_uses_native_cuda_without_layout_round_trips() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_torch_conv2d_plugin.cpp").read_text(
+        encoding="utf-8"
+    )
+    body = source.split("int32_t SanaWmShortConvPlugin::enqueue", maxsplit=1)[1].split(
+        "\nSanaWmGateProjPlugin::", maxsplit=1
+    )[0]
+
+    assert "launch_sana_wm_short_conv(" in body
+    assert "at::conv1d(" not in body
+    assert ".permute(" not in body
+    assert ".flip(" not in body
+
+
+def test_glumbconv_fuses_bias_activation_and_gate_elementwise_work() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_torch_conv2d_plugin.cpp").read_text(
+        encoding="utf-8"
+    )
+    body = source.split("int32_t SanaWmGlumbconvTempPlugin::enqueue", maxsplit=1)[1].split(
+        "\nSanaWmTimestepEmbedPlugin::", maxsplit=1
+    )[0]
+
+    assert "launch_sana_wm_bias_silu(" in body
+    assert "launch_sana_wm_gated_silu(" in body
+    assert "at::conv2d(x, inverted_weight, std::nullopt" in body
+    assert "at::conv2d(inverted, depth_weight, std::nullopt" in body
+    assert "at::silu(chunks[1])" not in body
+
+
+def test_camera_softmax_avoids_redundant_attention_layout_round_trips() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_torch_conv2d_plugin.cpp").read_text(
+        encoding="utf-8"
+    )
+    body = source.split("int32_t SanaWmSoftmaxAttentionPlugin::enqueue", maxsplit=1)[1].split(
+        "\nSanaWmTorchCamPrepPlugin::", maxsplit=1
+    )[0]
+
+    assert "auto q_bhnd =" in body
+    assert "auto k_bhnd =" in body
+    assert "auto v_bhnd =" in body
+    assert ".permute({0, 2, 3, 1})" not in body
+    assert ".transpose(-1, -2).contiguous()" not in body
+    assert "at::from_blob(outputs[0], {batch, tokens, heads_, head_dim_}" in body
+
+
+def test_t2i_modulation_fuses_bf16_elementwise_work_into_the_output() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_torch_conv2d_plugin.cpp").read_text(
+        encoding="utf-8"
+    )
+    body = source.split("int32_t SanaWmT2IModulatePlugin::enqueue", maxsplit=1)[1].split(
+        "\nSanaWmCaptionEmbedPlugin::", maxsplit=1
+    )[0]
+
+    assert "launch_sana_wm_t2i_modulate(" in body
+    assert "x * (scale + 1) + shift" not in body
+    assert "output.copy_(result)" not in body
+
+
+def test_camera_phase_c_output_uses_a_coalesced_tiled_transpose() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_gdn_plugin.cu").read_text(encoding="utf-8")
+
+    assert "__shared__ uint16_t tile[32][33];" in source
+    assert "dim3 phase_c_copy_threads(32, 8);" in source
+    assert "dim3 phase_c_copy_blocks(" in source
+
+
+def test_camera_prep_coalesces_qkv_outputs_without_changing_inflation_reduction() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_gdn_plugin.cu").read_text(encoding="utf-8")
+
+    assert "__global__ void cam_prep_output_tiled_kernel" in source
+    assert "__global__ void cam_prep_inflation_kernel" in source
+    assert "dim3 output_threads(32, 8);" in source
+    assert "cam_prep_kernel<" not in source
+
+
+def test_raw_phase_c_output_vectorizes_contiguous_head_channels() -> None:
+    source = (FAMILY_DIR / "native_plugins" / "sana_wm_gdn_plugin.cu").read_text(encoding="utf-8")
+
+    assert "__global__ void phase_c_raw_cublas_output_vectorized_kernel" in source
+    assert "const float4 raw = *reinterpret_cast<const float4*>" in source
+    assert "if (shape.head_dim % 4 == 0)" in source


### PR DESCRIPTION
## Background

Issue #637 reported that the SANA-WM Stage-1 denoiser remained 36.8% slower
than the aligned reference after the builder-search restrictions were removed.
Profiling the 320-frame GB300 workload showed that the remaining cost came from
repeated host synchronization, per-enqueue cuBLAS handle creation, layout
round-trips around camera attention, and scalar or layout-unfriendly native
plugin kernels.

Closes #637.

## Exit Criteria

- Preserve the BF16, 1280x704, batch-1, 320-output-frame workload and its
  validation contract.
- Capture and address the dominant Stage-1 denoiser hotspots on GB300.
- Bring the 10-sample end-to-end p50 within the configured 5% release margin
  of the aligned reference.
- Add regression contracts that prevent the optimized enqueue and kernel paths
  from reverting.

## Implementation

- Reuse one cuBLAS handle per host thread and device instead of creating and
  destroying handles in every GDN enqueue.
- Keep ATen-backed TensorRT plugin enqueues asynchronous on the TensorRT stream.
- Replace the short temporal convolution and T2I modulation layout round-trips
  with native CUDA kernels.
- Fuse GLUMB convolution bias, SiLU, and gate elementwise work while retaining
  the existing convolution tactics.
- Parallelize the raw GDN `b_z` reduction without changing its reduction order.
- Keep camera attention tensors in their native attention layout and remove
  redundant contiguous transposes.
- Coalesce camera preparation and phase-C output stores with tiled transposes,
  and vectorize contiguous raw phase-C output channels with a scalar fallback.
- Add source-level performance contracts for handle reuse, asynchronous
  enqueues, native fused paths, and coalesced camera/GDN layouts.

## Validation

- Source Quality: passed, including 158 architecture-contract tests.
- Ownership manifest and model impact: passed; only `sana_wm` is selected.
- Builder tests: 689 passed, 89 skipped.
- SANA-owned and performance-contract tests on GB300: 112 passed.
- Ruff, clang-format (including the CUDA source), and `git diff --check`:
  passed.
- GB300, TensorRT 11.2.0.113:
  - Stage-1 plan, 3 warmups + 10 measurements:
    - Before: 2029.583 ms p50.
    - After: 1516.648 ms p50.
    - Improvement: 25.3%.
  - Full 320-frame request, 1 warmup + 10 measurements:
    - p50: 106289.737 ms.
    - p95: 106340.833 ms.
    - Range: 106177.018-106341.132 ms.
    - Previous TRTMC p50: 138640.392 ms.
    - Aligned reference p50: 101382.703 ms.
    - New result: 23.3% faster than the previous TRTMC result and 4.84%
      slower than the reference, within the 5% release margin.
  - Every measured request produced 320 frames at 1280x704.
  - Output summary remained unchanged with 865075200 finite elements and a
    finite sum of 460647710.6516545.

## Notes For Future Readers

The explicit BF16 rounding boundaries and reduction order in the native kernels
are intentional. Faster alternatives that changed those boundaries caused
output drift and were rejected. The raw phase-C vector path is gated on
four-channel alignment and retains the scalar implementation as a fallback.
