### PR TITLE
fix(qwen-vl): use dynamic grid for mRoPE

### DIFF
--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -540,6 +540,20 @@ int32_t merged_grid_extent(int32_t configured_extent, int32_t fallback_extent, i
     return extent / (patch_size * merge_size);
 }
 
+std::pair<int32_t, int32_t> resolve_merged_grid(const QwenVlPreprocessedImage& preprocessed,
+                                                const QwenVlPreprocessConfig& config) {
+    if (preprocessed.image_grid_hws.size() >= 2 && config.merge_size > 0) {
+        return {preprocessed.image_grid_hws[0] / config.merge_size,
+                preprocessed.image_grid_hws[1] / config.merge_size};
+    }
+    return {
+        merged_grid_extent(config.fixed_image_height, config.fixed_image_size, config.patch_size,
+                           config.merge_size),
+        merged_grid_extent(config.fixed_image_width, config.fixed_image_size, config.patch_size,
+                           config.merge_size),
+    };
+}
+
 bool add_mrope_prefill_input(TrtModule& prefill, const std::vector<int32_t>& input_ids,
                              const QwenVlMropePositions* mrope, int32_t sequence_length,
                              std::vector<int32_t>& positions, TensorMap& inputs) {
@@ -609,8 +623,10 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
     auto input_ids = tokenizer_->encode(qwen_vl_format_prompt(prompt, vl_preprocess_, nf));
     auto [max_new, eos] = resolve_gen_limits(cfg);
     auto sp_vl = qwen_vl_sampling_params_from_config(cfg, eos);
-    auto out =
-        generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim, max_new, sp_vl);
+    const auto [merged_grid_height, merged_grid_width] =
+        resolve_merged_grid(preprocessed, vl_preprocess_);
+    auto out = generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim,
+                                    merged_grid_height, merged_grid_width, max_new, sp_vl);
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
@@ -675,7 +691,8 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
 std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
     const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
-    int32_t feature_dim, int32_t max_new_tokens, const QwenVlSamplingParams& params) {
+    int32_t feature_dim, int32_t merged_grid_height, int32_t merged_grid_width,
+    int32_t max_new_tokens, const QwenVlSamplingParams& params) {
     if (max_new_tokens == 0 || input_ids.empty())
         return input_ids;
 
@@ -685,16 +702,11 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
-    const int32_t grid_h =
-        merged_grid_extent(vl_preprocess_.fixed_image_height, vl_preprocess_.fixed_image_size,
-                           vl_preprocess_.patch_size, vl_preprocess_.merge_size);
-    const int32_t grid_w =
-        merged_grid_extent(vl_preprocess_.fixed_image_width, vl_preprocess_.fixed_image_size,
-                           vl_preprocess_.patch_size, vl_preprocess_.merge_size);
     const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
-    const auto mrope = use_mrope ? qwen_vl_build_mrope_positions(input_ids, config_.image_token_id,
-                                                                 num_features, grid_h, grid_w)
-                                 : QwenVlMropePositions{};
+    const auto mrope =
+        use_mrope ? qwen_vl_build_mrope_positions(input_ids, config_.image_token_id, num_features,
+                                                  merged_grid_height, merged_grid_width)
+                  : QwenVlMropePositions{};
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
                                 feature_dim, use_mrope ? &mrope : nullptr, logits)) {
         int32_t feature_index = 0;

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -113,7 +113,8 @@ class QwenVlPipeline final : public IPipeline {
     std::vector<int32_t> generate_vl_from_ids(
         const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
         const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
-        int32_t feature_dim, int32_t max_new_tokens, const QwenVlSamplingParams& params);
+        int32_t feature_dim, int32_t merged_grid_height, int32_t merged_grid_width,
+        int32_t max_new_tokens, const QwenVlSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
 

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -77,12 +77,15 @@ struct CountingTextStats {
     int32_t calls{0};
     std::unordered_map<std::string, std::vector<int64_t>> shapes;
     std::unordered_map<std::string, std::vector<float>> float_values;
+    std::unordered_map<std::string, std::vector<int32_t>> int_values;
 };
 
 class CountingTextModule final : public trtmc::ITrtModule {
   public:
-    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream,
+                       bool has_mrope_input = false)
         : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          has_mrope_input_(has_mrope_input),
           present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
                              : trtmc::DeviceTensor{}),
           present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
@@ -92,12 +95,17 @@ class CountingTextModule final : public trtmc::ITrtModule {
         ++stats_->calls;
         stats_->shapes.clear();
         stats_->float_values.clear();
+        stats_->int_values.clear();
         for (const auto& [name, tensor] : inputs) {
             stats_->shapes[name] = tensor.shape;
             if (tensor.dtype == trtmc::DType::kFloat32) {
                 const auto* begin = static_cast<const float*>(tensor.data);
                 stats_->float_values[name] =
                     std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            } else if (tensor.dtype == trtmc::DType::kInt32) {
+                const auto* begin = static_cast<const int32_t*>(tensor.data);
+                stats_->int_values[name] = std::vector<int32_t>(
+                    begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
             }
         }
         return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
@@ -115,7 +123,8 @@ class CountingTextModule final : public trtmc::ITrtModule {
     bool has_input(const std::string& name) const override {
         return name == "token_id" || name == "position_id" || name == "attention_mask" ||
                name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
-               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0" ||
+               (name == "mrope_position_ids" && has_mrope_input_);
     }
     bool has_output(const std::string& name) const override {
         return name == "logits" || name == "present_k_0" || name == "present_v_0";
@@ -150,6 +159,7 @@ class CountingTextModule final : public trtmc::ITrtModule {
     std::shared_ptr<CountingTextStats> stats_;
     bool prefill_{false};
     cudaStream_t stream_{nullptr};
+    bool has_mrope_input_{false};
     mutable trtmc::DeviceTensor present_k_;
     mutable trtmc::DeviceTensor present_v_;
     std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
@@ -157,10 +167,24 @@ class CountingTextModule final : public trtmc::ITrtModule {
 
 class FakeSequenceVisionModule final : public trtmc::ITrtModule {
   public:
+    explicit FakeSequenceVisionModule(int32_t num_features = 1)
+        : features_(static_cast<std::size_t>(num_features) * 4),
+          deepstack_(static_cast<std::size_t>(num_features) * 4) {
+        for (int32_t row = 0; row < num_features; ++row) {
+            for (int32_t column = 0; column < 4; ++column) {
+                const auto index = static_cast<std::size_t>(row * 4 + column);
+                features_[index] = static_cast<float>(10 + column);
+                deepstack_[index] = static_cast<float>(20 + column);
+            }
+        }
+    }
+
     trtmc::TensorMap forward(const trtmc::TensorMap&) override {
-        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+        const auto num_features = static_cast<int64_t>(features_.size() / 4);
+        return {{"image_features",
+                 trtmc::Tensor{features_.data(), {num_features, 4}, trtmc::DType::kFloat32}},
                 {"deepstack_features_0",
-                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+                 trtmc::Tensor{deepstack_.data(), {num_features, 4}, trtmc::DType::kFloat32}}};
     }
     trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
     void forward_device_async(const trtmc::DeviceTensorMap&) override {}
@@ -174,7 +198,10 @@ class FakeSequenceVisionModule final : public trtmc::ITrtModule {
         return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
     }
     std::vector<trtmc::TensorInfo> output_info() const override {
-        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+        return {{"image_features",
+                 {static_cast<int64_t>(features_.size() / 4), 4},
+                 trtmc::DType::kFloat32,
+                 false}};
     }
     bool has_input(const std::string& name) const override { return name == "pixel_values"; }
     bool has_output(const std::string& name) const override {
@@ -193,8 +220,8 @@ class FakeSequenceVisionModule final : public trtmc::ITrtModule {
     void keep_alive(std::shared_ptr<void>) override {}
 
   private:
-    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
-    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+    std::vector<float> features_;
+    std::vector<float> deepstack_;
 };
 
 // ---------------------------------------------------------------------------
@@ -203,6 +230,16 @@ class FakeSequenceVisionModule final : public trtmc::ITrtModule {
 class VLFixedTokenizer : public trtmc::ITokenizer {
   public:
     std::vector<int32_t> encode(const std::string&) const override { return {1, 2, 3}; }
+    std::string decode(const std::vector<int32_t>&) const override { return "out"; }
+    int32_t id_for_token(std::string_view) const override { return 0; }
+    std::string token_for_id(int32_t) const override { return ""; }
+};
+
+class VLDynamicGridTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override {
+        return {0, 1, 1, 1, 1, 1, 1, 2};
+    }
     std::string decode(const std::vector<int32_t>&) const override { return "out"; }
     int32_t id_for_token(std::string_view) const override { return 0; }
     std::string token_for_id(int32_t) const override { return ""; }
@@ -849,6 +886,56 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_dynamic_resolution_uses_actual_grid_for_mrope() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream, true);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream, true);
+    auto vision = std::make_unique<FakeSequenceVisionModule>(6);
+    auto cache = std::make_unique<trtmc::QwenVlKvCache>(1, 16, 4, stream);
+
+    trtmc::QwenVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 16;
+
+    trtmc::QwenVlPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "qwen_smart_resize_patchify";
+    vl_pp.fixed_image_size = 448;
+    vl_pp.patch_size = 14;
+    vl_pp.merge_size = 2;
+    vl_pp.temporal_patch_size = 2;
+    vl_pp.in_channels = 3;
+    vl_pp.dynamic_image_resolution = true;
+    vl_pp.min_pixels = 56 * 84;
+    vl_pp.max_pixels = 56 * 84;
+
+    auto tokenizer = std::make_shared<VLDynamicGridTokenizer>();
+    trtmc::QwenVlPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                   vl_pp, stream, tokenizer, "", nullptr, std::move(prefill));
+
+    std::vector<float> pixels(static_cast<std::size_t>(56 * 84 * 3), 0.5F);
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    (void)pipeline.generate("test", pixels.data(), 56, 84, gen_cfg);
+
+    check(prefill_stats->shapes["mrope_position_ids"] == std::vector<int64_t>({3, 8}),
+          "dynamic mrope: prefill shape follows token count");
+    check(prefill_stats->int_values["mrope_position_ids"] ==
+              std::vector<int32_t>(
+                  {0, 1, 1, 1, 1, 1, 1, 4, 0, 1, 1, 1, 2, 2, 2, 4, 0, 1, 2, 3, 1, 2, 3, 4}),
+          "dynamic mrope: pipeline uses actual 2x3 merged image grid");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -1079,6 +1166,7 @@ int main() {
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
     test_vl_sequence_prefill_uses_one_text_launch();
+    test_vl_dynamic_resolution_uses_actual_grid_for_mrope();
     test_vl_generate_with_tokenizer();
     test_vl_dynamic_lora_adapter_switching();
     test_vl_pool_isolates_concurrent_lora_selection();


### PR DESCRIPTION
## Background

  Dynamic Qwen-VL image preprocessing produces an image-dependent patch grid, but the text pipeline rebuilt mRoPE positions from the fixed image dimensions. Smart-resized
  requests could therefore use rotary positions that did not match the vision token layout.

  ## Exit Criteria

  - Build text mRoPE positions from the actual preprocessed image grid.
  - Preserve the fixed-resolution fallback for preprocessors that do not report a grid.
  - Cover the runtime handoff with one focused dynamic-resolution test.

  ## Implementation

  - Resolve the merged image grid from `image_grid_hws`.
  - Pass the resolved grid into multimodal generation.
  - Use that grid when constructing text mRoPE positions.
  - Keep the existing fixed-dimension calculation as a fallback.