### PR TITLE
fix(llama): reserve Nemotron Nano decode row

### DIFF
--- a/tests/e2e/models/llama/manifests/nemotron-nano-4b.json
+++ b/tests/e2e/models/llama/manifests/nemotron-nano-4b.json
@@ -8,6 +8,9 @@
   "precision": "fp16",
   "max_cache_length": 256,
   "trust_remote_code": false,
+  "task_eval": {
+    "build_generation_headroom": true
+  },
   "testcases": [
     {
       "name": "nemotron-nano-4b",

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4576,19 +4576,19 @@ def test_non_continuation_reserves_generation_headroom_by_default() -> None:
 
 
 def test_nemotron_nano_mcq_reserves_generation_cache_headroom() -> None:
-    suite = task_eval.suite_by_id(
-        task_eval.load_suites(), "mmlu_five_shot_mcq"
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(), "mmlu_five_shot_mcq"
     )
     model = next(
         model
-        for model in task_eval.load_manifest_records()
+        for model in validation_engine.load_manifest_records()
         if model["name"] == "nemotron-nano-4b"
     )
 
     assert (
-        task_eval.generation_cache_headroom(
+        validation_engine.generation_cache_headroom(
             scorer="mcq",
-            task_eval_config=task_eval.effective_task_eval_config(
+            validation_config=validation_engine.effective_validation_config(
                 suite, model
             ),
             generation=suite["generation"],

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4575,6 +4575,29 @@ def test_non_continuation_reserves_generation_headroom_by_default() -> None:
     )
 
 
+def test_nemotron_nano_mcq_reserves_generation_cache_headroom() -> None:
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(), "mmlu_five_shot_mcq"
+    )
+    model = next(
+        model
+        for model in task_eval.load_manifest_records()
+        if model["name"] == "nemotron-nano-4b"
+    )
+
+    assert (
+        task_eval.generation_cache_headroom(
+            scorer="mcq",
+            task_eval_config=task_eval.effective_task_eval_config(
+                suite, model
+            ),
+            generation=suite["generation"],
+            max_new_tokens=None,
+        )
+        == 1
+    )
+
+
 def test_eval_continuation_builds_for_prompt_and_generated_tokens(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Background

QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` reported Nemotron Nano as
passed even though its HF/TRTMC prediction agreement was only `0.90`. The
generic scorer issue is handled by the shared accuracy-gate PR; a forced-fresh
replay on current source also exposed a separate Llama-family execution bug
that prevented the full 20-sample workload from completing.

This PR is the model-family fix for:

- model: `nemotron-nano-4b`
- workload: `mmlu_five_shot_mcq`
- dataset: the same staged QA MMLU file, SHA-256
  `f4f8c39761c86510888a860915e9ecbb73f418dc226c1368319630538859a470`
- hardware/runtime: NVIDIA GB300, driver 580.105.08, TensorRT 11.2.0.113

## Exit Criteria

- The complete Nemotron Nano MMLU workload reserves the one decode row that
  the longest 401-token prompt requires.
- A current validation-engine regression fails if the model manifest stops
  opting into that generation headroom.
- No threshold, dataset, sample count, expected answer, or precision contract
  is weakened.
- CI coverage stays source-only and model-scoped; it does not add another
  model download, engine build, GPU allocation, or full QA lane.

## Root Cause

The longest selected QA prompt tokenizes to 401 rows and the MCQ workload
generates one answer token. Nemotron Nano did not opt in to task-eval
generation headroom, so the engine was built with exactly 401 KV-cache rows.
The first 13 samples happened to fit, but sample 14 required the missing
decode row and terminated with:

```text
Llama sequence exceeds the model's fixed KV cache capacity
```

The retry failed identically. This was a deterministic sizing error, not a
transient engine/cache failure.

## Implementation

- Set `task_eval.build_generation_headroom=true` in the Nemotron Nano
  manifest.
- Add a regression that loads the real suite and real model manifest and
  requires one row of MCQ generation headroom.

The resulting forced-fresh engine has:

```text
max_prompt_tokens=401
generation_cache_headroom=1
build_max_cache_length=402
```

No threshold, dataset, sample count, precision, or expected answer changed.

## Why CI Missed It

Existing Llama L0 cases do not exercise the report's longest five-shot MMLU
prompt, and there was no unit contract connecting this model manifest to
task-eval's MCQ engine-sizing calculation. The previous coverage could
therefore pass while a full QA run exhausted the fixed KV cache.

The new unit test evaluates that exact manifest/suite contract in constant
time. `model_ci.py impact` selects only the directly affected `llama` family:

```text
mode=models
direct_models=["llama"]
expected_count=1
fallback_models=[]
```

This adds no repository-wide model lane and no additional HF/TRTMC inference
to unit CI.

## Fail-Before Validation

Forced-fresh all-105 replay source:
`5dc37b757ae2ec93956acfb3672108372ff404e9`

- fresh HF reference: generated
- fresh engine: built with 401 rows
- samples completed: 13/20
- sample 14: fixed KV-cache capacity error
- retry: same failure
- validation: failed

The focused regression also fails before the manifest change because computed
MCQ generation headroom is `0`, not `1`.

## Pass-After Validation

Exact source:
`cc702b3cec43dd00c12a5944dc954d43d7048c0f`

The binary was built from its current-main parent because this PR changes only
the validation manifest and unit test; binary and plugin SHA-256 values are
recorded in the receipt.

Command:

```bash
/opt/venv/bin/python tools/trtmc_validate.py \
  nemotron-nano-4b mmlu_five_shot_mcq \
  --catalog tests/validation/model_workloads.yaml \
  --suites tests/task_eval/validation_suites.yaml \
  --models-dir tests/e2e/models \
  --force-hf --force-build --local-files-only \
  --cuda-visible-devices 0
```

Result over all 20 QA samples:

| Metric | HF | TRTMC | Gate |
|---|---:|---:|---:|
| Accuracy | 0.45 | 0.45 | drop <= 0.01 |
| Valid prediction rate | 1.00 | 1.00 | required |
| Prediction agreement | - | 1.00 | >= 0.98 |

Manual gate result: **PASS**. All 20 generated choices and token IDs match.

Additional checks:

- focused manifest/suite regression: `1 passed, 213 deselected in 0.28s`
- full Llama family suite: `67 passed, 6 skipped in 539.68s`
- model ownership validation: 78 manifests passed
- model impact selection: direct `llama` only, expected count 1

Compact receipt:

```text
/tmp/trtmc-accuracy-agent2/receipts/nemotron-nano-cc702b3c-gb300-receipt-v2.tar.gz
sha256 abdabc59c6485ba757ea9acc636c51df42b0ab51b5581496a3dfd0d3cb3782f7
72 files, 0 symlinks, all embedded SHA256SUMS verified
```

The 17 GB engine and model weights are intentionally excluded; fresh build
logs, raw predictions, comparison outputs, source/binary/dataset hashes, and
fail-before/pass-after evidence are included.

## Current-main Rebase Validation

The branch is rebased onto
`github/main@63c920304cb0236a995e933f49504e8f2f237317`; the exact PR head for
this validation is
`2c1c3b8434aa6bb8c8c1ddedb7c5060011ff087b`.

Current `main` removed the old task-eval module as the Python API owner. The
rebase repair migrated the manifest/suite regression to
`tests/tools/test_validation_engine.py` and the current
`tools.validation.engine` APIs (`load_suites`, `load_manifest_records`,
`effective_validation_config`, and `generation_cache_headroom`). The
manifest's `task_eval.build_generation_headroom` configuration key remains
the model contract; only the test/API owner changed.

- The provided frozen-image regression set passed with `243 passed` in
  `sha256:6e97af69eae7e9276e7f9061381edefd54a782ab6695c895117ecfff06188027`.
- This current-head pass is source-only. No GPU, model inference, or fresh
  TensorRT engine build was run during the rebase validation.
- The full 20-sample GB300 pass above remains the model-level evidence from
  exact repair source `cc702b3cec43dd00c12a5944dc954d43d7048c0f`; it is
  not a current-head GPU replay.

The added CI contract loads repository manifests and suite metadata and
computes one integer headroom value. It is constant-time relative to model
execution and adds no network access, fallback model, HF/TRTMC inference,
engine build, or GPU job.

## Notes For Future Readers

Keep the model-specific assertion on the current validation-engine API. The
one-row requirement is tied to the suite's one generated MCQ token; changing
the suite generation contract should require an intentional update here.


## Latest Main Compatibility Refresh (2026-08-07)

- Rebased without conflict onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `fcdf514acb833e5acb559c701ed1678f8d333f14`.
- `git range-diff` reports both Llama commits unchanged, preserving the manifest-only headroom contract and its current validation-engine regression.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `PYTHONPATH=/tmp/trtmc-accuracy-c.PAang6/deps:python:. python3 -m pytest -q -p no:cacheprovider tests/tools/test_validation_engine.py::test_nemotron_nano_mcq_reserves_generation_cache_headroom`: `1 passed in 0.66s`.
- `git diff --check github/main...HEAD` passed.

The CI check remains one constant-time manifest/suite calculation and adds no model download, engine build, inference, or GPU allocation.
