### PR TITLE
fix(perf): report task-level bundle rebuilds

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -233,10 +233,12 @@ report.html
 commands, bundle-preparation status and build time, and bounded diagnostic
 output. `report.html` shows the total campaign wall-clock span, each
 model-profile case's wall time, the family matrix, both infer-time p50 values,
-TRTMC bundle preparation, measured scopes, and traffic lights. Per-case wall
-time includes bundle preparation, GPU headroom waits, both commands, and
-orchestration overhead. It and bundle build time are reported for run
-observability but are excluded from the infer-time comparison.
+TRTMC bundle preparation, measured scopes, and traffic lights. Its self-contained
+filters search family, operation, model, or entry ID and select traffic-light or
+bundle-preparation status without a server dependency. Per-case wall time
+includes bundle preparation, GPU headroom waits, both commands, and orchestration
+overhead. It and bundle build time are reported for run observability but are
+excluded from the infer-time comparison.
 
 The preparation receipt uses schema `trtmc.perf-bundle-preparation/v1`, scope
 `test_task`, and the performance run's exact `git_commit`. Each entry under

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -68,6 +68,14 @@ Continue an interrupted run and automatically retry incomplete or failed entries
 python3 tools/perf_matrix.py resume artifacts/perf/<run-id>
 ```
 
+If bundle preparation ran before the matrix campaign, attach its receipt and
+regenerate the report:
+
+```bash
+python3 tools/perf_matrix.py report artifacts/perf/<run-id> \
+  --preparation-receipt artifacts/perf/bundle-preparation.json
+```
+
 `--entry` selects an exact matrix entry ID. Base contract rows use
 `family.operation`; additional profiles use `family.operation@model-profile`.
 It is not a model input or testcase name. The default is the complete matrix.
@@ -229,6 +237,15 @@ TRTMC bundle preparation, measured scopes, and traffic lights. Per-case wall
 time includes bundle preparation, GPU headroom waits, both commands, and
 orchestration overhead. It and bundle build time are reported for run
 observability but are excluded from the infer-time comparison.
+
+The preparation receipt uses schema `trtmc.perf-bundle-preparation/v1`, scope
+`test_task`, and the performance run's exact `git_commit`. Each entry under
+`bundles` records `model`, the final `bundle` path used by the campaign,
+`status`, `build_time_s`, and `included_in_performance_metrics: false`. The
+report command rejects a revision mismatch, invalid build time, duplicate
+record, or bundle that the campaign did not use. A matching task-level record
+takes precedence over the candidate command's later cache lookup, so a bundle
+rebuilt during preparation is reported as `Built`, not `Existing bundle`.
 
 Each report row shows the exact leaf commands that were executed:
 

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -918,6 +918,102 @@ def test_report_displays_campaign_and_model_profile_wall_times() -> None:
     assert "not used for traffic-light classification" in report
 
 
+def test_report_prefers_test_task_bundle_preparation_receipt() -> None:
+    bundle = "/shared/engines/example/cache-key/example.trtfb"
+    results = {
+        "git_commit": "tested-commit",
+        "cases": [
+            {
+                "id": "example.generate",
+                "family": "example",
+                "operation": "generate",
+                "model": "example-model",
+                "status": "green",
+                "baseline_contract": {},
+                "candidate": {
+                    "preparation": {
+                        "included_in_performance_metrics": False,
+                        "bundles": [
+                            {
+                                "model": "example-model",
+                                "bundle": bundle,
+                                "status": "reused",
+                                "build_time_s": None,
+                                "included_in_performance_metrics": False,
+                            }
+                        ],
+                    }
+                },
+            }
+        ],
+    }
+    receipt = {
+        "schema_version": "trtmc.perf-bundle-preparation/v1",
+        "scope": "test_task",
+        "git_commit": "tested-commit",
+        "included_in_performance_metrics": False,
+        "bundles": [
+            {
+                "model": "example-model",
+                "bundle": bundle,
+                "status": "built",
+                "build_time_s": 83.125,
+                "included_in_performance_metrics": False,
+            }
+        ],
+    }
+
+    perf_matrix._apply_bundle_preparation_receipt(results, receipt)
+    report = perf_matrix._report_html(results)
+
+    assert "Built · 1m 23.1s" in report
+    assert "Existing bundle" not in report
+    assert "1 built in this test task (1m 23.1s total)" in report
+
+
+def test_apply_bundle_preparation_receipt_rejects_unmatched_bundle() -> None:
+    results = {
+        "git_commit": "tested-commit",
+        "cases": [
+            {
+                "id": "example.generate",
+                "model": "example-model",
+                "candidate": {
+                    "preparation": {
+                        "bundles": [
+                            {
+                                "model": "example-model",
+                                "bundle": "/shared/engines/example.trtfb",
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+    }
+    receipt = {
+        "schema_version": "trtmc.perf-bundle-preparation/v1",
+        "scope": "test_task",
+        "git_commit": "tested-commit",
+        "included_in_performance_metrics": False,
+        "bundles": [
+            {
+                "model": "example-model",
+                "bundle": "/different/example.trtfb",
+                "status": "built",
+                "build_time_s": 1.0,
+                "included_in_performance_metrics": False,
+            }
+        ],
+    }
+
+    with pytest.raises(
+        perf_matrix.PerfMatrixError,
+        match="does not match a bundle used by the performance run",
+    ):
+        perf_matrix._apply_bundle_preparation_receipt(results, receipt)
+
+
 @pytest.mark.parametrize(
     "record",
     [
@@ -1059,7 +1155,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "TRTMC bundle preparation" in report
     assert "Built · 1m 23.1s" in report
     assert "83.125 s" in report
-    assert "1 built in this run (1m 23.1s total)" in report
+    assert "1 built in this test task (1m 23.1s total)" in report
     assert "excluded from the infer-time traffic-light comparison" in report
     assert ">10.450<" in report
     assert ">20.450<" in report

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -967,8 +967,71 @@ def test_report_prefers_test_task_bundle_preparation_receipt() -> None:
     report = perf_matrix._report_html(results)
 
     assert "Built · 1m 23.1s" in report
-    assert "Existing bundle" not in report
+    assert "data-filter-preparation='reused'" not in report
     assert "1 built in this test task (1m 23.1s total)" in report
+
+
+def test_report_includes_client_side_row_filters() -> None:
+    results = {
+        "cases": [
+            {
+                "id": "example.generate",
+                "family": "example",
+                "operation": "generate",
+                "model": "example-model",
+                "status": "green",
+                "baseline_contract": {},
+                "candidate": {
+                    "preparation": {
+                        "bundles": [
+                            {
+                                "model": "example-model",
+                                "bundle": "/shared/example.trtfb",
+                                "status": "built",
+                                "build_time_s": 1.0,
+                            }
+                        ]
+                    }
+                },
+            },
+            {
+                "id": "other.generate",
+                "family": "other",
+                "operation": "generate",
+                "model": "other-model",
+                "status": "red",
+                "baseline_contract": {},
+                "candidate": {
+                    "preparation": {
+                        "bundles": [
+                            {
+                                "model": "other-model",
+                                "bundle": "/shared/other.trtfb",
+                                "status": "reused",
+                            }
+                        ]
+                    }
+                },
+            },
+        ],
+    }
+
+    report = perf_matrix._report_html(results)
+
+    assert 'id="report-filter-search"' in report
+    assert 'id="report-filter-light"' in report
+    assert 'id="report-filter-preparation"' in report
+    assert 'id="report-filter-reset"' in report
+    assert 'id="report-filter-count">Showing 2 of 2 rows<' in report
+    assert (
+        "data-filter-search='example generate example-model example.generate'"
+        in report
+    )
+    assert "data-filter-light='green'" in report
+    assert "data-filter-preparation='built'" in report
+    assert "data-filter-light='red'" in report
+    assert "data-filter-preparation='reused'" in report
+    assert "row.hidden = !(matchesSearch && matchesLight && matchesPreparation);" in report
 
 
 def test_apply_bundle_preparation_receipt_rejects_unmatched_bundle() -> None:

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -50,6 +50,7 @@ from tensorrt_model_connect.python_profiles import (  # noqa: E402
 
 
 RESULT_SCHEMA = "trtmc.perf-matrix/v1"
+PREPARATION_SCHEMA = "trtmc.perf-bundle-preparation/v1"
 SUITE_SCHEMA = "trtmc.perf-suite/v2"
 ENVIRONMENT_SCHEMA = "trtmc.perf-environment/v1"
 L0_PROFILE_PATTERN = re.compile(r"(?:^|-)l0(?:-|$)", re.IGNORECASE)
@@ -131,6 +132,16 @@ def build_parser() -> argparse.ArgumentParser:
         )
     resume = commands.add_parser("resume", help="continue an incomplete run")
     resume.add_argument("run_directory", type=Path)
+    report = commands.add_parser(
+        "report",
+        help="render an existing run with optional test-task preparation evidence",
+    )
+    report.add_argument("run_directory", type=Path)
+    report.add_argument(
+        "--preparation-receipt",
+        type=Path,
+        help="JSON receipt for bundles prepared before the matrix campaign",
+    )
     return parser
 
 
@@ -2244,8 +2255,39 @@ def _bundle_preparation_records(row: Mapping[str, Any]) -> list[Mapping[str, Any
     return [bundle for bundle in bundles if isinstance(bundle, Mapping)]
 
 
-def _bundle_preparation_html(row: Mapping[str, Any]) -> str:
-    bundles = _bundle_preparation_records(row)
+def _test_task_bundle_preparation(
+    results: Mapping[str, Any],
+) -> dict[tuple[str, str], Mapping[str, Any]]:
+    preparation = results.get("bundle_preparation")
+    if not isinstance(preparation, Mapping):
+        return {}
+    bundles = preparation.get("bundles")
+    if not isinstance(bundles, list):
+        return {}
+    return {
+        (str(bundle.get("model", "")), str(bundle.get("bundle", ""))): bundle
+        for bundle in bundles
+        if isinstance(bundle, Mapping)
+    }
+
+
+def _effective_bundle_preparation_records(
+    results: Mapping[str, Any], row: Mapping[str, Any]
+) -> list[Mapping[str, Any]]:
+    task_records = _test_task_bundle_preparation(results)
+    return [
+        task_records.get(
+            (str(bundle.get("model", "")), str(bundle.get("bundle", ""))),
+            bundle,
+        )
+        for bundle in _bundle_preparation_records(row)
+    ]
+
+
+def _bundle_preparation_html(
+    results: Mapping[str, Any], row: Mapping[str, Any]
+) -> str:
+    bundles = _effective_bundle_preparation_records(results, row)
     if not bundles:
         return "—<div class='timing-meta'>Not recorded</div>"
     labels = {
@@ -2270,8 +2312,14 @@ def _bundle_preparation_html(row: Mapping[str, Any]) -> str:
     return "<br>".join(parts)
 
 
-def _bundle_preparation_summary(rows: list[Mapping[str, Any]]) -> str:
-    records = [record for row in rows for record in _bundle_preparation_records(row)]
+def _bundle_preparation_summary(
+    results: Mapping[str, Any], rows: list[Mapping[str, Any]]
+) -> str:
+    records = [
+        record
+        for row in rows
+        for record in _effective_bundle_preparation_records(results, row)
+    ]
     built = [record for record in records if record.get("status") == "built"]
     build_seconds = sum(
         float(record["build_time_s"])
@@ -2280,9 +2328,11 @@ def _bundle_preparation_summary(rows: list[Mapping[str, Any]]) -> str:
         and math.isfinite(float(record["build_time_s"]))
     )
     prebuilt = sum(record.get("status") in {"cache_hit", "reused"} for record in records)
-    unrecorded = sum(not _bundle_preparation_records(row) for row in rows)
+    unrecorded = sum(
+        not _effective_bundle_preparation_records(results, row) for row in rows
+    )
     return (
-        f"Bundle preparation: {len(built)} built in this run "
+        f"Bundle preparation: {len(built)} built in this test task "
         f"({_duration_html(build_seconds)} total), {prebuilt} cache hits or existing "
         f"bundles, and {unrecorded} rows not recorded. Preparation is reported for "
         "run observability and is excluded from the infer-time traffic-light comparison."
@@ -2352,7 +2402,7 @@ def _report_html(results: Mapping[str, Any]) -> str:
         candidate_timing = _timing_value_html(row.get("candidate"))
         baseline_timing = _timing_value_html(row.get("baseline"))
         model_wall_time = _wall_time_html(row)
-        bundle_preparation = _bundle_preparation_html(row)
+        bundle_preparation = _bundle_preparation_html(results, row)
         timing_scope = _timing_scope_html(row)
         body.append(
             "<tr>"
@@ -2403,7 +2453,9 @@ def _report_html(results: Mapping[str, Any]) -> str:
         f"{explicitly_excluded_profiles} explicitly excluded profile"
         + ("s" if explicitly_excluded_profiles != 1 else "")
     )
-    bundle_preparation_summary = html.escape(_bundle_preparation_summary(rows))
+    bundle_preparation_summary = html.escape(
+        _bundle_preparation_summary(results, rows)
+    )
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TRTMC performance matrix</title>
@@ -2439,6 +2491,121 @@ def _write_artifacts(output: Path, results: Mapping[str, Any]) -> None:
     legacy_replay = output / "reproduce.py"
     if legacy_replay.is_file():
         legacy_replay.unlink()
+
+
+def _apply_bundle_preparation_receipt(
+    results: MutableMapping[str, Any], receipt: Mapping[str, Any]
+) -> None:
+    if receipt.get("schema_version") != PREPARATION_SCHEMA:
+        raise PerfMatrixError(
+            f"preparation receipt schema_version must be {PREPARATION_SCHEMA!r}"
+        )
+    if receipt.get("scope") != "test_task":
+        raise PerfMatrixError("preparation receipt scope must be 'test_task'")
+    if receipt.get("git_commit") != results.get("git_commit"):
+        raise PerfMatrixError(
+            "preparation receipt repository revision does not match the performance run"
+        )
+    if receipt.get("included_in_performance_metrics") is not False:
+        raise PerfMatrixError(
+            "preparation receipt must exclude bundle preparation from performance metrics"
+        )
+    bundles = receipt.get("bundles")
+    if not isinstance(bundles, list) or not bundles:
+        raise PerfMatrixError("preparation receipt must contain at least one bundle")
+
+    run_bundles = {
+        (str(bundle.get("model", "")), str(bundle.get("bundle", "")))
+        for row in results.get("cases", [])
+        if isinstance(row, Mapping)
+        for bundle in _bundle_preparation_records(row)
+    }
+    seen: set[tuple[str, str]] = set()
+    allowed_statuses = {"built", "cache_hit", "reused"}
+    validated: list[dict[str, Any]] = []
+    for index, bundle in enumerate(bundles):
+        if not isinstance(bundle, Mapping):
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} must be a JSON object"
+            )
+        model = bundle.get("model")
+        path = bundle.get("bundle")
+        status = bundle.get("status")
+        if not isinstance(model, str) or not model:
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} has no model"
+            )
+        if not isinstance(path, str) or not path:
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} has no bundle path"
+            )
+        if status not in allowed_statuses:
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} has invalid status {status!r}"
+            )
+        if bundle.get("included_in_performance_metrics") is not False:
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} must be excluded from "
+                "performance metrics"
+            )
+        build_time = bundle.get("build_time_s")
+        if status == "built" and (
+            not isinstance(build_time, (int, float))
+            or isinstance(build_time, bool)
+            or not math.isfinite(float(build_time))
+            or float(build_time) < 0.0
+        ):
+            raise PerfMatrixError(
+                f"preparation receipt bundle {index} has invalid build_time_s"
+            )
+        key = (model, path)
+        if key in seen:
+            raise PerfMatrixError(
+                f"preparation receipt repeats bundle {path!r} for model {model!r}"
+            )
+        seen.add(key)
+        if key not in run_bundles:
+            raise PerfMatrixError(
+                f"preparation receipt bundle {path!r} for model {model!r} "
+                "does not match a bundle used by the performance run"
+            )
+        validated.append(deepcopy(dict(bundle)))
+
+    results["bundle_preparation"] = {
+        "schema_version": PREPARATION_SCHEMA,
+        "scope": "test_task",
+        "git_commit": receipt["git_commit"],
+        "included_in_performance_metrics": False,
+        "bundles": validated,
+    }
+
+
+def _read_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PerfMatrixError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PerfMatrixError(f"{label} must contain a JSON object")
+    return value
+
+
+def _report_existing(arguments: argparse.Namespace) -> int:
+    output = arguments.run_directory.resolve()
+    results = _read_json_object(output / "results.json", "performance results")
+    if results.get("schema_version") != RESULT_SCHEMA:
+        raise PerfMatrixError(f"cannot report non-{RESULT_SCHEMA} results")
+    if not isinstance(results.get("cases"), list):
+        raise PerfMatrixError("cannot report results without matrix entries")
+    if arguments.preparation_receipt is not None:
+        receipt = _read_json_object(
+            arguments.preparation_receipt.resolve(), "preparation receipt"
+        )
+        _apply_bundle_preparation_receipt(results, receipt)
+    _write_artifacts(output, results)
+    print(f"Results: {output / 'results.json'}")
+    print(f"Report: {output / 'report.html'}")
+    return 0
 
 
 def _existing_ancestor(path: Path) -> Path:
@@ -2720,6 +2887,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _run_new(arguments)
         if arguments.command == "resume":
             return _resume(arguments)
+        if arguments.command == "report":
+            return _report_existing(arguments)
         raise PerfMatrixError(f"unsupported command: {arguments.command}")
     except PerfMatrixError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -2339,6 +2339,16 @@ def _bundle_preparation_summary(
     )
 
 
+def _bundle_preparation_filter(
+    results: Mapping[str, Any], row: Mapping[str, Any]
+) -> str:
+    statuses = {
+        str(record.get("status", "unknown"))
+        for record in _effective_bundle_preparation_records(results, row)
+    }
+    return " ".join(sorted(statuses)) if statuses else "unrecorded"
+
+
 def _raw_commands_html(row: Mapping[str, Any], default_cwd: str) -> str:
     commands = row.get("commands", {})
     if not isinstance(commands, Mapping):
@@ -2397,6 +2407,12 @@ def _report_html(results: Mapping[str, Any]) -> str:
     default_cwd = str(results.get("repository_root", ""))
     for row in rows:
         status = str(row.get("status", "pending"))
+        light_filter = status if status in {"green", "yellow", "red"} else "white"
+        search_filter = " ".join(
+            str(row.get(key, ""))
+            for key in ("family", "operation", "model", "id")
+        ).lower()
+        preparation_filter = _bundle_preparation_filter(results, row)
         reason = html.escape(_report_note(row))
         commands = _raw_commands_html(row, default_cwd)
         candidate_timing = _timing_value_html(row.get("candidate"))
@@ -2405,7 +2421,9 @@ def _report_html(results: Mapping[str, Any]) -> str:
         bundle_preparation = _bundle_preparation_html(results, row)
         timing_scope = _timing_scope_html(row)
         body.append(
-            "<tr>"
+            f"<tr data-filter-search='{html.escape(search_filter)}' "
+            f"data-filter-light='{html.escape(light_filter)}' "
+            f"data-filter-preparation='{html.escape(preparation_filter)}'>"
             f"<td>{html.escape(str(row['family']))}</td>"
             f"<td>{html.escape(str(row['operation']))}</td>"
             f"<td><code>{html.escape(str(row['model']))}</code></td>"
@@ -2469,6 +2487,10 @@ th{{background:#e5e7eb}} tr:nth-child(even){{background:#f9fafb}} code{{font-siz
 .light{{font-size:20px;text-align:center}} .timing-value{{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}}
 .timing-meta{{color:#6b7280;font-size:11px;margin-top:2px}} .scope-side{{font-size:11px;margin-bottom:7px;min-width:270px}}
 .scope-title{{font-size:12px;font-weight:700;margin-bottom:2px}}
+.filters{{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin:16px 0;padding:12px;background:#f3f4f6;border:1px solid #d1d5db}}
+.filters label{{display:flex;flex-direction:column;gap:4px;font-size:12px;font-weight:600}}
+.filters input,.filters select,.filters button{{box-sizing:border-box;min-height:34px;padding:6px 9px;border:1px solid #9ca3af;background:#fff;color:#1f2937}}
+.filters input{{min-width:260px}} .filters button{{cursor:pointer}} .filter-count{{margin-left:auto;font-size:13px;color:#4b5563}}
 </style></head><body>
 <h1>TRTMC performance matrix</h1>
 <p class="meta">Generated {generated}. {family_count} families across {len(rows)} model-profile comparisons.{repeated_note}</p>
@@ -2479,9 +2501,57 @@ th{{background:#e5e7eb}} tr:nth-child(even){{background:#f9fafb}} code{{font-siz
 <p class="meta">Model-profile wall time spans the complete case from start to finish, including bundle preparation, GPU headroom waits, TRTMC and baseline commands, and orchestration overhead. It is reported for observability and is not used for traffic-light classification.</p>
 <p class="meta">{bundle_preparation_summary}</p>
 <p><strong>{summary}</strong></p>
+<div class="filters" aria-label="Report filters">
+<label>Search
+<input id="report-filter-search" type="search" placeholder="Family, operation, or model">
+</label>
+<label>Light
+<select id="report-filter-light"><option value="">All</option><option value="green">Green</option><option value="yellow">Yellow</option><option value="red">Red</option><option value="white">White</option></select>
+</label>
+<label>Bundle preparation
+<select id="report-filter-preparation"><option value="">All</option><option value="built">Built</option><option value="cache_hit">Cache hit</option><option value="reused">Existing bundle</option><option value="would_build">Would build</option><option value="unrecorded">Not recorded</option></select>
+</label>
+<button id="report-filter-reset" type="button">Reset</button>
+<span class="filter-count" id="report-filter-count">Showing {len(rows)} of {len(rows)} rows</span>
+</div>
 <div class="table-wrap"><table><thead><tr><th>Family</th><th>Operation</th><th>Model profile</th><th>Model-profile wall time</th><th>Baseline</th><th>TRTMC infer p50 (ms)</th><th>Baseline infer p50 (ms)</th><th>TRTMC bundle preparation</th><th>Measured scope</th><th>Light</th><th>Note</th><th>Commands</th></tr></thead>
 <tbody>{"".join(body)}</tbody></table></div>
 <p class="meta">Green: TRTMC is more than the configured margin faster. Yellow: within the margin. Red: TRTMC is more than the margin slower. White: not run, partial, or invalid comparison. Commands are the original recorded argv and must be run from the displayed working directory with the same model cache and dependencies.</p>
+<script>
+(() => {{
+  const search = document.getElementById("report-filter-search");
+  const light = document.getElementById("report-filter-light");
+  const preparation = document.getElementById("report-filter-preparation");
+  const reset = document.getElementById("report-filter-reset");
+  const count = document.getElementById("report-filter-count");
+  const rows = Array.from(document.querySelectorAll("tbody tr[data-filter-search]"));
+  const applyFilters = () => {{
+    const searchValue = search.value.trim().toLowerCase();
+    const lightValue = light.value;
+    const preparationValue = preparation.value;
+    let visible = 0;
+    for (const row of rows) {{
+      const matchesSearch = !searchValue || row.dataset.filterSearch.includes(searchValue);
+      const matchesLight = !lightValue || row.dataset.filterLight === lightValue;
+      const matchesPreparation = !preparationValue ||
+        row.dataset.filterPreparation.split(" ").includes(preparationValue);
+      row.hidden = !(matchesSearch && matchesLight && matchesPreparation);
+      if (!row.hidden) visible += 1;
+    }}
+    count.textContent = "Showing " + visible + " of " + rows.length + " rows";
+  }};
+  search.addEventListener("input", applyFilters);
+  light.addEventListener("change", applyFilters);
+  preparation.addEventListener("change", applyFilters);
+  reset.addEventListener("click", () => {{
+    search.value = "";
+    light.value = "";
+    preparation.value = "";
+    applyFilters();
+    search.focus();
+  }});
+}})();
+</script>
 </body></html>"""
 
 


### PR DESCRIPTION
## Background
The performance report only used bundle preparation recorded by each candidate
command. When a bundle was rebuilt immediately before the matrix campaign, the
candidate command later recorded a reuse and the report incorrectly labeled the
bundle as existing.

## Exit Criteria
- A bundle rebuilt during the same test task is reported as `Built`.
- Preparation evidence cannot be applied to a different revision, model, or
  bundle.
- Bundle preparation remains excluded from infer-time traffic-light metrics.
- Generated HTML can filter rows by text, traffic light, and bundle preparation
  without external assets or a server dependency.

## Implementation
- Add a validated task-level bundle preparation receipt and a `report` command
  that attaches it to an existing performance run.
- Match task-level records to the exact model and final bundle path consumed by
  the campaign, then prefer them over the later candidate cache lookup.
- Report build counts as occurring in the current test task and document the
  receipt workflow.
- Add self-contained row filters, a visible-row count, and a reset control to
  generated reports.

## Validation
- `pytest -q tests/tools/test_perf_matrix.py`: 86 passed.
- `python3 -m ruff check tools/perf_matrix.py tests/tools/test_perf_matrix.py`:
  passed.
- `git diff --check`: passed.

## Notes For Future Readers
- The receipt is intentionally fail-closed. Do not infer rebuilds from file
  modification times; attach explicit build evidence for the exact tested
  revision and final bundle path.
