### PR TITLE
fix(nemotron-h): preserve recurrent state accuracy

### DIFF
--- a/src/runtime/models/nemotron_h/recurrent_state.cpp
+++ b/src/runtime/models/nemotron_h/recurrent_state.cpp
@@ -17,11 +17,14 @@ NemotronHRecurrentState::NemotronHRecurrentState(int32_t num_layers, std::vector
                                                  cudaStream_t stream)
     : specs_(std::move(specs)), num_layers_(num_layers), stream_(stream) {
     state_.resize(specs_.size());
+    present_.resize(specs_.size());
 
     for (std::size_t si = 0; si < specs_.size(); ++si) {
         state_[si].reserve(static_cast<std::size_t>(num_layers));
+        present_[si].reserve(static_cast<std::size_t>(num_layers));
         for (int32_t li = 0; li < num_layers; ++li) {
             state_[si].emplace_back(specs_[si].shape, DType::kFloat32, stream);
+            present_[si].emplace_back(specs_[si].shape, DType::kFloat32, stream);
         }
     }
 
@@ -37,12 +40,12 @@ void NemotronHRecurrentState::bind_to(TrtModule& module) {
             auto suffix = "_" + std::to_string(li);
             auto uli = static_cast<std::size_t>(li);
 
-            // The recurrent engine reads each state tensor before writing its
-            // matching present tensor, so both bindings can share one stable
-            // address. This removes per-token state copies and is compatible
-            // with CUDA Graph replay.
+            // TensorRT does not guarantee that this model's recurrent input
+            // remains intact while its matching output is produced. Keep
+            // distinct stable addresses so CUDA Graph replay is safe without
+            // introducing an input/output write-after-read hazard.
             module.bind_external(name + suffix, state_[si][uli].data());
-            module.bind_external(out_prefix + suffix, state_[si][uli].data());
+            module.bind_external(out_prefix + suffix, present_[si][uli].data());
         }
     }
 }
@@ -50,6 +53,12 @@ void NemotronHRecurrentState::bind_to(TrtModule& module) {
 void NemotronHRecurrentState::prepare_step(TensorMap& /*inputs*/, int32_t /*seq_len*/) {}
 
 void NemotronHRecurrentState::advance(int32_t n_tokens) {
+    for (std::size_t si = 0; si < specs_.size(); ++si) {
+        for (int32_t li = 0; li < num_layers_; ++li) {
+            auto uli = static_cast<std::size_t>(li);
+            state_[si][uli].copy_from(present_[si][uli]);
+        }
+    }
     position_ += n_tokens;
 }
 
@@ -59,6 +68,7 @@ void NemotronHRecurrentState::reset() {
         for (int32_t li = 0; li < num_layers_; ++li) {
             auto uli = static_cast<std::size_t>(li);
             cudaMemsetAsync(state_[si][uli].data(), 0, state_[si][uli].nbytes(), stream_);
+            cudaMemsetAsync(present_[si][uli].data(), 0, present_[si][uli].nbytes(), stream_);
         }
     }
     cudaStreamSynchronize(stream_);
@@ -69,6 +79,8 @@ std::size_t NemotronHRecurrentState::device_memory_bytes() const {
     for (std::size_t si = 0; si < specs_.size(); ++si) {
         for (const auto& t : state_[si])
             total += t.nbytes();
+        for (const auto& t : present_[si])
+            total += t.nbytes();
     }
     return total;
 }
@@ -78,6 +90,12 @@ bool NemotronHRecurrentState::ok() const {
         if (state_[si].size() != static_cast<std::size_t>(num_layers_))
             return false;
         for (const auto& t : state_[si]) {
+            if (!t.ok())
+                return false;
+        }
+        if (present_[si].size() != static_cast<std::size_t>(num_layers_))
+            return false;
+        for (const auto& t : present_[si]) {
             if (!t.ok())
                 return false;
         }

--- a/src/runtime/models/nemotron_h/recurrent_state.h
+++ b/src/runtime/models/nemotron_h/recurrent_state.h
@@ -42,6 +42,7 @@ class NemotronHRecurrentState final : public NemotronHInferenceState {
   private:
     std::vector<TensorSpec> specs_;
     std::vector<std::vector<DeviceTensor>> state_;
+    std::vector<std::vector<DeviceTensor>> present_;
     int32_t num_layers_{0};
     int32_t position_{0};
     cudaStream_t stream_{nullptr};

--- a/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
+++ b/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
@@ -34,6 +34,7 @@
 #include "runtime/core/trt_common.h"
 
 #include <NvInfer.h>
+#include <array>
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
@@ -135,7 +136,7 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_state_decoder() {
         runtime->deserializeCudaEngine(plan->data(), plan->size()));
 }
 
-static void test_recurrent_state_updates_in_place() {
+static void test_recurrent_state_uses_distinct_io_buffers() {
     auto engine = build_mock_state_decoder();
     if (!engine) {
         std::cerr << "SKIP: can't build recurrent state engine\n";
@@ -152,16 +153,24 @@ static void test_recurrent_state_updates_in_place() {
 
     void* state_buffer = module.device_ptr("state_0");
     void* present_buffer = module.device_ptr("present_state_0");
-    check(state_buffer == present_buffer,
-          "recurrent state keeps input and output at one device address");
+    check(state_buffer != present_buffer,
+          "recurrent state keeps input and output at distinct device addresses");
+
+    const std::array<float, 4> expected = {1.0F, 2.0F, 3.0F, 4.0F};
+    std::array<float, 4> actual = {};
+    cudaMemcpyAsync(present_buffer, expected.data(), sizeof(expected), cudaMemcpyHostToDevice,
+                    stream);
     state.advance();
+    cudaMemcpyAsync(actual.data(), state_buffer, sizeof(actual), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
 
     check(module.device_ptr("state_0") == state_buffer,
           "recurrent state input address remains stable");
-    check(module.device_ptr("present_state_0") == state_buffer,
+    check(module.device_ptr("present_state_0") == present_buffer,
           "recurrent state output address remains stable");
-    check(state.device_memory_bytes() == 4 * sizeof(float),
-          "in-place recurrent state allocates one device buffer");
+    check(actual == expected, "recurrent state advances present output into the next input");
+    check(state.device_memory_bytes() == 8 * sizeof(float),
+          "recurrent state allocates distinct input and output buffers");
     cudaStreamDestroy(stream);
 }
 
@@ -367,7 +376,7 @@ static void test_argmax_recurrent() {
 
 int main() {
     test_argmax_recurrent();
-    test_recurrent_state_updates_in_place();
+    test_recurrent_state_uses_distinct_io_buffers();
     test_mamba_pipeline();
     test_rwkv_pipeline();
     test_hybrid_pipeline();


### PR DESCRIPTION
## Summary

Restore Nemotron-H recurrent-state accuracy by keeping TensorRT recurrent inputs and `present_*` outputs in distinct stable device buffers.

This is the Nemotron-H family fix for the QA run:

`trtmc-validate-gb300-2-20260726-c8291be0-all105`

## Failure and reproduction

The QA dashboard reported `nemotron-h-nano-9b` as passed even though the recorded MMLU prediction agreement was `0.95`, below the suite's declared `0.98` minimum.

A forced-fresh reproduction on GB300 / TensorRT 11.2 made the regression unambiguous:

| Metric | Pre-fix forced-fresh |
|---|---:|
| HF accuracy | 0.60 |
| TRTMC accuracy | 0.50 |
| Accuracy drop | 0.10 |
| Prediction agreement | 0.55 |
| Disagreements | 9 / 20 |
| Declared gate | **fail** |

The reproduction used the QA MMLU dataset and 20-sample roster with fresh HF predictions and a fresh engine (`--force-hf --force-build --local-files-only`).

## Root cause

Commit `29eaaf49` bound every recurrent state input and its matching `present_*` output to the same TensorRT device address. The Nemotron-H recurrent network is not input/output alias-safe: TensorRT may write the output before all consumers have finished reading the input, corrupting recurrent state and changing downstream logits.

## Fix

- Allocate distinct stable FP32 buffers for recurrent inputs and `present_*` outputs.
- Copy each present output into the next-step input state in `advance()`.
- Clear both buffer sets during reset.
- Keep both addresses stable, preserving CUDA Graph compatibility.

No model weights, precision contract, dataset, or accuracy threshold changed.

## Why CI missed it

Two independent gaps allowed the regression through:

1. The generic MCQ scorer computed agreement and accuracy but did not enforce the suite's declared gates, so the QA result was rendered green at `0.95 < 0.98`. That shared fail-closed gate enforcement is already owned by #715.
2. The existing Nemotron-H recurrent-state test asserted the unsafe input/output alias instead of checking numerical state advancement.

This PR changes the existing model-owned C++ test to require distinct addresses and verify the actual `present -> state` transfer. The pre-fix implementation fails two assertions; the fixed implementation passes.

The CI addition is bounded: it extends an existing focused test target and adds no model download, engine build, dataset pass, or new test executable. The focused test takes about 8 seconds; the three existing Nemotron-H model tests complete in under 9 seconds total on the validation host.

## Historical Exact-Source QA Validation

Exact source/runtime revision:

`6c89adb2c57749907d5819c0ba6d69546757b4ca`

Environment:

- NVIDIA GB300
- TensorRT `11.2.0.113`
- HF snapshot `6533e8de2c68e4536bf7c411d7a3ce5734111476`
- `/mnt/data/MMLU_five_shot/mmlu_dataset.json`
- 20 prepared / 20 HF / 20 TRTMC rows; 0 skipped
- fresh reference and engine; offline cache-only execution

Strict result:

| Metric | Exact-head fix | Gate |
|---|---:|---:|
| HF accuracy | 0.60 | diagnostic |
| TRTMC accuracy | 0.60 | diagnostic |
| Accuracy drop | 0.00 | <= 0.01 |
| Prediction agreement | 1.00 | >= 0.98 |
| Disagreements | 0 / 20 | diagnostic |
| Overall | **pass** | both gates |

The previously sensitive `mmlu_000005` changed from pre-fix `HF=B / TRTMC=D` to exact-head `HF=B / TRTMC=B`, including matching generated token ID `1398`.

Artifact identities:

- exact-head engine SHA-256: `1d32c07a5f08eb755ac590593ed9e2bf218152624c87d941916df359a493de77`
- comparison SHA-256: `0fc2659ad80c09a4dea42039c6b6bb5cc8577c8afb6da7ea2d1f3b1001579dcb`
- receipt archive SHA-256: `65c31692f18d9ce314ee96167f31ff8c4691e0d635e90ee5473520745c2315dc`
- end-to-end wall time: `629.08s`

The receipt archive excludes the engine, Hugging Face cache, and model weights.

## Tests

- [x] Pre-fix focused recurrent-state regression fails
- [x] Exact-head focused recurrent-state regression passes
- [x] All three existing Nemotron-H model C++ tests pass
- [x] Exact-head GB300 / TensorRT 11.2 forced-fresh MMLU validation passes both declared gates
- [x] Historical exact-source QA and focused model validation passed; the current rebased-head public checks are recorded below.

## Latest Main Compatibility And Exact-Head Validation (2026-08-07)

- Rebased without conflict onto `github/main@9fdce3abf3c250f37dbf7fc9c03c4c1ea02e9ae2`; exact head: `99f1c124960ed242793480e665c904cc243f9b6d`. Range-diff preserved every family commit.
- Mainline preservation is explicit: #817's repository-wide documentation/collaborative-review commit (`304125ca`), #843's Qwen-MoE clean-capacity contract (`50a05ed1`), and #842's draining-capacity lease fix (`9fdce3ab`) are all ancestors of this head. The PR has zero changed-path overlap with #842/#843.
- #837's public-surface cleanup remains intact: `.github/workflows/legal.yml`, `python/tensorrt_model_connect/families/flux/gen_fp8_bf16.py`, and `python/tensorrt_model_connect/families/pixart/diagnose_loop.py` remain absent.
- Bundle compatibility remains intact: the current `.bundle` / `BUNDLE\x01\x00` contract is unchanged, and case-insensitive scans of tracked paths and tracked content find zero `TRTFB` tokens. This PR does not restore the retired suffix, magic, or schema names.
- Exact-diff impact selection is bounded and was recomputed against this base: `mode=models`, direct `nemotron_h`, no fallback models, `expected_count=1`, builder-unit scope.
- Local exact-head validation: `python3 tools/model_ci.py validate`: **79 models**; `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed cyclomatic-complexity checks, changed-file Ruff/clang-format checks as applicable, and **157 architecture-contract tests**. The common #842 lease regressions passed (**4 passed, 145 deselected**). This C++-owned family diff also passed changed-file clang-format and the architecture contracts; no host-side GPU/model execution is claimed.
- Guard checks passed: `git diff --check`, exact-main ancestry, noreply committer identity, #837 deletion checks, and Bundle/TRTFB path-and-content scans.
- Exact-head public checks: `trtmc/premerge/required=SUCCESS`; CodeQL Python and JavaScript/TypeScript both `SUCCESS`; GitHub reports the non-draft PR as `MERGEABLE/CLEAN`.
- Observed exact-head required-CI execution: source-quality completed in 58s and the unit C++/Python job in 30s; the selected nemotron_h model job completed in 23m 49s; report, verdict, and status-publish completed in 12s, 4s, and 7s. Shared-runner queue latency is excluded from these execution durations. Its actual impact matrix was one direct `nemotron_h` model job, rather than the 79-model catalog; no acceptance threshold, retry, sample count, or model gate was reduced to obtain the pass.

The rebases change no family intent or QA workload. Current evidence is tied to the exact head above; earlier receipts in this description remain explicitly historical.
