### PR TITLE
ci: add trusted bridge to internal premerge

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: TensorRT-Model-Connect Internal CI Bridge
+
+run-name: >-
+  PR #${{ github.event.pull_request.number || inputs.pr_number }} · internal CI dispatch
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to test
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: >-
+    trtmc-private-dispatch-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize trusted trigger
+    if: >-
+      github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.ref == 'refs/heads/main' &&
+          github.event.label.name == 'run-internal-ci'
+        )
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    outputs:
+      pr_number: ${{ steps.snapshot.outputs.pr_number }}
+      base_sha: ${{ steps.snapshot.outputs.base_sha }}
+      head_sha: ${{ steps.snapshot.outputs.head_sha }}
+      merge_sha: ${{ steps.snapshot.outputs.merge_sha }}
+
+    steps:
+      # This trusted workflow reads PR metadata only. It never checks out or
+      # executes the pull-request head or merge commit.
+      - name: Capture the exact pull-request snapshot
+        id: snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+
+          actor_permission="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
+              --jq '.permission'
+          )"
+          case "$actor_permission" in
+            write|maintain|admin) ;;
+            *)
+              echo "::error::Only actors with write, maintain, or admin access may dispatch CI."
+              exit 1
+              ;;
+          esac
+
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -er '.state' <<<"$pull")"
+          base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
+          base_ref="$(jq -er '.base.ref' <<<"$pull")"
+          base_sha="$(jq -er '.base.sha' <<<"$pull")"
+          head_sha="$(jq -er '.head.sha' <<<"$pull")"
+          merge_sha="$(jq -r '.merge_commit_sha // ""' <<<"$pull")"
+
+          test "$state" = "open"
+          test "$base_repo" = "$GITHUB_REPOSITORY"
+          test "$base_ref" = "main"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            [[ "$EVENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+            test "$base_sha" = "$EVENT_BASE_SHA"
+            test "$head_sha" = "$EVENT_HEAD_SHA"
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "base_sha=$base_sha"
+            echo "head_sha=$head_sha"
+            echo "merge_sha=$merge_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Consume the trusted trigger label
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.snapshot.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method DELETE \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
+
+  dispatch:
+    name: Internal CI dispatch
+    needs: authorize
+    runs-on: ubuntu-24.04
+    environment: ci-dispatch
+    timeout-minutes: 5
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Mark the exact source snapshot pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            -f state=pending \
+            -f context=trtmc/premerge/required \
+            -f description="PENDING: TensorRT-Model-Connect premerge" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"
+
+      - name: Dispatch internal premerge CI
+        env:
+          # Fine-grained PAT scoped only to the internal CI repository with
+          # Actions: write. The protected environment owns this secret.
+          GH_TOKEN: ${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}
+          PRIVATE_CI_OWNER: ${{ secrets.TRTMC_PRIVATE_CI_OWNER }}
+          PRIVATE_CI_REPOSITORY: ${{ secrets.TRTMC_PRIVATE_CI_REPOSITORY }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$PRIVATE_CI_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
+          [[ "$PRIVATE_CI_REPOSITORY" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$ ]]
+
+          umask 077
+          payload="$RUNNER_TEMP/internal-ci-dispatch.json"
+          trap 'rm -f "$payload"' EXIT
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg base_sha "$BASE_SHA" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg merge_sha "$MERGE_SHA" \
+            '{
+              ref: "main",
+              inputs: {
+                pr_number: $pr_number,
+                base_sha: $base_sha,
+                head_sha: $head_sha,
+                merge_sha: $merge_sha
+              }
+            }' > "$payload"
+          gh api --silent --method POST \
+            "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches" \
+            --input "$payload"
+
+      - name: Fail closed if dispatch is not accepted
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            -f state=failure \
+            -f context=trtmc/premerge/required \
+            -f description="FAIL: TensorRT-Model-Connect premerge dispatch" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -41,6 +41,114 @@ def _single_default_model_config(filename: str) -> tuple[Path, dict]:
     return defaults[0]
 
 
+def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"
+    ).read_text(encoding="utf-8")
+    legacy_premerge = (
+        REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml"
+    ).read_text(encoding="utf-8")
+    authorize = workflow.split("\n  authorize:", maxsplit=1)[1].split(
+        "\n  dispatch:", maxsplit=1
+    )[0]
+    dispatch = workflow.split("\n  dispatch:", maxsplit=1)[1]
+    authorize_permissions = authorize.split(
+        "    permissions:", maxsplit=1
+    )[1].split("\n    outputs:", maxsplit=1)[0]
+    dispatch_permissions = dispatch.split("    permissions:", maxsplit=1)[1].split(
+        "\n\n", maxsplit=1
+    )[0]
+
+    assert "pull_request_target:" in workflow
+    assert "name: TensorRT-Model-Connect Internal CI Bridge" in workflow
+    assert "types: [labeled]" in workflow
+    assert "github.event.label.name == 'run-internal-ci'" in workflow
+    assert "run-internal-ci" not in legacy_premerge
+    assert "/labels/run-ci" not in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "github.repository == 'NVIDIA/TensorRT-Model-Connect'" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert "github.event_name == 'pull_request_target'" in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "permissions: {}" in workflow
+    assert authorize_permissions.strip() == "pull-requests: write"
+    assert dispatch_permissions.strip() == "statuses: write"
+
+    assert "collaborators/$ACTOR/permission" in authorize
+    assert "write|maintain|admin)" in authorize
+    assert "Only actors with write, maintain, or admin access" in authorize
+    assert "environment:" not in authorize
+    assert "secrets." not in authorize
+    assert "statuses: write" not in authorize
+    assert 'pull="$(gh api --method GET' in authorize
+    assert 'test "$state" = "open"' in authorize
+    assert 'test "$base_repo" = "$GITHUB_REPOSITORY"' in authorize
+    assert 'test "$base_ref" = "main"' in authorize
+    assert 'if [ "$EVENT_NAME" = "pull_request_target" ]; then' in authorize
+    assert 'test "$base_sha" = "$EVENT_BASE_SHA"' in authorize
+    assert 'test "$head_sha" = "$EVENT_HEAD_SHA"' in authorize
+    for name in ("base_sha", "head_sha", "merge_sha"):
+        assert f'[[ "${name}" =~ ^[0-9a-f]{{40}}$ ]]' in authorize
+        assert f'echo "{name}=${name}"' in authorize
+    assert "pr_number=$PR_NUMBER" in authorize
+    assert (
+        "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
+    ) in authorize
+    assert "gh api --silent --method DELETE" in authorize
+
+    assert "needs: authorize" in dispatch
+    assert "environment: ci-dispatch" in dispatch
+    secret_references = set(re.findall(r"secrets\.([A-Z][A-Z0-9_]*)", workflow))
+    assert secret_references == {
+        "TRTMC_CI_DISPATCH_TOKEN",
+        "TRTMC_PRIVATE_CI_OWNER",
+        "TRTMC_PRIVATE_CI_REPOSITORY",
+    }
+    for secret in secret_references:
+        assert secret not in authorize
+        assert secret in dispatch
+    assert workflow.count("${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}") == 1
+
+    assert "actions/create-github-app-token@" not in workflow
+    assert "permission-checks:" not in workflow
+    assert "actions/checkout@" not in workflow
+    assert "private_ci_bridge.py" not in workflow
+    assert "self-hosted" not in workflow
+    assert "secrets: inherit" not in workflow
+    assert "NVIDIA-dev/TensorRT-Model-Connect-CI" not in workflow
+    assert (
+        "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/"
+        "actions/workflows/premerge.yml/dispatches"
+    ) in workflow
+    assert re.search(r'"/repos/[A-Za-z0-9]', workflow) is None
+    assert '[[ "$PRIVATE_CI_OWNER" =~ ^[A-Za-z0-9]' in workflow
+    assert '[[ "$PRIVATE_CI_REPOSITORY" =~ ^[A-Za-z0-9]' in workflow
+    assert 'echo "$PRIVATE_CI_' not in dispatch
+    assert "GITHUB_STEP_SUMMARY" not in dispatch
+
+    assert "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" in dispatch
+    assert "-f state=pending" in dispatch
+    assert "-f state=failure" in dispatch
+    assert dispatch.count("-f context=trtmc/premerge/required") == 2
+    assert '-f description="PENDING: TensorRT-Model-Connect premerge"' in dispatch
+    assert (
+        '-f description="FAIL: TensorRT-Model-Connect premerge dispatch"'
+    ) in dispatch
+    assert dispatch.count(
+        '-f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"'
+    ) == 2
+    assert dispatch.index("/statuses/$MERGE_SHA") < dispatch.index(
+        "actions/workflows/premerge.yml/dispatches"
+    )
+
+    assert 'ref: "main"' in dispatch
+    for name in ("pr_number", "base_sha", "head_sha", "merge_sha"):
+        assert f"{name}: ${name}" in dispatch
+    assert "umask 077" in dispatch
+    assert 'trap \'rm -f "$payload"\' EXIT' in dispatch
+    assert 'if: ${{ failure() }}' in dispatch
+
+
 def test_ci_orchestration_uses_the_class_based_python_entrypoint() -> None:
     legacy_scripts = (
         ".github/scripts/ensure-ci-docker-image.sh",


### PR DESCRIPTION
## Background

Introduce the smallest public-repository bridge to the internal CI repository while leaving every existing Source CI workflow unchanged. Maintainers trigger the bridge with the dedicated `run-internal-ci` label; the public job validates and pins the exact PR snapshot, then dispatches the internal premerge workflow. The bridge never checks out or executes PR code.

This focused PR supersedes the broad migration approach in #631. It does not merge or disable any existing CI workflow.

## Exit Criteria

- Only actors with `write`, `maintain`, or `admin` repository permission can trigger internal CI.
- A labeled run is bound to the event's exact base and head SHAs and fails closed if the PR changes.
- The dispatch PAT and private routing values are available only through the protected `ci-dispatch` environment.
- Public output is limited to fixed pending/failure commit statuses and a Source `/tests` URL.
- Legacy `run-ci` and bridge `run-internal-ci` labels do not race.
- Existing Source CI remains available until a post-merge bridge canary succeeds.

## Implementation

- Add `.github/workflows/internal-ci-bridge.yml` with two jobs:
  - authorize and capture an exact open-PR snapshot without checking out code;
  - publish a pending status and dispatch `premerge.yml` in the internal repository.
- Consume the one-shot `run-internal-ci` label after successful authorization.
- Keep the internal repository owner/name and PAT in the `ci-dispatch` environment.
- Add a focused regression test for event, permission, snapshot, secret, logging, payload, and fail-closed boundaries.

## Validation

Validated on exact Source base `6ad142f0975e011bfc8115c7d7a706559d904333`, head `1aa67094993387addf1eb5c9e35041c47dff9f37`, and test merge `5744bc6a523f2534c2de05924f8e5a93bc812375`:

- `python3 -m pytest -q tests/tools/test_github_actions_ci.py` — 92 passed
- `python3 -m pytest -q tests/tools/test_model_ci.py tests/builder/test_quantization_ownership.py` — 79 passed
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality` — passed, including 158 tests
- `ruff check tests/tools/test_github_actions_ci.py` — passed
- `python3 tools/legal_headers.py --check` — 0 findings
- `python3 tools/model_ci.py validate` — 78 models validated
- `git diff --check github/main...HEAD` — passed
- secret/log surface assertions and independent security, GitHub Actions semantics, and test-coverage reviews — no blockers
- [Source premerge run 30495455357](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/30495455357) — passed legal, impact, source quality, unit, all five fallback model proofs, combined report, and final gate
- direct trusted dispatch of the same exact snapshot — passed receiver validation, two-parent snapshot validation, legal, impact, source quality, unit, all five fallback model proofs, combined report, final verdict, and result publication
- published Source status — `trtmc/premerge/required`, `PASS: TensorRT-Model-Connect premerge`, with only the exact Source `/tests` URL

No secret value, private routing value, internal run URL, runner detail, artifact URL, or raw internal log is included in the bridge output or returned Source status.

Not yet executable through the new bridge event itself: GitHub activates a new `pull_request_target` / `workflow_dispatch` workflow only after that workflow exists on the default branch. The complete label → bridge → internal CI → sanitized status path must therefore be tested immediately after merge on another open trusted PR while legacy Source CI remains enabled.

## Notes For Future Readers

- Use `run-internal-ci` for the bridge; `run-ci` continues to trigger legacy Source premerge during transition.
- Keep the `ci-dispatch` environment restricted to `main`.
- After merge, run one canary on an open PR and verify the returned `trtmc/premerge/required` status before disabling legacy Source CI.
- Do not disable repository Actions globally; the bridge and documentation Pages still require GitHub Actions.
