### PR TITLE
feat(qwen-vl): add dynamic smart-resize vision profiles

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -600,6 +600,149 @@ def add_windowed_self_attention_with_rope(
     return out
 
 
+def _runtime_rope_cache_3d(
+    network: trt.INetworkDefinition,
+    cache: trt.ITensor,
+    half_head_dim: int,
+    target_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Normalize a runtime [N, D/2] vision RoPE cache to [1, N, D/2]."""
+    if cache.dtype != target_dtype:
+        cache = network.add_cast(cache, target_dtype).get_output(0)
+    shaped = network.add_shuffle(cache)
+    shaped.reshape_dims = (1, -1, half_head_dim)
+    return shaped.get_output(0)
+
+
+def add_dynamic_self_attention_with_rope(
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    w_q: np.ndarray,
+    w_k: np.ndarray,
+    w_v: np.ndarray,
+    w_o: np.ndarray,
+    hidden_size: int,
+    num_heads: int,
+    cos_half: trt.ITensor,
+    sin_half: trt.ITensor,
+    q_bias: np.ndarray | None = None,
+    k_bias: np.ndarray | None = None,
+    v_bias: np.ndarray | None = None,
+    o_bias: np.ndarray | None = None,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Full vision attention for a runtime-variable number of patch rows."""
+    head_dim = hidden_size // num_heads
+    q = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_q, dtype=dtype)
+    k = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_k, dtype=dtype)
+    v = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_v, dtype=dtype)
+    if q_bias is not None:
+        q = add_bias_sum(network, q, hidden_size, q_bias, dtype=dtype)
+    if k_bias is not None:
+        k = add_bias_sum(network, k, hidden_size, k_bias, dtype=dtype)
+    if v_bias is not None:
+        v = add_bias_sum(network, v, hidden_size, v_bias, dtype=dtype)
+
+    cos_3d = _runtime_rope_cache_3d(
+        network, cos_half, head_dim // 2, q.dtype)
+    sin_3d = _runtime_rope_cache_3d(
+        network, sin_half, head_dim // 2, q.dtype)
+    q = add_apply_rope_native_sequence(
+        network, q, num_heads, head_dim, cos_3d, sin_3d,
+        rotary_embedding_dim=head_dim, sequence_length=None)
+    k = add_apply_rope_native_sequence(
+        network, k, num_heads, head_dim, cos_3d, sin_3d,
+        rotary_embedding_dim=head_dim, sequence_length=None)
+    context = add_attention_from_rows(
+        network, q, k, v, num_heads=num_heads, head_dim=head_dim,
+        q_seq=None, kv_seq=None)
+    out = add_matmul_rhs_constant(
+        network, context, hidden_size, hidden_size, w_o, dtype=dtype)
+    if o_bias is not None:
+        out = add_bias_sum(network, out, hidden_size, o_bias, dtype=dtype)
+    return out
+
+
+def add_dynamic_windowed_self_attention_with_rope(
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    w_q: np.ndarray,
+    w_k: np.ndarray,
+    w_v: np.ndarray,
+    w_o: np.ndarray,
+    hidden_size: int,
+    num_heads: int,
+    cos_half: trt.ITensor,
+    sin_half: trt.ITensor,
+    padded_window_indices: trt.ITensor,
+    compact_window_indices: trt.ITensor,
+    window_mask: trt.ITensor,
+    window_patch_size: int,
+    q_bias: np.ndarray | None = None,
+    k_bias: np.ndarray | None = None,
+    v_bias: np.ndarray | None = None,
+    o_bias: np.ndarray | None = None,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Windowed vision attention for runtime-variable smart-resize grids."""
+    if window_patch_size <= 0:
+        raise ValueError("window_patch_size must be positive")
+    head_dim = hidden_size // num_heads
+    q = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_q, dtype=dtype)
+    k = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_k, dtype=dtype)
+    v = add_matmul_rhs_constant(
+        network, hidden, hidden_size, hidden_size, w_v, dtype=dtype)
+    if q_bias is not None:
+        q = add_bias_sum(network, q, hidden_size, q_bias, dtype=dtype)
+    if k_bias is not None:
+        k = add_bias_sum(network, k, hidden_size, k_bias, dtype=dtype)
+    if v_bias is not None:
+        v = add_bias_sum(network, v, hidden_size, v_bias, dtype=dtype)
+
+    cos_3d = _runtime_rope_cache_3d(
+        network, cos_half, head_dim // 2, q.dtype)
+    sin_3d = _runtime_rope_cache_3d(
+        network, sin_half, head_dim // 2, q.dtype)
+    q = add_apply_rope_native_sequence(
+        network, q, num_heads, head_dim, cos_3d, sin_3d,
+        rotary_embedding_dim=head_dim, sequence_length=None)
+    k = add_apply_rope_native_sequence(
+        network, k, num_heads, head_dim, cos_3d, sin_3d,
+        rotary_embedding_dim=head_dim, sequence_length=None)
+
+    windowed_qkv = []
+    for tensor in (q, k, v):
+        padded = network.add_gather(
+            tensor, padded_window_indices, 0).get_output(0)
+        shaped = network.add_shuffle(padded)
+        shaped.reshape_dims = (-1, window_patch_size, num_heads, head_dim)
+        shaped.second_transpose = trt.Permutation([0, 2, 1, 3])
+        windowed_qkv.append(shaped.get_output(0))
+
+    if window_mask.dtype != windowed_qkv[0].dtype:
+        window_mask = network.add_cast(
+            window_mask, windowed_qkv[0].dtype).get_output(0)
+    context = add_attention_core(
+        network, *windowed_qkv, mask=window_mask,
+        scale=1.0 / np.sqrt(max(head_dim, 1)))
+    flattened = network.add_shuffle(context)
+    flattened.first_transpose = trt.Permutation([0, 2, 1, 3])
+    flattened.reshape_dims = (-1, hidden_size)
+    compact = network.add_gather(
+        flattened.get_output(0), compact_window_indices, 0).get_output(0)
+
+    out = add_matmul_rhs_constant(
+        network, compact, hidden_size, hidden_size, w_o, dtype=dtype)
+    if o_bias is not None:
+        out = add_bias_sum(network, out, hidden_size, o_bias, dtype=dtype)
+    return out
+
+
 def add_patch_embed_3d(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -17,7 +17,9 @@ Detection: ``deepstack_visual_indexes`` in vision_config means Qwen3-VL.
 
 from __future__ import annotations
 
+import json
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -84,6 +86,45 @@ def _fixed_image_dimensions(config: ModelConfig) -> tuple[int, int]:
         raise ValueError(
             "Rectangular vision profiles currently support Qwen2.5-VL only")
     return height, width
+
+
+def _vision_build_options(config: ModelConfig) -> dict:
+    family_options = config.raw.get("_family_build_options", {})
+    vision_options = (
+        family_options.get("qwen_vl_vision", {})
+        if isinstance(family_options, dict) else {}
+    )
+    if not isinstance(vision_options, dict):
+        raise ValueError("qwen_vl_vision build options must be an object")
+    return vision_options
+
+
+def _dynamic_vision_profile(
+    model_dir: str, config: ModelConfig,
+) -> tuple[bool, int, int, int]:
+    """Resolve dynamic smart-resize limits from build and processor configs."""
+    options = _vision_build_options(config)
+    enabled = bool(options.get("dynamic_resolution", False))
+    processor_config: dict = {}
+    processor_path = Path(model_dir) / "preprocessor_config.json"
+    if processor_path.exists():
+        with processor_path.open(encoding="utf-8") as handle:
+            loaded = json.load(handle)
+        if isinstance(loaded, dict):
+            processor_config = loaded
+
+    min_pixels = int(options.get("min_pixels", 0))
+    max_pixels = int(options.get("max_pixels", 0))
+    if min_pixels <= 0:
+        min_pixels = int(processor_config.get("min_pixels", 3136))
+    if max_pixels <= 0:
+        max_pixels = int(processor_config.get("max_pixels", 12845056))
+    opt_pixels = int(options.get("opt_pixels", 200704))
+    if not min_pixels <= opt_pixels <= max_pixels:
+        raise ValueError(
+            "qwen_vl_vision pixel limits must satisfy min_pixels <= "
+            "opt_pixels <= max_pixels")
+    return enabled, min_pixels, opt_pixels, max_pixels
 
 
 class QwenVLPlugin:
@@ -179,8 +220,19 @@ class QwenVLPlugin:
             "fp32" if precision == "fp16" and _VISION_COMPONENT in selected_fp32
             else precision)
         fixed_h, fixed_w = _fixed_image_dimensions(config)
+        dynamic_resolution, min_pixels, opt_pixels, max_pixels = (
+            _dynamic_vision_profile(model_dir, config))
+        config.raw["_qwen_vl_dynamic_vision_profile"] = {
+            "enabled": dynamic_resolution,
+            "min_pixels": min_pixels,
+            "opt_pixels": opt_pixels,
+            "max_pixels": max_pixels,
+        }
 
         if _is_qwen3_vl(config):
+            if dynamic_resolution:
+                raise NotImplementedError(
+                    "Dynamic image resolution currently supports Qwen2.5-VL only")
             from .qwen_vl_vision_builder import build_qwen3_vl_vision_engine
             return build_qwen3_vl_vision_engine(
                 vision_config, vision_weights,
@@ -195,6 +247,10 @@ class QwenVLPlugin:
                 fixed_image_size=_DEFAULT_FIXED_IMAGE_SIZE,
                 fixed_image_height=fixed_h,
                 fixed_image_width=fixed_w,
+                dynamic_image_resolution=dynamic_resolution,
+                min_image_pixels=min_pixels,
+                opt_image_pixels=opt_pixels,
+                max_image_pixels=max_pixels,
                 precision=vision_precision,
                 verbose=verbose)
 
@@ -211,21 +267,34 @@ class QwenVLPlugin:
         grid_w = fixed_w // patch_size
         num_patches = grid_h * grid_w
         num_merged = num_patches // (merge_size * merge_size)
-
-        # Rectangular buckets preserve the source aspect ratio before applying
-        # Qwen's required merge-group pixel ordering. Square profiles retain
-        # the established direct-resize behavior for compatibility.
-        preproc = (
-            "aspect_preserve_merge_group_chw"
-            if fixed_h != fixed_w else "merge_group_chw"
+        profile = config.raw.get("_qwen_vl_dynamic_vision_profile", {})
+        dynamic_resolution = bool(
+            profile.get(
+                "enabled",
+                _vision_build_options(config).get("dynamic_resolution", False),
+            )
         )
+
+        if dynamic_resolution:
+            if _is_qwen3_vl(config):
+                raise NotImplementedError(
+                    "Dynamic image resolution currently supports Qwen2.5-VL only")
+            preproc = "qwen_smart_resize_patchify"
+        else:
+            # Rectangular buckets preserve the source aspect ratio before
+            # applying Qwen's required merge-group pixel ordering.
+            preproc = (
+                "aspect_preserve_merge_group_chw"
+                if fixed_h != fixed_w else "merge_group_chw"
+            )
 
         vl_cfg = {
             "image_token_id": 151655,
             "fixed_image_size": _DEFAULT_FIXED_IMAGE_SIZE,
             "fixed_image_height": fixed_h,
             "fixed_image_width": fixed_w,
-            "num_image_pad_tokens": num_merged,
+            "num_image_pad_tokens": 0 if dynamic_resolution else num_merged,
+            "dynamic_image_resolution": dynamic_resolution,
             "vision_output_dim": config.hidden_size,
             "preprocessor_type": preproc,
             "vl_prompt_template": (
@@ -237,6 +306,26 @@ class QwenVLPlugin:
             ),
             "image_token_str": "<|image_pad|>",
         }
+
+        if dynamic_resolution:
+            options = _vision_build_options(config)
+            vl_cfg.update({
+                "min_pixels": int(
+                    profile.get("min_pixels", options.get("min_pixels") or 3136)),
+                "max_pixels": int(
+                    profile.get("max_pixels", options.get("max_pixels") or 12845056)),
+                "vision_embed_dim": int(
+                    vision_config.get(
+                        "embed_dim", vision_config.get("hidden_size", 1280))),
+                "vision_num_heads": int(
+                    vision_config.get(
+                        "num_heads",
+                        vision_config.get("num_attention_heads", 16))),
+                "vision_window_size": int(
+                    vision_config.get("window_size", 112)),
+                "vision_rope_theta": float(
+                    vision_config.get("rope_theta", 10000.0)),
+            })
 
         if _is_qwen3_vl(config):
             ds_indexes = vision_config.get("deepstack_visual_indexes", [])

--- a/python/tensorrt_model_connect/families/qwen_vl/qwen_vl_vision_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/qwen_vl_vision_builder.py
@@ -169,6 +169,10 @@ def build_qwen_vl_vision_engine(
     fixed_image_size: int = 448,
     fixed_image_height: int | None = None,
     fixed_image_width: int | None = None,
+    dynamic_image_resolution: bool = False,
+    min_image_pixels: int = 3136,
+    opt_image_pixels: int = 200704,
+    max_image_pixels: int = 12845056,
     precision: str = "fp32",
     verbose: bool = False,
 ) -> bytes:
@@ -183,6 +187,10 @@ def build_qwen_vl_vision_engine(
         fixed_image_size: Square image height/width fallback.
         fixed_image_height: Optional rectangular image height.
         fixed_image_width: Optional rectangular image width.
+        dynamic_image_resolution: Accept runtime Qwen smart-resize patch grids.
+        min_image_pixels: Minimum dynamic optimization-profile image area.
+        opt_image_pixels: Preferred dynamic optimization-profile image area.
+        max_image_pixels: Maximum dynamic optimization-profile image area.
         verbose: Print detailed logs.
 
     Returns:
@@ -215,7 +223,8 @@ def build_qwen_vl_vision_engine(
     if fixed_h % patch_size or fixed_w % patch_size:
         raise ValueError("fixed image dimensions must be divisible by patch_size")
 
-    # Compute grid dimensions for fixed image size
+    # Compute grid dimensions for the fixed path. The dynamic path uses these
+    # only for diagnostics and profile defaults.
     grid_h = fixed_h // patch_size
     grid_w = fixed_w // patch_size
     num_patches = grid_h * grid_w
@@ -230,15 +239,37 @@ def build_qwen_vl_vision_engine(
         # Fallback: try to infer from config
         text_hidden_size = vision_config.get("text_hidden_size", embed_dim)
 
+    patch_pixels = patch_size * patch_size
+    merge_unit = merge_size * merge_size
+    if dynamic_image_resolution:
+        profile_pixels = (
+            int(min_image_pixels), int(opt_image_pixels), int(max_image_pixels))
+        if any(value <= 0 for value in profile_pixels):
+            raise ValueError("dynamic Qwen-VL image pixel limits must be positive")
+        if not profile_pixels[0] <= profile_pixels[1] <= profile_pixels[2]:
+            raise ValueError(
+                "dynamic Qwen-VL image pixel limits must satisfy min <= opt <= max")
+        profile_patches = tuple(
+            max(merge_unit, (value // patch_pixels // merge_unit) * merge_unit)
+            for value in profile_pixels
+        )
+    else:
+        profile_patches = (num_patches, num_patches, num_patches)
+
     if verbose:
-        print(f"[trtmc build] Vision: image={fixed_h}x{fixed_w}, "
-              f"grid={grid_h}x{grid_w}, patches={num_patches}, "
+        resolution = (
+            f"dynamic-patches={profile_patches}"
+            if dynamic_image_resolution else
+            f"image={fixed_h}x{fixed_w}, grid={grid_h}x{grid_w}"
+        )
+        print(f"[trtmc build] Vision: {resolution}, patches={num_patches}, "
               f"merged={num_merged}, embed={embed_dim}, "
               f"text_hidden={text_hidden_size}", file=sys.stderr)
 
+    workspace_bytes = 8 << 30 if dynamic_image_resolution else 2 << 30
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=2 << 30,
+        workspace_bytes=workspace_bytes,
     )
     builder = builder_context.builder
     network = builder_context.network
@@ -249,13 +280,17 @@ def build_qwen_vl_vision_engine(
         dtype=work_np_dtype)
 
     # ---------------------------------------------------------------
-    # Input: pixel_values [T*C, H, W]
-    # For temporal_patch_size=2, T*C = 2*3 = 6
+    # Fixed profiles consume [T*C, H, W]. Dynamic profiles consume the exact
+    # Hugging Face patchified representation [N, T*C*P*P].
     # ---------------------------------------------------------------
     input_channels = temporal_patch_size * in_channels
-    pixel_values = network.add_input(
-        "pixel_values", trt.float32,
-        (input_channels, fixed_h, fixed_w))
+    patch_vector_size = input_channels * patch_size * patch_size
+    pixel_shape = (
+        (-1, patch_vector_size)
+        if dynamic_image_resolution
+        else (input_channels, fixed_h, fixed_w)
+    )
+    pixel_values = network.add_input("pixel_values", trt.float32, pixel_shape)
     if work_trt_dtype != trt.float32:
         pixel_values = network.add_cast(
             pixel_values, work_trt_dtype).get_output(0)
@@ -270,28 +305,54 @@ def build_qwen_vl_vision_engine(
     if patch_embed_w is None:
         raise RuntimeError("Missing visual.patch_embed.proj.weight")
 
-    hidden = graph_ops.add_patch_embed_3d(
-        network, pixel_values,
-        patch_embed_w.astype(work_np_dtype),
-        patch_embed_b.astype(work_np_dtype) if patch_embed_b is not None else None,
-        in_channels=in_channels,
-        embed_dim=embed_dim,
-        temporal_patch_size=temporal_patch_size,
-        patch_size=patch_size,
-        dtype=work_np_dtype)
+    if dynamic_image_resolution:
+        patch_matrix = patch_embed_w.reshape(embed_dim, patch_vector_size).T
+        hidden = graph_ops.add_matmul_rhs_constant(
+            network, pixel_values, patch_vector_size, embed_dim,
+            patch_matrix.astype(work_np_dtype), dtype=work_np_dtype)
+        if patch_embed_b is not None:
+            hidden = graph_ops.add_bias_sum(
+                network, hidden, embed_dim,
+                patch_embed_b.astype(work_np_dtype), dtype=work_np_dtype)
+    else:
+        hidden = graph_ops.add_patch_embed_3d(
+            network, pixel_values,
+            patch_embed_w.astype(work_np_dtype),
+            patch_embed_b.astype(work_np_dtype) if patch_embed_b is not None else None,
+            in_channels=in_channels,
+            embed_dim=embed_dim,
+            temporal_patch_size=temporal_patch_size,
+            patch_size=patch_size,
+            dtype=work_np_dtype)
 
     # ---------------------------------------------------------------
     # Stage 2: Precompute RoPE tables + window index
     # ---------------------------------------------------------------
     window_size = int(vision_config.get("window_size", 112))
-    merge_unit = merge_size * merge_size
-
-    cos_table, sin_table, window_index, reverse_indices, window_patch_counts = \
-        _compute_vision_rope_tables(
-            grid_h, grid_w, embed_dim, num_heads,
-            merge_size=merge_size, window_size=window_size,
-            patch_size=patch_size, rope_theta=rope_theta,
-            return_window_patch_counts=True)
+    head_dim = embed_dim // num_heads
+    if dynamic_image_resolution:
+        cos_half = network.add_input(
+            "vision_cos_half", trt.float32, (-1, head_dim // 2))
+        sin_half = network.add_input(
+            "vision_sin_half", trt.float32, (-1, head_dim // 2))
+        window_index_tensor = network.add_input(
+            "vision_window_indices", trt.int32, (-1,))
+        padded_window_indices = network.add_input(
+            "vision_padded_window_indices", trt.int32, (-1,))
+        compact_window_indices = network.add_input(
+            "vision_compact_window_indices", trt.int32, (-1,))
+        reverse_indices_tensor = network.add_input(
+            "vision_reverse_indices", trt.int32, (-1,))
+        window_mask = None
+        cos_table = sin_table = window_index = reverse_indices = None
+        window_patch_counts = np.empty((0,), dtype=np.int32)
+    else:
+        cos_table, sin_table, window_index, reverse_indices, window_patch_counts = \
+            _compute_vision_rope_tables(
+                grid_h, grid_w, embed_dim, num_heads,
+                merge_size=merge_size, window_size=window_size,
+                patch_size=patch_size, rope_theta=rope_theta,
+                return_window_patch_counts=True)
 
     # Windowed vs full attention config
     vit_merger_window_size = window_size // merge_size // patch_size
@@ -302,6 +363,10 @@ def build_qwen_vl_vision_engine(
     # Number of real, non-empty windows. Edge windows can be partial when the
     # processor's smart-resized image is not window-aligned.
     num_windows = int(len(window_patch_counts))
+    if dynamic_image_resolution:
+        window_mask = network.add_input(
+            "vision_window_mask", trt.float32,
+            (-1, 1, 1, patches_per_window))
 
     fullatt_block_indexes = set(
         vision_config.get("fullatt_block_indexes", [7, 15, 23, 31]))
@@ -311,9 +376,10 @@ def build_qwen_vl_vision_engine(
               f"rope_dim={embed_dim // num_heads // 2}, "
               f"window_size={window_size}, "
               f"vit_merger_window_size={vit_merger_window_size}, "
-              f"num_windows={num_windows}, "
+              f"num_windows={'dynamic' if dynamic_image_resolution else num_windows}, "
               f"patches_per_window={patches_per_window}, "
-              f"actual_window_patch_counts={window_patch_counts.tolist()}, "
+              f"actual_window_patch_counts="
+              f"{'runtime' if dynamic_image_resolution else window_patch_counts.tolist()}, "
               f"fullatt_blocks={sorted(fullatt_block_indexes)}",
               file=sys.stderr)
 
@@ -322,17 +388,28 @@ def build_qwen_vl_vision_engine(
     # hidden: [num_patches, embed_dim] -> reorder groups of merge_unit
     # ---------------------------------------------------------------
     reshp_win = network.add_shuffle(hidden)
-    reshp_win.reshape_dims = (num_merged, merge_unit, embed_dim)
+    reshp_win.reshape_dims = (
+        (-1, merge_unit, embed_dim)
+        if dynamic_image_resolution
+        else (num_merged, merge_unit, embed_dim)
+    )
 
-    win_idx_weights = trt.Weights(np.ascontiguousarray(window_index))
-    win_idx_layer = network.add_constant((num_merged,), win_idx_weights)
-    win_idx_cast = network.add_cast(win_idx_layer.get_output(0), trt.int32)
+    if dynamic_image_resolution:
+        win_idx_cast = window_index_tensor
+    else:
+        win_idx_weights = trt.Weights(np.ascontiguousarray(window_index))
+        win_idx_layer = network.add_constant((num_merged,), win_idx_weights)
+        win_idx_cast = network.add_cast(
+            win_idx_layer.get_output(0), trt.int32).get_output(0)
 
     gathered_win = network.add_gather(
-        reshp_win.get_output(0), win_idx_cast.get_output(0), 0)
+        reshp_win.get_output(0), win_idx_cast, 0)
 
     reshp_back = network.add_shuffle(gathered_win.get_output(0))
-    reshp_back.reshape_dims = (num_patches, embed_dim)
+    reshp_back.reshape_dims = (
+        (-1, embed_dim)
+        if dynamic_image_resolution else (num_patches, embed_dim)
+    )
     hidden = reshp_back.get_output(0)
 
     # ---------------------------------------------------------------
@@ -385,16 +462,13 @@ def build_qwen_vl_vision_engine(
         use_full_attn = (layer_idx in fullatt_block_indexes)
         w_o_np = (w_o.astype(work_np_dtype).T.copy() if w_o is not None
                   else np.zeros((embed_dim, embed_dim), dtype=work_np_dtype))
-        attn_kwargs = dict(
+        common_attn_kwargs = dict(
             w_q=w_q.astype(work_np_dtype),
             w_k=w_k.astype(work_np_dtype),
             w_v=w_v.astype(work_np_dtype),
             w_o=w_o_np,
             hidden_size=embed_dim,
             num_heads=num_heads,
-            seq_length=num_patches,
-            cos_table=cos_table,
-            sin_table=sin_table,
             q_bias=q_bias.astype(work_np_dtype) if q_bias is not None else None,
             k_bias=k_bias.astype(work_np_dtype) if k_bias is not None else None,
             v_bias=v_bias.astype(work_np_dtype) if v_bias is not None else None,
@@ -402,16 +476,33 @@ def build_qwen_vl_vision_engine(
             dtype=work_np_dtype,
         )
 
-        if use_full_attn:
+        if dynamic_image_resolution and use_full_attn:
+            attn_out = graph_ops.add_dynamic_self_attention_with_rope(
+                network, normed, cos_half=cos_half, sin_half=sin_half,
+                **common_attn_kwargs)
+        elif dynamic_image_resolution:
+            attn_out = graph_ops.add_dynamic_windowed_self_attention_with_rope(
+                network, normed, cos_half=cos_half, sin_half=sin_half,
+                padded_window_indices=padded_window_indices,
+                compact_window_indices=compact_window_indices,
+                window_mask=window_mask,
+                window_patch_size=patches_per_window,
+                **common_attn_kwargs)
+        elif use_full_attn:
             attn_out = graph_ops.add_self_attention_block_with_rope(
-                network, normed, **attn_kwargs)
+                network, normed, seq_length=num_patches,
+                cos_table=cos_table, sin_table=sin_table,
+                **common_attn_kwargs)
         else:
             attn_out = graph_ops.add_windowed_self_attention_with_rope(
                 network,
                 normed,
+                seq_length=num_patches,
+                cos_table=cos_table,
+                sin_table=sin_table,
                 num_windows=num_windows,
                 window_patch_counts=window_patch_counts,
-                **attn_kwargs,
+                **common_attn_kwargs,
             )
 
         # Residual
@@ -526,7 +617,10 @@ def build_qwen_vl_vision_engine(
 
     # 2. Group every merge_unit consecutive patches (matches HF's view(-1, hidden_size))
     reshape_merge = network.add_shuffle(normed_patches)
-    reshape_merge.reshape_dims = (num_merged, merged_dim)
+    reshape_merge.reshape_dims = (
+        (-1, merged_dim)
+        if dynamic_image_resolution else (num_merged, merged_dim)
+    )
     merged_features = reshape_merge.get_output(0)
 
     # 3. MLP: [num_merged, merged_dim] -> [num_merged, text_hidden_size]
@@ -553,12 +647,16 @@ def build_qwen_vl_vision_engine(
                                           dtype=work_np_dtype)
 
     # 4. Reverse window reorder: restore original spatial order
-    rev_idx_weights = trt.Weights(np.ascontiguousarray(reverse_indices))
-    rev_idx_layer = network.add_constant((num_merged,), rev_idx_weights)
-    rev_idx_cast = network.add_cast(rev_idx_layer.get_output(0), trt.int32)
+    if dynamic_image_resolution:
+        rev_idx_cast = reverse_indices_tensor
+    else:
+        rev_idx_weights = trt.Weights(np.ascontiguousarray(reverse_indices))
+        rev_idx_layer = network.add_constant((num_merged,), rev_idx_weights)
+        rev_idx_cast = network.add_cast(
+            rev_idx_layer.get_output(0), trt.int32).get_output(0)
 
     reversed_out = network.add_gather(
-        fc2_out, rev_idx_cast.get_output(0), 0)
+        fc2_out, rev_idx_cast, 0)
 
     # ---------------------------------------------------------------
     # Output: image_features [num_merged, text_hidden_size]
@@ -573,10 +671,60 @@ def build_qwen_vl_vision_engine(
     # ---------------------------------------------------------------
     # Build
     # ---------------------------------------------------------------
+    if dynamic_image_resolution:
+        min_patches, opt_patches, max_patches = profile_patches
+
+        def padded_rows(rows: int) -> int:
+            return max(
+                patches_per_window,
+                ((rows + patches_per_window - 1) // patches_per_window)
+                * patches_per_window,
+            )
+
+        min_padded = padded_rows(min_patches)
+        opt_padded = padded_rows(opt_patches)
+        # Edge windows can require more padding than a flat row-count
+        # estimate, so reserve up to twice the maximum patch rows.
+        max_padded = padded_rows(max_patches * 2)
+        min_merged = min_patches // merge_unit
+        opt_merged = opt_patches // merge_unit
+        max_merged = max_patches // merge_unit
+        profile = builder.create_optimization_profile()
+        profile.set_shape(
+            "pixel_values",
+            (min_patches, patch_vector_size),
+            (opt_patches, patch_vector_size),
+            (max_patches, patch_vector_size),
+        )
+        for name in ("vision_cos_half", "vision_sin_half"):
+            profile.set_shape(
+                name,
+                (min_patches, head_dim // 2),
+                (opt_patches, head_dim // 2),
+                (max_patches, head_dim // 2),
+            )
+        for name in ("vision_window_indices", "vision_reverse_indices"):
+            profile.set_shape(
+                name, (min_merged,), (opt_merged,), (max_merged,))
+        profile.set_shape(
+            "vision_padded_window_indices",
+            (min_padded,), (opt_padded,), (max_padded,))
+        profile.set_shape(
+            "vision_compact_window_indices",
+            (min_patches,), (opt_patches,), (max_patches,))
+        profile.set_shape(
+            "vision_window_mask",
+            (min_padded // patches_per_window, 1, 1, patches_per_window),
+            (opt_padded // patches_per_window, 1, 1, patches_per_window),
+            (max_padded // patches_per_window, 1, 1, patches_per_window),
+        )
+        trt_config.add_optimization_profile(profile)
+
     if verbose:
         print(f"[trtmc build] Building Qwen VL vision TRT engine "
               f"({num_layers} layers, embed={embed_dim}, "
-              f"patches={num_patches}, merged={num_merged}, "
+              f"patches={'dynamic' if dynamic_image_resolution else num_patches}, "
+              f"merged={'dynamic' if dynamic_image_resolution else num_merged}, "
               f"text_hidden={text_hidden_size}) ...", file=sys.stderr)
 
     plan = builder.build_serialized_network(network, trt_config)

--- a/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
@@ -55,6 +55,33 @@ VISION_SCHEMA = Schema(
             allowed_layers=_BUILD,
             validator=lambda value: isinstance(value, int) and value > 0,
         ),
+        ConfigField(
+            name="dynamic_resolution",
+            type_tag="bool",
+            default=False,
+            allowed_layers=_BUILD,
+        ),
+        ConfigField(
+            name="min_pixels",
+            type_tag="int32",
+            default=0,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value >= 0,
+        ),
+        ConfigField(
+            name="opt_pixels",
+            type_tag="int32",
+            default=200704,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value > 0,
+        ),
+        ConfigField(
+            name="max_pixels",
+            type_tag="int32",
+            default=0,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value >= 0,
+        ),
     ),
 )
 

--- a/src/runtime/models/qwen_vl/image_preprocessor.cpp
+++ b/src/runtime/models/qwen_vl/image_preprocessor.cpp
@@ -11,9 +11,14 @@
 #include "utils/json_helpers.h"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
 #include <string>
+#include <thread>
+#include <utility>
 
 namespace trtmc {
 
@@ -26,7 +31,8 @@ static stbir_filter resolve_stbir_filter(const std::string& interpolation) {
         return STBIR_FILTER_TRIANGLE;
     if (interpolation == "nearest")
         return STBIR_FILTER_POINT_SAMPLE;
-    // "bicubic" or anything else -> Catmull-Rom (matches PIL BICUBIC)
+    // "bicubic" or anything else -> Catmull-Rom. Qwen's native dynamic path
+    // uses the PyTorch-compatible antialiased implementation below instead.
     return STBIR_FILTER_CATMULLROM;
 }
 
@@ -42,12 +48,87 @@ struct LoadedImage {
     bool ok{false};
 };
 
+static int32_t preprocess_worker_count() {
+    static const int32_t workers = [] {
+        constexpr int32_t default_cap = 8;
+        int32_t requested = default_cap;
+        if (const char* value = std::getenv("TRTMC_QWEN_VL_PREPROCESS_THREADS")) {
+            char* end = nullptr;
+            const long parsed = std::strtol(value, &end, 10);
+            if (end != value && *end == '\0' && parsed > 0)
+                requested = static_cast<int32_t>(std::min(parsed, 64L));
+        }
+        const unsigned hardware = std::thread::hardware_concurrency();
+        return std::max<int32_t>(
+            1, std::min<int32_t>(requested, hardware == 0 ? default_cap : hardware));
+    }();
+    return workers;
+}
+
+template <typename Function>
+static void parallel_for_ranges(int32_t count, int32_t min_grain, Function&& function) {
+    if (count <= 0)
+        return;
+    const int32_t by_grain = (count + min_grain - 1) / min_grain;
+    const int32_t workers = std::min({count, by_grain, preprocess_worker_count()});
+    if (workers <= 1) {
+        function(0, count);
+        return;
+    }
+
+    std::vector<std::thread> threads;
+    threads.reserve(static_cast<std::size_t>(workers - 1));
+    for (int32_t worker = 0; worker < workers - 1; ++worker) {
+        const int32_t begin = count * worker / workers;
+        const int32_t end = count * (worker + 1) / workers;
+        threads.emplace_back([&, begin, end] { function(begin, end); });
+    }
+    function(count * (workers - 1) / workers, count);
+    for (auto& thread : threads)
+        thread.join();
+}
+
 static int target_height(const QwenVlPreprocessConfig& config) {
     return config.fixed_image_height > 0 ? config.fixed_image_height : config.fixed_image_size;
 }
 
 static int target_width(const QwenVlPreprocessConfig& config) {
     return config.fixed_image_width > 0 ? config.fixed_image_width : config.fixed_image_size;
+}
+
+std::array<int32_t, 2> qwen_vl_smart_resize(int32_t image_height, int32_t image_width,
+                                            int32_t factor, int32_t min_pixels,
+                                            int32_t max_pixels) {
+    if (image_height <= 0 || image_width <= 0 || factor <= 0 || min_pixels <= 0 ||
+        max_pixels < min_pixels) {
+        throw std::invalid_argument("invalid Qwen-VL smart-resize configuration");
+    }
+    const double long_side = static_cast<double>(std::max(image_height, image_width));
+    const double short_side = static_cast<double>(std::min(image_height, image_width));
+    if (long_side / short_side > 200.0)
+        throw std::invalid_argument("Qwen-VL image aspect ratio exceeds 200");
+
+    const auto aligned_round = [factor](double extent) {
+        return std::max(factor, static_cast<int32_t>(std::nearbyint(extent / factor)) * factor);
+    };
+    int32_t height = aligned_round(image_height);
+    int32_t width = aligned_round(image_width);
+    const int64_t aligned_pixels = static_cast<int64_t>(height) * width;
+    const double source_pixels = static_cast<double>(image_height) * image_width;
+    if (aligned_pixels > max_pixels) {
+        const double beta = std::sqrt(source_pixels / max_pixels);
+        height = std::max(factor,
+                          static_cast<int32_t>(std::floor(image_height / beta / factor)) * factor);
+        width = std::max(factor,
+                         static_cast<int32_t>(std::floor(image_width / beta / factor)) * factor);
+    } else if (aligned_pixels < min_pixels) {
+        const double beta = std::sqrt(static_cast<double>(min_pixels) / source_pixels);
+        height = std::max(factor,
+                          static_cast<int32_t>(std::ceil(image_height * beta / factor)) * factor);
+        width =
+            std::max(factor, static_cast<int32_t>(std::ceil(image_width * beta / factor)) * factor);
+    }
+    return {height, width};
 }
 
 // Resize raw uint8 RGB pixels to the fixed vision profile dimensions.
@@ -66,21 +147,210 @@ static std::vector<unsigned char> resize_raw(const unsigned char* raw, int width
     return resized;
 }
 
+// Qwen2-VL's fast Hugging Face processor resizes uint8 tensors with
+// torchvision bicubic interpolation and antialiasing enabled. In particular,
+// downsampling widens the cubic support; a plain Catmull-Rom resize does not.
+// The fixed-point coefficient conversion and per-axis uint8 rounding below
+// mirror PyTorch's CPU uint8 path so preprocessing does not drift before the
+// vision transformer.
+struct AntialiasWeights {
+    std::vector<int32_t> starts;
+    std::vector<int32_t> sizes;
+    std::vector<int16_t> values;
+    int32_t stride{0};
+    uint32_t precision{0};
+};
+
+static double keys_cubic(double x) {
+    constexpr double a = -0.5;
+    x = std::abs(x);
+    if (x < 1.0)
+        return ((a + 2.0) * x - (a + 3.0)) * x * x + 1.0;
+    if (x < 2.0)
+        return ((a * x - 5.0 * a) * x + 8.0 * a) * x - 4.0 * a;
+    return 0.0;
+}
+
+static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32_t output_size) {
+    constexpr int32_t interp_size = 4;
+    const double scale = static_cast<double>(input_size) / output_size;
+    const double support = scale >= 1.0 ? (interp_size * 0.5) * scale : interp_size * 0.5;
+    const int32_t kernel_size = static_cast<int32_t>(std::ceil(support)) * 2 + 1;
+
+    // PyTorch pads each int16 coefficient row to a 32-bit-aligned size in its
+    // optimized uint8 path. The padding does not participate in convolution.
+    int32_t coefficient_stride = kernel_size;
+    while (coefficient_stride % static_cast<int32_t>(sizeof(int32_t)) != 0)
+        ++coefficient_stride;
+
+    AntialiasWeights result;
+    result.starts.resize(static_cast<std::size_t>(output_size));
+    result.sizes.resize(static_cast<std::size_t>(output_size));
+    result.values.assign(static_cast<std::size_t>(output_size) * coefficient_stride, 0);
+    result.stride = coefficient_stride;
+
+    std::vector<double> floating(static_cast<std::size_t>(output_size) * kernel_size, 0.0);
+    double maximum_weight = 0.0;
+    for (int32_t output_index = 0; output_index < output_size; ++output_index) {
+        const double center = scale * (output_index + 0.5);
+        const double inverse_scale = scale >= 1.0 ? 1.0 / scale : 1.0;
+        const int32_t start = std::max(static_cast<int32_t>(center - support + 0.5), 0);
+        const int32_t size =
+            std::clamp(std::min(static_cast<int32_t>(center + support + 0.5), input_size) - start,
+                       0, kernel_size);
+        result.starts[static_cast<std::size_t>(output_index)] = start;
+        result.sizes[static_cast<std::size_t>(output_index)] = size;
+
+        double total = 0.0;
+        double* row = floating.data() + static_cast<std::size_t>(output_index) * kernel_size;
+        for (int32_t index = 0; index < size; ++index) {
+            row[index] = keys_cubic((index + start - center + 0.5) * inverse_scale);
+            total += row[index];
+        }
+        if (total != 0.0) {
+            for (int32_t index = 0; index < size; ++index) {
+                row[index] /= total;
+                maximum_weight = std::max(maximum_weight, row[index]);
+            }
+        }
+    }
+
+    // Select the greatest fixed-point precision whose largest coefficient fits
+    // in int16, exactly as PyTorch's uint8 antialias implementation does.
+    for (; result.precision < 22; ++result.precision) {
+        const int32_t next = static_cast<int32_t>(
+            0.5 + maximum_weight * static_cast<double>(uint32_t{1} << (result.precision + 1)));
+        if (next >= (1 << 15))
+            break;
+    }
+
+    const double multiplier = static_cast<double>(uint32_t{1} << result.precision);
+    for (int32_t output_index = 0; output_index < output_size; ++output_index) {
+        const double* source =
+            floating.data() + static_cast<std::size_t>(output_index) * kernel_size;
+        int16_t* destination =
+            result.values.data() + static_cast<std::size_t>(output_index) * coefficient_stride;
+        for (int32_t index = 0; index < kernel_size; ++index) {
+            const double value = source[index] * multiplier;
+            destination[index] =
+                static_cast<int16_t>(value < 0.0 ? static_cast<int32_t>(value - 0.5)
+                                                 : static_cast<int32_t>(value + 0.5));
+        }
+    }
+    return result;
+}
+
+static uint8_t fixed_point_pixel(const uint8_t* source, int32_t source_stride,
+                                 const int16_t* weights, int32_t count, uint32_t precision) {
+    int32_t value = int32_t{1} << (precision - 1);
+    for (int32_t index = 0; index < count; ++index)
+        value += static_cast<int32_t>(source[static_cast<std::size_t>(index) * source_stride]) *
+                 weights[index];
+    return static_cast<uint8_t>(std::clamp(value >> precision, 0, 255));
+}
+
+std::vector<unsigned char> qwen_vl_resize_bicubic_antialias_u8(const unsigned char* raw,
+                                                               int32_t width, int32_t height,
+                                                               int32_t target_width,
+                                                               int32_t target_height) {
+    if (raw == nullptr || width <= 0 || height <= 0 || target_width <= 0 || target_height <= 0)
+        return {};
+    if (width == target_width && height == target_height) {
+        return {raw, raw + static_cast<std::size_t>(width) * height * 3};
+    }
+
+    std::vector<unsigned char> horizontal;
+    const unsigned char* vertical_source = raw;
+    if (width != target_width) {
+        const auto weights = make_bicubic_antialias_weights(width, target_width);
+        horizontal.resize(static_cast<std::size_t>(height) * target_width * 3);
+        parallel_for_ranges(height, 16, [&](int32_t begin_y, int32_t end_y) {
+            for (int32_t y = begin_y; y < end_y; ++y) {
+                for (int32_t x = 0; x < target_width; ++x) {
+                    const int32_t start = weights.starts[static_cast<std::size_t>(x)];
+                    const int32_t count = weights.sizes[static_cast<std::size_t>(x)];
+                    const int16_t* coefficients =
+                        weights.values.data() + static_cast<std::size_t>(x) * weights.stride;
+                    for (int32_t channel = 0; channel < 3; ++channel) {
+                        const auto source_offset =
+                            (static_cast<std::size_t>(y) * width + start) * 3 + channel;
+                        const auto destination_offset =
+                            (static_cast<std::size_t>(y) * target_width + x) * 3 + channel;
+                        horizontal[destination_offset] = fixed_point_pixel(
+                            raw + source_offset, 3, coefficients, count, weights.precision);
+                    }
+                }
+            }
+        });
+        vertical_source = horizontal.data();
+    }
+
+    if (height == target_height)
+        return horizontal;
+
+    const auto weights = make_bicubic_antialias_weights(height, target_height);
+    std::vector<unsigned char> resized(static_cast<std::size_t>(target_height) * target_width * 3);
+    const int32_t row_stride = target_width * 3;
+    parallel_for_ranges(target_height, 16, [&](int32_t begin_y, int32_t end_y) {
+        for (int32_t y = begin_y; y < end_y; ++y) {
+            const int32_t start = weights.starts[static_cast<std::size_t>(y)];
+            const int32_t count = weights.sizes[static_cast<std::size_t>(y)];
+            const int16_t* coefficients =
+                weights.values.data() + static_cast<std::size_t>(y) * weights.stride;
+            for (int32_t x = 0; x < target_width; ++x) {
+                for (int32_t channel = 0; channel < 3; ++channel) {
+                    const auto source_offset =
+                        (static_cast<std::size_t>(start) * target_width + x) * 3 + channel;
+                    const auto destination_offset =
+                        (static_cast<std::size_t>(y) * target_width + x) * 3 + channel;
+                    resized[destination_offset] =
+                        fixed_point_pixel(vertical_source + source_offset, row_stride, coefficients,
+                                          count, weights.precision);
+                }
+            }
+        }
+    });
+    return resized;
+}
+
 // Convert resized uint8 HWC buffer to float32 CHW, normalizing per channel.
 static bool normalize_to_chw(const std::vector<unsigned char>& resized, int target_width,
                              int target_height, const QwenVlPreprocessConfig& config,
                              std::vector<float>& out_chw) {
-    ImageNormalizationParams params;
-    params.width = target_width;
-    params.height = target_height;
-    params.channels = config.in_channels;
-    params.image_mean[0] = config.image_mean[0];
-    params.image_mean[1] = config.image_mean[1];
-    params.image_mean[2] = config.image_mean[2];
-    params.image_std[0] = config.image_std[0];
-    params.image_std[1] = config.image_std[1];
-    params.image_std[2] = config.image_std[2];
-    return normalize_hwc_u8_to_chw(resized, params, out_chw);
+    if (target_width <= 0 || target_height <= 0 || config.in_channels <= 0 ||
+        config.in_channels > 3) {
+        return false;
+    }
+    const std::size_t pixel_count = static_cast<std::size_t>(target_width) * target_height;
+    const std::size_t required_size = pixel_count * config.in_channels;
+    if (resized.size() < required_size)
+        return false;
+
+    out_chw.resize(required_size);
+    parallel_for_ranges(
+        config.in_channels * target_height, 16, [&](int32_t begin_row, int32_t end_row) {
+            for (int32_t row = begin_row; row < end_row; ++row) {
+                const int32_t channel = row / target_height;
+                const int32_t y = row % target_height;
+                const float mean = config.image_mean[channel];
+                const float standard_deviation = config.image_std[channel];
+                const float inverse_standard_deviation =
+                    standard_deviation > 1.0e-8F ? 1.0F / standard_deviation : 1.0F;
+                const std::size_t source_row =
+                    static_cast<std::size_t>(y) * target_width * config.in_channels + channel;
+                const std::size_t destination_row =
+                    static_cast<std::size_t>(channel) * pixel_count +
+                    static_cast<std::size_t>(y) * target_width;
+                for (int32_t x = 0; x < target_width; ++x) {
+                    const float pixel =
+                        static_cast<float>(resized[source_row + static_cast<std::size_t>(x) *
+                                                                    config.in_channels]) /
+                        255.0F;
+                    out_chw[destination_row + x] = (pixel - mean) * inverse_standard_deviation;
+                }
+            }
+        });
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +384,40 @@ static LoadedImage load_resize_normalize(const runtime::adapters::io::DecodedIma
     }
     loaded.target_height = dst_h;
     loaded.target_width = dst_w;
+    loaded.channels = config.in_channels;
+    loaded.ok = true;
+    return loaded;
+}
+
+static LoadedImage load_smart_resize_normalize(const runtime::adapters::io::DecodedImage& image,
+                                               const QwenVlPreprocessConfig& config) {
+    LoadedImage loaded;
+    if (image.empty()) {
+        std::cerr << "[trtmc] Failed to preprocess smart-resized image: decoded image missing"
+                  << std::endl;
+        return loaded;
+    }
+    std::array<int32_t, 2> target{};
+    try {
+        target =
+            qwen_vl_smart_resize(image.height, image.width, config.patch_size * config.merge_size,
+                                 config.min_pixels, config.max_pixels);
+    } catch (const std::invalid_argument& error) {
+        std::cerr << "[trtmc] Failed to smart-resize Qwen-VL image: " << error.what() << std::endl;
+        return loaded;
+    }
+    auto resized = config.interpolation == "bicubic"
+                       ? qwen_vl_resize_bicubic_antialias_u8(image.pixels.data(), image.width,
+                                                             image.height, target[1], target[0])
+                       : resize_raw(image.pixels.data(), image.width, image.height, target[1],
+                                    target[0], resolve_stbir_filter(config.interpolation));
+    if (resized.empty() ||
+        !normalize_to_chw(resized, target[1], target[0], config, loaded.img_chw)) {
+        std::cerr << "[trtmc] Failed to resize or normalize Qwen-VL image" << std::endl;
+        return loaded;
+    }
+    loaded.target_height = target[0];
+    loaded.target_width = target[1];
     loaded.channels = config.in_channels;
     loaded.ok = true;
     return loaded;
@@ -381,6 +685,205 @@ static QwenVlPreprocessedImage preprocess_patchify_chw(const LoadedImage& loaded
     return result;
 }
 
+static std::vector<int32_t> build_dynamic_window_order(int32_t grid_h, int32_t grid_w,
+                                                       const QwenVlPreprocessConfig& config,
+                                                       QwenVlPreprocessedImage& result) {
+    const int32_t merged_h = grid_h / config.merge_size;
+    const int32_t merged_w = grid_w / config.merge_size;
+    const int32_t window_groups = config.vision_window_size / config.merge_size / config.patch_size;
+    const int32_t windows_h = (merged_h + window_groups - 1) / window_groups;
+    const int32_t windows_w = (merged_w + window_groups - 1) / window_groups;
+    const int32_t num_groups = merged_h * merged_w;
+    result.vision_window_indices.reserve(static_cast<std::size_t>(num_groups));
+    result.vision_reverse_indices.resize(static_cast<std::size_t>(num_groups));
+    std::vector<int32_t> group_counts;
+    group_counts.reserve(static_cast<std::size_t>(windows_h * windows_w));
+    for (int32_t window_h = 0; window_h < windows_h; ++window_h) {
+        for (int32_t window_w = 0; window_w < windows_w; ++window_w) {
+            int32_t count = 0;
+            for (int32_t local_h = 0; local_h < window_groups; ++local_h) {
+                for (int32_t local_w = 0; local_w < window_groups; ++local_w) {
+                    const int32_t row = window_h * window_groups + local_h;
+                    const int32_t col = window_w * window_groups + local_w;
+                    if (row >= merged_h || col >= merged_w)
+                        continue;
+                    const int32_t group = row * merged_w + col;
+                    result.vision_reverse_indices[static_cast<std::size_t>(group)] =
+                        static_cast<int32_t>(result.vision_window_indices.size());
+                    result.vision_window_indices.push_back(group);
+                    ++count;
+                }
+            }
+            if (count > 0)
+                group_counts.push_back(count);
+        }
+    }
+    return group_counts;
+}
+
+static void build_dynamic_vision_rope(int32_t merged_w, const QwenVlPreprocessConfig& config,
+                                      QwenVlPreprocessedImage& result) {
+    const int32_t head_dim = config.vision_embed_dim / config.vision_num_heads;
+    const int32_t half_head_dim = head_dim / 2;
+    const int32_t axis_frequencies = half_head_dim / 2;
+    const int32_t merge = config.merge_size;
+    const std::size_t patch_count =
+        result.vision_window_indices.size() * static_cast<std::size_t>(merge * merge);
+    result.vision_rope_half_dim = half_head_dim;
+    result.vision_cos_half.reserve(patch_count * static_cast<std::size_t>(half_head_dim));
+    result.vision_sin_half.reserve(patch_count * static_cast<std::size_t>(half_head_dim));
+
+    // RoPE values depend only on the spatial position and frequency. A large
+    // document can contain tens of thousands of patches but only a few
+    // hundred distinct row/column positions. Compute each position/frequency
+    // pair once instead of repeating pow/cos/sin for every patch.
+    int32_t max_group_h = -1;
+    int32_t max_group_w = -1;
+    for (const int32_t group : result.vision_window_indices) {
+        max_group_h = std::max(max_group_h, group / merged_w);
+        max_group_w = std::max(max_group_w, group % merged_w);
+    }
+    const int32_t position_count_h = (max_group_h + 1) * merge;
+    const int32_t position_count_w = (max_group_w + 1) * merge;
+
+    const auto build_axis_cache = [&](int32_t position_count) {
+        std::pair<std::vector<float>, std::vector<float>> cache;
+        cache.first.resize(static_cast<std::size_t>(position_count) * axis_frequencies);
+        cache.second.resize(static_cast<std::size_t>(position_count) * axis_frequencies);
+        for (int32_t position = 0; position < position_count; ++position) {
+            for (int32_t frequency = 0; frequency < axis_frequencies; ++frequency) {
+                const double exponent = static_cast<double>(2 * frequency) / half_head_dim;
+                const double angle = position / std::pow(config.vision_rope_theta, exponent);
+                const std::size_t offset =
+                    static_cast<std::size_t>(position) * axis_frequencies + frequency;
+                cache.first[offset] = static_cast<float>(std::cos(angle));
+                cache.second[offset] = static_cast<float>(std::sin(angle));
+            }
+        }
+        return cache;
+    };
+    const auto height_cache = build_axis_cache(position_count_h);
+    const auto width_cache = build_axis_cache(position_count_w);
+
+    for (const int32_t group : result.vision_window_indices) {
+        const int32_t group_h = group / merged_w;
+        const int32_t group_w = group % merged_w;
+        for (int32_t merge_h = 0; merge_h < merge; ++merge_h) {
+            for (int32_t merge_w = 0; merge_w < merge; ++merge_w) {
+                const int32_t position_h = group_h * merge + merge_h;
+                const int32_t position_w = group_w * merge + merge_w;
+                for (const auto& [position, cache] :
+                     {std::pair{position_h, &height_cache}, std::pair{position_w, &width_cache}}) {
+                    const std::size_t begin = static_cast<std::size_t>(position) * axis_frequencies;
+                    result.vision_cos_half.insert(result.vision_cos_half.end(),
+                                                  cache->first.begin() + begin,
+                                                  cache->first.begin() + begin + axis_frequencies);
+                    result.vision_sin_half.insert(result.vision_sin_half.end(),
+                                                  cache->second.begin() + begin,
+                                                  cache->second.begin() + begin + axis_frequencies);
+                }
+            }
+        }
+    }
+}
+
+static void build_dynamic_window_padding(const std::vector<int32_t>& group_counts,
+                                         const QwenVlPreprocessConfig& config,
+                                         QwenVlPreprocessedImage& result) {
+    const int32_t merge_unit = config.merge_size * config.merge_size;
+    const int32_t window_groups = config.vision_window_size / config.merge_size / config.patch_size;
+    const int32_t patches_per_window = window_groups * window_groups * merge_unit;
+    result.vision_window_count = static_cast<int32_t>(group_counts.size());
+    result.vision_patches_per_window = patches_per_window;
+    int32_t compact_offset = 0;
+    for (const int32_t groups : group_counts) {
+        const int32_t real_patches = groups * merge_unit;
+        const int32_t padded_offset =
+            static_cast<int32_t>(result.vision_padded_window_indices.size());
+        for (int32_t patch = 0; patch < patches_per_window; ++patch) {
+            const bool real = patch < real_patches;
+            result.vision_padded_window_indices.push_back(compact_offset + (real ? patch : 0));
+            result.vision_window_mask.push_back(real ? 0.0F : -1.0e9F);
+            if (real)
+                result.vision_compact_window_indices.push_back(padded_offset + patch);
+        }
+        compact_offset += real_patches;
+    }
+}
+
+static QwenVlPreprocessedImage
+preprocess_qwen_smart_resize_patchify(const LoadedImage& loaded,
+                                      const QwenVlPreprocessConfig& config) {
+    QwenVlPreprocessedImage result;
+    const int32_t patch = config.patch_size;
+    const int32_t merge = config.merge_size;
+    const int32_t grid_h = loaded.target_height / patch;
+    const int32_t grid_w = loaded.target_width / patch;
+    if (patch <= 0 || merge <= 0 || grid_h % merge || grid_w % merge ||
+        config.temporal_patch_size <= 0 || config.vision_num_heads <= 0 ||
+        config.vision_embed_dim % config.vision_num_heads) {
+        std::cerr << "[trtmc] Invalid dynamic Qwen-VL patch configuration" << std::endl;
+        return result;
+    }
+
+    const int32_t patch_vector = loaded.channels * config.temporal_patch_size * patch * patch;
+    const int32_t num_patches = grid_h * grid_w;
+    result.pixel_values.resize(static_cast<std::size_t>(num_patches) * patch_vector);
+    const int32_t group_rows = grid_h / merge;
+    const int32_t group_columns = grid_w / merge;
+    parallel_for_ranges(group_rows, 2, [&](int32_t begin_group_h, int32_t end_group_h) {
+        for (int32_t group_h = begin_group_h; group_h < end_group_h; ++group_h) {
+            for (int32_t group_w = 0; group_w < group_columns; ++group_w) {
+                for (int32_t merge_h = 0; merge_h < merge; ++merge_h) {
+                    for (int32_t merge_w = 0; merge_w < merge; ++merge_w) {
+                        const std::size_t patch_index =
+                            ((static_cast<std::size_t>(group_h) * group_columns + group_w) * merge +
+                             merge_h) *
+                                merge +
+                            merge_w;
+                        float* patch_destination =
+                            result.pixel_values.data() + patch_index * patch_vector;
+                        for (int32_t channel = 0; channel < loaded.channels; ++channel) {
+                            for (int32_t temporal = 0; temporal < config.temporal_patch_size;
+                                 ++temporal) {
+                                for (int32_t patch_h = 0; patch_h < patch; ++patch_h) {
+                                    const int32_t source_h =
+                                        (group_h * merge + merge_h) * patch + patch_h;
+                                    const int32_t source_w = (group_w * merge + merge_w) * patch;
+                                    const std::size_t source =
+                                        (static_cast<std::size_t>(channel) * loaded.target_height +
+                                         source_h) *
+                                            loaded.target_width +
+                                        source_w;
+                                    const std::size_t destination =
+                                        ((static_cast<std::size_t>(channel) *
+                                              config.temporal_patch_size +
+                                          temporal) *
+                                             patch +
+                                         patch_h) *
+                                        patch;
+                                    std::copy_n(loaded.img_chw.data() + source, patch,
+                                                patch_destination + destination);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    result.image_grid_hws = {grid_h, grid_w};
+    result.channels = patch_vector;
+    result.height = loaded.target_height;
+    result.width = loaded.target_width;
+    const auto group_counts = build_dynamic_window_order(grid_h, grid_w, config, result);
+    build_dynamic_vision_rope(grid_w / merge, config, result);
+    build_dynamic_window_padding(group_counts, config, result);
+    result.ok = true;
+    return result;
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -398,6 +901,8 @@ struct PreprocessDispatch {
 };
 
 static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preprocessor_type) {
+    if (preprocessor_type == "qwen_smart_resize_patchify")
+        return {load_smart_resize_normalize, preprocess_qwen_smart_resize_patchify, false};
     if (preprocessor_type == "aspect_preserve_merge_group_chw")
         return {load_aspect_preserve_resize_normalize, preprocess_merge_group_chw, false};
     if (preprocessor_type == "center_crop_chw")
@@ -467,12 +972,13 @@ QwenVlPreprocessedImage qwen_vl_load_and_preprocess_image(const std::string& ima
 }
 
 std::string qwen_vl_format_prompt(const std::string& user_prompt,
-                                  const QwenVlPreprocessConfig& config) {
+                                  const QwenVlPreprocessConfig& config, int32_t image_pad_tokens) {
     // Build image_pads string: repeat image_token_str num_image_pad_tokens times
     std::string image_pads;
-    image_pads.reserve(static_cast<std::size_t>(config.num_image_pad_tokens) *
-                       config.image_token_str.size());
-    for (int32_t i = 0; i < config.num_image_pad_tokens; ++i) {
+    const int32_t pad_count =
+        image_pad_tokens >= 0 ? image_pad_tokens : config.num_image_pad_tokens;
+    image_pads.reserve(static_cast<std::size_t>(pad_count) * config.image_token_str.size());
+    for (int32_t i = 0; i < pad_count; ++i) {
         image_pads += config.image_token_str;
     }
 
@@ -567,6 +1073,16 @@ static void parse_base_vl_config(const std::string& config_text, QwenVlPreproces
         extract_json_int(config_text, "temporal_patch_size", cfg.temporal_patch_size);
     cfg.num_image_pad_tokens = extract_json_int(config_text, "num_image_pad_tokens", 256);
     cfg.vision_output_dim = extract_json_int(config_text, "vision_output_dim", 0);
+    cfg.dynamic_image_resolution =
+        extract_json_bool(config_text, "dynamic_image_resolution", false);
+    cfg.vision_embed_dim = extract_json_int(config_text, "vision_embed_dim", cfg.vision_embed_dim);
+    cfg.vision_num_heads = extract_json_int(config_text, "vision_num_heads", cfg.vision_num_heads);
+    cfg.vision_window_size =
+        extract_json_int(config_text, "vision_window_size", cfg.vision_window_size);
+    cfg.vision_rope_theta =
+        extract_json_float(config_text, "vision_rope_theta", cfg.vision_rope_theta);
+    cfg.min_pixels = extract_json_int(config_text, "min_pixels", cfg.min_pixels);
+    cfg.max_pixels = extract_json_int(config_text, "max_pixels", cfg.max_pixels);
     cfg.vl_prompt_template = extract_json_string(config_text, "vl_prompt_template", "");
     cfg.image_token_str = extract_json_string(config_text, "image_token_str", "");
     cfg.interpolation = extract_json_string(config_text, "interpolation", "bicubic");
@@ -598,6 +1114,8 @@ static void apply_preprocessor_config_overrides(const std::string& config_text,
     cfg.patch_size = extract_json_int(preprocessor_config_text, "patch_size", 14);
     cfg.merge_size = extract_json_int(preprocessor_config_text, "merge_size", 2);
     cfg.temporal_patch_size = extract_json_int(preprocessor_config_text, "temporal_patch_size", 2);
+    cfg.min_pixels = extract_json_int(preprocessor_config_text, "min_pixels", cfg.min_pixels);
+    cfg.max_pixels = extract_json_int(preprocessor_config_text, "max_pixels", cfg.max_pixels);
 
     auto mean_vals = extract_json_float_array(preprocessor_config_text, "image_mean", 3);
     assign_image_norm_triplet(mean_vals, cfg.image_mean);

--- a/src/runtime/models/qwen_vl/image_preprocessor.cpp
+++ b/src/runtime/models/qwen_vl/image_preprocessor.cpp
@@ -171,25 +171,17 @@ static double keys_cubic(double x) {
     return 0.0;
 }
 
-static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32_t output_size) {
-    constexpr int32_t interp_size = 4;
-    const double scale = static_cast<double>(input_size) / output_size;
-    const double support = scale >= 1.0 ? (interp_size * 0.5) * scale : interp_size * 0.5;
-    const int32_t kernel_size = static_cast<int32_t>(std::ceil(support)) * 2 + 1;
+static int32_t aligned_coefficient_stride(int32_t kernel_size) {
+    int32_t stride = kernel_size;
+    while (stride % static_cast<int32_t>(sizeof(int32_t)) != 0)
+        ++stride;
+    return stride;
+}
 
-    // PyTorch pads each int16 coefficient row to a 32-bit-aligned size in its
-    // optimized uint8 path. The padding does not participate in convolution.
-    int32_t coefficient_stride = kernel_size;
-    while (coefficient_stride % static_cast<int32_t>(sizeof(int32_t)) != 0)
-        ++coefficient_stride;
-
-    AntialiasWeights result;
-    result.starts.resize(static_cast<std::size_t>(output_size));
-    result.sizes.resize(static_cast<std::size_t>(output_size));
-    result.values.assign(static_cast<std::size_t>(output_size) * coefficient_stride, 0);
-    result.stride = coefficient_stride;
-
-    std::vector<double> floating(static_cast<std::size_t>(output_size) * kernel_size, 0.0);
+static double build_floating_antialias_weights(int32_t input_size, int32_t output_size,
+                                               double scale, double support, int32_t kernel_size,
+                                               AntialiasWeights& result,
+                                               std::vector<double>& floating) {
     double maximum_weight = 0.0;
     for (int32_t output_index = 0; output_index < output_size; ++output_index) {
         const double center = scale * (output_index + 0.5);
@@ -214,7 +206,12 @@ static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32
             }
         }
     }
+    return maximum_weight;
+}
 
+static void quantize_antialias_weights(const std::vector<double>& floating, int32_t output_size,
+                                       int32_t kernel_size, double maximum_weight,
+                                       AntialiasWeights& result) {
     // Select the greatest fixed-point precision whose largest coefficient fits
     // in int16, exactly as PyTorch's uint8 antialias implementation does.
     for (; result.precision < 22; ++result.precision) {
@@ -229,7 +226,7 @@ static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32
         const double* source =
             floating.data() + static_cast<std::size_t>(output_index) * kernel_size;
         int16_t* destination =
-            result.values.data() + static_cast<std::size_t>(output_index) * coefficient_stride;
+            result.values.data() + static_cast<std::size_t>(output_index) * result.stride;
         for (int32_t index = 0; index < kernel_size; ++index) {
             const double value = source[index] * multiplier;
             destination[index] =
@@ -237,6 +234,26 @@ static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32
                                                  : static_cast<int32_t>(value + 0.5));
         }
     }
+}
+
+static AntialiasWeights make_bicubic_antialias_weights(int32_t input_size, int32_t output_size) {
+    constexpr int32_t interp_size = 4;
+    const double scale = static_cast<double>(input_size) / output_size;
+    const double support = scale >= 1.0 ? (interp_size * 0.5) * scale : interp_size * 0.5;
+    const int32_t kernel_size = static_cast<int32_t>(std::ceil(support)) * 2 + 1;
+
+    // PyTorch pads each int16 coefficient row to a 32-bit-aligned size in its
+    // optimized uint8 path. The padding does not participate in convolution.
+    AntialiasWeights result;
+    result.stride = aligned_coefficient_stride(kernel_size);
+    result.starts.resize(static_cast<std::size_t>(output_size));
+    result.sizes.resize(static_cast<std::size_t>(output_size));
+    result.values.assign(static_cast<std::size_t>(output_size) * result.stride, 0);
+
+    std::vector<double> floating(static_cast<std::size_t>(output_size) * kernel_size, 0.0);
+    const double maximum_weight = build_floating_antialias_weights(
+        input_size, output_size, scale, support, kernel_size, result, floating);
+    quantize_antialias_weights(floating, output_size, kernel_size, maximum_weight, result);
     return result;
 }
 
@@ -249,11 +266,67 @@ static uint8_t fixed_point_pixel(const uint8_t* source, int32_t source_stride,
     return static_cast<uint8_t>(std::clamp(value >> precision, 0, 255));
 }
 
+static bool valid_resize_dimensions(const unsigned char* raw, int32_t width, int32_t height,
+                                    int32_t target_width, int32_t target_height) {
+    return raw != nullptr && width > 0 && height > 0 && target_width > 0 && target_height > 0;
+}
+
+static std::vector<unsigned char> resize_bicubic_horizontal(const unsigned char* raw, int32_t width,
+                                                            int32_t height, int32_t target_width) {
+    const auto weights = make_bicubic_antialias_weights(width, target_width);
+    std::vector<unsigned char> resized(static_cast<std::size_t>(height) * target_width * 3);
+    parallel_for_ranges(height, 16, [&](int32_t begin_y, int32_t end_y) {
+        for (int32_t y = begin_y; y < end_y; ++y) {
+            for (int32_t x = 0; x < target_width; ++x) {
+                const int32_t start = weights.starts[static_cast<std::size_t>(x)];
+                const int32_t count = weights.sizes[static_cast<std::size_t>(x)];
+                const int16_t* coefficients =
+                    weights.values.data() + static_cast<std::size_t>(x) * weights.stride;
+                for (int32_t channel = 0; channel < 3; ++channel) {
+                    const auto source_offset =
+                        (static_cast<std::size_t>(y) * width + start) * 3 + channel;
+                    const auto destination_offset =
+                        (static_cast<std::size_t>(y) * target_width + x) * 3 + channel;
+                    resized[destination_offset] = fixed_point_pixel(
+                        raw + source_offset, 3, coefficients, count, weights.precision);
+                }
+            }
+        }
+    });
+    return resized;
+}
+
+static std::vector<unsigned char> resize_bicubic_vertical(const unsigned char* raw, int32_t width,
+                                                          int32_t height, int32_t target_height) {
+    const auto weights = make_bicubic_antialias_weights(height, target_height);
+    std::vector<unsigned char> resized(static_cast<std::size_t>(target_height) * width * 3);
+    const int32_t row_stride = width * 3;
+    parallel_for_ranges(target_height, 16, [&](int32_t begin_y, int32_t end_y) {
+        for (int32_t y = begin_y; y < end_y; ++y) {
+            const int32_t start = weights.starts[static_cast<std::size_t>(y)];
+            const int32_t count = weights.sizes[static_cast<std::size_t>(y)];
+            const int16_t* coefficients =
+                weights.values.data() + static_cast<std::size_t>(y) * weights.stride;
+            for (int32_t x = 0; x < width; ++x) {
+                for (int32_t channel = 0; channel < 3; ++channel) {
+                    const auto source_offset =
+                        (static_cast<std::size_t>(start) * width + x) * 3 + channel;
+                    const auto destination_offset =
+                        (static_cast<std::size_t>(y) * width + x) * 3 + channel;
+                    resized[destination_offset] = fixed_point_pixel(
+                        raw + source_offset, row_stride, coefficients, count, weights.precision);
+                }
+            }
+        }
+    });
+    return resized;
+}
+
 std::vector<unsigned char> qwen_vl_resize_bicubic_antialias_u8(const unsigned char* raw,
                                                                int32_t width, int32_t height,
                                                                int32_t target_width,
                                                                int32_t target_height) {
-    if (raw == nullptr || width <= 0 || height <= 0 || target_width <= 0 || target_height <= 0)
+    if (!valid_resize_dimensions(raw, width, height, target_width, target_height))
         return {};
     if (width == target_width && height == target_height) {
         return {raw, raw + static_cast<std::size_t>(width) * height * 3};
@@ -262,55 +335,14 @@ std::vector<unsigned char> qwen_vl_resize_bicubic_antialias_u8(const unsigned ch
     std::vector<unsigned char> horizontal;
     const unsigned char* vertical_source = raw;
     if (width != target_width) {
-        const auto weights = make_bicubic_antialias_weights(width, target_width);
-        horizontal.resize(static_cast<std::size_t>(height) * target_width * 3);
-        parallel_for_ranges(height, 16, [&](int32_t begin_y, int32_t end_y) {
-            for (int32_t y = begin_y; y < end_y; ++y) {
-                for (int32_t x = 0; x < target_width; ++x) {
-                    const int32_t start = weights.starts[static_cast<std::size_t>(x)];
-                    const int32_t count = weights.sizes[static_cast<std::size_t>(x)];
-                    const int16_t* coefficients =
-                        weights.values.data() + static_cast<std::size_t>(x) * weights.stride;
-                    for (int32_t channel = 0; channel < 3; ++channel) {
-                        const auto source_offset =
-                            (static_cast<std::size_t>(y) * width + start) * 3 + channel;
-                        const auto destination_offset =
-                            (static_cast<std::size_t>(y) * target_width + x) * 3 + channel;
-                        horizontal[destination_offset] = fixed_point_pixel(
-                            raw + source_offset, 3, coefficients, count, weights.precision);
-                    }
-                }
-            }
-        });
+        horizontal = resize_bicubic_horizontal(raw, width, height, target_width);
         vertical_source = horizontal.data();
     }
 
     if (height == target_height)
         return horizontal;
 
-    const auto weights = make_bicubic_antialias_weights(height, target_height);
-    std::vector<unsigned char> resized(static_cast<std::size_t>(target_height) * target_width * 3);
-    const int32_t row_stride = target_width * 3;
-    parallel_for_ranges(target_height, 16, [&](int32_t begin_y, int32_t end_y) {
-        for (int32_t y = begin_y; y < end_y; ++y) {
-            const int32_t start = weights.starts[static_cast<std::size_t>(y)];
-            const int32_t count = weights.sizes[static_cast<std::size_t>(y)];
-            const int16_t* coefficients =
-                weights.values.data() + static_cast<std::size_t>(y) * weights.stride;
-            for (int32_t x = 0; x < target_width; ++x) {
-                for (int32_t channel = 0; channel < 3; ++channel) {
-                    const auto source_offset =
-                        (static_cast<std::size_t>(start) * target_width + x) * 3 + channel;
-                    const auto destination_offset =
-                        (static_cast<std::size_t>(y) * target_width + x) * 3 + channel;
-                    resized[destination_offset] =
-                        fixed_point_pixel(vertical_source + source_offset, row_stride, coefficients,
-                                          count, weights.precision);
-                }
-            }
-        }
-    });
-    return resized;
+    return resize_bicubic_vertical(vertical_source, target_width, height, target_height);
 }
 
 // Convert resized uint8 HWC buffer to float32 CHW, normalizing per channel.
@@ -811,17 +843,56 @@ static void build_dynamic_window_padding(const std::vector<int32_t>& group_count
     }
 }
 
+static bool valid_dynamic_patch_config(const LoadedImage& loaded,
+                                       const QwenVlPreprocessConfig& config) {
+    return config.patch_size > 0 && config.merge_size > 0 && config.temporal_patch_size > 0 &&
+           config.vision_num_heads > 0 && config.vision_embed_dim % config.vision_num_heads == 0 &&
+           loaded.channels > 0;
+}
+
+static void copy_dynamic_patch(const LoadedImage& loaded, const QwenVlPreprocessConfig& config,
+                               int32_t group_columns, int32_t group_h, int32_t group_w,
+                               int32_t merge_h, int32_t merge_w, int32_t patch_vector,
+                               std::vector<float>& destination) {
+    const int32_t patch = config.patch_size;
+    const int32_t merge = config.merge_size;
+    const std::size_t patch_index =
+        ((static_cast<std::size_t>(group_h) * group_columns + group_w) * merge + merge_h) * merge +
+        merge_w;
+    float* patch_destination = destination.data() + patch_index * patch_vector;
+    for (int32_t channel = 0; channel < loaded.channels; ++channel) {
+        for (int32_t temporal = 0; temporal < config.temporal_patch_size; ++temporal) {
+            for (int32_t patch_h = 0; patch_h < patch; ++patch_h) {
+                const int32_t source_h = (group_h * merge + merge_h) * patch + patch_h;
+                const int32_t source_w = (group_w * merge + merge_w) * patch;
+                const std::size_t source =
+                    (static_cast<std::size_t>(channel) * loaded.target_height + source_h) *
+                        loaded.target_width +
+                    source_w;
+                const std::size_t target =
+                    ((static_cast<std::size_t>(channel) * config.temporal_patch_size + temporal) *
+                         patch +
+                     patch_h) *
+                    patch;
+                std::copy_n(loaded.img_chw.data() + source, patch, patch_destination + target);
+            }
+        }
+    }
+}
+
 static QwenVlPreprocessedImage
 preprocess_qwen_smart_resize_patchify(const LoadedImage& loaded,
                                       const QwenVlPreprocessConfig& config) {
     QwenVlPreprocessedImage result;
     const int32_t patch = config.patch_size;
     const int32_t merge = config.merge_size;
+    if (!valid_dynamic_patch_config(loaded, config)) {
+        std::cerr << "[trtmc] Invalid dynamic Qwen-VL patch configuration" << std::endl;
+        return result;
+    }
     const int32_t grid_h = loaded.target_height / patch;
     const int32_t grid_w = loaded.target_width / patch;
-    if (patch <= 0 || merge <= 0 || grid_h % merge || grid_w % merge ||
-        config.temporal_patch_size <= 0 || config.vision_num_heads <= 0 ||
-        config.vision_embed_dim % config.vision_num_heads) {
+    if (grid_h % merge != 0 || grid_w % merge != 0) {
         std::cerr << "[trtmc] Invalid dynamic Qwen-VL patch configuration" << std::endl;
         return result;
     }
@@ -836,37 +907,8 @@ preprocess_qwen_smart_resize_patchify(const LoadedImage& loaded,
             for (int32_t group_w = 0; group_w < group_columns; ++group_w) {
                 for (int32_t merge_h = 0; merge_h < merge; ++merge_h) {
                     for (int32_t merge_w = 0; merge_w < merge; ++merge_w) {
-                        const std::size_t patch_index =
-                            ((static_cast<std::size_t>(group_h) * group_columns + group_w) * merge +
-                             merge_h) *
-                                merge +
-                            merge_w;
-                        float* patch_destination =
-                            result.pixel_values.data() + patch_index * patch_vector;
-                        for (int32_t channel = 0; channel < loaded.channels; ++channel) {
-                            for (int32_t temporal = 0; temporal < config.temporal_patch_size;
-                                 ++temporal) {
-                                for (int32_t patch_h = 0; patch_h < patch; ++patch_h) {
-                                    const int32_t source_h =
-                                        (group_h * merge + merge_h) * patch + patch_h;
-                                    const int32_t source_w = (group_w * merge + merge_w) * patch;
-                                    const std::size_t source =
-                                        (static_cast<std::size_t>(channel) * loaded.target_height +
-                                         source_h) *
-                                            loaded.target_width +
-                                        source_w;
-                                    const std::size_t destination =
-                                        ((static_cast<std::size_t>(channel) *
-                                              config.temporal_patch_size +
-                                          temporal) *
-                                             patch +
-                                         patch_h) *
-                                        patch;
-                                    std::copy_n(loaded.img_chw.data() + source, patch,
-                                                patch_destination + destination);
-                                }
-                            }
-                        }
+                        copy_dynamic_patch(loaded, config, group_columns, group_h, group_w, merge_h,
+                                           merge_w, patch_vector, result.pixel_values);
                     }
                 }
             }

--- a/src/runtime/models/qwen_vl/image_preprocessor.h
+++ b/src/runtime/models/qwen_vl/image_preprocessor.h
@@ -28,6 +28,13 @@ struct QwenVlPreprocessConfig {
     int32_t num_image_pad_tokens{256};
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
+    bool dynamic_image_resolution{false};
+    int32_t min_pixels{3136};
+    int32_t max_pixels{12845056};
+    int32_t vision_embed_dim{1280};
+    int32_t vision_num_heads{16};
+    int32_t vision_window_size{112};
+    float vision_rope_theta{10000.0F};
     std::string vl_prompt_template;
     std::string image_token_str;
     // Preprocessing strategy: "merge_group_chw", "simple_chw",
@@ -41,7 +48,17 @@ struct QwenVlPreprocessConfig {
 struct QwenVlPreprocessedImage {
     std::vector<float> pixel_values;     // Layout depends on preprocessor_type
     std::vector<int32_t> image_grid_hws; // [height, width] patch grid for patchified inputs
-    int32_t channels{0};                 // C*T for merge_group_chw, C for simple_chw
+    std::vector<float> vision_cos_half;
+    std::vector<float> vision_sin_half;
+    std::vector<int32_t> vision_window_indices;
+    std::vector<int32_t> vision_padded_window_indices;
+    std::vector<int32_t> vision_compact_window_indices;
+    std::vector<int32_t> vision_reverse_indices;
+    std::vector<float> vision_window_mask;
+    int32_t vision_window_count{0};
+    int32_t vision_patches_per_window{0};
+    int32_t vision_rope_half_dim{0};
+    int32_t channels{0}; // C*T for merge_group_chw, C for simple_chw
     int32_t height{0};
     int32_t width{0};
     bool ok{false};
@@ -51,6 +68,18 @@ struct QwenVlMropePositions {
     std::vector<std::array<int32_t, 3>> token_positions;
     int32_t next_position{0};
 };
+
+// Mirror Hugging Face Qwen2-VL smart_resize. Returned dimensions are aligned
+// to patch_size * merge_size and constrained by min/max pixel area.
+std::array<int32_t, 2> qwen_vl_smart_resize(int32_t image_height, int32_t image_width,
+                                            int32_t factor, int32_t min_pixels, int32_t max_pixels);
+
+// Resize HWC uint8 RGB pixels with the bicubic-antialias contract used by the
+// Hugging Face fast Qwen2-VL image processor.
+std::vector<unsigned char> qwen_vl_resize_bicubic_antialias_u8(const unsigned char* pixels,
+                                                               int32_t width, int32_t height,
+                                                               int32_t target_width,
+                                                               int32_t target_height);
 
 // Build Hugging Face-compatible Qwen2.5-VL temporal/height/width positions
 // for a single image. grid_height/grid_width are post-merge token dimensions.
@@ -83,7 +112,8 @@ QwenVlPreprocessedImage qwen_vl_load_and_preprocess_image(const std::string& ima
 // Format a VL prompt with image pad tokens from the template.
 // Replaces {image_pads} and {prompt} in vl_prompt_template.
 std::string qwen_vl_format_prompt(const std::string& user_prompt,
-                                  const QwenVlPreprocessConfig& config);
+                                  const QwenVlPreprocessConfig& config,
+                                  int32_t image_pad_tokens = -1);
 
 // Parse QwenVlPreprocessConfig from config.json text.
 QwenVlPreprocessConfig qwen_vl_parse_preprocess_config(const std::string& config_text,

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -447,6 +447,12 @@ Tensor make_pixel_values_tensor(const QwenVlPreprocessedImage& preprocessed,
             break;
         }
     }
+    if (pixel_t.shape.size() == 2 && preprocessed.image_grid_hws.size() >= 2 &&
+        preprocessed.channels > 0) {
+        const int64_t patches =
+            static_cast<int64_t>(preprocessed.image_grid_hws[0]) * preprocessed.image_grid_hws[1];
+        pixel_t.shape = {patches, preprocessed.channels};
+    }
     if (pixel_t.shape.empty())
         pixel_t.shape = {static_cast<int64_t>(preprocessed.pixel_values.size())};
     pixel_t.dtype = DType::kFloat32;
@@ -463,6 +469,38 @@ void add_image_grid_input(TensorMap& inputs, const QwenVlPreprocessedImage& prep
     grid_t.shape = {static_cast<int64_t>(preprocessed.image_grid_hws.size() / 2), 2};
     grid_t.dtype = DType::kInt32;
     inputs["image_grid_hws"] = grid_t;
+}
+
+void add_dynamic_vision_metadata(TensorMap& inputs, const QwenVlPreprocessedImage& preprocessed,
+                                 const TrtModule& encoder) {
+    const auto add_float = [&](const char* name, const std::vector<float>& values,
+                               std::vector<int64_t> shape) {
+        if (encoder.has_input(name)) {
+            inputs[name] =
+                Tensor{const_cast<float*>(values.data()), std::move(shape), DType::kFloat32};
+        }
+    };
+    const auto add_int = [&](const char* name, const std::vector<int32_t>& values) {
+        if (encoder.has_input(name)) {
+            inputs[name] = Tensor{const_cast<int32_t*>(values.data()),
+                                  {static_cast<int64_t>(values.size())},
+                                  DType::kInt32};
+        }
+    };
+    const int64_t patches =
+        preprocessed.image_grid_hws.size() >= 2
+            ? static_cast<int64_t>(preprocessed.image_grid_hws[0]) * preprocessed.image_grid_hws[1]
+            : 0;
+    add_float("vision_cos_half", preprocessed.vision_cos_half,
+              {patches, preprocessed.vision_rope_half_dim});
+    add_float("vision_sin_half", preprocessed.vision_sin_half,
+              {patches, preprocessed.vision_rope_half_dim});
+    add_int("vision_window_indices", preprocessed.vision_window_indices);
+    add_int("vision_padded_window_indices", preprocessed.vision_padded_window_indices);
+    add_int("vision_compact_window_indices", preprocessed.vision_compact_window_indices);
+    add_int("vision_reverse_indices", preprocessed.vision_reverse_indices);
+    add_float("vision_window_mask", preprocessed.vision_window_mask,
+              {preprocessed.vision_window_count, 1, 1, preprocessed.vision_patches_per_window});
 }
 
 bool copy_float_output(const TensorMap& outputs, const std::string& name,
@@ -568,7 +606,7 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
     int32_t nf = static_cast<int32_t>(features.size() / static_cast<std::size_t>(dim));
 
     // Format prompt, tokenize, generate with vision features
-    auto input_ids = tokenizer_->encode(qwen_vl_format_prompt(prompt, vl_preprocess_));
+    auto input_ids = tokenizer_->encode(qwen_vl_format_prompt(prompt, vl_preprocess_, nf));
     auto [max_new, eos] = resolve_gen_limits(cfg);
     auto sp_vl = qwen_vl_sampling_params_from_config(cfg, eos);
     auto out =
@@ -808,6 +846,7 @@ bool QwenVlPipeline::run_vision_encoder(const QwenVlPreprocessedImage& preproces
     TensorMap inputs;
     inputs["pixel_values"] = make_pixel_values_tensor(preprocessed, *vision_encoder_);
     add_image_grid_input(inputs, preprocessed, *vision_encoder_);
+    add_dynamic_vision_metadata(inputs, preprocessed, *vision_encoder_);
 
     auto outputs = vision_encoder_->forward(inputs);
 

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -1060,7 +1060,14 @@ static void test_vl_pool_isolates_concurrent_lora_selection() {
     cudaStreamDestroy(stream_b);
 }
 
+static void test_qwen_vl_smart_resize() {
+    const auto resized = trtmc::qwen_vl_smart_resize(1000, 2000, 28, 3136, 200704);
+    check(resized[0] == 308 && resized[1] == 616,
+          "smart_resize: preserves aspect ratio within the pixel limit");
+}
+
 int main() {
+    test_qwen_vl_smart_resize();
     test_vl_text_only();
     test_vl_text_only_max_tokens();
     test_vl_validates_decoder();


### PR DESCRIPTION
## Background

  Qwen2.5-VL normally uses smart resize to preserve image aspect ratio and select an image-token grid based on configurable pixel limits.

  The existing TMC vision path builds a fixed image profile, which forces every image into the same resolution and can produce a different vision-token layout from the Hugging Face processor.

  ## Exit Criteria

  - Support opt-in dynamic image resolution for Qwen2.5-VL.
  - Match the Qwen smart-resize dimension selection and patch ordering.
  - Build TensorRT optimization profiles for configurable minimum, optimum, and maximum image sizes.
  - Preserve the existing fixed-resolution behavior by default.
  - Bind runtime RoPE, window-attention metadata, and image pad counts to the actual resized input.
  - Do not change the Qwen3-VL vision path.

  ## Implementation

  - Added the following `qwen_vl_vision` build options:
    - `dynamic_resolution`
    - `min_pixels`
    - `opt_pixels`
    - `max_pixels`
  - Added Qwen-compatible smart resize and bicubic antialias preprocessing.
  - Added runtime patchification for dynamically sized images.
  - Added dynamic vision RoPE and window-attention inputs.
  - Added dynamic TensorRT profiles for patch rows and attention metadata.
  - Updated prompt construction to use the actual number of merged image tokens.
  - Kept fixed 448×448 vision profiles as the default for backward compatibility.

  ## Validation

  - Built the Qwen-VL C++ runtime and test target with TensorRT 11.2 on an L40S.
  - Passed the focused smart-resize test:
    - Input: `1000 × 2000`
    - Pixel limit: `200704`
    - Output: `308 × 616`
  - Passed 6 existing Qwen-VL Python tests.
  - Successfully built synthetic dynamic Qwen2.5-VL vision engines covering:
    - Full attention
    - Windowed attention