### PR TITLE
fix(starcoder2): honor effective GPT-2 tokenizer contract

### DIFF
--- a/src/runtime/models/starcoder2/MODEL.toml
+++ b/src/runtime/models/starcoder2/MODEL.toml
@@ -7,3 +7,7 @@ runtime_plugins = ["plugin.cpp|register_starcoder2_plugin"]
 runtime_strategies = ["starcoder2_decoder_kv_cache"]
 [validation_profiles]
 decoder_debug = ["starcoder2_decoder_kv_cache"]
+
+runtime_tests = [
+  "test_starcoder2_tokenizer_contract|test_starcoder2_tokenizer_contract.cpp|_|_|_",
+]

--- a/tests/cpp/models/starcoder2/test_starcoder2_tokenizer_contract.cpp
+++ b/tests/cpp/models/starcoder2/test_starcoder2_tokenizer_contract.cpp
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// StarCoder2's tokenizer_config declares GPT2Tokenizer while its published
+// tokenizer.json wraps ByteLevel in Sequence[Digits, ByteLevel]. Verify that
+// the native runtime already applies the effective GPT-2 token boundaries.
+
+#include "trtmc/tokenizer.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    const std::string tokenizer_json = R"({
+      "model": {
+        "type": "BPE",
+        "vocab": {
+          "\u010a": 0,
+          "\u0120": 1,
+          "0": 2,
+          ".": 3,
+          "5": 4,
+          "\u010a\u0120": 5,
+          "\u010a\u0120\u0120": 6,
+          "\u010a\u0120\u0120\u0120": 7,
+          "\u010a\u0120\u0120\u0120\u0120": 8
+        },
+        "merges": [
+          "\u010a \u0120",
+          "\u010a\u0120 \u0120",
+          "\u010a\u0120\u0120 \u0120",
+          "\u010a\u0120\u0120\u0120 \u0120"
+        ]
+      },
+      "pre_tokenizer": {
+        "type": "Sequence",
+        "pretokenizers": [
+          {"type": "Digits", "individual_digits": true},
+          {
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": true,
+            "use_regex": true
+          }
+        ]
+      },
+      "decoder": {
+        "type": "ByteLevel",
+        "add_prefix_space": true,
+        "trim_offsets": true,
+        "use_regex": true
+      }
+    })";
+
+    auto tokenizer =
+        trtmc::CreateBpeTokenizer(tokenizer_json.data(), tokenizer_json.size(), false);
+    if (!tokenizer) {
+        std::cerr << "FAIL: native StarCoder2 tokenizer was not created\n";
+        return 1;
+    }
+
+    const std::vector<int32_t> expected{7, 1, 2, 3, 4};
+    const auto actual = tokenizer->encode("\n    0.5");
+    if (actual != expected) {
+        std::cerr << "FAIL: effective GPT-2 token boundaries differ\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/starcoder2/test_starcoder2_tokenizer_contract.cpp
+++ b/tests/cpp/models/starcoder2/test_starcoder2_tokenizer_contract.cpp
@@ -56,8 +56,7 @@ int main() {
       }
     })";
 
-    auto tokenizer =
-        trtmc::CreateBpeTokenizer(tokenizer_json.data(), tokenizer_json.size(), false);
+    auto tokenizer = trtmc::CreateBpeTokenizer(tokenizer_json.data(), tokenizer_json.size(), false);
     if (!tokenizer) {
         std::cerr << "FAIL: native StarCoder2 tokenizer was not created\n";
         return 1;

--- a/tests/e2e/models/starcoder2/manifests/starcoder2-3b.json
+++ b/tests/e2e/models/starcoder2/manifests/starcoder2-3b.json
@@ -15,7 +15,7 @@
       "reference_family": "code_base_completion",
       "user_contract": "code_completion",
       "reference_precision": "fp32",
-      "prompt": "def fibonacci(n):",
+      "prompt": "def f():\n    0.5",
       "max_new_tokens": 20
     }
   ]

--- a/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
+++ b/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""StarCoder2-owned task-eval tokenizer contract regression."""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+from tokenizers import Tokenizer
+
+from tools.task_eval import (
+    _effective_bundle_tokenizer_payload,
+    _load_text_input_contract,
+)
+
+
+def _published_backend_payload() -> bytes:
+    return json.dumps(
+        {
+            "model": {
+                "type": "BPE",
+                "vocab": {
+                    "\u010a": 0,
+                    "\u0120": 1,
+                    "0": 2,
+                    ".": 3,
+                    "5": 4,
+                    "\u010a\u0120": 5,
+                    "\u010a\u0120\u0120": 6,
+                    "\u010a\u0120\u0120\u0120": 7,
+                    "\u010a\u0120\u0120\u0120\u0120": 8,
+                },
+                "merges": [
+                    "\u010a \u0120",
+                    "\u010a\u0120 \u0120",
+                    "\u010a\u0120\u0120 \u0120",
+                    "\u010a\u0120\u0120\u0120 \u0120",
+                ],
+            },
+            "pre_tokenizer": {
+                "type": "Sequence",
+                "pretokenizers": [
+                    {"type": "Digits", "individual_digits": True},
+                    {
+                        "type": "ByteLevel",
+                        "add_prefix_space": False,
+                        "trim_offsets": True,
+                        "use_regex": True,
+                    },
+                ],
+            },
+            "decoder": {
+                "type": "ByteLevel",
+                "add_prefix_space": True,
+                "trim_offsets": True,
+                "use_regex": True,
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def test_gpt2_wrapper_uses_effective_byte_level_contract() -> None:
+    source = _published_backend_payload()
+    raw_ids = Tokenizer.from_str(source.decode("utf-8")).encode("\n    0.5").ids
+
+    effective = _effective_bundle_tokenizer_payload(
+        source,
+        {
+            "tokenizer_class": "GPT2Tokenizer",
+            "add_prefix_space": False,
+        },
+    )
+    effective_ids = Tokenizer.from_str(effective.decode("utf-8")).encode(
+        "\n    0.5"
+    ).ids
+
+    assert raw_ids == [8, 2, 3, 4]
+    assert effective_ids == [7, 1, 2, 3, 4]
+    assert json.loads(source)["pre_tokenizer"]["type"] == "Sequence"
+    assert json.loads(effective)["pre_tokenizer"]["type"] == "ByteLevel"
+
+
+def test_non_gpt2_wrapper_does_not_refine_backend() -> None:
+    source = _published_backend_payload()
+
+    assert (
+        _effective_bundle_tokenizer_payload(
+            source,
+            {"tokenizer_class": "CodeLlamaTokenizer"},
+        )
+        == source
+    )
+
+
+def _write_bundle(path: Path, sections: dict[str, bytes]) -> None:
+    offset = 0
+    metadata = {}
+    for name, payload in sections.items():
+        metadata[name] = {"offset": offset, "size": len(payload)}
+        offset += len(payload)
+    header = json.dumps({"sections": metadata}).encode("utf-8")
+    path.write_bytes(
+        b"TRTFB\x00\x01\x00"
+        + struct.pack("<Q", len(header))
+        + header
+        + b"".join(sections.values())
+    )
+
+
+def test_input_contract_loads_effective_bundled_wrapper(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "starcoder2.trtfb"
+    _write_bundle(
+        bundle,
+        {
+            "config.json": b"{}",
+            "tokenizer.json": _published_backend_payload(),
+            "tokenizer_config.json": json.dumps(
+                {
+                    "tokenizer_class": "GPT2Tokenizer",
+                    "add_prefix_space": False,
+                }
+            ).encode("utf-8"),
+        },
+    )
+    hf_tokenizer = object()
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained",
+        lambda *_args, **_kwargs: hf_tokenizer,
+    )
+
+    loaded_hf, bundled, config = _load_text_input_contract(
+        model={"hf_id": "bigcode/starcoder2-3b"},
+        bundle_path=bundle,
+        local_files_only=True,
+        trust_remote_code=False,
+    )
+
+    assert loaded_hf is hf_tokenizer
+    assert bundled.encode("\n    0.5").ids == [7, 1, 2, 3, 4]
+    assert config == {}

--- a/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
+++ b/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
@@ -104,7 +104,7 @@ def _write_bundle(path: Path, sections: dict[str, bytes]) -> None:
         offset += len(payload)
     header = json.dumps({"sections": metadata}).encode("utf-8")
     path.write_bytes(
-        b"TRTFB\x00\x01\x00"
+        b"BUNDLE\x01\x00"
         + struct.pack("<Q", len(header))
         + header
         + b"".join(sections.values())
@@ -115,7 +115,7 @@ def test_input_contract_loads_effective_bundled_wrapper(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    bundle = tmp_path / "starcoder2.trtfb"
+    bundle = tmp_path / "starcoder2.bundle"
     _write_bundle(
         bundle,
         {

--- a/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
+++ b/tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from tokenizers import Tokenizer
 
-from tools.task_eval import (
+from tools.validation.engine import (
     _effective_bundle_tokenizer_payload,
     _load_text_input_contract,
 )

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -9534,6 +9534,91 @@ def _read_bundle_section(bundle_path: Path, section_name: str) -> bytes:
         return data
 
 
+def _read_optional_bundle_json_object(
+    bundle_path: Path,
+    section_name: str,
+) -> dict[str, Any]:
+    """Read an optional JSON-object section without hiding malformed data."""
+
+    try:
+        raw = _read_bundle_section(bundle_path, section_name)
+    except ValueError as exc:
+        if str(exc) == f"{bundle_path} has no {section_name!r} section":
+            return {}
+        raise
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{bundle_path} {section_name} must contain an object")
+    return payload
+
+
+def _effective_bundle_tokenizer_payload(
+    source_payload: bytes,
+    tokenizer_config: Mapping[str, Any],
+) -> bytes:
+    """Apply a declared GPT-2 wrapper to its bundled backend tokenizer.
+
+    StarCoder2 publishes ``Sequence[Digits, ByteLevel]`` in tokenizer.json but
+    declares ``GPT2Tokenizer`` in tokenizer_config.json. Transformers replaces
+    that sequence with its ByteLevel component. The native BPE runtime already
+    uses GPT-2 splitting for this sequence, so input-contract validation must
+    compare the same effective tokenizer instead of the raw backend file.
+
+    Keep the refinement fail-closed: only the exact BPE/Digits/ByteLevel shape
+    with a matching add-prefix-space contract is rewritten.
+    """
+
+    tokenizer_class = str(tokenizer_config.get("tokenizer_class", "") or "")
+    if tokenizer_class.removesuffix("Fast") != "GPT2Tokenizer":
+        return source_payload
+
+    tokenizer = json.loads(source_payload.decode("utf-8"))
+    if not isinstance(tokenizer, dict):
+        raise ValueError("tokenizer.json must contain an object")
+    model = tokenizer.get("model")
+    pre_tokenizer = tokenizer.get("pre_tokenizer")
+    if (
+        not isinstance(model, dict)
+        or model.get("type") != "BPE"
+        or not isinstance(pre_tokenizer, dict)
+        or pre_tokenizer.get("type") != "Sequence"
+    ):
+        return source_payload
+
+    sequence = pre_tokenizer.get("pretokenizers")
+    if not isinstance(sequence, list) or len(sequence) != 2:
+        return source_payload
+    digits = [
+        item
+        for item in sequence
+        if isinstance(item, dict) and item.get("type") == "Digits"
+    ]
+    byte_levels = [
+        item
+        for item in sequence
+        if isinstance(item, dict) and item.get("type") == "ByteLevel"
+    ]
+    if (
+        len(digits) != 1
+        or digits[0].get("individual_digits") is not True
+        or len(byte_levels) != 1
+    ):
+        return source_payload
+
+    byte_level = dict(byte_levels[0])
+    configured_prefix = tokenizer_config.get("add_prefix_space")
+    if (
+        configured_prefix is not None
+        and (
+            not isinstance(configured_prefix, bool)
+            or byte_level.get("add_prefix_space") is not configured_prefix
+        )
+    ):
+        return source_payload
+    tokenizer["pre_tokenizer"] = byte_level
+    return json.dumps(tokenizer, separators=(",", ":")).encode("utf-8")
+
+
 def _load_text_input_contract(
     *,
     model: Mapping[str, Any],
@@ -9555,8 +9640,16 @@ def _load_text_input_contract(
         str(model["hf_id"]),
         **tokenizer_kwargs,
     )
+    tokenizer_payload = _read_bundle_section(bundle_path, "tokenizer.json")
+    tokenizer_config = _read_optional_bundle_json_object(
+        bundle_path,
+        "tokenizer_config.json",
+    )
     bundle_tokenizer = Tokenizer.from_str(
-        _read_bundle_section(bundle_path, "tokenizer.json").decode("utf-8")
+        _effective_bundle_tokenizer_payload(
+            tokenizer_payload,
+            tokenizer_config,
+        ).decode("utf-8")
     )
     bundle_config = json.loads(
         _read_bundle_section(bundle_path, "config.json").decode("utf-8")


### PR DESCRIPTION
## Background

The original QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` recorded StarCoder2-3B as
passed: all 10 HumanEval samples completed with exact-match and token-prefix
agreement both equal to `1.0`. It was not one of that report's 36 failures.

While replaying the same complete workload against the current accuracy-fix
integration source `5dc37b757ae2ec93956acfb3672108372ff404e9`, a
forced-fresh, QA-equivalent run exposed a new validator regression before
model inference:

- sample: `HumanEval/2`
- first differing input-token position: `75`
- HF token count: `83`
- task-eval's raw-bundle token count: `82`
- HF window: `[56, 51, 58, 46, 303, 244, 53, 51, 58, 303, 1547, 222]`
- raw-bundle window: `[56, 51, 58, 46, 294, 53, 51, 58, 303, 1547, 222]`

Because the input-contract gate stopped before the TRTMC benchmark, this was a
validator false failure rather than a measured model-output accuracy
regression.

## Exit Criteria

- Validation compares Hugging Face against the effective GPT-2 wrapper
  contract that the native runtime actually implements.
- The exposing decimal prompt reaches full inference instead of failing on a
  false raw-tokenizer mismatch.
- Unsupported tokenizer shapes remain unchanged and fail closed; no accuracy
  gate, sample count, precision, or expected result is relaxed.
- CI closes the blind spot with bounded family-owned tests and no additional
  model-proof row.

## Root Cause

`bigcode/starcoder2-3b` publishes two related tokenizer contracts:

- `tokenizer.json` contains
  `Sequence[Digits(individual_digits=true), ByteLevel]`.
- `tokenizer_config.json` declares `GPT2Tokenizer`.

Transformers applies the GPT-2 wrapper and replaces that sequence with its
ByteLevel component. The native C++ BPE runtime already treats a Sequence with
no Split pre-tokenizer as GPT-2 semantics, so TRTMC and Hugging Face use the
same effective input tokens.

The input-contract loader (then in `tools/task_eval.py`, and now owned by
`tools/validation/engine.py`) read only the raw bundled `tokenizer.json`. It
therefore
compared Hugging Face's effective wrapper against a raw backend tokenizer that
the product runtime does not use, and falsely rejected prompts containing an
indented decimal.

## Implementation

- Read the optional bundled `tokenizer_config.json` during input-contract
  validation.
- Reconstruct the effective GPT-2 ByteLevel pre-tokenizer only for the exact
  BPE plus two-member Digits/ByteLevel shape and a matching
  `add_prefix_space` contract. All other tokenizer shapes remain unchanged.
- Add a StarCoder2-owned Python bundle test for raw-versus-effective
  tokenization and the end-to-end validation-engine loader.
- Add a StarCoder2-owned native C++ test proving the runtime tokenizer already
  emits the Hugging Face-effective IDs for `"\n    0.5"`.
- Replace the existing one-prompt L0 input with an exposing decimal prompt.
  The testcase count and `max_new_tokens=20` are unchanged.

## Why CI Missed It

The existing StarCoder2 L0 prompt, `def fibonacci(n):`, did not contain the
newline, indentation, and decimal combination that distinguishes the raw
published backend from the effective GPT-2 wrapper. There was also no
family-owned test connecting the bundled `tokenizer_config.json` to
the validation engine's input-contract tokenizer.

The new Python test catches the original validator behavior without a model
download, engine build, or GPU. The native C++ contract prevents a future
validator change from masking a real runtime-tokenizer divergence.

## Runtime Bound

This PR adds no fallback model and no extra model-proof testcase. StarCoder2
still runs one L0 prompt with 20 generated tokens; only the prompt content
changes.

- original repair-head Python tokenizer regressions: `3 passed` in `5.11s`
- original repair-head native tokenizer contract: `1 passed` in `0.35s`
- impact selection: only `starcoder2`, with no fallback model

The new fast tests cover the CI blind spot without adding another model
download, engine build, or GPU allocation. The existing direct StarCoder2
model-proof row changes its exposing prompt but keeps the same testcase count
and generation length.

## Validation

Fail-before receipt:

- source: `5dc37b757ae2ec93956acfb3672108372ff404e9`
- hardware: GB300, single-device execution
- TensorRT: `11.2.0.113`
- model snapshot:
  `bigcode/starcoder2-3b@733247c55e3f73af49ce8e9c7949bf14af205928`
- workload: `humaneval_code_continuation_parity`, `10/10` prepared samples
- freshness: `--force-hf --force-build --local-files-only`;
  reference-cache status `generated`
- result: input-token contract mismatch at `HumanEval/2`; inference and
  accuracy comparison were not run

Authoritative pass-after receipt:

- exact source: `5569148845eab886d6490a3366a47a456817ff1b`
- base: `9f22e1f44bee20bb8138eb5e2e3c897cc5458d60`
- hardware: GB300, single-device execution
- TensorRT builder/runtime: `11.2.0.113`
- reference profile:
  `/opt/trtmc-python-profiles/reference_common-424321ab2bba/bin/python`
- model snapshot:
  `bigcode/starcoder2-3b@733247c55e3f73af49ce8e9c7949bf14af205928`
- workload: `humaneval_code_continuation_parity`, full `10/10` samples
- precision: TRTMC FP16 / HF FP16
- freshness: `--force-hf --force-build --local-files-only`
- execution: one attempt, no retries, `407.771s`
- input-token contract: all `10/10` samples aligned, including `HumanEval/2`
- result: validation passed with no gate failures
  - exact match: `9/10` (`0.9`)
  - token-prefix agreement: `0.921875`
  - diagnostic divergences: `1/10`

This workload is explicitly `diagnostic_only` and configures no numeric gate;
the PR does not add, remove, or relax an acceptance threshold. The
current-head replay failure was the fail-closed input-token contract rejecting
the run before any accuracy comparison. The repaired validator now reaches and
records the full comparison. This is a preventive regression fix found while
validating the aggregate repair set, not a reclassification of the original
QA result.

The exact repair-head TRT 11.2 binary, benchmark, backend, and StarCoder2 plugin were
built in a network-disabled container with no GPU devices. Their SHA-256
receipts are recorded before the GPU stage.

Additional checks:

- targeted repair-head Python JUnit: `3 passed`
- repair-head C++ JUnit: `1 passed`
- `ruff check` on changed Python files: passed
- `python3 tools/model_ci.py validate`: passed for 78 models
- `tools/model_ci.py impact --base github/main --head HEAD`: only
  `starcoder2`, no fallback model
- `git diff --check github/main...HEAD`: passed

Local pass-after receipt root:
`/tmp/trtmc-accuracy-agent2/starcoder2-validation/exact-55691488-strict-r1/starcoder2-3b-full10`.

Frozen receipt SHA-256 values:

- comparison JSON:
  `8f58231009b3041071c47763ebec9d7dafe996eb3c30ac825162d11795e8df66`
- Python JUnit:
  `80b2e44ba5da9ba7042b5371767a034052e72398e5c9e9d1c7f6d03894c39c39`
- C++ JUnit:
  `cff8890944576d55bb41269d76bdd8a9af736e98bf15cc42e088b04bcdee0eba`
- engine:
  `3ed67878dd815fd794b2264b821808ee409bd9741e7066c619806a4e1a84986c`
- host GPU lock:
  `58d9e8d679932dafe28ee958e14f4ed4f039c243cbe59e50ac6cddb51636c24b`
- GPU monitor before / after:
  `a942648ea2854c9073998f1e68be0ba6bfa73f9aeb91bfd11ccdc069b1b9fedd`
  /
  `558259dd2f232c43caee0c0ce55fda5cbbec759fd41ee0675dfdfcf74d79a624`

Both before/after compute-process receipts are empty and hash to the SHA-256
of an empty file, confirming exclusive container-visible GPU use at the
boundaries. The lock receipt records exit code `0`; the complete manifest is
`provenance/SHA256SUMS.strict` under the local validation root and passes
`sha256sum -c`.

## Current-main Rebase Validation

The branch is rebased onto
`github/main@63c920304cb0236a995e933f49504e8f2f237317`; the exact PR head for
this validation is
`ab6f16ebfd71f67e60b109fdd3a688e6e83d9f81`.

Current `main` removed `tools.task_eval` as the Python API owner. The rebase
repair updates the StarCoder2-owned regression to import
`_effective_bundle_tokenizer_payload` and `_load_text_input_contract` from
their current owner, `tools.validation.engine`, so the test collects against
the current tree without changing the tokenizer contract.

- The provided frozen-image regression set passed with `245 passed` in
  `sha256:6e97af69eae7e9276e7f9061381edefd54a782ab6695c895117ecfff06188027`.
- A real cached `bigcode/starcoder2-3b` tokenizer check exercised six prompts;
  all six matched between the Hugging Face-effective tokenizer and the
  refined bundled tokenizer.
- This current-head validation was source/CPU-only. No current-head GPU
  inference, TensorRT engine build, or full HumanEval replay was run.
- The complete 10-sample GB300 receipt above remains the model-level evidence
  from exact repair source
  `5569148845eab886d6490a3366a47a456817ff1b`; it is not a current-head GPU
  replay.
- Private CI for this branch is held behind shared prerequisite #834 at the
  time of this update.

The current-head checks preserve the existing runtime bound: the new
tokenizer regressions are CPU-only, and the direct StarCoder2 model-proof
matrix still has one prompt and 20 generated tokens. There is no additional
model download, engine build, fallback model, GPU allocation, or full QA
lane.

## Notes For Future Readers

Review `_effective_bundle_tokenizer_payload` first, then the synthetic Python
bundle contract, and finally the native tokenizer test. The acceptance
criteria are unchanged; this PR repairs the validator so it checks the
effective tokenizer contract used by both Hugging Face and TRTMC.


## Latest Main Bundle Compatibility Refresh (2026-08-07)

- Rebased without a textual conflict onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `41c415130479e47d4494d7660cc7bc7ccf747dcc`.
- The conflict-free replay initially retained a stale test fixture using `starcoder2.trtfb` and `TRTFB\x00\x01\x00`. The fixture now uses `starcoder2.bundle` and the current `BUNDLE\x01\x00` magic, so the tokenizer regression exercises the parser shipped by #839.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `ruff check` and `py_compile` passed for the changed regression.
- `PYTHONPATH=/tmp/trtmc-accuracy-c.PAang6/deps:python:. python3 -m pytest -q -p no:cacheprovider tests/e2e/models/starcoder2/test_starcoder2_task_eval_tokenizer.py`: `3 passed in 0.94s`, including the current bundle parser round trip.
- `git diff --check github/main...HEAD` passed.

The compatibility repair only updates an in-memory test fixture. It adds no model download, engine build, inference, GPU work, threshold change, or CI fanout.
