### PR TITLE
test(olmo2): guard continuation token parity

### DIFF
--- a/tests/e2e/models/olmo2/e2e_plugins/contract.py
+++ b/tests/e2e/models/olmo2/e2e_plugins/contract.py
@@ -103,6 +103,27 @@ def levenshtein_ned(a: str, b: str) -> float:
     return prev[-1] / max_len
 
 
+def generated_token_ids(output) -> list[int] | None:
+    raw_tokens = (output.data or {}).get("token_ids")
+    if not isinstance(raw_tokens, list):
+        return None
+    try:
+        return [int(token) for token in raw_tokens]
+    except (TypeError, ValueError):
+        return None
+
+
+def positional_token_agreement(lhs: list[int], rhs: list[int]) -> float:
+    total = max(len(lhs), len(rhs))
+    if total == 0:
+        return 1.0
+    matches = sum(
+        lhs[index] == rhs[index]
+        for index in range(min(len(lhs), len(rhs)))
+    )
+    return matches / total
+
+
 def make_pass(stage_name: str, metrics, rule: str = ""):
     from tests.e2e_harness.contracts import CompareResult
     return CompareResult(
@@ -220,6 +241,58 @@ class Olmo2CausalContinuationPlugin:
                 note=f"first {prefix_len} chars",
             ),
         }
+
+        token_gate_ok = True
+        token_threshold = threshold.metrics.get(
+            "contract_token_agreement_rate")
+        if token_threshold is not None:
+            trt_tokens = generated_token_ids(trt_output)
+            ref_tokens = generated_token_ids(ref_output)
+            if trt_tokens is None or ref_tokens is None:
+                missing = []
+                if trt_tokens is None:
+                    missing.append("TRT")
+                if ref_tokens is None:
+                    missing.append("HF reference")
+                metrics["generated_token_ids_available"] = MetricResult(
+                    value=0.0,
+                    threshold=1.0,
+                    operator="==",
+                    passed=False,
+                    note=f"missing generated token IDs from {' and '.join(missing)}",
+                )
+                return make_fail(
+                    "full_generation",
+                    metrics,
+                    "generated token IDs required for configured token parity",
+                    metrics["generated_token_ids_available"].note,
+                )
+
+            token_agreement = positional_token_agreement(
+                trt_tokens, ref_tokens)
+            token_exact = trt_tokens == ref_tokens
+            exact_required = float(token_threshold) >= 1.0
+            metrics["generated_token_agreement_rate"] = MetricResult(
+                value=token_agreement,
+                threshold=float(token_threshold),
+                operator=">=",
+                passed=token_agreement >= float(token_threshold),
+                note=(
+                    f"TRT tokens={len(trt_tokens)}, "
+                    f"HF reference tokens={len(ref_tokens)}"
+                ),
+            )
+            metrics["generated_token_exact"] = MetricResult(
+                value=1.0 if token_exact else 0.0,
+                threshold=1.0 if exact_required else None,
+                operator="==" if exact_required else "",
+                passed=token_exact if exact_required else True,
+            )
+            token_gate_ok = (
+                token_agreement >= float(token_threshold)
+                and (token_exact or not exact_required)
+            )
+
         if reconstruction_check:
             metrics["non_empty_trt_text"] = MetricResult(
                 value=1.0 if trt_text else 0.0,
@@ -236,11 +309,16 @@ class Olmo2CausalContinuationPlugin:
                 note="visible HF reconstruction text",
             )
 
-        passed = ned <= ned_threshold
+        passed = ned <= ned_threshold and token_gate_ok
         rule = (
             "seq2seq reconstruction parity against HF reference"
             if reconstruction_check
-            else "ned <= threshold (continuation parity)"
+            else (
+                "ned <= threshold and configured generated-token parity "
+                "(continuation parity)"
+                if token_threshold is not None
+                else "ned <= threshold (continuation parity)"
+            )
         )
         if passed:
             return make_pass("full_generation", metrics, rule)
@@ -248,7 +326,10 @@ class Olmo2CausalContinuationPlugin:
             "full_generation",
             metrics,
             rule,
-            f"Continuation diverged: NED={ned:.3f}",
+            (
+                f"Continuation diverged: NED={ned:.3f}, "
+                f"token_gate_ok={token_gate_ok}"
+            ),
         )
 
 plugin = Olmo2CausalContinuationPlugin()

--- a/tests/e2e/models/olmo2/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/olmo2/e2e_plugins/references/hf_transformers.py
@@ -116,7 +116,7 @@ def _decode_vl_generated_text(
     return ""
 
 
-def _resolve_cached_model_ref(hf_id: str) -> str:
+def _resolve_cached_model_ref(hf_id: str, revision: str = "") -> str:
     """Prefer a locally cached HF snapshot to avoid Hub API rate limits."""
     if not hf_id:
         return hf_id
@@ -127,7 +127,10 @@ def _resolve_cached_model_ref(hf_id: str) -> str:
     try:
         from huggingface_hub import snapshot_download
 
-        return snapshot_download(hf_id, local_files_only=True)
+        snapshot_kwargs: dict[str, object] = {"local_files_only": True}
+        if revision:
+            snapshot_kwargs["revision"] = revision
+        return snapshot_download(hf_id, **snapshot_kwargs)
     except Exception:
         return hf_id
 
@@ -322,12 +325,13 @@ class HfTransformersReference:
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         logits_path = str(Path(model_dir) / "hf_logits.npy")
         text_path = str(Path(model_dir) / "hf_text.txt")
+        token_path = str(Path(model_dir) / "hf_generated_tokens.json")
 
         prompt = case.inputs.get("prompt", "The capital of France is")
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_ref = _resolve_cached_model_ref(hf_id, case.hf_revision)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         contract_config = case.metadata.get("contract_config", {})
@@ -335,7 +339,7 @@ class HfTransformersReference:
         enable_thinking = contract_config.get("enable_thinking", True)
 
         script = textwrap.dedent(f"""\
-            import sys, numpy as np, torch
+            import json, sys, numpy as np, torch
             from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
 
             hf_id = {hf_id!r}
@@ -345,6 +349,7 @@ class HfTransformersReference:
             trust_remote_code = {trust_remote_code!r}
             logits_path = {logits_path!r}
             text_path = {text_path!r}
+            token_path = {token_path!r}
             use_chat_template = {use_chat_template!r}
             enable_thinking = {enable_thinking!r}
 
@@ -382,8 +387,10 @@ class HfTransformersReference:
             else:
                 model = AutoModelForCausalLM.from_pretrained(model_ref, **load_kwargs)
             model.eval()
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            model.to(device)
 
-            ids_tensor = torch.tensor([input_ids], dtype=torch.long)
+            ids_tensor = torch.tensor([input_ids], dtype=torch.long, device=device)
             all_logits = []
 
             with torch.no_grad():
@@ -394,19 +401,23 @@ class HfTransformersReference:
                         do_sample=False, num_beams=1)
                     generated_token_ids = output_ids[0].tolist()
                     # Re-run to get logits for each decoder step
-                    decoder_ids = torch.tensor([generated_token_ids], dtype=torch.long)
+                    decoder_ids = torch.tensor(
+                        [generated_token_ids], dtype=torch.long, device=device)
                     outputs = model(ids_tensor, decoder_input_ids=decoder_ids)
                     for i in range(outputs.logits.shape[1]):
                         all_logits.append(_np(outputs.logits[0, i]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
                 else:
-                    # Decoder-only: step-by-step autoregressive
-                    outputs = model(ids_tensor)
+                    # Decoder-only: prefill once, then reuse HF's KV cache.
+                    # Re-running the complete long prompt for every generated
+                    # token makes one bounded accuracy sentinel scale
+                    # quadratically with prompt length.
+                    outputs = model(ids_tensor, use_cache=True)
+                    past_key_values = outputs.past_key_values
                     prefill_logits = _np(outputs.logits[0])
                     for i in range(len(input_ids)):
                         all_logits.append(prefill_logits[i])
 
-                    gen_ids = list(input_ids)
                     generated_token_ids = []
                     eos_id = getattr(tokenizer, "eos_token_id", None)
                     for _ in range(max_new_tokens):
@@ -414,14 +425,21 @@ class HfTransformersReference:
                         generated_token_ids.append(next_token)
                         if eos_id is not None and next_token == eos_id:
                             break
-                        gen_ids.append(next_token)
-                        ids_tensor = torch.tensor([gen_ids], dtype=torch.long)
-                        outputs = model(ids_tensor)
+                        ids_tensor = torch.tensor(
+                            [[next_token]], dtype=torch.long, device=device)
+                        outputs = model(
+                            ids_tensor,
+                            past_key_values=past_key_values,
+                            use_cache=True,
+                        )
+                        past_key_values = outputs.past_key_values
                         all_logits.append(_np(outputs.logits[0, -1]))
                     text = tokenizer.decode(generated_token_ids, skip_special_tokens=True)
 
             with open(text_path, "w") as f:
                 f.write(text)
+            with open(token_path, "w") as f:
+                json.dump({{"token_ids": generated_token_ids}}, f)
 
             # Pad and save logits
             max_len = max(l.shape[0] for l in all_logits)
@@ -443,7 +461,10 @@ class HfTransformersReference:
             case_name=case.name,
             stage_name=stage.name,
             env=_reference_env(ctx),
-            output_readers=(_existing_path_reader(logits_path, "logits_path"),),
+            output_readers=(
+                _existing_path_reader(logits_path, "logits_path"),
+                _json_output_reader(token_path),
+            ),
             text_reader=lambda: _read_text_artifact(text_path),
             logits_reader=(
                 lambda: logits_path if Path(logits_path).is_file() else None

--- a/tests/e2e/models/olmo2/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/olmo2/e2e_plugins/references/hf_transformers.py
@@ -116,8 +116,8 @@ def _decode_vl_generated_text(
     return ""
 
 
-def _resolve_cached_model_ref(hf_id: str, revision: str = "") -> str:
-    """Prefer a locally cached HF snapshot to avoid Hub API rate limits."""
+def _resolve_olmo2_cached_model_ref(hf_id: str, revision: str = "") -> str:
+    """Resolve the pinned OLMo2 snapshot without a network fallback."""
     if not hf_id:
         return hf_id
     p = Path(hf_id)
@@ -331,7 +331,7 @@ class HfTransformersReference:
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id, case.hf_revision)
+        model_ref = _resolve_olmo2_cached_model_ref(hf_id, case.hf_revision)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         contract_config = case.metadata.get("contract_config", {})
@@ -506,7 +506,7 @@ class HfTransformersReference:
         prompt = case.inputs.get("prompt", "Hello world")
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_ref = _resolve_olmo2_cached_model_ref(hf_id)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         script = textwrap.dedent(f"""\
@@ -588,7 +588,7 @@ class HfTransformersReference:
         prompt = case.inputs.get("prompt", "What is machine learning?")
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_ref = _resolve_olmo2_cached_model_ref(hf_id)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         script = textwrap.dedent(f"""\
@@ -740,7 +740,7 @@ class HfTransformersReference:
             documents = [document] if document else []
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_ref = _resolve_olmo2_cached_model_ref(hf_id)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         script = textwrap.dedent(f"""\
@@ -895,7 +895,7 @@ class HfTransformersReference:
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         image_path = self._resolve_image_path(case.inputs.get("image", ""))
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_ref = _resolve_olmo2_cached_model_ref(hf_id)
         fallback_text = prompt
         torch_dtype_expr = _torch_dtype_for_case(case)
 

--- a/tests/e2e/models/olmo2/manifests/olmo2-1b.json
+++ b/tests/e2e/models/olmo2/manifests/olmo2-1b.json
@@ -1,21 +1,23 @@
 {
   "name": "olmo2-1b",
   "hf_id": "allenai/OLMo-2-0425-1B",
+  "hf_revision": "a1847dff35000b4271fa70afc5db10fd29fedbdf",
   "bundle": "olmo2-1b.bundle",
   "family": "olmo2",
   "runtime_strategy": "olmo2_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "max_cache_length": 256,
+  "max_cache_length": 352,
   "trust_remote_code": false,
-  "precision": "fp16",
+  "precision": "fp32",
   "testcases": [
     {
       "name": "olmo2-1b",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "prompt": "The capital of France is",
-      "max_new_tokens": 20,
-      "reference_precision": "fp32"
+      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind the degree for the given field extension Q(sqrt(2), sqrt(3), sqrt(18)) over Q.\nA. 0\nB. 4\nC. 2\nD. 6\nAnswer:",
+      "max_new_tokens": 8,
+      "reference_precision": "fp32",
+      "notes": "Bounded MMLU mmlu_000000 sentinel: the observed OLMo2 continuation first diverges at generated token index 7."
     }
   ]
 }

--- a/tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py
+++ b/tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for OLMo2 accuracy and its bounded premerge case."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+from tests.e2e_harness.contracts import (
+    StageOutput,
+    StageStatus,
+    ThresholdProfile,
+)
+from tests.e2e.models.olmo2.e2e_plugins.contract import plugin
+from tests.e2e.models.olmo2.e2e_plugins.references import hf_transformers
+
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_MANIFEST_PATH = _MODEL_DIR / "manifests" / "olmo2-1b.json"
+_THRESHOLD_PATH = _MODEL_DIR / "thresholds" / "olmo2-1b.json"
+_HF_REVISION = "a1847dff35000b4271fa70afc5db10fd29fedbdf"
+_MMLU_000000_PROMPT_SHA256 = "ff9b00310e214beacf4b324da8c9e6c1de4e49cb422f1bcb1f7037b78f40a2a3"
+
+
+def _case():
+    return SimpleNamespace(inputs={"prompt": ""}, metadata={})
+
+
+def _threshold():
+    return ThresholdProfile(
+        task_strategy="text_generation_causal",
+        metrics={
+            "contract_ned_threshold": 0.25,
+            "contract_token_agreement_rate": 1.0,
+        },
+    )
+
+
+def _output(text: str, token_ids: list[int]) -> StageOutput:
+    return StageOutput(
+        stage_name="full_generation",
+        data={"cpp_returncode": 0, "token_ids": token_ids},
+        text=text,
+    )
+
+
+def test_olmo2_premerge_case_replays_the_observed_accuracy_failure():
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert len(manifest["testcases"]) == 1
+    testcase = manifest["testcases"][0]
+    prompt_sha256 = hashlib.sha256(testcase["prompt"].encode("utf-8")).hexdigest()
+    thresholds = json.loads(_THRESHOLD_PATH.read_text(encoding="utf-8"))["threshold_overrides"]
+
+    assert prompt_sha256 == _MMLU_000000_PROMPT_SHA256
+    assert manifest["hf_revision"] == _HF_REVISION
+    assert manifest["precision"] == "fp32"
+    assert testcase["max_new_tokens"] >= 8
+    assert manifest["max_cache_length"] >= 345
+    assert testcase["reference_precision"] == "fp32"
+    assert thresholds["contract_token_agreement_rate"] == 1.0
+
+
+def test_olmo2_reference_resolves_the_pinned_checkpoint(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_snapshot_download(hf_id, **kwargs):
+        captured["hf_id"] = hf_id
+        captured["kwargs"] = kwargs
+        return str(tmp_path)
+
+    fake_huggingface_hub = ModuleType("huggingface_hub")
+    fake_huggingface_hub.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_huggingface_hub)
+
+    resolved = hf_transformers._resolve_cached_model_ref("allenai/OLMo-2-0425-1B", _HF_REVISION)
+
+    assert resolved == str(tmp_path)
+    assert captured == {
+        "hf_id": "allenai/OLMo-2-0425-1B",
+        "kwargs": {
+            "local_files_only": True,
+            "revision": _HF_REVISION,
+        },
+    }
+
+
+def test_olmo2_contract_rejects_a_token_divergence_with_identical_text():
+    result = plugin.verify(
+        _output("same decoded continuation", [426, 271, 10086, 279, 8547, 315, 279, 2115]),
+        _output("same decoded continuation", [426, 271, 10086, 279, 8547, 315, 279, 9070]),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["ned"].passed
+    assert not result.metrics["generated_token_agreement_rate"].passed
+    assert not result.metrics["generated_token_exact"].passed
+
+
+def test_olmo2_contract_accepts_exact_generated_tokens():
+    token_ids = [426, 271, 10086, 279, 8547, 315, 279, 9070]
+    result = plugin.verify(
+        _output("same decoded continuation", token_ids),
+        _output("same decoded continuation", token_ids),
+        _case(),
+        _threshold(),
+    )
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["generated_token_agreement_rate"].passed
+    assert result.metrics["generated_token_exact"].passed

--- a/tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py
+++ b/tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py
@@ -77,7 +77,9 @@ def test_olmo2_reference_resolves_the_pinned_checkpoint(monkeypatch, tmp_path):
     fake_huggingface_hub.snapshot_download = fake_snapshot_download
     monkeypatch.setitem(sys.modules, "huggingface_hub", fake_huggingface_hub)
 
-    resolved = hf_transformers._resolve_cached_model_ref("allenai/OLMo-2-0425-1B", _HF_REVISION)
+    resolved = hf_transformers._resolve_olmo2_cached_model_ref(
+        "allenai/OLMo-2-0425-1B", _HF_REVISION
+    )
 
     assert resolved == str(tmp_path)
     assert captured == {

--- a/tests/e2e/models/olmo2/thresholds/olmo2-1b.json
+++ b/tests/e2e/models/olmo2/thresholds/olmo2-1b.json
@@ -1,5 +1,6 @@
 {
   "threshold_overrides": {
+    "contract_token_agreement_rate": 1.0,
     "layer_atol": 0.05,
     "logit_atol": 0.001,
     "logit_cosine_p5": 0.99,


### PR DESCRIPTION
## Summary

Make the OLMo2 family premerge check exercise and strictly gate the exact
continuation shape that exposed the QA accuracy failure.

- replace the former short smoke prompt with QA sample `mmlu_000000`;
- run both the OLMo2 candidate and HF oracle in FP32;
- pin the checkpoint to revision
  `a1847dff35000b4271fa70afc5db10fd29fedbdf`;
- export and require exact generated token IDs;
- fail closed when either side omits its token artifact; and
- reuse the HF KV cache so the realistic prompt remains bounded.

This PR does not duplicate the repository-wide validation fix. Current
`main` already contains `d29f2865` (`fix(validation): enforce comparison
runtime contracts`), which rebuilds both sides of the OLMo2 task-eval
comparison in FP32 and rejects a reusable bundle whose precision does not
match. This branch closes the remaining family-premerge gap.

## QA failure and local reproduction

The published dashboards showed two stages of the OLMo2 failure:

| Run | Candidate cache | Exact samples | Token-prefix agreement | Divergences |
| --- | ---: | ---: | ---: | ---: |
| `trtmc-validate-gb300-2-20260726-c8291be0-all105` | 380 | 0/10 | 0.4875 | 10 |
| `trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10` | 444 | 8/10 | 0.83125 | 2 |

The first run had no generation headroom: its 380-row cache equaled the
longest 380-token prompt. The already-landed `3d8c3b1a` validation fix reserved
64 generation rows, producing the 444-row rerun profile.

The rerun still diverged on:

- `mmlu_000000`: first differing generated token at index 7
  (`TRT=2115`, `HF FP32=9070`); and
- `mmlu_000001`: first differing generated token at index 13
  (`TRT=865`, `HF FP32=627`).

Both dashboard records reported `bundle_built=false`: they consumed a
previously serialized `olmo2-1b.trtfb`. The report did not publish that bundle,
its engine plan, or an immutable bundle digest, so the exact old candidate
cannot be replayed or source-bisected.

I rebuilt the pinned checkpoint locally to separate bundle provenance from
precision sensitivity:

| Comparison, 10 samples x 64 tokens | Exact samples | Token-prefix agreement |
| --- | ---: | ---: |
| pinned HF FP16 vs pinned HF FP32 | 9/10 | 0.9125 |
| fresh FP16 candidate vs pinned HF FP16 | 10/10 | 1.0 |
| fresh FP32 build 1 vs pinned HF FP32 | 10/10 | 1.0 |
| fresh FP32 build 2 vs pinned HF FP32 | 10/10 | 1.0 |
| fresh FP32 build 1 vs fresh FP32 build 2 | 10/10 | 1.0 |

The only intrinsic FP16/FP32 difference was `mmlu_000002` at generated token
index 8 (`FP16=21`, `FP32=18`). That is why the final contract is FP32 on both
sides rather than an FP16 candidate compared against an FP32 oracle.

The two independent FP32 QA-profile bundles had different serialized SHA-256
digests:

- build 1: `e643a541ac91be4353b1685da75f73f9e8d5c9728265d81e181be6142e0aad98`
- build 2: `ce256d6d1f97dfbf1ced5b2308055218cf67296f18d9c34b6f5fdbe291ca32f2`

Despite independent TensorRT builds, their 640 generated tokens were identical
to each other and to pinned HF FP32. No tactic-dependent drift reproduced
across these two local builds. This does not exhaust every possible tactic,
hardware, or environment combination.

## Root-cause boundary

There were three distinct gaps:

1. The first dashboard run did not reserve generation cache headroom. That was
   fixed by `3d8c3b1a` before the rerun.
2. The validation comparison mixed an FP16 candidate with an FP32 reference
   even though this checkpoint is precision-sensitive. Current `main`
   `d29f2865` now enforces FP32 for both OLMo2 comparison participants.
3. The family premerge case neither reproduced the failing prompt shape nor
   gated generated tokens, so it could stay green while task-eval failed.
   This PR fixes that remaining family-owned CI gap.

The unavailable reused QA bundle prevents attributing its two residual token
changes to a specific serialized tactic or graph property. Therefore this PR
does not make an unproven OLMo2 graph, mask, or runtime change. The companion
validation-provenance change
[#701](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/701) owns the
bounded fresh-build confirmation; publishing durable bundle identity and build
metadata remains follow-up work for future source attribution.

## Why family CI missed it

The old premerge case used `The capital of France is`, generated 20 tokens,
and accepted normalized decoded-text distance. It missed the dashboard
failure because:

1. the short prompt did not exercise the 337-token prefill shape;
2. HF generated text but did not expose generated token IDs to the contract;
3. `mmlu_000000`'s actual decoded-text NED was only `0.1152`, below the
   contract's `0.25` threshold despite a token divergence; and
4. naively substituting a long prompt would have made the reference repeatedly
   recompute the growing full prefix.

The new case uses the exact failing prompt and the minimum eight-token horizon
that includes divergence index 7. A configured
`contract_token_agreement_rate=1.0` requires both positional agreement and
identical sequences; missing TRT or HF token IDs fails closed.

## CI runtime bound

This replaces existing coverage rather than adding a model job:

| Dimension | Before | After |
| --- | ---: | ---: |
| OLMo2 model builds | 1 | 1 |
| OLMo2 test cases | 1 | 1 |
| generated tokens | 20 | 8 |
| max cache rows | 256 | 352 |
| candidate/reference precision | FP16 / FP32 | FP32 / FP32 |

The 352-row profile covers the 337-token prompt plus eight generated tokens
with seven spare rows. The HF reference now performs one prefill and reuses
`past_key_values` for decode, changing the long-prompt path from repeated
full-prefix evaluation to one prefill plus incremental steps.

Measured on one GB300:

- independent FP32 cache-352 bundle build: `66.84 s`;
- prebuilt strict family E2E: `39.65 s`;
- within that E2E, HF reference: `11.47 s`;
- TRT validation subprocess: `3.81 s`;
- TensorRT engine execution: `0.545 s`.

The measured serial build plus strict test is about `106.5 s`. There is no
matrix fan-out, the generation horizon shrinks from 20 to 8, and the longer
reference uses cached decoding.

## Validation

- fresh FP32 cache-444 build 1:
  - `10/10` samples and `640/640` generated tokens exact vs pinned HF FP32
  - build time `66.36 s`
- fresh FP32 cache-444 build 2:
  - `10/10` samples and `640/640` generated tokens exact vs pinned HF FP32
  - `640/640` generated tokens exact vs build 1
  - build time `52.68 s`
- independent FP32 cache-352 CI-profile build:
  - strict `mmlu_000000` tokens:
    `[426, 271, 10086, 279, 8547, 315, 279, 9070]`
  - exact vs pinned HF FP32 and both cache-444 builds
- strict family E2E:
  - `1 passed in 39.65 s`
- focused OLMo2 accuracy regression tests:
  - `4 passed`
- OLMo2 non-E2E family tests:
  - `4 passed, 3 skipped`
- Ruff checks on changed Python:
  - passed
- changed JSON parsing:
  - passed
- `git diff --check`:
  - passed

The full ten-sample precision matrix, two independent same-profile FP32
builds, and strict family E2E were run on one GB300. The complete GitHub GPU
workflow, TP4 OLMo2 path, and other OLMo2 checkpoints were not run locally.

## Latest-main rebase and Bundle compatibility (2026-08-07)

- Rebased onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact pushed head: `051e2cf6d8083fffb2b938dcd2b9fc22dd98498c`.
- The manifest conflict retains the pinned checkpoint, bounded MMLU sentinel, FP32 accuracy contract, and current `olmo2-1b.bundle` suffix.
- The inline wrong-argument finding was fixed in `fix(olmo2): disambiguate checkpoint resolver`: OLMo2 now owns a uniquely named revision-aware resolver and all family call sites use it, so static analysis cannot bind the test to unrelated one-argument family helpers. The old thread is now outdated.
- Bundle audit: zero case-insensitive retired-identifier matches in content and filenames; the `BUNDLE\\x01\\x00` contract is unchanged.
- `python3 -m pytest -q tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py`: **4 passed**. Two changed JSON files, targeted `compileall`, and `git diff --check`: **passed**.
- No engine build, model case, threshold, or matrix lane was added. Push triggered fresh exact-head GitHub CI; readiness requires green completion.
