### PR TITLE
feat(qwen-vl): configure prefill build limits

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -38,19 +38,42 @@ if TYPE_CHECKING:
     from ...quantization.context import QuantContext
 
 
-def _decode_attention_backend(config: ModelConfig) -> str:
+def _decoder_build_options(config: ModelConfig) -> dict:
     family_options = config.raw.get("_family_build_options", {})
     if not isinstance(family_options, dict):
-        return "native"
+        return {}
     decoder_options = family_options.get("qwen_vl_decoder", {})
     if not isinstance(decoder_options, dict):
         raise ValueError("qwen_vl_decoder build options must be an object")
+    return decoder_options
+
+
+def _decode_attention_backend(config: ModelConfig) -> str:
+    decoder_options = _decoder_build_options(config)
     backend = str(decoder_options.get("decode_attention", "native"))
     if backend not in {"native", "decomposed"}:
         raise ValueError(
             "qwen_vl_decoder.decode_attention must be 'native' or "
             f"'decomposed', got {backend!r}")
     return backend
+
+
+def _decoder_profile_options(config: ModelConfig) -> tuple[int, int | None, int]:
+    decoder_options = _decoder_build_options(config)
+    max_prefill_length = int(decoder_options.get("max_prefill_length", 0))
+    opt_prefill_length = int(decoder_options.get("opt_prefill_length", 64))
+    builder_workspace_gib = int(decoder_options.get("builder_workspace_gib", 1))
+    if max_prefill_length < 0:
+        raise ValueError("qwen_vl_decoder.max_prefill_length must be >= 0")
+    if opt_prefill_length <= 0:
+        raise ValueError("qwen_vl_decoder.opt_prefill_length must be > 0")
+    if builder_workspace_gib <= 0:
+        raise ValueError("qwen_vl_decoder.builder_workspace_gib must be > 0")
+    return (
+        opt_prefill_length,
+        max_prefill_length or None,
+        builder_workspace_gib << 30,
+    )
 
 
 def _mark_debug_output(
@@ -153,6 +176,8 @@ def build_standard_decoder_engine(
     split_decode = (
         embed_input and active_split and decoder_engine_role == "decode")
     decode_attention = _decode_attention_backend(config)
+    opt_prefill_length, max_prefill_length, builder_workspace_bytes = (
+        _decoder_profile_options(config))
     if (decode_attention == "decomposed"
             and decoder_engine_role != "prefill"
             and not split_decode):
@@ -183,6 +208,9 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             embed_input=embed_input,
             verbose=verbose,
+            opt_prefill_length=opt_prefill_length,
+            max_prefill_length=max_prefill_length,
+            builder_workspace_bytes=builder_workspace_bytes,
             force_decomposed_attention=(
                 split_decode and decode_attention == "decomposed"),
             profile_mode=(
@@ -226,7 +254,7 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
+        workspace_bytes=builder_workspace_bytes,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -153,6 +153,7 @@ def build_dual_profile_decoder_engine(
     precision: str = "fp16",
     opt_prefill_length: int = 64,
     max_prefill_length: int | None = None,
+    builder_workspace_bytes: int = 1 << 30,
     quant_ctx: "QuantContext | None" = None,
     norm_type: str = "rmsnorm",
     mlp_type: str = "swiglu",
@@ -181,6 +182,10 @@ def build_dual_profile_decoder_engine(
 
     ``force_decomposed_attention`` replaces native ``IAttention`` with an
     explicit FP32-score QK/softmax/V graph.
+
+    ``opt_prefill_length`` and ``max_prefill_length`` bound the prefill
+    optimization profile independently from the KV cache capacity.
+    ``builder_workspace_bytes`` controls TensorRT tactic workspace.
 
     ``profile_mode`` controls which optimization profiles are emitted:
 
@@ -255,7 +260,7 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
+        workspace_bytes=builder_workspace_bytes,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
@@ -23,6 +23,27 @@ DECODER_SCHEMA = Schema(
             allowed_layers=_BUILD,
             validator=lambda value: value in {"native", "decomposed"},
         ),
+        ConfigField(
+            name="max_prefill_length",
+            type_tag="int32",
+            default=0,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value >= 0,
+        ),
+        ConfigField(
+            name="opt_prefill_length",
+            type_tag="int32",
+            default=64,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value > 0,
+        ),
+        ConfigField(
+            name="builder_workspace_gib",
+            type_tag="int32",
+            default=1,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value > 0,
+        ),
     ),
 )
 

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -130,6 +130,38 @@ def test_qwen25_vl_split_decode_uses_decode_profile(monkeypatch) -> None:
     assert calls["build"][3]["profile_mode"] == "decode"
 
 
+def test_qwen25_vl_split_prefill_forwards_build_options(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-vl-prefill-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = _config(qwen3=False)
+    config.raw["_decoder_engine_role"] = "prefill"
+    config.raw["_active_split_decoder_build"] = True
+    config.raw["_family_build_options"] = {
+        "qwen_vl_decoder": {
+            "max_prefill_length": 24,
+            "opt_prefill_length": 12,
+            "builder_workspace_gib": 6,
+        },
+    }
+
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"qwen-vl-prefill-plan"
+    kwargs = calls["build"][3]
+    assert kwargs["profile_mode"] == "prefill"
+    assert kwargs["max_prefill_length"] == 24
+    assert kwargs["opt_prefill_length"] == 12
+    assert kwargs["builder_workspace_bytes"] == 6 << 30
+
+
 def test_qwen25_vl_lora_keeps_dual_profile_prefill(monkeypatch) -> None:
     module = importlib.import_module(
         "tensorrt_model_connect.families.qwen_vl.default_decoder")


### PR DESCRIPTION
## Background

Qwen-VL currently derives the maximum prefill profile length from the KV cache capacity and uses a fixed 1 GiB TensorRT builder workspace. Deployments with long generation caches need to bound prefill independently and select an appropriate tactic workspace without modifying builder code.

## Exit Criteria

- Expose maximum and optimal prefill profile lengths under `qwen_vl_decoder`.
- Expose TensorRT builder workspace under `qwen_vl_decoder`.
- Preserve the current defaults when the new options are not configured.
- Forward the options to Qwen-VL split and dual-profile builds.

## Implementation

- Add `max_prefill_length`, `opt_prefill_length`, and `builder_workspace_gib` to the Qwen-VL build schema.
- Treat `max_prefill_length=0` as the existing behavior of using `max_cache_length`.
- Convert workspace GiB to bytes at the builder boundary.
- Apply the configured workspace to both the profile-based and legacy Qwen-VL decoder builders.
- Add one focused test covering option forwarding for a split prefill build.

## Validation

- `python3 -m pytest tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py -q -p no:cacheprovider` (`8 passed`)
- `CI_BASE_REF=d331f79cbac7548fa32a2ee27dd807f2dc3f8111 python3 -m tools.ci pipeline source-quality`
  - cyclomatic complexity passed
  - changed-file Python lint passed
  - model architecture contracts passed (`158 passed`)
- `git diff --check origin/main...HEAD`

## Notes For Future Readers

- `max_prefill_length=0` intentionally preserves the current default. The existing builder clamps an explicit maximum to `max_cache_length`.
- The existing builder also clamps `opt_prefill_length` to the effective maximum prefill length.
