### PR TITLE
fix(ci): dispatch exact PR head only

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -44,21 +44,18 @@ jobs:
       pull-requests: write
     outputs:
       pr_number: ${{ steps.snapshot.outputs.pr_number }}
-      base_sha: ${{ steps.snapshot.outputs.base_sha }}
       head_sha: ${{ steps.snapshot.outputs.head_sha }}
-      merge_sha: ${{ steps.snapshot.outputs.merge_sha }}
 
     steps:
       # This trusted workflow reads PR metadata only. It never checks out or
-      # executes the pull-request head or merge commit.
-      - name: Capture the exact pull-request snapshot
+      # executes the pull-request head.
+      - name: Capture the exact pull-request head
         id: snapshot
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
@@ -81,27 +78,19 @@ jobs:
           state="$(jq -er '.state' <<<"$pull")"
           base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
           base_ref="$(jq -er '.base.ref' <<<"$pull")"
-          base_sha="$(jq -er '.base.sha' <<<"$pull")"
           head_sha="$(jq -er '.head.sha' <<<"$pull")"
-          merge_sha="$(jq -r '.merge_commit_sha // ""' <<<"$pull")"
 
           test "$state" = "open"
           test "$base_repo" = "$GITHUB_REPOSITORY"
           test "$base_ref" = "main"
-          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            [[ "$EVENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
             [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-            test "$base_sha" = "$EVENT_BASE_SHA"
             test "$head_sha" = "$EVENT_HEAD_SHA"
           fi
           {
             echo "pr_number=$PR_NUMBER"
-            echo "base_sha=$base_sha"
             echo "head_sha=$head_sha"
-            echo "merge_sha=$merge_sha"
           } >> "$GITHUB_OUTPUT"
 
       - name: Consume the trusted trigger label
@@ -124,7 +113,7 @@ jobs:
       statuses: write
 
     steps:
-      - name: Mark the exact source snapshot pending
+      - name: Mark the exact source head pending
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
@@ -146,9 +135,7 @@ jobs:
           PRIVATE_CI_OWNER: ${{ secrets.TRTMC_PRIVATE_CI_OWNER }}
           PRIVATE_CI_REPOSITORY: ${{ secrets.TRTMC_PRIVATE_CI_REPOSITORY }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
-          BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
         run: |
           set -euo pipefail
           [[ "$PRIVATE_CI_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
@@ -159,16 +146,12 @@ jobs:
           trap 'rm -f "$payload"' EXIT
           jq -n \
             --arg pr_number "$PR_NUMBER" \
-            --arg base_sha "$BASE_SHA" \
             --arg head_sha "$HEAD_SHA" \
-            --arg merge_sha "$MERGE_SHA" \
             '{
               ref: "main",
               inputs: {
                 pr_number: $pr_number,
-                base_sha: $base_sha,
-                head_sha: $head_sha,
-                merge_sha: $merge_sha
+                head_sha: $head_sha
               }
             }' > "$payload"
           gh api --silent --method POST \

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -41,7 +41,7 @@ def _single_default_model_config(filename: str) -> tuple[Path, dict]:
     return defaults[0]
 
 
-def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
+def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     workflow = (
         REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"
     ).read_text(encoding="utf-8")
@@ -85,12 +85,18 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
     assert 'test "$base_repo" = "$GITHUB_REPOSITORY"' in authorize
     assert 'test "$base_ref" = "main"' in authorize
     assert 'if [ "$EVENT_NAME" = "pull_request_target" ]; then' in authorize
-    assert 'test "$base_sha" = "$EVENT_BASE_SHA"' in authorize
     assert 'test "$head_sha" = "$EVENT_HEAD_SHA"' in authorize
-    for name in ("base_sha", "head_sha", "merge_sha"):
-        assert f'[[ "${name}" =~ ^[0-9a-f]{{40}}$ ]]' in authorize
-        assert f'echo "{name}=${name}"' in authorize
+    assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
+    assert 'echo "head_sha=$head_sha"' in authorize
     assert "pr_number=$PR_NUMBER" in authorize
+    for legacy in (
+        "base_sha",
+        "merge_sha",
+        "BASE_SHA",
+        "MERGE_SHA",
+        "EVENT_BASE_SHA",
+    ):
+        assert legacy not in workflow
     assert (
         "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
     ) in authorize
@@ -129,10 +135,6 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
     assert (
         dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") == 3
     )
-    assert "HEAD_SHA: ${{ needs.authorize.outputs.merge_sha }}" not in dispatch
-    assert (
-        dispatch.count("MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}") == 1
-    )
     assert "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" in dispatch
     assert "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" not in dispatch
     assert "-f state=pending" in dispatch
@@ -150,7 +152,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_snapshot() -> None:
     )
 
     assert 'ref: "main"' in dispatch
-    for name in ("pr_number", "base_sha", "head_sha", "merge_sha"):
+    for name in ("pr_number", "head_sha"):
         assert f"{name}: ${name}" in dispatch
     assert "umask 077" in dispatch
     assert 'trap \'rm -f "$payload"\' EXIT' in dispatch


### PR DESCRIPTION
## Background
The first production bridge canary proved the sanitized head status path but
failed because the bridge dispatched inconsistent base and synthetic merge
metadata for a long-lived PR. The intended contract is to test the exact
approved PR head only.

## Exit Criteria
- The bridge dispatches only the PR number and exact PR head SHA.
- Authorization, label consumption, protected PAT access, and sanitized Source
  statuses remain unchanged.
- No Source PR code is checked out or executed by the bridge.

## Implementation
- Remove base and synthetic merge metadata from capture, outputs, and the
  workflow-dispatch payload.
- Retain the label-event head check so a push after approval cannot silently
  change the dispatched revision.
- Strengthen the Source contract test to reject legacy base/merge fields.

## Validation
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q`: 92 passed.
- Bridge YAML/contract parse: passed.
- Secret-reference comparison against `main`: passed; no secret or environment
  boundary changed.
- Independent blocking review: no findings.
- `git diff --check`: passed.

## Notes For Future Readers
- Depends on NVIDIA-dev/TensorRT-Model-Connect-CI#6.
- Merge the Internal CI PR first, then this PR. Do not trigger
  `run-internal-ci` during the brief interval between merges.
- After both land, rerun the production canary on Source PR #263 before
  disabling legacy Source CI.
- This intentionally tests the PR head without merging newer `main`; merge
  conflicts are handled by the normal PR/rebase flow.
