### PR TITLE
fix(validation): confirm reused-bundle failures

### DIFF
--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -2873,7 +2873,7 @@ def _run_binding_with_comparison_results(
     monkeypatch.setattr(
         trtmc_validate,
         "ensure_reference_sources",
-        lambda _family, _cache: trtmc_validate.ReferenceSourceSelection(
+        lambda _family, _cache, _contract=None: trtmc_validate.ReferenceSourceSelection(
             environment={},
         ),
     )
@@ -2962,7 +2962,7 @@ def _run_multiple_bindings_with_comparison_results(
     monkeypatch.setattr(
         trtmc_validate,
         "ensure_reference_sources",
-        lambda _family, _cache: trtmc_validate.ReferenceSourceSelection(
+        lambda _family, _cache, _contract=None: trtmc_validate.ReferenceSourceSelection(
             environment={},
         ),
     )

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -2702,6 +2702,232 @@ def test_run_binding_wires_reference_source_command_and_environment(
     assert captured["environment"]["EXTERNAL_REFERENCE_SENTINEL"] == "present"
 
 
+def _run_binding_with_comparison_results(
+    *,
+    tmp_path,
+    monkeypatch,
+    raw_results,
+    extra_args=(),
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "model-a",
+            "workload-a",
+            "--output",
+            str(tmp_path / "results"),
+            "--dataset",
+            str(tmp_path / "dataset.json"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            *extra_args,
+        ]
+    )
+    commands = []
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_environments",
+        lambda _profiles, _base: trtmc_validate.EnvironmentSelection(
+            base_python="/profiles/python",
+            names_and_paths=(),
+            overrides={},
+        ),
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_reference_sources",
+        lambda _family, _cache: trtmc_validate.ReferenceSourceSelection(
+            environment={},
+        ),
+    )
+
+    def run(command, log_path, _environment):
+        commands.append(command)
+        log_path.write_text(f"run {len(commands)}\n", encoding="utf-8")
+        summary = (
+            log_path.parent
+            / "validation"
+            / "workload-a"
+            / "eval_summary.json"
+        )
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps({"run": len(commands)}),
+            encoding="utf-8",
+        )
+        return 0
+
+    comparisons = iter(raw_results)
+
+    def comparison_result(binding, **_kwargs):
+        raw_result = next(comparisons)
+        return trtmc_validate._normalize_result(
+            {
+                "model": binding.model,
+                "workload": binding.workload,
+                "status": raw_result["status"],
+                "returncode": 0,
+                "raw_result": raw_result,
+            }
+        )
+
+    monkeypatch.setattr(trtmc_validate, "_run_subprocess", run)
+    monkeypatch.setattr(trtmc_validate, "_comparison_result", comparison_result)
+    result = trtmc_validate.run_binding(
+        trtmc_validate.Binding("model-a", "workload-a"),
+        arguments=arguments,
+        task_models={
+            "model-a": {
+                "family": "family-a",
+                "runtime_strategy": "text_generation",
+                "reference_backend": "hf_transformers",
+                "execution_profiles": {},
+            }
+        },
+        suites={"workload-a": {}},
+    )
+    return result, commands, arguments
+
+
+def test_reused_bundle_accuracy_failure_rebuilds_once_and_recovers(
+    tmp_path,
+    monkeypatch,
+):
+    result, commands, arguments = _run_binding_with_comparison_results(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        raw_results=[
+            {
+                "status": "failed",
+                "bundle_built": False,
+                "prediction_agreement_rate": 0.25,
+                "gate_failures": [
+                    {
+                        "gate": "min_prediction_agreement_rate",
+                        "actual": 0.25,
+                        "required": 1.0,
+                    }
+                ],
+                "error_type": "BenchmarkGateError",
+                "error": (
+                    "min_prediction_agreement_rate actual=0.25 required=1.0"
+                ),
+            },
+            {
+                "status": "passed",
+                "bundle_built": True,
+                "prediction_agreement_rate": 1.0,
+            },
+        ],
+    )
+
+    assert len(commands) == 2
+    assert "--force-build" not in commands[0]
+    assert commands[1][-1] == "--force-build"
+    assert result["validation"]["status"] == "passed"
+    assert result["bundle_revalidation"]["outcome"] == "recovered_after_rebuild"
+    initial_receipt = result["bundle_revalidation"]["initial"]
+    assert initial_receipt["validation_status"] == "failed"
+    assert initial_receipt["bundle_built"] is False
+    assert initial_receipt["error_type"] == "BenchmarkGateError"
+    assert "actual=0.25" in initial_receipt["error"]
+    assert initial_receipt["metrics"]["prediction_agreement_rate"] == 0.25
+    initial = Path(initial_receipt["artifacts"]["comparison_result"])
+    assert initial.is_file()
+    initial_summary = Path(
+        initial_receipt["artifacts"]["eval_summary.json"]
+    )
+    assert json.loads(initial_summary.read_text(encoding="utf-8")) == {"run": 1}
+    assert (
+        arguments.output
+        / "model-a"
+        / "workload-a"
+        / "execution.reused-bundle.log"
+    ).is_file()
+
+
+def test_reused_bundle_accuracy_failure_rebuilds_once_and_confirms_failure(
+    tmp_path,
+    monkeypatch,
+):
+    result, commands, _arguments = _run_binding_with_comparison_results(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        raw_results=[
+            {
+                "status": "failed",
+                "bundle_built": False,
+                "prediction_agreement_rate": 0.25,
+            },
+            {
+                "status": "failed",
+                "bundle_built": True,
+                "prediction_agreement_rate": 0.50,
+            },
+        ],
+    )
+
+    assert len(commands) == 2
+    assert commands[1].count("--force-build") == 1
+    assert result["validation"]["status"] == "failed"
+    assert result["bundle_revalidation"]["outcome"] == "confirmed_after_rebuild"
+
+
+def test_passing_reused_bundle_does_not_trigger_rebuild(
+    tmp_path,
+    monkeypatch,
+):
+    result, commands, _arguments = _run_binding_with_comparison_results(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        raw_results=[
+            {
+                "status": "passed",
+                "bundle_built": False,
+                "prediction_agreement_rate": 1.0,
+            }
+        ],
+    )
+
+    assert len(commands) == 1
+    assert "--force-build" not in commands[0]
+    assert result["validation"]["status"] == "passed"
+    assert "bundle_revalidation" not in result
+
+
+@pytest.mark.parametrize(
+    ("flag", "forwarded"),
+    [
+        ("--force-build", "--force-build"),
+        ("--no-build", "--require-prebuilt-bundles"),
+    ],
+)
+def test_explicit_bundle_build_policy_does_not_trigger_revalidation(
+    tmp_path,
+    monkeypatch,
+    flag,
+    forwarded,
+):
+    result, commands, _arguments = _run_binding_with_comparison_results(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        raw_results=[
+            {
+                "status": "failed",
+                "bundle_built": False,
+                "prediction_agreement_rate": 0.25,
+            }
+        ],
+        extra_args=(flag,),
+    )
+
+    assert len(commands) == 1
+    assert forwarded in commands[0]
+    assert result["validation"]["status"] == "failed"
+    assert "bundle_revalidation" not in result
+
+
 def test_compare_entrypoint_forwards_to_validation_backend(monkeypatch):
     captured = []
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -402,6 +402,17 @@ def test_all_defaults_to_continue_and_accepts_stop_policy():
     assert stop.on_model_failure == "stop"
     assert default.model_attempts == 2
     assert default.model_retry_delay_seconds == 5.0
+    assert default.reused_bundle_revalidation_limit == 1
+    assert default.reused_bundle_revalidation_attempts_used == 0
+
+
+def test_reused_bundle_revalidation_limit_rejects_negative_values():
+    parser = trtmc_validate.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["--all", "--reused-bundle-revalidation-limit", "-1"]
+        )
 
 
 @pytest.mark.parametrize(
@@ -568,6 +579,131 @@ def test_supervisor_retries_execution_error_but_not_disagreement(
     assert attempts == [1]
     assert disagreement["execution"]["status"] == "completed"
     assert disagreement["execution"]["attempt_count"] == 1
+
+
+def test_supervisor_propagates_revalidation_budget_to_next_worker(
+    tmp_path,
+    monkeypatch,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--model-attempts",
+            "1",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    seen = []
+
+    def run_worker(binding, *, arguments, catalog, attempt):
+        command = trtmc_validate._worker_command(binding, arguments)
+        option = "--reused-bundle-revalidation-attempts-used"
+        seen.append((binding.model, int(command[command.index(option) + 1])))
+        case_dir = trtmc_validate._case_directory(
+            arguments.output,
+            binding,
+        )
+        case_dir.mkdir(parents=True, exist_ok=True)
+        attempted = binding.model == "model-a"
+        return {
+            "model": binding.model,
+            "workload": binding.workload,
+            "execution": {"status": "completed", "exit_code": 0},
+            "validation": {
+                "status": "passed" if attempted else "failed",
+            },
+            "raw_result": {"status": "passed" if attempted else "failed"},
+            "bundle_revalidation": {
+                "attempted": attempted,
+                "attempt_count": 1 if attempted else 0,
+            },
+        }
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", run_worker)
+    catalog = {"sample_limits": {"workload-a": 1}}
+
+    trtmc_validate._run_supervised_binding_with_retries(
+        trtmc_validate.Binding("model-a", "workload-a"),
+        arguments=arguments,
+        catalog=catalog,
+    )
+    trtmc_validate._run_supervised_binding_with_retries(
+        trtmc_validate.Binding("model-b", "workload-a"),
+        arguments=arguments,
+        catalog=catalog,
+    )
+
+    assert seen == [("model-a", 0), ("model-b", 1)]
+
+
+def test_supervisor_retry_cannot_reset_revalidation_budget(
+    tmp_path,
+    monkeypatch,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--model-attempts",
+            "2",
+            "--model-retry-delay-seconds",
+            "0",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "workload-a")
+    seen = []
+
+    def run_worker(binding, *, arguments, catalog, attempt):
+        command = trtmc_validate._worker_command(binding, arguments)
+        option = "--reused-bundle-revalidation-attempts-used"
+        seen.append((attempt, int(command[command.index(option) + 1])))
+        case_dir = trtmc_validate._case_directory(
+            arguments.output,
+            binding,
+        )
+        case_dir.mkdir(parents=True, exist_ok=True)
+        rebuild_failed = attempt == 1
+        return {
+            "model": binding.model,
+            "workload": binding.workload,
+            "execution": {
+                "status": "error" if rebuild_failed else "completed",
+                "exit_code": 1,
+            },
+            "validation": {"status": "failed"},
+            "raw_result": {
+                "status": "failed",
+                "error_type": (
+                    "RebuildExecutionError" if rebuild_failed else ""
+                ),
+            },
+            "bundle_revalidation": {
+                "attempted": rebuild_failed,
+                "attempt_count": 1 if rebuild_failed else 0,
+            },
+        }
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", run_worker)
+
+    result = trtmc_validate._run_supervised_binding_with_retries(
+        binding,
+        arguments=arguments,
+        catalog={"sample_limits": {"workload-a": 1}},
+    )
+
+    assert seen == [(1, 0), (2, 1)]
+    assert result["execution"]["attempt_count"] == 2
+    assert result["execution"]["retry_count"] == 1
 
 
 def test_all_supervisor_records_not_compared_without_launching_worker(
@@ -2790,6 +2926,123 @@ def _run_binding_with_comparison_results(
     return result, commands, arguments
 
 
+def _run_multiple_bindings_with_comparison_results(
+    *,
+    tmp_path,
+    monkeypatch,
+    models,
+    raw_results,
+    extra_args=(),
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--model-worker",
+            "--output",
+            str(tmp_path / "results"),
+            "--dataset",
+            str(tmp_path / "dataset.json"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            *extra_args,
+        ]
+    )
+    commands = []
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_environments",
+        lambda _profiles, _base: trtmc_validate.EnvironmentSelection(
+            base_python="/profiles/python",
+            names_and_paths=(),
+            overrides={},
+        ),
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_reference_sources",
+        lambda _family, _cache: trtmc_validate.ReferenceSourceSelection(
+            environment={},
+        ),
+    )
+
+    def run(command, log_path, _environment):
+        commands.append(command)
+        log_path.write_text(f"run {len(commands)}\n", encoding="utf-8")
+        workload = log_path.parent.name
+        summary = (
+            log_path.parent
+            / "validation"
+            / workload
+            / "eval_summary.json"
+        )
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(
+            json.dumps({"run": len(commands)}),
+            encoding="utf-8",
+        )
+        return 0
+
+    comparisons = iter(raw_results)
+
+    def comparison_result(binding, **_kwargs):
+        raw_result = next(comparisons)
+        return trtmc_validate._normalize_result(
+            {
+                "model": binding.model,
+                "workload": binding.workload,
+                "status": raw_result["status"],
+                "returncode": 0,
+                "raw_result": raw_result,
+            }
+        )
+
+    monkeypatch.setattr(trtmc_validate, "_run_subprocess", run)
+    monkeypatch.setattr(trtmc_validate, "_comparison_result", comparison_result)
+    bindings = [
+        trtmc_validate.Binding(model, "workload-a")
+        for model in models
+    ]
+    task_models = {
+        model: {
+            "family": "family-a",
+            "runtime_strategy": "text_generation",
+            "reference_backend": "hf_transformers",
+            "execution_profiles": {},
+        }
+        for model in models
+    }
+    returncode = trtmc_validate._run_bindings(
+        bindings,
+        arguments=arguments,
+        catalog={
+            "sample_limits": {"workload-a": 1},
+            "models": {
+                model: {
+                    "default": "workload-a",
+                    "workloads": ["workload-a"],
+                }
+                for model in models
+            },
+        },
+        task_models=task_models,
+        suites={"workload-a": {}},
+    )
+    results = {
+        model: json.loads(
+            (
+                arguments.output
+                / model
+                / "workload-a"
+                / "comparison.json"
+            ).read_text(encoding="utf-8")
+        )
+        for model in models
+    }
+    return results, commands, returncode, arguments
+
+
 def test_reused_bundle_accuracy_failure_rebuilds_once_and_recovers(
     tmp_path,
     monkeypatch,
@@ -2872,6 +3125,136 @@ def test_reused_bundle_accuracy_failure_rebuilds_once_and_confirms_failure(
     assert commands[1].count("--force-build") == 1
     assert result["validation"]["status"] == "failed"
     assert result["bundle_revalidation"]["outcome"] == "confirmed_after_rebuild"
+
+
+def test_reused_bundle_revalidation_limit_caps_multi_binding_run(
+    tmp_path,
+    monkeypatch,
+):
+    results, commands, returncode, arguments = (
+        _run_multiple_bindings_with_comparison_results(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            models=("model-a", "model-b"),
+            raw_results=[
+                {
+                    "status": "failed",
+                    "bundle_built": False,
+                    "prediction_agreement_rate": 0.25,
+                },
+                {
+                    "status": "passed",
+                    "bundle_built": True,
+                    "prediction_agreement_rate": 1.0,
+                },
+                {
+                    "status": "failed",
+                    "bundle_built": False,
+                    "prediction_agreement_rate": 0.50,
+                },
+            ],
+        )
+    )
+
+    assert arguments.reused_bundle_revalidation_limit == 1
+    assert len(commands) == 3
+    assert sum("--force-build" in command for command in commands) == 1
+    assert results["model-a"]["validation"]["status"] == "passed"
+    assert results["model-a"]["bundle_revalidation"]["attempted"] is True
+    assert (
+        results["model-a"]["bundle_revalidation"]["outcome"]
+        == "recovered_after_rebuild"
+    )
+    capped = results["model-b"]
+    assert capped["validation"]["status"] == "failed"
+    assert capped["comparison"]["status"] == "disagreement"
+    assert capped["raw_result"]["bundle_built"] is False
+    assert capped["bundle_revalidation"]["attempted"] is False
+    assert capped["bundle_revalidation"]["attempt_count"] == 0
+    assert capped["bundle_revalidation"]["run_attempt_limit"] == 1
+    assert capped["bundle_revalidation"]["run_attempts_used"] == 1
+    assert (
+        capped["bundle_revalidation"]["outcome"]
+        == "not_attempted_run_limit_reached"
+    )
+    assert (
+        capped["bundle_revalidation"]["initial"]["validation_status"]
+        == "failed"
+    )
+    assert returncode == 1
+
+
+def test_zero_revalidation_limit_preserves_original_disagreement(
+    tmp_path,
+    monkeypatch,
+):
+    result, commands, _arguments = _run_binding_with_comparison_results(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        raw_results=[
+            {
+                "status": "failed",
+                "bundle_built": False,
+                "prediction_agreement_rate": 0.25,
+            }
+        ],
+        extra_args=("--reused-bundle-revalidation-limit", "0"),
+    )
+
+    assert len(commands) == 1
+    assert "--force-build" not in commands[0]
+    assert result["comparison"]["status"] == "disagreement"
+    assert result["validation"]["status"] == "failed"
+    assert result["raw_result"]["bundle_built"] is False
+    assert result["bundle_revalidation"]["attempted"] is False
+    assert result["bundle_revalidation"]["run_attempt_limit"] == 0
+    assert result["bundle_revalidation"]["run_attempts_used"] == 0
+    assert (
+        result["bundle_revalidation"]["outcome"]
+        == "not_attempted_run_limit_reached"
+    )
+
+
+def test_nonaccuracy_failure_does_not_consume_revalidation_budget(
+    tmp_path,
+    monkeypatch,
+):
+    results, commands, returncode, _arguments = (
+        _run_multiple_bindings_with_comparison_results(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            models=("model-error", "model-accuracy"),
+            raw_results=[
+                {
+                    "status": "failed",
+                    "bundle_built": False,
+                    "error_type": "ReferenceSetupError",
+                    "error": "reference environment is unavailable",
+                },
+                {
+                    "status": "failed",
+                    "bundle_built": False,
+                    "prediction_agreement_rate": 0.25,
+                },
+                {
+                    "status": "passed",
+                    "bundle_built": True,
+                    "prediction_agreement_rate": 1.0,
+                },
+            ],
+        )
+    )
+
+    assert len(commands) == 3
+    assert sum("--force-build" in command for command in commands) == 1
+    assert results["model-error"]["execution"]["status"] == "error"
+    assert "bundle_revalidation" not in results["model-error"]
+    assert results["model-accuracy"]["validation"]["status"] == "passed"
+    assert (
+        results["model-accuracy"]["bundle_revalidation"]["outcome"]
+        == "recovered_after_rebuild"
+    )
+    assert returncode == 1
 
 
 def test_passing_reused_bundle_does_not_trigger_rebuild(

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -65,6 +65,7 @@ DEFAULT_ENGINE_DIR = DEFAULT_OUTPUT / "engines"
 DEFAULT_REFERENCE_CACHE = DEFAULT_OUTPUT / "references"
 COMMON_REFERENCE_PROFILE = "reference_common"
 NOT_COMPARED_DIRECTORY = "not-compared"
+DEFAULT_REUSED_BUNDLE_REVALIDATION_LIMIT = 1
 LEGACY_E2E_REASON = (
     "E2E execution does not compare aligned reference and TRTMC outputs."
 )
@@ -1430,16 +1431,83 @@ def _should_revalidate_reused_bundle(
     ):
         return False
     execution = result.get("execution", {})
+    comparison = result.get("comparison", {})
     validation = result.get("validation", {})
     raw_result = result.get("raw_result", {})
     return (
         isinstance(execution, Mapping)
         and execution.get("status") == "completed"
+        and isinstance(comparison, Mapping)
+        and comparison.get("status") == "disagreement"
         and isinstance(validation, Mapping)
         and validation.get("status") == "failed"
         and isinstance(raw_result, Mapping)
         and raw_result.get("bundle_built") is False
     )
+
+
+@dataclass
+class _ReusedBundleRevalidationBudget:
+    """Bound forced fresh-bundle confirmations across one validation run."""
+
+    limit: int
+    attempts_used: int = 0
+
+    def __post_init__(self) -> None:
+        self.limit = max(0, int(self.limit))
+        self.attempts_used = min(
+            self.limit,
+            max(0, int(self.attempts_used)),
+        )
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.limit - self.attempts_used)
+
+    def reserve(self) -> bool:
+        if self.remaining == 0:
+            return False
+        self.attempts_used += 1
+        return True
+
+    def record_worker_result(self, result: Mapping[str, Any]) -> None:
+        receipt = result.get("bundle_revalidation", {})
+        if not isinstance(receipt, Mapping) or receipt.get("attempted") is not True:
+            return
+        try:
+            attempt_count = int(receipt.get("attempt_count", 0) or 0)
+        except (TypeError, ValueError):
+            attempt_count = 0
+        self.attempts_used = min(
+            self.limit,
+            self.attempts_used + max(0, attempt_count),
+        )
+
+
+def _reused_bundle_revalidation_budget(
+    arguments: argparse.Namespace,
+) -> _ReusedBundleRevalidationBudget:
+    budget = getattr(arguments, "_reused_bundle_revalidation_budget", None)
+    if isinstance(budget, _ReusedBundleRevalidationBudget):
+        return budget
+    budget = _ReusedBundleRevalidationBudget(
+        limit=int(
+            getattr(
+                arguments,
+                "reused_bundle_revalidation_limit",
+                DEFAULT_REUSED_BUNDLE_REVALIDATION_LIMIT,
+            )
+        ),
+        attempts_used=int(
+            getattr(
+                arguments,
+                "reused_bundle_revalidation_attempts_used",
+                0,
+            )
+        ),
+    )
+    setattr(arguments, "_reused_bundle_revalidation_budget", budget)
+    return budget
 
 
 def _archive_reused_bundle_failure(
@@ -1597,36 +1665,53 @@ def run_binding(
         user_contract=user_contract,
     )
     if _should_revalidate_reused_bundle(result, arguments):
+        budget = _reused_bundle_revalidation_budget(arguments)
         initial_result = result
-        archived = _archive_reused_bundle_failure(
-            case_dir=case_dir,
-            result=initial_result,
-        )
-        rebuild_command = [*command, "--force-build"]
-        rebuild_returncode = _run_subprocess(
-            rebuild_command,
-            case_dir / "execution.log",
-            process_env,
-        )
-        result = _comparison_result(
-            binding,
-            case_dir=case_dir,
-            returncode=rebuild_returncode,
-            reference_environment=environment,
-            dataset_command=dataset_command,
-            sample_limit=int(arguments.limit or 0),
-        )
-        result["bundle_revalidation"] = {
-            "attempted": True,
-            "trigger": "accuracy_failure_with_reused_bundle",
-            "attempt_count": 1,
-            "outcome": _bundle_revalidation_outcome(result),
-            "initial": _reused_bundle_failure_receipt(
-                initial_result,
-                archived,
-            ),
-            "rebuild_command": shlex.join(rebuild_command),
-        }
+        if budget.reserve():
+            archived = _archive_reused_bundle_failure(
+                case_dir=case_dir,
+                result=initial_result,
+            )
+            rebuild_command = [*command, "--force-build"]
+            rebuild_returncode = _run_subprocess(
+                rebuild_command,
+                case_dir / "execution.log",
+                process_env,
+            )
+            result = _comparison_result(
+                binding,
+                case_dir=case_dir,
+                returncode=rebuild_returncode,
+                reference_environment=environment,
+                dataset_command=dataset_command,
+                sample_limit=int(arguments.limit or 0),
+            )
+            result["bundle_revalidation"] = {
+                "attempted": True,
+                "trigger": "accuracy_failure_with_reused_bundle",
+                "attempt_count": 1,
+                "run_attempt_limit": budget.limit,
+                "run_attempts_used": budget.attempts_used,
+                "outcome": _bundle_revalidation_outcome(result),
+                "initial": _reused_bundle_failure_receipt(
+                    initial_result,
+                    archived,
+                ),
+                "rebuild_command": shlex.join(rebuild_command),
+            }
+        else:
+            result["bundle_revalidation"] = {
+                "attempted": False,
+                "trigger": "accuracy_failure_with_reused_bundle",
+                "attempt_count": 0,
+                "run_attempt_limit": budget.limit,
+                "run_attempts_used": budget.attempts_used,
+                "outcome": "not_attempted_run_limit_reached",
+                "initial": _reused_bundle_failure_receipt(
+                    initial_result,
+                    {},
+                ),
+            }
 
     comparison = case_dir / "comparison.json"
     comparison.write_text(
@@ -2715,6 +2800,13 @@ def _nonnegative_float(value: str) -> float:
     return parsed
 
 
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Validate TRTMC against model reference implementations."
@@ -2739,6 +2831,21 @@ def build_parser() -> argparse.ArgumentParser:
         type=_nonnegative_float,
         default=5.0,
         help="delay before retrying a model worker after an execution error",
+    )
+    parser.add_argument(
+        "--reused-bundle-revalidation-limit",
+        type=_nonnegative_int,
+        default=DEFAULT_REUSED_BUNDLE_REVALIDATION_LIMIT,
+        help=(
+            "maximum failed reused bundles to confirm with a forced fresh build "
+            "across the complete run (default: 1)"
+        ),
+    )
+    parser.add_argument(
+        "--reused-bundle-revalidation-attempts-used",
+        type=_nonnegative_int,
+        default=0,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--model-worker",
@@ -2885,6 +2992,14 @@ def _worker_command(
         ("--hf-python", arguments.hf_python),
         ("--model-attempts", arguments.model_attempts),
         ("--model-retry-delay-seconds", arguments.model_retry_delay_seconds),
+        (
+            "--reused-bundle-revalidation-limit",
+            arguments.reused_bundle_revalidation_limit,
+        ),
+        (
+            "--reused-bundle-revalidation-attempts-used",
+            arguments.reused_bundle_revalidation_attempts_used,
+        ),
     ):
         command.extend([option, str(value)])
     for option, value in (
@@ -3065,15 +3180,21 @@ def _run_supervised_binding_with_retries(
     catalog: Mapping[str, Any],
 ) -> dict[str, Any]:
     case_dir = _case_directory(arguments.output, binding)
+    revalidation_budget = _reused_bundle_revalidation_budget(arguments)
     attempts = []
     result: dict[str, Any] = {}
     for attempt in range(1, arguments.model_attempts + 1):
+        attempt_arguments = copy.copy(arguments)
+        attempt_arguments.reused_bundle_revalidation_attempts_used = (
+            revalidation_budget.attempts_used
+        )
         result = _run_supervised_binding(
             binding,
-            arguments=arguments,
+            arguments=attempt_arguments,
             catalog=catalog,
             attempt=attempt,
         )
+        revalidation_budget.record_worker_result(result)
         execution = result.get("execution", {})
         execution_error = (
             isinstance(execution, Mapping)
@@ -3125,6 +3246,7 @@ def _run_all_bindings(
     catalog: Mapping[str, Any],
 ) -> int:
     _prepare_run_directories(arguments)
+    _reused_bundle_revalidation_budget(arguments)
     write_run_metadata(
         arguments.output,
         cuda_visible_devices=arguments.cuda_visible_devices,
@@ -3188,6 +3310,7 @@ def _run_bindings(
     suites: Mapping[str, dict[str, Any]],
 ) -> int:
     _prepare_run_directories(arguments)
+    revalidation_budget = _reused_bundle_revalidation_budget(arguments)
     if not arguments.model_worker:
         write_run_metadata(
             arguments.output,
@@ -3212,6 +3335,9 @@ def _run_bindings(
                 _print_result(result, comparison, report_path)
             continue
         binding_arguments = copy.copy(arguments)
+        binding_arguments._reused_bundle_revalidation_budget = (
+            revalidation_budget
+        )
         binding_arguments.limit = resolve_sample_limit(
             catalog,
             binding,

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1413,6 +1413,132 @@ def _comparison_result(
     })
 
 
+def _should_revalidate_reused_bundle(
+    result: Mapping[str, Any],
+    arguments: argparse.Namespace,
+) -> bool:
+    """Return whether one accuracy failure needs a fresh-bundle confirmation.
+
+    This is intentionally separate from the worker execution retry policy:
+    comparison disagreements are normally never retried.  The sole exception
+    is a completed comparison that explicitly reports it reused a bundle.  A
+    single forced rebuild distinguishes a stale-cache false positive from a
+    reproducible model-family accuracy failure.
+    """
+    if bool(getattr(arguments, "force_build", False)) or bool(
+        getattr(arguments, "no_build", False)
+    ):
+        return False
+    execution = result.get("execution", {})
+    validation = result.get("validation", {})
+    raw_result = result.get("raw_result", {})
+    return (
+        isinstance(execution, Mapping)
+        and execution.get("status") == "completed"
+        and isinstance(validation, Mapping)
+        and validation.get("status") == "failed"
+        and isinstance(raw_result, Mapping)
+        and raw_result.get("bundle_built") is False
+    )
+
+
+def _archive_reused_bundle_failure(
+    *,
+    case_dir: Path,
+    result: Mapping[str, Any],
+) -> dict[str, str]:
+    """Preserve the pre-rebuild comparison receipt and its small text logs."""
+    archived: dict[str, str] = {}
+    comparison = case_dir / "comparison.reused-bundle.json"
+    comparison.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    archived["comparison_result"] = str(comparison)
+    workload = str(result.get("workload", "") or "")
+    summary = case_dir / "validation" / workload / "eval_summary.json"
+    if summary.is_file():
+        target = summary.with_name("eval_summary.reused-bundle.json")
+        summary.replace(target)
+        archived["eval_summary.json"] = str(target)
+    for name in ("execution.log", "disagreements.jsonl"):
+        source = case_dir / name
+        if not source.is_file():
+            continue
+        target = case_dir / f"{source.stem}.reused-bundle{source.suffix}"
+        shutil.copy2(source, target)
+        archived[name] = str(target)
+    return archived
+
+
+def _reused_bundle_failure_receipt(
+    result: Mapping[str, Any],
+    archived: Mapping[str, str],
+) -> dict[str, Any]:
+    """Keep the first disagreement self-contained in the published result."""
+    execution = result.get("execution", {})
+    validation = result.get("validation", {})
+    comparison = result.get("comparison", {})
+    raw_result = result.get("raw_result", {})
+    return {
+        "execution_status": (
+            str(execution.get("status", ""))
+            if isinstance(execution, Mapping)
+            else ""
+        ),
+        "validation_status": (
+            str(validation.get("status", ""))
+            if isinstance(validation, Mapping)
+            else ""
+        ),
+        "comparison_status": (
+            str(comparison.get("status", ""))
+            if isinstance(comparison, Mapping)
+            else ""
+        ),
+        "bundle_built": (
+            raw_result.get("bundle_built")
+            if isinstance(raw_result, Mapping)
+            else None
+        ),
+        "error_type": (
+            str(raw_result.get("error_type", "") or "")
+            if isinstance(raw_result, Mapping)
+            else ""
+        ),
+        "error": (
+            str(raw_result.get("error", "") or "")
+            if isinstance(raw_result, Mapping)
+            else ""
+        ),
+        "metrics": (
+            dict(comparison.get("metrics", {}))
+            if isinstance(comparison, Mapping)
+            and isinstance(comparison.get("metrics"), Mapping)
+            else {}
+        ),
+        "artifacts": dict(archived),
+    }
+
+
+def _bundle_revalidation_outcome(result: Mapping[str, Any]) -> str:
+    raw_result = result.get("raw_result", {})
+    rebuilt = (
+        raw_result.get("bundle_built")
+        if isinstance(raw_result, Mapping)
+        else None
+    )
+    execution = result.get("execution", {})
+    validation = result.get("validation", {})
+    if not isinstance(execution, Mapping) or execution.get("status") != "completed":
+        return "rebuild_execution_error"
+    if rebuilt is not True:
+        return "rebuild_not_confirmed"
+    if isinstance(validation, Mapping) and validation.get("status") == "passed":
+        return "recovered_after_rebuild"
+    return "confirmed_after_rebuild"
+
+
 def run_binding(
     binding: Binding,
     *,
@@ -1470,6 +1596,37 @@ def run_binding(
         task_type=task_type,
         user_contract=user_contract,
     )
+    if _should_revalidate_reused_bundle(result, arguments):
+        initial_result = result
+        archived = _archive_reused_bundle_failure(
+            case_dir=case_dir,
+            result=initial_result,
+        )
+        rebuild_command = [*command, "--force-build"]
+        rebuild_returncode = _run_subprocess(
+            rebuild_command,
+            case_dir / "execution.log",
+            process_env,
+        )
+        result = _comparison_result(
+            binding,
+            case_dir=case_dir,
+            returncode=rebuild_returncode,
+            reference_environment=environment,
+            dataset_command=dataset_command,
+            sample_limit=int(arguments.limit or 0),
+        )
+        result["bundle_revalidation"] = {
+            "attempted": True,
+            "trigger": "accuracy_failure_with_reused_bundle",
+            "attempt_count": 1,
+            "outcome": _bundle_revalidation_outcome(result),
+            "initial": _reused_bundle_failure_receipt(
+                initial_result,
+                archived,
+            ),
+            "rebuild_command": shlex.join(rebuild_command),
+        }
 
     comparison = case_dir / "comparison.json"
     comparison.write_text(


### PR DESCRIPTION
## Background

The QA accuracy runs reused bundles from the shared `/runs/engines` directory
without distinguishing a stale engine from a current model-family regression.
In both
`trtmc-validate-gb300-2-20260726-c8291be0-all105` and
`trtmc-validate-gb300-2-20260728-79f0e2ea-all105-r10`, the StableLM and OLMo2
comparison logs reported `bundle_built=False`.

The two runs represent different failure stages. In c829, StableLM's
384-row cache equaled its 384-token longest prompt and OLMo2's 380-row cache
equaled its 380-token longest prompt. Commit `3d8c3b1a` fixed that missing
generation headroom before r10. The remaining r10 disagreements were still
reported from reused bundles; fresh current-source QA-profile builds removed
them. Because the reused bundles were not published, those residuals are
reused-bundle ambiguities rather than source-attributable family regressions.

| Run source | Model | Exact match | Token prefix | Bundle |
|---|---|---:|---:|---|
| `c8291be0` | `stablelm2-1.6b` | 0.00 | 0.378125 | reused |
| `79f0e2ea` | `stablelm2-1.6b` | 0.90 | 0.928125 | reused |
| `c8291be0` | `olmo2-1b` | 0.00 | 0.487500 | reused |
| `79f0e2ea` | `olmo2-1b` | 0.80 | 0.831250 | reused |

All four raw results used the same stable bundle names under `/runs/engines`
and reported `bundle_built=False`. The table does not claim that all four
failures had one cause: c829 exposed the headroom defect, while this PR
addresses the missing confirmation boundary for the reused-bundle residuals.

The previous validation flow reported the first disagreement immediately. It
had no bounded confirmation step for a result produced by a reused `.trtfb`.
The original implementation of that confirmation could add one rebuild for
every ambiguous failure; head `e0574102` adds one shared run-wide budget so the
default policy can add at most one rebuild across the complete run.

The current all105 QA invocation explicitly uses `--force-build`. That policy
intentionally bypasses the reused-bundle confirmation branch, so the current
all105 run cannot be cited as direct execution proof of this new branch.

## Exit Criteria

- With the default run-wide limit, at most one completed accuracy failure that
  explicitly reused a bundle is confirmed with a forced fresh build.
- Additional reused-bundle disagreements remain failed and receive an explicit
  `not_attempted_run_limit_reached` receipt; the budget never turns a failure
  green.
- A passing reused bundle adds no build or comparison work.
- If the one fresh-bundle confirmation still fails, the failure is final;
  validation does not loop or relax any accuracy gate.
- Supervisor retries and later model workers cannot reset the run-wide budget.
- Explicit `--force-build` and `--no-build` policies keep their existing
  behavior.
- The initial disagreement remains available as an auditable receipt.

## Implementation

- Detect only the narrow ambiguous state: execution completed, validation
  failed, the comparison is a disagreement, and the raw result explicitly
  reported `bundle_built=False`.
- Track confirmations with a shared run-wide budget. The public
  `--reused-bundle-revalidation-limit` defaults to `1`; the supervisor forwards
  attempts already used to each model worker, and execution-error retries
  record rather than reset that state.
- Archive the initial normalized comparison, raw eval summary, execution log,
  and disagreement artifact before any forced rebuild.
- Publish a `bundle_revalidation` receipt containing the initial validation
  status, error, accuracy metrics, artifact paths, rebuild command, run limit,
  attempts used, and one of `recovered_after_rebuild`,
  `confirmed_after_rebuild`, `rebuild_execution_error`,
  `rebuild_not_confirmed`, or `not_attempted_run_limit_reached`.
- Keep reused-bundle confirmation separate from execution-error retries. A
  failed confirmation consumes the shared budget and cannot start another
  rebuild through a worker retry.

For `F` eligible reused-bundle accuracy failures and a configured run limit
`L`, the worst-case incremental work is `min(F, L)` additional builds and
comparisons. With the default `L=1`, that is `min(F, 1)`: no more than one
extra build and comparison across the entire run. Passing models, execution
errors, already-fresh failures, and explicit `--force-build` / `--no-build`
runs add no work through this branch.

This bounds CI runtime without changing accuracy thresholds or treating a
missing confirmation budget as success.

## Validation

- `python3 /tmp/trtmc-accuracy-agent2/701-validator-integration-e0574102/run_pytest.py`:
  passed, 73 tests in 0.95 seconds. The runner invoked
  `/usr/bin/python3 -m pytest tests/tools/test_trtmc_validate.py -q -p no:cacheprovider`
  with `CUDA_VISIBLE_DEVICES=''`, bytecode disabled, and both repository import
  roots on `PYTHONPATH`.
- `python -m ruff check tools/trtmc_validate.py tests/tools/test_trtmc_validate.py`:
  passed.
- `python3 /tmp/trtmc-accuracy-agent2/701-validator-integration-e0574102/run_integration.py`:
  passed a CPU-only supervisor-to-worker subprocess integration in 1.09
  seconds. Three pre-existing mock bundles produced four comparison processes:
  `model-a reuse`, `model-a force-build`, `model-b reuse`, and `model-c reuse`.
  Exactly one process used `--force-build`.

The integration ran the unmodified validator supervisor and real model-worker
subprocesses. The relevant validator and test paths at aggregate head
`5dc37b757ae2ec93956acfb3672108372ff404e9` were content-identical to PR head
`e05741028f0e8c196960bf70d504e8c941ae1cd7`. The first model remained
`failed/disagreement` after its fresh-build confirmation with outcome
`confirmed_after_rebuild`. The later two models remained
`failed/disagreement`, did not rebuild, and recorded
`not_attempted_run_limit_reached`. Every worker had one attempt and zero
execution retries. The validator returned `1` as expected because confirmed
accuracy failures must keep the run red.

CPU-only integration artifacts:

- Archive:
  `/tmp/trtmc-accuracy-agent2/701-validator-integration-e0574102.tar.gz`
- Archive SHA256:
  `97d4d947a7f370c8231aa9927991b23fff43a3ec96113a7805968d53e9b89566`
- Integration receipt SHA256:
  `43b31113a5034d217425e0104b776c51453c2735561cabbdb7a29be44a5d943b`
- Subprocess event ledger SHA256:
  `9079e29ceac9dedce3900c147f9276d3debd470859ca3b14b186f585b720da18`
- 73-test log SHA256:
  `75d7b7e83fb4a1ca3615ab84f78096489bf17a22fc1f5fbddc626676c26db1d1`

The 73 focused tests cover the budget state machine, supervisor-to-worker
attempt propagation, retry non-reset behavior, reuse followed by fresh pass,
reuse followed by fresh failure, zero-limit behavior, passing reuse, and the
explicit `--force-build` / `--no-build` guards. Those tests mock the comparison
subprocess and result reader; the separate integration receipt covers the
supervisor/worker subprocess and filesystem-result boundary.

The integration deliberately replaces only the lowest compare/build boundary
with a mock and does not use a GPU, a real `.trtfb` build, or a real model.
It proves the validator mechanism and its runtime bound, not model accuracy or
parity in the QA report environment. Because the current all105 invocation
uses `--force-build`, it also does not exercise the reused-bundle branch.

The family-owned long-context sentinels are reviewed separately in StableLM
[#699](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/699) and OLMo2
[#700](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/700). This PR owns
only the shared reused-bundle confirmation mechanism.

## Notes For Future Readers

- Review `run_binding()` and the run-wide budget propagation through
  `_worker_command()` and `_run_supervised_binding_with_retries()` first.
- Do not interpret the CPU-only mock integration as a real GPU/model
  qualification receipt. A future QA run that intends to exercise this branch
  must omit explicit `--force-build` and begin with an actually reused bundle.
- This PR does not claim that a passing legacy bundle was built from the
  current source revision. A path-scoped source/build fingerprint sidecar can
  add proactive invalidation later, but it is intentionally separate from this
  urgent false-positive fix.
- Accuracy thresholds and comparison criteria are unchanged.

## Latest-main rebase status (2026-08-06)

- At that stage, the branch was rebased onto `github/main@63c920304cb0236a995e933f49504e8f2f237317`; its then-current PR head was `38198a61f59107e7cafe77de9e9eb594d1ad6ae7`.
- Current main extended `ensure_reference_sources` with an optional reference-contract argument. The rebase exposed two stale test mocks that still accepted only the former two-argument signature; the exact head updates those mocks to accept `_contract=None`. Production validator behavior, accuracy gates, retry semantics, and the run-wide rebuild budget are unchanged.
- The targeted frozen-image regression selection passed at the exact head: **81 passed, 1 deselected**. The single deselection isolates the unrelated MiniMax-H3 current-main baseline tracked in #834; it is not treated as proof that the full private premerge is green.
- The signature repair changes test scaffolding only. It adds no subprocess, model, comparison, rebuild, or GPU work, so the documented default worst-case bound of at most one additional build-and-compare per validation run remains unchanged.

## Latest-main rebase, Bundle compatibility, and CI (2026-08-07)

- Rebased cleanly onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact pushed head: `7c1dcfef91f7ae144d00cc54bdbc49635a00ffad`.
- This latest rebase was conflict-free. It retains the earlier composable resolution in `_run_all_bindings()`: initialize `_reused_bundle_revalidation_budget(arguments)`, then preserve main's `write_run_metadata(...)` provenance call.
- The rebase preserves the #817 repository-wide collaborative documentation review, the #842 draining-capacity GPU lease fix, and the #843 Qwen-MoE clean-nightly-GPU lease. All three commits are ancestors of this exact head, and their changed paths remain intact.
- The #837 public-surface cleanup remains intact: `.github/workflows/legal.yml`, `python/tensorrt_model_connect/families/flux/gen_fp8_bf16.py`, and `python/tensorrt_model_connect/families/pixart/diagnose_loop.py` remain absent.
- Bundle audit: case-insensitive scans of tracked content and filenames returned zero matches for the retired TRTFB identifier; all metrics, schema names, and artifact semantics use the current `.bundle` / `BUNDLE\x01\x00` contract.
- Local exact-tree validation: `tests/tools/test_trtmc_validate.py` reported **89 passed**; targeted `compileall`, `git diff --check`, `tools/model_ci.py validate` (79 models), and `source-quality` (including 157 tests) passed.
- Runtime remains capped by `DEFAULT_REUSED_BUNDLE_REVALIDATION_LIMIT = 1` for the entire validation run. Exact-head impact analysis (`tools/model_ci.py impact --base github/main --head HEAD`) selects no direct model and the five fixed platform fallbacks (`deepseek_v2`, `ltx_video`, `patchtsmixer`, `segformer`, and `whisper`) with `unit_scope=all`; this bounded policy coverage is not per-model or full-catalog fan-out.
- The source-visible required status moved from `pending` at `2026-08-07T18:09:14Z` to `success` at `2026-08-07T20:01:40Z`: **1 hour 52 minutes 26 seconds** of end-to-end wall clock. That interval includes shared GPU queueing and workflow/model execution; it is not added test execution time introduced by this PR.
- At exact head `7c1dcfef91f7ae144d00cc54bdbc49635a00ffad`, source-visible `trtmc/premerge/required` and both CodeQL analyses completed successfully, and GitHub reports `MERGEABLE/CLEAN`.
