### PR TITLE
fix(qwen-vl): preserve decode mRoPE input rank

### DIFF
--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -90,7 +90,14 @@ TrtModuleImpl::TrtModuleImpl(nvinfer1::ICudaEngine* engine, nvinfer1::IExecution
         }
         cudaStreamSynchronize(stream_);
     }
-    allocate_buffers(engine);
+    try {
+        allocate_buffers(engine);
+    } catch (const std::exception& error) {
+        std::cerr << "[trt_module] Failed to allocate buffers: " << error.what() << '\n';
+        free_buffers();
+        delete ctx_;
+        ctx_ = nullptr;
+    }
 }
 
 void TrtModuleImpl::validate_initial_external_bindings(
@@ -218,6 +225,21 @@ std::vector<int64_t> TrtModuleImpl::dims_to_shape(const nvinfer1::Dims& dims) {
     return shape;
 }
 
+void TrtModuleImpl::set_input_shape_or_throw(const std::string& name, const nvinfer1::Dims& dims) {
+    if (ctx_ != nullptr && ctx_->setInputShape(name.c_str(), dims))
+        return;
+
+    std::ostringstream message;
+    message << "[trt_module] TensorRT rejected input shape for '" << name << "': [";
+    for (int32_t index = 0; index < dims.nbDims; ++index) {
+        if (index != 0)
+            message << ", ";
+        message << dims.d[index];
+    }
+    message << ']';
+    throw std::runtime_error(message.str());
+}
+
 void TrtModuleImpl::update_dynamic_shape(const std::string& name, BufferEntry& entry,
                                          const std::vector<int64_t>& new_shape) {
     // Skip static inputs: TRT rejects setInputShape on them even when the
@@ -232,7 +254,7 @@ void TrtModuleImpl::update_dynamic_shape(const std::string& name, BufferEntry& e
     dims.nbDims = static_cast<int32_t>(new_shape.size());
     for (int32_t d = 0; d < dims.nbDims; ++d)
         dims.d[d] = new_shape[d];
-    ctx_->setInputShape(name.c_str(), dims);
+    set_input_shape_or_throw(name, dims);
     entry.shape = new_shape;
 }
 
@@ -273,7 +295,7 @@ void TrtModuleImpl::set_dynamic_input_shapes(nvinfer1::ICudaEngine* engine, int3
             continue;
         if (dims_are_dynamic(engine->getTensorShape(name.c_str()))) {
             auto dims = engine->getProfileShape(name.c_str(), profile_idx_, selector);
-            ctx_->setInputShape(name.c_str(), dims);
+            set_input_shape_or_throw(name, dims);
         }
     }
 }
@@ -305,6 +327,9 @@ void TrtModuleImpl::allocate_single_input(nvinfer1::ICudaEngine* engine, const s
     entry.is_dynamic = is_dynamic;
     entry.shape = is_dynamic ? dims_to_shape(init_dims) : shape;
 
+    if (is_dynamic)
+        set_input_shape_or_throw(name, init_dims);
+
     const auto external = initial_external_bindings_.find(name);
     if (external != initial_external_bindings_.end()) {
         entry.d_ptr = external->second;
@@ -319,9 +344,6 @@ void TrtModuleImpl::allocate_single_input(nvinfer1::ICudaEngine* engine, const s
 
     if (entry.d_ptr)
         bind_tensor_address(name, entry);
-
-    if (is_dynamic)
-        ctx_->setInputShape(name.c_str(), init_dims);
 
     buffers_[name] = std::move(entry);
 }

--- a/src/runtime/backend/trt_module_impl.h
+++ b/src/runtime/backend/trt_module_impl.h
@@ -113,6 +113,7 @@ class TrtModuleImpl final : public ITrtModule {
     void allocate_output_buffers(nvinfer1::ICudaEngine* engine, int32_t num_io);
     void set_dynamic_input_shapes(nvinfer1::ICudaEngine* engine, int32_t num_io,
                                   nvinfer1::OptProfileSelector selector);
+    void set_input_shape_or_throw(const std::string& name, const nvinfer1::Dims& dims);
     void update_dynamic_shape(const std::string& name, BufferEntry& entry,
                               const std::vector<int64_t>& new_shape);
     void execute_enqueue();

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -502,6 +502,12 @@ int32_t merged_grid_extent(int32_t configured_extent, int32_t fallback_extent, i
     return extent / (patch_size * merge_size);
 }
 
+std::vector<int64_t> single_mrope_shape(const TrtModule& module) {
+    if (module.input_rank("mrope_position_ids") == 2)
+        return {3, 1};
+    return {3};
+}
+
 bool add_mrope_prefill_input(TrtModule& prefill, const std::vector<int32_t>& input_ids,
                              const QwenVlMropePositions* mrope, int32_t sequence_length,
                              std::vector<int32_t>& positions, TensorMap& inputs) {
@@ -777,8 +783,8 @@ void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* inp
     state_->prepare_step(inputs);
 
     if (mrope_position != nullptr && text_decoder_->has_input("mrope_position_ids")) {
-        inputs["mrope_position_ids"] =
-            Tensor{const_cast<int32_t*>(mrope_position->data()), {3}, DType::kInt32};
+        inputs["mrope_position_ids"] = Tensor{const_cast<int32_t*>(mrope_position->data()),
+                                              single_mrope_shape(*text_decoder_), DType::kInt32};
     }
 
     std::vector<float> zero_embed;

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -115,7 +115,8 @@ class CountingTextModule final : public trtmc::ITrtModule {
     bool has_input(const std::string& name) const override {
         return name == "token_id" || name == "position_id" || name == "attention_mask" ||
                name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
-               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+               name == "deepstack_embed_0" || name == "mrope_position_ids" || name == "cache_k_0" ||
+               name == "cache_v_0";
     }
     bool has_output(const std::string& name) const override {
         return name == "logits" || name == "present_k_0" || name == "present_v_0";
@@ -806,7 +807,7 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
 
     trtmc::QwenVlConfig cfg;
     cfg.vocab_size = 4;
-    cfg.id_eos = 2;
+    cfg.id_eos = 99;
     cfg.image_token_id = 1;
     cfg.vision_output_dim = 4;
     cfg.num_layers = 1;
@@ -824,15 +825,20 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
     float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
                                0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
     trtmc::GenerateConfig gen_cfg;
-    gen_cfg.max_new_tokens = 1;
-    gen_cfg.eos_token_id = 2;
+    gen_cfg.max_new_tokens = 2;
+    gen_cfg.eos_token_id = 99;
     auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
 
-    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(result.token_ids == std::vector<int32_t>({2, 2}),
+          "sequence prefill: output remains correct");
     check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
-    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(decode_stats->calls == 2, "sequence prefill: two decode launches");
     check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
           "sequence prefill: token shape");
+    check(prefill_stats->shapes["mrope_position_ids"] == std::vector<int64_t>({3, 3}),
+          "sequence prefill: mRoPE shape");
+    check(decode_stats->shapes["mrope_position_ids"] == std::vector<int64_t>({3, 1}),
+          "sequence decode: mRoPE shape");
     check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
           "sequence prefill: input embed shape");
     check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),

--- a/tests/cpp/test_trt_module.cpp
+++ b/tests/cpp/test_trt_module.cpp
@@ -42,6 +42,8 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 static int failures = 0;
@@ -432,6 +434,39 @@ static void test_profile_idx_default() {
     cudaStreamDestroy(stream);
 }
 
+static void test_rejected_dynamic_shape_throws() {
+    auto engine = build_dynamic_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto* ctx = engine->createExecutionContext();
+    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+    check(module.ok(), "dynamic shape: module is ok");
+
+    float input_data[4] = {1.0F, 2.0F, 3.0F, 4.0F};
+    trtmc::Tensor input_tensor;
+    input_tensor.data = input_data;
+    input_tensor.shape = {4};
+    input_tensor.dtype = trtmc::DType::kFloat32;
+
+    bool threw = false;
+    try {
+        module.forward_async({{"x", input_tensor}});
+    } catch (const std::runtime_error& error) {
+        threw = true;
+        const std::string message = error.what();
+        check(message.find("'x'") != std::string::npos, "dynamic shape: error identifies input");
+        check(message.find("[4]") != std::string::npos,
+              "dynamic shape: error includes rejected shape");
+    }
+    check(threw, "dynamic shape: rejected rank throws");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_profile_idx_invalid() {
     // Verify that an invalid profile index (engine has only 1 profile) fails gracefully
     auto engine = build_identity_engine();
@@ -493,6 +528,7 @@ int main() {
     test_forward_device();
     test_forward_device_with_input();
     test_profile_idx_default();
+    test_rejected_dynamic_shape_throws();
     test_profile_idx_invalid();
 
     if (failures > 0) {


### PR DESCRIPTION
## Background

Qwen-VL decoder engines can declare `mrope_position_ids` as a rank-two input, but the single-token decode path supplied a rank-one `[3]` tensor. TensorRT rejected that shape while the runtime ignored the `setInputShape` result and continued with stale execution-context dimensions.

## Exit Criteria

- Supply single-token mRoPE positions with the rank declared by the decoder engine.
- Stop execution when TensorRT rejects a dynamic input shape.
- Preserve existing rank-one engine compatibility and avoid bundle or configuration changes.

## Implementation

- Shape single-token mRoPE inputs as `[3, 1]` for rank-two decoder engines and retain `[3]` for rank-one engines.
- Route dynamic input shape updates through a checked helper that reports the input name and rejected dimensions.
- Validate initial, profile maximum, profile optimum, and runtime input shapes, and leave a module invalid if buffer initialization fails.
- Extend the existing Qwen-VL sequence prefill test to cover rank-two prefill and decode mRoPE shapes, plus a backend regression test for rejected ranks.

## Validation

- `ARCHITECTURE_CONTRACT_TIMEOUT=10m CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed; maximum CCN was 10 and all 158 architecture contract tests passed.
- `cmake --build /tmc-local/tmc-mrope-rank-build --target test_trt_module test_qwen_vl_vl_pipeline --parallel 16`: passed with TensorRT 11.2.0.121 on an NVIDIA L40S.
- `test_trt_module`: passed, including the rejected dynamic-rank regression.
- `test_qwen_vl_vl_pipeline`: passed, including `[3, 3]` prefill and `[3, 1]` decode mRoPE assertions.
- Public Qwen2.5-VL-3B dual-profile smoke, two fresh runs with four greedy decode tokens: passed with zero `setInputShape: Error Code 3` occurrences.

## Notes For Future Readers

- Review the Qwen-VL shape selection first, then the checked TensorRT shape helper and its backend test.
- This is a runtime shape-handling fix. It does not change the attention implementation, decoder engine layout, bundle format, or configuration schema.
- No ADR was added because this is a routine bug fix rather than an architectural change.
