### PR TITLE
fix(pixart): align Sigma text conditioning

### DIFF
--- a/python/tensorrt_model_connect/families/pixart/plugin.py
+++ b/python/tensorrt_model_connect/families/pixart/plugin.py
@@ -48,7 +48,11 @@ class PixArtPlugin:
     _T5_D_FF = 10240
     _T5_NUM_LAYERS = 24
     _T5_VOCAB_SIZE = 32128
-    _T5_MAX_SEQ_LEN = 120  # PixArt default max_sequence_length
+    _T5_MAX_SEQ_LEN_BY_PIPELINE = {
+        "PixArtAlphaPipeline": 120,
+        "PixArtSigmaPipeline": 300,
+    }
+    _T5_MAX_SEQ_LEN_FALLBACK = 120
 
     # PixArt DiT params (XL-2 configuration)
     _DIT_DIM = 1152  # 16 heads * 72 head_dim
@@ -78,6 +82,13 @@ class PixArtPlugin:
     def matches(self, model_type: str) -> bool:
         mt = model_type.lower()
         return mt in ("pixart", "pixart_sigma", "pixart_alpha", "pixartsigma", "pixartalpha")
+
+    def _text_sequence_length(self, config: ModelConfig) -> int:
+        """Return the Diffusers text-length contract for this PixArt pipeline."""
+        pipeline_class = str(config.raw.get("_class_name", "") or "")
+        return self._T5_MAX_SEQ_LEN_BY_PIPELINE.get(
+            pipeline_class, self._T5_MAX_SEQ_LEN_FALLBACK
+        )
 
     def load_weights(
         self,
@@ -199,6 +210,7 @@ class PixArtPlugin:
         t5_d_ff = t5_cfg.get("d_ff", self._T5_D_FF)
         t5_num_layers = t5_cfg.get("num_layers", self._T5_NUM_LAYERS)
         t5_vocab_size = t5_cfg.get("vocab_size", self._T5_VOCAB_SIZE)
+        text_seq_len = self._text_sequence_length(config)
 
         # Image and latent dimensions
         img_h = config.raw.get("image_height", self._IMAGE_HEIGHT)
@@ -236,7 +248,7 @@ class PixArtPlugin:
                 d_ff=t5_d_ff,
                 num_layers=t5_num_layers,
                 vocab_size=t5_vocab_size,
-                max_seq_len=self._T5_MAX_SEQ_LEN,
+                max_seq_len=text_seq_len,
                 precision=t5_precision,
                 verbose=verbose,
             )
@@ -271,7 +283,7 @@ class PixArtPlugin:
                         ffn_dim=ffn_dim,
                         context_dim=cross_attn_dim,
                         num_patches=num_patches,
-                        text_seq_len=self._T5_MAX_SEQ_LEN,
+                        text_seq_len=text_seq_len,
                         qk_norm=False,
                         cross_attn_norm=False,
                         ffn_activation="gelu_approximate",
@@ -288,7 +300,7 @@ class PixArtPlugin:
                     ffn_dim=ffn_dim,
                     context_dim=cross_attn_dim,
                     num_patches=num_patches,
-                    text_seq_len=self._T5_MAX_SEQ_LEN,
+                    text_seq_len=text_seq_len,
                     precision=dit_precision,
                     verbose=verbose,
                 )
@@ -465,7 +477,7 @@ class PixArtPlugin:
             "scale_factor_temporal": 1,
             "scale_factor_spatial": self._VAE_SCALE_FACTOR,
             "freq_dim": 256,  # Sinusoidal timestep embedding dim
-            "text_seq_len": self._T5_MAX_SEQ_LEN,
+            "text_seq_len": self._text_sequence_length(config),
             # Empty: DDIM models skip Wan-style denormalization.
             # VAE scaling (1/scaling_factor) is handled in the 2D VAE decode.
             "latents_mean": [],

--- a/src/runtime/models/pixart/diffusion_helpers.cpp
+++ b/src/runtime/models/pixart/diffusion_helpers.cpp
@@ -122,6 +122,7 @@ PixArtDiffusionConfig make_diffusion_config(const std::string& json) {
     dc.freq_dim = extract_json_int(json, "freq_dim", 256);
     dc.text_seq_len = extract_json_int(json, "text_seq_len", 512);
     dc.text_encoder_dim = extract_json_int(json, "text_encoder_dim", 4096);
+    dc.tokenizer_special_suffix_ids = extract_json_int_array(json, "tokenizer_special_suffix_ids");
     dc.num_vae_caches = extract_json_int(json, "num_vae_caches", 0);
     const auto latent_stat_count = static_cast<std::size_t>(dc.z_dim > 0 ? dc.z_dim : 16);
     dc.latents_mean = extract_json_float_array(json, "latents_mean", latent_stat_count);

--- a/src/runtime/models/pixart/pipeline.cpp
+++ b/src/runtime/models/pixart/pipeline.cpp
@@ -480,13 +480,9 @@ bool PixArtPipeline::run_t5_encoder(const std::vector<int32_t>& input_ids,
     const auto copy_len = std::min(static_cast<std::size_t>(seq_len), input_ids.size());
     std::copy_n(input_ids.begin(), copy_len, padded_ids.begin());
 
-    // Build attention mask: 0.0 for real tokens, -1e9 for padding
-    std::vector<float> mask(static_cast<std::size_t>(seq_len), -1e9F);
-    for (int32_t i = 0; i < seq_len; ++i) {
-        if (padded_ids[static_cast<std::size_t>(i)] != 0) {
-            mask[static_cast<std::size_t>(i)] = 0.0F;
-        }
-    }
+    // Derive the T5 mask from the exact normalized IDs sent to the encoder.
+    std::vector<float> mask =
+        diffusion::make_pixart_t5_attention_mask(padded_ids, static_cast<std::size_t>(seq_len));
 
     // Build TensorMap inputs
     TensorMap inputs;
@@ -1095,7 +1091,10 @@ ImageResult PixArtPipeline::generate_image(const std::string& prompt, const Gene
     // Tokenize prompt
     std::vector<int32_t> input_ids;
     if (tokenizer_) {
-        input_ids = tokenizer_->encode(prompt);
+        input_ids = tokenizer_->encode(diffusion::preprocess_pixart_prompt(prompt));
+        input_ids = diffusion::normalize_pixart_t5_input_ids(
+            input_ids, static_cast<std::size_t>(config_.text_seq_len),
+            config_.tokenizer_special_suffix_ids);
     }
 
     const int32_t requested_steps = (cfg.num_steps > 0) ? cfg.num_steps : -1;

--- a/src/runtime/models/pixart/pixart_diffusion_types.h
+++ b/src/runtime/models/pixart/pixart_diffusion_types.h
@@ -35,6 +35,7 @@ struct PixArtDiffusionConfig {
     int32_t freq_dim{0};
     int32_t text_seq_len{0};
     int32_t text_encoder_dim{0};
+    std::vector<int32_t> tokenizer_special_suffix_ids;
 
     int32_t num_vae_caches{0};
     std::vector<float> latents_mean;

--- a/src/runtime/models/pixart/pixart_generation_conditioning.h
+++ b/src/runtime/models/pixart/pixart_generation_conditioning.h
@@ -7,6 +7,8 @@
 
 #include "runtime/models/pixart/pixart_generation_plan.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -26,6 +28,51 @@ struct PixArtTextConditioning {
     std::vector<float> text_projected;
     std::vector<float> null_text;
 };
+
+// Diffusers normalizes every PixArt prompt with lower().strip() even when the optional
+// clean-caption dependencies are unavailable. Keep that baseline preprocessing in native C++.
+inline std::string preprocess_pixart_prompt(const std::string& prompt) {
+    const auto is_space = [](unsigned char value) { return std::isspace(value) != 0; };
+    const auto first = std::find_if_not(prompt.begin(), prompt.end(), is_space);
+    const auto last = std::find_if_not(prompt.rbegin(), prompt.rend(), is_space).base();
+    if (first >= last)
+        return {};
+
+    std::string normalized(first, last);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+    return normalized;
+}
+
+// HF truncates prompt content while retaining the tokenizer's special suffix. The native
+// tokenizer frames the full prompt first, so the PixArt runtime must apply the same ordering.
+inline std::vector<int32_t>
+normalize_pixart_t5_input_ids(const std::vector<int32_t>& input_ids, std::size_t sequence_length,
+                              const std::vector<int32_t>& special_suffix_ids) {
+    if (input_ids.size() <= sequence_length)
+        return input_ids;
+
+    const std::size_t suffix_length = std::min(sequence_length, special_suffix_ids.size());
+    const std::size_t content_length = sequence_length - suffix_length;
+
+    std::vector<int32_t> normalized;
+    normalized.reserve(sequence_length);
+    normalized.insert(normalized.end(), input_ids.begin(), input_ids.begin() + content_length);
+    normalized.insert(normalized.end(), special_suffix_ids.end() - suffix_length,
+                      special_suffix_ids.end());
+    return normalized;
+}
+
+inline std::vector<float> make_pixart_t5_attention_mask(const std::vector<int32_t>& input_ids,
+                                                        std::size_t sequence_length) {
+    std::vector<float> mask(sequence_length, -1e9F);
+    const std::size_t token_count = std::min(sequence_length, input_ids.size());
+    for (std::size_t index = 0; index < token_count; ++index) {
+        if (input_ids[index] != 0)
+            mask[index] = 0.0F;
+    }
+    return mask;
+}
 
 inline std::vector<float> make_pixart_null_attention_mask(std::size_t sequence_length) {
     std::vector<float> mask(sequence_length, -10000.0F);

--- a/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
+++ b/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -188,6 +189,32 @@ void test_pixart_null_attention_mask_only_keeps_eos_token() {
           "PixArt null mask rejects padding tokens");
 }
 
+void test_pixart_t5_truncation_preserves_bundled_eos_suffix() {
+    std::vector<int32_t> input_ids(149);
+    std::iota(input_ids.begin(), input_ids.end(), 2);
+    input_ids.back() = 1;
+
+    const auto normalized = trtmc::diffusion::normalize_pixart_t5_input_ids(input_ids, 120, {1});
+    check(normalized.size() == 120, "PixArt truncates T5 input to the engine sequence length");
+    check(std::equal(normalized.begin(), normalized.end() - 1, input_ids.begin()),
+          "PixArt preserves the leading 119 content tokens");
+    check(normalized.back() == 1, "PixArt preserves the bundled terminal EOS after truncation");
+
+    const auto mask = trtmc::diffusion::make_pixart_t5_attention_mask(normalized, 120);
+    check(mask.size() == normalized.size(),
+          "PixArt T5 IDs and attention mask use the same normalized length");
+    check(std::all_of(mask.begin(), mask.end(), [](float value) { return value == 0.0F; }),
+          "PixArt T5 attention mask keeps the normalized EOS token");
+}
+
+void test_pixart_prompt_preprocessing_matches_diffusers_baseline() {
+    const auto normalized = trtmc::diffusion::preprocess_pixart_prompt(" \tA Vibrant MACARON.\n");
+    check(normalized == "a vibrant macaron.",
+          "PixArt prompt preprocessing lowercases and strips surrounding whitespace");
+    check(trtmc::diffusion::preprocess_pixart_prompt(" \n\t").empty(),
+          "PixArt prompt preprocessing handles whitespace-only prompts");
+}
+
 void test_pixart_initial_latents_honor_override_and_requested_seed() {
     std::vector<float> latents;
     std::string error;
@@ -233,6 +260,8 @@ int main() {
     test_pixart_position_scale_matches_diffusers_for_runtime_grid();
     test_pixart_dpmsolver_matches_diffusers_order_two_golden();
     test_pixart_null_attention_mask_only_keeps_eos_token();
+    test_pixart_t5_truncation_preserves_bundled_eos_suffix();
+    test_pixart_prompt_preprocessing_matches_diffusers_baseline();
     test_pixart_initial_latents_honor_override_and_requested_seed();
     test_pixart_large_matmuls_use_gpu_policy();
 

--- a/tests/e2e/models/pixart/manifests/pixart-sigma-1024-l0.json
+++ b/tests/e2e/models/pixart/manifests/pixart-sigma-1024-l0.json
@@ -20,8 +20,8 @@
       "ci_tier": "l0_only",
       "reference_family": "diffusers_image_gen",
       "user_contract": "diffusion_image",
-      "description": "PixArt-Sigma XL-2 L0 representative at 512px with full cache and step count",
-      "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+      "description": "PixArt-Sigma XL-2 L0 long-prompt regression at 512px with full cache and step count",
+      "test_prompt": "A playful collection of 2x2 emoji icons, each resembling a vibrant macaron with a distinct facial expression. The top left macaron is a sunny yellow with a beaming smile, while the top right is a fiery red with furrowed brows and an angry scowl. Below them, the bottom left is a bright blue with wide, surprised eyes, and the bottom right is a soft lavender with a tearful, sobbing face. Each of the macaron emojis is whimsically topped with a miniature brown cowboy hat, adding a touch of whimsy to their appearance.",
       "test_type": "diffusion",
       "image_height": 512,
       "image_width": 512,
@@ -34,7 +34,7 @@
         }
       ],
       "skip_text_comparison": true,
-      "notes": "PR L0 repro for PixArt-Sigma. Uses the same checkpoint, PixArt model type, T5-XXL text encoder, DiT/VAE path, runner, comparator, full 256-token cache shape, 20-step denoising loop, and FP32 T5 selector as the full manifest. L0 uses 512px to reduce DiT/VAE spatial scale; nightly keeps 1024px coverage.",
+      "notes": "PR L0 repro for PixArt-Sigma using the long DPG prompt that exposed the native 120-token limit instead of Diffusers' 300-token Sigma contract. Uses the same checkpoint, PixArt model type, T5-XXL text encoder, DiT/VAE path, runner, comparator, full 256-token cache shape, 20-step denoising loop, and FP32 T5 selector as the full manifest. L0 uses 512px to reduce DiT/VAE spatial scale; nightly keeps 1024px coverage.",
       "metadata": {
         "contract_config": {
           "use_diffusers": true

--- a/tests/e2e/models/pixart/manifests/pixart-sigma-1024-l0.json
+++ b/tests/e2e/models/pixart/manifests/pixart-sigma-1024-l0.json
@@ -5,6 +5,7 @@
   "family": "pixart",
   "runtime_strategy": "diffusion_pixart",
   "task_strategy": "diffusion_media_generation",
+  "e2e_parallel_resource": "exclusive_gpu",
   "build_args": {
     "max_cache_length": 256
   },

--- a/tests/e2e/models/pixart/test_pixart_family_plugin.py
+++ b/tests/e2e/models/pixart/test_pixart_family_plugin.py
@@ -264,7 +264,11 @@ def test_build_components_uses_transformer_and_t5_configs(
         },
     }
 
-    config = _cfg(image_height=256, image_width=384)
+    config = _cfg(
+        image_height=256,
+        image_width=384,
+        _class_name="PixArtSigmaPipeline",
+    )
     config.raw["_fp32_layers"] = [2]
     out = pixart_mod.plugin.build_components(
         str(model_dir),
@@ -286,6 +290,8 @@ def test_build_components_uses_transformer_and_t5_configs(
     assert calls["build_vae_2d_decoder_engine"][1]["precision"] == "fp32"
     assert calls["build_standard_dit_engine"][1]["num_patches"] == 96
     assert calls["build_standard_dit_engine"][1]["context_dim"] == 64
+    assert calls["build_t5_encoder_engine"][1]["max_seq_len"] == 300
+    assert calls["build_standard_dit_engine"][1]["text_seq_len"] == 300
     assert calls["_serialize_preprocessor_weights"][0][1] == 1024
     assert calls["_serialize_preprocessor_weights"][0][2] == 32
 
@@ -399,6 +405,7 @@ def test_get_diffusion_config_uses_transformer_overrides() -> None:
     Postconditions: dit_dim/head/layer values are computed from overrides.
     """
     cfg = _cfg(
+        _class_name="PixArtSigmaPipeline",
         _transformer_config={
             "num_attention_heads": 5,
             "attention_head_dim": 6,
@@ -417,9 +424,19 @@ def test_get_diffusion_config_uses_transformer_overrides() -> None:
     assert dc["dit_num_layers"] == 3
     assert dc["image_height"] == 640
     assert dc["image_width"] == 832
+    assert dc["text_seq_len"] == 300
     assert dc["use_rope"] == 0
     assert dc["pos_embed_base_size"] == 64
     assert dc["pos_embed_interpolation_scale"] == 2
+
+
+def test_get_diffusion_config_keeps_pixart_alpha_text_length() -> None:
+    """PixArt Alpha retains the 120-token Diffusers pipeline contract."""
+    dc = pixart_mod.plugin.get_diffusion_config(
+        _cfg(_class_name="PixArtAlphaPipeline")
+    )
+
+    assert dc["text_seq_len"] == 120
 
 
 def test_load_pixart_dit_weights_maps_optional_biases(

--- a/tests/e2e/models/pixart/test_pixart_family_plugin.py
+++ b/tests/e2e/models/pixart/test_pixart_family_plugin.py
@@ -12,6 +12,7 @@ Postconditions: Plugin matches PixArt aliases, serializes preprocessor weights c
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import struct
 import sys
 import types
@@ -134,6 +135,16 @@ def test_pixart_pipeline_classes_resolve_to_pixart_plugin() -> None:
 
     for pipeline_class in ("PixArtSigmaPipeline", "PixArtAlphaPipeline"):
         assert find_diffusion_plugin(pipeline_class) is pixart_mod.plugin
+
+
+def test_pixart_sigma_l0_reserves_an_exclusive_gpu() -> None:
+    """The 300-token FP32 T5-XXL build must not share a GPU with other proofs."""
+    manifest_path = (
+        Path(__file__).parent / "manifests" / "pixart-sigma-1024-l0.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
 
 
 def test_load_weights_success_and_missing_model_index(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Align PixArt-Sigma native text conditioning with the Diffusers pipeline:

- build Sigma text/DiT engines for the model's 300-token contract;
- retain PixArt-Alpha's 120-token contract;
- apply Diffusers' baseline `lower().strip()` prompt normalization;
- keep token IDs, T5 masks, and DiT cross-attention masks on the same normalized
  sequence.

The exact QA image passes every existing image-quality gate with a fresh
manifest-aligned bundle. After the final rebase, the rebuilt branch-head binary
produced a bit-identical image from that bundle. No threshold was relaxed.

## QA failure and local reproduction

The original QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` and rerun
`trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10` both reported four of
five PixArt-Sigma DPG samples passing. The same failing sample was
`dpg_bench_000005`.

QA metrics for that sample:

| Metric | Actual | Existing gate |
|---|---:|---:|
| PSNR | 6.20755 dB | >= 10 dB |
| SSIM | 0.100879 | >= 0.75 |
| TRT/HF image CLIP cosine | 0.569953 | >= 0.85 |

I downloaded the exact prompt, HF frame, TRT frame, and shared initial latent.
`github/main@1118e725` reproduced the QA result at PSNR `6.20760` and SSIM `0.100876`;
the local current-main frame and the published QA TRT frame themselves matched
at PSNR `63.36` / SSIM `0.999998`.

## Root cause

There were two independent text-contract mismatches.

1. `PixArtSigmaPipeline.__call__` defaults to `max_sequence_length=300`, while
   the native plugin hard-coded 120 for T5, the DiT cross-attention shape, and
   the serialized runtime config. The QA prompt is longer than 120 tokens.
2. Diffusers preprocesses PixArt text with at least `lower().strip()` even when
   optional clean-caption dependencies are unavailable. Native C++ tokenized
   the original string. For the exact prompt, HF produced 150 tokens while
   native produced 149.

Changing only the sequence length improved the sample to PSNR `12.4365`, but
SSIM was still `0.709704`, proving that the first correction alone was
insufficient.

## Fix and final-head GPU result

- Resolve text length from the Diffusers pipeline class:
  - `PixArtAlphaPipeline`: 120
  - `PixArtSigmaPipeline`: 300
- Use that value consistently for T5, DiT, and runtime metadata.
- Normalize the native prompt with lowercase plus surrounding-whitespace
  removal before tokenization.
- Preserve the tokenizer's special suffix if an Alpha prompt is truncated.
- Derive T5 and cross-attention masks from the exact normalized IDs.

Combined result on the exact shared-latent QA sample, measured from the
manifest's mixed-precision contract (FP32 T5, FP16 DiT/VAE):

| Metric | Before | After | Existing gate |
|---|---:|---:|---:|
| PSNR | 6.20760 dB | 24.12498 dB | >= 10 dB |
| SSIM | 0.100876 | 0.981978 | >= 0.75 |
| TRT/HF image CLIP cosine | 0.569953 | 0.994226 | >= 0.85 |
| TRT prompt CLIPScore | 30.4805 | 30.9054 | diagnostic |
| HF prompt CLIPScore | 30.9932 | 30.9932 | diagnostic |

## Why CI missed it

The existing PixArt L0 case used a short prompt, so it never exceeded the
incorrect 120-token native limit. It therefore exercised the same model and
runner but not the broken Sigma text-shape contract.

This PR replaces that existing prompt with the exact long DPG prompt. The L0
case continues to run at 512px, while nightly retains the full 1024px case.

## CI runtime bound

This change does not add matrix fan-out:

- PixArt premerge cases: `1 -> 1`
- PixArt engine builds: `1 -> 1`
- denoising steps: unchanged at 20
- L0 spatial resolution: unchanged at 512px

For the full 1024px local build:

- build time: `303.9 s -> 398.9 s` (`+95.0 s`, `+31.3%`)
- bundle bytes: `20,417,413,261 -> 20,437,630,493`
  (`+20,217,232`, about `0.10%`)
- final-head fresh-bundle engine execution for the exact sample:
  T5 `20.26 ms`, DiT `414.46 ms`, VAE `28.54 ms`

The added check is therefore bounded to the already-selected PixArt job and
does not add another model build or inference case.

The actual 512px L0 before/after wall time was not measured locally; the
1024px build above is the available sizing proxy. Matrix fan-out is unchanged,
but this PR does not present that proxy as a measured 512px CI duration.

An independent manifest-aligned mixed-precision build on the family diff based
on `github/main@3f95b808` completed in `476.9 s`, produced a
`20,437,516,461`-byte bundle with SHA-256
`984c457c88f13ec8fc91d273db925d46c20ee5356db32d93deb201153614c9f4`,
and passed the exact 1024px shared-latent sample. The branch was then rebased
onto `github/main@508613d0`; the two new commits touched Bloom, the generic BPE
tokenizer, and model-proof tests, while PixArt uses the native Unigram
tokenizer. After rebuilding `trtmc` and `trtmc_model_pixart` at final head
`564dbe0c`, the same sample produced the identical PNG SHA-256
`517109c2e5839f52ff7f36e2680eb74cbb063b5b9a592cf53aaf6e3afdc75d6b`.
The earlier controlled `303.9 -> 398.9 s` comparison remains the available
same-environment sizing delta; build tactic variance means the independent
`476.9 s` value is reported separately rather than mixed into that delta.

## Validation

- Final-head binary with the fresh manifest-aligned bundle, 1024px QA
  shared-latent image: PSNR `24.12498`, SSIM `0.981978`, and image-CLIP cosine
  `0.994226`; all original gates passed and the PNG was bit-identical before
  and after the final rebase
- PixArt family plugin tests: `9 passed`
- PixArt C++ conditioning/denoising seam test: pass
- `clang-format --dry-run --Werror`: passed
- `ruff check`: passed
- `git diff --check`: passed

The final-head run covers the exact 1024px QA table, including the
`ef9fd0fb` preprocessing-matmul change. Draft-PR GPU CI separately needs to
exercise the 512px L0 long-prompt sentinel used by premerge; that 512px receipt
does not substitute for the 1024px table above. The complete five-sample DPG
workload and full GitHub workflow were not run locally.


## Latest-main CI follow-up

After rebasing onto `github/main@63c920304cb0236a995e933f49504e8f2f237317`,
the first exact-head private run
[`31076187191`](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31076187191)
passed source, unit, C++, and family checks. Its only primary failure was the
PixArt model job: the 300-token T5 encoder returned no serialized engine after
72.938 seconds while holding a shared GPU slot with no free-memory admission.
The isolated QA-equivalent 300-token T5 build had previously succeeded in
77.721 seconds on an otherwise idle GPU. This identified GPU build-memory
contention, not an accuracy regression or an invalid threshold.

The PixArt L0 manifest now declares
`e2e_parallel_resource: exclusive_gpu`. A family contract test pins that
scheduler requirement. This does not add a model, sample, engine, inference
case, or matrix row; it only prevents this memory-heavy T5 build from sharing a
GPU with another proof. Frozen-image scheduler and family tests passed.

The final exact head is
`48eb3df7b873049abd9d80723153013c7d47f652`. Private run
[`31077061452`](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31077061452)
then passed source, unit/C++, and the complete PixArt model proof. Both CodeQL
languages and `trtmc/premerge/required` passed on that same head, and the PR
was marked ready only after GitHub reported `MERGEABLE/CLEAN`.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased cleanly onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `32d5a58233a5d4ca5d8697d352cdc84d2aa4fc47`.
- Bundle audit: content and tracked filenames contain zero case-insensitive matches for the retired identifier; `.bundle` and `BUNDLE\\x01\\x00` remain the only artifact contract.
- Targeted family `compileall`, changed-manifest JSON parsing, and `git diff --check github/main...HEAD`: **passed**.
- `tests/e2e/models/pixart/test_pixart_family_plugin.py` was collected but skipped because this host lacks TensorRT and the matching agent-2 dev container is not running. The exact shared-latent QA GPU result documented above remains the parity receipt; fresh exact-head CI is required before merge.
- Rebase adds no build, case, denoising step, threshold, or CI matrix fan-out. Push triggered fresh exact-head GitHub CI; no green claim is made until completion.
