### PR TITLE
perf(z-image): use native FP16 attention

### DIFF
--- a/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
@@ -514,13 +514,16 @@ def _multi_head_attention(
         network, q, k, v, num_heads, head_dim, q_seq, kv_seq, scale_t,
         mask=None, dtype=np.float32):
     """Standard multi-head attention."""
+    if mask is not None and mask.dtype != q.dtype:
+        mask = network.add_cast(mask, q.dtype).get_output(0)
     return graph_ops.add_attention_from_rows(
         network, q, k, v,
         num_heads=num_heads, head_dim=head_dim,
         q_seq=q_seq, kv_seq=kv_seq,
         mask=mask,
         scale=scale_t,
-        explicit_attention=(dtype != np.float32))
+        fp32_accumulation=False,
+        explicit_attention=False)
 
 
 def _sandwich_prescale_params(

--- a/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
+++ b/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
@@ -73,6 +73,11 @@ class _Network:
     def mark_output(self, tensor):
         self.outputs.append(tensor)
 
+    def add_cast(self, _tensor, dtype):
+        layer = _Layer()
+        layer.get_output(0).dtype = dtype
+        return layer
+
     def __getattr__(self, attr: str):
         if attr.startswith("add_"):
 
@@ -83,7 +88,7 @@ class _Network:
         raise AttributeError(attr)
 
 
-def test_static_fp16_attention_uses_fp32_accumulation(
+def test_static_fp16_attention_uses_native_attention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[dict] = []
@@ -93,10 +98,15 @@ def test_static_fp16_attention_uses_fp32_accumulation(
         return _Tensor()
 
     monkeypatch.setattr(z_image_dit_builder.graph_ops, "add_attention_from_rows", _attention)
+    network = _Network()
+    q = _Tensor()
+    q.dtype = z_image_dit_builder.trt.float16
+    mask = _Tensor()
+    mask.dtype = z_image_dit_builder.trt.float32
 
     z_image_dit_builder._multi_head_attention(
-        None,
-        _Tensor(),
+        network,
+        q,
         _Tensor(),
         _Tensor(),
         num_heads=2,
@@ -104,10 +114,13 @@ def test_static_fp16_attention_uses_fp32_accumulation(
         q_seq=8,
         kv_seq=8,
         scale_t=0.5,
+        mask=mask,
         dtype=np.float16,
     )
 
-    assert calls[0]["explicit_attention"] is True
+    assert calls[0]["explicit_attention"] is False
+    assert calls[0]["fp32_accumulation"] is False
+    assert calls[0]["mask"].dtype == z_image_dit_builder.trt.float16
     assert calls[0]["scale"] == 0.5
 
 


### PR DESCRIPTION
## Summary

- replace Z-Image's explicit FP32 attention graph with TensorRT native FP16 attention
- cast the additive attention mask to the query dtype for strongly typed networks
- add regression coverage for the native-attention contract

## Why

The explicit path materialized the full attention score matrix and cast Q/K/V to FP32. At the release workload shape (sequence length 4608, 30 heads, head dimension 128), denoising dominated end-to-end latency.

## Validation

- `PYTHONPATH=python pytest -q tests/e2e/models/z_image --ignore=tests/e2e/models/z_image/test_z_image_e2e.py` — 26 passed
- Ruff passed for the changed files
- TensorRT 11.2 on GB300: bundle rebuilt successfully
- End-to-end benchmark, 3 warmups and 10 measured iterations:
  - before: p50 1160.35 ms
  - after: p50 772.45 ms, p95 778.48 ms
  - 33.4% lower p50 latency
- Generated output: 1024x1024 RGB, finite output summary

Closes #778
