### PR TITLE
fix(gemma): honor checkpoint gated activation

### DIFF
--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
@@ -142,16 +142,17 @@ def _swiglu_mlp(
     prefix: str,
     hidden: int,
     mlp_size: int,
+    activation: str,
+    work_np_dtype: np.dtype,
 ) -> trt.ITensor:
     gate = matmul(inp, hidden, mlp_size,
                   weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
     up = matmul(inp, hidden, mlp_size,
                 weights[f"{prefix}.w_up"], f"{prefix}.w_up")
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    activated = graph_ops.add_activation(
+        network, gate, activation, dtype=work_np_dtype)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        activated, up, trt.ElementWiseOperation.PROD)
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden,
                      weights[f"{prefix}.w_down"], f"{prefix}.w_down")
     return mlp_out
@@ -640,7 +641,8 @@ def build_dual_profile_decoder_engine(
             mlp_out = _swiglu_mlp(
                 network, norm2,
                 matmul=matmul, weights=weights, prefix=prefix,
-                hidden=hidden, mlp_size=mlp_size)
+                hidden=hidden, mlp_size=mlp_size,
+                activation=activation, work_np_dtype=work_np_dtype)
 
         # Final residual.
         if gemma2_norms:

--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
@@ -156,16 +156,17 @@ def _swiglu_mlp(
     prefix: str,
     hidden: int,
     mlp_size: int,
+    activation: str,
+    work_np_dtype: np.dtype,
 ) -> trt.ITensor:
     gate = matmul(inp, hidden, mlp_size,
                   weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
     up = matmul(inp, hidden, mlp_size,
                 weights[f"{prefix}.w_up"], f"{prefix}.w_up")
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    activated = graph_ops.add_activation(
+        network, gate, activation, dtype=work_np_dtype)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        activated, up, trt.ElementWiseOperation.PROD)
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden,
                      weights[f"{prefix}.w_down"], f"{prefix}.w_down")
     return mlp_out
@@ -628,7 +629,8 @@ def build_dual_profile_tp_decoder_engine(
             mlp_out = _swiglu_mlp(
                 network, norm2,
                 matmul=matmul, weights=weights, prefix=prefix,
-                hidden=hidden, mlp_size=mlp_size)
+                hidden=hidden, mlp_size=mlp_size,
+                activation=activation, work_np_dtype=work_np_dtype)
         mlp_out = add_all_reduce_sum(network, mlp_out, parallel.tp_size)
 
         # Final residual.

--- a/python/tensorrt_model_connect/families/gemma/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/gemma/graph_blocks.py
@@ -319,11 +319,12 @@ def add_swiglu_mlp(
     prefix: str,
     hidden_size: int,
     mlp_size: int,
+    activation: str = "silu",
     dtype: np.dtype = np.float32,
     quant_ctx: QuantContext | None = None,
     layer_prefix: str = "",
 ) -> trt.ITensor:
-    """Gate/up/down SwiGLU MLP. Returns output tensor."""
+    """Gate/up/down MLP with a checkpoint-selected gate activation."""
     matmul = _make_matmul_fn(network, dtype, quant_ctx)
     _lp = layer_prefix or prefix
 
@@ -332,11 +333,10 @@ def add_swiglu_mlp(
     up = matmul(inp, hidden_size, mlp_size,
                 weights[f"{prefix}.w_up"], f"{_lp}.w_up")
 
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    activated = graph_ops.add_activation(
+        network, gate, activation, dtype=dtype)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        activated, up, trt.ElementWiseOperation.PROD)
 
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden_size,
                      weights[f"{prefix}.w_down"], f"{_lp}.w_down")

--- a/python/tensorrt_model_connect/families/gemma/graph_ops.py
+++ b/python/tensorrt_model_connect/families/gemma/graph_ops.py
@@ -296,8 +296,8 @@ def add_activation(
     activation_type: str,
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Dispatch activation by name: 'silu', 'gelu_new', 'gelu', 'relu', 'relu2'/'squared_relu'."""
-    if activation_type in ("gelu_new", "gelu"):
+    """Dispatch activation by checkpoint-compatible name."""
+    if activation_type in ("gelu_new", "gelu", "gelu_pytorch_tanh"):
         return add_gelu_new(network, inp, dtype=dtype)
     elif activation_type == "relu":
         act = network.add_activation(inp, trt.ActivationType.RELU)

--- a/python/tensorrt_model_connect/families/gemma/plugin.py
+++ b/python/tensorrt_model_connect/families/gemma/plugin.py
@@ -63,6 +63,7 @@ class GemmaPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False, parallel_config=None,
     ) -> bytes:
+        activation = _checkpoint_gated_activation(config)
         parallel = normalize_parallel_config(parallel_config)
         if parallel.enabled:
             return build_dual_profile_tp_decoder_engine(
@@ -70,11 +71,28 @@ class GemmaPlugin:
                 precision=precision,
                 quant_ctx=quant_ctx,
                 verbose=verbose,
+                activation=activation,
                 parallel_config=parallel)
 
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision,
-            quant_ctx=quant_ctx, verbose=verbose)
+            quant_ctx=quant_ctx, verbose=verbose, activation=activation)
+
+
+def _checkpoint_gated_activation(config: ModelConfig) -> str:
+    """Return the checkpoint-declared activation for Gemma's gated MLP."""
+    activation = str(
+        config.hidden_act
+        or config.raw.get("hidden_activation")
+        or config.raw.get("hidden_act")
+        or ""
+    ).strip()
+    supported = {"gelu_pytorch_tanh", "gelu_new", "gelu", "silu"}
+    if activation not in supported:
+        raise ValueError(
+            "Gemma requires a supported checkpoint gated activation; "
+            f"got {activation or '<missing>'!r}")
+    return activation
 
 
 plugin = GemmaPlugin()

--- a/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
@@ -81,7 +81,7 @@ def build_standard_decoder_engine(
                   "gelu_fc" (2 projections: fc1/fc2 with activation).
         position_type: "rope" (rotary), "learned" (absolute position embeddings),
             or "alibi" (attention with linear biases, no position embeddings).
-        activation: Activation function for gelu_fc MLP ("gelu_new", "gelu", "relu", "relu2").
+        activation: Activation function for gated and gelu_fc MLPs.
         partial_rotary_factor: Fraction of head dims that get RoPE (default 1.0).
         interleaved_rope: If True, use interleaved RoPE (CodeGen/GPT-J) where
             adjacent dims (d, d+1) share frequencies. Default False uses
@@ -654,7 +654,8 @@ def _add_decoder_layer(
     else:
         mlp_out = graph_blocks.add_swiglu_mlp(
             network, norm2, weights=weights, prefix=prefix,
-            hidden_size=hidden_size, mlp_size=mlp_size, dtype=dtype,
+            hidden_size=hidden_size, mlp_size=mlp_size,
+            activation=activation, dtype=dtype,
             quant_ctx=quant_ctx, layer_prefix=prefix)
 
     # Final residual connection

--- a/tests/e2e/models/gemma/test_gemma_builder_engine.py
+++ b/tests/e2e/models/gemma/test_gemma_builder_engine.py
@@ -29,6 +29,12 @@ class GemmaPluginTester(FamilyPluginTester):
     plugin_module = "tensorrt_model_connect.families.gemma"
     model_type = "gemma"
 
+    def get_config_dict(self) -> dict:
+        config = super().get_config_dict()
+        config["hidden_act"] = "gelu_pytorch_tanh"
+        config["hidden_activation"] = "gelu_pytorch_tanh"
+        return config
+
 
 class TestGemmaEngine(FamilyPluginTestMixin):
     tester_class = GemmaPluginTester

--- a/tests/e2e/models/gemma/test_gemma_builder_tp.py
+++ b/tests/e2e/models/gemma/test_gemma_builder_tp.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 import importlib
+import math
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
@@ -21,10 +23,14 @@ except (ImportError, ModuleNotFoundError):
 
 def _config() -> SimpleNamespace:
     return SimpleNamespace(
-        raw={},
+        raw={
+            "hidden_act": "gelu_pytorch_tanh",
+            "hidden_activation": "gelu_pytorch_tanh",
+        },
+        hidden_act="gelu_pytorch_tanh",
         hidden_size=16,
         vocab_size=32,
-        num_hidden_layers=1,
+        num_hidden_layers=26,
         num_attention_heads=4,
         num_key_value_heads=4,
         head_dim=4,
@@ -60,3 +66,121 @@ def test_gemma_plugin_routes_parallel_builds(monkeypatch) -> None:
     assert max_cache_length == 23
     assert kwargs["parallel_config"] == parallel
     assert kwargs["verbose"] is True
+    assert kwargs["activation"] == "gelu_pytorch_tanh"
+
+
+def test_gemma_plugin_forwards_checkpoint_activation(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.gemma.plugin")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"gemma-plan"
+
+    monkeypatch.setattr(module, "build_standard_decoder_engine", fake_build)
+
+    result = module.GemmaPlugin().build_engine(
+        _config(),
+        {"_attention_size": 16, "_kv_attention_size": 16, "_mlp_size": 32},
+        23,
+    )
+
+    assert result == b"gemma-plan"
+    config, _, _, kwargs = calls["build"]
+    assert config.num_hidden_layers == 26
+    assert kwargs["activation"] == "gelu_pytorch_tanh"
+
+
+class _FakeLayer:
+    def __init__(self, output):
+        self._output = output
+
+    def get_output(self, index):
+        assert index == 0
+        return self._output
+
+
+class _FakeNetwork:
+    def __init__(self, trt):
+        self._trt = trt
+
+    def add_elementwise(self, lhs, rhs, operation):
+        if operation == self._trt.ElementWiseOperation.PROD:
+            return _FakeLayer(lhs * rhs)
+        if operation == self._trt.ElementWiseOperation.SUM:
+            return _FakeLayer(lhs + rhs)
+        raise AssertionError(f"unexpected elementwise operation: {operation}")
+
+    def add_activation(self, tensor, activation):
+        assert activation == self._trt.ActivationType.TANH
+        return _FakeLayer(np.tanh(tensor))
+
+
+def test_gemma_dual_profile_mlp_uses_checkpoint_gelu(
+    monkeypatch,
+) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.gemma.dual_profile_decoder_builder")
+    gate = np.array([-2.0, -0.5, 0.5, 2.0], dtype=np.float32)
+    up = np.ones_like(gate)
+
+    def fake_matmul(inp, lhs_width, rhs_width, weights, name):
+        del lhs_width, rhs_width, weights
+        if name.endswith("w_gate"):
+            return gate
+        if name.endswith("w_up"):
+            return up
+        return inp
+
+    def fake_constant(network, shape, values, dtype):
+        del network
+        return np.asarray(values, dtype=dtype).reshape(shape)
+
+    monkeypatch.setattr(module.graph_ops, "add_constant", fake_constant)
+    monkeypatch.setattr(
+        module.graph_ops,
+        "_cast_back_to_trt_dtype",
+        lambda network, tensor, dtype: tensor,
+    )
+
+    actual = module._swiglu_mlp(
+        _FakeNetwork(module.trt),
+        np.zeros_like(gate),
+        matmul=fake_matmul,
+        weights={
+            "layer.0.w_gate": None,
+            "layer.0.w_up": None,
+            "layer.0.w_down": None,
+        },
+        prefix="layer.0",
+        hidden=4,
+        mlp_size=4,
+        activation="gelu_pytorch_tanh",
+        work_np_dtype=np.float32,
+    )
+    expected = 0.5 * gate * (
+        1.0
+        + np.tanh(
+            math.sqrt(2.0 / math.pi)
+            * (gate + 0.044715 * np.power(gate, 3))
+        )
+    ) * up
+    silu = gate / (1.0 + np.exp(-gate))
+
+    np.testing.assert_allclose(actual, expected, atol=1e-7, rtol=0.0)
+    assert not np.allclose(actual, silu, atol=1e-3, rtol=0.0)
+
+
+def test_gemma_rejects_missing_checkpoint_activation() -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.gemma.plugin")
+    config = _config()
+    config.hidden_act = ""
+    config.raw = {}
+
+    with pytest.raises(
+        ValueError,
+        match="requires a supported checkpoint gated activation",
+    ):
+        module.GemmaPlugin().build_engine(config, {}, 23)


### PR DESCRIPTION
## Background

The QA accuracy report flags `gemma-2-2b / mmlu_five_shot_mcq`. A
QA-aligned, forced-fresh reproduction on source
`5dc37b757ae2ec93956acfb3672108372ff404e9` confirmed a real accuracy
regression and a CI false green:

| Metric | Fresh pre-fix | Declared gate |
| --- | ---: | ---: |
| HF accuracy | 0.35 | reference |
| TensorRT accuracy | 0.25 | drop <= 0.01 |
| HF accuracy drop | 0.10 | <= 0.01 |
| Prediction agreement | 0.50 | >= 0.98 |
| Disagreements | 10/20 | recorded |

Despite violating both gates, the generic runner recorded
`raw_result.status=passed`, `validation.status=passed`, and `failures=[]`.

The hard root cause was model-family behavior: the checkpoint declares
`hidden_activation=gelu_pytorch_tanh`, but the Gemma plugin did not forward
it. The serial builder inherited its `silu` default and the split/TP MLP
helpers hardcoded `gate * sigmoid(gate)`. All 26 Gemma 2 MLP blocks therefore
used SiLU instead of the checkpoint's tanh-GELU. An exact-base numeric probe
measured a maximum absolute gate error of `0.193003654`.

## Exit Criteria

- Honor the checkpoint gated activation in serial, split, and TP builders.
- Fail closed for a missing or unsupported checkpoint activation.
- Catch this family bug in the existing constant-time model-owned CI lane.
- On the QA GB300, force fresh HF and TensorRT outputs offline and pass
  agreement `>= 0.98` and HF accuracy drop `<= 0.01`.
- Do not weaken gates, alter the workload, or add GPU inference to premerge.

## Implementation

- Resolve `hidden_activation` / `hidden_act` from the checkpoint and forward
  it through serial and tensor-parallel plugin paths.
- Map `gelu_pytorch_tanh` to the existing tanh-approximate GELU graph.
- Apply the selected activation in each gated MLP instead of hardcoding SiLU.
- Add Gemma-owned tests for serial/TP forwarding, numeric GELU behavior, and
  fail-closed activation validation.

The generic evaluator recorded the metrics but did not enforce the suite
gates. Shared task-eval gate enforcement is handled by #718. This PR adds the
family-owned regression that catches this activation bug cheaply and avoids
duplicating that cross-family change.

`tools/model_ci.py impact` selects only `gemma`
(`expected_count=1`, `selection_kind=direct`, `unit_scope=builder`,
`run_unit_tests=true`). CI therefore reuses the existing model-owned unit lane:
O(1) scope, no repository-wide matrix expansion, and no added GPU inference.

## Validation

### Fail-before / pass-after model-owned proof

The same regression trio was run on exact base
`aa3779bb4576280f18c955535779eb9e5b452ca4` and exact fix head
`839b1d45f52ddf18f31e5a91a2990fab2b15d002`:

```text
PYTHONPATH=python /opt/venv/bin/python -m pytest -q \
  tests/e2e/models/gemma/test_gemma_builder_tp.py::test_gemma_plugin_routes_parallel_builds \
  tests/e2e/models/gemma/test_gemma_builder_tp.py::test_gemma_plugin_forwards_checkpoint_activation \
  tests/e2e/models/gemma/test_gemma_builder_tp.py::test_gemma_dual_profile_mlp_uses_checkpoint_gelu
```

- Base: `3 failed in 0.22s` (missing serial activation, missing TP
  activation, and no activation contract in the split MLP).
- Head: `3 passed in 0.14s`.
- `PYTHONPATH=python /opt/venv/bin/python -m pytest -q
  tests/e2e/models/gemma -m 'not gpu'`:
  `19 passed, 1 skipped, 3 deselected in 26.27s`.
- `python -m compileall` over the changed Gemma modules: passed.
- `git diff --check github/main...HEAD`: passed.
- `python3 tools/model_ci.py validate --revision 839b1d45...`: passed for
  all 78 registered models.
- `python3 tools/model_ci.py impact --base aa3779bb... --head 839b1d45...`:
  selected only `gemma` in the builder unit lane.

### Exact QA-environment reproduction

- Clean source: `839b1d45f52ddf18f31e5a91a2990fab2b15d002`
- Container: `trtmc-dev-gb300:manylinux_2_39-4a09683c461d`
- Image ID:
  `sha256:6e97af69eae7e9276e7f9061381edefd54a782ab6695c895117ecfff06188027`
- GPU: NVIDIA GB300,
  `GPU-8368d519-189f-6156-74d2-b47dcadf589d`
- Driver: `580.105.08`
- TensorRT: `11.2.0.113` (ABI 11.2)
- HF snapshot: `299a8560bedf22ed1c72a8a11e7dce4a7f9f51f8`
- Precision: TensorRT FP16 / HF FP16
- Window: `2026-07-29T12:41:34Z` to `12:50:34Z` (540 seconds)
- Flags: `--force-hf --force-build --local-files-only`
- Freshness: `hf_reused=false`, `hf_cache_status=generated`,
  `bundle_built=true`
- Execution: first attempt, no retry

Exact validator command:

```text
/opt/venv/bin/python /runs/worktrees/gemma-gated-gelu-accuracy/tools/trtmc_validate.py gemma-2-2b mmlu_five_shot_mcq \
  --catalog /runs/worktrees/gemma-gated-gelu-accuracy/tests/validation/model_workloads.yaml \
  --suites /runs/worktrees/gemma-gated-gelu-accuracy/tests/task_eval/validation_suites.yaml \
  --models-dir /runs/worktrees/gemma-gated-gelu-accuracy/tests/e2e/models \
  --output /runs/reruns/gemma-839b1d45-gated-gelu-offline-fresh-r1/results \
  --engine-dir /runs/reruns/gemma-839b1d45-gated-gelu-offline-fresh-r1/engines \
  --reference-cache-dir /runs/reruns/gemma-839b1d45-gated-gelu-offline-fresh-r1/references \
  --trtmc-binary /runs/tmp/build-gemma-839b1d45-trt112/trtmc \
  --benchmark-binary /runs/tmp/build-gemma-839b1d45-trt112/trtmc_dataset_benchmark \
  --hf-python /opt/venv/bin/python --model-attempts 2 \
  --model-retry-delay-seconds 5.0 \
  --backend-dir /runs/tmp/build-gemma-839b1d45-trt112 \
  --model-plugin-dir /runs/tmp/build-gemma-839b1d45-trt112/models \
  --cuda-visible-devices 0 --force-hf --force-build --local-files-only
```

An independent strict gate then passed:

| Metric | Exact post-fix | Gate |
| --- | ---: | ---: |
| HF accuracy | 0.35 | reference |
| TensorRT accuracy | 0.35 | drop <= 0.01 |
| HF accuracy drop | 0.00 | <= 0.01 |
| Prediction agreement | 1.00 | >= 0.98 |
| HF/TRT valid rates | 1.00 / 1.00 | recorded |
| Disagreements | 0/20 | recorded |

Key SHA256:

- post-fix bundle:
  `1d510ef1950df287c2967d572482bb8b192732f01f9b8bd5c978519a00e7c9ca`
- `trtmc`:
  `33056e17060aaed4562b43a238897b396a6edc1e58e4da3f0519a05ed8ad2534`
- benchmark:
  `95d1b3b1304a11f0602823d4ec190d001469a4a63711c952a67082824fb0d9a2`
- TRT backend:
  `13af717d1e124026adfc9307a3716d4f2d0c15ad6dfe72bc60d0ac00feeb866f`
- Gemma plugin:
  `2e25ec8f94c07b93cd594be402a99d855bbd50d8e5bde25f0935eb978cca6e90`
- post-fix comparison:
  `d0d034dfc74a770db8a4ff75e0a247ba6beef6d6a40f6092ef92cfbbaedc81a7`
- strict gate:
  `46a0b0b9c94c0d4262f797f38fdaac02562df7ed0d2981ea5422809767689587`
- fail-before comparison:
  `9a369eb3f252c7a3ca8d41ff7ae7efdb4aa0ce2a08bc07878a10b82f5387e4ae`

## Notes For Future Readers

- Review `plugin.py`, then `graph_ops.py` / `graph_blocks.py`, then the
  split/TP builder propagation.
- Do not replace the selected activation with a family default; Gemma
  checkpoints do not all share the same gated activation.
- The no-engine/no-cache/no-weights QA receipt is retained at
  `/tmp/trtmc-accuracy-agent2/reruns/gemma-839b1d45-gb300-receipt.tar.gz`,
  SHA256
  `9014893ca7b32407fed592fa4ae5158a7f90a49af224680a716d2dc5fffb2956`.
  Its audit reports 0 symlinks, 0 forbidden paths, 0 files over 10 MiB, and
  a fully passing internal manifest.
- Keep this PR limited to Gemma. Do not merge until exact-head CI is green.


## Latest Main Compatibility Refresh (2026-08-07)

- Rebased without conflict onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `f16a4d1323dd34a14cb9194fa350b61b28acfd55`.
- `git range-diff` reports the Gemma commit unchanged, and the family-only file scope is preserved.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `git diff --check`, `py_compile`, and `ruff check` passed for every changed Python file. The selected Gemma TensorRT tests were collected as skipped because TensorRT is unavailable on this host; current-head model proof remains a CI responsibility.

No threshold, model invocation, engine build, or CI fanout was added by this refresh.
