### PR TITLE
fix(deepseek-ocr): restore BF16 accuracy validation

### DIFF
--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
@@ -31,6 +31,10 @@
       "reference_backend": "hf_transformers",
       "reference_family": "ocr_markdown",
       "user_contract": "ocr_text",
+      "task_eval": {
+        "reference_precision": "bf16",
+        "allow_reference_precision_mismatch": true
+      },
       "metadata": {
         "contract_config": {
           "use_processor": true,

--- a/tests/tools/test_deepseek_ocr_task_eval.py
+++ b/tests/tools/test_deepseek_ocr_task_eval.py
@@ -144,7 +144,7 @@ def test_c829_deepseek_ocr_receipt_passes_declared_parity_gates() -> None:
             # QA run trtmc-validate-gb300-2-20260726-c8291be0-all105,
             # five-sample DeepSeek-OCR receipt.
             "hf": {"overall_accuracy": 0.6},
-            "trtfb": {"overall_accuracy": 0.6},
+            "bundle": {"overall_accuracy": 0.6},
             "prediction_agreement_rate": 1.0,
         },
         suite["gates"],
@@ -163,7 +163,7 @@ def test_deepseek_ocr_bad_receipt_fails_both_parity_gates() -> None:
     result = validation_engine.prediction_agreement_gate_result(
         {
             "hf": {"overall_accuracy": 0.6},
-            "trtfb": {"overall_accuracy": 0.4},
+            "bundle": {"overall_accuracy": 0.4},
             "prediction_agreement_rate": 0.8,
         },
         suite["gates"],

--- a/tests/tools/test_deepseek_ocr_task_eval.py
+++ b/tests/tools/test_deepseek_ocr_task_eval.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only validation precision tests for DeepSeek-OCR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tools.reference import transformers_vlm
+from tools.validation import catalog as validation_catalog
+from tools.validation import engine as validation_engine
+
+
+_MANIFEST_PATH = (
+    validation_catalog.REPO_ROOT
+    / "tests"
+    / "e2e"
+    / "models"
+    / "deepseek_ocr"
+    / "manifests"
+    / "deepseek-ocr.json"
+)
+
+
+def _write_vlm_inputs(tmp_path: Path, *, dtype: str) -> argparse.Namespace:
+    prompts = tmp_path / "prompts.jsonl"
+    answers = tmp_path / "answers.json"
+    manifest = tmp_path / "manifest.json"
+    prompts.write_text(
+        json.dumps(
+            {
+                "sample_id": "ocrbench_v2_000000",
+                "prompt": "Read the image.",
+                "images": ["/dataset/image.jpg"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    answers.write_text(
+        json.dumps({"requests": [{"answer": "recognized text"}]}),
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps({"generation": {"max_new_tokens": 32}}),
+        encoding="utf-8",
+    )
+    return transformers_vlm.build_parser().parse_args(
+        [
+            "--model",
+            "deepseek-ai/DeepSeek-OCR-2",
+            "--prompts",
+            str(prompts),
+            "--answers",
+            str(answers),
+            "--manifest",
+            str(manifest),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--dtype",
+            dtype,
+            "--device",
+            "cpu",
+            "--trust-remote-code",
+            "--local-files-only",
+        ]
+    )
+
+
+def test_deepseek_ocr_declares_model_owned_bf16_reference(
+    tmp_path: Path,
+) -> None:
+    raw_manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    model = validation_catalog.manifest_record(_MANIFEST_PATH)
+    suite = validation_catalog.resolve_suite_for_model(
+        validation_engine.suite_by_id(
+            validation_engine.load_suites(),
+            "ocrbench_v2_unified",
+        ),
+        model,
+    )
+    config = validation_engine.effective_validation_config(suite, model)
+
+    assert raw_manifest["precision"] == "fp16"
+    assert raw_manifest["fp32_layers"] == [6, 7, 8, 9, 10, 11, 12]
+    assert raw_manifest["testcases"][0]["reference_precision"] == "bf16"
+    assert config["reference_precision"] == "bf16"
+    assert config["allow_reference_precision_mismatch"] is True
+
+    work_dir = tmp_path / "deepseek-ocr"
+    work_dir.mkdir()
+    (work_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_kind": "vlm_unified_json",
+                "task_eval": config,
+            }
+        ),
+        encoding="utf-8",
+    )
+    contract = validation_engine.resolve_reference_precision_contract(
+        argparse.Namespace(hf_dtype="auto"),
+        model,
+        work_dir,
+    )
+
+    assert model["precision"] == "fp16"
+    assert contract == {
+        "trtmc_base_precision": "fp16",
+        "trtmc_quantization": "none",
+        "reference_precision": "bf16",
+        "reference_dtype": "bfloat16",
+        "comparison": "reference_defined",
+    }
+    assert suite["gates"] == {
+        "max_accuracy_drop_from_hf": 0.02,
+        "min_prediction_agreement": 0.95,
+    }
+    assert (
+        validation_engine.resolve_hf_reference_dtype(
+            argparse.Namespace(hf_dtype="auto"),
+            model,
+            work_dir,
+        )
+        == "bfloat16"
+    )
+
+
+def test_c829_deepseek_ocr_receipt_passes_declared_parity_gates() -> None:
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(),
+        "ocrbench_v2_unified",
+    )
+    result = validation_engine.prediction_agreement_gate_result(
+        {
+            # QA run trtmc-validate-gb300-2-20260726-c8291be0-all105,
+            # five-sample DeepSeek-OCR receipt.
+            "hf": {"overall_accuracy": 0.6},
+            "trtfb": {"overall_accuracy": 0.6},
+            "prediction_agreement_rate": 1.0,
+        },
+        suite["gates"],
+    )
+
+    assert result["status"] == "passed"
+    assert result["accuracy_drop_from_hf"] == 0.0
+    assert result["gate_failures"] == []
+
+
+def test_deepseek_ocr_bad_receipt_fails_both_parity_gates() -> None:
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(),
+        "ocrbench_v2_unified",
+    )
+    result = validation_engine.prediction_agreement_gate_result(
+        {
+            "hf": {"overall_accuracy": 0.6},
+            "trtfb": {"overall_accuracy": 0.4},
+            "prediction_agreement_rate": 0.8,
+        },
+        suite["gates"],
+    )
+
+    assert result["status"] == "failed"
+    assert result["error_type"] == "BenchmarkGateError"
+    assert result["accuracy_drop_from_hf"] == pytest.approx(0.2)
+    assert [failure["gate"] for failure in result["gate_failures"]] == [
+        "max_accuracy_drop_from_hf",
+        "min_prediction_agreement",
+    ]
+
+
+def test_unopted_unquantized_reference_mismatch_stays_fail_closed(
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_kind": "vlm_unified_json",
+                "task_eval": {"reference_precision": "bf16"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="reference precision bf16 does not match TRTMC base precision fp16",
+    ):
+        validation_engine.resolve_reference_precision_contract(
+            argparse.Namespace(hf_dtype="auto"),
+            {
+                "name": "unopted-model",
+                "precision": "fp16",
+                "task_eval": {"reference_precision": "bf16"},
+            },
+            work_dir,
+        )
+
+
+def test_deepseek_ocr_fp16_reference_fails_before_model_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments = _write_vlm_inputs(tmp_path, dtype="float16")
+
+    def fail_if_loaded():
+        raise AssertionError("model dependencies must not load")
+
+    monkeypatch.setattr(transformers_vlm, "_runtime_dependencies", fail_if_loaded)
+
+    with pytest.raises(
+        ValueError,
+        match="DeepSeek-OCR official remote-code reference requires.*BF16",
+    ):
+        transformers_vlm.run(arguments)
+
+
+def test_deepseek_ocr_bf16_runs_official_remote_infer_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments = _write_vlm_inputs(tmp_path, dtype="bfloat16")
+    calls: dict[str, object] = {}
+
+    class Processor:
+        def __call__(self, text, *, add_special_tokens):
+            assert text == "recognized text"
+            assert add_special_tokens is False
+            return SimpleNamespace(input_ids=[1, 2])
+
+    class Model:
+        def infer(self, processor, **kwargs):
+            calls["processor"] = processor
+            calls.update(kwargs)
+            return "recognized text"
+
+    processor = Processor()
+    model = Model()
+    monkeypatch.setattr(
+        transformers_vlm,
+        "_runtime_dependencies",
+        lambda: (SimpleNamespace(), SimpleNamespace(), SimpleNamespace()),
+    )
+
+    def fake_load_runtime(arguments, *_args):
+        assert arguments.dtype == "bfloat16"
+        return processor, model, "cpu"
+
+    monkeypatch.setattr(transformers_vlm, "_load_runtime", fake_load_runtime)
+
+    transformers_vlm.run(arguments)
+
+    assert calls["processor"] is processor
+    assert calls["prompt"] == "<image>\nRead the image."
+    assert calls["image_file"] == "/dataset/image.jpg"
+    assert calls["save_results"] is False
+    assert calls["eval_mode"] is True
+    payload = json.loads(arguments.predictions.read_text(encoding="utf-8"))
+    wall_ms = payload["responses"][0].pop("wall_ms")
+    assert isinstance(wall_ms, float)
+    assert payload == {
+        "responses": [
+            {
+                "sample_id": "ocrbench_v2_000000",
+                "output_text": "recognized text",
+                "generated_tokens": 2,
+                "generated_token_ids": [1, 2],
+                "source": "hf",
+            }
+        ]
+    }

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -661,13 +661,18 @@ suites:
       scorer: ocrbench_v2
     build:
       min_max_cache_length: 1024
+    gates:
+      max_accuracy_drop_from_hf: 0.02
+      min_prediction_agreement: 0.95
     ci:
       eligible: false
       lane: local_only
       notes: >
         Intended for manual local validation first. Pass --dataset for
         machine-specific data roots such as
-        /path/to/OCRBench_v2_repaired.
+        /path/to/OCRBench_v2_repaired. The parity gates compare
+        TRTMC with the same-run HF reference; they intentionally avoid an
+        absolute accuracy floor derived from a small validation slice.
 
   - id: librispeech_clean_asr
     description: >

--- a/tools/reference/transformers_vlm.py
+++ b/tools/reference/transformers_vlm.py
@@ -586,8 +586,25 @@ def _load_runtime(
     return processor, model, device
 
 
+def _is_deepseek_ocr_model_id(model_id: str) -> bool:
+    return "deepseek-ocr" in model_id.lower()
+
+
+def _validate_checkpoint_native_dtype(model_id: str, dtype: str) -> None:
+    if _is_deepseek_ocr_model_id(model_id) and dtype not in {
+        "auto",
+        "bfloat16",
+    }:
+        raise ValueError(
+            "DeepSeek-OCR official remote-code reference requires "
+            "checkpoint-native BF16 (`--dtype bfloat16` or `--dtype auto`); "
+            "its checkpoint, image preprocessing, and CUDA autocast path are "
+            "BF16-native"
+        )
+
+
 def _is_deepseek_ocr(model_id: str, model: Any) -> bool:
-    return "deepseek-ocr" in model_id.lower() and hasattr(model, "infer")
+    return _is_deepseek_ocr_model_id(model_id) and hasattr(model, "infer")
 
 
 def _deepseek_prompt(prompt: str) -> str:
@@ -808,6 +825,7 @@ def _vlm_response(
 
 
 def run(arguments: argparse.Namespace) -> None:
+    _validate_checkpoint_native_dtype(arguments.model, arguments.dtype)
     torch, transformers, processor_class = _runtime_dependencies()
     manifest = _load_json(arguments.manifest)
     answers = _load_json(arguments.answers)

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -11629,7 +11629,7 @@ def eval_one_model(
             "hf_valid_prediction_rate": summary["hf"].get("valid_prediction_rate"),
             "bundle_valid_prediction_rate": summary["bundle"].get("valid_prediction_rate"),
         }
-        if scorer in {"grounding_iou", "mcq", "asr_transcript"}:
+        if scorer in {"grounding_iou", "mcq", "ocrbench_v2", "asr_transcript"}:
             result.update(
                 prediction_agreement_gate_result(
                     summary,


### PR DESCRIPTION
## Background

The fresh reproduction of QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` exposed a DeepSeek-OCR
reference failure on current `main`:

- fresh run:
  `trtmc-validate-gb300-3-20260729T084401Z-5dc37b75-all105-offline-fresh-r4`
- source revision: `5dc37b757ae2ec93956acfb3672108372ff404e9`
- model / workload: `deepseek-ocr` / `ocrbench_v2_unified`
- input slice: the same 5 QA samples, `ocrbench_v2_000000` through
  `ocrbench_v2_000004`
- result: both attempts failed before comparison; `comparison=not_run`; zero
  TRTMC commands ran
- failing reference command selected `--dtype float16`
- error: `masked_scatter_` required matching dtypes but received `Half` and
  `Float`

DeepSeek-OCR-2 is checkpoint-native BF16. Its checkpoint declares BF16, and
its official remote-code `infer` path converts image inputs to BF16 and uses
BF16 CUDA autocast. The qualified TRTMC candidate is intentionally FP16 with
reviewed FP32 layers 6-12. Forcing the reference to the candidate base
precision therefore makes the official reference invalid; changing the
candidate to FP32 or casting one intermediate would no longer validate the
production runtime or the official reference.

The older c829 QA receipt confirms the intended same-run parity behavior when
the official reference executes:

- HF accuracy: `0.6`
- TRTMC accuracy: `0.6`
- accuracy delta: `0.0`
- prediction agreement: `1.0`

This five-sample receipt is used only to validate relative parity gates. It is
not used to invent an absolute `0.6` accuracy floor.

## Exit Criteria

- [x] Preserve the qualified FP16 TRTMC candidate and FP32 layer overrides.
- [x] Run the official DeepSeek-OCR reference with BF16.
- [x] Record candidate precision, reference precision, policy, and reason in
  comparison artifacts and HTML.
- [x] Keep arbitrary unquantized precision mismatches fail-closed.
- [x] Prevent a workload override from opting into or changing the
  checkpoint-native policy.
- [x] Add meaningful OCR parity gates without weakening any existing
  criterion.
- [x] Prove a known-good QA receipt passes and a regressed receipt fails.
- [x] Keep PR CI impact bounded to DeepSeek-OCR plus the tools tier.
- [x] Re-run this exact PR head on GB300 with the QA environment and record the
  fresh comparison receipt.

## Implementation

The DeepSeek-OCR model manifest now explicitly declares:

- TRTMC candidate: FP16 mixed precision, unchanged
- HF reference: BF16
- reference policy: `checkpoint_native`
- a reviewable reason explaining the asymmetric precision contract

The task-eval resolver accepts that mismatch only when the model manifest opts
in. It rejects undeclared mismatches, workload-only opt-ins, workload dtype
changes, aligned uses of the exception, and quantized candidates. The resolved
reason is included in `comparison.json` and rendered in the report.

The DeepSeek-OCR reference runner rejects direct FP16/FP32 invocations before
model loading and accepts BF16 or checkpoint-native `auto`, ensuring validation
reaches the official remote-code `model.infer` path instead of the known-invalid
dtype combination.

The OCRBench v2 suite now enforces:

- `max_accuracy_drop_from_hf: 0.02`
- `min_prediction_agreement: 0.95`

The generic task-quality path now actually applies declared parity gates.
Previously the OCR suite declared no gates, and the generic scorer did not
apply this existing gate vocabulary, so a completed run could be marked passed
without enforcing accuracy parity.

## Validation

### Fail-before reproduction

The forced-fresh main reproduction used the same QA workload and five samples.
It failed 2/2 reference attempts with the exact `Half`/`Float`
`masked_scatter_` error before TRTMC execution. The initial contract regression
test also failed on unmodified behavior because DeepSeek-OCR had no task-eval
reference precision.

### Exact-head GB300 QA rerun

The completed target-hardware run validated PR head
`018139661b1a7e6a0d6824236ecafee98e4f6454` against base
`aa3779bb4576280f18c955535779eb9e5b452ca4`.

Environment and input provenance:

- QA anchor: `trtmc-validate-gb300-2-20260726-c8291be0-all105`
- GPU: NVIDIA GB300 with TensorRT 11.2
- dataset: OCRBench v2 unified dataset
- dataset SHA-256:
  `e62c2fbdfe5d02f11d6e48d37ae548c854a19dcb3985eaa7ba3ba51492d10a94`
- selected samples: `ocrbench_v2_000000` through
  `ocrbench_v2_000004`
- checkpoint revision: `aaa02f3811945a91062062994c5c4a3f4c0af2b0`
- QA reference profiles: `reference_common-424321ab2bba` and
  `deepseek_ocr-6d793c281786`
- DeepSeek profile: Transformers `4.46.3`, huggingface-hub `0.26.5`,
  tokenizers `0.20.3`, addict `2.4.0`, easydict `1.13`, einops `0.8.1`

Freshness and precision contract:

- invoked with `--force-hf --force-build --local-files-only`
- `hf_reference_status=ran`, `hf_reused=false`,
  `hf_cache_status=generated`, `bundle_built=true`
- exact-head C++ build configured with
  `TRTMC_SOURCE_REVISION=018139661b1a7e6a0d6824236ecafee98e4f6454`
- TRTMC candidate remained FP16 with FP32 layers 6-12 and a 4096-token cache
- official checkpoint reference ran BF16 through remote-code `model.infer`
- completed on the first execution attempt; no retry was consumed

Accuracy receipt:

| Metric | HF | TRTMC | Gate |
| --- | ---: | ---: | --- |
| Accuracy | `0.6` (3/5) | `0.6` (3/5) | drop `0.0 <= 0.02`: pass |
| Valid / skipped | `5 / 0` | `5 / 0` | aligned IDs: pass |
| Prediction agreement | — | `1.0` | `>= 0.95`: pass |

All five sample-level correctness decisions agree: three are correct on both
sides and two are wrong on both sides. The runner gate and an independently
recomputed strict gate both passed.

Runtime:

- decoder engine: `1175.8 s`, `8924.9 MB`
- native vision engine: `266.4 s`, `882.1 MB`
- complete bundle build: `1455.2 s`
- complete validator: `1592.871 s`
- outer provenance window: `1601 s`
- resulting bundle: `10,293,479,501` bytes (about 9.6 GiB)

Artifact hashes:

- fresh bundle:
  `c246b06c9108c8154231fd65685cd0d6d913959c41ff35b92d65bbf43f41bfed`
- comparison:
  `1675a6aec0142ff78e305afbf539de7b24d2309f6c4a9c36bb975940a7822bc6`
- independent strict gate:
  `13d737be88f3bfc62ebf362c35ed682e3345608a8f65c7b062620b3037292cd8`
- exact `trtmc`:
  `1ce0a033002f25cc64dece823708c4778fe241f9be35c3c90e5b46e04d0d5baf`
- exact dataset benchmark:
  `289186db7b35830fc9ca8e373a08aa72f9c5d7ef7e93f84bf4c11980a70b27c8`
- TensorRT 11.2 backend:
  `bffb28612c05157a2717d8deb5e5ad43d34737cf79bf6913a072be45a899bc25`
- DeepSeek-OCR plugin:
  `c317b12ea620692a0ee9f18f836e3cbd63afe394cd10e7db06d96eb08850fb9e`

Receipt:

- run:
  `trtmc-validate-gb300-2-20260729T125514Z-01813966-deepseek-ocr-exact-fresh-r2`
- archive:
  `trtmc-validate-gb300-2-20260729T125514Z-01813966-deepseek-ocr-exact-fresh-r2-receipt.tar.gz`
- archive SHA-256:
  `60e18d58c51e61517fefb1acf249dfb50a658f550567d5ad8638ba8951a96da6`

The compact receipt contains source provenance, aligned predictions,
comparison reports, the independent gate, and fail-before summaries. It
intentionally excludes the 9.6 GiB engine,
model weights, Hugging Face cache, and generated reference cache.

The QA-equivalent replay used `trtmc_validate.py deepseek-ocr
ocrbench_v2_unified --force-hf --force-build --local-files-only`.

### Historical CPU and static validation (pre-rebase)

The following counts are retained as the pre-rebase fix-head receipt. The
current exact-head focused result is reported in the latest-main section below.

- `pytest tests/tools/test_deepseek_ocr_task_eval.py -q`
  - `8 passed in 0.37s`
  - verifies FP16 candidate / BF16 reference resolution
  - verifies direct FP16 reference fails before loading
  - verifies BF16 dispatches to the official `model.infer` API
  - verifies an unopted mismatch and workload-only opt-in fail closed
  - replays c829 `0.6 / 0.6 / 1.0` as passing
  - replays `0.6 / 0.4 / 0.8` as failing both parity gates
- `pytest tests/tools/test_task_eval.py tests/tools/test_trtmc_reference.py tests/tools/test_trtmc_validate.py tests/tools/test_deepseek_ocr_task_eval.py -q`
  - `316 passed in 11.72s`
- `ruff check --config ruff.toml ...`
  - passed
- manifest JSON, suite YAML, and `git diff --check`
  - passed

## Latest Main, Bundle Compatibility, Validation, CI Coverage, And Runtime (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `c57eb88c23830b1d227a33cc4a37227f61380950`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The DeepSeek-OCR regression uses the current Bundle summary schema. It preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- The pre-rebase receipt above remains historical: **8 focused tests** and **316 combined tests** passed on the earlier fix head. On the current exact head, the **6 focused DeepSeek-OCR tests** passed within a current combined validation-engine run of **257 passed, 1 skipped in 8.72s**. These are different historical and current suites, not a regression in coverage or behavior.
- Current exact-head source-quality passed **157 built-in tests in 19.77s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects direct `deepseek_ocr` plus exactly five fixed platform fallbacks: `deepseek_v2`, `ltx_video`, `patchtsmixer`, `segformer`, and `whisper` (`expected_count=6`). This is bounded policy coverage and adds neither a full-model roster nor another OCR inference/QA lane.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **1h52m09s**, including shared queue delay; this is not added test execution time.

## Notes For Future Readers

`checkpoint_native` is intentionally narrow. It is not permission to compare
arbitrary precisions or to hide candidate differences. The model owner must
declare the reference dtype and explain why the official checkpoint cannot
execute at the candidate base precision. The candidate remains unchanged and
the report makes the asymmetry visible.

The exact PR head has now passed a forced-fresh GB300 rerun using the QA
workload, dataset, checkpoint, reference profiles, and precision contract.
Static/CPU validation proves policy and regression coverage; the target-hardware
receipt proves the corrected official BF16 reference and the unchanged FP16
TRTMC candidate agree on all five selected samples.

