### PR TITLE
test(trt): align fake network layer counts

### DIFF
--- a/tests/builder/test_trt_compat_boundary.py
+++ b/tests/builder/test_trt_compat_boundary.py
@@ -91,6 +91,17 @@ def test_trt_compat_proxy_wraps_version_sensitive_builder_calls(monkeypatch):
     class FakeNetwork:
         def __init__(self, flags):
             self.flags = flags
+            self.layers: list[object] = []
+
+        @property
+        def num_layers(self) -> int:
+            return len(self.layers)
+
+        def add_identity(self, value):
+            calls.append(("add_identity", value))
+            layer = object()
+            self.layers.append(layer)
+            return layer
 
         def add_matrix_multiply(self, lhs, lhs_op, rhs, rhs_op):
             calls.append(("add_matrix_multiply", lhs, lhs_op, rhs, rhs_op))
@@ -143,15 +154,18 @@ def test_trt_compat_proxy_wraps_version_sensitive_builder_calls(monkeypatch):
     network = builder.create_network(flags)
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1024)
+    identity = network.add_identity("value")
     layer = network.add_matrix_multiply("lhs", "none", "rhs", "transpose")
     plan = builder.build_serialized_network(network, config)
 
     assert flags == 2
+    assert identity is trt_compat.unwrap(network).layers[0]
     assert layer == "layer"
     assert plan == b"plan"
     assert calls == [
         ("create_network", 2),
         ("set_memory_pool_limit", "workspace", 1024),
+        ("add_identity", "value"),
         ("add_matrix_multiply", "lhs", "none", "rhs", "transpose"),
     ]
 

--- a/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
+++ b/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
@@ -67,11 +67,18 @@ class _FakeNetwork:
         self.inputs: list[tuple[str, object, tuple[int, ...]]] = []
         self.outputs: list[_FakeTensor] = []
         self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+        self.layers: list[_FakeLayer] = []
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layers)
 
     def _record(self, op: str, *args, **kwargs) -> _FakeLayer:
         self.calls.append((op, args, kwargs))
         shape = next((tuple(arg.shape) for arg in args if hasattr(arg, "shape")), (1, 4))
-        return _FakeLayer(shape=shape)
+        layer = _FakeLayer(shape=shape)
+        self.layers.append(layer)
+        return layer
 
     def add_input(self, name: str, dtype: object, shape: tuple[int, ...]) -> _FakeTensor:
         self.inputs.append((name, dtype, shape))
@@ -82,7 +89,9 @@ class _FakeNetwork:
 
     def add_constant(self, shape: tuple[int, ...], weights: object) -> _FakeLayer:
         self.calls.append(("add_constant", (shape, weights), {}))
-        return _FakeLayer(shape=tuple(shape))
+        layer = _FakeLayer(shape=tuple(shape))
+        self.layers.append(layer)
+        return layer
 
     def add_cast(self, tensor, target_dtype, **kwargs) -> _FakeLayer:
         layer = self._record("add_cast", tensor, target_dtype, **kwargs)

--- a/tests/e2e/models/flux/test_flux_owned_encoder_builders_coverage.py
+++ b/tests/e2e/models/flux/test_flux_owned_encoder_builders_coverage.py
@@ -68,11 +68,18 @@ class _FakeNetwork:
         self.inputs: list[tuple[str, object, tuple[int, ...]]] = []
         self.outputs: list[_FakeTensor] = []
         self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+        self.layers: list[_FakeLayer] = []
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layers)
 
     def _record(self, op: str, *args, **kwargs) -> _FakeLayer:
         self.calls.append((op, args, kwargs))
         shape = next((tuple(arg.shape) for arg in args if hasattr(arg, "shape")), (1, 4))
-        return _FakeLayer(shape=shape)
+        layer = _FakeLayer(shape=shape)
+        self.layers.append(layer)
+        return layer
 
     def add_input(self, name: str, dtype: object, shape: tuple[int, ...]) -> _FakeTensor:
         self.inputs.append((name, dtype, shape))
@@ -83,7 +90,9 @@ class _FakeNetwork:
 
     def add_constant(self, shape: tuple[int, ...], weights: object) -> _FakeLayer:
         self.calls.append(("add_constant", (shape, weights), {}))
-        return _FakeLayer(shape=tuple(shape))
+        layer = _FakeLayer(shape=tuple(shape))
+        self.layers.append(layer)
+        return layer
 
     def add_cast(self, tensor, target_dtype, **kwargs) -> _FakeLayer:
         layer = self._record("add_cast", tensor, target_dtype, **kwargs)

--- a/tests/e2e/models/z_image/test_z_image_qwen3_encoder_builder.py
+++ b/tests/e2e/models/z_image/test_z_image_qwen3_encoder_builder.py
@@ -68,11 +68,18 @@ class _FakeNetwork:
         self.inputs: list[tuple[str, object, tuple[int, ...]]] = []
         self.outputs: list[_FakeTensor] = []
         self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+        self.layers: list[_FakeLayer] = []
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layers)
 
     def _record(self, op: str, *args, **kwargs) -> _FakeLayer:
         self.calls.append((op, args, kwargs))
         shape = next((tuple(arg.shape) for arg in args if hasattr(arg, "shape")), (1, 4))
-        return _FakeLayer(shape=shape)
+        layer = _FakeLayer(shape=shape)
+        self.layers.append(layer)
+        return layer
 
     def add_input(self, name: str, dtype: object, shape: tuple[int, ...]) -> _FakeTensor:
         self.inputs.append((name, dtype, shape))
@@ -83,7 +90,9 @@ class _FakeNetwork:
 
     def add_constant(self, shape: tuple[int, ...], weights: object) -> _FakeLayer:
         self.calls.append(("add_constant", (shape, weights), {}))
-        return _FakeLayer(shape=tuple(shape))
+        layer = _FakeLayer(shape=tuple(shape))
+        self.layers.append(layer)
+        return layer
 
     def add_cast(self, tensor, target_dtype, **kwargs) -> _FakeLayer:
         layer = self._record("add_cast", tensor, target_dtype, **kwargs)


### PR DESCRIPTION
## Background

The generic TensorRT network proxy added in #761 reads the real `INetworkDefinition.num_layers` contract while recording `add_*` operations. Three owned-builder test doubles did not preserve that interface, so their tests stopped at the first proxied network call instead of exercising the builder behavior.

## Exit Criteria

- Z-Image, BERT, and Flux builder fakes preserve TensorRT layer-count semantics.
- Source-unit coverage exercises the generic network proxy path.
- Production behavior and test passing criteria remain unchanged.

## Implementation

- Track fake layers created by layer-producing operations while keeping inputs and marked outputs out of `num_layers`.
- Extend the existing TensorRT compatibility boundary test with a generic `add_identity` call so this proxy path runs in L0.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python python3 -m pytest -p no:cacheprovider tests/builder/test_trt_compat_boundary.py tests/e2e/models/z_image/test_z_image_qwen3_encoder_builder.py tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py tests/e2e/models/flux/test_flux_owned_encoder_builders_coverage.py -q`: 18 passed.
- `python3 -m ruff check ...`: all four changed test files passed.
- `python3 tools/model_ci.py impact ...`: selected BERT, Flux, and Z-Image as direct model proofs and retained source-unit coverage.

## Notes For Future Readers

Review the compatibility boundary test first. The family-owned fake changes implement the same real TensorRT contract; no production fallback was added for incomplete test doubles.
