### PR TITLE
feat(flux): add Ulysses context parallelism

### DIFF
--- a/python/tensorrt_model_connect/benchmark/builder.py
+++ b/python/tensorrt_model_connect/benchmark/builder.py
@@ -390,6 +390,10 @@ def _base_build_options(model: ModelDescriptor, build_args: Mapping[str, Any]) -
 def _append_parallel_option(options: dict[str, Any], build_args: Mapping[str, Any]) -> None:
     parallel = build_args.get("parallel", {})
     if isinstance(parallel, Mapping):
+        cp_size = parallel.get("cp_size", parallel.get("context_parallel_size"))
+        if cp_size is not None and int(cp_size) > 1:
+            options["context_parallel_size"] = int(cp_size)
+            return
         tp_size = parallel.get("tp_size", parallel.get("tensor_parallel_size"))
         if tp_size is not None and int(tp_size) > 1:
             options["tensor_parallel_size"] = int(tp_size)
@@ -558,6 +562,7 @@ def _build_command(
         "quant_scales": "--quant-scales",
         "quantize": "--quantize",
         "tensor_parallel_size": "--tensor-parallel-size",
+        "context_parallel_size": "--context-parallel-size",
     }
     for name, flag in value_flags.items():
         if name in options:

--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -256,11 +256,18 @@ def _cmd_build(args: argparse.Namespace) -> int:
     from .parallel_config import ParallelConfig
 
     tp_size = int(getattr(args, "tensor_parallel_size", 1) or 1)
-    parallel_config = (
-        ParallelConfig(mode="tensor_parallel", tp_size=tp_size)
-        if tp_size > 1
-        else None
-    )
+    cp_size = int(getattr(args, "context_parallel_size", 1) or 1)
+    if tp_size > 1 and cp_size > 1:
+        raise ValueError(
+            "--tensor-parallel-size and --context-parallel-size are mutually exclusive")
+    if cp_size > 1:
+        parallel_config = ParallelConfig(
+            mode="context_parallel", cp_size=cp_size)
+    elif tp_size > 1:
+        parallel_config = ParallelConfig(
+            mode="tensor_parallel", tp_size=tp_size)
+    else:
+        parallel_config = None
 
     # RTX selection MUST happen before any TensorRT API is touched.
     if getattr(args, 'rtx', False):
@@ -802,7 +809,7 @@ def main() -> None:
     )
     build_p.add_argument("--dynamic-kv-cache", action="store_true",
                          help="Build decoder bundles with runtime-resizable KV cache support")
-    # TP is a narrow build-only path, not a generic runtime-config namespace.
+    # Distributed modes are narrow build-only paths, not generic runtime config.
     build_p.add_argument(
         "--tensor-parallel-size",
         "--tp-size",
@@ -811,6 +818,14 @@ def main() -> None:
         choices=[1, 2, 4, 8],
         default=1,
         help="Build a tensor-parallel decoder bundle with this TP size")
+    build_p.add_argument(
+        "--context-parallel-size",
+        "--cp-size",
+        dest="context_parallel_size",
+        type=int,
+        choices=[1, 2, 4, 8],
+        default=1,
+        help="Build a FLUX.1 Ulysses context-parallel bundle with this CP size")
     build_p.add_argument(
         "--dynamic-kv-profile-rows",
         type=_parse_profile_rows,

--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -825,7 +825,7 @@ def main() -> None:
         type=int,
         choices=[1, 2, 4, 8],
         default=1,
-        help="Build a FLUX.1 Ulysses context-parallel bundle with this CP size")
+        help="Build a context-parallel bundle with this CP size")
     build_p.add_argument(
         "--dynamic-kv-profile-rows",
         type=_parse_profile_rows,

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -46,6 +46,7 @@ from .parallel_config import (
     ParallelConfig,
     normalize_parallel_config,
     rank_engine_section,
+    require_tensorrt_11_for_distributed,
     require_tensorrt_11_for_tensor_parallel,
 )
 
@@ -952,6 +953,10 @@ def build_bundle(
             max_batch_size=max_batch_size)
         return
 
+    if parallel.cp_enabled:
+        raise NotImplementedError(
+            "Context parallelism is currently supported for FLUX.1 diffusion only")
+
     # 1. Parse config
     config = ModelConfig.from_dir(model_dir_path)
     config.raw["_model_dir"] = str(model_dir_path)
@@ -1628,9 +1633,9 @@ def _build_diffusion_bundle(
             f"Supported: {supported}")
 
     model_type = getattr(plugin, 'name', pipeline_class.lower())
-    if parallel.enabled:
-        require_tensorrt_11_for_tensor_parallel(
-            parallel, feature="Diffusion tensor-parallel builds")
+    if parallel.distributed:
+        require_tensorrt_11_for_distributed(
+            parallel, feature="Diffusion distributed builds")
     config = ModelConfig(model_type=model_type, raw=dict(pipeline_config))
     config.raw["max_cache_length"] = max_cache_length
     config.raw["_fp32_layers"] = sorted(set(fp32_layers or ()))
@@ -1731,9 +1736,10 @@ def _build_diffusion_bundle(
             build_components_kwargs["build_timing"] = build_timing
         if _call_supports_kwarg(build_components, "parallel_config"):
             build_components_kwargs["parallel_config"] = parallel
-        elif parallel.enabled:
+        elif parallel.distributed:
             raise NotImplementedError(
-                f"Plugin {plugin.name} does not accept parallel_config for diffusion TP")
+                f"Plugin {plugin.name} does not accept parallel_config for "
+                f"diffusion {parallel.mode}")
         # Only forward max_batch_size to plugins that opted in. Plugins that
         # don't accept it (older or non-batchified ones) silently stay on B=1.
         if _call_supports_kwarg(build_components, "max_batch_size"):

--- a/python/tensorrt_model_connect/families/flux/flux_dit_cp_builder.py
+++ b/python/tensorrt_model_connect/families/flux/flux_dit_cp_builder.py
@@ -1,0 +1,515 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FLUX.1 DiT Ulysses context-parallel engine builder.
+
+This is the context-parallel counterpart to ``flux_dit_builder.py`` and
+``flux_dit_tp_builder.py``. Weights stay replicated. Activations are sharded
+over the text and image sequence dimensions, while attention temporarily
+exchanges sequence shards for head shards with ALL_TO_ALL:
+
+    [S / CP, H, D] -> [S, H / CP, D] -> attention
+                    -> [S / CP, H, D]
+
+The ordering intentionally matches AITune's ``FluxUlyssesAttn``: each rank
+owns ``text_rank || image_rank`` and rotary caches are sliced from the text and
+image regions independently before being concatenated in that same order.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ...parallel_config import ParallelConfig, normalize_parallel_config
+from . import graph_ops
+from .flux_dit_builder import (
+    _adaln_modulate,
+    _apply_native_rope_from_full_cache,
+    _chunk_3,
+    _chunk_6,
+    _gate_1d,
+    _gelu_ffn,
+    _layernorm_modulate,
+    _linear,
+    _matmul_bias_1d,
+    _rms_norm_per_head_seq,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from .checkpoint_mapper import WeightDict
+
+
+def build_flux_dit_engine(
+    weights: "WeightDict",
+    *,
+    dim: int = 3072,
+    num_heads: int = 24,
+    num_layers: int = 19,
+    num_single_layers: int = 38,
+    num_img_tokens: int,
+    text_seq_len: int = 512,
+    mlp_ratio: float = 4.0,
+    eps: float = 1e-6,
+    verbose: bool = False,
+    parallel_config: ParallelConfig | None = None,
+) -> bytes:
+    """Build a rank-dynamic FLUX.1 Ulysses context-parallel denoiser plan."""
+    parallel = normalize_parallel_config(parallel_config)
+    _validate_context_parallel(
+        parallel,
+        num_heads=num_heads,
+        num_img_tokens=num_img_tokens,
+        text_seq_len=text_seq_len,
+    )
+
+    cp_size = parallel.cp_size
+    head_dim = dim // num_heads
+    ffn_dim = int(dim * mlp_ratio)
+    local_img_tokens = num_img_tokens // cp_size
+    local_text_seq = text_seq_len // cp_size
+    local_seq = local_text_seq + local_img_tokens
+    total_seq = text_seq_len + num_img_tokens
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # Keep the existing runtime interface. Every rank receives identical full
+    # inputs. REDUCE_SCATTER selects rank-local rows dynamically, which means
+    # one serialized plan can be shared by all CP ranks just like AITune's
+    # FluxTransformerWrapper.
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (num_img_tokens, dim))
+    encoder_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, dim))
+    temb_inp = network.add_input("temb", trt.float32, (dim,))
+    rotary_cos = network.add_input(
+        "rotary_cos", trt.float32, (total_seq, head_dim))
+    rotary_sin = network.add_input(
+        "rotary_sin", trt.float32, (total_seq, head_dim))
+
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    hidden = _reduce_scatter_replicated(network, hidden_inp, cp_size)
+    encoder_hidden = _reduce_scatter_replicated(
+        network, encoder_inp, cp_size)
+
+    # The full rotary is [all text | all image]. Slice both regions
+    # independently so local Q/K [text_rank | image_rank] gets matching phases.
+    txt_cos_full = _slice_rows(
+        network, rotary_cos, 0, text_seq_len, head_dim)
+    txt_sin_full = _slice_rows(
+        network, rotary_sin, 0, text_seq_len, head_dim)
+    img_cos_full = _slice_rows(
+        network, rotary_cos, text_seq_len, num_img_tokens, head_dim)
+    img_sin_full = _slice_rows(
+        network, rotary_sin, text_seq_len, num_img_tokens, head_dim)
+    txt_cos = _reduce_scatter_replicated(network, txt_cos_full, cp_size)
+    txt_sin = _reduce_scatter_replicated(network, txt_sin_full, cp_size)
+    img_cos = _reduce_scatter_replicated(network, img_cos_full, cp_size)
+    img_sin = _reduce_scatter_replicated(network, img_sin_full, cp_size)
+    local_cos = _concat_rows(network, txt_cos, img_cos)
+    local_sin = _concat_rows(network, txt_sin, img_sin)
+
+    # ===================== Joint Transformer Blocks =====================
+    for layer_idx in range(num_layers):
+        p = f"transformer_blocks.{layer_idx}"
+
+        temb_silu = network.add_activation(
+            temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu_out = network.add_elementwise(
+            temb_inp, temb_silu.get_output(0),
+            trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm1_proj = _matmul_bias_1d(
+            network, temb_silu_out, dim, 6 * dim,
+            weights[f"{p}.norm1.linear.weight"],
+            weights[f"{p}.norm1.linear.bias"])
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            _chunk_6(network, norm1_proj, dim))
+        normed_hidden = _adaln_modulate(
+            network, hidden, scale_msa, shift_msa, dim, eps_t,
+            local_img_tokens)
+
+        ctx_norm1_proj = _matmul_bias_1d(
+            network, temb_silu_out, dim, 6 * dim,
+            weights[f"{p}.norm1_context.linear.weight"],
+            weights[f"{p}.norm1_context.linear.bias"])
+        (c_shift_msa, c_scale_msa, c_gate_msa,
+         c_shift_mlp, c_scale_mlp, c_gate_mlp) = _chunk_6(
+            network, ctx_norm1_proj, dim)
+        normed_encoder = _adaln_modulate(
+            network, encoder_hidden, c_scale_msa, c_shift_msa,
+            dim, eps_t, local_text_seq)
+
+        q_img = _linear(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_q")
+        k_img = _linear(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_k")
+        v_img = _linear(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_v")
+        q_txt = _linear(
+            network, normed_encoder, dim, dim, weights,
+            f"{p}.attn.add_q_proj")
+        k_txt = _linear(
+            network, normed_encoder, dim, dim, weights,
+            f"{p}.attn.add_k_proj")
+        v_txt = _linear(
+            network, normed_encoder, dim, dim, weights,
+            f"{p}.attn.add_v_proj")
+
+        q_img = _rms_norm_per_head_seq(
+            network, q_img, num_heads, head_dim,
+            weights[f"{p}.attn.norm_q.weight"], eps_t, local_img_tokens)
+        k_img = _rms_norm_per_head_seq(
+            network, k_img, num_heads, head_dim,
+            weights[f"{p}.attn.norm_k.weight"], eps_t, local_img_tokens)
+        q_txt = _rms_norm_per_head_seq(
+            network, q_txt, num_heads, head_dim,
+            weights[f"{p}.attn.norm_added_q.weight"], eps_t,
+            local_text_seq)
+        k_txt = _rms_norm_per_head_seq(
+            network, k_txt, num_heads, head_dim,
+            weights[f"{p}.attn.norm_added_k.weight"], eps_t,
+            local_text_seq)
+
+        q_img = _apply_native_rope_from_full_cache(
+            network, q_img, img_cos, img_sin,
+            num_heads, head_dim, local_img_tokens)
+        k_img = _apply_native_rope_from_full_cache(
+            network, k_img, img_cos, img_sin,
+            num_heads, head_dim, local_img_tokens)
+        q_txt = _apply_native_rope_from_full_cache(
+            network, q_txt, txt_cos, txt_sin,
+            num_heads, head_dim, local_text_seq)
+        k_txt = _apply_native_rope_from_full_cache(
+            network, k_txt, txt_cos, txt_sin,
+            num_heads, head_dim, local_text_seq)
+
+        q_cat = _concat_rows(network, q_txt, q_img)
+        k_cat = _concat_rows(network, k_txt, k_img)
+        v_cat = _concat_rows(network, v_txt, v_img)
+        attn_out = _ulysses_attention_from_rows(
+            network, q_cat, k_cat, v_cat,
+            local_seq=local_seq,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            cp_size=cp_size,
+        )
+
+        txt_attn = _slice_rows(
+            network, attn_out, 0, local_text_seq, dim)
+        img_attn = _slice_rows(
+            network, attn_out, local_text_seq, local_img_tokens, dim)
+
+        img_attn_proj = _linear(
+            network, img_attn, dim, dim, weights, f"{p}.attn.to_out.0")
+        img_attn_gated = _gate_1d(
+            network, img_attn_proj, gate_msa, local_img_tokens)
+        hidden = network.add_elementwise(
+            hidden, img_attn_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        txt_attn_proj = _linear(
+            network, txt_attn, dim, dim, weights, f"{p}.attn.to_add_out")
+        txt_attn_gated = _gate_1d(
+            network, txt_attn_proj, c_gate_msa, local_text_seq)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, txt_attn_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ff = _layernorm_modulate(
+            network, hidden, scale_mlp, shift_mlp,
+            dim, eps_t, local_img_tokens)
+        ff_out = _gelu_ffn(network, normed_ff, dim, weights, f"{p}.ff")
+        ff_gated = _gate_1d(network, ff_out, gate_mlp, local_img_tokens)
+        hidden = network.add_elementwise(
+            hidden, ff_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ctx_ff = _layernorm_modulate(
+            network, encoder_hidden, c_scale_mlp, c_shift_mlp,
+            dim, eps_t, local_text_seq)
+        ctx_ff_out = _gelu_ffn(
+            network, normed_ctx_ff, dim, weights, f"{p}.ff_context")
+        ctx_ff_gated = _gate_1d(
+            network, ctx_ff_out, c_gate_mlp, local_text_seq)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, ctx_ff_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+    # ===================== Single Transformer Blocks =====================
+    for layer_idx in range(num_single_layers):
+        p = f"single_transformer_blocks.{layer_idx}"
+        residual = _concat_rows(network, encoder_hidden, hidden)
+
+        temb_silu = network.add_activation(
+            temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu_out = network.add_elementwise(
+            temb_inp, temb_silu.get_output(0),
+            trt.ElementWiseOperation.PROD).get_output(0)
+        norm_proj = _matmul_bias_1d(
+            network, temb_silu_out, dim, 3 * dim,
+            weights[f"{p}.norm.linear.weight"],
+            weights[f"{p}.norm.linear.bias"])
+        shift_msa_s, scale_msa_s, gate_msa_s = _chunk_3(
+            network, norm_proj, dim)
+        normed_cat = _adaln_modulate(
+            network, residual, scale_msa_s, shift_msa_s,
+            dim, eps_t, local_seq)
+
+        mlp_hidden = graph_ops.add_matmul_rhs_constant(
+            network, normed_cat, dim, ffn_dim,
+            weights[f"{p}.proj_mlp.weight"])
+        mlp_bias = weights.get(f"{p}.proj_mlp.bias")
+        if mlp_bias is not None:
+            mlp_hidden = graph_ops.add_bias_sum(
+                network, mlp_hidden, ffn_dim, mlp_bias)
+        mlp_hidden = graph_ops.add_gelu_tanh(network, mlp_hidden)
+
+        q_s = _linear(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_q")
+        k_s = _linear(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_k")
+        v_s = _linear(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_v")
+        q_s = _rms_norm_per_head_seq(
+            network, q_s, num_heads, head_dim,
+            weights[f"{p}.attn.norm_q.weight"], eps_t, local_seq)
+        k_s = _rms_norm_per_head_seq(
+            network, k_s, num_heads, head_dim,
+            weights[f"{p}.attn.norm_k.weight"], eps_t, local_seq)
+        q_s = _apply_native_rope_from_full_cache(
+            network, q_s, local_cos, local_sin,
+            num_heads, head_dim, local_seq)
+        k_s = _apply_native_rope_from_full_cache(
+            network, k_s, local_cos, local_sin,
+            num_heads, head_dim, local_seq)
+        attn_out_s = _ulysses_attention_from_rows(
+            network, q_s, k_s, v_s,
+            local_seq=local_seq,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            cp_size=cp_size,
+        )
+
+        cat_attn_mlp = network.add_concatenation([attn_out_s, mlp_hidden])
+        cat_attn_mlp.axis = 1
+        in_features = dim + ffn_dim
+        combined = graph_ops.add_matmul_rhs_constant(
+            network, cat_attn_mlp.get_output(0), in_features, dim,
+            weights[f"{p}.proj_out.weight"])
+        proj_out_bias = weights.get(f"{p}.proj_out.bias")
+        if proj_out_bias is not None:
+            combined = graph_ops.add_bias_sum(
+                network, combined, dim, proj_out_bias)
+
+        gated = _gate_1d(network, combined, gate_msa_s, local_seq)
+        cat_hidden_out = network.add_elementwise(
+            residual, gated, trt.ElementWiseOperation.SUM).get_output(0)
+        encoder_hidden = _slice_rows(
+            network, cat_hidden_out, 0, local_text_seq, dim)
+        hidden = _slice_rows(
+            network, cat_hidden_out, local_text_seq, local_img_tokens, dim)
+
+    # Pointwise final projection stays sequence-local. Gather image rows only
+    # at the engine boundary to preserve the existing full-output ABI.
+    temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_out = network.add_elementwise(
+        temb_inp, temb_silu.get_output(0),
+        trt.ElementWiseOperation.PROD).get_output(0)
+    final_proj = _matmul_bias_1d(
+        network, temb_silu_out, dim, 2 * dim,
+        weights["norm_out.linear.weight"], weights["norm_out.linear.bias"])
+    final_scale = network.add_slice(
+        final_proj, (0,), (dim,), (1,)).get_output(0)
+    final_shift = network.add_slice(
+        final_proj, (dim,), (dim,), (1,)).get_output(0)
+    output = _adaln_modulate(
+        network, hidden, final_scale, final_shift,
+        dim, eps_t, local_img_tokens)
+
+    proj_out_w = weights["proj_out.weight"]
+    out_channels = proj_out_w.shape[1]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, output, dim, out_channels, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(
+            network, output, out_channels, proj_out_b)
+    output = network.add_cast(output, trt.float32).get_output(0)
+    output = _add_collective(
+        network, output, trt.CollectiveOperation.ALL_GATHER, cp_size)
+    output.name = "output"
+    network.mark_output(output)
+
+    print(
+        f"[flux-dit] Building TRT Ulysses CP engine "
+        f"(dim={dim}, joint={num_layers}, single={num_single_layers}, "
+        f"img_tokens={num_img_tokens}, text_seq={text_seq_len}, "
+        f"cp={cp_size}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for FLUX DiT Ulysses CP")
+    return bytes(plan)
+
+
+def _validate_context_parallel(
+    parallel: ParallelConfig,
+    *,
+    num_heads: int,
+    num_img_tokens: int,
+    text_seq_len: int,
+) -> None:
+    if not parallel.cp_enabled:
+        raise ValueError("FLUX Ulysses requires parallel.mode=context_parallel and cp_size > 1")
+    cp_size = parallel.cp_size
+    for name, value in (
+        ("num_attention_heads", num_heads),
+        ("num_img_tokens", num_img_tokens),
+        ("text_seq_len", text_seq_len),
+    ):
+        if value % cp_size != 0:
+            raise ValueError(
+                f"FLUX Ulysses requires {name} divisible by cp_size "
+                f"({value} vs {cp_size})")
+
+
+def _slice_rows(network, tensor, start: int, rows: int, width: int):
+    return network.add_slice(
+        tensor, (start, 0), (rows, width), (1, 1)).get_output(0)
+
+
+def _concat_rows(network, first, second):
+    cat = network.add_concatenation([first, second])
+    cat.axis = 0
+    return cat.get_output(0)
+
+
+def _add_collective(
+    network,
+    tensor,
+    operation,
+    cp_size: int,
+    *,
+    reduce_operation=None,
+):
+    add_collective = getattr(network, "add_dist_collective", None)
+    if add_collective is None:
+        raise RuntimeError(
+            "FLUX Ulysses requires TensorRT 11.0+ Python bindings with "
+            "INetworkDefinition.add_dist_collective")
+    if reduce_operation is None:
+        reduce_operation = getattr(
+            trt.ReduceOperation, "NONE", trt.ReduceOperation.SUM)
+    layer = add_collective(tensor, operation, reduce_operation, -1, [])
+    if layer is None:
+        raise RuntimeError(f"TensorRT failed to add {operation} collective")
+    if not hasattr(layer, "num_ranks"):
+        raise RuntimeError(
+            "FLUX Ulysses requires TensorRT 11.0+ Python bindings with "
+            "IDistCollectiveLayer.num_ranks")
+    layer.num_ranks = int(cp_size)
+    return layer.get_output(0)
+
+
+def _reduce_scatter_replicated(network, tensor, cp_size: int):
+    """Shard identical full inputs without multiplying their values by CP."""
+    inv_cp = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0 / cp_size], dtype=np.float32))
+    scaled = network.add_elementwise(
+        tensor, inv_cp, trt.ElementWiseOperation.PROD).get_output(0)
+    return _add_collective(
+        network,
+        scaled,
+        trt.CollectiveOperation.REDUCE_SCATTER,
+        cp_size,
+        reduce_operation=trt.ReduceOperation.SUM,
+    )
+
+
+def _ulysses_seq_to_head(
+    network,
+    tensor,
+    *,
+    local_seq: int,
+    num_heads: int,
+    head_dim: int,
+    cp_size: int,
+):
+    """[S/CP, H*D] -> [1, H/CP, S, D], matching AITune."""
+    local_heads = num_heads // cp_size
+    routed = network.add_shuffle(tensor)
+    routed.reshape_dims = (local_seq, cp_size, local_heads, head_dim)
+    routed.second_transpose = trt.Permutation([1, 0, 2, 3])
+    exchanged = _add_collective(
+        network, routed.get_output(0),
+        trt.CollectiveOperation.ALL_TO_ALL, cp_size)
+    full_seq = network.add_shuffle(exchanged)
+    full_seq.first_transpose = trt.Permutation([2, 0, 1, 3])
+    full_seq.reshape_dims = (
+        1, local_heads, local_seq * cp_size, head_dim)
+    return full_seq.get_output(0)
+
+
+def _ulysses_head_to_seq(
+    network,
+    tensor,
+    *,
+    local_seq: int,
+    num_heads: int,
+    head_dim: int,
+    cp_size: int,
+):
+    """[1, H/CP, S, D] -> [S/CP, H*D], inverse of seq-to-head."""
+    local_heads = num_heads // cp_size
+    routed = network.add_shuffle(tensor)
+    routed.reshape_dims = (local_heads, cp_size, local_seq, head_dim)
+    routed.second_transpose = trt.Permutation([1, 0, 2, 3])
+    exchanged = _add_collective(
+        network, routed.get_output(0),
+        trt.CollectiveOperation.ALL_TO_ALL, cp_size)
+    local_rows = network.add_shuffle(exchanged)
+    local_rows.first_transpose = trt.Permutation([2, 0, 1, 3])
+    local_rows.reshape_dims = (local_seq, num_heads * head_dim)
+    return local_rows.get_output(0)
+
+
+def _ulysses_attention_from_rows(
+    network,
+    q,
+    k,
+    v,
+    *,
+    local_seq: int,
+    num_heads: int,
+    head_dim: int,
+    cp_size: int,
+):
+    q_full = _ulysses_seq_to_head(
+        network, q, local_seq=local_seq, num_heads=num_heads,
+        head_dim=head_dim, cp_size=cp_size)
+    k_full = _ulysses_seq_to_head(
+        network, k, local_seq=local_seq, num_heads=num_heads,
+        head_dim=head_dim, cp_size=cp_size)
+    v_full = _ulysses_seq_to_head(
+        network, v, local_seq=local_seq, num_heads=num_heads,
+        head_dim=head_dim, cp_size=cp_size)
+    context = graph_ops.add_attention_core(
+        network, q_full, k_full, v_full,
+        scale=float(1.0 / np.sqrt(head_dim)))
+    return _ulysses_head_to_seq(
+        network, context, local_seq=local_seq, num_heads=num_heads,
+        head_dim=head_dim, cp_size=cp_size)

--- a/python/tensorrt_model_connect/families/flux/plugin.py
+++ b/python/tensorrt_model_connect/families/flux/plugin.py
@@ -225,12 +225,12 @@ class FluxPlugin:
         Detects FLUX.1 vs FLUX.2 from the transformer config and dispatches
         to the appropriate builders.
         """
-        # TP + batch>1 is out of scope for the diffusion-batch series.
+        # Distributed denoisers + batch>1 are out of scope for this release.
         if max_batch_size > 1 and parallel_config is not None and getattr(
-                parallel_config, "enabled", False):
+                parallel_config, "distributed", False):
             raise NotImplementedError(
-                "FLUX tensor-parallel + max_batch_size > 1 is not supported "
-                "in this release; build with either TP=1 or max_batch_size=1."
+                "FLUX distributed + max_batch_size > 1 is not supported "
+                "in this release; build with either one rank or max_batch_size=1."
             )
 
         weights["_transformer_dir"]
@@ -241,6 +241,10 @@ class FluxPlugin:
 
         # Detect FLUX.2 via transformer config
         if _is_flux2(tc):
+            if parallel_config is not None and getattr(
+                    parallel_config, "cp_enabled", False):
+                raise NotImplementedError(
+                    "Ulysses context parallelism is currently supported for FLUX.1 only")
             return self._build_flux2_components(
                 model_dir, config, weights, tc=tc, verbose=verbose,
                 fp8_scales=fp8_scales, precision=precision,
@@ -267,16 +271,18 @@ class FluxPlugin:
         from .flux_dit_builder import build_flux_dit_engine, load_flux_dit_weights
         from .flux_dit_tp_builder import (
             build_flux_dit_engine as build_flux_dit_tp_engine)
+        from .flux_dit_cp_builder import (
+            build_flux_dit_engine as build_flux_dit_cp_engine)
         from ...parallel_config import (
             normalize_parallel_config,
-            require_tensorrt_11_for_tensor_parallel,
+            require_tensorrt_11_for_distributed,
         )
         import json
         from pathlib import Path
 
         parallel = normalize_parallel_config(parallel_config)
-        require_tensorrt_11_for_tensor_parallel(
-            parallel, feature="Flux tensor-parallel builds")
+        require_tensorrt_11_for_distributed(
+            parallel, feature="Flux distributed builds")
 
         # Per-component batch policy (design Decision C / E):
         # - DiT honours max_batch_size with opt = min(N, 4).
@@ -436,7 +442,23 @@ class FluxPlugin:
         dit_plan = None
         dit_rank_plans = None
         with timed_trt_compile(build_timing, "flux_dit"):
-            if parallel.enabled:
+            if parallel.cp_enabled:
+                print(
+                    f"[flux] Building shared FLUX DiT Ulysses CP{parallel.cp_size} plan ...",
+                    file=sys.stderr,
+                )
+                dit_plan = build_flux_dit_cp_engine(
+                    dit_weights,
+                    dim=dit_dim,
+                    num_heads=num_heads,
+                    num_layers=num_layers,
+                    num_single_layers=num_single_layers,
+                    num_img_tokens=num_img_tokens,
+                    text_seq_len=self._T5_MAX_SEQ_LEN,
+                    verbose=verbose,
+                    parallel_config=parallel,
+                )
+            elif parallel.enabled:
                 dit_rank_plans = {}
                 for rank in range(parallel.tp_size):
                     print(f"[flux] Building FLUX DiT TP rank {rank}/{parallel.tp_size} ...",
@@ -826,20 +848,27 @@ class FluxPlugin:
         return out
 
     def diffusion_bundle_sections(self, components: dict, *, parallel_config=None) -> list[tuple[str, bytes]]:
-        from ...parallel_config import normalize_parallel_config, rank_denoiser_section
+        from ...parallel_config import (
+            context_denoiser_section,
+            normalize_parallel_config,
+            rank_denoiser_section,
+        )
 
         parallel = normalize_parallel_config(parallel_config)
         sections: list[tuple[str, bytes]] = []
         for index, (_name, plan) in enumerate(components["text_encoders"]):
             sections.append((f"text_encoder_{index}_plan", plan))
-        if parallel.enabled:
+        if parallel.cp_enabled:
+            sections.append((context_denoiser_section(), components["denoiser"]))
+        elif parallel.enabled:
             denoiser_rank_plans = components["denoiser_ranks"]
             for rank in range(parallel.tp_size):
                 plan = denoiser_rank_plans.get(rank)
                 if plan is None:
                     plan = denoiser_rank_plans.get(str(rank))
                 if plan is None:
-                    raise ValueError(f"Missing FLUX tensor-parallel denoiser rank {rank}")
+                    raise ValueError(
+                        f"Missing FLUX {parallel.mode} denoiser rank {rank}")
                 sections.append((rank_denoiser_section(rank), plan))
         else:
             sections.append(("denoiser_plan", components["denoiser"]))

--- a/python/tensorrt_model_connect/families/flux/plugin.py
+++ b/python/tensorrt_model_connect/families/flux/plugin.py
@@ -271,8 +271,6 @@ class FluxPlugin:
         from .flux_dit_builder import build_flux_dit_engine, load_flux_dit_weights
         from .flux_dit_tp_builder import (
             build_flux_dit_engine as build_flux_dit_tp_engine)
-        from .flux_dit_cp_builder import (
-            build_flux_dit_engine as build_flux_dit_cp_engine)
         from ...parallel_config import (
             normalize_parallel_config,
             require_tensorrt_11_for_distributed,
@@ -443,6 +441,9 @@ class FluxPlugin:
         dit_rank_plans = None
         with timed_trt_compile(build_timing, "flux_dit"):
             if parallel.cp_enabled:
+                from .flux_dit_cp_builder import (
+                    build_flux_dit_engine as build_flux_dit_cp_engine)
+
                 print(
                     f"[flux] Building shared FLUX DiT Ulysses CP{parallel.cp_size} plan ...",
                     file=sys.stderr,

--- a/python/tensorrt_model_connect/parallel_config.py
+++ b/python/tensorrt_model_connect/parallel_config.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tensor-parallel build metadata and weight sharding helpers."""
+"""Distributed build metadata and tensor-parallel weight sharding helpers."""
 
 from __future__ import annotations
 
@@ -22,45 +22,85 @@ class ParallelConfig:
     tp_size: int = 1
     rank: int = -1
     require_mpirun: bool = True
+    cp_size: int = 1
 
     @property
     def enabled(self) -> bool:
+        """Whether tensor parallelism is enabled.
+
+        Keep this property TP-specific so existing decoder builders do not
+        accidentally accept context-parallel configurations.
+        """
         return self.mode == "tensor_parallel" and self.tp_size > 1
+
+    @property
+    def cp_enabled(self) -> bool:
+        return self.mode == "context_parallel" and self.cp_size > 1
+
+    @property
+    def distributed(self) -> bool:
+        return self.enabled or self.cp_enabled
+
+    @property
+    def world_size(self) -> int:
+        if self.cp_enabled:
+            return self.cp_size
+        return self.tp_size
 
     def for_rank(self, rank: int) -> "ParallelConfig":
         return replace(self, rank=rank)
 
     def validate(self) -> None:
-        if self.mode not in {"single", "tensor_parallel"}:
+        if self.mode not in {"single", "tensor_parallel", "context_parallel"}:
             raise ValueError(f"Unsupported parallel.mode={self.mode!r}")
         if self.tp_size not in {1, 2, 4, 8}:
             raise ValueError("parallel.tp_size must be one of 1, 2, 4, 8")
+        if self.cp_size not in {1, 2, 4, 8}:
+            raise ValueError("parallel.cp_size must be one of 1, 2, 4, 8")
         if self.rank < -1:
             raise ValueError("parallel.rank must be -1 or a non-negative rank")
-        if self.rank >= self.tp_size:
+        if self.rank >= self.world_size:
             raise ValueError(
-                f"parallel.rank={self.rank} must be smaller than tp_size={self.tp_size}")
-        if self.mode == "single" and self.tp_size != 1:
-            raise ValueError("parallel.mode=single requires parallel.tp_size=1")
+                f"parallel.rank={self.rank} must be smaller than "
+                f"world_size={self.world_size}")
+        if self.mode == "single" and (self.tp_size != 1 or self.cp_size != 1):
+            raise ValueError(
+                "parallel.mode=single requires parallel.tp_size=1 and parallel.cp_size=1")
+        if self.mode == "tensor_parallel" and self.cp_size != 1:
+            raise ValueError("parallel.mode=tensor_parallel requires parallel.cp_size=1")
+        if self.mode == "context_parallel" and self.tp_size != 1:
+            raise ValueError("parallel.mode=context_parallel requires parallel.tp_size=1")
 
     def to_config_dict(self) -> dict[str, object]:
         self.validate()
         return {
             "mode": self.mode,
             "tp_size": self.tp_size,
+            "cp_size": self.cp_size,
             "rank": self.rank,
             "require_mpirun": self.require_mpirun,
         }
 
     def to_bundle_config_fields(self) -> dict[str, object]:
-        if not self.enabled:
+        if not self.distributed:
             return {}
-        return {
+        fields: dict[str, object] = {
             "parallelism": self.to_config_dict(),
-            "tensor_parallel_mode": self.mode,
-            "tensor_parallel_size": self.tp_size,
-            "tensor_parallel_require_mpirun": int(self.require_mpirun),
+            "parallel_mode": self.mode,
         }
+        if self.enabled:
+            fields.update({
+                "tensor_parallel_mode": self.mode,
+                "tensor_parallel_size": self.tp_size,
+                "tensor_parallel_require_mpirun": int(self.require_mpirun),
+            })
+        else:
+            fields.update({
+                "context_parallel_mode": self.mode,
+                "context_parallel_size": self.cp_size,
+                "context_parallel_require_mpirun": int(self.require_mpirun),
+            })
+        return fields
 
 
 def normalize_parallel_config(value: ParallelConfig | None) -> ParallelConfig:
@@ -77,14 +117,18 @@ def rank_denoiser_section(rank: int) -> str:
     return f"denoiser_plan_tp_rank{int(rank)}"
 
 
-def require_tensorrt_11_for_tensor_parallel(
+def context_denoiser_section() -> str:
+    return "denoiser_plan_cp"
+
+
+def require_tensorrt_11_for_distributed(
     parallel: ParallelConfig,
     *,
-    feature: str = "Tensor-parallel builds",
+    feature: str = "Distributed builds",
 ) -> None:
-    """Raise unless an enabled tensor-parallel request is running on TRT 11.0+."""
+    """Raise unless an enabled distributed request is running on TRT 11.0+."""
     parallel.validate()
-    if not parallel.enabled:
+    if not parallel.distributed:
         return
 
     from . import trt_compat
@@ -95,6 +139,18 @@ def require_tensorrt_11_for_tensor_parallel(
     if major < 11:
         found = version or "unavailable"
         raise RuntimeError(f"{feature} requires TensorRT 11.0+; found {found}")
+
+
+def require_tensorrt_11_for_tensor_parallel(
+    parallel: ParallelConfig,
+    *,
+    feature: str = "Tensor-parallel builds",
+) -> None:
+    """Raise unless an enabled tensor-parallel request is running on TRT 11.0+."""
+    if not parallel.enabled:
+        parallel.validate()
+        return
+    require_tensorrt_11_for_distributed(parallel, feature=feature)
 
 
 def validate_standard_decoder_tp(

--- a/src/runtime/models/flux/plugin.cpp
+++ b/src/runtime/models/flux/plugin.cpp
@@ -35,15 +35,13 @@ DistributedRuntimeConfig parse_distributed_runtime_config(const std::string& con
         mode = extract_json_string(config_json, "context_parallel_mode", "single");
     cfg.context_parallel = (mode == "context_parallel");
     cfg.world_size = cfg.context_parallel
-        ? extract_json_int(config_json, "context_parallel_size", 1)
-        : extract_json_int(config_json, "tensor_parallel_size", 1);
-    cfg.enabled
-        = ((mode == "tensor_parallel" || cfg.context_parallel) && cfg.world_size > 1);
+                         ? extract_json_int(config_json, "context_parallel_size", 1)
+                         : extract_json_int(config_json, "tensor_parallel_size", 1);
+    cfg.enabled = ((mode == "tensor_parallel" || cfg.context_parallel) && cfg.world_size > 1);
     return cfg;
 }
 
-std::string distributed_denoiser_section_name(
-    int32_t rank, bool context_parallel) {
+std::string distributed_denoiser_section_name(int32_t rank, bool context_parallel) {
     if (context_parallel)
         return "denoiser_plan_cp";
     return "denoiser_plan_tp_rank" + std::to_string(rank);

--- a/src/runtime/models/flux/plugin.cpp
+++ b/src/runtime/models/flux/plugin.cpp
@@ -20,20 +20,32 @@ namespace trtmc {
 
 namespace {
 
-struct TensorParallelRuntimeConfig {
+struct DistributedRuntimeConfig {
     bool enabled{false};
-    int32_t tp_size{1};
+    bool context_parallel{false};
+    int32_t world_size{1};
 };
 
-TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
-    TensorParallelRuntimeConfig cfg;
-    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
-    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
-    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+DistributedRuntimeConfig parse_distributed_runtime_config(const std::string& config_json) {
+    DistributedRuntimeConfig cfg;
+    auto mode = extract_json_string(config_json, "parallel_mode", "single");
+    if (mode == "single")
+        mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    if (mode == "single")
+        mode = extract_json_string(config_json, "context_parallel_mode", "single");
+    cfg.context_parallel = (mode == "context_parallel");
+    cfg.world_size = cfg.context_parallel
+        ? extract_json_int(config_json, "context_parallel_size", 1)
+        : extract_json_int(config_json, "tensor_parallel_size", 1);
+    cfg.enabled
+        = ((mode == "tensor_parallel" || cfg.context_parallel) && cfg.world_size > 1);
     return cfg;
 }
 
-std::string tp_denoiser_section_name(int32_t rank) {
+std::string distributed_denoiser_section_name(
+    int32_t rank, bool context_parallel) {
+    if (context_parallel)
+        return "denoiser_plan_cp";
     return "denoiser_plan_tp_rank" + std::to_string(rank);
 }
 
@@ -46,14 +58,15 @@ class FluxPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        const auto distributed_config = parse_distributed_runtime_config(ctx.config_json);
         DistributedRuntimeGroup tp_group;
         std::string denoiser_section_name = "denoiser_plan";
         ModuleCreateOptions denoiser_opts = opts;
         const ModuleCreateOptions* denoiser_options = nullptr;
-        if (tp_config.enabled) {
-            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
-            denoiser_section_name = tp_denoiser_section_name(tp_group.rank);
+        if (distributed_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(distributed_config.world_size);
+            denoiser_section_name = distributed_denoiser_section_name(
+                tp_group.rank, distributed_config.context_parallel);
             denoiser_opts.distributed_communicator = tp_group.communicator;
             denoiser_opts.distributed_owner = tp_group.owner;
             denoiser_options = &denoiser_opts;

--- a/tests/builder/test_parallel_config.py
+++ b/tests/builder/test_parallel_config.py
@@ -11,7 +11,9 @@ import pytest
 from tensorrt_model_connect.config import ModelConfig
 from tensorrt_model_connect.parallel_config import (
     ParallelConfig,
+    context_denoiser_section,
     rank_denoiser_section,
+    require_tensorrt_11_for_distributed,
     require_tensorrt_11_for_tensor_parallel,
     shard_standard_decoder_weights,
     validate_dit_tp,
@@ -29,6 +31,36 @@ def test_parallel_config_accepts_supported_tp_sizes() -> None:
 def test_parallel_config_rejects_unsupported_tp_size() -> None:
     with pytest.raises(ValueError, match="parallel.tp_size"):
         ParallelConfig(mode="tensor_parallel", tp_size=3).validate()
+
+
+def test_parallel_config_accepts_context_parallel_cp4() -> None:
+    cfg = ParallelConfig(mode="context_parallel", cp_size=4, rank=2)
+
+    cfg.validate()
+
+    assert not cfg.enabled
+    assert cfg.cp_enabled
+    assert cfg.distributed
+    assert cfg.world_size == 4
+    assert cfg.to_bundle_config_fields() == {
+        "parallelism": {
+            "mode": "context_parallel",
+            "tp_size": 1,
+            "cp_size": 4,
+            "rank": 2,
+            "require_mpirun": True,
+        },
+        "parallel_mode": "context_parallel",
+        "context_parallel_mode": "context_parallel",
+        "context_parallel_size": 4,
+        "context_parallel_require_mpirun": 1,
+    }
+
+
+def test_parallel_config_rejects_mixed_tp_and_cp() -> None:
+    with pytest.raises(ValueError, match="requires parallel.tp_size=1"):
+        ParallelConfig(
+            mode="context_parallel", tp_size=2, cp_size=4).validate()
 
 
 def test_standard_decoder_weight_sharding_preserves_single_device() -> None:
@@ -83,8 +115,22 @@ def test_tensor_parallel_trt11_guard_ignores_single_device(monkeypatch) -> None:
     require_tensorrt_11_for_tensor_parallel(ParallelConfig())
 
 
+def test_context_parallel_requires_trt11(monkeypatch) -> None:
+    from tensorrt_model_connect import trt_compat
+
+    monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "10.13.3")
+
+    with pytest.raises(RuntimeError, match="TensorRT 11\\.0\\+"):
+        require_tensorrt_11_for_distributed(
+            ParallelConfig(mode="context_parallel", cp_size=4))
+
+
 def test_rank_denoiser_section_names_tp_sections() -> None:
     assert rank_denoiser_section(3) == "denoiser_plan_tp_rank3"
+
+
+def test_context_denoiser_section_names_shared_cp_plan() -> None:
+    assert context_denoiser_section() == "denoiser_plan_cp"
 
 
 def test_dit_tp_validation_requires_concrete_rank() -> None:

--- a/tests/e2e/models/flux/MODEL.toml
+++ b/tests/e2e/models/flux/MODEL.toml
@@ -11,6 +11,7 @@ test_manifests = [
   "manifests/flux-2-dev-l0.json",
   "manifests/flux-2-dev.json",
   "manifests/flux-schnell-l0-tp4.json",
+  "manifests/flux-schnell-l0-cp4.json",
   "manifests/flux-schnell-l0-batch2.json",
   "manifests/flux-schnell-l0.json",
   "manifests/flux-schnell.json",

--- a/tests/e2e/models/flux/manifests/flux-schnell-l0-cp4.json
+++ b/tests/e2e/models/flux/manifests/flux-schnell-l0-cp4.json
@@ -1,0 +1,97 @@
+{
+  "name": "flux-schnell-l0-cp4",
+  "hf_id": "black-forest-labs/FLUX.1-schnell",
+  "bundle": "flux-schnell-l0-cp4.trtfb",
+  "family": "flux",
+  "runtime_strategy": "diffusion_flux",
+  "task_strategy": "diffusion_media_generation",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "context_parallel",
+      "cp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "testcases": [
+    {
+      "name": "flux-schnell-l0-cp4",
+      "trace_id": "IT-E2E-FLXS-L0-CP4-01",
+      "model_type": "flux",
+      "gated": true,
+      "ci_tier": "multi_device",
+      "reference_family": "diffusers_image_gen",
+      "user_contract": "diffusion_image",
+      "preflight_requirements": [
+        {
+          "kind": "binary_exists",
+          "args": {},
+          "gating": true
+        },
+        {
+          "kind": "command_available",
+          "args": {
+            "command": "mpirun"
+          },
+          "gating": true
+        },
+        {
+          "kind": "gpu_count_min",
+          "args": {
+            "count": 4
+          },
+          "gating": true
+        },
+        {
+          "kind": "python_module_available",
+          "args": {
+            "module": "diffusers",
+            "phase": "build"
+          },
+          "gating": true
+        },
+        {
+          "kind": "python_module_available",
+          "args": {
+            "module": "ftfy",
+            "phase": "build"
+          },
+          "gating": true
+        },
+        {
+          "kind": "hf_auth_token_present",
+          "args": {},
+          "gating": true
+        }
+      ],
+      "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+      "test_type": "diffusion",
+      "image_height": 384,
+      "image_width": 384,
+      "video_num_frames": 1,
+      "num_inference_steps": 20,
+      "stages": [
+        {
+          "name": "end_to_end",
+          "required": true
+        }
+      ],
+      "metadata": {
+        "contract_config": {
+          "use_diffusers": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/models/flux/test_flux_dit_cp_layout.py
+++ b/tests/e2e/models/flux/test_flux_dit_cp_layout.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for the FLUX.1 Ulysses context-parallel layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+Tensor3D = list[list[list[int]]]
+
+
+def _reference_seq_to_head(shards: list[Tensor3D]) -> list[Tensor3D]:
+    """AITune layout: [S/CP,H,D] per rank -> [H/CP,S,D] per rank."""
+    cp_size = len(shards)
+    num_heads = len(shards[0][0])
+    local_heads = num_heads // cp_size
+    outputs = []
+    for destination in range(cp_size):
+        head_start = destination * local_heads
+        head_end = head_start + local_heads
+        outputs.append([
+            token[head_start:head_end]
+            for shard in shards
+            for token in shard
+        ])
+    return outputs
+
+
+def _reference_head_to_seq(head_shards: list[Tensor3D]) -> list[Tensor3D]:
+    """Inverse AITune layout: [H/CP,S,D] per rank -> [S/CP,H,D]."""
+    cp_size = len(head_shards)
+    full_seq = len(head_shards[0])
+    local_seq = full_seq // cp_size
+    outputs = []
+    for destination in range(cp_size):
+        seq_start = destination * local_seq
+        seq_end = seq_start + local_seq
+        outputs.append([
+            [head for shard in head_shards for head in shard[token_index]]
+            for token_index in range(seq_start, seq_end)
+        ])
+    return outputs
+
+
+def test_cp4_ulysses_sequence_head_exchange_is_exactly_invertible() -> None:
+    cp_size = 4
+    local_seq = 5
+    num_heads = 24
+    head_dim = 3
+    shards = [[
+        [[rank * 100_000 + token * 1_000 + head * 10 + dim
+          for dim in range(head_dim)]
+         for head in range(num_heads)]
+        for token in range(local_seq)
+    ] for rank in range(cp_size)]
+
+    head_shards = _reference_seq_to_head(shards)
+
+    assert [
+        (len(value), len(value[0]), len(value[0][0]))
+        for value in head_shards
+    ] == [
+        (local_seq * cp_size, num_heads // cp_size, head_dim)
+    ] * cp_size
+    restored = _reference_head_to_seq(head_shards)
+    for expected, actual in zip(shards, restored, strict=True):
+        assert actual == expected
+
+
+def test_cp_builder_keeps_aitune_permutations_and_split_rotary() -> None:
+    builder_path = (
+        Path(__file__).resolve().parents[4]
+        / "python/tensorrt_model_connect/families/flux/flux_dit_cp_builder.py"
+    )
+    source = builder_path.read_text()
+
+    assert "Permutation([1, 0, 2, 3])" in source
+    assert "Permutation([2, 0, 1, 3])" in source
+    assert "_reduce_scatter_replicated(network, hidden_inp, cp_size)" in source
+    assert "_reduce_scatter_replicated(network, txt_cos_full, cp_size)" in source
+    assert "_reduce_scatter_replicated(network, img_cos_full, cp_size)" in source
+    assert "local_cos = _concat_rows(network, txt_cos, img_cos)" in source
+    assert "CollectiveOperation.ALL_TO_ALL" in source
+    assert "CollectiveOperation.ALL_GATHER" in source

--- a/tests/e2e/models/flux/test_flux_manifest_contract.py
+++ b/tests/e2e/models/flux/test_flux_manifest_contract.py
@@ -73,3 +73,16 @@ def test_flux_batch2_manifest_declares_real_batch_contract() -> None:
     assert {spec["flag"] for spec in case.metadata["build_cli_args"]} >= {
         "--max-batch-size",
     }
+
+
+def test_flux_cp4_manifest_declares_ulysses_world_size() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "flux-schnell-l0-cp4.json"
+    case = load_manifest(manifest_path)
+
+    assert case.name == "flux-schnell-l0-cp4"
+    assert case.metadata["build_args"]["parallel"] == {
+        "mode": "context_parallel",
+        "cp_size": 4,
+    }
+    assert case.metadata["distributed_runtime"]["world_size"] == 4
+    assert case.reference_family == "diffusers_image_gen"

--- a/tests/e2e/models/flux/thresholds/flux-schnell-l0-cp4.json
+++ b/tests/e2e/models/flux/thresholds/flux-schnell-l0-cp4.json
@@ -1,0 +1,14 @@
+{
+  "threshold_overrides": {
+    "latent_cosine_per_step": 0.95,
+    "lpips": 0.3,
+    "max_pixel_mean": 0.85,
+    "min_pixel_mean": 0.15,
+    "min_pixel_std": 0.05,
+    "min_reference_std_ratio": 0.35,
+    "psnr": 5.0,
+    "reference_min_pixel_std_for_ratio": 0.08,
+    "ssim": 0.1,
+    "temporal_consistency": 0.6
+  }
+}

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -966,6 +966,7 @@ def _validate_manifest(raw: dict, path: str) -> None:
         raise TypeError(f"Manifest {path!r}: distributed_runtime must be an object")
     for field, value in (
         ("build_args.parallel.tp_size", parallel.get("tp_size")),
+        ("build_args.parallel.cp_size", parallel.get("cp_size")),
         ("distributed_runtime.world_size", distributed.get("world_size")),
     ):
         if value is None:

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -950,10 +950,34 @@ def _manifest_tensor_parallel_size(build_args: dict[str, Any]) -> int | None:
     return None
 
 
+def _manifest_context_parallel_size(build_args: dict[str, Any]) -> int | None:
+    if not isinstance(build_args, dict):
+        return None
+    parallel = build_args.get("parallel", {})
+    if isinstance(parallel, dict):
+        value = parallel.get("cp_size", parallel.get("context_parallel_size"))
+        mode = str(parallel.get("mode", "") or "").lower()
+    else:
+        value = build_args.get("cp_size", build_args.get("context_parallel_size"))
+        mode = str(build_args.get("parallel_mode", "") or "").lower()
+    if value is None:
+        return None
+    try:
+        cp_size = int(value)
+    except (TypeError, ValueError):
+        return None
+    if cp_size > 1 or mode == "context_parallel":
+        return cp_size
+    return None
+
+
 def _append_manifest_build_args(cmd: list[str], build_args: dict[str, Any]) -> None:
     tp_size = _manifest_tensor_parallel_size(build_args)
     if tp_size is not None and tp_size > 1:
         cmd.extend(["--tp-size", str(tp_size)])
+    cp_size = _manifest_context_parallel_size(build_args)
+    if cp_size is not None and cp_size > 1:
+        cmd.extend(["--cp-size", str(cp_size)])
 
 
 def _append_declared_build_cli_args(cmd: list[str], case: E2ECase) -> None:


### PR DESCRIPTION
## Background

FLUX.1 already supports tensor parallelism, which shards model weights and attention heads. This change adds Ulysses context parallelism as an independent build mode so long text/image token sequences can instead be sharded across GPUs while weights remain replicated.

## Exit Criteria

- Build and run FLUX.1-schnell with CP sizes 2, 4, and 8 using one shared rank-dynamic denoiser plan.
- Preserve the existing TP and single-device paths.
- Demonstrate CP4 end-to-end latency faster than single-device at identical prompt, seed, shape, precision, and denoising steps.
- Keep CP and TP mutually exclusive. FLUX.2 CP and distributed batch sizes greater than one remain out of scope.

## Implementation

- Adds `flux_dit_cp_builder.py`, separate from the existing SD and TP builders.
- Keeps full runtime inputs replicated, scales by `1 / cp_size`, then uses REDUCE_SCATTER SUM to select rank-local text and image rows.
- Shards text and image rotary caches independently and concatenates the local `text || image` order to match the AITune Ulysses implementation.
- Uses ALL_TO_ALL in every joint and single attention block to transform `[S / CP, H, D]` sequence shards into `[S, H / CP, D]` head shards, then applies the inverse exchange after attention.
- Uses ALL_GATHER for final image-token rows so the existing runtime ABI receives the complete denoiser output.
- Serializes a single shared `denoiser_plan_cp` section and initializes the existing distributed communicator from CP bundle metadata.
- Extends the builder CLI, manifest builder, runtime loader, and multi-GPU E2E manifest while retaining TP-specific behavior for existing decoder and diffusion builders.

## Choosing CP, TP, Or Single Device

Build CP4:

```bash
python -m tensorrt_model_connect build black-forest-labs/FLUX.1-schnell \
  -o flux-schnell-cp4.trtfb \
  --precision fp32 --image-height 384 --image-width 384 \
  --num-inference-steps 20 --cp-size 4
```

Run CP4:

```bash
mpirun --tag-output -np 4 trtmc run flux-schnell-cp4.trtfb \
  --prompt "A cinematic photograph of an astronaut riding a horse at sunset, highly detailed" \
  --height 384 --width 384 --num-inference-steps 20 --seed 123 \
  -o cp4.png
```

Build TP4 by selecting `--tp-size 4` instead:

```bash
python -m tensorrt_model_connect build black-forest-labs/FLUX.1-schnell \
  -o flux-schnell-tp4.trtfb \
  --precision fp32 --image-height 384 --image-width 384 \
  --num-inference-steps 20 --tp-size 4
mpirun --tag-output -np 4 trtmc run flux-schnell-tp4.trtfb \
  --prompt "A cinematic photograph of an astronaut riding a horse at sunset, highly detailed" \
  --height 384 --width 384 --num-inference-steps 20 --seed 123 \
  -o tp4.png
```

For single device, omit both parallel-size flags and run `trtmc` directly without `mpirun`. CP and TP cannot be enabled together. The bundle metadata selects the runtime path, so no separate CP/TP runtime flag is required.

## Benchmark Environment

- GPU: 8x NVIDIA A100-SXM4-80GB
- TensorRT: 11.1.0.106
- CUDA: 13
- NCCL: 2.29.7
- PyTorch: 2.13.0+cu130
- Model: `black-forest-labs/FLUX.1-schnell` at revision `741f7c3ce8b383c54771c7003378a50191e9efe9`
- Precision: FP32
- Workload: batch 1, 384x384, 20 denoising steps
- Prompt: `A photo of a cat sitting on a windowsill at sunset`
- Timing: one warmup followed by five measured rank-0 end-to-end generations
- SD timing samples used seeds 42-46; CP timing samples repeated seed 42; all retained comparison images use seed 42
- Engine build, bundle loading/deserialization, and PNG writing excluded from inference latency

| Mode | GPUs | Mean (ms) | P50 (ms) | Speedup vs SD | Latency reduction |
| --- | ---: | ---: | ---: | ---: | ---: |
| Single device | 1 | 5145.918 | 5145.170 | 1.000x | 0.00% |
| CP2 | 2 | 4169.386 | 4167.270 | 1.234x | 18.98% |
| CP4 | 4 | 3368.146 | 3367.840 | 1.528x | 34.55% |
| CP8 | 8 | 3176.454 | 3176.970 | 1.620x | 38.27% |

The latest run improves CP4 from 1.479x to 1.528x and CP8 from 1.534x to 1.620x versus the earlier measurements.

Same-seed outputs remained numerically close to single-device: 50.58 dB PSNR for CP2, 51.62 dB for CP4, and 54.63 dB for CP8. Floating-point collective reduction order means the images are not byte-identical.

## Validation

- `env PYTHONPATH=python /tmp/trtmc-cp-pr-tests/bin/python -m pytest -q tests/builder/test_parallel_config.py tests/e2e/models/flux/test_flux_dit_cp_layout.py tests/e2e/models/flux/test_flux_manifest_contract.py`: 21 passed on the rebased commit.
- Ruff over all changed Python source and test files: passed.
- Full SD/CP2/CP4/CP8 builds and end-to-end runs: passed; the latest measurements above satisfy the CP4 speedup gate.
- `cmake --build build-bench --target trtmc_model_flux -j8`: not rerun after rebase because the existing CMake cache records `/home/daichu/scratch1/TensorRT-Model-Connect` while the active checkout is `/localhome/local-daichu/scratch1/TensorRT-Model-Connect`. CMake stopped during cache regeneration before compiling source.

## Notes For Future Readers

- Review `flux_dit_cp_builder.py` first, then the FLUX plugin/bundle metadata wiring, followed by the native runtime loader and E2E manifest.
- CP currently supports FLUX.1 only, TensorRT 11+, batch size one, and CP sizes 2/4/8.
- TP weight sharding and CP sequence sharding remain separate modes by design.

