### PR TITLE
fix(modernbert): honor legacy RoPE layout

### DIFF
--- a/python/tensorrt_model_connect/families/modernbert/config.py
+++ b/python/tensorrt_model_connect/families/modernbert/config.py
@@ -10,6 +10,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+@dataclass(frozen=True)
+class AttentionContract:
+    """Resolved per-layer attention and RoPE settings."""
+
+    layer_types: tuple[str, ...]
+    full_rope_theta: float
+    sliding_rope_theta: float
+
+
 @dataclass
 class ModelConfig:
     """Parsed model architecture from HF config.json."""
@@ -237,3 +246,82 @@ class ModelConfig:
         if config_path.exists():
             return ModelConfig.from_json(config_path.read_text())
         return ModelConfig.from_json(config_path.read_text())
+
+
+def resolve_attention_contract(config: ModelConfig) -> AttentionContract:
+    """Resolve both current and legacy ModernBERT attention config layouts.
+
+    Newer Transformers configs materialize ``layer_types`` and
+    ``rope_parameters``.  Released ModernBERT checkpoints instead store the
+    equivalent contract as ``global_attn_every_n_layers`` plus separate global
+    and local RoPE theta values.  Model Connect reads the checkpoint JSON
+    directly, so it must perform the same normalization explicitly.
+    """
+
+    raw = config.raw
+    raw_layer_types = raw.get("layer_types")
+    if isinstance(raw_layer_types, list) and raw_layer_types:
+        if len(raw_layer_types) != config.num_hidden_layers:
+            raise ValueError(
+                "ModernBERT layer_types must contain one entry per hidden layer "
+                f"({len(raw_layer_types)} vs {config.num_hidden_layers})"
+            )
+        layer_types = tuple(str(layer_type) for layer_type in raw_layer_types)
+    else:
+        global_interval = raw.get("global_attn_every_n_layers")
+        if global_interval is None:
+            layer_types = ("full_attention",) * config.num_hidden_layers
+        else:
+            global_interval = int(global_interval)
+            if global_interval <= 0:
+                raise ValueError(
+                    "ModernBERT global_attn_every_n_layers must be positive"
+                )
+            layer_types = tuple(
+                "full_attention"
+                if layer_idx % global_interval == 0
+                else "sliding_attention"
+                for layer_idx in range(config.num_hidden_layers)
+            )
+
+    rope_parameters = raw.get("rope_parameters")
+    rope_parameters = (
+        rope_parameters if isinstance(rope_parameters, dict) else {}
+    )
+    full_parameters = rope_parameters.get("full_attention")
+    sliding_parameters = rope_parameters.get("sliding_attention")
+    full_parameters = (
+        full_parameters if isinstance(full_parameters, dict) else {}
+    )
+    sliding_parameters = (
+        sliding_parameters if isinstance(sliding_parameters, dict) else {}
+    )
+    full_rope_theta = float(
+        full_parameters.get(
+            "rope_theta", raw.get("global_rope_theta", 160000.0)
+        )
+    )
+    sliding_rope_theta = float(
+        sliding_parameters.get(
+            "rope_theta", raw.get("local_rope_theta", 10000.0)
+        )
+    )
+
+    valid_layer_types = {
+        "full_attention",
+        "global_attention",
+        "sliding_attention",
+        "local_attention",
+    }
+    invalid_layer_types = sorted(set(layer_types) - valid_layer_types)
+    if invalid_layer_types:
+        raise ValueError(
+            "Unsupported ModernBERT layer_types: "
+            + ", ".join(invalid_layer_types)
+        )
+
+    return AttentionContract(
+        layer_types=layer_types,
+        full_rope_theta=full_rope_theta,
+        sliding_rope_theta=sliding_rope_theta,
+    )

--- a/python/tensorrt_model_connect/families/modernbert/model/parallel.py
+++ b/python/tensorrt_model_connect/families/modernbert/model/parallel.py
@@ -12,7 +12,7 @@ import numpy as np
 from tensorrt_model_connect import trt_compat
 
 from . import model as graph_ops
-from ..config import ModelConfig
+from ..config import ModelConfig, resolve_attention_contract
 from ....parallel_config import add_all_reduce_sum, normalize_parallel_config
 
 trt = trt_compat.get_trt()
@@ -129,15 +129,10 @@ def build_tp_modernbert_engine(
     eps = config.raw.get("norm_eps", config.rms_norm_eps)
     max_seq = max_seq_length
 
-    layer_types = config.raw.get("layer_types", [])
-    rope_params = config.raw.get("rope_parameters", {})
-    full_theta = 160000.0
-    sliding_theta = 10000.0
-    if rope_params:
-        if "full_attention" in rope_params and rope_params["full_attention"]:
-            full_theta = rope_params["full_attention"].get("rope_theta", 160000.0)
-        if "sliding_attention" in rope_params and rope_params["sliding_attention"]:
-            sliding_theta = rope_params["sliding_attention"].get("rope_theta", 10000.0)
+    attention_contract = resolve_attention_contract(config)
+    layer_types = attention_contract.layer_types
+    full_theta = attention_contract.full_rope_theta
+    sliding_theta = attention_contract.sliding_rope_theta
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -188,11 +183,12 @@ def build_tp_modernbert_engine(
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
 
-        if layer_idx < len(layer_types):
-            lt = layer_types[layer_idx]
-            theta = full_theta if lt in ("full_attention", "global_attention") else sliding_theta
-        else:
-            theta = full_theta
+        lt = layer_types[layer_idx]
+        theta = (
+            full_theta
+            if lt in ("full_attention", "global_attention")
+            else sliding_theta
+        )
         cos_table, sin_table = rope_tables[theta]
 
         if f"{prefix}.attn_norm" in weights:

--- a/python/tensorrt_model_connect/families/modernbert/plugin.py
+++ b/python/tensorrt_model_connect/families/modernbert/plugin.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import numpy as np
 
-from .config import ModelConfig
+from .config import ModelConfig, resolve_attention_contract
 from .weights import (
     WeightDict,
     _open_safetensors,
@@ -179,17 +179,10 @@ class ModernbertPlugin:
         else:
             raise ValueError(f"Unsupported ModernBERT precision: {precision}")
 
-        # Per-layer RoPE theta from layer_types
-        layer_types = config.raw.get("layer_types", [])
-        rope_params = config.raw.get("rope_parameters", {})
-        # Default theta values
-        full_theta = 160000.0
-        sliding_theta = 10000.0
-        if rope_params:
-            if "full_attention" in rope_params and rope_params["full_attention"]:
-                full_theta = rope_params["full_attention"].get("rope_theta", 160000.0)
-            if "sliding_attention" in rope_params and rope_params["sliding_attention"]:
-                sliding_theta = rope_params["sliding_attention"].get("rope_theta", 10000.0)
+        attention_contract = resolve_attention_contract(config)
+        layer_types = attention_contract.layer_types
+        full_theta = attention_contract.full_rope_theta
+        sliding_theta = attention_contract.sliding_rope_theta
 
         logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
         builder = trt.Builder(logger)
@@ -253,14 +246,11 @@ class ModernbertPlugin:
             prefix = f"layer.{layer_idx}"
 
             # Determine RoPE theta for this layer
-            if layer_idx < len(layer_types):
-                lt = layer_types[layer_idx]
-                if lt in ("full_attention", "global_attention"):
-                    theta = full_theta
-                else:
-                    theta = sliding_theta
-            else:
+            lt = layer_types[layer_idx]
+            if lt in ("full_attention", "global_attention"):
                 theta = full_theta
+            else:
+                theta = sliding_theta
             cos_table, sin_table = rope_tables[theta]
 
             # Pre-norm attention

--- a/tests/e2e/models/modernbert/manifests/modernbert-base-tp4.json
+++ b/tests/e2e/models/modernbert/manifests/modernbert-base-tp4.json
@@ -32,7 +32,7 @@
       "reference_family": "encoder_base_features",
       "user_contract": "representation_parity",
       "ci_tier": "multi_device",
-      "prompt": "The capital of France is Paris.",
+      "prompt": "A man is slicing open a fish.",
       "max_new_tokens": 1,
       "preflight_requirements": [
         {

--- a/tests/e2e/models/modernbert/manifests/modernbert-base.json
+++ b/tests/e2e/models/modernbert/manifests/modernbert-base.json
@@ -13,7 +13,7 @@
       "reference_family": "encoder_base_features",
       "user_contract": "representation_parity",
       "reference_precision": "fp32",
-      "prompt": "The capital of France is Paris.",
+      "prompt": "A man is slicing open a fish.",
       "max_new_tokens": 1,
       "metadata": {
         "contract_config": {

--- a/tests/e2e/models/modernbert/test_modernbert_attention_contract.py
+++ b/tests/e2e/models/modernbert/test_modernbert_attention_contract.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModernBERT attention and RoPE config contract tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tensorrt_model_connect.families.modernbert.config import (
+    ModelConfig,
+    resolve_attention_contract,
+)
+
+
+def _config(**overrides) -> ModelConfig:
+    raw = {
+        "model_type": "modernbert",
+        "vocab_size": 32,
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "num_hidden_layers": 7,
+        "num_attention_heads": 4,
+        **overrides,
+    }
+    return ModelConfig.from_json(json.dumps(raw))
+
+
+def test_resolves_released_checkpoint_attention_layout() -> None:
+    contract = resolve_attention_contract(
+        _config(
+            global_attn_every_n_layers=3,
+            global_rope_theta=160000.0,
+            local_rope_theta=10000.0,
+            layer_types=None,
+            rope_parameters=None,
+        )
+    )
+
+    assert contract.layer_types == (
+        "full_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    )
+    assert contract.full_rope_theta == 160000.0
+    assert contract.sliding_rope_theta == 10000.0
+
+
+def test_prefers_materialized_attention_layout() -> None:
+    contract = resolve_attention_contract(
+        _config(
+            num_hidden_layers=2,
+            global_attn_every_n_layers=3,
+            global_rope_theta=160000.0,
+            local_rope_theta=10000.0,
+            layer_types=["sliding_attention", "full_attention"],
+            rope_parameters={
+                "full_attention": {"rope_theta": 200000.0},
+                "sliding_attention": {"rope_theta": 20000.0},
+            },
+        )
+    )
+
+    assert contract.layer_types == (
+        "sliding_attention",
+        "full_attention",
+    )
+    assert contract.full_rope_theta == 200000.0
+    assert contract.sliding_rope_theta == 20000.0
+
+
+def test_rejects_non_positive_global_attention_interval() -> None:
+    with pytest.raises(
+        ValueError, match="global_attn_every_n_layers must be positive"
+    ):
+        resolve_attention_contract(
+            _config(global_attn_every_n_layers=0, layer_types=None)
+        )


### PR DESCRIPTION
## Background

The original QA run `trtmc-validate-gb300-2-20260726-c8291be0-all105`
reported `modernbert-base / stsbenchmark_encoder_embedding_parity` at
`vector_pass_rate=0.95` with minimum cosine `0.990320`. Rerun
`trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10` reproduced the `0.95`
pass rate. The exact failing sentence, `A man is slicing open a fish.`,
reproduced on current `github/main`
(`1118e72505e14d336ce5e8f6999ff14e85b3b1de`) with minimum vector cosine
`0.9939271488`, below the unchanged `0.995` gate.

The released `answerdotai/ModernBERT-base` config stores its attention layout in legacy fields (`global_attn_every_n_layers`, `global_rope_theta`, and `local_rope_theta`). Both Model Connect builders only read the newer materialized `layer_types` / `rope_parameters` layout. Because those fields are absent, every layer incorrectly used the global RoPE theta `160000` instead of using local theta `10000` on sliding-attention layers.

## Exit Criteria

- Single-device and tensor-parallel builders resolve the same per-layer RoPE layout as Transformers for both legacy and current config formats.
- The exact QA failure passes the existing cosine gate without changing its threshold.
- The reconstructed 50-pair STS workload passes end to end.
- Premerge coverage catches this regression without adding another engine build or E2E case.

## Implementation

- Normalize legacy and materialized ModernBERT attention metadata through one validated resolver shared by the single-device and TP builders.
- Apply the resolved global or local RoPE theta for every layer.
- Replace the existing short E2E prompt with the exact QA failure sentinel in both SP and TP manifests. This keeps the same model build, case count, precision, runner, comparator, and thresholds.

## Why CI missed it

The existing France/Paris prompt still passed with the wrong all-global RoPE
layout, and no CPU contract test asserted how a released legacy config maps
local versus global attention layers. This PR adds that config-level contract
and makes the existing single GPU case use the discriminating QA sentence.

## Validation

- Current-main focused exact repro with the normal catalog/suite, the retained
  QA dataset, `--limit 1 --no-build --force-hf --local-files-only`: **failed**
  as expected; `vector_pass_rate=0.5`, minimum cosine `0.9939271488`,
  17.182 s.
- Patched exact repro using the same dataset and gate: **passed**; `vector_pass_rate=1.0`, minimum cosine `0.9999999999983`, 18.910 s.
- Patched reconstructed full workload with `--limit 50`: **passed**; 50 pairs / 100 vectors, `vector_pass_rate=1.0`, minimum cosine `0.9999999999971`, maximum pair-cosine delta `4.70e-7`, 182.801 s.
- `/opt/venv/bin/python -m pytest -q /runs/worktrees/modernbert-fix/tests/e2e/models/modernbert`: **17 passed, 1 skipped** in 34.37 s. The skip is the existing host-only TensorRT availability skip.
- `git diff --check`: **passed**.

## Notes For Future Readers

- Review `config.py` first, then the two builder call sites, then the manifest-only CI sentinel change.
- The dashboard workload contains short sequences (maximum 12 tokens in this 50-pair reconstruction), so this PR proves the legacy per-layer RoPE-theta root cause. It does not claim new long-sequence sliding-window-mask coverage.
- CI runtime remains bounded: cases/builds stay `1 -> 1`; the same new sentinel
  measured `17.182 s` before and `18.910 s` after. No suite, engine build,
  inference case, or threshold is added.
- The TP builder uses the same tested resolver, but TP4 inference was not rerun
  locally.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased cleanly onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `44dc5955b2f00114fd51b479b355f258b90b3fd5`.
- Bundle migration audit: `git grep -I -n -i trtfb HEAD` returned no matches, no tracked filename contains the retired identifier, and this PR keeps the current `.bundle` / `BUNDLE\\x01\\x00` contract unchanged.
- Latest-main CPU attention-contract regression: **3 passed**. The resolver test was imported directly because the host lacks the TensorRT Python package; no runtime path was mocked.
- `python3 -m compileall -q python/tensorrt_model_connect/families/modernbert tests/e2e/models/modernbert`: **passed**.
- Both changed JSON manifests parsed successfully; `git diff --check github/main...HEAD`: **passed**.
- This rebase adds no model case, engine build, threshold change, or CI matrix fan-out. The push triggered fresh exact-head GitHub CI; this section does not claim CI is green until those checks complete.
