### PR TITLE
fix(eagle-vlm): restore Nemotron reranker parity

### DIFF
--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -56,6 +56,19 @@ def _is_reranker(config: ModelConfig) -> bool:
     return False
 
 
+def _resolve_rope_scaling(config: ModelConfig) -> dict:
+    """Return the checkpoint RoPE scaling contract across HF schema versions."""
+    raw = config.raw
+    llm_config = raw.get("llm_config")
+    sources = (llm_config, raw) if isinstance(llm_config, dict) else (raw,)
+    for source in sources:
+        for key in ("rope_parameters", "rope_scaling"):
+            value = source.get(key)
+            if isinstance(value, dict):
+                return value
+    return {}
+
+
 class EagleVLMPlugin:
     name = "eagle_vlm"
 
@@ -389,9 +402,10 @@ def _build_eagle_engine(
 
     # --- RoPE tables ---
     graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
-    # Check for Llama3 RoPE scaling (from rope_parameters in llm_config)
-    rope_params = config.raw.get("llm_config", {}).get("rope_parameters", {})
-    rope_type = rope_params.get("rope_type", "")
+    # Hugging Face 5.x calls this rope_parameters, while the pinned Nemotron
+    # checkpoint still publishes llm_config.rope_scaling.
+    rope_params = _resolve_rope_scaling(config)
+    rope_type = rope_params.get("rope_type") or rope_params.get("type", "")
     if rope_type == "llama3":
         cos_half_np = _make_llama3_rope_table_half_dim(
             seq_length, head_dim, config.rope_theta, True,
@@ -535,17 +549,21 @@ def _build_eagle_engine(
 
     # --- Output ---
     if is_reranker and "score_weight" in weights:
-        # Reranking: apply score head to last token's hidden state
-        # Take last position: hidden_state[seq_length-1, :]
-        # For now, output all positions; C++ will pick the right one
+        # The pinned CrossEncoderHead is explicitly FP32 and casts the final
+        # hidden states before applying its linear projection. Preserve that
+        # small mixed-precision boundary instead of accumulating the score head
+        # in FP16.
+        score_input = hidden_state
+        if score_input.dtype != trt.float32:
+            score_input = network.add_cast(score_input, trt.float32).get_output(0)
         score = graph_ops.add_matmul_rhs_constant(
-            network, hidden_state, hidden,
+            network, score_input, hidden,
             weights["score_weight"].shape[1], weights["score_weight"],
-            dtype=work_np_dtype)
+            dtype=np.float32)
         if "score_bias" in weights:
             score = graph_ops.add_bias_sum(
                 network, score, weights["score_weight"].shape[1],
-                weights["score_bias"], dtype=work_np_dtype)
+                weights["score_bias"], dtype=np.float32)
         if score.dtype != trt.float32:
             score = network.add_cast(score, trt.float32).get_output(0)
         score.name = "score"

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
     pass
 
 
+_RERANKER_FP32_TAIL_LAYERS = 8
+
+
 def _is_reranker(config: ModelConfig) -> bool:
     """Detect reranking mode from config."""
     if config.raw.get("is_reranker", False):
@@ -436,6 +439,22 @@ def _build_eagle_engine(
     eps_tensor = graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
         dtype=work_np_dtype)
+    keep_reranker_tail_fp32 = is_reranker and work_np_dtype != np.float32
+    tail_cos_half_tensor = cos_half_tensor
+    tail_sin_half_tensor = sin_half_tensor
+    tail_eps_tensor = eps_tensor
+    if keep_reranker_tail_fp32:
+        # Ranking can hinge on score margins below FP16 resolution. Keep only
+        # a bounded transformer tail and classification head in FP32 rather
+        # than doubling the complete engine with an all-FP32 build.
+        tail_cos_half_tensor = graph_ops.add_constant(
+            network, cos_half_np.shape, cos_half_np, dtype=np.float32)
+        tail_sin_half_tensor = graph_ops.add_constant(
+            network, sin_half_np.shape, sin_half_np, dtype=np.float32)
+        tail_eps_tensor = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([config.rms_norm_eps], dtype=np.float32),
+            dtype=np.float32)
     attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
 
     # --- Build padding attention mask from attention_mask input ---
@@ -468,6 +487,10 @@ def _build_eagle_engine(
     pad_mask_2d = network.add_elementwise(
         query_zeros, pad_mask_row.get_output(0), trt.ElementWiseOperation.SUM)
     pad_mask_4d = graph_ops.add_2d_mask_to_4d(network, pad_mask_2d.get_output(0))
+    tail_pad_mask_4d = pad_mask_4d
+    if keep_reranker_tail_fp32 and pad_mask_4d.dtype != trt.float32:
+        tail_pad_mask_4d = network.add_cast(
+            pad_mask_4d, trt.float32).get_output(0)
 
     # --- Encoder layers (no KV cache -- full self-attention over seq_length) ---
     # Single-pass encoder: process all positions at once.
@@ -478,31 +501,45 @@ def _build_eagle_engine(
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        is_reranker_tail = (
+            keep_reranker_tail_fp32
+            and layer_idx >= max(num_layers - _RERANKER_FP32_TAIL_LAYERS, 0))
+        layer_np_dtype = np.float32 if is_reranker_tail else work_np_dtype
+        layer_eps_tensor = tail_eps_tensor if is_reranker_tail else eps_tensor
+        layer_cos_half_tensor = (
+            tail_cos_half_tensor if is_reranker_tail else cos_half_tensor)
+        layer_sin_half_tensor = (
+            tail_sin_half_tensor if is_reranker_tail else sin_half_tensor)
+        layer_pad_mask_4d = (
+            tail_pad_mask_4d if is_reranker_tail else pad_mask_4d)
+        if is_reranker_tail and hidden_state.dtype != trt.float32:
+            hidden_state = network.add_cast(
+                hidden_state, trt.float32).get_output(0)
 
         # Pre-norm
         norm1 = graph_blocks.apply_norm(
             network, hidden_state, hidden,
             weights[f"{prefix}.input_norm"],
-            None, eps_tensor, "rmsnorm", dtype=work_np_dtype)
+            None, layer_eps_tensor, "rmsnorm", dtype=layer_np_dtype)
 
         # Self-attention: Q, K, V projections
         q = graph_ops.add_matmul_rhs_constant(
             network, norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
-            dtype=work_np_dtype)
+            dtype=layer_np_dtype)
         k = graph_ops.add_matmul_rhs_constant(
             network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
-            dtype=work_np_dtype)
+            dtype=layer_np_dtype)
         v = graph_ops.add_matmul_rhs_constant(
             network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
-            dtype=work_np_dtype)
+            dtype=layer_np_dtype)
 
         q_rope = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, rope_position_ids,
+            layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
             head_dim, sequence_length=seq_length)
         k_rope = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, rope_position_ids,
+            layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
             head_dim, sequence_length=seq_length)
 
         attn_concat = graph_ops.add_attention_from_rows(
@@ -510,13 +547,13 @@ def _build_eagle_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=seq_length, kv_seq=seq_length,
-            mask=pad_mask_4d,
+            mask=layer_pad_mask_4d,
             scale=attn_scale)
 
         # Output projection
         proj_out = graph_ops.add_matmul_rhs_constant(
             network, attn_concat, attention_size, hidden,
-            weights[f"{prefix}.w_o"], dtype=work_np_dtype)
+            weights[f"{prefix}.w_o"], dtype=layer_np_dtype)
 
         # Residual
         residual1 = network.add_elementwise(
@@ -527,12 +564,12 @@ def _build_eagle_engine(
         norm2 = graph_blocks.apply_norm(
             network, residual1.get_output(0), hidden,
             weights[f"{prefix}.post_attn_norm"],
-            None, eps_tensor, "rmsnorm", dtype=work_np_dtype)
+            None, layer_eps_tensor, "rmsnorm", dtype=layer_np_dtype)
 
         mlp_out = graph_blocks.add_swiglu_mlp(
             network, norm2, weights=weights, prefix=prefix,
             hidden_size=hidden, mlp_size=mlp_size,
-            dtype=work_np_dtype)
+            dtype=layer_np_dtype)
 
         # Final residual
         residual2 = network.add_elementwise(
@@ -543,9 +580,16 @@ def _build_eagle_engine(
     # --- Final norm ---
     final_norm = weights.get("final_norm")
     if final_norm is not None and len(final_norm) > 0:
+        final_norm_dtype = (
+            np.float32 if keep_reranker_tail_fp32 else work_np_dtype)
+        final_eps_tensor = (
+            tail_eps_tensor if keep_reranker_tail_fp32 else eps_tensor)
+        if keep_reranker_tail_fp32 and hidden_state.dtype != trt.float32:
+            hidden_state = network.add_cast(
+                hidden_state, trt.float32).get_output(0)
         hidden_state = graph_blocks.apply_norm(
             network, hidden_state, hidden, final_norm, None,
-            eps_tensor, "rmsnorm", dtype=work_np_dtype)
+            final_eps_tensor, "rmsnorm", dtype=final_norm_dtype)
 
     # --- Output ---
     if is_reranker and "score_weight" in weights:

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     pass
 
 
-_RERANKER_FP32_TAIL_LAYERS = 8
+_RERANKER_FP32_TAIL_LAYERS = 16
 
 
 def _is_reranker(config: ModelConfig) -> bool:

--- a/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
@@ -16,7 +16,7 @@ from ...parallel_config import (
     normalize_parallel_config,
     shard_standard_decoder_weights,
 )
-from .plugin import _make_llama3_rope_table_half_dim
+from .plugin import _make_llama3_rope_table_half_dim, _resolve_rope_scaling
 
 if TYPE_CHECKING:
     from .config import ModelConfig
@@ -114,8 +114,8 @@ def build_eagle_vlm_tp_engine(
     hidden_state = merged.get_output(0)
 
     graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
-    rope_params = config.raw.get("llm_config", {}).get("rope_parameters", {})
-    rope_type = rope_params.get("rope_type", "")
+    rope_params = _resolve_rope_scaling(config)
+    rope_type = rope_params.get("rope_type") or rope_params.get("type", "")
     if rope_type == "llama3":
         cos_half_np = _make_llama3_rope_table_half_dim(
             seq_length, head_dim, config.rope_theta, True,

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -73,9 +73,10 @@ std::size_t checked_element_count(const std::vector<int64_t>& shape) {
 // ─── EncoderPipeline ───
 
 EncoderPipeline::EncoderPipeline(std::unique_ptr<TrtModule> encoder, std::string mode,
-                                 std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
+                                 std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                                 std::string reranking_pooling)
     : encoder_(std::move(encoder)), mode_(std::move(mode)), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)) {
+      model_id_(std::move(model_id_str)), reranking_pooling_(std::move(reranking_pooling)) {
     if (!encoder_ || !encoder_->ok())
         throw std::runtime_error("EncoderPipeline: invalid encoder module");
 }
@@ -122,9 +123,10 @@ EmbeddingResult EncoderPipeline::encode(const std::string& text) {
 float EncoderPipeline::rerank(const std::string& query, const std::string& document) {
     if (!tokenizer_)
         throw std::runtime_error("EncoderPipeline: no tokenizer configured");
-    // Match the text-only reranking template documented by the supported
-    // Nemotron rerank cross-encoder model card.
-    std::string combined = "question:" + query + "   passage:" + document;
+    // Match LlamaNemotronVLRerankProcessor.prompt_template_question_passage()
+    // from the pinned checkpoint. The whitespace is part of the trained input
+    // contract and changes the token sequence.
+    std::string combined = "question:" + query + " \n \n passage:" + document;
     auto ids = tokenizer_->encode(combined);
     if (ids.empty())
         throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
@@ -142,8 +144,8 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
         return output.result.data.front();
 
     // Eagle's score head emits one scalar per sequence position as
-    // [..., sequence, 1]. Match HF SequenceClassification, which selects the
-    // last non-padding token, instead of returning the first position.
+    // [..., sequence, 1]. Apply the pooling contract recorded by the pinned
+    // checkpoint to the valid input positions.
     if (output.shape.size() < 2 || output.shape.back() != 1)
         throw std::runtime_error(
             "EncoderPipeline: reranking score output must have one value per position");
@@ -153,10 +155,20 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
         throw std::runtime_error(
             "EncoderPipeline: reranking score output is shorter than the token sequence");
 
-    const auto score_index = ids.size() - 1;
-    if (score_index >= output.result.data.size())
-        throw std::runtime_error("EncoderPipeline: reranking score index is out of bounds");
-    return output.result.data[score_index];
+    if (reranking_pooling_ == "avg") {
+        double sum = 0.0;
+        for (std::size_t i = 0; i < ids.size(); ++i)
+            sum += output.result.data[i];
+        return static_cast<float>(sum / static_cast<double>(ids.size()));
+    }
+    if (reranking_pooling_ == "last") {
+        const auto score_index = ids.size() - 1;
+        if (score_index >= output.result.data.size())
+            throw std::runtime_error("EncoderPipeline: reranking score index is out of bounds");
+        return output.result.data[score_index];
+    }
+    throw std::runtime_error("EncoderPipeline: unsupported reranking pooling mode: " +
+                             reranking_pooling_);
 }
 
 EmbeddingResult EncoderPipeline::encode_ids(const std::vector<int32_t>& input_ids) {

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -93,6 +93,43 @@ void canonicalize_reranking_separator_tokens(const ITokenizer& tokenizer,
     ids = std::move(canonical);
 }
 
+void validate_reranking_score_output(const EmbeddingResult& result,
+                                     const std::vector<int64_t>& shape, std::size_t token_count) {
+    if (result.data.empty())
+        throw std::runtime_error("EncoderPipeline: reranking engine produced no score output");
+
+    const auto element_count = checked_element_count(shape);
+    if (element_count != result.data.size())
+        throw std::runtime_error("EncoderPipeline: reranking score shape does not match its data");
+    if (element_count == 1)
+        return;
+    if (shape.size() < 2 || shape.back() != 1)
+        throw std::runtime_error(
+            "EncoderPipeline: reranking score output must have one value per position");
+    if (token_count > element_count)
+        throw std::runtime_error(
+            "EncoderPipeline: reranking score output is shorter than the token sequence");
+}
+
+float average_prefix(const std::vector<float>& values, std::size_t count) {
+    double sum = 0.0;
+    for (std::size_t i = 0; i < count; ++i)
+        sum += values[i];
+    return static_cast<float>(sum / static_cast<double>(count));
+}
+
+float select_reranking_score(const EmbeddingResult& result, const std::vector<int64_t>& shape,
+                             std::size_t token_count, const std::string& pooling) {
+    validate_reranking_score_output(result, shape, token_count);
+    if (result.data.size() == 1)
+        return result.data.front();
+    if (pooling == "avg")
+        return average_prefix(result.data, token_count);
+    if (pooling == "last")
+        return result.data[token_count - 1];
+    throw std::runtime_error("EncoderPipeline: unsupported reranking pooling mode: " + pooling);
+}
+
 } // namespace
 
 // ─── EncoderPipeline ───
@@ -158,43 +195,10 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
         throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
 
     auto output = encode_ids_with_shape(ids);
-    if (output.result.data.empty())
-        throw std::runtime_error("EncoderPipeline: reranking engine produced no score output");
-
-    const auto element_count = checked_element_count(output.shape);
-    if (element_count != output.result.data.size())
-        throw std::runtime_error("EncoderPipeline: reranking score shape does not match its data");
-
-    // A graph may already reduce the per-position logits to one final score.
-    if (element_count == 1)
-        return output.result.data.front();
-
     // Eagle's score head emits one scalar per sequence position as
     // [..., sequence, 1]. Apply the pooling contract recorded by the pinned
     // checkpoint to the valid input positions.
-    if (output.shape.size() < 2 || output.shape.back() != 1)
-        throw std::runtime_error(
-            "EncoderPipeline: reranking score output must have one value per position");
-
-    const auto positions = element_count / static_cast<std::size_t>(output.shape.back());
-    if (ids.size() > positions)
-        throw std::runtime_error(
-            "EncoderPipeline: reranking score output is shorter than the token sequence");
-
-    if (reranking_pooling_ == "avg") {
-        double sum = 0.0;
-        for (std::size_t i = 0; i < ids.size(); ++i)
-            sum += output.result.data[i];
-        return static_cast<float>(sum / static_cast<double>(ids.size()));
-    }
-    if (reranking_pooling_ == "last") {
-        const auto score_index = ids.size() - 1;
-        if (score_index >= output.result.data.size())
-            throw std::runtime_error("EncoderPipeline: reranking score index is out of bounds");
-        return output.result.data[score_index];
-    }
-    throw std::runtime_error("EncoderPipeline: unsupported reranking pooling mode: " +
-                             reranking_pooling_);
+    return select_reranking_score(output.result, output.shape, ids.size(), reranking_pooling_);
 }
 
 EmbeddingResult EncoderPipeline::encode_ids(const std::vector<int32_t>& input_ids) {

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 
 namespace trtmc {
@@ -49,6 +50,22 @@ bool engine_mask_is_int32(const TrtModule& module) {
         if (info.name == "attention_mask")
             return info.dtype == DType::kInt32;
     return false;
+}
+
+std::size_t checked_element_count(const std::vector<int64_t>& shape) {
+    if (shape.empty())
+        throw std::runtime_error("EncoderPipeline: output tensor is missing shape metadata");
+
+    std::size_t count = 1;
+    for (const auto dim : shape) {
+        if (dim <= 0)
+            throw std::runtime_error("EncoderPipeline: output tensor has a non-positive dimension");
+        const auto size = static_cast<std::size_t>(dim);
+        if (count > std::numeric_limits<std::size_t>::max() / size)
+            throw std::runtime_error("EncoderPipeline: output tensor element count overflow");
+        count *= size;
+    }
+    return count;
 }
 
 } // namespace
@@ -109,11 +126,45 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
     // Nemotron rerank cross-encoder model card.
     std::string combined = "question:" + query + "   passage:" + document;
     auto ids = tokenizer_->encode(combined);
-    auto result = encode_ids(ids);
-    return result.data.empty() ? 0.0f : result.data[0];
+    if (ids.empty())
+        throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
+
+    auto output = encode_ids_with_shape(ids);
+    if (output.result.data.empty())
+        throw std::runtime_error("EncoderPipeline: reranking engine produced no score output");
+
+    const auto element_count = checked_element_count(output.shape);
+    if (element_count != output.result.data.size())
+        throw std::runtime_error("EncoderPipeline: reranking score shape does not match its data");
+
+    // A graph may already reduce the per-position logits to one final score.
+    if (element_count == 1)
+        return output.result.data.front();
+
+    // Eagle's score head emits one scalar per sequence position as
+    // [..., sequence, 1]. Match HF SequenceClassification, which selects the
+    // last non-padding token, instead of returning the first position.
+    if (output.shape.size() < 2 || output.shape.back() != 1)
+        throw std::runtime_error(
+            "EncoderPipeline: reranking score output must have one value per position");
+
+    const auto positions = element_count / static_cast<std::size_t>(output.shape.back());
+    if (ids.size() > positions)
+        throw std::runtime_error(
+            "EncoderPipeline: reranking score output is shorter than the token sequence");
+
+    const auto score_index = ids.size() - 1;
+    if (score_index >= output.result.data.size())
+        throw std::runtime_error("EncoderPipeline: reranking score index is out of bounds");
+    return output.result.data[score_index];
 }
 
 EmbeddingResult EncoderPipeline::encode_ids(const std::vector<int32_t>& input_ids) {
+    return encode_ids_with_shape(input_ids).result;
+}
+
+EncoderPipeline::EncodedOutput
+EncoderPipeline::encode_ids_with_shape(const std::vector<int32_t>& input_ids) {
     const auto n = input_ids.size();
     std::vector<int32_t> mask_i32(n, 1);
     std::vector<float> mask_f32(n, 1.0f);
@@ -142,20 +193,25 @@ EmbeddingResult EncoderPipeline::encode_ids(const std::vector<int32_t>& input_id
 
     auto outputs = encoder_->forward(inputs);
 
-    EmbeddingResult result;
+    EncodedOutput output;
     for (auto& [name, tensor] : outputs) {
         if (name.find("logits") != std::string::npos || name.find("embed") != std::string::npos ||
             name.find("output") != std::string::npos || name.find("hidden") != std::string::npos ||
             name.find("score") != std::string::npos) {
-            auto n = tensor.numel();
-            result.data.resize(static_cast<std::size_t>(n));
-            std::memcpy(result.data.data(), tensor.data, n * sizeof(float));
-            result.dim = static_cast<int32_t>(n);
+            const auto element_count = checked_element_count(tensor.shape);
+            if (!tensor.data)
+                throw std::runtime_error("EncoderPipeline: output tensor has no data");
+            if (element_count > static_cast<std::size_t>(std::numeric_limits<int32_t>::max()))
+                throw std::runtime_error("EncoderPipeline: output tensor is too large");
+            output.result.data.resize(element_count);
+            std::memcpy(output.result.data.data(), tensor.data, element_count * sizeof(float));
+            output.result.dim = static_cast<int32_t>(element_count);
+            output.shape = tensor.shape;
             break;
         }
     }
 
-    return result;
+    return output;
 }
 
 } // namespace trtmc

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -68,6 +68,31 @@ std::size_t checked_element_count(const std::vector<int64_t>& shape) {
     return count;
 }
 
+// The pinned Nemotron reranker processor's fixed " \n \n " separator is
+// encoded by the HF fast tokenizer as the single vocabulary token "ĠĊĠĊ".
+// TRTMC's BPE tokenizer currently preserves the two pre-tokenized "ĠĊ"
+// pieces instead. Canonicalize that merge at this family-owned input boundary
+// so the engine sees the checkpoint's exact token sequence.
+void canonicalize_reranking_separator_tokens(const ITokenizer& tokenizer,
+                                             std::vector<int32_t>& ids) {
+    const auto separator_piece = tokenizer.id_for_token("ĠĊ");
+    const auto merged_separator = tokenizer.id_for_token("ĠĊĠĊ");
+    if (separator_piece < 0 || merged_separator < 0 || separator_piece == merged_separator)
+        return;
+
+    std::vector<int32_t> canonical;
+    canonical.reserve(ids.size());
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        if (i + 1 < ids.size() && ids[i] == separator_piece && ids[i + 1] == separator_piece) {
+            canonical.push_back(merged_separator);
+            ++i;
+        } else {
+            canonical.push_back(ids[i]);
+        }
+    }
+    ids = std::move(canonical);
+}
+
 } // namespace
 
 // ─── EncoderPipeline ───
@@ -128,6 +153,7 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
     // contract and changes the token sequence.
     std::string combined = "question:" + query + " \n \n passage:" + document;
     auto ids = tokenizer_->encode(combined);
+    canonicalize_reranking_separator_tokens(*tokenizer_, ids);
     if (ids.empty())
         throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
 

--- a/src/runtime/models/eagle_vlm/pipeline.h
+++ b/src/runtime/models/eagle_vlm/pipeline.h
@@ -34,6 +34,13 @@ class EncoderPipeline final : public IPipeline {
     EmbeddingResult encode_ids(const std::vector<int32_t>& input_ids);
 
   private:
+    struct EncodedOutput {
+        EmbeddingResult result;
+        std::vector<int64_t> shape;
+    };
+
+    EncodedOutput encode_ids_with_shape(const std::vector<int32_t>& input_ids);
+
     std::unique_ptr<TrtModule> encoder_;
     std::string mode_; // "encoder_only", "embedding", "reranking"
     std::shared_ptr<ITokenizer> tokenizer_;

--- a/src/runtime/models/eagle_vlm/pipeline.h
+++ b/src/runtime/models/eagle_vlm/pipeline.h
@@ -21,7 +21,8 @@ namespace trtmc {
 class EncoderPipeline final : public IPipeline {
   public:
     EncoderPipeline(std::unique_ptr<TrtModule> encoder, std::string mode,
-                    std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "");
+                    std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
+                    std::string reranking_pooling = "last");
 
     EmbeddingResult embed(const std::string& text) override;
     EmbeddingResult encode(const std::string& text) override;
@@ -45,6 +46,7 @@ class EncoderPipeline final : public IPipeline {
     std::string mode_; // "encoder_only", "embedding", "reranking"
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
+    std::string reranking_pooling_;
 };
 
 } // namespace trtmc

--- a/src/runtime/models/eagle_vlm/plugin.cpp
+++ b/src/runtime/models/eagle_vlm/plugin.cpp
@@ -62,8 +62,10 @@ class EncoderPlugin final : public IPipelinePlugin {
 
         const std::string mode =
             (ctx.config.runtime_strategy == "eagle_vlm_reranking") ? "reranking" : "embedding";
+        const auto reranking_pooling = extract_json_string(ctx.config_json, "pooling", "last");
         return std::make_unique<EncoderPipeline>(std::move(loaded.module), mode,
-                                                 std::move(tokenizer), ctx.bundle.info.model_id);
+                                                 std::move(tokenizer), ctx.bundle.info.model_id,
+                                                 reranking_pooling);
     }
 };
 

--- a/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
+++ b/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
@@ -15,7 +15,8 @@
 // Preconditions:  TRT headers and CUDA available
 // Postconditions: Pipelines construct with mock engines and expose correct interfaces;
 //                 embed/encode/rerank methods return non-empty results;
-//                 rerank uses the checkpoint prompt template and pooling contract;
+//                 rerank uses the checkpoint prompt template, separator tokens,
+//                 and pooling contract;
 //                 invalid inputs and score shapes are rejected with std::exception;
 //                 score output name, 4D logits shape, and size==1 output branch covered
 // =============================================================================
@@ -66,12 +67,34 @@ class FixedTokenizer : public trtmc::ITokenizer {
     mutable std::string last_encoded_text;
 };
 
+class SeparatorTokenizer : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override {
+        return {128000, 10, 720, 720, 20};
+    }
+    std::string decode(const std::vector<int32_t>&) const override { return "test"; }
+    int32_t id_for_token(std::string_view token) const override {
+        if (token == "ĠĊ")
+            return 720;
+        if (token == "ĠĊĠĊ")
+            return 33006;
+        return -1;
+    }
+    std::string token_for_id(int32_t) const override { return ""; }
+};
+
 class FakeScoreModule final : public trtmc::ITrtModule {
   public:
     FakeScoreModule(std::vector<float> scores, std::vector<int64_t> shape)
         : scores_(std::move(scores)), shape_(std::move(shape)) {}
 
-    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        const auto input = inputs.find("input_ids");
+        if (input != inputs.end() && input->second.data && input->second.shape.size() == 1) {
+            const auto size = static_cast<std::size_t>(input->second.shape.front());
+            const auto* ids = static_cast<const int32_t*>(input->second.data);
+            input_ids_.assign(ids, ids + size);
+        }
         return {{"score", trtmc::Tensor{scores_.data(), shape_, trtmc::DType::kFloat32}}};
     }
     trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
@@ -106,10 +129,12 @@ class FakeScoreModule final : public trtmc::ITrtModule {
     void bind_external(const std::string&, void*) override {}
     bool ok() const override { return true; }
     void keep_alive(std::shared_ptr<void>) override {}
+    const std::vector<int32_t>& input_ids() const { return input_ids_; }
 
   private:
     std::vector<float> scores_;
     std::vector<int64_t> shape_;
+    std::vector<int32_t> input_ids_;
 };
 
 // ---------------------------------------------------------------------------
@@ -315,6 +340,19 @@ static void test_encoder_rerank() {
           "rerank: uses the checkpoint prompt template");
 }
 
+static void test_encoder_rerank_canonicalizes_checkpoint_separator_tokens() {
+    auto tokenizer = std::make_shared<SeparatorTokenizer>();
+    auto module = std::make_unique<FakeScoreModule>(std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f},
+                                                    std::vector<int64_t>{4, 1});
+    auto* module_ptr = module.get();
+    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer, "", "avg");
+
+    const float score = pipeline.rerank("query", "doc");
+    check(std::abs(score - 2.5f) < 1e-6f, "rerank separator: pools the canonical token sequence");
+    check(module_ptr->input_ids() == std::vector<int32_t>({128000, 10, 33006, 20}),
+          "rerank separator: merges the native separator pieces like HF");
+}
+
 static void test_encoder_rerank_preserves_last_and_scalar_outputs() {
     auto tokenizer = std::make_shared<FixedTokenizer>();
     auto last_module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.9f},
@@ -510,6 +548,7 @@ int main() {
     test_encoder_embed_mode();
     test_encoder_encode_mode();
     test_encoder_rerank();
+    test_encoder_rerank_canonicalizes_checkpoint_separator_tokens();
     test_encoder_rerank_preserves_last_and_scalar_outputs();
     test_encoder_rerank_rejects_invalid_score_shape();
     test_encoder_int32_mask();

--- a/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
+++ b/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
@@ -15,7 +15,8 @@
 // Preconditions:  TRT headers and CUDA available
 // Postconditions: Pipelines construct with mock engines and expose correct interfaces;
 //                 embed/encode/rerank methods return non-empty results;
-//                 invalid inputs are rejected with std::exception;
+//                 rerank selects the last valid token's per-position score;
+//                 invalid inputs and score shapes are rejected with std::exception;
 //                 score output name, 4D logits shape, and size==1 output branch covered
 // =============================================================================
 
@@ -57,6 +58,52 @@ class FixedTokenizer : public trtmc::ITokenizer {
     std::string decode(const std::vector<int32_t>&) const override { return "test"; }
     int32_t id_for_token(std::string_view) const override { return 0; }
     std::string token_for_id(int32_t) const override { return ""; }
+};
+
+class FakeScoreModule final : public trtmc::ITrtModule {
+  public:
+    FakeScoreModule(std::vector<float> scores, std::vector<int64_t> shape)
+        : scores_(std::move(scores)), shape_(std::move(shape)) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"score", trtmc::Tensor{scores_.data(), shape_, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {
+            {"input_ids", {4}, trtmc::DType::kInt32, true},
+            {"attention_mask", {4}, trtmc::DType::kInt32, true},
+        };
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"score", shape_, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override {
+        return name == "input_ids" || name == "attention_mask";
+    }
+    bool has_output(const std::string& name) const override { return name == "score"; }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return shape_; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {4};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> scores_;
+    std::vector<int64_t> shape_;
 };
 
 // ---------------------------------------------------------------------------
@@ -250,26 +297,30 @@ static void test_encoder_encode_mode() {
 }
 
 static void test_encoder_rerank() {
-    auto engine = build_encoder_engine_2d();
-    if (!engine) {
-        std::cerr << "SKIP encoder_rerank\n";
-        return;
-    }
-
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-
-    auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
-                                                         engine->createExecutionContext(), stream);
     auto tokenizer = std::make_shared<FixedTokenizer>();
-    trtmc::EncoderPipeline pipeline(std::move(module), "rerank", tokenizer);
+    auto module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.9f},
+                                                    std::vector<int64_t>{4, 1});
+    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer);
 
-    // rerank() applies the supported cross-encoder text template and returns data[0]
+    // FixedTokenizer produces four real tokens. The engine deliberately emits
+    // distinct scores per position so this catches selecting data[0].
     float score = pipeline.rerank("query", "doc");
-    // Score is a float (from engine constant output = 0.1f at index 0)
-    check(score >= -1e6f && score <= 1e6f, "rerank: returns a finite float");
+    check(score == 0.9f, "rerank: selects the last valid token score");
+}
 
-    cudaStreamDestroy(stream);
+static void test_encoder_rerank_rejects_invalid_score_shape() {
+    auto tokenizer = std::make_shared<FixedTokenizer>();
+    auto module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f},
+                                                    std::vector<int64_t>{2, 2});
+    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer);
+
+    bool threw = false;
+    try {
+        pipeline.rerank("query", "doc");
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, "rerank: invalid score shape throws");
 }
 
 static void test_encoder_int32_mask() {
@@ -412,6 +463,7 @@ int main() {
     test_encoder_embed_mode();
     test_encoder_encode_mode();
     test_encoder_rerank();
+    test_encoder_rerank_rejects_invalid_score_shape();
     test_encoder_int32_mask();
     test_encoder_validates();
     test_encoder_score_output();

--- a/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
+++ b/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
@@ -15,7 +15,7 @@
 // Preconditions:  TRT headers and CUDA available
 // Postconditions: Pipelines construct with mock engines and expose correct interfaces;
 //                 embed/encode/rerank methods return non-empty results;
-//                 rerank selects the last valid token's per-position score;
+//                 rerank uses the checkpoint prompt template and pooling contract;
 //                 invalid inputs and score shapes are rejected with std::exception;
 //                 score output name, 4D logits shape, and size==1 output branch covered
 // =============================================================================
@@ -31,6 +31,7 @@
 #include "trtmc/tokenizer.h"
 
 #include <NvInfer.h>
+#include <cmath>
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
@@ -54,10 +55,15 @@ static trtmc::TrtLogger g_logger;
 // ---------------------------------------------------------------------------
 class FixedTokenizer : public trtmc::ITokenizer {
   public:
-    std::vector<int32_t> encode(const std::string&) const override { return {1, 2, 3, 4}; }
+    std::vector<int32_t> encode(const std::string& text) const override {
+        last_encoded_text = text;
+        return {1, 2, 3, 4};
+    }
     std::string decode(const std::vector<int32_t>&) const override { return "test"; }
     int32_t id_for_token(std::string_view) const override { return 0; }
     std::string token_for_id(int32_t) const override { return ""; }
+
+    mutable std::string last_encoded_text;
 };
 
 class FakeScoreModule final : public trtmc::ITrtModule {
@@ -300,12 +306,29 @@ static void test_encoder_rerank() {
     auto tokenizer = std::make_shared<FixedTokenizer>();
     auto module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.9f},
                                                     std::vector<int64_t>{4, 1});
-    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer);
+    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer, "", "avg");
 
-    // FixedTokenizer produces four real tokens. The engine deliberately emits
-    // distinct scores per position so this catches selecting data[0].
+    // The pinned Nemotron reranker uses average pooling over valid positions.
     float score = pipeline.rerank("query", "doc");
-    check(score == 0.9f, "rerank: selects the last valid token score");
+    check(std::abs(score - 0.375f) < 1e-6f, "rerank: averages valid token scores");
+    check(tokenizer->last_encoded_text == "question:query \n \n passage:doc",
+          "rerank: uses the checkpoint prompt template");
+}
+
+static void test_encoder_rerank_preserves_last_and_scalar_outputs() {
+    auto tokenizer = std::make_shared<FixedTokenizer>();
+    auto last_module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.9f},
+                                                         std::vector<int64_t>{4, 1});
+    trtmc::EncoderPipeline last_pipeline(std::move(last_module), "reranking", tokenizer, "",
+                                         "last");
+    check(last_pipeline.rerank("query", "doc") == 0.9f, "rerank: preserves last-token pooling");
+
+    auto scalar_module =
+        std::make_unique<FakeScoreModule>(std::vector<float>{0.7f}, std::vector<int64_t>{1});
+    trtmc::EncoderPipeline scalar_pipeline(std::move(scalar_module), "reranking", tokenizer, "",
+                                           "avg");
+    check(scalar_pipeline.rerank("query", "doc") == 0.7f,
+          "rerank: preserves an engine-reduced scalar");
 }
 
 static void test_encoder_rerank_rejects_invalid_score_shape() {
@@ -321,6 +344,30 @@ static void test_encoder_rerank_rejects_invalid_score_shape() {
         threw = true;
     }
     check(threw, "rerank: invalid score shape throws");
+
+    auto short_module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f},
+                                                          std::vector<int64_t>{3, 1});
+    trtmc::EncoderPipeline short_pipeline(std::move(short_module), "reranking", tokenizer, "",
+                                          "avg");
+    threw = false;
+    try {
+        short_pipeline.rerank("query", "doc");
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, "rerank: score output shorter than the token sequence throws");
+
+    auto unsupported_module = std::make_unique<FakeScoreModule>(
+        std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f}, std::vector<int64_t>{4, 1});
+    trtmc::EncoderPipeline unsupported_pipeline(std::move(unsupported_module), "reranking",
+                                                tokenizer, "", "median");
+    threw = false;
+    try {
+        unsupported_pipeline.rerank("query", "doc");
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, "rerank: unsupported pooling mode throws");
 }
 
 static void test_encoder_int32_mask() {
@@ -463,6 +510,7 @@ int main() {
     test_encoder_embed_mode();
     test_encoder_encode_mode();
     test_encoder_rerank();
+    test_encoder_rerank_preserves_last_and_scalar_outputs();
     test_encoder_rerank_rejects_invalid_score_shape();
     test_encoder_int32_mask();
     test_encoder_validates();

--- a/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2-tp4.json
+++ b/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2-tp4.json
@@ -34,12 +34,10 @@
       "user_contract": "ranking_order",
       "ci_tier": "multi_device",
       "inputs": {
-        "prompt": "Which planet is known as the Red Planet?",
+        "prompt": "0-dimensional biomaterials show inductive properties.",
         "documents": [
-          "Venus is often called Earth's twin because of its similar size and proximity.",
-          "Mars, known for its reddish appearance, is often referred to as the Red Planet.",
-          "Jupiter, the largest planet in our solar system, has a prominent red spot.",
-          "Saturn, famous for its rings, is sometimes mistaken for the Red Planet."
+          "New opportunities: the use of nanotechnologies to manipulate and track stem cells.\n\nNanotechnologies are emerging platforms that could be useful in measuring, understanding, and manipulating stem cells. Examples include magnetic nanoparticles and quantum dots for stem cell labeling and in vivo tracking; nanoparticles, carbon nanotubes, and polyplexes for the intracellular delivery of genes/oligonucleotides and protein/peptides; and engineered nanometer-scale scaffolds for stem cell differentiation and transplantation. This review examines the use of nanotechnologies for stem cell tracking, differentiation, and transplantation. We further discuss their utility and the potential concerns regarding their cytotoxicity.",
+          "Immune dysregulation in major depression: a critical review of existing evidence.\n\nIt is now well established that depression is associated with immune dysregulation. It is not, however, known whether this immune dysregulation plays a role in the pathophysiology of major depression or whether it increases the susceptibility of the depressed patient to immune-related disorders. This article presents a critical review of existing evidence for immune dysregulation in major depression, including changes in leucocyte trafficking, lymphocyte function, and markers of immune activation. Possible mediators of immune dysregulation in major depression are briefly discussed. Finally, the relationship between major depression and several medical conditions such as infection, allergy and autoimmune disorders, cardiovascular diseases, cancer and AIDS is critically reviewed."
         ]
       },
       "max_new_tokens": 1,

--- a/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
+++ b/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
@@ -16,12 +16,10 @@
       "reference_family": "vl_rerank",
       "user_contract": "ranking_order",
       "inputs": {
-        "prompt": "Which planet is known as the Red Planet?",
+        "prompt": "0-dimensional biomaterials show inductive properties.",
         "documents": [
-          "Venus is often called Earth's twin because of its similar size and proximity.",
-          "Mars, known for its reddish appearance, is often referred to as the Red Planet.",
-          "Jupiter, the largest planet in our solar system, has a prominent red spot.",
-          "Saturn, famous for its rings, is sometimes mistaken for the Red Planet."
+          "New opportunities: the use of nanotechnologies to manipulate and track stem cells.\n\nNanotechnologies are emerging platforms that could be useful in measuring, understanding, and manipulating stem cells. Examples include magnetic nanoparticles and quantum dots for stem cell labeling and in vivo tracking; nanoparticles, carbon nanotubes, and polyplexes for the intracellular delivery of genes/oligonucleotides and protein/peptides; and engineered nanometer-scale scaffolds for stem cell differentiation and transplantation. This review examines the use of nanotechnologies for stem cell tracking, differentiation, and transplantation. We further discuss their utility and the potential concerns regarding their cytotoxicity.",
+          "Immune dysregulation in major depression: a critical review of existing evidence.\n\nIt is now well established that depression is associated with immune dysregulation. It is not, however, known whether this immune dysregulation plays a role in the pathophysiology of major depression or whether it increases the susceptibility of the depressed patient to immune-related disorders. This article presents a critical review of existing evidence for immune dysregulation in major depression, including changes in leucocyte trafficking, lymphocyte function, and markers of immune activation. Possible mediators of immune dysregulation in major depression are briefly discussed. Finally, the relationship between major depression and several medical conditions such as infection, allergy and autoimmune disorders, cardiovascular diseases, cancer and AIDS is critically reviewed."
         ]
       },
       "max_new_tokens": 1

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -100,6 +100,7 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
     trt_compat = importlib.import_module("tensorrt_model_connect.trt_compat")
     trt = trt_compat.get_trt()
     original_apply_norm = graph_blocks.apply_norm
+    assert plugin_module._RERANKER_FP32_TAIL_LAYERS == 16
     num_layers = plugin_module._RERANKER_FP32_TAIL_LAYERS + 2
 
     class FinalNormCaptured(RuntimeError):
@@ -182,7 +183,7 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
         "eps_dtype": trt.float32,
         "dtype": np.float32,
     }
-    assert calls == [fp16_call] * 4 + [fp32_call] * 17
+    assert calls == [fp16_call] * 4 + [fp32_call] * 33
 
 
 def test_eagle_vlm_tp_shards_text_backbone_weights() -> None:

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -55,6 +55,41 @@ def _weights() -> WeightDict:
     })
 
 
+def test_eagle_vlm_resolves_nested_legacy_rope_scaling() -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+
+    class Config(_Config):
+        raw = {
+            "llm_config": {
+                "rope_scaling": {
+                    "rope_type": "llama3",
+                    "factor": 32.0,
+                },
+            },
+        }
+
+    assert plugin_module._resolve_rope_scaling(Config()) == {
+        "rope_type": "llama3",
+        "factor": 32.0,
+    }
+
+
+def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+
+    class Config(_Config):
+        raw = {
+            "llm_config": {
+                "rope_parameters": {"rope_type": "llama3", "factor": 8.0},
+                "rope_scaling": {"rope_type": "llama3", "factor": 32.0},
+            },
+        }
+
+    assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
+
+
 def test_eagle_vlm_tp_shards_text_backbone_weights() -> None:
     from tensorrt_model_connect.families.eagle_vlm import tp_builder
 

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -90,6 +90,101 @@ def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
     assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
 
 
+def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
+    monkeypatch,
+) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+    graph_blocks = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.graph_blocks")
+    trt_compat = importlib.import_module("tensorrt_model_connect.trt_compat")
+    trt = trt_compat.get_trt()
+    original_apply_norm = graph_blocks.apply_norm
+    num_layers = plugin_module._RERANKER_FP32_TAIL_LAYERS + 2
+
+    class FinalNormCaptured(RuntimeError):
+        pass
+
+    calls = []
+
+    def capture_tail_norms(
+        network,
+        inp,
+        hidden_size,
+        gamma,
+        beta,
+        eps_tensor,
+        norm_type,
+        *,
+        dtype,
+        eps=None,
+    ):
+        calls.append({
+            "input_dtype": inp.dtype,
+            "eps_dtype": eps_tensor.dtype,
+            "dtype": dtype,
+        })
+        if len(calls) == 2 * num_layers + 1:
+            raise FinalNormCaptured
+        return original_apply_norm(
+            network,
+            inp,
+            hidden_size,
+            gamma,
+            beta,
+            eps_tensor,
+            norm_type,
+            dtype=dtype,
+            eps=eps,
+        )
+
+    monkeypatch.setattr(graph_blocks, "apply_norm", capture_tail_norms)
+
+    class RerankerConfig(_Config):
+        raw = {"is_reranker": True}
+        num_hidden_layers = num_layers
+        rms_norm_eps = 1e-5
+        rope_theta = 10_000.0
+
+    weights = _weights()
+    layer_weight_names = (
+        "input_norm",
+        "post_attn_norm",
+        "w_q",
+        "w_k",
+        "w_v",
+        "w_o",
+        "w_gate",
+        "w_up",
+        "w_down",
+    )
+    for layer_idx in range(1, num_layers):
+        for name in layer_weight_names:
+            weights[f"layer.{layer_idx}.{name}"] = (
+                weights[f"layer.0.{name}"].copy())
+
+    with pytest.raises(FinalNormCaptured):
+        plugin_module._build_eagle_engine(
+            RerankerConfig(),
+            weights,
+            max_cache_length=4,
+            is_reranker=True,
+            precision="fp16",
+        )
+
+    fp16_call = {
+        "input_dtype": trt.float16,
+        "eps_dtype": trt.float16,
+        "dtype": np.float16,
+    }
+    fp32_call = {
+        "input_dtype": trt.float32,
+        "eps_dtype": trt.float32,
+        "dtype": np.float32,
+    }
+    assert calls == [fp16_call] * 4 + [fp32_call] * 17
+
+
 def test_eagle_vlm_tp_shards_text_backbone_weights() -> None:
     from tensorrt_model_connect.families.eagle_vlm import tp_builder
 


### PR DESCRIPTION
## Background

QA run `trtmc-validate-gb300-2-20260726-c8291be0-all105` reported
`nemotron-rerank-vl-1b-v2 / beir_scifact_reranking` at mean pairwise ordering
agreement `0.72`. I reproduced the failure locally from `github/main` with the
same pinned checkpoint, SciFact workload, reference profile, TensorRT 11.2
environment, and strict ranking gates.

This is an Eagle-VLM family-owned fix. It depends on #718 for the shared
validation runner's declared-gate enforcement and prompt sizing; this PR does
not duplicate that cross-family CI logic.

## Root causes

The low accuracy was cumulative rather than a single last-token bug:

1. The runtime flattened a per-position `[sequence, 1]` score tensor and
   returned element zero, ignoring the bundle's reranking pooling contract.
   The pinned checkpoint declares average pooling over valid positions.
2. Native input framing used three spaces instead of the checkpoint processor's
   exact `question:{query} \n \n passage:{document}` template.
3. The native BPE path emitted separator pieces `720, 720`, while the pinned HF
   processor emitted the merged vocabulary token `33006`.
4. The builder looked only for the newer `llm_config.rope_parameters` spelling,
   while the pinned checkpoint publishes Llama-3 scaling in
   `llm_config.rope_scaling`.
5. The checkpoint's FP32 cross-encoder score head was accumulated in FP16.
6. Near-tie rankings remained sensitive to TensorRT build tactics while any of
   the 16 text-transformer layers stayed in FP16. An eight-layer FP32 tail
   passed one diagnostic build but failed a second fresh build on
   `scifact_test_48` and `scifact_test_100`.

## Implementation

- Preserve the score tensor shape, accept already-reduced scalars, validate
  per-position outputs, and apply the configured `avg` or `last` pooling mode.
  Unsupported pooling and malformed or undersized outputs fail closed.
- Match the checkpoint prompt template and canonicalize only the fixed
  Nemotron separator pair to the merged HF token.
- Resolve both HF RoPE schema spellings from the nested LLM config.
- Keep the reranker score head and the complete 16-layer text transformer in
  FP32. Embeddings and the vision encoder stay FP16, avoiding the cost of a
  fully FP32 bundle.
- Replace the old four-document sentinel with the exact two-document QA
  inversion in the SP and TP manifests.

## Why CI missed it, and how this fixes CI

The existing model sentinel happened to preserve its ordering under the broken
input, pooling, RoPE, separator, and precision paths. Unit coverage also did
not assert the checkpoint's exact prompt, token IDs, pooling, RoPE schema, or
mixed-precision graph boundary.

This PR adds family-local checks for all of those contracts:

- focused C++ tests capture the exact string and token IDs passed to the score
  engine, verify `avg` and `last` pooling, preserve scalar outputs, and reject
  invalid shapes and pooling modes;
- a CPU-only TensorRT graph test pins the mixed-precision boundary: two leading
  layers remain FP16 in an 18-layer synthetic graph, while the final 16 layers
  and final norm are FP32;
- the model sentinel is the real SciFact inversion that exposed the regression.

#718 makes the existing validation pass/fail decision honor the workload's
declared generic gates and sizes reranker engines from the actual tokenizer
framing. Together, the shared runner and these family-owned sentinels catch the
failure without weakening thresholds.

## CI runtime impact

- No new model, engine build, GPU job, or dataset evaluation is added.
- The exact graph-contract test constructs a tiny CPU graph and passed in
  `1.19 s`; it does not serialize an engine.
- The existing manifest sentinel shrinks from four documents to two, reducing
  rerank invocations and engine deserializations.
- The full 20-sample QA workload remains an explicit qualification run rather
  than being added to every premerge.

The production bundle impact is intentional and separately measured. The clean
tail-16 bundle is `5,300,053,553` bytes versus `3,354,311,793` bytes for the
all-FP16 text build (`+58%`), but remains `1,374,435,385` bytes (`20.6%`)
smaller than the fully FP32 diagnostic bundle. The clean build completed in
`141.2 s` versus `216.6 s` in the earlier FP16 receipt; build wall time is
tactic-dependent, so this is an observation rather than a promised speedup.

## Fail-before / pass-after evidence

All gates were unchanged:

- pairwise ordering agreement `>= 1.0`
- Kendall tau `>= 1.0`
- Spearman rho `>= 1.0`
- score correlation `>= 0.95`
- sample pass rate `>= 1.0`

Progressive reproduction:

- Original QA: mean pairwise agreement `0.72`.
- After the input, pooling, RoPE, head, and separator fixes:
  `19/20` passed; `scifact_test_100` still failed.
- Eight-layer FP32 tail, independent fresh build:
  `18/20` passed; `scifact_test_48` and `scifact_test_100` failed. The same
  source produced different bundle SHAs and opposite near-tie margins, proving
  that tail-8 was not stable across TensorRT tactics.
- Sixteen-layer text FP32, clean final run: `20/20` passed.

For the two precision-boundary samples in the clean run:

- `scifact_test_48`: HF document 2-3 margin `+0.0283728`; native `+0.0274`.
- `scifact_test_100`: HF document 2-3 margin `+0.0032091`; native `+0.0040`.

## Exact QA-environment validation

Clean qualification receipt:
`trtmc-validate-gb300-2-20260729T170410Z-8d256b5d-eagle-vlm-full20-fresh-final3`

- Integration source:
  `8d256b5ddd0cce6e23fde5f65cf895c68f9e66f4`
- Integration tree:
  `50d5eccc54da2e1144942391def9841c6387d33f`
- Base:
  `github/main@aa3779bb4576280f18c955535779eb9e5b452ca4`
- Checkpoint snapshot:
  `9c20c4aedf9ec87b6b7346c3bc4754ea030dab35`
- Reference profile:
  `reference_common-424321ab2bba`
- Dataset SHA-256:
  `552558ca483b31f48d07586605095e644cec96d09fdb44734f98a6767d3ed62b`
- TensorRT:
  `11.2.0.113`
- Invocation:
  empty reference and engine directories, `--limit 20 --force-hf
  --force-build --local-files-only`
- Freshness:
  `hf_reused=false`, `hf_cache_status=generated`, `bundle_built=true`
- Result:
  `20/20`, sample pass rate `1.0`, pairwise/tau/rho mean and minimum `1.0`,
  score correlation mean `0.9999998660`, minimum `0.9999988186`, HF and native
  top-1 accuracy `1.0`
- Bundle:
  SHA-256
  `b85a66b2074bc503d2953972fb781f7c4f6a4cc7948da6222f9e5a9fcc1052df`
- GPU isolation:
  physical GPU2 had zero compute processes before launch; 92 monitor
  observations contained at most one expected process per timestamp and no
  Qwen, DeepSeek, vLLM, or other competing process.

The complete token arrays for all 100 query/document pairs also matched the
pinned HF processor exactly; both paths' maximum input length was 685 tokens.

## Tests

- Family branch: `229 passed, 2 skipped` in `55.73 s`.
- Exact integration: `240 passed, 2 skipped` in `54.62 s`.
- `test_eagle_vlm_encoder_pipeline`: `1/1` passed in `6.63 s`.
- Exact mixed-precision graph contract: `1 passed` in `1.19 s`.
- Ruff and `git diff --check`: passed.

## Review order

1. `src/runtime/models/eagle_vlm/pipeline.cpp` for input, token, and pooling
   contracts.
2. `python/tensorrt_model_connect/families/eagle_vlm/plugin.py` for RoPE and
   precision boundaries.
3. The focused C++/Python tests and the SP/TP manifest sentinel.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased cleanly onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `47b3bc5a1bc4e662cc1e804d292c2f5ee049930c`.
- Bundle migration audit: repository content and tracked filenames have zero case-insensitive matches for the retired identifier. The current `.bundle` / `BUNDLE\\x01\\x00` contract is preserved.
- `python3 -m compileall -q python/tensorrt_model_connect/families/eagle_vlm tests/e2e/models/eagle_vlm`: **passed**; both changed JSON manifests parsed successfully; `git diff --check github/main...HEAD`: **passed**.
- The focused TensorRT graph test was collected but skipped on this host because the matching agent-2 dev container is not running. The exact QA GPU qualification already documented above remains the model-parity evidence; fresh exact-head GitHub CI is required before merge.
- The rebase adds no case, build, threshold, or matrix fan-out; the existing two-document sentinel remains bounded. The push triggered fresh CI and does not claim green status before completion.
