### PR TITLE
fix(xlnet): align reference parameter dtype

### DIFF
--- a/tests/e2e/models/xlnet/impact_diff_rules.json
+++ b/tests/e2e/models/xlnet/impact_diff_rules.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "xlnet_reference_parameter_dtype",
+    "path": "tools/reference/transformers_encoder.py",
+    "scope": {
+      "owner_family": true
+    },
+    "allowed_tokens": [
+      "requested_dtype",
+      "model_type",
+      "xlnet",
+      "transformers",
+      "parameters",
+      "reduced_dtype",
+      "hidden_states",
+      "model.to"
+    ],
+    "model_ci_changed_lines_sha256": "955ff4dacf1cfa609787510f786d5e88991baecd738a2573dc796af18f424b2f"
+  }
+]

--- a/tests/e2e/models/xlnet/test_xlnet_reference_dtype.py
+++ b/tests/e2e/models/xlnet/test_xlnet_reference_dtype.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools.reference import transformers_encoder
+
+
+class _FakeModel:
+    def __init__(self, model_type: str) -> None:
+        self.config = SimpleNamespace(model_type=model_type)
+        self.device = "mapped-device"
+        self.to_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def eval(self):
+        return self
+
+    def to(self, *args, **kwargs):
+        self.to_calls.append((args, kwargs))
+        return self
+
+
+def _load_runtime(model_type: str):
+    requested_dtype = object()
+    model = _FakeModel(model_type)
+    arguments = SimpleNamespace(
+        model="org/model",
+        model_revision="",
+        reference_family="encoder_base_features",
+        trust_remote_code=False,
+        local_files_only=True,
+        dtype="float16",
+        device="cuda",
+        device_map="",
+    )
+    transformers_module = SimpleNamespace(
+        logging=SimpleNamespace(set_verbosity_error=lambda: None),
+        AutoTokenizer=SimpleNamespace(
+            from_pretrained=lambda _model, **_kwargs: object()
+        ),
+        AutoModel=SimpleNamespace(
+            from_pretrained=lambda _model, **_kwargs: model
+        ),
+    )
+    torch_module = SimpleNamespace(
+        float16=requested_dtype,
+        device=lambda name: f"device:{name}",
+    )
+
+    transformers_encoder._load_runtime(
+        arguments,
+        torch_module,
+        transformers_module,
+    )
+    return model, requested_dtype
+
+
+def test_xlnet_reference_casts_all_parameters_to_requested_dtype() -> None:
+    model, requested_dtype = _load_runtime("xlnet")
+
+    assert model.to_calls == [
+        ((), {"dtype": requested_dtype}),
+        (("device:cuda",), {}),
+    ]
+
+
+def test_non_xlnet_reference_keeps_existing_load_behavior() -> None:
+    model, _requested_dtype = _load_runtime("bert")
+
+    assert model.to_calls == [(("device:cuda",), {})]

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -39,6 +39,10 @@ def _commit(repo: Path, message: str) -> str:
     return _git(repo, "rev-parse", "HEAD")
 
 
+def _changed_lines_digest(*lines: str) -> str:
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
 def _add_model(
     repo: Path,
     logical_id: str,
@@ -163,6 +167,11 @@ def _make_repo(
         "tools/reference/transformers_vlm.py",
     ):
         _write(repo, reference_runner, "# task-eval reference runner\n")
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        'requested_dtype = "auto"\n',
+    )
     _write(repo, "tools/test_impact.py", "# shared impact analyzer\n")
     _write(repo, "tools/task_eval.py", "# task-eval runner\n")
     _write(repo, "tools/trtmc_reference.py", "# task-eval reference runner\n")
@@ -708,7 +717,6 @@ def test_runtime_cli_changes_run_model_fallback(tmp_path: Path, path: str) -> No
         "CMakeLists.txt",
         ".github/workflows/trtmc-ci.yml",
         "src/runtime/providers/optimized_runtime_host.cpp",
-        "tools/model_ci.py",
         "new_platform/implementation.py",
     ),
 )
@@ -750,6 +758,342 @@ def test_mixed_model_and_broad_change_keeps_direct_model_plus_fallback(
     }
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == "all"
+
+
+def test_model_ci_changes_run_full_units_without_gpu_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "tools/model_ci.py", "# changed selective impact analyzer\n")
+    head = _commit(repo, "model CI change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["fallback_models"] == []
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
+def test_model_owned_digest_rule_narrows_exact_shared_diff(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    changed_lines = (
+        'requested_dtype = "auto"',
+        'requested_dtype = "float16"',
+        'model_type = "xlnet"',
+        "model.to(dtype=requested_dtype)",
+    )
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "\n".join(changed_lines[1:]) + "\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps(
+            [
+                {
+                    "name": "model_b_reference_dtype",
+                    "path": "tools/reference/transformers_encoder.py",
+                    "scope": {"owner_family": True},
+                    "allowed_tokens": [
+                        "requested_dtype",
+                        "model_type",
+                        "model.to",
+                    ],
+                    "model_ci_changed_lines_sha256": _changed_lines_digest(
+                        *changed_lines
+                    ),
+                }
+            ]
+        )
+        + "\n",
+    )
+    head = _commit(repo, "model-owned shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_b"]
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == []
+    assert result["unit_scope"] == "builder"
+    assert any(
+        classification.get("impact_rule") == "model_b_reference_dtype"
+        for change in result["changes"]
+        for classification in change["classifications"]
+    )
+
+
+def test_model_owned_digest_rule_falls_back_on_extra_shared_change(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    declared_lines = (
+        'requested_dtype = "auto"',
+        'requested_dtype = "float16"',
+        'model_type = "xlnet"',
+        "model.to(dtype=requested_dtype)",
+    )
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "\n".join((*declared_lines[1:], "unrelated_runtime_change = True"))
+        + "\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps(
+            [
+                {
+                    "name": "model_b_reference_dtype",
+                    "path": "tools/reference/transformers_encoder.py",
+                    "scope": {"owner_family": True},
+                    "allowed_tokens": [
+                        "requested_dtype",
+                        "model_type",
+                        "model.to",
+                    ],
+                    "model_ci_changed_lines_sha256": _changed_lines_digest(
+                        *declared_lines
+                    ),
+                }
+            ]
+        )
+        + "\n",
+    )
+    head = _commit(repo, "mixed shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a", "model_b"]
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
+    assert not any(
+        classification.get("impact_rule") == "model_b_reference_dtype"
+        for change in result["changes"]
+        for classification in change["classifications"]
+    )
+
+
+def test_model_owned_digest_rule_falls_back_when_rule_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        'requested_dtype = "float16"\n'
+        'model_type = "xlnet"\n'
+        "model.to(dtype=requested_dtype)\n",
+    )
+    head = _commit(repo, "undeclared shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+
+
+def test_model_owned_digest_rule_preserves_case_and_string_payload(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    declared_lines = (
+        'requested_dtype = "auto"',
+        'requested_dtype = "float16"',
+        'model_type = "xlnet"',
+        "model.to(dtype=requested_dtype)",
+    )
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        'requested_dtype = "float16"\n'
+        'MODEL_TYPE = "XLNET"\n'
+        "model.to(dtype=requested_dtype)\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps(
+            [
+                {
+                    "name": "model_b_reference_dtype",
+                    "path": "tools/reference/transformers_encoder.py",
+                    "scope": {"owner_family": True},
+                    "allowed_tokens": [
+                        "requested_dtype",
+                        "model_type",
+                        "model.to",
+                    ],
+                    "model_ci_changed_lines_sha256": _changed_lines_digest(
+                        *declared_lines
+                    ),
+                }
+            ]
+        )
+        + "\n",
+    )
+    head = _commit(repo, "case-drifted shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
+
+
+def test_model_owned_digest_rule_preserves_leading_indentation(
+    tmp_path: Path,
+) -> None:
+    repo, _ = _make_repo(tmp_path)
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "def load():\n"
+        '    requested_dtype = "auto"\n',
+    )
+    base = _commit(repo, "add indented reference baseline")
+    declared_lines = (
+        '    requested_dtype = "auto"',
+        '    requested_dtype = "float16"',
+        '    model_type = "xlnet"',
+        "    model.to(dtype=requested_dtype)",
+    )
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "def load():\n"
+        '    requested_dtype = "float16"\n'
+        '    model_type = "xlnet"\n'
+        "model.to(dtype=requested_dtype)\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps(
+            [
+                {
+                    "name": "model_b_reference_dtype",
+                    "path": "tools/reference/transformers_encoder.py",
+                    "scope": {"owner_family": True},
+                    "allowed_tokens": [
+                        "requested_dtype",
+                        "model_type",
+                        "model.to",
+                    ],
+                    "model_ci_changed_lines_sha256": _changed_lines_digest(
+                        *declared_lines
+                    ),
+                }
+            ]
+        )
+        + "\n",
+    )
+    head = _commit(repo, "outdented shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
+
+
+def test_model_owned_digest_rule_counts_punctuation_only_changes(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    declared_lines = (
+        'requested_dtype = "auto"',
+        'requested_dtype = "float16"',
+        'model_type = "xlnet"',
+        "model.to(dtype=requested_dtype)",
+    )
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "\n".join((*declared_lines[1:], ")")) + "\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps(
+            [
+                {
+                    "name": "model_b_reference_dtype",
+                    "path": "tools/reference/transformers_encoder.py",
+                    "scope": {"owner_family": True},
+                    "allowed_tokens": [
+                        "requested_dtype",
+                        "model_type",
+                        "model.to",
+                    ],
+                    "model_ci_changed_lines_sha256": _changed_lines_digest(
+                        *declared_lines
+                    ),
+                }
+            ]
+        )
+        + "\n",
+    )
+    head = _commit(repo, "punctuation shared reference change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
+
+
+def test_duplicate_model_owned_digest_rules_fail_back_to_broad_impact(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    changed_lines = (
+        'requested_dtype = "auto"',
+        'requested_dtype = "float16"',
+        'model_type = "xlnet"',
+        "model.to(dtype=requested_dtype)",
+    )
+    rule = {
+        "name": "model_b_reference_dtype",
+        "path": "tools/reference/transformers_encoder.py",
+        "scope": {"owner_family": True},
+        "allowed_tokens": [
+            "requested_dtype",
+            "model_type",
+            "model.to",
+        ],
+        "model_ci_changed_lines_sha256": _changed_lines_digest(
+            *changed_lines
+        ),
+    }
+    duplicate = dict(rule)
+    duplicate["name"] = "duplicate_reference_dtype"
+    _write(
+        repo,
+        "tools/reference/transformers_encoder.py",
+        "\n".join(changed_lines[1:]) + "\n",
+    )
+    _write(
+        repo,
+        "tests/e2e/models/model_b/impact_diff_rules.json",
+        json.dumps([rule, duplicate]) + "\n",
+    )
+    head = _commit(repo, "ambiguous shared reference rules")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
 
 
 def test_task_eval_only_pr_runs_units_without_model_proofs(tmp_path: Path) -> None:

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -165,6 +165,7 @@ UNIT_TEST_ONLY_EXACT = frozenset(
 FULL_UNIT_TEST_ONLY_EXACT = frozenset(
     {
         "tools/elf_hf_reference.py",
+        "tools/model_ci.py",
         "tools/prepare_elf_task_eval_datasets.py",
         "tools/prepare_media_task_eval_datasets.py",
         "tools/task_eval.py",
@@ -276,6 +277,15 @@ class DiffEntry:
     status: str
     old_path: str | None
     new_path: str | None
+
+
+@dataclass(frozen=True)
+class ModelOwnedImpactRule:
+    owner: str
+    name: str
+    path: str
+    allowed_tokens: tuple[str, ...]
+    changed_lines_sha256: str
 
 
 def _run_git(repo_root: Path, args: Sequence[str], *, text: bool = False):
@@ -618,6 +628,166 @@ def _owner_for_path(path: str, catalog: OwnershipCatalog) -> tuple[str | None, b
     return (unique[0] if unique else None), under_model_root
 
 
+def _normalize_diff_line(line: str) -> str:
+    return re.sub(r"[-\s]+", "_", line.lower())
+
+
+def _significant_diff_lines(diff_text: str) -> tuple[str, ...]:
+    lines: list[str] = []
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith(("diff --git", "index ", "@@", "---", "+++")):
+            continue
+        if not raw_line.startswith(("+", "-")):
+            continue
+        content = raw_line[1:]
+        if not content.strip():
+            continue
+        lines.append(content)
+    return tuple(lines)
+
+
+def _model_owned_impact_rules(
+    repo_root: Path,
+    catalog: OwnershipCatalog,
+) -> tuple[ModelOwnedImpactRule, ...]:
+    rules: list[ModelOwnedImpactRule] = []
+    catalog_paths = {entry.path for entry in catalog.entries}
+    suffix = "/impact_diff_rules.json"
+    prefix = "tests/e2e/models/"
+    for entry in catalog.entries:
+        if not entry.path.startswith(prefix) or not entry.path.endswith(suffix):
+            continue
+        owner, under_model_root = _owner_for_path(entry.path, catalog)
+        if owner is None or not under_model_root:
+            raise ModelCIError(
+                f"impact rule file has no model owner: {entry.path}"
+            )
+        try:
+            payload = json.loads(_read_blob(repo_root, entry.object_id))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ModelCIError(f"invalid model impact rules: {entry.path}") from exc
+        if not isinstance(payload, list):
+            raise ModelCIError(
+                f"model impact rules must be a JSON list: {entry.path}"
+            )
+        for index, raw_rule in enumerate(payload, start=1):
+            if not isinstance(raw_rule, dict):
+                raise ModelCIError(
+                    f"model impact rule must be an object: {entry.path}:{index}"
+                )
+            name = raw_rule.get("name")
+            path = raw_rule.get("path")
+            allowed_tokens = raw_rule.get("allowed_tokens")
+            scope = raw_rule.get("scope")
+            if not (
+                isinstance(name, str)
+                and name
+                and isinstance(path, str)
+                and path
+                and isinstance(allowed_tokens, list)
+                and allowed_tokens
+                and isinstance(scope, dict)
+            ):
+                raise ModelCIError(
+                    "model impact rule requires non-empty name, path, "
+                    f"allowed_tokens, and object scope: {entry.path}:{index}"
+                )
+            if not all(
+                isinstance(token, str) and _normalize_diff_line(token)
+                for token in allowed_tokens
+            ):
+                raise ModelCIError(
+                    "model impact rule allowed_tokens must be non-empty strings: "
+                    f"{entry.path}:{index}"
+                )
+            _validate_git_path(path)
+            if scope != {"owner_family": True}:
+                continue
+            changed_lines_sha256 = raw_rule.get(
+                "model_ci_changed_lines_sha256"
+            )
+            if not isinstance(changed_lines_sha256, str) or re.fullmatch(
+                r"[0-9a-f]{64}",
+                changed_lines_sha256,
+            ) is None:
+                continue
+            target_owner, under_model_root = _owner_for_path(path, catalog)
+            if target_owner is not None or under_model_root:
+                raise ModelCIError(
+                    "model impact rule target must be a shared path: "
+                    f"{entry.path}:{index}: {path}"
+                )
+            if path not in catalog_paths:
+                raise ModelCIError(
+                    "model impact rule target is absent from the revision: "
+                    f"{entry.path}:{index}: {path}"
+                )
+            rules.append(
+                ModelOwnedImpactRule(
+                    owner=owner,
+                    name=name,
+                    path=path,
+                    allowed_tokens=tuple(
+                        _normalize_diff_line(token) for token in allowed_tokens
+                    ),
+                    changed_lines_sha256=changed_lines_sha256,
+                )
+            )
+    return tuple(rules)
+
+
+def _refined_impact_rule(
+    repo_root: Path,
+    base: str,
+    head: str,
+    change: DiffEntry,
+    rules: Sequence[ModelOwnedImpactRule],
+) -> ModelOwnedImpactRule | None:
+    if (
+        change.status != "M"
+        or change.old_path is None
+        or change.new_path != change.old_path
+    ):
+        return None
+    path = change.new_path
+    matching_path_rules = [rule for rule in rules if rule.path == path]
+    if not matching_path_rules:
+        return None
+    diff_text = str(
+        _run_git(
+            repo_root,
+            [
+                "diff",
+                "--no-ext-diff",
+                "--no-color",
+                "--unified=0",
+                base,
+                head,
+                "--",
+                path,
+            ],
+            text=True,
+        )
+    )
+    lines = _significant_diff_lines(diff_text)
+    if not lines:
+        return None
+    normalized_lines = tuple(_normalize_diff_line(line) for line in lines)
+    digest = hashlib.sha256(
+        "\n".join(lines).encode("utf-8")
+    ).hexdigest()
+    matches = [
+        rule
+        for rule in matching_path_rules
+        if rule.changed_lines_sha256 == digest
+        and all(
+            any(token in line for token in rule.allowed_tokens)
+            for line in normalized_lines
+        )
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
 def _is_legal_or_docs(path: str) -> bool:
     return (
         path in LEGAL_OR_DOC_EXACT
@@ -957,6 +1127,7 @@ def calculate_impact(
         allow_legacy_device_tier=True,
     )
     head_catalog = discover_catalog(repo_root, head, allow_legacy_shared_runtime=True)
+    impact_rules = _model_owned_impact_rules(repo_root, head_catalog)
     affected: set[str] = set()
     fallback_selected: set[str] = set()
     broad_change = False
@@ -968,6 +1139,13 @@ def calculate_impact(
     )
     serialized_changes: list[dict[str, object]] = []
     for change in _diff_entries(repo_root, comparison_base, head_sha):
+        refined_rule = _refined_impact_rule(
+            repo_root,
+            comparison_base,
+            head_sha,
+            change,
+            impact_rules,
+        )
         classifications: list[dict[str, str]] = []
         path_catalogs = (
             (change.old_path, base_catalog),
@@ -981,9 +1159,18 @@ def calculate_impact(
             kind, owner = _classify_path(path, catalog)
             if path == "pyproject.toml" and pyproject_task_eval_only:
                 kind = "unit_tests"
+            if (
+                refined_rule is not None
+                and owner is None
+                and kind in {"platform", "ci_tooling", "unknown"}
+            ):
+                kind = "model"
+                owner = refined_rule.owner
             item = {"path": path, "kind": kind}
             if owner is not None:
                 item["model"] = owner
+                if refined_rule is not None and owner == refined_rule.owner:
+                    item["impact_rule"] = refined_rule.name
                 affected.add(owner)
                 unit_scope = _merge_unit_scope(unit_scope, "builder")
             elif kind == "unit_builder":

--- a/tools/reference/transformers_encoder.py
+++ b/tools/reference/transformers_encoder.py
@@ -206,6 +206,14 @@ def _load_runtime(
     if arguments.model_revision:
         model_kwargs["revision"] = arguments.model_revision
     model = model_class.from_pretrained(arguments.model, **model_kwargs).eval()
+    requested_dtype = _model_dtype(torch_module, arguments.dtype)
+    model_type = str(getattr(getattr(model, "config", None), "model_type", ""))
+    if model_type == "xlnet" and requested_dtype != "auto":
+        # Transformers leaves XLNet's directly registered relative-attention
+        # parameters (q/k/v/r and biases) in FP32 even when from_pretrained()
+        # receives a reduced dtype.  Cast the complete model explicitly so
+        # those tensors match the FP16/BF16 hidden states used by einsum.
+        model.to(dtype=requested_dtype)
     if arguments.device_map:
         device = model.device
     else:


### PR DESCRIPTION
## Summary

- cast the complete Hugging Face XLNet reference model to the requested
  reduced dtype after `from_pretrained()`;
- add XLNet-owned tests proving directly registered attention parameters are
  cast while non-XLNet reference loading is unchanged;
- add a fail-closed, content-addressed impact rule so this exact shared
  reference change selects XLNet without scheduling the full encoder fallback
  matrix;
- integrate with the global task-eval reference projection introduced by
  #758;
- keep all accuracy thresholds and workload limits unchanged.

## QA context and fail-before reproduction

The original QA run
`trtmc-validate-gb300-2-20260726-c8291be0-all105` recorded `xlnet-base` as
passed. It was not one of that run's 36 failures.

While replaying all 105 models against the current accuracy-fix integration
source, the same declared `stsbenchmark_encoder_embedding_parity` workload
exposed a current-head regression:

- all 50 STS pairs, or 100 encoder inputs, were prepared;
- the fresh Hugging Face FP16 reference failed before any TRTMC command ran;
- both allowed attempts raised
  `RuntimeError: expected scalar type Half but found Float`;
- the failure occurred in XLNet relative attention's `q_head_h` einsum;
- fail-before comparison receipt SHA-256:
  `28bd668700c8ef1ac9a642523c619313d082c488739022f4604f901d21668c4c`;
- fail-before Hugging Face log SHA-256:
  `7c5d353b1e559db5c7cd2f00794daf501c0b46530a69aee342644b2b3b756680`.

This PR fixes a regression found by the current-head all-model replay; it does
not reclassify the original QA result.

## Root cause

The reference runner passed `torch_dtype=torch.float16` to
`AutoModel.from_pretrained()`. Transformers converted XLNet's module weights,
but left directly registered relative-attention parameters and biases in FP32.
XLNet then combined those FP32 tensors with FP16 hidden states in
`torch.einsum`, so the reference crashed before the TensorRT candidate could
be measured.

The issue is XLNet-specific. Changing the generic requested dtype or falling
back to FP32 would either leave the crash in place or silently compare a
different precision contract.

## Fix

After loading a reference model, the runner checks the published
`config.model_type`. Only for exact `xlnet`, and only when the requested dtype
is explicit, it calls `model.to(dtype=requested_dtype)` before device
placement. That casts the directly registered q/k/v/r parameters and biases
along with the normal module weights.

The two XLNet-owned unit tests use a synthetic model to prove:

1. every XLNet parameter is cast to the requested dtype; and
2. non-XLNet reference models retain the existing load and placement behavior.

## Why CI missed it and how this stays bounded

The changed reference runner is shared by encoder families. The previous
impact logic could only choose between ignoring a shared change and scheduling
the broad encoder fallback matrix. The former misses XLNet; the latter expands
GPU runtime for unrelated families.

This PR adds a fail-closed, content-addressed ownership rule:

- XLNet declares the exact shared path and exact changed-line SHA-256
  (`955ff4dacf1cfa609787510f786d5e88991baecd738a2573dc796af18f424b2f`);
- the selector accepts the narrow scope only when the full changed-line digest
  and allowed tokens match;
- missing, extra, renamed, duplicated, case-changed, indentation-changed, or
  punctuation-changed content falls back to broad impact;
- a change to `tools/model_ci.py` itself runs the full CPU unit suite but does
  not schedule a GPU fallback model.

Eight retained selector regressions cover the narrow match and its
fail-closed fallback boundaries.

After #758, task-eval reference runners are part of the global platform
projection. The rebase therefore keeps #758's `create_projection()` behavior
unchanged and removes the superseded owner-only projection mechanism from the
old PR head. The XLNet ownership rule still controls model selection; it no
longer controls whether the shared runner is copied into the projection.

At exact rebased head
`f99902647320b263a0b54c2ff9bb4eb2ce65d8bf`:

- `model_ci impact` selects `direct_models=["xlnet"]`,
  `fallback_models=[]`, `unit_scope="all"`, expected model count 1;
- no new GPU testcase, model download, or engine build is added;
- the added premerge work is CPU-only selector and dtype-contract coverage;
- the existing one-model XLNet proof remains the only selected GPU row.

## Exact-head validation after rebase

Source:
`f99902647320b263a0b54c2ff9bb4eb2ce65d8bf`
(`e8c0adcd7edf6985de956a5a0ec0215285f2a52e` tree), based directly on
`github/main@d331f79cbac7548fa32a2ee27dd807f2dc3f8111`.

- `PYTHONPATH=python:. python -m pytest tests/tools/test_model_ci.py
  tests/e2e/models/xlnet/test_xlnet_reference_dtype.py -q`:
  81 passed in 12.16 seconds;
- `python -m ruff check` on the changed Python files: passed;
- `python tools/model_ci.py validate --revision HEAD`: passed for 78 models;
- `python tools/model_ci.py impact --base d331f79c --head HEAD`: XLNet only,
  zero fallback;
- `python tools/test_impact.py --validate`: passed for 204 models, 12 core
  components, and 78 families;
- actual `model_ci project --revision HEAD --model xlnet`: passed; #758
  projected `tools/reference/transformers_encoder.py` as a platform file;
- targeted `compileall` and `git diff --check`: passed;
- rebase range-diff: the dtype/reference commit is patch-equivalent; the CI
  commit differs only by removing the projection mechanism superseded by
  #758.

The GitHub exact-head premerge result for this rebased SHA is tracked
separately and must be green before merge.

## Family pass-after evidence

The XLNet model fix was validated on NVIDIA GB300 at the patch-equivalent
pre-rebase source `30a4cdbd7af36346ce56ea307bb408b5023001e5`.
The model-code commit is patch-equivalent to rebased commit
`7a08d863c9a0310c5bf387d8303922fb2f8686b8`; the final all-model campaign will
provide the promotion proof on the final aggregate head.

Execution contract:

- NVIDIA GB300,
  `GPU-595c627d-9b1b-9b22-54a3-730de3807132`;
- driver `580.105.08`, CUDA compiler `13.3`;
- TensorRT builder/runtime `11.2.0.113`;
- exact declared workload: 50 STS pairs / 100 inputs;
- TRTMC FP16 and Hugging Face FP16;
- `--force-hf --force-build --local-files-only`;
- `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`,
  `HF_DATASETS_OFFLINE=1`, and prebuilt-only reference profiles;
- new reference cache and newly built 225.2 MB bundle;
- one completed attempt, zero retries, exit code 0;
- 272 seconds from model start to finish.

| Check | Result |
|---|---:|
| Valid encoder inputs | 100 / 100 |
| Valid STS pairs | 50 / 50 |
| Vector pass rate | 1.0 |
| Mean vector cosine | 0.99999650 |
| Minimum vector cosine | 0.99998316 |
| Mean pair-cosine absolute delta | 0.00007904 |
| Maximum pair-cosine absolute delta | 0.00046548 |
| Disagreements | 0 |
| Validation status | PASS |

The host-level GitHub GPU reservation covered the full run. Continuous
sampling recorded 120 timestamps, zero query errors, and zero unowned process
observations.

Receipt root:
`/tmp/trtmc-accuracy-agent2/family-validation/trtmc-validate-gb300-1-20260729T210400Z-30a4cdbd-xlnet-full50-fresh-r7`

Key SHA-256 receipts:

- report:
  `3a61c2c6de6c7e18c76455af4bf449579d6a2050a7493dc5917e0aed4e7354d4`;
- comparison:
  `77d8097e0333e1388b98092db96e6613d327c216d9e5a41a69cbe69b598d78ba`;
- bundle:
  `71ec75fec2953c8db1e0462ae31daea1d98d8ad7b0eaba6cb895dce3fc95ae8f`;
- XLNet family plugin:
  `8abe54c8ed2c3ce166db28d3875ee589034aeff1111ee570fabb4021fb2cf43a`;
- host GPU lock:
  `dea676fdbdc4d41b567efd87c090ffa9a97c43f901ea51bf136718a7ca15d9b6`;
- continuous GPU monitor:
  `bc53376c2aa9825adff87d1827553ef878f203041eaff626c0ca04c10a16c9a8`.

Excluded setup attempts are preserved separately: one reached inference with
a build missing the XLNet family plugin, and two later starts failed the
idle-GPU preflight while that invalid process tree was still draining. None
produced or contributed to the authoritative family result.

## Review notes

Review the eight-line XLNet dtype correction and the two family-owned tests
first. For the CI mechanism, verify that the exact digest selects only XLNet,
that every deviation becomes a broad fail-closed match, and that the global
reference projection remains the implementation from #758.
