### PR TITLE
fix(sam3): pin gated offline reference snapshot

### DIFF
--- a/tests/e2e/models/sam3/e2e_plugins/reference.py
+++ b/tests/e2e/models/sam3/e2e_plugins/reference.py
@@ -42,7 +42,8 @@ class Sam3HfTransformersReference(HfTransformersReference):
         image_url = case.inputs.get("image_url", "")
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
-        model_ref = _resolve_cached_model_ref(hf_id)
+        model_revision = case.hf_revision
+        model_ref = _resolve_cached_model_ref(hf_id, model_revision)
         prompt = (
             case.inputs.get("text_prompt")
             or case.inputs.get("prompt")
@@ -59,6 +60,7 @@ class Sam3HfTransformersReference(HfTransformersReference):
 
             hf_id = {hf_id!r}
             model_ref = {model_ref!r}
+            model_revision = {model_revision!r}
             image_path = {image_path!r}
             image_url = {image_url!r}
             trust_remote_code = {trust_remote_code!r}
@@ -67,10 +69,14 @@ class Sam3HfTransformersReference(HfTransformersReference):
             segmented_image_path = {segmented_image_path!r}
             prompt = {prompt!r}
 
-            def _load_sam3_processor(model_ref, trust_remote_code):
+            load_kwargs = {{"trust_remote_code": trust_remote_code}}
+            if model_revision and not os.path.isdir(model_ref):
+                load_kwargs["revision"] = model_revision
+
+            def _load_sam3_processor(model_ref):
                 try:
                     return Sam3Processor.from_pretrained(
-                        model_ref, trust_remote_code=trust_remote_code)
+                        model_ref, **load_kwargs)
                 except Exception as processor_error:
                     if not os.path.isdir(model_ref):
                         raise processor_error
@@ -102,7 +108,7 @@ class Sam3HfTransformersReference(HfTransformersReference):
                     image_processor_kwargs.pop("processor_class", None)
                     image_processor = Sam3ImageProcessorFast(**image_processor_kwargs)
                     tokenizer = AutoTokenizer.from_pretrained(
-                        model_ref, trust_remote_code=trust_remote_code)
+                        model_ref, **load_kwargs)
                     return Sam3Processor(
                         image_processor,
                         tokenizer,
@@ -110,10 +116,10 @@ class Sam3HfTransformersReference(HfTransformersReference):
                     )
 
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            processor = _load_sam3_processor(model_ref, trust_remote_code)
+            processor = _load_sam3_processor(model_ref)
             model = Sam3Model.from_pretrained(
                 model_ref, torch_dtype={torch_dtype_expr},
-                trust_remote_code=trust_remote_code).to(device)
+                **load_kwargs).to(device)
             model.eval()
 
             if image_url:

--- a/tests/e2e/models/sam3/e2e_plugins/reference.py
+++ b/tests/e2e/models/sam3/e2e_plugins/reference.py
@@ -17,7 +17,7 @@ from .references.hf_transformers import (
     _existing_path_reader,
     _json_output_reader,
     _reference_env,
-    _resolve_cached_model_ref,
+    _resolve_pinned_sam3_model_ref,
     _torch_dtype_for_case,
     run_reference_subprocess,
 )
@@ -43,7 +43,7 @@ class Sam3HfTransformersReference(HfTransformersReference):
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
         model_revision = case.hf_revision
-        model_ref = _resolve_cached_model_ref(hf_id, model_revision)
+        model_ref = _resolve_pinned_sam3_model_ref(hf_id, model_revision)
         prompt = (
             case.inputs.get("text_prompt")
             or case.inputs.get("prompt")

--- a/tests/e2e/models/sam3/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/sam3/e2e_plugins/references/hf_transformers.py
@@ -116,7 +116,7 @@ def _decode_vl_generated_text(
     return ""
 
 
-def _resolve_cached_model_ref(hf_id: str) -> str:
+def _resolve_cached_model_ref(hf_id: str, revision: str = "") -> str:
     """Prefer a locally cached HF snapshot to avoid Hub API rate limits."""
     if not hf_id:
         return hf_id
@@ -127,8 +127,58 @@ def _resolve_cached_model_ref(hf_id: str) -> str:
     try:
         from huggingface_hub import snapshot_download
 
-        return snapshot_download(hf_id, local_files_only=True)
-    except Exception:
+        download_kwargs: dict[str, Any] = {"local_files_only": True}
+        if revision:
+            download_kwargs["revision"] = revision
+        return snapshot_download(hf_id, **download_kwargs)
+    except Exception as error:
+        if revision:
+            try:
+                from huggingface_hub import try_to_load_from_cache
+
+                config_path = try_to_load_from_cache(
+                    hf_id,
+                    "config.json",
+                    revision=revision,
+                )
+                if isinstance(config_path, str):
+                    snapshot = Path(config_path).parent
+                    required_files = (
+                        "config.json",
+                        "processor_config.json",
+                        "tokenizer_config.json",
+                    )
+                    has_tokenizer = (snapshot / "tokenizer.json").is_file() or (
+                        (snapshot / "vocab.json").is_file()
+                        and (snapshot / "merges.txt").is_file()
+                    )
+                    has_weights = any(
+                        (snapshot / name).is_file()
+                        for name in (
+                            "model.safetensors",
+                            "model.safetensors.index.json",
+                            "pytorch_model.bin",
+                            "pytorch_model.bin.index.json",
+                        )
+                    )
+                    exact_revision = (
+                        len(revision) != 40 or snapshot.name == revision
+                    )
+                    if (
+                        exact_revision
+                        and all(
+                            (snapshot / name).is_file()
+                            for name in required_files
+                        )
+                        and has_tokenizer
+                        and has_weights
+                    ):
+                        return str(snapshot)
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"pinned HF snapshot is unavailable offline: {hf_id}@{revision}"
+            ) from error
         return hf_id
 
 

--- a/tests/e2e/models/sam3/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/sam3/e2e_plugins/references/hf_transformers.py
@@ -116,7 +116,7 @@ def _decode_vl_generated_text(
     return ""
 
 
-def _resolve_cached_model_ref(hf_id: str, revision: str = "") -> str:
+def _resolve_cached_model_ref(hf_id: str) -> str:
     """Prefer a locally cached HF snapshot to avoid Hub API rate limits."""
     if not hf_id:
         return hf_id
@@ -127,59 +127,74 @@ def _resolve_cached_model_ref(hf_id: str, revision: str = "") -> str:
     try:
         from huggingface_hub import snapshot_download
 
-        download_kwargs: dict[str, Any] = {"local_files_only": True}
-        if revision:
-            download_kwargs["revision"] = revision
-        return snapshot_download(hf_id, **download_kwargs)
-    except Exception as error:
-        if revision:
-            try:
-                from huggingface_hub import try_to_load_from_cache
-
-                config_path = try_to_load_from_cache(
-                    hf_id,
-                    "config.json",
-                    revision=revision,
-                )
-                if isinstance(config_path, str):
-                    snapshot = Path(config_path).parent
-                    required_files = (
-                        "config.json",
-                        "processor_config.json",
-                        "tokenizer_config.json",
-                    )
-                    has_tokenizer = (snapshot / "tokenizer.json").is_file() or (
-                        (snapshot / "vocab.json").is_file()
-                        and (snapshot / "merges.txt").is_file()
-                    )
-                    has_weights = any(
-                        (snapshot / name).is_file()
-                        for name in (
-                            "model.safetensors",
-                            "model.safetensors.index.json",
-                            "pytorch_model.bin",
-                            "pytorch_model.bin.index.json",
-                        )
-                    )
-                    exact_revision = (
-                        len(revision) != 40 or snapshot.name == revision
-                    )
-                    if (
-                        exact_revision
-                        and all(
-                            (snapshot / name).is_file()
-                            for name in required_files
-                        )
-                        and has_tokenizer
-                        and has_weights
-                    ):
-                        return str(snapshot)
-            except Exception:
-                pass
-            raise RuntimeError(
-                f"pinned HF snapshot is unavailable offline: {hf_id}@{revision}"
-            ) from error
+        return snapshot_download(hf_id, local_files_only=True)
+    except Exception:
         return hf_id
+
+
+def _resolve_pinned_sam3_model_ref(hf_id: str, revision: str) -> str:
+    """Resolve the exact SAM3 revision from a complete offline snapshot."""
+    if not revision:
+        return _resolve_cached_model_ref(hf_id)
+    if not hf_id or Path(hf_id).exists():
+        return hf_id
+
+    try:
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(
+            hf_id,
+            local_files_only=True,
+            revision=revision,
+        )
+    except Exception as error:
+        try:
+            from huggingface_hub import try_to_load_from_cache
+
+            config_path = try_to_load_from_cache(
+                hf_id,
+                "config.json",
+                revision=revision,
+            )
+            if isinstance(config_path, str):
+                snapshot = Path(config_path).parent
+                required_files = (
+                    "config.json",
+                    "processor_config.json",
+                    "tokenizer_config.json",
+                )
+                has_tokenizer = (snapshot / "tokenizer.json").is_file() or (
+                    (snapshot / "vocab.json").is_file()
+                    and (snapshot / "merges.txt").is_file()
+                )
+                has_weights = any(
+                    (snapshot / name).is_file()
+                    for name in (
+                        "model.safetensors",
+                        "model.safetensors.index.json",
+                        "pytorch_model.bin",
+                        "pytorch_model.bin.index.json",
+                    )
+                )
+                exact_revision = len(revision) != 40 or snapshot.name == revision
+                if (
+                    exact_revision
+                    and all(
+                        (snapshot / name).is_file()
+                        for name in required_files
+                    )
+                    and has_tokenizer
+                    and has_weights
+                ):
+                    return str(snapshot)
+        except Exception:
+            logger.debug(
+                "Unable to inspect the pinned SAM3 cache after snapshot lookup failed",
+                exc_info=True,
+            )
+        raise RuntimeError(
+            f"pinned HF snapshot is unavailable offline: {hf_id}@{revision}"
+        ) from error
 
 
 ReferenceOutputReader = Callable[[], dict[str, Any]]

--- a/tests/e2e/models/sam3/manifests/sam3.json
+++ b/tests/e2e/models/sam3/manifests/sam3.json
@@ -1,6 +1,7 @@
 {
   "name": "sam3",
   "hf_id": "facebook/sam3",
+  "hf_revision": "3c879f39826c281e95690f02c7821c4de09afae7",
   "bundle": "sam3.bundle",
   "family": "sam3",
   "runtime_strategy": "sam3_prompted_segmentation",

--- a/tests/e2e/models/sam3/test_sam3_hf_reference.py
+++ b/tests/e2e/models/sam3/test_sam3_hf_reference.py
@@ -40,7 +40,7 @@ def test_cached_model_resolution_honors_sam3_revision(monkeypatch) -> None:
         SimpleNamespace(snapshot_download=fake_snapshot_download),
     )
 
-    resolved = hf_transformers._resolve_cached_model_ref(
+    resolved = hf_transformers._resolve_pinned_sam3_model_ref(
         "facebook/sam3",
         SAM3_REVISION,
     )
@@ -77,7 +77,7 @@ def test_missing_pinned_sam3_snapshot_fails_without_network(monkeypatch) -> None
             f"facebook/sam3@{SAM3_REVISION}"
         ),
     ):
-        hf_transformers._resolve_cached_model_ref(
+        hf_transformers._resolve_pinned_sam3_model_ref(
             "facebook/sam3",
             SAM3_REVISION,
         )
@@ -119,7 +119,7 @@ def test_incomplete_hub_snapshot_uses_pinned_runtime_files(
         ),
     )
 
-    resolved = hf_transformers._resolve_cached_model_ref(
+    resolved = hf_transformers._resolve_pinned_sam3_model_ref(
         "facebook/sam3",
         SAM3_REVISION,
     )
@@ -133,7 +133,7 @@ def test_sam3_reference_propagates_pinned_snapshot(monkeypatch) -> None:
 
     monkeypatch.setattr(
         reference,
-        "_resolve_cached_model_ref",
+        "_resolve_pinned_sam3_model_ref",
         lambda _hf_id, revision: (
             "/cache/pinned-sam3-snapshot"
             if revision == SAM3_REVISION

--- a/tests/e2e/models/sam3/test_sam3_hf_reference.py
+++ b/tests/e2e/models/sam3/test_sam3_hf_reference.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for the SAM3 Hugging Face reference contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tests.e2e.models.sam3.e2e_plugins import reference
+from tests.e2e.models.sam3.e2e_plugins.references import hf_transformers
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+SAM3_REVISION = "3c879f39826c281e95690f02c7821c4de09afae7"
+
+
+def test_sam3_manifest_pins_gated_snapshot() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "sam3.json"
+    case = load_manifest(manifest_path)
+
+    assert case.hf_id == "facebook/sam3"
+    assert case.hf_revision == SAM3_REVISION
+
+
+def test_cached_model_resolution_honors_sam3_revision(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_snapshot_download(repo_id: str, **kwargs: object) -> str:
+        calls.append((repo_id, kwargs))
+        return "/cache/pinned-sam3-snapshot"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    resolved = hf_transformers._resolve_cached_model_ref(
+        "facebook/sam3",
+        SAM3_REVISION,
+    )
+
+    assert resolved == "/cache/pinned-sam3-snapshot"
+    assert calls == [
+        (
+            "facebook/sam3",
+            {
+                "local_files_only": True,
+                "revision": SAM3_REVISION,
+            },
+        )
+    ]
+
+
+def test_missing_pinned_sam3_snapshot_fails_without_network(monkeypatch) -> None:
+    def missing_snapshot(*_args: object, **_kwargs: object) -> str:
+        raise FileNotFoundError("processor_config.json is not cached")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(
+            snapshot_download=missing_snapshot,
+            try_to_load_from_cache=lambda *_args, **_kwargs: None,
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "pinned HF snapshot is unavailable offline: "
+            f"facebook/sam3@{SAM3_REVISION}"
+        ),
+    ):
+        hf_transformers._resolve_cached_model_ref(
+            "facebook/sam3",
+            SAM3_REVISION,
+        )
+
+
+def test_incomplete_hub_snapshot_uses_pinned_runtime_files(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = tmp_path / SAM3_REVISION
+    snapshot.mkdir()
+    for name in (
+        "config.json",
+        "processor_config.json",
+        "tokenizer_config.json",
+        "tokenizer.json",
+        "model.safetensors",
+    ):
+        (snapshot / name).touch()
+
+    def incomplete_snapshot(*_args: object, **_kwargs: object) -> str:
+        raise RuntimeError("optional LICENSE and sam3.pt are absent")
+
+    def cached_file(
+        _repo_id: str,
+        filename: str,
+        **kwargs: object,
+    ) -> str:
+        assert filename == "config.json"
+        assert kwargs == {"revision": SAM3_REVISION}
+        return str(snapshot / filename)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(
+            snapshot_download=incomplete_snapshot,
+            try_to_load_from_cache=cached_file,
+        ),
+    )
+
+    resolved = hf_transformers._resolve_cached_model_ref(
+        "facebook/sam3",
+        SAM3_REVISION,
+    )
+
+    assert resolved == str(snapshot)
+
+
+def test_sam3_reference_propagates_pinned_snapshot(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    expected = object()
+
+    monkeypatch.setattr(
+        reference,
+        "_resolve_cached_model_ref",
+        lambda _hf_id, revision: (
+            "/cache/pinned-sam3-snapshot"
+            if revision == SAM3_REVISION
+            else ""
+        ),
+    )
+    monkeypatch.setattr(reference, "_reference_env", lambda _ctx: {})
+
+    def fake_run_reference_subprocess(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(
+        reference,
+        "run_reference_subprocess",
+        fake_run_reference_subprocess,
+    )
+    case = SimpleNamespace(
+        name="sam3",
+        task_strategy="prompted_segmentation",
+        hf_id="facebook/sam3",
+        hf_revision=SAM3_REVISION,
+        inputs={
+            "image": "/data/coco.jpg",
+            "text_prompt": "car",
+        },
+        metadata={
+            "precision": "fp32",
+            "reference_precision": "fp32",
+            "trust_remote_code": False,
+        },
+    )
+    stage = SimpleNamespace(name="full_inference")
+    ctx = SimpleNamespace(
+        artifacts_dir="",
+        reference_python_path=lambda: "/opt/venv/bin/python",
+        ld_library_path="",
+    )
+
+    result = reference.Sam3HfTransformersReference()._run_prompted_segmentation_ref(
+        case,
+        stage,
+        ctx,
+    )
+
+    assert result is expected
+    command = captured["command"]
+    assert isinstance(command, list)
+    script = command[2]
+    assert "model_ref = '/cache/pinned-sam3-snapshot'" in script
+    assert f"model_revision = '{SAM3_REVISION}'" in script
+    assert 'load_kwargs["revision"] = model_revision' in script

--- a/tests/e2e/models/sam3/test_sam3_hf_transformers_reference.py
+++ b/tests/e2e/models/sam3/test_sam3_hf_transformers_reference.py
@@ -13,8 +13,15 @@ from tests.e2e.models.sam3.e2e_plugins.references import hf_transformers as sam3
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
 
 
+SAM3_REVISION = "3c879f39826c281e95690f02c7821c4de09afae7"
+
+
 def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
+
+    def _fake_resolve_cached_model_ref(hf_id: str, revision: str) -> str:
+        captured["model_ref_request"] = (hf_id, revision)
+        return "/cached/sam3"
 
     def _fake_run(cmd, **kwargs):
         import numpy as np
@@ -41,7 +48,7 @@ def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         sam3_reference,
         "_resolve_cached_model_ref",
-        lambda hf_id: "/cached/sam3",
+        _fake_resolve_cached_model_ref,
     )
     monkeypatch.setattr(sam3_hf_base.subprocess, "run", _fake_run)
 
@@ -52,6 +59,7 @@ def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
         runtime_strategy="sam3_prompted_segmentation",
         task_strategy="prompted_segmentation",
         reference_family="prompted_segmentation_sam3",
+        hf_revision=SAM3_REVISION,
         inputs={"image": "data/test_img.jpeg", "prompt": "ear"},
         metadata={"trust_remote_code": False, "precision": "fp32"},
     )
@@ -68,17 +76,21 @@ def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
     cmd = captured["cmd"]
     assert cmd[:2] == ["/ref/python", "-c"]
     script = cmd[2]
+    assert captured["model_ref_request"] == ("facebook/sam3", SAM3_REVISION)
     assert "model_ref = '/cached/sam3'" in script
-    assert "def _load_sam3_processor(" in script
+    assert f"model_revision = '{SAM3_REVISION}'" in script
+    assert 'load_kwargs["revision"] = model_revision' in script
+    assert "def _load_sam3_processor(model_ref):" in script
     assert "Sam3Processor.from_pretrained(" in script
     assert "except Exception as processor_error:" in script
     assert '"target_size": 1008' in script
     assert "Sam3ImageProcessorFast(**image_processor_kwargs)" in script
     assert "AutoTokenizer.from_pretrained(" in script
-    assert "processor = _load_sam3_processor(model_ref, trust_remote_code)" in script
-    assert "model_ref, trust_remote_code=trust_remote_code" in script
+    assert "processor = _load_sam3_processor(model_ref)" in script
+    assert "model_ref, **load_kwargs)" in script
     assert "Sam3Model.from_pretrained(" in script
     assert "model_ref, torch_dtype=torch.float32" in script
+    assert "**load_kwargs).to(device)" in script
     assert "model.eval()" in script
     assert "with torch.no_grad():" in script
     for forbidden in ("torch.compile", "torch.export", "aoti", "onnx"):

--- a/tests/e2e/models/sam3/test_sam3_hf_transformers_reference.py
+++ b/tests/e2e/models/sam3/test_sam3_hf_transformers_reference.py
@@ -19,7 +19,7 @@ SAM3_REVISION = "3c879f39826c281e95690f02c7821c4de09afae7"
 def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
 
-    def _fake_resolve_cached_model_ref(hf_id: str, revision: str) -> str:
+    def _fake_resolve_pinned_sam3_model_ref(hf_id: str, revision: str) -> str:
         captured["model_ref_request"] = (hf_id, revision)
         return "/cached/sam3"
 
@@ -47,8 +47,8 @@ def test_reference_uses_cached_model_ref(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr(
         sam3_reference,
-        "_resolve_cached_model_ref",
-        _fake_resolve_cached_model_ref,
+        "_resolve_pinned_sam3_model_ref",
+        _fake_resolve_pinned_sam3_model_ref,
     )
     monkeypatch.setattr(sam3_hf_base.subprocess, "run", _fake_run)
 


### PR DESCRIPTION
## Summary

- pin the gated `facebook/sam3` reference to revision
  `3c879f39826c281e95690f02c7821c4de09afae7`;
- resolve that exact cached snapshot offline when every runtime-required
  processor, tokenizer, config, and weight file is present, even if optional
  repository files are absent;
- keep the resolver fail-closed when the pinned revision or a required runtime
  file is unavailable;
- add focused family-owned regression tests for the manifest and offline
  reference behavior.

No validation threshold or passing criterion is changed.

## QA failure and local reproduction

The source report was generated from source
`c8291be0390705ca1cdcccdff83e251e7d7e1767`.

For `sam3 / coco2017_prompted_segmentation`, QA selected all 20 declared
samples but the HF reference exited before producing `eval_summary.json`.
The report recorded `ComparisonProcessError`, zero TRTMC commands, and
validation status `failed`.

I reproduced the same fail-before boundary on GB300 with a fresh reference
run and fresh bundle request:

- source: `b13e89dbc5762a6798376130436b7c76d486304a`;
- result: 0 completed cases, 1 execution error, 2 failed attempts;
- concrete failure: Hugging Face `snapshot_download(...,
  local_files_only=True)` rejected the pinned cache as incomplete because
  optional `LICENSE` and `sam3.pt` files were absent;
- fail-before report SHA-256:
  `80085b13c79fe70dee2afab69fc874717c31cf2e01fdc404e98815cf948ee696`;
- fail-before native-reference log SHA-256:
  `b55c3a584ea59a059dd3838c3c42f2c82807f1e9e525717f70010326dc4fe366`.

## Root cause

The SAM3 manifest did not identify an immutable gated model revision. The
shared cache resolver also treated Hub snapshot completeness as equivalent to
runtime completeness. In the offline QA environment, the exact snapshot had
all files needed by the Transformers SAM3 reference, but two optional
repository files were missing. That made the reference fail before TRTMC
could build or run, and CI had no SAM3-owned test covering this gated,
offline, partially mirrored cache shape.

## Fix

The manifest now pins the exact revision and propagates it through processor,
tokenizer, model, and bundle construction. If the Hub snapshot API reports an
incomplete offline cache, the resolver locates `config.json` at that exact
revision and accepts its snapshot only when the required processor/config
files, tokenizer files, weights, and exact 40-character revision directory
are present. Otherwise it raises a pinned-snapshot error rather than falling
back to a floating model ID or network access.

## QA-equivalent pass-after validation

Validation source:
`49d47f92d9045f832ba6e4ab3d11459f2c58cb8a`
(`b2aa03106ba18eeb10b806013093256cce4f680d` tree).

Environment and execution contract:

- NVIDIA GB300,
  `GPU-595c627d-9b1b-9b22-54a3-730de3807132`;
- driver `580.105.08`, CUDA compiler `13.3`;
- TensorRT `11.2.0.113`;
- the QA `coco2017_prompted_segmentation` workload and its declared limit of
  20 samples;
- `--force-hf --force-build --local-files-only`;
- `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`,
  `HF_DATASETS_OFFLINE=1`, and prebuilt-only Python profiles;
- a new reference cache and a newly built 2.91 GB bundle;
- one completed attempt, zero retries.

Result:

| Check | Result | Required |
|---|---:|---:|
| Prepared / valid samples | 20 / 20 | 20 / 20 |
| Backend mask IoU | 0.93774856 | >= 0.70 |
| HF ground-truth IoU | 0.82688433 | reported |
| TRTMC ground-truth IoU | 0.78363783 | reported |
| Ground-truth IoU drop from HF | 0.04324650 | <= 0.05 |
| Strict suite result | PASS | PASS |

The host-level GitHub GPU reservation covered the entire shard. Continuous
sampling recorded 425 timestamps, zero query errors, and zero unowned GPU
process observations.

Receipt root:
`/tmp/trtmc-accuracy-agent2/family-validation/trtmc-validate-gb300-1-20260729T203000Z-49d47f92-sam3-full20-fresh-r3`

Key SHA-256 receipts:

- report:
  `0cfba564beb7d492d71ac15d7e808ac196734f96d0ad14e9d545e45dff918578`;
- comparison:
  `ac367425d5f542f30e50b0911bd8ce3efdb6fabe5fda41b4c7b0d1d038139286`;
- SAM3 bundle:
  `970b6ee27caee5b9dba9bcaf98332cedf8de7d495e831621c6cbec3ced1c55e0`;
- host GPU lock:
  `3517b3c66987a11043b75c45faa531f9f9c099a5123a3ecdd038396e5cb6d8e7`;
- continuous GPU monitor:
  `94d54c1977cbce5b647ef5af32a69cf892ff74a9b7c4cfbf8d0967dccab4a4a0`.

## CI coverage and runtime

`tools/model_ci.py` selects only the `sam3` family for this diff:
`direct_models=["sam3"]`, `fallback_models=[]`, `expected_count=1`.
The PR does not add a GPU matrix entry or broaden fallback coverage.

The five new source-only regression tests cover the pinned manifest, revision
propagation, an incomplete-but-runtime-complete cache, and fail-closed missing
cache behavior. They pass in `0.06s` in the isolated TRTMC CPU container.
Ruff and `git diff --check` also pass.

## Current-main Rebase and Exact-head CI

The branch is rebased onto
`github/main@63c920304cb0236a995e933f49504e8f2f237317`; the exact PR head for
this validation is
`b37fc245e9d268958475d37a75a62216e2b63602`.

- [Private premerge run `31079675756`](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31079675756)
  validated exact source head
  `b37fc245e9d268958475d37a75a62216e2b63602` and passed:
  - `3 / Unit / C++ and Python`: `07:11:01`-`07:11:28 UTC`
    (27 seconds);
  - `4 / Model / sam3 [direct] / sam3`:
    `07:11:32`-`07:22:51 UTC` (11 minutes 19 seconds), including the isolated
    model proof at `07:11:37`-`07:22:45 UTC` (11 minutes 8 seconds);
  - private verdict and exact source-status publication, completed by
    `07:23:14 UTC`.
- At that exact head, [CodeQL run `31079649495`](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/31079649495)
  passed for both Python and JavaScript/TypeScript, and
  `trtmc/premerge/required` reported `SUCCESS`. GitHub reported the non-draft
  PR as `MERGEABLE/CLEAN` when this description was updated on 2026-08-06.

The exact private run took 16 minutes 29 seconds from dispatch through final
status publication. Impact analysis selected one direct `sam3` job and no
fallback model; the change added no GPU matrix entry or full QA lane. The
source-only checks stay inside the existing unit job, so the additional CI
mechanism remains bounded.



## Latest Main Compatibility And Review Refresh (2026-08-07)

- Rebased onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `4be166b9debe455dce6096f4605db9b1e7c9b7a2`.
- The only rebase conflict was the SAM3 manifest. Resolution keeps the pinned HF revision from this PR and the canonical `sam3.bundle` artifact from #839.
- All five unresolved code-quality threads were reviewed and fixed. Revision-aware SAM3 lookup now uses a uniquely named model-owned resolver while the shared one-argument cache resolver retains its contract; cache-inspection exceptions now emit a debug diagnostic instead of using an empty `except`.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `ruff check` passed for all four touched review-fix files.
- `PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/e2e/models/sam3/test_sam3_hf_reference.py tests/e2e/models/sam3/test_sam3_hf_transformers_reference.py`: `6 passed in 0.06s`.
- `git diff --check github/main...HEAD` passed.

The review fixes change cache-resolution structure and diagnostics only. They add no network fallback, model load, inference pass, engine build, GPU allocation, or relaxed acceptance criterion.
