### PR TITLE
fix(qwen_vl): stabilize split native decode

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -604,6 +604,13 @@ def build_dual_profile_decoder_engine(
             num_kv_heads=num_kv_heads,
             q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
             scale=attn_scale,
+            # TRT 11.2 FP16 IAttention has large errors with the decoder's
+            # sparse prefix-plus-current-token mask at long context. Keep
+            # prefill and the surrounding graph in FP16, but use the existing
+            # FP32 attention boundary in the fixed-Sq=1 split decode engine.
+            # The dynamic prefill shape does not have a dedicated FP32 fused
+            # tactic and triggers a TRT 11.2 Myelin compiler failure.
+            fp32_accumulation=(profile_mode == "decode"),
             force_decomposed_attention=force_decomposed_attention,
             tag=f"{prefix}.attn")
 

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -1363,7 +1363,10 @@ def add_attention_core(
     # Allow TRT to decompose into primitive ops when no fused kernel is
     # available (e.g. unsupported head-dim or dtype).  This guarantees
     # correctness on any configuration at the cost of potential performance.
-    attn.decomposable = True
+    # Keep the FP32-accumulation path opaque: TRT 11.2's Myelin compiler can
+    # otherwise merge every decoder layer into one graph and fail SSA
+    # validation during a full Qwen-VL engine build.
+    attn.decomposable = not fp32_accumulation
     if mask is not None and not causal:
         attn.mask = mask
     return _cast_back_to_trt_dtype(network, attn.get_output(0), output_dtype)

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -578,6 +578,62 @@ class TestAddAttentionCore:
         np.testing.assert_allclose(out, ref, atol=1e-3,
                                    err_msg="masked attention mismatch")
 
+    @requires_trt
+    def test_qwen_vl_long_masked_gqa_fp32_matches_reference(self):
+        """The stable FP32 boundary matches long masked GQA attention."""
+        num_heads, num_kv_heads, head_dim = 16, 2, 128
+        q_seq, kv_seq = 1, 1665
+        rng = np.random.default_rng(20260731)
+        q = rng.standard_normal(
+            (q_seq, num_heads * head_dim)).astype(np.float16)
+        k = rng.standard_normal(
+            (kv_seq, num_kv_heads * head_dim)).astype(np.float16)
+        v = rng.standard_normal(
+            (kv_seq, num_kv_heads * head_dim)).astype(np.float16)
+        mask = np.full((q_seq, kv_seq), -1.0e4, dtype=np.float16)
+        mask[:, :1290] = 0.0
+        mask[:, -1] = 0.0
+
+        def build(network, trt_inputs):
+            mask_4d = qwen_vl_graph_ops.add_2d_mask_to_4d(
+                network, trt_inputs["mask"])
+            return {
+                "out": qwen_vl_graph_ops.add_attention_from_rows(
+                    network,
+                    trt_inputs["q"],
+                    trt_inputs["k"],
+                    trt_inputs["v"],
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    q_seq=q_seq,
+                    kv_seq=kv_seq,
+                    mask=mask_4d,
+                    scale=1.0 / np.sqrt(head_dim),
+                    fp32_accumulation=True,
+                )
+            }
+
+        out = _run_strongly_typed(
+            build, {"q": q, "k": k, "v": v, "mask": mask})["out"]
+
+        qh = q.reshape(1, q_seq, num_heads, head_dim).transpose(0, 2, 1, 3)
+        kh = k.reshape(1, kv_seq, num_kv_heads, head_dim).transpose(0, 2, 1, 3)
+        vh = v.reshape(1, kv_seq, num_kv_heads, head_dim).transpose(0, 2, 1, 3)
+        repeats = num_heads // num_kv_heads
+        kh = np.repeat(kh, repeats, axis=1)
+        vh = np.repeat(vh, repeats, axis=1)
+        scores = np.einsum("bhqd,bhkd->bhqk", qh.astype(np.float32),
+                           kh.astype(np.float32)) / np.sqrt(head_dim)
+        scores += mask.reshape(1, 1, q_seq, kv_seq).astype(np.float32)
+        scores -= scores.max(axis=-1, keepdims=True)
+        probs = np.exp(scores)
+        probs /= probs.sum(axis=-1, keepdims=True)
+        ref = np.einsum("bhqk,bhkd->bhqd", probs, vh.astype(np.float32))
+        ref = ref.transpose(0, 2, 1, 3).reshape(q_seq, -1)
+
+        np.testing.assert_allclose(out.astype(np.float32), ref, atol=2e-3)
+
 class TestAddApplyMropeNative:
     """Qwen2.5-VL M-RoPE selects T/H/W frequency sections."""
 


### PR DESCRIPTION
## Background

Qwen2.5-VL split/native decode can emit corrupted text at long context on
TensorRT 11.2. An isolated production-shaped attention graph shows large FP16
`IAttention` error with the decoder's sparse prefix-plus-current-token mask;
there is no numerical discontinuity at a power-of-two boundary.

At an active prefix of 1,290 tokens, FP16 native attention has max absolute
error 0.1587 and RMSE 0.0344 against an FP32 reference. The same graph with an
FP32 Q/K/V/mask boundary has max absolute error 0.000122 and RMSE 0.000013.

## Exit Criteria

- Split native decode remains accurate with the Qwen2.5-VL long-context mask.
- The public ComicsPAP LoRA result matches the HF reference and the existing
  decomposed path.
- Prefill and dual-profile behavior remain unchanged.
- Focused builder and Qwen-VL routing tests pass.

## Implementation

- Enable the existing FP32 attention boundary only for the fixed-`Sq=1`
  split decode profile, then cast the context back to the model dtype.
- Keep the FP32 `IAttention` layer non-decomposable. TensorRT 11.2 otherwise
  merges the decoder into Myelin and fails graph compilation.
- Add a production-shaped masked-GQA regression test using 16 query heads,
  2 KV heads, head dimension 128, and physical KV length 1,665.

## Validation

- `PYTHONPATH=python LD_LIBRARY_PATH=/opt/tensorrt/lib:$BUILD python3 -m pytest -q tests/builder/test_graph_ops_native_attn.py tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py`: **33 passed**.
- `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python3 run_comicspap_hf_precision.py`: fresh FP16 and BF16 HF LoRA references both generated token IDs `[9217, 25, 220, 15, 151645]` (`answer: 0`).
- `BUNDLE_PATH=<native-or-decomposed> python3 run_comicspap_tmc_smoke.py`, five independent repetitions per path: native and decomposed both returned `answer: 0` in 5/5 LoRA runs; native also remained deterministic for the base path.
- Public ComicsPAP LoRA decode telemetry over four launches: patched native mean 57.308 ms versus decomposed mean 58.756 ms, a **1.025x speedup** (2.46% less decode time).
- `git diff --check`: passed.

## Notes For Future Readers

- Review `default_dual_profile_decoder.py` first for the profile routing, then
  `graph_ops.py` for the opaque FP32 boundary, and finally the numerical test.
- This intentionally does not change dynamic dual-profile attention: TensorRT
  11.2 has no usable FP32 tactic for that graph.
- Dedicated FP32 `IAttention` tactic availability depends on physical KV
  capacity. Large-cache deployments must continue using
  `qwen_vl_decoder.decode_attention=decomposed` until a bucketed fallback or a
  larger-capacity TensorRT tactic is available.
