### PR TITLE
fix(codegen): preserve greedy continuation parity

### DIFF
--- a/python/tensorrt_model_connect/families/codegen/default_decoder.py
+++ b/python/tensorrt_model_connect/families/codegen/default_decoder.py
@@ -65,6 +65,9 @@ def build_standard_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    fp32_rope: bool = False,
+    fp32_qk_attention: bool = False,
+    fp32_lm_head: bool = False,
     embed_input: bool = False,
     verbose: bool = False,
     debug_layer_outputs: bool = False,
@@ -89,6 +92,10 @@ def build_standard_decoder_engine(
             rotated-half (LLaMA/Qwen) where (d, d+half) share frequencies.
         scale_attn_weights: Whether to scale attention scores by 1/sqrt(head_dim).
             Most models use this (True, default). GPT-Neo does NOT scale (False).
+        fp32_rope: Evaluate RoPE in FP32 and keep its query output in FP32.
+        fp32_qk_attention: Evaluate Q/K scores and softmax in FP32 while
+            retaining the value/probability output dtype.
+        fp32_lm_head: Evaluate the final vocabulary projection in FP32.
         embed_input: If True, add input_embed [1, hidden] and use_input_embed [1]
             engine inputs. When use_input_embed==1, the decoder uses input_embed
             directly instead of the embedding lookup. Used for VL models where
@@ -147,6 +154,9 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            fp32_rope=fp32_rope,
+            fp32_qk_attention=fp32_qk_attention,
+            fp32_lm_head=fp32_lm_head,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
@@ -303,12 +313,14 @@ def build_standard_decoder_engine(
         sin_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, False,
             partial_rotary_factor, interleaved=interleaved_rope)
+        rope_np_dtype = np.float32 if fp32_rope else work_np_dtype
         cos_half_tensor = graph_ops.add_constant(
-            network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
-        cos_half_tensor = _cast_work_dtype(cos_half_tensor)
+            network, cos_half_np.shape, cos_half_np, dtype=rope_np_dtype)
         sin_half_tensor = graph_ops.add_constant(
-            network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
-        sin_half_tensor = _cast_work_dtype(sin_half_tensor)
+            network, sin_half_np.shape, sin_half_np, dtype=rope_np_dtype)
+        if not fp32_rope:
+            cos_half_tensor = _cast_work_dtype(cos_half_tensor)
+            sin_half_tensor = _cast_work_dtype(sin_half_tensor)
     elif position_type == "learned":
         pos_embed_np = weights["position_embedding"]
         position_embed_table = graph_ops.add_constant(
@@ -444,6 +456,8 @@ def build_standard_decoder_engine(
             sin_half_tensor=sin_half_tensor,
             rotary_embedding_dim=rotary_embedding_dim,
             interleaved_rope=interleaved_rope,
+            fp32_rope=fp32_rope,
+            fp32_qk_attention=fp32_qk_attention,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
         )
@@ -478,21 +492,24 @@ def build_standard_decoder_engine(
     # Output vocab may differ from input vocab (e.g. Bark semantic: 129600 in, 10048 out).
     # Derive from w_out shape if available.
     out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
+    lm_head_dtype = np.float32 if fp32_lm_head else work_np_dtype
+    if fp32_lm_head and hidden_state.dtype != trt.float32:
+        hidden_state = network.add_cast(hidden_state, trt.float32).get_output(0)
     logits = graph_ops.add_matmul_rhs_constant(
         network, hidden_state, hidden, out_vocab, weights["w_out"],
-        dtype=work_np_dtype)
+        dtype=lm_head_dtype)
     # LM head bias (if present, e.g. CodeGen) or zero bias for C++ parity
     lm_bias = weights.get("lm_head_bias")
     if lm_bias is not None:
         logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias,
-                                        dtype=work_np_dtype)
+                                        dtype=lm_head_dtype)
     else:
-        b_out = np.zeros(out_vocab, dtype=work_np_dtype)
+        b_out = np.zeros(out_vocab, dtype=lm_head_dtype)
         logits = graph_ops.add_bias_sum(network, logits, out_vocab, b_out,
-                                        dtype=work_np_dtype)
+                                        dtype=lm_head_dtype)
 
     # Logits output: always FP32 for accurate argmax/sampling
-    if work_trt_dtype != trt.float32:
+    if logits.dtype != trt.float32:
         logits_cast = network.add_cast(logits, trt.float32)
         logits = logits_cast.get_output(0)
     logits.name = "logits"
@@ -576,6 +593,8 @@ def _add_decoder_layer(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    fp32_rope: bool = False,
+    fp32_qk_attention: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     eps: float | None = None,
@@ -602,6 +621,8 @@ def _add_decoder_layer(
         sin_half_tensor=sin_half_tensor,
         rotary_embedding_dim=rotary_embedding_dim,
         interleaved_rope=interleaved_rope,
+        fp32_rope=fp32_rope,
+        fp32_qk_accumulation=fp32_qk_attention,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
     )

--- a/python/tensorrt_model_connect/families/codegen/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/codegen/default_dual_profile_decoder.py
@@ -161,6 +161,9 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    fp32_rope: bool = False,
+    fp32_qk_attention: bool = False,
+    fp32_lm_head: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -356,12 +359,18 @@ def build_dual_profile_decoder_engine(
         sin_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, False,
             partial_rotary_factor, interleaved=interleaved_rope)
-        cos_half_table = _const_in_work_dtype(
-            network, cos_half_np.shape, cos_half_np,
-            work_np_dtype, work_trt_dtype)
-        sin_half_table = _const_in_work_dtype(
-            network, sin_half_np.shape, sin_half_np,
-            work_np_dtype, work_trt_dtype)
+        if fp32_rope:
+            cos_half_table = graph_ops.add_constant(
+                network, cos_half_np.shape, cos_half_np, dtype=np.float32)
+            sin_half_table = graph_ops.add_constant(
+                network, sin_half_np.shape, sin_half_np, dtype=np.float32)
+        else:
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np,
+                work_np_dtype, work_trt_dtype)
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np,
+                work_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -492,6 +501,12 @@ def build_dual_profile_decoder_engine(
         # Position embedding (RoPE only; learned was applied above and ALiBi
         # is added into the attention mask).
         if position_type == "rope":
+            key_output_dtype = k.dtype
+            if fp32_rope:
+                if q.dtype != trt.float32:
+                    q = network.add_cast(q, trt.float32).get_output(0)
+                if k.dtype != trt.float32:
+                    k = network.add_cast(k, trt.float32).get_output(0)
             q = graph_ops.add_apply_rope_native(
                 network, q, num_heads, head_dim,
                 cos_half_table, sin_half_table, position_id,
@@ -502,6 +517,8 @@ def build_dual_profile_decoder_engine(
                 cos_half_table, sin_half_table, position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
+            if fp32_rope and k.dtype != key_output_dtype:
+                k = network.add_cast(k, key_output_dtype).get_output(0)
 
         # Present K / V (this step's raw K / V), shape (Sq, attn_size).
         present_k_outs.append(k)
@@ -518,7 +535,9 @@ def build_dual_profile_decoder_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+            scale=attn_scale,
+            fp32_qk_accumulation=fp32_qk_attention,
+            tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")
@@ -600,19 +619,22 @@ def build_dual_profile_decoder_engine(
 
     out_vocab = (weights["w_out"].shape[1]
                  if isinstance(weights["w_out"], np.ndarray) else vocab)
+    lm_head_dtype = np.float32 if fp32_lm_head else work_np_dtype
+    if fp32_lm_head and last_hidden.dtype != trt.float32:
+        last_hidden = network.add_cast(last_hidden, trt.float32).get_output(0)
     logits = graph_ops.add_matmul_rhs_constant(
         network, last_hidden, hidden, out_vocab, weights["w_out"],
-        dtype=work_np_dtype)
+        dtype=lm_head_dtype)
     lm_bias = weights.get("lm_head_bias")
     if lm_bias is not None:
         logits = graph_ops.add_bias_sum(
-            network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+            network, logits, out_vocab, lm_bias, dtype=lm_head_dtype)
     else:
-        zero_bias = np.zeros(out_vocab, dtype=work_np_dtype)
+        zero_bias = np.zeros(out_vocab, dtype=lm_head_dtype)
         logits = graph_ops.add_bias_sum(
-            network, logits, out_vocab, zero_bias, dtype=work_np_dtype)
+            network, logits, out_vocab, zero_bias, dtype=lm_head_dtype)
 
-    if work_trt_dtype != trt.float32:
+    if logits.dtype != trt.float32:
         logits = network.add_cast(logits, trt.float32).get_output(0)
     logits.name = "logits"
     network.mark_output(logits)

--- a/python/tensorrt_model_connect/families/codegen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/codegen/dual_profile_decoder_tp_builder.py
@@ -233,6 +233,9 @@ def build_dual_profile_tp_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    fp32_rope: bool = False,
+    fp32_qk_attention: bool = False,
+    fp32_lm_head: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     parallel_config=None,
@@ -397,12 +400,18 @@ def build_dual_profile_tp_decoder_engine(
         sin_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, False,
             partial_rotary_factor, interleaved=interleaved_rope)
-        cos_half_table = _const_in_work_dtype(
-            network, cos_half_np.shape, cos_half_np,
-            work_np_dtype, work_trt_dtype)
-        sin_half_table = _const_in_work_dtype(
-            network, sin_half_np.shape, sin_half_np,
-            work_np_dtype, work_trt_dtype)
+        if fp32_rope:
+            cos_half_table = graph_ops.add_constant(
+                network, cos_half_np.shape, cos_half_np, dtype=np.float32)
+            sin_half_table = graph_ops.add_constant(
+                network, sin_half_np.shape, sin_half_np, dtype=np.float32)
+        else:
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np,
+                work_np_dtype, work_trt_dtype)
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np,
+                work_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -533,6 +542,12 @@ def build_dual_profile_tp_decoder_engine(
         # Position embedding (RoPE only; learned was applied above and ALiBi
         # is added into the attention mask).
         if position_type == "rope":
+            key_output_dtype = k.dtype
+            if fp32_rope:
+                if q.dtype != trt.float32:
+                    q = network.add_cast(q, trt.float32).get_output(0)
+                if k.dtype != trt.float32:
+                    k = network.add_cast(k, trt.float32).get_output(0)
             q = graph_ops.add_apply_rope_native(
                 network, q, num_heads, head_dim,
                 cos_half_table, sin_half_table, position_id,
@@ -543,6 +558,8 @@ def build_dual_profile_tp_decoder_engine(
                 cos_half_table, sin_half_table, position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
+            if fp32_rope and k.dtype != key_output_dtype:
+                k = network.add_cast(k, key_output_dtype).get_output(0)
 
         # Present K / V (this step's raw K / V), shape (Sq, attn_size).
         present_k_outs.append(k)
@@ -559,7 +576,9 @@ def build_dual_profile_tp_decoder_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+            scale=attn_scale,
+            fp32_qk_accumulation=fp32_qk_attention,
+            tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")
@@ -648,19 +667,22 @@ def build_dual_profile_tp_decoder_engine(
 
     out_vocab = (weights["w_out"].shape[1]
                  if isinstance(weights["w_out"], np.ndarray) else vocab)
+    lm_head_dtype = np.float32 if fp32_lm_head else work_np_dtype
+    if fp32_lm_head and last_hidden.dtype != trt.float32:
+        last_hidden = network.add_cast(last_hidden, trt.float32).get_output(0)
     logits = graph_ops.add_matmul_rhs_constant(
         network, last_hidden, hidden, out_vocab, weights["w_out"],
-        dtype=work_np_dtype)
+        dtype=lm_head_dtype)
     lm_bias = weights.get("lm_head_bias")
     if lm_bias is not None:
         logits = graph_ops.add_bias_sum(
-            network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+            network, logits, out_vocab, lm_bias, dtype=lm_head_dtype)
     else:
-        zero_bias = np.zeros(out_vocab, dtype=work_np_dtype)
+        zero_bias = np.zeros(out_vocab, dtype=lm_head_dtype)
         logits = graph_ops.add_bias_sum(
-            network, logits, out_vocab, zero_bias, dtype=work_np_dtype)
+            network, logits, out_vocab, zero_bias, dtype=lm_head_dtype)
 
-    if work_trt_dtype != trt.float32:
+    if logits.dtype != trt.float32:
         logits = network.add_cast(logits, trt.float32).get_output(0)
     logits.name = "logits"
     network.mark_output(logits)

--- a/python/tensorrt_model_connect/families/codegen/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/codegen/graph_blocks.py
@@ -146,6 +146,8 @@ def add_attention_block(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    fp32_rope: bool = False,
+    fp32_qk_accumulation: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
 ) -> dict[str, trt.ITensor]:
@@ -219,6 +221,12 @@ def add_attention_block(
                 "TRT native IRotaryEmbeddingLayer")
         rope_dim = rotary_embedding_dim or head_dim
         rope_dim = graph_ops.validate_native_rope_dim(rope_dim)
+        key_output_dtype = k.dtype
+        if fp32_rope:
+            if q.dtype != trt.float32:
+                q = network.add_cast(q, trt.float32).get_output(0)
+            if k.dtype != trt.float32:
+                k = network.add_cast(k, trt.float32).get_output(0)
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
@@ -227,6 +235,8 @@ def add_attention_block(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
             rope_dim, interleaved_rope)
+        if fp32_rope and k.dtype != key_output_dtype:
+            k = network.add_cast(k, key_output_dtype).get_output(0)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
@@ -280,6 +290,7 @@ def add_attention_block(
             causal=False,
             mask=mask_4d,
             scale=attention_scale,
+            fp32_qk_accumulation=fp32_qk_accumulation,
         )
     elif ffi_attention_kernel is not None:
         if num_kv_heads != num_heads:

--- a/python/tensorrt_model_connect/families/codegen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/codegen/graph_ops.py
@@ -820,6 +820,58 @@ def _repeat_kv_heads_4d(
     return concat.get_output(0)
 
 
+def _add_attention_core_fp32_qk(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    mask: trt.ITensor | None,
+    scale: float,
+) -> trt.ITensor:
+    """Match CodeGen's FP32 Q/K and FP16/BF16 probability-value boundary."""
+    output_dtype = v_4d.dtype
+    k_4d = _repeat_kv_heads_4d(
+        network, k_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+    v_4d = _repeat_kv_heads_4d(
+        network, v_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+
+    if q_4d.dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+    if k_4d.dtype != trt.float32:
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+    if mask is not None and mask.dtype != trt.float32:
+        mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    scores = network.add_matrix_multiply(
+        q_4d, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, trt.float32)
+    scores = network.add_elementwise(
+        scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    probs_t = probs.get_output(0)
+    if probs_t.dtype != output_dtype:
+        probs_t = network.add_cast(probs_t, output_dtype).get_output(0)
+
+    context = network.add_matrix_multiply(
+        probs_t, trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def _add_attention_core_with_logit_softcap(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
@@ -893,6 +945,7 @@ def add_attention_from_rows(
     scale: float | None = None,
     logit_softcap: float | None = None,
     fp32_accumulation: bool = False,
+    fp32_qk_accumulation: bool = False,
     tag: str | None = None,
 ) -> trt.ITensor:
     """Native IAttention for row-major [S, H * D] Q/K/V tensors.
@@ -922,6 +975,14 @@ def add_attention_from_rows(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
             mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif fp32_qk_accumulation:
+        if causal:
+            raise NotImplementedError(
+                "FP32 Q/K attention requires an explicit additive mask")
+        ctx_4d = _add_attention_core_fp32_qk(
+            network, q_4d, k_4d, v_4d,
+            num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
+            mask=mask, scale=scale)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/codegen/plugin.py
+++ b/python/tensorrt_model_connect/families/codegen/plugin.py
@@ -177,6 +177,9 @@ class CodeGenPlugin:
                 partial_rotary_factor=partial_rotary_factor,
                 interleaved_rope=True,
                 parallel_residual=True,
+                fp32_rope=True,
+                fp32_qk_attention=True,
+                fp32_lm_head=True,
                 verbose=verbose,
                 parallel_config=parallel)
 
@@ -190,6 +193,12 @@ class CodeGenPlugin:
             partial_rotary_factor=partial_rotary_factor,
             interleaved_rope=True,
             parallel_residual=True,
+            # Transformers keeps CodeGen's RoPE query and Q/K score path in
+            # FP32. Keep the LM head in FP32 as well so close logits do not
+            # collapse into an FP16 tie before greedy selection.
+            fp32_rope=True,
+            fp32_qk_attention=True,
+            fp32_lm_head=True,
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/tests/e2e/models/codegen/test_codegen_build_engine_integration.py
+++ b/tests/e2e/models/codegen/test_codegen_build_engine_integration.py
@@ -88,5 +88,7 @@ class TestCodeGenBuildEngine:
             self.VOCAB, self.HIDDEN, self.LAYERS, self.HEADS, self.MLP))
         cfg = ModelConfig.from_dir(tmp_path)
         weights = plugin.load_weights(str(tmp_path), cfg)
-        engine = plugin.build_engine(cfg, weights, max_cache_length=32, verbose=False)
+        engine = plugin.build_engine(
+            cfg, weights, max_cache_length=32, precision="fp16", verbose=False
+        )
         assert isinstance(engine, bytes) and len(engine) > 0

--- a/tests/e2e/models/codegen/test_codegen_builder_tp.py
+++ b/tests/e2e/models/codegen/test_codegen_builder_tp.py
@@ -32,6 +32,9 @@ MODEL_TYPE = 'codegen'
 TP_SIZE = 4
 RAW = {'rotary_dim': 2}
 EXPECTED_KWARGS = {'activation': 'gelu_new',
+ 'fp32_lm_head': True,
+ 'fp32_qk_attention': True,
+ 'fp32_rope': True,
  'interleaved_rope': True,
  'mlp_type': 'gelu_fc',
  'norm_type': 'layernorm',
@@ -98,6 +101,35 @@ def test_codegen_plugin_routes_tp_build(monkeypatch) -> None:
     assert kwargs["parallel_config"] == parallel
     for key, expected in EXPECTED_KWARGS.items():
         assert kwargs[key] == expected
+
+
+def test_codegen_plugin_routes_accuracy_precision_boundaries(monkeypatch) -> None:
+    plugin_mod = importlib.import_module(
+        f"tensorrt_model_connect.families.{FAMILY}.plugin")
+    captured: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        captured["kwargs"] = kwargs
+        return b"single-device-plan"
+
+    monkeypatch.setattr(
+        plugin_mod,
+        "build_standard_decoder_engine",
+        fake_build,
+    )
+
+    plan = getattr(plugin_mod, PLUGIN_CLASS)().build_engine(
+        _config(MODEL_TYPE, 1, RAW),
+        WeightDict(),
+        max_cache_length=17,
+        precision="fp16",
+    )
+
+    assert plan == b"single-device-plan"
+    kwargs = captured["kwargs"]
+    assert kwargs["fp32_rope"] is True
+    assert kwargs["fp32_qk_attention"] is True
+    assert kwargs["fp32_lm_head"] is True
 
 
 def test_codegen_plugin_rejects_quantized_tp(monkeypatch) -> None:

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -3174,16 +3174,16 @@ def test_codegen_humaneval_gate_rejects_qa_accuracy_replays(
             for index in range(10)
         ]
     }
-    trtfb = json.loads(json.dumps(hf))
+    bundle = json.loads(json.dumps(hf))
     for sample_index, divergence_index in divergences.items():
-        response = trtfb["responses"][sample_index]
+        response = bundle["responses"][sample_index]
         response["output_text"] = "divergent"
         response["generated_token_ids"][divergence_index:] = [
             1000 + sample_index
         ] * (64 - divergence_index)
 
     summary = validation_engine.compare_continuation_sets(
-        hf, trtfb, require_token_ids=True
+        hf, bundle, require_token_ids=True
     )
     result = {
         "exact_match_rate": summary["exact_match_rate"],

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -631,6 +631,17 @@ def test_default_suites_include_text_generation_gap_models() -> None:
         assert suite["default_model_names"] == model_names
         assert suite["gates"] == {}
 
+    codegen = next(
+        model
+        for model in task_eval.load_manifest_records()
+        if model["name"] == "codegen-350m"
+    )
+    humaneval = task_eval.suite_by_id(
+        suites, "humaneval_code_continuation_parity"
+    )
+    resolved_codegen = task_eval.resolve_suite_for_model(humaneval, codegen)
+    assert resolved_codegen["gates"] == {"min_exact_match_rate": 1.0}
+
     for suite_id in (
         "newstest2019_en_ru_marian_translation_parity",
         "wmt14_en_de_t5_translation_parity",
@@ -3136,6 +3147,99 @@ def test_continuation_suite_accepts_one_divergent_sample_in_ten() -> None:
 
     assert result["exact_match_rate"] == 0.9
     assert result["token_prefix_agreement"] == 0.9
+    assert result["status"] == "passed"
+
+
+@pytest.mark.parametrize(
+    ("divergences", "exact_match_rate", "token_prefix_agreement"),
+    [
+        ({6: 7, 7: 9}, 0.8, 0.825),
+        ({7: 9}, 0.9, 0.9140625),
+    ],
+)
+def test_codegen_humaneval_gate_rejects_qa_accuracy_replays(
+    divergences: dict[int, int],
+    exact_match_rate: float,
+    token_prefix_agreement: float,
+) -> None:
+    hf = {
+        "responses": [
+            {
+                "sample_id": f"HumanEval/{index}",
+                "output_text": "reference",
+                "generated_token_ids": list(range(64)),
+            }
+            for index in range(10)
+        ]
+    }
+    trtfb = json.loads(json.dumps(hf))
+    for sample_index, divergence_index in divergences.items():
+        response = trtfb["responses"][sample_index]
+        response["output_text"] = "divergent"
+        response["generated_token_ids"][divergence_index:] = [
+            1000 + sample_index
+        ] * (64 - divergence_index)
+
+    summary = task_eval.compare_continuation_sets(
+        hf, trtfb, require_token_ids=True
+    )
+    result = {
+        "exact_match_rate": summary["exact_match_rate"],
+        "token_prefix_agreement": summary["token_prefix_agreement"],
+    }
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(), "humaneval_code_continuation_parity"
+    )
+    codegen = next(
+        model
+        for model in task_eval.load_manifest_records()
+        if model["name"] == "codegen-350m"
+    )
+    suite = task_eval.resolve_suite_for_model(suite, codegen)
+
+    task_eval.apply_metric_gates(result, suite["gates"])
+
+    assert result["exact_match_rate"] == exact_match_rate
+    assert result["token_prefix_agreement"] == token_prefix_agreement
+    assert result["status"] == "failed"
+    assert result["gate_failures"] == [
+        {
+            "gate": "min_exact_match_rate",
+            "metric": "exact_match_rate",
+            "actual": exact_match_rate,
+            "required": 1.0,
+        }
+    ]
+
+
+def test_codegen_humaneval_gate_accepts_exact_replay() -> None:
+    predictions = {
+        "responses": [
+            {
+                "sample_id": f"HumanEval/{index}",
+                "output_text": "reference",
+                "generated_token_ids": list(range(64)),
+            }
+            for index in range(10)
+        ]
+    }
+    summary = task_eval.compare_continuation_sets(
+        predictions, predictions, require_token_ids=True
+    )
+    result = {"exact_match_rate": summary["exact_match_rate"]}
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(), "humaneval_code_continuation_parity"
+    )
+    codegen = next(
+        model
+        for model in task_eval.load_manifest_records()
+        if model["name"] == "codegen-350m"
+    )
+    suite = task_eval.resolve_suite_for_model(suite, codegen)
+
+    task_eval.apply_metric_gates(result, suite["gates"])
+
+    assert result["exact_match_rate"] == 1.0
     assert result["status"] == "passed"
 
 

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -633,13 +633,15 @@ def test_default_suites_include_text_generation_gap_models() -> None:
 
     codegen = next(
         model
-        for model in task_eval.load_manifest_records()
+        for model in validation_engine.load_manifest_records()
         if model["name"] == "codegen-350m"
     )
-    humaneval = task_eval.suite_by_id(
+    humaneval = validation_engine.suite_by_id(
         suites, "humaneval_code_continuation_parity"
     )
-    resolved_codegen = task_eval.resolve_suite_for_model(humaneval, codegen)
+    resolved_codegen = validation_engine.resolve_suite_for_model(
+        humaneval, codegen
+    )
     assert resolved_codegen["gates"] == {"min_exact_match_rate": 1.0}
 
     for suite_id in (
@@ -3180,24 +3182,24 @@ def test_codegen_humaneval_gate_rejects_qa_accuracy_replays(
             1000 + sample_index
         ] * (64 - divergence_index)
 
-    summary = task_eval.compare_continuation_sets(
+    summary = validation_engine.compare_continuation_sets(
         hf, trtfb, require_token_ids=True
     )
     result = {
         "exact_match_rate": summary["exact_match_rate"],
         "token_prefix_agreement": summary["token_prefix_agreement"],
     }
-    suite = task_eval.suite_by_id(
-        task_eval.load_suites(), "humaneval_code_continuation_parity"
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(), "humaneval_code_continuation_parity"
     )
     codegen = next(
         model
-        for model in task_eval.load_manifest_records()
+        for model in validation_engine.load_manifest_records()
         if model["name"] == "codegen-350m"
     )
-    suite = task_eval.resolve_suite_for_model(suite, codegen)
+    suite = validation_engine.resolve_suite_for_model(suite, codegen)
 
-    task_eval.apply_metric_gates(result, suite["gates"])
+    validation_engine.apply_metric_gates(result, suite["gates"])
 
     assert result["exact_match_rate"] == exact_match_rate
     assert result["token_prefix_agreement"] == token_prefix_agreement
@@ -3223,21 +3225,21 @@ def test_codegen_humaneval_gate_accepts_exact_replay() -> None:
             for index in range(10)
         ]
     }
-    summary = task_eval.compare_continuation_sets(
+    summary = validation_engine.compare_continuation_sets(
         predictions, predictions, require_token_ids=True
     )
     result = {"exact_match_rate": summary["exact_match_rate"]}
-    suite = task_eval.suite_by_id(
-        task_eval.load_suites(), "humaneval_code_continuation_parity"
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(), "humaneval_code_continuation_parity"
     )
     codegen = next(
         model
-        for model in task_eval.load_manifest_records()
+        for model in validation_engine.load_manifest_records()
         if model["name"] == "codegen-350m"
     )
-    suite = task_eval.resolve_suite_for_model(suite, codegen)
+    suite = validation_engine.resolve_suite_for_model(suite, codegen)
 
-    task_eval.apply_metric_gates(result, suite["gates"])
+    validation_engine.apply_metric_gates(result, suite["gates"])
 
     assert result["exact_match_rate"] == 1.0
     assert result["status"] == "passed"

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -229,6 +229,13 @@ suites:
       do_sample: false
     scoring:
       scorer: continuation
+    model_profiles:
+      codegen-350m:
+        gates:
+          # CodeGen greedy continuations are deterministic. Any token
+          # divergence is an accuracy regression, including the 1/10 failure
+          # that the original diagnostic-only suite silently accepted.
+          min_exact_match_rate: 1.0
     model_overrides:
       by_model:
         codegen-350m:


### PR DESCRIPTION
## Background

The QA aggregate reported `codegen-350m` below exact continuation parity, with one divergent HumanEval sample. A forced-fresh reproduction using the same effective profile produced a stricter result: `0.8000` exact match, `0.8250` generated-token prefix agreement, and divergences on HumanEval/6 and HumanEval/7. Input token IDs matched on all 10 samples.

The HumanEval path did not provide authoritative fail-closed gate enforcement for this generic continuation result, so the accuracy regression could be presented as passed.

## Root Cause

The two failures came from separate FP16 numerical boundaries:

- HumanEval/7 diverged because Hugging Face evaluates CodeGen rotary embeddings and the query/key score path in FP32, while the TensorRT graph kept both in FP16.
- HumanEval/6 hit an FP16 vocabulary-logit tie. The expected token recovered when the final language-model projection was evaluated in FP32.

## Exit Criteria

- [x] Reproduce the QA accuracy failure with the report's model, dataset, and generation profile.
- [x] Restore exact continuation parity on the preserved 10-prompt GB300 reproduction.
- [x] Make both the original `0.9000` result and the forced-fresh `0.8000` result fail the new source-level replay checks.
- [x] Keep added CI coverage bounded to static replay checks plus the existing CodeGen model proof.
- [x] Complete an exact-commit `--force-hf --force-build --local-files-only` receipt using an exact-head runtime and CodeGen plugin.

## Implementation

- Preserve the Hugging Face CodeGen precision boundaries in the standard and tensor-parallel builders:
  - compute rotary embeddings and transformed queries in FP32;
  - compute query/key scores, masking, and softmax in FP32, then cast probabilities back to the value dtype for the value matmul;
  - compute the final vocabulary projection in FP32.
- Apply the same behavior to legacy decode, dynamic prefill, and tensor-parallel paths.
- Add routing and FP16 engine-build coverage for the CodeGen-specific precision policy.
- Add a `codegen-350m` HumanEval profile with `min_exact_match_rate: 1.0`.
- Add static report replays proving that `0.9000` and `0.8000` exact-match results fail while `1.0000` passes.

No acceptance threshold is weakened.

## CI Coverage And Runtime

- The new CI assertions replay small static reports; they do not run HumanEval or build a large model in ordinary CPU CI.
- Exact-head impact selection resolves only `codegen`, with expected count 1 and no fallback-model fanout.
- The shared validation-suite update selects the existing `unit_scope=all`; it does not add a new GPU job.
- The complete task-evaluation unit suite took 7.55 seconds in local validation.

## Validation

### Source, unit, and integration checks

- Fail-before on exact `github/main` (`aa3779bb`): the forced-fresh `0.8000` result was accepted because no effective model threshold was applied.
- Pass-after source replay: the same result resolves `min_exact_match_rate: 1.0` and fails with the expected threshold violation.
- Focused changed tests: `7 passed`.
- CodeGen family tests: `17 passed, 1 skipped`; the subsequently added focused routing assertion also passed.
- Builder unit scope: `709 passed, 1 skipped`.
- Task-evaluation suite: `216 passed` in 7.55 seconds.
- Source checks: changed-file lint, cyclomatic complexity, and architecture contracts passed (`158 passed` for the contract suite).
- Tiny CodeGen FP16 TensorRT engine integration build passed.
- `tools/model_ci.py validate --revision 65d6319e`: all 78 models passed inventory validation.
- Exact `unit_scope=all` Python command reached `2,273 passed, 1 skipped` after correcting a test-environment ownership issue. The sole remaining failure was the unrelated `deepseek-v2-tiny`/`deepseek-v2-lite` L0 precision mismatch, reproduced unchanged on the exact base.

### Exact-head GB300 forced-fresh receipt

Validation used exact PR head `65d6319e8dd51467600c268afbc025fb8a11c460`, a GB300, and TensorRT 11.2.

The `trtmc` executable, TensorRT backend, benchmark, and CodeGen model plugin were built from that exact source revision. The Python builder origin also resolved to the exact-head CodeGen package. The model run then used:

- `Salesforce/codegen-350M-mono` snapshot `d9107f71cca463240db1143f4a75a927a27fcb27`;
- FP16 Hugging Face reference and FP16 TRTMC candidate;
- a fresh HF reference and freshly built 1,647,137,596-byte bundle;
- the complete 10-case HumanEval sample used by QA;
- 64 greedy generated tokens per sample;
- local-files-only execution.

Results:

- text exact match: **10/10 (1.0000)**;
- generated token-ID exact match: **10/10 (1.0000)**;
- generated token-ID prefix agreement: **1.0000**;
- matching generated tokens: **640/640**;
- divergent samples: **0**;
- divergence rate: **0.0000**;
- mean first-divergence position: **64.0**, meaning every sample matched through the full generation window;
- mean and maximum divergent severity: **0.0**;
- execution attempts: **1**, retries: **0**.

The engine, reference, comparison, summary, exact runtime, backend, and plugin checksums are retained with the validation receipt.

## Gate-Mechanism Boundary

HumanEval deliberately keeps its shared top-level `gates` mapping empty because CodeGen owns a stricter deterministic threshold in `model_profiles.codegen-350m.gates`. `resolve_suite_for_model` merges `min_exact_match_rate: 1.0` into the resolved suite before evaluation.

The exact-head r2 artifact reports `evaluation_policy: threshold_gated` and `gate_failures: []`; the continuation path applies the resolved model gate. The r2 receipt is therefore strict model-profile gate proof, not merely diagnostic metric evidence.

The new `1.0` policy requires every generated continuation to match and is stricter than the previous absence of a CodeGen-specific gate. No existing standard is lowered, and this proof does not depend on the generic-scorer enforcement already owned by #715.

## Notes

- The earlier local candidate receipt is superseded by the exact-head, forced-fresh receipt above.
- The accuracy-preserving FP32 boundaries have a measurable candidate cost on the same 10 prompts: mean decode latency increased from 48.7079 ms to 53.7994 ms, throughput decreased from 1,315.96 to 1,190.15 tokens/s (approximately 9.6%), and the plan grew from 1,367.8 MB to 1,567.6 MB (approximately 14.6%). This trade-off is explicit for review rather than hidden by the accuracy fix.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `07df1d85033b54b43249f73db21e1fd68a4a39a0`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The CodeGen parity checks use the current validation API and Bundle parity naming without changing the precision repair or strict `min_exact_match_rate: 1.0` gate. They preserve the `.bundle` / `BUNDLE\x01\x00` contract, keep #837's retired public surfaces deleted, and have zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the validation-engine replay passed **254 tests, 3 skipped in 9.46s**; source-quality passed **157 built-in tests in 19.82s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=all` and selects exactly one direct model proof, `codegen` (`expected_count=1`), with no fallback. Family-owned tests cover the base and tensor-parallel builder variants without adding a separate TP4 model job or full-model fan-out.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **1h59m18s**, including shared queue delay; this is not added test execution time.

