### PR TITLE
fix(ci): test policy documentation in L0

### DIFF
--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -578,6 +578,43 @@ def test_impact_treats_legal_and_docs_as_no_model_change(tmp_path: Path) -> None
     assert result["unit_scope"] == "none"
 
 
+@pytest.mark.parametrize(
+    ("path", "expected_scope", "expected_kind"),
+    (
+        (
+            "website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md",
+            "builder",
+            "unit_builder",
+        ),
+        ("tools/ci/README.md", "all", "unit_tests"),
+    ),
+)
+def test_impact_runs_units_for_test_consumed_docs(
+    tmp_path: Path,
+    path: str,
+    expected_scope: str,
+    expected_kind: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# Updated test-consumed documentation\n")
+    head = _commit(repo, "update test-consumed documentation")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == expected_scope
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {expected_kind}
+
+
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -121,6 +121,21 @@ LEGAL_OR_DOC_EXACT = frozenset(
 )
 LEGAL_OR_DOC_PREFIXES = ("website/",)
 
+# Non-code inputs consumed directly by the CPU-only builder contract suite.
+# Classify these before the blanket documentation rule so a documentation
+# rewrite cannot skip the tests that define its normative contract.
+BUILDER_UNIT_TEST_INPUT_EXACT = frozenset(
+    {
+        "website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md",
+    }
+)
+# Inputs consumed by the complete source-only tools/CI contract suite.
+FULL_UNIT_TEST_INPUT_EXACT = frozenset(
+    {
+        "tools/ci/README.md",
+    }
+)
+
 # These shared surfaces are covered by CPU/C++ unit tests and do not change a
 # model implementation or its isolated E2E contract. Model-root ownership is
 # resolved before this list, so model-owned C++ tests remain model impact.
@@ -621,6 +636,10 @@ def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | Non
         return "model", owner
     if under_model_root:
         raise ModelCIError(f"path is under a model root but has no MODEL.toml owner: {path}")
+    if path in BUILDER_UNIT_TEST_INPUT_EXACT:
+        return "unit_builder", None
+    if path in FULL_UNIT_TEST_INPUT_EXACT:
+        return "unit_tests", None
     if _is_legal_or_docs(path):
         return "legal_docs", None
     if path in MODEL_COUPLED_TEST_EXACT:
@@ -957,6 +976,8 @@ def calculate_impact(
             if owner is not None:
                 item["model"] = owner
                 affected.add(owner)
+                unit_scope = _merge_unit_scope(unit_scope, "builder")
+            elif kind == "unit_builder":
                 unit_scope = _merge_unit_scope(unit_scope, "builder")
             elif kind == "unit_cli":
                 unit_scope = _merge_unit_scope(unit_scope, "cli")

--- a/website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md
+++ b/website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md
@@ -30,7 +30,10 @@ The parser currently exposes `--quantize` values `fp8`, `int8`, `int8_sq`,
 `int4`, `int4_awq`, `nvfp4`, and `w4a8`, plus scale and calibration options.
 Parser acceptance is not a claim that every family supports every format.
 
-## Ownership rule
+## Ownership standard
+
+This section is normative. It defines the boundary for parallel model and core
+work.
 
 The shared core owns format mechanics. A family owns:
 
@@ -41,12 +44,58 @@ The shared core owns format mechanics. A family owns:
 - tensor-parallel compatibility
 - parity, health, and performance evidence
 
+### Family agent default scope
+
+A family agent default scope is family-owned code and evidence:
+
+- `python/tensorrt_model_connect/families/<family>/`, including `plugin.py`
+  and family-owned builders
+- family manifests, comparison policy, and tests
+
+Family work should use shared quantization interfaces without adding
+family-specific behavior to the shared core.
+
+### Core agent scope
+
+A core agent scope is the shared implementation under
+`python/tensorrt_model_connect/quantization/`.
+
+### Escalation rule
+
+A family task becomes a core task only when it adds or fixes a shared primitive
+such as a format, scale contract, common graph seam, or shared
+calibration/runtime behavior.
+
+### Shared-core hygiene
+
+- Shared quantization code must not import specific family plugins.
+- Shared quantization code must not branch on concrete family names.
+- Family-specific quantization policy belongs in plugin hooks such as
+  `quant_adapter()` and `quant_exclude_patterns()`.
+
+### Review rule
+
+If family onboarding reveals a required core change, isolate that change for
+core review instead of hiding it inside the family delta.
+
 The engine builder passes a quantization context only to plugins whose build
 entry point accepts it. That signature check is not a global support gate: a
 plugin can currently accept and ignore the context. Therefore parser
 acceptance and even a successful build do not prove that quantization was
 applied. Each family should reject unsupported combinations explicitly, and
 qualification must verify the resulting bundle metadata and task output.
+
+## Test enforcement
+
+`tests/builder/test_quantization_ownership.py` enforces that:
+
+- the fixed shared-core files exist
+- shared quantization code does not import concrete family modules
+- shared quantization code does not branch on concrete family names
+- family-specific Qwen hooks remain in the Qwen plugin
+
+These static ownership checks protect the architecture boundary. They do not
+replace family-specific build, parity, health, or performance qualification.
 
 ## Evidence
 


### PR DESCRIPTION
## Background

PR #675 updated the quantization ownership policy, but its final pre-merge run
classified every changed Markdown file as `legal_docs`. The impact job emitted
`run_unit_tests=false` and `unit_scope=none`, so `Unit / C++ and Python` was
skipped even though `tests/builder/test_quantization_ownership.py` directly
validates that policy document.

That left the merged branch with one failed ownership-contract assertion:
`## ownership standard` was no longer present. The same selector gap also
applied to `tools/ci/README.md`, which is read by
`tests/tools/test_github_actions_ci.py`.

## Exit Criteria

- Restore the current quantization ownership and test-enforcement contract
  without restoring obsolete implementation claims.
- Run the relevant CPU L0 suite whenever either test-consumed document changes.
- Keep ordinary documentation-only changes on the existing no-unit-test path.
- Do not add GPU/model execution for these documentation contracts.

## Implementation

- Restore the normative ownership, escalation, shared-core hygiene, review, and
  test-enforcement sections in the quantization policy.
- Classify the quantization policy as `unit_builder` and `tools/ci/README.md` as
  `unit_tests` before applying the blanket documentation classification.
- Add selector regression coverage for both exact paths and retain coverage
  proving ordinary documentation remains `mode=none`.

## Validation

- Baseline on current `main`:
  `tests/builder/test_quantization_ownership.py` -> 1 failed, 6 passed.
- With this fix:
  `tests/builder/test_quantization_ownership.py` -> 7 passed.
- `tests/tools/test_model_ci.py` -> 72 passed.
- `tests/tools/test_github_actions_ci.py` -> 91 passed.
- Source Quality pipeline -> passed, including 158 architecture tests.
- `ruff check tools/model_ci.py tests/tools/test_model_ci.py` -> passed.
- `python3 tools/model_ci.py validate` -> passed for 78 models.
- Strict documentation reference validation, legal header validation, cached
  Docusaurus production build, and `git diff --check` -> passed.

An exact replay of PR #675's final base/head with the patched selector changes
the result from `mode=none`, `run_unit_tests=false`, `unit_scope=none` to
`mode=unit`, `run_unit_tests=true`, `unit_scope=all`, with no affected or
fallback models.

## Notes For Future Readers

Markdown is not always presentation-only. A document that a test reads as a
normative contract must be mapped to that test's L0 scope before the generic
documentation rule. Exact-path mappings keep this exception narrow and avoid
making all documentation changes run the full unit suite.

The bridge-only PR #726 should rebase onto this change and rerun pre-merge after
this fix lands.
