### PR TITLE
fix(falcon): align GELU and ALiBi semantics

### DIFF
--- a/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
@@ -441,10 +441,9 @@ def build_dual_profile_decoder_engine(
     alibi_slopes_tensor: trt.ITensor | None = None
     alibi_cache_positions_fp32: trt.ITensor | None = None
     if position_type == "alibi":
-        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
-        # Slopes live as fp32 so the (key_pos - q_pos) math stays in fp32;
-        # add_alibi_mask_4d casts the final bias to work_trt_dtype before adding
-        # to the additive mask.
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads)
+        # HF rounds both slopes and positions to BF16 before multiplying, then
+        # promotes the resulting ALiBi tensor to FP32 with the QK logits.
         alibi_slopes_tensor = graph_ops.add_constant(
             network, (num_heads, 1, 1),
             alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32)
@@ -502,7 +501,8 @@ def build_dual_profile_decoder_engine(
         mask_4d = graph_ops.add_alibi_mask_4d(
             network, attention_mask_work, position_id,
             alibi_slopes_tensor, alibi_cache_positions_fp32,
-            num_heads, target_dtype=work_trt_dtype)
+            num_heads, target_dtype=work_trt_dtype,
+            bias_scale=float(alibi_bias_scale))
     else:
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
 

--- a/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_tp_builder.py
@@ -421,12 +421,10 @@ def build_dual_profile_tp_decoder_engine(
     alibi_cache_positions_fp32: trt.ITensor | None = None
     if position_type == "alibi":
         global_alibi_slopes = graph_ops.compute_alibi_slopes(config.num_attention_heads)
-        alibi_slopes_np = (
-            np.array_split(global_alibi_slopes, parallel.tp_size)[parallel.rank]
-            * float(alibi_bias_scale))
-        # Slopes live as fp32 so the (key_pos - q_pos) math stays in fp32;
-        # add_alibi_mask_4d casts the final bias to work_trt_dtype before adding
-        # to the additive mask.
+        alibi_slopes_np = np.array_split(
+            global_alibi_slopes, parallel.tp_size)[parallel.rank]
+        # HF rounds both slopes and positions to BF16 before multiplying, then
+        # promotes the resulting ALiBi tensor to FP32 with the QK logits.
         alibi_slopes_tensor = graph_ops.add_constant(
             network, (num_heads, 1, 1),
             alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32)
@@ -484,7 +482,8 @@ def build_dual_profile_tp_decoder_engine(
         mask_4d = graph_ops.add_alibi_mask_4d(
             network, attention_mask_work, position_id,
             alibi_slopes_tensor, alibi_cache_positions_fp32,
-            num_heads, target_dtype=work_trt_dtype)
+            num_heads, target_dtype=work_trt_dtype,
+            bias_scale=float(alibi_bias_scale))
     else:
         mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
 

--- a/python/tensorrt_model_connect/families/falcon/graph_ops.py
+++ b/python/tensorrt_model_connect/families/falcon/graph_ops.py
@@ -297,7 +297,10 @@ def add_activation(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Dispatch activation by name: 'silu', 'gelu_new', 'gelu', 'relu', 'relu2'/'squared_relu'."""
-    if activation_type in ("gelu_new", "gelu"):
+    if activation_type == "gelu":
+        return network.add_activation(
+            inp, trt.ActivationType.GELU_ERF).get_output(0)
+    elif activation_type == "gelu_new":
         return add_gelu_new(network, inp, dtype=dtype)
     elif activation_type == "relu":
         act = network.add_activation(inp, trt.ActivationType.RELU)
@@ -531,12 +534,13 @@ def add_alibi_mask_4d(
     cache_position_indices: trt.ITensor,
     num_heads: int,
     target_dtype: trt.DataType | None = None,
+    bias_scale: float = 1.0,
 ) -> trt.ITensor:
     """Build a per-head ALiBi additive mask for native IAttention.
 
     Args:
         mask_2d: [Sq, K] additive mask.
-        position_id: [Sq] query positions.
+        position_id: [Sq] current key positions.
         alibi_slopes_tensor: [H, 1, 1] per-head slopes.
         cache_position_indices: [cache_rows] key positions for cached rows.
         target_dtype: Optional dtype for the returned mask. Defaults to
@@ -544,8 +548,39 @@ def add_alibi_mask_4d(
 
     Returns:
         [1, H, Sq, K] additive mask containing both ``mask_2d`` and
-        ``slope[h] * (key_pos[k] - query_pos[q])``.
+        Falcon's BF16-rounded ``slope[h] * key_pos[k]`` bias.
     """
+    alibi_bias_t = add_alibi_bias_4d(
+        network,
+        mask_2d,
+        position_id,
+        alibi_slopes_tensor,
+        cache_position_indices,
+        num_heads,
+        target_dtype=target_dtype,
+        bias_scale=bias_scale,
+    )
+    mask_4d = add_2d_mask_to_4d(network, mask_2d)
+    out_dtype = target_dtype or mask_4d.dtype
+    if mask_4d.dtype != out_dtype:
+        mask_4d = network.add_cast(mask_4d, out_dtype).get_output(0)
+
+    combined = network.add_elementwise(
+        mask_4d, alibi_bias_t, trt.ElementWiseOperation.SUM)
+    return combined.get_output(0)
+
+
+def add_alibi_bias_4d(
+    network: trt.INetworkDefinition,
+    shape_source_2d: trt.ITensor,
+    position_id: trt.ITensor,
+    alibi_slopes_tensor: trt.ITensor,
+    cache_position_indices: trt.ITensor,
+    num_heads: int,
+    target_dtype: trt.DataType | None = None,
+    bias_scale: float = 1.0,
+) -> trt.ITensor:
+    """Build Falcon's BF16-rounded ALiBi bias without the padding mask."""
     pos_float = network.add_cast(position_id, trt.float32).get_output(0)
     cache_positions = cache_position_indices
     if cache_positions.dtype != trt.float32:
@@ -554,54 +589,44 @@ def add_alibi_mask_4d(
     key_pos = network.add_concatenation([cache_positions, pos_float])
     key_pos.axis = 0
 
-    mask_shape = network.add_shape(mask_2d).get_output(0)
+    mask_shape = network.add_shape(shape_source_2d).get_output(0)
     one_const = add_constant(
         network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
-    sq_size = network.add_slice(mask_shape, start=(0,), shape=(1,), stride=(1,))
     k_size = network.add_slice(mask_shape, start=(1,), shape=(1,), stride=(1,))
-    sq_size_t = sq_size.get_output(0)
     k_size_t = k_size.get_output(0)
-
-    key_pos_shape = network.add_concatenation([one_const, k_size_t])
-    key_pos_shape.axis = 0
-    key_pos_2d = network.add_shuffle(key_pos.get_output(0))
-    key_pos_2d.set_input(1, key_pos_shape.get_output(0))
-
-    query_pos_shape = network.add_concatenation([sq_size_t, one_const])
-    query_pos_shape.axis = 0
-    query_pos_2d = network.add_shuffle(pos_float)
-    query_pos_2d.set_input(1, query_pos_shape.get_output(0))
-
-    rel_pos = network.add_elementwise(
-        key_pos_2d.get_output(0), query_pos_2d.get_output(0),
-        trt.ElementWiseOperation.SUB)
 
     one_const2 = add_constant(
         network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
-    rel_shape = network.add_concatenation([one_const, one_const2, sq_size_t, k_size_t])
-    rel_shape.axis = 0
-    rel_4d = network.add_shuffle(rel_pos.get_output(0))
-    rel_4d.set_input(1, rel_shape.get_output(0))
+    one_const3 = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
+    key_pos_shape = network.add_concatenation(
+        [one_const, one_const2, one_const3, k_size_t])
+    key_pos_shape.axis = 0
+    key_pos_4d = network.add_shuffle(key_pos.get_output(0))
+    key_pos_4d.set_input(1, key_pos_shape.get_output(0))
+    key_pos_bf16 = network.add_cast(
+        key_pos_4d.get_output(0), trt.bfloat16).get_output(0)
 
     slopes = alibi_slopes_tensor
-    if slopes.dtype != trt.float32:
-        slopes = network.add_cast(slopes, trt.float32).get_output(0)
     slopes_4d = network.add_shuffle(slopes)
     slopes_4d.reshape_dims = (1, num_heads, 1, 1)
+    slopes_bf16 = network.add_cast(
+        slopes_4d.get_output(0), trt.bfloat16).get_output(0)
 
     alibi_bias = network.add_elementwise(
-        slopes_4d.get_output(0), rel_4d.get_output(0),
+        slopes_bf16, key_pos_bf16,
         trt.ElementWiseOperation.PROD)
     alibi_bias_t = alibi_bias.get_output(0)
 
-    mask_4d = add_2d_mask_to_4d(network, mask_2d)
-    out_dtype = target_dtype or mask_4d.dtype
+    out_dtype = target_dtype or shape_source_2d.dtype
     if alibi_bias_t.dtype != out_dtype:
         alibi_bias_t = network.add_cast(alibi_bias_t, out_dtype).get_output(0)
-
-    combined = network.add_elementwise(
-        mask_4d, alibi_bias_t, trt.ElementWiseOperation.SUM)
-    return combined.get_output(0)
+    if bias_scale != 1.0:
+        scale = _scalar_constant_for_trt_dtype(
+            network, (1, 1, 1, 1), bias_scale, out_dtype)
+        alibi_bias_t = network.add_elementwise(
+            alibi_bias_t, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    return alibi_bias_t
 
 
 def add_apply_rope_native(

--- a/tests/builder/test_falcon_graph_ops.py
+++ b/tests/builder/test_falcon_graph_ops.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused graph-operation tests for the Falcon family."""
+
+from __future__ import annotations
+
+import pytest
+
+
+trt = pytest.importorskip(
+    "tensorrt", reason="TensorRT is required for Falcon graph tests")
+
+from tensorrt_model_connect.families.falcon import graph_ops  # noqa: E402
+
+
+class _ActivationLayer:
+    def __init__(self, output):
+        self._output = output
+
+    def get_output(self, index: int):
+        assert index == 0
+        return self._output
+
+
+class _ActivationNetwork:
+    def __init__(self):
+        self.activation_type = None
+
+    def add_activation(self, tensor, activation_type):
+        self.activation_type = activation_type
+        return _ActivationLayer(tensor)
+
+
+class _Tensor:
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+
+class _GraphLayer:
+    def __init__(self, output):
+        self._output = output
+        self.axis = None
+        self.reshape_dims = None
+
+    def get_output(self, index: int):
+        assert index == 0
+        return self._output
+
+    def set_input(self, index: int, _tensor):
+        assert index == 1
+
+
+class _AlibiNetwork:
+    def __init__(self):
+        self.casts = []
+        self.elementwise = []
+
+    def add_cast(self, _tensor, dtype):
+        self.casts.append(dtype)
+        return _GraphLayer(_Tensor(dtype))
+
+    def add_concatenation(self, tensors):
+        return _GraphLayer(_Tensor(tensors[0].dtype))
+
+    def add_shape(self, _tensor):
+        return _GraphLayer(_Tensor(trt.int64))
+
+    def add_constant(self, _shape, weights):
+        return _GraphLayer(_Tensor(weights.dtype))
+
+    def add_slice(self, tensor, **_kwargs):
+        return _GraphLayer(_Tensor(tensor.dtype))
+
+    def add_shuffle(self, tensor):
+        return _GraphLayer(_Tensor(tensor.dtype))
+
+    def add_elementwise(self, lhs, rhs, operation):
+        self.elementwise.append((operation, lhs.dtype, rhs.dtype))
+        return _GraphLayer(_Tensor(lhs.dtype))
+
+
+def test_falcon_gelu_uses_exact_erf_variant():
+    network = _ActivationNetwork()
+    tensor = object()
+
+    output = graph_ops.add_activation(network, tensor, "gelu")
+
+    assert output is tensor
+    assert network.activation_type == trt.ActivationType.GELU_ERF
+
+
+def test_falcon_alibi_matches_reference_bfloat16_rounding_path():
+    network = _AlibiNetwork()
+
+    output = graph_ops.add_alibi_mask_4d(
+        network,
+        _Tensor(trt.float16),
+        _Tensor(trt.int32),
+        _Tensor(trt.float32),
+        _Tensor(trt.float32),
+        num_heads=32,
+        target_dtype=trt.float16,
+        bias_scale=0.125,
+    )
+
+    products = [
+        operands
+        for operation, *operands in network.elementwise
+        if operation == trt.ElementWiseOperation.PROD
+    ]
+    assert products == [
+        [trt.bfloat16, trt.bfloat16],
+        [trt.float16, trt.float16],
+    ]
+    assert all(
+        operation != trt.ElementWiseOperation.SUB
+        for operation, *_operands in network.elementwise
+    )
+    assert network.casts.count(trt.bfloat16) == 2
+    assert output.dtype == trt.float16

--- a/tests/e2e/models/falcon/test_falcon_builder_engine.py
+++ b/tests/e2e/models/falcon/test_falcon_builder_engine.py
@@ -144,10 +144,10 @@ class TestFalconEngine(FamilyPluginTestMixin):
         """Validate Falcon-RW ALiBi is scaled like HF Falcon attention logits.
 
         Intention:
-            HF Falcon adds ALiBi to raw QK attention scores and then scales the
-            combined logits by 1/sqrt(head_dim). TRT native attention scales QK
-            before applying the additive mask, so the Falcon plugin must
-            pre-scale ALiBi slopes to keep the same logit contract.
+            HF Falcon's default SDPA path rounds ALiBi in BF16, casts it to
+            the model dtype, and then scales the additive mask by
+            1/sqrt(head_dim). The Falcon plugin forwards that scale without
+            pre-scaling the slopes before their BF16 rounding boundary.
 
         Setup:
             Monkeypatch the shared decoder builder, build a tiny ALiBi Falcon


### PR DESCRIPTION
## Background

Falcon-RW continuation parity remained at 6/10 with aligned FP32 inputs and generation settings. Layer-level comparison isolated two TRTMC graph differences: exact `gelu` was routed through the `gelu_new` tanh approximation, and Falcon ALiBi did not preserve the reference BF16 rounding boundary.

## Exit Criteria

- Honor exact GELU independently from `gelu_new`.
- Match the reference Falcon ALiBi key-position and BF16 rounding contract.
- Apply the fix to single-device and tensor-parallel builders.
- Restore the aligned FP32 10-sample continuation case to the reviewed agreement gate.

## Implementation

- Route `gelu` to TensorRT's exact ERF activation while retaining the tanh approximation for `gelu_new`.
- Build Falcon ALiBi from BF16-rounded slopes and key positions, then cast and scale the resulting bias in the attention work dtype.
- Reuse the corrected bias construction in both decoder builders.
- Add focused graph tests for the activation selection and ALiBi dtype/operation sequence.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/builder/test_falcon_graph_ops.py tests/e2e/models/falcon/test_falcon_builder_engine.py -q -k 'not build_engine_succeeds and not engine_io_tensor_names and not engine_logits_output_shape'`: 15 passed, 3 GPU-only engine tests deselected.
- `CI_BASE_REF=github/main PYTHONPATH="$PWD/python:$PWD" python3 -m tools.ci pipeline source-quality`: passed, including 158 architecture-contract tests.
- Latest-validator GB300 continuation comparison, aligned HF FP32 versus TRTMC FP32: improved from 6/10 before the fixes to 10/10 exact matches with token-prefix agreement 1.0.

## Notes For Future Readers

- Falcon-RW greedy continuations remain sensitive to ordinary FP16 kernel rounding near tied logits. The validation-side precision contract is handled separately by PR #672; this PR fixes model graph semantics rather than changing an accuracy gate.

Closes #663
Closes #667
