### PR TITLE
fix(qwen): restore accurate FP8 precision contract

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -173,9 +173,11 @@ class QwenPlugin:
         ]
         if format_name == "fp8":
             patterns.extend([
+                "layer.*.w_q",
+                "layer.*.w_k",
+                "layer.*.w_v",
                 "layer.*.w_o",
                 "layer.*.w_gate",
-                "layer.*.w_up",
                 "layer.*.w_down",
             ])
         return patterns

--- a/tests/builder/test_quantization.py
+++ b/tests/builder/test_quantization.py
@@ -9,9 +9,12 @@ Preconditions: Quantization formats (FP8, INT8, INT4, NVFP4, W4A8) are registere
 Postconditions: All formats are discoverable, scale maps survive JSON serialization, and formats expose wrap_matmul
 """
 import json
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
+from tensorrt_model_connect import trt_compat
 from tensorrt_model_connect.quantization import get_format, list_formats, QuantScaleMap, LayerScales
 from tensorrt_model_connect.quantization.plan import QuantPlan, canonicalize_quant_format
 from tensorrt_model_connect.quantization.formats import QuantFormat
@@ -99,6 +102,87 @@ class TestQuantFormatProtocol:
         for name in list_formats():
             fmt = get_format(name)
             assert hasattr(fmt, "wrap_conv2d"), f"{name} missing wrap_conv2d"
+
+
+class TestFP8MatmulPrecision:
+    def test_fp16_base_casts_scales_and_accumulates_in_fp32(self, monkeypatch):
+        class FakeTensor:
+            def __init__(self, dtype):
+                self.dtype = dtype
+
+        class FakeLayer:
+            def __init__(self, output):
+                self.output = output
+
+            def get_output(self, index):
+                assert index == 0
+                return self.output
+
+        trt = SimpleNamespace(
+            float16="fp16",
+            float32="fp32",
+            fp8="fp8",
+            MatrixOperation=SimpleNamespace(NONE="none"),
+        )
+        quantize_dtypes = []
+        dequantize_dtypes = []
+        matmul_dtypes = []
+        cast_dtypes = []
+
+        class FakeNetwork:
+            def add_quantize(self, tensor, scale, dtype):
+                assert dtype == trt.fp8
+                quantize_dtypes.append((tensor.dtype, scale.dtype, dtype))
+                return FakeLayer(FakeTensor(dtype))
+
+            def add_dequantize(self, tensor, scale, dtype):
+                dequantize_dtypes.append((tensor.dtype, scale.dtype, dtype))
+                return FakeLayer(FakeTensor(dtype))
+
+            def add_matrix_multiply(self, lhs, lhs_op, rhs, rhs_op):
+                assert lhs_op == rhs_op == trt.MatrixOperation.NONE
+                matmul_dtypes.append((lhs.dtype, rhs.dtype))
+                return FakeLayer(FakeTensor(lhs.dtype))
+
+            def add_cast(self, tensor, dtype):
+                cast_dtypes.append((tensor.dtype, dtype))
+                return FakeLayer(FakeTensor(dtype))
+
+        class FakeGraphOps:
+            @staticmethod
+            def add_constant(network, shape, values, *, dtype):
+                del network, shape, values
+                return FakeTensor(
+                    trt.float16 if dtype == np.float16 else trt.float32
+                )
+
+        monkeypatch.setattr(trt_compat, "get_trt", lambda: trt)
+        result = get_format("fp8").wrap_matmul(
+            FakeNetwork(),
+            FakeTensor(trt.float16),
+            np.ones((2, 3), dtype=np.float16),
+            LayerScales(input_scale=0.25, weight_scale=0.5),
+            lhs_width=2,
+            rhs_width=3,
+            dtype=np.float16,
+            graph_ops=FakeGraphOps,
+        )
+
+        assert quantize_dtypes == [
+            (trt.float16, trt.float16, trt.fp8),
+            (trt.float16, trt.float16, trt.fp8),
+        ]
+        assert dequantize_dtypes == [
+            (trt.fp8, trt.float32, trt.float32),
+            (trt.fp8, trt.float32, trt.float32),
+        ]
+        assert matmul_dtypes == [(trt.float32, trt.float32)]
+        assert cast_dtypes == [
+            (trt.float32, trt.float16),
+            (trt.float32, trt.float16),
+            (trt.float32, trt.float16),
+        ]
+        assert result.dtype == trt.float16
 
 
 class TestQuantContextGraphOpsOwnership:

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
@@ -1,35 +1,39 @@
 {
   "name": "qwen3-0.6b-fp8",
   "hf_id": "Qwen/Qwen3-0.6B",
-  "bundle": "qwen3-0.6b-fp8-bf16base.bundle",
+  "bundle": "qwen3-0.6b-fp8-fp16base.bundle",
   "family": "qwen",
   "runtime_strategy": "qwen_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "user_contract": "text-generation",
-  "precision": "bf16",
+  "precision": "fp16",
   "quantization": {
     "format": "fp8",
     "scale_source": "modelopt",
     "calibration_samples": 64
   },
-  "max_cache_length": 256,
+  "max_cache_length": 405,
   "trust_remote_code": false,
   "testcases": [
     {
       "name": "qwen3-0.6b-fp8",
       "trace_id": "IT-E2E-QWN3-FP8-01",
-      "prompt": "What is the capital of France? Answer in one word.",
+      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind the degree for the given field extension Q(sqrt(2), sqrt(3), sqrt(18)) over Q.\nA. 0\nB. 4\nC. 2\nD. 6\nAnswer:",
       "expected_answers": [
-        "Paris"
+        "B"
       ],
       "task_eval": {
         "reference_backend": "hf_transformers",
         "reference_family": "chat_qwen3_posttrained",
         "user_contract": "chat_response",
-        "reference_precision": "bf16"
+        "reference_precision": "fp16"
       },
-      "max_new_tokens": 10,
-      "notes": "FP8 quantization can perturb raw logit distributions while preserving decoded answer semantics. Require the model-owned expected answer plus the default logit and token agreement gates for output confidence."
+      "contract_config": {
+        "use_chat_template": false,
+        "enable_thinking": false
+      },
+      "max_new_tokens": 1,
+      "notes": "The canonical E2E prompt is QA MMLU sample 0, which distinguishes the supported FP16-based FP8 contract from the inaccurate BF16-based route without adding another engine build."
     }
   ]
 }

--- a/tests/e2e/models/qwen/test_qwen_fp8_quantization_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_fp8_quantization_contract.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-owned FP8 projection-selection contracts."""
+
+from __future__ import annotations
+
+import fnmatch
+
+from tensorrt_model_connect.families.qwen.plugin import QwenPlugin
+
+
+def test_qwen_fp8_quantizes_only_up_projections() -> None:
+    patterns = QwenPlugin().quant_exclude_patterns("fp8")
+    projection_names = {
+        (layer, projection): f"qwen/layer.{layer}.w_{projection}"
+        for layer in range(28)
+        for projection in ("q", "k", "v", "o", "gate", "up", "down")
+    }
+
+    selected = {
+        layer_projection
+        for layer_projection, weight_name in projection_names.items()
+        if not any(
+            fnmatch.fnmatch(weight_name, pattern)
+            or fnmatch.fnmatch(weight_name.split("/", 1)[-1], pattern)
+            for pattern in patterns
+        )
+    }
+
+    assert selected == {
+        (layer, "up")
+        for layer in range(28)
+    }

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -57,6 +57,7 @@ def test_qwen3_fp8_manifest_declares_hf_text_generation_contract(
 
 def test_fp8_and_topp_use_deterministic_mmlu_validation_contract() -> None:
     manifest_dir = Path(__file__).with_name("manifests")
+    fp8_e2e = load_manifest(manifest_dir / "qwen3-0.6b-fp8.json")
     topp_e2e = load_manifest(manifest_dir / "qwen3-0.6b-topp.json")
     models = {
         name: validation_catalog.manifest_record(manifest_dir / f"{name}.json")
@@ -75,7 +76,21 @@ def test_fp8_and_topp_use_deterministic_mmlu_validation_contract() -> None:
             True,
             "selected",
         )
-    assert models["qwen3-0.6b-fp8"]["task_eval"]["reference_precision"] == "bf16"
+    fp8 = models["qwen3-0.6b-fp8"]
+    assert fp8["precision"] == "fp16"
+    assert fp8["bundle"] == "qwen3-0.6b-fp8-fp16base.bundle"
+    assert fp8["task_eval"]["reference_precision"] == "fp16"
+    assert fp8["max_cache_length"] == 405
+    assert fp8_e2e.inputs["prompt"].startswith(
+        "The following are multiple choice questions (with answers) "
+        "about abstract algebra."
+    )
+    assert fp8_e2e.metadata["expected_answers"] == ["B"]
+    assert fp8_e2e.inputs["max_new_tokens"] == 1
+    assert fp8_e2e.metadata["contract_config"] == {
+        "use_chat_template": False,
+        "enable_thinking": False,
+    }
     assert set(models) < set(suite["default_model_names"])
     assert topp_e2e.reference_backend == "invariant_only"
     assert topp_e2e.reference_family == "sampling_top_p"

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -2529,6 +2529,143 @@ def test_run_metadata_preserves_campaign_start_when_results_exist(
     assert metadata["duration_seconds"] is None
 
 
+def _build_identity_arguments(
+    tmp_path: Path,
+    *,
+    include_worker: bool = True,
+) -> argparse.Namespace:
+    build = tmp_path / "build"
+    models = build / "models"
+    models.mkdir(parents=True)
+    for name in (
+        "trtmc",
+        "trtmc_dataset_benchmark",
+        "libtrtmc_backend_trt.so",
+    ):
+        path = build / name
+        path.write_bytes(name.encode())
+        path.chmod(0o755)
+    if include_worker:
+        worker = build / "trtmc_benchmark_worker"
+        worker.write_bytes(b"worker")
+        worker.chmod(0o755)
+    return trtmc_validate.build_parser().parse_args(
+        [
+            "model-a",
+            "--trtmc-binary",
+            str(build / "trtmc"),
+            "--benchmark-binary",
+            str(build / "trtmc_dataset_benchmark"),
+            "--backend-dir",
+            str(build),
+            "--model-plugin-dir",
+            str(models),
+        ]
+    )
+
+
+def test_build_identity_preflight_accepts_exact_native_build(
+    monkeypatch,
+    tmp_path,
+):
+    arguments = _build_identity_arguments(tmp_path)
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "tested-revision")
+    monkeypatch.setattr(
+        trtmc_validate,
+        "worker_metadata",
+        lambda _worker: {
+            "schema_version": "trtmc.benchmark-worker-metadata/v1",
+            "build": {
+                "configuration": "Release",
+                "source_revision": "tested-revision",
+            },
+        },
+    )
+
+    identity = trtmc_validate._validate_build_identity(arguments)
+
+    assert identity["source_revision"] == "tested-revision"
+    assert identity["embedded_source_revision"] == "tested-revision"
+    assert identity["build_configuration"] == "Release"
+    assert set(identity["artifacts"]) == {
+        "trtmc binary",
+        "dataset benchmark",
+        "benchmark worker",
+        "TensorRT backend",
+    }
+    assert all(
+        len(artifact["sha256"]) == 64
+        for artifact in identity["artifacts"].values()
+    )
+
+
+def test_build_identity_preflight_rejects_stale_native_build(
+    monkeypatch,
+    tmp_path,
+):
+    arguments = _build_identity_arguments(tmp_path)
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "current-revision")
+    monkeypatch.setattr(
+        trtmc_validate,
+        "worker_metadata",
+        lambda _worker: {
+            "schema_version": "trtmc.benchmark-worker-metadata/v1",
+            "build": {
+                "configuration": "Release",
+                "source_revision": "stale-revision",
+            },
+        },
+    )
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="embedded stale-revision, expected current-revision",
+    ):
+        trtmc_validate._validate_build_identity(arguments)
+
+
+def test_build_identity_preflight_rejects_missing_worker(monkeypatch, tmp_path):
+    arguments = _build_identity_arguments(tmp_path, include_worker=False)
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "tested-revision")
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="benchmark worker is missing",
+    ):
+        trtmc_validate._validate_build_identity(arguments)
+
+
+def test_build_identity_preflight_rejects_mixed_plugin_directory(
+    monkeypatch,
+    tmp_path,
+):
+    arguments = _build_identity_arguments(tmp_path)
+    mixed_plugins = tmp_path / "stale-build" / "models"
+    mixed_plugins.mkdir(parents=True)
+    arguments.model_plugin_dir = mixed_plugins
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "tested-revision")
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="model plugin directory resolves .* outside",
+    ):
+        trtmc_validate._validate_build_identity(arguments)
+
+
+def test_build_identity_preflight_rejects_missing_source_revision(
+    monkeypatch,
+    tmp_path,
+):
+    arguments = _build_identity_arguments(tmp_path)
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "")
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="cannot determine the validation source revision",
+    ):
+        trtmc_validate._validate_build_identity(arguments)
+
+
 def test_finalize_run_metadata_records_completion(monkeypatch, tmp_path):
     started_at = datetime(2026, 7, 25, 1, 2, 3, tzinfo=timezone.utc)
     finished_at = datetime(2026, 7, 25, 4, 4, 6, 500000, tzinfo=timezone.utc)

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -12,6 +12,7 @@ import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import cache
+import hashlib
 import html
 import json
 import os
@@ -45,6 +46,7 @@ from tensorrt_model_connect.benchmark.task_adapters import (  # noqa: E402
     adapter_for_task_strategy,
 )
 from tensorrt_model_connect.benchmark.types import BenchmarkError  # noqa: E402
+from tensorrt_model_connect.benchmark.worker import worker_metadata  # noqa: E402
 from tools.reporting_html import (  # noqa: E402
     COMMON_REPORT_STYLES,
     TASK_TYPE_BY_USER_CONTRACT,
@@ -1491,6 +1493,130 @@ def _source_revision() -> str:
         text=True,
     )
     return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_build_identity(arguments: argparse.Namespace) -> dict[str, Any]:
+    """Fail before GPU work when source and native build provenance differ."""
+    expected_revision = _source_revision()
+    if not expected_revision:
+        raise ValidationError(
+            "cannot determine the validation source revision for build identity preflight"
+        )
+
+    benchmark_binary = arguments.benchmark_binary.expanduser().resolve()
+    build_root = benchmark_binary.parent
+    trtmc_binary = arguments.trtmc_binary.expanduser().resolve()
+    backend_dir = (
+        arguments.backend_dir.expanduser().resolve()
+        if arguments.backend_dir
+        else build_root
+    )
+    model_plugin_dir = (
+        arguments.model_plugin_dir.expanduser().resolve()
+        if arguments.model_plugin_dir
+        else build_root / "models"
+    )
+    worker = build_root / "trtmc_benchmark_worker"
+
+    expected_paths = {
+        "trtmc binary": build_root / "trtmc",
+        "dataset benchmark": build_root / "trtmc_dataset_benchmark",
+        "backend directory": build_root,
+        "model plugin directory": build_root / "models",
+    }
+    actual_paths = {
+        "trtmc binary": trtmc_binary,
+        "dataset benchmark": benchmark_binary,
+        "backend directory": backend_dir,
+        "model plugin directory": model_plugin_dir,
+    }
+    for label, expected in expected_paths.items():
+        actual = actual_paths[label]
+        if actual != expected.resolve():
+            raise ValidationError(
+                f"{label} resolves to {actual}, outside the benchmark worker "
+                f"build root {build_root}"
+            )
+
+    required_files = {
+        "trtmc binary": trtmc_binary,
+        "dataset benchmark": benchmark_binary,
+        "benchmark worker": worker,
+        "TensorRT backend": build_root / "libtrtmc_backend_trt.so",
+    }
+    for label, path in required_files.items():
+        if not path.is_file():
+            raise ValidationError(
+                f"{label} is missing for build identity preflight: {path}"
+            )
+    if not model_plugin_dir.is_dir():
+        raise ValidationError(
+            "model plugin directory is missing for build identity preflight: "
+            f"{model_plugin_dir}"
+        )
+
+    try:
+        metadata = worker_metadata(worker)
+    except BenchmarkError as exc:
+        raise ValidationError(
+            f"cannot verify benchmark worker build identity: {exc}"
+        ) from exc
+    build = metadata.get("build", {})
+    embedded_revision = str(build.get("source_revision", "") or "").strip()
+    configuration = str(build.get("configuration", "") or "").strip()
+    if not embedded_revision or embedded_revision == "unknown":
+        raise ValidationError(
+            "benchmark worker metadata is missing an embedded source revision"
+        )
+    if embedded_revision != expected_revision:
+        raise ValidationError(
+            "benchmark worker source revision mismatch: "
+            f"embedded {embedded_revision}, expected {expected_revision}"
+        )
+    if not configuration or configuration == "unknown":
+        raise ValidationError(
+            "benchmark worker metadata is missing its build configuration"
+        )
+
+    artifacts = {
+        label: {
+            "path": str(path),
+            "sha256": _sha256(path),
+        }
+        for label, path in required_files.items()
+    }
+    return {
+        "schema_version": "trtmc.validation-build-identity/v1",
+        "source_revision": expected_revision,
+        "embedded_source_revision": embedded_revision,
+        "build_configuration": configuration,
+        "build_root": str(build_root),
+        "backend_dir": str(backend_dir),
+        "model_plugin_dir": str(model_plugin_dir),
+        "artifacts": artifacts,
+    }
+
+
+def _write_build_identity(
+    output: Path,
+    identity: Mapping[str, Any],
+) -> Path:
+    """Persist the validated native-build receipt before model execution."""
+    output.mkdir(parents=True, exist_ok=True)
+    path = output / "build-identity.json"
+    path.write_text(
+        json.dumps(identity, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path
 
 
 def _utc_now() -> datetime:
@@ -3108,6 +3234,8 @@ def _main(arguments: argparse.Namespace) -> int:
         )
         return 0
     if not arguments.model_worker:
+        build_identity = _validate_build_identity(arguments)
+        _write_build_identity(arguments.output, build_identity)
         return _run_all_bindings(
             bindings,
             arguments=arguments,


### PR DESCRIPTION
## Summary

Restore the Qwen3-0.6B FP8 accuracy contract seen failing in the all-model QA report, add a model-owned QA canary, and make validation fail before GPU work when Python source and native build artifacts come from different revisions.

This family PR depends on #718 for shared generic task-eval gate enforcement. This PR does not relax or replace any declared threshold.

## QA reproduction

A fresh replay of the affected `qwen3-0.6b-fp8 / mmlu_five_shot_mcq` entry reproduced the failure with source and Release build both at `5dc37b757ae2ec93956acfb3672108372ff404e9`, fresh HF output, a fresh FP8 bundle, the complete 20-sample QA slice, and a 405-token build cache:

| Metric | Reproduced before fix |
|---|---:|
| Prepared inputs | 20 |
| HF accuracy | 0.35 |
| TRTMC accuracy | 0.40 |
| Prediction agreement | 0.90 (18/20) |
| Disagreements | 2 |
| Attempts / retries | 1 / 0 |
| Raw status | **passed** |

The MMLU suite already declares `min_prediction_agreement: 0.98`, so 0.90 should not have been green.

## Root cause

1. The family FP8 contract was on an unstable numerical route: the manifest requested a BF16 base/reference and the Qwen exclusion policy left attention Q/K/V projections quantized while excluding the more stable MLP up projections. The QA MMLU prompts expose output flips that the old smoke prompt did not.
2. Moving the supported FP8 route to an FP16 base also exposed a builder defect: FP8 Q/DQ matmuls used FP16 dequantization and accumulation. Long decoder projection dot products can exceed FP16's finite range before the result is cast, corrupting logits.
3. The existing model-owned test used a short capital-of-France prompt, a 256-token cache, and ten generated tokens. It did not exercise the QA prompt framing, 405-token boundary, one-token MCQ decision, or supported reference precision.
4. Validator provenance was not fail-closed. It was possible to run current Python orchestration against stale `trtmc`, benchmark, backend, and model-plugin artifacts. Those mixed runs are not valid accuracy evidence and could either hide a regression or manufacture one.

## Implementation

- Change the Qwen3-0.6B FP8 manifest to the validated FP16 base/reference contract.
- Quantize only the 28 Qwen MLP up-projection seams; keep Q/K/V/O, gate, and down projections out of FP8.
- Dequantize and accumulate FP8 matmuls in FP32 when the model base is FP16, then cast the completed result back to FP16. BF16 and FP32 retain their existing accumulation type.
- Replace the permissive smoke case with QA MMLU sample 0, `max_cache_length=405`, `max_new_tokens=1`, raw prompt framing, and thinking disabled. This reuses the existing Qwen E2E build rather than adding another model job.
- Add fail-closed model-owned tests for the exact precision, cache, prompt, and seam-selection contract, plus builder tests for FP32 accumulation and the final FP16 cast.
- Add one supervisor-level build-identity preflight to `trtmc_validate.py`:
  - require source revision provenance;
  - require `trtmc`, dataset benchmark, sibling benchmark worker, TensorRT backend, and model-plugin directory to share one build root;
  - query embedded worker revision/configuration and require an exact source-revision match;
  - hash the four native artifacts and write `build-identity.json`;
  - fail closed on missing, unknown, mixed-root, or stale provenance before model/GPU work.

## Why CI missed it, and how it is covered

The generic scorer calculated HF/TRTMC metrics but did not apply the suite's declared gate map, so CI trusted a false-green `status=passed`. #718 fixes that shared mechanism with constant-time gate evaluation and negative fail-closed coverage.

This PR supplies the family-specific half of the prevention:

- the canonical Qwen L0 case now exercises the same MMLU decision and precision contract as QA;
- static model-owned contract tests fail on precision/cache/prompt/seam drift;
- builder tests fail if FP16-base FP8 matmul returns to FP16 accumulation;
- validation refuses mixed native/source artifacts before consuming GPU time.

A negative replay against a previously used stale build now exits before GPU work because its benchmark worker provenance is missing.

No acceptance criterion or test threshold was weakened.

## CI runtime bound

The added provenance check runs once in the supervisor, not once per model. It performs one small metadata subprocess and SHA256 over four native files; it adds no HF call, dataset pass, engine build, inference, or GPU allocation. The model worker skips the duplicate preflight.

The Qwen canary replaces an existing testcase and therefore adds no model-matrix entry or additional bundle build. Current impact analysis selects six bounded jobs: direct `qwen` plus the repository's five fixed platform fallbacks (`deepseek_v2`, `ltx_video`, `patchtsmixer`, `segformer`, and `whisper`), not the complete model catalog. Shared gate PR #718 selects unit tests and zero additional model E2E jobs.

## Exact post-fix QA validation

The authoritative final proof is from clean commit `e3f7687425ad5e38234a02b60d4a2aa82128baa5`, tree `f5ad30b3b0de78df3a8fda756a82b009d48ea716`, based on `github/main@6ad142f0975e011bfc8115c7d7a706559d904333`.

Environment and isolation matched the QA class:

- NVIDIA GB300 with TensorRT `11.2.0.113`;
- network disabled except loopback;
- source, HF cache, dataset, and exact build mounted read-only;
- one isolated GPU held under a reservation lock for the complete attempt;
- fresh Release CMake build with embedded source revision matching the source checkout;
- fresh HF reference and fresh bundle (`--force-hf --force-build --local-files-only`);
- complete 20-sample QA slice, FP16 HF reference/base, FP8 quantization, 64 calibration samples, cache length 405, and one output token.

| Metric | Final exact-head result |
|---|---:|
| Prepared inputs | 20 |
| Prediction agreement | **1.00 (20/20)** |
| Disagreements | **0** |
| HF accuracy | 0.45 |
| TRTMC accuracy | 0.45 |
| Accuracy delta | 0.00 |
| HF reused | false |
| Bundle built | true |
| Reference dtype | float16 |
| Attempts / retries | 1 / 0 |
| Validator + strict gate | **exit 0** |
| Duration | 429.184 s |

The retained validation package includes source/tree identity, embedded build metadata, hashes for the native executables/backend and fresh bundle, the GPU reservation receipt, process monitoring, `comparison.json`, and the independent strict-gate result.

## Static and unit validation

- `ruff check` on all changed Python files: passed.
- Qwen contract + quantization builder + validator tests: `94 passed`.
- `tests/tools/test_model_ci.py`: `72 passed`.
- `tools/model_ci.py validate`: passed, 78 registered models.
- `git diff --check`: passed.
- A broader same-patch diagnostic before the final rebase produced `413 passed, 10 skipped`; the only non-passes were one failure and seven setup errors in the explicit A100/sm80 qualification file on this aarch64/GB300 sm103 host. They are not counted as final exact-head proof.

## Exact-head GitHub CI

Premerge run `30497237276` tested head `e3f7687425ad5e38234a02b60d4a2aa82128baa5` and passed every required job:

- Legal compliance, Source quality, Ownership and impact, and C++/Python Unit;
- direct Qwen model proof;
- all five bounded platform fallbacks: DeepSeek-V2, LTX-Video, PatchTSMixer, SegFormer, and Whisper;
- Combined HTML report and the final Premerge CI gate.

The model matrix remained six jobs as predicted; the Qwen direct proof completed in 9m58s. The only annotations were non-blocking GitHub Actions Node.js deprecation notices.

## Evidence boundaries

Earlier reduction diagnostics combined current Python with an older native build. They are intentionally excluded from the accuracy pass claim; their only use is demonstrating the provenance hole that the new preflight closes. Clean one-sample and pre-CI 20-sample diagnostics were useful while reducing the issue, but the isolated exact-head full-20 result above is the sole authoritative post-fix proof.

Review the family seam policy and FP8 accumulation change first, then the manifest/contract tests, and finally the validator build-identity preflight.


## Latest Main Bundle And Provenance Refresh (2026-08-07)

- Rebased onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `2300d55bf080cc99d0e64a2c1500cb446d0eab81`.
- The Qwen FP8 manifest conflict preserves this PR's validated FP16 base/reference, 405-row cache, and QA MMLU canary while adopting the canonical `qwen3-0.6b-fp8-fp16base.bundle` suffix.
- The validator conflict preserves both #833 GPU/run provenance and this PR's native build-identity preflight. To minimize interaction with #701, build-identity changes are confined to `_sha256`, `_validate_build_identity`, `_write_build_identity`, and `_main`; this PR no longer changes `_run_all_bindings`.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `ruff check`, `py_compile`, and `git diff --check` passed for the changed Python surface.
- `tests/e2e/models/qwen/test_qwen_manifest_contract.py`: `5 passed`.
- `tests/builder/test_quantization.py::TestFP8MatmulPrecision`: `1 passed`.
- `tests/tools/test_trtmc_validate.py -k build_identity`: `5 passed, 78 deselected`.
- The separate model-owned Qwen plugin regression requires TensorRT, which is unavailable on this host; current-head model proof remains a CI responsibility.

No gate or threshold changed. The provenance preflight still runs once before GPU/model work, hashes four local artifacts, and adds no inference, engine build, dataset pass, or matrix expansion.
