### PR TITLE
fix(validation): bound reranker prompt sizing

### DIFF
--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4698,9 +4698,9 @@ def test_max_prompt_token_length_uses_pinned_model_revision(
     captured: dict[str, Any] = {}
 
     class Tokenizer:
-        def __call__(self, text, *, add_special_tokens=False):
-            assert add_special_tokens is False
-            return argparse.Namespace(input_ids=text.split())
+        def __call__(self, text, *, add_special_tokens=True):
+            assert add_special_tokens is True
+            return argparse.Namespace(input_ids=["<bos>", *text.split()])
 
     class AutoTokenizer:
         @staticmethod
@@ -4722,7 +4722,7 @@ def test_max_prompt_token_length_uses_pinned_model_revision(
         local_files_only=True,
     )
 
-    assert length == 2
+    assert length == 3
     assert captured == {
         "model_id": "org/model",
         "revision": "0123456789abcdef",
@@ -4745,9 +4745,9 @@ def test_max_prompt_token_length_falls_back_to_raw_tokenizer(
             raise TypeError("invalid added tokens")
 
     class RawTokenizer:
-        def encode(self, text, *, add_special_tokens=False):
-            assert add_special_tokens is False
-            return argparse.Namespace(ids=text.split())
+        def encode(self, text, *, add_special_tokens=True):
+            assert add_special_tokens is True
+            return argparse.Namespace(ids=["<bos>", *text.split()])
 
         def decode(self, token_ids, *, skip_special_tokens=False):
             assert skip_special_tokens is False
@@ -4787,7 +4787,7 @@ def test_max_prompt_token_length_falls_back_to_raw_tokenizer(
         local_files_only=True,
     )
 
-    assert length == 3
+    assert length == 4
     assert captured == {
         "model_id": "org/model",
         "revision": "0123456789abcdef",
@@ -4795,6 +4795,59 @@ def test_max_prompt_token_length_falls_back_to_raw_tokenizer(
         "allow_patterns": ["tokenizer.json"],
         "tokenizer_file": str(tmp_path / "snapshot" / "tokenizer.json"),
     }
+
+
+def test_max_prompt_token_length_bounds_reranking_templates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text(
+        json.dumps(
+            {
+                "query": "query text",
+                "documents": ["short", "the longer document"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    captured: list[str] = []
+
+    class Tokenizer:
+        def __call__(self, text, *, add_special_tokens=True):
+            assert add_special_tokens is True
+            captured.append(text)
+            extra_tokens = 2 if "\n" in text else 0
+            return argparse.Namespace(
+                input_ids=["<bos>", *text.split(), *(["<newline>"] * extra_tokens)]
+            )
+
+    class AutoTokenizer:
+        @staticmethod
+        def from_pretrained(_model_id, **_kwargs):
+            return Tokenizer()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(AutoTokenizer=AutoTokenizer),
+    )
+
+    length = validation_engine.max_prompt_token_length(
+        model_id="org/reranker",
+        model_revision="0123456789abcdef",
+        prompts_path=prompts,
+        local_files_only=True,
+    )
+
+    assert captured == [
+        "question:query text   passage:short",
+        "question:query text \n \n passage:short",
+        "question:query text   passage:the longer document",
+        "question:query text \n \n passage:the longer document",
+    ]
+    assert length == 8
 
 
 def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch) -> None:

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -2759,6 +2759,24 @@ def load_jsonl(path: Path, *, errors: str = "strict") -> list[dict[str, Any]]:
     return rows
 
 
+class _RawTokenizerWrapper:
+    """Expose the small callable tokenizer surface used by validation."""
+
+    def __init__(self, tokenizer: Any) -> None:
+        self._tokenizer = tokenizer
+
+    def __call__(self, text: str, *, add_special_tokens: bool = True) -> Any:
+        encoding = self._tokenizer.encode(
+            text, add_special_tokens=add_special_tokens
+        )
+        return argparse.Namespace(input_ids=encoding.ids)
+
+    def decode(self, token_ids: Sequence[int], **_: Any) -> str:
+        return self._tokenizer.decode(
+            list(token_ids), skip_special_tokens=False
+        )
+
+
 def _load_prompt_tokenizer(
     *,
     model_id: str,
@@ -2800,26 +2818,12 @@ def _load_prompt_tokenizer(
                 "or tokenizer.json"
             ) from fallback_error
 
-        class RawTokenizerWrapper:
-            def __call__(self, text: str, *, add_special_tokens: bool = True) -> Any:
-                encoding = raw_tokenizer.encode(
-                    text, add_special_tokens=add_special_tokens
-                )
-
-                class Encoded:
-                    input_ids = encoding.ids
-
-                return Encoded()
-
-            def decode(self, token_ids: Sequence[int], **_: Any) -> str:
-                return raw_tokenizer.decode(list(token_ids), skip_special_tokens=False)
-
         print(
             f"warning: AutoTokenizer failed for {model_id!r} ({auto_error}); "
             "using tokenizer.json for prompt accounting",
             file=sys.stderr,
         )
-        return RawTokenizerWrapper()
+        return _RawTokenizerWrapper(raw_tokenizer)
 
 
 def truncate_prompt_rows(

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -2801,7 +2801,7 @@ def _load_prompt_tokenizer(
             ) from fallback_error
 
         class RawTokenizerWrapper:
-            def __call__(self, text: str, *, add_special_tokens: bool = False) -> Any:
+            def __call__(self, text: str, *, add_special_tokens: bool = True) -> Any:
                 encoding = raw_tokenizer.encode(
                     text, add_special_tokens=add_special_tokens
                 )
@@ -2931,13 +2931,22 @@ def max_prompt_token_length(
         documents = row.get("documents")
         if isinstance(documents, list) and documents:
             query = str(row.get("query", row.get("prompt", "")))
-            prompts = [
-                f"question:{query}   passage:{document}" for document in documents
-            ]
+            prompts = []
+            for document in documents:
+                # Bound both the current C++ runtime text and the pinned Eagle
+                # processor contract. Whitespace changes tokenization, and
+                # either representation can be the longer fixed-shape input.
+                prompts.extend(
+                    [
+                        f"question:{query}   passage:{document}",
+                        f"question:{query} \n \n passage:{document}",
+                    ]
+                )
         else:
             prompts = [str(row.get("prompt", ""))]
         for prompt in prompts:
-            length = len(tokenizer(prompt, add_special_tokens=False).input_ids)
+            # Match the default special-token framing embedded in the bundle.
+            length = len(tokenizer(prompt).input_ids)
             max_len = max(max_len, length)
     return max_len
 


### PR DESCRIPTION
## Background

QA run `trtmc-validate-gb300-2-20260726-c8291be0-all105` exposed a fixed-shape reranker sizing mismatch. Validation sized reranking engines from only the current three-space runtime prompt:

`question:{query}   passage:{document}`

The pinned Eagle processor uses:

`question:{query} \n \n passage:{document}`

These whitespace forms can tokenize to different lengths. Validation also excluded the tokenizer's default special-token framing even though bundle construction and runtime preserve that default contract. Together, those differences could under-size a fixed-shape engine.

This PR originally also enforced generic metric gates. That behavior has since landed through #715 in the current validation engine, so this rewrite intentionally retains only the remaining prompt-sizing fix.

## Exit Criteria

- Fixed-shape sizing covers both the current runtime prompt and the pinned Eagle processor prompt.
- Sizing includes the bundle tokenizer's default special-token framing.
- No task-eval entrypoint or generic gate behavior already owned by #715 is restored.
- The change adds no model execution, engine build, C++ rebuild, or additional E2E matrix entry.

## Root Cause

`max_prompt_token_length` formatted every reranking request using only the three-space runtime fallback and explicitly passed `add_special_tokens=False`.

That calculation did not bound the pinned processor representation or the tokenizer framing embedded in the bundle. Because either prompt representation can be longer depending on the tokenizer, the resulting fixed shape was not a safe upper bound.

## Implementation

- Tokenize both reranking prompt representations for every query/document pair:
  - current runtime three-space form;
  - pinned Eagle processor newline form.
- Use the tokenizer's default special-token behavior for both representations.
- Take the maximum token length across both forms.
- Align the raw `tokenizer.json` fallback with the same default special-token behavior.
- Add regression coverage for the pinned revision, raw-tokenizer fallback, exact prompt strings, and conservative maximum selection.

The additional work is bounded to one extra CPU tokenization per reranking document. It does not repeat HF inference, TRTMC inference, dataset preparation, or engine construction.

## Validation

Historical frozen-environment replay:

- Focused regression tests: `3 passed in 0.76s`.
- Full validation-engine suite: `243 passed in 10.45s`.
- Exact-main baseline with the same environment and command: `242 passed in 10.69s`.
- `ruff check tools/validation/engine.py tests/tools/test_validation_engine.py`: passed.
- `git diff --check`: passed.
- Test-impact selection: tools unit tier only, zero model E2E jobs, zero builder tests, and no C++ rebuild.

The original QA-equivalent combined validation with the Eagle family fix recorded a fresh GB300 / TensorRT `11.2.0.113` full-20 replay: `20/20` passed, HF/TRTMC top-1 `1.0/1.0`, and pairwise ordering agreement mean/min `1.0/1.0`.

## Notes For Future Readers

- #715 owns generic threshold enforcement; do not reintroduce the deleted task-eval implementation here.
- The Eagle runtime accuracy repair remains isolated in #693.
- This PR only ensures validation cannot under-size the corresponding fixed-shape bundle because of prompt-template or special-token framing drift.

## Latest Main, Bundle Compatibility, Validation, And Exact-head CI (2026-08-07)

- Rebased onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `b545e0709ea4420500f0e85479d8122df708a88b`.
- Ancestry and byte-for-byte checks preserve #817 (`304125ca4ac5d5749114661d6ad286331727dbdb`), #843 (`50a05ed1608de5f47bf0c3e4024197dfa3dd89af`), and #842 (`9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`). The Qwen-MoE manifest/contract and GPU-lease/model-proof files owned by #842/#843 are identical to `github/main` and do not overlap this PR.
- Review follow-up keeps the raw `tokenizer.json` adapter as the module-level callable `_RawTokenizerWrapper`, preserving prompt accounting and decode behavior while making the fallback contract visible to static analysis.
- The change uses the current Bundle validation engine. It preserves the `.bundle` / `BUNDLE\x01\x00` contract, keeps #837's retired public surfaces deleted, and has zero case-insensitive `TRTFB` matches in tracked content or paths.
- Current exact-head local validation: the three focused prompt-sizing regressions passed in **0.58s**; the #842/#843 model-proof and Qwen-MoE contract files passed **151 tests in 28.57s**; source-quality passed **157 built-in tests in 20.43s** plus changed-file lint/format, complexity, and architecture contracts; model inventory validation passed for all **79 models**.
- Current 9fd-based impact is tools-only (`unit_scope=all`, `expected_count=0`): no model proof, fallback, engine build, or C++ rebuild is added. The only runtime change is one extra CPU tokenization per reranking document during fixed-shape sizing.
- On this exact head, `trtmc/premerge/required` and both CodeQL analyses passed, and GitHub reports `MERGEABLE/CLEAN`. The source-visible pending-to-pass wall clock was **20m18s**, including shared queue delay; this is not added test execution time.
