### PR TITLE
fix(validation): flatten managed dataset paths

### DIFF
--- a/tests/tools/test_prepare_model_plugin_validation_datasets.py
+++ b/tests/tools/test_prepare_model_plugin_validation_datasets.py
@@ -8,6 +8,7 @@ import wave
 from pathlib import Path
 
 from PIL import Image
+import yaml
 
 from tools import prepare_model_plugin_validation_datasets as prepare
 
@@ -134,9 +135,13 @@ def test_prepare_all_writes_task_owned_public_datasets_and_hashes(
     tmp_path: Path,
 ) -> None:
     flores, full_duplex, mmlu, mmmu, seedtts = _write_sources(tmp_path)
+    output_root = tmp_path / "output"
+    unrelated = output_root / "OtherDataset" / "dataset.json"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("unmanaged\n", encoding="utf-8")
 
     outputs = prepare.prepare_all(
-        output_root=tmp_path / "output",
+        output_root=output_root,
         flores_source=flores,
         full_duplex_source=full_duplex,
         mmlu_source=mmlu,
@@ -145,12 +150,15 @@ def test_prepare_all_writes_task_owned_public_datasets_and_hashes(
     )
 
     assert len(outputs) == 7
-    root = tmp_path / "output" / prepare.DATASET_ROOT_NAME
+    root = output_root
+    assert not (root / "TRTMCValidation").exists()
     counts = {
-        path.parent.name: json.loads(path.read_text(encoding="utf-8"))[
-            "request_count"
-        ]
-        for path in root.glob("*/dataset.json")
+        directory_name: json.loads(
+            (root / directory_name / "dataset.json").read_text(
+                encoding="utf-8"
+            )
+        )["request_count"]
+        for directory_name in prepare.MANAGED_DATASET_DIRECTORIES
     }
     assert counts == {
         "flores200-en-fr": 10,
@@ -161,9 +169,17 @@ def test_prepare_all_writes_task_owned_public_datasets_and_hashes(
         "seedtts-en-omni-audio": 1,
     }
     manifest = json.loads(
-        (root / "dataset_manifest.json").read_text(encoding="utf-8")
+        (root / prepare.DATASET_MANIFEST_NAME).read_text(encoding="utf-8")
+    )
+    assert manifest["root"] == "."
+    assert manifest["managed_directories"] == list(
+        prepare.MANAGED_DATASET_DIRECTORIES
     )
     assert manifest["file_count"] == len(manifest["files"])
+    assert unrelated.is_file()
+    assert "OtherDataset/dataset.json" not in {
+        item["path"] for item in manifest["files"]
+    }
     assert all(
         prepare.sha256(root / item["path"]) == item["sha256"]
         for item in manifest["files"]
@@ -228,6 +244,42 @@ def test_prepare_all_writes_task_owned_public_datasets_and_hashes(
         dataset["license"] and dataset["license_url"]
         for dataset in (
             json.loads(path.read_text(encoding="utf-8"))
-            for path in root.glob("*/dataset.json")
+            for path in (
+                root / directory_name / "dataset.json"
+                for directory_name in prepare.MANAGED_DATASET_DIRECTORIES
+            )
         )
     )
+
+
+def test_model_plugin_validation_workloads_use_root_level_dataset_paths() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    payload = yaml.safe_load(
+        (repository / "tests/validation/workloads.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    suites = {suite["id"]: suite for suite in payload["suites"]}
+    expected = {
+        "mmmu_pro_vision_plugin_parity": "/mnt/data/mmmu-pro-vision/dataset.json",
+        "mmmu_pro_vision_square_plugin_parity": (
+            "/mnt/data/mmmu-pro-vision-square-448/dataset.json"
+        ),
+        "mmlu_generation_mode_parity": (
+            "/mnt/data/mmlu-generation-modes/dataset.json"
+        ),
+        "flores200_en_fr_seq2seq_parity": (
+            "/mnt/data/flores200-en-fr/dataset.json"
+        ),
+        "full_duplex_bench_speech_parity": (
+            "/mnt/data/full-duplex-bench/dataset.json"
+        ),
+        "seedtts_en_omni_audio_parity": (
+            "/mnt/data/seedtts-en-omni-audio/dataset.json"
+        ),
+    }
+
+    assert {
+        suite_id: suites[suite_id]["dataset"]["default_path"]
+        for suite_id in expected
+    } == expected

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -112,12 +112,15 @@ python tools/prepare_model_plugin_validation_datasets.py \
   --seedtts-source /mnt/data/SeedTTS_en_meta/seedtts_en_meta.json
 ```
 
-This writes `/mnt/data/TRTMCValidation` with MMMU-Pro Vision, MMLU-Pro,
-FLORES-200, Full-Duplex-Bench, and Seed-TTS-Eval slices, plus
-`dataset_manifest.json` containing each file's byte size and SHA256. Wan
-workloads read the existing public VBench asset directly. Dev/QA machines and
-NAS mirrors should copy the directory without changing its relative layout
-and verify the manifest after transfer.
+This writes the `mmmu-pro-vision`, `mmmu-pro-vision-square-448`,
+`mmlu-generation-modes`, `flores200-en-fr`, `full-duplex-bench`, and
+`seedtts-en-omni-audio` directories directly under `/mnt/data`. It also writes
+`/mnt/data/trtmc_model_plugin_validation_manifest.json`, which lists only
+those six managed directories and records each file's byte size and SHA256.
+There is intentionally no aggregate `TRTMCValidation` directory. Wan workloads
+read the existing root-level public `VBench` asset directly. Dev/QA machines
+and NAS mirrors should copy the six directories without changing their
+relative layouts and verify the manifest after transfer.
 
 Every agreement or disagreement therefore means that both backends consumed
 the aligned prepared inputs and produced outputs that were evaluated by the

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1587,7 +1587,7 @@ suites:
     default_model_names: [phi4-multimodal]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/mmmu-pro-vision/dataset.json
+      default_path: /mnt/data/mmmu-pro-vision/dataset.json
       input_asset_fields: [image]
     selectors:
       model_names: [phi4-multimodal]
@@ -1612,7 +1612,7 @@ suites:
     default_model_names: [lance-3b-x2t-image]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/mmmu-pro-vision-square-448/dataset.json
+      default_path: /mnt/data/mmmu-pro-vision-square-448/dataset.json
       input_asset_fields: [image]
     selectors:
       model_names: [lance-3b-x2t-image]
@@ -1636,7 +1636,7 @@ suites:
     default_model_names: [nemotron-labs-diffusion-8b]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/mmlu-generation-modes/dataset.json
+      default_path: /mnt/data/mmlu-generation-modes/dataset.json
     selectors:
       model_names: [nemotron-labs-diffusion-8b]
     scoring:
@@ -1656,7 +1656,7 @@ suites:
     default_model_names: [nllb-200-distilled-600m]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/flores200-en-fr/dataset.json
+      default_path: /mnt/data/flores200-en-fr/dataset.json
     selectors:
       model_names: [nllb-200-distilled-600m]
     scoring:
@@ -1677,7 +1677,7 @@ suites:
     default_model_names: [personaplex-7b]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/full-duplex-bench/dataset.json
+      default_path: /mnt/data/full-duplex-bench/dataset.json
       input_asset_fields: [audio]
     selectors:
       model_names: [personaplex-7b]
@@ -1701,7 +1701,7 @@ suites:
     default_model_names: [qwen3-omni-30b-a3b-instruct]
     dataset:
       kind: model_plugin_json
-      default_path: /mnt/data/TRTMCValidation/seedtts-en-omni-audio/dataset.json
+      default_path: /mnt/data/seedtts-en-omni-audio/dataset.json
     selectors:
       model_names: [qwen3-omni-30b-a3b-instruct]
     scoring:

--- a/tools/prepare_model_plugin_validation_datasets.py
+++ b/tools/prepare_model_plugin_validation_datasets.py
@@ -15,7 +15,15 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
-DATASET_ROOT_NAME = "TRTMCValidation"
+DATASET_MANIFEST_NAME = "trtmc_model_plugin_validation_manifest.json"
+MANAGED_DATASET_DIRECTORIES = (
+    "flores200-en-fr",
+    "full-duplex-bench",
+    "mmlu-generation-modes",
+    "mmmu-pro-vision",
+    "mmmu-pro-vision-square-448",
+    "seedtts-en-omni-audio",
+)
 FLORES_SOURCE = "facebook/flores-200 eng_Latn/fra_Latn devtest"
 FULL_DUPLEX_SOURCE = (
     "DanielLin94144/Full-Duplex-Bench v1.0 synthetic subsets "
@@ -539,23 +547,22 @@ def prepare_seedtts_omni_audio(
 
 def write_dataset_manifest(root: Path) -> Path:
     files = []
-    for path in sorted(
-        item
-        for item in root.rglob("*")
-        if item.is_file() and item.name != "dataset_manifest.json"
-    ):
-        files.append(
-            {
-                "path": path.relative_to(root).as_posix(),
-                "bytes": path.stat().st_size,
-                "sha256": sha256(path),
-            }
-        )
+    for directory_name in MANAGED_DATASET_DIRECTORIES:
+        directory = root / directory_name
+        for path in sorted(item for item in directory.rglob("*") if item.is_file()):
+            files.append(
+                {
+                    "path": path.relative_to(root).as_posix(),
+                    "bytes": path.stat().st_size,
+                    "sha256": sha256(path),
+                }
+            )
     return write_json(
-        root / "dataset_manifest.json",
+        root / DATASET_MANIFEST_NAME,
         {
             "schema_version": "trtmc.validation-dataset-manifest/v1",
-            "root": DATASET_ROOT_NAME,
+            "root": ".",
+            "managed_directories": list(MANAGED_DATASET_DIRECTORIES),
             "file_count": len(files),
             "files": files,
         },
@@ -571,7 +578,7 @@ def prepare_all(
     mmmu_source: Path,
     seedtts_source: Path,
 ) -> list[Path]:
-    root = output_root / DATASET_ROOT_NAME
+    root = output_root
     outputs = [
         prepare_mmmu_vision(mmmu_source, root),
         prepare_mmmu_vision(


### PR DESCRIPTION
## Background
The model-owned validation datasets were published under an extra `TRTMCValidation` wrapper even though TRTMC benchmark datasets share one root. This made workload paths inconsistent with the NAS dataset layout and left obsolete model-named fixtures beside the public datasets.

## Exit Criteria
- Publish the six model-owned validation datasets directly under the shared dataset root.
- Keep Wan2.1 and Wan2.2 on the existing root-level VBench dataset.
- Generate a manifest scoped only to the six directories managed by the preparation tool.
- Ensure validation workloads no longer depend on `/mnt/data/TRTMCValidation`.

## Implementation
- Write FLORES-200, Full-Duplex-Bench, MMLU generation modes, two MMMU-Pro Vision variants, and Seed-TTS data directly under the requested output root.
- Replace the aggregate manifest with `trtmc_model_plugin_validation_manifest.json`, including explicit managed-directory metadata.
- Update the six workload paths and dataset preparation documentation.
- Add regression coverage proving that no wrapper directory is created and unrelated root datasets are excluded from the manifest.

## Validation
- `.venv-trtmc/bin/ruff check --config ruff.toml tools/prepare_model_plugin_validation_datasets.py tests/tools/test_prepare_model_plugin_validation_datasets.py`: passed.
- `PYTHONPATH="$PWD/python:$PWD" .venv-trtmc/bin/python -m pytest -q tests/tools/test_prepare_model_plugin_validation_datasets.py tests/tools/test_validation_engine.py tests/tools/test_trtmc_validate.py`: 300 passed.
- `CI_BASE_REF=github/main PYTHONPATH="$PWD/python:$PWD" .venv-trtmc/bin/python -m tools.ci pipeline source-quality`: passed, including 158 model architecture tests.
- GB300-2 root-level dataset paths and the existing VBench workload file were verified readable.
- All 21 managed NAS files were verified against the published SHA-256 manifest.

## Notes For Future Readers
- The eight affected models use seven dataset sources: six managed directories plus the existing shared VBench asset for both Wan models.
- NAS migration removed the obsolete `TRTMCValidation/` and `TaskEvalGap20260714/` directories after moving and verifying the required data.
