### PR TITLE
feat(qwen-vl): allow decomposed attention for split decode

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -38,6 +38,21 @@ if TYPE_CHECKING:
     from ...quantization.context import QuantContext
 
 
+def _decode_attention_backend(config: ModelConfig) -> str:
+    family_options = config.raw.get("_family_build_options", {})
+    if not isinstance(family_options, dict):
+        return "native"
+    decoder_options = family_options.get("qwen_vl_decoder", {})
+    if not isinstance(decoder_options, dict):
+        raise ValueError("qwen_vl_decoder build options must be an object")
+    backend = str(decoder_options.get("decode_attention", "native"))
+    if backend not in {"native", "decomposed"}:
+        raise ValueError(
+            "qwen_vl_decoder.decode_attention must be 'native' or "
+            f"'decomposed', got {backend!r}")
+    return backend
+
+
 def _mark_debug_output(
     network: trt.INetworkDefinition,
     tensor: trt.ITensor,
@@ -137,6 +152,13 @@ def build_standard_decoder_engine(
     active_split = bool(config.raw.get("_active_split_decoder_build", False))
     split_decode = (
         embed_input and active_split and decoder_engine_role == "decode")
+    decode_attention = _decode_attention_backend(config)
+    if (decode_attention == "decomposed"
+            and decoder_engine_role != "prefill"
+            and not split_decode):
+        raise ValueError(
+            "qwen_vl_decoder.decode_attention=decomposed requires "
+            "--decoder-engine-layout split")
     # Preserve the historical dual-profile fallback when the generic builder
     # rejects a requested split layout. During an active Qwen-VL split build,
     # compile a decode-only profile instead.
@@ -161,6 +183,8 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             embed_input=embed_input,
             verbose=verbose,
+            force_decomposed_attention=(
+                split_decode and decode_attention == "decomposed"),
             profile_mode=(
                 "prefill" if decoder_engine_role == "prefill"
                 else "decode" if split_decode

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -165,6 +165,7 @@ def build_dual_profile_decoder_engine(
     embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    force_decomposed_attention: bool = False,
     profile_mode: str = "dual_profile",
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
@@ -177,6 +178,9 @@ def build_dual_profile_decoder_engine(
     ``quant_ctx`` (optional) routes every projection matmul through
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
+
+    ``force_decomposed_attention`` replaces native ``IAttention`` with an
+    explicit FP32-score QK/softmax/V graph.
 
     ``profile_mode`` controls which optimization profiles are emitted:
 
@@ -594,7 +598,9 @@ def build_dual_profile_decoder_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+            scale=attn_scale,
+            force_decomposed_attention=force_decomposed_attention,
+            tag=f"{prefix}.attn")
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -1520,6 +1520,7 @@ def add_attention_from_rows(
     scale: float | None = None,
     logit_softcap: float | None = None,
     fp32_accumulation: bool = False,
+    force_decomposed_attention: bool = False,
     tag: str | None = None,
 ) -> trt.ITensor:
     """Native IAttention for row-major [S, H * D] Q/K/V tensors.
@@ -1542,7 +1543,8 @@ def add_attention_from_rows(
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
     use_decomposed_attention = (
-        logit_softcap is not None and float(logit_softcap) > 0.0)
+        force_decomposed_attention
+        or (logit_softcap is not None and float(logit_softcap) > 0.0))
     if use_decomposed_attention:
         if causal:
             raise NotImplementedError(

--- a/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
@@ -13,6 +13,19 @@ from tensorrt_model_connect.runtime_config import ConfigField, Layer, Schema, re
 _BUILD = frozenset({Layer.BUILD_TIME, Layer.BUNDLE_DEFAULT, Layer.SESSION_REQUEST})
 
 
+DECODER_SCHEMA = Schema(
+    namespace="qwen_vl_decoder",
+    fields=(
+        ConfigField(
+            name="decode_attention",
+            type_tag="string",
+            default="native",
+            allowed_layers=_BUILD,
+            validator=lambda value: value in {"native", "decomposed"},
+        ),
+    ),
+)
+
 LORA_SCHEMA = Schema(
     namespace="qwen_vl_lora",
     fields=(
@@ -86,5 +99,6 @@ VISION_SCHEMA = Schema(
 )
 
 
+register_schema(DECODER_SCHEMA)
 register_schema(LORA_SCHEMA)
 register_schema(VISION_SCHEMA)

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -116,6 +116,9 @@ def test_qwen25_vl_split_decode_uses_decode_profile(monkeypatch) -> None:
     config = _config(qwen3=False)
     config.raw["_decoder_engine_role"] = "decode"
     config.raw["_active_split_decoder_build"] = True
+    config.raw["_family_build_options"] = {
+        "qwen_vl_decoder": {"decode_attention": "decomposed"},
+    }
     assert plugin.supports_split_embed_input is True
     assert plugin.supports_split_decoder_roles(config) is True
     result = module.build_standard_decoder_engine(
@@ -123,6 +126,7 @@ def test_qwen25_vl_split_decode_uses_decode_profile(monkeypatch) -> None:
 
     assert result == b"qwen-vl-dual-profile-plan"
     assert calls["build"][3]["embed_input"] is True
+    assert calls["build"][3]["force_decomposed_attention"] is True
     assert calls["build"][3]["profile_mode"] == "decode"
 
 


### PR DESCRIPTION
 ## Summary

  - add `qwen_vl_decoder.decode_attention` with `native` and `decomposed` options
  - apply decomposed FP32-score attention only to the split decode engine
  - keep native attention as the default
  - require split layout when decomposed decode is selected