### PR TITLE
fix(bark): restore seeded TTS accuracy

### DIFF
--- a/src/runtime/models/bark/bark_generation_plan.h
+++ b/src/runtime/models/bark/bark_generation_plan.h
@@ -66,15 +66,21 @@ inline int32_t compute_bark_coarse_steps(int32_t semantic_len, const BarkConfig&
     return std::max(frames * cfg.n_coarse_codebooks, 0);
 }
 
+inline float bark_semantic_to_coarse_ratio(const BarkConfig& cfg) {
+    return static_cast<float>(cfg.coarse_rate_hz) / cfg.semantic_rate_hz *
+           static_cast<float>(std::max(cfg.n_coarse_codebooks, 1));
+}
+
 inline std::vector<int32_t>
 build_bark_coarse_input_tokens(const std::vector<int32_t>& remapped_semantic,
                                const std::vector<int32_t>& coarse_tokens, const BarkConfig& cfg) {
     const int32_t semantic_len = static_cast<int32_t>(remapped_semantic.size());
     const int32_t total_generated = static_cast<int32_t>(coarse_tokens.size());
-    const int32_t max_semantic_history = static_cast<int32_t>(std::floor(
-        static_cast<float>(cfg.max_coarse_history) * cfg.semantic_rate_hz / cfg.coarse_rate_hz));
-    const int32_t semantic_idx = static_cast<int32_t>(std::round(
-        static_cast<float>(total_generated) * cfg.semantic_rate_hz / cfg.coarse_rate_hz));
+    const float semantic_to_coarse_ratio = bark_semantic_to_coarse_ratio(cfg);
+    const int32_t max_semantic_history = static_cast<int32_t>(
+        std::floor(static_cast<float>(cfg.max_coarse_history) / semantic_to_coarse_ratio));
+    const int32_t semantic_idx = static_cast<int32_t>(
+        std::round(static_cast<float>(total_generated) / semantic_to_coarse_ratio));
     const int32_t semantic_start = std::max(0, semantic_idx - max_semantic_history);
     const int32_t semantic_context_len =
         std::min(semantic_len - semantic_start, cfg.max_coarse_input_length);

--- a/src/runtime/models/bark/pipeline.cpp
+++ b/src/runtime/models/bark/pipeline.cpp
@@ -7,6 +7,7 @@
 
 #include "runtime/models/bark/bark_generation_plan.h"
 #include "runtime/models/bark/decode_runtime.h"
+#include "runtime/models/bark/sampler.h"
 #include "trtmc/tokenizer.h"
 
 #include <algorithm>
@@ -16,7 +17,6 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <numeric>
 #include <stdexcept>
 
 namespace trtmc {
@@ -92,16 +92,6 @@ void maybe_dump_tokens(const std::string& dump_path, const char* suffix,
     }
 }
 
-// Seed the sampler RNG from the request, falling back to audio_bark.seed.
-// A value of -1 (default) means "leave the RNG at its constructed state."
-void maybe_seed_bark_rng(std::mt19937& rng, std::int64_t seed) {
-    if (seed < 0)
-        return;
-    const auto converted = static_cast<std::mt19937::result_type>(seed);
-    rng.seed(converted);
-    std::cerr << "[trtmc] Bark: sampler seed=" << converted << std::endl;
-}
-
 std::vector<float> synthesize_simple_waveform(const std::vector<int32_t>& codes_flat,
                                               int32_t n_frames, const BarkConfig& cfg) {
     const int32_t samples_per_frame = cfg.sample_rate / cfg.coarse_rate_hz;
@@ -154,7 +144,7 @@ BarkPipeline::BarkPipeline(std::unique_ptr<TrtModule> semantic, std::unique_ptr<
       semantic_state_(std::move(semantic_state)), coarse_state_(std::move(coarse_state)),
       semantic_embed_(std::move(semantic_embed)), coarse_embed_(std::move(coarse_embed)),
       config_(std::move(config)), stream_(stream), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)) {
+      model_id_(std::move(model_id_str)), sampler_(std::make_unique<BarkSampler>(stream)) {
     if (!semantic_ || !semantic_->ok())
         throw std::runtime_error("BarkPipeline: invalid semantic module");
     if (!coarse_ || !coarse_->ok())
@@ -188,7 +178,12 @@ AudioResult BarkPipeline::generate_audio(const std::string& prompt, const Genera
 
     // A public request seed takes precedence over the session-level
     // audio_bark.seed fallback populated by bark_plugin.cpp.
-    maybe_seed_bark_rng(rng_, resolve_bark_seed(config_.seed, cfg.seed));
+    const int64_t sampler_seed = resolve_bark_seed(config_.seed, cfg.seed);
+    sampler_->reset(sampler_seed);
+    if (sampler_seed >= 0) {
+        std::cerr << "[trtmc] Bark: sampler seed=" << sampler_seed
+                  << ", type=" << sampler_->sampler_type() << std::endl;
+    }
 
     std::cerr << "[trtmc] Bark: starting pipeline with " << input_ids.size()
               << " text tokens, max_semantic=" << max_tokens << (config_.greedy ? " (greedy)" : "")
@@ -322,34 +317,7 @@ int32_t BarkPipeline::sample_top_k(const float* logits, int32_t vocab_size, floa
         return best;
     }
 
-    top_k = std::min(top_k, vocab_size);
-    std::vector<int32_t> indices(static_cast<std::size_t>(vocab_size));
-    std::iota(indices.begin(), indices.end(), 0);
-    if (top_k < vocab_size) {
-        std::partial_sort(indices.begin(), indices.begin() + top_k, indices.end(),
-                          [logits](int32_t a, int32_t b) { return logits[a] > logits[b]; });
-    }
-
-    std::vector<float> probs(static_cast<std::size_t>(top_k));
-    const float max_logit =
-        top_k < vocab_size ? logits[indices[0]] : *std::max_element(logits, logits + vocab_size);
-    float sum = 0.0F;
-    for (int32_t i = 0; i < top_k; ++i) {
-        probs[i] = std::exp((logits[indices[i]] - max_logit) / temperature);
-        sum += probs[i];
-    }
-    for (int32_t i = 0; i < top_k; ++i)
-        probs[i] /= sum;
-
-    std::uniform_real_distribution<float> dist(0.0F, 1.0F);
-    float r = dist(rng_);
-    float cumulative = 0.0F;
-    for (int32_t i = 0; i < top_k; ++i) {
-        cumulative += probs[i];
-        if (r < cumulative)
-            return indices[i];
-    }
-    return indices[top_k - 1];
+    return sampler_->sample(logits, vocab_size, temperature, top_k);
 }
 
 // ---------------------------------------------------------------------------
@@ -394,7 +362,7 @@ std::vector<int32_t> BarkPipeline::run_semantic(const std::vector<int32_t>& text
             break;
         suppress_semantic_logits(logits, cfg.semantic_pad_token);
 
-        const int32_t token = sample_top_k(logits.data(), cfg.semantic_pad_token + 1,
+        const int32_t token = sample_top_k(logits.data(), static_cast<int32_t>(logits.size()),
                                            cfg.semantic_temperature, cfg.top_k);
         if (token == cfg.semantic_pad_token)
             break;
@@ -535,11 +503,15 @@ std::vector<int32_t> BarkPipeline::run_fine(const std::vector<int32_t>& coarse_t
 
         if (bark_fine_uses_sampling(cfg)) {
             const int32_t valid_range = std::min(cfg.codebook_size, fine_cb_size);
+            // HF samples every padded frame in one batched torch.multinomial call,
+            // then discards the padded tail. Preserve that RNG consumption so the
+            // next codebook starts at the same Philox offset.
+            const std::vector<int32_t> sampled_tokens =
+                sampler_->sample_rows(host_logits.data(), max_seq, fine_cb_size, valid_range,
+                                      cfg.fine_temperature, valid_range);
             for (int32_t frame = 0; frame < plan.actual_frames; ++frame) {
-                const float* frame_logits =
-                    host_logits.data() + static_cast<std::size_t>(frame) * fine_cb_size;
                 codes[static_cast<std::size_t>(cb_idx) * plan.n_frames + frame] =
-                    sample_top_k(frame_logits, valid_range, cfg.fine_temperature, valid_range);
+                    sampled_tokens[static_cast<std::size_t>(frame)];
             }
         } else {
             update_fine_codes_from_logits(codes, host_logits, cb_idx, plan.n_frames,

--- a/src/runtime/models/bark/pipeline.h
+++ b/src/runtime/models/bark/pipeline.h
@@ -19,11 +19,12 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <memory>
-#include <random>
 #include <string>
 #include <vector>
 
 namespace trtmc {
+
+class BarkSampler;
 
 class BarkPipeline final : public IPipeline {
   public:
@@ -72,7 +73,7 @@ class BarkPipeline final : public IPipeline {
     cudaStream_t stream_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
-    std::mt19937 rng_{std::random_device{}()};
+    std::unique_ptr<BarkSampler> sampler_;
 };
 
 } // namespace trtmc

--- a/src/runtime/models/bark/sampler.cpp
+++ b/src/runtime/models/bark/sampler.cpp
@@ -1,0 +1,239 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/bark/sampler.h"
+
+#if TRTMC_HAS_CUDA_KERNELS
+#include "runtime/models/bark/sparse_multinomial_kernel.h"
+
+#include <cuda_runtime.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <random>
+#include <vector>
+
+namespace trtmc {
+
+namespace {
+
+struct FilteredDistribution {
+    std::vector<int32_t> indices;
+    std::vector<float> probabilities;
+    int32_t rows{0};
+    int32_t vocab_size{0};
+    int32_t keep{0};
+};
+
+FilteredDistribution build_filtered_distributions(const float* logits, int32_t rows,
+                                                  int32_t row_stride, int32_t vocab_size,
+                                                  float temperature, int32_t top_k) {
+    const int32_t keep = std::max(1, std::min(top_k, vocab_size));
+    FilteredDistribution distribution;
+    distribution.rows = rows;
+    distribution.vocab_size = vocab_size;
+    distribution.keep = keep;
+    distribution.indices.resize(static_cast<std::size_t>(rows) * keep);
+    distribution.probabilities.resize(static_cast<std::size_t>(rows) * keep);
+    const float safe_temperature = std::max(temperature, 1e-6F);
+    std::vector<int32_t> row_indices(static_cast<std::size_t>(vocab_size));
+    for (int32_t row = 0; row < rows; ++row) {
+        const float* row_logits = logits + static_cast<std::size_t>(row) * row_stride;
+        std::iota(row_indices.begin(), row_indices.end(), 0);
+        if (keep < vocab_size) {
+            std::partial_sort(row_indices.begin(), row_indices.begin() + keep, row_indices.end(),
+                              [row_logits](int32_t lhs, int32_t rhs) {
+                                  return row_logits[lhs] > row_logits[rhs];
+                              });
+        }
+
+        const int32_t max_token = *std::max_element(
+            row_indices.begin(), row_indices.begin() + keep,
+            [row_logits](int32_t lhs, int32_t rhs) { return row_logits[lhs] < row_logits[rhs]; });
+        const float normalizer_logit = row_logits[max_token];
+        const std::size_t output_offset = static_cast<std::size_t>(row) * keep;
+        float normalizer = 0.0F;
+        for (int32_t index = 0; index < keep; ++index) {
+            const int32_t token_id = row_indices[static_cast<std::size_t>(index)];
+            const float probability =
+                std::exp((row_logits[token_id] - normalizer_logit) / safe_temperature);
+            distribution.indices[output_offset + index] = token_id;
+            distribution.probabilities[output_offset + index] = probability;
+            normalizer += probability;
+        }
+        for (int32_t index = 0; index < keep; ++index) {
+            distribution.probabilities[output_offset + index] /= normalizer;
+        }
+    }
+    return distribution;
+}
+
+} // namespace
+
+class BarkSampler::Impl {
+  public:
+    explicit Impl(void* stream)
+#if TRTMC_HAS_CUDA_KERNELS
+        : stream_(static_cast<cudaStream_t>(stream))
+#endif
+    {
+#if TRTMC_HAS_CUDA_KERNELS
+        ensure_device_buffers(1, 1);
+#else
+        (void)stream;
+#endif
+    }
+
+    ~Impl() {
+#if TRTMC_HAS_CUDA_KERNELS
+        cudaFree(device_indices_);
+        cudaFree(device_probabilities_);
+        cudaFree(device_token_ids_);
+#endif
+    }
+
+    void reset(int64_t seed) {
+        if (seed < 0) {
+            return;
+        }
+#if TRTMC_HAS_CUDA_KERNELS
+        seed_ = static_cast<uint64_t>(seed);
+        current_offset_ = 0;
+#else
+        rng_.seed(static_cast<std::mt19937::result_type>(seed));
+#endif
+    }
+
+    int32_t sample(const float* logits, int32_t vocab_size, float temperature, int32_t top_k) {
+        const std::vector<int32_t> tokens =
+            sample_rows(logits, 1, vocab_size, vocab_size, temperature, top_k);
+        return tokens.empty() ? 0 : tokens.front();
+    }
+
+    std::vector<int32_t> sample_rows(const float* logits, int32_t rows, int32_t row_stride,
+                                     int32_t vocab_size, float temperature, int32_t top_k) {
+        if (logits == nullptr || rows <= 0 || row_stride < vocab_size || vocab_size <= 0) {
+            return {};
+        }
+        const FilteredDistribution distribution =
+            build_filtered_distributions(logits, rows, row_stride, vocab_size, temperature, top_k);
+        std::vector<int32_t> selected_tokens(static_cast<std::size_t>(rows));
+
+#if TRTMC_HAS_CUDA_KERNELS
+        const int32_t numel = rows * vocab_size;
+        ensure_execution_policy(numel);
+        ensure_device_buffers(static_cast<int32_t>(distribution.indices.size()), rows);
+        const std::size_t index_bytes = distribution.indices.size() * sizeof(int32_t);
+        const std::size_t probability_bytes = distribution.probabilities.size() * sizeof(float);
+        cudaMemcpyAsync(device_indices_, distribution.indices.data(), index_bytes,
+                        cudaMemcpyHostToDevice, stream_);
+        cudaMemcpyAsync(device_probabilities_, distribution.probabilities.data(), probability_bytes,
+                        cudaMemcpyHostToDevice, stream_);
+        bark_gpu_sparse_torch_multinomial_exact(
+            device_indices_, device_probabilities_, distribution.rows, distribution.vocab_size,
+            distribution.keep, seed_, current_offset_, total_threads_, device_token_ids_, stream_);
+        cudaMemcpyAsync(selected_tokens.data(), device_token_ids_,
+                        selected_tokens.size() * sizeof(int32_t), cudaMemcpyDeviceToHost, stream_);
+        cudaStreamSynchronize(stream_);
+        current_offset_ += counter_offset_;
+        return selected_tokens;
+#else
+        std::uniform_real_distribution<float> random(0.0F, 1.0F);
+        for (int32_t row = 0; row < rows; ++row) {
+            const float selected = random(rng_);
+            const std::size_t row_offset = static_cast<std::size_t>(row) * distribution.keep;
+            float cumulative = 0.0F;
+            int32_t token = distribution.indices[row_offset + distribution.keep - 1];
+            for (int32_t index = 0; index < distribution.keep; ++index) {
+                cumulative += distribution.probabilities[row_offset + index];
+                if (selected < cumulative) {
+                    token = distribution.indices[row_offset + index];
+                    break;
+                }
+            }
+            selected_tokens[static_cast<std::size_t>(row)] = token;
+        }
+        return selected_tokens;
+#endif
+    }
+
+    const char* sampler_type() const {
+#if TRTMC_HAS_CUDA_KERNELS
+        return "torch_cuda_multinomial";
+#else
+        return "host_multinomial";
+#endif
+    }
+
+  private:
+#if TRTMC_HAS_CUDA_KERNELS
+    void ensure_device_buffers(int32_t entries, int32_t rows) {
+        if (entries > entry_capacity_) {
+            cudaFree(device_indices_);
+            cudaFree(device_probabilities_);
+            cudaMalloc(&device_indices_, static_cast<std::size_t>(entries) * sizeof(int32_t));
+            cudaMalloc(&device_probabilities_, static_cast<std::size_t>(entries) * sizeof(float));
+            entry_capacity_ = entries;
+        }
+        if (rows > row_capacity_) {
+            cudaFree(device_token_ids_);
+            cudaMalloc(&device_token_ids_, static_cast<std::size_t>(rows) * sizeof(int32_t));
+            row_capacity_ = rows;
+        }
+    }
+
+    void ensure_execution_policy(int32_t numel) {
+        if (numel == cached_numel_) {
+            return;
+        }
+        const BarkTorchMultinomialExecutionPolicy policy =
+            bark_compute_torch_multinomial_execution_policy(numel);
+        cached_numel_ = numel;
+        total_threads_ = policy.total_threads;
+        counter_offset_ = policy.counter_offset;
+    }
+
+    uint64_t seed_{0};
+    uint64_t current_offset_{0};
+    cudaStream_t stream_{nullptr};
+    int32_t* device_indices_{nullptr};
+    float* device_probabilities_{nullptr};
+    int32_t* device_token_ids_{nullptr};
+    int32_t entry_capacity_{0};
+    int32_t row_capacity_{0};
+    int32_t cached_numel_{-1};
+    int32_t total_threads_{0};
+    uint64_t counter_offset_{0};
+#else
+    std::mt19937 rng_{std::random_device{}()};
+#endif
+};
+
+BarkSampler::BarkSampler(void* stream) : impl_(std::make_unique<Impl>(stream)) {}
+
+BarkSampler::~BarkSampler() = default;
+
+void BarkSampler::reset(int64_t seed) {
+    impl_->reset(seed);
+}
+
+int32_t BarkSampler::sample(const float* logits, int32_t vocab_size, float temperature,
+                            int32_t top_k) {
+    return impl_->sample(logits, vocab_size, temperature, top_k);
+}
+
+std::vector<int32_t> BarkSampler::sample_rows(const float* logits, int32_t rows, int32_t row_stride,
+                                              int32_t vocab_size, float temperature,
+                                              int32_t top_k) {
+    return impl_->sample_rows(logits, rows, row_stride, vocab_size, temperature, top_k);
+}
+
+const char* BarkSampler::sampler_type() const {
+    return impl_->sampler_type();
+}
+
+} // namespace trtmc

--- a/src/runtime/models/bark/sampler.h
+++ b/src/runtime/models/bark/sampler.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace trtmc {
+
+// Bark-owned sampling state shared by the semantic, coarse, and fine stages.
+//
+// The CUDA implementation follows PyTorch's CUDA multinomial RNG mapping so
+// that a request seed has the same meaning as the Hugging Face Bark reference.
+// Builds without the optional CUDA sampling bridge retain a host fallback.
+class BarkSampler {
+  public:
+    explicit BarkSampler(void* stream);
+    ~BarkSampler();
+
+    BarkSampler(const BarkSampler&) = delete;
+    BarkSampler& operator=(const BarkSampler&) = delete;
+
+    void reset(int64_t seed);
+    int32_t sample(const float* logits, int32_t vocab_size, float temperature, int32_t top_k);
+    std::vector<int32_t> sample_rows(const float* logits, int32_t rows, int32_t row_stride,
+                                     int32_t vocab_size, float temperature, int32_t top_k);
+
+    const char* sampler_type() const;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/bark/sparse_multinomial_kernel.cu
+++ b/src/runtime/models/bark/sparse_multinomial_kernel.cu
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/bark/sparse_multinomial_kernel.h"
+
+#include <algorithm>
+#include <cfloat>
+#include <curand_kernel.h>
+#include <limits>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int kDistributionBlockSize = 256;
+constexpr int kSamplerBlockSize = 128;
+constexpr uint64_t kGeneratorOffsetsPerCurandCall = 4;
+
+__device__ float torch_exponential_from_uniform(float value) {
+    const float log_value = value >= 1.0F - FLT_EPSILON / 2.0F ? -FLT_EPSILON / 2.0F : logf(value);
+    return -log_value;
+}
+
+__global__ void sparse_multinomial_exact_kernel(const int32_t* __restrict__ indices,
+                                                const float* __restrict__ probabilities,
+                                                int32_t rows, int32_t vocab_size, int32_t keep,
+                                                uint64_t seed, uint64_t base_offset,
+                                                int32_t total_threads,
+                                                int32_t* __restrict__ out_token_ids) {
+    __shared__ float scores[kSamplerBlockSize];
+    __shared__ int32_t tokens[kSamplerBlockSize];
+
+    const int32_t row = static_cast<int32_t>(blockIdx.x);
+    if (row >= rows) {
+        return;
+    }
+    const int32_t row_offset = row * keep;
+    const int thread_id = threadIdx.x;
+    float best_score = -FLT_MAX;
+    int32_t best_token = 0;
+
+    for (int32_t index = thread_id; index < keep; index += blockDim.x) {
+        const int32_t token_id = indices[row_offset + index];
+        const int64_t linear_index =
+            static_cast<int64_t>(row) * vocab_size + static_cast<int64_t>(token_id);
+        const int64_t quotient = linear_index / total_threads;
+        const uint64_t loop_iteration = static_cast<uint64_t>(quotient / 4);
+        const int component = static_cast<int>(quotient % 4);
+        const int64_t subsequence = linear_index % total_threads;
+
+        curandStatePhilox4_32_10_t state;
+        curand_init(seed, static_cast<unsigned long long>(subsequence),
+                    base_offset + kGeneratorOffsetsPerCurandCall * loop_iteration, &state);
+        const float4 random = curand_uniform4(&state);
+        const float uniform = component == 0   ? random.x
+                              : component == 1 ? random.y
+                              : component == 2 ? random.z
+                                               : random.w;
+        const float score =
+            probabilities[row_offset + index] / torch_exponential_from_uniform(uniform);
+        if (score > best_score) {
+            best_score = score;
+            best_token = token_id;
+        }
+    }
+
+    scores[thread_id] = best_score;
+    tokens[thread_id] = best_token;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (thread_id < stride && scores[thread_id + stride] > scores[thread_id]) {
+            scores[thread_id] = scores[thread_id + stride];
+            tokens[thread_id] = tokens[thread_id + stride];
+        }
+        __syncthreads();
+    }
+
+    if (thread_id == 0) {
+        out_token_ids[row] = tokens[0];
+    }
+}
+
+} // namespace
+
+BarkTorchMultinomialExecutionPolicy bark_compute_torch_multinomial_execution_policy(int32_t numel) {
+    if (numel <= 0) {
+        return {};
+    }
+
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceProp properties{};
+    cudaGetDeviceProperties(&properties, device);
+
+    const uint32_t blocks_per_sm =
+        static_cast<uint32_t>(properties.maxThreadsPerMultiProcessor / kDistributionBlockSize);
+    const uint32_t grid =
+        std::min(static_cast<uint32_t>(properties.multiProcessorCount) * blocks_per_sm,
+                 static_cast<uint32_t>((static_cast<uint64_t>(numel) + kDistributionBlockSize - 1) /
+                                       kDistributionBlockSize));
+    const uint64_t total_threads = static_cast<uint64_t>(grid) * kDistributionBlockSize;
+    const uint64_t counter_offset =
+        ((static_cast<uint64_t>(numel) - 1) / (total_threads * kGeneratorOffsetsPerCurandCall) +
+         1) *
+        kGeneratorOffsetsPerCurandCall;
+
+    BarkTorchMultinomialExecutionPolicy policy;
+    policy.total_threads = static_cast<int32_t>(total_threads);
+    policy.counter_offset = counter_offset;
+    return policy;
+}
+
+void bark_gpu_sparse_torch_multinomial_exact(const int32_t* d_indices, const float* d_probs,
+                                             int32_t rows, int32_t vocab_size, int32_t keep,
+                                             uint64_t seed, uint64_t base_offset,
+                                             int32_t total_threads, int32_t* d_token_ids,
+                                             cudaStream_t stream) {
+    if (rows <= 0 || vocab_size <= 0 || keep <= 0 || d_indices == nullptr || d_probs == nullptr ||
+        d_token_ids == nullptr || total_threads <= 0) {
+        return;
+    }
+
+    sparse_multinomial_exact_kernel<<<rows, kSamplerBlockSize, 0, stream>>>(
+        d_indices, d_probs, rows, vocab_size, keep, seed, base_offset, total_threads, d_token_ids);
+}
+
+} // namespace trtmc

--- a/src/runtime/models/bark/sparse_multinomial_kernel.h
+++ b/src/runtime/models/bark/sparse_multinomial_kernel.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+struct BarkTorchMultinomialExecutionPolicy {
+    int32_t total_threads{0};
+    uint64_t counter_offset{0};
+};
+
+BarkTorchMultinomialExecutionPolicy bark_compute_torch_multinomial_execution_policy(int32_t numel);
+
+void bark_gpu_sparse_torch_multinomial_exact(const int32_t* d_indices, const float* d_probs,
+                                             int32_t rows, int32_t vocab_size, int32_t keep,
+                                             uint64_t seed, uint64_t base_offset,
+                                             int32_t total_threads, int32_t* d_token_ids,
+                                             cudaStream_t stream);
+
+} // namespace trtmc

--- a/tests/cpp/models/bark/test_bark_generation_plan.cpp
+++ b/tests/cpp/models/bark/test_bark_generation_plan.cpp
@@ -72,6 +72,22 @@ void test_coarse_window_plan_builds_context_and_history() {
     check(window.input_tokens.back() == 20004, "bark window plan appends generated history");
 }
 
+void test_coarse_window_semantic_alignment_counts_codebooks() {
+    trtmc::BarkConfig cfg = make_config();
+    cfg.max_coarse_history = 4;
+    const auto coarse_plan = trtmc::make_bark_coarse_plan({10, 11, 12, 13, 14}, cfg);
+    const std::vector<int32_t> generated_tokens = {
+        20001, 20002, 20003, 20004, 20005, 20006, 20007, 20008,
+    };
+
+    const auto window = trtmc::make_bark_coarse_window_plan(coarse_plan, generated_tokens, cfg);
+
+    check(window.input_tokens[0] == 11,
+          "bark coarse window converts interleaved codebook tokens to semantic time");
+    check(window.input_tokens[1] == 12 && window.input_tokens[3] == 14,
+          "bark coarse window preserves HF semantic context alignment");
+}
+
 void test_codec_plan_prefers_fine_codes_when_available() {
     const std::vector<int32_t> fine_codes(16, 7);
     const std::vector<int32_t> coarse_tokens(12, 3);
@@ -184,6 +200,7 @@ void test_codec_input_builder_transposes_codebooks() {
 int main() {
     test_coarse_plan_derives_total_steps_and_windows();
     test_coarse_window_plan_builds_context_and_history();
+    test_coarse_window_semantic_alignment_counts_codebooks();
     test_codec_plan_prefers_fine_codes_when_available();
     test_fine_plan_and_code_initialization();
     test_fine_sampling_policy_matches_hf();

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -3614,6 +3614,100 @@ def test_tts_intelligibility_gate_accepts_matching_correctness() -> None:
     assert result["status"] == "passed"
 
 
+@pytest.mark.parametrize(
+    ("bundle_seconds", "expected_status", "expected_drop", "expected_agreement"),
+    [
+        (2.5, "failed", 1.0, 0.0),
+        (1.0, "passed", 0.0, 1.0),
+    ],
+)
+def test_eval_one_model_applies_tts_accuracy_gates(
+    tmp_path: Path,
+    monkeypatch,
+    bundle_seconds: float,
+    expected_status: str,
+    expected_drop: float,
+    expected_agreement: float,
+) -> None:
+    dataset = tmp_path / "SeedTTS_en_meta" / "seedtts_en_meta.json"
+    dataset.parent.mkdir()
+    _write_seedtts(dataset)
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(), "seedtts_en_tts_intelligibility"
+    )
+    model = {
+        "name": "bark-large",
+        "hf_id": "suno/bark",
+        "family": "bark",
+        "bundle": "bark-large.bundle",
+        "max_cache_length": 1024,
+        "precision": "fp32",
+        "trust_remote_code": False,
+        "build_args": {},
+        "quantization": {},
+    }
+
+    def fake_run_hf(_args, _model, work_dir):
+        wav_path = work_dir / "hf_audio" / "seedtts-1.wav"
+        _write_pcm_wav(wav_path)
+        validation_engine.write_predictions(
+            work_dir / "hf_predictions.json",
+            [
+                {
+                    "sample_id": "seedtts-1",
+                    "output_text": "The test sentence.",
+                    "wav_path": str(wav_path),
+                }
+            ],
+        )
+
+    def fake_ensure_bundle(*_args, **kwargs):
+        bundle = kwargs["bundle_path"]
+        bundle.parent.mkdir(parents=True, exist_ok=True)
+        bundle.write_bytes(b"bundle")
+        return bundle, True
+
+    def fake_run_bundle(args):
+        wav_path = Path(args.work_dir) / "bundle_audio" / "seedtts-1.wav"
+        _write_pcm_wav(wav_path, seconds=bundle_seconds)
+        validation_engine.write_predictions(
+            Path(args.work_dir) / "bundle_predictions.json",
+            [
+                {
+                    "sample_id": "seedtts-1",
+                    "output_text": "The test sentence.",
+                    "wav_path": str(wav_path),
+                }
+            ],
+        )
+
+    monkeypatch.setattr(validation_engine, "run_hf_reference_subprocess", fake_run_hf)
+    monkeypatch.setattr(validation_engine, "ensure_bundle", fake_ensure_bundle)
+    monkeypatch.setattr(validation_engine, "run_bundle", fake_run_bundle)
+    args = validation_engine.build_arg_parser().parse_args(
+        [
+            "eval",
+            "--dataset",
+            str(dataset),
+            "--work-root",
+            str(tmp_path / "work"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--model",
+            model["name"],
+            "--local-files-only",
+        ]
+    )
+
+    result = validation_engine.eval_one_model(suite=suite, model=model, args=args)
+
+    assert result["hf_accuracy"] == 1.0
+    assert result["bundle_accuracy"] == 1.0 - expected_drop
+    assert result["pass_rate_drop_from_hf"] == expected_drop
+    assert result["correctness_agreement_rate"] == expected_agreement
+    assert result["status"] == expected_status
+
+
 def test_run_tts_bundle_generates_audio_and_batches_asr(tmp_path: Path, monkeypatch) -> None:
     dataset = tmp_path / "SeedTTS_en_meta" / "seedtts_en_meta.json"
     dataset.parent.mkdir()


### PR DESCRIPTION
## Background

An all-model QA run reported Bark TTS accuracy regressions. A fresh report-equivalent rerun on GB300 / TensorRT 11.2.0.113 reproduced two independent problems:

- Bark runtime output diverged from the Hugging Face seeded reference. The fresh r4 receipt had Bark-large at HF `1.0` versus TRTMC `0.3333`, and Bark-small at HF `1.0` versus TRTMC `0.6667`.
- The TTS evaluator still returned `passed` because the generic prediction branch did not publish the TTS gate metrics or call `apply_metric_gates`.

The runtime divergence had two Bark-owned causes. Coarse sliding-window alignment omitted `n_coarse_codebooks` from the semantic-to-coarse ratio, and C++ used `std::mt19937` row-by-row while Transformers 5.2 uses one continued PyTorch CUDA Philox/multinomial stream across semantic, coarse, and batched padded fine frames. Separately, `task_eval` dropped manifest `build_env`, so Bark-small task builds ignored its verified timing-cache contract.

## Exit Criteria

- Bark-large and Bark-small each pass all three SeedTTS samples with the existing WER, NED, RMS, and duration thresholds.
- Existing suite gates (`max_pass_rate_drop_from_hf: 0.05`, `min_correctness_agreement: 0.95`) fail the reproduced r4 result and pass the fixed result.
- Task builds honor Bark-small's model-relative verified timing cache.
- The added guards are synthetic/unit checks. Because this PR changes Bark runtime code, exact-head impact still runs the existing direct `bark` proof; it adds no second Bark row, Whisper job, or fallback fan-out.
- No accuracy threshold is weakened.

## Implementation

- Add a Bark-owned CUDA multinomial sampler that follows PyTorch's Philox index/offset mapping, including one batched fine-stage draw over padded frames. CUDA-less builds retain the host fallback.
- Sample the full semantic output vocabulary so suppressed token positions still preserve PyTorch RNG indexing.
- Include both coarse codebooks in semantic-window alignment.
- Preserve and resolve manifest `build_env` entries in `task_eval.ensure_bundle`, with an explicitly selected CUDA device taking precedence.
- Emit `pass_rate_drop_from_hf` and correctness agreement for TTS, then apply the suite's existing gates.
- Add fail/pass evaluator coverage, model-relative build-env coverage, and a coarse-window regression test.

## Validation

Validated at historical fix head `ab1cc950368ed02080af211734c8762f8b13f7ad`.

- Before the evaluator fix, `PYTHONPATH=python python -m pytest tests/tools/test_task_eval.py::test_eval_one_model_applies_tts_accuracy_gates -q` failed with missing `pass_rate_drop_from_hf`; after the fix, both bad/good cases pass.
- `cmake --build <build-dir> --target trtmc_model_bark test_bark_generation_plan test_bark_config_schema -j8`: passed, including the Bark CUDA sampler/kernel build.
- `ctest --test-dir <build-dir> --output-on-failure -R 'test_bark_generation_plan|test_bark_config_schema'`: 2/2 passed in 0.34 s.
- `ctest --test-dir <build-dir> --output-on-failure -R '^test_bark_pipeline$'`: 1/1 passed in 5.61 s on GB300.
- `PYTHONPATH=python python3 -m pytest tests/tools/test_task_eval.py tests/tools/test_model_plugin_encapsulation_static.py tests/e2e/models/bark/test_bark_build_contract.py tests/e2e/models/bark/test_bark_timing_cache.py tests/e2e/models/bark/test_bark_runner_cli_alignment.py tests/e2e/models/bark/test_bark_hf_reference.py -q`: 389 passed in 29.51 s.
- `ruff check tools/task_eval.py tests/tools/test_task_eval.py`, `clang-format --dry-run --Werror ...`, `python tools/legal_headers.py --check`, and `git diff --check github/main...HEAD`: passed.

Report-equivalent model proof used NVIDIA GB300 with TensorRT 11.2, the r4 staged bundles, the original cached HF predictions, the same three SeedTTS samples, and the same Whisper scorer. HF snapshots were `suno/bark@70a8a7d34168586dc5d028fa9666aceade177992` and `suno/bark-small@1dbd7a128513b8ae4a4e2130fed57b7ac9da5bcd`.

- Bark-large: HF `1.0`, TRTMC `1.0`, correctness agreement `1.0`; 3/3 correct, every WER `0.0`, durations `2.64 / 5.16 / 8.9733` s. Summary SHA-256: `9c116a246efa71ee60d6ba9b85d8c0c796f4687dc653f8ee33602a9b8a958c9f`.
- Bark-small: HF `1.0`, TRTMC `1.0`, correctness agreement `1.0`; 3/3 correct, every WER `0.0`, durations `2.6133 / 4.04 / 6.9733` s. Summary SHA-256: `7e449c1bda0bfb9d4ae7acf99f12ba268e04efc247f4b8495d34bbecf3c00826`.
- Gate replay classifies the original r4 Bark-large receipt as `BenchmarkGateError` (`pass_rate_drop_from_hf=0.6667`, `correctness_agreement=0.3333`) and both fixed receipts as `passed` (`0.0`, `1.0`).
- A fresh Bark-small build through `task_eval.ensure_bundle` consumed the manifest's verified cache SHA-256 `fd5877cddb8c989017f18ee1084c6d2f4f2c69e89027e21803931f4e26ba14bc`, completed in 226.4 s, and independently passed the same 3/3 proof. Bundle SHA-256: `4f81fbdce4520db10623420df2b37e7c5eb19ab37519373dad3b54985f2fb2d2`; summary SHA-256: `019411c07255ff28da9e2ac8112699f8a0519ff7b965d5256c976a1e762de999`.

## Notes For Future Readers

Review the two `task_eval` tests first: they capture why the dashboard false-passed and why verified builds drifted. Then review the Bark coarse ratio and sampler together; the Philox offset must remain continuous across semantic, coarse, and the six batched fine codebooks. Converting fine sampling back to per-frame draws will preserve distributions but break seeded parity.

The model proof reuses the existing QA suite and unchanged gates. The added guards are synthetic and CPU-only. Because Bark runtime code changes, current exact-head impact still runs the existing direct `bark` proof; it adds no second Bark row, fallback, or Whisper job.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `6da2523807869e0a5187a09dd2032f562f186313`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The Bark accuracy repair uses the current Bundle evaluator and `.bundle` fixture schema. It preserves the `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the validation-engine suite passed **253 tests, 1 skipped in 8.83s**; the focused Bark CTest targets passed **2/2**; source-quality passed **157 built-in tests in 20.48s** plus Bark changed-file C++ format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects exactly one direct model proof, `bark` (`expected_count=1`), with no fallback or Whisper expansion. The CPU/static guards reuse that bounded existing proof instead of adding a second Bark row or a full-model lane.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **1h53m10s**, including shared queue delay; this is not added test execution time.

