### PR TITLE
fix(ci): publish bridge status on PR head

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -127,16 +127,16 @@ jobs:
       - name: Mark the exact source snapshot pending
         env:
           GH_TOKEN: ${{ github.token }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
-          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           gh api --silent --method POST \
-            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
             -f state=pending \
             -f context=trtmc/premerge/required \
             -f description="PENDING: TensorRT-Model-Connect premerge" \
-            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"
 
       - name: Dispatch internal premerge CI
         env:
@@ -179,13 +179,13 @@ jobs:
         if: ${{ failure() }}
         env:
           GH_TOKEN: ${{ github.token }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
-          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           gh api --silent --method POST \
-            "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" \
+            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
             -f state=failure \
             -f context=trtmc/premerge/required \
             -f description="FAIL: TensorRT-Model-Connect premerge dispatch" \
-            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -126,7 +126,15 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
     assert 'echo "$PRIVATE_CI_' not in dispatch
     assert "GITHUB_STEP_SUMMARY" not in dispatch
 
-    assert "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" in dispatch
+    assert (
+        dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") == 3
+    )
+    assert "HEAD_SHA: ${{ needs.authorize.outputs.merge_sha }}" not in dispatch
+    assert (
+        dispatch.count("MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}") == 1
+    )
+    assert "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" in dispatch
+    assert "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" not in dispatch
     assert "-f state=pending" in dispatch
     assert "-f state=failure" in dispatch
     assert dispatch.count("-f context=trtmc/premerge/required") == 2
@@ -135,9 +143,9 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
         '-f description="FAIL: TensorRT-Model-Connect premerge dispatch"'
     ) in dispatch
     assert dispatch.count(
-        '-f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$MERGE_SHA/tests"'
+        '-f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"'
     ) == 2
-    assert dispatch.index("/statuses/$MERGE_SHA") < dispatch.index(
+    assert dispatch.index("/statuses/$HEAD_SHA") < dispatch.index(
         "actions/workflows/premerge.yml/dispatches"
     )
 


### PR DESCRIPTION
## Background

The post-merge bridge canary completed successfully, but its commit status was attached to GitHub's synthetic pull-request merge commit. GitHub surfaces commit statuses for the pull-request head, so `trtmc/premerge/required` did not appear in the pull request's checks.

## Change

- Publish bridge pending and dispatch-failure statuses on the exact captured pull-request head.
- Continue dispatching the captured base, head, and exact merge snapshot so test execution remains pinned to the merge result.
- Add regression assertions that lock the status SHA to the captured head and the tested SHA to the captured merge commit.

## Validation

- `python3 -m pytest -q tests/tools/test_github_actions_ci.py` — 92 passed
- `python3 -m ruff check tests/tools/test_github_actions_ci.py`
- `python3 tools/legal_headers.py --check`
- `python3 tools/model_ci.py validate`
- `git diff --check`
