### PR TITLE
fix(validation): stabilize Z-Image reference

### DIFF
--- a/tests/e2e/models/z_image/e2e_plugins/references/hf_diffusers.py
+++ b/tests/e2e/models/z_image/e2e_plugins/references/hf_diffusers.py
@@ -82,7 +82,7 @@ class HfDiffusersReference:
         reference_precision = str(
             case.metadata.get(
                 "reference_precision",
-                task_reference_precision or "fp16",
+                task_reference_precision or "bf16",
             )
         ).lower()
         reference_torch_dtype = {
@@ -109,42 +109,20 @@ from diffusers import DiffusionPipeline
 transformers.logging.set_verbosity_error()
 
 pipe = DiffusionPipeline.from_pretrained(
-    {model_ref!r}, torch_dtype={reference_torch_dtype}, low_cpu_mem_usage=False)
-
-# Mirror the TRTMC mixed-precision bundle exactly: the VAE, both noise
-# refiners, and main transformer blocks 0-1 run in FP32; every component
-# boundary casts back to the FP16 base precision.
-base_dtype = {reference_torch_dtype}
-mixed_fp32_modules = [
-    *pipe.transformer.noise_refiner,
-    *pipe.transformer.layers[:2],
-]
-pipe.vae.to(dtype=torch.float32)
-
-def _cast_floating(value, dtype):
-    if isinstance(value, torch.Tensor):
-        return value.to(dtype=dtype) if value.is_floating_point() else value
-    if isinstance(value, tuple):
-        return tuple(_cast_floating(item, dtype) for item in value)
-    if isinstance(value, list):
-        return [_cast_floating(item, dtype) for item in value]
-    if isinstance(value, dict):
-        return {{key: _cast_floating(item, dtype) for key, item in value.items()}}
-    return value
-
-def _fp32_inputs(_module, args, kwargs):
-    return _cast_floating(args, torch.float32), _cast_floating(
-        kwargs, torch.float32)
-
-def _base_output(_module, _args, output):
-    return _cast_floating(output, base_dtype)
-
-for module in mixed_fp32_modules:
-    module.to(dtype=torch.float32)
-    module.register_forward_pre_hook(_fp32_inputs, with_kwargs=True)
-    module.register_forward_hook(_base_output)
-
+    {model_ref!r},
+    torch_dtype={reference_torch_dtype},
+    low_cpu_mem_usage=False,
+)
 pipe.to("cuda")
+
+def _require_finite_latents(_pipe, step, _timestep, callback_kwargs):
+    latents = callback_kwargs["latents"]
+    if not torch.isfinite(latents).all():
+        raise RuntimeError(
+            f"Z-Image HF reference produced non-finite latents at step {{step}}"
+        )
+    return callback_kwargs
+
 raw_latents = np.fromfile({str(initial_latents.path)!r}, dtype=np.float32)
 expected_shape = {initial_latents.shape!r}
 expected_size = int(np.prod(expected_shape))
@@ -154,7 +132,7 @@ if raw_latents.size != expected_size:
         f"expected {{expected_shape}} = {{expected_size}}"
     )
 initial_latents = torch.from_numpy(raw_latents.reshape(expected_shape)).to(
-    device="cuda", dtype=base_dtype)
+    device="cuda", dtype={reference_torch_dtype})
 output = pipe(
     prompt={prompt!r},
     num_inference_steps={num_steps},
@@ -163,10 +141,20 @@ output = pipe(
     guidance_scale={guidance_scale},
     generator=torch.Generator("cuda").manual_seed({int(case.inputs.get("seed", case.determinism.get("seed", 42)))}),
     latents=initial_latents,
+    callback_on_step_end=_require_finite_latents,
 )
 frames = output.images
 frames_dir = {frames_dir!r}
 for i, frame in enumerate(frames):
+    frame_array = np.asarray(frame, dtype=np.float32)
+    if not np.isfinite(frame_array).all():
+        raise RuntimeError(
+            f"Z-Image HF reference frame {{i}} contains non-finite pixels"
+        )
+    if frame_array.size == 0 or float(frame_array.std()) == 0.0:
+        raise RuntimeError(
+            f"Z-Image HF reference frame {{i}} is empty or uniform"
+        )
     if isinstance(frame, Image.Image):
         frame.save(os.path.join(frames_dir, f"frame_{{i:04d}}.png"))
     else:

--- a/tests/e2e/models/z_image/manifests/z-image-turbo.json
+++ b/tests/e2e/models/z_image/manifests/z-image-turbo.json
@@ -22,7 +22,7 @@
       "name": "z-image-turbo",
       "trace_id": "IT-E2E-ZIMG-01",
       "model_type": "z_image",
-      "reference_precision": "fp16",
+      "reference_precision": "bf16",
       "reference_family": "diffusers_image_gen",
       "user_contract": "diffusion_image",
       "ci_tier": "nightly_only",
@@ -37,7 +37,7 @@
       "num_inference_steps": 9,
       "guidance_scale": 0.0,
       "skip_text_comparison": true,
-      "notes": "Z-Image-Turbo uses an FP16 Qwen3 text encoder and DiT except for the VAE (selector 2), both noise refiners (3-4), and main DiT blocks 0-1 (7-8), which remain FP32. The HF reference mirrors those component precisions and casts back to FP16 at each selected block boundary. The context refiners, main blocks 2-29, and final layer remain FP16. Removing either noise refiner or main block 0/1 produces non-finite latents; an FP16 VAE produces a solid-white frame.",
+      "notes": "Z-Image-Turbo uses an FP16 Qwen3 text encoder and DiT except for the VAE (selector 2), both noise refiners (3-4), and main DiT blocks 0-1 (7-8), which remain FP32. The TensorRT FP16 blocks use compensated sandwich pre-scaling to prevent transient overflow, so the HF reference uses stable BF16 rather than an unsafe plain-PyTorch FP16 approximation. Removing either noise refiner or main block 0/1 produces non-finite TensorRT latents; an FP16 VAE produces a solid-white frame.",
       "metadata": {
         "contract_config": {
           "use_diffusers": true

--- a/tests/e2e/models/z_image/test_z_image_hf_diffusers_reference.py
+++ b/tests/e2e/models/z_image/test_z_image_hf_diffusers_reference.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Z-Image HF-to-TRTMC precision parity contract tests."""
+"""Z-Image HF reference precision and output-health contract tests."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from tests.e2e.models.z_image.e2e_plugins.references import hf_diffusers
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
 
 
-def test_hf_reference_mirrors_mixed_trtmc_precision(
+def test_hf_reference_uses_stable_precision_and_rejects_invalid_output(
     tmp_path, monkeypatch
 ) -> None:
     case = E2ECase(
@@ -24,9 +24,7 @@ def test_hf_reference_mirrors_mixed_trtmc_precision(
             "image_width": 512,
             "seed": 42,
         },
-        metadata={
-            "task_eval": {"reference_precision": "fp16"},
-        },
+        metadata={},
     )
     context = RunContext(
         case=case,
@@ -49,10 +47,11 @@ def test_hf_reference_mirrors_mixed_trtmc_precision(
     )
 
     script = captured["cmd"][2]
-    assert "torch_dtype=torch.float16" in script
-    assert "pipe.vae.to(dtype=torch.float32)" in script
-    assert "*pipe.transformer.noise_refiner" in script
-    assert "*pipe.transformer.layers[:2]" in script
-    assert "register_forward_pre_hook(_fp32_inputs, with_kwargs=True)" in script
-    assert "register_forward_hook(_base_output)" in script
-    assert "device=\"cuda\", dtype=base_dtype" in script
+    assert "torch_dtype=torch.bfloat16" in script
+    assert "pipeline_torch_dtypes" not in script
+    assert "mixed_fp32_modules" not in script
+    assert "torch.isfinite(latents).all()" in script
+    assert "callback_on_step_end=_require_finite_latents" in script
+    assert "np.isfinite(frame_array).all()" in script
+    assert "float(frame_array.std()) == 0.0" in script
+    assert 'device="cuda", dtype=torch.bfloat16' in script


### PR DESCRIPTION
## Background

The Z-Image validation reference loaded ordinary PyTorch blocks in FP16 to mimic the mixed TensorRT bundle. TensorRT's FP16 blocks also use compensated sandwich pre-scaling, so the Diffusers approximation overflowed to non-finite latents and silently cached uniform black PNGs. The real TRTMC output was healthy, but validation reported 0/5 agreement against the invalid reference.

## Exit Criteria

- Generate a finite, non-uniform HF reference for Z-Image.
- Pass the unchanged diffusion parity gates on all five selected DPG-Bench samples.
- Fail clearly instead of caching a non-finite or uniform reference image.

## Implementation

- restore the stable BF16 Diffusers reference path for Z-Image, including the default used by L0 manifests
- keep the TensorRT bundle precision contract unchanged
- reject non-finite denoising latents and non-finite, empty, or uniform reference frames before they enter the cache
- document why plain PyTorch FP16 is not equivalent to the compensated TensorRT FP16 graph

## Validation

- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m pytest -q tests/e2e/models/z_image --ignore=tests/e2e/models/z_image/test_z_image_e2e.py`: 27 passed
- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m ruff check tests/e2e/models/z_image/e2e_plugins/references/hf_diffusers.py tests/e2e/models/z_image/test_z_image_hf_diffusers_reference.py`: passed
- `/opt/venv/bin/python3 tools/trtmc_validate.py z-image-turbo dpg_bench_diffusion_image --catalog tests/validation/model_workloads.yaml --suites tests/validation/workloads.yaml --models-dir tests/e2e/models --output /runs/results/trtmc-validate-20260731-z-image-full-bf16 --engine-dir /runs/engines/z-image-turbo/dd6dff923d9a5c04 --reference-cache-dir /runs/results/trtmc-validate-20260731-z-image-full-bf16/references --trtmc-binary /runs/bin/trtmc-e2e --benchmark-binary /runs/bin/trtmc_benchmark_worker --hf-python /opt/venv/bin/python3 --model-attempts 2 --model-retry-delay-seconds 5.0 --dataset-root /data --backend-dir /runs/bin --model-plugin-dir /runs/bin/models/z_image --cuda-visible-devices 1 --no-build`: GB300 real run passed 5/5 in 95.66 seconds; mean image CLIP cosine 0.9844, SSIM 0.9050, and PSNR 22.56

## Notes For Future Readers

- Review the reference precision rationale first, then the generated-script health checks.
- Do not replace BF16 with plain Diffusers FP16 unless the TensorRT sandwich pre-scaling is also reproduced; selected FP32 module hooks alone still produce non-finite latents.
- This follows the Z-Image runtime performance work in #780 but does not change the engine or its acceptance thresholds.
