### PR TITLE
test(stablelm): guard long-context token parity

### DIFF
--- a/tests/e2e/models/stablelm/e2e_plugins/contract.py
+++ b/tests/e2e/models/stablelm/e2e_plugins/contract.py
@@ -103,6 +103,27 @@ def levenshtein_ned(a: str, b: str) -> float:
     return prev[-1] / max_len
 
 
+def generated_token_ids(output) -> list[int] | None:
+    raw_tokens = (output.data or {}).get("token_ids")
+    if not isinstance(raw_tokens, list):
+        return None
+    try:
+        return [int(token) for token in raw_tokens]
+    except (TypeError, ValueError):
+        return None
+
+
+def positional_token_agreement(lhs: list[int], rhs: list[int]) -> float:
+    total = max(len(lhs), len(rhs))
+    if total == 0:
+        return 1.0
+    matches = sum(
+        lhs[index] == rhs[index]
+        for index in range(min(len(lhs), len(rhs)))
+    )
+    return matches / total
+
+
 def make_pass(stage_name: str, metrics, rule: str = ""):
     from tests.e2e_harness.contracts import CompareResult
     return CompareResult(
@@ -220,6 +241,58 @@ class StablelmCausalContinuationPlugin:
                 note=f"first {prefix_len} chars",
             ),
         }
+
+        token_gate_ok = True
+        token_threshold = threshold.metrics.get(
+            "contract_token_agreement_rate")
+        if token_threshold is not None:
+            trt_tokens = generated_token_ids(trt_output)
+            ref_tokens = generated_token_ids(ref_output)
+            if trt_tokens is None or ref_tokens is None:
+                missing = []
+                if trt_tokens is None:
+                    missing.append("TRT")
+                if ref_tokens is None:
+                    missing.append("HF reference")
+                metrics["generated_token_ids_available"] = MetricResult(
+                    value=0.0,
+                    threshold=1.0,
+                    operator="==",
+                    passed=False,
+                    note=f"missing generated token IDs from {' and '.join(missing)}",
+                )
+                return make_fail(
+                    "full_generation",
+                    metrics,
+                    "generated token IDs required for configured token parity",
+                    metrics["generated_token_ids_available"].note,
+                )
+
+            token_agreement = positional_token_agreement(
+                trt_tokens, ref_tokens)
+            token_exact = trt_tokens == ref_tokens
+            exact_required = float(token_threshold) >= 1.0
+            metrics["generated_token_agreement_rate"] = MetricResult(
+                value=token_agreement,
+                threshold=float(token_threshold),
+                operator=">=",
+                passed=token_agreement >= float(token_threshold),
+                note=(
+                    f"TRT tokens={len(trt_tokens)}, "
+                    f"HF reference tokens={len(ref_tokens)}"
+                ),
+            )
+            metrics["generated_token_exact"] = MetricResult(
+                value=1.0 if token_exact else 0.0,
+                threshold=1.0 if exact_required else None,
+                operator="==" if exact_required else "",
+                passed=token_exact if exact_required else True,
+            )
+            token_gate_ok = (
+                token_agreement >= float(token_threshold)
+                and (token_exact or not exact_required)
+            )
+
         if reconstruction_check:
             metrics["non_empty_trt_text"] = MetricResult(
                 value=1.0 if trt_text else 0.0,
@@ -236,11 +309,16 @@ class StablelmCausalContinuationPlugin:
                 note="visible HF reconstruction text",
             )
 
-        passed = ned <= ned_threshold
+        passed = ned <= ned_threshold and token_gate_ok
         rule = (
             "seq2seq reconstruction parity against HF reference"
             if reconstruction_check
-            else "ned <= threshold (continuation parity)"
+            else (
+                "ned <= threshold and configured generated-token parity "
+                "(continuation parity)"
+                if token_threshold is not None
+                else "ned <= threshold (continuation parity)"
+            )
         )
         if passed:
             return make_pass("full_generation", metrics, rule)
@@ -248,7 +326,10 @@ class StablelmCausalContinuationPlugin:
             "full_generation",
             metrics,
             rule,
-            f"Continuation diverged: NED={ned:.3f}",
+            (
+                f"Continuation diverged: NED={ned:.3f}, "
+                f"token_gate_ok={token_gate_ok}"
+            ),
         )
 
 plugin = StablelmCausalContinuationPlugin()

--- a/tests/e2e/models/stablelm/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/stablelm/e2e_plugins/references/hf_transformers.py
@@ -322,6 +322,7 @@ class HfTransformersReference:
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         logits_path = str(Path(model_dir) / "hf_logits.npy")
         text_path = str(Path(model_dir) / "hf_text.txt")
+        token_path = str(Path(model_dir) / "hf_generated_tokens.json")
 
         prompt = case.inputs.get("prompt", "The capital of France is")
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
@@ -335,7 +336,7 @@ class HfTransformersReference:
         enable_thinking = contract_config.get("enable_thinking", True)
 
         script = textwrap.dedent(f"""\
-            import sys, numpy as np, torch
+            import json, sys, numpy as np, torch
             from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
 
             hf_id = {hf_id!r}
@@ -345,6 +346,7 @@ class HfTransformersReference:
             trust_remote_code = {trust_remote_code!r}
             logits_path = {logits_path!r}
             text_path = {text_path!r}
+            token_path = {token_path!r}
             use_chat_template = {use_chat_template!r}
             enable_thinking = {enable_thinking!r}
 
@@ -382,8 +384,10 @@ class HfTransformersReference:
             else:
                 model = AutoModelForCausalLM.from_pretrained(model_ref, **load_kwargs)
             model.eval()
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            model.to(device)
 
-            ids_tensor = torch.tensor([input_ids], dtype=torch.long)
+            ids_tensor = torch.tensor([input_ids], dtype=torch.long, device=device)
             all_logits = []
 
             with torch.no_grad():
@@ -394,19 +398,23 @@ class HfTransformersReference:
                         do_sample=False, num_beams=1)
                     generated_token_ids = output_ids[0].tolist()
                     # Re-run to get logits for each decoder step
-                    decoder_ids = torch.tensor([generated_token_ids], dtype=torch.long)
+                    decoder_ids = torch.tensor(
+                        [generated_token_ids], dtype=torch.long, device=device)
                     outputs = model(ids_tensor, decoder_input_ids=decoder_ids)
                     for i in range(outputs.logits.shape[1]):
                         all_logits.append(_np(outputs.logits[0, i]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
                 else:
-                    # Decoder-only: step-by-step autoregressive
-                    outputs = model(ids_tensor)
+                    # Decoder-only: prefill once, then reuse HF's KV cache.
+                    # Re-running the complete long prompt for every generated
+                    # token makes one bounded accuracy sentinel scale
+                    # quadratically with prompt length.
+                    outputs = model(ids_tensor, use_cache=True)
+                    past_key_values = outputs.past_key_values
                     prefill_logits = _np(outputs.logits[0])
                     for i in range(len(input_ids)):
                         all_logits.append(prefill_logits[i])
 
-                    gen_ids = list(input_ids)
                     generated_token_ids = []
                     eos_id = getattr(tokenizer, "eos_token_id", None)
                     for _ in range(max_new_tokens):
@@ -414,14 +422,21 @@ class HfTransformersReference:
                         generated_token_ids.append(next_token)
                         if eos_id is not None and next_token == eos_id:
                             break
-                        gen_ids.append(next_token)
-                        ids_tensor = torch.tensor([gen_ids], dtype=torch.long)
-                        outputs = model(ids_tensor)
+                        ids_tensor = torch.tensor(
+                            [[next_token]], dtype=torch.long, device=device)
+                        outputs = model(
+                            ids_tensor,
+                            past_key_values=past_key_values,
+                            use_cache=True,
+                        )
+                        past_key_values = outputs.past_key_values
                         all_logits.append(_np(outputs.logits[0, -1]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
 
             with open(text_path, "w") as f:
                 f.write(text)
+            with open(token_path, "w") as f:
+                json.dump({{"token_ids": generated_token_ids}}, f)
 
             # Pad and save logits
             max_len = max(l.shape[0] for l in all_logits)
@@ -443,7 +458,10 @@ class HfTransformersReference:
             case_name=case.name,
             stage_name=stage.name,
             env=_reference_env(ctx),
-            output_readers=(_existing_path_reader(logits_path, "logits_path"),),
+            output_readers=(
+                _existing_path_reader(logits_path, "logits_path"),
+                _json_output_reader(token_path),
+            ),
             text_reader=lambda: _read_text_artifact(text_path),
             logits_reader=(
                 lambda: logits_path if Path(logits_path).is_file() else None

--- a/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
+++ b/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
@@ -1,12 +1,13 @@
 {
   "name": "stablelm2-1.6b",
   "hf_id": "stabilityai/stablelm-2-1_6b",
+  "hf_revision": "f499ead74c53749bd93cebc6ce8bc0d7bdf1eaef",
   "bundle": "stablelm2-1.6b.bundle",
   "family": "stablelm",
   "runtime_strategy": "stablelm_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
-  "max_cache_length": 256,
+  "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [
     {
@@ -14,9 +15,10 @@
       "trace_id": "IT-E2E-SLM2-01",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "reference_precision": "fp32",
-      "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "reference_precision": "fp16",
+      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind all zeros in the indicated finite field of the given polynomial with coefficients in that field. x^5 + 3x^3 + x^2 + 2x in Z_5\nA. 0\nB. 1\nC. 0,1\nD. 0,4\nAnswer:",
+      "max_new_tokens": 20,
+      "notes": "Exact StableLM regression sentinel for QA MMLU sample mmlu_000002. It replaces the former short prompt and reaches the published first divergence at generated-token index 18 without adding another model build or case."
     }
   ]
 }

--- a/tests/e2e/models/stablelm/test_stablelm_accuracy_regression.py
+++ b/tests/e2e/models/stablelm/test_stablelm_accuracy_regression.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for StableLM continuation accuracy and its CI sentinel."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests.e2e_harness.contracts import (
+    StageOutput,
+    StageStatus,
+    ThresholdProfile,
+)
+from tests.e2e.models.stablelm.e2e_plugins.contract import plugin
+
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_MANIFEST_PATH = _MODEL_DIR / "manifests" / "stablelm2-1.6b.json"
+_THRESHOLD_PATH = _MODEL_DIR / "thresholds" / "stablelm2-1.6b.json"
+_STABLELM_REVISION = "f499ead74c53749bd93cebc6ce8bc0d7bdf1eaef"
+_MMLU_000002_PROMPT_SHA256 = (
+    "de28bf6b76387fa017c1ffa8e379f87c46439a0b0fc0186798c0f7b4b6a17330"
+)
+_QA_COMMON_PREFIX = [
+    362,
+    271,
+    10086,
+    682,
+    10105,
+    311,
+    279,
+    24524,
+    304,
+    1901,
+    62,
+    18,
+    13,
+    865,
+    61,
+    17,
+    489,
+    220,
+]
+
+
+def _case():
+    return SimpleNamespace(inputs={"prompt": ""}, metadata={})
+
+
+def _threshold():
+    return ThresholdProfile(
+        task_strategy="text_generation_causal",
+        metrics={
+            "contract_ned_threshold": 0.25,
+            "contract_token_agreement_rate": 1.0,
+        },
+    )
+
+
+def _output(text: str, token_ids: list[int]) -> StageOutput:
+    return StageOutput(
+        stage_name="full_generation",
+        data={"cpp_returncode": 0, "token_ids": token_ids},
+        text=text,
+    )
+
+
+def test_stablelm_premerge_case_replays_the_published_accuracy_signal():
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    testcase = manifest["testcases"][0]
+    prompt_sha256 = hashlib.sha256(
+        testcase["prompt"].encode("utf-8")).hexdigest()
+    thresholds = json.loads(
+        _THRESHOLD_PATH.read_text(encoding="utf-8"))["threshold_overrides"]
+
+    assert manifest["hf_revision"] == _STABLELM_REVISION
+    assert prompt_sha256 == _MMLU_000002_PROMPT_SHA256
+    assert testcase["max_new_tokens"] >= 19
+    assert testcase["reference_precision"] == manifest["precision"] == "fp16"
+    assert manifest["max_cache_length"] >= 384
+    assert thresholds["contract_token_agreement_rate"] == 1.0
+
+
+def test_stablelm_contract_rejects_the_published_token_18_divergence():
+    result = plugin.verify(
+        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 17]),
+        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 16]),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["ned"].passed
+    assert not result.metrics["generated_token_agreement_rate"].passed
+    assert not result.metrics["generated_token_exact"].passed
+
+
+def test_stablelm_contract_accepts_exact_generated_tokens():
+    exact_tokens = [*_QA_COMMON_PREFIX, 16]
+    result = plugin.verify(
+        _output("same decoded continuation", exact_tokens),
+        _output("same decoded continuation", exact_tokens),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["generated_token_agreement_rate"].passed
+    assert result.metrics["generated_token_exact"].passed
+
+
+def test_stablelm_contract_requires_reference_token_ids_for_strict_gate():
+    trt_output = _output("same decoded continuation", [*_QA_COMMON_PREFIX, 16])
+    reference_output = StageOutput(
+        stage_name="full_generation",
+        data={},
+        text="same decoded continuation",
+    )
+
+    result = plugin.verify(
+        trt_output,
+        reference_output,
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert not result.metrics["generated_token_ids_available"].passed

--- a/tests/e2e/models/stablelm/thresholds/stablelm2-1.6b.json
+++ b/tests/e2e/models/stablelm/thresholds/stablelm2-1.6b.json
@@ -1,5 +1,6 @@
 {
   "threshold_overrides": {
+    "contract_token_agreement_rate": 1.0,
     "layer_atol": 0.05,
     "logit_atol": 0.001,
     "logit_cosine_p5": 0.99,


### PR DESCRIPTION
## Summary

This change makes the StableLM2 premerge check exercise and strictly gate the
long-context continuation that exposed the QA accuracy failure.

- replace the former short `The capital of France is` smoke prompt with the
  exact `mmlu_000002` continuation that failed in QA;
- compare generated token IDs exactly, in addition to the existing decoded-text
  NED contract;
- pin the HF checkpoint revision used by the strict token oracle;
- export HF generated token IDs from the family-owned reference plugin;
- keep the check bounded to the existing one model build and one test case; and
- reuse the HF KV cache so the longer prompt does not make reference generation
  scale quadratically.

This is deliberately a StableLM accuracy-sentinel PR, not a fabricated runtime
fix. Current `main` produces exact output from two independently rebuilt
StableLM bundles, while the serialized QA bundle that produced the divergence
was reused and was not published. Companion PR
[#701](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/701) owns the
validation-system root cause: a failed comparison from a reused bundle must be
rerun once after a forced fresh build before the dashboard publishes it as a
model-family accuracy failure.

## QA reproduction and root-cause boundary

The dashboard captured two StableLM failure stages:

| Run | Candidate cache | Exact samples | Token-prefix agreement | Divergences |
| --- | ---: | ---: | ---: | ---: |
| `trtmc-validate-gb300-2-20260726-c8291be0-all105` | 384 | 0/10 | 0.378125 | 10 |
| `trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10` | 448 | 9/10 | 0.928125 | 1 |

The first run had no generation headroom: its 384-row cache equaled the
longest 384-token prompt. The already-landed `3d8c3b1a` validation fix reserved
64 generation rows, producing the 448-row rerun profile and removing nine of
the ten disagreements.

The remaining r10 divergence was `mmlu_000002`:

- the first 18 generated tokens matched;
- at generated-token index 18, HF emitted token ID `16` and TRT emitted `17`;
- both continuations were 64 tokens long; and
- the failing sample's token-prefix agreement was `18 / 64 = 0.28125`.

The original c829 run and the r10 rerun both recorded `bundle_built=false` for
StableLM. They consumed a previously serialized `stablelm2-1.6b.trtfb`; neither
published that bundle or its engine plans as a downloadable artifact. The
recorded QA plan sizes also differ from both fresh local builds. Consequently,
the exact r10 engine behind the residual token-18 divergence cannot be replayed
or bisected against current source.

I rebuilt from current `main` twice and replayed all ten QA prompts with the
same FP16 HF oracle:

| Fresh bundle profile | Result on all 10 samples | `mmlu_000002` |
| --- | --- | --- |
| max cache 425 | 10/10 exact, 64/64 tokens | token 18 = `16` |
| max cache 448 (exact QA cache profile) | 10/10 exact, 64/64 tokens | token 18 = `16` |

The exact-QA-profile bundle was independently serialized and had SHA-256
`053c2e5e2af2ad038bebcef2dcc319c8a35c569b68f747643c36be8becc71ad9`.
This proves the r10 residual accuracy symptom is not present in a fresh current
build, including at the QA cache boundary. It does not prove which internal
property of the unavailable r10 bundle caused token 18 to change.

For that reason this PR does not change StableLM graph or runtime code. The
source-level root cause is not reproducible from current `main`; making an
unproven mask, tactic, or sampler change would hide the provenance gap instead
of fixing a demonstrated defect. The companion validation change preserves the
first disagreement receipt and, only for a failed reused bundle, performs one
forced rebuild and confirmation run. Publishing the bundle digest, effective
config, source revision, environment identity, and immutable bundle locator is
still recommended follow-up provenance work; this PR does not claim that
sidecar mechanism already exists.

## Why CI missed it

The existing StableLM premerge case could not observe this failure:

1. Its prompt was only `The capital of France is`, so it never exercised the
   361-token MMLU prefill shape that preceded the QA divergence.
2. Its HF reference did not export generated token IDs, and the contract gated
   only decoded-text NED. A token-level divergence could therefore be missed
   when decoding normalized to similar or identical visible text.
3. The HF reference re-ran the complete prefix at every decode step. Simply
   dropping a realistic long prompt into that implementation would make
   reference work grow approximately quadratically.

The new case uses the exact 361-token prompt and generates 20 tokens, which is
the minimum bounded horizon that includes the first divergent token at index
18. A configured `contract_token_agreement_rate` of `1.0` now requires both
positional agreement and identical token sequences; missing TRT or HF token IDs
also fails closed.

## CI runtime budget

This change does not add a model, build, matrix entry, or test case:

| Dimension | Before | After |
| --- | ---: | ---: |
| StableLM model builds | 1 | 1 |
| StableLM cases | 1 | 1 |
| generated tokens | 20 | 20 |
| max cache length | 256 | 384 |

The prompt becomes longer, but HF now performs one prefill and then reuses
`past_key_values` for the 20 decode steps. That changes the family reference
path from repeatedly evaluating the growing full prefix to one prefill plus
incremental decoding. The cache length is 384 rather than the QA run's 448
because `361 + 20 = 381`; this retains three cache rows of headroom while
keeping the engine profile bounded.

The exact 384-row premerge build was not timed because that E2E run was stopped
before completion. As a conservative local sizing proxy, the larger 425-row
fresh build completed in `314.5 s`; the actual 256-row before/384-row after
comparison remains a required CI receipt. Matrix fan-out is unchanged, so this
is a bounded single-slot cost rather than an added job.

Strict patched E2E receipt:

- not completed in this worktree: the shared GB300 was reassigned to the OLMo2
  precision/tactic investigation;
- the StableLM run was stopped during its fresh engine build, before inference
  or comparison, and is not reported as a pass; and
- the two independent fresh current-main QA replays above remain the available
  GPU accuracy receipts. A full patched-manifest run is still required before
  merge.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/e2e/models/stablelm --ignore=tests/e2e/models/stablelm/test_stablelm_e2e.py`
  - `4 passed, 3 skipped`
- `python3 -m ruff check` on the changed Python files
  - passed
- JSON parsing for the changed manifest and threshold profile
  - passed
- family manifest load, including the pinned checkpoint revision and bounded
  cache/generation settings
  - passed
- `git diff --check`
  - passed
- strict patched-manifest E2E
  - not completed; stopped during fresh engine build when the shared GPU was
    reassigned, before any pass/fail result
- fresh current-main max-cache-425 QA replay
  - 10/10 samples and 640/640 generated tokens exact
- fresh current-main max-cache-448 QA-profile replay
  - 10/10 samples and 640/640 generated tokens exact

The focused regression tests also prove that the former decoded-text-only
contract accepts the text while the new token gate rejects the published
token-18 divergence, accepts exact tokens, and fails closed when the HF token
artifact is missing.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `795e291b487378ef3d78358366332af36bb567b6`.
- The manifest conflict was resolved by retaining the pinned HF revision, long-context QA sentinel, precision/cache settings, and current `stablelm2-1.6b.bundle` artifact suffix.
- Bundle audit: zero case-insensitive retired-identifier matches in content and filenames; the `BUNDLE\\x01\\x00` header contract is unchanged.
- `python3 -m pytest -q tests/e2e/models/stablelm/test_stablelm_accuracy_regression.py`: **4 passed**. Two JSON files, targeted `compileall`, and `git diff --check`: **passed**.
- No engine build, model case, threshold, or matrix lane was added by conflict repair. Push triggered fresh exact-head CI; readiness requires green completion.
