### PR TITLE
fix(validation): forward Qwen3-Omni plugin path

### DIFF
--- a/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
@@ -79,6 +79,9 @@ class OmniMultimodalRunner:
                 },
             )
 
+        if ctx.model_plugin_dir:
+            cmd.extend(["--model-plugin-dir", ctx.model_plugin_dir])
+
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", runtime_cli_python])

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
@@ -29,7 +29,9 @@ def _make_case(inputs: dict | None = None, **overrides) -> E2ECase:
     return E2ECase(**defaults)
 
 
-def _make_ctx(case: E2ECase, tmp_path) -> RunContext:
+def _make_ctx(
+    case: E2ECase, tmp_path, *, model_plugin_dir: str = ""
+) -> RunContext:
     binary_path = tmp_path / "trtmc"
     binary_path.write_text("", encoding="utf-8")
     return RunContext(
@@ -37,6 +39,7 @@ def _make_ctx(case: E2ECase, tmp_path) -> RunContext:
         artifacts_dir=str(tmp_path),
         binary_path=str(binary_path),
         engine_dir=str(tmp_path),
+        model_plugin_dir=model_plugin_dir,
     )
 
 
@@ -61,6 +64,32 @@ def test_thinker_stage_drops_unsupported_stage_flag(monkeypatch, tmp_path) -> No
     assert captured["timeout"] == 600
     assert out.metadata["cli_stage_supported"] is False
     assert out.metadata["entrypoint"] == "run"
+
+
+def test_omni_runner_forwards_model_plugin_dir(monkeypatch, tmp_path) -> None:
+    case = _make_case(inputs={"prompt": "hello"})
+    model_plugin_dir = tmp_path / "model-plugins"
+    ctx = _make_ctx(
+        case,
+        tmp_path,
+        model_plugin_dir=str(model_plugin_dir),
+    )
+    captured: dict = {}
+
+    def _fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(omni.subprocess, "run", _fake_run)
+
+    omni.OmniMultimodalRunner().run_stage(
+        case, StageSpec(name="talker_decode"), ctx
+    )
+
+    assert captured["cmd"][-2:] == [
+        "--model-plugin-dir",
+        str(model_plugin_dir),
+    ]
 
 
 def test_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Background

`trtmc-validate --model-plugin-dir` populated `RunContext.model_plugin_dir`, but the Qwen3-Omni runner never appended it to the C++ command. Real validation therefore failed to discover the model DSO unless `TRTMC_MODEL_PLUGIN_DIR` was also set manually.

## Exit Criteria

- Make every supported Qwen3-Omni runtime entrypoint honor `RunContext.model_plugin_dir`.
- Pass a real GB300 validation run with `TRTMC_MODEL_PLUGIN_DIR` explicitly unset.

## Implementation

- append `--model-plugin-dir <path>` to the omni runtime command before optional HF Python arguments
- add a runner contract test that covers the propagated path

## Validation

- `env PYTHONPATH=python /home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m pytest -q tests/e2e/models/qwen3_omni --ignore=tests/e2e/models/qwen3_omni/test_qwen3_omni_e2e.py`: 42 passed
- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m ruff check tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py`: passed
- GB300 real `trtmc-validate` with `TRTMC_MODEL_PLUGIN_DIR` explicitly unset: 1/1 passed; the emitted `generate-audio` command contained `--model-plugin-dir /runs/bin/models/qwen3_omni`
- A separate fresh-cache GB300 run executed both HF and TRTMC (`hf_reused=false`) and passed 1/1 in 73.13 seconds with exact Thinker text and waveform cosine 0.7816

## Notes For Future Readers

- Review the command construction first, then the regression test.
- This follows the Qwen3-Omni runtime performance work in #782 and changes only validation command plumbing.
