### PR TITLE
fix(cli): validate FP8 scale files

### DIFF
--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -67,6 +67,30 @@ def _optimized_cli_public_options(args: argparse.Namespace) -> dict:
     return public_options
 
 
+def _load_fp8_scales(path: str | Path) -> dict[str, object]:
+    """Load a user-provided FP8 scale map from a UTF-8 JSON file."""
+
+    scales_path = Path(path)
+    try:
+        with scales_path.open(encoding="utf-8") as scales_file:
+            scales = json.load(scales_file)
+    except OSError as exc:
+        raise ValueError(
+            f"could not read FP8 scales file {scales_path}: {exc}"
+        ) from exc
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"invalid JSON in FP8 scales file {scales_path}: {exc}"
+        ) from exc
+
+    if not isinstance(scales, dict):
+        raise ValueError(
+            f"FP8 scales file {scales_path} must contain a JSON object, "
+            f"got {type(scales).__name__}"
+        )
+    return scales
+
+
 def _cmd_build(args: argparse.Namespace) -> int:
     if not args.model:
         print("Error: model (HF repo ID or local directory) required",
@@ -167,9 +191,11 @@ def _cmd_build(args: argparse.Namespace) -> int:
     fp8_scales = None
     fp8_auto = getattr(args, 'fp8', False)
     if getattr(args, 'fp8_scales', None):
-        import json as _json
-        with open(args.fp8_scales) as _f:
-            fp8_scales = _json.load(_f)
+        try:
+            fp8_scales = _load_fp8_scales(args.fp8_scales)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
         print(f"[trtmc build] Loaded FP8 scales from {args.fp8_scales} "
               f"({len(fp8_scales)} layers)", file=sys.stderr)
     elif fp8_auto:

--- a/tests/builder/test_cli.py
+++ b/tests/builder/test_cli.py
@@ -297,6 +297,22 @@ class TestCmdInspect:
 class TestCmdBuildMocked:
     """Tests for _cmd_build with mocked engine_builder."""
 
+    @staticmethod
+    def _fp8_build_args(tmp_path, scales_path):
+        return argparse.Namespace(
+            model="some-model",
+            output=str(tmp_path / "out.trtfb"),
+            max_cache_length=256,
+            precision="fp16",
+            method="trt",
+            quantize=None,
+            quant_scales=None,
+            quant_calibration_samples=512,
+            verbose=False,
+            fp8_scales=str(scales_path),
+            _skip_profile_resolution=True,
+        )
+
     def test_build_calls_engine_builder_with_correct_args(self, tmp_path):
         """Verify _cmd_build passes model, output, cache length, verbose to build()."""
         from tensorrt_model_connect.build_cli import _cmd_build
@@ -590,6 +606,85 @@ class TestCmdBuildMocked:
             assert result == 1
         finally:
             eb._build_native_impl = original_build
+
+    def test_missing_fp8_scales_fails_before_native_build(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        from tensorrt_model_connect.build_cli import _cmd_build
+        import tensorrt_model_connect.engine_builder as eb
+
+        native_calls = []
+        monkeypatch.setattr(eb, "_try_build_optimized_runtime",
+                            lambda *args, **kwargs: None)
+        monkeypatch.setattr(eb, "_build_native_impl",
+                            lambda *args, **kwargs: native_calls.append(kwargs))
+        scales_path = tmp_path / "missing-scales.json"
+
+        result = _cmd_build(self._fp8_build_args(tmp_path, scales_path))
+
+        assert result == 1
+        assert native_calls == []
+        stderr = capsys.readouterr().err
+        assert str(scales_path) in stderr
+        assert "could not read FP8 scales file" in stderr
+
+    @pytest.mark.parametrize(
+        ("contents", "expected_error"),
+        [
+            ("not-json", "invalid JSON in FP8 scales file"),
+            ("[]", "must contain a JSON object, got list"),
+            ("1", "must contain a JSON object, got int"),
+        ],
+    )
+    def test_invalid_fp8_scales_fails_before_native_build(
+        self, monkeypatch, tmp_path, capsys, contents, expected_error
+    ):
+        from tensorrt_model_connect.build_cli import _cmd_build
+        import tensorrt_model_connect.engine_builder as eb
+
+        native_calls = []
+        monkeypatch.setattr(eb, "_try_build_optimized_runtime",
+                            lambda *args, **kwargs: None)
+        monkeypatch.setattr(eb, "_build_native_impl",
+                            lambda *args, **kwargs: native_calls.append(kwargs))
+        scales_path = tmp_path / "invalid-scales.json"
+        scales_path.write_text(contents, encoding="utf-8")
+
+        result = _cmd_build(self._fp8_build_args(tmp_path, scales_path))
+
+        assert result == 1
+        assert native_calls == []
+        stderr = capsys.readouterr().err
+        assert str(scales_path) in stderr
+        assert expected_error in stderr
+
+    def test_valid_fp8_scales_reach_native_build(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        from tensorrt_model_connect.build_cli import _cmd_build
+        import tensorrt_model_connect.engine_builder as eb
+
+        native_calls = []
+        monkeypatch.setattr(eb, "_try_build_optimized_runtime",
+                            lambda *args, **kwargs: None)
+        monkeypatch.setattr(eb, "_build_native_impl",
+                            lambda *args, **kwargs: native_calls.append(kwargs))
+        scales_path = tmp_path / "scales.json"
+        scales = {
+            "transformer.block.0": {
+                "input_scale": 0.5,
+                "weight_scale": 0.25,
+            }
+        }
+        scales_path.write_text(json.dumps(scales), encoding="utf-8")
+
+        result = _cmd_build(self._fp8_build_args(tmp_path, scales_path))
+
+        assert result == 0
+        assert len(native_calls) == 1
+        assert native_calls[0]["fp8_scales"] == scales
+        stderr = capsys.readouterr().err
+        assert f"Loaded FP8 scales from {scales_path}" in stderr
 
     def test_build_reexecs_into_declared_python_profile(self, monkeypatch, tmp_path):
         """Families with declared profiles should re-exec into that Python profile."""


### PR DESCRIPTION
## Background

`trtmc build --fp8-scales` decoded user input before the CLI's guarded build block. Missing files, malformed JSON, and non-object JSON could therefore escape as raw exceptions or reach the builder with an invalid type.

Closes #678.

## Exit Criteria

- Reject unreadable, malformed, and non-object scale files at the CLI boundary.
- Print a concise path-specific error and return a non-zero status.
- Do not invoke the native builder for invalid input.
- Preserve downstream family-specific scale-schema validation.

## Implementation

- Add a UTF-8 JSON loader for FP8 scale maps.
- Normalize file I/O, decoding, and top-level type failures into actionable CLI errors.
- Add GPU-free tests for missing, malformed, list, scalar, and valid-object inputs.

## Validation

- `python -m pytest tests/builder/test_cli.py -q`: passed, 42 tests.
- `python -m ruff check python/tensorrt_model_connect/build_cli.py tests/builder/test_cli.py`: passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- No ADR was added because this is input validation for an existing CLI option.
- The loader intentionally validates only the top-level JSON-object contract; model-family scale keys and values remain downstream responsibilities.
