### PR TITLE
perf(canary): vectorize single-request decoding

### DIFF
--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -762,28 +762,15 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
                                       const TranscriptionConfig& cfg) {
     validate_canary_audio_input(audio_data, num_samples);
 
-    auto initial_tokens = make_canary_request_tokens(canary_config_, cfg, tokenizer_.get());
-    validate_canary_output_budget(canary_config_, cfg, initial_tokens.size());
+    std::vector<TranscriptionRequest> requests(1);
+    requests.front().audio_samples.assign(audio_data, audio_data + num_samples);
+    requests.front().config = cfg;
 
-    const int32_t sample_rate =
-        cfg.input_sample_rate > 0 ? cfg.input_sample_rate : mel_sampling_rate_;
-    const double duration_seconds = validate_canary_input_duration(num_samples, sample_rate, cfg);
-    const double model_segment_seconds = static_cast<double>(mel_chunk_length_);
-    const double segment_seconds =
-        resolve_canary_segment_duration(duration_seconds, model_segment_seconds, cfg);
-    const auto spans =
-        plan_canary_segments(num_samples, sample_rate, static_cast<float>(segment_seconds),
-                             cfg.segment_min_duration_seconds, cfg.segment_overlap_seconds);
-
-    TextResult combined;
-    for (const auto& span : spans) {
-        auto segment = transcribe_segment(audio_data + span.offset, span.count, sample_rate,
-                                          initial_tokens, cfg.max_output_tokens, cfg.beam_size,
-                                          cfg.length_penalty, cfg.beam_fallback_max_size);
-        append_canary_transcription_segment(combined, std::move(segment), span.offset, span.count,
-                                            sample_rate, cfg, canary_config_.eot_token_id);
-    }
-    return combined;
+    auto results = transcribe_batch(requests);
+    if (results.size() != 1)
+        throw std::runtime_error(
+            "Canary single-request transcription returned an unexpected result count");
+    return std::move(results.front());
 }
 
 std::vector<TextResult>

--- a/tests/cpp/models/canary/test_canary_pipeline.cpp
+++ b/tests/cpp/models/canary/test_canary_pipeline.cpp
@@ -102,6 +102,13 @@ void test_canary_transcribe() {
     check(beam.token_ids == std::vector<int32_t>({2}),
           "canary beam search runs with branchable inference states");
 
+    trtmc::TranscriptionRequest batch_request;
+    batch_request.audio_samples = audio;
+    batch_request.config = request;
+    const auto batch_results = pipeline.transcribe_batch({batch_request});
+    check(batch_results.size() == 1 && batch_results.front().token_ids == beam.token_ids,
+          "canary single-request and batch APIs preserve output parity");
+
     cudaStreamDestroy(stream);
 }
 


### PR DESCRIPTION
## Background

Canary long-audio transcription plans five overlapping windows for each
120-second customer sample. The single-request API decoded those windows
independently even though the batch API can advance the windows and their beam
lanes together.

## Exit Criteria

- Preserve the existing window planning, overlap, LCS merge, fallback, and
  decoding configuration.
- Make external batch-1 transcription use vectorized window and beam execution.
- Preserve the existing transcription output.

## Implementation

- Route `CanaryPipeline::transcribe()` through the existing
  `transcribe_batch()` implementation using one request.
- Retain the existing capacity and fallback behavior inside the batch path.
- Add coverage that checks output parity between the single-request and batch
  APIs.

## Validation

- `clang-format --dry-run --Werror src/runtime/models/canary/pipeline.cpp tests/cpp/models/canary/test_canary_pipeline.cpp`: passed.
- `ctest --test-dir build-customer --output-on-failure -R "test_canary_(decode_policy|host_plan|pipeline)"`: 3/3 tests passed on L40S with TensorRT 11.2.
- Customer 20-file L40S benchmark, three measured passes: 0.813 seconds mean
  end-to-end time per 120-second file; all 60 transcriptions completed with
  identical transcripts and token counts across passes.

## Notes For Future Readers

- External batch size remains one. The batch path groups the five long-audio
  windows and four beam lanes internally while preserving result order and
  merge semantics.
- Standalone performance reports and raw benchmark artifacts are intentionally
  excluded from this PR.
