### PR TITLE
fix(elf): preserve de-en replay parity

### DIFF
--- a/tests/e2e/models/elf_flow/manifests/elf-b-de-en-l0.json
+++ b/tests/e2e/models/elf_flow/manifests/elf-b-de-en-l0.json
@@ -5,16 +5,7 @@
   "family": "elf_flow",
   "runtime_strategy": "elf_flow",
   "task_strategy": "diffusion_text_generation",
-  "precision": "fp16",
-  "fp32_layers": [
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11
-  ],
+  "precision": "fp32",
   "max_cache_length": 128,
   "testcases": [
     {
@@ -69,7 +60,7 @@
         "github_reference": "https://github.com/lillian039/ELF",
         "upstream_entrypoint": "src/eval.py --config configs/training_configs/train_de-en_ELF-B.yml",
         "expected_report": "Conditional ELF evaluation reports generated translations and BLEU/ROUGE-style task metrics when online evaluation is enabled.",
-        "notes": "Replays the tensors exported from the official ELF JAX evaluator for the checked-in source sentence and requires exact normalized text plus token-id parity. Decoder blocks 0-4 and the final boundary run in FP16 with FP32 GEMM accumulation. Blocks 5-11 remain FP32 because casting the growing flow activations back to FP16 overflows before block 6."
+        "notes": "Replays the tensors exported from the official ELF JAX evaluator for the checked-in source sentence and requires exact normalized text plus token-id parity. The exact replay contract uses FP32 because the former mixed FP16/FP32 build crosses a discrete token boundary on Auto Thor."
       }
     }
   ]

--- a/tests/e2e/models/elf_flow/test_elf_flow_contract.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_contract.py
@@ -691,6 +691,9 @@ def test_elf_l0_manifests_use_upstream_replay_contract() -> None:
         assert "skip_reason" not in case.metadata
         assert Path(case.inputs["elf_replay_artifact"]).is_file()
         assert any(stage.artifact_type == "text_samples" for stage in case.stages)
+        if name == "elf-b-de-en-l0":
+            assert case.metadata["precision"] == "fp32"
+            assert "fp32_layers" not in case.metadata
         if name == "elf-b-owt-l0":
             assert case.metadata["e2e_parallel_resource"] == "exclusive_gpu"
             build_env = case.metadata["build_env"]


### PR DESCRIPTION
## Background
The ELF-B de-en exact upstream replay is stable on Auto Thor but the mixed FP16/FP32 engine changes one token (`is` to `are`). A matching 128-token FP32 diagnostic build preserves the checked-in upstream token sequence exactly.

## Exit Criteria
- The de-en replay uses a precision mode that preserves exact text and token parity on Auto Thor.
- Existing exact comparison thresholds remain unchanged.

## Implementation
- Build the ELF-B de-en replay engine in FP32 instead of the previous mixed-precision configuration.
- Cover the precision choice in the ELF manifest contract test.

## Validation
- `PYTHONPATH=python:. python -m pytest tests/e2e/models/elf_flow/test_elf_flow_contract.py -q`: 17 passed.
- Auto Thor formal single-case E2E (`elf-b-de-en-l0`, TensorRT 11.2.0.106): 1 passed in 53.26s.
- Five repeated mixed-precision runs produced the same mismatching token, while the FP32 diagnostic produced the exact upstream text and token IDs.

## Notes For Future Readers
- This intentionally prioritizes the exact L1 upstream replay contract. Do not restore mixed precision without demonstrating exact parity on Auto Thor.
