### PR TITLE
fix(validation): enforce comparison runtime contracts

### DIFF
--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -157,6 +157,10 @@ suites:
           # Reserve the suite's 64 generated tokens inside its 2048 limit.
           prompt_token_limit: 1984
           prompt_truncation_side: left
+        falcon-rw-1b:
+          # This checkpoint is numerically sensitive in FP16. Compare both
+          # sides in FP32 instead of measuring different FP16 kernel rounding.
+          comparison_precision: fp32
         granite-3.1-2b:
           # This checkpoint is numerically sensitive in FP16. Compare both
           # sides in FP32 instead of measuring different FP16 kernel rounding.

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -157,6 +157,14 @@ suites:
           # Reserve the suite's 64 generated tokens inside its 2048 limit.
           prompt_token_limit: 1984
           prompt_truncation_side: left
+        granite-3.1-2b:
+          # This checkpoint is numerically sensitive in FP16. Compare both
+          # sides in FP32 instead of measuring different FP16 kernel rounding.
+          comparison_precision: fp32
+        olmo2-1b:
+          # This checkpoint is numerically sensitive in FP16. Compare both
+          # sides in FP32 instead of measuring different FP16 kernel rounding.
+          comparison_precision: fp32
         opt-125m:
           # Reserve the suite's 64 generated tokens inside OPT's 2048 limit.
           prompt_token_limit: 1984

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -1819,7 +1819,9 @@ def test_continuation_suite_limits_prompts_to_model_context(
     assert config["prompt_truncation_side"] == "left"
 
 
-@pytest.mark.parametrize("model_name", ["granite-3.1-2b", "olmo2-1b"])
+@pytest.mark.parametrize(
+    "model_name", ["falcon-rw-1b", "granite-3.1-2b", "olmo2-1b"]
+)
 def test_continuation_suite_uses_aligned_fp32_comparison_for_sensitive_models(
     model_name: str,
 ) -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3551,6 +3551,21 @@ def test_ensure_bundle_replaces_mismatched_precision(
     assert [command[1] for command in commands] == ["inspect", "build"]
 
 
+def test_bundle_reuse_rejects_unrecognized_precision(monkeypatch) -> None:
+    monkeypatch.setattr(task_eval, "runtime_tensorrt_abi", lambda: "11.2")
+
+    assert not task_eval._bundle_can_be_reused(
+        {
+            "TRT ABI": "11.2",
+            "Max cache length": "256",
+            "Precision": "unknown",
+        },
+        max_cache_length=256,
+        expected_precision="fp32",
+        allow_unknown=False,
+    )
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -1819,6 +1819,22 @@ def test_continuation_suite_limits_prompts_to_model_context(
     assert config["prompt_truncation_side"] == "left"
 
 
+@pytest.mark.parametrize("model_name", ["granite-3.1-2b", "olmo2-1b"])
+def test_continuation_suite_uses_aligned_fp32_comparison_for_sensitive_models(
+    model_name: str,
+) -> None:
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(),
+        "mmlu_continuation_parity",
+    )
+    config = task_eval.effective_task_eval_config(
+        suite,
+        {"name": model_name, "family": "", "task_eval": {}},
+    )
+
+    assert config["comparison_precision"] == "fp32"
+
+
 def test_mmlu_suite_disables_hf_cache_for_internlm() -> None:
     suite = task_eval.suite_by_id(task_eval.load_suites(), "mmlu_five_shot_mcq")
     config = task_eval.effective_task_eval_config(
@@ -3349,6 +3365,38 @@ def test_ensure_bundle_replaces_existing_file_before_build(
     assert bundle.read_bytes() == b"new"
 
 
+def test_ensure_bundle_applies_selected_cuda_device_to_build(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    captured: dict[str, str] = {}
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command, **kwargs):
+        captured["cuda_visible_devices"] = kwargs["env"]["CUDA_VISIBLE_DEVICES"]
+        Path(command[command.index("-o") + 1]).write_bytes(b"bundle")
+        return Result()
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "parent-device")
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+
+    task_eval.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        cuda_visible_devices="selected-device",
+    )
+
+    assert captured["cuda_visible_devices"] == "selected-device"
+
+
 def test_ensure_bundle_removes_partial_replacement_after_failed_build(
     tmp_path: Path,
     monkeypatch,
@@ -3458,6 +3506,51 @@ def test_ensure_bundle_replaces_incompatible_tensorrt_abi(
     assert [command[1] for command in commands] == ["inspect", "build"]
 
 
+def test_ensure_bundle_replaces_mismatched_precision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    bundle.parent.mkdir()
+    bundle.write_bytes(b"fp16")
+    commands: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = (
+            "TRT ABI:            11.2\n"
+            "Max cache length:   256\n"
+            "Precision:          fp16\n"
+        )
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        if command[1] == "inspect":
+            return Result()
+        output = Path(command[command.index("-o") + 1])
+        output.write_bytes(b"fp32")
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+    monkeypatch.setattr(task_eval, "runtime_tensorrt_abi", lambda: "11.2")
+
+    _, built = task_eval.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        max_cache_length=256,
+        replace_existing=True,
+    )
+
+    assert built is True
+    assert bundle.read_bytes() == b"fp32"
+    assert [command[1] for command in commands] == ["inspect", "build"]
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}
@@ -3519,12 +3612,16 @@ def test_eval_continuation_builds_for_prompt_and_generated_tokens(
     suite = task_eval.suite_by_id(
         task_eval.load_suites(), "mmlu_continuation_parity"
     )
+    suite["model_overrides"]["by_model"]["decoder-small"] = {
+        "comparison_precision": "fp32"
+    }
     model = {
         "name": "decoder-small",
         "hf_id": "example-org/decoder-small",
+        "hf_revision": "0123456789abcdef",
         "bundle": "decoder-small.trtfb",
         "max_cache_length": 256,
-        "precision": "fp32",
+        "precision": "fp16",
         "trust_remote_code": False,
         "build_args": {},
         "quantization": {},
@@ -3543,9 +3640,11 @@ def test_eval_continuation_builds_for_prompt_and_generated_tokens(
     ]
 
     def fake_run_hf(_args, _model, work_dir):
+        assert _model["precision"] == "fp32"
         task_eval.write_predictions(work_dir / "hf_predictions.json", responses)
 
     def fake_ensure_bundle(*_args, **kwargs):
+        assert _args[0]["precision"] == "fp32"
         assert kwargs["max_cache_length"] == 445
         bundle = kwargs["bundle_path"]
         bundle.parent.mkdir(parents=True, exist_ok=True)
@@ -3557,7 +3656,15 @@ def test_eval_continuation_builds_for_prompt_and_generated_tokens(
             Path(args.work_dir) / "trtfb_predictions.json", responses
         )
 
-    monkeypatch.setattr(task_eval, "max_prompt_token_length", lambda **_kwargs: 381)
+    def fake_max_prompt_token_length(**kwargs):
+        assert kwargs["model_revision"] == "0123456789abcdef"
+        return 381
+
+    monkeypatch.setattr(
+        task_eval,
+        "max_prompt_token_length",
+        fake_max_prompt_token_length,
+    )
     monkeypatch.setattr(
         task_eval, "run_hf_reference_subprocess", fake_run_hf
     )
@@ -3609,6 +3716,48 @@ def test_prompt_length_validation_rejects_over_cache(tmp_path: Path, monkeypatch
         assert "max_prompt_tokens=513" in str(exc)
     else:
         raise AssertionError("expected prompt length validation failure")
+
+
+def test_max_prompt_token_length_uses_pinned_model_revision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text(json.dumps({"prompt": "one two"}) + "\n", encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    class Tokenizer:
+        def __call__(self, text, *, add_special_tokens=False):
+            assert add_special_tokens is False
+            return argparse.Namespace(input_ids=text.split())
+
+    class AutoTokenizer:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            captured["model_id"] = model_id
+            captured.update(kwargs)
+            return Tokenizer()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(AutoTokenizer=AutoTokenizer),
+    )
+
+    length = task_eval.max_prompt_token_length(
+        model_id="org/model",
+        model_revision="0123456789abcdef",
+        prompts_path=prompts,
+        local_files_only=True,
+    )
+
+    assert length == 2
+    assert captured == {
+        "model_id": "org/model",
+        "revision": "0123456789abcdef",
+        "local_files_only": True,
+        "trust_remote_code": False,
+    }
 
 
 def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch) -> None:
@@ -3739,6 +3888,53 @@ def test_explicit_reference_dtype_must_match_engine_precision(tmp_path: Path) ->
             argparse.Namespace(hf_dtype="bfloat16"),
             {"precision": "fp16"},
             work_dir,
+        )
+
+
+def test_comparison_precision_overrides_both_candidate_and_reference(
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "manifest.json").write_text(
+        json.dumps({"dataset_kind": "mmlu_five_shot_json"}),
+        encoding="utf-8",
+    )
+    original = {
+        "name": "sensitive-model",
+        "precision": "fp16",
+        "quantization": {},
+    }
+
+    model = task_eval.apply_comparison_precision(
+        original,
+        {"comparison_precision": "fp32"},
+    )
+    contract = task_eval.resolve_reference_precision_contract(
+        argparse.Namespace(hf_dtype="auto"),
+        model,
+        work_dir,
+    )
+
+    assert original["precision"] == "fp16"
+    assert model["precision"] == "fp32"
+    assert contract["trtmc_base_precision"] == "fp32"
+    assert contract["reference_precision"] == "fp32"
+    assert contract["comparison"] == "aligned"
+
+
+def test_comparison_precision_rejects_quantized_models() -> None:
+    with pytest.raises(
+        ValueError,
+        match="FP8 quantization.*may only override unquantized base precision",
+    ):
+        task_eval.apply_comparison_precision(
+            {
+                "name": "quantized-model",
+                "precision": "fp16",
+                "quantization": {"format": "fp8"},
+            },
+            {"comparison_precision": "fp32"},
         )
 
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1998,6 +1998,7 @@ def test_finalize_run_metadata_records_completion(monkeypatch, tmp_path):
 
 def test_comparison_command_uses_validation_entrypoint(tmp_path):
     arguments = argparse.Namespace(
+        models_dir=tmp_path / "models",
         engine_dir=tmp_path / "engines",
         reference_cache_dir=tmp_path / "references",
         trtmc_binary=tmp_path / "trtmc",
@@ -2034,6 +2035,9 @@ def test_comparison_command_uses_validation_entrypoint(tmp_path):
     )
     assert command[command.index("--model") + 1] == "model-a"
     assert command[command.index("--suite") + 1] == "workload-a"
+    assert command[command.index("--models-dir") + 1] == str(
+        tmp_path / "models"
+    )
     assert command[command.index("--hf-python") + 1] == "/profiles/python"
     assert command[command.index("--reference-cache-dir") + 1] == str(
         tmp_path / "references"

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -2840,6 +2840,7 @@ def apply_work_prompt_token_limit(
     *,
     work_dir: Path,
     model_id: str,
+    model_revision: str = "",
     token_limit: int,
     truncation_side: str = "left",
     local_files_only: bool = False,
@@ -2850,11 +2851,13 @@ def apply_work_prompt_token_limit(
     except Exception as exc:  # pragma: no cover - runtime dependency
         raise RuntimeError("Prompt truncation requires transformers") from exc
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_id,
-        local_files_only=local_files_only,
-        trust_remote_code=trust_remote_code,
-    )
+    tokenizer_kwargs = {
+        "local_files_only": local_files_only,
+        "trust_remote_code": trust_remote_code,
+    }
+    if model_revision:
+        tokenizer_kwargs["revision"] = model_revision
+    tokenizer = AutoTokenizer.from_pretrained(model_id, **tokenizer_kwargs)
     prompts_path = work_dir / "prompts.jsonl"
     rows = load_jsonl(prompts_path)
     summary = truncate_prompt_rows(
@@ -2880,6 +2883,7 @@ def apply_work_prompt_token_limit(
 def max_prompt_token_length(
     *,
     model_id: str,
+    model_revision: str = "",
     prompts_path: Path,
     local_files_only: bool = False,
     trust_remote_code: bool = False,
@@ -2889,11 +2893,13 @@ def max_prompt_token_length(
     except Exception as exc:  # pragma: no cover - runtime dependency
         raise RuntimeError("Prompt length check requires transformers") from exc
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_id,
-        local_files_only=local_files_only,
-        trust_remote_code=trust_remote_code,
-    )
+    tokenizer_kwargs = {
+        "local_files_only": local_files_only,
+        "trust_remote_code": trust_remote_code,
+    }
+    if model_revision:
+        tokenizer_kwargs["revision"] = model_revision
+    tokenizer = AutoTokenizer.from_pretrained(model_id, **tokenizer_kwargs)
     max_len = 0
     for row in load_jsonl(prompts_path):
         documents = row.get("documents")
@@ -2920,6 +2926,7 @@ def validate_prompt_lengths_for_cache(
 ) -> int:
     max_prompt_len = max_prompt_token_length(
         model_id=str(model["hf_id"]),
+        model_revision=str(model.get("hf_revision", "") or ""),
         prompts_path=work_dir / "prompts.jsonl",
         local_files_only=local_files_only,
         trust_remote_code=trust_remote_code or bool(model.get("trust_remote_code", False)),
@@ -8550,6 +8557,7 @@ def _bundle_can_be_reused(
     inspection: Mapping[str, str],
     *,
     max_cache_length: int | None,
+    expected_precision: str,
     allow_unknown: bool,
 ) -> bool:
     if not inspection:
@@ -8560,6 +8568,19 @@ def _bundle_can_be_reused(
             if int(raw_cache) < max_cache_length:
                 return False
         except ValueError:
+            return False
+    raw_precision = inspection.get("Precision")
+    if expected_precision:
+        if raw_precision is None:
+            if not allow_unknown:
+                return False
+        elif (
+            _canonical_reference_precision(
+                raw_precision,
+                field="bundle precision",
+            )
+            != expected_precision
+        ):
             return False
     bundle_abi = inspection.get("TRT ABI", "")
     runtime_abi = runtime_tensorrt_abi()
@@ -8584,12 +8605,18 @@ def ensure_bundle(
     replace_existing: bool = False,
     extra_build_args: list[str] | None = None,
     log_path: Path | None = None,
+    cuda_visible_devices: str = "",
 ) -> tuple[Path, bool]:
+    expected_precision = _canonical_reference_precision(
+        model.get("precision", "fp32"),
+        field="TRTMC base precision",
+    )
     if bundle_path.is_file() and not force_build:
         inspection = bundle_inspection(bundle_path, trtmc_binary)
         if _bundle_can_be_reused(
             inspection,
             max_cache_length=max_cache_length,
+            expected_precision=expected_precision,
             allow_unknown=not replace_existing,
         ):
             return bundle_path, False
@@ -8607,10 +8634,21 @@ def ensure_bundle(
     )
     log_path = log_path or bundle_path.with_suffix(".build.log")
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    build_env = None
+    if cuda_visible_devices:
+        build_env = os.environ.copy()
+        build_env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
     with log_path.open("w", encoding="utf-8") as log_f:
         log_f.write(f"$ {shlex.join(cmd)}\n")
         log_f.flush()
-        proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT)
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            env=build_env,
+        )
     if proc.returncode != 0:
         _remove_bundle_before_or_after_replacement(
             bundle_path,
@@ -8742,6 +8780,30 @@ def _model_quantization_format(model: Mapping[str, Any]) -> str:
     if model.get("fp8_scales"):
         return "fp8"
     return ""
+
+
+def apply_comparison_precision(
+    model: Mapping[str, Any],
+    task_eval_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Apply one validation base precision to both TRTMC and its reference."""
+
+    configured = task_eval_config.get("comparison_precision")
+    updated = copy.deepcopy(dict(model))
+    if configured in (None, ""):
+        return updated
+    quantization = _model_quantization_format(updated)
+    if quantization:
+        model_name = str(updated.get("name", "") or "quantized model")
+        raise ValueError(
+            f"{model_name} uses {quantization.upper()} quantization; "
+            "comparison_precision may only override unquantized base precision"
+        )
+    updated["precision"] = _canonical_reference_precision(
+        configured,
+        field="task_eval.comparison_precision",
+    )
+    return updated
 
 
 def _configured_reference_precision(
@@ -10006,6 +10068,7 @@ def eval_one_model(
         model.get("reference_backend", "hf_transformers") or "hf_transformers"
     )
     task_eval_config = effective_task_eval_config(suite, model)
+    model = apply_comparison_precision(model, task_eval_config)
     suite_reference = suite.get("reference", {})
     if isinstance(suite_reference, dict) and suite_reference:
         task_eval_config["reference"] = suite_reference
@@ -10046,6 +10109,7 @@ def eval_one_model(
         prompt_normalization = apply_work_prompt_token_limit(
             work_dir=work_dir,
             model_id=str(model["hf_id"]),
+            model_revision=str(model.get("hf_revision", "") or ""),
             token_limit=prompt_token_limit,
             truncation_side=str(task_eval_config.get("prompt_truncation_side", "left")),
             local_files_only=args.local_files_only,
@@ -10087,6 +10151,7 @@ def eval_one_model(
         prompt_rows_path = work_dir / "prompts.jsonl"
         max_prompt_len = max_prompt_token_length(
             model_id=str(model["hf_id"]),
+            model_revision=str(model.get("hf_revision", "") or ""),
             prompts_path=prompt_rows_path,
             local_files_only=args.local_files_only,
             trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
@@ -10128,6 +10193,7 @@ def eval_one_model(
         ),
         extra_build_args=args.extra_build_arg,
         log_path=work_dir / "build.log",
+        cuda_visible_devices=args.cuda_visible_devices,
     )
 
     if (
@@ -10809,12 +10875,15 @@ def _model_tokenizer(model: dict[str, Any], args: argparse.Namespace) -> Any:
     try:
         from transformers import AutoTokenizer
 
-        tok = AutoTokenizer.from_pretrained(
-            str(model["hf_id"]),
-            trust_remote_code=getattr(args, "trust_remote_code", False)
+        tokenizer_kwargs = {
+            "trust_remote_code": getattr(args, "trust_remote_code", False)
             or bool(model.get("trust_remote_code", False)),
-            local_files_only=getattr(args, "local_files_only", False),
-        )
+            "local_files_only": getattr(args, "local_files_only", False),
+        }
+        model_revision = str(model.get("hf_revision", "") or "")
+        if model_revision:
+            tokenizer_kwargs["revision"] = model_revision
+        tok = AutoTokenizer.from_pretrained(str(model["hf_id"]), **tokenizer_kwargs)
         return lambda s: tok(s, add_special_tokens=False).input_ids  # noqa: E731
     except Exception:
         return None

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8574,14 +8574,16 @@ def _bundle_can_be_reused(
         if raw_precision is None:
             if not allow_unknown:
                 return False
-        elif (
-            _canonical_reference_precision(
-                raw_precision,
-                field="bundle precision",
-            )
-            != expected_precision
-        ):
-            return False
+        else:
+            try:
+                bundle_precision = _canonical_reference_precision(
+                    raw_precision,
+                    field="bundle precision",
+                )
+            except ValueError:
+                return False
+            if bundle_precision != expected_precision:
+                return False
     bundle_abi = inspection.get("TRT ABI", "")
     runtime_abi = runtime_tensorrt_abi()
     return not bundle_abi or not runtime_abi or bundle_abi == runtime_abi

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -552,6 +552,8 @@ def _comparison_command(
         str(dataset),
         "--model",
         binding.model,
+        "--models-dir",
+        str(arguments.models_dir),
         "--work-root",
         str(work_root),
         "--engine-dir",


### PR DESCRIPTION
## Background

The outer validation run could select one model manifest, revision, device, or base precision while a child process silently used another. Those differences can look like model accuracy regressions even though they are framework setup errors.

## Exit Criteria

- Carry model revisions, custom catalogs, and selected CUDA devices through every comparison/build worker.
- Compare HF and TRTMC at one explicit base precision for sensitive unquantized cases.
- Reject unsupported precision shortcuts for quantized profiles.
- Reuse a shared bundle only when its precision matches the requested comparison and replace mismatches at the same path.

## Implementation

- Propagate pinned revisions and custom model catalogs through prompt and comparison workers.
- Apply the selected CUDA device to engine builds as well as inference.
- Add an unquantized `comparison_precision` contract that updates both HF and TRTMC.
- Inspect shared-bundle precision before reuse and replace mismatched or uninspectable bundles in place.
- Compare Falcon-RW 1B, Granite 3.1 2B, and OLMo2 1B in aligned FP32 for continuation parity.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_task_eval.py tests/tools/test_trtmc_validate.py -q`: 275 passed.
- `CI_BASE_REF=github/main PYTHONPATH="$PWD/python:$PWD" python3 -m tools.ci pipeline source-quality`: passed, including 158 architecture-contract tests.
- Latest-validator GB300 aligned FP32 continuation runs:
  - Falcon-RW 1B: 10/10 exact matches, token-prefix agreement 1.0.
  - Granite 3.1 2B: 9/10 exact matches, satisfying the reviewed 0.9 gate.
  - OLMo2 1B: 10/10 exact matches, token-prefix agreement 1.0.

## Notes For Future Readers

- Comparison precision is a validation contract, not a relaxation of the accuracy gate.
- Quantized FP8, FP4, NVFP4, and MXFP profiles must keep their explicit reference policy and cannot use this unquantized override.
- Shared bundles remain bounded to one path per model; a rebuild overwrites the mismatched bundle rather than accumulating another artifact.

Closes #666
Closes #668
Closes #670
Closes #671
