### PR TITLE
fix(internlm): pin compatible sentencepiece

### DIFF
--- a/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
@@ -1,4 +1,5 @@
 einops==0.8.1
 huggingface-hub==0.26.5
+sentencepiece==0.2.0
 tokenizers==0.20.3
 transformers==4.46.3

--- a/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import einops
+import sentencepiece
 import transformers
 from transformers.cache_utils import DynamicCache
 
+assert sentencepiece.__version__ == "0.2.0"
 assert hasattr(DynamicCache, "from_legacy_cache")
 assert hasattr(DynamicCache, "get_max_cache_shape")
-print(f"einops={einops.__version__} transformers={transformers.__version__}")
+print(
+    f"einops={einops.__version__} "
+    f"sentencepiece={sentencepiece.__version__} "
+    f"transformers={transformers.__version__}"
+)

--- a/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
+++ b/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
@@ -83,6 +83,8 @@ def test_reference_profile_supports_current_internlm_dynamic_cache_api() -> None
     verify = (_FAMILY_DIR / "python_profile_verify.py").read_text(encoding="utf-8")
 
     assert "huggingface-hub==0.26.5" in lock
+    assert "sentencepiece==0.2.0" in lock
     assert "tokenizers==0.20.3" in lock
     assert "transformers==4.46.3" in lock
+    assert 'sentencepiece.__version__ == "0.2.0"' in verify
     assert 'hasattr(DynamicCache, "get_max_cache_shape")' in verify


### PR DESCRIPTION
## Summary

- pin SentencePiece 0.2.0 in the InternLM Python profile
- verify the pinned version so the profile cannot silently inherit incompatible SentencePiece 0.2.2
- cover the dependency contract in the InternLM manifest profile test

## Validation

- `PYTHONPATH=python:. python -m pytest tests/e2e/models/internlm/test_internlm_manifest_profiles.py -q` (4 passed)
- Auto Thor revalidation: SentencePiece 0.2.0 restores both slow and fast tokenizer loading and the Hugging Face reference completes; execution then reaches the independent TensorRT engine-deserialization capacity limit on the 6 GiB CUDA partition

No validation thresholds or passing criteria are changed.