### PR TITLE
feat(canary): add customer decoding controls

### DIFF
--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -67,6 +67,12 @@ struct TranscriptionConfig {
     int32_t input_sample_rate{0};
     // 1 preserves greedy decoding. Values greater than 1 select beam search.
     int32_t beam_size{1};
+    // Beam-search length normalization exponent. 0 ranks hypotheses by their
+    // accumulated log probability; 1 ranks by mean log probability.
+    float length_penalty{1.0F};
+    // 0 disables automatic fallback. Otherwise, an unterminated decode is
+    // retried with doubled beam sizes up to this value.
+    int32_t beam_fallback_max_size{0};
     std::string source_language{"en"};
     std::string target_language{"en"};
     TranscriptionTask task{TranscriptionTask::kTranscribe};
@@ -76,8 +82,20 @@ struct TranscriptionConfig {
     // hard input limit in seconds; longer inputs are rejected.
     float max_input_duration_seconds{0.0F};
     // 0 processes one model-sized segment. A positive value splits the input
-    // into independent segments of this many seconds and joins their text.
+    // into segments no longer than this many seconds and joins their text.
     float segment_duration_seconds{0.0F};
+    // 0 keeps fixed-size segmentation. A positive value enables dynamic
+    // segmentation: long inputs are covered by approximately equal windows
+    // between this minimum and segment_duration_seconds, minimizing short
+    // padded tail windows.
+    float segment_min_duration_seconds{0.0F};
+    // Requested overlap between adjacent segments. Dynamic segmentation can
+    // increase the overlap when needed to keep every window at least
+    // segment_min_duration_seconds long.
+    float segment_overlap_seconds{0.0F};
+    // Merge overlapping segment token sequences with a boundary-constrained
+    // longest common subsequence instead of concatenating their text.
+    bool lcs_merge{false};
 };
 
 struct TranscriptionRequest {

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -223,9 +223,11 @@ void print_usage() {
            "  trtmc solve           <bundle.trtfb> --field-input CSV\n"
            "  trtmc solve           <bundle.trtfb> --branch-input CSV [--trunk-input CSV]\n"
            "  trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] "
-           "[--beam-size N] [--language TAG] [--source-language TAG] [--target-language TAG] "
+           "[--beam-size N] [--beam-fallback-max-size N] [--length-penalty F] [--language TAG] "
+           "[--source-language TAG] [--target-language TAG] "
            "[--task transcribe|translate] [--punctuation|--no-punctuation] [--timestamps] "
-           "[--max-input-seconds F] [--segment-length-seconds F] "
+           "[--max-input-seconds F] [--segment-length-seconds F] [--segment-min-seconds F] "
+           "[--segment-overlap-seconds F] [--lcs-merge] "
            "[--stream] [--chunk-ms N] [--att-context-size L,R] "
            "[--pad-and-drop-preencoded] [--hf-python PATH]\n"
            "  trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav\n"
@@ -609,13 +611,33 @@ CliArgs parse_args(int argc, char** argv) {
             continue;
         }
         if (arg == "--beam-size" && need_value(arg)) {
-            auto value = parse_int_value(arg, "an integer in [1, 16]");
-            if (!value || *value < 1 || *value > 16) {
+            auto value = parse_int_value(arg, "an integer in [1, 32]");
+            if (!value || *value < 1 || *value > 32) {
                 args.parse_error = true;
-                args.error_message = arg + " expects an integer in [1, 16]";
+                args.error_message = arg + " expects an integer in [1, 32]";
                 return args;
             }
             args.beam_size = *value;
+            continue;
+        }
+        if (arg == "--length-penalty" && need_value(arg)) {
+            auto value = parse_float_value(arg, "a finite number >= 0");
+            if (!value || *value < 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number >= 0";
+                return args;
+            }
+            args.length_penalty = *value;
+            continue;
+        }
+        if (arg == "--beam-fallback-max-size" && need_value(arg)) {
+            auto value = parse_int_value(arg, "an integer in [1, 32]");
+            if (!value || *value < 1 || *value > 32) {
+                args.parse_error = true;
+                args.error_message = arg + " expects an integer in [1, 32]";
+                return args;
+            }
+            args.beam_fallback_max_size = *value;
             continue;
         }
         if (arg == "--source-language" && need_value(arg)) {
@@ -669,6 +691,30 @@ CliArgs parse_args(int argc, char** argv) {
                 return args;
             }
             args.segment_length_seconds = *value;
+            continue;
+        }
+        if (arg == "--segment-min-seconds" && need_value(arg)) {
+            auto value = parse_float_value(arg, "a finite number > 0");
+            if (!value || *value <= 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number > 0";
+                return args;
+            }
+            args.segment_min_seconds = *value;
+            continue;
+        }
+        if (arg == "--segment-overlap-seconds" && need_value(arg)) {
+            auto value = parse_float_value(arg, "a finite number >= 0");
+            if (!value || *value < 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number >= 0";
+                return args;
+            }
+            args.segment_overlap_seconds = *value;
+            continue;
+        }
+        if (arg == "--lcs-merge") {
+            args.lcs_merge = true;
             continue;
         }
         if (arg == "--point-x" && need_value(arg)) {

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -72,6 +72,8 @@ struct CliArgs {
     int att_context_right{13};
     std::string language;
     int beam_size{1};
+    float length_penalty{1.0F};
+    int beam_fallback_max_size{0};
     std::string source_language{"en"};
     std::string target_language{"en"};
     std::string transcription_task{"transcribe"};
@@ -79,6 +81,9 @@ struct CliArgs {
     bool timestamps{false};
     float max_input_seconds{0.0F};
     float segment_length_seconds{0.0F};
+    float segment_min_seconds{0.0F};
+    float segment_overlap_seconds{0.0F};
+    bool lcs_merge{false};
     std::string runtime_cache;
     std::vector<std::string> backend_search_paths;
     std::vector<std::string> model_plugin_search_paths;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1340,9 +1340,11 @@ int cmd_transcribe(const CliArgs& args) {
             return EXIT_FAILURE;
         }
         const bool has_offline_only_controls =
-            args.beam_size != 1 || args.transcription_task != "transcribe" || !args.punctuation ||
-            args.timestamps || args.max_input_seconds > 0.0F ||
-            args.segment_length_seconds > 0.0F ||
+            args.beam_size != 1 || args.length_penalty != 1.0F ||
+            args.beam_fallback_max_size != 0 || args.transcription_task != "transcribe" ||
+            !args.punctuation || args.timestamps || args.max_input_seconds > 0.0F ||
+            args.segment_length_seconds > 0.0F || args.segment_min_seconds > 0.0F ||
+            args.segment_overlap_seconds > 0.0F || args.lcs_merge ||
             (args.language.empty() &&
              (args.source_language != "en" || args.target_language != "en"));
         if (has_offline_only_controls) {
@@ -1390,6 +1392,8 @@ int cmd_transcribe(const CliArgs& args) {
         request.config.max_output_tokens = max_tokens;
         request.config.input_sample_rate = audio.sample_rate;
         request.config.beam_size = args.beam_size;
+        request.config.length_penalty = args.length_penalty;
+        request.config.beam_fallback_max_size = args.beam_fallback_max_size;
         request.config.source_language = args.source_language;
         request.config.target_language = args.target_language;
         request.config.task = args.transcription_task == "translate"
@@ -1399,6 +1403,9 @@ int cmd_transcribe(const CliArgs& args) {
         request.config.timestamps = args.timestamps;
         request.config.max_input_duration_seconds = args.max_input_seconds;
         request.config.segment_duration_seconds = args.segment_length_seconds;
+        request.config.segment_min_duration_seconds = args.segment_min_seconds;
+        request.config.segment_overlap_seconds = args.segment_overlap_seconds;
+        request.config.lcs_merge = args.lcs_merge;
         requests.push_back(std::move(request));
     }
 

--- a/src/runtime/models/canary/canary_decode_policy.h
+++ b/src/runtime/models/canary/canary_decode_policy.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -15,6 +16,30 @@
 namespace trtmc {
 
 inline constexpr float CanaryDefaultBeamLengthPenalty = 1.0F;
+
+inline int32_t canary_beam_output_budget(int32_t requested_tokens, int32_t cache_length,
+                                         std::size_t prompt_tokens) {
+    if (requested_tokens <= 0 || cache_length <= 0 ||
+        prompt_tokens > static_cast<std::size_t>(cache_length)) {
+        return 0;
+    }
+    // Prompt execution fills prompt_tokens cache rows. The final generated
+    // token is selected from existing logits and does not need another cache
+    // row, hence the inclusive +1.
+    const int32_t cache_budget = cache_length - static_cast<int32_t>(prompt_tokens) + 1;
+    return std::min(requested_tokens, cache_budget);
+}
+
+inline std::vector<int32_t> canary_beam_fallback_sizes(int32_t initial_beam_size,
+                                                       int32_t maximum_beam_size) {
+    std::vector<int32_t> sizes;
+    for (int32_t beam_size = initial_beam_size; beam_size > 0 && beam_size < maximum_beam_size;) {
+        beam_size = static_cast<int32_t>(
+            std::min<int64_t>(static_cast<int64_t>(beam_size) * 2, maximum_beam_size));
+        sizes.push_back(beam_size);
+    }
+    return sizes;
+}
 
 struct CanaryDecodeLoopResult {
     std::vector<int32_t> output_ids;

--- a/src/runtime/models/canary/canary_request.h
+++ b/src/runtime/models/canary/canary_request.h
@@ -20,7 +20,7 @@
 
 namespace trtmc {
 
-constexpr int32_t CanaryMaxBeamSize = 16;
+constexpr int32_t CanaryMaxBeamSize = 32;
 
 inline int32_t canary_token_id(const ITokenizer* tokenizer, std::string_view token,
                                int32_t configured_id) {
@@ -57,11 +57,24 @@ inline void validate_canary_output_limits(const CanaryConfig& model,
     }
 }
 
-inline void validate_canary_request_options(const TranscriptionConfig& request) {
+inline void validate_canary_beam_options(const TranscriptionConfig& request) {
     if (request.beam_size < 1 || request.beam_size > CanaryMaxBeamSize) {
         throw std::invalid_argument("Canary beam_size must be in [1, " +
                                     std::to_string(CanaryMaxBeamSize) + "]");
     }
+    if (!std::isfinite(request.length_penalty) || request.length_penalty < 0.0F) {
+        throw std::invalid_argument("Canary length_penalty must be a finite value >= 0");
+    }
+    if (request.beam_fallback_max_size < 0 || request.beam_fallback_max_size > CanaryMaxBeamSize ||
+        (request.beam_fallback_max_size > 0 &&
+         request.beam_fallback_max_size < request.beam_size)) {
+        throw std::invalid_argument("Canary beam_fallback_max_size must be 0 or in [beam_size, " +
+                                    std::to_string(CanaryMaxBeamSize) + "]");
+    }
+}
+
+inline void validate_canary_request_options(const TranscriptionConfig& request) {
+    validate_canary_beam_options(request);
     if (request.input_sample_rate < 0) {
         throw std::invalid_argument("Canary input_sample_rate must be 0 or a positive Hz value");
     }
@@ -101,16 +114,50 @@ inline void validate_canary_language_pair(const CanaryConfig& model,
     }
 }
 
-inline void validate_canary_durations(const TranscriptionConfig& request) {
-    if (!std::isfinite(request.max_input_duration_seconds) ||
-        request.max_input_duration_seconds < 0.0F) {
+inline void validate_canary_nonnegative_duration(float value, const char* option_name) {
+    if (!std::isfinite(value) || value < 0.0F) {
+        throw std::invalid_argument(std::string("Canary ") + option_name +
+                                    " must be a finite value >= 0");
+    }
+}
+
+inline void validate_canary_dynamic_segment_bounds(const TranscriptionConfig& request) {
+    if (request.segment_min_duration_seconds > 0.0F && request.segment_duration_seconds <= 0.0F) {
         throw std::invalid_argument(
-            "Canary max_input_duration_seconds must be a finite value >= 0");
+            "Canary dynamic segmentation requires segment_duration_seconds > 0");
     }
-    if (!std::isfinite(request.segment_duration_seconds) ||
-        request.segment_duration_seconds < 0.0F) {
-        throw std::invalid_argument("Canary segment_duration_seconds must be a finite value >= 0");
+    if (request.segment_min_duration_seconds > request.segment_duration_seconds &&
+        request.segment_duration_seconds > 0.0F) {
+        throw std::invalid_argument(
+            "Canary segment_min_duration_seconds must not exceed segment_duration_seconds");
     }
+}
+
+inline void validate_canary_segment_overlap(const TranscriptionConfig& request) {
+    const float overlap_limit = request.segment_min_duration_seconds > 0.0F
+                                    ? request.segment_min_duration_seconds
+                                    : request.segment_duration_seconds;
+    if (request.segment_overlap_seconds > 0.0F &&
+        (overlap_limit <= 0.0F || request.segment_overlap_seconds >= overlap_limit)) {
+        throw std::invalid_argument(
+            "Canary segment_overlap_seconds must be less than the active segment duration");
+    }
+    if (request.lcs_merge && request.segment_overlap_seconds <= 0.0F) {
+        throw std::invalid_argument("Canary lcs_merge requires segment_overlap_seconds > 0");
+    }
+}
+
+inline void validate_canary_durations(const TranscriptionConfig& request) {
+    validate_canary_nonnegative_duration(request.max_input_duration_seconds,
+                                         "max_input_duration_seconds");
+    validate_canary_nonnegative_duration(request.segment_duration_seconds,
+                                         "segment_duration_seconds");
+    validate_canary_nonnegative_duration(request.segment_min_duration_seconds,
+                                         "segment_min_duration_seconds");
+    validate_canary_nonnegative_duration(request.segment_overlap_seconds,
+                                         "segment_overlap_seconds");
+    validate_canary_dynamic_segment_bounds(request);
+    validate_canary_segment_overlap(request);
 }
 
 inline void validate_canary_request(const CanaryConfig& model, const TranscriptionConfig& request,

--- a/src/runtime/models/canary/canary_segment_utils.h
+++ b/src/runtime/models/canary/canary_segment_utils.h
@@ -1,0 +1,290 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+
+struct CanarySegmentSpan {
+    int64_t offset{0};
+    int32_t count{0};
+};
+
+inline int64_t canary_seconds_to_samples(float seconds, int32_t sample_rate,
+                                         const char* option_name) {
+    const double samples = static_cast<double>(seconds) * static_cast<double>(sample_rate);
+    if (!std::isfinite(samples) || samples < 0.0 ||
+        samples > static_cast<double>(std::numeric_limits<int32_t>::max())) {
+        throw std::invalid_argument(std::string("Canary ") + option_name +
+                                    " produces an invalid sample count");
+    }
+    return static_cast<int64_t>(std::llround(samples));
+}
+
+inline void validate_canary_segment_audio_dimensions(int32_t num_samples, int32_t sample_rate) {
+    if (num_samples <= 0)
+        throw std::invalid_argument("Canary segment planning requires positive audio dimensions");
+    if (sample_rate <= 0)
+        throw std::invalid_argument("Canary segment planning requires positive audio dimensions");
+}
+
+inline void validate_canary_segment_sample_bounds(int64_t max_samples, int64_t min_samples,
+                                                  int64_t overlap_samples) {
+    if (max_samples <= 0)
+        throw std::invalid_argument("Canary segment duration/overlap configuration is invalid");
+    if (min_samples > max_samples)
+        throw std::invalid_argument("Canary segment duration/overlap configuration is invalid");
+    if (overlap_samples >= (min_samples > 0 ? min_samples : max_samples)) {
+        throw std::invalid_argument("Canary segment duration/overlap configuration is invalid");
+    }
+}
+
+inline std::vector<CanarySegmentSpan>
+plan_canary_fixed_segments(int64_t input_samples, int64_t max_samples, int64_t overlap_samples) {
+    std::vector<CanarySegmentSpan> spans;
+    const int64_t stride = max_samples - overlap_samples;
+    for (int64_t offset = 0; offset < input_samples; offset += stride) {
+        const int64_t count = std::min(max_samples, input_samples - offset);
+        spans.push_back({offset, static_cast<int32_t>(count)});
+        if (offset + count == input_samples)
+            break;
+    }
+    return spans;
+}
+
+inline std::vector<CanarySegmentSpan> plan_canary_dynamic_segments(int64_t input_samples,
+                                                                   int64_t max_samples,
+                                                                   int64_t min_samples,
+                                                                   int64_t overlap_samples) {
+    // Use the fewest windows that can cover the signal at the requested
+    // overlap. Equalize their lengths to avoid a heavily padded tail window.
+    const int64_t stride_cap = max_samples - overlap_samples;
+    const int64_t segment_count =
+        std::max<int64_t>(2, (input_samples - overlap_samples + stride_cap - 1) / stride_cap);
+    int64_t window_samples =
+        (input_samples + (segment_count - 1) * overlap_samples + segment_count - 1) / segment_count;
+    window_samples = std::max(window_samples, min_samples);
+    if (window_samples > max_samples) {
+        throw std::invalid_argument(
+            "Canary cannot cover the input with the requested dynamic segment bounds");
+    }
+
+    const int64_t offset_span = input_samples - window_samples;
+    std::vector<CanarySegmentSpan> spans;
+    spans.reserve(static_cast<std::size_t>(segment_count));
+    for (int64_t index = 0; index < segment_count; ++index) {
+        const int64_t offset =
+            (index * offset_span + (segment_count - 1) / 2) / (segment_count - 1);
+        spans.push_back({offset, static_cast<int32_t>(window_samples)});
+    }
+    return spans;
+}
+
+inline std::vector<CanarySegmentSpan> plan_canary_segments(int32_t num_samples, int32_t sample_rate,
+                                                           float max_segment_seconds,
+                                                           float min_segment_seconds,
+                                                           float overlap_seconds) {
+    validate_canary_segment_audio_dimensions(num_samples, sample_rate);
+    const int64_t max_samples =
+        canary_seconds_to_samples(max_segment_seconds, sample_rate, "segment duration");
+    const int64_t min_samples = min_segment_seconds > 0.0F
+                                    ? canary_seconds_to_samples(min_segment_seconds, sample_rate,
+                                                                "minimum segment duration")
+                                    : 0;
+    const int64_t overlap_samples =
+        canary_seconds_to_samples(overlap_seconds, sample_rate, "segment overlap");
+    validate_canary_segment_sample_bounds(max_samples, min_samples, overlap_samples);
+
+    const int64_t input_samples = num_samples;
+    if (input_samples <= max_samples)
+        return {{0, num_samples}};
+    if (min_samples == 0)
+        return plan_canary_fixed_segments(input_samples, max_samples, overlap_samples);
+    return plan_canary_dynamic_segments(input_samples, max_samples, min_samples, overlap_samples);
+}
+
+template <typename T>
+inline std::vector<uint16_t>
+build_canary_lcs_lengths(const std::vector<T>& left, const std::vector<T>& right,
+                         std::size_t left_begin, std::size_t right_size) {
+    const std::size_t left_size = left.size() - left_begin;
+    std::vector<uint16_t> lengths((left_size + 1) * (right_size + 1), 0);
+    const auto at = [&lengths, right_size](std::size_t i, std::size_t j) -> uint16_t& {
+        return lengths[i * (right_size + 1) + j];
+    };
+    for (std::size_t i = 1; i <= left_size; ++i) {
+        for (std::size_t j = 1; j <= right_size; ++j) {
+            if (left[left_begin + i - 1] == right[j - 1]) {
+                at(i, j) = static_cast<uint16_t>(at(i - 1, j - 1) + 1);
+            } else {
+                at(i, j) = std::max(at(i - 1, j), at(i, j - 1));
+            }
+        }
+    }
+    return lengths;
+}
+
+template <typename T>
+inline std::vector<std::pair<std::size_t, std::size_t>>
+backtrack_canary_lcs_matches(const std::vector<T>& left, const std::vector<T>& right,
+                             std::size_t left_begin, std::size_t right_size,
+                             const std::vector<uint16_t>& lengths) {
+    const std::size_t left_size = left.size() - left_begin;
+    const auto at = [&lengths, right_size](std::size_t i, std::size_t j) {
+        return lengths[i * (right_size + 1) + j];
+    };
+    std::vector<std::pair<std::size_t, std::size_t>> matches;
+    std::size_t i = left_size;
+    std::size_t j = right_size;
+    while (i > 0 && j > 0) {
+        if (left[left_begin + i - 1] == right[j - 1]) {
+            matches.emplace_back(left_begin + i - 1, j - 1);
+            --i;
+            --j;
+        } else if (at(i - 1, j) >= at(i, j - 1)) {
+            --i;
+        } else {
+            --j;
+        }
+    }
+    std::reverse(matches.begin(), matches.end());
+    return matches;
+}
+
+inline bool
+canary_lcs_matches_boundary(const std::vector<std::pair<std::size_t, std::size_t>>& matches,
+                            std::size_t left_size, std::size_t minimum_matches) {
+    if (matches.empty() || matches.size() < minimum_matches)
+        return false;
+    const std::size_t boundary_slack = std::max<std::size_t>(8, matches.size());
+    if (matches.front().second > boundary_slack)
+        return false;
+    if (left_size - 1 - matches.back().first > boundary_slack)
+        return false;
+    const std::size_t left_overlap = left_size - matches.front().first;
+    const std::size_t right_overlap = matches.back().second + 1;
+    return matches.size() * 3 >= std::min(left_overlap, right_overlap);
+}
+
+template <typename T>
+inline std::vector<T>
+merge_canary_lcs_boundary(const std::vector<T>& left, const std::vector<T>& right,
+                          std::size_t boundary_window = 32, std::size_t minimum_matches = 2) {
+    if (left.empty())
+        return right;
+    if (right.empty())
+        return left;
+
+    const std::size_t left_begin =
+        left.size() > boundary_window ? left.size() - boundary_window : 0;
+    const std::size_t right_size = std::min(right.size(), boundary_window);
+    const auto lengths = build_canary_lcs_lengths(left, right, left_begin, right_size);
+    const auto matches = backtrack_canary_lcs_matches(left, right, left_begin, right_size, lengths);
+    if (!canary_lcs_matches_boundary(matches, left.size(), minimum_matches))
+        return {};
+
+    const auto [left_pivot, right_pivot] = matches.back();
+    std::vector<T> merged;
+    merged.reserve(left_pivot + 1 + right.size() - right_pivot - 1);
+    merged.insert(merged.end(), left.begin(),
+                  left.begin() + static_cast<std::ptrdiff_t>(left_pivot + 1));
+    merged.insert(merged.end(), right.begin() + static_cast<std::ptrdiff_t>(right_pivot + 1),
+                  right.end());
+    return merged;
+}
+
+inline std::vector<int32_t> merge_canary_token_segments(const std::vector<int32_t>& left,
+                                                        const std::vector<int32_t>& right,
+                                                        int32_t eot_token_id) {
+    auto content = [eot_token_id](const std::vector<int32_t>& tokens) {
+        auto end = tokens.end();
+        while (end != tokens.begin() && *(end - 1) == eot_token_id)
+            --end;
+        return std::vector<int32_t>(tokens.begin(), end);
+    };
+    const auto left_content = content(left);
+    const auto right_content = content(right);
+    auto merged = merge_canary_lcs_boundary(left_content, right_content);
+    if (merged.empty()) {
+        merged = left_content;
+        merged.insert(merged.end(), right_content.begin(), right_content.end());
+    }
+    if ((!left.empty() && left.back() == eot_token_id) ||
+        (!right.empty() && right.back() == eot_token_id)) {
+        merged.push_back(eot_token_id);
+    }
+    return merged;
+}
+
+struct CanaryBoundaryWord {
+    std::string original;
+    std::string normalized;
+
+    bool operator==(const CanaryBoundaryWord& other) const {
+        return normalized == other.normalized;
+    }
+};
+
+inline std::vector<CanaryBoundaryWord> split_canary_boundary_words(const std::string& text) {
+    std::istringstream input(text);
+    std::vector<CanaryBoundaryWord> words;
+    std::string word;
+    while (input >> word) {
+        std::string normalized = word;
+        while (!normalized.empty() &&
+               std::ispunct(static_cast<unsigned char>(normalized.front())) != 0) {
+            normalized.erase(normalized.begin());
+        }
+        while (!normalized.empty() &&
+               std::ispunct(static_cast<unsigned char>(normalized.back())) != 0) {
+            normalized.pop_back();
+        }
+        std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                       [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        if (!normalized.empty())
+            words.push_back({std::move(word), std::move(normalized)});
+    }
+    return words;
+}
+
+inline std::string merge_canary_text_segments(const std::string& left, const std::string& right) {
+    if (left.empty())
+        return right;
+    if (right.empty())
+        return left;
+    const auto left_words = split_canary_boundary_words(left);
+    const auto right_words = split_canary_boundary_words(right);
+    constexpr std::size_t CanaryMaxMergedBoundaryWords = 12;
+    auto merged = merge_canary_lcs_boundary(left_words, right_words, 16, 1);
+    // At conversational speech rates, a two-second overlap is normally no
+    // more than about twelve words. A larger deletion is more likely an
+    // ambiguous match against repeated boilerplate than the actual boundary.
+    const std::size_t removed_words =
+        merged.empty() ? 0 : left_words.size() + right_words.size() - merged.size();
+    if (merged.empty() || removed_words > CanaryMaxMergedBoundaryWords)
+        return left + ' ' + right;
+
+    std::ostringstream output;
+    for (std::size_t index = 0; index < merged.size(); ++index) {
+        if (index > 0)
+            output << ' ';
+        output << merged[index].original;
+    }
+    return output.str();
+}
+
+} // namespace trtmc

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -12,6 +12,7 @@
 #include "runtime/models/canary/canary_host_plan.h"
 #include "runtime/models/canary/canary_mel_spectrogram.h"
 #include "runtime/models/canary/canary_request.h"
+#include "runtime/models/canary/canary_segment_utils.h"
 #include "runtime/models/canary/decode_runtime.h"
 #include "trtmc/tokenizer.h"
 #include "utils/wav_reader.h"
@@ -27,10 +28,27 @@
 #include <numeric>
 #include <sstream>
 #include <stdexcept>
-#include <unordered_map>
 #include <vector>
 
 namespace trtmc {
+
+struct CanaryBatchSegment {
+    std::size_t request_index{0};
+    int64_t offset{0};
+    int32_t count{0};
+    int32_t sample_rate{0};
+    std::vector<int32_t> initial_tokens;
+    int32_t max_output_tokens{0};
+    int32_t beam_size{1};
+    float length_penalty{CanaryDefaultBeamLengthPenalty};
+    int32_t beam_fallback_max_size{0};
+};
+
+struct CanaryBatchWorkGroup {
+    int32_t beam_size{1};
+    float length_penalty{CanaryDefaultBeamLengthPenalty};
+    std::vector<std::size_t> indices;
+};
 
 namespace {
 
@@ -152,18 +170,9 @@ double resolve_canary_segment_duration(double input_duration_seconds, double mod
     return segment_seconds;
 }
 
-int32_t canary_segment_sample_count(double segment_seconds, int32_t sample_rate) {
-    const int64_t segment_samples =
-        static_cast<int64_t>(std::llround(segment_seconds * static_cast<double>(sample_rate)));
-    if (segment_samples <= 0 || segment_samples > std::numeric_limits<int32_t>::max()) {
-        throw std::invalid_argument("Canary segment duration produces an invalid sample count");
-    }
-    return static_cast<int32_t>(segment_samples);
-}
-
 void append_canary_transcription_segment(TextResult& combined, TextResult segment, int64_t offset,
                                          int32_t count, int32_t sample_rate,
-                                         const TranscriptionConfig& cfg) {
+                                         const TranscriptionConfig& cfg, int32_t eot_token_id) {
     if (!cfg.punctuation) {
         segment.text = remove_punctuation_outside_control_tokens(segment.text);
     }
@@ -175,12 +184,19 @@ void append_canary_transcription_segment(TextResult& combined, TextResult segmen
         timed.token_ids = segment.token_ids;
         combined.segments.push_back(std::move(timed));
     }
-    if (!combined.text.empty() && !segment.text.empty()) {
-        combined.text += '\n';
+    if (cfg.lcs_merge) {
+        combined.text = merge_canary_text_segments(combined.text, segment.text);
+        combined.token_ids =
+            merge_canary_token_segments(combined.token_ids, segment.token_ids, eot_token_id);
+        if (!cfg.punctuation)
+            combined.text = remove_punctuation_outside_control_tokens(combined.text);
+    } else {
+        if (!combined.text.empty() && !segment.text.empty())
+            combined.text += '\n';
+        combined.text += segment.text;
+        combined.token_ids.insert(combined.token_ids.end(), segment.token_ids.begin(),
+                                  segment.token_ids.end());
     }
-    combined.text += segment.text;
-    combined.token_ids.insert(combined.token_ids.end(), segment.token_ids.begin(),
-                              segment.token_ids.end());
     combined.prefill_ms += segment.prefill_ms;
     combined.decode_ms += segment.decode_ms;
 }
@@ -220,24 +236,9 @@ void* allocate_canary_cross_kv_buffer(int32_t num_decoder_layers, std::size_t by
     return buffer;
 }
 
-struct CanaryBatchSegment {
-    std::size_t request_index{0};
-    int64_t offset{0};
-    int32_t count{0};
-    int32_t sample_rate{0};
-    std::vector<int32_t> initial_tokens;
-    int32_t max_output_tokens{0};
-    int32_t beam_size{1};
-};
-
 struct CanaryPreparedSegment {
     canary::MelResult mel;
     int32_t actual_encoder_length{0};
-};
-
-struct CanaryBatchWorkGroups {
-    std::unordered_map<int32_t, std::vector<std::size_t>> by_beam_size;
-    std::vector<int32_t> beam_order;
 };
 
 struct CanaryPreparedBatchChunk {
@@ -271,26 +272,33 @@ build_canary_batch_work(const std::vector<TranscriptionRequest>& requests,
             validate_canary_input_duration(sample_count, sample_rate, request.config);
         const double segment_seconds = resolve_canary_segment_duration(
             duration_seconds, static_cast<double>(mel_chunk_length), request.config);
-        const int32_t segment_samples = canary_segment_sample_count(segment_seconds, sample_rate);
+        const auto spans = plan_canary_segments(
+            sample_count, sample_rate, static_cast<float>(segment_seconds),
+            request.config.segment_min_duration_seconds, request.config.segment_overlap_seconds);
 
-        for (int64_t offset = 0; offset < sample_count; offset += segment_samples) {
-            const int32_t count = static_cast<int32_t>(
-                std::min<int64_t>(segment_samples, static_cast<int64_t>(sample_count) - offset));
-            work.push_back({request_index, offset, count, sample_rate, initial_tokens,
-                            request.config.max_output_tokens, request.config.beam_size});
+        for (const auto& span : spans) {
+            work.push_back({request_index, span.offset, span.count, sample_rate, initial_tokens,
+                            request.config.max_output_tokens, request.config.beam_size,
+                            request.config.length_penalty, request.config.beam_fallback_max_size});
         }
     }
     return work;
 }
 
-CanaryBatchWorkGroups group_canary_batch_work(const std::vector<CanaryBatchSegment>& work) {
-    CanaryBatchWorkGroups groups;
+std::vector<CanaryBatchWorkGroup>
+group_canary_batch_work(const std::vector<CanaryBatchSegment>& work) {
+    std::vector<CanaryBatchWorkGroup> groups;
     for (std::size_t index = 0; index < work.size(); ++index) {
-        const int32_t beam_size = work[index].beam_size;
-        auto [it, inserted] = groups.by_beam_size.try_emplace(beam_size);
-        if (inserted)
-            groups.beam_order.push_back(beam_size);
-        it->second.push_back(index);
+        const auto found =
+            std::find_if(groups.begin(), groups.end(), [&work, index](const auto& group) {
+                return group.beam_size == work[index].beam_size &&
+                       group.length_penalty == work[index].length_penalty;
+            });
+        if (found != groups.end()) {
+            found->indices.push_back(index);
+        } else {
+            groups.push_back({work[index].beam_size, work[index].length_penalty, {index}});
+        }
     }
     return groups;
 }
@@ -415,13 +423,13 @@ void report_canary_batch_timing(CanaryClock::time_point begin, std::size_t batch
 std::vector<TextResult>
 merge_canary_batch_segments(const std::vector<TranscriptionRequest>& requests,
                             const std::vector<CanaryBatchSegment>& work,
-                            std::vector<TextResult>& segment_results) {
+                            std::vector<TextResult>& segment_results, int32_t eot_token_id) {
     std::vector<TextResult> results(requests.size());
     for (std::size_t index = 0; index < work.size(); ++index) {
         const auto& item = work[index];
         append_canary_transcription_segment(
             results[item.request_index], std::move(segment_results[index]), item.offset, item.count,
-            item.sample_rate, requests[item.request_index].config);
+            item.sample_rate, requests[item.request_index].config, eot_token_id);
     }
     return results;
 }
@@ -605,7 +613,7 @@ bool canary_beam_candidate_is_active(const CanaryBeamCandidate& candidate, bool 
 
 bool append_canary_next_beam_sample(const std::vector<CanaryBeamHypothesis>& current_beams,
                                     int32_t max_new_tokens, int32_t step, int32_t batch,
-                                    int32_t beam_size, int32_t eot_token_id,
+                                    int32_t beam_size, float length_penalty, int32_t eot_token_id,
                                     std::vector<int32_t>& parent_lanes,
                                     std::vector<int32_t>& tokens,
                                     std::vector<CanaryBeamHypothesis>& next_beams) {
@@ -616,7 +624,7 @@ bool append_canary_next_beam_sample(const std::vector<CanaryBeamHypothesis>& cur
                                         sample_finished, status)) {
         throw std::runtime_error("Canary batched beam search failed: " + status.error);
     }
-    rank_canary_beam_candidates(candidates, beam_size, CanaryDefaultBeamLengthPenalty);
+    rank_canary_beam_candidates(candidates, beam_size, length_penalty);
     const bool final_step = step + 1 >= max_new_tokens;
     for (int32_t beam = 0; beam < beam_size; ++beam) {
         const int32_t lane = batch * beam_size + beam;
@@ -638,7 +646,7 @@ bool append_canary_next_beam_sample(const std::vector<CanaryBeamHypothesis>& cur
 CanaryBeamBatchStep make_canary_beam_batch_step(const CanaryBeamBatch& beams,
                                                 const std::vector<int32_t>& max_new_tokens,
                                                 int32_t step, int32_t beam_size,
-                                                int32_t eot_token_id) {
+                                                float length_penalty, int32_t eot_token_id) {
     const int32_t request_batch = static_cast<int32_t>(beams.size());
     const auto decoder_lanes = static_cast<std::size_t>(request_batch * beam_size);
     CanaryBeamBatchStep next;
@@ -648,7 +656,7 @@ CanaryBeamBatchStep make_canary_beam_batch_step(const CanaryBeamBatch& beams,
     for (int32_t batch = 0; batch < request_batch; ++batch) {
         next.any_active |= append_canary_next_beam_sample(
             beams[static_cast<std::size_t>(batch)], max_new_tokens[static_cast<std::size_t>(batch)],
-            step, batch, beam_size, eot_token_id, next.parent_lanes, next.tokens,
+            step, batch, beam_size, length_penalty, eot_token_id, next.parent_lanes, next.tokens,
             next.beams[static_cast<std::size_t>(batch)]);
     }
     return next;
@@ -763,16 +771,17 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     const double model_segment_seconds = static_cast<double>(mel_chunk_length_);
     const double segment_seconds =
         resolve_canary_segment_duration(duration_seconds, model_segment_seconds, cfg);
-    const int32_t segment_samples = canary_segment_sample_count(segment_seconds, sample_rate);
+    const auto spans =
+        plan_canary_segments(num_samples, sample_rate, static_cast<float>(segment_seconds),
+                             cfg.segment_min_duration_seconds, cfg.segment_overlap_seconds);
 
     TextResult combined;
-    for (int64_t offset = 0; offset < num_samples; offset += segment_samples) {
-        const int32_t count = static_cast<int32_t>(
-            std::min<int64_t>(segment_samples, static_cast<int64_t>(num_samples) - offset));
-        auto segment = transcribe_segment(audio_data + offset, count, sample_rate, initial_tokens,
-                                          cfg.max_output_tokens, cfg.beam_size);
-        append_canary_transcription_segment(combined, std::move(segment), offset, count,
-                                            sample_rate, cfg);
+    for (const auto& span : spans) {
+        auto segment = transcribe_segment(audio_data + span.offset, span.count, sample_rate,
+                                          initial_tokens, cfg.max_output_tokens, cfg.beam_size,
+                                          cfg.length_penalty, cfg.beam_fallback_max_size);
+        append_canary_transcription_segment(combined, std::move(segment), span.offset, span.count,
+                                            sample_rate, cfg, canary_config_.eot_token_id);
     }
     return combined;
 }
@@ -788,53 +797,83 @@ CanaryPipeline::transcribe_batch(const std::vector<TranscriptionRequest>& reques
     std::vector<TextResult> segment_results(work.size());
     const auto groups = group_canary_batch_work(work);
 
-    for (const int32_t beam_size : groups.beam_order) {
-        const auto& indices = groups.by_beam_size.at(beam_size);
-        if (beam_size > decoder_lane_capacity_) {
-            for (const std::size_t index : indices) {
-                const auto& item = work[index];
-                const auto& audio = requests[item.request_index].audio_samples;
-                segment_results[index] =
-                    transcribe_segment(audio.data() + item.offset, item.count, item.sample_rate,
-                                       item.initial_tokens, item.max_output_tokens, item.beam_size);
-            }
+    for (const auto& group : groups)
+        transcribe_batch_group(group, work, requests, segment_results);
+    retry_batch_fallback_segments(work, requests, segment_results);
+    return merge_canary_batch_segments(requests, work, segment_results,
+                                       canary_config_.eot_token_id);
+}
+
+void CanaryPipeline::transcribe_batch_group(const CanaryBatchWorkGroup& group,
+                                            const std::vector<CanaryBatchSegment>& work,
+                                            const std::vector<TranscriptionRequest>& requests,
+                                            std::vector<TextResult>& segment_results) {
+    const int32_t beam_size = group.beam_size;
+    const auto& indices = group.indices;
+    if (beam_size > decoder_lane_capacity_) {
+        for (const std::size_t index : indices) {
+            const auto& item = work[index];
+            const auto& audio = requests[item.request_index].audio_samples;
+            segment_results[index] =
+                transcribe_segment(audio.data() + item.offset, item.count, item.sample_rate,
+                                   item.initial_tokens, item.max_output_tokens, item.beam_size,
+                                   item.length_penalty, item.beam_fallback_max_size);
+        }
+        return;
+    }
+
+    const int32_t decoder_request_capacity =
+        std::max(decoder_lane_capacity_ / std::max(beam_size, 1), 1);
+    const std::size_t chunk_capacity =
+        static_cast<std::size_t>(std::min(encoder_batch_capacity_, decoder_request_capacity));
+    for (std::size_t chunk_start = 0; chunk_start < indices.size(); chunk_start += chunk_capacity) {
+        const std::size_t chunk_end = std::min(chunk_start + chunk_capacity, indices.size());
+        const auto chunk_begin_time = CanaryClock::now();
+
+        auto futures = launch_canary_batch_preparation(
+            indices, chunk_start, chunk_end, work, requests, mel_fb_.get(), mel_n_fft_,
+            mel_win_length_, mel_hop_length_, mel_chunk_length_, mel_sampling_rate_, mel_preemph_,
+            mel_normalize_per_feature_, canary_config_);
+        auto chunk = collect_canary_prepared_batch_chunk(futures, indices, chunk_start, work,
+                                                         segment_results);
+        if (chunk.valid_indices.empty())
+            continue;
+
+        run_encoder_batch(chunk.mel_batch, chunk.mel_bins, chunk.mel_frames, chunk.valid_frames);
+        auto output_ids = run_decoder_batch(chunk.prompts, chunk.output_limits, beam_size,
+                                            group.length_penalty, chunk.actual_encoder_lengths);
+        store_canary_batch_decodes(output_ids, chunk.valid_indices, tokenizer_.get(),
+                                   canary_config_.eot_token_id, segment_results);
+        report_canary_batch_timing(chunk_begin_time, chunk.valid_indices.size(), beam_size);
+    }
+}
+
+void CanaryPipeline::retry_batch_fallback_segments(
+    const std::vector<CanaryBatchSegment>& work, const std::vector<TranscriptionRequest>& requests,
+    std::vector<TextResult>& segment_results) {
+    for (std::size_t index = 0; index < work.size(); ++index) {
+        const auto& item = work[index];
+        const auto fallback_sizes =
+            canary_beam_fallback_sizes(item.beam_size, item.beam_fallback_max_size);
+        if (fallback_sizes.empty() ||
+            (!segment_results[index].token_ids.empty() &&
+             segment_results[index].token_ids.back() == canary_config_.eot_token_id)) {
             continue;
         }
-
-        const int32_t decoder_request_capacity =
-            std::max(decoder_lane_capacity_ / std::max(beam_size, 1), 1);
-        const std::size_t chunk_capacity =
-            static_cast<std::size_t>(std::min(encoder_batch_capacity_, decoder_request_capacity));
-        for (std::size_t chunk_start = 0; chunk_start < indices.size();
-             chunk_start += chunk_capacity) {
-            const std::size_t chunk_end = std::min(chunk_start + chunk_capacity, indices.size());
-            const auto chunk_begin_time = CanaryClock::now();
-
-            auto futures = launch_canary_batch_preparation(
-                indices, chunk_start, chunk_end, work, requests, mel_fb_.get(), mel_n_fft_,
-                mel_win_length_, mel_hop_length_, mel_chunk_length_, mel_sampling_rate_,
-                mel_preemph_, mel_normalize_per_feature_, canary_config_);
-            auto chunk = collect_canary_prepared_batch_chunk(futures, indices, chunk_start, work,
-                                                             segment_results);
-            if (chunk.valid_indices.empty())
-                continue;
-
-            run_encoder_batch(chunk.mel_batch, chunk.mel_bins, chunk.mel_frames,
-                              chunk.valid_frames);
-            auto output_ids = run_decoder_batch(chunk.prompts, chunk.output_limits, beam_size,
-                                                chunk.actual_encoder_lengths);
-            store_canary_batch_decodes(output_ids, chunk.valid_indices, tokenizer_.get(),
-                                       canary_config_.eot_token_id, segment_results);
-            report_canary_batch_timing(chunk_begin_time, chunk.valid_indices.size(), beam_size);
-        }
+        const auto& audio = requests[item.request_index].audio_samples;
+        segment_results[index] =
+            transcribe_segment(audio.data() + item.offset, item.count, item.sample_rate,
+                               item.initial_tokens, item.max_output_tokens, fallback_sizes.front(),
+                               item.length_penalty, item.beam_fallback_max_size);
     }
-    return merge_canary_batch_segments(requests, work, segment_results);
 }
 
 TextResult CanaryPipeline::transcribe_segment(const float* audio_data, int32_t num_samples,
                                               int32_t input_sample_rate,
                                               const std::vector<int32_t>& initial_tokens,
-                                              int32_t max_output_tokens, int32_t beam_size) {
+                                              int32_t max_output_tokens, int32_t beam_size,
+                                              float length_penalty,
+                                              int32_t beam_fallback_max_size) {
     const bool report_stage_timing = canary_stage_timing_enabled();
     const auto transcribe_start = CanaryClock::now();
 
@@ -895,7 +934,8 @@ TextResult CanaryPipeline::transcribe_segment(const float* audio_data, int32_t n
 
     // Step 4: Run decoder
     std::cerr << "[canary] Running decoder ..." << std::endl;
-    auto output_ids = run_decoder(initial_tokens, max_output_tokens, beam_size);
+    auto output_ids = run_decoder_with_fallback(initial_tokens, max_output_tokens, beam_size,
+                                                length_penalty, beam_fallback_max_size);
     const auto decoder_end = CanaryClock::now();
 
     // Step 5: Decode token IDs
@@ -1054,10 +1094,11 @@ void CanaryPipeline::setup_cross_attention(const std::vector<int32_t>& actual_en
 }
 
 std::vector<int32_t> CanaryPipeline::run_decoder(const std::vector<int32_t>& initial_tokens,
-                                                 int32_t max_new_tokens, int32_t beam_size) {
+                                                 int32_t max_new_tokens, int32_t beam_size,
+                                                 float length_penalty) {
     batch_cache().set_batch_size(1);
     if (beam_size > 1)
-        return run_beam_decoder(initial_tokens, max_new_tokens, beam_size);
+        return run_beam_decoder(initial_tokens, max_new_tokens, beam_size, length_penalty);
 
     state_->reset();
     state_->bind_to(*decoder_);
@@ -1084,6 +1125,7 @@ std::vector<int32_t> CanaryPipeline::run_decoder(const std::vector<int32_t>& ini
 std::vector<std::vector<int32_t>>
 CanaryPipeline::run_decoder_batch(const std::vector<std::vector<int32_t>>& initial_tokens,
                                   const std::vector<int32_t>& max_new_tokens, int32_t beam_size,
+                                  float length_penalty,
                                   const std::vector<int32_t>& actual_enc_seq_lens) {
     if (initial_tokens.empty() || initial_tokens.size() != max_new_tokens.size() ||
         initial_tokens.size() != actual_enc_seq_lens.size()) {
@@ -1094,7 +1136,8 @@ CanaryPipeline::run_decoder_batch(const std::vector<std::vector<int32_t>>& initi
     setup_cross_attention(actual_enc_seq_lens, identity);
     if (beam_size <= 1)
         return run_greedy_decoder_batch(initial_tokens, max_new_tokens);
-    return run_beam_decoder_batch(initial_tokens, max_new_tokens, beam_size, actual_enc_seq_lens);
+    return run_beam_decoder_batch(initial_tokens, max_new_tokens, beam_size, length_penalty,
+                                  actual_enc_seq_lens);
 }
 
 std::vector<std::vector<int32_t>>
@@ -1139,7 +1182,7 @@ CanaryPipeline::run_greedy_decoder_batch(const std::vector<std::vector<int32_t>>
 std::vector<std::vector<int32_t>>
 CanaryPipeline::run_beam_decoder_batch(const std::vector<std::vector<int32_t>>& initial_tokens,
                                        const std::vector<int32_t>& max_new_tokens,
-                                       int32_t beam_size,
+                                       int32_t beam_size, float length_penalty,
                                        const std::vector<int32_t>& actual_enc_seq_lens) {
     const int32_t request_batch = static_cast<int32_t>(initial_tokens.size());
     const int32_t decoder_lanes = request_batch * beam_size;
@@ -1147,8 +1190,16 @@ CanaryPipeline::run_beam_decoder_batch(const std::vector<std::vector<int32_t>>& 
         throw std::invalid_argument("Canary batched beam search exceeds decoder lane capacity");
 
     const std::size_t prompt_length = validate_canary_batch_prompts(initial_tokens);
-
     auto& scratch = batch_cache();
+    std::vector<int32_t> cache_bounded_output_limits = max_new_tokens;
+    if (scratch.batch_capacity() > 1) {
+        std::transform(max_new_tokens.begin(), max_new_tokens.end(),
+                       cache_bounded_output_limits.begin(),
+                       [this, prompt_length](int32_t requested_tokens) {
+                           return canary_beam_output_budget(requested_tokens, state_->max_length(),
+                                                            prompt_length);
+                       });
+    }
     scratch.set_batch_size(request_batch);
     state_->reset();
     state_->bind_to(*decoder_);
@@ -1177,10 +1228,11 @@ CanaryPipeline::run_beam_decoder_batch(const std::vector<std::vector<int32_t>>& 
     const auto beam_lane_to_sample = make_canary_beam_lane_to_sample(decoder_lanes, beam_size);
     setup_cross_attention(actual_enc_seq_lens, beam_lane_to_sample);
 
-    const int32_t max_steps = *std::max_element(max_new_tokens.begin(), max_new_tokens.end());
+    const int32_t max_steps =
+        *std::max_element(cache_bounded_output_limits.begin(), cache_bounded_output_limits.end());
     for (int32_t step = 0; step < max_steps; ++step) {
-        auto next = make_canary_beam_batch_step(beams, max_new_tokens, step, beam_size,
-                                                canary_config_.eot_token_id);
+        auto next = make_canary_beam_batch_step(beams, cache_bounded_output_limits, step, beam_size,
+                                                length_penalty, canary_config_.eot_token_id);
         beams = std::move(next.beams);
         if (!next.any_active)
             break;
@@ -1195,11 +1247,16 @@ CanaryPipeline::run_beam_decoder_batch(const std::vector<std::vector<int32_t>>& 
 }
 
 std::vector<int32_t> CanaryPipeline::run_beam_decoder(const std::vector<int32_t>& initial_tokens,
-                                                      int32_t max_new_tokens, int32_t beam_size) {
+                                                      int32_t max_new_tokens, int32_t beam_size,
+                                                      float length_penalty) {
     ensure_beam_state_capacity(beam_size);
+    const int32_t cache_bounded_output_limit =
+        batch_cache().batch_capacity() > 1
+            ? canary_beam_output_budget(max_new_tokens, state_->max_length(), initial_tokens.size())
+            : max_new_tokens;
     auto result = run_canary_beam_search(
-        initial_tokens, max_new_tokens, canary_config_.eot_token_id, beam_size,
-        CanaryDefaultBeamLengthPenalty,
+        initial_tokens, cache_bounded_output_limit, canary_config_.eot_token_id, beam_size,
+        length_penalty,
         [this](const std::vector<int32_t>& prefix, std::vector<float>& logits, std::string& error) {
             try {
                 state_->reset();
@@ -1230,6 +1287,21 @@ std::vector<int32_t> CanaryPipeline::run_beam_decoder(const std::vector<int32_t>
     if (result.prefill_failed || result.decode_failed)
         throw std::runtime_error("Canary beam search failed: " + result.error);
     return result.output_ids;
+}
+
+std::vector<int32_t>
+CanaryPipeline::run_decoder_with_fallback(const std::vector<int32_t>& initial_tokens,
+                                          int32_t max_new_tokens, int32_t beam_size,
+                                          float length_penalty, int32_t beam_fallback_max_size) {
+    auto output_ids = run_decoder(initial_tokens, max_new_tokens, beam_size, length_penalty);
+    for (const int32_t retry_beam : canary_beam_fallback_sizes(beam_size, beam_fallback_max_size)) {
+        if (!output_ids.empty() && output_ids.back() == canary_config_.eot_token_id)
+            break;
+        std::cerr << "[canary] Decode did not terminate; retrying with beam " << retry_beam
+                  << std::endl;
+        output_ids = run_decoder(initial_tokens, max_new_tokens, retry_beam, length_penalty);
+    }
+    return output_ids;
 }
 
 void CanaryPipeline::ensure_beam_state_capacity(int32_t beam_size) {

--- a/src/runtime/models/canary/pipeline.h
+++ b/src/runtime/models/canary/pipeline.h
@@ -24,6 +24,8 @@
 namespace trtmc {
 
 struct MelFilterbank;
+struct CanaryBatchSegment;
+struct CanaryBatchWorkGroup;
 
 class CanaryPipeline final : public IPipeline {
   public:
@@ -51,7 +53,15 @@ class CanaryPipeline final : public IPipeline {
     TextResult transcribe_segment(const float* audio_data, int32_t num_samples,
                                   int32_t input_sample_rate,
                                   const std::vector<int32_t>& initial_tokens,
-                                  int32_t max_output_tokens, int32_t beam_size);
+                                  int32_t max_output_tokens, int32_t beam_size,
+                                  float length_penalty, int32_t beam_fallback_max_size);
+    void transcribe_batch_group(const CanaryBatchWorkGroup& group,
+                                const std::vector<CanaryBatchSegment>& work,
+                                const std::vector<TranscriptionRequest>& requests,
+                                std::vector<TextResult>& segment_results);
+    void retry_batch_fallback_segments(const std::vector<CanaryBatchSegment>& work,
+                                       const std::vector<TranscriptionRequest>& requests,
+                                       std::vector<TextResult>& segment_results);
     void run_encoder(const float* mel_data, int32_t mel_bins, int32_t mel_length,
                      int32_t valid_mel_frames);
     void run_encoder_batch(const std::vector<std::vector<float>>& mel_data, int32_t mel_bins,
@@ -60,20 +70,26 @@ class CanaryPipeline final : public IPipeline {
     void setup_cross_attention(const std::vector<int32_t>& actual_enc_seq_lens,
                                const std::vector<int32_t>& lane_to_sample);
     std::vector<int32_t> run_decoder(const std::vector<int32_t>& initial_tokens,
-                                     int32_t max_new_tokens, int32_t beam_size);
+                                     int32_t max_new_tokens, int32_t beam_size,
+                                     float length_penalty);
+    std::vector<int32_t> run_decoder_with_fallback(const std::vector<int32_t>& initial_tokens,
+                                                   int32_t max_new_tokens, int32_t beam_size,
+                                                   float length_penalty,
+                                                   int32_t beam_fallback_max_size);
     std::vector<std::vector<int32_t>>
     run_decoder_batch(const std::vector<std::vector<int32_t>>& initial_tokens,
                       const std::vector<int32_t>& max_new_tokens, int32_t beam_size,
-                      const std::vector<int32_t>& actual_enc_seq_lens);
+                      float length_penalty, const std::vector<int32_t>& actual_enc_seq_lens);
     std::vector<std::vector<int32_t>>
     run_greedy_decoder_batch(const std::vector<std::vector<int32_t>>& initial_tokens,
                              const std::vector<int32_t>& max_new_tokens);
     std::vector<std::vector<int32_t>>
     run_beam_decoder_batch(const std::vector<std::vector<int32_t>>& initial_tokens,
                            const std::vector<int32_t>& max_new_tokens, int32_t beam_size,
-                           const std::vector<int32_t>& actual_enc_seq_lens);
+                           float length_penalty, const std::vector<int32_t>& actual_enc_seq_lens);
     std::vector<int32_t> run_beam_decoder(const std::vector<int32_t>& initial_tokens,
-                                          int32_t max_new_tokens, int32_t beam_size);
+                                          int32_t max_new_tokens, int32_t beam_size,
+                                          float length_penalty);
     void run_decoder_step(int32_t token_id, std::vector<float>& logits);
     void run_decoder_step_batch(const std::vector<int32_t>& token_ids, std::vector<float>& logits);
     void ensure_beam_state_capacity(int32_t beam_size);

--- a/tests/cpp/models/canary/test_canary_decode_policy.cpp
+++ b/tests/cpp/models/canary/test_canary_decode_policy.cpp
@@ -15,6 +15,7 @@
 // =============================================================================
 
 #include "runtime/models/canary/canary_decode_policy.h"
+#include "runtime/models/canary/canary_segment_utils.h"
 
 #include <cstdint>
 #include <iostream>
@@ -216,6 +217,82 @@ void test_beam_search_applies_default_length_normalization() {
           "Canary length-normalized beam score can retain the longer sequence");
 }
 
+void test_beam_output_budget_stops_before_cache_exhaustion() {
+    check(trtmc::canary_beam_output_budget(256, 256, 6) == 251,
+          "Canary beam budget accounts for prompt rows in a fixed cache");
+    check(trtmc::canary_beam_output_budget(240, 256, 6) == 240,
+          "Canary beam budget preserves requests that fit the cache");
+    check(trtmc::canary_beam_output_budget(1, 4, 4) == 1,
+          "Canary beam budget includes the token selected from final prompt logits");
+    check(trtmc::canary_beam_output_budget(1, 4, 5) == 0,
+          "Canary beam budget rejects prompts larger than the cache");
+}
+
+void test_beam_fallback_sizes_double_through_configured_limit() {
+    check(trtmc::canary_beam_fallback_sizes(4, 32) == std::vector<int32_t>({8, 16, 32}),
+          "Canary fallback doubles beam size through 32");
+    check(trtmc::canary_beam_fallback_sizes(4, 24) == std::vector<int32_t>({8, 16, 24}),
+          "Canary fallback stops at a non-power-of-two limit");
+    check(trtmc::canary_beam_fallback_sizes(4, 4).empty(),
+          "Canary fallback is empty when the initial beam is already at the limit");
+}
+
+void test_dynamic_segments_cover_long_audio_with_balanced_overlap() {
+    const auto spans = trtmc::plan_canary_segments(120 * 16000, 16000, 30.0F, 20.0F, 2.0F);
+    check(spans.size() == 5, "Canary dynamic planner uses five windows for 120 seconds");
+    check(spans.front().offset == 0 && spans.back().offset + spans.back().count == 120 * 16000,
+          "Canary dynamic planner covers both input boundaries");
+    for (const auto& span : spans) {
+        check(span.count >= 20 * 16000 && span.count <= 30 * 16000,
+              "Canary dynamic planner keeps every window inside configured bounds");
+    }
+    for (std::size_t i = 1; i < spans.size(); ++i) {
+        check(spans[i].offset < spans[i - 1].offset + spans[i - 1].count,
+              "Canary dynamic planner overlaps adjacent windows");
+    }
+}
+
+void test_fixed_segments_preserve_short_tail_behavior() {
+    const auto spans = trtmc::plan_canary_segments(65 * 16000, 16000, 30.0F, 0.0F, 0.0F);
+    check(spans.size() == 3, "Canary fixed planner keeps three windows for 65 seconds");
+    check(spans[0].count == 30 * 16000 && spans[1].count == 30 * 16000 &&
+              spans[2].count == 5 * 16000,
+          "Canary fixed planner preserves the short tail window");
+}
+
+void test_lcs_merge_removes_overlapping_token_prefix() {
+    const std::vector<int32_t> left = {10, 11, 12, 13, 99};
+    const std::vector<int32_t> right = {12, 77, 13, 14, 15, 99};
+    const auto merged = trtmc::merge_canary_token_segments(left, right, 99);
+    check(merged == std::vector<int32_t>({10, 11, 12, 13, 14, 15, 99}),
+          "Canary LCS merge tolerates one disagreement inside the overlap");
+
+    const auto no_overlap = trtmc::merge_canary_token_segments({1, 2, 99}, {3, 4, 99}, 99);
+    check(no_overlap == std::vector<int32_t>({1, 2, 3, 4, 99}),
+          "Canary LCS merge concatenates when the boundary has no reliable match");
+
+    const std::vector<int32_t> sparse_left = {10, 1, 1,  1, 20, 2, 2, 2, 30, 3,
+                                              3,  3, 40, 4, 4,  4, 4, 4, 4,  50};
+    const std::vector<int32_t> sparse_right = {10, 5, 5,  5, 20, 6, 6, 6, 30, 7,
+                                               7,  7, 40, 8, 8,  8, 8, 8, 8,  50};
+    check(trtmc::merge_canary_lcs_boundary(sparse_left, sparse_right).empty(),
+          "Canary LCS merge rejects sparse matches across unrelated boundary text");
+
+    check(trtmc::merge_canary_text_segments("princípio da dialeticidade previsto.",
+                                            "de eletricidade previsto no artigo 1010.") ==
+              "princípio da dialeticidade previsto. no artigo 1010.",
+          "Canary text LCS keeps the better side of an imperfect word overlap");
+
+    const std::string repeated_left =
+        "42 processo 063 85 26 13 2021 806 000 50 mil embargo de declaracao civil recurso "
+        "conhecido e nao provido outro item comeca aqui";
+    const std::string repeated_right =
+        "50 mil embargo de declaracao civil recurso conhecido e nao provido 43 processo 53 22";
+    check(trtmc::merge_canary_text_segments(repeated_left, repeated_right) ==
+              repeated_left + " " + repeated_right,
+          "Canary text LCS rejects ambiguous repeated boilerplate");
+}
+
 } // namespace
 
 int main() {
@@ -227,6 +304,11 @@ int main() {
     test_beam_search_reports_prefill_failure();
     test_beam_search_reports_branch_advance_failure();
     test_beam_search_applies_default_length_normalization();
+    test_beam_output_budget_stops_before_cache_exhaustion();
+    test_beam_fallback_sizes_double_through_configured_limit();
+    test_dynamic_segments_cover_long_audio_with_balanced_overlap();
+    test_fixed_segments_preserve_short_tail_behavior();
+    test_lcs_merge_removes_overlapping_token_prefix();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " canary decode policy test(s) failed\n";

--- a/tests/cpp/models/canary/test_canary_host_plan.cpp
+++ b/tests/cpp/models/canary/test_canary_host_plan.cpp
@@ -129,7 +129,7 @@ void test_configurable_request_validation() {
     request.source_language = "de";
     check(rejects(request), "Canary rejects language absent from bundle metadata");
     request.source_language = "en";
-    request.beam_size = 17;
+    request.beam_size = 33;
     check(rejects(request), "Canary rejects beam size above supported bound");
     request.beam_size = 1;
     request.max_output_tokens = 65;
@@ -137,6 +137,21 @@ void test_configurable_request_validation() {
     request.max_output_tokens = 20;
     request.segment_duration_seconds = -1.0F;
     check(rejects(request), "Canary rejects negative segment duration");
+    request.segment_duration_seconds = 30.0F;
+    request.segment_min_duration_seconds = 20.0F;
+    request.segment_overlap_seconds = 2.0F;
+    request.lcs_merge = true;
+    request.beam_size = 4;
+    request.beam_fallback_max_size = 32;
+    check(!rejects(request), "Canary accepts customer dynamic segmentation controls");
+    request.length_penalty = -1.0F;
+    check(rejects(request), "Canary rejects negative beam length penalty");
+    request.length_penalty = 0.0F;
+    request.beam_fallback_max_size = 2;
+    check(rejects(request), "Canary rejects fallback below the initial beam size");
+    request.beam_fallback_max_size = 32;
+    request.segment_overlap_seconds = 0.0F;
+    check(rejects(request), "Canary rejects LCS merge without overlapping segments");
 }
 
 void test_mel_padding_and_truncation_are_row_major() {

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -203,7 +203,11 @@ void test_canary_transcription_flags_and_batch() {
                        "--audio",
                        "two.wav",
                        "--beam-size",
-                       "4",
+                       "32",
+                       "--beam-fallback-max-size",
+                       "32",
+                       "--length-penalty",
+                       "0",
                        "--source-language",
                        "en",
                        "--target-language",
@@ -215,11 +219,18 @@ void test_canary_transcription_flags_and_batch() {
                        "--max-input-seconds",
                        "45.5",
                        "--segment-length-seconds",
-                       "20"});
+                       "30",
+                       "--segment-min-seconds",
+                       "20",
+                       "--segment-overlap-seconds",
+                       "2",
+                       "--lcs-merge"});
     check(!args.parse_error, "Canary transcription controls parse");
     check(args.audio_inputs == std::vector<std::string>({"one.wav", "two.wav"}),
           "Canary repeated audio inputs form batch");
-    check(args.beam_size == 4, "Canary beam size");
+    check(args.beam_size == 32, "Canary beam size");
+    check(args.beam_fallback_max_size == 32, "Canary beam fallback limit");
+    check(args.length_penalty == 0.0F, "Canary beam length penalty");
     check(args.source_language == "en" && args.target_language == "fr",
           "Canary source and target languages");
     check(args.transcription_task == "translate", "Canary translation task");
@@ -227,11 +238,24 @@ void test_canary_transcription_flags_and_batch() {
     check(args.timestamps, "Canary timestamp toggle");
     check(args.max_input_seconds > 45.49F && args.max_input_seconds < 45.51F,
           "Canary maximum input seconds");
-    check(args.segment_length_seconds == 20.0F, "Canary segment length seconds");
+    check(args.segment_length_seconds == 30.0F, "Canary segment length seconds");
+    check(args.segment_min_seconds == 20.0F, "Canary dynamic segment minimum");
+    check(args.segment_overlap_seconds == 2.0F, "Canary segment overlap");
+    check(args.lcs_merge, "Canary LCS merge");
 
     check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--beam-size", "0"})
               .parse_error,
           "Canary rejects zero beam size");
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--beam-size", "33"})
+              .parse_error,
+          "Canary rejects beam size above 32");
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--beam-fallback-max-size",
+                 "33"})
+              .parse_error,
+          "Canary rejects beam fallback above 32");
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--length-penalty", "-1"})
+              .parse_error,
+          "Canary rejects negative length penalty");
     check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--task", "other"})
               .parse_error,
           "Canary rejects unknown task");


### PR DESCRIPTION
## Background

Canary decoding previously fixed beam length normalization at 1.0, limited
beam requests to 16, and split long audio into independent fixed windows.
That cannot represent deployments that use length penalty 0.0, balanced
20–30 second windows with overlap/LCS merging, and automatic beam fallback
through 32.

## Exit Criteria

- Expose the required decoding controls through both the C++ API and CLI.
- Preserve existing defaults for callers that do not opt in.
- Support complete long-audio transcription and an executable beam-32 path.
- Keep the customer-aligned L4 configuration within its latency target.

## Implementation

- Adds configurable beam length penalty and unterminated-decode fallback with
  a 4 → 8 → 16 → 32 schedule.
- Raises the supported Canary beam limit to 32 and bounds generated output by
  the fixed decoder-cache capacity.
- Adds balanced dynamic window planning, configurable overlap, and a guarded
  boundary LCS merge for tokens and rendered text.
- Threads the controls through single-request, batched, and CLI transcription.
  Batched fallback resumes at the next beam size instead of repeating the
  initial decode.
- Adds request validation and focused tests for CLI parsing, fallback
  scheduling, cache budgeting, dynamic coverage, fixed-window compatibility,
  and LCS safety.

## Validation

- `tmp_dir=$(mktemp -d)`: created an isolated host-test output directory.
- `g++ -std=c++17 -O2 -Iinclude -Isrc tests/cpp/models/canary/test_canary_decode_policy.cpp -o "$tmp_dir/test_canary_decode_policy"`:
  compiled successfully.
- `g++ -std=c++17 -O2 -Iinclude -Isrc tests/cpp/models/canary/test_canary_host_plan.cpp -o "$tmp_dir/test_canary_host_plan"`:
  compiled successfully.
- `g++ -std=c++17 -O2 -Iinclude -Isrc tests/cpp/test_cli_args.cpp src/cli/args.cpp -o "$tmp_dir/test_cli_args"`:
  compiled successfully.
- `"$tmp_dir/test_canary_decode_policy" && "$tmp_dir/test_canary_host_plan" && "$tmp_dir/test_cli_args"`:
  all host-only tests passed.
- `cmake --build build-customer -j 8 --target test_cli_args test_canary_host_plan test_canary_decode_policy test_canary_pipeline`:
  passed in the TRT 11.2.0.121 x86_64 L4 container.
- `./test_cli_args && ./test_canary_host_plan && ./test_canary_decode_policy && ./test_canary_pipeline`:
  all four targeted binaries passed in that container.
- `CI_BASE_REF=$(git rev-parse github/main) PATH=/tmp/canary-ci-venv/bin:$PATH /tmp/canary-ci-venv/bin/python -m tools.ci pipeline source-quality`:
  passed with maximum CCN 10, clean changed-file lint/formatting and
  architecture contracts, and 158 quality tests passing.
- L4 end-to-end run with beam 4, length penalty 0.0, balanced 20–30 second
  windows, 2-second overlap, guarded LCS, and fallback limit 32: all 20
  120-second files completed, mean latency was 5.065 seconds per file
  (1.266 seconds per 30-second equivalent), and no fallback was needed.
- Direct beam-32 smoke test: a real 120-second file completed successfully on
  the L4.
- `clang-format --dry-run --Werror include/trtmc/pipeline.h src/cli/args.cpp src/cli/args.h src/cli/main.cpp src/runtime/models/canary/canary_decode_policy.h src/runtime/models/canary/canary_request.h src/runtime/models/canary/canary_segment_utils.h src/runtime/models/canary/pipeline.cpp src/runtime/models/canary/pipeline.h tests/cpp/models/canary/test_canary_decode_policy.cpp tests/cpp/models/canary/test_canary_host_plan.cpp tests/cpp/test_cli_args.cpp`:
  passed.
- `git diff --check`: passed.

## Notes For Future Readers

- Review the public config surface first, then `canary_segment_utils.h`, then
  the pipeline threading and tests.
- The overlap value remains caller-configurable because the external
  deployment description specifies dynamic windows and LCS behavior but not a
  numeric overlap or an exact merge implementation.
- The private fine-tuned checkpoint was not available, so accuracy validation
  used the public `nvidia/canary-1b-v2` checkpoint. Full FP32 did not improve
  WER and was 1.73× slower on the largest-regression subset, so this change
  does not promote model layers to FP32.
