### PR TITLE
fix(gpt-neox): prevent prefill mask leakage

### DIFF
--- a/src/runtime/models/gpt_neox/MODEL.toml
+++ b/src/runtime/models/gpt_neox/MODEL.toml
@@ -5,5 +5,8 @@ id = "gpt_neox"
 runtime_library = "libtrtmc_model_gpt_neox.so"
 runtime_plugins = ["plugin.cpp|register_gpt_neox_plugin"]
 runtime_strategies = ["gpt_neox_decoder_kv_cache"]
+runtime_tests = [
+  "test_gpt_neox_attention_mask|test_gpt_neox_attention_mask.cpp|trtmc_model_gpt_neox|_|_",
+]
 [validation_profiles]
 decoder_debug = ["gpt_neox_decoder_kv_cache"]

--- a/src/runtime/models/gpt_neox/kv_cache.cpp
+++ b/src/runtime/models/gpt_neox/kv_cache.cpp
@@ -67,7 +67,7 @@ GptNeoxKvCache::GptNeoxKvCache(int32_t num_layers, int32_t max_length, int32_t k
 }
 
 // Masked score constant is model-local.
-static constexpr float kMaskedScore = -1.0e4F;
+static constexpr float kMaskedScore = -1.0e9F;
 
 void GptNeoxKvCache::build_attention_mask(std::vector<float>& mask) const {
     // DEPRECATED: use prepare_step() instead.

--- a/tests/cpp/models/gpt_neox/test_gpt_neox_attention_mask.cpp
+++ b/tests/cpp/models/gpt_neox/test_gpt_neox_attention_mask.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/gpt_neox/kv_cache.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr float kExpectedMaskedScore = -1.0e9F;
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", name);
+        ++failures;
+    }
+}
+
+void check_masked(float value, const char* name) {
+    check(value == kExpectedMaskedScore, name);
+}
+
+void test_decode_mask_uses_numerically_safe_sentinel() {
+    // Zero layers keeps this mask-only unit test CPU-only: no KV device buffers
+    // are allocated, while the production mask construction remains unchanged.
+    trtmc::GptNeoxKvCache cache(0, 4, 2, nullptr);
+    cache.set_position(2);
+
+    std::vector<float> mask;
+    cache.build_attention_mask(mask);
+
+    check(mask.size() == 5, "decode mask has cache rows plus current token");
+    check(mask[0] == 0.0F && mask[1] == 0.0F, "valid decode cache rows are visible");
+    check_masked(mask[2], "first stale decode cache row uses -1e9");
+    check_masked(mask[3], "last stale decode cache row uses -1e9");
+    check(mask[4] == 0.0F, "current decode token is visible");
+}
+
+void test_batched_prefill_mask_uses_numerically_safe_sentinel() {
+    trtmc::GptNeoxKvCache cache(0, 4, 2, nullptr);
+    trtmc::TensorMap inputs;
+    cache.prepare_step(inputs, 3);
+
+    const auto it = inputs.find("attention_mask");
+    check(it != inputs.end(), "batched prefill emits an attention mask");
+    if (it == inputs.end())
+        return;
+
+    const auto& tensor = it->second;
+    check(tensor.shape == std::vector<int64_t>({3, 7}),
+          "batched prefill mask shape covers cache and prompt rows");
+    const auto* mask = static_cast<const float*>(tensor.data);
+
+    // With an empty cache, every fixed cache column must stay masked.
+    for (int row = 0; row < 3; ++row) {
+        for (int column = 0; column < 4; ++column)
+            check_masked(mask[row * 7 + column], "prefill cache slot uses -1e9");
+    }
+
+    // Prompt columns are causal.
+    check(mask[0 * 7 + 4] == 0.0F, "prefill row 0 sees prompt token 0");
+    check_masked(mask[0 * 7 + 5], "prefill row 0 masks future token 1");
+    check_masked(mask[0 * 7 + 6], "prefill row 0 masks future token 2");
+    check(mask[1 * 7 + 4] == 0.0F && mask[1 * 7 + 5] == 0.0F,
+          "prefill row 1 sees prompt tokens 0 and 1");
+    check_masked(mask[1 * 7 + 6], "prefill row 1 masks future token 2");
+    check(mask[2 * 7 + 4] == 0.0F && mask[2 * 7 + 5] == 0.0F &&
+              mask[2 * 7 + 6] == 0.0F,
+          "prefill row 2 sees the full causal prefix");
+}
+
+} // namespace
+
+int main() {
+    test_decode_mask_uses_numerically_safe_sentinel();
+    test_batched_prefill_mask_uses_numerically_safe_sentinel();
+
+    if (failures == 0)
+        std::fprintf(stderr, "All GPT-NeoX attention mask tests passed.\n");
+    return failures;
+}

--- a/tests/cpp/models/gpt_neox/test_gpt_neox_attention_mask.cpp
+++ b/tests/cpp/models/gpt_neox/test_gpt_neox_attention_mask.cpp
@@ -68,8 +68,7 @@ void test_batched_prefill_mask_uses_numerically_safe_sentinel() {
     check(mask[1 * 7 + 4] == 0.0F && mask[1 * 7 + 5] == 0.0F,
           "prefill row 1 sees prompt tokens 0 and 1");
     check_masked(mask[1 * 7 + 6], "prefill row 1 masks future token 2");
-    check(mask[2 * 7 + 4] == 0.0F && mask[2 * 7 + 5] == 0.0F &&
-              mask[2 * 7 + 6] == 0.0F,
+    check(mask[2 * 7 + 4] == 0.0F && mask[2 * 7 + 5] == 0.0F && mask[2 * 7 + 6] == 0.0F,
           "prefill row 2 sees the full causal prefix");
 }
 

--- a/tests/e2e/models/gpt_neox/e2e_plugins/contract.py
+++ b/tests/e2e/models/gpt_neox/e2e_plugins/contract.py
@@ -103,6 +103,27 @@ def levenshtein_ned(a: str, b: str) -> float:
     return prev[-1] / max_len
 
 
+def generated_token_ids(output) -> list[int] | None:
+    raw_tokens = (output.data or {}).get("token_ids")
+    if not isinstance(raw_tokens, list):
+        return None
+    try:
+        return [int(token) for token in raw_tokens]
+    except (TypeError, ValueError):
+        return None
+
+
+def positional_token_agreement(lhs: list[int], rhs: list[int]) -> float:
+    total = max(len(lhs), len(rhs))
+    if total == 0:
+        return 1.0
+    matches = sum(
+        lhs[index] == rhs[index]
+        for index in range(min(len(lhs), len(rhs)))
+    )
+    return matches / total
+
+
 def make_pass(stage_name: str, metrics, rule: str = ""):
     from tests.e2e_harness.contracts import CompareResult
     return CompareResult(
@@ -220,6 +241,58 @@ class GptNeoxCausalContinuationPlugin:
                 note=f"first {prefix_len} chars",
             ),
         }
+
+        token_gate_ok = True
+        token_threshold = threshold.metrics.get(
+            "contract_token_agreement_rate")
+        if token_threshold is not None:
+            trt_tokens = generated_token_ids(trt_output)
+            ref_tokens = generated_token_ids(ref_output)
+            if trt_tokens is None or ref_tokens is None:
+                missing = []
+                if trt_tokens is None:
+                    missing.append("TRT")
+                if ref_tokens is None:
+                    missing.append("HF reference")
+                metrics["generated_token_ids_available"] = MetricResult(
+                    value=0.0,
+                    threshold=1.0,
+                    operator="==",
+                    passed=False,
+                    note=f"missing generated token IDs from {' and '.join(missing)}",
+                )
+                return make_fail(
+                    "full_generation",
+                    metrics,
+                    "generated token IDs required for configured token parity",
+                    metrics["generated_token_ids_available"].note,
+                )
+
+            token_agreement = positional_token_agreement(
+                trt_tokens, ref_tokens)
+            token_exact = trt_tokens == ref_tokens
+            exact_required = float(token_threshold) >= 1.0
+            metrics["generated_token_agreement_rate"] = MetricResult(
+                value=token_agreement,
+                threshold=float(token_threshold),
+                operator=">=",
+                passed=token_agreement >= float(token_threshold),
+                note=(
+                    f"TRT tokens={len(trt_tokens)}, "
+                    f"HF reference tokens={len(ref_tokens)}"
+                ),
+            )
+            metrics["generated_token_exact"] = MetricResult(
+                value=1.0 if token_exact else 0.0,
+                threshold=1.0 if exact_required else None,
+                operator="==" if exact_required else "",
+                passed=token_exact if exact_required else True,
+            )
+            token_gate_ok = (
+                token_agreement >= float(token_threshold)
+                and (token_exact or not exact_required)
+            )
+
         if reconstruction_check:
             metrics["non_empty_trt_text"] = MetricResult(
                 value=1.0 if trt_text else 0.0,
@@ -236,11 +309,16 @@ class GptNeoxCausalContinuationPlugin:
                 note="visible HF reconstruction text",
             )
 
-        passed = ned <= ned_threshold
+        passed = ned <= ned_threshold and token_gate_ok
         rule = (
             "seq2seq reconstruction parity against HF reference"
             if reconstruction_check
-            else "ned <= threshold (continuation parity)"
+            else (
+                "ned <= threshold and configured generated-token parity "
+                "(continuation parity)"
+                if token_threshold is not None
+                else "ned <= threshold (continuation parity)"
+            )
         )
         if passed:
             return make_pass("full_generation", metrics, rule)
@@ -248,7 +326,10 @@ class GptNeoxCausalContinuationPlugin:
             "full_generation",
             metrics,
             rule,
-            f"Continuation diverged: NED={ned:.3f}",
+            (
+                f"Continuation diverged: NED={ned:.3f}, "
+                f"token_gate_ok={token_gate_ok}"
+            ),
         )
 
 plugin = GptNeoxCausalContinuationPlugin()

--- a/tests/e2e/models/gpt_neox/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/gpt_neox/e2e_plugins/references/hf_transformers.py
@@ -322,6 +322,7 @@ class HfTransformersReference:
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         logits_path = str(Path(model_dir) / "hf_logits.npy")
         text_path = str(Path(model_dir) / "hf_text.txt")
+        token_path = str(Path(model_dir) / "hf_generated_tokens.json")
 
         prompt = case.inputs.get("prompt", "The capital of France is")
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
@@ -335,7 +336,7 @@ class HfTransformersReference:
         enable_thinking = contract_config.get("enable_thinking", True)
 
         script = textwrap.dedent(f"""\
-            import sys, numpy as np, torch
+            import json, sys, numpy as np, torch
             from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
 
             hf_id = {hf_id!r}
@@ -345,6 +346,7 @@ class HfTransformersReference:
             trust_remote_code = {trust_remote_code!r}
             logits_path = {logits_path!r}
             text_path = {text_path!r}
+            token_path = {token_path!r}
             use_chat_template = {use_chat_template!r}
             enable_thinking = {enable_thinking!r}
 
@@ -382,8 +384,10 @@ class HfTransformersReference:
             else:
                 model = AutoModelForCausalLM.from_pretrained(model_ref, **load_kwargs)
             model.eval()
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            model.to(device)
 
-            ids_tensor = torch.tensor([input_ids], dtype=torch.long)
+            ids_tensor = torch.tensor([input_ids], dtype=torch.long, device=device)
             all_logits = []
 
             with torch.no_grad():
@@ -394,19 +398,23 @@ class HfTransformersReference:
                         do_sample=False, num_beams=1)
                     generated_token_ids = output_ids[0].tolist()
                     # Re-run to get logits for each decoder step
-                    decoder_ids = torch.tensor([generated_token_ids], dtype=torch.long)
+                    decoder_ids = torch.tensor(
+                        [generated_token_ids], dtype=torch.long, device=device)
                     outputs = model(ids_tensor, decoder_input_ids=decoder_ids)
                     for i in range(outputs.logits.shape[1]):
                         all_logits.append(_np(outputs.logits[0, i]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
                 else:
-                    # Decoder-only: step-by-step autoregressive
-                    outputs = model(ids_tensor)
+                    # Decoder-only: prefill once, then reuse HF's KV cache.
+                    # Re-running the complete long prompt for every generated
+                    # token makes one bounded accuracy sentinel scale
+                    # quadratically with prompt length.
+                    outputs = model(ids_tensor, use_cache=True)
+                    past_key_values = outputs.past_key_values
                     prefill_logits = _np(outputs.logits[0])
                     for i in range(len(input_ids)):
                         all_logits.append(prefill_logits[i])
 
-                    gen_ids = list(input_ids)
                     generated_token_ids = []
                     eos_id = getattr(tokenizer, "eos_token_id", None)
                     for _ in range(max_new_tokens):
@@ -414,14 +422,21 @@ class HfTransformersReference:
                         generated_token_ids.append(next_token)
                         if eos_id is not None and next_token == eos_id:
                             break
-                        gen_ids.append(next_token)
-                        ids_tensor = torch.tensor([gen_ids], dtype=torch.long)
-                        outputs = model(ids_tensor)
+                        ids_tensor = torch.tensor(
+                            [[next_token]], dtype=torch.long, device=device)
+                        outputs = model(
+                            ids_tensor,
+                            past_key_values=past_key_values,
+                            use_cache=True,
+                        )
+                        past_key_values = outputs.past_key_values
                         all_logits.append(_np(outputs.logits[0, -1]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
 
             with open(text_path, "w") as f:
                 f.write(text)
+            with open(token_path, "w") as f:
+                json.dump({{"token_ids": generated_token_ids}}, f)
 
             # Pad and save logits
             max_len = max(l.shape[0] for l in all_logits)
@@ -443,7 +458,10 @@ class HfTransformersReference:
             case_name=case.name,
             stage_name=stage.name,
             env=_reference_env(ctx),
-            output_readers=(_existing_path_reader(logits_path, "logits_path"),),
+            output_readers=(
+                _existing_path_reader(logits_path, "logits_path"),
+                _json_output_reader(token_path),
+            ),
             text_reader=lambda: _read_text_artifact(text_path),
             logits_reader=(
                 lambda: logits_path if Path(logits_path).is_file() else None

--- a/tests/e2e/models/gpt_neox/manifests/pythia-70m.json
+++ b/tests/e2e/models/gpt_neox/manifests/pythia-70m.json
@@ -6,7 +6,7 @@
   "runtime_strategy": "gpt_neox_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp32",
-  "max_cache_length": 256,
+  "max_cache_length": 400,
   "trust_remote_code": false,
   "testcases": [
     {
@@ -14,8 +14,9 @@
       "trace_id": "IT-E2E-PYTH-01",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nStatement 1 | A factor group of a non-Abelian group is non-Abelian. Statement 2 | If K is a normal subgroup of H and H is a normal subgroup of G, then K is a normal subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer:",
+      "max_new_tokens": 32,
+      "notes": "PR accuracy repro for MMLU sample mmlu_000003. The former 20-token capital prompt did not exercise the long batched-prefill mask failure; this case reaches the observed generated-token index 25 while keeping one existing Pythia premerge case."
     }
   ]
 }

--- a/tests/e2e/models/gpt_neox/test_gpt_neox_accuracy_regression.py
+++ b/tests/e2e/models/gpt_neox/test_gpt_neox_accuracy_regression.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for GPT-NeoX accuracy and its premerge case."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests.e2e_harness.contracts import (
+    StageOutput,
+    StageStatus,
+    ThresholdProfile,
+)
+from tests.e2e.models.gpt_neox.e2e_plugins.contract import plugin
+
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_MANIFEST_PATH = _MODEL_DIR / "manifests" / "pythia-70m.json"
+_THRESHOLD_PATH = _MODEL_DIR / "thresholds" / "pythia-70m.json"
+_MMLU_000003_PROMPT_SHA256 = (
+    "61f41777dda57d6f63957816782b22ea5951a914e04c60ee15ca2235bdb1eb0e"
+)
+
+
+def _case():
+    return SimpleNamespace(inputs={"prompt": ""}, metadata={})
+
+
+def _threshold():
+    return ThresholdProfile(
+        task_strategy="text_generation_causal",
+        metrics={
+            "contract_ned_threshold": 0.25,
+            "contract_token_agreement_rate": 1.0,
+        },
+    )
+
+
+def _output(text: str, token_ids: list[int]) -> StageOutput:
+    return StageOutput(
+        stage_name="full_generation",
+        data={"cpp_returncode": 0, "token_ids": token_ids},
+        text=text,
+    )
+
+
+def test_pythia_premerge_case_replays_the_observed_accuracy_failure():
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    testcase = manifest["testcases"][0]
+    prompt_sha256 = hashlib.sha256(
+        testcase["prompt"].encode("utf-8")).hexdigest()
+    thresholds = json.loads(
+        _THRESHOLD_PATH.read_text(encoding="utf-8"))["threshold_overrides"]
+
+    assert prompt_sha256 == _MMLU_000003_PROMPT_SHA256
+    assert testcase["max_new_tokens"] >= 26
+    assert manifest["max_cache_length"] >= 393
+    assert thresholds["contract_token_agreement_rate"] == 1.0
+
+
+def test_pythia_contract_rejects_a_token_divergence_with_identical_text():
+    result = plugin.verify(
+        _output("same decoded continuation", [329, 187, 16708]),
+        _output("same decoded continuation", [329, 187, 11793]),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["ned"].passed
+    assert not result.metrics["generated_token_agreement_rate"].passed
+    assert not result.metrics["generated_token_exact"].passed
+
+
+def test_pythia_contract_accepts_exact_generated_tokens():
+    result = plugin.verify(
+        _output("same decoded continuation", [329, 187, 16708]),
+        _output("same decoded continuation", [329, 187, 16708]),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["generated_token_agreement_rate"].passed
+    assert result.metrics["generated_token_exact"].passed

--- a/tests/e2e/models/gpt_neox/thresholds/pythia-70m.json
+++ b/tests/e2e/models/gpt_neox/thresholds/pythia-70m.json
@@ -1,5 +1,6 @@
 {
   "threshold_overrides": {
+    "contract_token_agreement_rate": 1.0,
     "layer_atol": 0.05,
     "logit_atol": 0.1,
     "logit_cosine_p5": 0.99,


### PR DESCRIPTION
## Summary

Fix GPT-NeoX/Pythia continuation accuracy by using a numerically safe additive
attention-mask sentinel in the split batched-prefill runtime.

The change also replaces the existing one-case Pythia premerge check with the
exact MMLU prompt that exposed the failure and requires exact generated-token
parity against the HF reference.

## QA failure and local reproduction

The published all-model dashboards reported ten divergent Pythia samples:

- original run `trtmc-validate-gb300-2-20260726-c8291be0-all105`: exact match
  `0.0`, token-prefix agreement `0.1796875`, ten divergences
- rerun `trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10`: exact match
  `0.0`, token-prefix agreement `0.2046875`, ten divergences

After replaying the same inputs on `github/main@1118e725` with the
already-landed reference-precision correction, nine samples became exact.
`mmlu_000003` remained a true family-runtime divergence: exact match `0.9`,
generated-token prefix agreement `0.9390625`, one divergence.

I reproduced that sample locally on current `main` and then ran a fail-before /
pass-after comparison with the same serialized bundle:

- bundle SHA256:
  `bfe42abcb5a7262bc7f6974931a3d6c2976a6e0093cefda2150b331db725552d`
- old runtime: generated-token agreement `0.96875`; divergence at generated
  token index 25 (`TRT=11793`, `HF=16708`)
- fixed runtime: generated-token agreement `1.0`; all 32 generated tokens exact
- full ten-sample QA replay: `0.9 exact / 1 divergence` to
  `1.0 exact / 0 divergences`

## Root cause

GPT-NeoX uses separate batched-prefill and decode engines. The family-owned KV
runtime filled masked attention scores with `-1e4`.

That value was not negative enough for the fused attention implementation:
masked cache/future columns leaked into the prefill result. Layer-level
instrumentation on the same engine and prompt showed:

| Measurement | `-1e4` mask | `-1e9` mask |
|---|---:|---:|
| Prefill-logit max absolute difference vs HF | 6.467 | 0.00500 |
| Layer 4 K-cache max absolute difference | 0.997 | 0.00471 |
| Layer 4 V-cache max absolute difference | 0.259 | 0.00141 |

Decode steps already tracked HF once given correct prefill state, which excluded
the decoder and KV handoff as the primary cause.

## Fix

- Change the GPT-NeoX masked score from `-1e4` to `-1e9`.
- Add a CPU unit test for both decode and batched-prefill mask construction.
- Replace the existing short Pythia prompt with exact QA sample
  `mmlu_000003`.
- Export HF generated token IDs and gate the Pythia case on exact token parity.
- Reuse HF `past_key_values` after one prefill so the longer sentinel does not
  repeatedly recompute the full prompt.

No acceptance threshold was relaxed.

## Why CI missed it

The existing Pythia premerge case used `The capital of France is` and generated
20 tokens. It exercised batched prefill, but was not numerically sensitive to
the weak mask value and therefore did not expose the leakage.

The contract also gated normalized decoded text. The observed one-token
substitution still passed that text-distance threshold. The updated check uses
the exact failing prompt and compares generated token IDs directly.

## CI runtime bound

This replaces existing coverage instead of adding another model job:

- model cases: `1 -> 1`
- engine builds: `1 -> 1`
- TRT inference for the sentinel: about `20 ms`
- cache rows: `256 -> 400`, sufficient for the 361-token prompt plus 32
  generated tokens
- measured build: `59.78 s -> 97.54 s` (`+37.76 s` absolute)
- HF reference generation: about `45.1 s -> 10.7 s` after switching from
  repeated full-prefix forwards to one prefill plus cached decode

The check therefore adds no matrix fan-out and keeps the extra work bounded to
one small Pythia engine.

## Validation

- Old-runtime strict sentinel: expected failure, token agreement `0.96875`
- Fixed-runtime strict sentinel: pass, token agreement `1.0`
- Ten-sample QA replay: exact match `1.0`, zero divergences
- Fresh-build E2E: `1 passed` in `147.70 s`
- `ctest -R test_gpt_neox_attention_mask`: `1 passed`
- Focused accuracy regression tests: `3 passed`
- GPT-NeoX non-E2E family tests: `18 passed`
- `git diff --check`: passed

The exact Pythia-70m sentinel and full ten-input Pythia replay were run on one
GB300. The complete GitHub GPU workflow and other GPT-NeoX checkpoints were not
run locally.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased cleanly onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `82b2ddf30901b2e9befe26beb4dc2c0e29955705`.
- Bundle audit: zero case-insensitive retired-identifier matches in content and filenames; the current `.bundle` / `BUNDLE\\x01\\x00` contract is unchanged.
- `python3 -m pytest -q tests/e2e/models/gpt_neox/test_gpt_neox_accuracy_regression.py`: **3 passed**. Changed JSON files parsed successfully; targeted `compileall` and `git diff --check github/main...HEAD`: **passed**.
- The rebase changes no mask threshold, accuracy threshold, model case count, engine build count, or matrix fan-out. The existing exact MMLU sentinel remains bounded to one build/case.
- Push triggered fresh exact-head GitHub CI; merge readiness is not claimed until it completes successfully.
