### PR TITLE
fix(segformer): restore semantic parity

### DIFF
--- a/python/tensorrt_model_connect/families/segformer/graph_ops.py
+++ b/python/tensorrt_model_connect/families/segformer/graph_ops.py
@@ -15,6 +15,18 @@ from tensorrt_model_connect import trt_compat
 trt = trt_compat.get_trt()
 
 
+def resolve_numerical_contract(config) -> tuple[float, str]:
+    """Return the normalization and activation contract from HF config."""
+    layer_norm_eps = float(config.rms_norm_eps)
+    hidden_act = config.hidden_act or "gelu"
+    if layer_norm_eps <= 0.0:
+        raise ValueError(
+            f"SegFormer layer_norm_eps must be positive, got {layer_norm_eps}")
+    if hidden_act not in ("gelu", "gelu_new", "gelu_fast", "gelu_pytorch_tanh"):
+        raise ValueError(f"Unsupported SegFormer activation: {hidden_act}")
+    return layer_norm_eps, hidden_act
+
+
 def _cast_back_to_trt_dtype(
     network: trt.INetworkDefinition,
     tensor: trt.ITensor,
@@ -188,6 +200,54 @@ def add_gelu_new(
         half_x.get_output(0), one_plus_tanh.get_output(0),
         trt.ElementWiseOperation.PROD)
     return result.get_output(0)
+
+
+def add_gelu_erf(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """GELU (exact, erf-based): 0.5*x*(1+erf(x/sqrt(2)))."""
+    target_dtype = inp.dtype
+    const_shape = (1,) * max(1, len(tuple(inp.shape)))
+
+    def _const(value):
+        constant = add_constant(
+            network,
+            const_shape,
+            np.array([value], dtype=np.float32),
+            dtype=dtype,
+        )
+        return _cast_back_to_trt_dtype(network, constant, target_dtype)
+
+    scaled = network.add_elementwise(
+        inp, _const(1.0 / np.sqrt(2.0)), trt.ElementWiseOperation.PROD)
+    erf = network.add_unary(
+        scaled.get_output(0), trt.UnaryOperation.ERF)
+    one_plus_erf = network.add_elementwise(
+        _const(1.0), erf.get_output(0), trt.ElementWiseOperation.SUM)
+    half_x = network.add_elementwise(
+        _const(0.5), inp, trt.ElementWiseOperation.PROD)
+    result = network.add_elementwise(
+        half_x.get_output(0),
+        one_plus_erf.get_output(0),
+        trt.ElementWiseOperation.PROD,
+    )
+    return result.get_output(0)
+
+
+def add_activation(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    activation_type: str,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Add the activation declared by the SegFormer checkpoint."""
+    if activation_type == "gelu":
+        return add_gelu_erf(network, inp, dtype=dtype)
+    if activation_type in ("gelu_new", "gelu_fast", "gelu_pytorch_tanh"):
+        return add_gelu_new(network, inp, dtype=dtype)
+    raise ValueError(f"Unsupported SegFormer activation: {activation_type}")
 
 
 # Alias: add_gelu_tanh is the same as add_gelu_new (tanh approximation)

--- a/python/tensorrt_model_connect/families/segformer/plugin.py
+++ b/python/tensorrt_model_connect/families/segformer/plugin.py
@@ -253,6 +253,7 @@ class SegformerPlugin:
         strides = raw.get("strides", [4, 2, 2, 2])
         num_classes = raw.get("num_labels", 150)
         decoder_hidden_size = raw.get("decoder_hidden_size", 256)
+        layer_norm_eps, hidden_act = graph_ops.resolve_numerical_contract(config)
         if precision == "fp16":
             work_np_dtype, work_trt_dtype = np.float16, trt.float16
         elif precision == "fp32":
@@ -330,7 +331,7 @@ class SegformerPlugin:
             pe_ln_w = weights[f"stage{stage_idx}.patch_embed.norm.weight"]
             pe_ln_b = weights[f"stage{stage_idx}.patch_embed.norm.bias"]
             eps_t = graph_ops.add_constant(
-                network, (1, 1), np.array([1e-5], dtype=work_np_dtype),
+                network, (1, 1), np.array([layer_norm_eps], dtype=work_np_dtype),
                 dtype=work_np_dtype)
             hidden_state = graph_ops.add_layer_norm(
                 network, reshape_to_seq.get_output(0), hidden,
@@ -486,8 +487,9 @@ class SegformerPlugin:
                 dw_back.reshape_dims = (seq_len, ffn_hidden)
 
                 # GELU activation
-                gelu_out = graph_ops.add_gelu_new(
-                    network, dw_back.get_output(0), dtype=work_np_dtype)
+                gelu_out = graph_ops.add_activation(
+                    network, dw_back.get_output(0), hidden_act,
+                    dtype=work_np_dtype)
 
                 # FC2: [seq, ffn_hidden] -> [seq, hidden]
                 fc2 = graph_ops.add_matmul_rhs_constant(

--- a/python/tensorrt_model_connect/families/segformer/segformer_tp_builder.py
+++ b/python/tensorrt_model_connect/families/segformer/segformer_tp_builder.py
@@ -100,6 +100,7 @@ def build_segformer_tp_engine(
     strides = raw.get("strides", [4, 2, 2, 2])
     num_classes = raw.get("num_labels", 150)
     decoder_hidden_size = raw.get("decoder_hidden_size", 256)
+    layer_norm_eps, hidden_act = graph_ops.resolve_numerical_contract(config)
 
     image_size = raw.get("_resolved_image_size", 512)
     H_in, W_in = image_size, image_size
@@ -149,7 +150,8 @@ def build_segformer_tp_engine(
 
         pe_ln_w = weights[f"stage{stage_idx}.patch_embed.norm.weight"]
         pe_ln_b = weights[f"stage{stage_idx}.patch_embed.norm.bias"]
-        eps_t = graph_ops.add_constant(network, (1, 1), np.array([1e-5], dtype=np.float32))
+        eps_t = graph_ops.add_constant(
+            network, (1, 1), np.array([layer_norm_eps], dtype=np.float32))
         hidden_state = graph_ops.add_layer_norm(
             network, reshape_to_seq.get_output(0), hidden, pe_ln_w, pe_ln_b, eps_t)
 
@@ -268,7 +270,8 @@ def build_segformer_tp_engine(
             dw_back.first_transpose = trt.Permutation([0, 2, 3, 1])
             dw_back.reshape_dims = (seq_len, local_ffn_hidden)
 
-            gelu_out = graph_ops.add_gelu_new(network, dw_back.get_output(0))
+            gelu_out = graph_ops.add_activation(
+                network, dw_back.get_output(0), hidden_act)
 
             fc2_w = _slice_mlp_rows(
                 weights[f"{w_prefix}.mlp.fc2.weight"], ffn_hidden, parallel)

--- a/tests/e2e/models/segformer/test_segformer_builder_engine.py
+++ b/tests/e2e/models/segformer/test_segformer_builder_engine.py
@@ -101,7 +101,8 @@ class SegformerPluginTester(FamilyPluginTester):
             "strides": _STRIDES,
             "num_labels": _NUM_CLASSES,
             "decoder_hidden_size": _DECODER_HIDDEN,
-            "layer_norm_eps": 1e-5,
+            "layer_norm_eps": 1e-6,
+            "hidden_act": "gelu",
         }
 
     def write_model_dir(self, tmp_path):

--- a/tests/e2e/models/segformer/test_segformer_ci_evidence.py
+++ b/tests/e2e/models/segformer/test_segformer_ci_evidence.py
@@ -26,7 +26,7 @@ from tests.e2e_harness.contracts import (
     ThresholdProfile,
 )
 from tests.e2e_harness.orchestrator import _auto_register_artifacts
-from tools import task_eval
+from tools.validation import engine as validation_engine
 
 
 def _output(class_map: np.ndarray) -> StageOutput:
@@ -97,7 +97,7 @@ def test_single_gpu_thresholds_reject_the_reproduced_regression() -> None:
     assert thresholds["min_pixel_agreement"] == 0.99
 
 
-def test_task_eval_compares_equivalent_postprocessed_class_maps(
+def test_validation_compares_equivalent_postprocessed_class_maps(
     tmp_path: Path,
 ) -> None:
     """Keep the QA gate on HF/TRT maps produced after the same post-process."""
@@ -116,7 +116,7 @@ def test_task_eval_compares_equivalent_postprocessed_class_maps(
         np.save(path, values)
         paths[name] = path
 
-    summary = task_eval.compare_semantic_segmentation_prediction_sets(
+    summary = validation_engine.compare_semantic_segmentation_prediction_sets(
         {
             "responses": [
                 {

--- a/tests/e2e/models/segformer/test_segformer_ci_evidence.py
+++ b/tests/e2e/models/segformer/test_segformer_ci_evidence.py
@@ -26,6 +26,7 @@ from tests.e2e_harness.contracts import (
     ThresholdProfile,
 )
 from tests.e2e_harness.orchestrator import _auto_register_artifacts
+from tools import task_eval
 
 
 def _output(class_map: np.ndarray) -> StageOutput:
@@ -94,6 +95,65 @@ def test_single_gpu_thresholds_reject_the_reproduced_regression() -> None:
     assert thresholds["mIoU"] == 0.94
     assert thresholds["pixel_accuracy"] == 0.99
     assert thresholds["min_pixel_agreement"] == 0.99
+
+
+def test_task_eval_compares_equivalent_postprocessed_class_maps(
+    tmp_path: Path,
+) -> None:
+    """Keep the QA gate on HF/TRT maps produced after the same post-process."""
+    ground = np.array([[0, 0], [1, 1]], dtype=np.uint8)
+    hf_postprocessed = ground.copy()
+    trtmc_postprocessed = ground.copy()
+    hf_raw = np.array([[0]], dtype=np.uint8)
+    paths = {}
+    for name, values in (
+        ("ground", ground),
+        ("hf_postprocessed", hf_postprocessed),
+        ("trtmc_postprocessed", trtmc_postprocessed),
+        ("hf_raw", hf_raw),
+    ):
+        path = tmp_path / f"{name}.npy"
+        np.save(path, values)
+        paths[name] = path
+
+    summary = task_eval.compare_semantic_segmentation_prediction_sets(
+        {
+            "responses": [
+                {
+                    "sample_id": "segformer-boundary",
+                    "class_map_path": str(paths["hf_postprocessed"]),
+                    "raw_class_map_path": str(paths["hf_raw"]),
+                }
+            ]
+        },
+        {
+            "responses": [
+                {
+                    "sample_id": "segformer-boundary",
+                    "class_map_path": str(paths["trtmc_postprocessed"]),
+                }
+            ]
+        },
+        {
+            "requests": [
+                {
+                    "sample_id": "segformer-boundary",
+                    "mask": str(paths["ground"]),
+                }
+            ]
+        },
+        gates={
+            "min_backend_pixel_agreement": 1.0,
+            "min_backend_mean_iou": 1.0,
+            "max_mean_iou_drop_from_hf": 0.0,
+        },
+        num_classes=2,
+        ignore_index=255,
+    )
+
+    assert summary["status"] == "passed"
+    assert summary["backend_pixel_agreement"] == 1.0
+    assert summary["backend_mean_iou"] == 1.0
 
 
 def test_trt_visualization_matches_hf_palette_and_input_size(

--- a/tests/e2e/models/segformer/test_segformer_numerical_contract.py
+++ b/tests/e2e/models/segformer/test_segformer_numerical_contract.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused checks for SegFormer's checkpoint-owned numerical contract."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+pytest.importorskip("tensorrt", reason="TensorRT is required for SegFormer graph tests")
+
+from tensorrt_model_connect.families.segformer import graph_ops  # noqa: E402
+
+
+def test_numerical_contract_preserves_checkpoint_eps_and_exact_gelu() -> None:
+    config = SimpleNamespace(rms_norm_eps=1e-6, hidden_act="gelu")
+
+    layer_norm_eps, hidden_act = graph_ops.resolve_numerical_contract(config)
+
+    assert layer_norm_eps == 1e-6
+    assert hidden_act == "gelu"
+
+
+def test_numerical_contract_rejects_unsupported_activation() -> None:
+    config = SimpleNamespace(rms_norm_eps=1e-6, hidden_act="not-gelu")
+
+    with pytest.raises(ValueError, match="Unsupported SegFormer activation"):
+        graph_ops.resolve_numerical_contract(config)
+
+
+def test_gelu_dispatch_keeps_exact_and_tanh_variants_distinct(monkeypatch) -> None:
+    calls = []
+    exact = object()
+    approximate = object()
+
+    monkeypatch.setattr(
+        graph_ops,
+        "add_gelu_erf",
+        lambda _network, _inp, dtype=np.float32: calls.append(("erf", dtype)) or exact,
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "add_gelu_new",
+        lambda _network, _inp, dtype=np.float32: calls.append(("tanh", dtype))
+        or approximate,
+    )
+
+    assert graph_ops.add_activation(None, None, "gelu") is exact
+    assert graph_ops.add_activation(None, None, "gelu_new") is approximate
+    assert calls == [("erf", np.float32), ("tanh", np.float32)]

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -985,7 +985,7 @@ def test_semantic_segmentation_parity_reports_dataset_miou(tmp_path: Path) -> No
     assert summary["backend_pixel_agreement"] == 1.0
 
 
-def test_semantic_segmentation_uses_raw_hf_map_for_backend_parity(
+def test_semantic_segmentation_uses_postprocessed_hf_map_for_backend_parity(
     tmp_path: Path,
 ) -> None:
     import numpy as np
@@ -993,13 +993,13 @@ def test_semantic_segmentation_uses_raw_hf_map_for_backend_parity(
     ground = np.array([[0, 0], [1, 1]], dtype=np.uint8)
     hf_postprocessed = ground.copy()
     hf_raw = np.array([[0]], dtype=np.uint8)
-    bundle_raw = hf_raw.copy()
+    bundle_postprocessed = hf_postprocessed.copy()
     paths = {}
     for name, values in (
         ("ground", ground),
         ("hf", hf_postprocessed),
         ("hf_raw", hf_raw),
-        ("bundle", bundle_raw),
+        ("bundle", bundle_postprocessed),
     ):
         path = tmp_path / f"{name}.npy"
         np.save(path, values)

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -10236,12 +10236,15 @@ def compare_semantic_segmentation_prediction_sets(
             continue
         ground_truth = _load_segmentation_array(str(request["mask"]))
         hf_map = _load_segmentation_array(str(hf_by_id[sample_id]["class_map_path"]))
-        hf_backend_map = _load_segmentation_array(
-            str(
-                hf_by_id[sample_id].get("raw_class_map_path")
-                or hf_by_id[sample_id]["class_map_path"]
-            )
-        )
+        # The TRTMC segmentation runtime returns the user-facing class map:
+        # logits are bilinearly resized to the input image size before
+        # argmax.  Compare it with the equivalent HF post-processed map.
+        #
+        # The optional HF raw map is argmax(logits) at the model's lower
+        # output resolution.  Nearest-neighbor resizing that label map is
+        # not equivalent to resizing logits before argmax and creates false
+        # boundary disagreements even when both backends agree.
+        hf_backend_map = hf_map
         bundle_map = _load_segmentation_array(
             str(bundle_by_id[sample_id]["class_map_path"])
         )


### PR DESCRIPTION
## Background

Both the user-reported `trtmc-validate-gb300-2-20260726-c8291be0-all105` run
and `trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10` reported the same
50-image SegFormer failure:

- backend pixel agreement: `0.9858563640498788`
- backend mean IoU: `0.8416438365590322`
- HF task mIoU: `0.2373463669`
- TRT task mIoU: `0.2399239909`

The task-quality numbers already showed that TRT was not worse than HF. The backend-parity failure had two causes.

First, task-eval compared different postprocessing stages. It preferred HF's 128x128 `raw_class_map` (argmax first, then nearest-neighbor label resize) while TRT returned the official user-facing map (bilinear resize logits to the input size, then argmax). On the exact QA sample 35, comparing HF raw-nearest against HF's own official postprocess produces pixel agreement `0.983630850846` and mIoU `0.682586769281`, almost exactly reproducing the dashboard's false disagreement.

Second, after correcting the comparator, a very small genuine model drift remained. The checkpoint declares `layer_norm_eps=1e-6` and exact `hidden_act=gelu`; both Model Connect builders hardcoded `1e-5` and tanh-approximate GELU.

## Exit Criteria

- Compare HF and TRT class maps after equivalent official postprocessing.
- Honor the checkpoint normalization and activation contract in both single-device and TP builders.
- Pass the original pixel, backend-mIoU, and task-quality gates on the exact 50 QA samples without relaxing a threshold.
- Make CI reject both regressions without adding another engine build or E2E case.

## Implementation

- Use HF's postprocessed `class_map_path` for backend parity. Keep `raw_class_map_path` as diagnostic data, but do not resize a low-resolution argmax map and treat it as equivalent to resized logits.
- Resolve `layer_norm_eps` and the GELU variant from the model config.
- Dispatch exact `gelu` to ERF and retain tanh only for explicitly approximate GELU variants.
- Apply the same contract in the single-device and tensor-parallel builders.
- Add focused CPU regressions for the scorer boundary and numerical-config dispatch. Existing manifests, case counts, and thresholds are unchanged.

## Why CI missed it

The 50-image ADE20K task-eval suite is marked `ci.eligible: false` and
`lane: local_only`, so ordinary premerge did not execute the scorer path that
mixed HF's raw 128x128 argmax map with TRT's official postprocessed map. The
existing single-image model E2E stayed inside the family comparator and did not
cross that task-eval postprocessing boundary. CI also had no CPU contract test
that bound the checkpoint's `layer_norm_eps` and exact GELU declaration to
either builder. This PR adds millisecond CPU sentinels for both gaps without
adding a GPU case.

## Validation

- Exact r10 50-image recomputation with the old scorer: pixel `0.985856364050`, backend mIoU `0.841643836559` (exact dashboard reproduction).
- Comparator-only correction: pixel `0.998226846850`, backend mIoU `0.949991423751`.
- Combined comparator and model fix: pixel `0.998247768015`, backend mIoU `0.952385120711`; HF task mIoU `0.237346310674`, TRT task mIoU `0.239899039035`, quality drop `-0.002552728361`. **All original gates pass.**
- Raw-logit maximum error on the representative QA sample: `0.101250 -> 0.081738`; wrong postprocessed pixels: `392 -> 354`.
- Real FP16 bundle build: **passed** in 147.144 s versus 150.7 s on current main; bundle size remains 10.1 MB.
- Existing model-owned single-case E2E: **1 passed** in 28.84 s.
- Focused SegFormer tests: **29 passed, 3 skipped** in 1.64 s.
- Differential segmentation tests: **12 passed**.
- `tests/tools/test_task_eval.py`: **204 passed** in 6.59 s.
- Ruff, compileall, and `git diff --check`: **passed**.

## Notes For Future Readers

- Review the task-eval postprocessing correction first, then the config resolver/GELU dispatch, then the CPU regression tests.
- No threshold, manifest, engine build, GPU inference case, or CI lane is added. The new scorer and numerical-contract sentinels run on CPU in milliseconds.
- The TP builder is updated symmetrically and covered statically, but TP4 runtime was not executed because the local validation environment exposed one dedicated GPU.
- The exact 50-image maps and scorer receipts were retained locally for this
  investigation; the numeric before/after results required for review are
  included above.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `9dc1a52c6c4cf889817ae7f00e46730a6986024a`.
- The rebase conflict was limited to `tools/validation/engine.py` and `tests/tools/test_validation_engine.py`: the SegFormer fix still compares the official postprocessed HF map, while all renamed data structures and assertions use the current Bundle schema.
- Bundle migration audit: content and tracked filenames have zero case-insensitive matches for the retired identifier; the current `.bundle` / `BUNDLE\\x01\\x00` contract is preserved.
- `python3 -m pytest -q tests/e2e/models/segformer/test_segformer_ci_evidence.py tests/e2e/models/segformer/test_segformer_numerical_contract.py tests/tools/test_validation_engine.py`: **259 passed, 1 skipped**. The skip is the existing TensorRT-unavailable host boundary.
- Targeted `compileall` and `git diff --check github/main...HEAD`: **passed**.
- Conflict repair adds no engine build, model case, threshold change, or CI fan-out. The CPU scorer/numerical sentinels remain the only added premerge work. The push triggered fresh exact-head GitHub CI; green status is required before merge.
