### PR TITLE
fix(byok): expose raw graph ops and CuTe DSL flow

### DIFF
--- a/examples/byok/export_cutedsl_residual_add.py
+++ b/examples/byok/export_cutedsl_residual_add.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export a fixed-shape FP16 residual add as a TVM-FFI DSO."""
+
+import argparse
+from importlib import metadata
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROWS = 256
+COLS = 768
+THREADS = 256
+SUM_OP = "LayerType.ELEMENTWISE/ElementWiseOperation.SUM"
+
+
+def _verify_contract(snapshot_path: Path, selection_path: Path) -> dict:
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    selection = json.loads(selection_path.read_text(encoding="utf-8"))
+    if selection.get("graph_fingerprint") != snapshot.get("fingerprint"):
+        raise SystemExit("selection and graph snapshot fingerprints differ")
+    if selection.get("workspace_bytes") != 0 or selection.get("extra_args") != []:
+        raise SystemExit("this kernel requires zero workspace and no extra arguments")
+    if selection.get("output_shape_input") is not None:
+        raise SystemExit("this fixed-shape kernel does not accept a dynamic output")
+
+    input_ids = selection.get("input_tensor_ids")
+    output_ids = selection.get("output_tensor_ids")
+    node_ids = selection.get("node_ids")
+    if not isinstance(input_ids, list) or len(input_ids) != 2:
+        raise SystemExit("this kernel requires exactly two inputs")
+    if not isinstance(output_ids, list) or len(output_ids) != 1:
+        raise SystemExit("this kernel requires exactly one output")
+    if not isinstance(node_ids, list) or len(node_ids) != 1:
+        raise SystemExit("this example replaces exactly one TensorRT node")
+
+    nodes = {node["id"]: node for node in snapshot["nodes"]}
+    node = nodes.get(node_ids[0])
+    if node is None or node.get("op") != SUM_OP:
+        raise SystemExit(f"selected node must be {SUM_OP}")
+    if node.get("inputs") != input_ids or node.get("outputs") != output_ids:
+        raise SystemExit("selection boundary does not match the selected node")
+
+    tensors = {tensor["id"]: tensor for tensor in snapshot["tensors"]}
+    for tensor_id in [*input_ids, *output_ids]:
+        tensor = tensors.get(tensor_id)
+        if tensor is None:
+            raise SystemExit(f"snapshot does not contain {tensor_id}")
+        if tensor.get("dtype") != "DataType.HALF":
+            raise SystemExit(f"{tensor_id} must use FP16")
+        if tensor.get("shape") != [ROWS, COLS]:
+            raise SystemExit(f"{tensor_id} must have shape [{ROWS}, {COLS}]")
+        if tensor.get("location") != "TensorLocation.DEVICE":
+            raise SystemExit(f"{tensor_id} must be a device tensor")
+        if tensor.get("is_shape_tensor"):
+            raise SystemExit(f"{tensor_id} must not be a shape tensor")
+    return selection
+
+
+def _compile():
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+
+    @cute.kernel
+    def residual_add_kernel(
+        hidden: cute.Tensor,
+        attention_projection: cute.Tensor,
+        output: cute.Tensor,
+    ):
+        thread_x, _, _ = cute.arch.thread_idx()
+        block_x, _, _ = cute.arch.block_idx()
+        block_size, _, _ = cute.arch.block_dim()
+        linear_index = block_x * block_size + thread_x
+        row = linear_index // COLS
+        column = linear_index % COLS
+        output[row, column] = hidden[row, column] + attention_projection[row, column]
+
+    @cute.jit
+    def run(
+        hidden: cute.Tensor,
+        attention_projection: cute.Tensor,
+        output: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        residual_add_kernel(hidden, attention_projection, output).launch(
+            grid=((ROWS * COLS) // THREADS, 1, 1),
+            block=(THREADS, 1, 1),
+            stream=stream,
+        )
+
+    def tensor():
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float16,
+            (ROWS, COLS),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+
+    return cute.compile(
+        run,
+        tensor(),
+        tensor(),
+        tensor(),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi --opt-level 3",
+    )
+
+
+def _runtime_archive() -> Path:
+    distribution = metadata.distribution("nvidia-cutlass-dsl-libs-base")
+    archive = Path(
+        distribution.locate_file("nvidia_cutlass_dsl/lib/libcuda_dialect_runtime_static.a")
+    ).resolve()
+    if not archive.is_file():
+        raise SystemExit(f"CuTe DSL runtime archive not found: {archive}")
+    return archive
+
+
+def _link(compiled, output: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="trtmc-cutedsl-") as temporary:
+        root = Path(temporary)
+        object_file = root / "kernel.o"
+        exports = root / "exports.map"
+        compiled.export_to_c(
+            str(object_file),
+            function_name="run",
+            enable_pic=True,
+            export_only_tvm_ffi_symbols=True,
+        )
+        exports.write_text("{\n  global: __tvm_ffi_*;\n  local: *;\n};\n")
+        subprocess.run(
+            [
+                shutil.which("gcc") or "gcc",
+                "-shared",
+                "-o",
+                str(output),
+                str(object_file),
+                "-Wl,--whole-archive",
+                str(_runtime_archive()),
+                "-Wl,--no-whole-archive",
+                f"-Wl,--version-script={exports}",
+                "-L/usr/local/cuda/lib64",
+                "-lcudart",
+                "-ldl",
+                "-lpthread",
+            ],
+            check=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snapshot", required=True, type=Path)
+    parser.add_argument("--selection", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    arguments = parser.parse_args()
+
+    import tvm_ffi  # noqa: F401 - required by the generated ABI
+
+    selection = _verify_contract(arguments.snapshot, arguments.selection)
+    if arguments.output.exists():
+        raise SystemExit(f"refusing to overwrite {arguments.output}")
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    _link(_compile(), arguments.output)
+    print(f"binding_id={selection['binding_id']}")
+    print(f"abi_sha256={selection['abi_sha256']}")
+    print(arguments.output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tensorrt_model_connect/trt_compat.py
+++ b/python/tensorrt_model_connect/trt_compat.py
@@ -454,6 +454,22 @@ class _BuilderProxy(_HandleProxy):
 
 
 class _NetworkProxy(_HandleProxy):
+    def __getattr__(self, name: str) -> Any:
+        attr = super().__getattr__(name)
+        if not name.startswith("add_") or not callable(attr):
+            return attr
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            before = int(self._raw.num_layers)
+            result = attr(*args, **kwargs)
+            if int(self._raw.num_layers) == before + 1:
+                from .tvm_ffi.graph_build import record_layer_operation
+
+                record_layer_operation(self._raw, before, result)
+            return result
+
+        return call
+
     def _add_attention(self, method: str, *args: Any, **kwargs: Any) -> Any:
         attention = getattr(self._raw, method)(
             *[unwrap(arg) for arg in args],

--- a/python/tensorrt_model_connect/tvm_ffi/graph_build.py
+++ b/python/tensorrt_model_connect/tvm_ffi/graph_build.py
@@ -36,6 +36,7 @@ class _Session:
     completed: bool = False
     slot: dict[str, str] | None = None
     attentions: dict[int, list[Any]] = field(default_factory=dict)
+    operation_layers: dict[int, dict[int, Any]] = field(default_factory=dict)
     recipes: dict[int, list[dict[str, Any]]] = field(default_factory=dict)
 
 
@@ -111,6 +112,14 @@ def record_attention(network: Any, attention: Any) -> None:
     session = _ACTIVE.get()
     if session is not None and attention is not None:
         session.attentions.setdefault(id(network), []).append(attention)
+
+
+def record_layer_operation(network: Any, index: int, layer: Any) -> None:
+    """Record a raw TensorRT operation subtype while its derived view exists."""
+
+    session = _ACTIVE.get()
+    if session is not None:
+        session.operation_layers.setdefault(id(network), {})[index] = layer
 
 
 @contextmanager
@@ -211,10 +220,16 @@ def process_network(network: Any) -> None:
         raise GraphPatchError(f"engine role {role!r} was built more than once")
     metadata = _metadata(session)
     attentions = session.attentions.get(id(network), ())
+    operation_layers = session.operation_layers.get(id(network), {})
     recipes = session.recipes.get(id(network), ())
     if recipes:
         metadata["graph_recipes"] = list(recipes)
-    snapshot = snapshot_network(network, metadata=metadata, attentions=attentions)
+    snapshot = snapshot_network(
+        network,
+        metadata=metadata,
+        attentions=attentions,
+        operation_layers=operation_layers,
+    )
     if session.mode == "inspect":
         assert session.path is not None
         write_snapshot(snapshot, session.path)
@@ -243,6 +258,7 @@ def process_network(network: Any) -> None:
         replacement,
         metadata=metadata,
         attentions=attentions,
+        operation_layers=operation_layers,
     )
     session.slot = {
         "id": selection.binding_id,

--- a/python/tensorrt_model_connect/tvm_ffi/graph_patch.py
+++ b/python/tensorrt_model_connect/tvm_ffi/graph_patch.py
@@ -339,6 +339,18 @@ def _shape(tensor: Any) -> tuple[int | str, ...]:
     return tuple(result)
 
 
+def _layer_operation(layer: Any, derived_layer: Any | None = None) -> str:
+    operation = str(getattr(layer, "type", type(layer).__name__))
+    source = derived_layer if derived_layer is not None else layer
+    try:
+        subtype = source.op
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return operation
+    if subtype is None:
+        return operation
+    return f"{operation}/{subtype}"
+
+
 _ATTENTION_INPUT_PROPERTIES = (
     "mask",
     "normalization_quantize_scale",
@@ -386,6 +398,7 @@ def _capture(
     network: Any,
     metadata: Mapping[str, Any] | None,
     attentions: Sequence[Any] = (),
+    operation_layers: Mapping[int, Any] | None = None,
 ) -> _Captured:
     metadata_copy = _json_object(dict(metadata or {}), "metadata")
     if not isinstance(metadata_copy.get("engine_role"), str) or not metadata_copy["engine_role"]:
@@ -456,7 +469,10 @@ def _capture(
             Node(
                 node_id,
                 str(getattr(layer, "name", "") or ""),
-                str(getattr(layer, "type", type(layer).__name__)),
+                _layer_operation(
+                    layer,
+                    operation_layers.get(index) if operation_layers else None,
+                ),
                 tuple(inputs),
                 layer_outputs[index],
             )
@@ -518,9 +534,10 @@ def snapshot_network(
     *,
     metadata: Mapping[str, Any] | None = None,
     attentions: Sequence[Any] = (),
+    operation_layers: Mapping[int, Any] | None = None,
 ) -> GraphSnapshot:
     """Capture a raw TensorRT network in deterministic build order."""
-    return _capture(network, metadata, attentions).snapshot
+    return _capture(network, metadata, attentions, operation_layers).snapshot
 
 
 def _boundary(
@@ -720,9 +737,10 @@ def apply_region(
     *,
     metadata: Mapping[str, Any] | None = None,
     attentions: Sequence[Any] = (),
+    operation_layers: Mapping[int, Any] | None = None,
 ) -> RewireResult:
     """Validate and replace one selected region before TRT serialization."""
-    captured = _capture(network, metadata, attentions)
+    captured = _capture(network, metadata, attentions, operation_layers)
     _validate_selection(captured.snapshot, selection)
     selected = set(selection.node_ids)
     output_indexes = {

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -188,7 +188,7 @@ void print_usage() {
         << "Usage:\n"
            "  trtmc build           <hf-model-or-dir> -o <bundle.trtfb> [builder args...]\n"
            "  trtmc kernel slots    <hf-model-or-dir> [--model-revision REV]\n"
-           "  trtmc graph           <inspect|list|recipe|select> [args...]\n"
+           "  trtmc graph           <inspect|list|recipes|select> [args...]\n"
            "  trtmc run             <bundle.trtfb> --prompt \"text\" [--image PATH] "
            "[--max-new-tokens N] [--temperature F] [--top-p F] [--min-p F] "
            "[--top-k N] [--seed N] [--benchmark N] [--warmup N] [--hf-python PATH] "

--- a/tests/builder/test_graph_patch.py
+++ b/tests/builder/test_graph_patch.py
@@ -180,6 +180,19 @@ def test_snapshot_round_trip_preserves_duplicate_input_slots(tmp_path) -> None:
     assert snapshot.tensors[0].consumers == ("node:0", "node:0")
 
 
+def test_snapshot_exposes_tensorrt_operation_subtype() -> None:
+    value = FakeTensor("value")
+    layer = FakeLayer("sum", [value, value], op="LayerType.ELEMENTWISE")
+    layer.op = "ElementWiseOperation.SUM"
+    consumer = FakeLayer("consumer", [layer.get_output(0)])
+
+    snapshot = _snapshot(FakeNetwork([value], [layer, consumer], [consumer.get_output(0)]))
+
+    assert snapshot.nodes[0].op == (
+        "LayerType.ELEMENTWISE/ElementWiseOperation.SUM"
+    )
+
+
 def test_apply_rewires_every_external_consumer() -> None:
     network, layers = _network()
     selection = select_region(_snapshot(network), ["node:1"], binding_id="attention")

--- a/tests/builder/test_graph_patch_trt.py
+++ b/tests/builder/test_graph_patch_trt.py
@@ -9,10 +9,45 @@ trt = pytest.importorskip("tensorrt")
 
 from tensorrt_model_connect.tvm_ffi.graph_patch import (  # noqa: E402
     apply_region,
+    load_snapshot,
     select_region,
     snapshot_network,
 )
-from tensorrt_model_connect.trt_compat import network_creation_flags  # noqa: E402
+from tensorrt_model_connect.tvm_ffi import graph_build  # noqa: E402
+from tensorrt_model_connect.trt_compat import (  # noqa: E402
+    get_trt,
+    network_creation_flags,
+    unwrap,
+)
+
+
+@pytest.mark.gpu
+@pytest.mark.trt
+def test_capture_exposes_elementwise_operation_subtype(tmp_path) -> None:
+    compat_trt = get_trt()
+    logger = compat_trt.Logger(compat_trt.Logger.ERROR)
+    builder = compat_trt.Builder(logger)
+    path = tmp_path / "graph.json"
+
+    with pytest.raises(graph_build.GraphInspectionComplete):
+        with graph_build.inspect_graph(path, engine_role="decode", metadata={}):
+            network = builder.create_network(network_creation_flags())
+            with graph_build.engine_role("decode"):
+                lhs = network.add_input("lhs", compat_trt.float16, (1, 8))
+                rhs = network.add_input("rhs", compat_trt.float16, (1, 8))
+                selected = network.add_elementwise(
+                    lhs,
+                    rhs,
+                    compat_trt.ElementWiseOperation.SUM,
+                )
+                selected.op = compat_trt.ElementWiseOperation.PROD
+                consumer = network.add_identity(selected.get_output(0))
+                network.mark_output(consumer.get_output(0))
+                graph_build.process_network(unwrap(network))
+
+    assert load_snapshot(path).nodes[0].op == (
+        "LayerType.ELEMENTWISE/ElementWiseOperation.PROD"
+    )
 
 
 @pytest.mark.gpu

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -17,6 +17,7 @@ catch_all benchmarks/performance/release.yaml # release matrix workloads and com
 catch_all conanfile.py # release wheel native packaging recipe; catch-all stays conservative
 catch_all conftest.py # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all docker-compose.yml # tracked path has no precise impact rule yet; catch-all stays conservative
+catch_all examples/byok/export_cutedsl_residual_add.py # standalone GPU tutorial exporter has no precise impact rule yet; catch-all stays conservative
 catch_all examples/trtmc_dataset_benchmark.cpp # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all hf_links_wave1.txt # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all NOTICE # top-level legal attribution metadata; conservative full-suite fallback is intentionally retained

--- a/website/docs/tutorials/beginner/bring-your-own-kernel.md
+++ b/website/docs/tutorials/beginner/bring-your-own-kernel.md
@@ -49,15 +49,23 @@ prebuilt `logits + zero` recipe. The operation is intentionally simple: it
 lets a first-time user test recipe selection, graph replacement, load-time
 binding, correctness, and performance before adapting a real kernel.
 
+This tutorial builds its example DSO from the source tree, so use the native
+CLI from that same configured build.
+
 ```bash
 export MODEL=Qwen/Qwen3-8B
 export REVISION=b968826d9c46dd6066d109eabc6255188de91218
 export WORK="$PWD/artifacts/qwen3-graph-slot"
-export BUILD_DIR="${BUILD_DIR:-$PWD/build-runtime-trt}"
+export BUILD_DIR="${BUILD_DIR:-$PWD/build}"
+export TRTMC="${TRTMC:-$BUILD_DIR/trtmc}"
 mkdir -p "$WORK"
 
 test -f "$BUILD_DIR/CMakeCache.txt" || {
   echo "BUILD_DIR must name an already configured native TVM-FFI build"
+  exit 1
+}
+test -x "$TRTMC" || {
+  echo "TRTMC must name the native CLI from BUILD_DIR"
   exit 1
 }
 
@@ -88,7 +96,7 @@ Build the slot-ready bundle directly:
 ```bash
 export BINDING_ID=qwen.decode_logits_copy@1
 
-trtmc build "${BUILD_ARGS[@]}" \
+"$TRTMC" build "${BUILD_ARGS[@]}" \
   --recipe "$BINDING_ID" decoder.logits_zero_bias \
   -o "$WORK/qwen3-slot-ready.trtfb"
 ```
@@ -113,12 +121,12 @@ If a family tutorial does not give you the Recipe and instance names, inspect
 them without compiling an engine:
 
 ```bash
-trtmc graph inspect \
+"$TRTMC" graph inspect \
   --engine-role decode \
   --snapshot "$WORK/decode.graph.json" \
   "${BUILD_ARGS[@]}"
 
-trtmc graph recipes "$WORK/decode.graph.json" \
+"$TRTMC" graph recipes "$WORK/decode.graph.json" \
   | tee "$WORK/decode.recipes.txt"
 ```
 
@@ -201,7 +209,7 @@ and every slot in the bundle must be bound exactly once.
 Load and run:
 
 ```bash
-trtmc run "$WORK/qwen3-slot-ready.trtfb" \
+"$TRTMC" run "$WORK/qwen3-slot-ready.trtfb" \
   --kernel-bindings "$WORK/kernel-bindings.json" \
   --prompt "Explain grouped-query attention in one sentence." \
   --max-new-tokens 32 \
@@ -217,7 +225,7 @@ Editing a manifest does not affect an existing pipeline.
 Build the native comparison with the same arguments:
 
 ```bash
-trtmc build "${BUILD_ARGS[@]}" -o "$WORK/qwen3-native.trtfb"
+"$TRTMC" build "${BUILD_ARGS[@]}" -o "$WORK/qwen3-native.trtfb"
 ```
 
 Compare deterministic output:
@@ -226,12 +234,12 @@ Compare deterministic output:
 TEST_PROMPT='Explain grouped-query attention, KV caching, and decode latency.'
 MAX_NEW_TOKENS=64
 
-trtmc run "$WORK/qwen3-native.trtfb" \
+"$TRTMC" run "$WORK/qwen3-native.trtfb" \
   --prompt "$TEST_PROMPT" \
   --max-new-tokens "$MAX_NEW_TOKENS" --greedy \
   --output "$WORK/native.jsonl"
 
-trtmc run "$WORK/qwen3-slot-ready.trtfb" \
+"$TRTMC" run "$WORK/qwen3-slot-ready.trtfb" \
   --kernel-bindings "$WORK/kernel-bindings.json" \
   --prompt "$TEST_PROMPT" \
   --max-new-tokens "$MAX_NEW_TOKENS" --greedy \
@@ -246,11 +254,11 @@ complete numerical qualification.
 Benchmark both bundles on the same idle GPU:
 
 ```bash
-trtmc run "$WORK/qwen3-native.trtfb" \
+"$TRTMC" run "$WORK/qwen3-native.trtfb" \
   --prompt "$TEST_PROMPT" --max-new-tokens "$MAX_NEW_TOKENS" --greedy \
   --warmup 3 --benchmark 10 > "$WORK/native.perf.log" 2>&1
 
-trtmc run "$WORK/qwen3-slot-ready.trtfb" \
+"$TRTMC" run "$WORK/qwen3-slot-ready.trtfb" \
   --kernel-bindings "$WORK/kernel-bindings.json" \
   --prompt "$TEST_PROMPT" --max-new-tokens "$MAX_NEW_TOKENS" --greedy \
   --warmup 3 --benchmark 10 > "$WORK/external.perf.log" 2>&1
@@ -291,7 +299,7 @@ accept a known regression. Repeat an edge result on an idle GPU.
 Qwen also records one raw decode-attention recipe per layer:
 
 ```bash
-trtmc build "${BUILD_ARGS[@]}" \
+"$TRTMC" build "${BUILD_ARGS[@]}" \
   --recipe qwen.decode_attention_region@1 \
            decoder.layers.0.decode_attention \
   -o "$WORK/qwen3-attention-slot.trtfb"
@@ -327,7 +335,7 @@ If you want to run that shipped FlashInfer kernel on an SM 10.3 GPU, use its
 published Direct Slot flow:
 
 ```bash
-trtmc kernel slots "$MODEL" --model-revision "$REVISION"
+"$TRTMC" kernel slots "$MODEL" --model-revision "$REVISION"
 
 python -m pip install \
   "flashinfer-python==0.6.15" \
@@ -348,11 +356,11 @@ sed "s/@SHA256@/$(sha256sum "$FI_WORK/flashinfer-qwen3.so" | awk '{print $1}')/"
   python/tensorrt_model_connect/families/qwen/examples/byok_flashinfer/qwen3-flashinfer.yaml.in \
   > "$FI_WORK/qwen3-flashinfer.yaml"
 
-trtmc build "${BUILD_ARGS[@]}" \
+"$TRTMC" build "${BUILD_ARGS[@]}" \
   --kernel "$FI_WORK/qwen3-flashinfer.yaml" \
   -o "$FI_WORK/qwen3-flashinfer.trtfb"
 
-trtmc run "$FI_WORK/qwen3-flashinfer.trtfb" \
+"$TRTMC" run "$FI_WORK/qwen3-flashinfer.trtfb" \
   --prompt "Explain grouped-query attention in one sentence." \
   --max-new-tokens 32 \
   --greedy
@@ -374,12 +382,12 @@ The build and runtime mechanisms stay identical; only selection changes.
 Capture the raw decode graph, then list its final layers:
 
 ```bash
-trtmc graph inspect \
+"$TRTMC" graph inspect \
   --engine-role decode \
   --snapshot "$WORK/decode.graph.json" \
   "${BUILD_ARGS[@]}"
 
-trtmc graph list "$WORK/decode.graph.json" \
+"$TRTMC" graph list "$WORK/decode.graph.json" \
   | tee "$WORK/decode.nodes.txt" \
   | tail -n 10
 ```
@@ -400,7 +408,7 @@ and leave the final FP32 logits cast in the graph:
 export BINDING_ID=qwen3.decode.logits_copy.manual@1
 NODES=(node:3598 node:3599 node:3600)
 
-trtmc graph select "$WORK/decode.graph.json" \
+"$TRTMC" graph select "$WORK/decode.graph.json" \
   --nodes "${NODES[@]}" \
   --binding-id "$BINDING_ID" \
   --workspace-bytes 0 \
@@ -410,7 +418,9 @@ trtmc graph select "$WORK/decode.graph.json" \
 Node IDs above are a receipt for the pinned build, not a stable API. Always
 copy IDs from your own snapshot. Use `--match GLOB` to filter the displayed
 node ID, operation, or name, then follow tensor edges. `--match` only changes
-the display; it never selects nodes.
+the display; it never selects nodes. For programmatic TensorRT layers, the
+`OP` column appends the current `.op` subtype when available, for example
+`LayerType.ELEMENTWISE/ElementWiseOperation.SUM`.
 
 Start with the smallest boundary that matches the kernel. The requested nodes
 must form one connected, convex region: no path may leave the region and later
@@ -437,7 +447,7 @@ Allowed types are `none`, signed 32-bit `int`, finite `float`, and null `ptr`.
 Build the slot-ready bundle through the existing advanced path:
 
 ```bash
-trtmc build "${BUILD_ARGS[@]}" \
+"$TRTMC" build "${BUILD_ARGS[@]}" \
   --graph-patch "$WORK/manual.selection.json" \
   -o "$WORK/qwen3-manual-slot-ready.trtfb"
 ```
@@ -460,6 +470,10 @@ alone never makes an existing DSO compatible.
   or INT32.
 - The selection is tied to its graph fingerprint and build metadata. Reuse the
   exact build arguments and recapture after graph-producing code changes.
+- Parser-created or otherwise raw TRT layers may expose only their base
+  `LayerType` in a snapshot. Treat the `OP` and `NAME` columns as inspection
+  aids, not a semantic kernel contract; the selected tensor boundary and your
+  DSO implementation remain authoritative.
 - Binding occurs only while a new pipeline loads. There is no in-place rebind
   API for a running pipeline.
 - v1 rejects a selected engine whose deserialization is deferred until first

--- a/website/docs/tutorials/beginner/bring-your-own-kernel.md
+++ b/website/docs/tutorials/beginner/bring-your-own-kernel.md
@@ -2,7 +2,8 @@
 title: "Bring Your Own Kernel"
 ---
 
-This tutorial replaces part of a Qwen3-8B TensorRT graph with a TVM-FFI
+This tutorial starts by replacing part of a Qwen3-8B TensorRT graph with a
+TVM-FFI kernel, then manually replaces a DistilBERT region with a CuTe DSL
 kernel. You do not write TensorRT C++.
 
 Start with the simplest graph workflow and move to the escape hatch only when
@@ -11,7 +12,7 @@ you need it:
 | Level | How the region is chosen | Who should use it |
 | --- | --- | --- |
 | Recommended | The model family publishes a versioned recipe and you choose one exact instance. | Most kernel authors. |
-| Advanced | You inspect the raw TensorRT graph and type every node ID yourself. | Authors whose region has no recipe. |
+| Advanced | You inspect the raw TensorRT graph and type every node ID yourself; if needed, you also author the TVM-FFI kernel. | Authors whose region has no recipe or supplied DSO. |
 
 A recipe is only a family-owned shortcut for a known manual selection. It
 records exact TRT node IDs, workspace, scalar arguments, and output-shape rule
@@ -20,7 +21,7 @@ the graph, passes those values to the same `select_region()` validator used by
 the advanced path, and then runs the ordinary graph-patch build. It adds no
 semantic graph, matching language, plugin schema, or runtime behavior.
 
-The two levels use the same backend:
+Both levels use the same backend:
 
 ```text
 Recipe: build --recipe -----------------------> slot-ready bundle + selection receipt
@@ -457,6 +458,243 @@ boundary, first implement the exact ABI in its selection JSON using the rules
 in step 2. Then repeat the load-time binding and verification in steps 3 and
 4, reading `abi_sha256` from `manual.selection.json`. A matching operation name
 alone never makes an existing DSO compatible.
+
+### 7. Manually author and bridge a CuTe DSL kernel
+
+Step 6 changed only selection and reused a supplied DSO. This second worked
+example changes both halves: you manually select a raw TensorRT residual-add
+node, then write and export the matching CuTe DSL kernel.
+
+The example uses DistilBERT so graph capture and compilation stay small. Its
+fixed boundary is useful for learning the mechanics, but the single scalar add
+is **not** an acceleration candidate. The validated measurement below rejects
+it.
+
+Set up a separate pinned build:
+
+```bash
+export CUTE_REVISION=12040accade4e8a0f71eabdb258fecc2e7e948be
+export CUTE_MODEL="${CUTE_MODEL:-distilbert/distilbert-base-uncased}"
+export CUTE_WORK="$PWD/artifacts/distilbert-cutedsl"
+export CUTE_BINDING_ID=distilbert.layer0.attention_residual_add.cutedsl@1
+mkdir -p "$CUTE_WORK"
+
+CUTE_BUILD_ARGS=(
+  "$CUTE_MODEL"
+  --model-revision "$CUTE_REVISION"
+  --precision fp16
+)
+```
+
+The Hub ID requires normal Hugging Face access. In an offline environment, set
+`CUTE_MODEL` to the absolute directory of that exact cached revision before
+running the block. Keep the same value for inspect and both builds.
+
+Capture the raw graph and narrow the display to elementwise sums:
+
+```bash
+"$TRTMC" graph inspect \
+  --engine-role decode \
+  --snapshot "$CUTE_WORK/decode.graph.json" \
+  "${CUTE_BUILD_ARGS[@]}"
+
+"$TRTMC" graph list "$CUTE_WORK/decode.graph.json" \
+  --match '*ElementWiseOperation.SUM*' \
+  | tee "$CUTE_WORK/elementwise-sum.nodes.txt"
+```
+
+For this exact revision and build, the first attention residual add is:
+
+```text
+node:49  LayerType.ELEMENTWISE/ElementWiseOperation.SUM
+         tensor:22,tensor:50 -> tensor:51
+```
+
+Select that node yourself:
+
+```bash
+"$TRTMC" graph select "$CUTE_WORK/decode.graph.json" \
+  --nodes node:49 \
+  --binding-id "$CUTE_BINDING_ID" \
+  --workspace-bytes 0 \
+  -o "$CUTE_WORK/residual-add.selection.json"
+```
+
+`node:49` is a receipt for this pinned graph, not a stable semantic name. After
+any model revision, build-option, or graph-code change, inspect again and
+follow the displayed tensor edges. Here the selection receipt plus snapshot
+define this ordered contract:
+
+```text
+input[0]  hidden                FP16 device [256, 768]
+input[1]  attention projection  FP16 device [256, 768]
+output[0] residual              FP16 device [256, 768]
+workspace 0 bytes
+extra args none
+```
+
+Install the exporter dependencies in the Python environment on the target GPU:
+
+```bash
+python -m pip install \
+  'nvidia-cutlass-dsl==4.5.0' \
+  'apache-tvm-ffi==0.1.12'
+```
+
+The operation-specific part of
+`examples/byok/export_cutedsl_residual_add.py` is ordinary CuTe DSL:
+
+```python
+ROWS, COLS, THREADS = 256, 768, 256
+
+@cute.kernel
+def residual_add_kernel(
+    hidden: cute.Tensor,
+    attention_projection: cute.Tensor,
+    output: cute.Tensor,
+):
+    thread_x, _, _ = cute.arch.thread_idx()
+    block_x, _, _ = cute.arch.block_idx()
+    block_size, _, _ = cute.arch.block_dim()
+    index = block_x * block_size + thread_x
+    row, column = index // COLS, index % COLS
+    output[row, column] = hidden[row, column] + attention_projection[row, column]
+
+@cute.jit
+def run(
+    hidden: cute.Tensor,
+    attention_projection: cute.Tensor,
+    output: cute.Tensor,
+    stream: cuda.CUstream,
+):
+    residual_add_kernel(hidden, attention_projection, output).launch(
+        grid=((ROWS * COLS) // THREADS, 1, 1),
+        block=(THREADS, 1, 1),
+        stream=stream,
+    )
+```
+
+For your own region, copy this exporter and update its shape constants,
+contract check, and two CuTe functions to match your selection receipt. Keep
+the TVM-FFI environment stream and compile/export/link scaffold.
+
+The exporter supplies
+`make_fake_stream(use_tvm_ffi_env_stream=True)`, so `stream` is TensorRT's
+current CUDA stream delivered through TVM-FFI. It is not another argument in
+the selection ABI: the exported call remains `run(input0, input1, output)`.
+Do not synchronize inside the kernel wrapper or launch on the default stream.
+
+Compile for the active GPU and export `run` through TVM-FFI:
+
+```bash
+test ! -e "$CUTE_WORK/residual-add-cutedsl.so" || {
+  echo "Choose a fresh CUTE_WORK; the exporter will not overwrite a DSO"
+  exit 1
+}
+
+python examples/byok/export_cutedsl_residual_add.py \
+  --snapshot "$CUTE_WORK/decode.graph.json" \
+  --selection "$CUTE_WORK/residual-add.selection.json" \
+  --output "$CUTE_WORK/residual-add-cutedsl.so"
+```
+
+The exporter first checks that the selected node is a two-input FP16 sum with
+the exact fixed shapes above. It then compiles the CuTe code, links the CuTe
+runtime, and exports `__tvm_ffi_run`. The native-versus-BYOK comparison below
+is the end-to-end correctness test.
+
+Build the slot-ready and matched native bundles:
+
+```bash
+"$TRTMC" build "${CUTE_BUILD_ARGS[@]}" \
+  --graph-patch "$CUTE_WORK/residual-add.selection.json" \
+  -o "$CUTE_WORK/distilbert-slot-ready.trtfb"
+
+"$TRTMC" build "${CUTE_BUILD_ARGS[@]}" \
+  -o "$CUTE_WORK/distilbert-native.trtfb"
+```
+
+Bind the new DSO using the ABI hash computed from the selected boundary:
+
+```bash
+CUTE_ABI_SHA256="$(
+  python -c 'import json,sys; print(json.load(open(sys.argv[1]))["abi_sha256"])' \
+    "$CUTE_WORK/residual-add.selection.json"
+)"
+
+cat > "$CUTE_WORK/kernel-bindings.json" <<EOF
+{
+  "schema_version": 1,
+  "bindings": [
+    {
+      "id": "$CUTE_BINDING_ID",
+      "abi_sha256": "$CUTE_ABI_SHA256",
+      "library": "./residual-add-cutedsl.so",
+      "function": "run"
+    }
+  ]
+}
+EOF
+```
+
+There is intentionally no DSO hash. The ABI hash makes the manifest target the
+selected call contract while another compatible DSO can be supplied at the
+next pipeline load. It does not inspect the DSO's signature; the kernel author
+must still implement the ordered contract exactly.
+
+Compare full embeddings rather than byte-diffing them. Moving the FP16 rounding
+point can produce small differences that propagate through later layers:
+
+```bash
+CUTE_PROMPT='The quick brown fox jumps over the lazy dog.'
+
+"$TRTMC" embed "$CUTE_WORK/distilbert-native.trtfb" \
+  --prompt "$CUTE_PROMPT" \
+  > "$CUTE_WORK/native.json" 2> "$CUTE_WORK/native.stderr"
+
+"$TRTMC" embed "$CUTE_WORK/distilbert-slot-ready.trtfb" \
+  --kernel-bindings "$CUTE_WORK/kernel-bindings.json" \
+  --prompt "$CUTE_PROMPT" \
+  > "$CUTE_WORK/byok.json" 2> "$CUTE_WORK/byok.stderr"
+
+python - "$CUTE_WORK/native.json" "$CUTE_WORK/byok.json" <<'PY'
+import json
+import math
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as file:
+    native = json.load(file)["embedding"]
+with open(sys.argv[2], encoding="utf-8") as file:
+    byok = json.load(file)["embedding"]
+if not native or len(native) != len(byok):
+    raise SystemExit("FAIL: embedding lengths differ")
+max_abs = max(abs(a - b) for a, b in zip(native, byok))
+denominator = math.sqrt(
+    sum(value * value for value in native) * sum(value * value for value in byok)
+)
+cosine = sum(a * b for a, b in zip(native, byok)) / denominator
+print(f"values={len(native)} max_abs={max_abs:.6g} cosine={cosine:.9f}")
+if max_abs > 0.02 or cosine < 0.999:
+    raise SystemExit("FAIL: numerical gate")
+print("PASS: numerical gate")
+PY
+```
+
+The validated GB300 result was 196,608 values, maximum absolute difference
+0.01563, and cosine similarity 0.999997915.
+
+Finally, apply the same 2% no-regression rule as step 4 with a task-appropriate
+benchmark. The retained validation used one warm-up per arm followed by six
+alternating fresh-process `trtmc embed` pairs. It measured median engine
+execution at 1.644208 ms native and 2.070288 ms BYOK on GB300:
+**25.914% slower**. This example therefore fails the performance gate and must
+not ship as an acceleration.
+
+For a real optimization, circle a larger or fused high-work region whose
+eliminated TensorRT work outweighs the plugin and kernel-launch overhead,
+implement that selection's exact ABI, and repeat the correctness and 2%
+no-regression gates. The success criterion is not “the DSO loaded”; it is
+“correct output without a measured regression.”
 
 ## Current graph-slot limits
 


### PR DESCRIPTION
## Background

Independent beginner BYOK application testing found that `trtmc graph list`
exposed only generic `LayerType.ELEMENTWISE` values for programmatically built
TensorRT layers. That made a manual kernel author unable to distinguish
operations such as `SUM` and `PROD`. The same testing also found that the
beginner tutorial did not consistently invoke the native source-build CLI, and
the top-level help named the implemented `recipes` subcommand incorrectly.

The tutorial now also needs to show the complete advanced path: manually circle
a raw TRT region, manually author the matching CuTe DSL kernel, export it
through TVM-FFI, and bind it without changing Model Connect.

## Exit Criteria

- Raw graph snapshots append the final TensorRT `.op` subtype when the
  compatibility layer can observe it.
- A legal operation mutation before serialization is reflected in the snapshot
  and fingerprint.
- The beginner tutorial consistently uses the native CLI from its configured
  source build.
- A beginner can follow one complete raw-selection plus CuTe DSL export,
  load-time binding, correctness, and performance-decision example.
- The existing explicit-node selection and graph rewiring design remains
  unchanged; no semantic graph or lowering map is added.

## Implementation

- Retain derived TensorRT layer views during an active graph-build session and
  resolve their current `.op` only when the final snapshot is captured.
- Include the observed subtype in the existing raw node operation field and use
  the same data during selection validation.
- Route tutorial commands through `TRTMC`, align its default build directory
  with the installation guide, document parser/raw-layer best-effort behavior,
  and fix the `graph recipes` help spelling.
- Add one example-side CuTe DSL residual-add exporter. It validates the exact
  selection boundary, compiles on the active GPU, uses TensorRT's TVM-FFI
  environment stream, and exports a `__tvm_ffi_run` DSO with the CuTe runtime
  statically linked.
- Extend the advanced tutorial without changing the backend: capture and select
  a pinned DistilBERT residual-add node, author the kernel, create the ABI-only
  runtime manifest, compare full embeddings, and explicitly reject the
  teaching kernel's measured slowdown.

## Validation

- `PYTHONPATH=python pytest -q tests/builder/test_graph_cli.py tests/builder/test_graph_patch.py tests/builder/test_kernel_slots.py`:
  27 passed.
- `PYTHONPATH=python pytest -q tests/builder/test_graph_patch_trt.py`: 3 passed
  with TensorRT 11.2, including a `SUM` layer mutated to `PROD` before capture.
- `PYTHONPATH=python pytest -q tests/builder/test_trt_compat_boundary.py`: 4
  passed.
- `python tools/check_doc_file_references.py --strict website/docs/tutorials/beginner`:
  3 documents scanned, 0 errors, 0 warnings.
- `python tools/legal_headers.py --check`: 0 findings.
- `ruff check examples/byok/export_cutedsl_residual_add.py` and
  `ruff format --check examples/byok/export_cutedsl_residual_add.py`: passed.
- `npm run build --prefix website`: Docusaurus client and server builds passed.
- Final exporter GPU check: the checked-in source compiled with CuTe DSL 4.5.0
  on GB300 and exported `__tvm_ffi_run`.
- Final runtime check: that DSO loaded through the existing slot-ready
  DistilBERT bundle with an ABI-only manifest; 196,608 output values passed
  `max_abs <= 0.02` and `cosine >= 0.999` with `max_abs=0.01563` and
  `cosine=0.999997915`.
- Fresh Qwen3-8B recipe E2E: byte-identical 64-token output; primary
  external/native throughput ratio `1.0090`, repeated ratio `1.0289`, pooled
  ratio `0.9932` (all above the documented `0.98` gate).
- Fresh ViT runtime-swap E2E: one unchanged slot-ready engine loaded two
  different same-ABI DSOs in separate pipelines; A/B logits were bit-exact,
  wrong ABI and a forbidden `sha256` field were rejected, and balanced latency
  ratios were `0.9986` and `0.9992` versus native.
- Retained six-pair DistilBERT timing receipt: the deliberately tiny ADD
  replacement was 25.914% slower and is documented as a rejected
  application choice, not an acceleration recipe.

## Notes For Future Readers

Parser-created or otherwise raw TensorRT layers may still expose only their
base `LayerType`; this PR deliberately avoids an unreliable ONNX-to-TRT
semantic mapping. The graph listing is an inspection aid, while the selected
tensor boundary and DSO ABI remain the kernel contract.

The CuTe DSL example is intentionally small enough to understand. Its purpose
is to prove the manual bridge workflow; production candidates must still pass
the tutorial's correctness and no-regression gates.
