### PR TITLE
fix(canary): restore cached NeMo reference

### DIFF
--- a/tests/tools/test_speech_reference.py
+++ b/tests/tools/test_speech_reference.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from tools.reference import speech
+
+
+def _install_fake_nemo_asr(
+    monkeypatch,
+    *,
+    model_class: type,
+) -> None:
+    nemo = ModuleType("nemo")
+    nemo.__path__ = []
+    collections = ModuleType("nemo.collections")
+    collections.__path__ = []
+    asr = ModuleType("nemo.collections.asr")
+    asr.models = SimpleNamespace(ASRModel=model_class)
+    nemo.collections = collections
+    collections.asr = asr
+    monkeypatch.setitem(sys.modules, "nemo", nemo)
+    monkeypatch.setitem(sys.modules, "nemo.collections", collections)
+    monkeypatch.setitem(sys.modules, "nemo.collections.asr", asr)
+
+
+def _recording_model(
+    from_pretrained_calls: list[tuple[object, ...]],
+    restore_calls: list[dict[str, object]],
+) -> type:
+    class FakeModel:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            from_pretrained_calls.append((*args, kwargs))
+            return cls()
+
+        @classmethod
+        def restore_from(cls, **kwargs):
+            restore_calls.append(kwargs)
+            return cls()
+
+        def eval(self):
+            return self
+
+    return FakeModel
+
+
+@pytest.mark.parametrize(
+    "revision",
+    [
+        "87bc52657add533cd0156b3fc1aef027280754bf",
+        "",
+    ],
+)
+def test_canary_offline_reference_restores_cached_archive(
+    tmp_path: Path,
+    monkeypatch,
+    revision: str,
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    archive = snapshot / "canary-1b-v2.nemo"
+    archive.write_bytes(b"checkpoint")
+    download_calls: list[dict[str, object]] = []
+    from_pretrained_calls: list[tuple[object, ...]] = []
+    restore_calls: list[dict[str, object]] = []
+
+    def fake_snapshot_download(*args, **kwargs):
+        assert not args
+        download_calls.append(kwargs)
+        return str(snapshot)
+
+    huggingface_hub = ModuleType("huggingface_hub")
+    huggingface_hub.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", huggingface_hub)
+    _install_fake_nemo_asr(
+        monkeypatch,
+        model_class=_recording_model(from_pretrained_calls, restore_calls),
+    )
+
+    responses = speech._run_nemo_asr(
+        SimpleNamespace(
+            model="nvidia/canary-1b-v2",
+            model_revision=revision,
+            local_files_only=True,
+            device="cpu",
+            predictions=tmp_path / "hf_predictions.json",
+        ),
+        [],
+        {"sample_rate": 16000},
+    )
+
+    assert responses == []
+    expected_download = {
+        "repo_id": "nvidia/canary-1b-v2",
+        "allow_patterns": ["*.nemo"],
+        "local_files_only": True,
+    }
+    if revision:
+        expected_download["revision"] = revision
+    assert download_calls == [expected_download]
+    assert from_pretrained_calls == []
+    assert restore_calls == [
+        {
+            "restore_path": str(archive),
+            "map_location": "cpu",
+        }
+    ]
+
+
+def test_canary_online_reference_keeps_nemo_from_pretrained(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from_pretrained_calls: list[tuple[object, ...]] = []
+    restore_calls: list[dict[str, object]] = []
+
+    _install_fake_nemo_asr(
+        monkeypatch,
+        model_class=_recording_model(from_pretrained_calls, restore_calls),
+    )
+
+    responses = speech._run_nemo_asr(
+        SimpleNamespace(
+            model="nvidia/canary-1b-v2",
+            model_revision="ignored-by-existing-online-path",
+            local_files_only=False,
+            device="cpu",
+            predictions=tmp_path / "hf_predictions.json",
+        ),
+        [],
+        {"sample_rate": 16000},
+    )
+
+    assert responses == []
+    assert from_pretrained_calls == [
+        (
+            "nvidia/canary-1b-v2",
+            {"map_location": "cpu"},
+        )
+    ]
+    assert restore_calls == []

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -408,7 +408,11 @@ def _run_nemotron35_asr(
     return responses
 
 
-def _resolve_nemotron35_archive(arguments: argparse.Namespace) -> Path:
+def _resolve_nemo_archive(
+    arguments: argparse.Namespace,
+    *,
+    model_label: str,
+) -> Path:
     model_path = Path(arguments.model)
     if model_path.is_file() and model_path.suffix == ".nemo":
         return model_path
@@ -419,7 +423,7 @@ def _resolve_nemotron35_archive(arguments: argparse.Namespace) -> Path:
 
         snapshot = Path(
             snapshot_download(
-                arguments.model,
+                repo_id=arguments.model,
                 allow_patterns=["*.nemo"],
                 local_files_only=arguments.local_files_only,
                 **(
@@ -432,9 +436,16 @@ def _resolve_nemotron35_archive(arguments: argparse.Namespace) -> Path:
         archives = sorted(snapshot.glob("*.nemo"))
     if not archives:
         raise FileNotFoundError(
-            f"Nemotron 3.5 ASR NeMo archive is missing for {arguments.model}"
+            f"{model_label} NeMo archive is missing for {arguments.model}"
         )
     return archives[0]
+
+
+def _resolve_nemotron35_archive(arguments: argparse.Namespace) -> Path:
+    return _resolve_nemo_archive(
+        arguments,
+        model_label="Nemotron 3.5 ASR",
+    )
 
 
 def _load_nemotron35_model(
@@ -455,6 +466,22 @@ def _load_nemotron35_model(
     return torch, model
 
 
+def _load_nemo_asr_model(arguments: argparse.Namespace, nemo_asr: Any) -> Any:
+    if arguments.local_files_only:
+        archive = _resolve_nemo_archive(
+            arguments,
+            model_label="ASR",
+        )
+        return nemo_asr.models.ASRModel.restore_from(
+            restore_path=str(archive),
+            map_location=arguments.device,
+        )
+    return nemo_asr.models.ASRModel.from_pretrained(
+        arguments.model,
+        map_location=arguments.device,
+    )
+
+
 def _run_nemo_asr(
     arguments: argparse.Namespace,
     prompts: Sequence[Mapping[str, Any]],
@@ -473,10 +500,7 @@ def _run_nemo_asr(
             target_rate,
             output_dir,
         )
-    model = nemo_asr.models.ASRModel.from_pretrained(
-        arguments.model,
-        map_location=arguments.device,
-    )
+    model = _load_nemo_asr_model(arguments, nemo_asr)
     if arguments.device != "cpu" and hasattr(model, "to"):
         model = model.to(arguments.device)
     model.eval()


### PR DESCRIPTION
## Background

The controlled rerun of the QA `all105` roster uses fresh references with
`--force-hf --local-files-only` so external Hugging Face availability and rate
limits cannot determine the result. In that rerun,
`canary-1b-v2 / librispeech_clean_asr` failed both attempts before TRTMC
inference. NeMo's `ASRModel.from_pretrained("nvidia/canary-1b-v2")`
unconditionally called `HfApi.file_exists`, which raised
`OfflineModeIsEnabled` even though the exact 6,358,958,080-byte
`canary-1b-v2.nemo` archive was already present in the local Hub snapshot
`87bc52657add533cd0156b3fc1aef027280754bf`.

The original online QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` did not expose this loader
defect: Canary completed with HF accuracy `0.9`, TRTMC accuracy `0.9`, and
prediction agreement `1.0`. This PR fixes the deterministic offline
reproduction path; it does not change Canary's comparator, thresholds, or
accuracy result.

Current CI missed the issue because the native speech reference tests did not
exercise the NeMo Canary loader with `local_files_only=True`. A focused CPU
regression now covers both a pinned snapshot and the cached `main` ref used by
the rerun.

## Exit Criteria

- Offline Canary reference inference resolves an existing local `.nemo`
  archive without a Hub metadata request.
- A supplied model revision selects that exact cached snapshot; an empty
  revision resolves the cached `main` ref.
- Online reference inference continues to use NeMo `from_pretrained` exactly
  as before.
- Accuracy gates and comparison criteria remain unchanged.
- The added Canary regressions remain CPU-only and do not add a direct Canary
  model-proof row or full-model roster.

## Implementation

- Generalize the existing NeMo archive resolver so Canary and Nemotron 3.5
  share the same local-file, local-directory, and Hugging Face snapshot-cache
  resolution contract.
- When `local_files_only` is enabled, load Canary through
  `ASRModel.restore_from(restore_path=..., map_location=...)` using the
  resolved archive. The online branch still calls
  `ASRModel.from_pretrained(model, map_location=...)`.
- Add CPU-only tests that prove pinned and unpinned offline cache resolution
  uses `restore_from` and never calls `from_pretrained`, plus a compatibility
  test for the unchanged online branch.

## Validation

- Fail-before on
  `github/main@aa3779bb4576280f18c955535779eb9e5b452ca4`:
  `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_speech_reference.py::test_canary_offline_reference_restores_cached_archive`
  failed because the cache resolver had zero calls and the old code called
  `from_pretrained`.
- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_speech_reference.py`:
  **3 passed in 0.07s**.
- Network-disabled, no-GPU replay:
  `python3 -m pytest -q -p no:cacheprovider tests/tools/test_speech_reference.py tests/tools/test_trtmc_reference.py`:
  **34 passed in 3.60s**.
- Exact-cache probe with `HF_HUB_OFFLINE=1`, `local_files_only=True`, and no
  network/GPU: both revision
  `87bc52657add533cd0156b3fc1aef027280754bf` and the cached `main` ref resolved
  the same 6,358,958,080-byte archive.
- NeMo config-only CPU restore on that exact archive:
  `ASRModel.restore_from(restore_path=path, map_location="cpu", return_config=True)`
  passed and resolved target
  `nemo.collections.asr.models.aed_multitask_models.EncDecMultiTaskModel`.
- `python3 -m ruff check --config ruff.toml tools/reference/speech.py tests/tools/test_speech_reference.py`:
  **passed**.
- The added Canary regressions remain CPU-only. Current impact uses the tools
  unit tier and the five fixed platform fallbacks; it adds no direct Canary
  model-proof row or full-model roster.

### Historical fix-head GB300 model proof

The QA workload was rerun from a detached worktree at fix source
`f66282fab9b89747d56c91bb24cc12d6a144429c`. The validation harness and Canary
reference loader came from that worktree. The compiled TRTMC runtime and model
plugins were the existing QA TRT 11.2 build from
`5dc37b757ae2ec93956acfb3672108372ff404e9`; this distinction is recorded so
the reference-fix proof is not misrepresented as a rebuild of unrelated C++
runtime code.

- Environment: NVIDIA GB300 with TensorRT 11.2.
- Model source: cached `nvidia/canary-1b-v2` archive revision
  `87bc52657add533cd0156b3fc1aef027280754bf`, 6,358,958,080 bytes.
- Workload and freshness: `librispeech_clean_asr`, 10 samples,
  `--force-hf --force-build --local-files-only`.
- Result: **passed**, 10 valid and 0 skipped samples; HF accuracy `0.9`, TRTMC
  accuracy `0.9`, accuracy drop `0.0`, prediction agreement `1.0`, normalized
  transcript exact agreement `1.0`, correctness agreement `1.0`, and zero
  disagreements.
- Strict gates: accuracy drop `0.0 <= 0.05`; prediction agreement
  `1.0 >= 0.90`.
- HF and TRTMC WER: both `0.019892473118279567`.
- Wall time: `685.646` seconds, including a forced fresh engine build and a
  forced fresh HF reference.
- Runtime binary SHA-256:
  `1b300d8587e6a05e3a35fa4b7d8b36582d00710e96ee6c3a0d08919f6c57650d`.
- Engine bundle SHA-256:
  `96b9faeebece76a50a1076668010b5db9b49fdc9788b0d41848a9d77f828a682`
  (1,927,202,642 bytes; intentionally excluded from the receipt archive).
- Reference manifest / prediction SHA-256:
  `119dc60668d544e0f565414959cc68ac396ce4e64c330e11e829825dfe5a1462` /
  `cef8e63587e443e1483dd1163d0a5ad2f440585f73bf329bb0ce7cfc85416202`.
- Comparison SHA-256:
  `6113e43baa8b689f52f0555c1d5b5577f30e48f482f9bf28ada75e5659258f8e`.
- Receipt archive: 4,873,054 bytes, SHA-256
  `dff7e05203c8e0e380c67ca11ec79bcf65eb7a1a054b029931efc9f5e5347b5a`.
  Its member-list audit contains no `engines/`, `.trtfb`, or `hf-cache/`.

## Notes For Future Readers

- In the fail-before receipt, both attempts failed at NeMo `api.file_exists`
  before TRTMC inference.
- The exact-head GB300 run above closes the model-proof gap for Canary: it
  reproduces the QA workload with fresh reference and engine paths, then
  passes the unchanged strict accuracy gates.
- No Nemotron streaming validation was run as part of this Canary-family
  receipt.
- Do not replace the direct offline restore with `from_pretrained`: current
  NeMo performs a remote existence probe before consulting its local archive
  cache.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `904d74959fdb92e35465c7c29770bf543224fd1b`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- This source-only change does not alter Bundle call sites, artifact naming, or format. It preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the three Canary speech-reference regressions passed in **0.07s**; source-quality passed **157 built-in tests in 20.56s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects exactly the five fixed platform fallbacks `deepseek_v2`, `ltx_video`, `patchtsmixer`, `segformer`, and `whisper` (`expected_count=5`). No direct Canary proof is added, and the bounded CPU regressions do not expand to a full-model roster.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **1h58m48s**, including shared queue delay; this is not added test execution time.

