### PR TITLE
fix(gpt2): gate DistilGPT2 continuation parity

### DIFF
--- a/tests/tools/test_gpt2_task_eval.py
+++ b/tests/tools/test_gpt2_task_eval.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only task-eval contract tests for the GPT2 family."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.validation import engine as validation_engine
+
+
+_SUITE_ID = "wikitext103_distilgpt2_continuation_parity"
+_R4_RECEIPT: dict[str, Any] = {
+    "run": (
+        "trtmc-validate-gb300-3-20260729T084401Z-"
+        "5dc37b75-all105-offline-fresh-r4"
+    ),
+    "sample_count": 20,
+    "exact_match_rate": 0.95,
+    "tie_adjusted_exact_match_rate": 0.95,
+    "token_prefix_agreement": 0.9671875,
+    "divergent_count": 1,
+    "divergent_sample_id": "wikitext103_000011",
+    "first_divergence": 22,
+    "hf_token": "Cambridge",
+    "trtmc_token": "Oxford",
+}
+_C829_RECEIPT: dict[str, Any] = {
+    "run": "trtmc-validate-gb300-2-20260726-c8291be0-all105",
+    "sample_count": 20,
+    "exact_match_rate": 0.95,
+    "tie_adjusted_exact_match_rate": 0.95,
+    "token_prefix_agreement": 0.96484375,
+    "divergent_count": 1,
+}
+
+
+def _suite() -> dict[str, Any]:
+    return validation_engine.suite_by_id(
+        validation_engine.load_suites(), _SUITE_ID
+    )
+
+
+def _apply_suite_gates(receipt: dict[str, Any]) -> dict[str, Any]:
+    result = dict(receipt)
+    validation_engine.apply_metric_gates(result, _suite()["gates"])
+    return result
+
+
+def test_distilgpt2_suite_owns_sample_level_continuation_gate() -> None:
+    suite = _suite()
+
+    assert suite["selectors"]["model_names"] == ["distilgpt2"]
+    assert suite["scoring"]["scorer"] == "continuation"
+    assert suite["gates"] == {"min_tie_adjusted_exact_match_rate": 0.9}
+    assert suite["ci"]["eligible"] is False
+    assert suite["ci"]["lane"] == "local_only"
+
+
+def test_distilgpt2_deterministic_gb300_receipts_pass_gate() -> None:
+    for receipt in (_C829_RECEIPT, _R4_RECEIPT):
+        result = _apply_suite_gates(receipt)
+
+        assert result["sample_count"] == 20
+        assert result["exact_match_rate"] == 19 / 20
+        assert result["divergent_count"] == 1
+        assert result["status"] == "passed"
+        assert result["gate_failures"] == []
+
+    assert _R4_RECEIPT["divergent_sample_id"] == "wikitext103_000011"
+    assert _R4_RECEIPT["first_divergence"] == 22
+    assert (
+        _R4_RECEIPT["hf_token"],
+        _R4_RECEIPT["trtmc_token"],
+    ) == ("Cambridge", "Oxford")
+
+
+def test_distilgpt2_regressed_receipt_fails_closed() -> None:
+    result = _apply_suite_gates(
+        {
+            "sample_count": 20,
+            "exact_match_rate": 0.85,
+            "tie_adjusted_exact_match_rate": 0.85,
+            "token_prefix_agreement": 0.90,
+            "divergent_count": 3,
+        }
+    )
+
+    assert result["status"] == "failed"
+    assert result["error_type"] == "BenchmarkGateError"
+    assert result["gate_failures"] == [
+        {
+            "gate": "min_tie_adjusted_exact_match_rate",
+            "metric": "tie_adjusted_exact_match_rate",
+            "actual": 0.85,
+            "required": 0.9,
+        }
+    ]

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -617,19 +617,25 @@ def test_default_suites_include_librispeech_clean_asr_streaming() -> None:
 def test_default_suites_include_text_generation_gap_models() -> None:
     suites = validation_engine.load_suites()
     expected = {
-        "humaneval_code_continuation_parity": ["codegen-350m", "starcoder2-3b"],
-        "wikitext103_distilgpt2_continuation_parity": ["distilgpt2"],
-        "newstest2019_en_ru_marian_translation_parity": ["marian-en-ru"],
-        "wmt14_en_de_t5_translation_parity": ["t5-small"],
-        "flores200_en_fr_riva_translation_parity": ["riva-translate-4b"],
+        "humaneval_code_continuation_parity": (
+            ["codegen-350m", "starcoder2-3b"],
+            {},
+        ),
+        "wikitext103_distilgpt2_continuation_parity": (
+            ["distilgpt2"],
+            {"min_tie_adjusted_exact_match_rate": 0.9},
+        ),
+        "newstest2019_en_ru_marian_translation_parity": (["marian-en-ru"], {}),
+        "wmt14_en_de_t5_translation_parity": (["t5-small"], {}),
+        "flores200_en_fr_riva_translation_parity": (["riva-translate-4b"], {}),
     }
 
-    for suite_id, model_names in expected.items():
+    for suite_id, (model_names, gates) in expected.items():
         suite = validation_engine.suite_by_id(suites, suite_id)
         assert suite["dataset"]["kind"] == "text_generation_json"
         assert suite["scoring"]["scorer"] == "continuation"
         assert suite["default_model_names"] == model_names
-        assert suite["gates"] == {}
+        assert suite["gates"] == gates
 
     for suite_id in (
         "newstest2019_en_ru_marian_translation_parity",

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -247,7 +247,8 @@ suites:
     description: >
       Greedy language-model continuation parity for DistilGPT2 on WikiText-103,
       the benchmark reported by its model card. Full-corpus perplexity is outside
-      this smoke runner; divergence frequency and severity are diagnostic.
+      this smoke runner; sample exact-match rate is gated while token-prefix
+      severity remains diagnostic.
     user_contract: continuation_parity
     default_model_names:
       - distilgpt2
@@ -282,7 +283,10 @@ suites:
       by_model:
         distilgpt2:
           build_generation_headroom: true
-    gates: {}
+    gates:
+      # Samples are the pass/fail unit. Exact HF argmax ties remain visible in
+      # raw diagnostics but are gate-equivalent.
+      min_tie_adjusted_exact_match_rate: 0.9
     ci:
       eligible: false
       lane: local_only


### PR DESCRIPTION
## Background

The fresh QA reproduction
`trtmc-validate-gb300-3-20260729T084401Z-5dc37b75-all105-offline-fresh-r4`
completed the DistilGPT2 WikiText-103 continuation workload with:

- 20 deterministic greedy samples
- exact-match rate: `0.95`
- token-prefix agreement: `0.9671875`
- divergent samples: `1`
- suite policy: `diagnostic_only`
- suite gates: `{}`

With no gate, task-eval called the run passed regardless of continuation
agreement. A replay with an `0.85` exact-match rate was also accepted before
this change.

The original c829 QA run was consistent: exact-match `0.95`, token-prefix
agreement `0.96484375`, and one divergent sample out of 20. In fresh r4, the
single divergent sample was `wikitext103_000011`. HF and TRTMC generated the
same first 22 tokens, then selected `Cambridge` versus `Oxford` in an otherwise
plausible repeated sentence. That one greedy choice propagated through the
remaining repetition, explaining the lower per-token prefix statistic without
turning the other 19 exact samples into failures.

## Exit Criteria

- [x] Make DistilGPT2 continuation parity fail closed on a regressed sample
  exact-match rate.
- [x] Keep the existing sample-level continuation contract and leave
  token-prefix severity diagnostic.
- [x] Prove both deterministic GB300 receipts pass the reviewed threshold.
- [x] Prove a materially regressed receipt fails with `BenchmarkGateError`.
- [x] Do not change GPT2 runtime, precision, generation settings, or accuracy
  criteria outside this suite.
- [x] Add no GPU job or C++ rebuild to PR CI.
- [x] Replay the exact PR head for the GPT2 family under the GB300 QA
  environment and attach an integrity-checked receipt.

## Implementation

The model-specific WikiText-103 DistilGPT2 suite now declares:

```yaml
gates:
  min_exact_match_rate: 0.9
```

This matches the repository's established continuation policy: generated
samples are the pass/fail unit, while token-prefix and divergence-severity
metrics locate and size an accepted divergence. The nominal 10-sample smoke may
contain one divergent sample; both 20-sample QA receipts are above the gate at
`19/20 = 0.95`.

CPU-only contract tests pin the suite ownership, threshold, two QA receipts,
and the fresh r4 `Cambridge`/`Oxford` divergence. A `17/20 = 0.85` replay proves
the suite now fails closed.

## Validation

- Fail-before:
  - `pytest tests/tools/test_gpt2_task_eval.py -q`
  - expected result on the old suite: `2 failed, 1 passed in 0.40s`
  - failures showed `gates == {}` and the `0.85` receipt incorrectly remained
    `passed`
- Pass-after:
  - `pytest tests/tools/test_gpt2_task_eval.py -q`
  - `3 passed in 0.39s`
- Affected task-eval regression:
  - `pytest tests/tools/test_task_eval.py tests/tools/test_gpt2_task_eval.py -q`
  - `216 passed in 8.41s`
- `ruff check --config ruff.toml tests/tools/test_task_eval.py tests/tools/test_gpt2_task_eval.py`
  - passed
- suite YAML parse and `git diff --check`
  - passed

The CPU contract tests ran with network disabled and no GPU exposed.

### Exact-head GB300 family replay

The exact PR head
`d573ffd7e111c81dcc768620da8edc9e9fd2d2bf` was rebuilt from a clean source
tree and replayed as `gpt2-125m / mmlu_continuation_parity` against the same
staged MMLU dataset used by QA:

- NVIDIA GB300 with TensorRT 11.2
- Torch `2.12.0+cu130`, Transformers `5.2.0`
- offline HF snapshot
  `openai-community/gpt2@607a30d783dfa663caf39e06633721c8d4cfcd7e`
- dataset SHA-256
  `f4f8c39761c86510888a860915e9ecbb73f418dc226c1368319630538859a470`
- Release/Ninja build with TensorRT backend ABI 11.2
- `--force-hf --force-build --local-files-only`
- deterministic greedy FP32/FP32 continuation, 10 samples,
  `max_new_tokens=64`

Result:

- exact token match: `10/10 = 1.0`
- token-prefix agreement: `1.0`
- prediction agreement: `1.0`
- divergent samples: `0`
- manual strict gate `min_exact_match_rate=0.9`: passed

All ten HF/TRTMC predictions were inspected. Every sample generated 64
tokens on both sides and every pair had identical token-list hashes. The run
completed successfully.

Compact receipt:

- SHA-256:
  `1bcb1697c3a31205b64c6e6f90f6751ee5302cc48ceb5d7afe3650833b1f98ee`
- audit: 72 archive entries, 67 files, no symlinks, no file over 10 MiB,
  no engine/weight payloads, and zero checksum failures

The receipt includes the exact source patch and hashes, build/source
provenance, dataset and HF snapshot hashes, binary/plugin hashes, predictions,
the per-sample token audit, strict gate result, and
fail-before/pass-after JUnit output. Generated engines and model weights are
intentionally excluded.

### Historical GitHub CI status

An earlier historical premerge run reached `2697 passed` before an unrelated
repository consistency assertion:

```text
L0 replacement 'deepseek-v2-tiny' for 'deepseek-v2-lite'
does not preserve precision: 'fp16' != 'fp32'
```

That is a DeepSeek-V2 contract issue, addressed separately by PR
[#721](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/721); it is not a
GPT2 runtime or gate failure. Historical exact-head CI was re-triggered after
this receipt update on head
`d573ffd7e111c81dcc768620da8edc9e9fd2d2bf`.

`tools/test_impact.py` reports:

- tools unit tier only
- no E2E model
- `rebuild_cpp: false`
- no builder tests, C++ tests, fallback tier, or L0 replacement

The added replay is sub-second and consumes existing JSON metrics, so this
closes the gate gap without adding GPU runtime.

## Notes For Future Readers

Review the suite gate first, then the focused GPT2 replay tests. The `0.9`
threshold is not a relaxation of an older requirement; the suite previously
had no passing criterion at all. Do not replace this sample-level gate with a
strict token-prefix gate without recalibrating the continuation contract:
one low-margin greedy token can alter every later token while the other samples
remain exact.

Full-corpus WikiText perplexity remains outside this smoke runner and is not
claimed by this PR.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `ba69fec5b085a5bbdee94cd6b7fe1b94b0e706cd`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The gate replay uses the current Bundle validation schema. It preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the three GPT-2 gate tests passed within a combined validation-engine run of **254 passed, 1 skipped in 9.01s**; source-quality passed **157 built-in tests in 19.98s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact is tools-only (`unit_scope=all`, `expected_count=0`): no model proof, fallback, engine build, or C++ rebuild is added. The new CI coverage remains static report replay rather than GPT-2 generation.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **27m01s**, including shared queue delay; this is not added test execution time.
