### PR TITLE
perf(qwen3-omni): multiply only routed experts

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -1009,46 +1009,65 @@ class Qwen3OmniPlugin:
 # MoE block for Omni (standard top-k softmax, same as Mixtral pattern)
 # ---------------------------------------------------------------------------
 
-def _add_packed_swiglu_experts(
+def _add_routed_swiglu_experts(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
+    top_indices: trt.ITensor,
+    routing_weights: trt.ITensor,
     hidden_size: int,
+    top_k: int,
     w_gate: np.ndarray,
     w_up: np.ndarray,
     w_down: np.ndarray,
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Compute every expert with three batched matmuls for a dynamic token count."""
-    num_experts, _, intermediate_size = w_gate.shape
+    """Compute only the top-k routed experts for each token."""
     inp_4d = network.add_shuffle(inp)
     inp_4d.reshape_dims = (-1, 1, 1, hidden_size)
 
     def packed_weight(values: np.ndarray) -> trt.ITensor:
         tensor = graph_ops.add_constant(
-            network, (1, *values.shape), values.reshape(1, *values.shape), dtype=dtype)
+            network, values.shape, values, dtype=dtype)
         if tensor.dtype != inp.dtype:
             tensor = network.add_cast(tensor, inp.dtype).get_output(0)
         return tensor
 
+    gate_weights = packed_weight(w_gate)
+    up_weights = packed_weight(w_up)
+    down_weights = packed_weight(w_down)
+    selected_gate = network.add_gather(gate_weights, top_indices, 0)
+    selected_up = network.add_gather(up_weights, top_indices, 0)
     gate = network.add_matrix_multiply(
         inp_4d.get_output(0), trt.MatrixOperation.NONE,
-        packed_weight(w_gate), trt.MatrixOperation.NONE)
+        selected_gate.get_output(0), trt.MatrixOperation.NONE)
     up = network.add_matrix_multiply(
         inp_4d.get_output(0), trt.MatrixOperation.NONE,
-        packed_weight(w_up), trt.MatrixOperation.NONE)
+        selected_up.get_output(0), trt.MatrixOperation.NONE)
 
-    sigmoid = network.add_activation(gate.get_output(0), trt.ActivationType.SIGMOID)
+    sigmoid = network.add_activation(
+        gate.get_output(0), trt.ActivationType.SIGMOID)
     swish = network.add_elementwise(
-        gate.get_output(0), sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+        gate.get_output(0), sigmoid.get_output(0),
+        trt.ElementWiseOperation.PROD)
     gated = network.add_elementwise(
-        swish.get_output(0), up.get_output(0), trt.ElementWiseOperation.PROD)
+        swish.get_output(0), up.get_output(0),
+        trt.ElementWiseOperation.PROD)
 
+    selected_down = network.add_gather(down_weights, top_indices, 0)
     down = network.add_matrix_multiply(
         gated.get_output(0), trt.MatrixOperation.NONE,
-        packed_weight(w_down), trt.MatrixOperation.NONE)
+        selected_down.get_output(0), trt.MatrixOperation.NONE)
     output = network.add_shuffle(down.get_output(0))
-    output.reshape_dims = (-1, num_experts, hidden_size)
-    return output.get_output(0)
+    output.reshape_dims = (-1, top_k, hidden_size)
+
+    route_weights = network.add_shuffle(routing_weights)
+    route_weights.reshape_dims = (-1, top_k, 1)
+    weighted = network.add_elementwise(
+        output.get_output(0), route_weights.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    return network.add_reduce(
+        weighted.get_output(0), trt.ReduceOperation.SUM, 1 << 1,
+        keep_dims=False).get_output(0)
 
 
 def _add_omni_moe_block(
@@ -1084,48 +1103,14 @@ def _add_omni_moe_block(
         top_values, sum_val.get_output(0),
         trt.ElementWiseOperation.DIV)
 
-    # Compute all expert outputs as [Sq, E, H] with three packed matmuls.
-    stacked_out = _add_packed_swiglu_experts(
-        network, inp, hidden_size,
+    # Gather each token's routed expert weights before the expert matmuls.
+    return _add_routed_swiglu_experts(
+        network, inp, top_indices, norm_weights.get_output(0), hidden_size, top_k,
         weights[f"{prefix}.experts.w_gate"],
         weights[f"{prefix}.experts.w_up"],
         weights[f"{prefix}.experts.w_down"],
         dtype=dtype,
     )
-
-    # Build token-row indices [Sq, K] and pair them with the router's expert
-    # indices. GatherND then selects K experts independently for every token.
-    routing_shape = network.add_shape(top_indices).get_output(0)
-    fill_start = network.add_constant(
-        (), trt.Weights(np.array(0, dtype=np.int32))).get_output(0)
-    fill_delta = network.add_constant(
-        (2,), trt.Weights(np.array([1, 0], dtype=np.int32))).get_output(0)
-    row_indices = network.add_fill(
-        (1, top_k), trt.FillOperation.LINSPACE, trt.int32)
-    row_indices.set_input(0, routing_shape)
-    row_indices.set_input(1, fill_start)
-    row_indices.set_input(2, fill_delta)
-
-    row_3d = network.add_shuffle(row_indices.get_output(0))
-    row_3d.reshape_dims = (-1, top_k, 1)
-    expert_3d = network.add_shuffle(top_indices)
-    expert_3d.reshape_dims = (-1, top_k, 1)
-    gather_indices = network.add_concatenation(
-        [row_3d.get_output(0), expert_3d.get_output(0)])
-    gather_indices.axis = 2
-
-    selected = network.add_gather(
-        stacked_out, gather_indices.get_output(0), 0)
-    selected.mode = trt.GatherMode.ND
-
-    weights_3d = network.add_shuffle(norm_weights.get_output(0))
-    weights_3d.reshape_dims = (-1, top_k, 1)
-    weighted = network.add_elementwise(
-        selected.get_output(0), weights_3d.get_output(0),
-        trt.ElementWiseOperation.PROD)
-    summed = network.add_reduce(
-        weighted.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=False)
-    return summed.get_output(0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -235,3 +235,83 @@ def test_thinker_load_weights_preserves_bf16_storage(monkeypatch, tmp_path) -> N
     assert weights["layer.0.experts.w_down"].shape == (8, 32, 16)
     assert weights["w_out"].dtype.name == "bfloat16"
     assert weights["final_norm"].dtype == np.float32
+
+
+def test_thinker_moe_batches_only_routed_expert_multiplies(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen3_omni.plugin")
+    constants = []
+    matrix_multiplies = []
+    gathers = []
+
+    class Tensor:
+        def __init__(self, name: str, shape=(), dtype="bf16"):
+            self.name = name
+            self.shape = tuple(shape)
+            self.dtype = dtype
+
+    class Layer:
+        def __init__(self, output: Tensor):
+            self.output = output
+
+        def get_output(self, _index):
+            return self.output
+
+        @property
+        def reshape_dims(self):
+            return self.output.shape
+
+        @reshape_dims.setter
+        def reshape_dims(self, shape):
+            self.output.shape = tuple(shape)
+
+    class Network:
+        def add_shuffle(self, tensor):
+            return Layer(Tensor(f"shuffle({tensor.name})", tensor.shape, tensor.dtype))
+
+        def add_gather(self, data, indices, axis):
+            gathers.append((data.name, indices.name, axis))
+            return Layer(Tensor(f"gather({data.name})", dtype=data.dtype))
+
+        def add_matrix_multiply(self, lhs, _lhs_op, rhs, _rhs_op):
+            matrix_multiplies.append((lhs.name, rhs.name))
+            return Layer(Tensor(f"mm({lhs.name},{rhs.name})", dtype=lhs.dtype))
+
+        def add_activation(self, tensor, _operation):
+            return Layer(Tensor(f"activation({tensor.name})", dtype=tensor.dtype))
+
+        def add_elementwise(self, lhs, rhs, _operation):
+            return Layer(Tensor(f"elementwise({lhs.name},{rhs.name})", dtype=lhs.dtype))
+
+        def add_reduce(self, tensor, _operation, _axes, keep_dims):
+            del keep_dims
+            return Layer(Tensor(f"reduce({tensor.name})", dtype=tensor.dtype))
+
+    def add_constant(_network, shape, values, dtype=np.float32):
+        del values, dtype
+        tensor = Tensor(f"weight{len(constants)}", shape)
+        constants.append(tensor)
+        return tensor
+
+    monkeypatch.setattr(plugin_module.graph_ops, "add_constant", add_constant)
+    network = Network()
+    output = plugin_module._add_routed_swiglu_experts(
+        network,
+        Tensor("input", (-1, 16)),
+        Tensor("top_indices", (-1, 2), "int32"),
+        Tensor("routing_weights", (-1, 2)),
+        hidden_size=16,
+        top_k=2,
+        w_gate=np.ones((8, 16, 32), dtype=np.float32),
+        w_up=np.ones((8, 16, 32), dtype=np.float32),
+        w_down=np.ones((8, 32, 16), dtype=np.float32),
+    )
+
+    assert output.dtype == "bf16"
+    assert len(matrix_multiplies) == 3
+    assert all(rhs.startswith("gather(weight") for _lhs, rhs in matrix_multiplies)
+    assert [entry for entry in gathers if entry[0].startswith("weight")] == [
+        ("weight0", "top_indices", 0),
+        ("weight1", "top_indices", 0),
+        ("weight2", "top_indices", 0),
+    ]


### PR DESCRIPTION
## Background

Qwen3-Omni's Thinker computed all 128 SwiGLU experts for every token and only gathered the routed top 8 outputs afterward. That made MoE prefill dominate the release workload and left TensorRT slower than the BF16 reference.

## Exit Criteria

- compute gate, up, and down projections only for each token's routed experts
- keep bundle build time within the existing range
- improve the GB300 release workload below the BF16 reference latency
- pass the pinned official-HF audio golden contract

## Implementation

- gather each token's top-k gate, up, and down weights before expert computation
- evaluate the routed experts with three batched matrix multiplies instead of expanding the graph per route
- apply normalized router weights and reduce across top-k outputs
- add a regression test that requires all three matrix multiplies to consume gathered expert weights

## Validation

- `PYTHONPATH=python pytest -q tests/e2e/models/qwen3_omni --ignore=tests/e2e/models/qwen3_omni/test_qwen3_omni_e2e.py`: 42 passed
- `ruff check python/tensorrt_model_connect/families/qwen3_omni/plugin.py tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py`: passed
- TensorRT 11.2 on GB300: full BF16 bundle rebuilt in 477.96 seconds; the prior bundle build took 491.36 seconds
- release workload, 3 warmups and 10 measured iterations:
  - before: p50 4274.00 ms
  - after: p50 3212.01 ms, p95 3271.33 ms
  - BF16 reference: p50 3302.63 ms
  - p50 latency decreased by 24.8%
- pinned official-HF audio E2E:
  - generated text matched exactly
  - generated 37,845 samples, exactly matching the reference
  - waveform cosine 0.7648 (required minimum 0.25)
  - WAV validity, duration, RMS, peak, and fallback-absence checks all passed

## Notes For Future Readers

- Keep the routed expert computation batched. Expanding top-k into separate matrix-multiply branches preserved inference speed but caused unacceptable engine build-time growth.
- Review the routed weight shapes first, then the regression test that locks the three-batched-matmul structure.

Closes #777
