### PR TITLE
fix(ci): project task-eval reference runners

### DIFF
--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -151,9 +151,20 @@ def _make_repo(
     _write(repo, "tools/diff_logits.py", "# shared logits diff\n")
     _write(repo, "tools/diff_vl.py", "# shared vision-language diff\n")
     _write(repo, "tools/diffusion_helpers.py", "# shared diffusion helpers\n")
+    _write(repo, "tools/elf_hf_reference.py", "# ELF reference helper\n")
     _write(repo, "tools/model_plugin_isolation.py", "# proof verifier\n")
+    for reference_runner in (
+        "tools/reference/elf_prepared.py",
+        "tools/reference/plugin_reference.py",
+        "tools/reference/speech.py",
+        "tools/reference/transformers_encoder.py",
+        "tools/reference/transformers_text.py",
+        "tools/reference/transformers_vlm.py",
+    ):
+        _write(repo, reference_runner, "# task-eval reference runner\n")
     _write(repo, "tools/test_impact.py", "# shared impact analyzer\n")
     _write(repo, "tools/task_eval.py", "# task-eval runner\n")
+    _write(repo, "tools/trtmc_reference.py", "# task-eval reference runner\n")
     _write(repo, "tests/task_eval/validation_suites.yaml", "suites: []\n")
     _write(repo, "tests/tools/test_task_eval.py", "# task-eval unit tests\n")
     _write(repo, "tools/tool_helpers.py", "# shared tool helpers\n")
@@ -1083,10 +1094,18 @@ def test_projection_contains_only_selected_model_and_stable_git_blobs(
         "tools/diff_logits.py",
         "tools/diff_vl.py",
         "tools/diffusion_helpers.py",
+        "tools/elf_hf_reference.py",
         "tools/model_plugin_isolation.py",
+        "tools/reference/elf_prepared.py",
+        "tools/reference/plugin_reference.py",
+        "tools/reference/speech.py",
+        "tools/reference/transformers_encoder.py",
+        "tools/reference/transformers_text.py",
+        "tools/reference/transformers_vlm.py",
         "tools/task_eval.py",
         "tools/test_impact.py",
         "tools/tool_helpers.py",
+        "tools/trtmc_reference.py",
         "tools/ci/__init__.py",
         "tools/ci/__main__.py",
         "tools/ci/model_proof.py",

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -85,10 +85,18 @@ PLATFORM_PROJECTION_EXACT = frozenset(
         "tools/diff_logits.py",
         "tools/diff_vl.py",
         "tools/diffusion_helpers.py",
+        "tools/elf_hf_reference.py",
         "tools/model_plugin_isolation.py",
+        "tools/reference/elf_prepared.py",
+        "tools/reference/plugin_reference.py",
+        "tools/reference/speech.py",
+        "tools/reference/transformers_encoder.py",
+        "tools/reference/transformers_text.py",
+        "tools/reference/transformers_vlm.py",
         "tools/task_eval.py",
         "tools/test_impact.py",
         "tools/tool_helpers.py",
+        "tools/trtmc_reference.py",
         *MODEL_ROOT_PLATFORM_FILES,
     }
 )


### PR DESCRIPTION
## Background

Nightly task evaluation launches `tools/trtmc_reference.py` from an isolated
model source projection. The projection omitted that dispatcher and its native
runner closure, so model build and E2E validation could pass while task
evaluation exited before reference execution.

The pre-merge L0 suite did not catch this because task evaluation is a
nightly-only stage, and the projection contract test did not previously include
the standalone reference runner files.

## Exit Criteria

- Isolated model projections contain the tracked task-eval dispatcher and its
  exact native runner closure.
- Model isolation remains exact; no broad `tools/reference/` prefix is added.
- Test thresholds, model behavior, and workflow behavior remain unchanged.

## Implementation

- Add the dispatcher, six native runner entrypoints, and the ELF helper to the
  exact platform projection allowlist.
- Extend the projection regression fixture and assertions to cover the same
  dependency closure.

## Validation

- `python3 -m pytest -q tests/tools/test_model_ci.py` — 72 passed
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality` — 158 passed
- Ruff — passed
- Legal headers — passed
- Model manifest validation — 78 models
- Real TimesFM projection — all 8 reference files present and byte-identical
- Time-series runner resolution — `plugin_reference.py` found and hashed
- `git diff --check` — passed

## Notes For Future Readers

Task evaluation is currently nightly-only. If the reference dispatcher gains a
new native runner, keep the exact projection allowlist and regression fixture in
sync.
