### PR TITLE
fix(internlm): skip unused decoder steps

### DIFF
--- a/src/runtime/models/internlm/MODEL.toml
+++ b/src/runtime/models/internlm/MODEL.toml
@@ -10,4 +10,5 @@ decoder_debug = ["internlm_decoder_kv_cache"]
 
 runtime_tests = [
   "test_internlm_chat_template|test_internlm_chat_template.cpp|trtmc_model_internlm|_|_",
+  "test_internlm_pipeline|test_internlm_pipeline.cpp|trtmc_model_internlm|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/internlm/pipeline.cpp
+++ b/src/runtime/models/internlm/pipeline.cpp
@@ -468,34 +468,11 @@ bool InternlmTextGenerationPipeline::run_prefill_batched(const std::vector<int32
     return true;
 }
 
-void InternlmTextGenerationPipeline::prime_decoder_after_batched_prefill(
-    const std::vector<int32_t>& input_ids) {
-    if (input_ids.empty())
-        return;
-
-    TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
-        return;
-
-    int32_t token_id = input_ids.back();
-    TensorMap inputs;
-    Tensor token_tensor;
-    token_tensor.data = &token_id;
-    token_tensor.shape = {1};
-    token_tensor.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = token_tensor;
-
-    state_->prepare_step(inputs);
-    decoder.forward_async(inputs);
-    decoder.sync();
-}
-
 void InternlmTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                                  std::vector<float>& logits, bool gpu_sampling) {
     // Fast path: batched prefill engine writes K/V for the whole prompt in
     // one forward and returns last-token logits on host.
     if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
-        prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
     }
@@ -959,6 +936,11 @@ int32_t InternlmTextGenerationPipeline::run_decode_loop(
                                   result.is_eos))
             break;
         if (result.is_eos)
+            break;
+        // The sampled token is already the final requested output. Running
+        // another decoder step would compute logits that no caller consumes;
+        // at full QA context it also exceeds the valid MHA cache read window.
+        if (step + 1 >= max_new_tokens)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/internlm/pipeline.h
+++ b/src/runtime/models/internlm/pipeline.h
@@ -191,7 +191,6 @@ class InternlmTextGenerationPipeline final : public IPipeline {
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
     bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
-    void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,
                                bool is_eos) const;

--- a/tests/cpp/models/internlm/test_internlm_pipeline.cpp
+++ b/tests/cpp/models/internlm/test_internlm_pipeline.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Regression coverage for the one-token task-eval path used by MMLU. The
+// Regression coverage for the one-token MMLU validation path. The
 // batched prefill logits already supply that token, so touching the CUDA-graph
 // decoder is both unnecessary and unsafe at the longest prompt shape.
 
@@ -141,12 +141,14 @@ void test_one_token_batched_prefill_does_not_touch_decoder() {
     request.max_new_tokens = 1;
     request.temperature = 0.0F;
     request.top_k = 1;
-    request.eos_token_id = 2;
+    // Keep the prefill argmax (token 2) non-EOS so this exercises the explicit
+    // final-token stop instead of passing through the earlier EOS branch.
+    request.eos_token_id = 3;
 
     std::vector<int32_t> prompt(700, 1);
     const auto result = pipeline.generate_ids(prompt, request);
     check(result.token_ids.size() == 701 && result.token_ids.back() == 2,
-          "one-token result comes from prefill logits");
+          "one non-EOS token comes from prefill logits");
     check(prefill_stats->calls == 1, "long batched prefill launches once");
     check(decode_stats->calls == 0, "one-token request does not prime decoder");
     check(prefill_stats->shapes["token_id"] == std::vector<int64_t>({700}),

--- a/tests/cpp/models/internlm/test_internlm_pipeline.cpp
+++ b/tests/cpp/models/internlm/test_internlm_pipeline.cpp
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Regression coverage for the one-token task-eval path used by MMLU. The
+// batched prefill logits already supply that token, so touching the CUDA-graph
+// decoder is both unnecessary and unsafe at the longest prompt shape.
+
+#include "runtime/models/internlm/kv_cache.h"
+#include "runtime/models/internlm/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+struct ModuleStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+};
+
+class CountingModule final : public trtmc::ITrtModule {
+  public:
+    CountingModule(std::shared_ptr<ModuleStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({704, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({704, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        record(inputs);
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { record(inputs); }
+    void sync() override { cudaStreamSynchronize(stream_); }
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override { cuda_graph_active_ = true; }
+    bool cuda_graph_active() const override { return cuda_graph_active_; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {704, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    void record(const trtmc::TensorMap& inputs) {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        for (const auto& [name, tensor] : inputs)
+            stats_->shapes[name] = tensor.shape;
+    }
+
+    std::shared_ptr<ModuleStats> stats_;
+    bool prefill_{false};
+    bool cuda_graph_active_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+void test_one_token_batched_prefill_does_not_touch_decoder() {
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+        std::cerr << "FAIL: create CUDA stream\n";
+        ++failures;
+        return;
+    }
+
+    auto decode_stats = std::make_shared<ModuleStats>();
+    auto prefill_stats = std::make_shared<ModuleStats>();
+    auto decoder = std::make_unique<CountingModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingModule>(prefill_stats, true, stream);
+    auto cache =
+        std::make_unique<trtmc::InternlmKvCache>(1, 704, 4, stream, trtmc::DType::kFloat32);
+
+    trtmc::InternlmTextGenConfig config;
+    config.vocab_size = 4;
+    config.id_eos = 2;
+    config.num_layers = 1;
+    config.kv_dim = 4;
+    config.prefill_max_length = 704;
+    config.disable_cuda_graph = false;
+
+    std::vector<trtmc::InternlmTextGenerationPipeline::DecoderContext> decoders;
+    decoders.push_back({704, std::move(decoder)});
+    trtmc::InternlmTextGenerationPipeline pipeline(std::move(decoders), std::move(cache), config,
+                                                   stream, nullptr, "", nullptr,
+                                                   std::move(prefill));
+
+    trtmc::GenerateConfig request;
+    request.max_new_tokens = 1;
+    request.temperature = 0.0F;
+    request.top_k = 1;
+    request.eos_token_id = 2;
+
+    std::vector<int32_t> prompt(700, 1);
+    const auto result = pipeline.generate_ids(prompt, request);
+    check(result.token_ids.size() == 701 && result.token_ids.back() == 2,
+          "one-token result comes from prefill logits");
+    check(prefill_stats->calls == 1, "long batched prefill launches once");
+    check(decode_stats->calls == 0, "one-token request does not prime decoder");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>({700}),
+          "prefill receives the complete prompt");
+
+    cudaStreamDestroy(stream);
+}
+
+} // namespace
+
+int main() {
+    test_one_token_batched_prefill_does_not_touch_decoder();
+    return failures;
+}


### PR DESCRIPTION
## Background

The QA benchmark run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` reported InternLM as
passed, but that result was not reproducible once engines and references were
forced fresh. The same 20-row `mmlu_five_shot_mcq` workload on GB300 with
TensorRT 11.2 crashed with a CUDA illegal memory access after inference.

`compute-sanitizer` localized invalid global reads to the TensorRT Myelin MHA
kernel called from `InternlmTextGenerationPipeline::run_step`. The runtime
sampled the requested final token from prefill logits and then launched an
additional decoder step whose logits no caller consumed. The batched-prefill
path also primed the CUDA-graph decoder with another unused step. At the full
QA prompt shape those launches read beyond the valid KV-cache window.

The report also exposed two independent validation issues:

- its `internlm-ae6eea210811` reference profile resolved
  `transformers==5.2.0`, which is not a valid oracle for the current aligned
  FP16 InternLM contract;
- the generic MCQ evaluator recorded a `0.0` agreement rate but did not enforce
  the suite's declared `min_prediction_agreement: 0.98` gate.

The repaired InternLM profile landed separately in
`edfe5e44e85e4486fca335538e911acab66dff52` (#626). Generic gate enforcement
is owned by the validation-engine migration in #715. This PR fixes the model
runtime fault and adds bounded, model-owned regression coverage.

## Exit Criteria

- The exact 20 QA prompts complete on GB300/TRT 11.2 with forced-fresh HF
  reference and TensorRT engine artifacts.
- With the repaired, landed InternLM profile, TRTMC and HF output text and
  generated token IDs agree for all 20 prompts.
- Replaying the original QA profile is retained as a strict failure
  reproduction; no threshold is relaxed to make an invalid oracle pass.
- CI fails if a one-token, long-prompt request touches the decoder after
  batched prefill.
- The added CI coverage remains model-owned and does not add another engine
  build or full QA lane.

## Implementation

- Stop the decode loop immediately after sampling the final requested token.
- Remove the unused decoder-prime launch after batched prefill.
- Add a model-owned GPU regression with a 700-token prefill and
  `max_new_tokens=1`; it asserts one prefill launch, zero decoder launches, and
  the expected sampled token.
- Register that regression in InternLM's `MODEL.toml`, so normal impact
  analysis selects only the InternLM family.

## Exact QA Environment Validation

All profile-transition runs below used exact PR head
`6a0b2329f6613757ca5b72f0bdc70d9ecde39634`, all 20 published QA rows,
NVIDIA GB300, driver `580.105.08`, CUDA 13.0, TensorRT `11.2.0.113`, and
PyTorch `2.12.0+cu130`. Both used `--force-hf --force-build
--local-files-only`; receipts record `hf_reused=false`,
`hf_cache_status=generated`, and `bundle_built=true`.

### Original QA profile: faithful strict failure reproduction

- Materialized the report's exact `internlm-ae6eea210811` profile, including
  `einops==0.8.1` and `transformers==5.2.0`.
- The patched runtime completed all 20 rows without the original CUDA fault,
  proving the runtime fix independently of the reference environment.
- Independent gate result: **FAIL**, as required.
- Prediction agreement: `0.0`; exact text: `0/20`; exact generated token IDs:
  `0/20`; HF/TRTMC accuracy: `0.00/0.15`.
- Failed declared gate: `min_prediction_agreement`, actual `0.0`, required
  `0.98`.
- Comparison SHA-256:
  `a32143d0720ba4565d1ce85d2ddf912c05081593d324cf634769e7b09882bb5e`.

### Repaired landed profile: strict full-20 pass

- Used `internlm-20b3634ee78d`, which pins `transformers==4.46.3`,
  `tokenizers==0.20.3`, `huggingface_hub==0.26.5`, and `einops==0.8.1`.
- Verified the profile lock and runtime verifier are byte-identical to their
  source in landed commit
  `edfe5e44e85e4486fca335538e911acab66dff52`, which is an ancestor of the
  recorded GitHub `main` revision
  `aa3779bb4576280f18c955535779eb9e5b452ca4`.
- Independent gate result: **PASS**.
- Prediction agreement: `1.0`; exact text: `20/20`; exact generated token IDs:
  `20/20`; HF/TRTMC accuracy: `0.15/0.15`; accuracy delta: `0.0`.
- Comparison SHA-256:
  `83b17bd2e5c27bae4786b188f3b8c3697141c778d7ea9054e572b9a6ee93482b`.

The independent transition audit passed and proves that the two runs used
byte-identical freshly built `trtmc`, `trtmc_dataset_benchmark`,
`libtrtmc_backend_trt.so`, and `libtrtmc_model_internlm.so` binaries. It also
proves that the prepared prompts and answers are byte-identical to the
published QA artifacts. This isolates the pass/fail transition to the repaired
reference profile rather than a runtime or input change.

Compact receipt (results, references, published QA artifacts, scripts, and
provenance; no engine or model weights):
`pr716-6a0b2329-internlm-profile-transition-gb300-receipt.tar.gz`, SHA-256
`a0708e4b3a28d879fa3235dd549eea26e5cbad9d52eb4a10da02b3edc567c45b`.
The extracted manifest verifies all files; the archive contains no symlinks,
no file over 10 MiB, and no engine/model payload.

## Additional Validation

- `compute-sanitizer ... trtmc_dataset_benchmark ... --max-new-tokens 1`:
  reproduced invalid global reads in the Myelin MHA kernel from
  `InternlmTextGenerationPipeline::run_step` before the fix.
- `test_internlm_pipeline`: passed on GB300 after the fix.
- `python tools/model_ci.py validate`: passed for all 78 model ownership
  manifests.
- `python tools/model_ci.py impact --base
  aa3779bb4576280f18c955535779eb9e5b452ca4 --head
  6a0b2329f6613757ca5b72f0bdc70d9ecde39634 --platform-change-policy
  fallback --fallback-model qwen3-0.6b`: selected exactly one direct model,
  `internlm`, with no fallback models.

## CI Runtime

The regression reuses the existing InternLM C++ test binary and a tiny
in-memory mock. It performs one lightweight GPU test process, no Hugging Face
inference, no TensorRT engine build, and no additional full-validation job.
Impact selection is limited to `internlm`, so unrelated model PRs do not pay
this cost.

The generic gate bug is fixed by the validation-engine migration in #715,
which applies the already-declared thresholds during normal comparison
evaluation without adding model runs or engine builds. This PR does not weaken
or duplicate those thresholds.

## Historical Rebase And Exact-head CI (2026-08-06)

The branch is rebased onto
`github/main@63c920304cb0236a995e933f49504e8f2f237317`; the exact PR head for
this validation is
`cc5685cc293750b6568f762ae2485fd3fd49b50f`.

- The rebased model-owned regression now keeps the sampled final token
  non-EOS. This specifically exercises the new explicit final-token stop
  instead of allowing the pre-existing EOS branch to hide an extra decoder
  launch.
- The historical regression set passed with `30 passed, 2 skipped`.
- The InternLM C++ test DSO built successfully against that historical exact
  head.
- The full 20-row GB300 profile-transition receipt above remains tied to exact
  repair head `6a0b2329f6613757ca5b72f0bdc70d9ecde39634`; it is not relabeled as a
  replay of a newer head.
- At historical exact head `cc5685cc293750b6568f762ae2485fd3fd49b50f`,
  both Source-visible CodeQL analyses passed and
  `trtmc/premerge/required` reported `SUCCESS`. GitHub reported the non-draft
  PR as `MERGEABLE/CLEAN` when this description was updated on 2026-08-06.

The CI cost remains bounded to the directly selected `internlm` family. The
regression reuses its existing model-owned C++ test DSO and an in-memory
counting module; it adds no model download, TensorRT engine build, Hugging Face
inference, fallback model, or full QA lane. Historical exact-head impact
selected one direct InternLM model job.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `fc05b0621331953e0bbadd8998662bdf4479629d`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- The regression keeps the sampled final token non-EOS, directly proving the explicit final-token stop. This runtime-only repair preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: source-quality passed **157 built-in tests in 20.03s** plus InternLM changed-file C++ format, complexity, and architecture contracts; the rebuilt focused GPU CTest passed **1/1 in 2.20s**; model inventory validation passed for all **79 models**.
- Current 9fd-based impact uses `unit_scope=builder` and selects exactly one direct model proof, `internlm` (`expected_count=1`), with no fallback. The regression reuses the existing model-owned C++ test and adds no model download, Hugging Face inference, new TensorRT engine build, or full QA lane.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **2h00m44s**, including shared queue delay; this is not added test execution time.

## Notes For Future Readers

The final sampled token is already valid output. Do not restore a decoder
launch after that token unless a caller consumes its logits and the cache
bounds are extended accordingly. Review `pipeline.cpp` first, then the focused
regression and `MODEL.toml` registration.

