### PR TITLE
fix(gpt-oss): use checkpoint-native BF16 reference

### DIFF
--- a/tests/e2e/models/gpt_oss/manifests/gpt-oss-20b-l0.json
+++ b/tests/e2e/models/gpt_oss/manifests/gpt-oss-20b-l0.json
@@ -1,12 +1,18 @@
 {
   "name": "gpt-oss-20b-l0",
   "hf_id": "openai/gpt-oss-20b",
+  "hf_revision": "6cee5e81ee83917806bbde320786a8fb61efebee",
   "bundle": "gpt-oss-20b-l0.bundle",
   "family": "gpt_oss",
   "runtime_strategy": "gpt_oss_decoder_moe",
   "task_strategy": "text_generation_causal",
   "e2e_parallel_resource": "exclusive_gpu",
   "precision": "fp16",
+  "reference_precision": "bf16",
+  "task_eval": {
+    "reference_precision": "bf16",
+    "allow_reference_precision_mismatch": true
+  },
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
@@ -14,7 +20,6 @@
       "name": "gpt-oss-20b-l0",
       "trace_id": "IT-E2E-GOSS-L0-01",
       "ci_tier": "l0_only",
-      "reference_precision": "fp32",
       "reference_family": "chat_instruct_template",
       "user_contract": "chat_response",
       "prompt": "<|start|>system<|message|>You are a helpful assistant.<|end|><|start|>user<|message|>What is the capital of France?<|end|><|start|>assistant",

--- a/tests/e2e/models/gpt_oss/manifests/gpt-oss-20b.json
+++ b/tests/e2e/models/gpt_oss/manifests/gpt-oss-20b.json
@@ -1,12 +1,18 @@
 {
   "name": "gpt-oss-20b",
   "hf_id": "openai/gpt-oss-20b",
+  "hf_revision": "6cee5e81ee83917806bbde320786a8fb61efebee",
   "bundle": "gpt-oss-20b.bundle",
   "family": "gpt_oss",
   "runtime_strategy": "gpt_oss_decoder_moe",
   "task_strategy": "text_generation_causal",
   "e2e_parallel_resource": "exclusive_gpu",
   "precision": "fp16",
+  "reference_precision": "bf16",
+  "task_eval": {
+    "reference_precision": "bf16",
+    "allow_reference_precision_mismatch": true
+  },
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/tools/test_gpt_oss_reference_precision.py
+++ b/tests/tools/test_gpt_oss_reference_precision.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for GPT-OSS model-owned reference precision."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.e2e.models.gpt_oss.e2e_plugins.references.hf_transformers import (
+    _torch_dtype_for_case,
+)
+from tests.e2e_harness.manifest_loader import load_model_manifest
+from tools.validation import catalog as validation_catalog
+from tools.validation import engine as validation_engine
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_DIR = REPO_ROOT / "tests" / "e2e" / "models" / "gpt_oss" / "manifests"
+GPT_OSS_REVISION = "6cee5e81ee83917806bbde320786a8fb61efebee"
+
+
+@pytest.mark.parametrize(
+    ("manifest_name", "candidate_precision"),
+    [
+        ("gpt-oss-20b.json", "fp16"),
+        ("gpt-oss-20b-l0.json", "fp16"),
+    ],
+)
+def test_gpt_oss_e2e_reference_uses_bf16(
+    manifest_name: str,
+    candidate_precision: str,
+) -> None:
+    model = load_model_manifest(MANIFEST_DIR / manifest_name)
+
+    assert model.hf_revision == GPT_OSS_REVISION
+    for case in model.testcases:
+        assert case.metadata.get("precision", "fp32") == candidate_precision
+        assert case.metadata["reference_precision"] == "bf16"
+        assert _torch_dtype_for_case(case) == "torch.bfloat16"
+
+
+def _validation_model() -> dict[str, Any]:
+    return validation_catalog.manifest_record(MANIFEST_DIR / "gpt-oss-20b.json")
+
+
+def _work_dir(tmp_path: Path, task_config: dict[str, Any] | None = None) -> Path:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    manifest: dict[str, Any] = {"dataset_kind": "mmlu_five_shot_json"}
+    if task_config is not None:
+        manifest["task_eval"] = task_config
+    (work_dir / "manifest.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    return work_dir
+
+
+def test_gpt_oss_validation_declares_model_owned_bf16(
+    tmp_path: Path,
+) -> None:
+    model = _validation_model()
+    contract = validation_engine.resolve_reference_precision_contract(
+        argparse.Namespace(hf_dtype="auto"),
+        model,
+        _work_dir(tmp_path),
+    )
+
+    assert model["precision"] == "fp16"
+    assert model["hf_revision"] == GPT_OSS_REVISION
+    assert contract == {
+        "trtmc_base_precision": "fp16",
+        "trtmc_quantization": "none",
+        "reference_precision": "bf16",
+        "reference_dtype": "bfloat16",
+        "comparison": "reference_defined",
+    }
+    assert model["task_eval"]["allow_reference_precision_mismatch"] is True
+
+
+def test_gpt_oss_reference_subprocess_receives_bfloat16(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command: list[str], **_kwargs: Any) -> Result:
+        captured["command"] = command
+        return Result()
+
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+    args = argparse.Namespace(
+        hf_python="/opt/reference/bin/python",
+        reference_cache_dir="",
+        reference_cache_identity="",
+        hf_dtype="auto",
+        hf_device="cuda",
+        hf_device_map="",
+        hf_attn_impl="",
+        trust_remote_code=False,
+        local_files_only=True,
+        do_sample=False,
+        apply_chat_template=False,
+        force_hf=True,
+        max_new_tokens=None,
+        temperature=None,
+        top_k=None,
+        top_p=None,
+        min_p=None,
+        seed=None,
+        elf_reference_repo="",
+    )
+
+    validation_engine.run_hf_reference_subprocess(
+        args,
+        _validation_model(),
+        _work_dir(tmp_path),
+    )
+
+    command = captured["command"]
+    assert command[command.index("--dtype") + 1] == "bfloat16"
+    assert command[command.index("--model-revision") + 1] == GPT_OSS_REVISION
+
+
+def test_gpt_oss_rejects_conflicting_float16_reference(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="--hf-dtype fp16 conflicts with task_eval.reference_precision bf16",
+    ):
+        validation_engine.resolve_reference_precision_contract(
+            argparse.Namespace(hf_dtype="float16"),
+            _validation_model(),
+            _work_dir(tmp_path),
+        )


### PR DESCRIPTION
## Background

GPT-OSS uses an MXFP4 checkpoint whose Transformers fallback dequantizes expert matrices to BF16. Native task evaluation previously inherited the FP16 TRTMC candidate precision for the Hugging Face reference, which can produce a `Half` versus `BFloat16` expert-matmul failure before the candidate is built.

The existing testcase-level reference field was available to the E2E harness but was not part of task-eval's nested model configuration, so source-level CI did not assert the final reference dtype argument.

## Exit Criteria

- Keep the TRTMC candidate at FP16 and use BF16 for the checkpoint-native reference.
- Make invalid precision exceptions fail closed.
- Cover the resolved reference command in CPU CI without adding broad model fanout.
- Re-run the QA-aligned 20-case workload with a fresh HF reference and a freshly built candidate bundle on GB300.

## Implementation

- Pin the full and L0 manifests to checkpoint revision `6cee5e81ee83917806bbde320786a8fb61efebee`.
- Declare BF16 reference precision for both E2E and task-eval consumers.
- Add a `checkpoint_native` policy that requires a model-owned precision and rationale, rejects quantized or aligned candidates, and rejects workload or CLI conflicts.
- Add command-level regression coverage for dtype and revision propagation.

No acceptance threshold or accuracy gate is changed.

## CI Coverage And Runtime

- `tests/tools/test_gpt_oss_reference_precision.py` checks both manifests, the precision contract, the exact BF16/revision subprocess arguments, and conflict rejection.
- The new checks run in the existing tools unit tier. Impact analysis selects one direct family (`gpt_oss`), its existing L0 representative, no C++ rebuild, and no fallback tier.
- This adds six CPU-only tests; it does not add a GPU job, a four-GPU TP4 job, or broad model fanout.

## Validation

### Source and unit validation

- `python -m pytest tests/tools/test_gpt_oss_reference_precision.py -q`: **6 passed**.
- `python -m pytest tests/tools/test_gpt_oss_reference_precision.py tests/tools/test_task_eval.py -q`: **219 passed**.
- `python -m pytest tests/e2e/models/gpt_oss -q`: **13 passed, 3 skipped**.
- `ruff check --config ruff.toml tools/task_eval.py tests/tools/test_gpt_oss_reference_precision.py`: **passed**.
- `python tools/model_ci.py validate --revision HEAD`: **passed**.

### QA-aligned GB300 validation

Validation used PR head `3c299336476b1b7f9b7bd48cf2478e7fca6dcfe8`, a GB300, and TensorRT 11.2.0.113. The exact-head validator, task evaluator, and manifests ran with `--force-hf`, `--force-build`, `--local-files-only`, and the full 20-case MMLU workload.

The prebuilt runtime, benchmark, and GPT-OSS plugin from the same QA TensorRT environment were reused because this PR changes no C++ or model-plugin source. The 39 GiB model bundle was rebuilt from scratch.

- HF reference: BF16, pinned checkpoint revision, 20/20 predictions generated.
- TRTMC candidate: FP16, fresh bundle, 20/20 predictions generated.
- HF accuracy: **0.35**.
- TRTMC accuracy: **0.35**.
- Accuracy delta (TRTMC minus HF): **0.00**.
- Prediction agreement: **1.00**.
- Valid prediction rate: **1.00** for both backends.
- Disagreements: **0**.
- Execution: **one attempt, zero retries**.

The artifact checksums and runtime provenance are retained with the validation receipt.

### Historical exact-head premerge qualification

The historical rebased head was requalified on NVIDIA GB300 with TensorRT
11.2.

- exact head: `051b17d5dfa59942c8e862aab2d8f3e14f3e99e9`
- rebased base: `9c429cdd6331f56745574e51240f8fb8250d3cb1`
- Source-visible exact-head premerge result: **success**
- L0 reference case: `gpt-oss-20b-l0`, **1/1 E2E passed**
- candidate/reference contract: TRTMC FP16 versus checkpoint-native HF BF16
- TRTMC and HF generated the same eight-token continuation,
  `analysisWe need to answer:`
- comparison: `exact_match=1.0`, `NED=0.0`
- family tests: **14/14 passed**
- engine build: exactly one invocation and one attempt, with no recovery
- `trtmc/premerge/required`: **success** on the exact head
- CodeQL Python and JavaScript/TypeScript: **success** on the exact head
- PR state before leaving draft: **MERGEABLE/CLEAN**

The full 20-case QA receipt remains the workload-level accuracy qualification.
The L0 premerge case is the bounded exact-head regression: it rechecks the
checkpoint-native dtype contract and TRTMC/HF continuation parity without
adding the expensive four-GPU TP4 lane or broad model fanout.

### Gate-mechanism limitation

The configured MCQ thresholds are a maximum HF accuracy drop of `0.01` and minimum prediction agreement of `0.98`; the observed metrics satisfy both.

However, the current generic MCQ runner does not persist and apply the suite's configured `gates` in the same way as its specialized gated paths. Therefore, this PR does not treat the runner's exit code or empty failure list alone as proof that strict gate enforcement executed. A shared task-eval fix is still required for fail-closed generic MCQ gate enforcement. This family PR fixes the GPT-OSS reference crash and records the exact metrics without weakening or bypassing the intended thresholds.

## Notes For Future Readers

- Review the manifest declarations first, then the fail-closed resolver policy, then the command-level regression test.
- If another family lands the shared checkpoint-native policy first, retain the GPT-OSS declarations and tests while resolving the common implementation during rebase.
- The multi-device TP4 manifest is intentionally unchanged; this CI guard does not add a four-GPU validation job.
- The latest exact-head receipt must be refreshed after any future rebase or model-contract change.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `d69c84b2750aee4c385d27911685f2954d849fe2`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- Rebase resolution preserves the pinned GPT-OSS checkpoint revision and BF16 checkpoint-native reference contract while using current Bundle artifact names. It preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- The gate-mechanism limitation above records the earlier runner state. On the current base, the validation-engine path applies the configured generic MCQ gates; this family PR still changes no acceptance threshold and adds no duplicate model run.
- Current exact-head local validation: the focused GPT-OSS precision regressions passed **5 tests in 0.07s**; source-quality passed **157 built-in tests in 20.03s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects exactly one direct model proof, `gpt_oss` (`expected_count=1`), with no fallback. It uses the existing bounded L0 representative and does not add a four-GPU TP4 job, C++ rebuild, or broad model fan-out.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **2h02m53s**, including shared queue delay; this is not added test execution time.

