### PR TITLE
fix(perf): validate reference precision

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -1359,6 +1359,7 @@ def _load_diffusers(
         values["guidance_scale"] = guidance
     if arguments.family == "qwen_image" and cfg_scale >= 0:
         values["true_cfg_scale"] = cfg_scale
+    values["output_type"] = "np"
     image_path = str(request.get("image_path", "") or "")
     if image_path and ("image" in accepted or accepts_extra):
         values["image"] = Image.open(_asset_path(arguments, request, "image_path")).convert("RGB")
@@ -1470,13 +1471,25 @@ def _media_summary(media: Any, media_type: str) -> dict[str, Any]:
                 height, width, channels = shape[-3:]
             elif shape[-3] in {1, 3, 4}:
                 channels, height, width = shape[-3:]
-    return {
+    summary = {
         "media_type": media_type,
         "media_count": count,
         "height": height,
         "width": width,
         "channels": channels,
     }
+    try:
+        import numpy as np
+
+        array = np.asarray(media)
+        if np.issubdtype(array.dtype, np.number):
+            finite = bool(np.isfinite(array).all())
+            if not finite:
+                raise RuntimeError("reference returned non-finite media values")
+            summary["finite"] = True
+    except (TypeError, ValueError):
+        pass
+    return summary
 
 
 def _numeric_values(request: Mapping[str, Any], key: str) -> list[float]:

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from types import ModuleType, SimpleNamespace
 
+import numpy as np
 import pytest
 import yaml
 
@@ -561,7 +562,10 @@ def test_backend_waits_for_gpu_headroom_before_each_command(
     monkeypatch.setattr(
         perf_matrix,
         "_baseline_argv",
-        lambda _case, _resolved, _output, _options: (["baseline"], "base"),
+        lambda _case, _resolved, _output, _options: (
+            ["baseline", "--precision", "fp16"],
+            "base",
+        ),
     )
     monkeypatch.setattr(
         perf_matrix,
@@ -1538,6 +1542,57 @@ def test_task_reference_can_require_local_model_files_per_case(tmp_path: Path) -
     assert "--local-files-only" in argv
 
 
+def test_task_reference_uses_manifest_reference_precision(tmp_path: Path) -> None:
+    case = {
+        "baseline": {
+            "adapter": "hf-diffusers",
+            "timing_scope": "task-pipeline-call-wall",
+            "input_preparation_included": True,
+            "asset_loading_included": False,
+        },
+        "measurement": {"warmup": 1, "iterations": 2},
+        "workload": {"testcase": "z-image-turbo"},
+    }
+    resolved = {
+        "testcase": "z-image-turbo",
+        "operation": "generate_image",
+        "request": {"prompt": "cat"},
+        "runtime": {},
+        "model": {
+            "family": "z_image",
+            "hf_id": "Tongyi-MAI/Z-Image-Turbo",
+            "manifest_path": str(tmp_path / "manifest.json"),
+            "precision": "fp16",
+            "task_strategy": "diffusion_media_generation",
+        },
+    }
+    manifest = {
+        "testcases": [
+            {
+                "name": "z-image-turbo",
+                "reference_precision": "bf16",
+            }
+        ]
+    }
+    options = Namespace(
+        local_files_only=False,
+        task_reference_runner=tmp_path / "task_reference.py",
+    )
+
+    argv = perf_matrix._task_reference_argv(
+        case=case,
+        resolved=resolved,
+        manifest=manifest,
+        output=tmp_path / "baseline.json",
+        options=options,
+        profile="default",
+        python="python",
+        mode="hf-eager",
+    )
+
+    assert argv[argv.index("--precision") + 1] == "bf16"
+
+
 def test_entry_is_the_only_run_selection() -> None:
     cases = perf_matrix._cases(perf_matrix._read_yaml(SUITE))
 
@@ -2409,6 +2464,63 @@ def test_diffusers_media_count_accepts_array_like_video_frames() -> None:
 
     assert runner["_media_count"](Frames(), "video") == 5
     assert runner["_media_count"](Frames(), "image") == 1
+
+
+def test_diffusers_adapter_requests_numeric_output_before_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = runpy.run_path(
+        str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py")
+    )
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def to(self, _device):
+            return self
+
+        def __call__(self, *, prompt, output_type):
+            captured.update(prompt=prompt, output_type=output_type)
+            return Namespace(images=np.zeros((1, 4, 6, 3), dtype=np.float32))
+
+    globals_ = runner["_load_diffusers"].__globals__
+    globals_["_diffusion_pipeline"] = lambda *_args: FakePipeline()
+    globals_["_resolved_revision"] = lambda *_args: "snapshot"
+    arguments = Namespace(
+        family="z_image",
+        precision="bf16",
+        model="Tongyi-MAI/Z-Image-Turbo",
+        revision=None,
+    )
+
+    session = runner["_load_diffusers"](
+        arguments,
+        {"prompt": "cat", "media_type": "image"},
+        {},
+    )
+
+    assert session.invoke()["finite"] is True
+    assert captured == {"prompt": "cat", "output_type": "np"}
+
+
+def test_diffusers_media_summary_rejects_non_finite_pixels() -> None:
+    runner = runpy.run_path(
+        str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py")
+    )
+    finite = np.zeros((1, 4, 6, 3), dtype=np.float32)
+
+    assert runner["_media_summary"](finite, "image") == {
+        "media_type": "image",
+        "media_count": 1,
+        "height": 4,
+        "width": 6,
+        "channels": 3,
+        "finite": True,
+    }
+
+    invalid = finite.copy()
+    invalid[0, 0, 0, 0] = np.nan
+    with pytest.raises(RuntimeError, match="non-finite"):
+        runner["_media_summary"](invalid, "image")
 
 
 def test_personaplex_loader_adds_vendored_moshi_package_root() -> None:

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -1215,6 +1215,32 @@ def _manifest_values(resolved: Mapping[str, Any]) -> dict[str, Any]:
     return value
 
 
+def _reference_precision(
+    case: Mapping[str, Any],
+    resolved: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> str:
+    explicit = case["baseline"].get("precision")
+    if explicit is not None:
+        return str(explicit)
+    testcase_name = str(
+        resolved.get("testcase") or case.get("workload", {}).get("testcase") or ""
+    )
+    testcases = manifest.get("testcases", [])
+    if isinstance(testcases, list):
+        for testcase in testcases:
+            if (
+                isinstance(testcase, Mapping)
+                and str(testcase.get("name") or "") == testcase_name
+                and testcase.get("reference_precision") is not None
+            ):
+                return str(testcase["reference_precision"])
+    declared = manifest.get("reference_precision")
+    if declared is not None:
+        return str(declared)
+    return str(resolved["model"]["precision"])
+
+
 def _baseline_task(resolved: Mapping[str, Any]) -> str:
     strategy = str(resolved["model"]["task_strategy"])
     runtime = str(resolved["model"]["runtime_strategy"])
@@ -1249,6 +1275,7 @@ def _baseline_argv(
     profile, python = _reference_python(resolved, baseline)
     model = resolved["model"]
     manifest = _manifest_values(resolved)
+    reference_precision = _reference_precision(case, resolved, manifest)
     mode = str(baseline.get("mode", "torch-compile"))
     if baseline.get("runner") == "task-reference":
         return _task_reference_argv(
@@ -1273,7 +1300,7 @@ def _baseline_argv(
         "--request-json",
         json.dumps(resolved["request"], ensure_ascii=True, separators=(",", ":")),
         "--precision",
-        str(baseline.get("precision", model["precision"])),
+        reference_precision,
         "--max-length",
         str(max_length),
         "--padding",
@@ -1328,6 +1355,7 @@ def _task_reference_argv(
     baseline = case["baseline"]
     model = resolved["model"]
     adapter_options = _resolved_adapter_options(baseline)
+    reference_precision = _reference_precision(case, resolved, manifest)
     argv = [
         python,
         str(options.task_reference_runner.resolve()),
@@ -1361,7 +1389,7 @@ def _task_reference_argv(
             separators=(",", ":"),
         ),
         "--precision",
-        str(baseline.get("precision", model["precision"])),
+        reference_precision,
         "--mode",
         mode,
         "--padding",
@@ -1765,8 +1793,14 @@ def _classify(
     baseline: Mapping[str, Any],
     *,
     request: Mapping[str, Any] | None = None,
+    reference_precision: str | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    mismatch = _baseline_contract_mismatch(case, candidate, baseline)
+    mismatch = _baseline_contract_mismatch(
+        case,
+        candidate,
+        baseline,
+        reference_precision=reference_precision,
+    )
     if mismatch:
         return "contract-mismatch", {"reason": mismatch}
     outputs_match, reason = _output_contract(
@@ -1792,6 +1826,8 @@ def _baseline_contract_mismatch(
     case: Mapping[str, Any],
     candidate: Mapping[str, Any],
     baseline: Mapping[str, Any],
+    *,
+    reference_precision: str | None = None,
 ) -> str:
     timing_mismatch = _timing_contract_mismatch(case, candidate, baseline)
     if timing_mismatch:
@@ -1799,7 +1835,11 @@ def _baseline_contract_mismatch(
     expected_mode = str(case["baseline"].get("mode", "torch-compile"))
     if baseline.get("mode") != expected_mode:
         return "baseline mode differs from the suite"
-    expected_precision = case["baseline"].get("precision", candidate.get("precision"))
+    expected_precision = (
+        reference_precision
+        if reference_precision is not None
+        else case["baseline"].get("precision", candidate.get("precision"))
+    )
     if baseline.get("precision") != expected_precision:
         return "baseline precision differs from the suite"
     expected_padding = case["baseline"].get("padding", "longest")
@@ -1933,6 +1973,8 @@ def _run_supported_case(
     candidate_argv = [*_candidate_base_argv(case, options), "--output", str(candidate_dir)]
     baseline_argv, profile = _baseline_argv(case, resolved, baseline_path, options)
     row["resolved_settings"]["baseline_python_profile"] = profile
+    reference_precision = baseline_argv[baseline_argv.index("--precision") + 1]
+    row["resolved_settings"]["baseline_precision"] = reference_precision
     commands = {
         "trtmc": {"argv": candidate_argv, "rendered": shlex.join(candidate_argv)},
         "baseline": {"argv": baseline_argv, "rendered": shlex.join(baseline_argv)},
@@ -1961,6 +2003,7 @@ def _run_supported_case(
         candidate,
         baseline,
         request=resolved["request"],
+        reference_precision=reference_precision,
     )
     row["candidate"] = candidate
     row["baseline"] = baseline


### PR DESCRIPTION
## Background

Performance baselines inherited the candidate bundle precision when the suite did not override it. That ignored the selected manifest testcase's `reference_precision`, and Diffusers could turn non-finite float output into an apparently valid PIL image.

## Exit Criteria

- Use the selected testcase's declared reference precision unless the suite explicitly overrides it.
- Reject non-finite Diffusers media before image conversion can hide invalid output.
- Keep baseline contract validation aligned with the effective precision.

## Implementation

- Resolve baseline precision from the suite override, selected testcase, manifest default, then candidate precision.
- Request NumPy output from compatible Diffusers pipelines and validate all numeric pixels are finite.
- Record and compare the effective baseline precision in performance results.

## Validation

- `pytest -q tests/tools/test_perf_matrix.py`: 88 passed.
- `ruff check tools/perf_matrix.py benchmarks/performance/baselines/task_reference.py tests/tools/test_perf_matrix.py`: passed.

## Notes For Future Readers

- Review `tools/perf_matrix.py` first for the precision precedence contract, then `task_reference.py` for output validation.
- This fixes report correctness only; model-side Z-Image performance work remains tracked separately.

Refs #778
