### PR TITLE
ci: add trusted internal CI dispatcher

### DIFF
--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: TensorRT-Model-Connect CI Dispatch
+
+run-name: >-
+  PR #${{ github.event.pull_request.number || inputs.pr_number }} · internal CI
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - labeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to test
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  authorize:
+    name: Authorize trusted trigger
+    if: >-
+      ${{
+        github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
+        github.ref == 'refs/heads/main' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          github.event.label.name == 'run-ci'
+        )
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.snapshot.outputs.pr_number }}
+      base_sha: ${{ steps.snapshot.outputs.base_sha }}
+      head_sha: ${{ steps.snapshot.outputs.head_sha }}
+      merge_sha: ${{ steps.snapshot.outputs.merge_sha }}
+
+    steps:
+      # This trusted workflow reads PR metadata only. It never checks out or
+      # executes the pull-request head or merge commit.
+      - name: Capture exact pull-request snapshot
+        id: snapshot
+        env:
+          ACTOR: ${{ github.triggering_actor }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Invalid pull request number"
+            exit 1
+          }
+
+          actor_permission="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
+              --jq '.permission'
+          )"
+          case "$actor_permission" in
+            write|admin) ;;
+            *)
+              echo "::error::Only actors with write, maintain, or admin access may dispatch CI."
+              exit 1
+              ;;
+          esac
+
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -er '.state' <<<"$pull")"
+          base_ref="$(jq -er '.base.ref' <<<"$pull")"
+          head_sha="$(jq -er '.head.sha' <<<"$pull")"
+          merge_sha="$(jq -er '.merge_commit_sha' <<<"$pull")"
+
+          test "$state" = "open"
+          test "$base_ref" = "main"
+          for sha in "$head_sha" "$merge_sha"; do
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::GitHub did not provide an exact pull-request snapshot"
+              exit 1
+            }
+          done
+
+          merge="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/git/commits/$merge_sha"
+          )"
+          parent_count="$(jq -er '.parents | length' <<<"$merge")"
+          test "$parent_count" -eq 2 || {
+            echo "::error::Expected a two-parent pull-request merge snapshot"
+            exit 1
+          }
+          base_sha="$(jq -er '.parents[0].sha' <<<"$merge")"
+          merge_head_sha="$(jq -er '.parents[1].sha' <<<"$merge")"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
+          test "$merge_head_sha" = "$head_sha" || {
+            echo "::error::Merge snapshot head does not match the pull-request head"
+            exit 1
+          }
+
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "base_sha=$base_sha"
+            echo "head_sha=$head_sha"
+            echo "merge_sha=$merge_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  dispatch:
+    name: Dispatch internal CI
+    needs: authorize
+    runs-on: ubuntu-24.04
+    environment: ci-dispatch
+    timeout-minutes: 5
+    concurrency:
+      group: trtmc-ci-dispatch-${{ needs.authorize.outputs.merge_sha }}
+      cancel-in-progress: false
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Mark internal CI pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            -f state=pending \
+            -f context="trtmc/premerge/required" \
+            -f description="PENDING: TensorRT-Model-Connect premerge" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"
+
+      - name: Dispatch exact snapshot
+        env:
+          BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+          GH_TOKEN: ${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          PRIVATE_CI_OWNER: ${{ secrets.TRTMC_PRIVATE_CI_OWNER }}
+          PRIVATE_CI_REPOSITORY: ${{ secrets.TRTMC_PRIVATE_CI_REPOSITORY }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PRIVATE_CI_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
+          [[ "$PRIVATE_CI_REPOSITORY" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$ ]]
+
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg base_sha "$BASE_SHA" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg merge_sha "$MERGE_SHA" \
+            '{
+              ref: "main",
+              inputs: {
+                pr_number: $pr_number,
+                base_sha: $base_sha,
+                head_sha: $head_sha,
+                merge_sha: $merge_sha
+              }
+            }' > "$RUNNER_TEMP/internal-ci-dispatch.json"
+
+          if ! gh api --silent --method POST \
+            "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches" \
+            --input "$RUNNER_TEMP/internal-ci-dispatch.json" \
+            >/dev/null 2>&1; then
+            echo "::error::Internal CI dispatch request failed"
+            exit 1
+          fi
+
+      - name: Mark dispatch failure
+        if: ${{ failure() || cancelled() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            -f state=failure \
+            -f context="trtmc/premerge/required" \
+            -f description="FAIL: internal CI dispatch failed" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"

--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -104,6 +104,15 @@ jobs:
             echo "::error::Merge snapshot head does not match the pull-request head"
             exit 1
           }
+          current_base_sha="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/commits/main" \
+              --jq '.sha'
+          )"
+          test "$base_sha" = "$current_base_sha" || {
+            echo "::error::GitHub has not refreshed the pull-request merge snapshot against current main"
+            exit 1
+          }
 
           {
             echo "pr_number=$PR_NUMBER"


### PR DESCRIPTION
## Background

Keep the existing Source premerge and nightly workflows running during the
shadow period while allowing trusted maintainers to dispatch an exact
pull-request snapshot to the internal CI repository.

## Exit criteria

- Existing Source workflows and test files remain unchanged.
- Only a write-, maintain-, or admin-level actor can trigger the internal run.
- The dispatcher never checks out or executes pull-request code.
- Internal CI receives the exact PR number, base SHA, head SHA, and GitHub
  merge SHA.
- Public output is limited to a fixed pending/failure status and a link to the
  tested Source tree.
- No token, routing value, private repository name, internal path, or raw
  internal log is emitted.

## Implementation

Adds one workflow, `.github/workflows/ci-dispatch.yml`:

- `run-ci` label and manual `workflow_dispatch` triggers.
- Permission check against the actual triggering actor.
- Fail-closed validation of an open PR targeting `main` and its two-parent
  merge snapshot.
- Dispatch through the protected `ci-dispatch` environment using named secrets
  only.
- Concurrency only after authorization, keyed by the validated merge SHA.
- Fixed sanitized commit-status reporting for dispatch state.

## Validation

- `actionlint .github/workflows/ci-dispatch.yml`
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q` - 91 passed
- `python3 tools/legal_headers.py --check` - 0 findings
- `git diff --cached --check`
- Sensitive-token, private-key, internal-path, hostname, checkout, and
  inherited-secret scan - no matches
- Live snapshot contract check confirmed that the merge commit parents match
  the current base SHA and PR head SHA.

## Rollout

This is a draft shadow-mode change. It does not remove or replace any existing
CI workflow and should not be merged until reviewed. After it reaches `main`, a
trusted maintainer can test it with the `run-ci` label or manual dispatch.
