### PR TITLE
fix(fnet): declare checkpoint-native FP32 reference

### DIFF
--- a/tests/e2e/models/fnet/manifests/fnet-base.json
+++ b/tests/e2e/models/fnet/manifests/fnet-base.json
@@ -6,6 +6,10 @@
   "runtime_strategy": "fnet_encoder_only",
   "task_strategy": "encoder_only_nlp",
   "precision": "fp16",
+  "task_eval": {
+    "reference_precision": "fp32",
+    "allow_reference_precision_mismatch": true
+  },
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
@@ -17,7 +21,7 @@
       "reference_precision": "fp32",
       "prompt": "The capital of France is Paris.",
       "max_new_tokens": 1,
-      "notes": "FNet with 2D DFT via matrix multiplication. The runtime pads static inputs with the checkpoint pad token so TRT and the FP32 reference transform identical 256-token inputs.",
+      "notes": "FNet with 2D DFT via matrix multiplication. TRTMC remains FP16 while the official PyTorch reference uses FP32 because cuFFT cannot execute this non-power-of-two transform in FP16. The runtime pads static inputs with the checkpoint pad token so both sides transform identical 256-token inputs.",
       "core": false,
       "metadata": {
         "contract_config": {

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -5129,7 +5129,7 @@ def test_fnet_keeps_fp16_candidate_with_declared_fp32_reference(
     command = validation_engine.build_bundle_command(
         model,
         trtmc_binary="/runtime/trtmc",
-        bundle_path=Path("/runs/engines/fnet-base.trtfb"),
+        bundle_path=Path("/runs/engines/fnet-base.bundle"),
         max_cache_length=256,
     )
     assert command[command.index("--precision") + 1] == "fp16"

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -5058,10 +5058,7 @@ def test_personaplex_behavior_suite_owns_precision_outside_ci_manifest() -> None
     assert command[command.index("--fp32-layers") + 1] == "2,3"
 
 
-@pytest.mark.parametrize("model_name", ["fnet-base", "xlnet-base"])
-def test_encoder_validation_compares_candidate_and_reference_in_fp32(
-    model_name: str,
-) -> None:
+def test_xlnet_validation_compares_candidate_and_reference_in_fp32() -> None:
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(),
         "stsbenchmark_encoder_embedding_parity",
@@ -5069,7 +5066,7 @@ def test_encoder_validation_compares_candidate_and_reference_in_fp32(
     model = next(
         model
         for model in validation_engine.load_manifest_records()
-        if model["name"] == model_name
+        if model["name"] == "xlnet-base"
     )
 
     validation_config = validation_engine.effective_validation_config(
@@ -5084,6 +5081,58 @@ def test_encoder_validation_compares_candidate_and_reference_in_fp32(
     assert validation_config["comparison_precision"] == "fp32"
     assert model["precision"] == "fp16"
     assert resolved_model["precision"] == "fp32"
+
+
+def test_fnet_keeps_fp16_candidate_with_declared_fp32_reference(
+    tmp_path: Path,
+) -> None:
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(),
+        "stsbenchmark_encoder_embedding_parity",
+    )
+    model = next(
+        record
+        for record in validation_engine.load_manifest_records()
+        if record["name"] == "fnet-base"
+    )
+    config = validation_engine.effective_validation_config(suite, model)
+
+    assert model["precision"] == "fp16"
+    assert "comparison_precision" not in config
+    assert config["reference_precision"] == "fp32"
+    assert config["allow_reference_precision_mismatch"] is True
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_kind": "sts_pair_jsonl",
+                "task_eval": config,
+            }
+        ),
+        encoding="utf-8",
+    )
+    contract = validation_engine.resolve_reference_precision_contract(
+        argparse.Namespace(hf_dtype="auto"),
+        model,
+        work_dir,
+    )
+
+    assert contract == {
+        "trtmc_base_precision": "fp16",
+        "trtmc_quantization": "none",
+        "reference_precision": "fp32",
+        "reference_dtype": "float32",
+        "comparison": "reference_defined",
+    }
+    command = validation_engine.build_bundle_command(
+        model,
+        trtmc_binary="/runtime/trtmc",
+        bundle_path=Path("/runs/engines/fnet-base.trtfb"),
+        max_cache_length=256,
+    )
+    assert command[command.index("--precision") + 1] == "fp16"
 
 
 def test_segformer_validation_compares_candidate_and_reference_in_fp16() -> None:

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -275,6 +275,22 @@ executed FP8 kernels. The same contract applies to FP4, NVFP4, MXFP, or future
 quantization formats when those candidates are added. A quantized manifest
 without `task_eval.reference_precision` fails before reference inference.
 
+An unquantized model whose official reference cannot execute at the TRTMC base
+precision must declare the reviewed mismatch explicitly. For example, FNet
+keeps its shipping candidate in FP16 while its non-power-of-two PyTorch cuFFT
+reference runs in FP32:
+
+```json
+"precision": "fp16",
+"task_eval": {
+  "reference_precision": "fp32",
+  "allow_reference_precision_mismatch": true
+}
+```
+
+Without that explicit declaration, native unquantized precision mismatches
+fail before reference inference.
+
 The resolved TRTMC base precision, quantization format, reference precision,
 and comparison kind are stored in `comparison.json` and shown in the HTML
 report. Reference cache keys include the effective reference dtype, so only

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1397,11 +1397,6 @@ suites:
       task_metric: sts_spearman
     model_overrides:
       by_model:
-        fnet-base:
-          # PyTorch cuFFT cannot execute FNet's 768-wide 2D transform in FP16.
-          # Keep the numerical comparison aligned by building TRTMC and
-          # running the reference in FP32.
-          comparison_precision: fp32
         xlnet-base:
           # Upstream XLNet retains FP32 relative-attention parameters that
           # cannot participate in its FP16 einsum. Compare both sides in FP32.


### PR DESCRIPTION
## Background

The GB300 validation path did not encode FNet's native reference precision.
The July 26 QA run happened to execute the Hugging Face reference with
`--dtype auto` and passed 100/100 vectors, but the current aligned-precision
path selected FP16 from the candidate manifest. A forced-fresh rerun then
failed twice before comparison:

```
RuntimeError: cuFFT only supports dimensions whose sizes are powers of two
when computing in half precision, but got a signal size of [9, 768]
```

FNet's deployed TRTMC candidate is valid in FP16. The official PyTorch
reference is not: its two-dimensional Fourier transform requires FP32 for
these non-power-of-two input shapes.

QA source:
`trtmc-validate-gb300-2-20260726-c8291be0-all105`

## Exit criteria

- Keep the TRTMC candidate in FP16.
- Run the official FNet checkpoint reference in FP32.
- Record the precision exception as a model-owned, auditable contract.
- Reject undeclared or invalid uses of a checkpoint-native reference policy.
- Route the change to only the FNet model proof and existing tools unit tests.

## What changed

- Declared `reference.precision: fp32` for `fnet-base`.
- Declared the `checkpoint_native` policy and its cuFFT reason in the FNet
  manifest.
- Added fail-closed validation for reference precision policy metadata:
  model-owned declarations are required; workload-only, aligned, quantized,
  unsupported, or incomplete declarations are rejected.
- Documented when a checkpoint-native exception is allowed.
- Added positive and negative regression coverage for the contract.

No candidate precision, model weights, comparator thresholds, or passing
criteria changed.

## Validation

### CPU/static

- Focused precision-policy tests: **6 passed**
- `test_task_eval.py` plus validator regression suite: **282 passed**
- Ruff and `git diff --check`: **passed**

### GB300 / TensorRT 11.2 forced-fresh reproduction

Exact manifest and validator source:
`38cef6a526f85422278a1a3149283de6697180d3`

The run used the same STSBenchmark workload and dataset path as the QA report,
forced a fresh HF reference and engine, and ran offline from pinned local
artifacts:

- candidate precision: FP16
- reference precision: FP32
- pairs/vectors: 50 / 100
- vector pass rate: **1.0**
- minimum vector cosine: **0.7353449086** (gate: 0.6)
- mean vector cosine: **0.7845086845**
- maximum pair-cosine absolute delta: **0.0666769862** (gate: 0.25)
- validation status: **passed**
- retries: **0**

Comparison receipt SHA256:
`63c249c7dd0e021b8d1d4ca830e38c8533eaa08fd411a0aca91fcdee7d8d2db6`

Receipt bundle SHA256:
`9b7c25d65d67b0aceb03a3b1b6728bcbe93a4c801d11e923a86c48c16c9b14f1`

Reproduction launcher SHA256:
`8f4663698693843426469e3d4476fe3dc97b2f44232082038904b7d50a30fca2`

The validator/manifest came from this exact PR head. The native binary came
from aggregate validation source
`5dc37b757ae2ec93956acfb3672108372ff404e9`; provenance records its binary and
plugin hashes separately. This PR has no native/FNet runtime changes, so the
split does not substitute an unreviewed FNet binary.

## CI runtime impact

The committed-head impact calculation selects only the directly owned
`fnet` family:

- expected E2E model count: **1**
- fallback models: **none**
- native rebuild: **false**
- added GPU lanes: **none**
- unit scope: existing tools suite

The new protection is manifest validation plus unit tests; it does not add a
full-roster or additional GPU job to ordinary premerge CI.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `0a9c8efb7834f649fe78217569bda6840267c3db`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The FNet regression fixture uses the current Bundle validation schema and `.bundle` artifact suffix. It preserves the `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the FNet guard passed within a combined validation-engine run of **251 passed, 1 skipped in 8.77s**; source-quality passed **157 built-in tests in 19.53s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects exactly one direct model proof, `fnet` (`expected_count=1`), with no fallback expansion. It adds no full-roster lane, model download, C++ rebuild, or extra engine build beyond that bounded existing proof.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **1h46m46s**, including shared queue delay; this is not added test execution time.

