### PR TITLE
feat(llm): add full-context native KV for Qwen and Llama

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ python3.12 -m venv .venv-trtmc
 pip install ./tensorrt_model_connect-0.1.0-py312-none-manylinux_2_39_aarch64.whl
 
 trtmc version
-trtmc build Qwen/Qwen3-0.6B -o /tmp/qwen3.trtfb --max-cache-length 256
-trtmc run /tmp/qwen3.trtfb \
+trtmc build Qwen/Qwen3-0.6B
+trtmc run Qwen3-0.6B.trtfb \
   --prompt "The capital of France is" \
   --max-new-tokens 20 \
   --greedy
@@ -60,8 +60,8 @@ pip install -e . -C py-only=true
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 
-./build/trtmc build Qwen/Qwen3-0.6B -o /tmp/qwen3.trtfb --max-cache-length 256
-./build/trtmc run /tmp/qwen3.trtfb \
+./build/trtmc build Qwen/Qwen3-0.6B
+./build/trtmc run Qwen3-0.6B.trtfb \
   --prompt "The capital of France is" \
   --max-new-tokens 20 \
   --greedy

--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -64,6 +64,11 @@ def _optimized_cli_public_options(args: argparse.Namespace) -> dict:
     }
     if public_options.get("precision") is None:
         public_options["precision"] = "fp32"
+    # Keep the existing optimized-runtime request contract unchanged. Native
+    # builders may derive an omitted capacity from model-owned configuration,
+    # while legacy capsules still own their established 256-token profile.
+    if public_options.get("max_cache_length") is None:
+        public_options["max_cache_length"] = 256
     return public_options
 
 
@@ -91,14 +96,27 @@ def _load_fp8_scales(path: str | Path) -> dict[str, object]:
     return scales
 
 
+def _default_bundle_path(model: str) -> str:
+    """Derive the no-flag CLI output name from an HF id or local model path."""
+    model_name = Path(model.rstrip("/")).name or "model"
+    safe_name = "".join(
+        ch if ch.isalnum() or ch in (".", "-", "_") else "-"
+        for ch in model_name
+    ).strip(".-_")
+    return f"{safe_name or 'model'}.trtfb"
+
+
 def _cmd_build(args: argparse.Namespace) -> int:
     if not args.model:
         print("Error: model (HF repo ID or local directory) required",
               file=sys.stderr)
         return 1
     if not args.output:
-        print("Error: -o / --output required", file=sys.stderr)
-        return 1
+        args.output = _default_bundle_path(args.model)
+        print(
+            f"[trtmc build] Output: {args.output} (derived from model)",
+            file=sys.stderr,
+        )
 
     # Optimized dispatch resolves the model family internally and scans only
     # that family's Builder folder. The current platform remains implicit; no
@@ -616,7 +634,7 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command")
 
-    # trtmc build <model> -o <out.trtfb>
+    # trtmc build <model> [-o <out.trtfb>]
     build_p = subparsers.add_parser("build", help="Build a .trtfb bundle")
     build_p.add_argument("model",
                          help="HF repo ID (for example, org/model-name) or local directory")
@@ -625,12 +643,20 @@ def main() -> None:
         default=None,
         help="Hugging Face model revision (commit, tag, or branch) to build",
     )
-    build_p.add_argument("-o", "--output", required=True,
-                         help="Output .trtfb file path")
+    build_p.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output .trtfb path (default: <model-name>.trtfb)",
+    )
     build_p.add_argument("--trust-remote-code", action="store_true",
                          help="Allow Hugging Face model code that requires trust_remote_code")
-    build_p.add_argument("--max-cache-length", type=int, default=256,
-                         help="KV cache length (default: 256)")
+    build_p.add_argument(
+        "--max-cache-length",
+        type=int,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
     build_p.add_argument(
         "--decoder-engine-layout",
         choices=["split", "dual_profile"],

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -58,6 +58,13 @@ except ImportError:
         cudart = None  # type: ignore[assignment]
 
 
+class _OmittedMaxCacheLength(int):
+    """Preserve the public 256 default while detecting an omitted argument."""
+
+
+_OMITTED_MAX_CACHE_LENGTH = _OmittedMaxCacheLength(256)
+
+
 def _setup_trt_import(rtx: bool) -> None:
     """Select the TensorRT Python backend before any TRT API is touched."""
     if not rtx:
@@ -1822,7 +1829,7 @@ def _build_diffusion_bundle(
 def _build_native_impl(
     model_id_or_path: str,
     output_path: str,
-    max_cache_length: int | None = None,
+    max_cache_length: int | None = _OMITTED_MAX_CACHE_LENGTH,
     *,
     model_revision: str | None = None,
     decoder_engine_layout: str = "split",
@@ -1869,6 +1876,8 @@ def _build_native_impl(
         fp8_scales: Per-layer FP8 scales dict, or ``"auto"`` for auto-calibration.
         save_fp8_scales: Path to save calibrated FP8 scales JSON.
     """
+    if max_cache_length is _OMITTED_MAX_CACHE_LENGTH:
+        max_cache_length = None
     revision_kwargs = {"revision": model_revision} if model_revision else {}
     model_dir = _resolve_model(model_id_or_path, **revision_kwargs)
     build_bundle._model_id_or_path_orig = model_id_or_path
@@ -1992,7 +2001,7 @@ def _try_build_optimized_runtime(
 def build(
     model_id_or_path: str,
     output_path: str,
-    max_cache_length: int | None = None,
+    max_cache_length: int | None = _OMITTED_MAX_CACHE_LENGTH,
     *,
     model_revision: str | None = None,
     decoder_engine_layout: str = "split",
@@ -2031,6 +2040,8 @@ def build(
     """
 
     build_arguments = dict(locals())
+    if build_arguments["max_cache_length"] is _OMITTED_MAX_CACHE_LENGTH:
+        build_arguments["max_cache_length"] = None
     public_options = {
         name: value
         for name, value in build_arguments.items()

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -26,6 +26,7 @@ from .engine_build_budget import enforce_single_full_bundle_build
 from .families import (
     available_plugin_ids,
     family_has_capability,
+    family_prefers_native_default_build,
     find_plugin,
     find_diffusion_plugin,
     resolve_config_from_model_dir,
@@ -834,7 +835,7 @@ def _prepare_tokenizer_special_frame(
 def build_bundle(
     model_dir: str,
     output_path: str,
-    max_cache_length: int = 256,
+    max_cache_length: int | None = None,
     *,
     decoder_engine_layout: str = "split",
     dynamic_kv_cache: bool = False,
@@ -869,7 +870,9 @@ def build_bundle(
     Args:
         model_dir: Path to HF model directory with config.json + safetensors.
         output_path: Where to write the .trtfb bundle.
-        max_cache_length: KV cache length for the engine.
+        max_cache_length: KV cache length for the engine. ``None`` selects the
+            model-owned default; decoder families may use the model's official
+            context capacity.
         decoder_engine_layout: ``"split"`` builds separate prefill/decode
             engines for supported decoder LLMs. ``"dual_profile"`` keeps the
             low-VRAM single-engine/multi-profile layout.
@@ -900,6 +903,8 @@ def build_bundle(
 
     diffusion_entrypoint = _resolve_diffusion_entrypoint(model_dir_path)
     if diffusion_entrypoint is not None:
+        if max_cache_length is None:
+            max_cache_length = 256
         _, diffusion_plugin = diffusion_entrypoint
         precision = str(
             precision
@@ -925,6 +930,16 @@ def build_bundle(
     config.raw["_decoder_engine_layout"] = decoder_engine_layout
     config.raw["_fp32_layers"] = sorted(set(fp32_layers or ()))
     config.raw["_family_build_options"] = dict(family_build_options or {})
+    config.raw["_parallel_build_enabled"] = bool(parallel.enabled)
+    config.raw["_rtx_build_requested"] = bool(rtx)
+    config.raw["_runtime_dynamic_kv_requested"] = bool(
+        dynamic_kv_cache or triattention_stats_path
+    )
+    # Family routing chooses defaults before the quantization context exists.
+    # Preserve the user's build mode on the parsed config so a native-only
+    # family does not select its full-context defaults for an unsupported
+    # quantized build and only fall back after loading the checkpoint.
+    config.raw["_quantized_build_requested"] = bool(quantize)
     _apply_family_builder_capabilities(config)
     print(f"[trtmc build] Model: {config.model_type} "
           f"(layers={config.num_hidden_layers}, hidden={config.hidden_size}, "
@@ -939,7 +954,23 @@ def build_bundle(
             f"Supported: {supported}")
 
     print(f"[trtmc build] Family: {plugin.name}", file=sys.stderr)
-    precision = str(precision or "fp32").lower()
+    default_precision = getattr(plugin, "default_build_precision", "fp32")
+    if callable(default_precision):
+        default_precision = default_precision(config)
+    precision = str(precision or default_precision).lower()
+    config.raw["_resolved_build_precision"] = precision
+    if max_cache_length is None:
+        default_capacity = getattr(plugin, "default_max_cache_length", None)
+        max_cache_length = int(
+            default_capacity(config) if callable(default_capacity) else 256
+        )
+        print(
+            "[trtmc build] KV cache capacity: "
+            f"{max_cache_length} tokens (model default)",
+            file=sys.stderr,
+        )
+    if max_cache_length < 1:
+        raise ValueError("max_cache_length must be >= 1")
 
     # 3. Load weights
     t1 = time.monotonic()
@@ -1791,7 +1822,7 @@ def _build_diffusion_bundle(
 def _build_native_impl(
     model_id_or_path: str,
     output_path: str,
-    max_cache_length: int = 256,
+    max_cache_length: int | None = None,
     *,
     model_revision: str | None = None,
     decoder_engine_layout: str = "split",
@@ -1831,7 +1862,8 @@ def _build_native_impl(
         model_id_or_path: HF repo ID or local directory with config.json + safetensors.
         output_path: Where to write the .trtfb bundle.
         model_revision: Optional Hugging Face revision to resolve for remote model IDs.
-        max_cache_length: KV cache length for the engine.
+        max_cache_length: Explicit KV cache length for the engine. ``None``
+            lets the selected family resolve its model-owned default.
         decoder_engine_layout: ``"split"`` or ``"dual_profile"``.
         verbose: Print detailed TRT builder logs.
         fp8_scales: Per-layer FP8 scales dict, or ``"auto"`` for auto-calibration.
@@ -1915,6 +1947,7 @@ def _try_build_optimized_runtime(
     from .runtime_provider.orchestrator import try_build_optimized_runtime
 
     resolved_model_ref = model_id_or_path
+    model_config: ModelConfig | None = None
     try:
         revision_kwargs = {"revision": model_revision} if model_revision else {}
         resolved_model_ref = _resolve_model(model_id_or_path, **revision_kwargs)
@@ -1928,13 +1961,19 @@ def _try_build_optimized_runtime(
                 or ""
             )
         else:
-            selected_family = str(resolve_family_id(ModelConfig.from_dir(model_dir)) or "")
+            model_config = ModelConfig.from_dir(model_dir)
+            selected_family = str(resolve_family_id(model_config) or "")
     except Exception:
         # Optimized dispatch is optional. Preserve the native path's exact
         # model-resolution behavior and diagnostics when family discovery
         # cannot resolve the request in this environment.
         return None
     if not selected_family:
+        return None
+    if (
+        model_config is not None
+        and family_prefers_native_default_build(model_config)
+    ):
         return None
 
     return try_build_optimized_runtime(
@@ -1953,7 +1992,7 @@ def _try_build_optimized_runtime(
 def build(
     model_id_or_path: str,
     output_path: str,
-    max_cache_length: int = 256,
+    max_cache_length: int | None = None,
     *,
     model_revision: str | None = None,
     decoder_engine_layout: str = "split",
@@ -2001,6 +2040,8 @@ def build(
     # native builder to resolve a model-owned precision.
     if public_options["precision"] is None:
         public_options["precision"] = "fp32"
+    if public_options["max_cache_length"] is None:
+        public_options["max_cache_length"] = 256
     revision_kwargs = (
         {"model_revision": model_revision} if model_revision else {}
     )

--- a/python/tensorrt_model_connect/families/__init__.py
+++ b/python/tensorrt_model_connect/families/__init__.py
@@ -52,6 +52,7 @@ class _FamilyMetadata:
     hf_warm_files: tuple[str, ...] = ()
     config_adapter: str = ""
     model_dir_adapter: str = ""
+    default_build_route: str = ""
     debug_runner: str = ""
     debug_runtime_strategies: frozenset[str] = frozenset()
     python_profile_specs: tuple[str, ...] = ()
@@ -221,6 +222,8 @@ def _load_family_metadata() -> list[_FamilyMetadata]:
             if isinstance(raw.get("config_adapter"), str) else "",
             model_dir_adapter=raw.get("model_dir_adapter", "")
             if isinstance(raw.get("model_dir_adapter"), str) else "",
+            default_build_route=raw.get("default_build_route", "")
+            if isinstance(raw.get("default_build_route"), str) else "",
             debug_runner=raw.get("debug_runner", "")
             if isinstance(raw.get("debug_runner"), str) else "",
             debug_runtime_strategies=_metadata_strings(
@@ -616,6 +619,26 @@ def resolve_family_model_dir(model_dir: str | Path) -> str | None:
             )
         return str(result)
     return None
+
+
+def family_prefers_native_default_build(
+    config: object,
+) -> bool:
+    """Ask model-owned metadata whether this family owns the native build."""
+    metadata = _matching_family_metadata(config)
+    if not metadata or not metadata[0].default_build_route:
+        return False
+    route = _load_metadata_callable_from_file(
+        metadata[0],
+        metadata[0].default_build_route,
+    )
+    result = route(config)
+    if not isinstance(result, bool):
+        raise TypeError(
+            f"Default build route {metadata[0].default_build_route!r} for "
+            f"family {metadata[0].id} must return bool"
+        )
+    return result
 
 
 def resolve_nemo_archive_model_dir(nemo_path: str | Path) -> str | None:

--- a/python/tensorrt_model_connect/families/llama/MODEL.toml
+++ b/python/tensorrt_model_connect/families/llama/MODEL.toml
@@ -13,6 +13,7 @@ prefixes = [
   "llama",
 ]
 debug_runner = "debug_runner.py|runner_from_bundle"
+default_build_route = "build_routing.py|prefer_native_default"
 debug_runtime_strategies = [
   "llama_decoder_kv_cache",
 ]

--- a/python/tensorrt_model_connect/families/llama/build_routing.py
+++ b/python/tensorrt_model_connect/families/llama/build_routing.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Routing contract for dense Llama models using TensorRT native KV cache."""
+
+from __future__ import annotations
+
+import math
+import operator
+
+_INT32_MAX = (1 << 31) - 1
+_UINT64_MAX = (1 << 64) - 1
+
+
+class NativeKvCapability:
+    """Small, loader-safe capability result (no dataclass dependency)."""
+
+    __slots__ = ("applicable", "eligible", "reason")
+
+    def __init__(
+        self,
+        applicable: bool,
+        eligible: bool,
+        reason: str,
+    ) -> None:
+        self.applicable = applicable
+        self.eligible = eligible
+        self.reason = reason
+
+
+def _result(
+    *,
+    applicable: bool = True,
+    reasons: list[str] | tuple[str, ...] = (),
+) -> NativeKvCapability:
+    return NativeKvCapability(
+        applicable,
+        applicable and not reasons,
+        "; ".join(reasons) or "supported",
+    )
+
+
+def _raw(config: object) -> dict:
+    value = getattr(config, "raw", {})
+    return value if isinstance(value, dict) else {}
+
+
+def _integer(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(operator.index(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _positive(config: object, name: str) -> int:
+    value = _integer(getattr(config, name, None), name)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    if value > _INT32_MAX:
+        raise ValueError(f"{name} exceeds TensorRT's int32 dimension limit")
+    return value
+
+
+def resolved_head_dim(config: object) -> int:
+    """Return the explicit HF head width, or derive it when absent."""
+
+    raw = _raw(config)
+    explicit = raw.get("head_dim", getattr(config, "_head_dim", 0))
+    if "head_dim" in raw or explicit not in (None, 0):
+        head_dim = _integer(explicit, "head_dim")
+    else:
+        hidden = _positive(config, "hidden_size")
+        heads = _positive(config, "num_attention_heads")
+        if hidden % heads:
+            raise ValueError(
+                "hidden_size must be divisible by num_attention_heads when "
+                "head_dim is absent"
+            )
+        head_dim = hidden // heads
+    if not 0 < head_dim <= _INT32_MAX:
+        raise ValueError("head_dim must be a positive TensorRT dimension")
+    return head_dim
+
+
+def _checked_product(label: str, *values: int) -> int:
+    product = 1
+    for value in values:
+        if value <= 0 or product > _UINT64_MAX // value:
+            raise ValueError(f"native Llama KV {label} exceeds uint64")
+        product *= value
+    return product
+
+
+def native_kv_cache_geometry(
+    config: object,
+    capacity: int,
+    *,
+    element_bytes: int = 2,
+) -> tuple[int, int]:
+    """Return runtime byte geometry for the required full-context cache."""
+
+    capacity = _integer(capacity, "max_cache_length")
+    context = _positive(config, "max_position_embeddings")
+    if capacity != context:
+        raise ValueError(
+            "native Llama KV requires max_cache_length == "
+            f"max_position_embeddings ({context}), got {capacity}"
+        )
+    row_bytes = _checked_product(
+        "row size",
+        2,
+        _positive(config, "num_hidden_layers"),
+        _positive(config, "num_key_value_heads"),
+        resolved_head_dim(config),
+        _integer(element_bytes, "element_bytes"),
+    )
+    return row_bytes, _checked_product("cache size", capacity, row_bytes)
+
+
+def _enabled(value: object) -> bool:
+    return value not in (None, False, 0, "", (), [], {})
+
+
+def _validate_rope(raw: dict, reasons: list[str]) -> None:
+    parameters = raw.get("rope_parameters")
+    scaling = raw.get("rope_scaling")
+    if parameters is not None and scaling is not None:
+        reasons.append("RoPE configuration is ambiguous")
+        return
+    rope = parameters if parameters is not None else scaling
+    if rope is None:
+        return
+    if not isinstance(rope, dict):
+        reasons.append("RoPE configuration must be an object")
+        return
+    rope_type = str(rope.get("rope_type", rope.get("type", "default"))).lower()
+    if rope_type in ("", "default"):
+        if any(
+            key in rope
+            for key in (
+                "factor",
+                "low_freq_factor",
+                "high_freq_factor",
+                "original_max_position_embeddings",
+            )
+        ):
+            reasons.append("default RoPE must not contain scaling parameters")
+        return
+    if rope_type != "llama3":
+        reasons.append(f"native Llama does not support rope_type={rope_type!r}")
+        return
+    required = (
+        "factor",
+        "low_freq_factor",
+        "high_freq_factor",
+        "original_max_position_embeddings",
+    )
+    if any(name not in rope for name in required):
+        reasons.append("llama3 RoPE is missing required scaling parameters")
+        return
+    try:
+        factor = float(rope["factor"])
+        low = float(rope["low_freq_factor"])
+        high = float(rope["high_freq_factor"])
+        original = _integer(
+            rope["original_max_position_embeddings"],
+            "original_max_position_embeddings",
+        )
+    except (TypeError, ValueError, OverflowError):
+        reasons.append("llama3 RoPE scaling parameters must be numeric")
+        return
+    if (
+        not all(math.isfinite(value) for value in (factor, low, high))
+        or factor < 1.0
+        or low <= 0.0
+        or high <= low
+        or original <= 0
+    ):
+        reasons.append("llama3 RoPE scaling parameters are invalid")
+
+
+def native_kv_architecture_capability(
+    config: object,
+) -> NativeKvCapability:
+    """Accept any model size that retains the dense Llama graph contract."""
+
+    model_type = str(getattr(config, "model_type", "")).lower()
+    if not model_type.startswith("llama"):
+        return _result(applicable=False)
+    if model_type != "llama":
+        return _result(reasons=["model_type must be exactly 'llama'"])
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if tuple(getattr(config, "architectures", ()) or ()) != (
+        "LlamaForCausalLM",
+    ):
+        reasons.append("architectures must contain exactly LlamaForCausalLM")
+
+    try:
+        dimensions = {
+            name: _positive(config, name)
+            for name in (
+                "vocab_size",
+                "hidden_size",
+                "intermediate_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "max_position_embeddings",
+            )
+        }
+        head_dim = resolved_head_dim(config)
+        if dimensions["num_attention_heads"] % dimensions[
+            "num_key_value_heads"
+        ]:
+            reasons.append(
+                "num_attention_heads must be divisible by "
+                "num_key_value_heads"
+            )
+        if head_dim != 128:
+            reasons.append("native Llama attention requires head_dim=128")
+    except ValueError as exc:
+        reasons.append(str(exc))
+
+    if str(getattr(config, "hidden_act", "")).lower() != "silu":
+        reasons.append("native Llama requires hidden_act='silu'")
+    for name in ("rms_norm_eps", "rope_theta"):
+        try:
+            value = float(getattr(config, name))
+        except (TypeError, ValueError, OverflowError):
+            value = 0.0
+        if not math.isfinite(value) or value <= 0:
+            reasons.append(f"{name} must be finite and positive")
+
+    unsupported_flags = (
+        "attention_bias",
+        "mlp_bias",
+        "is_encoder_decoder",
+        "use_sliding_window",
+        "sliding_window",
+        "rope_interleaved",
+        "interleaved_rope",
+        "num_experts",
+        "num_local_experts",
+        "num_experts_per_tok",
+    )
+    enabled = [name for name in unsupported_flags if _enabled(raw.get(name))]
+    if enabled:
+        reasons.append("unsupported Llama fields: " + ", ".join(enabled))
+    try:
+        if _integer(raw.get("pretraining_tp", 1), "pretraining_tp") != 1:
+            reasons.append("native Llama requires pretraining_tp=1")
+    except ValueError as exc:
+        reasons.append(str(exc))
+    try:
+        if float(raw.get("partial_rotary_factor", 1.0)) != 1.0:
+            reasons.append("native Llama requires full rotary embeddings")
+    except (TypeError, ValueError, OverflowError):
+        reasons.append("partial_rotary_factor must be numeric")
+    layer_types = raw.get("layer_types")
+    if layer_types is not None and (
+        not isinstance(layer_types, (list, tuple))
+        or any(str(value).lower() != "full_attention" for value in layer_types)
+    ):
+        reasons.append("native Llama does not support hybrid layer types")
+    _validate_rope(raw, reasons)
+    return _result(reasons=reasons)
+
+
+def native_kv_build_capability(
+    config: object,
+    *,
+    precision: str = "bf16",
+    max_cache_length: int | None = None,
+    parallel_enabled: bool | None = None,
+    dynamic_kv_cache: bool | None = None,
+    quantized: bool | None = None,
+    debug_layer_outputs: bool = False,
+) -> NativeKvCapability:
+    """Apply deployment constraints once, after architecture routing."""
+
+    architecture = native_kv_architecture_capability(config)
+    if not architecture.eligible:
+        return architecture
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if str(precision).lower() != "bf16":
+        reasons.append("native Llama requires BF16")
+    if str(raw.get("_decoder_engine_layout", "split")) != "split":
+        reasons.append("native Llama requires split prefill/decode engines")
+    if raw.get("_rtx_build_requested"):
+        reasons.append("native Llama requires the standard TensorRT backend")
+    if parallel_enabled or raw.get("_parallel_build_enabled"):
+        reasons.append("native Llama does not support tensor parallel builds")
+    if (
+        dynamic_kv_cache
+        or raw.get("_runtime_dynamic_kv_requested")
+        or raw.get("dynamic_kv_cache")
+    ):
+        reasons.append("native Llama uses one fixed physical KV capacity")
+    if (
+        quantized
+        or raw.get("quantization_config")
+        or raw.get("_quantized_build_requested")
+    ):
+        reasons.append("native Llama does not support quantized builds")
+    if raw.get("_fp32_layers"):
+        reasons.append("native Llama does not support FP32 layer overrides")
+    if debug_layer_outputs:
+        reasons.append("native Llama does not support debug layer outputs")
+    try:
+        native_kv_cache_geometry(
+            config,
+            (
+                int(getattr(config, "max_position_embeddings"))
+                if max_cache_length is None
+                else max_cache_length
+            ),
+        )
+    except ValueError as exc:
+        reasons.append(str(exc))
+    return _result(reasons=reasons)
+
+
+def prefer_native_default(
+    config: object,
+) -> bool:
+    """Route dense Llama to native KV without a user-facing build flag."""
+
+    capability = native_kv_architecture_capability(config)
+    if capability.applicable and not capability.eligible:
+        raise ValueError(
+            "Unsupported dense Llama native-KV model: " + capability.reason
+        )
+    return capability.eligible

--- a/python/tensorrt_model_connect/families/llama/build_routing.py
+++ b/python/tensorrt_model_connect/families/llama/build_routing.py
@@ -331,9 +331,4 @@ def prefer_native_default(
 ) -> bool:
     """Route dense Llama to native KV without a user-facing build flag."""
 
-    capability = native_kv_architecture_capability(config)
-    if capability.applicable and not capability.eligible:
-        raise ValueError(
-            "Unsupported dense Llama native-KV model: " + capability.reason
-        )
-    return capability.eligible
+    return native_kv_architecture_capability(config).eligible

--- a/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -27,17 +27,21 @@ debug outputs, hidden-state outputs, and the VL ``embed_input`` path stay
 on ``standard_decoder_builder`` for now and are dispatched there from
 inside ``build_standard_decoder_engine``.
 
-Tensor contract (matches the C++ runtime KvCache naming):
-  Inputs (dynamic shapes — Sq varies by profile)
+Tensor contract for the TensorRT native KV-cache path:
+  Inputs (Sq varies by profile; cache capacity is static)
     token_id        int32   (-1,)
     position_id     int32   (-1,)
-    attention_mask  float32 (-1, -1)                 # (Sq, max_cache + Sq)
-    cache_k_i       fp16/f32 (max_cache, kv_size)    # static
-    cache_v_i       fp16/f32 (max_cache, kv_size)    # static
+    cache_write_indices int32 (1,)                   # update start offset
+    key_value_lengths   int32 (1,)                   # active length after update
+    cache_k_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
+    cache_v_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
   Outputs
     logits          float32 (1, vocab)               # last-row sliced inside the engine
-    present_k_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
-    present_v_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
+    present_k_i     bf16 (1, Hkv, capacity, D)       # aliases cache_k_i
+    present_v_i     bf16 (1, Hkv, capacity, D)       # aliases cache_v_i
+
+The legacy generic path remains available for non-Llama families that import
+this builder and still use dense masks plus incremental present K/V outputs.
 """
 
 from __future__ import annotations
@@ -57,6 +61,9 @@ if TYPE_CHECKING:
     from .config import ModelConfig
     from .checkpoint_mapper import WeightDict
     from ...quantization.context import QuantContext
+
+
+_NATIVE_PREFILL_CHUNK_TOKENS = 32768
 
 
 def _const_in_work_dtype(
@@ -226,6 +233,7 @@ def build_dual_profile_decoder_engine(
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
+    native_kv_cache: bool = False,
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
@@ -249,23 +257,44 @@ def build_dual_profile_decoder_engine(
       prefill on the prompt.
     * ``"prefill"``: one prefill profile only. This is used by split-engine
       bundles, where decode is served by a separate fixed-Sq=1 engine.
+    * ``"decode"``: one fixed-Sq=1 profile only. This is the decode half of a
+      split-engine bundle.
 
     Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
     mode. In either mode, cache_k/cache_v inputs are declared dynamic when
     bucket profiles are requested so each profile can constrain their row count.
+
+    ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` and
+    ``IAttention.key_value_lengths`` contract. Llama enables it internally by
+    default; it is not exposed as a user build flag.
     """
     _supports_config(config, weights)
-    if profile_mode not in ("dual_profile", "prefill"):
+    if profile_mode not in ("dual_profile", "prefill", "decode"):
         raise ValueError(
-            "profile_mode must be 'dual_profile' or 'prefill', "
+            "profile_mode must be 'dual_profile', 'prefill', or 'decode', "
             f"got {profile_mode!r}")
 
     if max_prefill_length is None:
-        max_prefill_length = max_cache_length
+        # Physical KV capacity and one TensorRT enqueue's query length are
+        # separate limits. Keep the complete model context in the cache while
+        # bounding activation/workspace pressure for very long prompts; the
+        # family runtime transparently advances through multiple chunks.
+        max_prefill_length = (
+            min(max_cache_length, _NATIVE_PREFILL_CHUNK_TOKENS)
+            if native_kv_cache
+            else max_cache_length
+        )
     max_prefill_length = max(1, min(max_prefill_length, max_cache_length))
     opt_prefill_length = max(1, min(opt_prefill_length, max_prefill_length))
 
     multi_bucket_decode = bool(dynamic_kv_profile_rows)
+    if native_kv_cache and multi_bucket_decode:
+        raise ValueError(
+            "TensorRT native KV cache requires one fixed physical capacity; "
+            "dynamic KV-cache bucket profiles are not supported")
+    if native_kv_cache and position_type == "alibi":
+        raise NotImplementedError(
+            "TensorRT native KV cache prototype does not support ALiBi")
     if multi_bucket_decode:
         decode_buckets: list[int] = []
         seen = set()
@@ -290,13 +319,31 @@ def build_dual_profile_decoder_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    native_rope_inv_freq: np.ndarray | None = None
+    if native_kv_cache and position_type == "rope":
+        rope_scaling = (
+            config.raw.get("rope_parameters")
+            or config.raw.get("rope_scaling")
+        )
+        native_rope_inv_freq = graph_ops.make_native_active_rope_inv_freq(
+            head_dim,
+            config.rope_theta,
+            partial_rotary_factor,
+            rope_scaling=rope_scaling,
+        )
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Full-context Llama prefill can require a large fused-attention tactic
+    # workspace while TensorRT is building the plan. This is build-time
+    # scratch only (it is not serialized as runtime KV memory), and the limit
+    # does not allocate the bytes eagerly.
+    workspace_bytes = 16 << 30 if native_kv_cache else 1 << 30
+    trt_config.set_memory_pool_limit(
+        trt.MemoryPoolType.WORKSPACE, workspace_bytes)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
@@ -308,10 +355,22 @@ def build_dual_profile_decoder_engine(
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
-    attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    attention_mask: trt.ITensor | None = None
+    cache_write_indices: trt.ITensor | None = None
+    key_value_lengths: trt.ITensor | None = None
+    if native_kv_cache:
+        cache_write_indices = network.add_input(
+            "cache_write_indices", trt.int32, (1,))
+        key_value_lengths = network.add_input(
+            "key_value_lengths", trt.int32, (1,))
+    else:
+        attention_mask = network.add_input(
+            "attention_mask", trt.float32, (-1, -1))
 
-    cache_shape: tuple[int, int]
-    if multi_bucket_decode:
+    cache_shape: tuple[int, ...]
+    if native_kv_cache:
+        cache_shape = (1, num_kv_heads, max_cache_length, head_dim)
+    elif multi_bucket_decode:
         cache_shape = (-1, kv_attention_size)
     else:
         cache_shape = (max_cache_length, kv_attention_size)
@@ -327,12 +386,14 @@ def build_dual_profile_decoder_engine(
         cache_k_inputs.append(ck)
         cache_v_inputs.append(cv)
 
-    # Cast mask to compute dtype for elementwise broadcast.
-    if work_trt_dtype != trt.float32:
+    # Cast the legacy dense mask to compute dtype for elementwise broadcast.
+    attention_mask_work: trt.ITensor | None = attention_mask
+    if (
+        attention_mask is not None
+        and work_trt_dtype != trt.float32
+    ):
         attention_mask_work = network.add_cast(
             attention_mask, work_trt_dtype).get_output(0)
-    else:
-        attention_mask_work = attention_mask
 
     # Two (or 1+N) optimization profiles — same graph, different Sq / cache.
     def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False,
@@ -343,11 +404,12 @@ def build_dual_profile_decoder_engine(
         min_sq = opt_sq if fixed else 1
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
-        prof.set_shape(
-            "attention_mask",
-            (min_sq, max_cache_length + min_sq),
-            (opt_sq, max_cache_length + opt_sq),
-            (max_sq, max_cache_length + max_sq))
+        if not native_kv_cache:
+            prof.set_shape(
+                "attention_mask",
+                (min_sq, max_cache_length + min_sq),
+                (opt_sq, max_cache_length + opt_sq),
+                (max_sq, max_cache_length + max_sq))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -367,6 +429,8 @@ def build_dual_profile_decoder_engine(
         _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
                      cache_rows_min=1, cache_rows_opt=max_cache_length,
                      cache_rows_max=max_cache_length)
+    elif profile_mode == "decode":
+        _add_profile(1, 1, fixed=True)
     elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
         # Diagnostic: build a one-profile engine with dynamic-shape inputs
         # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
@@ -404,29 +468,44 @@ def build_dual_profile_decoder_engine(
         network, (vocab, hidden), weights["embedding"],
         work_np_dtype, work_trt_dtype)
 
-    # RoPE tables (only when position_type == "rope"). Built for the worst
-    # case key length max_cache_length + max_prefill_length, since RoPE is
-    # gathered by position_id at runtime. The half-dim tables feed TRT's
-    # native IRotaryEmbeddingLayer.
+    # Native KV derives RoPE only for runtime-active positions, so the engine
+    # stores a small [D/2] inverse-frequency constant instead of serializing an
+    # O(context_capacity) table. The legacy graph retains its indexed table.
     cos_half_table: trt.ITensor | None = None
     sin_half_table: trt.ITensor | None = None
+    rope_position_id: trt.ITensor | None = position_id
     if position_type == "rope":
-        kmax = max_cache_length + max_prefill_length
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
-        cos_half_np = graph_ops.make_rope_table_half_dim(
-            kmax, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope,
-            rope_scaling=config.raw.get("rope_scaling"))
-        sin_half_np = graph_ops.make_rope_table_half_dim(
-            kmax, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope,
-            rope_scaling=config.raw.get("rope_scaling"))
-        cos_half_table = _const_in_work_dtype(
-            network, cos_half_np.shape, cos_half_np,
-            work_np_dtype, work_trt_dtype)
-        sin_half_table = _const_in_work_dtype(
-            network, sin_half_np.shape, sin_half_np,
-            work_np_dtype, work_trt_dtype)
+        if native_kv_cache:
+            assert native_rope_inv_freq is not None
+            cos_half_table, sin_half_table = graph_ops.add_active_rope_cache(
+                network,
+                position_id,
+                native_rope_inv_freq,
+                work_trt_dtype,
+            )
+            rope_position_id = None
+        else:
+            kmax = max_cache_length + max_prefill_length
+            cos_half_np = graph_ops.make_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, True,
+                partial_rotary_factor, interleaved=interleaved_rope,
+                rope_scaling=config.raw.get("rope_scaling"))
+            sin_half_np = graph_ops.make_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, False,
+                partial_rotary_factor, interleaved=interleaved_rope,
+                rope_scaling=config.raw.get("rope_scaling"))
+            # BF16 must round directly from the FP32 indexed table. Routing
+            # through FP16 storage would introduce FP16 -> BF16 double rounding.
+            rope_np_dtype = (
+                np.float32 if work_trt_dtype == trt.bfloat16 else work_np_dtype
+            )
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np,
+                rope_np_dtype, work_trt_dtype)
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np,
+                rope_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -495,14 +574,20 @@ def build_dual_profile_decoder_engine(
             network, hidden_state, hidden, embed_norm, embed_norm_beta,
             eps_tensor, "layernorm", work_np_dtype)
 
-    # Build the 4D additive mask once — shared across layers. ALiBi
-    # variants augment the mask with per-head linear bias.
-    if position_type == "alibi":
+    # The native cache path uses LOWER_RIGHT causal attention plus
+    # key_value_lengths, so it does not materialize a dense [Sq, capacity]
+    # mask. The legacy path retains its existing additive-mask graph.
+    mask_4d: trt.ITensor | None
+    if native_kv_cache:
+        mask_4d = None
+    elif position_type == "alibi":
+        assert attention_mask_work is not None
         mask_4d = graph_ops.add_alibi_mask_4d(
             network, attention_mask_work, position_id,
             alibi_slopes_tensor, alibi_cache_positions_fp32,
             num_heads, target_dtype=work_trt_dtype)
     else:
+        assert attention_mask_work is not None
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
 
     present_k_outs: list[trt.ITensor] = []
@@ -559,31 +644,54 @@ def build_dual_profile_decoder_engine(
         if position_type == "rope":
             q = graph_ops.add_apply_rope_native(
                 network, q, num_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
+                cos_half_table, sin_half_table, rope_position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
             k = graph_ops.add_apply_rope_native(
                 network, k, num_kv_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
+                cos_half_table, sin_half_table, rope_position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
 
-        # Present K / V (this step's raw K / V), shape (Sq, attn_size).
-        present_k_outs.append(k)
-        present_v_outs.append(v)
-
-        # Concatenate cached + current K / V along the sequence dim.
-        all_k_cat = network.add_concatenation([cache_k_inputs[layer_idx], k])
-        all_k_cat.axis = 0
-        all_v_cat = network.add_concatenation([cache_v_inputs[layer_idx], v])
-        all_v_cat.axis = 0
-
-        context = graph_ops.add_attention_from_rows(
-            network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
-            num_heads=num_heads, head_dim=head_dim,
-            num_kv_heads=num_kv_heads,
-            q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+        if native_kv_cache:
+            assert cache_write_indices is not None
+            assert key_value_lengths is not None
+            native_attention = graph_ops.add_native_kv_cache_attention_from_rows(
+                network,
+                q,
+                k,
+                v,
+                cache_k_inputs[layer_idx],
+                cache_v_inputs[layer_idx],
+                cache_write_indices,
+                key_value_lengths,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                q_seq=None,
+                scale=attn_scale,
+                tag=f"{prefix}.attn",
+            )
+            context = native_attention["context"]
+            present_k_outs.append(native_attention["present_k"])
+            present_v_outs.append(native_attention["present_v"])
+        else:
+            # Legacy contract: export only this step's raw K/V and materialize
+            # cache + update with concatenation for attention.
+            present_k_outs.append(k)
+            present_v_outs.append(v)
+            all_k_cat = network.add_concatenation(
+                [cache_k_inputs[layer_idx], k])
+            all_k_cat.axis = 0
+            all_v_cat = network.add_concatenation(
+                [cache_v_inputs[layer_idx], v])
+            all_v_cat.axis = 0
+            context = graph_ops.add_attention_from_rows(
+                network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
+                num_heads=num_heads, head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
+                scale=attn_scale, tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")

--- a/python/tensorrt_model_connect/families/llama/graph_ops.py
+++ b/python/tensorrt_model_connect/families/llama/graph_ops.py
@@ -9,6 +9,7 @@ Tensor names and shapes must stay compatible with the C++ bundle runtime.
 from __future__ import annotations
 
 from collections.abc import Mapping
+import math
 from typing import Any
 
 import numpy as np
@@ -443,6 +444,134 @@ def validate_native_rope_dim(
     return rotary_embedding_dim
 
 
+def make_native_active_rope_inv_freq(
+    head_dim: int,
+    rope_theta: float,
+    partial_rotary_factor: float = 1.0,
+    *,
+    rope_scaling: Mapping[str, Any] | None = None,
+) -> np.ndarray:
+    """Return HF/Torch-exact frequencies for native active-position RoPE.
+
+    Hugging Face initializes Llama inverse frequencies on CPU with Torch before
+    moving the model to the inference device. NumPy ``power`` can differ from
+    that operation by one ULP at long positions. The legacy indexed-table
+    helper below is intentionally unchanged.
+    """
+    rotary_ndims = validate_native_rope_dim(
+        int(head_dim * partial_rotary_factor))
+    rope_theta = float(rope_theta)
+    if not np.isfinite(rope_theta) or rope_theta <= 0.0:
+        raise ValueError(
+            "TRT native RoPE requires rope_theta to be finite and positive; "
+            f"got {rope_theta}")
+    try:
+        import torch
+    except (ImportError, OSError) as exc:
+        raise RuntimeError(
+            "TensorRT native Llama KV build requires PyTorch in the Model "
+            "Connect build environment to generate Hugging Face-exact RoPE "
+            "frequencies"
+        ) from exc
+
+    with torch.no_grad():
+        exponents = torch.arange(
+            0,
+            rotary_ndims,
+            2,
+            dtype=torch.int64,
+            device="cpu",
+        ).to(dtype=torch.float32) / rotary_ndims
+        inv_freq = 1.0 / (rope_theta ** exponents)
+        if rope_scaling:
+            rope_type = str(
+                rope_scaling.get("rope_type")
+                or rope_scaling.get("type")
+                or ""
+            ).lower()
+            if rope_type in ("", "default"):
+                rope_scaling = None
+            elif rope_type != "llama3":
+                raise ValueError(
+                    "native active-position RoPE supports only llama3 scaling"
+                )
+        if rope_scaling:
+            factor = float(rope_scaling["factor"])
+            low = float(rope_scaling["low_freq_factor"])
+            high = float(rope_scaling["high_freq_factor"])
+            original = int(
+                rope_scaling["original_max_position_embeddings"]
+            )
+            wavelength = 2 * math.pi / inv_freq
+            low_wavelength = original / low
+            high_wavelength = original / high
+            scaled = torch.where(
+                wavelength > low_wavelength,
+                inv_freq / factor,
+                inv_freq,
+            )
+            smooth = (
+                original / wavelength - low
+            ) / (high - low)
+            interpolated = (
+                (1 - smooth) * scaled / factor + smooth * scaled
+            )
+            medium = (
+                ~(wavelength < high_wavelength)
+                * ~(wavelength > low_wavelength)
+            )
+            inv_freq = torch.where(medium, interpolated, scaled)
+    return np.asarray(
+        inv_freq.detach().cpu().contiguous().numpy(),
+        dtype=np.float32,
+    ).copy()
+
+
+def add_active_rope_cache(
+    network: trt.INetworkDefinition,
+    position_id: trt.ITensor,
+    inv_freq: np.ndarray,
+    output_dtype: trt.DataType,
+) -> tuple[trt.ITensor, trt.ITensor]:
+    """Build ``[1, Sq, D/2]`` cos/sin tensors for active positions only."""
+    inv_freq = np.asarray(inv_freq, dtype=np.float32)
+    if inv_freq.ndim != 1 or inv_freq.size == 0:
+        raise ValueError(
+            "active RoPE inverse frequencies must be a non-empty rank-1 array")
+
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    pos_col = network.add_shuffle(pos_float)
+    pos_col.reshape_dims = (-1, 1)
+    inv_freq_tensor = add_constant(
+        network,
+        (1, int(inv_freq.size)),
+        inv_freq.reshape(1, -1),
+        dtype=np.float32,
+    )
+    angles = network.add_elementwise(
+        pos_col.get_output(0),
+        inv_freq_tensor,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    cos_2d = network.add_unary(
+        angles, trt.UnaryOperation.COS).get_output(0)
+    sin_2d = network.add_unary(
+        angles, trt.UnaryOperation.SIN).get_output(0)
+
+    cos_3d = network.add_shuffle(cos_2d)
+    cos_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    sin_3d = network.add_shuffle(sin_2d)
+    sin_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    cos_cache = cos_3d.get_output(0)
+    sin_cache = sin_3d.get_output(0)
+    if cos_cache.dtype != output_dtype:
+        cos_cache = network.add_cast(
+            cos_cache, output_dtype).get_output(0)
+        sin_cache = network.add_cast(
+            sin_cache, output_dtype).get_output(0)
+    return cos_cache, sin_cache
+
+
 def make_rope_table_half_dim(
     max_cache_length: int,
     head_dim: int,
@@ -693,7 +822,7 @@ def add_apply_rope_native(
     head_dim: int,
     cos_cache_2d: trt.ITensor,
     sin_cache_2d: trt.ITensor,
-    position_id: trt.ITensor,
+    position_id: trt.ITensor | None,
     rotary_embedding_dim: int,
     interleaved: bool = False,
     sequence_length: int | None = 1,
@@ -703,11 +832,17 @@ def add_apply_rope_native(
     Handles both single-token decoder steps and dynamic-Sq prefill/decode
     graphs without a manual rotate-half matmul chain.
 
-    Shape contract (IRotaryEmbeddingLayer with position_ids):
+    Shape contract with indexed, full-capacity caches:
       input:           [1, num_heads, Sq, head_dim]  (reshaped internally)
       cos_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
       sin_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
       position_id:     [Sq] int32, reshaped to [1, Sq] internally
+
+    Shape contract with active-position caches:
+      input:           [1, num_heads, Sq, head_dim]
+      cos_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      sin_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      position_id:     None; the caches already correspond to active positions
       interleaved:     False → rotate-half (LLaMA/Qwen)
                        True  → adjacent-pair (CodeGen/GPT-J)
 
@@ -717,7 +852,8 @@ def add_apply_rope_native(
         head_dim:             Per-head dimension.
         cos_cache_2d:         Pre-built 2-D cos table constant.
         sin_cache_2d:         Pre-built 2-D sin table constant.
-        position_id:          Runtime position indices, shape [Sq] int32.
+        position_id:          Runtime position indices, shape [Sq] int32, or
+                              ``None`` for active-position rank-3 caches.
         rotary_embedding_dim: Number of head dims that participate in RoPE.
         interleaved:          Frequency layout (see above).
         sequence_length:      Static Sq, or None for runtime-dynamic Sq.
@@ -731,11 +867,6 @@ def add_apply_rope_native(
     inp_4d = reshape_rows_to_heads_4d(
         network, inp, num_heads, head_dim, sequence_length)
 
-    # Reshape position_id [Sq] -> [1, Sq] (batch=1).
-    seq_dim = -1 if sequence_length is None else sequence_length
-    pos_2d = network.add_shuffle(position_id)
-    pos_2d.reshape_dims = (1, seq_dim)
-
     rope = network.add_rotary_embedding(
         inp_4d,
         cos_cache_2d,
@@ -743,7 +874,12 @@ def add_apply_rope_native(
         interleaved,
         rotary_embedding_dim,
     )
-    rope.set_input(3, pos_2d.get_output(0))
+    if position_id is not None:
+        # Reshape position_id [Sq] -> [1, Sq] (batch=1).
+        seq_dim = -1 if sequence_length is None else sequence_length
+        pos_2d = network.add_shuffle(position_id)
+        pos_2d.reshape_dims = (1, seq_dim)
+        rope.set_input(3, pos_2d.get_output(0))
 
     return reshape_heads_4d_to_rows(
         network, rope.get_output(0), attention_size, sequence_length)
@@ -824,6 +960,135 @@ def add_attention_core(
     if mask is not None and not causal:
         attn.mask = mask
     return _cast_back_to_trt_dtype(network, attn.get_output(0), output_dtype)
+
+
+def add_native_kv_cache_attention_from_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k_update: trt.ITensor,
+    v_update: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    q_seq: int | None,
+    scale: float | None = None,
+    tag: str | None = None,
+) -> dict[str, trt.ITensor]:
+    """Update a user-owned KV cache and attend over its active prefix.
+
+    ``IKVCacheUpdateLayer`` writes this step's K/V rows into the static,
+    full-capacity cache in place. ``IAttention`` consumes the aliased cache
+    outputs, while ``key_value_lengths`` limits work to the valid prefix.
+    ``LOWER_RIGHT`` causal alignment gives correct autoregressive semantics
+    when the query sequence is shorter than the active KV sequence.
+
+    Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The runtime
+    must bind each output to the same device address as its corresponding
+    input, as required by TensorRT's KV-cache aliasing contract.
+    """
+    if not hasattr(network, "add_kv_cache_update") or not hasattr(
+        network, "add_attention_v2"
+    ):
+        raise RuntimeError(
+            "Llama native KV cache requires TensorRT add_kv_cache_update "
+            "and add_attention_v2 support"
+        )
+
+    k_update_4d = reshape_rows_to_heads_4d(
+        network,
+        k_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".k_update",
+    )
+    v_update_4d = reshape_rows_to_heads_4d(
+        network,
+        v_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".v_update",
+    )
+
+    update_k = network.add_kv_cache_update(
+        cache_k,
+        k_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    update_v = network.add_kv_cache_update(
+        cache_v,
+        v_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    if update_k is None or update_v is None:
+        raise RuntimeError("TensorRT failed to create Llama KV-cache update layers")
+    if tag:
+        update_k.name = tag + ".cache_k_update"
+        update_v.name = tag + ".cache_v_update"
+    updated_k = update_k.get_output(0)
+    updated_v = update_v.get_output(0)
+
+    q_4d = reshape_rows_to_heads_4d(
+        network,
+        q,
+        num_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".q",
+    )
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    if q_4d.dtype != trt.bfloat16:
+        raise ValueError("Llama native KV attention requires BF16 queries")
+    # Keep the exact score scale until the Q product, matching HF SDPA.  If
+    # the constant is rounded to BF16 first, near-tied logits can diverge at
+    # long context even though IAttention itself remains on the fused path.
+    q_scale_input = network.add_cast(q_4d, trt.float32).get_output(0)
+    scale_t = add_constant(
+        network,
+        (1, 1, 1, 1),
+        np.array([[[[scale]]]]),
+        dtype=np.float32,
+    )
+    q_scaled = network.add_elementwise(
+        q_scale_input, scale_t, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    q_scaled = network.add_cast(q_scaled, trt.bfloat16).get_output(0)
+
+    attention = network.add_attention_v2(
+        q_scaled,
+        updated_k,
+        updated_v,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        trt.CausalMaskKind.LOWER_RIGHT,
+    )
+    if attention is None:
+        raise RuntimeError("TensorRT failed to create Llama native attention")
+    attention.decomposable = False
+    attention.key_value_lengths = key_value_lengths
+    if tag:
+        attention.name = tag
+
+    context = reshape_heads_4d_to_rows(
+        network,
+        attention.get_output(0),
+        num_heads * head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".ctx",
+    )
+    return {
+        "context": context,
+        "present_k": updated_k,
+        "present_v": updated_v,
+    }
 
 
 def _scalar_constant_for_trt_dtype(

--- a/python/tensorrt_model_connect/families/llama/native_kv_contract.py
+++ b/python/tensorrt_model_connect/families/llama/native_kv_contract.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mapped-weight contract for Llama's TensorRT native KV graph."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from .build_routing import resolved_head_dim
+
+_LAYER_KEY = re.compile(r"^layer\.(\d+)\.")
+_BIAS_SUFFIXES = (
+    "input_norm_beta",
+    "q_bias",
+    "k_bias",
+    "v_bias",
+    "o_bias",
+    "post_attn_norm_beta",
+    "gate_bias",
+    "up_bias",
+    "down_bias",
+)
+
+
+def _shape(value: object, name: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(dim) for dim in value.shape)
+    except (AttributeError, TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"native Llama weight {name} has an invalid shape"
+        ) from exc
+
+
+def _require(
+    weights: Mapping[str, object],
+    name: str,
+    expected: tuple[int, ...],
+) -> None:
+    if name not in weights:
+        raise ValueError(f"missing native Llama weight {name}")
+    actual = _shape(weights[name], name)
+    if actual != expected:
+        raise ValueError(
+            f"native Llama weight {name} must have shape "
+            f"{expected}, got {actual}"
+        )
+
+
+def validate_native_kv_weights(
+    config: object,
+    weights: Mapping[str, object],
+) -> None:
+    """Validate mapped tensors once, before TensorRT graph construction."""
+
+    if not isinstance(weights, Mapping):
+        raise ValueError("native Llama weights must be a mapping")
+
+    hidden = int(getattr(config, "hidden_size"))
+    vocab = int(getattr(config, "vocab_size"))
+    mlp = int(getattr(config, "intermediate_size"))
+    layers = int(getattr(config, "num_hidden_layers"))
+    heads = int(getattr(config, "num_attention_heads"))
+    kv_heads = int(getattr(config, "num_key_value_heads"))
+    head_dim = resolved_head_dim(config)
+    attention = heads * head_dim
+    kv_attention = kv_heads * head_dim
+
+    layer_indices: set[int] = set()
+    malformed: list[str] = []
+    for name in weights:
+        if not isinstance(name, str) or not name.startswith("layer."):
+            continue
+        match = _LAYER_KEY.match(name)
+        if match is None:
+            malformed.append(name)
+        else:
+            layer_indices.add(int(match.group(1)))
+    if malformed or layer_indices != set(range(layers)):
+        raise ValueError(
+            "native Llama weights require continuous layer indices; "
+            f"malformed={sorted(malformed)}, found={sorted(layer_indices)}"
+        )
+
+    for name, expected in (
+        ("_attention_size", attention),
+        ("_kv_attention_size", kv_attention),
+        ("_mlp_size", mlp),
+    ):
+        if name in weights and int(weights[name]) != expected:
+            raise ValueError(
+                f"native Llama metadata {name} must be {expected}"
+            )
+
+    _require(weights, "embedding", (vocab, hidden))
+    _require(weights, "final_norm", (hidden,))
+    _require(weights, "w_out", (hidden, vocab))
+    forbidden = [
+        name
+        for name in ("final_norm_beta", "lm_head_bias")
+        if name in weights
+    ]
+
+    for layer in range(layers):
+        prefix = f"layer.{layer}"
+        for suffix, expected in (
+            ("input_norm", (hidden,)),
+            ("w_q", (hidden, attention)),
+            ("w_k", (hidden, kv_attention)),
+            ("w_v", (hidden, kv_attention)),
+            ("w_o", (attention, hidden)),
+            ("post_attn_norm", (hidden,)),
+            ("w_gate", (hidden, mlp)),
+            ("w_up", (hidden, mlp)),
+            ("w_down", (mlp, hidden)),
+        ):
+            _require(weights, f"{prefix}.{suffix}", expected)
+        for suffix, expected in (
+            ("q_norm", (attention,)),
+            ("k_norm", (kv_attention,)),
+        ):
+            name = f"{prefix}.{suffix}"
+            if name in weights:
+                _require(weights, name, expected)
+        forbidden.extend(
+            f"{prefix}.{suffix}"
+            for suffix in _BIAS_SUFFIXES
+            if f"{prefix}.{suffix}" in weights
+        )
+
+    if forbidden:
+        raise ValueError(
+            "native dense Llama does not support bias weights: "
+            + ", ".join(sorted(forbidden))
+        )

--- a/python/tensorrt_model_connect/families/llama/plugin.py
+++ b/python/tensorrt_model_connect/families/llama/plugin.py
@@ -26,26 +26,12 @@ class LlamaPlugin:
 
     def default_build_precision(self, config: ModelConfig) -> str:
         capability = native_kv_architecture_capability(config)
-        if capability.eligible:
-            return "bf16"
-        if capability.applicable:
-            raise ValueError(
-                "Unsupported dense Llama native-KV model-only build: "
-                + capability.reason
-            )
-        return "fp32"
+        return "bf16" if capability.eligible else "fp32"
 
     def default_max_cache_length(self, config: ModelConfig) -> int:
         """Use the model's complete context for native Llama."""
         capability = native_kv_architecture_capability(config)
-        if capability.eligible:
-            return int(config.max_position_embeddings)
-        if capability.applicable:
-            raise ValueError(
-                "Unsupported dense Llama native-KV model-only build: "
-                + capability.reason
-            )
-        return 256
+        return int(config.max_position_embeddings) if capability.eligible else 256
 
     def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
         return not bool(config.raw.get("_fp32_layers"))
@@ -73,12 +59,6 @@ class LlamaPlugin:
             quantized=quant_ctx is not None,
             debug_layer_outputs=debug_layer_outputs,
         )
-        if capability.applicable and not capability.eligible:
-            config.raw.pop("_native_kv_cache_metadata", None)
-            raise ValueError(
-                "Unsupported dense Llama native-KV build: "
-                + capability.reason
-            )
         if capability.eligible:
             validate_native_kv_weights(config, weights)
             config.raw["_decoder_engine_layout_supported"] = True

--- a/python/tensorrt_model_connect/families/llama/plugin.py
+++ b/python/tensorrt_model_connect/families/llama/plugin.py
@@ -7,6 +7,12 @@ from __future__ import annotations
 
 from .config import ModelConfig
 from .checkpoint_mapper import WeightDict, load_standard_weights
+from .build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+)
+from .native_kv_contract import validate_native_kv_weights
+from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
 from .standard_decoder_builder import build_standard_decoder_engine
 
 
@@ -17,6 +23,29 @@ class LlamaPlugin:
 
     def matches(self, model_type: str) -> bool:
         return model_type.lower().startswith("llama")
+
+    def default_build_precision(self, config: ModelConfig) -> str:
+        capability = native_kv_architecture_capability(config)
+        if capability.eligible:
+            return "bf16"
+        if capability.applicable:
+            raise ValueError(
+                "Unsupported dense Llama native-KV model-only build: "
+                + capability.reason
+            )
+        return "fp32"
+
+    def default_max_cache_length(self, config: ModelConfig) -> int:
+        """Use the model's complete context for native Llama."""
+        capability = native_kv_architecture_capability(config)
+        if capability.eligible:
+            return int(config.max_position_embeddings)
+        if capability.applicable:
+            raise ValueError(
+                "Unsupported dense Llama native-KV model-only build: "
+                + capability.reason
+            )
+        return 256
 
     def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
         return not bool(config.raw.get("_fp32_layers"))
@@ -37,10 +66,57 @@ class LlamaPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False, debug_layer_outputs: bool = False,
     ) -> bytes:
+        capability = native_kv_build_capability(
+            config,
+            precision=precision,
+            max_cache_length=max_cache_length,
+            quantized=quant_ctx is not None,
+            debug_layer_outputs=debug_layer_outputs,
+        )
+        if capability.applicable and not capability.eligible:
+            config.raw.pop("_native_kv_cache_metadata", None)
+            raise ValueError(
+                "Unsupported dense Llama native-KV build: "
+                + capability.reason
+            )
+        if capability.eligible:
+            validate_native_kv_weights(config, weights)
+            config.raw["_decoder_engine_layout_supported"] = True
+            config.raw["_native_kv_cache_metadata"] = {
+                "native_kv_contract_version": 1,
+                "native_kv_cache": True,
+            }
+            role = str(
+                config.raw.get("_decoder_engine_role", "")
+            )
+            if role not in ("prefill", "decode"):
+                raise ValueError(
+                    "native Llama requires explicit split engine role "
+                    f"'prefill' or 'decode', got {role!r}"
+                )
+            return build_dual_profile_decoder_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision="bf16",
+                quant_ctx=None,
+                verbose=verbose,
+                profile_mode=role,
+                native_kv_cache=True,
+            )
+
+        config.raw.pop("_native_kv_cache_metadata", None)
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision,
             quant_ctx=quant_ctx, verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
+
+    def get_bundle_config_overrides(
+        self, config: ModelConfig,
+    ) -> dict | None:
+        """Mark bundles that use the native KV runtime contract."""
+        metadata = config.raw.get("_native_kv_cache_metadata")
+        return dict(metadata) if isinstance(metadata, dict) else None
 
 
 plugin = LlamaPlugin()

--- a/python/tensorrt_model_connect/families/qwen/MODEL.toml
+++ b/python/tensorrt_model_connect/families/qwen/MODEL.toml
@@ -17,6 +17,7 @@ prefixes = [
   "qwq",
 ]
 debug_runner = "debug_runner.py|runner_from_bundle"
+default_build_route = "build_routing.py|prefer_native_default"
 debug_runtime_strategies = [
   "qwen_decoder_kv_cache",
 ]

--- a/python/tensorrt_model_connect/families/qwen/build_routing.py
+++ b/python/tensorrt_model_connect/families/qwen/build_routing.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Routing contract for dense Qwen3 models using TensorRT native KV cache."""
+
+from __future__ import annotations
+
+import math
+import operator
+
+_INT32_MAX = (1 << 31) - 1
+_UINT64_MAX = (1 << 64) - 1
+
+
+class NativeKvCapability:
+    """Small, loader-safe capability result (no dataclass dependency)."""
+
+    __slots__ = ("applicable", "eligible", "reason")
+
+    def __init__(
+        self,
+        applicable: bool,
+        eligible: bool,
+        reason: str,
+    ) -> None:
+        self.applicable = applicable
+        self.eligible = eligible
+        self.reason = reason
+
+
+def _result(
+    *,
+    applicable: bool = True,
+    reasons: list[str] | tuple[str, ...] = (),
+) -> NativeKvCapability:
+    return NativeKvCapability(
+        applicable,
+        applicable and not reasons,
+        "; ".join(reasons) or "supported",
+    )
+
+
+def _raw(config: object) -> dict:
+    value = getattr(config, "raw", {})
+    return value if isinstance(value, dict) else {}
+
+
+def _integer(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(operator.index(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _positive(config: object, name: str) -> int:
+    value = _integer(getattr(config, name, None), name)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    if value > _INT32_MAX:
+        raise ValueError(f"{name} exceeds TensorRT's int32 dimension limit")
+    return value
+
+
+def resolved_head_dim(config: object) -> int:
+    """Return the explicit HF head width, or derive it when absent."""
+
+    raw = _raw(config)
+    explicit = raw.get("head_dim", getattr(config, "_head_dim", 0))
+    if "head_dim" in raw or explicit not in (None, 0):
+        head_dim = _integer(explicit, "head_dim")
+    else:
+        hidden = _positive(config, "hidden_size")
+        heads = _positive(config, "num_attention_heads")
+        if hidden % heads:
+            raise ValueError(
+                "hidden_size must be divisible by num_attention_heads when "
+                "head_dim is absent"
+            )
+        head_dim = hidden // heads
+    if not 0 < head_dim <= _INT32_MAX:
+        raise ValueError("head_dim must be a positive TensorRT dimension")
+    return head_dim
+
+
+def _checked_product(label: str, *values: int) -> int:
+    product = 1
+    for value in values:
+        if value <= 0 or product > _UINT64_MAX // value:
+            raise ValueError(f"native Qwen KV {label} exceeds uint64")
+        product *= value
+    return product
+
+
+def native_kv_cache_geometry(
+    config: object,
+    capacity: int,
+    *,
+    element_bytes: int = 2,
+) -> tuple[int, int]:
+    """Return runtime byte geometry for the required full-context cache."""
+
+    capacity = _integer(capacity, "max_cache_length")
+    context = _positive(config, "max_position_embeddings")
+    if capacity != context:
+        raise ValueError(
+            "native Qwen KV requires max_cache_length == "
+            f"max_position_embeddings ({context}), got {capacity}"
+        )
+    row_bytes = _checked_product(
+        "row size",
+        2,
+        _positive(config, "num_hidden_layers"),
+        _positive(config, "num_key_value_heads"),
+        resolved_head_dim(config),
+        _integer(element_bytes, "element_bytes"),
+    )
+    return row_bytes, _checked_product("cache size", capacity, row_bytes)
+
+
+def _enabled(value: object) -> bool:
+    return value not in (None, False, 0, "", (), [], {})
+
+
+def _validate_default_rope(raw: dict, reasons: list[str]) -> None:
+    parameters = raw.get("rope_parameters")
+    scaling = raw.get("rope_scaling")
+    if parameters is not None and scaling is not None:
+        reasons.append("RoPE configuration is ambiguous")
+        return
+    rope = parameters if parameters is not None else scaling
+    if rope is None:
+        return
+    if not isinstance(rope, dict):
+        reasons.append("RoPE configuration must be an object")
+        return
+    rope_type = str(rope.get("rope_type", rope.get("type", "default"))).lower()
+    if rope_type not in ("", "default") or any(
+        key in rope
+        for key in (
+            "attention_factor",
+            "beta_fast",
+            "beta_slow",
+            "factor",
+            "original_max_position_embeddings",
+        )
+    ):
+        reasons.append("native Qwen3 supports only unscaled default RoPE")
+
+
+def native_kv_architecture_capability(
+    config: object,
+) -> NativeKvCapability:
+    """Accept any model size that retains the dense Qwen3 graph contract."""
+
+    if str(getattr(config, "model_type", "")).lower() != "qwen3":
+        return _result(applicable=False)
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if tuple(getattr(config, "architectures", ()) or ()) != (
+        "Qwen3ForCausalLM",
+    ):
+        reasons.append("architectures must contain exactly Qwen3ForCausalLM")
+
+    try:
+        dimensions = {
+            name: _positive(config, name)
+            for name in (
+                "vocab_size",
+                "hidden_size",
+                "intermediate_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "max_position_embeddings",
+            )
+        }
+        head_dim = resolved_head_dim(config)
+        if dimensions["num_attention_heads"] % dimensions[
+            "num_key_value_heads"
+        ]:
+            reasons.append(
+                "num_attention_heads must be divisible by "
+                "num_key_value_heads"
+            )
+        if head_dim != 128:
+            reasons.append("native Qwen3 attention requires head_dim=128")
+    except ValueError as exc:
+        reasons.append(str(exc))
+
+    if str(getattr(config, "hidden_act", "")).lower() != "silu":
+        reasons.append("native Qwen3 requires hidden_act='silu'")
+    for name in ("rms_norm_eps", "rope_theta"):
+        try:
+            value = float(getattr(config, name))
+        except (TypeError, ValueError, OverflowError):
+            value = 0.0
+        if not math.isfinite(value) or value <= 0:
+            reasons.append(f"{name} must be finite and positive")
+
+    unsupported_flags = (
+        "attention_bias",
+        "mlp_bias",
+        "is_encoder_decoder",
+        "use_sliding_window",
+        "sliding_window",
+        "rope_interleaved",
+        "interleaved_rope",
+        "num_experts",
+        "num_local_experts",
+        "num_experts_per_tok",
+        "moe_intermediate_size",
+        "shared_expert_intermediate_size",
+        "full_attention_interval",
+        "linear_conv_kernel_dim",
+        "linear_key_head_dim",
+        "linear_num_key_heads",
+        "linear_num_value_heads",
+        "linear_value_head_dim",
+    )
+    enabled = [name for name in unsupported_flags if _enabled(raw.get(name))]
+    if enabled:
+        reasons.append("unsupported Qwen3 fields: " + ", ".join(enabled))
+
+    try:
+        if float(raw.get("partial_rotary_factor", 1.0)) != 1.0:
+            reasons.append("native Qwen3 requires full rotary embeddings")
+    except (TypeError, ValueError, OverflowError):
+        reasons.append("partial_rotary_factor must be numeric")
+    layer_types = raw.get("layer_types")
+    if layer_types is not None and (
+        not isinstance(layer_types, (list, tuple))
+        or any(str(value).lower() != "full_attention" for value in layer_types)
+    ):
+        reasons.append("native Qwen3 does not support hybrid layer types")
+    _validate_default_rope(raw, reasons)
+    return _result(reasons=reasons)
+
+
+def native_kv_build_capability(
+    config: object,
+    *,
+    precision: str = "bf16",
+    max_cache_length: int | None = None,
+    parallel_enabled: bool | None = None,
+    dynamic_kv_cache: bool | None = None,
+    quantized: bool | None = None,
+    debug_layer_outputs: bool = False,
+) -> NativeKvCapability:
+    """Apply deployment constraints once, after architecture routing."""
+
+    architecture = native_kv_architecture_capability(config)
+    if not architecture.eligible:
+        return architecture
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if str(precision).lower() != "bf16":
+        reasons.append("native Qwen3 requires BF16")
+    if str(raw.get("_decoder_engine_layout", "split")) != "split":
+        reasons.append("native Qwen3 requires split prefill/decode engines")
+    if raw.get("_rtx_build_requested"):
+        reasons.append("native Qwen3 requires the standard TensorRT backend")
+    if parallel_enabled or raw.get("_parallel_build_enabled"):
+        reasons.append("native Qwen3 does not support tensor parallel builds")
+    if (
+        dynamic_kv_cache
+        or raw.get("_runtime_dynamic_kv_requested")
+        or raw.get("dynamic_kv_cache")
+    ):
+        reasons.append("native Qwen3 uses one fixed physical KV capacity")
+    if (
+        quantized
+        or raw.get("quantization_config")
+        or raw.get("_quantized_build_requested")
+    ):
+        reasons.append("native Qwen3 does not support quantized builds")
+    if raw.get("_fp32_layers"):
+        reasons.append("native Qwen3 does not support FP32 layer overrides")
+    if debug_layer_outputs:
+        reasons.append("native Qwen3 does not support debug layer outputs")
+    try:
+        native_kv_cache_geometry(
+            config,
+            (
+                int(getattr(config, "max_position_embeddings"))
+                if max_cache_length is None
+                else max_cache_length
+            ),
+        )
+    except ValueError as exc:
+        reasons.append(str(exc))
+    return _result(reasons=reasons)
+
+
+def prefer_native_default(
+    config: object,
+) -> bool:
+    """Route dense Qwen3 to native KV without a user-facing build flag."""
+
+    capability = native_kv_architecture_capability(config)
+    if capability.applicable and not capability.eligible:
+        raise ValueError(
+            "Unsupported dense Qwen3 native-KV model: " + capability.reason
+        )
+    return capability.eligible

--- a/python/tensorrt_model_connect/families/qwen/build_routing.py
+++ b/python/tensorrt_model_connect/families/qwen/build_routing.py
@@ -300,9 +300,4 @@ def prefer_native_default(
 ) -> bool:
     """Route dense Qwen3 to native KV without a user-facing build flag."""
 
-    capability = native_kv_architecture_capability(config)
-    if capability.applicable and not capability.eligible:
-        raise ValueError(
-            "Unsupported dense Qwen3 native-KV model: " + capability.reason
-        )
-    return capability.eligible
+    return native_kv_architecture_capability(config).eligible

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -27,18 +27,22 @@ debug outputs, hidden-state outputs, and the VL ``embed_input`` path stay
 on ``standard_decoder_builder`` for now and are dispatched there from
 inside ``build_standard_decoder_engine``.
 
-Tensor contract (matches the C++ runtime KvCache naming):
-  Inputs (dynamic shapes — Sq varies by profile)
+Tensor contract for the Qwen3 TensorRT native KV-cache path:
+  Inputs (Sq varies by profile; cache capacity is static)
     token_id        int32   (-1,)
     position_id     int32   (-1,)
-    attention_mask  float32 (-1, -1)                 # (Sq, max_cache + Sq)
-    cache_k_i       fp16/f32 (max_cache, kv_size)    # static
-    cache_v_i       fp16/f32 (max_cache, kv_size)    # static
+    cache_write_indices int32 (1,)                    # update start slot
+    key_value_lengths   int32 (1,)                    # valid length after update
+    cache_k_i       bf16 (1, Hkv, capacity, D)        # static, user-owned
+    cache_v_i       bf16 (1, Hkv, capacity, D)        # static, user-owned
   Outputs
     logits          float32 (1, vocab)               # last-row sliced inside the engine
                     or (Sq, vocab) for full-logits diffusion builds
-    present_k_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
-    present_v_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
+    present_k_i     bf16 (1, Hkv, capacity, D)        # aliases cache_k_i
+    present_v_i     bf16 (1, Hkv, capacity, D)        # aliases cache_v_i
+
+The legacy dense-mask/row-cache contract remains available for the other model
+types handled by this family.
 """
 
 from __future__ import annotations
@@ -58,6 +62,9 @@ if TYPE_CHECKING:
     from .config import ModelConfig
     from .checkpoint_mapper import WeightDict
     from ...quantization.context import QuantContext
+
+
+_NATIVE_PREFILL_CHUNK_TOKENS = 32768
 
 
 def _const_in_work_dtype(
@@ -270,6 +277,7 @@ def build_dual_profile_decoder_engine(
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
     full_logits_output: bool = False,
+    native_kv_cache: bool = False,
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
@@ -291,19 +299,36 @@ def build_dual_profile_decoder_engine(
       prefill on the prompt.
     * ``"prefill"``: one prefill profile only. This is used by split-engine
       bundles, where decode is served by a separate fixed-Sq=1 engine.
+    * ``"decode"``: one fixed-Sq=1 profile only. This is the decode half of a
+      split-engine bundle.
 
-    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
-    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
-    bucket profiles are requested so each profile can constrain their row count.
+    ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` and
+    ``IAttention.key_value_lengths`` contract. It is an internal model-family
+    choice, not a user-facing build flag. The legacy dense-mask graph remains
+    available for non-Qwen3 models handled by this family.
     """
     _supports_config(config, weights)
-    if profile_mode not in ("dual_profile", "prefill"):
+    if profile_mode not in ("dual_profile", "prefill", "decode"):
         raise ValueError(
-            "profile_mode must be 'dual_profile' or 'prefill', "
+            "profile_mode must be 'dual_profile', 'prefill', or 'decode', "
             f"got {profile_mode!r}")
-
+    if native_kv_cache and dynamic_kv_profile_rows:
+        raise ValueError(
+            "TensorRT native KV cache requires one fixed physical capacity; "
+            "dynamic KV-cache bucket profiles are not supported")
+    if native_kv_cache and position_type == "alibi":
+        raise NotImplementedError(
+            "TensorRT native KV cache prototype does not support ALiBi")
     if max_prefill_length is None:
-        max_prefill_length = max_cache_length
+        # Physical KV capacity and one TensorRT enqueue's query length are
+        # separate limits. Keep the complete model context in the cache while
+        # bounding activation/workspace pressure for very long prompts; the
+        # family runtime transparently advances through multiple chunks.
+        max_prefill_length = (
+            min(max_cache_length, _NATIVE_PREFILL_CHUNK_TOKENS)
+            if native_kv_cache
+            else max_cache_length
+        )
     max_prefill_length = max(1, min(max_prefill_length, max_cache_length))
     opt_prefill_length = max(1, min(opt_prefill_length, max_prefill_length))
 
@@ -321,17 +346,43 @@ def build_dual_profile_decoder_engine(
             decode_buckets = [max_cache_length]
             multi_bucket_decode = False
 
-    attention_size = weights.get("_attention_size", config.attention_size)
-    mlp_size = weights.get("_mlp_size", config.intermediate_size)
     hidden = config.hidden_size
     vocab = config.vocab_size
     num_layers = config.num_hidden_layers
     num_heads = config.num_attention_heads
     num_kv_heads = config.num_key_value_heads
-    head_dim = attention_size // num_heads
+    if native_kv_cache:
+        from .build_routing import resolved_head_dim
+
+        head_dim = resolved_head_dim(config)
+        attention_size = num_heads * head_dim
+        mlp_size = config.intermediate_size
+    else:
+        attention_size = weights.get(
+            "_attention_size", config.attention_size)
+        mlp_size = weights.get("_mlp_size", config.intermediate_size)
+        head_dim = attention_size // num_heads
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+
+    native_active_rope_inv_freq: np.ndarray | None = None
+    if native_kv_cache and position_type == "rope":
+        if _yarn_rope_kwargs(config) is not None:
+            raise ValueError(
+                "Qwen native KV active-position RoPE only supports "
+                "the default frequency schedule"
+            )
+        # Resolve the HF-exact build-only constant before creating any TRT
+        # objects, so a torch-free environment fails closed without beginning
+        # engine construction.
+        native_active_rope_inv_freq = (
+            graph_ops.make_native_active_rope_inv_freq(
+                head_dim,
+                config.rope_theta,
+                partial_rotary_factor,
+            )
+        )
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -350,10 +401,22 @@ def build_dual_profile_decoder_engine(
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
-    attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    attention_mask: trt.ITensor | None = None
+    cache_write_indices: trt.ITensor | None = None
+    key_value_lengths: trt.ITensor | None = None
+    if native_kv_cache:
+        cache_write_indices = network.add_input(
+            "cache_write_indices", trt.int32, (1,))
+        key_value_lengths = network.add_input(
+            "key_value_lengths", trt.int32, (1,))
+    else:
+        attention_mask = network.add_input(
+            "attention_mask", trt.float32, (-1, -1))
 
-    cache_shape: tuple[int, int]
-    if multi_bucket_decode:
+    cache_shape: tuple[int, ...]
+    if native_kv_cache:
+        cache_shape = (1, num_kv_heads, max_cache_length, head_dim)
+    elif multi_bucket_decode:
         cache_shape = (-1, kv_attention_size)
     else:
         cache_shape = (max_cache_length, kv_attention_size)
@@ -369,12 +432,11 @@ def build_dual_profile_decoder_engine(
         cache_k_inputs.append(ck)
         cache_v_inputs.append(cv)
 
-    # Cast mask to compute dtype for elementwise broadcast.
-    if work_trt_dtype != trt.float32:
+    # Cast the legacy dense mask to compute dtype for elementwise broadcast.
+    attention_mask_work: trt.ITensor | None = attention_mask
+    if attention_mask is not None and work_trt_dtype != trt.float32:
         attention_mask_work = network.add_cast(
             attention_mask, work_trt_dtype).get_output(0)
-    else:
-        attention_mask_work = attention_mask
 
     # Two (or 1+N) optimization profiles — same graph, different Sq / cache.
     def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False,
@@ -385,11 +447,12 @@ def build_dual_profile_decoder_engine(
         min_sq = opt_sq if fixed else 1
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
-        prof.set_shape(
-            "attention_mask",
-            (min_sq, max_cache_length + min_sq),
-            (opt_sq, max_cache_length + opt_sq),
-            (max_sq, max_cache_length + max_sq))
+        if not native_kv_cache:
+            prof.set_shape(
+                "attention_mask",
+                (min_sq, max_cache_length + min_sq),
+                (opt_sq, max_cache_length + opt_sq),
+                (max_sq, max_cache_length + max_sq))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -409,6 +472,8 @@ def build_dual_profile_decoder_engine(
         _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
                      cache_rows_min=1, cache_rows_opt=max_cache_length,
                      cache_rows_max=max_cache_length)
+    elif profile_mode == "decode":
+        _add_profile(1, 1, fixed=True)
     elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
         # Diagnostic: build a one-profile engine with dynamic-shape inputs
         # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
@@ -446,44 +511,58 @@ def build_dual_profile_decoder_engine(
         network, (vocab, hidden), weights["embedding"],
         work_np_dtype, work_trt_dtype)
 
-    # RoPE tables (only when position_type == "rope"). Built for the worst
-    # case key length max_cache_length + max_prefill_length, since RoPE is
-    # gathered by position_id at runtime. The half-dim tables feed TRT's
-    # native IRotaryEmbeddingLayer.
+    # Native KV derives RoPE only for runtime-active positions, so the engine
+    # stores a small [D/2] inverse-frequency constant instead of serializing an
+    # O(context_capacity) table. The legacy graph retains its indexed table.
     cos_half_table: trt.ITensor | None = None
     sin_half_table: trt.ITensor | None = None
+    rope_position_id: trt.ITensor | None = position_id
     q_position_scale_table: trt.ITensor | None = None
     if position_type == "rope":
-        kmax = max_cache_length + max_prefill_length
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
         yarn_kwargs = _yarn_rope_kwargs(config)
-        if yarn_kwargs is not None:
-            cos_half_np = graph_ops.make_yarn_rope_table_half_dim(
-                kmax, head_dim, config.rope_theta, True,
-                interleaved=interleaved_rope, **yarn_kwargs)
-            sin_half_np = graph_ops.make_yarn_rope_table_half_dim(
-                kmax, head_dim, config.rope_theta, False,
-                interleaved=interleaved_rope, **yarn_kwargs)
+        if native_kv_cache:
+            assert native_active_rope_inv_freq is not None
+            cos_half_table, sin_half_table = graph_ops.add_active_rope_cache(
+                network,
+                position_id,
+                native_active_rope_inv_freq,
+                work_trt_dtype,
+            )
+            rope_position_id = None
         else:
-            cos_half_np = graph_ops.make_rope_table_half_dim(
-                kmax, head_dim, config.rope_theta, True,
-                partial_rotary_factor, interleaved=interleaved_rope)
-            sin_half_np = graph_ops.make_rope_table_half_dim(
-                kmax, head_dim, config.rope_theta, False,
-                partial_rotary_factor, interleaved=interleaved_rope)
-        cos_half_table = _const_in_work_dtype(
-            network, cos_half_np.shape, cos_half_np,
-            work_np_dtype, work_trt_dtype)
-        sin_half_table = _const_in_work_dtype(
-            network, sin_half_np.shape, sin_half_np,
-            work_np_dtype, work_trt_dtype)
-        llama4_scale_kwargs = _llama4_attention_scale_kwargs(config)
-        if llama4_scale_kwargs is not None:
-            q_scale_np = graph_ops.make_llama4_attention_scale_table(
-                kmax, **llama4_scale_kwargs)
-            q_position_scale_table = _const_in_work_dtype(
-                network, q_scale_np.shape, q_scale_np,
-                work_np_dtype, work_trt_dtype)
+            kmax = max_cache_length + max_prefill_length
+            if yarn_kwargs is not None:
+                cos_half_np = graph_ops.make_yarn_rope_table_half_dim(
+                    kmax, head_dim, config.rope_theta, True,
+                    interleaved=interleaved_rope, **yarn_kwargs)
+                sin_half_np = graph_ops.make_yarn_rope_table_half_dim(
+                    kmax, head_dim, config.rope_theta, False,
+                    interleaved=interleaved_rope, **yarn_kwargs)
+            else:
+                cos_half_np = graph_ops.make_rope_table_half_dim(
+                    kmax, head_dim, config.rope_theta, True,
+                    partial_rotary_factor, interleaved=interleaved_rope)
+                sin_half_np = graph_ops.make_rope_table_half_dim(
+                    kmax, head_dim, config.rope_theta, False,
+                    partial_rotary_factor, interleaved=interleaved_rope)
+            # Preserve direct FP32 -> BF16 rounding for indexed legacy tables.
+            rope_np_dtype = (
+                np.float32 if work_trt_dtype == trt.bfloat16 else work_np_dtype
+            )
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np,
+                rope_np_dtype, work_trt_dtype)
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np,
+                rope_np_dtype, work_trt_dtype)
+            llama4_scale_kwargs = _llama4_attention_scale_kwargs(config)
+            if llama4_scale_kwargs is not None:
+                q_scale_np = graph_ops.make_llama4_attention_scale_table(
+                    kmax, **llama4_scale_kwargs)
+                q_position_scale_table = _const_in_work_dtype(
+                    network, q_scale_np.shape, q_scale_np,
+                    work_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -552,14 +631,19 @@ def build_dual_profile_decoder_engine(
             network, hidden_state, hidden, embed_norm, embed_norm_beta,
             eps_tensor, "layernorm", work_np_dtype)
 
-    # Build the 4D additive mask once — shared across layers. ALiBi
-    # variants augment the mask with per-head linear bias.
-    if position_type == "alibi":
+    # Native attention uses LOWER_RIGHT causal alignment plus active lengths.
+    # Legacy attention retains its explicit additive mask.
+    mask_4d: trt.ITensor | None
+    if native_kv_cache:
+        mask_4d = None
+    elif position_type == "alibi":
+        assert attention_mask_work is not None
         mask_4d = graph_ops.add_alibi_mask_4d(
             network, attention_mask_work, position_id,
             alibi_slopes_tensor, alibi_cache_positions_fp32,
             num_heads, target_dtype=work_trt_dtype)
     else:
+        assert attention_mask_work is not None
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
 
     present_k_outs: list[trt.ITensor] = []
@@ -616,12 +700,12 @@ def build_dual_profile_decoder_engine(
         if position_type == "rope":
             q = graph_ops.add_apply_rope_native(
                 network, q, num_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
+                cos_half_table, sin_half_table, rope_position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
             k = graph_ops.add_apply_rope_native(
                 network, k, num_kv_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
+                cos_half_table, sin_half_table, rope_position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
             if q_position_scale_table is not None:
@@ -630,22 +714,42 @@ def build_dual_profile_decoder_engine(
                     q_scale = network.add_cast(q_scale, q.dtype).get_output(0)
                 q = network.add_elementwise(q, q_scale, trt.ElementWiseOperation.PROD).get_output(0)
 
-        # Present K / V (this step's raw K / V), shape (Sq, attn_size).
-        present_k_outs.append(k)
-        present_v_outs.append(v)
-
-        # Concatenate cached + current K / V along the sequence dim.
-        all_k_cat = network.add_concatenation([cache_k_inputs[layer_idx], k])
-        all_k_cat.axis = 0
-        all_v_cat = network.add_concatenation([cache_v_inputs[layer_idx], v])
-        all_v_cat.axis = 0
-
-        context = graph_ops.add_attention_from_rows(
-            network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
-            num_heads=num_heads, head_dim=head_dim,
-            num_kv_heads=num_kv_heads,
-            q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+        if native_kv_cache:
+            assert cache_write_indices is not None
+            assert key_value_lengths is not None
+            native_attention = graph_ops.add_native_kv_cache_attention_from_rows(
+                network,
+                q,
+                k,
+                v,
+                cache_k_inputs[layer_idx],
+                cache_v_inputs[layer_idx],
+                cache_write_indices,
+                key_value_lengths,
+                num_heads=num_heads, head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                q_seq=None,
+                scale=attn_scale, tag=f"{prefix}.attn")
+            context = native_attention["context"]
+            present_k_outs.append(native_attention["present_k"])
+            present_v_outs.append(native_attention["present_v"])
+        else:
+            # Legacy contract: export only this step's K/V rows and materialize
+            # cache + update with concatenation for attention.
+            present_k_outs.append(k)
+            present_v_outs.append(v)
+            all_k_cat = network.add_concatenation(
+                [cache_k_inputs[layer_idx], k])
+            all_k_cat.axis = 0
+            all_v_cat = network.add_concatenation(
+                [cache_v_inputs[layer_idx], v])
+            all_v_cat.axis = 0
+            context = graph_ops.add_attention_from_rows(
+                network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
+                num_heads=num_heads, head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
+                scale=attn_scale, tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")
@@ -755,7 +859,10 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        mode_label = {
+            "prefill": "prefill-profile",
+            "decode": "decode-profile",
+        }.get(profile_mode, "dual-profile")
         print(f"[trtmc build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -494,6 +494,105 @@ def validate_native_rope_dim(
     return rotary_embedding_dim
 
 
+def make_native_active_rope_inv_freq(
+    head_dim: int,
+    rope_theta: float,
+    partial_rotary_factor: float = 1.0,
+) -> np.ndarray:
+    """Return the exact HF/Torch CPU frequencies for native active RoPE.
+
+    Hugging Face initializes Qwen3's non-persistent ``inv_freq`` buffer on the
+    CPU before moving the model to CUDA.  NumPy and Torch ``pow`` can differ by
+    one FP32 ULP; that difference changes BF16 cos/sin values at long
+    positions. Keep this Torch dependency confined to the native build path;
+    the legacy indexed-table implementation below stays unchanged.
+    """
+    rotary_ndims = validate_native_rope_dim(
+        int(head_dim * partial_rotary_factor)
+    )
+    rope_theta = float(rope_theta)
+    if not np.isfinite(rope_theta) or rope_theta <= 0.0:
+        raise ValueError(
+            "TRT native RoPE requires rope_theta to be finite and positive; "
+            f"got {rope_theta}"
+        )
+
+    try:
+        import torch
+    except (ImportError, OSError) as exc:
+        raise RuntimeError(
+            "Qwen native active-position RoPE requires PyTorch at build time "
+            "to reproduce Hugging Face FP32 inverse frequencies exactly. "
+            "Install the Model Connect build dependencies, including torch."
+        ) from exc
+
+    with torch.no_grad():
+        dims = torch.arange(
+            0,
+            rotary_ndims,
+            2,
+            dtype=torch.int64,
+            device="cpu",
+        ).to(dtype=torch.float32)
+        # Preserve transformers Qwen3RotaryEmbedding's operation order:
+        # exponent division, power, then reciprocal, all in CPU FP32.
+        inv_freq = 1.0 / (
+            rope_theta ** (dims / rotary_ndims)
+        )
+    return np.asarray(
+        inv_freq.detach().cpu().numpy(),
+        dtype=np.float32,
+    ).copy()
+
+
+def add_active_rope_cache(
+    network: trt.INetworkDefinition,
+    position_id: trt.ITensor,
+    inv_freq: np.ndarray,
+    output_dtype: trt.DataType,
+) -> tuple[trt.ITensor, trt.ITensor]:
+    """Build rank-3 cos/sin tensors only for runtime-active positions.
+
+    ``IRotaryEmbeddingLayer`` accepts ``[B, Sq, D/2]`` caches without a
+    separate position-ids input.  Computing those rows from the runtime
+    ``position_id`` tensor avoids serializing an ``O(context_capacity)`` RoPE
+    table while preserving the native TensorRT RoPE layer.
+    """
+    inv_freq = np.asarray(inv_freq, dtype=np.float32)
+    if inv_freq.ndim != 1 or inv_freq.size == 0:
+        raise ValueError(
+            "active RoPE inverse frequencies must be a non-empty rank-1 array"
+        )
+
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    pos_col = network.add_shuffle(pos_float)
+    pos_col.reshape_dims = (-1, 1)
+    inv_freq_tensor = add_constant(
+        network,
+        (1, int(inv_freq.size)),
+        inv_freq.reshape(1, -1),
+        dtype=np.float32,
+    )
+    angles = network.add_elementwise(
+        pos_col.get_output(0),
+        inv_freq_tensor,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    cos_2d = network.add_unary(angles, trt.UnaryOperation.COS).get_output(0)
+    sin_2d = network.add_unary(angles, trt.UnaryOperation.SIN).get_output(0)
+
+    cos_3d = network.add_shuffle(cos_2d)
+    cos_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    sin_3d = network.add_shuffle(sin_2d)
+    sin_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    cos_cache = cos_3d.get_output(0)
+    sin_cache = sin_3d.get_output(0)
+    if cos_cache.dtype != output_dtype:
+        cos_cache = network.add_cast(cos_cache, output_dtype).get_output(0)
+        sin_cache = network.add_cast(sin_cache, output_dtype).get_output(0)
+    return cos_cache, sin_cache
+
+
 def make_rope_table_half_dim(
     max_cache_length: int,
     head_dim: int,
@@ -683,7 +782,7 @@ def add_apply_rope_native(
     head_dim: int,
     cos_cache_2d: trt.ITensor,
     sin_cache_2d: trt.ITensor,
-    position_id: trt.ITensor,
+    position_id: trt.ITensor | None,
     rotary_embedding_dim: int,
     interleaved: bool = False,
     sequence_length: int | None = 1,
@@ -693,11 +792,17 @@ def add_apply_rope_native(
     Handles both single-token decoder steps and dynamic-Sq prefill/decode
     graphs without a manual rotate-half matmul chain.
 
-    Shape contract (IRotaryEmbeddingLayer with position_ids):
+    Shape contract with indexed, full-capacity caches:
       input:           [1, num_heads, Sq, head_dim]  (reshaped internally)
       cos_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
       sin_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
       position_id:     [Sq] int32, reshaped to [1, Sq] internally
+
+    Shape contract with active-position caches:
+      input:           [1, num_heads, Sq, head_dim]
+      cos_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      sin_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      position_id:     None; the caches already correspond to active positions
       interleaved:     False → rotate-half (LLaMA/Qwen)
                        True  → adjacent-pair (CodeGen/GPT-J)
 
@@ -707,7 +812,8 @@ def add_apply_rope_native(
         head_dim:             Per-head dimension.
         cos_cache_2d:         Pre-built 2-D cos table constant.
         sin_cache_2d:         Pre-built 2-D sin table constant.
-        position_id:          Runtime position indices, shape [Sq] int32.
+        position_id:          Runtime position indices, shape [Sq] int32, or
+                              ``None`` for active-position rank-3 caches.
         rotary_embedding_dim: Number of head dims that participate in RoPE.
         interleaved:          Frequency layout (see above).
         sequence_length:      Static Sq, or None for runtime-dynamic Sq.
@@ -720,11 +826,6 @@ def add_apply_rope_native(
 
     inp_4d = reshape_rows_to_heads_4d(network, inp, num_heads, head_dim, sequence_length)
 
-    # Reshape position_id [Sq] -> [1, Sq] (batch=1).
-    seq_dim = -1 if sequence_length is None else sequence_length
-    pos_2d = network.add_shuffle(position_id)
-    pos_2d.reshape_dims = (1, seq_dim)
-
     rope = network.add_rotary_embedding(
         inp_4d,
         cos_cache_2d,
@@ -732,7 +833,12 @@ def add_apply_rope_native(
         interleaved,
         rotary_embedding_dim,
     )
-    rope.set_input(3, pos_2d.get_output(0))
+    if position_id is not None:
+        # Reshape position_id [Sq] -> [1, Sq] (batch=1).
+        seq_dim = -1 if sequence_length is None else sequence_length
+        pos_2d = network.add_shuffle(position_id)
+        pos_2d.reshape_dims = (1, seq_dim)
+        rope.set_input(3, pos_2d.get_output(0))
 
     return reshape_heads_4d_to_rows(network, rope.get_output(0), attention_size, sequence_length)
 
@@ -1022,6 +1128,138 @@ def add_attention_from_rows(
         sequence_length=q_seq,
         tag=None if tag is None else tag + ".ctx",
     )
+
+
+def add_native_kv_cache_attention_from_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k_update: trt.ITensor,
+    v_update: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    q_seq: int | None,
+    scale: float | None = None,
+    tag: str | None = None,
+) -> dict[str, trt.ITensor]:
+    """Update a user-owned KV cache and attend over its active prefix.
+
+    ``IKVCacheUpdateLayer`` writes this step's K/V rows into the static,
+    full-capacity cache in place. ``IAttention`` consumes the aliased cache
+    outputs, while ``key_value_lengths`` limits work to the valid prefix.
+    ``LOWER_RIGHT`` causal alignment gives correct autoregressive semantics
+    when the query sequence is shorter than the active KV sequence.
+
+    Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The caller
+    must bind each output to the same device address as its corresponding
+    input, as required by TensorRT's KV-cache aliasing contract.
+    """
+    if not hasattr(network, "add_kv_cache_update") or not hasattr(
+        network, "add_attention_v2"
+    ):
+        raise RuntimeError(
+            "Qwen native KV cache requires TensorRT add_kv_cache_update "
+            "and add_attention_v2 support"
+        )
+
+    k_update_4d = reshape_rows_to_heads_4d(
+        network,
+        k_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".k_update",
+    )
+    v_update_4d = reshape_rows_to_heads_4d(
+        network,
+        v_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".v_update",
+    )
+
+    update_k = network.add_kv_cache_update(
+        cache_k,
+        k_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    update_v = network.add_kv_cache_update(
+        cache_v,
+        v_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    if update_k is None or update_v is None:
+        raise RuntimeError("TensorRT failed to create Qwen KV-cache update layers")
+    if tag:
+        update_k.name = tag + ".cache_k_update"
+        update_v.name = tag + ".cache_v_update"
+    updated_k = update_k.get_output(0)
+    updated_v = update_v.get_output(0)
+
+    q_4d = reshape_rows_to_heads_4d(
+        network,
+        q,
+        num_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".q",
+    )
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    if q_4d.dtype != trt.bfloat16:
+        raise ValueError("Qwen native KV attention requires BF16 queries")
+    # Keep the exact score scale until the Q product, matching HF SDPA.  If
+    # the constant is rounded to BF16 first, near-tied logits can diverge at
+    # long context even though IAttention itself remains on the fused path.
+    q_scale_input = network.add_cast(q_4d, trt.float32).get_output(0)
+    scale_t = add_constant(
+        network,
+        (1, 1, 1, 1),
+        np.array([[[[scale]]]]),
+        dtype=np.float32,
+    )
+    q_scaled = network.add_elementwise(
+        q_scale_input, scale_t, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    q_scaled = network.add_cast(q_scaled, trt.bfloat16).get_output(0)
+
+    attention = network.add_attention_v2(
+        q_scaled,
+        updated_k,
+        updated_v,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        trt.CausalMaskKind.LOWER_RIGHT,
+    )
+    if attention is None:
+        raise RuntimeError("TensorRT failed to create Qwen native attention")
+    # The prototype deliberately requires TensorRT's fused attention tactic.
+    # Unsupported dtype/head geometries fail at build time instead of silently
+    # falling back to a primitive graph with materially lower decode speed.
+    attention.decomposable = False
+    attention.key_value_lengths = key_value_lengths
+    if tag:
+        attention.name = tag
+
+    context = reshape_heads_4d_to_rows(
+        network,
+        attention.get_output(0),
+        num_heads * head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".ctx",
+    )
+    return {
+        "context": context,
+        "present_k": updated_k,
+        "present_v": updated_v,
+    }
 
 
 # Backward-compatible name used by existing tests and call sites.

--- a/python/tensorrt_model_connect/families/qwen/native_kv_contract.py
+++ b/python/tensorrt_model_connect/families/qwen/native_kv_contract.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mapped-weight contract for Qwen3's TensorRT native KV graph."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from .build_routing import resolved_head_dim
+
+_LAYER_KEY = re.compile(r"^layer\.(\d+)\.")
+_BIAS_SUFFIXES = (
+    "input_norm_beta",
+    "q_bias",
+    "k_bias",
+    "v_bias",
+    "o_bias",
+    "post_attn_norm_beta",
+    "gate_bias",
+    "up_bias",
+    "down_bias",
+)
+
+
+def _shape(value: object, name: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(dim) for dim in value.shape)
+    except (AttributeError, TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"native Qwen3 weight {name} has an invalid shape"
+        ) from exc
+
+
+def _require(
+    weights: Mapping[str, object],
+    name: str,
+    expected: tuple[int, ...],
+) -> None:
+    if name not in weights:
+        raise ValueError(f"missing native Qwen3 weight {name}")
+    actual = _shape(weights[name], name)
+    if actual != expected:
+        raise ValueError(
+            f"native Qwen3 weight {name} must have shape "
+            f"{expected}, got {actual}"
+        )
+
+
+def validate_native_kv_weights(
+    config: object,
+    weights: Mapping[str, object],
+) -> None:
+    """Validate mapped tensors once, before TensorRT graph construction."""
+
+    if not isinstance(weights, Mapping):
+        raise ValueError("native Qwen3 weights must be a mapping")
+
+    hidden = int(getattr(config, "hidden_size"))
+    vocab = int(getattr(config, "vocab_size"))
+    mlp = int(getattr(config, "intermediate_size"))
+    layers = int(getattr(config, "num_hidden_layers"))
+    heads = int(getattr(config, "num_attention_heads"))
+    kv_heads = int(getattr(config, "num_key_value_heads"))
+    head_dim = resolved_head_dim(config)
+    attention = heads * head_dim
+    kv_attention = kv_heads * head_dim
+
+    layer_indices: set[int] = set()
+    malformed: list[str] = []
+    for name in weights:
+        if not isinstance(name, str) or not name.startswith("layer."):
+            continue
+        match = _LAYER_KEY.match(name)
+        if match is None:
+            malformed.append(name)
+        else:
+            layer_indices.add(int(match.group(1)))
+    if malformed or layer_indices != set(range(layers)):
+        raise ValueError(
+            "native Qwen3 weights require continuous layer indices; "
+            f"malformed={sorted(malformed)}, found={sorted(layer_indices)}"
+        )
+
+    for name, expected in (
+        ("_attention_size", attention),
+        ("_kv_attention_size", kv_attention),
+        ("_mlp_size", mlp),
+    ):
+        if name in weights and int(weights[name]) != expected:
+            raise ValueError(
+                f"native Qwen3 metadata {name} must be {expected}"
+            )
+
+    _require(weights, "embedding", (vocab, hidden))
+    _require(weights, "final_norm", (hidden,))
+    _require(weights, "w_out", (hidden, vocab))
+    forbidden = [
+        name
+        for name in ("final_norm_beta", "lm_head_bias")
+        if name in weights
+    ]
+
+    for layer in range(layers):
+        prefix = f"layer.{layer}"
+        for suffix, expected in (
+            ("input_norm", (hidden,)),
+            ("w_q", (hidden, attention)),
+            ("w_k", (hidden, kv_attention)),
+            ("w_v", (hidden, kv_attention)),
+            ("w_o", (attention, hidden)),
+            ("post_attn_norm", (hidden,)),
+            ("w_gate", (hidden, mlp)),
+            ("w_up", (hidden, mlp)),
+            ("w_down", (mlp, hidden)),
+            ("q_norm", (attention,)),
+            ("k_norm", (kv_attention,)),
+        ):
+            _require(weights, f"{prefix}.{suffix}", expected)
+        forbidden.extend(
+            f"{prefix}.{suffix}"
+            for suffix in _BIAS_SUFFIXES
+            if f"{prefix}.{suffix}" in weights
+        )
+
+    if forbidden:
+        raise ValueError(
+            "native dense Qwen3 does not support bias weights: "
+            + ", ".join(sorted(forbidden))
+        )

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -78,21 +78,11 @@ class QwenPlugin:
 
     def default_build_precision(self, config: ModelConfig) -> str:
         capability = native_kv_architecture_capability(config)
-        if capability.applicable and not capability.eligible:
-            raise ValueError(
-                "Unsupported dense Qwen3 native-KV model: "
-                + capability.reason
-            )
         return "bf16" if capability.eligible else "fp32"
 
     def default_max_cache_length(self, config: ModelConfig) -> int:
         """Use the model's complete context for native Qwen3."""
         capability = native_kv_architecture_capability(config)
-        if capability.applicable and not capability.eligible:
-            raise ValueError(
-                "Unsupported dense Qwen3 native-KV model: "
-                + capability.reason
-            )
         return int(config.max_position_embeddings) if capability.eligible else 256
 
     def load_weights(
@@ -116,12 +106,6 @@ class QwenPlugin:
             quantized=quant_ctx is not None,
             debug_layer_outputs=debug_layer_outputs,
         )
-        if capability.applicable and not capability.eligible:
-            config.raw.pop("_native_kv_cache_metadata", None)
-            raise ValueError(
-                "Unsupported dense Qwen3 native-KV build: "
-                + capability.reason
-            )
         if capability.eligible:
             validate_native_kv_weights(config, weights)
             config.raw["_decoder_engine_layout_supported"] = True

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -3,11 +3,8 @@
 
 """Qwen family plugin — Qwen, Qwen2, Qwen3, QwQ (text-only, not VL).
 
-Calls the standard decoder builder, which now dispatches to the
-dual-profile builder by default (one engine, two optimization profiles —
-profile 0 = batched prefill, profile 1 = single-token decode). Quantized
-and TriAttention (``dynamic_kv_cache``) bundles fall back to the legacy
-single-profile graph automatically inside the standard builder.
+Dense Qwen3 uses the family-owned TensorRT native KV path. Other Qwen
+variants retain their existing legacy graph routes.
 """
 
 from __future__ import annotations
@@ -16,6 +13,12 @@ from .config import ModelConfig
 from .checkpoint_mapper import WeightDict, load_standard_weights
 from ...parallel_config import normalize_parallel_config
 from ...quantization.adapters import StandardDecoderCalibrationAdapter
+from .build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+)
+from .native_kv_contract import validate_native_kv_weights
+from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
 from .standard_decoder_builder import build_standard_decoder_engine
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
 
@@ -73,6 +76,25 @@ class QwenPlugin:
             return False
         return mt.startswith("qwen") or mt.startswith("qwq")
 
+    def default_build_precision(self, config: ModelConfig) -> str:
+        capability = native_kv_architecture_capability(config)
+        if capability.applicable and not capability.eligible:
+            raise ValueError(
+                "Unsupported dense Qwen3 native-KV model: "
+                + capability.reason
+            )
+        return "bf16" if capability.eligible else "fp32"
+
+    def default_max_cache_length(self, config: ModelConfig) -> int:
+        """Use the model's complete context for native Qwen3."""
+        capability = native_kv_architecture_capability(config)
+        if capability.applicable and not capability.eligible:
+            raise ValueError(
+                "Unsupported dense Qwen3 native-KV model: "
+                + capability.reason
+            )
+        return int(config.max_position_embeddings) if capability.eligible else 256
+
     def load_weights(
         self, model_dir: str, config: ModelConfig,
         *, precision: str = "fp32",
@@ -86,6 +108,47 @@ class QwenPlugin:
         debug_layer_outputs: bool = False,
     ) -> bytes:
         parallel = normalize_parallel_config(parallel_config)
+        capability = native_kv_build_capability(
+            config,
+            precision=precision,
+            max_cache_length=max_cache_length,
+            parallel_enabled=parallel.enabled,
+            quantized=quant_ctx is not None,
+            debug_layer_outputs=debug_layer_outputs,
+        )
+        if capability.applicable and not capability.eligible:
+            config.raw.pop("_native_kv_cache_metadata", None)
+            raise ValueError(
+                "Unsupported dense Qwen3 native-KV build: "
+                + capability.reason
+            )
+        if capability.eligible:
+            validate_native_kv_weights(config, weights)
+            config.raw["_decoder_engine_layout_supported"] = True
+            config.raw["_native_kv_cache_metadata"] = {
+                "native_kv_contract_version": 1,
+                "native_kv_cache": True,
+            }
+            role = str(
+                config.raw.get("_decoder_engine_role", "")
+            )
+            if role not in ("prefill", "decode"):
+                raise ValueError(
+                    "native Qwen3 requires explicit split engine role "
+                    f"'prefill' or 'decode', got {role!r}"
+                )
+            return build_dual_profile_decoder_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision="bf16",
+                quant_ctx=None,
+                verbose=verbose,
+                profile_mode=role,
+                native_kv_cache=True,
+            )
+
+        config.raw.pop("_native_kv_cache_metadata", None)
         if parallel.enabled:
             if debug_layer_outputs:
                 raise NotImplementedError(
@@ -108,6 +171,13 @@ class QwenPlugin:
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs,
         )
+
+    def get_bundle_config_overrides(
+        self, config: ModelConfig,
+    ) -> dict | None:
+        """Mark bundles that use the native KV runtime contract."""
+        metadata = config.raw.get("_native_kv_cache_metadata")
+        return dict(metadata) if isinstance(metadata, dict) else None
 
     def calibration_data(self, format_name: str) -> list[str] | None:
         return list(self._CALIBRATION_PROMPTS)

--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -69,6 +69,7 @@ TrtModuleImpl::TrtModuleImpl(nvinfer1::ICudaEngine* engine, nvinfer1::IExecution
     if (!ctx_)
         return;
     try {
+        discover_tensor_aliases(engine);
         validate_initial_external_bindings(engine, external_bindings);
     } catch (const std::exception& error) {
         std::cerr << "[trt_module] Invalid external binding: " << error.what() << '\n';
@@ -93,6 +94,34 @@ TrtModuleImpl::TrtModuleImpl(nvinfer1::ICudaEngine* engine, nvinfer1::IExecution
     allocate_buffers(engine);
 }
 
+void TrtModuleImpl::discover_tensor_aliases(nvinfer1::ICudaEngine* engine) {
+#if NV_TENSORRT_MAJOR >= 11
+    for (int32_t index = 0; index < engine->getNbIOTensors(); ++index) {
+        const char* raw_output_name = engine->getIOTensorName(index);
+        if (raw_output_name == nullptr ||
+            engine->getTensorIOMode(raw_output_name) != nvinfer1::TensorIOMode::kOUTPUT) {
+            continue;
+        }
+        const char* raw_input_name = engine->getAliasedInputTensor(raw_output_name);
+        if (raw_input_name == nullptr)
+            continue;
+        if (!engine_has_io_tensor(engine, raw_input_name) ||
+            engine->getTensorIOMode(raw_input_name) != nvinfer1::TensorIOMode::kINPUT) {
+            throw std::invalid_argument("Aliased output '" + std::string(raw_output_name) +
+                                        "' refers to invalid input '" +
+                                        std::string(raw_input_name) + "'");
+        }
+        const std::string output_name(raw_output_name);
+        const std::string input_name(raw_input_name);
+        alias_input_by_output_.emplace(output_name, input_name);
+        alias_outputs_by_input_[input_name].push_back(output_name);
+        alias_groups_ready_ = false;
+    }
+#else
+    (void)engine;
+#endif
+}
+
 void TrtModuleImpl::validate_initial_external_bindings(
     nvinfer1::ICudaEngine* engine, const std::vector<ModuleExternalBinding>& external_bindings) {
     for (const auto& binding : external_bindings) {
@@ -105,6 +134,11 @@ void TrtModuleImpl::validate_initial_external_bindings(
 
         if (!engine_has_io_tensor(engine, binding.tensor_name))
             throw std::invalid_argument("unknown tensor '" + binding.tensor_name + "'");
+        if (alias_input_by_output_.count(binding.tensor_name) != 0 ||
+            alias_outputs_by_input_.count(binding.tensor_name) != 0) {
+            throw std::invalid_argument("TensorRT alias tensor '" + binding.tensor_name +
+                                        "' must be bound after module creation");
+        }
 
         const auto dims = engine->getTensorShape(binding.tensor_name.c_str());
         if (dims_are_dynamic(dims)) {
@@ -309,7 +343,7 @@ void TrtModuleImpl::allocate_single_input(nvinfer1::ICudaEngine* engine, const s
     if (external != initial_external_bindings_.end()) {
         entry.d_ptr = external->second;
         entry.is_external = true;
-    } else if (nbytes > 0) {
+    } else if (should_allocate_input(name, nbytes)) {
         auto err = cudaMalloc(&entry.d_ptr, nbytes);
         if (err != cudaSuccess)
             entry.d_ptr = nullptr;
@@ -365,6 +399,11 @@ void TrtModuleImpl::allocate_output_buffers(nvinfer1::ICudaEngine* engine, int32
         entry.nbytes = nbytes;
         entry.is_input = false;
 
+        if (alias_input_by_output_.count(name) != 0) {
+            buffers_[name] = std::move(entry);
+            continue;
+        }
+
         const auto external = initial_external_bindings_.find(name);
         if (external != initial_external_bindings_.end()) {
             entry.d_ptr = external->second;
@@ -391,7 +430,6 @@ void TrtModuleImpl::allocate_output_buffers(nvinfer1::ICudaEngine* engine, int32
 void TrtModuleImpl::allocate_buffers(nvinfer1::ICudaEngine* engine) {
     const int32_t num_io = engine->getNbIOTensors();
     const int32_t num_profiles = engine->getNbOptimizationProfiles();
-
     detect_dynamic_shapes(engine, num_io);
 
     // Pass 1: allocate input buffers (use profile-0 max shape for dynamic inputs).
@@ -409,6 +447,96 @@ void TrtModuleImpl::allocate_buffers(nvinfer1::ICudaEngine* engine) {
 
     initial_external_bindings_.clear();
     cudaStreamSynchronize(stream_);
+}
+
+bool TrtModuleImpl::should_allocate_input(const std::string& name, std::size_t nbytes) const {
+    return nbytes > 0 && alias_outputs_by_input_.count(name) == 0;
+}
+
+void TrtModuleImpl::validate_alias_outputs_exist(
+    const std::vector<std::string>& output_names) const {
+    for (const auto& output_name : output_names) {
+        if (buffers_.count(output_name) == 0) {
+            throw std::invalid_argument("Incomplete TensorRT alias group for output '" +
+                                        output_name + "'");
+        }
+    }
+}
+
+void TrtModuleImpl::bind_alias_outputs_or_invalidate(const std::vector<std::string>& output_names,
+                                                     void* ptr) {
+    for (const auto& output_name : output_names) {
+        auto output = buffers_.find(output_name);
+        BufferEntry candidate_output = output->second;
+        candidate_output.d_ptr = ptr;
+        candidate_output.is_external = true;
+        if (!bind_tensor_address(output_name, candidate_output)) {
+            // TensorRT address updates are not transactional. Once part of a
+            // group has changed, discard the context rather than risk enqueue
+            // with mixed state addresses.
+            if (cuda_graph_)
+                cuda_graph_->reset();
+            delete ctx_;
+            ctx_ = nullptr;
+            throw std::runtime_error("TensorRT rejected external alias output '" + output_name +
+                                     "'");
+        }
+    }
+}
+
+void TrtModuleImpl::reset_alias_cuda_graph_if_rebound(void* previous_ptr, void* ptr) {
+    if (previous_ptr != ptr && use_cuda_graph_ && cuda_graph_)
+        cuda_graph_->reset();
+}
+
+void TrtModuleImpl::bind_alias_group(const std::string& input_name, void* ptr) {
+    if (ptr == nullptr)
+        throw std::invalid_argument("External alias buffer for '" + input_name + "' is null");
+
+    auto input = buffers_.find(input_name);
+    const auto outputs = alias_outputs_by_input_.find(input_name);
+    if (input == buffers_.end() || outputs == alias_outputs_by_input_.end()) {
+        throw std::invalid_argument("Incomplete TensorRT alias group for input '" + input_name +
+                                    "'");
+    }
+    validate_alias_outputs_exist(outputs->second);
+
+    BufferEntry candidate_input = input->second;
+    candidate_input.d_ptr = ptr;
+    candidate_input.is_external = true;
+    if (!bind_tensor_address(input_name, candidate_input)) {
+        throw std::runtime_error("TensorRT rejected external alias input '" + input_name + "'");
+    }
+
+    bind_alias_outputs_or_invalidate(outputs->second, ptr);
+
+    reset_alias_cuda_graph_if_rebound(input->second.d_ptr, ptr);
+    input->second.d_ptr = ptr;
+    input->second.is_external = true;
+    for (const auto& output_name : outputs->second) {
+        auto& output = buffers_.at(output_name);
+        output.d_ptr = ptr;
+        output.is_external = true;
+    }
+    alias_groups_ready_ = false;
+}
+
+void TrtModuleImpl::validate_alias_groups_bound() const {
+    for (const auto& [input_name, output_names] : alias_outputs_by_input_) {
+        const auto input = buffers_.find(input_name);
+        if (input == buffers_.end() || input->second.d_ptr == nullptr) {
+            throw std::runtime_error("TensorRT alias input '" + input_name +
+                                     "' has no external buffer");
+        }
+        for (const auto& output_name : output_names) {
+            const auto output = buffers_.find(output_name);
+            if (output == buffers_.end() || output->second.d_ptr == nullptr ||
+                output->second.d_ptr != input->second.d_ptr) {
+                throw std::runtime_error("TensorRT alias output '" + output_name +
+                                         "' is not bound to input '" + input_name + "'");
+            }
+        }
+    }
 }
 
 void TrtModuleImpl::free_buffers() {
@@ -492,6 +620,12 @@ void TrtModuleImpl::forward_async(const TensorMap& inputs) {
 }
 
 void TrtModuleImpl::execute_enqueue() {
+    if (!ctx_)
+        throw std::runtime_error("TensorRT execution context is unavailable");
+    if (!alias_groups_ready_) {
+        validate_alias_groups_bound();
+        alias_groups_ready_ = true;
+    }
     record_timed_enqueue();
 }
 
@@ -737,6 +871,16 @@ void TrtModuleImpl::bind_external(const std::string& name, void* external_device
     auto it = buffers_.find(name);
     if (it == buffers_.end())
         return;
+
+    if (alias_input_by_output_.count(name) != 0) {
+        throw std::invalid_argument("Bind TensorRT alias input '" +
+                                    alias_input_by_output_.at(name) + "', not output '" + name +
+                                    "'");
+    }
+    if (alias_outputs_by_input_.count(name) != 0) {
+        bind_alias_group(name, external_device_ptr);
+        return;
+    }
 
     auto& entry = it->second;
 

--- a/src/runtime/backend/trt_module_impl.h
+++ b/src/runtime/backend/trt_module_impl.h
@@ -91,19 +91,29 @@ class TrtModuleImpl final : public ITrtModule {
     void* distributed_communicator_{nullptr};
     bool has_dynamic_shapes_{false};
     bool use_cuda_graph_{false};
+    bool alias_groups_ready_{true};
     std::unique_ptr<CudaGraphExec> cuda_graph_;
     std::vector<std::shared_ptr<void>> keep_alive_;
     std::unordered_map<std::string, void*> initial_external_bindings_;
     std::unordered_map<std::string, BufferEntry> buffers_;
+    std::unordered_map<std::string, std::string> alias_input_by_output_;
+    std::unordered_map<std::string, std::vector<std::string>> alias_outputs_by_input_;
     std::unordered_map<std::string, std::vector<uint8_t>> host_output_staging_;
     std::unordered_map<std::string, DeviceTensor> output_device_tensors_;
     std::string timing_label_{"engine"};
     std::vector<TimingEvent> timing_events_;
 
     void allocate_buffers(nvinfer1::ICudaEngine* engine);
+    void discover_tensor_aliases(nvinfer1::ICudaEngine* engine);
     void
     validate_initial_external_bindings(nvinfer1::ICudaEngine* engine,
                                        const std::vector<ModuleExternalBinding>& external_bindings);
+    void bind_alias_group(const std::string& input_name, void* ptr);
+    bool should_allocate_input(const std::string& name, std::size_t nbytes) const;
+    void validate_alias_outputs_exist(const std::vector<std::string>& output_names) const;
+    void bind_alias_outputs_or_invalidate(const std::vector<std::string>& output_names, void* ptr);
+    void reset_alias_cuda_graph_if_rebound(void* previous_ptr, void* ptr);
+    void validate_alias_groups_bound() const;
     void free_buffers();
     void detect_dynamic_shapes(nvinfer1::ICudaEngine* engine, int32_t num_io);
     void allocate_input_buffers(nvinfer1::ICudaEngine* engine, int32_t num_io,

--- a/src/runtime/models/llama/MODEL.toml
+++ b/src/runtime/models/llama/MODEL.toml
@@ -12,4 +12,5 @@ runtime_tests = [
   "test_llama_plugin_helpers|test_llama_plugin_helpers.cpp|_|plugin_helpers.cpp|_",
   "test_llama_chat_template|test_llama_chat_template.cpp|trtmc_model_llama|_|_",
   "test_llama_pipeline|test_llama_pipeline.cpp|trtmc_model_llama,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_llama_native_kv_cache|test_llama_native_kv_cache.cpp|trtmc_model_llama|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/llama/kv_cache.cpp
+++ b/src/runtime/models/llama/kv_cache.cpp
@@ -25,6 +25,52 @@ int32_t round_up_rows(int32_t value, int32_t bucket, int32_t maximum) {
     return std::min(rounded, maximum);
 }
 
+void validate_native_scalar_input(TrtModule& module, const std::string& name) {
+    if (module.tensor_dtype(name) != DType::kInt32 ||
+        module.tensor_shape(name) != std::vector<int64_t>{1}) {
+        throw std::runtime_error("Llama native KV input '" + name + "' must be int32 [1]");
+    }
+}
+
+bool valid_native_cache_shape(const std::vector<int64_t>& shape, int32_t max_length,
+                              int32_t kv_dim) {
+    if (shape.size() != 4)
+        return false;
+    if (shape[0] != 1 || shape[2] != static_cast<int64_t>(max_length))
+        return false;
+    if (shape[1] <= 0 || shape[3] <= 0)
+        return false;
+    return shape[1] * shape[3] == kv_dim;
+}
+
+void validate_native_cache_pair(TrtModule& module, const std::string& cache_name,
+                                const std::string& present_name, int32_t max_length, int32_t kv_dim,
+                                DType cache_dtype) {
+    if (!module.has_input(cache_name) || !module.has_output(present_name)) {
+        throw std::runtime_error("Llama native KV engine is missing cache/present pair '" +
+                                 cache_name + "'/'" + present_name + "'");
+    }
+    const auto cache_shape = module.tensor_shape(cache_name);
+    const auto present_shape = module.tensor_shape(present_name);
+    if (!valid_native_cache_shape(cache_shape, max_length, kv_dim) ||
+        present_shape != cache_shape) {
+        throw std::runtime_error("Llama native KV cache/present tensors must share static "
+                                 "[1,Hkv,max_length,D] shape");
+    }
+    if (module.tensor_dtype(cache_name) != cache_dtype ||
+        module.tensor_dtype(present_name) != cache_dtype) {
+        throw std::runtime_error("Llama native KV cache dtype does not match model precision");
+    }
+}
+
+bool all_tensors_ok(const std::vector<DeviceTensor>& tensors) {
+    for (const auto& tensor : tensors) {
+        if (!tensor.ok())
+            return false;
+    }
+    return true;
+}
+
 } // namespace
 
 LlamaKvCache::LlamaKvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
@@ -47,6 +93,11 @@ LlamaKvCache::LlamaKvCache(int32_t num_layers, int32_t max_length, int32_t kv_di
             names_.present_v.push_back("present_v" + suffix);
         }
     }
+    const auto expected_names = static_cast<std::size_t>(num_layers);
+    if (names_.cache_k.size() != expected_names || names_.cache_v.size() != expected_names ||
+        names_.present_k.size() != expected_names || names_.present_v.size() != expected_names) {
+        throw std::invalid_argument("LlamaKvCache: per-layer tensor name count mismatch");
+    }
 
     cache_k_.reserve(static_cast<std::size_t>(num_layers));
     cache_v_.reserve(static_cast<std::size_t>(num_layers));
@@ -55,15 +106,102 @@ LlamaKvCache::LlamaKvCache(int32_t num_layers, int32_t max_length, int32_t kv_di
 
     for (int32_t i = 0; i < num_layers; ++i) {
         cache_k_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
+        if (!cache_k_.back().ok())
+            return;
         cache_v_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
-        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
-        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
+        if (!cache_v_.back().ok())
+            return;
     }
 
     // Pre-allocate mask buffer: [max_length + 1] for dense causal mask.
     mask_buf_.resize(static_cast<std::size_t>(max_length) + 1);
 
     reset();
+}
+
+bool LlamaKvCache::configure_binding_mode(TrtModule& module) {
+    const bool has_write_indices = module.has_input(names_.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(names_.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error("Llama native KV engine must expose both cache_write_indices and "
+                                 "key_value_lengths");
+    }
+
+    const bool native_mode = has_write_indices && has_kv_lengths;
+    if (binding_mode_initialized_ && native_mode != native_kv_update_enabled_) {
+        throw std::runtime_error(
+            "Llama prefill and decode engines use incompatible KV cache contracts");
+    }
+    binding_mode_initialized_ = true;
+    native_kv_update_enabled_ = native_mode;
+    if (native_mode)
+        validate_native_kv_contract(module);
+    return native_mode;
+}
+
+void LlamaKvCache::validate_native_kv_contract(TrtModule& module) const {
+    validate_native_scalar_input(module, names_.cache_write_indices);
+    validate_native_scalar_input(module, names_.key_value_lengths);
+
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        validate_native_cache_pair(module, names_.cache_k[li], names_.present_k[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+        validate_native_cache_pair(module, names_.cache_v[li], names_.present_v[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+    }
+}
+
+void LlamaKvCache::ensure_legacy_present_buffers() {
+    if (!present_k_.empty())
+        return;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        if (!present_k_.back().ok() || !present_v_.back().ok()) {
+            throw std::runtime_error("Llama legacy KV present-buffer allocation failed");
+        }
+    }
+}
+
+void LlamaKvCache::bind_native_cache(TrtModule& module) {
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        module.bind_external(names_.cache_k[li], cache_k_[li].data());
+        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (module.device_ptr(names_.cache_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.present_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.cache_v[li]) != cache_v_[li].data() ||
+            module.device_ptr(names_.present_v[li]) != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "Llama native KV engine did not preserve cache/present aliasing");
+        }
+    }
+}
+
+void LlamaKvCache::validate_native_aliases(const std::vector<const void*>& present_k,
+                                           const std::vector<const void*>& present_v) const {
+    if (static_cast<int32_t>(present_k.size()) != num_layers_ ||
+        static_cast<int32_t>(present_v.size()) != num_layers_) {
+        throw std::runtime_error("Llama native KV per-layer pointer count mismatch");
+    }
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        if (present_k[li] != cache_k_[li].data() || present_v[li] != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "Llama native prefill present tensors must alias the KV cache");
+        }
+    }
+}
+
+void LlamaKvCache::write_native_kv_inputs(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len > max_length_ - position_) {
+        throw std::runtime_error("Llama sequence exceeds the model's fixed KV cache capacity");
+    }
+    cache_write_index_ = position_;
+    key_value_length_ = position_ + seq_len;
+    inputs[names_.cache_write_indices] = Tensor{&cache_write_index_, {1}, DType::kInt32};
+    inputs[names_.key_value_lengths] = Tensor{&key_value_length_, {1}, DType::kInt32};
 }
 
 // Masked score constant is model-local.
@@ -199,6 +337,10 @@ void LlamaKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
     write_position_input(inputs, seq_len);
+    if (native_kv_update_enabled_) {
+        write_native_kv_inputs(inputs, seq_len);
+        return;
+    }
     if (seq_len > 1)
         write_batched_mask(inputs, seq_len);
     else
@@ -208,6 +350,10 @@ void LlamaKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
 void LlamaKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
+    if (native_kv_update_enabled_) {
+        throw std::runtime_error("Llama native TensorRT KV cache supports causal attention only; "
+                                 "bidirectional block decoding is unsupported");
+    }
     write_position_input(inputs, seq_len);
     write_bidirectional_mask(inputs, seq_len);
 }
@@ -215,6 +361,13 @@ void LlamaKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len
 void LlamaKvCache::bind_to(TrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
+    ensure_legacy_present_buffers();
     // Enable dynamic row binding only when cache_k[0] itself is dynamic.
     // Static-shape engines with fixed [max_length, kv_dim] cache reject
     // setInputShape on cache inputs even when other inputs are dynamic.
@@ -241,7 +394,14 @@ void LlamaKvCache::bind_to(TrtModule& module) {
 }
 
 void LlamaKvCache::bind_cache_inputs(TrtModule& module) {
+    bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
         module.bind_external(names_.cache_k[li], cache_k_[li].data());
@@ -259,6 +419,11 @@ void LlamaKvCache::write_prefill_kv(const std::vector<const void*>& prefill_k,
         static_cast<int32_t>(prefill_v.size()) != num_layers_) {
         throw std::runtime_error(
             "LlamaKvCache::write_prefill_kv: per-layer pointer count mismatch");
+    }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ = seq_len;
+        return;
     }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
@@ -283,6 +448,11 @@ void LlamaKvCache::append_prefill_kv(const std::vector<const void*>& prefill_k,
         throw std::runtime_error(
             "LlamaKvCache::append_prefill_kv: per-layer pointer count mismatch");
     }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ += seq_len;
+        return;
+    }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
     const auto offset = static_cast<std::size_t>(position_) * row_bytes;
@@ -305,6 +475,14 @@ void LlamaKvCache::advance(int32_t n_tokens) {
     // n_tokens > 1 reserved for future batched prefill (TASK-10).
     assert(n_tokens == 1 && "LlamaKvCache::advance: only n_tokens==1 supported");
     (void)n_tokens;
+
+    if (native_kv_update_enabled_) {
+        if (position_ >= max_length_) {
+            throw std::runtime_error("Llama sequence exceeds the model's fixed KV cache capacity");
+        }
+        ++position_;
+        return;
+    }
 
     // Copy present K/V (single row) into cache at current position.
     // present_k_[layer] is [1, kv_dim] → copy to cache_k_[layer][position_, :]
@@ -344,6 +522,8 @@ void LlamaKvCache::reset() {
     // Reset only the logical sequence length. Attention masks hide every
     // stale cache row, and each present row is overwritten before use.
     position_ = 0;
+    cache_write_index_ = 0;
+    key_value_length_ = 0;
 }
 
 std::size_t LlamaKvCache::device_memory_bytes() const {
@@ -360,13 +540,13 @@ std::size_t LlamaKvCache::device_memory_bytes() const {
 }
 
 bool LlamaKvCache::ok() const {
-    if (cache_k_.size() != static_cast<std::size_t>(num_layers_))
+    const auto expected_layers = static_cast<std::size_t>(num_layers_);
+    if (cache_k_.size() != expected_layers)
         return false;
-    for (const auto& t : cache_k_) {
-        if (!t.ok())
-            return false;
-    }
-    return true;
+    if (cache_v_.size() != expected_layers)
+        return false;
+    return all_tensors_ok(cache_k_) && all_tensors_ok(cache_v_) && all_tensors_ok(present_k_) &&
+           all_tensors_ok(present_v_);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/llama/kv_cache.h
+++ b/src/runtime/models/llama/kv_cache.h
@@ -8,8 +8,9 @@
 // LlamaKvCache: autoregressive KV cache state manager.
 // HF equivalent: DynamicCache / past_key_values.
 //
-// Manages per-layer K/V device tensors, position tracking, and attention mask
-// construction. Binds directly to a TrtModule via bind_to().
+// Manages per-layer K/V device tensors and position tracking. Native TensorRT
+// KV engines update these buffers in place; legacy engines use present rows
+// plus an attention mask.
 
 #include "runtime/models/llama/inference_state.h"
 #include "trtmc/runtime/device_tensor.h"
@@ -30,6 +31,8 @@ struct LlamaKvCacheNames {
     std::vector<std::string> cache_v;
     std::vector<std::string> present_k;
     std::vector<std::string> present_v;
+    std::string cache_write_indices{"cache_write_indices"};
+    std::string key_value_lengths{"key_value_lengths"};
     std::string position_id{"position_id"};
     std::string attention_mask{"attention_mask"};
 };
@@ -52,7 +55,7 @@ class LlamaKvCache : public LlamaInferenceState {
     int32_t max_length() const override { return max_length_; }
     int32_t preferred_cache_rows() const override;
     int32_t num_layers() const override { return num_layers_; }
-    bool needs_attention_mask() const override { return true; }
+    bool needs_attention_mask() const override { return !native_kv_update_enabled_; }
     std::size_t device_memory_bytes() const override;
     const char* state_type() const override { return "dense_kv_cache"; }
     bool ok() const override;
@@ -67,9 +70,9 @@ class LlamaKvCache : public LlamaInferenceState {
     DeviceTensor& cache_k(int32_t layer) { return cache_k_[static_cast<std::size_t>(layer)]; }
     DeviceTensor& cache_v(int32_t layer) { return cache_v_[static_cast<std::size_t>(layer)]; }
 
-    // Write per-layer KV produced by a batched prefill engine into the cache
-    // at positions [0, seq_len). Device-to-device copy on this cache's stream;
-    // advances position_ to seq_len. Requires seq_len <= max_length.
+    // Complete a batched prefill and advance position_ to seq_len. Native
+    // TensorRT KV engines have already updated the aliased cache in place;
+    // legacy engines copy their per-layer outputs into the cache.
     void write_prefill_kv(const std::vector<const void*>& prefill_k,
                           const std::vector<const void*>& prefill_v, int32_t seq_len);
 
@@ -86,14 +89,18 @@ class LlamaKvCache : public LlamaInferenceState {
     // remain masked out by subsequent prepare_step calls.
     void set_position(int32_t position);
 
-    // Bind only the cache_k/v INPUT pointers to `module`. Used for the
-    // prefill TrtModule whose present_k/v outputs have shape (Sq, kv_dim)
-    // — too big for LlamaKvCache's single-row present buffer. The caller reads
-    // the prefill outputs directly from the module's own allocations and
-    // copies them via write_prefill_kv().
+    // Bind prefill KV tensors. Native TensorRT engines bind cache and present
+    // to the same full-capacity storage; legacy engines bind cache inputs only.
     void bind_cache_inputs(TrtModule& module);
 
   private:
+    bool configure_binding_mode(TrtModule& module);
+    void validate_native_kv_contract(TrtModule& module) const;
+    void validate_native_aliases(const std::vector<const void*>& present_k,
+                                 const std::vector<const void*>& present_v) const;
+    void ensure_legacy_present_buffers();
+    void bind_native_cache(TrtModule& module);
+    void write_native_kv_inputs(TensorMap& inputs, int32_t seq_len);
     void rebind_cache_rows(int32_t cache_rows);
     std::vector<int64_t> mask_shape_for_engine(int32_t mask_width, std::size_t mask_buf_size) const;
     void write_position_input(TensorMap& inputs, int32_t seq_len);
@@ -101,10 +108,11 @@ class LlamaKvCache : public LlamaInferenceState {
     void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
     void write_decode_mask(TensorMap& inputs);
 
-    std::vector<DeviceTensor> cache_k_;   // [num_layers], shape [max_length, kv_dim]
-    std::vector<DeviceTensor> cache_v_;   // [num_layers]
-    std::vector<DeviceTensor> present_k_; // [num_layers], shape [1, kv_dim] (single step output)
-    std::vector<DeviceTensor> present_v_; // [num_layers]
+    std::vector<DeviceTensor> cache_k_; // [num_layers], shape [max_length, kv_dim]
+    std::vector<DeviceTensor> cache_v_; // [num_layers]
+    // Legacy-only single-step outputs, allocated lazily when a legacy engine is bound.
+    std::vector<DeviceTensor> present_k_;
+    std::vector<DeviceTensor> present_v_;
     int32_t num_layers_{0};
     int32_t max_length_{0};
     int32_t kv_dim_{0};
@@ -113,7 +121,11 @@ class LlamaKvCache : public LlamaInferenceState {
     // Buffers owned by this object — Tensor.data in prepare_step() points here.
     std::vector<float> mask_buf_;
     std::vector<int32_t> pos_buf_vec_;
+    int32_t cache_write_index_{0};
+    int32_t key_value_length_{0};
     bool has_position_input_{false};
+    bool binding_mode_initialized_{false};
+    bool native_kv_update_enabled_{false};
     bool dynamic_binding_enabled_{false};
     int32_t bound_cache_rows_{0};
     DType cache_dtype_{DType::kFloat32};

--- a/src/runtime/models/llama/pipeline.cpp
+++ b/src/runtime/models/llama/pipeline.cpp
@@ -150,6 +150,14 @@ single_decoder_context(std::unique_ptr<TrtModule> decoder) {
     return decoders;
 }
 
+LlamaTextGenConfig normalize_eos_token_ids(LlamaTextGenConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
 std::string normalize_generation_mode(std::string mode) {
     std::transform(mode.begin(), mode.end(), mode.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -291,8 +299,8 @@ LlamaTextGenerationPipeline::LlamaTextGenerationPipeline(
     std::shared_ptr<void> distributed_owner)
     : distributed_owner_(std::move(distributed_owner)), decoders_(std::move(decoders)),
       prefill_(std::move(prefill)), linear_spec_lora_prefill_(std::move(linear_spec_lora_prefill)),
-      state_(std::move(state)), config_(std::move(config)), stream_(stream),
-      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      state_(std::move(state)), config_(normalize_eos_token_ids(std::move(config))),
+      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       sampler_(std::move(sampler)), logits_output_name_(config_.logits_output_name) {
     if (decoders_.empty()) {
         throw std::runtime_error("LlamaTextGenerationPipeline: no decoder modules");
@@ -350,9 +358,7 @@ TextResult LlamaTextGenerationPipeline::generate(const std::string& prompt,
 
     auto input_ids = encode_prompt(*tokenizer_, config_, prompt, cfg);
     int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-
-    auto sp = llama_sampling_params_from_config(cfg, eos);
+    auto sp = llama_sampling_params_from_config(cfg, config_.id_eos_ids);
     last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
@@ -372,8 +378,7 @@ LlamaTextGenerationPipeline::GenerationResult
 LlamaTextGenerationPipeline::generate_ids(const std::vector<int32_t>& input_ids,
                                           const GenerateConfig& cfg) {
     int32_t max_new = cfg.max_new_tokens; // honour exact value (0 = no generation)
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    auto sp = llama_sampling_params_from_config(cfg, eos);
+    auto sp = llama_sampling_params_from_config(cfg, config_.id_eos_ids);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp, cfg).token_ids};
 }
 
@@ -411,16 +416,46 @@ bool batched_prefill_supported(const TrtModule* prefill, const LlamaTextGenConfi
                                LlamaInferenceState* state) {
     if (prefill == nullptr || sq <= 0)
         return false;
-    if (cfg.prefill_max_length > 0 && sq > cfg.prefill_max_length)
-        return false;
     if (cfg.num_layers <= 0 || cfg.vocab_size <= 0)
         return false;
     return dynamic_cast<LlamaKvCache*>(state) != nullptr;
 }
+
+int32_t resolve_prefill_chunk_limit(const LlamaKvCache& kv, const LlamaTextGenConfig& cfg,
+                                    int32_t sq) {
+    if (kv.needs_attention_mask()) {
+        if (cfg.prefill_max_length > 0 && sq > cfg.prefill_max_length)
+            return 0;
+        return sq;
+    }
+    if (cfg.prefill_max_length <= 0)
+        throw std::runtime_error("Llama native KV prefill engine has no valid profile capacity");
+    return cfg.prefill_max_length;
+}
+
+void validate_generation_capacity(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+                                  LlamaInferenceState* state, const TrtModule* module) {
+    if (module == nullptr || !module->has_input("cache_write_indices") ||
+        !module->has_input("key_value_lengths")) {
+        return;
+    }
+    const auto* kv = dynamic_cast<const LlamaKvCache*>(state);
+    if (kv == nullptr)
+        return;
+
+    const auto capacity = static_cast<std::size_t>(kv->max_length());
+    if (input_ids.size() > capacity ||
+        (max_new_tokens > 0 &&
+         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size())) {
+        throw std::runtime_error(
+            "Llama requested prompt and generation exceed the model's fixed KV cache capacity");
+    }
+}
 } // namespace
 
 bool LlamaTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
-                                                      std::vector<float>& logits) {
+                                                      std::vector<float>& logits,
+                                                      bool retain_device_logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     if (!batched_prefill_supported(prefill_.get(), config_, sq, state_.get()))
         return false;
@@ -430,42 +465,95 @@ bool LlamaTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>
     // decode module(s), so we rebind the cache_k/cache_v inputs onto the
     // prefill execution context before running.
     kv->bind_cache_inputs(*prefill_);
-
-    TensorMap inputs;
-    Tensor tok_t;
-    tok_t.data = const_cast<int32_t*>(input_ids.data());
-    tok_t.shape = {static_cast<int64_t>(sq)};
-    tok_t.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = tok_t;
-    state_->prepare_step(inputs, sq);
-
-    TensorMap outputs = prefill_->forward(inputs);
-    auto logits_it = outputs.find(config_.logits_output_name);
-    if (logits_it == outputs.end())
-        return false;
-
-    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
-    const auto& lt = logits_it->second;
-    if (static_cast<std::size_t>(lt.numel()) < vocab)
-        return false;
-    logits.resize(vocab);
-    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
-    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
+    if (sq > kv->max_length()) {
+        throw std::runtime_error("Llama sequence exceeds the model's fixed KV cache capacity");
+    }
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
         return false;
-    kv->write_prefill_kv(pk, pv, sq);
-    if (config_.log_runtime_stats) {
-        std::cerr << "[trtmc] Batched prefill (";
-        if (!config_.prefill_log_label.empty()) {
-            std::cerr << config_.prefill_log_label;
-        } else {
-            std::cerr << "profile " << config_.prefill_profile_index;
-        }
-        std::cerr << "): " << sq << " tokens in one call\n";
+
+    const int32_t chunk_limit = resolve_prefill_chunk_limit(*kv, config_, sq);
+    if (chunk_limit == 0)
+        return false;
+
+    int32_t chunk_count = 0;
+    for (int32_t start = 0; start < sq;) {
+        const int32_t chunk_size = std::min(chunk_limit, sq - start);
+        run_prefill_chunk(input_ids.data() + start, chunk_size, pk, pv, *kv, logits,
+                          retain_device_logits);
+        ++chunk_count;
+        start += chunk_size;
     }
+
+    log_batched_prefill(sq, chunk_count, chunk_limit);
     return true;
+}
+
+void LlamaTextGenerationPipeline::run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                                                    const std::vector<const void*>& present_k,
+                                                    const std::vector<const void*>& present_v,
+                                                    LlamaKvCache& kv, std::vector<float>& logits,
+                                                    bool retain_device_logits) {
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = const_cast<int32_t*>(token_ids);
+    token_tensor.shape = {static_cast<int64_t>(chunk_size)};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+    state_->prepare_step(inputs, chunk_size);
+
+    TensorMap outputs = prefill_->forward(inputs);
+    const auto logits_it = outputs.find(config_.logits_output_name);
+    if (logits_it == outputs.end()) {
+        throw std::runtime_error(
+            "LlamaTextGenerationPipeline: prefill module has no logits output");
+    }
+
+    const auto& logits_tensor = logits_it->second;
+    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab) {
+        throw std::runtime_error(
+            "LlamaTextGenerationPipeline: prefill logits are smaller than vocabulary");
+    }
+
+    logits.resize(vocab);
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+    if (retain_device_logits) {
+        const auto* device_logits =
+            static_cast<const float*>(prefill_->device_ptr(config_.logits_output_name));
+        if (device_logits == nullptr) {
+            throw std::runtime_error(
+                "LlamaTextGenerationPipeline: prefill logits have no device buffer");
+        }
+        d_logits_ptr_ = device_logits + logits_offset;
+    }
+    kv.append_prefill_kv(present_k, present_v, chunk_size);
+}
+
+void LlamaTextGenerationPipeline::log_batched_prefill(int32_t token_count, int32_t chunk_count,
+                                                      int32_t chunk_limit) const {
+    if (!config_.log_runtime_stats)
+        return;
+
+    std::cerr << "[trtmc] Batched prefill (";
+    if (!config_.prefill_log_label.empty()) {
+        std::cerr << config_.prefill_log_label;
+    } else {
+        std::cerr << "profile " << config_.prefill_profile_index;
+    }
+    std::cerr << "): " << token_count << " tokens in " << chunk_count << " call";
+    if (chunk_count != 1)
+        std::cerr << 's';
+    std::cerr << " (max chunk=" << chunk_limit << ")\n";
+}
+
+const TrtModule* LlamaTextGenerationPipeline::generation_capacity_module() const {
+    if (prefill_ != nullptr)
+        return prefill_.get();
+    return decoders_.front().module.get();
 }
 
 void LlamaTextGenerationPipeline::prime_decoder_after_batched_prefill(
@@ -492,9 +580,9 @@ void LlamaTextGenerationPipeline::prime_decoder_after_batched_prefill(
 
 void LlamaTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                               std::vector<float>& logits, bool gpu_sampling) {
-    // Fast path: batched prefill engine writes K/V for the whole prompt in
-    // one forward and returns last-token logits on host.
-    if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
+    // Fast path: batched prefill writes K/V in profile-bounded chunks and
+    // exposes last-token logits on the sampler's requested host or device path.
+    if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
         prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
@@ -604,6 +692,7 @@ void LlamaTextGenerationPipeline::reset_generation_context() {
     using Clock = std::chrono::steady_clock;
     const auto start = Clock::now();
     state_->reset();
+    d_logits_ptr_ = nullptr;
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
         decoder_ctx.module->reset_execution_context();
@@ -676,7 +765,7 @@ bool LlamaTextGenerationPipeline::append_tokens_until_eos(const std::vector<int3
                                                           const LlamaSamplingParams& params) const {
     for (int32_t token : tokens) {
         output.push_back(token);
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (llama_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -746,7 +835,7 @@ bool LlamaTextGenerationPipeline::append_linear_spec_tokens(
         const int32_t token = ar_tokens[static_cast<std::size_t>(i)];
         output.push_back(token);
         ++generated;
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (llama_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -758,6 +847,8 @@ LlamaTextGenerationPipeline::TimedGenResult LlamaTextGenerationPipeline::generat
     using Clock = std::chrono::steady_clock;
     if (max_new_tokens == 0 || input_ids.empty())
         return TimedGenResult{input_ids, 0.0, 0.0};
+    validate_generation_capacity(input_ids, max_new_tokens, state_.get(),
+                                 generation_capacity_module());
 
     const std::string mode = resolve_generation_mode(cfg);
     if (mode == "diffusion" || mode == "dlm")
@@ -876,7 +967,7 @@ LlamaTextGenerationPipeline::generate_linear_spec_from_ids(const std::vector<int
 
     std::vector<int32_t> output = input_ids;
     output.push_back(next_token);
-    if (params.eos_token_id >= 0 && next_token == params.eos_token_id) {
+    if (llama_is_eos_token(params, next_token)) {
         return TimedGenResult{std::move(output),
                               std::chrono::duration<double, std::milli>(t1 - t0).count(), 0.0};
     }
@@ -950,12 +1041,12 @@ int32_t LlamaTextGenerationPipeline::run_decode_loop(
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         const float* sample_ptr = gpu_sampling ? d_logits_ptr_ : logits.data();
         const LlamaSampleResult result = sampler->sample(sample_ptr, vocab_size, params);
+        const bool is_eos = result.is_eos || llama_is_eos_token(params, result.token_id);
         output.push_back(result.token_id);
         ++steps;
-        if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval,
-                                  result.is_eos))
+        if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval, is_eos))
             break;
-        if (result.is_eos)
+        if (is_eos)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/llama/pipeline.h
+++ b/src/runtime/models/llama/pipeline.h
@@ -30,6 +30,7 @@ struct LlamaTextGenConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
     int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
     bool has_position_input{true};
     std::string chat_template_format{};
     std::string token_id_name{"token_id"};
@@ -42,9 +43,8 @@ struct LlamaTextGenConfig {
 
     // Batched-prefill plumbing — populated when the bundle ships with a
     // dedicated prefill optimization profile. The runtime forwards the
-    // whole prompt through `prefill_module` once (writing per-layer K/V
-    // into the shared cache via write_prefill_kv) before falling back to
-    // the per-token decode loop.
+    // prompt through `prefill_module` in one or more profile-bounded chunks
+    // before falling back to the per-token decode loop.
     std::string present_k_pattern{"present_k_{i}"};
     std::string present_v_pattern{"present_v_{i}"};
     int32_t prefill_max_length{0};
@@ -189,7 +189,14 @@ class LlamaTextGenerationPipeline final : public IPipeline {
                            TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
-    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
+                             bool retain_device_logits);
+    void run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                           const std::vector<const void*>& present_k,
+                           const std::vector<const void*>& present_v, LlamaKvCache& kv,
+                           std::vector<float>& logits, bool retain_device_logits);
+    void log_batched_prefill(int32_t token_count, int32_t chunk_count, int32_t chunk_limit) const;
+    const TrtModule* generation_capacity_module() const;
     void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,

--- a/src/runtime/models/llama/plugin.cpp
+++ b/src/runtime/models/llama/plugin.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cuda_runtime_api.h>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -69,13 +70,27 @@ int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
 }
 
 int32_t cache_row_dim_from_module(const TrtModule& module, const std::string& tensor_name) {
-    const int32_t static_dim = dim_at(module.tensor_shape(tensor_name), 1);
+    const auto row_dim = [](const std::vector<int64_t>& shape) -> int32_t {
+        if (shape.size() == 2)
+            return dim_at(shape, 1);
+        if (shape.size() == 4) {
+            const int32_t heads = dim_at(shape, 1);
+            const int32_t head_dim = dim_at(shape, 3);
+            if (heads > 0 && head_dim > 0 &&
+                heads <= std::numeric_limits<int32_t>::max() / head_dim) {
+                return heads * head_dim;
+            }
+        }
+        return -1;
+    };
+
+    const int32_t static_dim = row_dim(module.tensor_shape(tensor_name));
     if (static_dim > 0)
         return static_dim;
     const int32_t profile_count = module.optimization_profile_count();
     for (int32_t profile_idx = 0; profile_idx < profile_count; ++profile_idx) {
-        const int32_t profile_dim = dim_at(
-            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax), 1);
+        const int32_t profile_dim = row_dim(
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax));
         if (profile_dim > 0)
             return profile_dim;
     }
@@ -125,13 +140,16 @@ int32_t profile_token_max_length(const TrtModule& module, const std::string& tok
 
 int32_t profile_cache_rows(const TrtModule& module, const std::string& cache_name,
                            int32_t profile_idx, int32_t fallback_rows) {
-    const int32_t static_rows = dim_at(module.tensor_shape(cache_name), 0);
+    const auto cache_rows = [](const std::vector<int64_t>& shape) {
+        return dim_at(shape, shape.size() == 4 ? 2 : 0);
+    };
+    const int32_t static_rows = cache_rows(module.tensor_shape(cache_name));
     if (static_rows > 0)
         return static_rows;
 
     if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
-        const int32_t max_rows = dim_at(
-            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax), 0);
+        const int32_t max_rows = cache_rows(
+            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax));
         if (max_rows > 0)
             return max_rows;
     }
@@ -194,47 +212,96 @@ std::string format_bytes(std::uint64_t bytes) {
     return oss.str();
 }
 
-KvCacheRuntimeSizing
-resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& module,
-                                const LlamaKvCacheNames& kv_names, DType cache_dtype,
-                                const LlamaTriAttentionConfig& tri_cfg, int32_t kv_dim) {
-    KvCacheRuntimeSizing sizing;
-    const auto elem_bytes = static_cast<std::uint64_t>(dtype_size(cache_dtype));
-    sizing.row_bytes = static_cast<std::uint64_t>(ctx.config.num_layers) *
-                       static_cast<std::uint64_t>(kv_dim) * elem_bytes * 2ULL;
-    if (sizing.row_bytes == 0)
-        throw std::runtime_error("Computed zero bytes per KV row");
+bool engine_uses_native_kv_updates(const TrtModule& module, const LlamaKvCacheNames& kv_names) {
+    const bool has_write_indices = module.has_input(kv_names.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(kv_names.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error("Llama native KV engine must expose both cache_write_indices and "
+                                 "key_value_lengths");
+    }
+    return has_write_indices;
+}
 
-    const int32_t bundle_max_rows = ctx.config.max_cache_length;
-    sizing.runtime_rows = bundle_max_rows;
-    sizing.cache_bytes = static_cast<std::uint64_t>(bundle_max_rows) * sizing.row_bytes;
+void validate_native_kv_marker(const std::string& config_json, bool engine_uses_native_kv) {
+    const bool declares_native_kv = extract_json_bool(config_json, "native_kv_cache", false);
+    const bool has_version =
+        config_json.find("\"native_kv_contract_version\"") != std::string::npos;
+    if (!declares_native_kv && !has_version && !engine_uses_native_kv)
+        return;
+    if (!declares_native_kv || !engine_uses_native_kv ||
+        extract_json_int(config_json, "native_kv_contract_version", 0) != 1) {
+        throw std::runtime_error("Llama native KV metadata does not match the engine contract");
+    }
+}
 
-    if (ctx.kv_cache_size_bytes == 0)
-        return sizing;
+std::uint64_t checked_multiply(std::uint64_t lhs, std::uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<std::uint64_t>::max() / lhs)
+        throw std::overflow_error("Llama native KV byte accounting overflow");
+    return lhs * rhs;
+}
 
+void admit_native_kv_allocation(const PipelineContext& ctx, bool native_kv,
+                                const KvCacheRuntimeSizing& sizing) {
+    if (!native_kv)
+        return;
+
+    std::size_t free_bytes = 0;
+    std::size_t total_bytes = 0;
+    const cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Llama native KV CUDA memory query failed: ") +
+                                 cudaGetErrorString(status));
+    }
+
+    constexpr std::uint64_t kTwoGiB = 2ULL << 30;
+    const auto free = static_cast<std::uint64_t>(free_bytes);
+    const auto total = static_cast<std::uint64_t>(total_bytes);
+    const auto reserve = std::max(kTwoGiB, total / 10);
+    const auto available = free > reserve ? free - reserve : 0;
+    if (sizing.cache_bytes > available) {
+        throw std::runtime_error(
+            "Llama native KV cache admission failed before allocation: capacity=" +
+            std::to_string(ctx.config.max_cache_length) +
+            " tokens, required=" + format_bytes(sizing.cache_bytes) +
+            ", free=" + format_bytes(free) + ", reserve=" + format_bytes(reserve));
+    }
+}
+
+void reject_native_kv_size_override(const PipelineContext& ctx) {
+    if (ctx.kv_cache_size_bytes != 0) {
+        throw std::invalid_argument(
+            "Llama native TensorRT KV cache allocates the model's complete fixed "
+            "capacity; kv_cache_size_bytes is not supported");
+    }
+}
+
+void apply_runtime_kv_size_override(const PipelineContext& ctx, const TrtModule& module,
+                                    const LlamaKvCacheNames& kv_names,
+                                    const LlamaTriAttentionConfig& tri_cfg, int32_t bundle_max_rows,
+                                    KvCacheRuntimeSizing& sizing) {
     if (!cache_input_supports_runtime_rows(module, kv_names.cache_k.front())) {
         throw std::runtime_error(
             "This bundle was not built with runtime-resizable KV cache support. "
             "Rebuild with trtmc build --dynamic-kv-cache to use --kv-cache-size.");
     }
 
-    const std::uint64_t requested_rows_u64 = ctx.kv_cache_size_bytes / sizing.row_bytes;
-    if (requested_rows_u64 == 0) {
+    const std::uint64_t requested_rows = ctx.kv_cache_size_bytes / sizing.row_bytes;
+    if (requested_rows == 0) {
         throw std::runtime_error("--kv-cache-size is smaller than one KV row (" +
                                  format_bytes(sizing.row_bytes) + ")");
     }
 
-    std::uint64_t runtime_rows_u64 = requested_rows_u64;
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(bundle_max_rows)) {
-        runtime_rows_u64 = static_cast<std::uint64_t>(bundle_max_rows);
+    std::uint64_t runtime_rows = requested_rows;
+    if (runtime_rows > static_cast<std::uint64_t>(bundle_max_rows)) {
+        runtime_rows = static_cast<std::uint64_t>(bundle_max_rows);
         sizing.clamped_to_bundle_max = true;
     }
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
+    if (runtime_rows > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
         throw std::runtime_error("Resolved KV cache rows exceed int32 runtime limits");
     }
 
-    sizing.runtime_rows = static_cast<int32_t>(runtime_rows_u64);
-    sizing.cache_bytes = runtime_rows_u64 * sizing.row_bytes;
+    sizing.runtime_rows = static_cast<int32_t>(runtime_rows);
+    sizing.cache_bytes = runtime_rows * sizing.row_bytes;
     sizing.override_applied = true;
 
     if (tri_cfg.enabled && sizing.runtime_rows < tri_cfg.kv_budget) {
@@ -244,8 +311,54 @@ resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& mod
             " rows, but this TriAttention bundle needs at least " +
             std::to_string(tri_cfg.kv_budget) + " rows (" + format_bytes(minimum_bytes) + ")");
     }
+}
 
+KvCacheRuntimeSizing resolve_kv_cache_runtime_sizing(
+    const PipelineContext& ctx, const TrtModule& module, const LlamaKvCacheNames& kv_names,
+    DType cache_dtype, const LlamaTriAttentionConfig& tri_cfg, int32_t kv_dim, bool native_kv) {
+    KvCacheRuntimeSizing sizing;
+    const int32_t bundle_max_rows = ctx.config.max_cache_length;
+    if (ctx.config.num_layers <= 0 || kv_dim <= 0 || bundle_max_rows <= 0)
+        throw std::runtime_error("Llama KV geometry must be positive");
+    sizing.row_bytes = checked_multiply(
+        checked_multiply(checked_multiply(static_cast<std::uint64_t>(ctx.config.num_layers),
+                                          static_cast<std::uint64_t>(kv_dim)),
+                         static_cast<std::uint64_t>(dtype_size(cache_dtype))),
+        2);
+    sizing.runtime_rows = bundle_max_rows;
+    sizing.cache_bytes =
+        checked_multiply(static_cast<std::uint64_t>(bundle_max_rows), sizing.row_bytes);
+
+    if (native_kv) {
+        reject_native_kv_size_override(ctx);
+        return sizing;
+    }
+
+    if (ctx.kv_cache_size_bytes == 0)
+        return sizing;
+
+    apply_runtime_kv_size_override(ctx, module, kv_names, tri_cfg, bundle_max_rows, sizing);
     return sizing;
+}
+
+void validate_native_kv_runtime(const PipelineContext& ctx, const TrtModule& module,
+                                const LlamaKvCacheNames& kv_names, DType cache_dtype,
+                                const LlamaTriAttentionConfig& tri_cfg,
+                                const TensorParallelRuntimeConfig& tp_config, bool native_kv) {
+    validate_native_kv_marker(ctx.config_json, native_kv);
+    if (!native_kv)
+        return;
+    if (cache_dtype != DType::kBFloat16 || tri_cfg.enabled || tp_config.enabled) {
+        throw std::runtime_error(
+            "Llama native KV requires BF16, single-GPU, non-TriAttention runtime");
+    }
+
+    const std::vector<int64_t> expected_shape{1, ctx.config.num_kv_heads,
+                                              ctx.config.max_cache_length, 128};
+    if (module.tensor_shape(kv_names.cache_k.front()) != expected_shape) {
+        throw std::runtime_error(
+            "Llama native KV requires cache shape [1,num_kv_heads,capacity,128]");
+    }
 }
 
 } // namespace
@@ -279,9 +392,12 @@ class DecoderPlugin final : public IPipelinePlugin {
             throw std::runtime_error("No decoder engine profiles were loaded");
         TrtModule& metadata_module = *profile_modules.modules.front().module;
 
+        const bool native_kv = engine_uses_native_kv_updates(metadata_module, kv_names);
+        validate_native_kv_runtime(ctx, metadata_module, kv_names, cache_dtype, tri_cfg,
+                                   tp_runtime.config, native_kv);
         const int32_t kv_dim = cache_row_dim_from_module(metadata_module, kv_names.cache_k.front());
-        const auto sizing = resolve_kv_cache_runtime_sizing(ctx, metadata_module, kv_names,
-                                                            cache_dtype, tri_cfg, kv_dim);
+        const auto sizing = resolve_kv_cache_runtime_sizing(
+            ctx, metadata_module, kv_names, cache_dtype, tri_cfg, kv_dim, native_kv);
 
         const auto decode_profile_roles = detect_decoder_profile_roles(
             metadata_module, io.token_id, kv_names.cache_k.front(), ctx.config.max_cache_length);
@@ -302,6 +418,10 @@ class DecoderPlugin final : public IPipelinePlugin {
                 prefill_module = std::move(split_prefill_module);
         }
 
+        // Split prefill deserialization can consume additional execution-context
+        // memory. Admit the KV allocation against the free memory that remains
+        // after every engine/context needed by this pipeline has been loaded.
+        admit_native_kv_allocation(ctx, native_kv, sizing);
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
         log_kv_cache_sizing(ctx, sizing, state.get());
@@ -309,9 +429,8 @@ class DecoderPlugin final : public IPipelinePlugin {
         LlamaTextGenConfig tgc;
         populate_text_gen_config(ctx, tgc, io, decoders.front(), ctx.runtime_config);
         apply_chat_template_format(ctx.bundle, tgc);
-        // Wire batched prefill: the pipeline forwards the whole prompt
-        // through `prefill_module` (TRT optimization profile 0) and copies
-        // per-layer K/V into the shared cache via write_prefill_kv.
+        // Wire batched prefill. Native TensorRT KV engines update the shared
+        // aliased cache in place; legacy engines copy prefill outputs into it.
         tgc.prefill_max_length = prefill_max_length;
         tgc.prefill_profile_index = prefill_profile_idx;
         tgc.prefill_log_label = std::move(prefill_log_label);
@@ -524,6 +643,7 @@ class DecoderPlugin final : public IPipelinePlugin {
         tgc.vocab_size = ctx.config.vocab_size;
         tgc.id_bos = ctx.config.id_bos;
         tgc.id_eos = ctx.config.id_eos;
+        tgc.id_eos_ids = ctx.config.id_eos_ids;
         tgc.has_position_input = first_dec.module->has_input(io.position_id);
         tgc.token_id_name = io.token_id;
         tgc.logits_output_name = io.logits;

--- a/src/runtime/models/llama/sampler.cpp
+++ b/src/runtime/models/llama/sampler.cpp
@@ -30,9 +30,17 @@
 
 namespace trtmc {
 
+bool llama_is_eos_token(const LlamaSamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
 // Shared argmax helper — returns {token_id, logprob} for the highest logit.
 static LlamaSampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
-                                            int32_t eos_token_id) {
+                                            const LlamaSamplingParams& params) {
     LlamaSampleResult result;
     const float* best = logits;
     for (int32_t i = 1; i < vocab_size; ++i) {
@@ -41,7 +49,7 @@ static LlamaSampleResult argmax_over_logits(const float* logits, int32_t vocab_s
     }
     result.token_id = static_cast<int32_t>(best - logits);
     result.logprob = *best;
-    result.is_eos = (result.token_id == eos_token_id);
+    result.is_eos = llama_is_eos_token(params, result.token_id);
     return result;
 }
 
@@ -182,11 +190,11 @@ class GreedySampler final : public LlamaISampler {
         if (vocab_size <= 0 || logits == nullptr) {
             LlamaSampleResult result;
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = llama_is_eos_token(params, 0);
             return result;
         }
 
-        return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+        return argmax_over_logits(logits, vocab_size, params);
     }
 
     LlamaLogitsLocation logits_location() const override { return LlamaLogitsLocation::HOST; }
@@ -210,12 +218,12 @@ class TopKSampler final : public LlamaISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = llama_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
 
@@ -233,7 +241,7 @@ class TopKSampler final : public LlamaISampler {
                 result.token_id = dist.indices[static_cast<std::size_t>(i)];
                 result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(i)],
                                                    std::numeric_limits<float>::min()));
-                result.is_eos = (result.token_id == params.eos_token_id);
+                result.is_eos = llama_is_eos_token(params, result.token_id);
                 return result;
             }
         }
@@ -241,7 +249,7 @@ class TopKSampler final : public LlamaISampler {
         result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
         result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(dist.keep - 1)],
                                            std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = llama_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -278,12 +286,12 @@ class TorchCudaMultinomialSampler final : public LlamaISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = llama_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
         ensure_execution_policy(vocab_size);
@@ -312,7 +320,7 @@ class TorchCudaMultinomialSampler final : public LlamaISampler {
             }
         }
         result.logprob = std::log(std::max(picked_prob, std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = llama_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -381,7 +389,7 @@ class GpuGreedySampler final : public LlamaISampler {
         LlamaSampleResult result;
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = llama_is_eos_token(params, 0);
             return result;
         }
 
@@ -397,7 +405,7 @@ class GpuGreedySampler final : public LlamaISampler {
 
         result.token_id = h_token_id_;
         result.logprob = h_logit_val_;
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = llama_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -417,16 +425,26 @@ class GpuGreedySampler final : public LlamaISampler {
 // Factory
 // ─────────────────────────────────────────────────────────────
 
-LlamaSamplingParams llama_sampling_params_from_config(const GenerateConfig& cfg,
-                                                      int32_t default_eos) {
+LlamaSamplingParams
+llama_sampling_params_from_config(const GenerateConfig& cfg,
+                                  const std::vector<int32_t>& default_eos_token_ids) {
     LlamaSamplingParams p;
     p.temperature = cfg.temperature;
     p.top_k = cfg.top_k;
     p.top_p = cfg.top_p;
     p.min_p = cfg.min_p;
     p.seed = cfg.seed;
-    p.eos_token_id = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : default_eos;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
     return p;
+}
+
+LlamaSamplingParams llama_sampling_params_from_config(const GenerateConfig& cfg,
+                                                      int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return llama_sampling_params_from_config(cfg, defaults);
 }
 
 std::unique_ptr<LlamaISampler>

--- a/src/runtime/models/llama/sampler.h
+++ b/src/runtime/models/llama/sampler.h
@@ -30,6 +30,7 @@ struct LlamaSamplingParams {
     float repetition_penalty{1.0f};
     int32_t seed{-1}; // -1 = deterministic (argmax)
     int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
 };
 
 /// Factory options for choosing concrete sampler implementations.
@@ -78,8 +79,14 @@ class LlamaISampler {
 /// Forward-declared here; defined in sampler.cpp alongside the factory.
 struct GenerateConfig; // defined in trtmc/pipeline.h
 
+LlamaSamplingParams
+llama_sampling_params_from_config(const GenerateConfig& cfg,
+                                  const std::vector<int32_t>& default_eos_token_ids);
 LlamaSamplingParams llama_sampling_params_from_config(const GenerateConfig& cfg,
                                                       int32_t default_eos = -1);
+
+/// Return true when token_id matches any effective EOS token.
+bool llama_is_eos_token(const LlamaSamplingParams& params, int32_t token_id);
 
 /// Factory: create sampler from LlamaSamplingParams.
 /// - top_k <= 1 && top_p/min_p disabled && seed == -1 => GreedySampler

--- a/src/runtime/models/qwen/MODEL.toml
+++ b/src/runtime/models/qwen/MODEL.toml
@@ -8,6 +8,7 @@ runtime_strategies = ["qwen_decoder_kv_cache"]
 runtime_tests = [
   "test_qwen_tensor_names|test_qwen_tensor_names.cpp|_|_|_",
   "test_qwen_sampler|test_qwen_sampler.cpp|trtmc_model_qwen|_|_",
+  "test_qwen_native_kv_cache|test_qwen_native_kv_cache.cpp|trtmc_model_qwen,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
 [validation_profiles]
 decoder_debug = ["qwen_decoder_kv_cache"]

--- a/src/runtime/models/qwen/kv_cache.cpp
+++ b/src/runtime/models/qwen/kv_cache.cpp
@@ -25,6 +25,52 @@ int32_t round_up_rows(int32_t value, int32_t bucket, int32_t maximum) {
     return std::min(rounded, maximum);
 }
 
+void validate_native_scalar_input(TrtModule& module, const std::string& name) {
+    if (module.tensor_dtype(name) != DType::kInt32 ||
+        module.tensor_shape(name) != std::vector<int64_t>{1}) {
+        throw std::runtime_error("Qwen native KV input '" + name + "' must be int32 [1]");
+    }
+}
+
+bool valid_native_cache_shape(const std::vector<int64_t>& shape, int32_t max_length,
+                              int32_t kv_dim) {
+    if (shape.size() != 4)
+        return false;
+    if (shape[0] != 1 || shape[2] != static_cast<int64_t>(max_length))
+        return false;
+    if (shape[1] <= 0 || shape[3] <= 0)
+        return false;
+    return shape[1] * shape[3] == kv_dim;
+}
+
+void validate_native_cache_pair(TrtModule& module, const std::string& cache_name,
+                                const std::string& present_name, int32_t max_length, int32_t kv_dim,
+                                DType cache_dtype) {
+    if (!module.has_input(cache_name) || !module.has_output(present_name)) {
+        throw std::runtime_error("Qwen native KV engine is missing cache/present pair '" +
+                                 cache_name + "'/'" + present_name + "'");
+    }
+    const auto cache_shape = module.tensor_shape(cache_name);
+    const auto present_shape = module.tensor_shape(present_name);
+    if (!valid_native_cache_shape(cache_shape, max_length, kv_dim) ||
+        present_shape != cache_shape) {
+        throw std::runtime_error("Qwen native KV cache/present tensors must share static "
+                                 "[1,Hkv,max_length,D] shape");
+    }
+    if (module.tensor_dtype(cache_name) != cache_dtype ||
+        module.tensor_dtype(present_name) != cache_dtype) {
+        throw std::runtime_error("Qwen native KV cache dtype does not match model precision");
+    }
+}
+
+bool all_tensors_ok(const std::vector<DeviceTensor>& tensors) {
+    for (const auto& tensor : tensors) {
+        if (!tensor.ok())
+            return false;
+    }
+    return true;
+}
+
 } // namespace
 
 QwenKvCache::QwenKvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
@@ -47,6 +93,11 @@ QwenKvCache::QwenKvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
             names_.present_v.push_back("present_v" + suffix);
         }
     }
+    const auto expected_names = static_cast<std::size_t>(num_layers);
+    if (names_.cache_k.size() != expected_names || names_.cache_v.size() != expected_names ||
+        names_.present_k.size() != expected_names || names_.present_v.size() != expected_names) {
+        throw std::invalid_argument("QwenKvCache: per-layer tensor name count mismatch");
+    }
 
     cache_k_.reserve(static_cast<std::size_t>(num_layers));
     cache_v_.reserve(static_cast<std::size_t>(num_layers));
@@ -55,15 +106,101 @@ QwenKvCache::QwenKvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
 
     for (int32_t i = 0; i < num_layers; ++i) {
         cache_k_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
+        if (!cache_k_.back().ok())
+            return;
         cache_v_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
-        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
-        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
+        if (!cache_v_.back().ok())
+            return;
     }
 
     // Pre-allocate mask buffer: [max_length + 1] for dense causal mask.
     mask_buf_.resize(static_cast<std::size_t>(max_length) + 1);
 
     reset();
+}
+
+bool QwenKvCache::configure_binding_mode(TrtModule& module) {
+    const bool has_write_indices = module.has_input(names_.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(names_.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error("Qwen native KV engine must expose both cache_write_indices and "
+                                 "key_value_lengths");
+    }
+
+    const bool native_mode = has_write_indices && has_kv_lengths;
+    if (binding_mode_initialized_ && native_mode != native_kv_update_enabled_) {
+        throw std::runtime_error(
+            "Qwen prefill and decode engines use incompatible KV cache contracts");
+    }
+    binding_mode_initialized_ = true;
+    native_kv_update_enabled_ = native_mode;
+    if (native_mode)
+        validate_native_kv_contract(module);
+    return native_mode;
+}
+
+void QwenKvCache::validate_native_kv_contract(TrtModule& module) const {
+    validate_native_scalar_input(module, names_.cache_write_indices);
+    validate_native_scalar_input(module, names_.key_value_lengths);
+
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        validate_native_cache_pair(module, names_.cache_k[li], names_.present_k[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+        validate_native_cache_pair(module, names_.cache_v[li], names_.present_v[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+    }
+}
+
+void QwenKvCache::ensure_legacy_present_buffers() {
+    if (!present_k_.empty())
+        return;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        if (!present_k_.back().ok() || !present_v_.back().ok()) {
+            throw std::runtime_error("Qwen legacy KV present-buffer allocation failed");
+        }
+    }
+}
+
+void QwenKvCache::bind_native_cache(TrtModule& module) {
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        module.bind_external(names_.cache_k[li], cache_k_[li].data());
+        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (module.device_ptr(names_.cache_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.present_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.cache_v[li]) != cache_v_[li].data() ||
+            module.device_ptr(names_.present_v[li]) != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "Qwen native KV engine did not preserve cache/present aliasing");
+        }
+    }
+}
+
+void QwenKvCache::validate_native_aliases(const std::vector<const void*>& present_k,
+                                          const std::vector<const void*>& present_v) const {
+    if (static_cast<int32_t>(present_k.size()) != num_layers_ ||
+        static_cast<int32_t>(present_v.size()) != num_layers_) {
+        throw std::runtime_error("Qwen native KV per-layer pointer count mismatch");
+    }
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        if (present_k[li] != cache_k_[li].data() || present_v[li] != cache_v_[li].data()) {
+            throw std::runtime_error("Qwen native prefill present tensors must alias the KV cache");
+        }
+    }
+}
+
+void QwenKvCache::write_native_kv_inputs(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len > max_length_ - position_) {
+        throw std::runtime_error("Qwen sequence exceeds the model's fixed KV cache capacity");
+    }
+    cache_write_index_ = position_;
+    key_value_length_ = position_ + seq_len;
+    inputs[names_.cache_write_indices] = Tensor{&cache_write_index_, {1}, DType::kInt32};
+    inputs[names_.key_value_lengths] = Tensor{&key_value_length_, {1}, DType::kInt32};
 }
 
 // Masked score constant is model-local.
@@ -199,6 +336,10 @@ void QwenKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
     write_position_input(inputs, seq_len);
+    if (native_kv_update_enabled_) {
+        write_native_kv_inputs(inputs, seq_len);
+        return;
+    }
     if (seq_len > 1)
         write_batched_mask(inputs, seq_len);
     else
@@ -208,6 +349,10 @@ void QwenKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
 void QwenKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
+    if (native_kv_update_enabled_) {
+        throw std::runtime_error("Qwen native TensorRT KV cache supports causal attention only; "
+                                 "bidirectional block decoding is unsupported");
+    }
     write_position_input(inputs, seq_len);
     write_bidirectional_mask(inputs, seq_len);
 }
@@ -215,6 +360,13 @@ void QwenKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len)
 void QwenKvCache::bind_to(TrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
+    ensure_legacy_present_buffers();
     // Enable dynamic row binding only when cache_k[0] itself is dynamic.
     // Static-shape engines with fixed [max_length, kv_dim] cache reject
     // setInputShape on cache inputs even when other inputs are dynamic.
@@ -241,7 +393,14 @@ void QwenKvCache::bind_to(TrtModule& module) {
 }
 
 void QwenKvCache::bind_cache_inputs(TrtModule& module) {
+    bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
         module.bind_external(names_.cache_k[li], cache_k_[li].data());
@@ -258,6 +417,11 @@ void QwenKvCache::write_prefill_kv(const std::vector<const void*>& prefill_k,
     if (static_cast<int32_t>(prefill_k.size()) != num_layers_ ||
         static_cast<int32_t>(prefill_v.size()) != num_layers_) {
         throw std::runtime_error("QwenKvCache::write_prefill_kv: per-layer pointer count mismatch");
+    }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ = seq_len;
+        return;
     }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
@@ -282,6 +446,11 @@ void QwenKvCache::append_prefill_kv(const std::vector<const void*>& prefill_k,
         throw std::runtime_error(
             "QwenKvCache::append_prefill_kv: per-layer pointer count mismatch");
     }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ += seq_len;
+        return;
+    }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
     const auto offset = static_cast<std::size_t>(position_) * row_bytes;
@@ -304,6 +473,14 @@ void QwenKvCache::advance(int32_t n_tokens) {
     // n_tokens > 1 reserved for future batched prefill (TASK-10).
     assert(n_tokens == 1 && "QwenKvCache::advance: only n_tokens==1 supported");
     (void)n_tokens;
+
+    if (native_kv_update_enabled_) {
+        if (position_ >= max_length_) {
+            throw std::runtime_error("Qwen sequence exceeds the model's fixed KV cache capacity");
+        }
+        ++position_;
+        return;
+    }
 
     // Copy present K/V (single row) into cache at current position.
     // present_k_[layer] is [1, kv_dim] → copy to cache_k_[layer][position_, :]
@@ -343,6 +520,8 @@ void QwenKvCache::reset() {
     // Reset only the logical sequence length. Attention masks hide every
     // stale cache row, and each present row is overwritten before use.
     position_ = 0;
+    cache_write_index_ = 0;
+    key_value_length_ = 0;
 }
 
 std::size_t QwenKvCache::device_memory_bytes() const {
@@ -359,13 +538,13 @@ std::size_t QwenKvCache::device_memory_bytes() const {
 }
 
 bool QwenKvCache::ok() const {
-    if (cache_k_.size() != static_cast<std::size_t>(num_layers_))
+    const auto expected_layers = static_cast<std::size_t>(num_layers_);
+    if (cache_k_.size() != expected_layers)
         return false;
-    for (const auto& t : cache_k_) {
-        if (!t.ok())
-            return false;
-    }
-    return true;
+    if (cache_v_.size() != expected_layers)
+        return false;
+    return all_tensors_ok(cache_k_) && all_tensors_ok(cache_v_) && all_tensors_ok(present_k_) &&
+           all_tensors_ok(present_v_);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/qwen/kv_cache.h
+++ b/src/runtime/models/qwen/kv_cache.h
@@ -8,8 +8,9 @@
 // QwenKvCache: autoregressive KV cache state manager.
 // HF equivalent: DynamicCache / past_key_values.
 //
-// Manages per-layer K/V device tensors, position tracking, and attention mask
-// construction. Binds directly to a TrtModule via bind_to().
+// Manages per-layer K/V device tensors and position tracking. Native TensorRT
+// KV engines update these buffers in place; legacy engines use present rows
+// plus an attention mask.
 
 #include "runtime/models/qwen/inference_state.h"
 #include "trtmc/runtime/device_tensor.h"
@@ -30,6 +31,8 @@ struct QwenKvCacheNames {
     std::vector<std::string> cache_v;
     std::vector<std::string> present_k;
     std::vector<std::string> present_v;
+    std::string cache_write_indices{"cache_write_indices"};
+    std::string key_value_lengths{"key_value_lengths"};
     std::string position_id{"position_id"};
     std::string attention_mask{"attention_mask"};
 };
@@ -52,7 +55,7 @@ class QwenKvCache : public QwenInferenceState {
     int32_t max_length() const override { return max_length_; }
     int32_t preferred_cache_rows() const override;
     int32_t num_layers() const override { return num_layers_; }
-    bool needs_attention_mask() const override { return true; }
+    bool needs_attention_mask() const override { return !native_kv_update_enabled_; }
     std::size_t device_memory_bytes() const override;
     const char* state_type() const override { return "dense_kv_cache"; }
     bool ok() const override;
@@ -67,9 +70,9 @@ class QwenKvCache : public QwenInferenceState {
     DeviceTensor& cache_k(int32_t layer) { return cache_k_[static_cast<std::size_t>(layer)]; }
     DeviceTensor& cache_v(int32_t layer) { return cache_v_[static_cast<std::size_t>(layer)]; }
 
-    // Write per-layer KV produced by a batched prefill engine into the cache
-    // at positions [0, seq_len). Device-to-device copy on this cache's stream;
-    // advances position_ to seq_len. Requires seq_len <= max_length.
+    // Complete a batched prefill and advance position_ to seq_len. Native
+    // TensorRT KV engines have already updated the aliased cache in place;
+    // legacy engines copy their per-layer outputs into the cache.
     void write_prefill_kv(const std::vector<const void*>& prefill_k,
                           const std::vector<const void*>& prefill_v, int32_t seq_len);
 
@@ -86,14 +89,18 @@ class QwenKvCache : public QwenInferenceState {
     // remain masked out by subsequent prepare_step calls.
     void set_position(int32_t position);
 
-    // Bind only the cache_k/v INPUT pointers to `module`. Used for the
-    // prefill TrtModule whose present_k/v outputs have shape (Sq, kv_dim)
-    // — too big for QwenKvCache's single-row present buffer. The caller reads
-    // the prefill outputs directly from the module's own allocations and
-    // copies them via write_prefill_kv().
+    // Bind prefill KV tensors. Native TensorRT engines bind cache and present
+    // to the same full-capacity storage; legacy engines bind cache inputs only.
     void bind_cache_inputs(TrtModule& module);
 
   private:
+    bool configure_binding_mode(TrtModule& module);
+    void validate_native_kv_contract(TrtModule& module) const;
+    void validate_native_aliases(const std::vector<const void*>& present_k,
+                                 const std::vector<const void*>& present_v) const;
+    void ensure_legacy_present_buffers();
+    void bind_native_cache(TrtModule& module);
+    void write_native_kv_inputs(TensorMap& inputs, int32_t seq_len);
     void rebind_cache_rows(int32_t cache_rows);
     std::vector<int64_t> mask_shape_for_engine(int32_t mask_width, std::size_t mask_buf_size) const;
     void write_position_input(TensorMap& inputs, int32_t seq_len);
@@ -101,10 +108,11 @@ class QwenKvCache : public QwenInferenceState {
     void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
     void write_decode_mask(TensorMap& inputs);
 
-    std::vector<DeviceTensor> cache_k_;   // [num_layers], shape [max_length, kv_dim]
-    std::vector<DeviceTensor> cache_v_;   // [num_layers]
-    std::vector<DeviceTensor> present_k_; // [num_layers], shape [1, kv_dim] (single step output)
-    std::vector<DeviceTensor> present_v_; // [num_layers]
+    std::vector<DeviceTensor> cache_k_; // [num_layers], shape [max_length, kv_dim]
+    std::vector<DeviceTensor> cache_v_; // [num_layers]
+    // Legacy-only single-step outputs, allocated lazily when a legacy engine is bound.
+    std::vector<DeviceTensor> present_k_;
+    std::vector<DeviceTensor> present_v_;
     int32_t num_layers_{0};
     int32_t max_length_{0};
     int32_t kv_dim_{0};
@@ -113,7 +121,11 @@ class QwenKvCache : public QwenInferenceState {
     // Buffers owned by this object — Tensor.data in prepare_step() points here.
     std::vector<float> mask_buf_;
     std::vector<int32_t> pos_buf_vec_;
+    int32_t cache_write_index_{0};
+    int32_t key_value_length_{0};
     bool has_position_input_{false};
+    bool binding_mode_initialized_{false};
+    bool native_kv_update_enabled_{false};
     bool dynamic_binding_enabled_{false};
     int32_t bound_cache_rows_{0};
     DType cache_dtype_{DType::kFloat32};

--- a/src/runtime/models/qwen/pipeline.cpp
+++ b/src/runtime/models/qwen/pipeline.cpp
@@ -417,16 +417,109 @@ bool batched_prefill_supported(const TrtModule* prefill, const QwenTextGenConfig
                                QwenInferenceState* state) {
     if (prefill == nullptr || sq <= 0)
         return false;
-    if (cfg.prefill_max_length > 0 && sq > cfg.prefill_max_length)
-        return false;
     if (cfg.num_layers <= 0 || cfg.vocab_size <= 0)
         return false;
     return dynamic_cast<QwenKvCache*>(state) != nullptr;
 }
+
+void validate_generation_capacity(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+                                  QwenInferenceState* state, const TrtModule* prefill,
+                                  const TrtModule* decoder) {
+    const TrtModule* module = prefill;
+    if (module == nullptr)
+        module = decoder;
+    if (module == nullptr || !module->has_input("cache_write_indices") ||
+        !module->has_input("key_value_lengths")) {
+        return;
+    }
+    const auto* kv = dynamic_cast<const QwenKvCache*>(state);
+    if (kv == nullptr)
+        return;
+
+    const auto capacity = static_cast<std::size_t>(kv->max_length());
+    if (input_ids.size() > capacity ||
+        (max_new_tokens > 0 &&
+         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size())) {
+        throw std::runtime_error(
+            "Qwen requested prompt and generation exceed the model's fixed KV cache capacity");
+    }
+}
+
+int32_t resolve_batched_prefill_chunk_limit(const QwenKvCache& kv, const QwenTextGenConfig& config,
+                                            int32_t token_count) {
+    if (kv.needs_attention_mask()) {
+        if (config.prefill_max_length > 0 && token_count > config.prefill_max_length)
+            return 0;
+        return token_count;
+    }
+    if (config.prefill_max_length <= 0)
+        throw std::runtime_error("Qwen native KV prefill engine has no valid profile capacity");
+    return config.prefill_max_length;
+}
 } // namespace
 
+void QwenTextGenerationPipeline::run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                                                   QwenKvCache& kv,
+                                                   const std::vector<const void*>& present_k,
+                                                   const std::vector<const void*>& present_v,
+                                                   std::vector<float>& logits,
+                                                   bool retain_device_logits) {
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = const_cast<int32_t*>(token_ids);
+    token_tensor.shape = {static_cast<int64_t>(chunk_size)};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+    state_->prepare_step(inputs, chunk_size);
+
+    TensorMap outputs = prefill_->forward(inputs);
+    auto logits_it = outputs.find(config_.logits_output_name);
+    if (logits_it == outputs.end()) {
+        throw std::runtime_error("QwenTextGenerationPipeline: prefill module has no logits output");
+    }
+
+    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
+    const auto& logits_tensor = logits_it->second;
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab) {
+        throw std::runtime_error(
+            "QwenTextGenerationPipeline: prefill logits are smaller than vocabulary");
+    }
+    logits.resize(vocab);
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+
+    if (retain_device_logits) {
+        const auto* device_logits =
+            static_cast<const float*>(prefill_->device_ptr(config_.logits_output_name));
+        if (device_logits == nullptr) {
+            throw std::runtime_error(
+                "QwenTextGenerationPipeline: prefill logits have no device buffer");
+        }
+        d_logits_ptr_ = device_logits + logits_offset;
+    }
+    kv.append_prefill_kv(present_k, present_v, chunk_size);
+}
+
+void QwenTextGenerationPipeline::log_batched_prefill(int32_t token_count, int32_t chunk_count,
+                                                     int32_t chunk_limit) const {
+    if (!config_.log_runtime_stats)
+        return;
+
+    std::cerr << "[trtmc] Batched prefill (";
+    if (!config_.prefill_log_label.empty())
+        std::cerr << config_.prefill_log_label;
+    else
+        std::cerr << "profile " << config_.prefill_profile_index;
+    std::cerr << "): " << token_count << " tokens in " << chunk_count << " call";
+    if (chunk_count != 1)
+        std::cerr << 's';
+    std::cerr << " (max chunk=" << chunk_limit << ")\n";
+}
+
 bool QwenTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
-                                                     std::vector<float>& logits) {
+                                                     std::vector<float>& logits,
+                                                     bool retain_device_logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     if (!batched_prefill_supported(prefill_.get(), config_, sq, state_.get()))
         return false;
@@ -436,41 +529,28 @@ bool QwenTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>&
     // decode module(s), so we rebind the cache_k/cache_v inputs onto the
     // prefill execution context before running.
     kv->bind_cache_inputs(*prefill_);
-
-    TensorMap inputs;
-    Tensor tok_t;
-    tok_t.data = const_cast<int32_t*>(input_ids.data());
-    tok_t.shape = {static_cast<int64_t>(sq)};
-    tok_t.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = tok_t;
-    state_->prepare_step(inputs, sq);
-
-    TensorMap outputs = prefill_->forward(inputs);
-    auto logits_it = outputs.find(config_.logits_output_name);
-    if (logits_it == outputs.end())
-        return false;
-
-    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
-    const auto& lt = logits_it->second;
-    if (static_cast<std::size_t>(lt.numel()) < vocab)
-        return false;
-    logits.resize(vocab);
-    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
-    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
+    if (sq > kv->max_length()) {
+        throw std::runtime_error("Qwen sequence exceeds the model's fixed KV cache capacity");
+    }
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
         return false;
-    kv->write_prefill_kv(pk, pv, sq);
-    if (config_.log_runtime_stats) {
-        std::cerr << "[trtmc] Batched prefill (";
-        if (!config_.prefill_log_label.empty()) {
-            std::cerr << config_.prefill_log_label;
-        } else {
-            std::cerr << "profile " << config_.prefill_profile_index;
-        }
-        std::cerr << "): " << sq << " tokens in one call\n";
+
+    const int32_t chunk_limit = resolve_batched_prefill_chunk_limit(*kv, config_, sq);
+    if (chunk_limit <= 0)
+        return false;
+
+    int32_t chunk_count = 0;
+    for (int32_t start = 0; start < sq;) {
+        const int32_t chunk_size = std::min(chunk_limit, sq - start);
+        run_prefill_chunk(input_ids.data() + start, chunk_size, *kv, pk, pv, logits,
+                          retain_device_logits);
+        ++chunk_count;
+        start += chunk_size;
     }
+
+    log_batched_prefill(sq, chunk_count, chunk_limit);
     return true;
 }
 
@@ -498,9 +578,9 @@ void QwenTextGenerationPipeline::prime_decoder_after_batched_prefill(
 
 void QwenTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                              std::vector<float>& logits, bool gpu_sampling) {
-    // Fast path: batched prefill engine writes K/V for the whole prompt in
-    // one forward and returns last-token logits on host.
-    if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
+    // Fast path: batched prefill writes K/V in profile-bounded chunks and
+    // exposes last-token logits on the sampler's requested host or device path.
+    if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
         prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
@@ -610,6 +690,7 @@ void QwenTextGenerationPipeline::reset_generation_context() {
     using Clock = std::chrono::steady_clock;
     const auto start = Clock::now();
     state_->reset();
+    d_logits_ptr_ = nullptr;
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
         decoder_ctx.module->reset_execution_context();
@@ -765,6 +846,8 @@ QwenTextGenerationPipeline::TimedGenResult QwenTextGenerationPipeline::generate_
     using Clock = std::chrono::steady_clock;
     if (max_new_tokens == 0 || input_ids.empty())
         return TimedGenResult{input_ids, 0.0, 0.0};
+    validate_generation_capacity(input_ids, max_new_tokens, state_.get(), prefill_.get(),
+                                 decoders_.front().module.get());
 
     const std::string mode = resolve_generation_mode(cfg);
     if (mode == "diffusion" || mode == "dlm")

--- a/src/runtime/models/qwen/pipeline.h
+++ b/src/runtime/models/qwen/pipeline.h
@@ -43,9 +43,8 @@ struct QwenTextGenConfig {
 
     // Batched-prefill plumbing — populated when the bundle ships with a
     // dedicated prefill optimization profile. The runtime forwards the
-    // whole prompt through `prefill_module` once (writing per-layer K/V
-    // into the shared cache via write_prefill_kv) before falling back to
-    // the per-token decode loop.
+    // prompt through `prefill_module` in one or more profile-bounded chunks
+    // before falling back to the per-token decode loop.
     std::string present_k_pattern{"present_k_{i}"};
     std::string present_v_pattern{"present_v_{i}"};
     int32_t prefill_max_length{0};
@@ -188,7 +187,13 @@ class QwenTextGenerationPipeline final : public IPipeline {
                            TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
-    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
+                             bool retain_device_logits);
+    void run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size, QwenKvCache& kv,
+                           const std::vector<const void*>& present_k,
+                           const std::vector<const void*>& present_v, std::vector<float>& logits,
+                           bool retain_device_logits);
+    void log_batched_prefill(int32_t token_count, int32_t chunk_count, int32_t chunk_limit) const;
     void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,

--- a/src/runtime/models/qwen/plugin.cpp
+++ b/src/runtime/models/qwen/plugin.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cuda_runtime_api.h>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -68,13 +69,27 @@ int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
 }
 
 int32_t cache_row_dim_from_module(const TrtModule& module, const std::string& tensor_name) {
-    const int32_t static_dim = dim_at(module.tensor_shape(tensor_name), 1);
+    const auto row_dim = [](const std::vector<int64_t>& shape) -> int32_t {
+        if (shape.size() == 2)
+            return dim_at(shape, 1);
+        if (shape.size() == 4) {
+            const int32_t heads = dim_at(shape, 1);
+            const int32_t head_dim = dim_at(shape, 3);
+            if (heads > 0 && head_dim > 0 &&
+                heads <= std::numeric_limits<int32_t>::max() / head_dim) {
+                return heads * head_dim;
+            }
+        }
+        return -1;
+    };
+
+    const int32_t static_dim = row_dim(module.tensor_shape(tensor_name));
     if (static_dim > 0)
         return static_dim;
     const int32_t profile_count = module.optimization_profile_count();
     for (int32_t profile_idx = 0; profile_idx < profile_count; ++profile_idx) {
-        const int32_t profile_dim = dim_at(
-            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax), 1);
+        const int32_t profile_dim = row_dim(
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax));
         if (profile_dim > 0)
             return profile_dim;
     }
@@ -124,13 +139,16 @@ int32_t profile_token_max_length(const TrtModule& module, const std::string& tok
 
 int32_t profile_cache_rows(const TrtModule& module, const std::string& cache_name,
                            int32_t profile_idx, int32_t fallback_rows) {
-    const int32_t static_rows = dim_at(module.tensor_shape(cache_name), 0);
+    const auto cache_rows = [](const std::vector<int64_t>& shape) {
+        return dim_at(shape, shape.size() == 4 ? 2 : 0);
+    };
+    const int32_t static_rows = cache_rows(module.tensor_shape(cache_name));
     if (static_rows > 0)
         return static_rows;
 
     if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
-        const int32_t max_rows = dim_at(
-            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax), 0);
+        const int32_t max_rows = cache_rows(
+            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax));
         if (max_rows > 0)
             return max_rows;
     }
@@ -193,47 +211,118 @@ std::string format_bytes(std::uint64_t bytes) {
     return oss.str();
 }
 
-KvCacheRuntimeSizing
-resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& module,
+bool engine_uses_native_kv_updates(const TrtModule& module, const QwenKvCacheNames& kv_names) {
+    const bool has_write_indices = module.has_input(kv_names.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(kv_names.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error("Qwen native KV engine must expose both cache_write_indices and "
+                                 "key_value_lengths");
+    }
+    return has_write_indices;
+}
+
+void validate_native_kv_marker(const std::string& config_json, bool engine_uses_native_kv) {
+    const bool declares_native_kv = extract_json_bool(config_json, "native_kv_cache", false);
+    const bool has_version =
+        config_json.find("\"native_kv_contract_version\"") != std::string::npos;
+    if (!declares_native_kv && !has_version && !engine_uses_native_kv)
+        return;
+    if (!declares_native_kv || !engine_uses_native_kv ||
+        extract_json_int(config_json, "native_kv_contract_version", 0) != 1) {
+        throw std::runtime_error("Qwen native KV metadata does not match the engine contract");
+    }
+}
+
+bool validate_native_kv_runtime(const PipelineContext& ctx, const TrtModule& module,
                                 const QwenKvCacheNames& kv_names, DType cache_dtype,
-                                const QwenTriAttentionConfig& tri_cfg, int32_t kv_dim) {
-    KvCacheRuntimeSizing sizing;
-    const auto elem_bytes = static_cast<std::uint64_t>(dtype_size(cache_dtype));
-    sizing.row_bytes = static_cast<std::uint64_t>(ctx.config.num_layers) *
-                       static_cast<std::uint64_t>(kv_dim) * elem_bytes * 2ULL;
-    if (sizing.row_bytes == 0)
-        throw std::runtime_error("Computed zero bytes per KV row");
+                                const QwenTriAttentionConfig& tri_cfg,
+                                const TensorParallelRuntimeConfig& tp_cfg) {
+    const bool native_kv = engine_uses_native_kv_updates(module, kv_names);
+    validate_native_kv_marker(ctx.config_json, native_kv);
+    if (!native_kv)
+        return false;
 
-    const int32_t bundle_max_rows = ctx.config.max_cache_length;
-    sizing.runtime_rows = bundle_max_rows;
-    sizing.cache_bytes = static_cast<std::uint64_t>(bundle_max_rows) * sizing.row_bytes;
+    if (cache_dtype != DType::kBFloat16 || tri_cfg.enabled || tp_cfg.enabled) {
+        throw std::runtime_error(
+            "Qwen native KV requires BF16, single-GPU, non-TriAttention runtime");
+    }
+    const std::vector<int64_t> expected_shape{1, ctx.config.num_kv_heads,
+                                              ctx.config.max_cache_length, 128};
+    if (module.tensor_shape(kv_names.cache_k.front()) != expected_shape) {
+        throw std::runtime_error(
+            "Qwen native KV requires cache shape [1,num_kv_heads,capacity,128]");
+    }
+    return true;
+}
 
-    if (ctx.kv_cache_size_bytes == 0)
-        return sizing;
+std::uint64_t checked_multiply(std::uint64_t lhs, std::uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<std::uint64_t>::max() / lhs)
+        throw std::overflow_error("Qwen native KV byte accounting overflow");
+    return lhs * rhs;
+}
 
+void admit_native_kv_allocation(const PipelineContext& ctx, bool native_kv,
+                                const KvCacheRuntimeSizing& sizing) {
+    if (!native_kv)
+        return;
+
+    std::size_t free_bytes = 0;
+    std::size_t total_bytes = 0;
+    const cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Qwen native KV CUDA memory query failed: ") +
+                                 cudaGetErrorString(status));
+    }
+
+    constexpr std::uint64_t kTwoGiB = 2ULL << 30;
+    const auto free = static_cast<std::uint64_t>(free_bytes);
+    const auto total = static_cast<std::uint64_t>(total_bytes);
+    const auto reserve = std::max(kTwoGiB, total / 10);
+    const auto available = free > reserve ? free - reserve : 0;
+    if (sizing.cache_bytes > available) {
+        throw std::runtime_error(
+            "Qwen native KV cache admission failed before allocation: capacity=" +
+            std::to_string(ctx.config.max_cache_length) +
+            " tokens, required=" + format_bytes(sizing.cache_bytes) +
+            ", free=" + format_bytes(free) + ", reserve=" + format_bytes(reserve));
+    }
+}
+
+void reject_native_kv_size_override(const PipelineContext& ctx) {
+    if (ctx.kv_cache_size_bytes != 0) {
+        throw std::invalid_argument(
+            "Qwen native TensorRT KV cache allocates the model's complete fixed "
+            "capacity; kv_cache_size_bytes is not supported");
+    }
+}
+
+void apply_runtime_kv_size_override(const PipelineContext& ctx, const TrtModule& module,
+                                    const QwenKvCacheNames& kv_names,
+                                    const QwenTriAttentionConfig& tri_cfg, int32_t bundle_max_rows,
+                                    KvCacheRuntimeSizing& sizing) {
     if (!cache_input_supports_runtime_rows(module, kv_names.cache_k.front())) {
         throw std::runtime_error(
             "This bundle was not built with runtime-resizable KV cache support. "
             "Rebuild with trtmc build --dynamic-kv-cache to use --kv-cache-size.");
     }
 
-    const std::uint64_t requested_rows_u64 = ctx.kv_cache_size_bytes / sizing.row_bytes;
-    if (requested_rows_u64 == 0) {
+    const std::uint64_t requested_rows = ctx.kv_cache_size_bytes / sizing.row_bytes;
+    if (requested_rows == 0) {
         throw std::runtime_error("--kv-cache-size is smaller than one KV row (" +
                                  format_bytes(sizing.row_bytes) + ")");
     }
 
-    std::uint64_t runtime_rows_u64 = requested_rows_u64;
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(bundle_max_rows)) {
-        runtime_rows_u64 = static_cast<std::uint64_t>(bundle_max_rows);
+    std::uint64_t runtime_rows = requested_rows;
+    if (runtime_rows > static_cast<std::uint64_t>(bundle_max_rows)) {
+        runtime_rows = static_cast<std::uint64_t>(bundle_max_rows);
         sizing.clamped_to_bundle_max = true;
     }
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
+    if (runtime_rows > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
         throw std::runtime_error("Resolved KV cache rows exceed int32 runtime limits");
     }
 
-    sizing.runtime_rows = static_cast<int32_t>(runtime_rows_u64);
-    sizing.cache_bytes = runtime_rows_u64 * sizing.row_bytes;
+    sizing.runtime_rows = static_cast<int32_t>(runtime_rows);
+    sizing.cache_bytes = runtime_rows * sizing.row_bytes;
     sizing.override_applied = true;
 
     if (tri_cfg.enabled && sizing.runtime_rows < tri_cfg.kv_budget) {
@@ -243,7 +332,33 @@ resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& mod
             " rows, but this TriAttention bundle needs at least " +
             std::to_string(tri_cfg.kv_budget) + " rows (" + format_bytes(minimum_bytes) + ")");
     }
+}
 
+KvCacheRuntimeSizing resolve_kv_cache_runtime_sizing(
+    const PipelineContext& ctx, const TrtModule& module, const QwenKvCacheNames& kv_names,
+    DType cache_dtype, const QwenTriAttentionConfig& tri_cfg, int32_t kv_dim, bool native_kv) {
+    KvCacheRuntimeSizing sizing;
+    const int32_t bundle_max_rows = ctx.config.max_cache_length;
+    if (ctx.config.num_layers <= 0 || kv_dim <= 0 || bundle_max_rows <= 0)
+        throw std::runtime_error("Qwen KV geometry must be positive");
+    sizing.row_bytes = checked_multiply(
+        checked_multiply(checked_multiply(static_cast<std::uint64_t>(ctx.config.num_layers),
+                                          static_cast<std::uint64_t>(kv_dim)),
+                         static_cast<std::uint64_t>(dtype_size(cache_dtype))),
+        2);
+    sizing.runtime_rows = bundle_max_rows;
+    sizing.cache_bytes =
+        checked_multiply(static_cast<std::uint64_t>(bundle_max_rows), sizing.row_bytes);
+
+    if (native_kv) {
+        reject_native_kv_size_override(ctx);
+        return sizing;
+    }
+
+    if (ctx.kv_cache_size_bytes == 0)
+        return sizing;
+
+    apply_runtime_kv_size_override(ctx, module, kv_names, tri_cfg, bundle_max_rows, sizing);
     return sizing;
 }
 
@@ -278,9 +393,11 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
             throw std::runtime_error("No decoder engine profiles were loaded");
         TrtModule& metadata_module = *profile_modules.modules.front().module;
 
+        const bool native_kv = validate_native_kv_runtime(ctx, metadata_module, kv_names,
+                                                          cache_dtype, tri_cfg, tp_runtime.config);
         const int32_t kv_dim = cache_row_dim_from_module(metadata_module, kv_names.cache_k.front());
-        const auto sizing = resolve_kv_cache_runtime_sizing(ctx, metadata_module, kv_names,
-                                                            cache_dtype, tri_cfg, kv_dim);
+        const auto sizing = resolve_kv_cache_runtime_sizing(
+            ctx, metadata_module, kv_names, cache_dtype, tri_cfg, kv_dim, native_kv);
 
         const auto decode_profile_roles = detect_decoder_profile_roles(
             metadata_module, io.token_id, kv_names.cache_k.front(), ctx.config.max_cache_length);
@@ -301,6 +418,10 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
                 prefill_module = std::move(split_prefill_module);
         }
 
+        // Split prefill deserialization can consume additional execution-context
+        // memory. Admit the KV allocation against the free memory that remains
+        // after every engine/context needed by this pipeline has been loaded.
+        admit_native_kv_allocation(ctx, native_kv, sizing);
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
         log_kv_cache_sizing(ctx, sizing, state.get());
@@ -308,9 +429,8 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
         QwenTextGenConfig tgc;
         populate_text_gen_config(ctx, tgc, io, decoders.front(), ctx.runtime_config);
         apply_chat_template_format(ctx.bundle, tgc);
-        // Wire batched prefill: the pipeline forwards the whole prompt
-        // through `prefill_module` (TRT optimization profile 0) and copies
-        // per-layer K/V into the shared cache via write_prefill_kv.
+        // Wire batched prefill. Native TensorRT KV engines update the shared
+        // aliased cache in place; legacy engines copy prefill outputs into it.
         tgc.prefill_max_length = prefill_max_length;
         tgc.prefill_profile_index = prefill_profile_idx;
         tgc.prefill_log_label = std::move(prefill_log_label);

--- a/tests/builder/test_cli.py
+++ b/tests/builder/test_cli.py
@@ -149,6 +149,82 @@ class TestMainParser:
         assert captured["args"].build_timing_json == str(tmp_path / "timing.json")
         assert not hasattr(captured["args"], "_explicit_public_options")
 
+    def test_build_model_only_uses_optional_output(self, monkeypatch):
+        """The public parser accepts the model as the only build argument."""
+        import tensorrt_model_connect.build_cli as cli
+
+        captured: dict[str, argparse.Namespace] = {}
+
+        def _fake_cmd_build(args):
+            captured["args"] = args
+            return 0
+
+        monkeypatch.setattr(cli, "_cmd_build", _fake_cmd_build)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["trtmc", "build", "example-org/GenericDecoder-0.6B"],
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+        assert exc_info.value.code == 0
+        assert captured["args"].output is None
+        assert captured["args"].max_cache_length is None
+
+
+def test_default_bundle_path_uses_model_name():
+    from tensorrt_model_connect.build_cli import _default_bundle_path
+
+    assert (
+        _default_bundle_path("example-org/GenericDecoder-0.6B")
+        == "GenericDecoder-0.6B.trtfb"
+    )
+    assert _default_bundle_path("/models/My Model/") == "My-Model.trtfb"
+
+
+def test_cmd_build_derives_output_and_keeps_native_capacity_unset(monkeypatch):
+    import tensorrt_model_connect.build_cli as cli
+    import tensorrt_model_connect.engine_builder as engine_builder
+
+    captured = {}
+
+    optimized_call = {}
+
+    def _no_optimized(*_args, **kwargs):
+        optimized_call.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        engine_builder,
+        "_try_build_optimized_runtime",
+        _no_optimized,
+    )
+
+    def _fake_native_build(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(engine_builder, "_build_native_impl", _fake_native_build)
+    args = argparse.Namespace(
+        model="example-org/GenericDecoder-0.6B",
+        output=None,
+        max_cache_length=None,
+        precision=None,
+        quantize=None,
+        quant_scales=None,
+        quant_calibration_samples=512,
+        verbose=False,
+        method="trt",
+        tensor_parallel_size=1,
+        _skip_profile_resolution=True,
+    )
+
+    assert cli._cmd_build(args) == 0
+    assert captured["output_path"] == "GenericDecoder-0.6B.trtfb"
+    assert captured["max_cache_length"] is None
+    assert optimized_call == {}
+
 
 class TestInspectArgs:
     def test_inspect_parses(self):

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -28,6 +28,7 @@ from tests.builder.owned_graph_modules import load_family_graph_ops, load_graph_
 
 pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
 graph_ops = load_graph_ops()
+qwen_graph_ops = load_family_graph_ops("qwen")
 qwen_vl_graph_ops = load_family_graph_ops("qwen_vl")
 
 
@@ -363,6 +364,75 @@ class TestAddApplyRopeNative:
 
         np.testing.assert_allclose(result, ref, atol=1e-3,
                                    err_msg="multi-token native RoPE mismatch")
+
+    @requires_trt
+    def test_active_position_cache_matches_high_position_reference(self):
+        """Active rank-3 caches avoid a serialized context-capacity table."""
+        import tensorrt as trt
+
+        num_heads, head_dim = 4, 128
+        attention_size = num_heads * head_dim
+        rope_theta = 1_000_000.0
+        positions = np.array([0, 3, 40_934, 131_071], dtype=np.int32)
+
+        rng = np.random.default_rng(20260728)
+        x = rng.standard_normal(
+            (len(positions), attention_size)
+        ).astype(np.float32)
+        inv_freq = qwen_graph_ops.make_native_active_rope_inv_freq(
+            head_dim, rope_theta
+        )
+
+        def build(network, trt_inputs):
+            cos_active, sin_active = qwen_graph_ops.add_active_rope_cache(
+                network,
+                trt_inputs["pos"],
+                inv_freq,
+                trt.float32,
+            )
+            out = qwen_graph_ops.add_apply_rope_native(
+                network,
+                trt_inputs["x"],
+                num_heads,
+                head_dim,
+                cos_active,
+                sin_active,
+                None,
+                head_dim,
+                interleaved=False,
+                sequence_length=None,
+            )
+            return {
+                "out": out,
+                "cos": cos_active,
+                "sin": sin_active,
+            }
+
+        result = _run_strongly_typed(build, {"x": x, "pos": positions})
+
+        angles = positions.astype(np.float32)[:, None] * inv_freq[None, :]
+        cos_ref = np.asarray(np.cos(angles), dtype=np.float32)
+        sin_ref = np.asarray(np.sin(angles), dtype=np.float32)
+        rows = []
+        for row in range(len(positions)):
+            cos_full = np.concatenate([cos_ref[row], cos_ref[row]])
+            sin_full = np.concatenate([sin_ref[row], sin_ref[row]])
+            rows.append(
+                _ref_rope(
+                    x[row : row + 1],
+                    cos_full,
+                    sin_full,
+                    num_heads,
+                    head_dim,
+                )
+            )
+        ref = np.concatenate(rows, axis=0)
+
+        assert result["cos"].shape == (1, len(positions), head_dim // 2)
+        assert result["sin"].shape == (1, len(positions), head_dim // 2)
+        np.testing.assert_allclose(result["cos"][0], cos_ref, atol=1e-7)
+        np.testing.assert_allclose(result["sin"][0], sin_ref, atol=1e-7)
+        np.testing.assert_allclose(result["out"], ref, atol=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/builder/test_optimized_runtime_public_routing.py
+++ b/tests/builder/test_optimized_runtime_public_routing.py
@@ -148,7 +148,9 @@ def test_python_build_treats_omitted_and_explicit_defaults_identically(
     assert calls[0]["precision"] == "fp32"
 
 
-def test_python_build_preserves_native_call_when_no_capsule_matches(monkeypatch) -> None:
+def test_python_build_preserves_omitted_native_capacity_for_family_default(
+    monkeypatch,
+) -> None:
     import tensorrt_model_connect.engine_builder as engine_builder
 
     native_calls: list[dict] = []
@@ -169,7 +171,16 @@ def test_python_build_preserves_native_call_when_no_capsule_matches(monkeypatch)
     assert native_calls[0]["model_id_or_path"] == "native/model"
     assert native_calls[0]["output_path"] == "native.trtfb"
     assert native_calls[0]["precision"] is None
-    assert native_calls[0]["max_cache_length"] == 256
+    assert native_calls[0]["max_cache_length"] is None
+
+    engine_builder.build(
+        "native/model",
+        "explicit.trtfb",
+        max_cache_length=256,
+    )
+
+    assert len(native_calls) == 2
+    assert native_calls[1]["max_cache_length"] == 256
 
 
 def test_cli_delegation_uses_existing_options_without_native_discovery(monkeypatch) -> None:
@@ -346,7 +357,7 @@ def test_build_cli_does_not_expose_runtime_selection_or_target_flags() -> None:
     assert "--target" not in result.stdout
     assert "--runtime" not in result.stdout
     assert "optimized-runtime" not in result.stdout.lower()
-    assert "--max-cache-length" in result.stdout
+    assert "--max-cache-length" not in result.stdout
 
 
 def test_optimized_factory_header_is_private() -> None:

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -18,91 +18,145 @@ _FAMILIES = (
 )
 
 
-def _add_native_attention(graph_ops, dtype):
-    logger = trt.Logger(trt.Logger.ERROR)
-    builder = trt.Builder(logger)
-    network = builder.create_network(
-        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+class _FakeTensor:
+    def __init__(self, name, dtype):
+        self.name = name
+        self.dtype = dtype
+
+
+class _FakeLayer:
+    def __init__(self, output):
+        self._output = output
+
+    def get_output(self, index):
+        assert index == 0
+        return self._output
+
+
+class _FakeNetwork:
+    def __init__(self):
+        self.calls = []
+
+    def _layer(self, operation, dtype):
+        return _FakeLayer(_FakeTensor(f"{operation}_{len(self.calls)}", dtype))
+
+    def add_kv_cache_update(self, cache, update, indices, mode):
+        layer = self._layer("kv_cache_update", cache.dtype)
+        self.calls.append(("kv_cache_update", cache, update, indices, mode, layer))
+        return layer
+
+    def add_cast(self, tensor, dtype):
+        layer = self._layer("cast", dtype)
+        self.calls.append(("cast", tensor, dtype, layer))
+        return layer
+
+    def add_elementwise(self, lhs, rhs, operation):
+        layer = self._layer("elementwise", lhs.dtype)
+        self.calls.append(("elementwise", lhs, rhs, operation, layer))
+        return layer
+
+    def add_attention_v2(self, q, k, v, normalization, causal_mask):
+        layer = self._layer("attention", q.dtype)
+        self.calls.append(("attention", q, k, v, normalization, causal_mask, layer))
+        return layer
+
+
+def _add_native_attention(monkeypatch, graph_ops, dtype):
+    network = _FakeNetwork()
+    heads, kv_heads, head_dim = 4, 2, 128
+    tensors = {
+        "q": _FakeTensor("q", dtype),
+        "k": _FakeTensor("k", dtype),
+        "v": _FakeTensor("v", dtype),
+        "cache_k": _FakeTensor("cache_k", dtype),
+        "cache_v": _FakeTensor("cache_v", dtype),
+        "write_indices": _FakeTensor("cache_write_indices", trt.int32),
+        "lengths": _FakeTensor("key_value_lengths", trt.int32),
+    }
+    monkeypatch.setattr(
+        graph_ops,
+        "reshape_rows_to_heads_4d",
+        lambda _network, tensor, *_args, **_kwargs: tensor,
     )
-    heads, kv_heads, head_dim, capacity = 4, 2, 128, 8
-    q = network.add_input("q", dtype, (1, heads * head_dim))
-    k = network.add_input("k", dtype, (1, kv_heads * head_dim))
-    v = network.add_input("v", dtype, (1, kv_heads * head_dim))
-    cache_shape = (1, kv_heads, capacity, head_dim)
-    cache_k = network.add_input("cache_k", dtype, cache_shape)
-    cache_v = network.add_input("cache_v", dtype, cache_shape)
-    write_indices = network.add_input("cache_write_indices", trt.int32, (1,))
-    lengths = network.add_input("key_value_lengths", trt.int32, (1,))
-    graph_ops.add_native_kv_cache_attention_from_rows(
+    monkeypatch.setattr(
+        graph_ops,
+        "reshape_heads_4d_to_rows",
+        lambda _network, tensor, *_args, **_kwargs: tensor,
+    )
+    result = graph_ops.add_native_kv_cache_attention_from_rows(
         network,
-        q,
-        k,
-        v,
-        cache_k,
-        cache_v,
-        write_indices,
-        lengths,
+        tensors["q"],
+        tensors["k"],
+        tensors["v"],
+        tensors["cache_k"],
+        tensors["cache_v"],
+        tensors["write_indices"],
+        tensors["lengths"],
         num_heads=heads,
         num_kv_heads=kv_heads,
         head_dim=head_dim,
         q_seq=1,
     )
-    return network, lengths
+    return network, tensors, result
 
 
 @pytest.mark.parametrize("module_name", _FAMILIES)
 def test_bf16_uses_exact_fp32_scale_before_fused_attention(
-    monkeypatch, module_name,
+    monkeypatch,
+    module_name,
 ):
     graph_ops = importlib.import_module(module_name)
     constants: list[tuple[tuple[int, ...], np.ndarray, np.dtype]] = []
-    real_add_constant = graph_ops.add_constant
 
     def _record(network, shape, values, dtype=np.float32):
         constants.append((shape, np.asarray(values).copy(), np.dtype(dtype)))
-        return real_add_constant(network, shape, values, dtype=dtype)
+        tensor = _FakeTensor("scale", trt.float32)
+        network.calls.append(("constant", tensor))
+        return tensor
 
     monkeypatch.setattr(graph_ops, "add_constant", _record)
-    network, lengths = _add_native_attention(graph_ops, trt.bfloat16)
-    relevant = {
-        trt.LayerType.CAST,
-        trt.LayerType.CONSTANT,
-        trt.LayerType.ELEMENTWISE,
-        trt.LayerType.ATTENTION_INPUT,
-    }
-    layers = [
-        network.get_layer(index)
-        for index in range(network.num_layers)
-        if network.get_layer(index).type in relevant
+    network, tensors, result = _add_native_attention(monkeypatch, graph_ops, trt.bfloat16)
+    relevant = [
+        call
+        for call in network.calls
+        if call[0] in {"cast", "constant", "elementwise", "attention"}
     ]
 
     assert len(constants) == 1
     shape, values, dtype = constants[0]
     assert shape == (1, 1, 1, 1)
     assert dtype == np.dtype(np.float32)
-    assert float(values.item()) == pytest.approx(
-        1.0 / np.sqrt(128), rel=0.0, abs=0.0
-    )
-    assert [layer.type for layer in layers] == [
-        trt.LayerType.CAST,
-        trt.LayerType.CONSTANT,
-        trt.LayerType.ELEMENTWISE,
-        trt.LayerType.CAST,
-        trt.LayerType.ATTENTION_INPUT,
+    assert float(values.item()) == pytest.approx(1.0 / np.sqrt(128), rel=0.0, abs=0.0)
+    assert [call[0] for call in relevant] == [
+        "cast",
+        "constant",
+        "elementwise",
+        "cast",
+        "attention",
     ]
-    upcast, constant, product, downcast, attention = layers
-    assert upcast.get_output(0).dtype == trt.float32
-    assert constant.get_output(0).dtype == trt.float32
-    assert product.get_input(0) is upcast.get_output(0)
-    assert downcast.get_input(0) is product.get_output(0)
-    assert downcast.get_output(0).dtype == trt.bfloat16
-    assert attention.get_input(0) is downcast.get_output(0)
-    assert attention.get_input(6) is lengths
+    upcast, constant, product, downcast, attention = relevant
+    assert upcast[1] is tensors["q"]
+    assert upcast[2] == trt.float32
+    assert upcast[3].get_output(0).dtype == trt.float32
+    assert constant[1].dtype == trt.float32
+    assert product[1] is upcast[3].get_output(0)
+    assert product[2] is constant[1]
+    assert product[3] == trt.ElementWiseOperation.PROD
+    assert downcast[1] is product[4].get_output(0)
+    assert downcast[2] == trt.bfloat16
+    assert attention[1] is downcast[3].get_output(0)
+    assert attention[2] is result["present_k"]
+    assert attention[3] is result["present_v"]
+    assert attention[4] == trt.AttentionNormalizationOp.SOFTMAX
+    assert attention[5] == trt.CausalMaskKind.LOWER_RIGHT
+    assert attention[6].decomposable is False
+    assert attention[6].key_value_lengths is tensors["lengths"]
+    assert result["context"] is attention[6].get_output(0)
 
 
 @pytest.mark.parametrize("module_name", _FAMILIES)
-def test_unqualified_fp16_graph_fails_closed(module_name):
+def test_unqualified_fp16_graph_fails_closed(monkeypatch, module_name):
     graph_ops = importlib.import_module(module_name)
 
     with pytest.raises(ValueError, match="requires BF16"):
-        _add_native_attention(graph_ops, trt.float16)
+        _add_native_attention(monkeypatch, graph_ops, trt.float16)

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT topology checks for the qualified BF16 native-KV path."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+trt = pytest.importorskip("tensorrt")
+
+_FAMILIES = (
+    "tensorrt_model_connect.families.qwen.graph_ops",
+    "tensorrt_model_connect.families.llama.graph_ops",
+)
+
+
+def _add_native_attention(graph_ops, dtype):
+    logger = trt.Logger(trt.Logger.ERROR)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    )
+    heads, kv_heads, head_dim, capacity = 4, 2, 128, 8
+    q = network.add_input("q", dtype, (1, heads * head_dim))
+    k = network.add_input("k", dtype, (1, kv_heads * head_dim))
+    v = network.add_input("v", dtype, (1, kv_heads * head_dim))
+    cache_shape = (1, kv_heads, capacity, head_dim)
+    cache_k = network.add_input("cache_k", dtype, cache_shape)
+    cache_v = network.add_input("cache_v", dtype, cache_shape)
+    write_indices = network.add_input("cache_write_indices", trt.int32, (1,))
+    lengths = network.add_input("key_value_lengths", trt.int32, (1,))
+    graph_ops.add_native_kv_cache_attention_from_rows(
+        network,
+        q,
+        k,
+        v,
+        cache_k,
+        cache_v,
+        write_indices,
+        lengths,
+        num_heads=heads,
+        num_kv_heads=kv_heads,
+        head_dim=head_dim,
+        q_seq=1,
+    )
+    return network, lengths
+
+
+@pytest.mark.parametrize("module_name", _FAMILIES)
+def test_bf16_uses_exact_fp32_scale_before_fused_attention(
+    monkeypatch, module_name,
+):
+    graph_ops = importlib.import_module(module_name)
+    constants: list[tuple[tuple[int, ...], np.ndarray, np.dtype]] = []
+    real_add_constant = graph_ops.add_constant
+
+    def _record(network, shape, values, dtype=np.float32):
+        constants.append((shape, np.asarray(values).copy(), np.dtype(dtype)))
+        return real_add_constant(network, shape, values, dtype=dtype)
+
+    monkeypatch.setattr(graph_ops, "add_constant", _record)
+    network, lengths = _add_native_attention(graph_ops, trt.bfloat16)
+    relevant = {
+        trt.LayerType.CAST,
+        trt.LayerType.CONSTANT,
+        trt.LayerType.ELEMENTWISE,
+        trt.LayerType.ATTENTION_INPUT,
+    }
+    layers = [
+        network.get_layer(index)
+        for index in range(network.num_layers)
+        if network.get_layer(index).type in relevant
+    ]
+
+    assert len(constants) == 1
+    shape, values, dtype = constants[0]
+    assert shape == (1, 1, 1, 1)
+    assert dtype == np.dtype(np.float32)
+    assert float(values.item()) == pytest.approx(
+        1.0 / np.sqrt(128), rel=0.0, abs=0.0
+    )
+    assert [layer.type for layer in layers] == [
+        trt.LayerType.CAST,
+        trt.LayerType.CONSTANT,
+        trt.LayerType.ELEMENTWISE,
+        trt.LayerType.CAST,
+        trt.LayerType.ATTENTION_INPUT,
+    ]
+    upcast, constant, product, downcast, attention = layers
+    assert upcast.get_output(0).dtype == trt.float32
+    assert constant.get_output(0).dtype == trt.float32
+    assert product.get_input(0) is upcast.get_output(0)
+    assert downcast.get_input(0) is product.get_output(0)
+    assert downcast.get_output(0).dtype == trt.bfloat16
+    assert attention.get_input(0) is downcast.get_output(0)
+    assert attention.get_input(6) is lengths
+
+
+@pytest.mark.parametrize("module_name", _FAMILIES)
+def test_unqualified_fp16_graph_fails_closed(module_name):
+    graph_ops = importlib.import_module(module_name)
+
+    with pytest.raises(ValueError, match="requires BF16"):
+        _add_native_attention(graph_ops, trt.float16)

--- a/tests/cpp/models/llama/test_llama_native_kv_cache.cpp
+++ b/tests/cpp/models/llama/test_llama_native_kv_cache.cpp
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../../native_kv_cache_contract_test.h"
+#include "runtime/models/llama/kv_cache.h"
+#include "runtime/models/llama/pipeline.h"
+
+int main() {
+    return trtmc::test::run_native_kv_contract_tests<
+        trtmc::LlamaTextGenerationPipeline, trtmc::LlamaKvCache, trtmc::LlamaTextGenConfig>(
+        "Llama");
+}

--- a/tests/cpp/models/llama/test_llama_pipeline.cpp
+++ b/tests/cpp/models/llama/test_llama_pipeline.cpp
@@ -251,6 +251,67 @@ static void test_generate_stops_at_eos() {
     cudaStreamDestroy(stream);
 }
 
+static void test_generate_stops_at_any_default_eos() {
+    auto engine = build_mock_decoder();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
+                                                         engine->createExecutionContext(), stream);
+    auto cache = std::make_unique<trtmc::LlamaKvCache>(1, 8, 4, stream);
+
+    trtmc::LlamaTextGenConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 1;
+    cfg.id_eos_ids = {1, 2};
+    cfg.has_position_input = false;
+
+    trtmc::LlamaTextGenerationPipeline pipeline(std::move(module), std::move(cache), cfg, stream);
+
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 10;
+
+    auto result = pipeline.generate_ids({1}, gen_cfg);
+    check(result.token_ids == std::vector<int32_t>({1, 2}),
+          "second configured EOS stops generation");
+
+    cudaStreamDestroy(stream);
+}
+
+static void test_explicit_eos_override_replaces_default_set() {
+    auto engine = build_mock_decoder();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
+                                                         engine->createExecutionContext(), stream);
+    auto cache = std::make_unique<trtmc::LlamaKvCache>(1, 8, 4, stream);
+
+    trtmc::LlamaTextGenConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 1;
+    cfg.id_eos_ids = {1, 2};
+    cfg.has_position_input = false;
+
+    trtmc::LlamaTextGenerationPipeline pipeline(std::move(module), std::move(cache), cfg, stream);
+
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 3;
+    gen_cfg.eos_token_id = 3;
+
+    auto result = pipeline.generate_ids({1}, gen_cfg);
+    check(result.token_ids == std::vector<int32_t>({1, 2, 2, 2}),
+          "explicit scalar EOS override replaces the default EOS set");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_generate_max_tokens() {
     auto engine = build_mock_decoder();
     if (!engine) {
@@ -436,6 +497,8 @@ int main() {
     test_argmax();
     test_pipeline_construction();
     test_generate_stops_at_eos();
+    test_generate_stops_at_any_default_eos();
+    test_explicit_eos_override_replaces_default_set();
     test_generate_max_tokens();
     test_zero_max_tokens();
     test_kv_reset_is_logical_and_masks_stale_rows();

--- a/tests/cpp/models/qwen/test_qwen_native_kv_cache.cpp
+++ b/tests/cpp/models/qwen/test_qwen_native_kv_cache.cpp
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../../native_kv_cache_contract_test.h"
+#include "runtime/backend/trt_module_impl.h"
+#include "runtime/models/qwen/kv_cache.h"
+#include "runtime/models/qwen/pipeline.h"
+
+#include <NvInfer.h>
+#include <cstring>
+#include <cuda_runtime_api.h>
+
+#if NV_TENSORRT_MAJOR >= 11
+namespace {
+
+int test_trt_external_alias() {
+    trtmc::TrtLogger logger;
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(logger));
+    if (!builder)
+        return 1;
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    if (!network || !config)
+        return 1;
+    auto* cache =
+        network->addInput("cache", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4{1, 1, 4, 1});
+    auto* update =
+        network->addInput("update", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4{1, 1, 2, 1});
+    auto* index = network->addInput("index", nvinfer1::DataType::kINT32, nvinfer1::Dims{1, {1}});
+    if (!cache || !update || !index)
+        return 1;
+    auto* layer =
+        network->addKVCacheUpdate(*cache, *update, *index, nvinfer1::KVCacheMode::kLINEAR);
+    if (!layer)
+        return 1;
+    layer->getOutput(0)->setName("present");
+    network->markOutput(*layer->getOutput(0));
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+    auto runtime = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(logger));
+    if (!plan || !runtime)
+        return 1;
+    auto engine = trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        runtime->deserializeCudaEngine(plan->data(), plan->size()));
+    const char* alias = engine ? engine->getAliasedInputTensor("present") : nullptr;
+    if (!alias || std::strcmp(alias, "cache") != 0)
+        return 1;
+    cudaStream_t stream = nullptr;
+    void* storage = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess ||
+        cudaMalloc(&storage, 4 * sizeof(float)) != cudaSuccess)
+        return 1;
+    float values[4]{1, 2, 3, 4};
+    float replacement[2]{7, 8};
+    int32_t write_index[1]{1};
+    cudaMemcpy(storage, values, sizeof(values), cudaMemcpyHostToDevice);
+    int failures = 0;
+    {
+        trtmc::TrtModuleImpl module(engine.get(), engine->createExecutionContext(), stream);
+        module.bind_external("cache", storage);
+        if (!module.ok() || module.device_ptr("cache") != storage ||
+            module.device_ptr("present") != storage)
+            ++failures;
+        module.forward(
+            {{"update", trtmc::Tensor{replacement, {1, 1, 2, 1}, trtmc::DType::kFloat32}},
+             {"index", trtmc::Tensor{write_index, {1}, trtmc::DType::kInt32}}});
+        cudaMemcpy(values, storage, sizeof(values), cudaMemcpyDeviceToHost);
+        if (values[0] != 1 || values[1] != 7 || values[2] != 8 || values[3] != 4)
+            ++failures;
+    }
+    cudaFree(storage);
+    cudaStreamDestroy(stream);
+    return failures;
+}
+
+} // namespace
+#endif
+
+int main() {
+    int failures = trtmc::test::run_native_kv_contract_tests<
+        trtmc::QwenTextGenerationPipeline, trtmc::QwenKvCache, trtmc::QwenTextGenConfig>("Qwen");
+#if NV_TENSORRT_MAJOR >= 11
+    failures += test_trt_external_alias();
+#endif
+    return failures;
+}

--- a/tests/cpp/native_kv_cache_contract_test.h
+++ b/tests/cpp/native_kv_cache_contract_test.h
@@ -1,0 +1,339 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace trtmc::test {
+
+struct NativeKvCall {
+    std::vector<int32_t> tokens;
+    std::vector<int32_t> positions;
+    int32_t write_index{-1};
+    int32_t kv_length{-1};
+};
+
+struct NativeKvTrace {
+    std::vector<NativeKvCall> calls;
+};
+
+class NativeKvModuleStub final : public ITrtModule {
+  public:
+    NativeKvModuleStub(cudaStream_t stream, int32_t layers, int32_t capacity, int32_t kv_heads,
+                       int32_t head_dim, DType dtype, bool native = true,
+                       std::shared_ptr<NativeKvTrace> trace = nullptr, int32_t profile_limit = 4,
+                       int32_t vocab_size = 16)
+        : stream_(stream), native_(native), trace_(std::move(trace)), vocab_size_(vocab_size) {
+        if (native_) {
+            add("cache_write_indices", {1}, DType::kInt32, true);
+            add("key_value_lengths", {1}, DType::kInt32, true);
+        }
+        add("position_id", {1}, DType::kInt32, true);
+        if (trace_) {
+            add("token_id", {profile_limit}, DType::kInt32, true);
+            add("logits", {profile_limit, vocab_size}, DType::kFloat32, false);
+        }
+        for (int32_t i = 0; i < layers; ++i) {
+            const auto suffix = "_" + std::to_string(i);
+            const std::vector<int64_t> cache_shape =
+                native_ ? std::vector<int64_t>{1, kv_heads, capacity, head_dim}
+                        : std::vector<int64_t>{capacity, kv_heads * head_dim};
+            const std::vector<int64_t> present_shape =
+                native_ ? cache_shape : std::vector<int64_t>{1, kv_heads * head_dim};
+            add("cache_k" + suffix, cache_shape, dtype, true);
+            add("cache_v" + suffix, cache_shape, dtype, true);
+            add("present_k" + suffix, present_shape, dtype, false);
+            add("present_v" + suffix, present_shape, dtype, false);
+        }
+    }
+
+    void set_tensor(const std::string& name, std::vector<int64_t> shape, DType dtype) {
+        auto& entry = tensors_.at(name);
+        entry.shape = std::move(shape);
+        entry.dtype = dtype;
+    }
+
+    TensorMap forward(const TensorMap& inputs) override {
+        if (!trace_)
+            return {};
+        NativeKvCall call{ints(inputs, "token_id"), ints(inputs, "position_id"),
+                          scalar(inputs, "cache_write_indices"),
+                          scalar(inputs, "key_value_lengths")};
+        trace_->calls.push_back(call);
+        const int32_t rows = static_cast<int32_t>(call.tokens.size());
+        logits_.assign(static_cast<std::size_t>(rows * vocab_size_), -10.0F);
+        for (int32_t row = 0; row < rows; ++row) {
+            const int32_t token = call.positions[static_cast<std::size_t>(row)];
+            logits_[static_cast<std::size_t>(row * vocab_size_ + token)] = 10.0F;
+        }
+        return {{"logits", Tensor{logits_.data(), {rows, vocab_size_}, DType::kFloat32}}};
+    }
+    DeviceTensorMap forward_device(const DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const DeviceTensorMap&) override {}
+    void forward_async(const TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<TensorInfo> input_info() const override { return {}; }
+    std::vector<TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override { return has(name, true); }
+    bool has_output(const std::string& name) const override { return has(name, false); }
+    DType tensor_dtype(const std::string& name) const override { return tensors_.at(name).dtype; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        const auto it = tensors_.find(name);
+        return it == tensors_.end() ? std::vector<int64_t>{} : it->second.shape;
+    }
+    std::vector<int64_t> input_profile_shape(const std::string& name, int32_t,
+                                             ProfileShapeSelector) const override {
+        return tensor_shape(name);
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string& name) const override {
+        const auto it = bindings_.find(name);
+        return it == bindings_.end() ? nullptr : it->second;
+    }
+    void bind_external(const std::string& name, void* ptr) override {
+        if (tensors_.count(name) == 0)
+            return;
+        bindings_[name] = ptr;
+        if (native_ && name.rfind("cache_", 0) == 0)
+            bindings_["present_" + name.substr(6)] = ptr;
+    }
+    int32_t input_rank(const std::string& name) const override {
+        return has_input(name) ? static_cast<int32_t>(tensor_shape(name).size()) : 0;
+    }
+    bool input_is_dynamic(const std::string&) const override { return false; }
+    bool ok() const override { return stream_ != nullptr; }
+    void keep_alive(std::shared_ptr<void> value) override {
+        keep_alive_.push_back(std::move(value));
+    }
+
+  private:
+    struct Entry {
+        std::vector<int64_t> shape;
+        DType dtype;
+        bool input;
+    };
+    void add(std::string name, std::vector<int64_t> shape, DType dtype, bool input) {
+        tensors_.emplace(std::move(name), Entry{std::move(shape), dtype, input});
+    }
+    bool has(const std::string& name, bool input) const {
+        const auto it = tensors_.find(name);
+        return it != tensors_.end() && it->second.input == input;
+    }
+    static std::vector<int32_t> ints(const TensorMap& inputs, const std::string& name) {
+        const auto& tensor = inputs.at(name);
+        const auto* values = static_cast<const int32_t*>(tensor.data);
+        return {values, values + tensor.numel()};
+    }
+    static int32_t scalar(const TensorMap& inputs, const std::string& name) {
+        return ints(inputs, name).at(0);
+    }
+
+    cudaStream_t stream_;
+    bool native_;
+    std::shared_ptr<NativeKvTrace> trace_;
+    int32_t vocab_size_;
+    std::vector<float> logits_;
+    std::unordered_map<std::string, Entry> tensors_;
+    std::unordered_map<std::string, void*> bindings_;
+    std::vector<std::shared_ptr<void>> keep_alive_;
+};
+
+inline int32_t scalar(const TensorMap& inputs, const std::string& name) {
+    return *static_cast<const int32_t*>(inputs.at(name).data);
+}
+
+template <typename Cache, typename Mutate>
+bool rejects_native_contract(cudaStream_t stream, Mutate mutate) {
+    Cache cache(1, 11, 2, stream, DType::kFloat16);
+    NativeKvModuleStub module(stream, 1, 11, 1, 2, DType::kFloat16);
+    mutate(module);
+    try {
+        cache.bind_cache_inputs(module);
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+    return false;
+}
+
+template <typename Pipeline, typename Cache, typename Config>
+int run_native_kv_contract_tests(const char* model) {
+    int failures = 0;
+    const auto check = [&](bool condition, const std::string& message) {
+        if (!condition) {
+            std::cerr << "FAIL [" << model << "]: " << message << '\n';
+            ++failures;
+        }
+    };
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess)
+        return 1;
+
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("key_value_lengths", {2}, DType::kInt32); }),
+          "rejects a non-scalar key_value_lengths input");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_write_indices", {1}, DType::kFloat32); }),
+          "rejects a non-int32 cache_write_indices input");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16); }),
+          "rejects a cache with the wrong capacity");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32); }),
+          "rejects a cache with the wrong dtype");
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub prefill(stream, 1, 11, 1, 2, DType::kFloat16);
+        NativeKvModuleStub decode(stream, 1, 11, 1, 2, DType::kFloat16);
+        cache.bind_cache_inputs(prefill);
+        cache.bind_to(decode);
+        check(cache.ok() && cache.device_memory_bytes() == 88,
+              "allocates one state-owned FP16 K/V cache");
+        check(prefill.device_ptr("cache_k_0") == cache.cache_k(0).data() &&
+                  prefill.device_ptr("present_k_0") == cache.cache_k(0).data(),
+              "prefill cache and present K share state storage");
+        check(decode.device_ptr("cache_k_0") == prefill.device_ptr("cache_k_0") &&
+                  decode.device_ptr("present_v_0") == prefill.device_ptr("cache_v_0"),
+              "prefill and decode contexts share the same K/V storage");
+
+        TensorMap inputs;
+        cache.prepare_step(inputs, 4);
+        check(inputs.count("attention_mask") == 0 && scalar(inputs, "cache_write_indices") == 0 &&
+                  scalar(inputs, "key_value_lengths") == 4,
+              "native metadata describes the current write without a dense mask");
+
+        cache.set_position(10);
+        inputs.clear();
+        cache.prepare_step(inputs);
+        check(scalar(inputs, "cache_write_indices") == 10 &&
+                  scalar(inputs, "key_value_lengths") == 11,
+              "the final cache row is usable");
+        cache.advance();
+        bool overflow = false;
+        try {
+            cache.prepare_step(inputs);
+        } catch (const std::runtime_error&) {
+            overflow = true;
+        }
+        check(overflow && cache.position() == 11,
+              "an over-capacity write is rejected without logical progression");
+    }
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub legacy(stream, 1, 11, 1, 2, DType::kFloat16, false);
+        cache.bind_to(legacy);
+        TensorMap inputs;
+        cache.prepare_step(inputs);
+        cache.advance();
+        check(cache.needs_attention_mask() && inputs.count("attention_mask") == 1 &&
+                  inputs.count("cache_write_indices") == 0 && cache.position() == 1,
+              "legacy attention-mask cache path still advances normally");
+    }
+
+    const auto make_config = [] {
+        Config config;
+        config.vocab_size = 16;
+        config.id_eos = 9;
+        config.disable_cuda_graph = true;
+        config.prefill_max_length = 4;
+        config.num_layers = 1;
+        config.kv_dim = 2;
+        return config;
+    };
+    const auto make_request = [](int32_t max_new_tokens) {
+        GenerateConfig request;
+        request.max_new_tokens = max_new_tokens;
+        request.temperature = 0.0F;
+        request.top_k = 1;
+        request.seed = -1;
+        return request;
+    };
+    const std::vector<int32_t> prompt{10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+
+    {
+        auto prefill_trace = std::make_shared<NativeKvTrace>();
+        auto decode_trace = std::make_shared<NativeKvTrace>();
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, 11, 2, stream, DType::kFloat16);
+        Cache* cache_ptr = cache.get();
+        std::vector<typename Pipeline::DecoderContext> decoders;
+        decoders.push_back(typename Pipeline::DecoderContext{11, std::move(decoder)});
+        Pipeline pipeline(std::move(decoders), std::move(cache), make_config(), stream, nullptr, "",
+                          nullptr, std::move(prefill));
+        const auto result = pipeline.generate_ids(prompt, make_request(1));
+
+        check(prefill_trace->calls.size() == 3, "split prefill runs 4/4/2 chunks");
+        const int32_t starts[] = {0, 4, 8};
+        const int32_t sizes[] = {4, 4, 2};
+        if (prefill_trace->calls.size() == 3) {
+            for (int32_t i = 0; i < 3; ++i) {
+                const auto& call = prefill_trace->calls[static_cast<std::size_t>(i)];
+                check(static_cast<int32_t>(call.tokens.size()) == sizes[i] &&
+                          call.write_index == starts[i] && call.kv_length == starts[i] + sizes[i],
+                      "chunk " + std::to_string(i) + " has correct size and KV range");
+                for (int32_t j = 0; j < sizes[i]; ++j)
+                    check(call.tokens[static_cast<std::size_t>(j)] == 10 + starts[i] + j &&
+                              call.positions[static_cast<std::size_t>(j)] == starts[i] + j,
+                          "chunk token and absolute position progress together");
+            }
+        }
+        check(result.token_ids.size() == 11 && result.token_ids.back() == 9 &&
+                  cache_ptr->position() == 10 && decode_trace->calls.empty(),
+              "final prefill row supplies EOS without an extra decode");
+    }
+
+    {
+        auto prefill_trace = std::make_shared<NativeKvTrace>();
+        auto decode_trace = std::make_shared<NativeKvTrace>();
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, 11, 2, stream, DType::kFloat16);
+        Cache* cache_ptr = cache.get();
+        std::vector<typename Pipeline::DecoderContext> decoders;
+        decoders.push_back(typename Pipeline::DecoderContext{11, std::move(decoder)});
+        Pipeline pipeline(std::move(decoders), std::move(cache), make_config(), stream, nullptr, "",
+                          nullptr, std::move(prefill));
+        bool overflow = false;
+        try {
+            (void)pipeline.generate_ids(prompt, make_request(2));
+        } catch (const std::runtime_error&) {
+            overflow = true;
+        }
+        check(overflow && prefill_trace->calls.empty() && decode_trace->calls.empty() &&
+                  cache_ptr->position() == 0,
+              "request over capacity is rejected before any runtime progression");
+    }
+
+    cudaStreamDestroy(stream);
+    return failures;
+}
+
+} // namespace trtmc::test

--- a/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
@@ -5,8 +5,6 @@
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "precision": "fp16",
-  "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
     {

--- a/tests/e2e/models/llama/manifests/minitron-4b-width.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width.json
@@ -5,8 +5,6 @@
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "precision": "fp16",
-  "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
     {

--- a/tests/e2e/models/llama/test_llama_build_contract.py
+++ b/tests/e2e/models/llama/test_llama_build_contract.py
@@ -8,9 +8,36 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.e2e_harness.manifest_loader import load_manifest
+
 
 def test_falcon3_split_decoder_build_reserves_an_exclusive_gpu() -> None:
     manifest_path = Path(__file__).parent / "manifests" / "falcon3-1b.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_native_minitron_manifests_use_family_build_defaults() -> None:
+    for manifest_name in (
+        "minitron-4b-width.json",
+        "minitron-4b-width-l0.json",
+    ):
+        manifest_path = Path(__file__).parent / "manifests" / manifest_name
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        case = load_manifest(manifest_path)
+
+        assert "precision" not in manifest, manifest_name
+        assert "max_cache_length" not in manifest, manifest_name
+        assert "precision" not in case.metadata, manifest_name
+        assert "max_cache_length" not in case.inputs, manifest_name
+
+
+def test_tinyllama_keeps_legacy_build_contract() -> None:
+    manifest_path = (
+        Path(__file__).parent / "manifests" / "tinyllama-1.1b.json"
+    )
+    case = load_manifest(manifest_path)
+
+    assert case.metadata["precision"] == "fp16"
+    assert case.inputs["max_cache_length"] == 256

--- a/tests/e2e/models/llama/test_llama_builder_engine.py
+++ b/tests/e2e/models/llama/test_llama_builder_engine.py
@@ -8,8 +8,15 @@ Intent: Validate the LLaMA family plugin weight loading and standard decoder key
 Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU required for engine build tests.
 Postconditions: All standard decoder weight keys are present with correct shapes and the engine builds successfully.
 """
-from tests.builder.family_plugin_tester import FamilyPluginTester
-from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
+from __future__ import annotations
+
+import pytest
+
+from tests.builder.family_plugin_tester import FamilyPluginTester, TinyModelSpec
+from tests.builder.family_plugin_test_mixin import (
+    FamilyPluginTestMixin,
+    requires_trt,
+)
 
 
 class LlamaPluginTester(FamilyPluginTester):
@@ -17,5 +24,139 @@ class LlamaPluginTester(FamilyPluginTester):
     model_type = "llama"
 
 
+class NativeLlamaPluginTester(LlamaPluginTester):
+    """Smallest production-shaped dense Llama accepted by native attention."""
+
+    spec = TinyModelSpec(
+        vocab_size=32,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=128,
+        max_position_embeddings=16,
+        max_cache_length=16,
+    )
+
+    def get_config_dict(self) -> dict:
+        config = super().get_config_dict()
+        config.update(
+            architectures=["LlamaForCausalLM"],
+            hidden_act="silu",
+        )
+        return config
+
+
+def _deserialize(plan: bytes):
+    import tensorrt as trt
+
+    return trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(plan)
+
+
+def _io_names(engine) -> tuple[set[str], set[str]]:
+    import tensorrt as trt
+
+    inputs: set[str] = set()
+    outputs: set[str] = set()
+    for index in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(index)
+        target = (
+            inputs
+            if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT
+            else outputs
+        )
+        target.add(name)
+    return inputs, outputs
+
+
 class TestLlamaEngine(FamilyPluginTestMixin):
     tester_class = LlamaPluginTester
+
+    @staticmethod
+    def _build_legacy_engine(tester, tmp_path) -> bytes:
+        from tensorrt_model_connect.families.llama.standard_decoder_builder import (
+            build_standard_decoder_engine,
+        )
+
+        config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+        return build_standard_decoder_engine(
+            config,
+            weights,
+            tester.spec.max_cache_length,
+            precision="fp32",
+            verbose=False,
+        )
+
+    @requires_trt
+    def test_build_engine_succeeds(self, tester, tmp_path):
+        """Keep the generic dense-mask Llama builder smoke covered."""
+        plan = self._build_legacy_engine(tester, tmp_path)
+        assert isinstance(plan, bytes)
+        assert plan
+
+    @requires_trt
+    def test_engine_io_tensor_names(self, tester, tmp_path):
+        """Keep the legacy Python-builder/C++ tensor naming contract covered."""
+        engine = _deserialize(self._build_legacy_engine(tester, tmp_path))
+        assert engine is not None
+        inputs, outputs = _io_names(engine)
+        assert inputs == tester.expected_engine_input_names()
+        assert outputs == tester.expected_engine_output_names()
+
+    @requires_trt
+    def test_engine_logits_output_shape(self, tester, tmp_path):
+        """Keep the legacy single-row logits contract covered."""
+        engine = _deserialize(self._build_legacy_engine(tester, tmp_path))
+        assert engine is not None
+        assert tuple(engine.get_tensor_shape("logits")) == (
+            1,
+            tester.spec.vocab_size,
+        )
+
+    @pytest.mark.parametrize("role", ["prefill", "decode"])
+    @requires_trt
+    def test_native_split_role_engine_contract(self, tmp_path, role):
+        """Qualified BF16 split engines expose full-capacity aliased KV state."""
+        import tensorrt as trt
+
+        tester = NativeLlamaPluginTester()
+        config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+        config.raw["_decoder_engine_role"] = role
+
+        plan = tester.get_plugin().build_engine(
+            config,
+            weights,
+            tester.spec.max_cache_length,
+            precision="bf16",
+            verbose=False,
+        )
+        engine = _deserialize(plan)
+        assert engine is not None
+        assert engine.num_optimization_profiles == 1
+
+        inputs, outputs = _io_names(engine)
+        assert "attention_mask" not in inputs
+        assert {"cache_write_indices", "key_value_lengths"} <= inputs
+        assert {"cache_k_0", "cache_v_0"} <= inputs
+        assert {"present_k_0", "present_v_0"} <= outputs
+
+        cache_shape = (
+            1,
+            tester.spec.num_key_value_heads,
+            tester.spec.max_cache_length,
+            tester.spec.head_dim,
+        )
+        for stem in ("k", "v"):
+            cache = f"cache_{stem}_0"
+            present = f"present_{stem}_0"
+            assert tuple(engine.get_tensor_shape(cache)) == cache_shape
+            assert tuple(engine.get_tensor_shape(present)) == cache_shape
+            assert engine.get_tensor_dtype(cache) == trt.bfloat16
+            assert engine.get_aliased_input_tensor(present) == cache
+
+        profile = engine.get_tensor_profile_shape("token_id", 0)
+        assert tuple(profile[0]) == (1,)
+        assert tuple(profile[2]) == (
+            tester.spec.max_cache_length if role == "prefill" else 1,
+        )

--- a/tests/e2e/models/llama/test_llama_native_kv_routing.py
+++ b/tests/e2e/models/llama/test_llama_native_kv_routing.py
@@ -286,3 +286,73 @@ def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
         "native_kv_contract_version": 1,
         "native_kv_cache": True,
     }
+
+
+def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.llama.plugin"
+    )
+
+    config = _small_config(role="decode")
+    config.raw["_native_kv_cache_metadata"] = {"stale": True}
+    quant_ctx = object()
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+        quant_ctx=quant_ctx,
+    )
+
+    assert result == b"legacy-plan"
+    assert captured["args"][2] == 128
+    assert captured["kwargs"]["precision"] == "fp16"
+    assert captured["kwargs"]["quant_ctx"] is quant_ctx
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+def test_plugin_falls_back_outside_the_native_architecture_contract(
+    monkeypatch,
+):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.llama.plugin"
+    )
+    config = _small_config()
+    config._head_dim = 64
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _build,
+    )
+
+    assert not prefer_native_default(config)
+    assert plugin_module.plugin.default_build_precision(config) == "fp32"
+    assert plugin_module.plugin.default_max_cache_length(config) == 256
+    assert plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+    ) == b"legacy-plan"
+    assert captured["args"][2] == 128
+    assert captured["kwargs"]["precision"] == "fp16"

--- a/tests/e2e/models/llama/test_llama_native_kv_routing.py
+++ b/tests/e2e/models/llama/test_llama_native_kv_routing.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only contract tests for Llama's TensorRT native KV path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+
+import pytest
+
+from tensorrt_model_connect.families.llama.build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+    native_kv_cache_geometry,
+    prefer_native_default,
+    resolved_head_dim,
+)
+from tensorrt_model_connect.families.llama.config import ModelConfig
+from tensorrt_model_connect.families.llama.native_kv_contract import (
+    validate_native_kv_weights,
+)
+
+
+_LLAMA3_ROPE = {
+    "rope_type": "llama3",
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+}
+
+
+def _config(
+    *,
+    raw_updates: dict | None = None,
+    llama3_rope: bool = True,
+    **overrides,
+) -> ModelConfig:
+    values = {
+        "model_type": "llama",
+        "architectures": ["LlamaForCausalLM"],
+        "vocab_size": 128256,
+        "hidden_size": 4096,
+        "intermediate_size": 14336,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 500_000.0,
+        "max_position_embeddings": 131072,
+        "hidden_act": "silu",
+        "_head_dim": 0,
+    }
+    values.update(overrides)
+    raw = {
+        "_decoder_engine_layout": "split",
+        "rope_scaling": dict(_LLAMA3_ROPE) if llama3_rope else None,
+    }
+    raw.update(raw_updates or {})
+    values["raw"] = raw
+    return ModelConfig(**values)
+
+
+@pytest.mark.parametrize(
+    (
+        "hidden",
+        "mlp",
+        "layers",
+        "heads",
+        "kv_heads",
+        "context",
+    ),
+    [
+        (4096, 14336, 32, 32, 8, 131072),
+        (5120, 13824, 40, 40, 40, 4096),
+        (8192, 28672, 80, 64, 8, 131072),
+    ],
+    ids=("llama-8b-shape", "llama-13b-shape", "llama-70b-shape"),
+)
+def test_dense_llama_sizes_share_one_native_contract(
+    hidden, mlp, layers, heads, kv_heads, context,
+):
+    config = _config(
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=kv_heads,
+        max_position_embeddings=context,
+    )
+
+    architecture = native_kv_architecture_capability(config)
+    build = native_kv_build_capability(config)
+    row_bytes, cache_bytes = native_kv_cache_geometry(config, context)
+
+    assert architecture.eligible, architecture.reason
+    assert build.eligible, build.reason
+    assert prefer_native_default(config)
+    assert resolved_head_dim(config) == 128
+    assert row_bytes == 2 * layers * kv_heads * 128 * 2
+    assert cache_bytes == context * row_bytes
+
+
+def test_route_uses_architecture_not_checkpoint_identity():
+    config = _config(
+        raw_updates={
+            "_model_dir": "/models/renamed-checkpoint",
+            "name_or_path": "any-owner/any-llama",
+            "checkpoint_sha256": "a" * 64,
+        }
+    )
+
+    assert native_kv_architecture_capability(config).eligible
+    assert prefer_native_default(config)
+
+
+def test_explicit_head_dim_is_supported_when_hidden_width_is_decoupled():
+    config = _config(
+        hidden_size=3072,
+        num_attention_heads=32,
+        _head_dim=128,
+    )
+
+    assert resolved_head_dim(config) == 128
+    assert native_kv_architecture_capability(config).eligible
+
+
+@pytest.mark.parametrize(
+    ("overrides", "raw_updates", "reason"),
+    [
+        ({"model_type": "llama4"}, {}, "model_type"),
+        ({"architectures": ["OtherForCausalLM"]}, {}, "architectures"),
+        ({"hidden_size": 4100}, {}, "divisible"),
+        ({"_head_dim": 64}, {}, "head_dim=128"),
+        ({"num_key_value_heads": 6}, {}, "divisible"),
+        ({"hidden_act": "gelu"}, {}, "hidden_act"),
+        ({}, {"sliding_window": 4096}, "unsupported Llama fields"),
+        ({}, {"num_experts": 8}, "unsupported Llama fields"),
+        ({}, {"pretraining_tp": 2}, "pretraining_tp"),
+        (
+            {},
+            {"layer_types": ["full_attention", "linear_attention"]},
+            "hybrid",
+        ),
+        (
+            {},
+            {"rope_scaling": {"rope_type": "linear", "factor": 2.0}},
+            "rope_type",
+        ),
+    ],
+)
+def test_architecture_variants_fail_closed(overrides, raw_updates, reason):
+    decision = native_kv_architecture_capability(
+        _config(raw_updates=raw_updates, **overrides)
+    )
+
+    assert decision.applicable
+    assert not decision.eligible
+    assert reason in decision.reason
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "raw_updates", "reason"),
+    [
+        ({"precision": "fp16"}, {}, "BF16"),
+        ({"max_cache_length": 131071}, {}, "max_cache_length"),
+        ({"parallel_enabled": True}, {}, "tensor parallel"),
+        ({"dynamic_kv_cache": True}, {}, "fixed physical"),
+        ({"quantized": True}, {}, "quantized"),
+        ({"debug_layer_outputs": True}, {}, "debug"),
+        ({}, {"_fp32_layers": ["layer.0"]}, "FP32 layer"),
+        ({}, {"_decoder_engine_layout": "dual_profile"}, "split"),
+        ({}, {"_rtx_build_requested": True}, "standard TensorRT"),
+    ],
+)
+def test_unqualified_build_modes_fail_closed(kwargs, raw_updates, reason):
+    decision = native_kv_build_capability(
+        _config(raw_updates=raw_updates),
+        **kwargs,
+    )
+
+    assert not decision.eligible
+    assert reason in decision.reason
+
+
+@dataclass
+class _Tensor:
+    shape: tuple[int, ...]
+
+
+def _small_config(*, role: str = "prefill") -> ModelConfig:
+    return _config(
+        vocab_size=32,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        max_position_embeddings=256,
+        llama3_rope=False,
+        raw_updates={"_decoder_engine_role": role},
+    )
+
+
+def _weights(config: ModelConfig) -> dict[str, object]:
+    hidden = config.hidden_size
+    attention = config.num_attention_heads * 128
+    kv_attention = config.num_key_value_heads * 128
+    mlp = config.intermediate_size
+    weights: dict[str, object] = {
+        "embedding": _Tensor((config.vocab_size, hidden)),
+        "final_norm": _Tensor((hidden,)),
+        "w_out": _Tensor((hidden, config.vocab_size)),
+        "_attention_size": attention,
+        "_kv_attention_size": kv_attention,
+        "_mlp_size": mlp,
+    }
+    for name, shape in (
+        ("input_norm", (hidden,)),
+        ("w_q", (hidden, attention)),
+        ("w_k", (hidden, kv_attention)),
+        ("w_v", (hidden, kv_attention)),
+        ("w_o", (attention, hidden)),
+        ("post_attn_norm", (hidden,)),
+        ("w_gate", (hidden, mlp)),
+        ("w_up", (hidden, mlp)),
+        ("w_down", (mlp, hidden)),
+    ):
+        weights[f"layer.0.{name}"] = _Tensor(shape)
+    return weights
+
+
+def test_weight_contract_rejects_missing_shape_and_bias():
+    config = _small_config()
+    weights = _weights(config)
+    validate_native_kv_weights(config, weights)
+
+    missing = dict(weights)
+    missing.pop("layer.0.w_k")
+    with pytest.raises(ValueError, match="missing.*w_k"):
+        validate_native_kv_weights(config, missing)
+
+    wrong_shape = dict(weights)
+    wrong_shape["layer.0.w_q"] = _Tensor((127, 128))
+    with pytest.raises(ValueError, match="must have shape"):
+        validate_native_kv_weights(config, wrong_shape)
+
+    biased = dict(weights)
+    biased["layer.0.q_bias"] = _Tensor((128,))
+    with pytest.raises(ValueError, match="bias"):
+        validate_native_kv_weights(config, biased)
+
+
+def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.llama.plugin"
+    )
+
+    config = _small_config(role="prefill")
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_dual_profile_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        256,
+        precision="bf16",
+    )
+
+    assert result == b"plan"
+    assert captured["kwargs"]["profile_mode"] == "prefill"
+    assert captured["kwargs"]["native_kv_cache"] is True
+    assert plugin_module.plugin.get_bundle_config_overrides(config) == {
+        "native_kv_contract_version": 1,
+        "native_kv_cache": True,
+    }

--- a/tests/e2e/models/qwen/MODEL.toml
+++ b/tests/e2e/models/qwen/MODEL.toml
@@ -6,6 +6,7 @@ plugin = "qwen"
 test_manifests = [
   "manifests/qwen3-0.6b-fp16-tp4.json",
   "manifests/qwen3-0.6b-fp16.json",
+  "manifests/qwen3-0.6b-native-l0.json",
   "manifests/qwen3-0.6b-fp8-tp4.json",
   "manifests/qwen3-0.6b-fp8.json",
   "manifests/qwen3-0.6b-topp-tp4.json",

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-native-l0.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-native-l0.json
@@ -1,0 +1,21 @@
+{
+  "name": "qwen3-0.6b-native-l0",
+  "hf_id": "Qwen/Qwen3-0.6B",
+  "bundle": "qwen3-0.6b-native-l0.trtfb",
+  "family": "qwen",
+  "runtime_strategy": "qwen_decoder_kv_cache",
+  "task_strategy": "text_generation_causal",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "qwen3-0.6b-native-l0",
+      "trace_id": "IT-E2E-QWN3-NATIVE-L0-01",
+      "ci_tier": "l0_only",
+      "reference_family": "chat_qwen3_posttrained",
+      "user_contract": "chat_response",
+      "reference_precision": "bf16",
+      "prompt": "What is the capital of France? Answer in one word.",
+      "max_new_tokens": 10
+    }
+  ]
+}

--- a/tests/e2e/models/qwen/test_qwen_builder_engine.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_engine.py
@@ -8,21 +8,129 @@ Intent: Validate the Qwen family plugin weight loading and standard decoder key 
 Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU required for engine build tests.
 Postconditions: All standard decoder weight keys are present with correct shapes and the engine builds successfully.
 """
+
+import numpy as np
 import pytest
 
 pytest.importorskip("tensorrt", reason="Qwen builder tests require TensorRT")
 
-from tests.builder.family_plugin_tester import FamilyPluginTester
+from tests.builder.family_plugin_tester import FamilyPluginTester, TinyModelSpec
 from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
 
 
 class QwenPluginTester(FamilyPluginTester):
     plugin_module = "tensorrt_model_connect.families.qwen"
-    model_type = "qwen3"
+    # Keep the shared mixin on Qwen2's legacy dense-mask graph. Native Qwen3
+    # has a stricter BF16, head-dimension, and split-engine contract below.
+    model_type = "qwen2"
 
 
 class TestQwenEngine(FamilyPluginTestMixin):
     tester_class = QwenPluginTester
+
+
+class Qwen3NativePluginTester(FamilyPluginTester):
+    plugin_module = "tensorrt_model_connect.families.qwen"
+    model_type = "qwen3"
+    spec = TinyModelSpec(
+        vocab_size=32,
+        hidden_size=512,
+        intermediate_size=1024,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=128,
+        max_position_embeddings=16,
+        max_cache_length=16,
+    )
+
+    def get_config_dict(self):
+        config = super().get_config_dict()
+        config.update(
+            {
+                "architectures": ["Qwen3ForCausalLM"],
+                "hidden_act": "silu",
+                "head_dim": self.spec.head_dim,
+            }
+        )
+        return config
+
+    def make_hf_tensors(self):
+        tensors = super().make_hf_tensors()
+        for layer_idx in range(self.spec.num_hidden_layers):
+            prefix = f"model.layers.{layer_idx}.self_attn"
+            tensors[f"{prefix}.q_norm.weight"] = np.ones(self.spec.head_dim, dtype=np.float32)
+            tensors[f"{prefix}.k_norm.weight"] = np.ones(self.spec.head_dim, dtype=np.float32)
+        return tensors
+
+
+@pytest.mark.parametrize(
+    ("role", "profile_shapes"),
+    [
+        ("prefill", [(1,), (16,), (16,)]),
+        ("decode", [(1,), (1,), (1,)]),
+    ],
+)
+@pytest.mark.trt
+@pytest.mark.gpu
+def test_native_qwen3_split_role_engine_contract(tmp_path, role, profile_shapes):
+    import tensorrt as trt
+
+    tester = Qwen3NativePluginTester()
+    config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+    config.raw["_decoder_engine_role"] = role
+    plan = tester.get_plugin().build_engine(
+        config,
+        weights,
+        tester.spec.max_cache_length,
+        precision="bf16",
+        verbose=False,
+    )
+    engine = trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(plan)
+
+    assert engine is not None
+    assert engine.num_optimization_profiles == 1
+    assert [
+        tuple(shape) for shape in engine.get_tensor_profile_shape("token_id", 0)
+    ] == profile_shapes
+
+    inputs = {
+        engine.get_tensor_name(index)
+        for index in range(engine.num_io_tensors)
+        if engine.get_tensor_mode(engine.get_tensor_name(index)) == trt.TensorIOMode.INPUT
+    }
+    outputs = {
+        engine.get_tensor_name(index)
+        for index in range(engine.num_io_tensors)
+        if engine.get_tensor_mode(engine.get_tensor_name(index)) == trt.TensorIOMode.OUTPUT
+    }
+    assert inputs == {
+        "token_id",
+        "position_id",
+        "cache_write_indices",
+        "key_value_lengths",
+        "cache_k_0",
+        "cache_v_0",
+    }
+    assert outputs == {"logits", "present_k_0", "present_v_0"}
+    assert tuple(engine.get_tensor_shape("logits")) == (
+        1,
+        tester.spec.vocab_size,
+    )
+
+    expected_cache_shape = (
+        1,
+        tester.spec.num_key_value_heads,
+        tester.spec.max_cache_length,
+        tester.spec.head_dim,
+    )
+    for stem in ("k", "v"):
+        cache_name = f"cache_{stem}_0"
+        present_name = f"present_{stem}_0"
+        assert tuple(engine.get_tensor_shape(cache_name)) == expected_cache_shape
+        assert tuple(engine.get_tensor_shape(present_name)) == expected_cache_shape
+        assert engine.get_tensor_dtype(cache_name) == trt.bfloat16
+        assert engine.get_aliased_input_tensor(present_name) == cache_name
 
 
 def _qwen_tp_builder_module():

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -5,12 +5,38 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from tests.e2e_harness.manifest_loader import load_manifest
 from tools import task_eval
+
+
+def test_premerge_native_manifest_uses_family_build_defaults() -> None:
+    manifest_path = (
+        Path(__file__).with_name("manifests") / "qwen3-0.6b-native-l0.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    case = load_manifest(manifest_path)
+
+    assert case.metadata["ci_tier"] == "l0_only"
+    assert "precision" not in manifest
+    assert "max_cache_length" not in manifest
+    assert "precision" not in case.metadata
+    assert "max_cache_length" not in case.inputs
+    assert case.metadata["reference_precision"] == "bf16"
+
+
+def test_fp16_manifest_keeps_legacy_build_contract() -> None:
+    manifest_path = (
+        Path(__file__).with_name("manifests") / "qwen3-0.6b-fp16.json"
+    )
+    case = load_manifest(manifest_path)
+
+    assert case.metadata["precision"] == "fp16"
+    assert case.inputs["max_cache_length"] == 256
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -273,3 +273,73 @@ def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
         "native_kv_contract_version": 1,
         "native_kv_cache": True,
     }
+
+
+def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+
+    config = _small_config(role="decode")
+    config.raw["_native_kv_cache_metadata"] = {"stale": True}
+    quant_ctx = object()
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+        quant_ctx=quant_ctx,
+    )
+
+    assert result == b"legacy-plan"
+    assert captured["args"][2] == 128
+    assert captured["kwargs"]["precision"] == "fp16"
+    assert captured["kwargs"]["quant_ctx"] is quant_ctx
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+def test_plugin_falls_back_outside_the_native_architecture_contract(
+    monkeypatch,
+):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config()
+    config._head_dim = 64
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _build,
+    )
+
+    assert not prefer_native_default(config)
+    assert plugin_module.plugin.default_build_precision(config) == "fp32"
+    assert plugin_module.plugin.default_max_cache_length(config) == 256
+    assert plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+    ) == b"legacy-plan"
+    assert captured["args"][2] == 128
+    assert captured["kwargs"]["precision"] == "fp16"

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only contract tests for Qwen3's TensorRT native KV path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+
+import pytest
+
+from tensorrt_model_connect.families.qwen.build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+    native_kv_cache_geometry,
+    prefer_native_default,
+    resolved_head_dim,
+)
+from tensorrt_model_connect.families.qwen.config import ModelConfig
+from tensorrt_model_connect.families.qwen.native_kv_contract import (
+    validate_native_kv_weights,
+)
+
+
+def _config(*, raw_updates: dict | None = None, **overrides) -> ModelConfig:
+    values = {
+        "model_type": "qwen3",
+        "architectures": ["Qwen3ForCausalLM"],
+        "vocab_size": 151936,
+        "hidden_size": 1024,
+        "intermediate_size": 3072,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 1_000_000.0,
+        "max_position_embeddings": 40960,
+        "hidden_act": "silu",
+        "_head_dim": 128,
+    }
+    values.update(overrides)
+    raw = {
+        "attention_bias": False,
+        "sliding_window": None,
+        "use_sliding_window": False,
+        "rope_scaling": None,
+        "_decoder_engine_layout": "split",
+    }
+    raw.update(raw_updates or {})
+    values["raw"] = raw
+    return ModelConfig(**values)
+
+
+@pytest.mark.parametrize(
+    (
+        "hidden",
+        "mlp",
+        "layers",
+        "heads",
+        "kv_heads",
+        "context",
+    ),
+    [
+        (1024, 3072, 28, 16, 8, 40960),
+        (2560, 9728, 36, 32, 8, 262144),
+        (4096, 12288, 36, 32, 8, 40960),
+    ],
+    ids=("qwen3-0.6b", "qwen3-4b-shape", "qwen3-8b-shape"),
+)
+def test_dense_qwen3_sizes_share_one_native_contract(
+    hidden, mlp, layers, heads, kv_heads, context,
+):
+    config = _config(
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=kv_heads,
+        max_position_embeddings=context,
+    )
+
+    architecture = native_kv_architecture_capability(config)
+    build = native_kv_build_capability(config)
+    row_bytes, cache_bytes = native_kv_cache_geometry(config, context)
+
+    assert architecture.eligible, architecture.reason
+    assert build.eligible, build.reason
+    assert prefer_native_default(config)
+    assert row_bytes == 2 * layers * kv_heads * 128 * 2
+    assert cache_bytes == context * row_bytes
+
+
+def test_route_uses_architecture_not_checkpoint_identity():
+    config = _config(
+        raw_updates={
+            "_model_dir": "/models/renamed-checkpoint",
+            "name_or_path": "any-owner/any-qwen3",
+            "checkpoint_sha256": "f" * 64,
+        }
+    )
+
+    assert native_kv_architecture_capability(config).eligible
+    assert prefer_native_default(config)
+
+
+def test_explicit_hf_head_dim_overrides_hidden_divided_by_heads():
+    config = _config(
+        hidden_size=3584,
+        num_attention_heads=32,
+        _head_dim=0,
+        raw_updates={"head_dim": 128},
+    )
+
+    assert resolved_head_dim(config) == 128
+    assert native_kv_architecture_capability(config).eligible
+
+
+@pytest.mark.parametrize(
+    ("overrides", "raw_updates", "reason"),
+    [
+        ({"architectures": ["OtherForCausalLM"]}, {}, "architectures"),
+        ({"hidden_act": "gelu"}, {}, "hidden_act"),
+        ({"_head_dim": 64}, {}, "head_dim=128"),
+        ({"num_key_value_heads": 6}, {}, "divisible"),
+        ({}, {"use_sliding_window": True}, "unsupported Qwen3 fields"),
+        ({}, {"num_experts": 8}, "unsupported Qwen3 fields"),
+        (
+            {},
+            {"layer_types": ["full_attention", "linear_attention"]},
+            "hybrid",
+        ),
+        (
+            {},
+            {"rope_scaling": {"rope_type": "yarn", "factor": 4.0}},
+            "unscaled default RoPE",
+        ),
+    ],
+)
+def test_architecture_variants_fail_closed(overrides, raw_updates, reason):
+    decision = native_kv_architecture_capability(
+        _config(raw_updates=raw_updates, **overrides)
+    )
+
+    assert decision.applicable
+    assert not decision.eligible
+    assert reason in decision.reason
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "raw_updates", "reason"),
+    [
+        ({"precision": "fp16"}, {}, "BF16"),
+        ({"max_cache_length": 40959}, {}, "max_cache_length"),
+        ({"parallel_enabled": True}, {}, "tensor parallel"),
+        ({"dynamic_kv_cache": True}, {}, "fixed physical"),
+        ({"quantized": True}, {}, "quantized"),
+        ({"debug_layer_outputs": True}, {}, "debug"),
+        ({}, {"_fp32_layers": ["layer.0"]}, "FP32 layer"),
+        ({}, {"_decoder_engine_layout": "dual_profile"}, "split"),
+        ({}, {"_rtx_build_requested": True}, "standard TensorRT"),
+    ],
+)
+def test_unqualified_build_modes_fail_closed(kwargs, raw_updates, reason):
+    decision = native_kv_build_capability(
+        _config(raw_updates=raw_updates),
+        **kwargs,
+    )
+
+    assert not decision.eligible
+    assert reason in decision.reason
+
+
+@dataclass
+class _Tensor:
+    shape: tuple[int, ...]
+
+
+def _small_config(*, role: str = "prefill") -> ModelConfig:
+    return _config(
+        vocab_size=32,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        max_position_embeddings=256,
+        raw_updates={"_decoder_engine_role": role},
+    )
+
+
+def _weights(config: ModelConfig) -> dict[str, object]:
+    hidden = config.hidden_size
+    attention = config.num_attention_heads * 128
+    kv_attention = config.num_key_value_heads * 128
+    mlp = config.intermediate_size
+    weights: dict[str, object] = {
+        "embedding": _Tensor((config.vocab_size, hidden)),
+        "final_norm": _Tensor((hidden,)),
+        "w_out": _Tensor((hidden, config.vocab_size)),
+        "_attention_size": attention,
+        "_kv_attention_size": kv_attention,
+        "_mlp_size": mlp,
+    }
+    for name, shape in (
+        ("input_norm", (hidden,)),
+        ("w_q", (hidden, attention)),
+        ("w_k", (hidden, kv_attention)),
+        ("w_v", (hidden, kv_attention)),
+        ("w_o", (attention, hidden)),
+        ("post_attn_norm", (hidden,)),
+        ("w_gate", (hidden, mlp)),
+        ("w_up", (hidden, mlp)),
+        ("w_down", (mlp, hidden)),
+        ("q_norm", (attention,)),
+        ("k_norm", (kv_attention,)),
+    ):
+        weights[f"layer.0.{name}"] = _Tensor(shape)
+    return weights
+
+
+def test_weight_contract_rejects_missing_shape_and_bias():
+    config = _small_config()
+    weights = _weights(config)
+    validate_native_kv_weights(config, weights)
+
+    missing = dict(weights)
+    missing.pop("layer.0.w_k")
+    with pytest.raises(ValueError, match="missing.*w_k"):
+        validate_native_kv_weights(config, missing)
+
+    wrong_shape = dict(weights)
+    wrong_shape["layer.0.w_q"] = _Tensor((127, 128))
+    with pytest.raises(ValueError, match="must have shape"):
+        validate_native_kv_weights(config, wrong_shape)
+
+    biased = dict(weights)
+    biased["layer.0.q_bias"] = _Tensor((128,))
+    with pytest.raises(ValueError, match="bias"):
+        validate_native_kv_weights(config, biased)
+
+
+def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+
+    config = _small_config(role="decode")
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_dual_profile_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        256,
+        precision="bf16",
+    )
+
+    assert result == b"plan"
+    assert captured["kwargs"]["profile_mode"] == "decode"
+    assert captured["kwargs"]["native_kv_cache"] is True
+    assert plugin_module.plugin.get_bundle_config_overrides(config) == {
+        "native_kv_contract_version": 1,
+        "native_kv_cache": True,
+    }

--- a/tests/e2e/models/qwen/thresholds/qwen3-0.6b-native-l0.json
+++ b/tests/e2e/models/qwen/thresholds/qwen3-0.6b-native-l0.json
@@ -1,0 +1,13 @@
+{
+  "threshold_overrides": {
+    "layer_atol": 0.05,
+    "logit_atol": 0.001,
+    "logit_cosine_p5": 0.99,
+    "logit_rel_l2_p95": 0.05,
+    "normalized_text_edit_distance": 0.2,
+    "stable_margin": 0.1,
+    "stable_top1_match_rate": 0.9,
+    "token_agreement_rate": 0.8,
+    "unstable_topk_hit_rate": 0.8
+  }
+}

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -520,10 +520,11 @@ def _build_inputs(manifest: dict, defaults: dict[str, Any]) -> dict:
 
     # Max new tokens
     inputs["max_new_tokens"] = manifest.get("max_new_tokens", 30)
-    inputs["max_cache_length"] = manifest.get(
-        "max_cache_length",
-        manifest.get("build_args", {}).get("max_cache_length", 256),
-    )
+    build_args = manifest.get("build_args", {})
+    if "max_cache_length" in manifest:
+        inputs["max_cache_length"] = manifest["max_cache_length"]
+    elif "max_cache_length" in build_args:
+        inputs["max_cache_length"] = build_args["max_cache_length"]
 
     # Generation parameters (optional, default to each runtime's configured value)
     for key in ("temperature", "top_p", "top_k", "min_p", "seed"):

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -335,8 +335,6 @@ def _resolve_bundle(
         candidate = project_root / hf_id
         if candidate.exists():
             hf_id = str(candidate)
-    max_cache = case.inputs.get("max_cache_length", 256)
-
     build_args = case.metadata.get("build_args", {})
     build_method = _manifest_build_method(build_args)
 
@@ -349,9 +347,11 @@ def _resolve_bundle(
         hf_id,
         "-o",
         str(bundle_path),
-        "--max-cache-length",
-        str(max_cache),
     ]
+    if "max_cache_length" in case.inputs:
+        cmd.extend(
+            ["--max-cache-length", str(case.inputs["max_cache_length"])]
+        )
     if case.hf_revision:
         cmd.extend(["--model-revision", case.hf_revision])
     _append_declared_build_cli_args(cmd, case)
@@ -779,7 +779,6 @@ def _build_repro_commands(
     repro: dict[str, str] = {}
 
     # Build command
-    max_cache = case.inputs.get("max_cache_length", 256)
     bundle_target = bundle_path or str(Path(ctx.engine_dir) / case.bundle)
     build_parts = [
         ctx.build_python_path() or "python",
@@ -789,9 +788,11 @@ def _build_repro_commands(
         case.hf_id,
         "-o",
         bundle_target,
-        "--max-cache-length",
-        str(max_cache),
     ]
+    if "max_cache_length" in case.inputs:
+        build_parts.extend(
+            ["--max-cache-length", str(case.inputs["max_cache_length"])]
+        )
     if case.hf_revision:
         build_parts.extend(["--model-revision", case.hf_revision])
     build_method = _manifest_build_method(case.metadata.get("build_args", {}))

--- a/tests/e2e_harness/test_orchestrator_phases.py
+++ b/tests/e2e_harness/test_orchestrator_phases.py
@@ -222,6 +222,48 @@ def test_ci_engine_build_guard_passes_manifest_identity_to_builder(
     assert command[command.index("-o") + 1] == str(Path(ctx.engine_dir) / case.bundle)
 
 
+@pytest.mark.parametrize(
+    ("max_cache_length", "expected_flag"),
+    ((None, False), (256, True)),
+)
+def test_bundle_build_only_emits_declared_max_cache_length(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    max_cache_length: int | None,
+    expected_flag: bool,
+) -> None:
+    case = _make_case("unit-build")
+    if max_cache_length is not None:
+        case.inputs["max_cache_length"] = max_cache_length
+    ctx = _make_ctx(tmp_path, case)
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        Path(cmd[cmd.index("-o") + 1]).write_bytes(b"bundle")
+        Path(cmd[cmd.index("--build-timing-json") + 1]).write_text(
+            '{"total_s": 1.0}\n',
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="built", stderr="")
+
+    monkeypatch.setattr(orchestrator.subprocess, "run", fake_run)
+
+    bundle, _elapsed, error, _build_info = orchestrator._resolve_bundle(
+        case,
+        ctx,
+    )
+    repro = orchestrator._build_repro_commands(case, ctx, bundle, {})
+
+    assert error == ""
+    assert len(commands) == 1
+    assert ("--max-cache-length" in commands[0]) is expected_flag
+    assert ("--max-cache-length" in repro["build_bundle"]) is expected_flag
+    if expected_flag:
+        index = commands[0].index("--max-cache-length")
+        assert commands[0][index + 1] == str(max_cache_length)
+
+
 def test_ci_bundle_build_recovers_one_sigsegv_in_a_fresh_process(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -540,6 +540,44 @@ def test_wan22_premerge_selects_standalone_l0_manifest(tmp_path: Path) -> None:
     assert "model_reference_cache" not in selection
 
 
+def test_qwen_premerge_selects_native_defaults_l0(tmp_path: Path) -> None:
+    selection = _run_test_selection(tmp_path, "qwen", "premerge")
+
+    assert selection["suite"] == "premerge"
+    assert [
+        (
+            case["name"],
+            case["model"],
+            case["manifest"],
+            case["ci_tier"],
+        )
+        for case in selection["e2e_cases"]
+    ] == [
+        (
+            "qwen3-0.6b-native-l0",
+            "qwen3-0.6b-native-l0",
+            "qwen3-0.6b-native-l0.json",
+            "l0_only",
+        )
+    ]
+
+
+def test_qwen_nightly_keeps_production_cases(tmp_path: Path) -> None:
+    selection = _run_test_selection(tmp_path, "qwen", "nightly")
+
+    assert selection["suite"] == "nightly"
+    assert {case["name"] for case in selection["e2e_cases"]} == {
+        "qwen3-0.6b-fp16",
+        "qwen3-0.6b-fp8",
+        "qwen3-0.6b-topp",
+        "qwen3-4b-instruct-2507",
+    }
+    assert all(
+        case["ci_tier"] != "l0_only"
+        for case in selection["e2e_cases"]
+    )
+
+
 @pytest.mark.parametrize(
     ("family", "expected_family_tests"),
     (


### PR DESCRIPTION
## Summary

This PR consolidates #628 and the original #673 stack into one review surface
for full-context native TensorRT KV cache support in dense Qwen3 and Llama
models.

The intended user flow is model-only at build time:

```bash
trtmc build Qwen/Qwen3-0.6B
trtmc run Qwen3-0.6B.trtfb --prompt "Hello" --max-new-tokens 32
```

Eligible models automatically build BF16 split prefill/decode engines and use
the model's declared `max_position_embeddings` as runtime KV capacity. Users
do not need to specify a KV-cache or sequence-length build flag.

## Behavior

- Eligible dense Qwen3 and Llama configurations select the family-owned native
  path without a model-ID or parameter-count allowlist.
- The runtime allocates one full-capacity K/V state and binds it into both
  TensorRT execution contexts. Active lengths control the attended prefix, so
  decode does not scan the full capacity on every token.
- Prefill is profile-bounded (`P <= 32K`) and chunked when a prompt is longer
  than `P`, allowing the runtime to progress through the full physical
  capacity `C`.
- Explicit legacy settings such as FP16, FP8, a shorter cache, tensor
  parallelism, quantization, debug outputs, or an architecture outside the
  native contract continue through the existing standard builders.
- Existing legacy manifests remain covered; the new L0 manifests intentionally
  omit precision and cache flags to prove the model-only user flow end to end.

## Implementation

- Qwen3 and Llama builders emit role-specific BF16 engines using TensorRT
  `IKVCacheUpdateLayer`, `IAttentionV2`, runtime key/value lengths, and native
  input/output alias metadata.
- Qwen and Llama runtimes share the same runtime-owned K/V buffers across
  prefill and decode.
- Active-position RoPE avoids serializing an `O(C)` table into the engine.
- Minimal shared changes preserve omitted build arguments and bind TensorRT
  aliases; model-specific graph and runtime logic stays family-owned.
- No custom attention plugin or custom kernel is introduced. The EdgeLLM
  adapter is unchanged.

The consolidated diff is 55 files with 5,194 additions and 428 deletions
(5,622 changed lines), about 67% smaller than the former stacked
#628 + #673 diff of 17,183 changed lines. Removed scope includes duplicated
helpers, qualification ledgers, fault-injection seams, reports, and unrelated
tooling.

## Validation

Local validation on the consolidated branch:

- Source quality: passed; maximum cyclomatic complexity 10, lint/format clean,
  and 158 architecture-contract tests passed.
- Python source-only unit suite: 2,950 passed, 1 skipped.
- Qwen/Llama routing and family tests: 389 passed, 15 skipped. The only
  non-runnable cases were A100-only EdgeLLM hardware tests on GB300.
- Qwen3-0.6B model-only build: BF16 split engines, 40,960-token capacity,
  exact Hugging Face text parity, 32,769-token prompt success, and exact
  40,960-token boundary success.
- Llama-3.1-Minitron-4B-Width model-only build: BF16 split engines,
  131,072-token capacity, exact Hugging Face text parity, and a 32,769-token
  prompt success.
- Legacy compatibility: TinyLlama FP16/256 and Qwen3-0.6B FP16/256 both built,
  loaded, and ran through the existing path.
- One allocator ordering test exceeded its 90-second coordination window under
  full-suite host load; the exact test passed in isolation without changing
  its criteria.

Exact-head GitHub CI:

- Current head: `531150c06b3ddf5991b0e20733fe4c5dc1d7aca1`
- Current base: `main@bf4f09e01d1bec5ebce701af25d3520f4d6346b6`
- Run: https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/30412091839
- Pinned merge snapshot:
  `27aad3ef44d49e8bd02d156847055ae6dcc4b903`
  (`main@bf4f09e0` + PR head `531150c0`).
- Status: passed. Legal, Source quality, Ownership/impact, Unit, all five
  fallback model jobs, Qwen direct, Llama direct, Combined report, and the
  required Premerge CI check are green.
- The branch was rebased after `main` advanced through #680 and #681.
  `range-diff` shows the five PR commits are equivalent; the only conflict
  resolution keeps both main's FP8-scale loader and this PR's model-derived
  output helper.
- Rebase validation: 154 focused CLI/checkpoint/routing/harness tests passed
  (8 skipped); source quality passed with 158 architecture tests and maximum
  cyclomatic complexity 10.
- Qwen exact-head receipt: model-only build command; 40,960 KV rows
  (4.38 GiB); TRT and Hugging Face both generated `Paris`;
  `exact_match=1`, `NED=0`.
- Llama exact-head receipt: model-only build command; 131,072 KV rows
  (16.00 GiB); TRT and Hugging Face generated identical text;
  `prefix_match=1`, `NED=0`.

## Current Prototype Boundary

- TensorRT 11, BF16, batch 1, single GPU, split prefill/decode.
- Dense Qwen3 or Llama with head dimension 128.
- The runtime currently allocates the model's full KV capacity. A
  user-selectable percentage or smaller runtime allocation is intentionally
  deferred.

Supersedes #628.
