### PR TITLE
feat(byok): add family-owned TVM-FFI kernel slots

### DIFF
--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -34,6 +34,7 @@ __version__ = _get_version()
 _OPTIMIZED_ROUTING_INTERNAL_FIELDS = frozenset({
     "active_python_profile",
     "command",
+    "kernel",
     "model",
     "model_revision",
     "output",
@@ -118,6 +119,12 @@ def _cmd_build(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    kernel_path = getattr(args, "kernel", None)
+    if kernel_path and getattr(args, "rtx", False):
+        print("Error: --kernel requires the native TensorRT backend",
+              file=sys.stderr)
+        return 1
+
     # Optimized dispatch resolves the model family internally and scans only
     # that family's Builder folder. The current platform remains implicit; no
     # public API or CLI option is added for runtime selection.
@@ -128,12 +135,14 @@ def _cmd_build(args: argparse.Namespace) -> int:
         revision_kwargs = (
             {"model_revision": model_revision} if model_revision else {}
         )
-        optimized = _try_build_optimized_runtime(
-            args.model,
-            args.output,
-            _optimized_cli_public_options(args),
-            **revision_kwargs,
-        )
+        optimized = None
+        if kernel_path is None:
+            optimized = _try_build_optimized_runtime(
+                args.model,
+                args.output,
+                _optimized_cli_public_options(args),
+                **revision_kwargs,
+            )
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)
         if getattr(args, "verbose", False):
@@ -161,6 +170,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
                 traceback.print_exc()
             return 1
 
+    build_family = ""
     if not getattr(args, "_skip_profile_resolution", False):
         try:
             build_model_ref, build_family = _resolve_build_model_metadata(
@@ -183,6 +193,13 @@ def _cmd_build(args: argparse.Namespace) -> int:
         )
         if reexec_rc is not None:
             return reexec_rc
+
+    if kernel_path and not build_family:
+        _, build_family = _resolve_build_model_metadata(
+            build_model_ref,
+            method_name,
+            **revision_kwargs,
+        )
 
     from .parallel_config import ParallelConfig
 
@@ -243,6 +260,30 @@ def _cmd_build(args: argparse.Namespace) -> int:
             print(f"Error resolving config: {exc}", file=sys.stderr)
             return 1
         family_build_options = _resolved_config_values(resolved_bundle)
+
+    if kernel_path:
+        from .kernel_slots import (
+            activate_kernel_slot,
+            load_family_kernel_slots,
+            load_kernel_spec,
+        )
+
+        try:
+            spec = load_kernel_spec(kernel_path)
+            slots = {slot.id: slot for slot in load_family_kernel_slots(build_family)}
+            slot = slots.get(spec.slot)
+            if slot is None:
+                available = ", ".join(sorted(slots)) or "none"
+                raise ValueError(
+                    f"Model family {build_family!r} does not publish slot "
+                    f"{spec.slot!r}; available: {available}"
+                )
+            if slot.validate_build is not None:
+                slot.validate_build(args)
+            build = activate_kernel_slot(spec, slot)(build)
+        except Exception as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
 
     try:
         build(
@@ -615,6 +656,12 @@ def cmd_version(args: argparse.Namespace) -> int:
     return _cmd_version(args)
 
 
+def _cmd_kernel(args: argparse.Namespace) -> int:
+    from .kernel_cli import run
+
+    return run(args)
+
+
 def main() -> None:
     # RTX selection MUST happen before ANY tensorrt_model_connect module touches TRT.
     # We do an early argv scan before argparse touches anything.
@@ -638,6 +685,11 @@ def main() -> None:
     build_p = subparsers.add_parser("build", help="Build a .trtfb bundle")
     build_p.add_argument("model",
                          help="HF repo ID (for example, org/model-name) or local directory")
+    build_p.add_argument(
+        "--kernel",
+        metavar="YAML",
+        help="Replace a family-owned kernel slot using this YAML manifest",
+    )
     build_p.add_argument(
         "--model-revision",
         default=None,
@@ -793,13 +845,20 @@ def main() -> None:
     inspect_p.add_argument("--list-engines", action="store_true",
                            help="List only TRT engine plan sections with roles")
 
+    kernel_p = subparsers.add_parser(
+        "kernel",
+        help="Discover family-owned external-kernel slots",
+    )
+    from .kernel_cli import configure_parser as configure_kernel_parser
+    configure_kernel_parser(kernel_p)
+
     # python -m tensorrt_model_connect version
     subparsers.add_parser("version", help="Show version info")
 
     # Keep direct module compatibility: `python -m tensorrt_model_connect
     # <model-dir> -o out.trtfb` still means build. The public native CLI uses
     # explicit `trtmc build`.
-    command_names = {"build", "inspect", "version"}
+    command_names = {"build", "inspect", "kernel", "version"}
     cli_argv = sys.argv[1:]
     if cli_argv and cli_argv[0] not in command_names and cli_argv[0] not in ("--help", "-h"):
         cli_argv = ["build"] + cli_argv
@@ -812,6 +871,7 @@ def main() -> None:
     dispatch = {
         "build": _cmd_build,
         "inspect": _cmd_inspect,
+        "kernel": _cmd_kernel,
         "version": _cmd_version,
     }
 

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import inspect
 import json
@@ -1510,20 +1511,40 @@ def build_bundle(
     if not embedded_config_json:
         sections.append(BundleSection("config.json", make_runtime_config_json(None)))
 
-    # Package FFI kernel .so files into the bundle
-    if kernel_artifacts:
-        import json as _json
+    # Fail before writing if the family did not wire every selected instance.
+    from .kernel_slots import finish_active_kernel_slot
+
+    finish_active_kernel_slot()
+
+    # Package explicit artifacts plus the active CLI slot, if any.
+    artifacts: list[tuple[str, ...]] = list(kernel_artifacts or [])
+    from .kernel_slots import active_kernel_artifact
+
+    active_artifact = active_kernel_artifact()
+    if active_artifact is not None:
+        artifacts.append(active_artifact)
+    if artifacts:
         manifest_entries = []
-        for global_name, so_path in kernel_artifacts:
+        for artifact in artifacts:
+            if len(artifact) not in (2, 4):
+                raise ValueError("Kernel artifact must contain 2 or 4 fields")
+            global_name, so_path = artifact[:2]
+            function_name = artifact[2] if len(artifact) == 4 else "run"
+            expected_digest = artifact[3] if len(artifact) == 4 else None
             section_name = f"kernel_{global_name.replace('.', '_')}.so"
             so_data = Path(so_path).read_bytes()
+            if (
+                expected_digest is not None
+                and hashlib.sha256(so_data).hexdigest() != expected_digest
+            ):
+                raise ValueError(f"Kernel library changed after validation: {so_path}")
             sections.append(BundleSection(section_name, so_data))
             manifest_entries.append({
                 "global_name": global_name,
-                "func_name": "run",
+                "func_name": function_name,
                 "section": section_name,
             })
-        manifest_json = _json.dumps({"kernels": manifest_entries}).encode("utf-8")
+        manifest_json = json.dumps({"kernels": manifest_entries}).encode("utf-8")
         sections.append(BundleSection("kernel_manifest.json", manifest_json))
 
     write_t0 = time.monotonic()

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -729,7 +729,12 @@ def build_dual_profile_decoder_engine(
                 num_heads=num_heads, head_dim=head_dim,
                 num_kv_heads=num_kv_heads,
                 q_seq=None,
-                scale=attn_scale, tag=f"{prefix}.attn")
+                scale=attn_scale, tag=f"{prefix}.attn",
+                kernel_slot_instance=(
+                    f"decoder.layers.{layer_idx}.decode_attention"
+                    if profile_mode == "decode"
+                    else None
+                ))
             context = native_attention["context"]
             present_k_outs.append(native_attention["present_k"])
             present_v_outs.append(native_attention["present_v"])

--- a/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/export_flashinfer_kernel.py
+++ b/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/export_flashinfer_kernel.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export the FlashInfer CuTe Qwen3-8B decode kernel as a TVM-FFI DSO."""
+
+import argparse
+from importlib import metadata
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+HEAD_DIM = 128
+NUM_HEADS = 32
+NUM_KV_HEADS = 8
+KV_CAPACITY = 40960
+PAGE_SIZE = 64
+NUM_PAGES = KV_CAPACITY // PAGE_SIZE
+
+
+def _compile():
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.typing import Float32, Int32
+    from flashinfer.cute_dsl.attention.fusion.mask import DenseMask
+    from flashinfer.cute_dsl.attention.gqa_decode_paged import (
+        GroupedQueryAttentionDecodePaged,
+    )
+
+    attention = GroupedQueryAttentionDecodePaged(
+        PAGE_SIZE,
+        HEAD_DIM,
+        grouped_head_tile=NUM_HEADS // NUM_KV_HEADS,
+        prediction_tile=1,
+        sequence_tile=256,
+        reduction_mode="none",
+    )
+
+    @cute.jit
+    def run(
+        query: cute.Tensor,
+        key: cute.Tensor,
+        value: cute.Tensor,
+        key_value_lengths: cute.Tensor,
+        page_offsets: cute.Tensor,
+        page_table: cute.Tensor,
+        context: cute.Tensor,
+        sm_scale: Float32,
+        stream: cuda.CUstream,
+    ):
+        q_batch = query.shape[0] * query.stride[0]
+        o_batch = context.shape[0] * context.stride[0]
+        q_layout = cute.make_layout(
+            (1, 1, query.shape[0], query.shape[1]),
+            stride=(q_batch, q_batch, query.stride[0], query.stride[1]),
+        )
+        k_layout = cute.make_layout(
+            (NUM_PAGES, PAGE_SIZE, key.shape[1], key.shape[3]),
+            stride=(
+                PAGE_SIZE * key.stride[2],
+                key.stride[2],
+                key.stride[1],
+                key.stride[3],
+            ),
+        )
+        v_layout = cute.make_layout(
+            (NUM_PAGES, PAGE_SIZE, value.shape[1], value.shape[3]),
+            stride=(
+                PAGE_SIZE * value.stride[2],
+                value.stride[2],
+                value.stride[1],
+                value.stride[3],
+            ),
+        )
+        o_layout = cute.make_layout(
+            (1, 1, context.shape[0], context.shape[1]),
+            stride=(o_batch, o_batch, context.stride[0], context.stride[1]),
+        )
+        attention(
+            Int32(1),
+            key_value_lengths,
+            page_offsets,
+            page_table,
+            cute.make_tensor(key.iterator, k_layout),
+            cute.make_tensor(value.iterator, v_layout),
+            cute.make_tensor(query.iterator, q_layout),
+            cute.make_tensor(context.iterator, o_layout),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            DenseMask(),
+            sm_scale,
+            Float32(1.0),
+            None,
+            stream,
+            False,
+        )
+
+    query = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (NUM_HEADS, HEAD_DIM),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    key = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (1, NUM_KV_HEADS, KV_CAPACITY, HEAD_DIM),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    value = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (1, NUM_KV_HEADS, KV_CAPACITY, HEAD_DIM),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    key_value_lengths = cute.runtime.make_fake_compact_tensor(
+        Int32,
+        (1,),
+        assumed_align=4,
+    )
+    page_offsets = cute.runtime.make_fake_compact_tensor(
+        Int32,
+        (1,),
+        assumed_align=4,
+    )
+    page_table = cute.runtime.make_fake_compact_tensor(
+        Int32,
+        (NUM_PAGES,),
+        assumed_align=4,
+    )
+    context = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (NUM_HEADS, HEAD_DIM),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    return cute.compile(
+        run,
+        query,
+        key,
+        value,
+        key_value_lengths,
+        page_offsets,
+        page_table,
+        context,
+        Float32(1.0 / HEAD_DIM**0.5),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi --opt-level 3",
+    )
+
+
+def _runtime_archive() -> Path:
+    distribution = metadata.distribution("nvidia-cutlass-dsl-libs-base")
+    archive = Path(
+        distribution.locate_file("nvidia_cutlass_dsl/lib/libcuda_dialect_runtime_static.a")
+    ).resolve()
+    if not archive.is_file():
+        raise SystemExit(f"CUTLASS DSL runtime archive not found: {archive}")
+    return archive
+
+
+def _link(compiled, output: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="trtmc-byok-") as temporary:
+        root = Path(temporary)
+        obj = root / "kernel.o"
+        exports = root / "exports.map"
+        compiled.export_to_c(
+            str(obj),
+            function_name="run",
+            enable_pic=True,
+            export_only_tvm_ffi_symbols=True,
+        )
+        exports.write_text("{\n  global: __tvm_ffi_*;\n  local: *;\n};\n")
+        subprocess.run(
+            [
+                shutil.which("gcc") or "gcc",
+                "-shared",
+                "-o",
+                str(output),
+                str(obj),
+                "-Wl,--whole-archive",
+                str(_runtime_archive()),
+                "-Wl,--no-whole-archive",
+                f"-Wl,--version-script={exports}",
+                "-L/usr/local/cuda/lib64",
+                "-lcudart",
+                "-ldl",
+                "-lpthread",
+            ],
+            check=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--device", type=int, default=0)
+    args = parser.parse_args()
+
+    import torch
+    import tvm_ffi  # noqa: F401 - required by the generated ABI
+
+    torch.cuda.set_device(args.device)
+    if torch.cuda.get_device_capability(args.device) != (10, 3):
+        raise SystemExit("This example kernel requires an SM 10.3 GPU")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if args.output.exists():
+        raise SystemExit(f"Refusing to overwrite {args.output}")
+    _link(_compile(), args.output)
+    print(args.output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/prompt.txt
+++ b/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/prompt.txt
@@ -1,0 +1,1 @@
+Explain grouped-query attention in two short sentences.

--- a/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/qwen3-flashinfer.yaml.in
+++ b/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/qwen3-flashinfer.yaml.in
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: 1
+slot: qwen.decode_attention@1
+instances:
+  all: true
+  expect_count: 36
+kernel:
+  library: ./flashinfer-qwen3.so
+  sha256: "@SHA256@"
+  function: run

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -1146,6 +1146,7 @@ def add_native_kv_cache_attention_from_rows(
     q_seq: int | None,
     scale: float | None = None,
     tag: str | None = None,
+    kernel_slot_instance: str | None = None,
 ) -> dict[str, trt.ITensor]:
     """Update a user-owned KV cache and attend over its active prefix.
 
@@ -1214,6 +1215,69 @@ def add_native_kv_cache_attention_from_rows(
     )
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+
+    kernel_spec = None
+    if kernel_slot_instance is not None:
+        from ...kernel_slots import select_kernel_slot
+
+        kernel_spec = select_kernel_slot(
+            "qwen.decode_attention@1",
+            kernel_slot_instance,
+        )
+    if kernel_spec is not None:
+        if q.dtype != trt.bfloat16:
+            raise ValueError("qwen.decode_attention@1 requires BF16 tensors")
+        capacity = int(updated_k.shape[2])
+        page_size = 64
+        if capacity % page_size:
+            raise ValueError(
+                "qwen.decode_attention@1 requires KV capacity divisible by 64"
+            )
+        query_heads_layer = network.add_shuffle(q)
+        query_heads_layer.reshape_dims = (num_heads, head_dim)
+        if tag:
+            query_heads_layer.name = tag + ".slot_query"
+
+        from .kernel_slots import DECODE_ATTENTION
+
+        kernel_context = add_tvm_ffi_kernel(
+            network,
+            kernel_name=kernel_spec.global_name,
+            inputs=[
+                query_heads_layer.get_output(0),
+                updated_k,
+                updated_v,
+                key_value_lengths,
+                add_constant(
+                    network,
+                    (1,),
+                    np.zeros((1,), dtype=np.int32),
+                    dtype=np.int32,
+                ),
+                add_constant(
+                    network,
+                    (capacity // page_size,),
+                    np.arange(capacity // page_size, dtype=np.int32),
+                    dtype=np.int32,
+                ),
+            ],
+            output_specs=[
+                {"dims": output.shape, "dtype": output.dtype}
+                for output in DECODE_ATTENTION.outputs
+            ],
+            workspace_bytes=DECODE_ATTENTION.workspace_bytes,
+            extra_args=[{"type": "float", "value": float(scale)}],
+        )[0]
+        context_rows = network.add_shuffle(kernel_context)
+        context_rows.reshape_dims = (1, num_heads * head_dim)
+        if tag:
+            context_rows.name = tag + ".slot_context"
+        return {
+            "context": context_rows.get_output(0),
+            "present_k": updated_k,
+            "present_v": updated_v,
+        }
+
     if q_4d.dtype != trt.bfloat16:
         raise ValueError("Qwen native KV attention requires BF16 queries")
     # Keep the exact score scale until the Q product, matching HF SDPA.  If
@@ -1351,8 +1415,10 @@ def add_tvm_ffi_kernel(
     """
     import json
 
+    trt_compat.load_native_backend_plugins()
     registry = trt.get_plugin_registry()
-    creator = registry.get_plugin_creator("TvmFfiKernel", "1", "")
+    get_creator = getattr(registry, "get_creator", None) or registry.get_plugin_creator
+    creator = get_creator("TvmFfiKernel", "1", "")
     if creator is None:
         raise RuntimeError(
             "TvmFfiKernel plugin not found in TRT registry. "

--- a/python/tensorrt_model_connect/families/qwen/kernel_slots.py
+++ b/python/tensorrt_model_connect/families/qwen/kernel_slots.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct external-kernel slots owned by the Qwen family."""
+
+from ...kernel_slots import ArgumentSpec, KernelSlot, TensorSpec
+
+
+def _decode_attention_instances(config: object) -> tuple[str, ...]:
+    return tuple(
+        f"decoder.layers.{index}.decode_attention"
+        for index in range(int(getattr(config, "num_hidden_layers")))
+    )
+
+
+def _validate_decode_attention_build(arguments: object) -> None:
+    precision = getattr(arguments, "precision", None)
+    if precision not in (None, "bf16"):
+        raise ValueError("qwen.decode_attention@1 requires --precision bf16")
+    if getattr(arguments, "decoder_engine_layout", "split") != "split":
+        raise ValueError("qwen.decode_attention@1 requires split decoder engines")
+    if int(getattr(arguments, "tensor_parallel_size", 1) or 1) != 1:
+        raise ValueError("qwen.decode_attention@1 does not support tensor parallel builds")
+    if getattr(arguments, "triattention_stats", None) is not None:
+        raise ValueError("qwen.decode_attention@1 cannot be combined with TriAttention")
+    if getattr(arguments, "quantize", None) is not None:
+        raise ValueError("qwen.decode_attention@1 does not support quantized builds")
+
+
+DECODE_ATTENTION = KernelSlot(
+    id="qwen.decode_attention@1",
+    description=(
+        "Single-token post-RoPE grouped-query attention over native Qwen KV cache "
+        "exposed as 64-token pages."
+    ),
+    inputs=(
+        TensorSpec("query", "bfloat16", ("num_query_heads", "head_dim")),
+        TensorSpec(
+            "key",
+            "bfloat16",
+            (1, "num_kv_heads", "kv_capacity", "head_dim"),
+        ),
+        TensorSpec(
+            "value",
+            "bfloat16",
+            (1, "num_kv_heads", "kv_capacity", "head_dim"),
+        ),
+        TensorSpec("key_value_lengths", "int32", (1,)),
+        TensorSpec("page_offsets", "int32", (1,)),
+        TensorSpec("page_table", "int32", ("num_pages",)),
+    ),
+    outputs=(TensorSpec("context", "bfloat16", "same_as_input_0"),),
+    workspace_bytes=0,
+    model_arguments=(ArgumentSpec("softmax_scale", "float32"),),
+    instances=_decode_attention_instances,
+    validate_build=_validate_decode_attention_build,
+)
+
+
+SLOTS = (DECODE_ATTENTION,)

--- a/python/tensorrt_model_connect/kernel_cli.py
+++ b/python/tensorrt_model_connect/kernel_cli.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI for discovering family-owned external-kernel slots."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from .kernel_slots import KernelSlot, load_family_kernel_slots
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> None:
+    commands = parser.add_subparsers(dest="kernel_command", required=True)
+    slots = commands.add_parser(
+        "slots",
+        help="List the external-kernel slots published by a model family",
+    )
+    slots.add_argument(
+        "model",
+        help="HF repo ID or local model directory",
+    )
+    slots.add_argument(
+        "--model-revision",
+        default=None,
+        help="Hugging Face model revision",
+    )
+
+
+def _shape(value: tuple[int | str, ...] | str) -> str:
+    if type(value) is str:
+        return value
+    return "[" + ", ".join(str(dimension) for dimension in value) + "]"
+
+
+def _print_slot(slot: KernelSlot, config: object) -> None:
+    print(slot.id)
+    print(f"  {slot.description}")
+    print("  inputs:")
+    for tensor in slot.inputs:
+        print(f"    {tensor.name}: {tensor.dtype} {_shape(tensor.shape)}")
+    print("  outputs:")
+    for tensor in slot.outputs:
+        print(f"    {tensor.name}: {tensor.dtype} {_shape(tensor.shape)}")
+    print(f"  workspace: {slot.workspace_bytes} bytes")
+    instance_ids = slot.instances(config)
+    print(f"  instances ({len(instance_ids)}):")
+    for instance_id in instance_ids:
+        print(f"    {instance_id}")
+    if slot.model_arguments:
+        print("  model arguments:")
+        for argument in slot.model_arguments:
+            print(f"    {argument.name}: {argument.type}")
+    print("  call order: inputs, workspace (when nonzero), outputs, model arguments")
+
+
+def _resolve_model_config(model: str, revision: str | None) -> tuple[object, str]:
+    from .config import ModelConfig
+    from .families import resolve_family_id
+
+    model_path = Path(model)
+    if model_path.is_dir():
+        config = ModelConfig.from_dir(model_path)
+    else:
+        from huggingface_hub import hf_hub_download
+
+        kwargs = {"revision": revision} if revision else {}
+        config_path = hf_hub_download(
+            repo_id=model,
+            filename="config.json",
+            **kwargs,
+        )
+        config = ModelConfig.from_json(Path(config_path).read_text(encoding="utf-8"))
+    family = resolve_family_id(config)
+    if family is None:
+        raise ValueError(f"No Model Connect family recognizes {model!r}")
+    return config, family
+
+
+def run(arguments: argparse.Namespace) -> int:
+    if arguments.kernel_command != "slots":
+        return 1
+    try:
+        revision = getattr(arguments, "model_revision", None)
+        config, family = _resolve_model_config(
+            arguments.model,
+            revision,
+        )
+        slots = load_family_kernel_slots(family)
+        if not slots:
+            print(f"Model family {family!r} publishes no kernel slots")
+            return 0
+        for index, slot in enumerate(slots):
+            if index:
+                print()
+            _print_slot(slot, config)
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1

--- a/python/tensorrt_model_connect/kernel_slots.py
+++ b/python/tensorrt_model_connect/kernel_slots.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small, family-owned slots for declarative TVM-FFI kernels."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+import hashlib
+import importlib
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import yaml
+
+
+class KernelSlotError(ValueError):
+    """A kernel manifest does not conform to a family-owned slot."""
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    name: str
+    dtype: str
+    shape: tuple[int | str, ...] | str
+
+
+@dataclass(frozen=True)
+class ArgumentSpec:
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class KernelSlot:
+    """The ABI that one model family exposes at graph-construction time."""
+
+    id: str
+    description: str
+    inputs: tuple[TensorSpec, ...]
+    outputs: tuple[TensorSpec, ...]
+    workspace_bytes: int
+    instances: Callable[[Any], tuple[str, ...]]
+    model_arguments: tuple[ArgumentSpec, ...] = ()
+    validate_build: Callable[[Any], None] | None = None
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    """The only data supplied by an existing-slot kernel user."""
+
+    slot: str
+    instance_ids: tuple[str, ...] | None
+    expect_count: int
+    library: Path
+    library_sha256: str
+    function: str
+
+    @property
+    def global_name(self) -> str:
+        identity = f"{self.slot}\0{self.library_sha256}\0{self.function}"
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+        return f"trtmc.byok.{digest}"
+
+    @property
+    def kernel_artifact(self) -> tuple[str, str, str, str]:
+        return (
+            self.global_name,
+            str(self.library),
+            self.function,
+            self.library_sha256,
+        )
+
+
+def _mapping(value: Any, where: str, keys: set[str]) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise KernelSlotError(f"{where} must be a mapping")
+    if any(type(key) is not str for key in value):
+        raise KernelSlotError(f"{where} keys must be strings")
+    unknown = sorted(set(value) - keys)
+    if unknown:
+        raise KernelSlotError(f"{where} contains unknown field(s): " + ", ".join(unknown))
+    return value
+
+
+def _string(value: Any, where: str) -> str:
+    if type(value) is not str or not value:
+        raise KernelSlotError(f"{where} must be a non-empty string")
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise KernelSlotError(f"Cannot read kernel library {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def load_kernel_spec(path: str | Path) -> KernelSpec:
+    """Parse one strict YAML document and verify its DSO digest."""
+
+    manifest_path = Path(path)
+    try:
+        source = manifest_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise KernelSlotError(f"Cannot read kernel YAML {manifest_path}: {exc}") from exc
+    try:
+        document = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        raise KernelSlotError(f"Invalid kernel YAML {manifest_path}: {exc}") from exc
+
+    root = _mapping(
+        document,
+        "kernel YAML",
+        {"schema_version", "slot", "instances", "kernel"},
+    )
+    if type(root.get("schema_version")) is not int or root["schema_version"] != 1:
+        raise KernelSlotError("schema_version must be 1")
+
+    selection = _mapping(
+        root.get("instances"),
+        "instances",
+        {"all", "expect_count", "ids"},
+    )
+    select_all = selection.get("all")
+    raw_ids = selection.get("ids")
+    if select_all is True:
+        if raw_ids is not None:
+            raise KernelSlotError("instances cannot contain both all and ids")
+        expect_count = selection.get("expect_count")
+        if type(expect_count) is not int or expect_count < 1:
+            raise KernelSlotError(
+                "instances.expect_count must be a positive integer with all: true"
+            )
+        instance_ids = None
+    else:
+        if select_all is not None:
+            raise KernelSlotError("instances.all, when present, must be true")
+        if type(raw_ids) is not list or not raw_ids:
+            raise KernelSlotError(
+                "instances must use all: true plus expect_count, or a non-empty ids list"
+            )
+        instance_ids = tuple(
+            _string(value, f"instances.ids[{index}]") for index, value in enumerate(raw_ids)
+        )
+        if len(set(instance_ids)) != len(instance_ids):
+            raise KernelSlotError("instances.ids contains a duplicate")
+        if "expect_count" in selection:
+            raise KernelSlotError("instances.expect_count is only valid with all: true")
+        expect_count = len(instance_ids)
+
+    kernel = _mapping(
+        root.get("kernel"),
+        "kernel",
+        {"library", "sha256", "function"},
+    )
+    library = Path(_string(kernel.get("library"), "kernel.library"))
+    if not library.is_absolute():
+        library = manifest_path.parent / library
+    library = library.resolve()
+    if not library.is_file():
+        raise KernelSlotError(f"kernel.library is not a file: {library}")
+    expected_digest = _string(kernel.get("sha256"), "kernel.sha256")
+    if len(expected_digest) != 64 or any(
+        character not in "0123456789abcdef" for character in expected_digest
+    ):
+        raise KernelSlotError("kernel.sha256 must be a lowercase 64-character SHA-256")
+    actual_digest = _sha256_file(library)
+    if actual_digest != expected_digest:
+        raise KernelSlotError(
+            f"Kernel library SHA-256 mismatch: expected {expected_digest}, got {actual_digest}"
+        )
+
+    return KernelSpec(
+        slot=_string(root.get("slot"), "slot"),
+        instance_ids=instance_ids,
+        expect_count=expect_count,
+        library=library,
+        library_sha256=expected_digest,
+        function=_string(kernel.get("function"), "kernel.function"),
+    )
+
+
+def load_family_kernel_slots(family: str) -> tuple[KernelSlot, ...]:
+    """Load an optional ``kernel_slots.py`` module owned by one family."""
+
+    family = _string(family, "family").replace("-", "_")
+    if not family.isidentifier():
+        raise KernelSlotError(f"Invalid model family {family!r}")
+    module_name = f"{__package__}.families.{family}.kernel_slots"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            return ()
+        raise
+    slots = getattr(module, "SLOTS", ())
+    if type(slots) is not tuple or any(type(slot) is not KernelSlot for slot in slots):
+        raise KernelSlotError(f"{module_name}.SLOTS must be a tuple of KernelSlot values")
+    ids = [slot.id for slot in slots]
+    if len(ids) != len(set(ids)):
+        raise KernelSlotError(f"{module_name}.SLOTS contains a duplicate slot ID")
+    return slots
+
+
+class _Selection:
+    def __init__(self, spec: KernelSpec, slot: KernelSlot) -> None:
+        self.spec = spec
+        self.slot = slot
+        self.seen: set[str] = set()
+
+    def select(self, slot_id: str, instance_id: str) -> KernelSpec | None:
+        if slot_id != self.slot.id:
+            return None
+        selected = self.spec.instance_ids is None or instance_id in self.spec.instance_ids
+        if not selected:
+            return None
+        if instance_id in self.seen:
+            raise KernelSlotError(f"Kernel slot instance {instance_id!r} was built more than once")
+        self.seen.add(instance_id)
+        return self.spec
+
+    def finish(self) -> None:
+        if self.spec.instance_ids is None:
+            if len(self.seen) != self.spec.expect_count:
+                raise KernelSlotError(
+                    f"Slot {self.slot.id!r} matched {len(self.seen)} instances; "
+                    f"YAML expected {self.spec.expect_count}"
+                )
+            return
+        missing = sorted(set(self.spec.instance_ids) - self.seen)
+        if missing:
+            raise KernelSlotError(
+                "Requested kernel slot instance(s) were not built: " + ", ".join(missing)
+            )
+
+
+_ACTIVE: ContextVar[_Selection | None] = ContextVar(
+    "tensorrt_model_connect_kernel_slot",
+    default=None,
+)
+
+
+@contextmanager
+def activate_kernel_slot(
+    spec: KernelSpec,
+    slot: KernelSlot,
+) -> Iterator[None]:
+    """Activate one direct slot for exactly one native bundle build."""
+
+    if _ACTIVE.get() is not None:
+        raise KernelSlotError("Kernel slot activations cannot be nested")
+    selection = _Selection(spec, slot)
+    token = _ACTIVE.set(selection)
+    try:
+        yield
+        selection.finish()
+    finally:
+        _ACTIVE.reset(token)
+
+
+def active_kernel_artifact() -> tuple[str, str, str, str] | None:
+    active = _ACTIVE.get()
+    return active.spec.kernel_artifact if active is not None else None
+
+
+def finish_active_kernel_slot() -> None:
+    """Validate that the active slot was wired before writing the bundle."""
+
+    active = _ACTIVE.get()
+    if active is not None:
+        active.finish()
+
+
+def select_kernel_slot(slot_id: str, instance_id: str) -> KernelSpec | None:
+    """Return the active kernel when this exact family slot instance is selected."""
+
+    active = _ACTIVE.get()
+    if active is None:
+        return None
+    return active.select(
+        _string(slot_id, "slot_id"),
+        _string(instance_id, "instance_id"),
+    )

--- a/python/tensorrt_model_connect/trt_compat.py
+++ b/python/tensorrt_model_connect/trt_compat.py
@@ -34,6 +34,8 @@ _TIMING_CACHE_DIR_ENV = "TRTMC_TRT_TIMING_CACHE_DIR"
 _BUILDER_OPT_LEVEL_ENV = "TRTMC_BUILDER_OPTIMIZATION_LEVEL"
 _MAX_NUM_TACTICS_ENV = "TRTMC_MAX_NUM_TACTICS"
 _AVG_TIMING_ITERATIONS_ENV = "TRTMC_AVG_TIMING_ITERATIONS"
+_NATIVE_BIN_DIR_ENV = "_TRTMC_INTERNAL_NATIVE_BIN_DIR"
+_native_backend_handle: Any | None = None
 
 
 def configure_backend(*, rtx: bool = False) -> None:
@@ -179,6 +181,30 @@ def network_creation_flags(
 def get_trt() -> "TensorRTModuleProxy":
     """Return a proxy bound to the currently selected/imported TRT module."""
     return TensorRTModuleProxy(load_module())
+
+
+def load_native_backend_plugins() -> None:
+    """Load the packaged TensorRT backend so its plugin creators register."""
+
+    global _native_backend_handle
+    if _native_backend_handle is not None:
+        return
+
+    import ctypes
+
+    roots = [Path(__file__).resolve().parent / "bin"]
+    native_bin = os.environ.get(_NATIVE_BIN_DIR_ENV)
+    if native_bin:
+        roots.insert(0, Path(native_bin))
+    for root in roots:
+        library = root / "libtrtmc_backend_trt.so"
+        if library.is_file():
+            _native_backend_handle = ctypes.CDLL(
+                str(library),
+                mode=ctypes.RTLD_GLOBAL,
+            )
+            return
+    raise RuntimeError("Cannot find the packaged TensorRT backend plugin library")
 
 
 def add_matrix_multiply(

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -187,6 +187,7 @@ void print_usage() {
     std::cerr
         << "Usage:\n"
            "  trtmc build           <hf-model-or-dir> -o <bundle.trtfb> [builder args...]\n"
+           "  trtmc kernel slots    <hf-model-or-dir> [--model-revision REV]\n"
            "  trtmc run             <bundle.trtfb> --prompt \"text\" [--image PATH] "
            "[--max-new-tokens N] [--temperature F] [--top-p F] [--min-p F] "
            "[--top-k N] [--seed N] [--benchmark N] [--warmup N] [--hf-python PATH] "
@@ -262,7 +263,7 @@ CliArgs parse_args(int argc, char** argv) {
         return args;
     }
 
-    if (args.command == "build") {
+    if (args.command == "build" || args.command == "kernel") {
         for (int i = 2; i < argc; ++i)
             args.build_args.emplace_back(argv[i]);
         return args;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -260,6 +260,11 @@ int run_python_module(const std::vector<std::string>& argv) {
         const std::string pythonpath = build_pythonpath();
         if (!pythonpath.empty())
             setenv("PYTHONPATH", pythonpath.c_str(), 1);
+        const auto executable = current_executable_path();
+        if (!executable.empty()) {
+            const std::string native_bin_dir = executable.parent_path().string();
+            setenv("_TRTMC_INTERNAL_NATIVE_BIN_DIR", native_bin_dir.c_str(), 1);
+        }
         execvp(exec_argv[0], exec_argv.data());
         std::cerr << "Error: failed to execute " << argv[0] << ": " << std::strerror(errno) << '\n';
         _exit(127);
@@ -283,12 +288,12 @@ int run_python_module(const std::vector<std::string>& argv) {
     return EXIT_FAILURE;
 }
 
-int cmd_build(const CliArgs& args) {
+int cmd_python(const CliArgs& args) {
     std::vector<std::string> command = {
         build_python_executable(),
         "-m",
         "tensorrt_model_connect",
-        "build",
+        args.command,
     };
     command.insert(command.end(), args.build_args.begin(), args.build_args.end());
     return run_python_module(command);
@@ -1602,8 +1607,8 @@ int main(int argc, char** argv) {
     try {
         if (args.command == "version")
             return cmd_version();
-        if (args.command == "build")
-            return cmd_build(args);
+        if (args.command == "build" || args.command == "kernel")
+            return cmd_python(args);
         if (args.command == "run")
             return cmd_run(args);
         if (args.command == "encode")

--- a/src/plugins/tvm_ffi_kernel_plugin.cpp
+++ b/src/plugins/tvm_ffi_kernel_plugin.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <string>
 #include <tvm/ffi/c_api.h>
+#include <tvm/ffi/extra/c_env_api.h>
 #include <utility>
 #include <vector>
 
@@ -271,7 +272,8 @@ bool TvmFfiKernelPlugin::supportsFormatCombination(int32_t pos,
     return inOut[pos].format == nvinfer1::TensorFormat::kLINEAR &&
            (inOut[pos].type == nvinfer1::DataType::kBF16 ||
             inOut[pos].type == nvinfer1::DataType::kFLOAT ||
-            inOut[pos].type == nvinfer1::DataType::kHALF);
+            inOut[pos].type == nvinfer1::DataType::kHALF ||
+            inOut[pos].type == nvinfer1::DataType::kINT32);
 }
 
 void TvmFfiKernelPlugin::configurePlugin(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
@@ -302,30 +304,50 @@ void report_tvm_ffi_error(const std::string& kernel_name) {
     }
 }
 
-// Fill a DLTensor from a TRT tensor descriptor.
-void fill_dl_tensor(DLTensor& t, void* data, const nvinfer1::PluginTensorDesc& desc,
-                    int device_id) {
+constexpr int32_t kMaxTensorRank = 8;
+
+// Keep explicit DLPack shape and contiguous-stride storage alive for the FFI
+// call. CuTe's TVM-FFI wrapper reads both arrays.
+bool fill_dl_tensor(DLTensor& t, int64_t* shape, int64_t* strides, void* data,
+                    const nvinfer1::PluginTensorDesc& desc, int device_id) {
+    if (desc.dims.nbDims < 0 || desc.dims.nbDims > kMaxTensorRank)
+        return false;
+    int64_t stride = 1;
+    for (int32_t dim = desc.dims.nbDims - 1; dim >= 0; --dim) {
+        if (desc.dims.d[dim] < 0)
+            return false;
+        shape[dim] = desc.dims.d[dim];
+        strides[dim] = stride;
+        stride *= shape[dim];
+    }
     t.data = data;
     t.device = {kDLCUDA, device_id};
     t.ndim = desc.dims.nbDims;
-    t.shape = const_cast<int64_t*>(reinterpret_cast<const int64_t*>(desc.dims.d));
-    t.strides = nullptr;
+    t.shape = shape;
+    t.strides = strides;
     t.byte_offset = 0;
     if (desc.type == nvinfer1::DataType::kFLOAT)
         t.dtype = DLDataType{kDLFloat, 32, 1};
     else if (desc.type == nvinfer1::DataType::kBF16)
         t.dtype = DLDataType{kDLBfloat, 16, 1};
+    else if (desc.type == nvinfer1::DataType::kINT32)
+        t.dtype = DLDataType{kDLInt, 32, 1};
     else
         t.dtype = DLDataType{kDLFloat, 16, 1};
+    return true;
 }
 
 // Bind tensor descriptors to DLTensor + TVMFFIAny argument arrays.
 // Returns the next argument index after all bound tensors.
-int32_t bind_tensors(DLTensor* dl_tensors, TVMFFIAny* args, nvinfer1::PluginTensorDesc const* descs,
-                     void const* const* buffers, int32_t count, int32_t arg_idx, int device_id) {
+int32_t bind_tensors(DLTensor* dl_tensors, int64_t* shapes, int64_t* strides, TVMFFIAny* args,
+                     nvinfer1::PluginTensorDesc const* descs, void const* const* buffers,
+                     int32_t count, int32_t arg_idx, int device_id) {
     for (int32_t i = 0; i < count; ++i, ++arg_idx) {
         auto tidx = static_cast<std::size_t>(arg_idx);
-        fill_dl_tensor(dl_tensors[tidx], const_cast<void*>(buffers[i]), descs[i], device_id);
+        if (!fill_dl_tensor(dl_tensors[tidx], shapes + tidx * kMaxTensorRank,
+                            strides + tidx * kMaxTensorRank, const_cast<void*>(buffers[i]),
+                            descs[i], device_id))
+            return -1;
         args[arg_idx].type_index = kTVMFFIDLTensorPtr;
         args[arg_idx].v_ptr = &dl_tensors[tidx];
     }
@@ -334,14 +356,15 @@ int32_t bind_tensors(DLTensor* dl_tensors, TVMFFIAny* args, nvinfer1::PluginTens
 
 // Bind the workspace tensor if present. Returns the next argument index.
 int32_t bind_workspace_tensor(DLTensor* dl_tensors, TVMFFIAny* args, void* workspace,
-                              int64_t* workspace_shape, int32_t arg_idx, int device_id) {
+                              int64_t* workspace_shape, int64_t* workspace_strides, int32_t arg_idx,
+                              int device_id) {
     auto tidx = static_cast<std::size_t>(arg_idx);
     DLTensor& wt = dl_tensors[tidx];
     wt.data = workspace;
     wt.device = {kDLCUDA, device_id};
     wt.ndim = 1;
     wt.shape = workspace_shape;
-    wt.strides = nullptr;
+    wt.strides = workspace_strides;
     wt.byte_offset = 0;
     wt.dtype = {kDLUInt, 8, 1};
     args[arg_idx].type_index = kTVMFFIDLTensorPtr;
@@ -365,57 +388,85 @@ void append_extra_args(TVMFFIAny* args, int32_t base_idx,
     }
 }
 
+bool resolve_tvm_ffi_function(const std::string& kernel_name, void** function) {
+    if (*function != nullptr)
+        return true;
+    TVMFFIByteArray name{kernel_name.data(), kernel_name.size()};
+    if (TVMFFIFunctionGetGlobal(&name, function) == 0 && *function != nullptr)
+        return true;
+    std::cerr << "[TvmFfiKernelPlugin] Failed to resolve kernel: " << kernel_name << '\n';
+    return false;
+}
+
+int32_t invoke_tvm_ffi_function(void* function, TVMFFIAny* args, int32_t num_args, int device_id,
+                                cudaStream_t stream, const std::string& kernel_name) {
+    TVMFFIStreamHandle previous_stream = nullptr;
+    if (TVMFFIEnvSetStream(kDLCUDA, device_id, reinterpret_cast<TVMFFIStreamHandle>(stream),
+                           &previous_stream) != 0) {
+        report_tvm_ffi_error(kernel_name);
+        return -1;
+    }
+
+    TVMFFIAny result{};
+    result.type_index = kTVMFFINone;
+    const int call_status = TVMFFIFunctionCall(function, args, num_args, &result);
+    if (call_status != 0)
+        report_tvm_ffi_error(kernel_name);
+    const int restore_status = TVMFFIEnvSetStream(kDLCUDA, device_id, previous_stream, nullptr);
+    if (restore_status != 0)
+        report_tvm_ffi_error(kernel_name);
+    if (result.type_index >= kTVMFFIStaticObjectBegin && result.v_obj != nullptr)
+        TVMFFIObjectDecRef(result.v_obj);
+    return call_status == 0 && restore_status == 0 ? 0 : -1;
+}
+
 } // namespace
 
 int32_t TvmFfiKernelPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc,
                                     nvinfer1::PluginTensorDesc const* outputDesc,
                                     void const* const* inputs, void* const* outputs,
                                     void* workspace, cudaStream_t stream) noexcept {
-    // 1. Lazy-resolve the TVM-FFI function handle
-    if (cached_fn_ == nullptr) {
-        TVMFFIByteArray name_arr;
-        name_arr.data = kernel_name_.c_str();
-        name_arr.size = static_cast<int64_t>(kernel_name_.size());
-        if (TVMFFIFunctionGetGlobal(&name_arr, &cached_fn_) != 0 || cached_fn_ == nullptr) {
-            std::cerr << "[TvmFfiKernelPlugin] Failed to resolve kernel: " << kernel_name_ << '\n';
-            return -1;
-        }
-    }
+    if (!resolve_tvm_ffi_function(kernel_name_, &cached_fn_))
+        return -1;
 
     // 2. Build argument array: [inputs..., workspace_tmp, outputs..., extra_args...]
-    const bool has_workspace = (workspace_bytes_ > 0 && workspace != nullptr);
+    const bool has_workspace = workspace_bytes_ > 0;
+    if (has_workspace && workspace == nullptr) {
+        std::cerr << "[TvmFfiKernelPlugin] TensorRT did not provide configured workspace\n";
+        return -1;
+    }
     const int32_t total_tensors = num_inputs_ + (has_workspace ? 1 : 0) + num_outputs_;
     const int32_t total_args = total_tensors + static_cast<int32_t>(extra_args_.size());
     std::vector<DLTensor> dl_tensors(static_cast<std::size_t>(total_tensors));
+    std::vector<int64_t> shapes(static_cast<std::size_t>(total_tensors) * kMaxTensorRank);
+    std::vector<int64_t> strides(static_cast<std::size_t>(total_tensors) * kMaxTensorRank);
     std::vector<TVMFFIAny> args(static_cast<std::size_t>(total_args));
 
     int device_id = 0;
-    cudaGetDevice(&device_id);
+    if (cudaGetDevice(&device_id) != cudaSuccess)
+        return -1;
 
     // Bind inputs, optional workspace, outputs, and extra args
-    int32_t arg_idx =
-        bind_tensors(dl_tensors.data(), args.data(), inputDesc, inputs, num_inputs_, 0, device_id);
+    int32_t arg_idx = bind_tensors(dl_tensors.data(), shapes.data(), strides.data(), args.data(),
+                                   inputDesc, inputs, num_inputs_, 0, device_id);
+    if (arg_idx < 0)
+        return -1;
 
     int64_t workspace_shape[1] = {workspace_bytes_};
+    int64_t workspace_strides[1] = {1};
     if (has_workspace)
         arg_idx = bind_workspace_tensor(dl_tensors.data(), args.data(), workspace, workspace_shape,
-                                        arg_idx, device_id);
+                                        workspace_strides, arg_idx, device_id);
 
     auto* out_bufs = reinterpret_cast<void const* const*>(outputs);
-    arg_idx = bind_tensors(dl_tensors.data(), args.data(), outputDesc, out_bufs, num_outputs_,
-                           arg_idx, device_id);
+    arg_idx = bind_tensors(dl_tensors.data(), shapes.data(), strides.data(), args.data(),
+                           outputDesc, out_bufs, num_outputs_, arg_idx, device_id);
+    if (arg_idx < 0)
+        return -1;
 
     append_extra_args(args.data(), arg_idx, extra_args_);
-
-    // 3. Call the TVM-FFI function
-    TVMFFIAny result;
-    result.type_index = kTVMFFINone;
-    int ret = TVMFFIFunctionCall(cached_fn_, args.data(), total_args, &result);
-    if (ret != 0) {
-        report_tvm_ffi_error(kernel_name_);
-        return -1;
-    }
-    return 0;
+    return invoke_tvm_ffi_function(cached_fn_, args.data(), total_args, device_id, stream,
+                                   kernel_name_);
 }
 
 } // namespace trtmc

--- a/tests/builder/test_kernel_slots.py
+++ b/tests/builder/test_kernel_slots.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_model_connect.kernel_slots import (
+    KernelSlotError,
+    activate_kernel_slot,
+    load_family_kernel_slots,
+    load_kernel_spec,
+    select_kernel_slot,
+)
+
+
+def _manifest(tmp_path, instances: str = "all: true\n  expect_count: 2"):
+    library = tmp_path / "kernel.so"
+    library.write_bytes(b"test TVM-FFI DSO")
+    digest = hashlib.sha256(library.read_bytes()).hexdigest()
+    manifest = tmp_path / "kernel.yaml"
+    manifest.write_text(
+        f"""\
+schema_version: 1
+slot: qwen.decode_attention@1
+instances:
+  {instances}
+kernel:
+  library: ./kernel.so
+  sha256: {digest}
+  function: run
+""",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_qwen_manifest_matches_family_owned_abi(tmp_path):
+    spec = load_kernel_spec(_manifest(tmp_path))
+    (slot,) = load_family_kernel_slots("qwen")
+
+    assert spec.library == (tmp_path / "kernel.so").resolve()
+    assert spec.kernel_artifact == (
+        spec.global_name,
+        str(spec.library),
+        "run",
+        spec.library_sha256,
+    )
+    assert spec.global_name.startswith("trtmc.byok.")
+    assert [tensor.name for tensor in slot.inputs] == [
+        "query",
+        "key",
+        "value",
+        "key_value_lengths",
+        "page_offsets",
+        "page_table",
+    ]
+    assert [tensor.name for tensor in slot.outputs] == ["context"]
+    assert slot.instances(SimpleNamespace(num_hidden_layers=2)) == (
+        "decoder.layers.0.decode_attention",
+        "decoder.layers.1.decode_attention",
+    )
+
+
+def test_exact_instance_selection_is_checked(tmp_path):
+    spec = load_kernel_spec(
+        _manifest(
+            tmp_path,
+            "ids:\n    - decoder.layers.0.decode_attention\n"
+            "    - decoder.layers.2.decode_attention",
+        )
+    )
+    (slot,) = load_family_kernel_slots("qwen")
+
+    with activate_kernel_slot(spec, slot):
+        assert select_kernel_slot(slot.id, "decoder.layers.0.decode_attention") is spec
+        assert select_kernel_slot(slot.id, "decoder.layers.1.decode_attention") is None
+        assert select_kernel_slot(slot.id, "decoder.layers.2.decode_attention") is spec
+
+    assert select_kernel_slot(slot.id, "decoder.layers.0.decode_attention") is None
+
+
+def test_manifest_and_match_count_fail_closed(tmp_path):
+    manifest = _manifest(tmp_path)
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "attributes:\n  scale: 1.0\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(KernelSlotError, match="unknown field"):
+        load_kernel_spec(manifest)
+
+    spec = load_kernel_spec(_manifest(tmp_path))
+    (slot,) = load_family_kernel_slots("qwen")
+    with pytest.raises(KernelSlotError, match="matched 1 instances"):
+        with activate_kernel_slot(spec, slot):
+            select_kernel_slot(slot.id, "decoder.layers.0.decode_attention")

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -73,6 +73,10 @@ void test_build_forwards_args_verbatim() {
     check(args.build_args.size() == 5, "build forwards arg count");
     check(args.build_args[0] == "Example/Decoder-0.6B", "build forwards model");
     check(args.build_args[4] == "fp16", "build forwards final value");
+
+    auto kernel = parse({"trtmc", "kernel", "slots", "Example/Decoder-0.6B"});
+    check(kernel.command == "kernel" && kernel.build_args.size() == 2,
+          "kernel command forwards to Python");
 }
 
 void test_run_parses_common_flags() {

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -160,6 +160,8 @@ shared_builder_module python/tensorrt_model_connect/hf_snapshot.py # shared HF s
 shared_builder_module python/tensorrt_model_connect/engine_defs/__init__.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/engine_defs/base.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/fp8_calibrate.py # shared Python builder surface; broad builder impact is intentional
+shared_builder_module python/tensorrt_model_connect/kernel_cli.py # shared family-dispatch kernel-slot CLI; broad builder impact is intentional
+shared_builder_module python/tensorrt_model_connect/kernel_slots.py # shared direct-slot manifest and activation contract; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/kernels/__init__.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/kernels/flashinfer_decode.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_provider/__init__.py # shared delegated-build dispatcher surface; conservative all-model impact is intentional while model-owned adapter edits remain family-only

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -28,6 +28,7 @@ python -m tensorrt_model_connect build <hf-repo-or-local-dir> -o <output.trtfb>
 
 | Option | Purpose |
 | --- | --- |
+| `--kernel FILE.yaml` | Replace a model-family kernel slot with a trusted TVM-FFI DSO. |
 | `--max-cache-length N` | KV cache length, default `256`. |
 | `--dynamic-kv-cache` | Enable runtime-resizable KV cache support. |
 | `--dynamic-kv-profile-rows A,B,C` | Override dynamic-KV optimization profiles. |
@@ -50,6 +51,15 @@ TriAttention options are also exposed for experimental KV compaction: `--triatte
 
 TensorRT is the build backend; there is no public build-method selector. Older
 `--method trt` and `--method auto` spellings remain accepted for compatibility.
+
+## `trtmc kernel slots`
+
+List the external-kernel contracts and exact instance IDs published for a
+model without downloading its weights:
+
+```bash
+trtmc kernel slots <hf-repo-or-local-dir> [--model-revision REV]
+```
 
 ## Runtime commands
 

--- a/website/docs/tutorials/beginner/bring-your-own-kernel.md
+++ b/website/docs/tutorials/beginner/bring-your-own-kernel.md
@@ -1,0 +1,252 @@
+---
+title: "Bring Your Own Kernel"
+---
+
+This tutorial replaces Qwen3-8B decode attention with a FlashInfer TVM-FFI
+kernel. The same workflow works for any kernel that implements a slot already
+published by a model family.
+
+You bring only:
+
+- a trusted TVM-FFI shared library (`.so`);
+- a small YAML file.
+
+You do not edit Model Connect and you do not write TensorRT C++. The Qwen
+family owns where the slot connects to the TensorRT graph.
+
+Before you start, complete [Installation](../../getting-started/installation.md),
+clone this repository, and run every command below from its root directory.
+Building the included exporter requires an SM 10.3 GPU; on another supported
+GPU, bring an already compiled DSO that implements the same slot instead. The
+reference Qwen3-8B build produced about 31 GB per bundle, so reserve at least
+70 GB of disk for the native and patched pair.
+
+## 1. See the available slots
+
+Pin the model revision so that the model and slot contract cannot change under
+you:
+
+```bash
+export MODEL=Qwen/Qwen3-8B
+export REVISION=b968826d9c46dd6066d109eabc6255188de91218
+
+trtmc kernel slots "$MODEL" --model-revision "$REVISION"
+```
+
+For this tutorial, the output includes:
+
+```text
+qwen.decode_attention@1
+  Single-token post-RoPE grouped-query attention over native Qwen KV cache exposed as 64-token pages.
+  inputs:
+    query: bfloat16 [num_query_heads, head_dim]
+    key: bfloat16 [1, num_kv_heads, kv_capacity, head_dim]
+    value: bfloat16 [1, num_kv_heads, kv_capacity, head_dim]
+    key_value_lengths: int32 [1]
+    page_offsets: int32 [1]
+    page_table: int32 [num_pages]
+  outputs:
+    context: bfloat16 same_as_input_0
+  workspace: 0 bytes
+  instances (36):
+    decoder.layers.0.decode_attention
+    ...
+    decoder.layers.35.decode_attention
+  model arguments:
+    softmax_scale: float32
+```
+
+A slot is a model-owned call site. It defines tensor shapes, data types,
+workspace, argument order, and how inputs and outputs connect to TensorRT.
+YAML selects a slot; it does not try to rediscover model semantics.
+For this slot, `key_value_lengths[0]` is the live prefix length,
+`page_offsets[0]` is zero, and `page_table` is the identity mapping over
+64-token pages.
+
+## 2. Prepare a TVM-FFI kernel
+
+If you already have a compatible DSO, skip this step. This repository also
+contains the small FlashInfer CuTe exporter used by the example:
+
+```bash
+python -m pip install \
+  "flashinfer-python==0.6.15" \
+  "nvidia-cutlass-dsl==4.5.0" \
+  "apache-tvm-ffi==0.1.12"
+
+mkdir -p artifacts/qwen3-byok
+
+python python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/export_flashinfer_kernel.py \
+  --output artifacts/qwen3-byok/flashinfer-qwen3.so
+```
+
+The exporter requires FlashInfer, CUTLASS DSL, TVM FFI, CUDA PyTorch, and an
+SM 10.3 GPU. It exports a function named `run` with the ABI owned by
+`qwen.decode_attention@1`. The example was tested with FlashInfer 0.6.15,
+CUTLASS DSL 4.5.0, and Apache TVM FFI 0.1.12.
+
+For the pinned Qwen3-8B revision, the symbolic dimensions above resolve to
+32 query heads, 8 KV heads, head dimension 128, and KV capacity 40960. It uses
+64-token pages, so the page table has 640 entries. The included exporter is
+statically specialized to those values and an SM 10.3 GPU; do not reuse its DSO
+for another model merely because that model publishes a slot with the same name.
+
+:::warning Trusted native code only
+A DSO can execute native code when it is loaded. SHA-256 checks identity, not
+safety. Use only a library that you trust.
+:::
+
+## 3. Write the YAML
+
+Copy your DSO beside the YAML, calculate its digest, and fill the example
+template:
+
+```bash
+export WORK="$PWD/artifacts/qwen3-byok"
+export DSO="$WORK/flashinfer-qwen3.so"
+
+sha256sum "$DSO"
+
+sed "s/@SHA256@/$(sha256sum "$DSO" | awk '{print $1}')/" \
+  python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/qwen3-flashinfer.yaml.in \
+  > "$WORK/qwen3-flashinfer.yaml"
+
+cat "$WORK/qwen3-flashinfer.yaml"
+```
+
+The complete contract is intentionally small:
+
+```yaml
+schema_version: 1
+slot: qwen.decode_attention@1
+instances:
+  all: true
+  expect_count: 36
+kernel:
+  library: ./flashinfer-qwen3.so
+  sha256: <the lowercase SHA-256 printed above>
+  function: run
+```
+
+`expect_count` prevents an accidental partial replacement if a different
+model variant has another layer count. To replace only specific layers, use:
+
+```yaml
+instances:
+  ids:
+    - decoder.layers.0.decode_attention
+```
+
+Qwen owns the slot's tensor ABI, so the YAML does not repeat shapes, ports,
+workspace, TensorRT layer names, or Model Connect's internal function alias.
+
+## 4. Build native and patched bundles
+
+First build the native comparison bundle:
+
+```bash
+trtmc build "$MODEL" \
+  --model-revision "$REVISION" \
+  --precision bf16 \
+  --max-cache-length 40960 \
+  -o "$WORK/qwen3-native.trtfb"
+```
+
+Then add only `--kernel`:
+
+```bash
+trtmc build "$MODEL" \
+  --model-revision "$REVISION" \
+  --precision bf16 \
+  --max-cache-length 40960 \
+  --kernel "$WORK/qwen3-flashinfer.yaml" \
+  -o "$WORK/qwen3-flashinfer.trtfb"
+```
+
+Build validates the YAML, DSO digest, slot, and instance count. It then
+connects the slot directly and embeds the exact DSO in the output bundle.
+There is no capture, lowering-map, selection-lock, or graph-patch workflow.
+
+## 5. Check correctness
+
+Run deterministic generation through both bundles:
+
+```bash
+PROMPT="$(<"$PWD/python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/prompt.txt")"
+COMMON_ARGS=(
+  --prompt "$PROMPT"
+  --max-new-tokens 64
+  --greedy
+)
+
+trtmc run "$WORK/qwen3-native.trtfb" "${COMMON_ARGS[@]}" \
+  > "$WORK/native.txt"
+
+trtmc run "$WORK/qwen3-flashinfer.trtfb" "${COMMON_ARGS[@]}" \
+  > "$WORK/flashinfer.txt"
+
+diff -u "$WORK/native.txt" "$WORK/flashinfer.txt"
+```
+
+An empty diff passes this smoke. If it fails, use the native bundle and fix
+the kernel or YAML.
+
+## 6. Check performance does not regress
+
+Use a longer fixed prompt so attention work is measurable, then benchmark both
+bundles on the same idle GPU:
+
+```bash
+PERF_UNIT='Grouped-query attention shares key and value heads across several query heads, reducing cache bandwidth while preserving distinct query projections. This fixed paragraph creates a stable decode benchmark with enough context for attention work to be measurable. '
+PERF_PROMPT=
+for _ in {1..12}; do
+  PERF_PROMPT+="$PERF_UNIT"
+done
+
+trtmc run "$WORK/qwen3-native.trtfb" \
+  --prompt "$PERF_PROMPT" --max-new-tokens 64 --greedy \
+  --warmup 3 --benchmark 10 > "$WORK/native.perf.log" 2>&1
+
+trtmc run "$WORK/qwen3-flashinfer.trtfb" \
+  --prompt "$PERF_PROMPT" --max-new-tokens 64 --greedy \
+  --warmup 3 --benchmark 10 > "$WORK/flashinfer.perf.log" 2>&1
+```
+
+Compare decode throughput:
+
+```bash
+python - "$WORK/native.perf.log" "$WORK/flashinfer.perf.log" <<'PY'
+import re
+import sys
+
+def throughput(path):
+    text = open(path, encoding="utf-8").read()
+    values = [float(x) for x in re.findall(r"tokens_per_sec=([0-9.]+)", text)]
+    if not values:
+        raise SystemExit(f"{path}: tokens_per_sec was not reported")
+    return values[-1]
+
+native = throughput(sys.argv[1])
+patched = throughput(sys.argv[2])
+print(f"native={native:.2f} patched={patched:.2f} tokens/s")
+if patched < native:
+    raise SystemExit("FAIL: the external kernel is slower")
+print("PASS: patched is not slower than native")
+PY
+```
+
+The gate is simple: on the same model revision, prompt, settings, and hardware,
+the patched throughput must be at least the native throughput. In the reference
+SM 10.3 run used to qualify this example, native measured 88.68 tokens/s and
+FlashInfer measured 94.62 tokens/s, with byte-identical generated text. Treat
+those numbers as a receipt, not a promise for different hardware.
+
+## What requires a Model Connect change?
+
+- Another kernel for `qwen.decode_attention@1`: no change; bring YAML + DSO.
+- A different subset of the 36 instances: no change; edit `instances`.
+- A new operation boundary or tensor ABI: the owning model family adds one
+  new versioned slot.
+
+This boundary keeps every model family encapsulated while letting kernel
+authors use the same two-file workflow.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -26,6 +26,7 @@ const sidebars = {
       items: [
         'tutorials/beginner/inspect-bundles',
         'tutorials/beginner/text-generation',
+        'tutorials/beginner/bring-your-own-kernel',
         'tutorials/intermediate/multimodal-and-speech',
         'tutorials/intermediate/canary-decoding',
         'tutorials/intermediate/diffusion-and-time-series',


### PR DESCRIPTION
## Summary

Add a minimal Bring Your Own Kernel path built around family-owned Direct Slots:

- a model family publishes a versioned tensor ABI and exact call sites;
- an existing-slot user brings only a trusted TVM-FFI DSO and a small YAML file;
- `trtmc build --kernel manifest.yaml` wires the DSO into the TensorRT graph and embeds it in the bundle;
- `trtmc kernel slots MODEL` shows the ABI and selectable instances.

Qwen3-8B decode attention is the working reference. Its 36 decode-attention
instances can be replaced by the included FlashInfer CuTe exporter without
user TensorRT C++ or changes to Model Connect.

## KISS scope

This rewrite intentionally removes the previous capture, semantic-graph,
lowering-map, selection-lock, graph-patch, qualification-framework, and
provider-registry designs.

The boundary is:

- another kernel for an existing slot: YAML + DSO only;
- another subset of existing instances: edit YAML only;
- a new operation boundary or ABI: add a small versioned slot inside the
  owning model family.

The final diff is 20 files, `+1348/-58`. Tests are limited to three Python
contract cases and a small extension to the existing C++ CLI test.

## User contract

```yaml
schema_version: 1
slot: qwen.decode_attention@1
instances:
  all: true
  expect_count: 36
kernel:
  library: ./flashinfer-qwen3.so
  sha256: <sha256>
  function: run
```

The family owns shapes, dtypes, workspace, model-provided arguments, graph
wiring, and instance IDs. The manifest is strict, verifies the DSO digest, and
fails closed if the selected instance count does not match.

## Working example

- Model: `Qwen/Qwen3-8B`
- Revision: `b968826d9c46dd6066d109eabc6255188de91218`
- Slot: `qwen.decode_attention@1`
- Kernel: FlashInfer paged grouped-query decode attention exported through
  TVM-FFI
- Tutorial: `website/docs/tutorials/beginner/bring-your-own-kernel.md`
- Exporter: `python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/export_flashinfer_kernel.py`

## Validation

- Focused Python tests: `61 passed`
- C++ CLI forwarding: passed
- Existing C++ TVM-FFI plugin smoke: passed
- Ruff on all changed Python: passed
- Docusaurus optimized production build: passed
- `python tools/legal_headers.py --check`: passed with zero findings
- `git diff --check`: passed
- Qwen3-8B native and patched bundle builds: passed
- Deterministic 64-token output: byte-identical
  (`d89db1eedd28a4bbee49515318bf7d13a1b4c26a6e4d8e2b420b115b0ed7eaa8`)
- Long-prompt benchmark output: byte-identical
  (`b1339012f3ca9c8caebc69e5dc8ca469072ebadfd41f5bc7a02a0c89b479b10e`)

Performance receipt on the same SM 10.3 GPU, pinned model revision, fixed
approximately 493-token prompt, 64 decode tokens, 3 warmups, and 10 benchmark
iterations:

| Bundle | Decode throughput |
| --- | ---: |
| Native | 88.68 tokens/s |
| FlashInfer Direct Slot | 94.62 tokens/s |

The patched route was 6.7% faster in this run and, most importantly for this
functional tutorial, did not regress performance.
