### PR TITLE
fix(deepseek-v2): align L0 FP16 reference

### DIFF
--- a/tests/e2e/models/deepseek_v2/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/deepseek_v2/e2e_plugins/references/hf_transformers.py
@@ -48,6 +48,14 @@ def _torch_dtype_for_case(case: E2ECase) -> str:
     return _PRECISION_TO_TORCH_DTYPE.get(precision, "torch.float32")
 
 
+def _experts_implementation_for_case(case: E2ECase) -> str:
+    """Return the model-owned Transformers MoE backend, when declared."""
+    task_eval = case.metadata.get("task_eval", {})
+    if not isinstance(task_eval, Mapping):
+        return ""
+    return str(task_eval.get("hf_experts_implementation", "") or "").strip()
+
+
 def _vl_prompt_has_image_placeholder(text: str) -> bool:
     """Return true when a rendered VL prompt still carries an image placeholder."""
     return any(marker in text for marker in (
@@ -332,6 +340,7 @@ class HfTransformersReference:
         hf_id = case.hf_id
         model_ref = _resolve_cached_model_ref(hf_id, case.hf_revision)
         torch_dtype_expr = _torch_dtype_for_case(case)
+        experts_implementation = _experts_implementation_for_case(case)
 
         contract_config = case.metadata.get("contract_config", {})
         use_chat_template = contract_config.get("use_chat_template", False)
@@ -346,6 +355,7 @@ class HfTransformersReference:
             prompt = {prompt!r}
             max_new_tokens = {max_new_tokens}
             trust_remote_code = {trust_remote_code!r}
+            experts_implementation = {experts_implementation!r}
             logits_path = {logits_path!r}
             text_path = {text_path!r}
             use_chat_template = {use_chat_template!r}
@@ -375,6 +385,8 @@ class HfTransformersReference:
                 "trust_remote_code": trust_remote_code,
                 "torch_dtype": {torch_dtype_expr},
             }}
+            if experts_implementation:
+                load_kwargs["experts_implementation"] = experts_implementation
             # Detect encoder-decoder models by checking config
             from transformers import AutoConfig
             _cfg = AutoConfig.from_pretrained(model_ref, trust_remote_code=trust_remote_code)
@@ -451,7 +463,10 @@ class HfTransformersReference:
             logits_reader=(
                 lambda: logits_path if Path(logits_path).is_file() else None
             ),
-            metadata={"trust_remote_code": trust_remote_code},
+            metadata={
+                "trust_remote_code": trust_remote_code,
+                "experts_implementation": experts_implementation,
+            },
             include_stdio_metadata=True,
             failure_label="HF reference",
         )

--- a/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-tiny.json
+++ b/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-tiny.json
@@ -6,19 +6,22 @@
   "family": "deepseek_v2",
   "runtime_strategy": "deepseek_v2_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "precision": "fp32",
+  "precision": "fp16",
   "max_cache_length": 64,
   "trust_remote_code": false,
+  "task_eval": {
+    "hf_experts_implementation": "batched_mm"
+  },
   "testcases": [
     {
       "name": "deepseek-v2-tiny",
       "trace_id": "IT-E2E-DSV2T-01",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "reference_precision": "fp32",
+      "reference_precision": "fp16",
       "prompt": "The capital of France is",
       "max_new_tokens": 10,
-      "notes": "Finite-weight DeepSeek-V3 tiny model using aligned FP32 precision for stable grouped sigmoid MoE routing coverage."
+      "notes": "Finite-weight DeepSeek-V3 tiny model using aligned FP16 model/reference precision while retaining FP32 router scoring for stable grouped sigmoid MoE coverage."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_v2/test_deepseek_v2_hf_reference.py
+++ b/tests/e2e/models/deepseek_v2/test_deepseek_v2_hf_reference.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from tests.e2e.models.deepseek_v2.e2e_plugins.references import hf_transformers
 
 
@@ -35,3 +37,70 @@ def test_cached_model_resolution_honors_pinned_revision(monkeypatch) -> None:
             },
         )
     ]
+
+
+def test_full_generation_propagates_model_owned_experts_backend(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    expected = object()
+
+    monkeypatch.setattr(
+        hf_transformers,
+        "_resolve_cached_model_ref",
+        lambda _hf_id, _revision: "/cache/pinned-snapshot",
+    )
+    monkeypatch.setattr(hf_transformers, "_reference_env", lambda _ctx: {})
+
+    def fake_run_reference_subprocess(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(
+        hf_transformers,
+        "run_reference_subprocess",
+        fake_run_reference_subprocess,
+    )
+    case = SimpleNamespace(
+        name="deepseek-v2-tiny",
+        task_strategy="text_generation_causal",
+        hf_id="katuni4ka/tiny-random-deepseek-v3",
+        hf_revision="ba144b0d3331a5892aa588d82722d382be2b6e6b",
+        inputs={
+            "prompt": "The capital of France is",
+            "max_new_tokens": 10,
+        },
+        metadata={
+            "precision": "fp16",
+            "reference_precision": "fp16",
+            "trust_remote_code": False,
+            "task_eval": {
+                "hf_experts_implementation": "batched_mm",
+            },
+        },
+    )
+    stage = SimpleNamespace(name="full_generation")
+    ctx = SimpleNamespace(
+        artifacts_dir="",
+        reference_python_path=lambda: "/opt/venv/bin/python",
+    )
+
+    result = hf_transformers.HfTransformersReference()._run_full_generation(
+        case,
+        stage,
+        ctx,
+    )
+
+    assert result is expected
+    command = captured["command"]
+    assert isinstance(command, list)
+    script = command[2]
+    assert "experts_implementation = 'batched_mm'" in script
+    assert (
+        'load_kwargs["experts_implementation"] = experts_implementation'
+        in script
+    )
+    assert captured["metadata"] == {
+        "trust_remote_code": False,
+        "experts_implementation": "batched_mm",
+    }

--- a/tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py
+++ b/tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py
@@ -22,3 +22,18 @@ def test_deepseek_v2_lite_builds_reserve_an_exclusive_gpu(
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_deepseek_v2_l0_replacement_preserves_precision() -> None:
+    manifests = Path(__file__).with_name("manifests")
+    lite = json.loads(
+        (manifests / "deepseek-v2-lite.json").read_text(encoding="utf-8")
+    )
+    tiny = json.loads(
+        (manifests / "deepseek-v2-tiny.json").read_text(encoding="utf-8")
+    )
+
+    assert lite["testcases"][0]["l0_replacement"] == tiny["name"]
+    assert lite["precision"] == tiny["precision"] == "fp16"
+    assert tiny["testcases"][0]["reference_precision"] == tiny["precision"]
+    assert tiny["task_eval"]["hf_experts_implementation"] == "batched_mm"

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3780,6 +3780,16 @@ def test_max_prompt_token_length_uses_pinned_model_revision(
 def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch) -> None:
     work_dir = tmp_path / "work"
     work_dir.mkdir()
+    (work_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "task_eval": {
+                    "hf_experts_implementation": "batched_mm",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     captured: dict[str, list[str]] = {}
 
     class Result:
@@ -3829,6 +3839,9 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
     assert captured["cmd"][
         captured["cmd"].index("--reference-cache-identity") + 1
     ] == "org/model/reference-contract-v1"
+    assert captured["cmd"][
+        captured["cmd"].index("--experts-implementation") + 1
+    ] == "batched_mm"
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -377,6 +377,25 @@ def test_reference_cache_key_changes_with_inference_setting(
     assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 2
 
 
+def test_reference_cache_key_changes_with_experts_implementation(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first)
+    _prepare_work(second)
+
+    first_key, _ = trtmc_reference.reference_key(
+        _args(first, cache_dir, "--experts-implementation", "batched_mm")
+    )
+    second_key, _ = trtmc_reference.reference_key(
+        _args(second, cache_dir, "--experts-implementation", "eager")
+    )
+
+    assert first_key != second_key
+
+
 def test_reference_cache_key_changes_with_model_revision(
     tmp_path: Path,
     monkeypatch,
@@ -453,6 +472,8 @@ def test_causal_reference_uses_native_transformers_entrypoint(
         cache_dir,
         "--model-revision",
         "0123456789abcdef",
+        "--experts-implementation",
+        "batched_mm",
     )
     arguments.reference_family = "causal_base_continuation"
     manifest_path = work_dir / "manifest.json"
@@ -501,6 +522,7 @@ def test_causal_reference_uses_native_transformers_entrypoint(
     command = captured["command"]
     assert command[1].endswith("tools/reference/transformers_text.py")
     assert command[command.index("--model-revision") + 1] == "0123456789abcdef"
+    assert command[command.index("--experts-implementation") + 1] == "batched_mm"
     assert "task_eval.py" not in " ".join(command)
     assert (work_dir / "hf_native_run.log").is_symlink()
     assert (work_dir / "hf_native_repro.json").is_symlink()
@@ -526,6 +548,8 @@ def test_transformers_reference_metadata_is_direct_and_sample_selectable(
             str(tmp_path / "raw.jsonl"),
             "--repro-metadata",
             str(metadata),
+            "--experts-implementation",
+            "batched_mm",
             "--local-files-only",
         ]
     )
@@ -537,7 +561,60 @@ def test_transformers_reference_metadata_is_direct_and_sample_selectable(
     assert command[1].endswith("tools/reference/transformers_text.py")
     assert command[command.index("--sample-id") + 1] == "{sample_id}"
     assert command[command.index("--prompts") + 1] == "{work_dir}/prompts.jsonl"
+    assert command[command.index("--experts-implementation") + 1] == "batched_mm"
     assert "task_eval.py" not in " ".join(command)
+
+
+def test_transformers_text_forwards_experts_implementation(monkeypatch) -> None:
+    arguments = transformers_text.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--prompts",
+            "/tmp/prompts.jsonl",
+            "--answers",
+            "/tmp/answers.json",
+            "--manifest",
+            "/tmp/manifest.json",
+            "--predictions",
+            "/tmp/predictions.json",
+            "--raw-output",
+            "/tmp/raw.jsonl",
+            "--dtype",
+            "float16",
+            "--experts-implementation",
+            "batched_mm",
+        ]
+    )
+    captured: dict[str, object] = {}
+    tokenizer = SimpleNamespace(pad_token_id=0)
+    model = SimpleNamespace(device="cuda", to=lambda _device: None)
+    transformers_module = SimpleNamespace(
+        logging=SimpleNamespace(set_verbosity_error=lambda: None),
+        AutoTokenizer=SimpleNamespace(
+            from_pretrained=lambda _model_id, **_kwargs: tokenizer
+        ),
+    )
+
+    def fake_load_model(
+        _transformers_module,
+        _model_id,
+        *,
+        model_kwargs,
+        **_kwargs,
+    ):
+        captured.update(model_kwargs)
+        return model, False
+
+    monkeypatch.setattr(transformers_text, "_load_model", fake_load_model)
+
+    transformers_text._load_runtime(
+        arguments,
+        SimpleNamespace(float16=object(), device=lambda name: name),
+        transformers_module,
+    )
+
+    assert captured["experts_implementation"] == "batched_mm"
 
 
 def test_transformers_text_reference_accepts_float32_dtype() -> None:

--- a/tools/reference/transformers_text.py
+++ b/tools/reference/transformers_text.py
@@ -148,6 +148,7 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
         ("--model-revision", arguments.model_revision),
         ("--device-map", arguments.device_map),
         ("--attn-impl", arguments.attn_impl),
+        ("--experts-implementation", arguments.experts_implementation),
         ("--max-new-tokens", arguments.max_new_tokens),
         ("--temperature", arguments.temperature),
         ("--top-k", arguments.top_k),
@@ -260,6 +261,8 @@ def _load_runtime(
         model_kwargs["device_map"] = arguments.device_map
     if arguments.attn_impl:
         model_kwargs["attn_implementation"] = arguments.attn_impl
+    if arguments.experts_implementation:
+        model_kwargs["experts_implementation"] = arguments.experts_implementation
     if arguments.model_revision:
         model_kwargs["revision"] = arguments.model_revision
     model, is_encoder_decoder = _load_model(
@@ -442,6 +445,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--device-map", default="")
     parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--experts-implementation", default="")
     parser.add_argument("--trust-remote-code", action="store_true")
     parser.add_argument("--local-files-only", action="store_true")
     parser.add_argument("--do-sample", action="store_true")

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8711,6 +8711,12 @@ def selected_models_for_suite(
 def _namespace_for_run_hf(
     args: argparse.Namespace, model: dict[str, Any], work_dir: Path
 ) -> argparse.Namespace:
+    task_config = model.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    if (work_dir / "manifest.json").is_file():
+        work_config = work_manifest(work_dir).get("task_eval", {})
+        if isinstance(work_config, dict):
+            task_config = work_config
     return argparse.Namespace(
         model=model["hf_id"],
         model_revision=str(model.get("hf_revision", "") or ""),
@@ -8723,6 +8729,9 @@ def _namespace_for_run_hf(
         device=args.hf_device,
         device_map=args.hf_device_map,
         attn_impl=args.hf_attn_impl,
+        experts_implementation=str(
+            task_config.get("hf_experts_implementation", "") or ""
+        ),
         trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
         local_files_only=args.local_files_only,
         do_sample=args.do_sample,
@@ -9179,6 +9188,13 @@ def run_hf_reference_subprocess(
         cmd.extend(["--device-map", str(hf_args.device_map)])
     if hf_args.attn_impl:
         cmd.extend(["--attn-impl", str(hf_args.attn_impl)])
+    if hf_args.experts_implementation:
+        cmd.extend(
+            [
+                "--experts-implementation",
+                str(hf_args.experts_implementation),
+            ]
+        )
     if hf_args.trust_remote_code:
         cmd.append("--trust-remote-code")
     if hf_args.local_files_only:

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -165,6 +165,7 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
         "device": args.device,
         "device_map": args.device_map,
         "attn_impl": args.attn_impl,
+        "experts_implementation": args.experts_implementation,
         "trust_remote_code": args.trust_remote_code,
         "local_files_only": args.local_files_only,
         "do_sample": args.do_sample,
@@ -423,6 +424,13 @@ def _native_reference_command(
         command.extend(["--elf-reference-repo", str(args.elf_reference_repo)])
     if runner == _SPEECH_REFERENCE_RUNNER and args.family:
         command.extend(["--family", str(args.family)])
+    if runner == _TRANSFORMERS_TEXT_RUNNER and args.experts_implementation:
+        command.extend(
+            [
+                "--experts-implementation",
+                str(args.experts_implementation),
+            ]
+        )
     for flag, value in (
         ("--device-map", args.device_map),
         ("--attn-impl", args.attn_impl),
@@ -559,6 +567,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--device-map", default="")
     parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--experts-implementation", default="")
     parser.add_argument("--trust-remote-code", action="store_true")
     parser.add_argument("--local-files-only", action="store_true")
     parser.add_argument("--do-sample", action="store_true")


### PR DESCRIPTION
## Background

The QA dashboard run `trtmc-validate-gb300-2-20260726-c8291be0-all105`
exposed a DeepSeek-V2 validation gap. `deepseek-v2-lite` delegates L0 coverage
to `deepseek-v2-tiny`, but the lite manifest is FP16 while the tiny replacement
declared FP32 for both the TRTMC engine and HF reference. Selective CI therefore
exercised a different precision contract and could not catch FP16-only behavior.

An exact forced-FP16 reproduction exposed a second blocker before TRTMC ran:
Transformers 5.2 chose `grouped_mm` for the tiny checkpoint's unaligned expert
dimensions and failed with `RuntimeError: strides should be multiple of 16
bytes`. The generic run prepared all 10 inputs, retried twice, and recorded zero
TRTMC commands, so this was an HF execution failure rather than an accuracy
divergence.

The first exact-head GitHub model job then exposed a third CI-only gap: the
family E2E HF-reference plugin did not honor the manifest's
`task_eval.hf_experts_implementation`. It silently selected `grouped_mm`, so the
job failed after 128.85 seconds with the same stride error even though the
standard task-eval reproduction used `batched_mm`. Commit `46922811` closes that
last path and adds focused regression coverage.

## Exit criteria

- The L0 replacement uses the same FP16 engine/reference precision as
  `deepseek-v2-lite`.
- The standard offline QA runner completes all 10 MMLU continuation samples
  with `max_new_tokens=64` and strict exact-match rate at least 0.9.
- Both task-eval and family E2E reference paths honor the model-owned experts
  backend.
- CI fails closed if L0 precision or reference-backend routing drifts again.
- Added CI work remains O(1); no unbounded model matrix or sample loop is added.

## Root cause and fix

- Change `deepseek-v2-tiny` from FP32/FP32 to aligned FP16/FP16.
- Declare model-owned
  `task_eval.hf_experts_implementation=batched_mm`. This is a supported
  Transformers MoE backend for the checkpoint shape; it does not change the
  checkpoint, prompts, deterministic generation settings, or accuracy gate.
- Propagate `--experts-implementation` through task-eval, the shared reference
  cache, the native reproduction command, Transformers `from_pretrained`, and
  the family E2E HF-reference plugin.
- Include the backend choice in cache keys and reproduction metadata, preventing
  reuse across different reference implementations.
- Add fail-closed contracts tying the lite manifest to its L0 replacement and
  reference precision, plus tests for CLI propagation, cache separation,
  metadata, model-loader kwargs, and E2E-plugin routing.

No gate is weakened. The strict threshold remains
`min_exact_match_rate=0.9`; the post-fix run achieved 1.0.

## Fail-before evidence

- Exact base `aa3779bb4576280f18c955535779eb9e5b452ca4` with the new
  contract test: **failed as expected** with
  `deepseek-v2-lite precision fp16 != deepseek-v2-tiny precision fp32`.
- Forced-FP16 QA command with the default Transformers backend: **failed before
  TRTMC** on both attempts with `RuntimeError: strides should be multiple of 16
  bytes`; 10 inputs were prepared, HF used `float16`, and the report contained
  zero TRTMC commands.
- First exact-head GitHub family E2E job at `d9c2c44d`: **failed** after 128.85
  seconds because the E2E plugin ignored the manifest backend and invoked
  `grouped_mm`.
- On the first prepared QA input, `batched_mm` and `eager` produced identical 64
  deterministic token IDs. Token-list SHA-256:
  `27549d887e2996bdcc17002d0af34e12b1f45848f4e28c0262bf10dcd8b7907b`.

## QA-equivalent GB300 validation

The standard model-first validator was run from a fresh Release/Ninja build
with `--force-hf --force-build --local-files-only`, using the QA workload,
manifest, and validation-suite definitions:

```text
/opt/venv/bin/python tools/trtmc_validate.py \
  deepseek-v2-tiny mmlu_continuation_parity \
  --catalog tests/validation/model_workloads.yaml \
  --suites tests/task_eval/validation_suites.yaml \
  --models-dir tests/e2e/models \
  --output <fresh-output> --engine-dir <fresh-engine-dir> \
  --reference-cache-dir <fresh-reference-dir> \
  --trtmc-binary <fresh-release-build>/trtmc \
  --benchmark-binary <fresh-release-build>/trtmc_dataset_benchmark \
  --hf-python /opt/venv/bin/python \
  --model-attempts 2 --model-retry-delay-seconds 5 \
  --backend-dir <fresh-release-build> \
  --model-plugin-dir <fresh-release-build>/models \
  --cuda-visible-devices 0 --force-hf --force-build --local-files-only
```

Result on the first attempt:

- Checkpoint:
  `katuni4ka/tiny-random-deepseek-v3@ba144b0d3331a5892aa588d82722d382be2b6e6b`
- Samples / generation: 10 / 64 max new tokens
- Precision: TRTMC FP16, HF `float16`, comparison aligned
- Exact match: **1.0 (10/10)**
- Token-prefix agreement: **1.0**
- Prediction agreement: **1.0**
- Divergent samples: **0**
- Strict gate failures: **none**
- Hardware/runtime: NVIDIA GB300, driver 580.105.08, CUDA 13 runtime,
  TensorRT 11.2.0.113, PyTorch 2.12.0+cu130, Transformers 5.2.0
- Image: `trtmc-dev-gb300:manylinux_2_39-4a09683c461d`
- Offline/forced-fresh wall-clock window including clean runtime build:
  `2026-07-29T13:24:59Z`–`13:27:06Z`

The validated `d9c2c44d` delta has binary-diff SHA-256
`44972ae3c76e9528c226896c8b58722861677afe03e59fb63c44cda71a1d4b`.
The follow-up `46922811` changes only the E2E backend propagation and its focused
tests; it is validated by the exact-head GitHub run below.

Runtime hashes for the QA-equivalent receipt:

- `trtmc`: `ad9cd18f77164c4d9753a46d56be14672e7780b2386a9f9ad65cc31b56a5bb3e`
- `trtmc_dataset_benchmark`: `1da4a79089e9551d955a5fa433aaaa6e27e667d8c789ff5539163644027b9303`
- TensorRT 11.2 backend: `460fc1610d5b6e086e8aad02d0165a5ce6131bb9bf734eddf8422e422e873daf`
- DeepSeek-V2 plugin: `38cfe02ab2dd00baf2db09bd90f088053650e488dfb04e19a8e34c9f351574cd`

Compact local receipt:
`/tmp/trtmc-accuracy-agent2/reruns/deepseek-v2-d9c2c44d-gb300-receipt.tar.gz`,
SHA-256
`6b2e83ec029c38b3a931e0cbca5ff42400c92dd5a9fd849ba8c8b03c43e03a35`.
The archive audit reports 63 files, zero symlinks, zero runtime-payload paths,
and zero checksum failures.

## Tests and exact-head GitHub CI

Local focused checks:

- DeepSeek manifest contract: **3 passed**.
- Task-eval/reference/manifest suite: **249 passed**.
- Ruff on all touched Python files: **passed**.

Exact head `46922811a8e1c307c6e824d0fc615d8cd0f71787`, GitHub Actions run
[`30468310702`](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/30468310702):

- Legal compliance: **passed**
- Source quality: **passed**
- Ownership and impact: **passed**
- Unit / C++ and Python: **passed** (23m45s)
- `deepseek_v2` direct model job: **passed** (3m20s)
- Bounded fallback jobs `ltx_video`, `patchtsmixer`, `segformer`, `whisper`:
  **all passed** (11m05s maximum)
- Combined HTML report and aggregate Premerge CI: **passed**

## Why CI missed it and runtime bound

Before this PR, selective CI accepted an L0 replacement whose precision differed
from the replaced model, and the task-eval/backend choice was not consistently
propagated into the E2E reference path. The new manifest contract and focused
unit tests fail closed on both mistakes.

Impact analysis remains the repository's fixed fallback mode with exactly five
model jobs: direct `deepseek_v2` plus `ltx_video`, `patchtsmixer`, `segformer`,
and `whisper`. The added checks are O(1) assertions and introduce neither a
new data-dependent model matrix nor an extra QA sample loop. The exact-head run
above demonstrates the bounded wall-clock behavior.

## Reviewer notes

Review the manifest and family contract first, then follow backend propagation
through `tools/task_eval.py`, `tools/trtmc_reference.py`,
`tools/reference/transformers_text.py`, and the E2E HF-reference plugin. Do not
remove the explicit backend until the default Transformers grouped
implementation supports this checkpoint's unaligned FP16 expert dimensions;
doing so currently makes the reference fail before TRTMC and can mask the
precision contract.
