### PR TITLE
test(ci): isolate model-proof allocator affinity

### DIFF
--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -206,6 +206,7 @@ def _fake_proof_environment(
     (tmp_path / "hf-cache" / "modules").mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
     env.pop("TRTMC_GPU_ID", None)
+    env.pop("TRTMC_GPU_SLOT_ID", None)
     env.update(
         {
             "PATH": f"{fake_bin}:{env['PATH']}",
@@ -3612,7 +3613,10 @@ def test_explicit_runner_gpu_must_be_in_the_configured_allowlist(tmp_path: Path)
 @pytest.mark.model_proof_allocator
 def test_four_shared_proofs_use_unique_slots_on_one_gpu(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("TRTMC_GPU_ID", "7")
+    monkeypatch.setenv("TRTMC_GPU_SLOT_ID", "3")
     processes: list[tuple[subprocess.Popen[str], Path, Path]] = []
     release_file = tmp_path / "release-four-shared"
     for index in range(4):


### PR DESCRIPTION
## Background

The model-proof allocator tests copied the runner environment but removed only
`TRTMC_GPU_ID`. Slot-based runners also inject `TRTMC_GPU_SLOT_ID`, so fake
proof subprocesses could inherit an incomplete or conflicting GPU affinity and
exit before acquiring their test lease. The tests then waited for their full
coordination timeout and reported a misleading lock failure.

## Exit Criteria

- Fake model-proof subprocesses do not inherit either runner GPU-affinity variable.
- The affected concurrent allocator cases pass when the parent environment contains both variables.
- The complete allocator test subset remains green.

## Implementation

- Remove `TRTMC_GPU_SLOT_ID` alongside `TRTMC_GPU_ID` when constructing a fake proof environment.
- Explicitly inject both variables in the shared-slot concurrency test so the runner-environment contract is covered deterministically.

## Validation

- `TRTMC_GPU_SLOT_ID=3 PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_proof_runner.py::test_four_shared_proofs_use_unique_slots_on_one_gpu tests/tools/test_model_proof_runner.py::test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared -q -x`: 2 passed.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_proof_runner.py -q -x -p no:cacheprovider -m model_proof_allocator`: 19 passed.
- `python3 -m ruff check tests/tools/test_model_proof_runner.py`: passed.
- `python3 tools/legal_headers.py --check --repo-root .`: passed with no findings.

## Notes For Future Readers

- This fixes test-process isolation only. It does not change allocator behavior, lease timeouts, or product passing criteria.
- The two observed CI failures surfaced in different concurrency cases because both used the same leaking helper.
