### PR TITLE
fix(qwen3.5): preserve FP32 DeltaNet state

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_5/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_5/plugin.py
@@ -467,10 +467,6 @@ class Qwen35Plugin:
                 network.add_cast(x, work_trt_dtype).get_output(0)
                 for x in conv_state_inputs
             ]
-            ssm_state_inputs = [
-                network.add_cast(x, work_trt_dtype).get_output(0)
-                for x in ssm_state_inputs
-            ]
             cache_k_inputs = [
                 network.add_cast(x, work_trt_dtype).get_output(0)
                 for x in cache_k_inputs
@@ -540,8 +536,9 @@ class Qwen35Plugin:
                     hidden=layer_cast(hidden_state),
                     conv_state_in=layer_cast(
                         conv_state_inputs[mamba_counter]),
-                    ssm_state_in=layer_cast(
-                        ssm_state_inputs[mamba_counter]),
+                    # Transformers casts the DeltaNet recurrence and its
+                    # persistent state to FP32 even for FP16 checkpoints.
+                    ssm_state_in=ssm_state_inputs[mamba_counter],
                     eps_tensor=layer_cast(eps_tensor),
                     weights=weights,
                     prefix=prefix,
@@ -859,20 +856,30 @@ def _add_deltanet_layer(
     v_t = v_heads.get_output(0)
 
     # ===== 7. Compute decay: -exp(A_log) * softplus(a + dt_bias) per head =====
+    # Transformers performs the decay and recurrent rule in FP32 even when
+    # the model projections use FP16.  Keeping these tensors in the model
+    # storage dtype quantizes the persistent state again on every token.
+    recurrent_dtype = trt.float32
+
+    def recurrent_cast(tensor: trt.ITensor) -> trt.ITensor:
+        if tensor.dtype == recurrent_dtype:
+            return tensor
+        return network.add_cast(tensor, recurrent_dtype).get_output(0)
+
     # A: [num_heads] (precomputed as -exp(A_log))
     A_const = graph_ops.add_constant(
-        network, (1, num_heads), weights[f"{prefix}.A"], dtype=dtype)
+        network, (1, num_heads), weights[f"{prefix}.A"], dtype=np.float32)
 
     # dt_bias: [num_heads]
     dt_bias_const = graph_ops.add_constant(
-        network, (1, num_heads), weights[f"{prefix}.dt_bias"], dtype=dtype)
+        network, (1, num_heads), weights[f"{prefix}.dt_bias"], dtype=np.float32)
     a_biased = network.add_elementwise(
-        a_raw, dt_bias_const, trt.ElementWiseOperation.SUM)
+        recurrent_cast(a_raw), dt_bias_const, trt.ElementWiseOperation.SUM)
 
     # softplus(a + dt_bias): log(1 + exp(x))
     a_exp = network.add_unary(a_biased.get_output(0), trt.UnaryOperation.EXP)
     one = graph_ops.add_constant(
-        network, (1, 1), np.array([1.0], dtype=dtype), dtype=dtype)
+        network, (1, 1), np.array([1.0], dtype=np.float32), dtype=np.float32)
     a_exp_p1 = network.add_elementwise(
         a_exp.get_output(0), one, trt.ElementWiseOperation.SUM)
     a_softplus = network.add_unary(
@@ -891,7 +898,7 @@ def _add_deltanet_layer(
     # b_raw: [1, num_heads]
     beta = network.add_activation(b_raw, trt.ActivationType.SIGMOID)
     # [1, num_heads] -> [num_heads, 1]
-    beta_reshaped = network.add_shuffle(beta.get_output(0))
+    beta_reshaped = network.add_shuffle(recurrent_cast(beta.get_output(0)))
     beta_reshaped.reshape_dims = (num_heads, 1)
 
     # ===== 9. Delta rule state update =====
@@ -901,12 +908,16 @@ def _add_deltanet_layer(
 
     # 9a. Decay state first: state = state * exp(g)
     decayed_state = network.add_elementwise(
-        decay_exp.get_output(0), ssm_state_in,
+        decay_exp.get_output(0), recurrent_cast(ssm_state_in),
         trt.ElementWiseOperation.PROD)
 
     # 9b. kv_mem = state^T @ k: read old value for this key
     # [H, V, K] @ [H, K, 1] = [H, V, 1]  (transpose state to swap K/V axes)
-    k_col = network.add_shuffle(k_t)
+    k_recurrent = recurrent_cast(k_t)
+    v_recurrent = recurrent_cast(v_t)
+    q_recurrent = recurrent_cast(q_expanded)
+
+    k_col = network.add_shuffle(k_recurrent)
     k_col.reshape_dims = (num_heads, head_dim, 1)
     kv_old_3d = network.add_matrix_multiply(
         decayed_state.get_output(0), trt.MatrixOperation.TRANSPOSE,
@@ -916,14 +927,14 @@ def _add_deltanet_layer(
 
     # 9c. delta = (v - kv_mem) * beta
     v_minus_old = network.add_elementwise(
-        v_t, kv_old.get_output(0), trt.ElementWiseOperation.SUB)
+        v_recurrent, kv_old.get_output(0), trt.ElementWiseOperation.SUB)
     v_delta = network.add_elementwise(
         v_minus_old.get_output(0), beta_reshaped.get_output(0),
         trt.ElementWiseOperation.PROD)
 
     # 9d. state_new = decayed_state + outer(k, delta)
     # outer: k[:, :, None] * delta[:, None, :] = [H, K, 1] @ [H, 1, V] = [H, K, V]
-    k_col2 = network.add_shuffle(k_t)
+    k_col2 = network.add_shuffle(k_recurrent)
     k_col2.reshape_dims = (num_heads, head_dim, 1)
     v_delta_row = network.add_shuffle(v_delta.get_output(0))
     v_delta_row.reshape_dims = (num_heads, 1, head_dim)
@@ -940,9 +951,9 @@ def _add_deltanet_layer(
     # HF applies: query *= 1/sqrt(k_dim)
     q_scale = graph_ops.add_constant(
         network, (1, 1),
-        np.array([1.0 / np.sqrt(head_dim)], dtype=dtype), dtype=dtype)
+        np.array([1.0 / np.sqrt(head_dim)], dtype=np.float32), dtype=np.float32)
     q_scaled = network.add_elementwise(
-        q_expanded, q_scale, trt.ElementWiseOperation.PROD)
+        q_recurrent, q_scale, trt.ElementWiseOperation.PROD)
     # [H, V, K] @ [H, K, 1] = [H, V, 1]
     q_col = network.add_shuffle(q_scaled.get_output(0))
     q_col.reshape_dims = (num_heads, head_dim, 1)
@@ -953,6 +964,13 @@ def _add_deltanet_layer(
     output_flat.reshape_dims = (1, d_inner)
 
     # ===== 10. Gated RMSNorm per-head: weight * norm(output) * silu(z) =====
+    # The reference recurrent kernel returns the attention output in the model
+    # storage dtype before Qwen3_5RMSNormGated casts it back to FP32.
+    recurrent_output = output_flat.get_output(0)
+    if recurrent_output.dtype != hidden.dtype:
+        recurrent_output = network.add_cast(
+            recurrent_output, hidden.dtype).get_output(0)
+
     # HF norm operates per head_v_dim: reshape to [num_heads, head_dim], norm, reshape back
     deltanet_norm_w = weights[f"{prefix}.deltanet_norm"]
     # Use same eps as HF Qwen3_5RMSNormGated (config.rms_norm_eps = 1e-6)
@@ -961,7 +979,7 @@ def _add_deltanet_layer(
         np.array([1e-6], dtype=np.float32), dtype=np.float32)
 
     # Reshape output and z to [num_heads, head_dim] for per-head norm
-    output_heads = network.add_shuffle(output_flat.get_output(0))
+    output_heads = network.add_shuffle(recurrent_output)
     output_heads.reshape_dims = (num_heads, head_dim)
     norm_input = output_heads.get_output(0)
     norm_output_dtype = norm_input.dtype

--- a/python/tensorrt_model_connect/families/qwen3_5/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_5/plugin.py
@@ -81,6 +81,7 @@ from . import graph_blocks
 
 trt = trt_compat.get_trt()
 
+
 def _parse_layer_types(raw_types: list[str]) -> list[str]:
     """Normalize layer type strings to 'deltanet' or 'attention'."""
     mapping = {
@@ -90,6 +91,42 @@ def _parse_layer_types(raw_types: list[str]) -> list[str]:
         "full_attention": "attention",
     }
     return [mapping.get(t.lower(), t.lower()) for t in raw_types]
+
+
+def _prepare_runtime_inputs(
+    network,
+    work_trt_dtype,
+    attention_mask,
+    conv_state_inputs,
+    ssm_state_inputs,
+    cache_k_inputs,
+    cache_v_inputs,
+):
+    """Cast storage tensors while preserving DeltaNet recurrence in FP32."""
+    if work_trt_dtype == trt.float32:
+        return (
+            attention_mask,
+            conv_state_inputs,
+            ssm_state_inputs,
+            cache_k_inputs,
+            cache_v_inputs,
+        )
+
+    def cast_all(tensors):
+        return [
+            network.add_cast(tensor, work_trt_dtype).get_output(0)
+            for tensor in tensors
+        ]
+
+    return (
+        network.add_cast(attention_mask, work_trt_dtype).get_output(0),
+        cast_all(conv_state_inputs),
+        # HF keeps the DeltaNet recurrent state in FP32. Never quantize this
+        # persistent input before the per-token recurrence.
+        ssm_state_inputs,
+        cast_all(cache_k_inputs),
+        cast_all(cache_v_inputs),
+    )
 
 
 class Qwen35Plugin:
@@ -460,21 +497,21 @@ class Qwen35Plugin:
             cache_k_inputs.append(ck)
             cache_v_inputs.append(cv)
 
-        if work_trt_dtype != trt.float32:
-            attention_mask = network.add_cast(
-                attention_mask, work_trt_dtype).get_output(0)
-            conv_state_inputs = [
-                network.add_cast(x, work_trt_dtype).get_output(0)
-                for x in conv_state_inputs
-            ]
-            cache_k_inputs = [
-                network.add_cast(x, work_trt_dtype).get_output(0)
-                for x in cache_k_inputs
-            ]
-            cache_v_inputs = [
-                network.add_cast(x, work_trt_dtype).get_output(0)
-                for x in cache_v_inputs
-            ]
+        (
+            attention_mask,
+            conv_state_inputs,
+            ssm_state_inputs,
+            cache_k_inputs,
+            cache_v_inputs,
+        ) = _prepare_runtime_inputs(
+            network,
+            work_trt_dtype,
+            attention_mask,
+            conv_state_inputs,
+            ssm_state_inputs,
+            cache_k_inputs,
+            cache_v_inputs,
+        )
 
         # --- Shared constants ---
         embedding_table = graph_ops.add_constant(

--- a/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
+++ b/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
+trt = pytest.importorskip(
+    "tensorrt", reason="TensorRT is required for family builder tests"
+)
 
 
 try:
@@ -51,6 +53,62 @@ def test_parse_layer_types_normalizes_aliases():
     parsed = qwen3_5._parse_layer_types(
         ["linear", "FULL", "linear_attention", "full_attention", "Custom"])
     assert parsed == ["deltanet", "attention", "deltanet", "attention", "custom"]
+
+
+def test_fp16_runtime_inputs_preserve_fp32_recurrent_state():
+    """FP16 storage must not quantize the persistent DeltaNet state."""
+
+    class _Tensor:
+        def __init__(self, name: str, dtype):
+            self.name = name
+            self.dtype = dtype
+
+    class _Layer:
+        def __init__(self, output: _Tensor):
+            self.output = output
+
+        def get_output(self, index: int) -> _Tensor:
+            assert index == 0
+            return self.output
+
+    class _Network:
+        def __init__(self):
+            self.cast_inputs: list[_Tensor] = []
+
+        def add_cast(self, tensor: _Tensor, dtype):
+            self.cast_inputs.append(tensor)
+            return _Layer(_Tensor(f"{tensor.name}_cast", dtype))
+
+    network = _Network()
+    attention_mask = _Tensor("attention_mask", trt.float32)
+    conv_state = _Tensor("conv_state", trt.float32)
+    ssm_state = _Tensor("ssm_state", trt.float32)
+    cache_k = _Tensor("cache_k", trt.float16)
+    cache_v = _Tensor("cache_v", trt.float16)
+
+    (
+        prepared_mask,
+        prepared_conv,
+        prepared_ssm,
+        prepared_cache_k,
+        prepared_cache_v,
+    ) = qwen3_5._prepare_runtime_inputs(
+        network,
+        trt.float16,
+        attention_mask,
+        [conv_state],
+        [ssm_state],
+        [cache_k],
+        [cache_v],
+    )
+
+    assert prepared_mask.dtype == trt.float16
+    assert prepared_conv[0].dtype == trt.float16
+    assert prepared_cache_k[0].dtype == trt.float16
+    assert prepared_cache_v[0].dtype == trt.float16
+    assert prepared_ssm == [ssm_state]
+    assert prepared_ssm[0].dtype == trt.float32
+    assert ssm_state not in network.cast_inputs
 
 
 def test_load_weights_mixed_branches_and_fallbacks(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Background

QA run `trtmc-validate-gb300-2-20260726-c8291be0-all105` exposed a
Qwen3.5-9B MMLU accuracy regression. A forced-fresh, QA-equivalent replay of
the full 20-sample workload reproduced it on the old runtime:

- HF accuracy: `0.45`
- TRTMC accuracy: `0.15`
- accuracy drop: `0.30` (required: at most `0.01`)
- prediction agreement: `0.35` (required: at least `0.98`)

The same prompts and answers were used for the fail-before and pass-after
receipts.

## Root Cause

The Qwen3.5 DeltaNet path cast its persistent SSM state and every step of the
recurrent update to the model storage dtype. For an FP16 bundle, that
quantized the state again on every generated token. Hugging Face keeps the
DeltaNet recurrence and persistent state in FP32, so the accumulating
round-off error made long five-shot MMLU prompts diverge.

A separate formula-only diagnostic did not repair the workload: on five fresh
samples it still produced HF/TRTMC accuracy `0.60/0.20` and agreement `0.20`.
That change is intentionally excluded from this PR.

## Implementation

- Preserve the DeltaNet SSM input state in FP32 at the runtime-input boundary.
- Evaluate decay constants, query/key/value tensors, and the recurrent state
  update in FP32.
- Cast the recurrent attention output back to the model storage dtype before
  the gated RMSNorm, matching the reference precision boundary.
- Add a family-owned regression test proving FP16 runtime preparation cannot
  cast the persistent SSM state.

The change is limited to the Qwen3.5 family plugin and its family test.

## Why CI Missed It

Existing family tests exercised layer parsing and weight-loading branches but
did not assert the dtype contract of the persistent recurrent state. The
problem therefore required a long GPU sequence to become visible.

The new test checks that precision boundary directly with a small fake TensorRT
network. It catches the original cast without building an engine or running a
model.

## Runtime Bound

This PR adds no fallback model and no additional GPU workload beyond the already-required direct Qwen3.5 proof. The targeted
Qwen3.5 tests complete in `0.22s` (`6 passed`). Impact analysis selects only
`qwen3_5`; the new check is constant-size CPU/Python graph-contract coverage.

## Validation

Authoritative pass-after receipt:

- exact source: `1b0ff76d4b56c62635df62a0390b594be0566041`
- hardware: GB300 GPU, single-device execution
- TensorRT builder: `11.2.0.113`
- reference profile:
  `/opt/trtmc-python-profiles/reference_common-424321ab2bba/bin/python`
- model snapshot:
  `Qwen/Qwen3.5-9B@c202236235762e1c871ad0ccb60c8ee5ba337b9a`
- workload: `mmlu_five_shot_mcq`, `20/20` prepared samples
- precision: TRTMC FP16 / HF FP16
- freshness: `--force-hf --force-build`; `hf_reused=false`,
  `hf_cache_status=generated`, `bundle_built=true`
- result: HF/TRTMC accuracy `0.45/0.45`, accuracy drop `0.00`,
  prediction agreement `1.00`
- per-sample parity: `20/20` output texts and generated token IDs match
- attempts: one, with no retry

The strict run started with no other compute process on the assigned GPU and
continuous host PID snapshots observed only its own builder/benchmark
processes. An earlier result collected after an unrelated CI process appeared
on that GPU was excluded; the clean rerun above is the authoritative receipt.

Additional checks:

- `pytest tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
  tests/e2e/models/qwen3_5/test_qwen3_5_schedule.py
  tests/e2e/models/qwen3_5/test_qwen3_5_debug_runner.py -q`:
  `6 passed in 0.22s`
- `ruff check` on both changed files: passed
- `python3 tools/model_ci.py validate`: passed for 78 models
- `tools/model_ci.py impact --base github/main --head HEAD`: only
  `qwen3_5`, no fallback model set
- `git diff --check github/main...HEAD`: passed

Local receipt root:
`/tmp/trtmc-accuracy-agent2/qwen35-validation/exact-1b0ff76d-strict-r2/qwen35-9b-full20`.

## Review Notes

Review `_prepare_runtime_inputs` first, then the FP32 recurrence in
`_add_deltanet_layer`, and finally
`test_fp16_runtime_inputs_preserve_fp32_recurrent_state`. The acceptance
criteria are unchanged; this PR repairs the runtime so the existing gates pass.


## Latest Main Compatibility Refresh (2026-08-07)

- Rebased without conflict onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `c2e6584316d0dfb51d53ce4ad54ccb5d275cf308`.
- `git range-diff` reports both Qwen3.5 commits unchanged, preserving the family-only runtime and test scope.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `git diff --check`, `py_compile`, and `ruff check` passed for the changed plugin and regression. The selected TensorRT-backed regression was collected as skipped because TensorRT is unavailable on this host; current-head model proof remains a CI responsibility.

No threshold, extra model execution, engine build, or CI matrix entry was introduced by this refresh.
