### PR TITLE
fix(deepseek-v2): restore L0 precision parity

### DIFF
--- a/tests/e2e/models/deepseek_v2/MODEL.toml
+++ b/tests/e2e/models/deepseek_v2/MODEL.toml
@@ -6,6 +6,7 @@ plugin = "deepseek_v2"
 test_manifests = [
   "manifests/deepseek-v2-lite-tp4.json",
   "manifests/deepseek-v2-lite.json",
+  "manifests/deepseek-v2-tiny-fp16-l0.json",
   "manifests/deepseek-v2-tiny-tp2.json",
   "manifests/deepseek-v2-tiny.json",
 ]

--- a/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-lite.json
+++ b/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-lite.json
@@ -17,8 +17,8 @@
       "user_contract": "continuation_parity",
       "reference_precision": "fp32",
       "ci_tier": "nightly_only",
-      "l0_replacement": "deepseek-v2-tiny",
-      "l0_replacement_reason": "DeepSeek-V2 Lite is scale coverage; deepseek-v2-tiny keeps the DeepSeek-V2 decoder path for PR L0.",
+      "l0_replacement": "deepseek-v2-tiny-fp16-l0",
+      "l0_replacement_reason": "DeepSeek-V2 Lite is scale coverage; deepseek-v2-tiny-fp16-l0 keeps the FP16 DeepSeek-V2 decoder path for PR L0.",
       "prompt": "The capital of France is",
       "max_new_tokens": 10
     }

--- a/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-tiny-fp16-l0.json
+++ b/tests/e2e/models/deepseek_v2/manifests/deepseek-v2-tiny-fp16-l0.json
@@ -1,0 +1,26 @@
+{
+  "name": "deepseek-v2-tiny-fp16-l0",
+  "hf_id": "katuni4ka/tiny-random-deepseek-v3",
+  "hf_revision": "ba144b0d3331a5892aa588d82722d382be2b6e6b",
+  "bundle": "deepseek-v2-tiny-fp16-l0.trtfb",
+  "family": "deepseek_v2",
+  "runtime_strategy": "deepseek_v2_decoder_kv_cache",
+  "task_strategy": "text_generation_causal",
+  "precision": "fp16",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 64,
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "deepseek-v2-tiny-fp16-l0",
+      "trace_id": "IT-E2E-DSV2T-FP16-L0-01",
+      "reference_family": "causal_base_continuation",
+      "user_contract": "continuation_parity",
+      "reference_precision": "fp32",
+      "ci_tier": "l0_only",
+      "prompt": "The capital of France is",
+      "max_new_tokens": 10,
+      "notes": "Finite-weight DeepSeek-V3 tiny model using FP16 to preserve the DeepSeek-V2 Lite execution contract for PR L0."
+    }
+  ]
+}

--- a/tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py
+++ b/tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py
@@ -22,3 +22,40 @@ def test_deepseek_v2_lite_builds_reserve_an_exclusive_gpu(
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_deepseek_v2_lite_has_a_precision_matched_l0() -> None:
+    model_dir = Path(__file__).parent
+    lite = json.loads(
+        (model_dir / "manifests" / "deepseek-v2-lite.json").read_text(encoding="utf-8")
+    )
+    replacement = json.loads(
+        (
+            model_dir
+            / "manifests"
+            / "deepseek-v2-tiny-fp16-l0.json"
+        ).read_text(encoding="utf-8")
+    )
+    replacement_threshold = json.loads(
+        (
+            model_dir
+            / "thresholds"
+            / "deepseek-v2-tiny-fp16-l0.json"
+        ).read_text(encoding="utf-8")
+    )
+    lite_threshold = json.loads(
+        (model_dir / "thresholds" / "deepseek-v2-lite.json").read_text(encoding="utf-8")
+    )
+
+    assert lite["testcases"][0]["l0_replacement"] == replacement["name"]
+    for field in ("family", "runtime_strategy", "precision", "quantization"):
+        assert lite.get(field) == replacement.get(field)
+    assert replacement["hf_id"] == "katuni4ka/tiny-random-deepseek-v3"
+    assert replacement["hf_revision"] == "ba144b0d3331a5892aa588d82722d382be2b6e6b"
+    assert replacement["bundle"] == "deepseek-v2-tiny-fp16-l0.trtfb"
+    assert replacement["e2e_parallel_resource"] == "exclusive_gpu"
+    assert replacement["testcases"][0]["ci_tier"] == "l0_only"
+    assert replacement["testcases"][0]["reference_precision"] == "fp32"
+    for field in ("prompt", "max_new_tokens"):
+        assert replacement["testcases"][0].get(field) == lite["testcases"][0].get(field)
+    assert replacement_threshold == lite_threshold

--- a/tests/e2e/models/deepseek_v2/thresholds/deepseek-v2-tiny-fp16-l0.json
+++ b/tests/e2e/models/deepseek_v2/thresholds/deepseek-v2-tiny-fp16-l0.json
@@ -1,0 +1,13 @@
+{
+  "threshold_overrides": {
+    "layer_atol": 0.1,
+    "logit_atol": 0.01,
+    "logit_cosine_p5": 0.99,
+    "logit_rel_l2_p95": 0.05,
+    "normalized_text_edit_distance": 0.2,
+    "stable_margin": 0.1,
+    "stable_top1_match_rate": 0.9,
+    "token_agreement_rate": 0.8,
+    "unstable_topk_hit_rate": 0.8
+  }
+}

--- a/website/docs/reference/e2e-l0-replacements.md
+++ b/website/docs/reference/e2e-l0-replacements.md
@@ -27,7 +27,7 @@ manifest or model-specific E2E data.
 | --- | --- | --- |
 | `bark-large` | `bark-small` | Smaller Bark checkpoint. |
 | `deepseek-ocr` | `deepseek-ocr-l0` | Same checkpoint; shorter OCR decode. |
-| `deepseek-v2-lite` | `deepseek-v2-tiny` | Tiny DeepSeek-V2 checkpoint. |
+| `deepseek-v2-lite` | `deepseek-v2-tiny-fp16-l0` | Tiny FP16 DeepSeek-V2-compatible checkpoint. |
 | `flux-2-dev` | `flux-2-dev-l0` | Same checkpoint; 384px, 20-step image run. |
 | `flux-2-dev-fp8` | `flux-2-dev-fp8-l0` | Same checkpoint and FP8 scales; 384px, 20-step image run. |
 | `flux-schnell` | `flux-schnell-l0` | Same checkpoint; 384px, 20-step image run. |


### PR DESCRIPTION
## Background

The current `main` branch fails the repository-wide test-impact consistency check because `deepseek-v2-lite` is FP16 while its `deepseek-v2-tiny` L0 replacement is now FP32. The FP32 tiny profile is intentional for stable DeepSeek-V3 routing parity, so changing it back would undo that coverage.

## Exit Criteria

- Preserve the FP16 execution contract when DeepSeek-V2 Lite is replaced in PR L0.
- Keep the existing FP32 tiny profile unchanged for routing parity coverage.
- Make the repository-wide test-impact consistency validation pass.

## Implementation

- Add a finite-checkpoint `deepseek-v2-tiny-fp16-l0` profile with the same family, runtime strategy, precision, prompt, reference precision, and thresholds as the Lite contract requires.
- Point the nightly Lite profile at the new FP16-only L0 representative.
- Add a family-owned regression test that locks the replacement's execution contract and document the replacement.

## Validation

- `python -m pytest tests/tools/test_test_impact.py tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py -q`: 253 passed.
- `python -m pytest tests/builder/test_manifest_validation.py -q`: 46 passed.
- `python -m pytest tests/e2e_harness/test_model_selection.py tests/e2e_harness/test_orchestrator_phases.py -q`: 24 passed.
- `python tools/legal_headers.py --check`: passed with no findings.
- `python -m ruff check tests/e2e/models/deepseek_v2/test_deepseek_v2_manifest_contract.py`: passed.
- JSON parsing and `git diff --check`: passed.
- The broader source-only Unit command reached 676 passed locally, then stopped because the local TensorRT package lacks `CausalMaskKind`; the matching CI image is required for the remainder.

## Notes For Future Readers

- The FP16 L0 profile is deliberately separate from `deepseek-v2-tiny`. Do not collapse them unless the DeepSeek-V2 Lite production precision also changes.
