### PR TITLE
fix(qwen-vl): restore Qwen2.5-VL and Qwen3-VL accuracy parity

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/config.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/config.py
@@ -10,6 +10,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+def get_rope_scaling(raw: dict) -> dict:
+    """Return decoder RoPE settings from flat or multimodal HF configs."""
+    rope_scaling = raw.get("rope_scaling")
+    if isinstance(rope_scaling, dict):
+        return rope_scaling
+
+    for key in ("text_config", "language_config", "llm_config"):
+        nested = raw.get(key)
+        if not isinstance(nested, dict):
+            continue
+        rope_scaling = nested.get("rope_scaling")
+        if isinstance(rope_scaling, dict):
+            return rope_scaling
+
+    thinker = raw.get("thinker_config")
+    if isinstance(thinker, dict):
+        nested = thinker.get("text_config")
+        if isinstance(nested, dict):
+            rope_scaling = nested.get("rope_scaling")
+            if isinstance(rope_scaling, dict):
+                return rope_scaling
+    return {}
+
+
 @dataclass
 class ModelConfig:
     """Parsed model architecture from HF config.json."""

--- a/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
@@ -6,7 +6,7 @@
 This mirrors the single-device Qwen-VL decoder paths while adding only tensor
 parallel projection sharding and distributed ALL_REDUCE joins. It keeps the VL
 ``input_embed`` override used by Qwen2.5-VL and optionally injects Qwen3-VL
-DeepStack features after attention residuals.
+DeepStack features after complete decoder layers.
 """
 
 from __future__ import annotations
@@ -387,20 +387,6 @@ def _add_tp_decoder_layer(
     else:
         residual1 = network.add_elementwise(
             hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
-        if deepstack_embed is not None and deepstack_active is not None:
-            ds_active_broadcast = network.add_shuffle(deepstack_active)
-            ds_active_broadcast.reshape_dims = (1, 1)
-            active = ds_active_broadcast.get_output(0)
-            deepstack_for_math = deepstack_embed
-            if deepstack_for_math.dtype != residual1.dtype:
-                deepstack_for_math = network.add_cast(
-                    deepstack_for_math, residual1.dtype).get_output(0)
-            if active.dtype != deepstack_for_math.dtype:
-                active = network.add_cast(active, deepstack_for_math.dtype).get_output(0)
-            ds_scaled = network.add_elementwise(
-                deepstack_for_math, active, trt.ElementWiseOperation.PROD).get_output(0)
-            residual1 = network.add_elementwise(
-                residual1, ds_scaled, trt.ElementWiseOperation.SUM).get_output(0)
         norm2 = _apply_norm(
             network, residual1, hidden_size,
             weights[f"{prefix}.post_attn_norm"],
@@ -423,6 +409,23 @@ def _add_tp_decoder_layer(
         residual2 = network.add_elementwise(
             residual1, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
         post_attn_tensor = residual1
+
+    if deepstack_embed is not None and deepstack_active is not None:
+        ds_active_broadcast = network.add_shuffle(deepstack_active)
+        ds_active_broadcast.reshape_dims = (1, 1)
+        active = ds_active_broadcast.get_output(0)
+        deepstack_for_math = deepstack_embed
+        if deepstack_for_math.dtype != residual2.dtype:
+            deepstack_for_math = network.add_cast(
+                deepstack_for_math, residual2.dtype).get_output(0)
+        if active.dtype != deepstack_for_math.dtype:
+            active = network.add_cast(
+                active, deepstack_for_math.dtype).get_output(0)
+        ds_scaled = network.add_elementwise(
+            deepstack_for_math, active,
+            trt.ElementWiseOperation.PROD).get_output(0)
+        residual2 = network.add_elementwise(
+            residual2, ds_scaled, trt.ElementWiseOperation.SUM).get_output(0)
 
     return {
         "hidden": residual2,

--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -26,7 +26,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
-from .config import ModelConfig
+from .config import ModelConfig, get_rope_scaling
 from .default_dual_profile_decoder import build_dual_profile_decoder_engine
 from .lora import DynamicLoraConfig
 from .utils import const_in_work_dtype, create_builder_context
@@ -232,7 +232,7 @@ def build_standard_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
     dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
-    rope_scaling = config.raw.get("rope_scaling") or {}
+    rope_scaling = get_rope_scaling(config.raw)
     raw_mrope_section = (
         rope_scaling.get("mrope_section")
         if isinstance(rope_scaling, dict) else None)

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -50,6 +50,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
+from .config import get_rope_scaling
 from .lora import DynamicLoraConfig
 from .utils import (
     const_in_work_dtype as _const_in_work_dtype,
@@ -240,7 +241,7 @@ def build_dual_profile_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
     lora_config = DynamicLoraConfig.from_model_config(config)
-    rope_scaling = config.raw.get("rope_scaling") or {}
+    rope_scaling = get_rope_scaling(config.raw)
     raw_mrope_section = (
         rope_scaling.get("mrope_section")
         if isinstance(rope_scaling, dict) else None)

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
@@ -388,11 +388,9 @@ def add_swiglu_mlp(
     up = matmul(inp, hidden_size, mlp_size,
                 weights[f"{prefix}.w_up"], f"{_lp}.w_up")
 
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    swish_output = graph_ops.add_silu(network, gate)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        swish_output, up, trt.ElementWiseOperation.PROD)
 
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden_size,
                      weights[f"{prefix}.w_down"], f"{_lp}.w_down")

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
@@ -174,6 +174,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     mrope_position_ids: trt.ITensor | None = None,
     mrope_section: tuple[int, int, int] | None = None,
+    mrope_interleaved: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     sequence_length: int | None = 1,
@@ -252,17 +253,21 @@ def add_attention_block(
         rope_dim = rotary_embedding_dim or head_dim
         rope_dim = graph_ops.validate_native_rope_dim(rope_dim)
         if mrope_position_ids is not None and mrope_section is not None:
-            if sequence_length != 1:
-                raise NotImplementedError(
-                    "graph_blocks mRoPE currently supports single-token execution")
-            q = graph_ops.add_apply_mrope_native(
+            apply_mrope = (
+                graph_ops.add_apply_mrope_native
+                if sequence_length == 1
+                else graph_ops.add_apply_mrope_native_sequence
+            )
+            q = apply_mrope(
                 network, q, num_heads, head_dim,
                 cos_half_tensor, sin_half_tensor, mrope_position_ids,
-                mrope_section, rope_dim, interleaved_rope)
-            k = graph_ops.add_apply_mrope_native(
+                mrope_section, rope_dim, interleaved_rope,
+                mrope_interleaved)
+            k = apply_mrope(
                 network, k, num_kv_heads, head_dim,
                 cos_half_tensor, sin_half_tensor, mrope_position_ids,
-                mrope_section, rope_dim, interleaved_rope)
+                mrope_section, rope_dim, interleaved_rope,
+                mrope_interleaved)
         else:
             q = graph_ops.add_apply_rope_native(
                 network, q, num_heads, head_dim,

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -1215,7 +1215,6 @@ def add_apply_mrope_native(
     interleaved: bool = False,
     mrope_interleaved: bool = False,
 ) -> trt.ITensor:
-    """Apply Qwen2.5-VL temporal/height/width RoPE to one token."""
     rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
     sections = _validate_mrope_sections(
         mrope_section, rotary_embedding_dim, mrope_interleaved)

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -309,12 +309,18 @@ def add_gelu_new(
     fp16, runtime trt_dtype is bfloat16) or any other non-matching combo.
     """
     target_dtype = inp.dtype
+    fp32_compute = target_dtype == trt.bfloat16
+    if fp32_compute:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+    compute_dtype = inp.dtype
+    constant_np_dtype = np.float32 if fp32_compute else dtype
     const_shape = (1,) * max(1, len(tuple(inp.shape)))
 
     def _const(name, value):
         c = add_constant(
-            network, const_shape, np.array([value], dtype=np.float32), dtype=dtype)
-        return _cast_back_to_trt_dtype(network, c, target_dtype)
+            network, const_shape, np.array([value], dtype=np.float32),
+            dtype=constant_np_dtype)
+        return _cast_back_to_trt_dtype(network, c, compute_dtype)
 
     # x^3
     x_sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
@@ -347,7 +353,8 @@ def add_gelu_new(
     result = network.add_elementwise(
         half_x.get_output(0), one_plus_tanh.get_output(0),
         trt.ElementWiseOperation.PROD)
-    return result.get_output(0)
+    return _cast_back_to_trt_dtype(
+        network, result.get_output(0), target_dtype)
 
 
 def add_activation(
@@ -369,12 +376,31 @@ def add_activation(
             trt.ElementWiseOperation.PROD)
         return sq.get_output(0)
     elif activation_type == "silu":
-        sigmoid = network.add_activation(inp, trt.ActivationType.SIGMOID)
-        swish = network.add_elementwise(
-            inp, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
-        return swish.get_output(0)
+        return add_silu(network, inp)
     else:
         raise ValueError(f"Unsupported activation: {activation_type}")
+
+
+def add_silu(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+) -> trt.ITensor:
+    """Apply SiLU with the same BF16 precision boundary as PyTorch.
+
+    PyTorch evaluates the sigmoid/product in FP32 for a BF16 input, then
+    publishes the activation back in BF16 before any following operation.
+    """
+    target_dtype = inp.dtype
+    activation_input = inp
+    if target_dtype == trt.bfloat16:
+        activation_input = network.add_cast(
+            inp, trt.float32).get_output(0)
+    sigmoid = network.add_activation(
+        activation_input, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        activation_input, sigmoid.get_output(0),
+        trt.ElementWiseOperation.PROD).get_output(0)
+    return _cast_back_to_trt_dtype(network, swish, target_dtype)
 
 
 def compute_alibi_slopes(num_heads: int) -> np.ndarray:
@@ -776,20 +802,48 @@ def add_patch_embed_3d(
         # [T, C, H, W] -> [1, T*C, H, W]
         reshape_in.reshape_dims = (1, temporal_patch_size * in_channels, -1, 0)
 
-    # Conv2D with kernel [embed_dim, T*C, patch_size, patch_size]
-    # weight shape from HF: [embed_dim, T*C, patch_size, patch_size]
-    conv_w = trt.Weights(np.ascontiguousarray(weight, dtype=dtype))
-    conv_b = trt.Weights()
-    if bias is not None:
-        conv_b = trt.Weights(np.ascontiguousarray(bias, dtype=dtype))
-
-    conv = network.add_convolution_nd(
-        reshape_in.get_output(0),
-        num_output_maps=embed_dim,
-        kernel_shape=(patch_size, patch_size),
-        kernel=conv_w,
-        bias=conv_b,
+    # Conv2D with kernel [embed_dim, T*C, patch_size, patch_size].
+    # Static convolution weights cannot express BF16 through NumPy. For a
+    # BF16 input, bind FP16-backed constants as tensor inputs and cast them to
+    # BF16 first, preserving the same runtime rounding boundary as HF.
+    conv_input = reshape_in.get_output(0)
+    conv_weight = np.asarray(weight).reshape(
+        embed_dim,
+        temporal_patch_size * in_channels,
+        patch_size,
+        patch_size,
     )
+    if conv_input.dtype == trt.bfloat16:
+        weight_t = add_constant(
+            network, tuple(conv_weight.shape), conv_weight, dtype=dtype)
+        weight_t = network.add_cast(
+            weight_t, trt.bfloat16).get_output(0)
+        conv = network.add_convolution_nd(
+            conv_input,
+            num_output_maps=embed_dim,
+            kernel_shape=(patch_size, patch_size),
+            kernel=trt.Weights(),
+            bias=trt.Weights(),
+        )
+        conv.set_input(1, weight_t)
+        if bias is not None:
+            bias_t = add_constant(
+                network, (embed_dim,), bias, dtype=dtype)
+            bias_t = network.add_cast(
+                bias_t, trt.bfloat16).get_output(0)
+            conv.set_input(2, bias_t)
+    else:
+        conv_w = trt.Weights(np.ascontiguousarray(conv_weight, dtype=dtype))
+        conv_b = trt.Weights()
+        if bias is not None:
+            conv_b = trt.Weights(np.ascontiguousarray(bias, dtype=dtype))
+        conv = network.add_convolution_nd(
+            conv_input,
+            num_output_maps=embed_dim,
+            kernel_shape=(patch_size, patch_size),
+            kernel=conv_w,
+            bias=conv_b,
+        )
     conv.stride_nd = (patch_size, patch_size)
 
     # Output shape: [1, embed_dim, H', W'] -> flatten to [num_patches, embed_dim]
@@ -1188,6 +1242,19 @@ def add_apply_rope_native_sequence(
 ) -> trt.ITensor:
     """Apply native RoPE with per-position caches [1, Sq, rotary_dim / 2]."""
     rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    output_dtype = inp.dtype
+    # HF Qwen-VL explicitly promotes Q/K and the rotary tables to FP32 for
+    # the multiply/add sequence, then publishes BF16 Q/K to attention.
+    # TensorRT's BF16 rotary intrinsic otherwise rounds each internal op at a
+    # different boundary and can flip close vision-language logits.
+    compute_dtype = (
+        trt.float32 if output_dtype == trt.bfloat16 else output_dtype)
+    if inp.dtype != compute_dtype:
+        inp = network.add_cast(inp, compute_dtype).get_output(0)
+    cos_cache_3d = _cast_back_to_trt_dtype(
+        network, cos_cache_3d, compute_dtype)
+    sin_cache_3d = _cast_back_to_trt_dtype(
+        network, sin_cache_3d, compute_dtype)
     attention_size = num_heads * head_dim
     inp_4d = reshape_rows_to_heads_4d(
         network, inp, num_heads, head_dim, sequence_length)
@@ -1198,8 +1265,9 @@ def add_apply_rope_native_sequence(
         interleaved,
         rotary_embedding_dim,
     )
-    return reshape_heads_4d_to_rows(
+    output = reshape_heads_4d_to_rows(
         network, rope.get_output(0), attention_size, sequence_length)
+    return _cast_back_to_trt_dtype(network, output, output_dtype)
 
 
 def add_apply_mrope_native(

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -1213,19 +1213,18 @@ def add_apply_mrope_native(
     mrope_section: tuple[int, int, int],
     rotary_embedding_dim: int,
     interleaved: bool = False,
+    mrope_interleaved: bool = False,
 ) -> trt.ITensor:
     """Apply Qwen2.5-VL temporal/height/width RoPE to one token."""
     rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
-    sections = tuple(int(value) for value in mrope_section)
-    if len(sections) != 3 or any(value <= 0 for value in sections):
-        raise ValueError("mrope_section must contain three positive integers")
-    if sum(sections) != rotary_embedding_dim // 2:
-        raise ValueError(
-            "mrope_section must sum to half the rotary embedding dimension; "
-            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+    sections = _validate_mrope_sections(
+        mrope_section, rotary_embedding_dim, mrope_interleaved)
 
     def build_cache(cache: trt.ITensor) -> trt.ITensor:
         selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        if mrope_interleaved:
+            return _select_interleaved_mrope_columns(
+                network, selected, sections, rotary_embedding_dim)
         offset = 0
         parts = []
         for axis, width in enumerate(sections):
@@ -1256,20 +1255,24 @@ def add_apply_mrope_native_sequence(
     mrope_section: tuple[int, int, int],
     rotary_embedding_dim: int,
     interleaved: bool = False,
+    mrope_interleaved: bool = False,
 ) -> trt.ITensor:
-    """Apply Qwen2.5-VL mRoPE to a runtime-dynamic token sequence."""
+    """Apply Qwen-VL mRoPE to a runtime-dynamic token sequence.
+
+    ``interleaved`` controls the native RoPE pair layout.  Qwen models use
+    rotate-half, so it normally remains false.  ``mrope_interleaved`` is a
+    separate Qwen3-VL contract: it interleaves the temporal/height/width
+    *frequency columns* while still applying rotate-half RoPE.
+    """
     rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
-    sections = tuple(int(value) for value in mrope_section)
-    if len(sections) != 3 or any(value <= 0 for value in sections):
-        raise ValueError("mrope_section must contain three positive integers")
-    half_dim = rotary_embedding_dim // 2
-    if sum(sections) != half_dim:
-        raise ValueError(
-            "mrope_section must sum to half the rotary embedding dimension; "
-            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+    sections = _validate_mrope_sections(
+        mrope_section, rotary_embedding_dim, mrope_interleaved)
 
     def build_cache(cache: trt.ITensor) -> trt.ITensor:
         selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        if mrope_interleaved:
+            return _select_interleaved_mrope_columns(
+                network, selected, sections, rotary_embedding_dim)
         offset = 0
         parts = []
         for axis, width in enumerate(sections):
@@ -1290,6 +1293,90 @@ def add_apply_mrope_native_sequence(
         network, inp, num_heads, head_dim,
         build_cache(cos_cache_2d), build_cache(sin_cache_2d),
         rotary_embedding_dim, interleaved, sequence_length=None)
+
+
+def mrope_frequency_axis_map(
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    *,
+    interleaved: bool,
+) -> np.ndarray:
+    """Return the T/H/W source axis for every half-dimension frequency.
+
+    Qwen2.5-VL uses contiguous ``[T... H... W...]`` sections.  Qwen3-VL's
+    ``mrope_interleaved`` flag instead uses ``[T H W T H W ... T-tail]``.
+    This is intentionally independent from TensorRT's native ``interleaved``
+    RoPE flag, which selects adjacent-pair rather than rotate-half RoPE.
+    """
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    sections = tuple(int(value) for value in mrope_section)
+    if len(sections) != 3 or any(value <= 0 for value in sections):
+        raise ValueError("mrope_section must contain three positive integers")
+    half_dim = rotary_embedding_dim // 2
+    if sum(sections) != half_dim:
+        raise ValueError(
+            "mrope_section must sum to half the rotary embedding dimension; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+    if not interleaved:
+        return np.repeat(np.arange(3, dtype=np.int32), sections)
+
+    axes = np.zeros(half_dim, dtype=np.int32)
+    for axis in (1, 2):
+        columns = np.arange(axis, sections[axis] * 3, 3, dtype=np.int32)
+        if len(columns) != sections[axis] or (
+                len(columns) > 0 and int(columns[-1]) >= half_dim):
+            raise ValueError(
+                "interleaved mrope_section cannot be represented within half "
+                f"the rotary dimension; got {sections} for rotary dimension "
+                f"{rotary_embedding_dim}")
+        axes[columns] = axis
+    if int(np.count_nonzero(axes == 0)) != sections[0]:
+        raise ValueError(
+            "interleaved mrope_section leaves the wrong temporal tail width; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+    return axes
+
+
+def _validate_mrope_sections(
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    interleaved: bool,
+) -> tuple[int, int, int]:
+    sections = tuple(int(value) for value in mrope_section)
+    # Build the axis map here as the single validation source for both cache
+    # layouts.  In particular, this validates Qwen3-VL's temporal tail.
+    mrope_frequency_axis_map(
+        sections, rotary_embedding_dim, interleaved=interleaved)
+    return sections
+
+
+def _select_interleaved_mrope_columns(
+    network: trt.INetworkDefinition,
+    selected: trt.ITensor,
+    sections: tuple[int, int, int],
+    rotary_embedding_dim: int,
+) -> trt.ITensor:
+    """Select Qwen3-VL T/H/W columns from ``selected`` shaped [3, Sq, D/2]."""
+    axes = mrope_frequency_axis_map(
+        sections, rotary_embedding_dim, interleaved=True)
+    axis_values = []
+    for axis in range(3):
+        axis_index = add_constant(
+            network, (1,), np.array([axis], dtype=np.int32), dtype=np.int32)
+        axis_values.append(
+            network.add_gather(selected, axis_index, 0).get_output(0))
+
+    result = axis_values[0]
+    for axis in (1, 2):
+        mask = add_constant(
+            network,
+            (1, 1, len(axes)),
+            np.asarray(axes == axis, dtype=np.bool_),
+            dtype=np.bool_,
+        )
+        result = network.add_select(
+            mask, axis_values[axis], result).get_output(0)
+    return result
 
 
 def add_attention_core(

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -59,6 +59,22 @@ def _is_qwen3_vl(config: ModelConfig) -> bool:
     return bool(vc.get("deepstack_visual_indexes"))
 
 
+def _add_nan_safe_deepstack_gate(
+    network: trt.INetworkDefinition,
+    deepstack_embed: trt.ITensor,
+    active: trt.ITensor,
+) -> trt.ITensor:
+    """Hard-zero an inactive DeepStack input without propagating NaNs."""
+    zero = graph_ops.add_constant(
+        network, (1, 1), np.zeros((1, 1), dtype=np.float32),
+        dtype=np.float32)
+    if zero.dtype != active.dtype:
+        zero = network.add_cast(zero, active.dtype).get_output(0)
+    condition = network.add_elementwise(
+        active, zero, trt.ElementWiseOperation.GREATER).get_output(0)
+    return network.add_select(condition, deepstack_embed, zero).get_output(0)
+
+
 def _fixed_image_dimensions(config: ModelConfig) -> tuple[int, int]:
     """Resolve and validate the fixed Qwen-VL vision profile dimensions."""
     family_options = config.raw.get("_family_build_options", {})
@@ -793,22 +809,8 @@ def _build_qwen3_vl_decoder(
                 fp32_ds_embed_inputs[layer_idx]
                 if layer_is_fp32 else ds_embed_inputs[layer_idx])
             assert layer_ds_active is not None
-            # NaN-safe gate: select(active > 0, deepstack_embed, 0) instead of
-            # deepstack_embed * active. On text/decode steps the embed buffer can
-            # carry uninitialized/NaN residue; a plain multiply propagates it as
-            # NaN * 0 = NaN and poisons every logit. The hard-zero branch keeps
-            # the inactive contribution exactly 0 regardless of the buffer.
-            ds_zero = graph_ops.add_constant(
-                network, (1, 1), np.zeros((1, 1), dtype=np.float32),
-                dtype=np.float32)
-            if ds_zero.dtype != layer_ds_active.dtype:
-                ds_zero = network.add_cast(
-                    ds_zero, layer_ds_active.dtype).get_output(0)
-            ds_cond = network.add_elementwise(
-                layer_ds_active, ds_zero,
-                trt.ElementWiseOperation.GREATER).get_output(0)
-            ds_gated = network.add_select(
-                ds_cond, layer_ds_embed, ds_zero).get_output(0)
+            ds_gated = _add_nan_safe_deepstack_gate(
+                network, layer_ds_embed, layer_ds_active)
             post_attn_ds = network.add_elementwise(
                 post_attn, ds_gated, trt.ElementWiseOperation.SUM)
             post_attn = post_attn_ds.get_output(0)

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -583,6 +583,19 @@ def _build_qwen3_vl_decoder(
     head_dim = attention_size // num_heads
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    rope_scaling = config.raw.get("rope_scaling") or {}
+    raw_mrope_section = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict) else None)
+    mrope_section = (
+        tuple(int(value) for value in raw_mrope_section)
+        if raw_mrope_section is not None else None)
+    mrope_interleaved = bool(
+        rope_scaling.get("mrope_interleaved", False)
+        if isinstance(rope_scaling, dict) else False)
+    if mrope_section is not None:
+        graph_ops.mrope_frequency_axis_map(
+            mrope_section, head_dim, interleaved=mrope_interleaved)
     attention_window = max_cache_length + 1
     opt_prefill_length = min(64, max_cache_length)
 
@@ -595,6 +608,9 @@ def _build_qwen3_vl_decoder(
     # --- Inputs ---
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
+    mrope_position_ids = (
+        network.add_input("mrope_position_ids", trt.int32, (3, -1))
+        if mrope_section is not None else None)
     attention_mask = network.add_input(
         "attention_mask", trt.float32, (-1, -1))
 
@@ -634,6 +650,10 @@ def _build_qwen3_vl_decoder(
         min_sq = opt_sq if fixed else 1
         profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        if mrope_position_ids is not None:
+            profile.set_shape(
+                "mrope_position_ids",
+                (3, min_sq), (3, opt_sq), (3, max_sq))
         profile.set_shape(
             "attention_mask",
             (min_sq, max_cache_length + min_sq),
@@ -790,6 +810,9 @@ def _build_qwen3_vl_decoder(
             dtype=layer_np_dtype,
             quant_ctx=quant_ctx,
             sequence_length=None,
+            mrope_position_ids=mrope_position_ids,
+            mrope_section=mrope_section,
+            mrope_interleaved=mrope_interleaved,
         )
 
         attn_out = attn["attn_out"]

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -315,6 +315,26 @@ class QwenVLPlugin:
                 if fixed_h != fixed_w else "merge_group_chw"
             )
 
+        if _is_qwen3_vl(config):
+            # Qwen3-VL's checkpoint chat template has no default system turn.
+            # Keep the image placeholder before user text exactly as rendered
+            # by AutoProcessor so visual positions and text tokens agree.
+            prompt_template = (
+                "<|im_start|>user\n"
+                "<|vision_start|>{image_pads}<|vision_end|>{prompt}<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            )
+        else:
+            # Qwen2.5-VL includes the default system turn, then places the
+            # image placeholder before the user text.
+            prompt_template = (
+                "<|im_start|>system\n"
+                "You are a helpful assistant.<|im_end|>\n"
+                "<|im_start|>user\n"
+                "<|vision_start|>{image_pads}<|vision_end|>{prompt}<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            )
+
         vl_cfg = {
             "image_token_id": 151655,
             "fixed_image_size": _DEFAULT_FIXED_IMAGE_SIZE,
@@ -324,13 +344,7 @@ class QwenVLPlugin:
             "dynamic_image_resolution": dynamic_resolution,
             "vision_output_dim": config.hidden_size,
             "preprocessor_type": preproc,
-            "vl_prompt_template": (
-                "<|im_start|>system\n"
-                "You are a helpful assistant.<|im_end|>\n"
-                "<|im_start|>user\n"
-                "{prompt}<|vision_start|>{image_pads}<|vision_end|><|im_end|>\n"
-                "<|im_start|>assistant\n"
-            ),
+            "vl_prompt_template": prompt_template,
             "image_token_str": "<|image_pad|>",
         }
 

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
-from .config import ModelConfig
+from .config import ModelConfig, get_rope_scaling
 from .checkpoint_mapper import (
     WeightDict,
     load_standard_weights,
@@ -236,11 +236,9 @@ class QwenVLPlugin:
             for index in selected_fp32
             if index >= _VISION_LAYER_OFFSET
         }
-        # The vision tower is a separate, unquantized engine at a fixed
-        # precision and does not follow the decoder's bf16 work dtype (it has no
-        # bf16 path). Keep it at fp32 for a bf16 decoder — matching the deployed
-        # baseline, where the ViT is not affected by --precision.
-        if precision == "bf16":
+        # Qwen2.5-VL's vision tower has no BF16 path; Qwen3-VL does and must
+        # follow the decoder BF16 precision contract.
+        if precision == "bf16" and not _is_qwen3_vl(config):
             vision_precision = "fp32"
         elif precision == "fp16" and _VISION_COMPONENT in selected_fp32:
             vision_precision = "fp32"
@@ -552,8 +550,9 @@ def _build_qwen3_vl_decoder(
     """Build Qwen3-VL text decoder with DeepStack injection.
 
     Uses graph_blocks composition instead of standard_decoder_builder so
-    that DeepStack embeddings can be injected between attention and MLP
-    at the first N layers (where N = deepstack_num_levels).
+    that DeepStack embeddings can be injected after each of the first N
+    complete decoder layers (where N = deepstack_num_levels), matching the
+    Hugging Face Qwen3-VL text-model forward order.
 
     Extra engine inputs (when deepstack_num_levels > 0):
       - deepstack_embed_0..N: [Sq, hidden] per-level embeddings
@@ -597,7 +596,7 @@ def _build_qwen3_vl_decoder(
     head_dim = attention_size // num_heads
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
-    rope_scaling = config.raw.get("rope_scaling") or {}
+    rope_scaling = get_rope_scaling(config.raw)
     raw_mrope_section = (
         rope_scaling.get("mrope_section")
         if isinstance(rope_scaling, dict) else None)
@@ -838,20 +837,6 @@ def _build_qwen3_vl_decoder(
             layer_hidden, attn_out, trt.ElementWiseOperation.SUM)
         post_attn = residual1.get_output(0)
 
-        # DeepStack injection: add visual features after attention residual
-        if layer_idx < deepstack_num_levels and ds_active_tensor is not None:
-            layer_ds_active = (
-                fp32_ds_active_tensor if layer_is_fp32 else ds_active_tensor)
-            layer_ds_embed = (
-                fp32_ds_embed_inputs[layer_idx]
-                if layer_is_fp32 else ds_embed_inputs[layer_idx])
-            assert layer_ds_active is not None
-            ds_gated = _add_nan_safe_deepstack_gate(
-                network, layer_ds_embed, layer_ds_active)
-            post_attn_ds = network.add_elementwise(
-                post_attn, ds_gated, trt.ElementWiseOperation.SUM)
-            post_attn = post_attn_ds.get_output(0)
-
         # Post-attention norm
         norm2 = graph_blocks.apply_norm(
             network, post_attn, hidden,
@@ -870,6 +855,22 @@ def _build_qwen3_vl_decoder(
             post_attn, mlp_out, trt.ElementWiseOperation.SUM)
         hidden_state = graph_blocks.cast_to_dtype(
             network, residual2.get_output(0), work_trt_dtype)
+
+        # Hugging Face applies DeepStack after the complete decoder layer,
+        # including the MLP residual, before passing state to the next layer.
+        if layer_idx < deepstack_num_levels and ds_active_tensor is not None:
+            layer_ds_active = (
+                fp32_ds_active_tensor if layer_is_fp32 else ds_active_tensor)
+            layer_ds_embed = (
+                fp32_ds_embed_inputs[layer_idx]
+                if layer_is_fp32 else ds_embed_inputs[layer_idx])
+            assert layer_ds_active is not None
+            ds_gated = _add_nan_safe_deepstack_gate(
+                network, layer_ds_embed, layer_ds_active)
+            deepstack_sum = network.add_elementwise(
+                hidden_state, ds_gated, trt.ElementWiseOperation.SUM)
+            hidden_state = graph_blocks.cast_to_dtype(
+                network, deepstack_sum.get_output(0), work_trt_dtype)
 
         if debug_layer_outputs:
             _mark_debug_output(network, residual1.get_output(0),

--- a/python/tensorrt_model_connect/families/qwen_vl/qwen_vl_vision_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/qwen_vl_vision_builder.py
@@ -37,6 +37,32 @@ if TYPE_CHECKING:
     from .checkpoint_mapper import WeightDict
 
 
+def _round_float32_to_bf16(values: np.ndarray) -> np.ndarray:
+    """Round FP32 values to BF16 while retaining NumPy FP32 storage."""
+    values = np.ascontiguousarray(values, dtype=np.float32)
+    bits = values.view(np.uint32)
+    rounded = bits + np.uint32(0x7FFF) + ((bits >> 16) & 1)
+    return (rounded & np.uint32(0xFFFF0000)).view(np.float32)
+
+
+def _interpolate_qwen3_position_bf16(
+    position_embeddings: np.ndarray,
+    positions: tuple[int, int, int, int],
+    blend_weights: tuple[float, float, float, float],
+) -> np.ndarray:
+    """Match HF's four BF16 multiplies and left-to-right BF16 additions."""
+    rounded_weights = _round_float32_to_bf16(
+        np.asarray(blend_weights, dtype=np.float32))
+    terms = [
+        _round_float32_to_bf16(
+            _round_float32_to_bf16(position_embeddings[position]) * weight)
+        for position, weight in zip(positions, rounded_weights)
+    ]
+    interpolated = _round_float32_to_bf16(terms[0] + terms[1])
+    interpolated = _round_float32_to_bf16(interpolated + terms[2])
+    return _round_float32_to_bf16(interpolated + terms[3])
+
+
 # ---------------------------------------------------------------------------
 # Vision RoPE + window index (exact port of HF Qwen2.5-VL)
 # ---------------------------------------------------------------------------
@@ -845,11 +871,16 @@ def build_qwen3_vl_vision_engine(
     requested_fp32_layers = {int(index) for index in (fp32_layers or set())}
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
+    elif precision == "bf16":
+        # NumPy has no native BF16. Store checkpoint constants in FP16 and
+        # explicitly cast them to TensorRT BF16 at graph boundaries.
+        work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
     elif precision == "fp32":
         work_np_dtype, work_trt_dtype = np.float32, trt.float32
     else:
         raise ValueError(
-            f"Unsupported Qwen3-VL precision {precision!r}; expected fp32 or fp16")
+            f"Unsupported Qwen3-VL precision {precision!r}; "
+            "expected fp32, fp16 or bf16")
 
     grid_h = fixed_image_size // patch_size
     grid_w = fixed_image_size // patch_size
@@ -942,13 +973,29 @@ def build_qwen3_vl_vision_engine(
                     i01 = h_floor[hi] * num_grid_per_side + w_ceil[wi]
                     i10 = h_ceil[hi] * num_grid_per_side + w_floor[wi]
                     i11 = h_ceil[hi] * num_grid_per_side + w_ceil[wi]
-                    pos_embed_interp[idx] = (w00 * pos_embed_w[i00] + w01 * pos_embed_w[i01]
-                                             + w10 * pos_embed_w[i10] + w11 * pos_embed_w[i11])
+                    if precision == "bf16":
+                        pos_embed_interp[idx] = (
+                            _interpolate_qwen3_position_bf16(
+                                pos_embed_w,
+                                (i00, i01, i10, i11),
+                                (w00, w01, w10, w11),
+                            )
+                        )
+                    else:
+                        pos_embed_interp[idx] = (
+                            w00 * pos_embed_w[i00]
+                            + w01 * pos_embed_w[i01]
+                            + w10 * pos_embed_w[i10]
+                            + w11 * pos_embed_w[i11]
+                        )
                     idx += 1
 
     pos_const = graph_ops.add_constant(
         network, (num_patches, embed_dim), pos_embed_interp,
-        dtype=work_np_dtype)
+        dtype=np.float32 if precision == "bf16" else work_np_dtype)
+    if pos_const.dtype != work_trt_dtype:
+        pos_const = network.add_cast(
+            pos_const, work_trt_dtype).get_output(0)
     pos_add = network.add_elementwise(
         hidden, pos_const, trt.ElementWiseOperation.SUM)
     hidden = pos_add.get_output(0)
@@ -1019,7 +1066,7 @@ def build_qwen3_vl_vision_engine(
         prefix = f"visual.blocks.{layer_idx}"
         layer_np_dtype = (
             np.float32
-            if work_np_dtype == np.float16 and layer_idx in requested_fp32_layers
+            if precision == "fp16" and layer_idx in requested_fp32_layers
             else work_np_dtype)
         layer_trt_dtype = (
             trt.float32 if layer_np_dtype == np.float32 else work_trt_dtype)

--- a/python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py
@@ -209,6 +209,23 @@ class TrtRunner:
         err, self._d_position_id = cudart.cudaMalloc(4)
         _check_cuda(err)
 
+        # Qwen3-VL decoders require rank-2 multimodal rotary positions even
+        # for a single text/decode token. Keep all three axes equal for this
+        # text-only debug step, matching the production decode path.
+        self._h_mrope_position_ids: np.ndarray | None = None
+        self._d_mrope_position_ids = 0
+        if any(
+            self.engine.get_tensor_name(index) == "mrope_position_ids"
+            for index in range(self.engine.num_io_tensors)
+        ):
+            mrope_shape = _profile_min_shape(
+                self.engine, "mrope_position_ids", self._profile_index)
+            self._h_mrope_position_ids = np.zeros(
+                mrope_shape, dtype=np.int32)
+            err, self._d_mrope_position_ids = cudart.cudaMalloc(
+                self._h_mrope_position_ids.nbytes)
+            _check_cuda(err)
+
         # attention_mask
         self._h_mask = np.zeros((1, attention_window), dtype=np.float32)
         err, self._d_mask = cudart.cudaMalloc(attention_window * 4)
@@ -340,6 +357,12 @@ class TrtRunner:
         cudart.cudaMemcpyAsync(
             self._d_position_id, self._h_position_id.ctypes.data,
             4, H2D, stream)
+        if self._h_mrope_position_ids is not None:
+            self._h_mrope_position_ids.fill(position_id)
+            cudart.cudaMemcpyAsync(
+                self._d_mrope_position_ids,
+                self._h_mrope_position_ids.ctypes.data,
+                self._h_mrope_position_ids.nbytes, H2D, stream)
         cudart.cudaMemcpyAsync(
             self._d_mask, self._h_mask.ctypes.data,
             attention_window * 4, H2D, stream)
@@ -381,6 +404,9 @@ class TrtRunner:
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
         self.context.set_tensor_address("position_id", self._d_position_id)
+        if self._d_mrope_position_ids:
+            self.context.set_tensor_address(
+                "mrope_position_ids", self._d_mrope_position_ids)
         self.context.set_tensor_address("attention_mask", self._d_mask)
         self.context.set_tensor_address("logits", self._d_logits)
 
@@ -412,7 +438,8 @@ class TrtRunner:
             self.context.set_input_shape(name, shape)
 
         # Execute
-        self.context.execute_async_v3(stream)
+        if not self.context.execute_async_v3(stream):
+            raise RuntimeError("TensorRT Qwen-VL debug decoder execution failed")
 
         # D2D cache update
         row_bytes = self.attention_size * self._cache_elem_bytes
@@ -504,8 +531,9 @@ class TrtRunner:
         if cudart is None:
             return
         bufs = []
-        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
-                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+        for name in ("_d_token_id", "_d_position_id", "_d_mrope_position_ids",
+                     "_d_mask", "_d_logits", "_d_input_embed",
+                     "_d_use_input_embed", "_d_deepstack_active"):
             d_ptr = getattr(self, name, 0)
             if d_ptr:
                 bufs.append(d_ptr)

--- a/src/runtime/models/qwen_vl/MODEL.toml
+++ b/src/runtime/models/qwen_vl/MODEL.toml
@@ -6,5 +6,6 @@ runtime_library = "libtrtmc_model_qwen_vl.so"
 runtime_plugins = ["plugin.cpp|register_qwen_vl_plugin"]
 runtime_strategies = ["qwen_vl_vision_language"]
 runtime_tests = [
+  "test_qwen_vl_sampler|test_qwen_vl_sampler.cpp|trtmc_model_qwen_vl|_|_",
   "test_qwen_vl_vl_pipeline|test_qwen_vl_vl_pipeline.cpp|trtmc_model_qwen_vl,trtmc_backend_trt|_|REQUIRES_TRT",
 ]

--- a/src/runtime/models/qwen_vl/kv_cache.cpp
+++ b/src/runtime/models/qwen_vl/kv_cache.cpp
@@ -131,7 +131,10 @@ void QwenVlKvCache::write_position_input(TensorMap& inputs, int32_t seq_len) {
         mrope_pos_buf_.fill(position_);
         Tensor mrope_t;
         mrope_t.data = mrope_pos_buf_.data();
-        mrope_t.shape = {3};
+        mrope_t.shape =
+            bound_module_ != nullptr && bound_module_->input_rank("mrope_position_ids") == 2
+                ? std::vector<int64_t>{3, 1}
+                : std::vector<int64_t>{3};
         mrope_t.dtype = DType::kInt32;
         inputs["mrope_position_ids"] = mrope_t;
     }

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -66,6 +66,14 @@ void sync_vision_config(QwenVlConfig& config, const QwenVlPreprocessConfig& prep
         config.vision_output_dim = preprocess.vision_output_dim;
 }
 
+QwenVlConfig normalize_eos_token_ids(QwenVlConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
 } // namespace
 
 QwenVlPipeline::QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
@@ -89,9 +97,10 @@ QwenVlPipeline::QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
                                std::unique_ptr<TrtModule> prefill,
                                std::shared_ptr<qwen_vl::LoraAdapterCache> adapter_cache)
     : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
-      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
-      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)),
+      config_(normalize_eos_token_ids(std::move(config))), vl_preprocess_(std::move(vl_preprocess)),
+      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      sampler_(std::move(sampler)) {
     validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
     sync_vision_config(config_, vl_preprocess_);
 
@@ -194,8 +203,8 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const GenerateCon
 
     select_lora_adapter(cfg.lora_adapter_id);
     auto input_ids = tokenizer_->encode(prompt);
-    auto [max_new, eos] = resolve_gen_limits(cfg);
-    auto sp = qwen_vl_sampling_params_from_config(cfg, eos);
+    const int32_t max_new = resolve_max_new_tokens(cfg);
+    auto sp = qwen_vl_sampling_params_from_config(cfg, config_.id_eos_ids);
     auto output_ids = generate_from_ids(input_ids, max_new, sp);
 
     std::vector<int32_t> new_tokens(
@@ -575,10 +584,8 @@ bool add_mrope_prefill_input(TrtModule& prefill, const std::vector<int32_t>& inp
 
 } // namespace
 
-std::pair<int32_t, int32_t> QwenVlPipeline::resolve_gen_limits(const GenerateConfig& cfg) const {
-    int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    return {max_new, eos};
+int32_t QwenVlPipeline::resolve_max_new_tokens(const GenerateConfig& cfg) const {
+    return (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
 }
 
 QwenVlISampler* QwenVlPipeline::prepare_sampler(const QwenVlSamplingParams& params,
@@ -621,8 +628,8 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
 
     // Format prompt, tokenize, generate with vision features
     auto input_ids = tokenizer_->encode(qwen_vl_format_prompt(prompt, vl_preprocess_, nf));
-    auto [max_new, eos] = resolve_gen_limits(cfg);
-    auto sp_vl = qwen_vl_sampling_params_from_config(cfg, eos);
+    const int32_t max_new = resolve_max_new_tokens(cfg);
+    auto sp_vl = qwen_vl_sampling_params_from_config(cfg, config_.id_eos_ids);
     const auto [merged_grid_height, merged_grid_width] =
         resolve_merged_grid(preprocessed, vl_preprocess_);
     auto out = generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim,
@@ -639,8 +646,7 @@ QwenVlPipeline::GenerationResult QwenVlPipeline::generate_ids(const std::vector<
                                                               const GenerateConfig& cfg) {
     select_lora_adapter(cfg.lora_adapter_id);
     int32_t max_new = cfg.max_new_tokens;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    auto sp = qwen_vl_sampling_params_from_config(cfg, eos);
+    auto sp = qwen_vl_sampling_params_from_config(cfg, config_.id_eos_ids);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
 }
 
@@ -680,7 +686,7 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         QwenVlSampleResult result = active_sampler->sample(logits.data(), vocab_size, params);
         output.push_back(result.token_id);
-        if (result.is_eos)
+        if (result.is_eos || qwen_vl_is_eos_token(params, result.token_id))
             break;
         run_text_step(result.token_id, logits);
     }
@@ -791,7 +797,7 @@ void QwenVlPipeline::run_vl_decode_loop(QwenVlISampler* sampler, const QwenVlSam
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         QwenVlSampleResult result = sampler->sample(logits.data(), vocab_size, params);
         output.push_back(result.token_id);
-        if (result.is_eos)
+        if (result.is_eos || qwen_vl_is_eos_token(params, result.token_id))
             break;
         run_text_step(result.token_id, logits, mrope_position);
         if (mrope_position >= 0)

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -404,6 +404,11 @@ std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string&
     return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
 }
 
+std::vector<int64_t> mrope_position_shape(const TrtModule& decoder) {
+    return decoder.input_rank("mrope_position_ids") == 2 ? std::vector<int64_t>{3, 1}
+                                                         : std::vector<int64_t>{3};
+}
+
 void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
                                     const std::vector<const float*>& deepstack_embeds,
                                     float& deepstack_active, std::vector<float>& zero_deepstack) {
@@ -833,8 +838,9 @@ void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* inp
     state_->prepare_step(inputs);
 
     if (mrope_position != nullptr && text_decoder_->has_input("mrope_position_ids")) {
-        inputs["mrope_position_ids"] =
-            Tensor{const_cast<int32_t*>(mrope_position->data()), {3}, DType::kInt32};
+        inputs["mrope_position_ids"] = Tensor{const_cast<int32_t*>(mrope_position->data()),
+                                              mrope_position_shape(*text_decoder_),
+                                              DType::kInt32};
     }
 
     std::vector<float> zero_embed;

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -839,8 +839,7 @@ void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* inp
 
     if (mrope_position != nullptr && text_decoder_->has_input("mrope_position_ids")) {
         inputs["mrope_position_ids"] = Tensor{const_cast<int32_t*>(mrope_position->data()),
-                                              mrope_position_shape(*text_decoder_),
-                                              DType::kInt32};
+                                              mrope_position_shape(*text_decoder_), DType::kInt32};
     }
 
     std::vector<float> zero_embed;

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -30,6 +30,7 @@ struct QwenVlConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
     int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
@@ -116,7 +117,7 @@ class QwenVlPipeline final : public IPipeline {
         int32_t feature_dim, int32_t merged_grid_height, int32_t merged_grid_width,
         int32_t max_new_tokens, const QwenVlSamplingParams& params);
 
-    std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+    int32_t resolve_max_new_tokens(const GenerateConfig& cfg) const;
 
     void reset_generation_context(int32_t prompt_length);
 

--- a/src/runtime/models/qwen_vl/plugin.cpp
+++ b/src/runtime/models/qwen_vl/plugin.cpp
@@ -313,6 +313,7 @@ QwenVlConfig make_pipeline_config(const PipelineContext& ctx, const ITrtModule& 
     config.vocab_size = ctx.config.vocab_size;
     config.id_bos = ctx.config.id_bos;
     config.id_eos = ctx.config.id_eos;
+    config.id_eos_ids = ctx.config.id_eos_ids;
     config.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
     config.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
     config.has_position_input = decode.has_input("position_id");

--- a/src/runtime/models/qwen_vl/sampler.cpp
+++ b/src/runtime/models/qwen_vl/sampler.cpp
@@ -30,9 +30,17 @@
 
 namespace trtmc {
 
+bool qwen_vl_is_eos_token(const QwenVlSamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
 // Shared argmax helper — returns {token_id, logprob} for the highest logit.
 static QwenVlSampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
-                                             int32_t eos_token_id) {
+                                             const QwenVlSamplingParams& params) {
     QwenVlSampleResult result;
     const float* best = logits;
     for (int32_t i = 1; i < vocab_size; ++i) {
@@ -41,7 +49,7 @@ static QwenVlSampleResult argmax_over_logits(const float* logits, int32_t vocab_
     }
     result.token_id = static_cast<int32_t>(best - logits);
     result.logprob = *best;
-    result.is_eos = (result.token_id == eos_token_id);
+    result.is_eos = qwen_vl_is_eos_token(params, result.token_id);
     return result;
 }
 
@@ -182,11 +190,11 @@ class GreedySampler final : public QwenVlISampler {
         if (vocab_size <= 0 || logits == nullptr) {
             QwenVlSampleResult result;
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_vl_is_eos_token(params, 0);
             return result;
         }
 
-        return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+        return argmax_over_logits(logits, vocab_size, params);
     }
 
     QwenVlLogitsLocation logits_location() const override { return QwenVlLogitsLocation::HOST; }
@@ -210,12 +218,12 @@ class TopKSampler final : public QwenVlISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_vl_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
 
@@ -233,7 +241,7 @@ class TopKSampler final : public QwenVlISampler {
                 result.token_id = dist.indices[static_cast<std::size_t>(i)];
                 result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(i)],
                                                    std::numeric_limits<float>::min()));
-                result.is_eos = (result.token_id == params.eos_token_id);
+                result.is_eos = qwen_vl_is_eos_token(params, result.token_id);
                 return result;
             }
         }
@@ -241,7 +249,7 @@ class TopKSampler final : public QwenVlISampler {
         result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
         result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(dist.keep - 1)],
                                            std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_vl_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -278,12 +286,12 @@ class TorchCudaMultinomialSampler final : public QwenVlISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_vl_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
         ensure_execution_policy(vocab_size);
@@ -312,7 +320,7 @@ class TorchCudaMultinomialSampler final : public QwenVlISampler {
             }
         }
         result.logprob = std::log(std::max(picked_prob, std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_vl_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -381,7 +389,7 @@ class GpuGreedySampler final : public QwenVlISampler {
         QwenVlSampleResult result;
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = qwen_vl_is_eos_token(params, 0);
             return result;
         }
 
@@ -397,7 +405,7 @@ class GpuGreedySampler final : public QwenVlISampler {
 
         result.token_id = h_token_id_;
         result.logprob = h_logit_val_;
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = qwen_vl_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -417,16 +425,26 @@ class GpuGreedySampler final : public QwenVlISampler {
 // Factory
 // ─────────────────────────────────────────────────────────────
 
-QwenVlSamplingParams qwen_vl_sampling_params_from_config(const GenerateConfig& cfg,
-                                                         int32_t default_eos) {
+QwenVlSamplingParams
+qwen_vl_sampling_params_from_config(const GenerateConfig& cfg,
+                                    const std::vector<int32_t>& default_eos_token_ids) {
     QwenVlSamplingParams p;
     p.temperature = cfg.temperature;
     p.top_k = cfg.top_k;
     p.top_p = cfg.top_p;
     p.min_p = cfg.min_p;
     p.seed = cfg.seed;
-    p.eos_token_id = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : default_eos;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
     return p;
+}
+
+QwenVlSamplingParams qwen_vl_sampling_params_from_config(const GenerateConfig& cfg,
+                                                         int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return qwen_vl_sampling_params_from_config(cfg, defaults);
 }
 
 std::unique_ptr<QwenVlISampler>

--- a/src/runtime/models/qwen_vl/sampler.h
+++ b/src/runtime/models/qwen_vl/sampler.h
@@ -30,6 +30,7 @@ struct QwenVlSamplingParams {
     float repetition_penalty{1.0f};
     int32_t seed{-1}; // -1 = deterministic (argmax)
     int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
 };
 
 /// Factory options for choosing concrete sampler implementations.
@@ -78,8 +79,14 @@ class QwenVlISampler {
 /// Forward-declared here; defined in sampler.cpp alongside the factory.
 struct GenerateConfig; // defined in trtmc/pipeline.h
 
+QwenVlSamplingParams
+qwen_vl_sampling_params_from_config(const GenerateConfig& cfg,
+                                    const std::vector<int32_t>& default_eos_token_ids);
 QwenVlSamplingParams qwen_vl_sampling_params_from_config(const GenerateConfig& cfg,
                                                          int32_t default_eos = -1);
+
+/// Return true when token_id matches any effective EOS token.
+bool qwen_vl_is_eos_token(const QwenVlSamplingParams& params, int32_t token_id);
 
 /// Factory: create sampler from QwenVlSamplingParams.
 /// - top_k <= 1 && top_p/min_p disabled && seed == -1 => GreedySampler

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -637,6 +637,40 @@ class TestAddAttentionCore:
 class TestAddApplyMropeNative:
     """Qwen2.5-VL M-RoPE selects T/H/W frequency sections."""
 
+    def test_qwen3_interleaved_axis_map_preserves_temporal_tail(self):
+        axes = qwen_vl_graph_ops.mrope_frequency_axis_map(
+            (24, 20, 20), 128, interleaved=True)
+
+        np.testing.assert_array_equal(
+            axes[:60], np.tile(np.array([0, 1, 2], dtype=np.int32), 20))
+        np.testing.assert_array_equal(
+            axes[60:], np.zeros(4, dtype=np.int32))
+        assert [int(np.count_nonzero(axes == axis)) for axis in range(3)] == [
+            24, 20, 20]
+
+    def test_chunked_and_interleaved_layouts_are_distinct(self):
+        chunked = qwen_vl_graph_ops.mrope_frequency_axis_map(
+            (2, 1, 1), 8, interleaved=False)
+        interleaved = qwen_vl_graph_ops.mrope_frequency_axis_map(
+            (2, 1, 1), 8, interleaved=True)
+
+        np.testing.assert_array_equal(chunked, [0, 0, 1, 2])
+        np.testing.assert_array_equal(interleaved, [0, 1, 2, 0])
+
+    @pytest.mark.parametrize(
+        ("sections", "rotary_dim", "error"),
+        [
+            ((24, 20, 19), 128, "must sum"),
+            ((1, 2, 1), 8, "cannot be represented"),
+        ],
+    )
+    def test_interleaved_axis_map_rejects_invalid_sections(
+        self, sections, rotary_dim, error
+    ):
+        with pytest.raises(ValueError, match=error):
+            qwen_vl_graph_ops.mrope_frequency_axis_map(
+                sections, rotary_dim, interleaved=True)
+
     @requires_trt
     def test_matches_numpy_reference(self):
         num_heads, head_dim = 2, 16
@@ -678,3 +712,89 @@ class TestAddApplyMropeNative:
             [first * cos_m - second * sin_m,
              second * cos_m + first * sin_m], axis=-1).reshape(1, -1)
         np.testing.assert_allclose(out, ref, atol=1e-4)
+
+    @requires_trt
+    def test_qwen3_dynamic_sequence_matches_interleaved_rotate_half(self):
+        num_heads, head_dim, sq = 2, 16, 3
+        sections = (4, 2, 2)
+        positions = np.array(
+            [
+                [2, 3, 4],
+                [5, 6, 7],
+                [8, 9, 10],
+            ],
+            dtype=np.int32,
+        )
+        rng = np.random.default_rng(20260729)
+        x = rng.standard_normal(
+            (sq, num_heads * head_dim)).astype(np.float32)
+        cos = qwen_vl_graph_ops.make_rope_table_half_dim(
+            16, head_dim, 10000.0, True)
+        sin = qwen_vl_graph_ops.make_rope_table_half_dim(
+            16, head_dim, 10000.0, False)
+
+        def build(network, trt_inputs):
+            cos_t = qwen_vl_graph_ops.add_constant(
+                network, cos.shape, cos, dtype=np.float32)
+            sin_t = qwen_vl_graph_ops.add_constant(
+                network, sin.shape, sin, dtype=np.float32)
+            return {
+                "out": qwen_vl_graph_ops.add_apply_mrope_native_sequence(
+                    network,
+                    trt_inputs["x"],
+                    num_heads,
+                    head_dim,
+                    cos_t,
+                    sin_t,
+                    trt_inputs["positions"],
+                    sections,
+                    head_dim,
+                    interleaved=False,
+                    mrope_interleaved=True,
+                )
+            }
+
+        out = _run_strongly_typed(
+            build, {"x": x, "positions": positions})["out"]
+
+        axes = qwen_vl_graph_ops.mrope_frequency_axis_map(
+            sections, head_dim, interleaved=True)
+        columns = np.arange(head_dim // 2)
+        rows = []
+        ordinary_rows = []
+        adjacent_rows = []
+        for row in range(sq):
+            cos_m = cos[positions[axes, row], columns]
+            sin_m = sin[positions[axes, row], columns]
+            cos_full = np.concatenate([cos_m, cos_m])
+            sin_full = np.concatenate([sin_m, sin_m])
+            rows.append(_ref_rope(
+                x[row:row + 1], cos_full, sin_full,
+                num_heads, head_dim))
+
+            temporal_cos = cos[positions[0, row]]
+            temporal_sin = sin[positions[0, row]]
+            ordinary_rows.append(_ref_rope(
+                x[row:row + 1],
+                np.concatenate([temporal_cos, temporal_cos]),
+                np.concatenate([temporal_sin, temporal_sin]),
+                num_heads,
+                head_dim,
+            ))
+
+            heads = x[row].reshape(num_heads, head_dim)
+            pairs = heads.reshape(num_heads, head_dim // 2, 2)
+            adjacent = np.empty_like(pairs)
+            adjacent[..., 0] = (
+                pairs[..., 0] * cos_m - pairs[..., 1] * sin_m)
+            adjacent[..., 1] = (
+                pairs[..., 1] * cos_m + pairs[..., 0] * sin_m)
+            adjacent_rows.append(adjacent.reshape(1, -1))
+
+        ref = np.concatenate(rows, axis=0)
+        ordinary_1d = np.concatenate(ordinary_rows, axis=0)
+        wrong_adjacent_pair = np.concatenate(adjacent_rows, axis=0)
+
+        np.testing.assert_allclose(out, ref, atol=1e-4)
+        assert float(np.max(np.abs(ref - ordinary_1d))) > 0.1
+        assert float(np.max(np.abs(ref - wrong_adjacent_pair))) > 0.1

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_sampler.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_sampler.cpp
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// =============================================================================
+// test_qwen_vl_sampler.cpp -- CPU tests for Qwen-VL EOS sampling behavior
+// =============================================================================
+
+#include "runtime/models/qwen_vl/sampler.h"
+#include "trtmc/pipeline.h"
+
+#include <iostream>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static trtmc::QwenVlSampleResult greedy_sample(const trtmc::QwenVlSamplingParams& params,
+                                               int32_t winning_token) {
+    std::vector<float> logits(8, 0.0F);
+    logits[static_cast<std::size_t>(winning_token)] = 1.0F;
+    auto sampler = trtmc::create_qwen_vl_sampler(params);
+    return sampler->sample(logits.data(), static_cast<int32_t>(logits.size()), params);
+}
+
+static void test_any_default_eos_stops_generation() {
+    trtmc::GenerateConfig config;
+    const std::vector<int32_t> defaults{5, 7};
+    const auto params = trtmc::qwen_vl_sampling_params_from_config(config, defaults);
+
+    check(params.eos_token_ids == defaults, "sampler: preserves all default EOS IDs");
+    check(greedy_sample(params, 7).is_eos, "sampler: second default EOS stops generation");
+}
+
+static void test_request_eos_overrides_model_defaults() {
+    trtmc::GenerateConfig config;
+    config.eos_token_id = 3;
+    const auto params =
+        trtmc::qwen_vl_sampling_params_from_config(config, std::vector<int32_t>{5, 7});
+
+    check(params.eos_token_ids == std::vector<int32_t>({3}),
+          "sampler: request EOS replaces model defaults");
+    check(!greedy_sample(params, 7).is_eos,
+          "sampler: overridden model EOS no longer stops generation");
+    check(greedy_sample(params, 3).is_eos, "sampler: explicit request EOS stops generation");
+}
+
+int main() {
+    test_any_default_eos_stops_generation();
+    test_request_eos_overrides_model_defaults();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All Qwen-VL sampler tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -84,8 +84,7 @@ class CountingTextModule final : public trtmc::ITrtModule {
   public:
     CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream,
                        int32_t mrope_rank = 0)
-        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
-          mrope_rank_(mrope_rank),
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream), mrope_rank_(mrope_rank),
           present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
                              : trtmc::DeviceTensor{}),
           present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -83,9 +83,9 @@ struct CountingTextStats {
 class CountingTextModule final : public trtmc::ITrtModule {
   public:
     CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream,
-                       bool has_mrope_input = false)
+                       int32_t mrope_rank = 0)
         : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
-          has_mrope_input_(has_mrope_input),
+          mrope_rank_(mrope_rank),
           present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
                              : trtmc::DeviceTensor{}),
           present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
@@ -124,7 +124,7 @@ class CountingTextModule final : public trtmc::ITrtModule {
         return name == "token_id" || name == "position_id" || name == "attention_mask" ||
                name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
                name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0" ||
-               (name == "mrope_position_ids" && has_mrope_input_);
+               (name == "mrope_position_ids" && mrope_rank_ > 0);
     }
     bool has_output(const std::string& name) const override {
         return name == "logits" || name == "present_k_0" || name == "present_v_0";
@@ -149,6 +149,8 @@ class CountingTextModule final : public trtmc::ITrtModule {
     }
     void bind_external(const std::string&, void*) override {}
     int32_t input_rank(const std::string& name) const override {
+        if (name == "mrope_position_ids")
+            return mrope_rank_;
         return name == "token_id" || name == "position_id" ? 1 : 2;
     }
     bool input_is_dynamic(const std::string&) const override { return prefill_; }
@@ -159,7 +161,7 @@ class CountingTextModule final : public trtmc::ITrtModule {
     std::shared_ptr<CountingTextStats> stats_;
     bool prefill_{false};
     cudaStream_t stream_{nullptr};
-    bool has_mrope_input_{false};
+    int32_t mrope_rank_{0};
     mutable trtmc::DeviceTensor present_k_;
     mutable trtmc::DeviceTensor present_v_;
     std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
@@ -892,8 +894,8 @@ static void test_vl_dynamic_resolution_uses_actual_grid_for_mrope() {
 
     auto decode_stats = std::make_shared<CountingTextStats>();
     auto prefill_stats = std::make_shared<CountingTextStats>();
-    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream, true);
-    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream, true);
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream, 2);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream, 2);
     auto vision = std::make_unique<FakeSequenceVisionModule>(6);
     auto cache = std::make_unique<trtmc::QwenVlKvCache>(1, 16, 4, stream);
 
@@ -932,6 +934,44 @@ static void test_vl_dynamic_resolution_uses_actual_grid_for_mrope() {
               std::vector<int32_t>(
                   {0, 1, 1, 1, 1, 1, 1, 4, 0, 1, 1, 1, 2, 2, 2, 4, 0, 1, 2, 3, 1, 2, 3, 4}),
           "dynamic mrope: pipeline uses actual 2x3 merged image grid");
+
+    cudaStreamDestroy(stream);
+}
+
+static void test_vl_decode_uses_rank_two_mrope_position_shape() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream, 2);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::QwenVlKvCache>(1, 8, 4, stream);
+
+    trtmc::QwenVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 99;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+
+    trtmc::QwenVlPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::QwenVlPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                   vl_pp, stream, tokenizer);
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 2;
+    gen_cfg.eos_token_id = 99;
+    (void)pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(decode_stats->shapes["mrope_position_ids"] == std::vector<int64_t>({3, 1}),
+          "mrope decode: rank-two engine receives [3, 1]");
 
     cudaStreamDestroy(stream);
 }
@@ -1167,6 +1207,7 @@ int main() {
     test_vl_generate_with_embed_decoder();
     test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_dynamic_resolution_uses_actual_grid_for_mrope();
+    test_vl_decode_uses_rank_two_mrope_position_shape();
     test_vl_generate_with_tokenizer();
     test_vl_dynamic_lora_adapter_switching();
     test_vl_pool_isolates_concurrent_lora_selection();

--- a/tests/e2e/models/qwen_vl/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/qwen_vl/e2e_plugins/references/hf_transformers.py
@@ -877,6 +877,8 @@ class HfTransformersReference:
         model_ref = _resolve_cached_model_ref(hf_id)
         fallback_text = f"<|vision_start|><|image_pad|><|vision_end|>{prompt}"
         torch_dtype_expr = _torch_dtype_for_case(case)
+        reference_precision = case.metadata.get(
+            "reference_precision", case.metadata.get("precision", "fp32"))
 
         script = textwrap.dedent(f"""\
             import sys, torch
@@ -918,6 +920,11 @@ class HfTransformersReference:
                 model = transformers.AutoModelForCausalLM.from_pretrained(
                     model_ref, trust_remote_code=True,
                     torch_dtype={torch_dtype_expr})
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "Qwen-VL HF reference requires CUDA to match QA validation")
+            device = torch.device("cuda")
+            model.to(device)
             model.eval()
 
             image = Image.open(image_path).convert("RGB")
@@ -961,6 +968,11 @@ class HfTransformersReference:
                     inputs = processor(
                         text=fallback_text, images=image, return_tensors="pt")
 
+            inputs = {{
+                key: value.to(device) if hasattr(value, "to") else value
+                for key, value in inputs.items()
+            }}
+
             with torch.no_grad():
                 generated_ids = model.generate(
                     **inputs, max_new_tokens=max_new_tokens)
@@ -993,7 +1005,11 @@ class HfTransformersReference:
             env=_reference_env(ctx),
             output_readers=(lambda: {"text": _read_text_artifact(text_path)},),
             text_reader=lambda: _read_text_artifact(text_path),
-            metadata={"trust_remote_code": trust_remote_code},
+            metadata={
+                "trust_remote_code": trust_remote_code,
+                "reference_device": "cuda",
+                "reference_precision": reference_precision,
+            },
             failure_label="HF VL generation",
         )
 

--- a/tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py
@@ -207,6 +207,23 @@ class TrtRunner:
         err, self._d_position_id = cudart.cudaMalloc(4)
         _check_cuda(err)
 
+        # Qwen3-VL decoders require rank-2 multimodal rotary positions even
+        # for a single text/decode token. Keep all three axes equal for this
+        # text-only debug step, matching the production decode path.
+        self._h_mrope_position_ids: np.ndarray | None = None
+        self._d_mrope_position_ids = 0
+        if any(
+            self.engine.get_tensor_name(index) == "mrope_position_ids"
+            for index in range(self.engine.num_io_tensors)
+        ):
+            mrope_shape = _profile_min_shape(
+                self.engine, "mrope_position_ids", self._profile_index)
+            self._h_mrope_position_ids = np.zeros(
+                mrope_shape, dtype=np.int32)
+            err, self._d_mrope_position_ids = cudart.cudaMalloc(
+                self._h_mrope_position_ids.nbytes)
+            _check_cuda(err)
+
         # attention_mask
         self._h_mask = np.zeros((1, attention_window), dtype=np.float32)
         err, self._d_mask = cudart.cudaMalloc(attention_window * 4)
@@ -338,6 +355,12 @@ class TrtRunner:
         cudart.cudaMemcpyAsync(
             self._d_position_id, self._h_position_id.ctypes.data,
             4, H2D, stream)
+        if self._h_mrope_position_ids is not None:
+            self._h_mrope_position_ids.fill(position_id)
+            cudart.cudaMemcpyAsync(
+                self._d_mrope_position_ids,
+                self._h_mrope_position_ids.ctypes.data,
+                self._h_mrope_position_ids.nbytes, H2D, stream)
         cudart.cudaMemcpyAsync(
             self._d_mask, self._h_mask.ctypes.data,
             attention_window * 4, H2D, stream)
@@ -379,6 +402,9 @@ class TrtRunner:
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
         self.context.set_tensor_address("position_id", self._d_position_id)
+        if self._d_mrope_position_ids:
+            self.context.set_tensor_address(
+                "mrope_position_ids", self._d_mrope_position_ids)
         self.context.set_tensor_address("attention_mask", self._d_mask)
         self.context.set_tensor_address("logits", self._d_logits)
 
@@ -410,7 +436,8 @@ class TrtRunner:
             self.context.set_input_shape(name, shape)
 
         # Execute
-        self.context.execute_async_v3(stream)
+        if not self.context.execute_async_v3(stream):
+            raise RuntimeError("TensorRT Qwen-VL debug decoder execution failed")
 
         # D2D cache update
         row_bytes = self.attention_size * self._cache_elem_bytes
@@ -502,8 +529,9 @@ class TrtRunner:
         if cudart is None:
             return
         bufs = []
-        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
-                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+        for name in ("_d_token_id", "_d_position_id", "_d_mrope_position_ids",
+                     "_d_mask", "_d_logits", "_d_input_embed",
+                     "_d_use_input_embed", "_d_deepstack_active"):
             d_ptr = getattr(self, name, 0)
             if d_ptr:
                 bufs.append(d_ptr)

--- a/tests/e2e/models/qwen_vl/manifests/qwen25vl-3b.json
+++ b/tests/e2e/models/qwen_vl/manifests/qwen25vl-3b.json
@@ -5,7 +5,7 @@
   "family": "qwen_vl",
   "runtime_strategy": "qwen_vl_vision_language",
   "task_strategy": "vision_language_generation",
-  "precision": "fp16",
+  "precision": "bf16",
   "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/qwen_vl/manifests/qwen25vl-3b.json
+++ b/tests/e2e/models/qwen_vl/manifests/qwen25vl-3b.json
@@ -5,7 +5,7 @@
   "family": "qwen_vl",
   "runtime_strategy": "qwen_vl_vision_language",
   "task_strategy": "vision_language_generation",
-  "precision": "bf16",
+  "precision": "fp32",
   "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/qwen_vl/manifests/qwen3-vl-2b.json
+++ b/tests/e2e/models/qwen_vl/manifests/qwen3-vl-2b.json
@@ -6,6 +6,7 @@
   "runtime_strategy": "qwen_vl_vision_language",
   "task_strategy": "vision_language_generation",
   "precision": "bf16",
+  "reference_precision": "bf16",
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/qwen_vl/manifests/qwen3-vl-2b.json
+++ b/tests/e2e/models/qwen_vl/manifests/qwen3-vl-2b.json
@@ -5,12 +5,7 @@
   "family": "qwen_vl",
   "runtime_strategy": "qwen_vl_vision_language",
   "task_strategy": "vision_language_generation",
-  "precision": "fp16",
-  "fp32_layers": [
-    0,
-    1,
-    2
-  ],
+  "precision": "bf16",
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/qwen_vl/test_qwen3_vl_mrope_builder.py
+++ b/tests/e2e/models/qwen_vl/test_qwen3_vl_mrope_builder.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-VL text-builder contracts for multimodal rotary positions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tests.builder.conftest import requires_trt
+
+pytest.importorskip(
+    "tensorrt_model_connect",
+    reason="Qwen3-VL builder tests require TensorRT",
+)
+
+
+def _tiny_qwen3_vl_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={
+            "rope_scaling": {
+                "mrope_section": [2, 1, 1],
+                "mrope_interleaved": True,
+                "rope_type": "default",
+            },
+            "_decoder_engine_role": "dual_profile",
+        },
+        hidden_size=16,
+        vocab_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        attention_size=16,
+        intermediate_size=16,
+        rms_norm_eps=1e-6,
+        rope_theta=5000000.0,
+    )
+
+
+def _tiny_qwen3_vl_weights() -> dict[str, np.ndarray | int]:
+    rng = np.random.default_rng(20260729)
+
+    def rand(*shape: int) -> np.ndarray:
+        return rng.standard_normal(shape).astype(np.float32) * 0.02
+
+    hidden = 16
+    kv_attention = 8
+    mlp = 16
+    return {
+        "_attention_size": hidden,
+        "_kv_attention_size": kv_attention,
+        "_mlp_size": mlp,
+        "embedding": rand(16, hidden),
+        "layer.0.input_norm": np.ones(hidden, dtype=np.float32),
+        "layer.0.post_attn_norm": np.ones(hidden, dtype=np.float32),
+        "layer.0.w_q": rand(hidden, hidden),
+        "layer.0.w_k": rand(hidden, kv_attention),
+        "layer.0.w_v": rand(hidden, kv_attention),
+        "layer.0.w_o": rand(hidden, hidden),
+        "layer.0.w_gate": rand(hidden, mlp),
+        "layer.0.w_up": rand(hidden, mlp),
+        "layer.0.w_down": rand(mlp, hidden),
+        "final_norm": np.ones(hidden, dtype=np.float32),
+        "w_out": rand(hidden, 16),
+    }
+
+
+@requires_trt
+def test_qwen3_vl_decoder_declares_rank_two_mrope_profiles() -> None:
+    import tensorrt as trt
+
+    from tensorrt_model_connect.families.qwen_vl.plugin import (
+        _build_qwen3_vl_decoder,
+    )
+
+    plan = _build_qwen3_vl_decoder(
+        _tiny_qwen3_vl_config(),
+        _tiny_qwen3_vl_weights(),
+        4,
+        precision="fp32",
+    )
+
+    logger = trt.Logger(trt.Logger.ERROR)
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(plan)
+    assert engine is not None
+    assert engine.get_tensor_shape("mrope_position_ids") == (3, -1)
+    assert engine.num_optimization_profiles == 2
+    assert tuple(engine.get_tensor_profile_shape(
+        "mrope_position_ids", 0)) == ((3, 1), (3, 4), (3, 4))
+    assert tuple(engine.get_tensor_profile_shape(
+        "mrope_position_ids", 1)) == ((3, 1), (3, 1), (3, 1))

--- a/tests/e2e/models/qwen_vl/test_qwen3_vl_mrope_builder.py
+++ b/tests/e2e/models/qwen_vl/test_qwen3_vl_mrope_builder.py
@@ -21,10 +21,12 @@ pytest.importorskip(
 def _tiny_qwen3_vl_config() -> SimpleNamespace:
     return SimpleNamespace(
         raw={
-            "rope_scaling": {
-                "mrope_section": [2, 1, 1],
-                "mrope_interleaved": True,
-                "rope_type": "default",
+            "text_config": {
+                "rope_scaling": {
+                    "mrope_section": [2, 1, 1],
+                    "mrope_interleaved": True,
+                    "rope_type": "default",
+                },
             },
             "_decoder_engine_role": "dual_profile",
         },

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
@@ -31,7 +31,7 @@ def test_qwen_vl_rejects_observed_point_eight_prediction_agreement() -> None:
 
     observed_summary = {
         "hf": {"overall_accuracy": 0.0},
-        "trtfb": {"overall_accuracy": 0.0},
+        "bundle": {"overall_accuracy": 0.0},
         "prediction_agreement_rate": 0.8,
         "correctness_agreement_rate": 1.0,
     }

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-VL accuracy and validation-gate contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.validation import engine as validation_engine
+
+
+def test_qwen25_validation_uses_aligned_fp32_precision() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "qwen25vl-3b.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["precision"] == "fp32"
+    assert {
+        testcase["reference_precision"] for testcase in manifest["testcases"]
+    } == {"fp32"}
+
+
+def test_qwen_vl_rejects_observed_point_eight_prediction_agreement() -> None:
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(),
+        "vlm_mmmu_pro_vision_fixed_mcq",
+    )
+    gates = suite["gates"]
+    assert gates["min_prediction_agreement"] == 0.95
+
+    observed_summary = {
+        "hf": {"overall_accuracy": 0.0},
+        "trtfb": {"overall_accuracy": 0.0},
+        "prediction_agreement_rate": 0.8,
+        "correctness_agreement_rate": 1.0,
+    }
+    observed_result = validation_engine.prediction_agreement_gate_result(
+        observed_summary,
+        gates,
+    )
+
+    assert observed_result["status"] == "failed"
+    assert observed_result["error_type"] == "BenchmarkGateError"
+    assert observed_result["gate_failures"] == [
+        {
+            "gate": "min_prediction_agreement",
+            "metric": "prediction_agreement_rate",
+            "actual": 0.8,
+            "required": 0.95,
+        }
+    ]
+
+    boundary_summary = {
+        **observed_summary,
+        "prediction_agreement_rate": 0.95,
+    }
+    boundary_result = validation_engine.prediction_agreement_gate_result(
+        boundary_summary,
+        gates,
+    )
+    assert boundary_result["status"] == "passed"
+    assert boundary_result["gate_failures"] == []

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_bf16_precision_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_bf16_precision_contract.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast precision-contract regressions for Qwen-VL BF16 accuracy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip(
+    "tensorrt_model_connect",
+    reason="Qwen-VL precision contracts require TensorRT",
+)
+
+from tensorrt_model_connect.families.qwen_vl import (  # noqa: E402
+    graph_blocks,
+    graph_ops,
+)
+from tensorrt_model_connect.families.qwen_vl.config import (  # noqa: E402
+    get_rope_scaling,
+)
+from tensorrt_model_connect.families.qwen_vl.qwen_vl_vision_builder import (  # noqa: E402
+    _interpolate_qwen3_position_bf16,
+)
+
+
+@dataclass
+class _Tensor:
+    name: str
+    dtype: object
+    shape: tuple[int, ...] = (1, 4)
+
+
+class _Layer:
+    def __init__(self, output: _Tensor) -> None:
+        self._output = output
+
+    def get_output(self, index: int) -> _Tensor:
+        assert index == 0
+        return self._output
+
+
+class _Network:
+    def __init__(self) -> None:
+        self.operations: list[tuple] = []
+
+    def add_cast(self, tensor: _Tensor, dtype: object) -> _Layer:
+        self.operations.append(("cast", tensor.name, tensor.dtype, dtype))
+        return _Layer(_Tensor(f"{tensor.name}_as_{dtype}", dtype, tensor.shape))
+
+    def add_activation(self, tensor: _Tensor, operation: object) -> _Layer:
+        self.operations.append(
+            ("activation", tensor.name, tensor.dtype, operation))
+        return _Layer(_Tensor("activation", tensor.dtype, tensor.shape))
+
+    def add_elementwise(
+        self, lhs: _Tensor, rhs: _Tensor, operation: object,
+    ) -> _Layer:
+        self.operations.append(
+            ("elementwise", lhs.name, lhs.dtype, rhs.name, rhs.dtype, operation))
+        assert lhs.dtype == rhs.dtype
+        return _Layer(_Tensor("elementwise", lhs.dtype, lhs.shape))
+
+    def add_shuffle(self, tensor: _Tensor) -> _Layer:
+        self.operations.append(("shuffle", tensor.name, tensor.dtype))
+        return _Layer(_Tensor("shuffle", tensor.dtype, tensor.shape))
+
+    def add_rotary_embedding(
+        self,
+        tensor: _Tensor,
+        cos: _Tensor,
+        sin: _Tensor,
+        interleaved: bool,
+        rotary_embedding_dim: int,
+    ) -> _Layer:
+        self.operations.append(
+            (
+                "rotary",
+                tensor.dtype,
+                cos.dtype,
+                sin.dtype,
+                interleaved,
+                rotary_embedding_dim,
+            ))
+        assert tensor.dtype == cos.dtype == sin.dtype
+        return _Layer(_Tensor("rotary", tensor.dtype, tensor.shape))
+
+
+def test_rope_scaling_reads_multimodal_text_config() -> None:
+    nested = {
+        "text_config": {
+            "rope_scaling": {
+                "mrope_section": [24, 20, 20],
+                "mrope_interleaved": True,
+            },
+        },
+    }
+
+    assert get_rope_scaling(nested) == nested["text_config"]["rope_scaling"]
+    assert get_rope_scaling({"rope_scaling": {"rope_type": "default"}}) == {
+        "rope_type": "default",
+    }
+
+
+def test_qwen3_position_interpolation_matches_bf16_operation_order() -> None:
+    rng = np.random.default_rng(20260729)
+    embeddings = rng.standard_normal((8, 16)).astype(np.float32)
+    positions = (1, 3, 4, 7)
+    weights = (0.1234, 0.2345, 0.3456, 0.2965)
+
+    actual = _interpolate_qwen3_position_bf16(
+        embeddings, positions, weights)
+
+    embeddings_t = torch.from_numpy(embeddings).to(torch.bfloat16)
+    weights_t = torch.tensor(weights, dtype=torch.bfloat16)
+    expected = embeddings_t[positions[0]] * weights_t[0]
+    for position, weight in zip(positions[1:], weights_t[1:]):
+        expected = expected + embeddings_t[position] * weight
+    expected = expected.float().numpy()
+
+    np.testing.assert_array_equal(
+        actual.view(np.uint32), expected.view(np.uint32))
+
+
+def test_bf16_swiglu_uses_fp32_silu_then_bf16_up_product(
+    monkeypatch,
+) -> None:
+    network = _Network()
+    trt = graph_blocks.trt
+    matmul_inputs: list[tuple[str, object]] = []
+
+    def fake_make_matmul_fn(*_args, **_kwargs):
+        def matmul(lhs, _lhs_w, _rhs_w, _weights, weight_name):
+            matmul_inputs.append((weight_name, lhs.dtype))
+            if weight_name.endswith("w_gate"):
+                name = "gate"
+            elif weight_name.endswith("w_up"):
+                name = "up"
+            else:
+                name = "down"
+            return _Tensor(name, lhs.dtype)
+
+        return matmul
+
+    monkeypatch.setattr(
+        graph_blocks, "_make_matmul_fn", fake_make_matmul_fn)
+    result = graph_blocks.add_swiglu_mlp(
+        network,
+        _Tensor("input", trt.bfloat16),
+        weights={
+            "mlp.w_gate": object(),
+            "mlp.w_up": object(),
+            "mlp.w_down": object(),
+        },
+        prefix="mlp",
+        hidden_size=4,
+        mlp_size=4,
+        dtype=np.float16,
+    )
+
+    assert result.dtype == trt.bfloat16
+    assert matmul_inputs == [
+        ("mlp.w_gate", trt.bfloat16),
+        ("mlp.w_up", trt.bfloat16),
+        ("mlp.w_down", trt.bfloat16),
+    ]
+    assert network.operations[0] == (
+        "cast", "gate", trt.bfloat16, trt.float32)
+    assert network.operations[1] == (
+        "activation",
+        f"gate_as_{trt.float32}",
+        trt.float32,
+        trt.ActivationType.SIGMOID,
+    )
+    assert network.operations[-2] == (
+        "cast", "elementwise", trt.float32, trt.bfloat16)
+    assert network.operations[-1][0:5] == (
+        "elementwise",
+        f"elementwise_as_{trt.bfloat16}",
+        trt.bfloat16,
+        "up",
+        trt.bfloat16,
+    )
+
+
+def test_bf16_silu_uses_fp32_internal_compute() -> None:
+    network = _Network()
+    trt = graph_ops.trt
+
+    result = graph_ops.add_silu(
+        network, _Tensor("input", trt.bfloat16))
+
+    assert result.dtype == trt.bfloat16
+    assert network.operations == [
+        ("cast", "input", trt.bfloat16, trt.float32),
+        (
+            "activation",
+            f"input_as_{trt.float32}",
+            trt.float32,
+            trt.ActivationType.SIGMOID,
+        ),
+        (
+            "elementwise",
+            f"input_as_{trt.float32}",
+            trt.float32,
+            "activation",
+            trt.float32,
+            trt.ElementWiseOperation.PROD,
+        ),
+        ("cast", "elementwise", trt.float32, trt.bfloat16),
+    ]
+
+
+def test_bf16_gelu_uses_fp32_internal_compute(monkeypatch) -> None:
+    network = _Network()
+    trt = graph_ops.trt
+
+    def fake_constant(_network, shape, _values, dtype=np.float32):
+        constant_dtype = trt.float32 if dtype == np.float32 else trt.float16
+        return _Tensor("constant", constant_dtype, tuple(shape))
+
+    monkeypatch.setattr(graph_ops, "add_constant", fake_constant)
+    result = graph_ops.add_gelu_new(
+        network, _Tensor("input", trt.bfloat16), dtype=np.float16)
+
+    assert result.dtype == trt.bfloat16
+    assert network.operations[0] == (
+        "cast", "input", trt.bfloat16, trt.float32)
+    assert network.operations[-1] == (
+        "cast", "elementwise", trt.float32, trt.bfloat16)
+    assert all(
+        operation[2] == operation[4] == trt.float32
+        for operation in network.operations
+        if operation[0] == "elementwise"
+    )
+
+
+def test_bf16_vision_rope_computes_in_fp32_then_publishes_bf16() -> None:
+    network = _Network()
+    trt = graph_ops.trt
+    output = graph_ops.add_apply_rope_native_sequence(
+        network,
+        _Tensor("q", trt.bfloat16, (4, 8)),
+        num_heads=2,
+        head_dim=4,
+        cos_cache_3d=_Tensor("cos", trt.bfloat16, (1, 4, 2)),
+        sin_cache_3d=_Tensor("sin", trt.bfloat16, (1, 4, 2)),
+        rotary_embedding_dim=4,
+        sequence_length=4,
+    )
+
+    assert output.dtype == trt.bfloat16
+    assert network.operations[:3] == [
+        ("cast", "q", trt.bfloat16, trt.float32),
+        ("cast", "cos", trt.bfloat16, trt.float32),
+        ("cast", "sin", trt.bfloat16, trt.float32),
+    ]
+    rotary = next(
+        operation for operation in network.operations
+        if operation[0] == "rotary")
+    assert rotary == (
+        "rotary",
+        trt.float32,
+        trt.float32,
+        trt.float32,
+        False,
+        4,
+    )
+    assert network.operations[-1] == (
+        "cast", "shuffle", trt.float32, trt.bfloat16)

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -219,6 +219,32 @@ def test_qwen3_vl_vision_component_can_stay_fp32(monkeypatch) -> None:
     assert calls["build"][2]["fp32_layers"] == {5}
 
 
+def test_qwen3_vl_vision_preserves_bf16_precision(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.plugin")
+    vision_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.qwen_vl_vision_builder")
+    calls: dict[str, object] = {}
+
+    def fake_load(_model_dir, _config):
+        return {"vision": "weights"}
+
+    def fake_build(vision_config, weights, **kwargs):
+        calls["build"] = (vision_config, weights, kwargs)
+        return b"qwen3-vl-bf16-vision-plan"
+
+    monkeypatch.setattr(module, "_load_vision_weights", fake_load)
+    monkeypatch.setattr(
+        vision_module, "build_qwen3_vl_vision_engine", fake_build)
+
+    config = _config(qwen3=True)
+    result = module.QwenVLPlugin().build_vision_engine(
+        "/tmp/model", config, {}, precision="bf16")
+
+    assert result == b"qwen3-vl-bf16-vision-plan"
+    assert calls["build"][2]["precision"] == "bf16"
+
+
 def test_qwen3_vl_text_decoder_component_can_stay_fp32(monkeypatch) -> None:
     module = importlib.import_module(
         "tensorrt_model_connect.families.qwen_vl.plugin")

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 
 import pytest
 
@@ -60,3 +61,16 @@ def test_profile_min_shape_rejects_unresolved_profile(module_name) -> None:
 
     with pytest.raises(RuntimeError, match="Invalid optimization profile shape"):
         module._profile_min_shape(engine, "input_embed", 0)
+
+
+@pytest.mark.parametrize("module_name", RUNNER_MODULES)
+def test_debug_runner_binds_mrope_and_fails_closed(module_name) -> None:
+    module = importlib.import_module(module_name)
+    init_source = inspect.getsource(module.TrtRunner.__init__)
+    step_source = inspect.getsource(module.TrtRunner.step)
+
+    assert '"mrope_position_ids"' in init_source
+    assert "self._h_mrope_position_ids.fill(position_id)" in step_source
+    assert '"mrope_position_ids", self._d_mrope_position_ids' in step_source
+    assert "if not self.context.execute_async_v3(stream):" in step_source
+    assert "TensorRT Qwen-VL debug decoder execution failed" in step_source

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_deepstack_gate.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_deepstack_gate.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-VL DeepStack gating regression tests."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+
+
+plugin = importlib.import_module(
+    "tensorrt_model_connect.families.qwen_vl.plugin")
+
+
+@dataclass
+class _Tensor:
+    name: str
+    dtype: object
+
+
+class _Layer:
+    def __init__(self, output: _Tensor) -> None:
+        self.output = output
+
+    def get_output(self, index: int) -> _Tensor:
+        assert index == 0
+        return self.output
+
+
+class _Network:
+    def __init__(self) -> None:
+        self.operations: list[tuple] = []
+
+    def add_cast(self, tensor: _Tensor, dtype: object) -> _Layer:
+        self.operations.append(("cast", tensor.name, dtype))
+        return _Layer(_Tensor("zero_cast", dtype))
+
+    def add_elementwise(
+        self, lhs: _Tensor, rhs: _Tensor, operation: object,
+    ) -> _Layer:
+        self.operations.append(("elementwise", lhs.name, rhs.name, operation))
+        return _Layer(_Tensor("condition", plugin.trt.bool))
+
+    def add_select(
+        self, condition: _Tensor, when_true: _Tensor, when_false: _Tensor,
+    ) -> _Layer:
+        self.operations.append(
+            ("select", condition.name, when_true.name, when_false.name))
+        return _Layer(_Tensor("gated", when_true.dtype))
+
+
+def test_deepstack_gate_uses_hard_zero_select(monkeypatch) -> None:
+    network = _Network()
+    embed = _Tensor("deepstack_embed", plugin.trt.float16)
+    active = _Tensor("deepstack_active", plugin.trt.float16)
+
+    monkeypatch.setattr(
+        plugin.graph_ops,
+        "add_constant",
+        lambda *_args, **_kwargs: _Tensor("zero", plugin.trt.float32),
+    )
+
+    gated = plugin._add_nan_safe_deepstack_gate(network, embed, active)
+
+    assert gated.name == "gated"
+    assert network.operations == [
+        ("cast", "zero", plugin.trt.float16),
+        (
+            "elementwise",
+            "deepstack_active",
+            "zero_cast",
+            plugin.trt.ElementWiseOperation.GREATER,
+        ),
+        ("select", "condition", "deepstack_embed", "zero_cast"),
+    ]
+    assert all(
+        operation[-1] != plugin.trt.ElementWiseOperation.PROD
+        for operation in network.operations
+        if operation[0] == "elementwise"
+    )

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_deepstack_gate.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_deepstack_gate.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from dataclasses import dataclass
 
 
@@ -79,3 +80,15 @@ def test_deepstack_gate_uses_hard_zero_select(monkeypatch) -> None:
         for operation in network.operations
         if operation[0] == "elementwise"
     )
+
+
+def test_qwen3_deepstack_is_after_complete_decoder_layer() -> None:
+    source = inspect.getsource(plugin._build_qwen3_vl_decoder)
+
+    final_residual = source.index(
+        "residual2 = network.add_elementwise(")
+    deepstack_sum = source.index(
+        "deepstack_sum = network.add_elementwise(")
+
+    assert final_residual < deepstack_sum
+    assert "post_attn_ds" not in source

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_hf_transformers_reference.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_hf_transformers_reference.py
@@ -41,6 +41,30 @@ def test_owner_reference_falls_back_to_tokenizer_chat_template() -> None:
     assert "tokenizer chat template produced no image placeholder" in source
 
 
+def test_owner_reference_uses_qa_cuda_device_contract() -> None:
+    source = inspect.getsource(
+        qwen_vl_hf_transformers.HfTransformersReference._run_vl_full_generation
+    )
+    assert "if not torch.cuda.is_available():" in source
+    assert "Qwen-VL HF reference requires CUDA to match QA validation" in source
+    assert 'device = torch.device("cuda")' in source
+    assert "model.to(device)" in source
+    assert 'value.to(device) if hasattr(value, "to") else value' in source
+    assert '"reference_device": "cuda"' in source
+
+
+def test_qwen3_manifest_pins_qa_reference_precision() -> None:
+    manifest = json.loads(
+        (
+            qwen_vl_hf_transformers.PROJECT_DIR
+            / "tests/e2e/models/qwen_vl/manifests/qwen3-vl-2b.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert manifest["precision"] == "bf16"
+    assert manifest["reference_precision"] == "bf16"
+
+
 def test_vl_decode_uses_generated_suffix_for_full_sequences() -> None:
     processor = _FakeProcessor({
         (101, 102): "prompt",

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_prompt_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_prompt_contract.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint-native Qwen-VL prompt framing contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip(
+    "tensorrt",
+    reason="Qwen-VL prompt tests import the TensorRT-backed family plugin",
+)
+
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.qwen_vl.plugin import QwenVLPlugin
+
+
+_QWEN25_TEMPLATE = (
+    "<|im_start|>system\n"
+    "You are a helpful assistant.<|im_end|>\n"
+    "<|im_start|>user\n"
+    "<|vision_start|>{image_pads}<|vision_end|>{prompt}<|im_end|>\n"
+    "<|im_start|>assistant\n"
+)
+_QWEN3_TEMPLATE = (
+    "<|im_start|>user\n"
+    "<|vision_start|>{image_pads}<|vision_end|>{prompt}<|im_end|>\n"
+    "<|im_start|>assistant\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("model_type", "patch_size", "expected_pad_count", "expected_template"),
+    (
+        ("qwen2_vl", 14, 256, _QWEN25_TEMPLATE),
+        ("qwen3_vl", 16, 196, _QWEN3_TEMPLATE),
+    ),
+)
+def test_vl_prompt_template_matches_checkpoint_chat_contract(
+    model_type: str,
+    patch_size: int,
+    expected_pad_count: int,
+    expected_template: str,
+) -> None:
+    config = ModelConfig.from_json(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "hidden_size": 32,
+                "num_attention_heads": 4,
+                "vision_config": {
+                    "patch_size": patch_size,
+                    "spatial_merge_size": 2,
+                    "deepstack_visual_indexes": (
+                        [0] if model_type == "qwen3_vl" else []
+                    ),
+                },
+            }
+        )
+    )
+
+    vl_config = QwenVLPlugin().get_vl_config(config)
+
+    assert vl_config is not None
+    assert vl_config["num_image_pad_tokens"] == expected_pad_count
+    assert vl_config["vl_prompt_template"] == expected_template
+    rendered = expected_template.format(
+        image_pads="<|image_pad|>" * expected_pad_count,
+        prompt="What is shown?",
+    )
+    assert rendered.count("<|image_pad|>") == expected_pad_count
+    assert rendered.index("<|vision_start|>") < rendered.index("What is shown?")


### PR DESCRIPTION
## Background

This PR restores Qwen-VL accuracy parity for `qwen25vl-3b` and
`qwen3-vl-2b`, and closes the CI gaps that allowed incorrect or invalid
accuracy evidence to appear green.

The source benchmark failure is the Qwen-VL portion of the internal QA run
[`trtmc-validate-gb300-2-20260726-c8291be0-all105`](http://dlswqa-nas.nvidia.com:8080/mobile/Safety/trtmc/report-browser/?tab=benchmark&run=trtmc-validate-gb300-2-20260726-c8291be0-all105).
The reproduction used its validation contract: an NVIDIA GB300, TensorRT
`11.2.0.113`, the QA container and offline model/reference caches, the same
MMMU-Pro vision snapshot, `vlm_mmmu_pro_vision_fixed_mcq`, five selected
samples, fresh runtime/bundle/reference state, forced HF and engine rebuilds,
and no retry.

The original Qwen3-VL reproduction was:

| Model | HF predictions | TRTMC predictions | Agreement | Accuracy drop | Result |
| --- | --- | --- | ---: | ---: | --- |
| Qwen3-VL-2B | `A/B/H/J/I` | `A/B/C/J/G` | `0.60` | `0.40` | fail |

The image and prompt-token hashes matched for all five samples, isolating the
failure to model execution parity rather than benchmark-input drift.
Qwen2.5-VL also exposed a CI blind spot: an observed `0.80` prediction
agreement was reported as passed even though the suite declares a `0.95`
minimum.

After the original family fixes were validated, #830 replaced the shared
vehicle fixture, including `tests/e2e/models/qwen_vl/data/test_img.jpeg`, with
an approved photograph containing a clearly visible white vehicle. That
asset-only mainline change made the earlier model receipt stale for the
current fixture and forced a new exact-head reproduction.

At pre-fix head `9fdb87615f0d695b842300fa5031e91d4cd1b5da`, internal premerge run
`31133689072` / artifact `8977830201` reproduced the current-main fixture:

- prompt: `What color is the vehicle in this image? Answer in one word.`
- TRTMC answer: `white`, which matches the visible fixture
- HF reference answer: `brown`
- full-generation comparison: failed (`exact_match=0`, `NED=1.0`)
- environment: NVIDIA GB300, TensorRT `11.2.0.113`, PyTorch `2.12.0+cu130`,
  Transformers `5.2.0`

This was not a new TRTMC accuracy regression. It exposed a stale CI oracle:
the family-owned premerge HF helper constructed BF16 inputs and the model on
CPU, while the QA validator's default reference contract runs HF on CUDA.

The same artifact exposed a second false-green path. The Qwen3 decoder smoke
step did not bind its required `mrope_position_ids` input. TensorRT returned
`false` from `execute_async_v3()` and logged two missing-binding API errors,
but the debug runner ignored that return value and `diff_vl.py` still printed
`ALL TESTS PASSED` for the stage.

## Exit Criteria

- Qwen2.5-VL and Qwen3-VL meet the unchanged QA accuracy gates:
  `max_accuracy_drop_from_hf=0.02` and
  `min_prediction_agreement=0.95`.
- The current shared white-vehicle fixture produces matching TRTMC and CUDA HF
  reference answers on the exact PR head.
- Premerge and QA use the same Qwen-VL HF device and precision contract.
- A missing Qwen3 multimodal rotary input or rejected TensorRT execution fails
  closed instead of producing a green smoke stage.
- Exact-head `trtmc/premerge/required`, CodeQL, and mergeability are green.
- No thresholds, sample counts, retry policy, fixtures, prompts, or pass
  criteria are relaxed.

## Root Causes

### Qwen2.5-VL model parity

- The validation manifest compared a BF16 TRTMC path at an unstable near-tie
  against the QA reference contract. Aligning both sides to FP32 removes the
  precision-induced answer flip.
- Native prompt framing did not exactly match the checkpoint chat contract.
- Multi-EOS generation and native sampling could continue past a valid
  terminator or read a stale cache row.

### Qwen3-VL model parity

- HF stores `rope_scaling` under `text_config`, but the decoder builders only
  inspected the top-level config, so the engine omitted multimodal RoPE.
- DeepStack features were injected after the attention residual; HF injects
  them after the complete decoder layer, including the MLP residual.
- The BF16 vision tower was forced to FP32, while the QA HF reference executes
  it in BF16.
- Learned-position interpolation, GELU, SiLU, convolution weights, and vision
  RoPE used rounding boundaries that differed from PyTorch BF16.

### CI coverage

- The former generic MCQ/VLM scoring path did not enforce the suite's declared
  prediction gates. The current shared validation engine enforces those gates,
  and this PR adds a Qwen-VL-owned contract proving that observed agreement
  `0.80` fails while the unchanged `0.95` boundary passes.
- The Qwen-VL premerge HF reference stayed on CPU instead of following the QA
  CUDA reference contract. The #830 fixture replacement made this mismatch
  visible as a wrong HF oracle answer.
- The Qwen3 decoder smoke runner neither bound `mrope_position_ids` nor checked
  the boolean result of `execute_async_v3()`, allowing TensorRT API rejection
  to be reported as success.

## Implementation

### Family accuracy fixes

- Honor all configured EOS token IDs and stop native generation at EOS.
- Correct Qwen-VL prompt framing, image-token placement, multimodal position
  IDs, KV-cache indexing, and native sampling state.
- Read multimodal RoPE settings from supported nested HF config locations.
- Apply Qwen3 DeepStack after the complete decoder layer in both single-device
  and tensor-parallel builders.
- Preserve Qwen3 BF16 vision execution and align PyTorch BF16 boundaries for
  learned-position interpolation, GELU, SiLU, convolution weights, and vision
  RoPE.
- Align Qwen2.5-VL validation and its reference to FP32.

### CI and current-fixture fixes

- Require CUDA for the Qwen-VL HF reference; move the model and every tensor
  input to the leased CUDA device, and record `reference_device=cuda` in the
  result metadata.
- Pin `reference_precision=bf16` for `qwen3-vl-2b` instead of silently deriving
  the oracle contract from the DUT precision.
- In both debug-runner copies, discover `mrope_position_ids`, allocate its
  profile-minimum rank-2 shape, populate all three axes for the decode token,
  bind it before execution, and release the allocation.
- Raise immediately when `execute_async_v3()` returns `false`.
- Add family-owned regression tests for the QA CUDA oracle, explicit BF16
  reference precision, mRoPE binding, and fail-closed TensorRT execution.

## CI Runtime Boundary

The CI changes do not add another model build, model load, or inference pass.
They make the existing reference and smoke work authoritative:

- The existing HF reference moves from CPU to the already leased CUDA device;
  the number of reference invocations remains unchanged.
- mRoPE adds one tiny profile-shaped `int32` allocation and host-to-device copy
  to the existing decoder smoke step (three values for the current profile),
  not another engine execution.
- The prediction-gate and source-contract tests are constant-time Python checks
  and do not execute a model.

The exact-head model job completed in 15 minutes, including the existing
scratch build, one engine build, one TRTMC inference, one CUDA HF reference,
the family test suite, artifact upload, and certification. The model E2E case
took 369.787 seconds; its bundle build took 260.849 seconds and its CUDA HF
reference took 70.736 seconds. The full workflow took 38 minutes 25 seconds,
including runner queue time. No runtime claim depends on reducing coverage or
weakening a gate.

## Validation

### Historical QA-equivalent model receipt

Before #830 changed the fixture, receipt
`qwen-vl-current-main-30fb772f-full5-both-r7` validated the original family
fixes on one exclusively reserved physical GB300:

| Model | HF accuracy | TRTMC accuracy | Agreement | Accuracy drop |
| --- | ---: | ---: | ---: | ---: |
| Qwen2.5-VL-3B | `0.00` | `0.00` | `1.00` | `0.00` |
| Qwen3-VL-2B | `0.60` | `0.60` | `1.00` | `0.00` |

Qwen3 predictions exactly matched HF: `A/B/H/J/I`. This receipt remains
evidence for the MMMU-Pro family fixes, but it is explicitly not current-main
fixture qualification after #830.

### Current-head local checks

- `git diff --check`: passed.
- `python3 -m py_compile python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py tests/e2e/models/qwen_vl/e2e_plugins/references/hf_transformers.py tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py tests/e2e/models/qwen_vl/test_qwen_vl_hf_transformers_reference.py`: passed.
- `ruff check python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py tests/e2e/models/qwen_vl/e2e_plugins/references/hf_transformers.py tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py tests/e2e/models/qwen_vl/test_qwen_vl_hf_transformers_reference.py`: passed.
- `PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/e2e/models/qwen_vl/test_qwen_vl_hf_transformers_reference.py tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py -k 'not tensorrt_model_connect.families.qwen_vl.vl_debug_runner'`: `17 passed, 4 deselected`.

The four deselected parameterizations import the production runner and require
TensorRT, which is not installed on the host. Exact model/GPU validation is
therefore delegated to the required internal CI lane below, not claimed from
the host-only checks.

### Exact-head CI and artifact receipt

- head: `593588905f6e17f30c2f26f746d590defed589a3`
- tree: `856209f8060de0386740f6f6c70f18aecdd9e0e2`
- rebased base: `9c429cdd6331f56745574e51240f8fb8250d3cb1`
- internal premerge run: `31138009244`
- private run conclusion: **success**
- `trtmc/premerge/required`: **success** on the exact head
- CodeQL JavaScript/TypeScript: **success** on the exact head
- CodeQL Python: **success** on the exact head
- exact-head model artifact: `model-proof-qwen_vl-593588905f6e17f30c2f26f746d590defed589a3-1`
  (ID `8979461667`)
- artifact `model-proof-status.json`: **passed**, with
  `source_revision=593588905f6e17f30c2f26f746d590defed589a3`
- model E2E: **1/1 passed**; the Qwen-VL family test suite also passed
- current fixture TRTMC answer: `white`
- current fixture CUDA HF answer: `white`
- full-generation comparison: `exact_match=1.0`, `NED=0.0`
- result metadata: `reference_device=cuda`, `reference_precision=bf16`
- decoder smoke: return code `0`, vision encoder passed, decoder embed-input
  smoke passed, and no missing `mrope_position_ids`, rejected
  `execute_async_v3()`, or TensorRT API usage error appears in the artifact
- engine-build count: **1**, with no retry or recovery path
- runtime: model job `15m00s`; model E2E `369.787s`; bundle build `260.849s`;
  CUDA HF reference `70.736s`; full workflow `38m25s` including queue time
- mergeability: **MERGEABLE/CLEAN** on the exact head

## Notes For Future Readers

- Review the manifest and HF-reference contract first, then the two debug
  runners, then the model-parity implementation and family-owned tests.
- A fixture-only change can invalidate a model receipt even when prompts remain
  semantically valid. Exact-head qualification must use the asset present on
  the merge base.
- Do not move this HF reference back to CPU without also changing and
  requalifying the QA reference contract; CPU BF16 was not a valid stand-in for
  the QA CUDA oracle here.
- Do not ignore `execute_async_v3()` return values. TensorRT can log an API
  error and return `false` without causing the surrounding Python process to
  fail unless the caller checks it.
- No thresholds, fixtures, prompts, sample counts, retries, or pass criteria
  were changed to obtain a pass.


## Latest Main Bundle Compatibility Refresh (2026-08-07)

- Rebased without conflict onto `github/main@c3608b73056587e3b8081e1c389aa3760e583020`; exact head: `bbe0f3a2dc27d82e9b6d61dded5534573f80edb3`.
- `git range-diff` reports all nine existing Qwen-VL commits unchanged. One bounded follow-up updates the family accuracy regression from the retired `summary["trtfb"]` key to the current `summary["bundle"]` validation schema.
- The post-#839 Bundle invariant passes: a case-insensitive full-tree search finds no `trtfb` token.
- `ruff check`, `py_compile`, and `git diff --check` passed for the compatibility change.
- `PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py`: `2 passed in 0.22s`.

The follow-up changes only the constant-time regression input schema. It does not alter Qwen-VL implementation, prompts, fixtures, thresholds, model invocations, engine builds, or CI fanout. The older exact-head GPU receipt in this description predates this rebase; fresh exact-head CI is required before merge.
