### PR TITLE
perf(qwen): avoid reduced-precision FP32 staging

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/qwen/checkpoint_mapper.py
@@ -18,9 +18,9 @@ import numpy as np
 
 # Register bfloat16 dtype with numpy (needed for safetensors without torch).
 try:
-    import ml_dtypes  # noqa: F401
+    import ml_dtypes
 except ImportError:
-    pass
+    ml_dtypes = None
 
 from safetensors import safe_open
 
@@ -43,6 +43,31 @@ def _transpose_2d(arr: np.ndarray, name: str, precision: str = "fp32") -> np.nda
     if arr.ndim != 2:
         raise ValueError(f"Expected rank-2 tensor for transpose: {name}")
     return np.ascontiguousarray(arr.T, dtype=_target_np_dtype(precision))
+
+
+def _copy_to_numpy(tensor, dtype: np.dtype, *, transpose_name: str | None = None) -> np.ndarray:
+    """Copy a checkpoint tensor directly into an owned contiguous NumPy array."""
+    if transpose_name is not None and tensor.ndim != 2:
+        raise ValueError(f"Expected rank-2 tensor for transpose: {transpose_name}")
+
+    if hasattr(tensor, "numpy"):
+        import torch
+
+        source = tensor.transpose(0, 1) if transpose_name is not None else tensor
+        torch_dtype = torch.float16 if dtype == np.float16 else torch.float32
+        output = torch.empty(tuple(source.shape), dtype=torch_dtype, device="cpu")
+        output.copy_(source)
+        return output.numpy()
+
+    source = np.asarray(tensor)
+    if source.dtype == np.uint16:
+        if ml_dtypes is not None:
+            source = source.view(ml_dtypes.bfloat16)
+        else:
+            source = (source.astype(np.uint32) << 16).view(np.float32)
+    if transpose_name is not None:
+        source = source.T
+    return np.array(source, dtype=dtype, order="C", copy=True)
 
 
 def _repeat_head_norm(norm: np.ndarray, num_heads: int) -> np.ndarray:
@@ -100,10 +125,10 @@ def load_standard_weights(
     # Embedding
     if embedding_key is None:
         embedding_key = f"{model_prefix}.embed_tokens.weight"
-    embedding = _load_tensor(readers, embedding_key)
+    embedding = _load_tensor_as_dtype(readers, embedding_key, target_dtype)
     assert embedding.shape == (vocab, hidden), (
         f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
-    weights["embedding"] = embedding.astype(target_dtype)
+    weights["embedding"] = embedding
 
     def _load_layer(layer_idx: int) -> tuple[int, WeightDict, int, int]:
         prefix = f"layer.{layer_idx}"
@@ -119,25 +144,23 @@ def load_standard_weights(
         layer[f"{prefix}.post_attn_norm"] = post_norm.astype(np.float32)
 
         # Q/K/V/O projections
-        q_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.q_proj.weight", model_prefix))
-        k_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.k_proj.weight", model_prefix))
-        v_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.v_proj.weight", model_prefix))
-        o_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.o_proj.weight", model_prefix))
+        # Transpose [out, in] -> [in, out] while copying directly to the
+        # final storage dtype. In particular, FP16/BF16 builds must not stage
+        # these model-sized tensors through FP32 first.
+        q_t = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "self_attn.q_proj.weight", model_prefix),
+            "q_proj", target_dtype)
+        k_t = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "self_attn.k_proj.weight", model_prefix),
+            "k_proj", target_dtype)
+        v_t = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "self_attn.v_proj.weight", model_prefix),
+            "v_proj", target_dtype)
+        o_t = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "self_attn.o_proj.weight", model_prefix),
+            "o_proj", target_dtype)
 
-        q_hidden = q_raw.shape[0]
-        gate_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.gate_proj.weight", model_prefix))
-        layer_mlp_size = gate_raw.shape[0]
-
-        # Transpose all projections [out, in] -> [in, out]
-        q_t = _transpose_2d(q_raw, "q_proj", precision=precision)
-        k_t = _transpose_2d(k_raw, "k_proj", precision=precision)
-        v_t = _transpose_2d(v_raw, "v_proj", precision=precision)
-        o_t = _transpose_2d(o_raw, "o_proj", precision=precision)
+        q_hidden = q_t.shape[1]
 
         layer[f"{prefix}.w_q"] = q_t
         layer[f"{prefix}.w_k"] = k_t
@@ -171,17 +194,16 @@ def load_standard_weights(
                 num_kv_heads)
 
         # MLP projections
-        up_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.up_proj.weight", model_prefix))
-        down_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.down_proj.weight", model_prefix))
-
-        layer[f"{prefix}.w_gate"] = _transpose_2d(
-            gate_raw, "gate_proj", precision=precision)
-        layer[f"{prefix}.w_up"] = _transpose_2d(
-            up_raw, "up_proj", precision=precision)
-        layer[f"{prefix}.w_down"] = _transpose_2d(
-            down_raw, "down_proj", precision=precision)
+        layer[f"{prefix}.w_gate"] = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "mlp.gate_proj.weight", model_prefix),
+            "gate_proj", target_dtype)
+        layer[f"{prefix}.w_up"] = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "mlp.up_proj.weight", model_prefix),
+            "up_proj", target_dtype)
+        layer[f"{prefix}.w_down"] = _load_transposed_tensor(
+            readers, _layer_key(layer_idx, "mlp.down_proj.weight", model_prefix),
+            "down_proj", target_dtype)
+        layer_mlp_size = layer[f"{prefix}.w_gate"].shape[1]
 
         return layer_idx, layer, q_hidden, layer_mlp_size
 
@@ -219,12 +241,12 @@ def load_standard_weights(
 
     # LM head
     if _has_tensor(readers, lm_head_key):
-        weights["w_out"] = _transpose_2d(
-            _load_tensor(readers, lm_head_key), "lm_head", precision=precision)
+        weights["w_out"] = _load_transposed_tensor(
+            readers, lm_head_key, "lm_head", target_dtype)
     else:
         # Tied embeddings
-        weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied",
-                                         precision=precision)
+        weights["w_out"] = _transpose_2d(
+            embedding, "embedding_tied", precision=precision)
 
     weights["_attention_size"] = attention_size  # type: ignore[assignment]
     weights["_kv_attention_size"] = kv_attention_size  # type: ignore[assignment]
@@ -360,14 +382,32 @@ def _to_numpy_fp32(t) -> np.ndarray:
     return np.asarray(t, dtype=np.float32)
 
 
-def _load_tensor(readers: list, name: str) -> np.ndarray:
+def _get_tensor(readers: list, name: str):
     tensor_map = getattr(readers, "tensor_map", None)
     if tensor_map is not None:
         reader = tensor_map.get(name)
         if reader is None:
             raise KeyError(f"Tensor not found: {name}")
-        return _to_numpy_fp32(reader.get_tensor(name))
-    for r in readers:
-        if name in r.keys():
-            return _to_numpy_fp32(r.get_tensor(name))
+        return reader.get_tensor(name)
+    for reader in readers:
+        if name in reader.keys():
+            return reader.get_tensor(name)
     raise KeyError(f"Tensor not found: {name}")
+
+
+def _load_tensor_as_dtype(readers: list, name: str, dtype: np.dtype) -> np.ndarray:
+    return _copy_to_numpy(_get_tensor(readers, name), dtype)
+
+
+def _load_transposed_tensor(
+    readers: list,
+    name: str,
+    transpose_name: str,
+    dtype: np.dtype,
+) -> np.ndarray:
+    return _copy_to_numpy(
+        _get_tensor(readers, name), dtype, transpose_name=transpose_name)
+
+
+def _load_tensor(readers: list, name: str) -> np.ndarray:
+    return _to_numpy_fp32(_get_tensor(readers, name))

--- a/tests/builder/test_checkpoint_mapper.py
+++ b/tests/builder/test_checkpoint_mapper.py
@@ -27,6 +27,7 @@ _QWEN_ROOT = Path(__file__).resolve().parents[2] / "python/tensorrt_model_connec
 _MAPPER_MODULE = "weights" if (_QWEN_ROOT / "weights/__init__.py").is_file() else "checkpoint_mapper"
 _mapper = import_module(f"tensorrt_model_connect.families.qwen.{_MAPPER_MODULE}")
 _transpose_2d = _mapper._transpose_2d
+_copy_to_numpy = _mapper._copy_to_numpy
 _repeat_head_norm = _mapper._repeat_head_norm
 _has_tensor = _mapper._has_tensor
 _load_tensor = _mapper._load_tensor
@@ -61,6 +62,20 @@ class TestTranspose2d:
         result = _transpose_2d(arr, "test")
         assert result.dtype == np.float32
         assert result.flags["C_CONTIGUOUS"]
+
+
+def test_copy_to_numpy_transposes_bfloat16_to_fp16():
+    """Torch BF16 inputs convert directly into contiguous FP16 outputs."""
+    torch = pytest.importorskip("torch")
+    source = torch.tensor(
+        [[1.0, -2.5, 3.25], [4.5, 5.75, -6.0]], dtype=torch.bfloat16)
+
+    result = _copy_to_numpy(source, np.float16, transpose_name="test")
+
+    expected = source.float().numpy().T.astype(np.float16)
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.float16
+    assert result.flags["C_CONTIGUOUS"]
 
 
 class TestRepeatHeadNorm:
@@ -129,7 +144,8 @@ class TestLoadStandardWeights:
                           vocab: int = 32,
                           num_heads: int = 4,
                           num_kv_heads: int = 4,
-                          mlp_size: int = 32) -> Path:
+                          mlp_size: int = 32,
+                          tensor_dtype=np.float32) -> Path:
         """Create a minimal model directory with safetensors."""
         from safetensors.numpy import save_file
 
@@ -141,31 +157,32 @@ class TestLoadStandardWeights:
 
         # Embedding
         tensors["model.embed_tokens.weight"] = np.random.randn(
-            vocab, hidden).astype(np.float32)
+            vocab, hidden).astype(tensor_dtype)
 
         for i in range(num_layers):
             prefix = f"model.layers.{i}"
             tensors[f"{prefix}.input_layernorm.weight"] = np.random.randn(
-                hidden).astype(np.float32)
+                hidden).astype(tensor_dtype)
             tensors[f"{prefix}.post_attention_layernorm.weight"] = \
-                np.random.randn(hidden).astype(np.float32)
+                np.random.randn(hidden).astype(tensor_dtype)
             tensors[f"{prefix}.self_attn.q_proj.weight"] = np.random.randn(
-                hidden, hidden).astype(np.float32)
+                hidden, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.self_attn.k_proj.weight"] = np.random.randn(
-                kv_hidden, hidden).astype(np.float32)
+                kv_hidden, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.self_attn.v_proj.weight"] = np.random.randn(
-                kv_hidden, hidden).astype(np.float32)
+                kv_hidden, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.self_attn.o_proj.weight"] = np.random.randn(
-                hidden, hidden).astype(np.float32)
+                hidden, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.mlp.gate_proj.weight"] = np.random.randn(
-                mlp_size, hidden).astype(np.float32)
+                mlp_size, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.mlp.up_proj.weight"] = np.random.randn(
-                mlp_size, hidden).astype(np.float32)
+                mlp_size, hidden).astype(tensor_dtype)
             tensors[f"{prefix}.mlp.down_proj.weight"] = np.random.randn(
-                hidden, mlp_size).astype(np.float32)
+                hidden, mlp_size).astype(tensor_dtype)
 
-        tensors["model.norm.weight"] = np.random.randn(hidden).astype(np.float32)
-        tensors["lm_head.weight"] = np.random.randn(vocab, hidden).astype(np.float32)
+        tensors["model.norm.weight"] = np.random.randn(hidden).astype(tensor_dtype)
+        tensors["lm_head.weight"] = np.random.randn(
+            vocab, hidden).astype(tensor_dtype)
 
         save_file(tensors, str(tmp_path / "model.safetensors"))
         return tmp_path
@@ -203,6 +220,67 @@ class TestLoadStandardWeights:
         assert fp16_weights["embedding"].dtype == np.float16
         assert fp16_weights["layer.0.w_q"].dtype == np.float16
         assert fp16_weights["layer.0.input_norm"].dtype == np.float32
+
+    @pytest.mark.parametrize("precision", ["fp16", "bf16"])
+    def test_reduced_precision_matrices_bypass_fp32_staging(
+        self, tmp_path, monkeypatch, precision,
+    ):
+        """FP16/BF16 builds copy rank-2 tensors directly to final storage."""
+        from safetensors import safe_open
+
+        tensor_dtype = np.float16
+        if precision == "bf16":
+            ml_dtypes = pytest.importorskip("ml_dtypes")
+            tensor_dtype = ml_dtypes.bfloat16
+
+        config = {
+            "model_type": "standard_decoder",
+            "vocab_size": 32,
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+        }
+        model_dir = self._create_model_dir(
+            tmp_path, config, num_layers=1, num_kv_heads=2,
+            tensor_dtype=tensor_dtype)
+        cfg = ModelConfig.from_dir(model_dir)
+
+        fp32_shapes = []
+        original_to_numpy_fp32 = _mapper._to_numpy_fp32
+
+        def record_fp32_conversion(tensor):
+            fp32_shapes.append(tuple(tensor.shape))
+            return original_to_numpy_fp32(tensor)
+
+        monkeypatch.setattr(_mapper, "_to_numpy_fp32", record_fp32_conversion)
+        weights = load_standard_weights(model_dir, cfg, precision=precision)
+
+        assert fp32_shapes
+        assert all(len(shape) == 1 for shape in fp32_shapes)
+        matrix_keys = (
+            "embedding",
+            "layer.0.w_q",
+            "layer.0.w_k",
+            "layer.0.w_v",
+            "layer.0.w_o",
+            "layer.0.w_gate",
+            "layer.0.w_up",
+            "layer.0.w_down",
+            "w_out",
+        )
+        for key in matrix_keys:
+            assert weights[key].dtype == np.float16
+            assert weights[key].flags["C_CONTIGUOUS"]
+
+        with safe_open(str(model_dir / "model.safetensors"), framework="numpy") as reader:
+            q_source = reader.get_tensor(
+                "model.layers.0.self_attn.q_proj.weight")
+            embedding_source = reader.get_tensor("model.embed_tokens.weight")
+        np.testing.assert_array_equal(
+            weights["layer.0.w_q"], q_source.T.astype(np.float16))
+        np.testing.assert_array_equal(
+            weights["embedding"], embedding_source.astype(np.float16))
 
     def test_transpose_applied(self, tmp_path):
         """Verify projections are transposed from [out, in] to [in, out]."""


### PR DESCRIPTION
## Background

Qwen FP16 and BF16 builds staged model-sized checkpoint tensors through FP32 before immediately converting them to their final FP16 representation. This added guaranteed conversion work and transient host memory during checkpoint loading.

Closes #677.

## Exit Criteria

- Load reduced-precision embedding and projection tensors directly into owned target-dtype buffers.
- Preserve FP32 handling for normalization weights and FP32 build modes.
- Cover FP16/BF16 values, shape, dtype, layout, and the FP32-staging boundary with CPU-only tests.

## Implementation

- Split raw tensor lookup from conversion so callers can choose the required output dtype.
- Fuse projection transpose and target-dtype conversion into one owned contiguous copy.
- Keep normalization tensors on the existing FP32 path.
- Preserve tied-embedding and LM-head behavior.

## Validation

- `python -m pytest tests/builder/test_checkpoint_mapper.py -q`: passed, 36 tests.
- `python -m ruff check python/tensorrt_model_connect/families/qwen/checkpoint_mapper.py tests/builder/test_checkpoint_mapper.py`: passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- No ADR was added because this is a focused checkpoint-loader optimization with no persisted schema or runtime architecture change.
- A full-size checkpoint benchmark and GPU TensorRT build were not run; the regression suite is CPU-only and verifies the conversion contract directly.
