### PR TITLE
feat(reports): align validation and perf views

### DIFF
--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -888,6 +888,8 @@ def test_report_displays_campaign_and_model_profile_wall_times() -> None:
                 "family": "example",
                 "operation": "generate",
                 "model": "example-model",
+                "task_type": "Text → Text",
+                "task_strategy": "text_generation_causal",
                 "status": "green",
                 "started_at": "2026-07-29T07:20:00+00:00",
                 "finished_at": "2026-07-29T07:21:30+00:00",
@@ -900,7 +902,7 @@ def test_report_displays_campaign_and_model_profile_wall_times() -> None:
 
     assert "Total campaign wall time:</strong> 1h 2m 3s" in report
     assert "3,723.000 s" in report
-    assert "<th>Model-profile wall time</th>" in report
+    assert "<th>Model wall time</th>" in report
     assert "1m 30.0s" in report
     assert "90.000 s" in report
     assert "including bundle preparation, GPU headroom waits" in report
@@ -917,6 +919,8 @@ def test_report_prefers_test_task_bundle_preparation_receipt() -> None:
                 "family": "example",
                 "operation": "generate",
                 "model": "example-model",
+                "task_type": "Text → Text",
+                "task_strategy": "text_generation_causal",
                 "status": "green",
                 "baseline_contract": {},
                 "candidate": {
@@ -968,6 +972,8 @@ def test_report_includes_client_side_row_filters() -> None:
                 "family": "example",
                 "operation": "generate",
                 "model": "example-model",
+                "task_type": "Text → Text",
+                "task_strategy": "text_generation_causal",
                 "status": "green",
                 "baseline_contract": {},
                 "candidate": {
@@ -988,6 +994,8 @@ def test_report_includes_client_side_row_filters() -> None:
                 "family": "other",
                 "operation": "generate",
                 "model": "other-model",
+                "task_type": "Image + Text → Text",
+                "task_strategy": "vision_language_generation",
                 "status": "red",
                 "baseline_contract": {},
                 "candidate": {
@@ -1008,19 +1016,47 @@ def test_report_includes_client_side_row_filters() -> None:
     report = perf_matrix._report_html(results)
 
     assert 'id="report-filter-search"' in report
-    assert 'id="report-filter-light"' in report
+    assert 'id="report-filter-model-type"' in report
+    assert 'id="report-filter-operation"' in report
+    assert 'id="report-filter-task-type"' in report
+    assert 'id="report-filter-status"' in report
     assert 'id="report-filter-preparation"' in report
     assert 'id="report-filter-reset"' in report
     assert 'id="report-filter-count">Showing 2 of 2 rows<' in report
     assert (
         "data-filter-search='example generate example-model example.generate'"
-        in report
+        not in report
     )
-    assert "data-filter-light='green'" in report
+    assert "example generate example-model text → text" in report
+    assert "data-filter-model-type='example'" in report
+    assert "data-filter-operation='generate'" in report
+    assert "data-filter-task-type='Text → Text'" in report
+    assert "data-filter-status='green'" in report
     assert "data-filter-preparation='built'" in report
-    assert "data-filter-light='red'" in report
+    assert "data-filter-status='red'" in report
     assert "data-filter-preparation='reused'" in report
-    assert "row.hidden = !(matchesSearch && matchesLight && matchesPreparation);" in report
+    assert "const matches = controls.every((control)" in report
+    assert "row.hidden = !matches;" in report
+
+
+def test_report_recovers_task_type_from_an_existing_result_manifest() -> None:
+    task_type, user_contract, task_strategy = perf_matrix._report_task_metadata(
+        {
+            "model": "codegen-350m",
+            "operation": "generate",
+            "resolved_settings": {
+                "testcase": "codegen-350m",
+                "model": {
+                    "manifest": "codegen/manifests/codegen-350m.json",
+                    "task_strategy": "text_generation_causal",
+                },
+            },
+        }
+    )
+
+    assert task_type == "Text → Code"
+    assert user_contract == "code_completion"
+    assert task_strategy == "text_generation_causal"
 
 
 def test_apply_bundle_preparation_receipt_rejects_unmatched_bundle() -> None:
@@ -1186,8 +1222,8 @@ def test_run_consolidates_results_and_records_replayable_commands(
     report = (output / "report.html").read_text(encoding="utf-8")
     assert ">gpt2<" in report
     assert "HF eager" in report
-    assert "76 families" in report
-    assert "105 model-profile comparisons" in report
+    assert "76 model types" in report
+    assert "105 model comparisons" in report
     assert "105 single-process profiles" in report
     assert "0 explicitly excluded profiles" in report
     assert (
@@ -1198,9 +1234,10 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert (
         f"{expected_catalog_coverage['other_profiles']} other or unsupported profiles"
     ) in report
-    assert "<th>Model profile</th>" in report
+    assert "<th>Model</th>" in report
+    assert "<th>Task type</th>" in report
     assert "Total campaign wall time:" in report
-    assert "<th>Model-profile wall time</th>" in report
+    assert "<th>Model wall time</th>" in report
     assert "not used for traffic-light classification" in report
     assert "TRTMC infer p50 (ms)" in report
     assert "Baseline infer p50 (ms)" in report
@@ -1211,7 +1248,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "excluded from the infer-time traffic-light comparison" in report
     assert ">10.450<" in report
     assert ">20.450<" in report
-    assert "<th>Status</th>" not in report
+    assert "<th>Status</th>" in report
     assert "<td>green</td>" not in report
     assert "Needs alignment" not in report
     assert "Measured scope" in report

--- a/tests/tools/test_reporting_html.py
+++ b/tests/tools/test_reporting_html.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from tools.reporting_html import (
+    ReportFilter,
+    render_report_filter_script,
+    render_report_filters,
+    task_type_label,
+)
+
+
+def test_report_filters_share_stable_ids_and_escape_values() -> None:
+    document = render_report_filters(
+        row_count=2,
+        search_placeholder='Model "name"',
+        filters=(
+            ReportFilter("model-type", "Model type", ("qwen", "vision&language")),
+            ReportFilter(
+                "status",
+                "Status",
+                (("green", "Green"), ("white", "Not run")),
+            ),
+        ),
+    )
+
+    assert 'id="report-filter-search"' in document
+    assert 'placeholder="Model &quot;name&quot;"' in document
+    assert 'id="report-filter-model-type"' in document
+    assert 'id="report-filter-status"' in document
+    assert ">vision&amp;language</option>" in document
+    assert 'id="report-filter-count">Showing 2 of 2 rows<' in document
+    assert "data-report-filter" in document
+    assert "row.hidden = !matches;" in render_report_filter_script()
+
+
+def test_task_type_contract_precedes_strategy_fallback() -> None:
+    assert (
+        task_type_label(
+            user_contract="code_completion",
+            task_strategy="text_generation_causal",
+            operation="generate",
+        )
+        == "Text → Code"
+    )
+
+
+def test_task_type_distinguishes_media_requests() -> None:
+    common = {
+        "task_strategy": "diffusion_media_generation",
+        "operation": "generate_image",
+    }
+
+    assert task_type_label(**common, request={"media_type": "image"}) == "Text → Image"
+    assert task_type_label(**common, request={"media_type": "video"}) == "Text → Video"
+    assert (
+        task_type_label(
+            **common, request={"media_type": "image", "image_path": "input.png"}
+        )
+        == "Image + Text → Image"
+    )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1709,6 +1709,22 @@ class TestUnitTiers:
     @pytest.mark.parametrize(
         "path",
         [
+            "tools/perf_matrix.py",
+            "tools/reporting_html.py",
+        ],
+    )
+    def test_report_generation_tool_triggers_tools_tier(self, imap, path):
+        """Report generator edits run tools-tier tests without E2E."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "report_generation_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
             "tools/validation/README.md",
             "tools/validation/__init__.py",
             "tools/validation/artifacts.py",

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1089,6 +1089,9 @@ def test_write_report_links_each_comparison(tmp_path):
             {
                 "model": "model-a",
                 "workload": "workload-a",
+                "family": "example",
+                "operation": "generate_audio",
+                "task_strategy": "text_to_audio",
                 "task_type": "Text → Audio",
                 "user_contract": "tts_audio",
                 "status": "passed",
@@ -1138,6 +1141,9 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "🟢 1 &nbsp; 🟡 0 &nbsp;" in document
     assert "🔴 0 &nbsp; ⚪ 0" in document
     assert "Vanilla reproduction" in document
+    assert "<th>Model type</th>" in document
+    assert "<th>Operation</th>" in document
+    assert "<th>Model</th>" in document
     assert "<th>Task type</th>" in document
     assert "Text → Audio" in document
     assert "tts_audio" in document
@@ -1150,6 +1156,15 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document
+    assert 'id="report-filter-search"' in document
+    assert 'id="report-filter-model-type"' in document
+    assert 'id="report-filter-operation"' in document
+    assert 'id="report-filter-task-type"' in document
+    assert 'id="report-filter-status"' in document
+    assert 'data-filter-model-type="example"' in document
+    assert 'data-filter-operation="generate_audio"' in document
+    assert 'data-filter-task-type="Text → Audio"' in document
+    assert 'data-filter-status="green"' in document
 
 
 def test_write_report_surfaces_quantized_reference_precision_contract(
@@ -1217,6 +1232,9 @@ def test_report_infers_task_type_for_legacy_standard_result(tmp_path):
     _, html_path, report = trtmc_validate.write_report(tmp_path)
 
     result = report["results"][0]
+    assert result["family"] == "bark"
+    assert result["operation"] == "generate_audio"
+    assert result["task_strategy"] == "text_to_audio"
     assert result["task_type"] == "Text → Audio"
     assert result["user_contract"] == "tts_audio"
     document = html_path.read_text(encoding="utf-8")

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -11,6 +11,7 @@ from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import cache
 import hashlib
 import html
 import json
@@ -46,6 +47,14 @@ from tensorrt_model_connect.benchmark.worker import (  # noqa: E402
 from tensorrt_model_connect.python_profiles import (  # noqa: E402
     default_execution_profiles,
     resolve_profile_python,
+)
+from tools.reporting_html import (  # noqa: E402
+    COMMON_REPORT_STYLES,
+    ReportFilter,
+    render_report_filter_script,
+    render_report_filters,
+    sorted_filter_values,
+    task_type_label,
 )
 
 
@@ -1927,7 +1936,7 @@ def _comparison_status(ratio: float, margin: float) -> str:
 def _case_row(
     case: Mapping[str, Any], resolved: Mapping[str, Any], workload_digest: str
 ) -> dict[str, Any]:
-    return {
+    row = {
         "id": case["id"],
         "family": case["family"],
         "operation": case["operation"],
@@ -1957,6 +1966,15 @@ def _case_row(
         "commands": {},
         "started_at": _now(),
     }
+    task_type, user_contract, task_strategy = _report_task_metadata(row)
+    row.update(
+        {
+            "task_type": task_type,
+            "user_contract": user_contract,
+            "task_strategy": task_strategy,
+        }
+    )
+    return row
 
 
 def _run_supported_case(
@@ -2435,6 +2453,54 @@ def _raw_commands_html(row: Mapping[str, Any], default_cwd: str) -> str:
     return "".join(parts)
 
 
+@cache
+def _manifest_user_contract(manifest: str, testcase: str) -> str:
+    path = REPOSITORY / "tests" / "e2e" / "models" / manifest
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    testcases = payload.get("testcases", [])
+    if not isinstance(testcases, list):
+        return ""
+    selected = next(
+        (
+            candidate
+            for candidate in testcases
+            if isinstance(candidate, Mapping) and candidate.get("name") == testcase
+        ),
+        None,
+    )
+    if selected is None:
+        selected = next(
+            (candidate for candidate in testcases if isinstance(candidate, Mapping)),
+            {},
+        )
+    return str(selected.get("user_contract", "") or "")
+
+
+def _report_task_metadata(row: Mapping[str, Any]) -> tuple[str, str, str]:
+    resolved = row.get("resolved_settings", {})
+    resolved = resolved if isinstance(resolved, Mapping) else {}
+    model = resolved.get("model", {})
+    model = model if isinstance(model, Mapping) else {}
+    task_strategy = str(row.get("task_strategy", "") or model.get("task_strategy", "") or "")
+    user_contract = str(row.get("user_contract", "") or "")
+    if not user_contract:
+        user_contract = _manifest_user_contract(
+            str(model.get("manifest", "") or ""),
+            str(resolved.get("testcase", row.get("model", "")) or ""),
+        )
+    request = resolved.get("request", {})
+    task_type = str(row.get("task_type", "") or "") or task_type_label(
+        user_contract=user_contract,
+        task_strategy=task_strategy,
+        operation=row.get("operation", ""),
+        request=request,
+    )
+    return task_type, user_contract, task_strategy
+
+
 def _report_html(results: Mapping[str, Any]) -> str:
     rows = list(results["cases"])
     family_counts = Counter(str(row["family"]) for row in rows)
@@ -2450,10 +2516,18 @@ def _report_html(results: Mapping[str, Any]) -> str:
     default_cwd = str(results.get("repository_root", ""))
     for row in rows:
         status = str(row.get("status", "pending"))
-        light_filter = status if status in {"green", "yellow", "red"} else "white"
+        status_filter = status if status in {"green", "yellow", "red"} else "white"
+        task_type, user_contract, task_strategy = _report_task_metadata(row)
         search_filter = " ".join(
-            str(row.get(key, ""))
-            for key in ("family", "operation", "model", "id")
+            (
+                str(row.get("family", "")),
+                str(row.get("operation", "")),
+                str(row.get("model", "")),
+                task_type,
+                user_contract,
+                task_strategy,
+                str(row.get("id", "")),
+            )
         ).lower()
         preparation_filter = _bundle_preparation_filter(results, row)
         reason = html.escape(_report_note(row))
@@ -2463,13 +2537,22 @@ def _report_html(results: Mapping[str, Any]) -> str:
         model_wall_time = _wall_time_html(row)
         bundle_preparation = _bundle_preparation_html(results, row)
         timing_scope = _timing_scope_html(row)
+        task_type_detail = (
+            f"<div class='detail'>{html.escape(user_contract)}</div>"
+            if user_contract
+            else ""
+        )
         body.append(
             f"<tr data-filter-search='{html.escape(search_filter)}' "
-            f"data-filter-light='{html.escape(light_filter)}' "
+            f"data-filter-model-type='{html.escape(str(row['family']))}' "
+            f"data-filter-operation='{html.escape(str(row['operation']))}' "
+            f"data-filter-task-type='{html.escape(task_type)}' "
+            f"data-filter-status='{html.escape(status_filter)}' "
             f"data-filter-preparation='{html.escape(preparation_filter)}'>"
-            f"<td>{html.escape(str(row['family']))}</td>"
-            f"<td>{html.escape(str(row['operation']))}</td>"
+            f"<td><code>{html.escape(str(row['family']))}</code></td>"
+            f"<td><code>{html.escape(str(row['operation']))}</code></td>"
             f"<td><code>{html.escape(str(row['model']))}</code></td>"
+            f"<td><strong>{html.escape(task_type or '—')}</strong>{task_type_detail}</td>"
             f"<td class='timing-value'>{model_wall_time}</td>"
             f"<td>{html.escape(_baseline_label(row))}</td>"
             f"<td class='timing-value'>{candidate_timing}</td>"
@@ -2517,84 +2600,91 @@ def _report_html(results: Mapping[str, Any]) -> str:
     bundle_preparation_summary = html.escape(
         _bundle_preparation_summary(results, rows)
     )
+    report_filters = render_report_filters(
+        row_count=len(rows),
+        search_placeholder="Model type, operation, model, or task type",
+        filters=(
+            ReportFilter(
+                "model-type",
+                "Model type",
+                sorted_filter_values(row.get("family", "") for row in rows),
+            ),
+            ReportFilter(
+                "operation",
+                "Operation",
+                sorted_filter_values(row.get("operation", "") for row in rows),
+            ),
+            ReportFilter(
+                "task-type",
+                "Task type",
+                sorted_filter_values(_report_task_metadata(row)[0] for row in rows),
+            ),
+            ReportFilter(
+                "status",
+                "Status",
+                tuple(
+                    (status, label)
+                    for status, label in (
+                        ("green", "Green"),
+                        ("yellow", "Yellow"),
+                        ("red", "Red"),
+                        ("white", "White"),
+                    )
+                    if any(
+                        (
+                            str(row.get("status", "pending"))
+                            if row.get("status") in {"green", "yellow", "red"}
+                            else "white"
+                        )
+                        == status
+                        for row in rows
+                    )
+                ),
+            ),
+            ReportFilter(
+                "preparation",
+                "Bundle preparation",
+                (
+                    ("built", "Built"),
+                    ("cache_hit", "Cache hit"),
+                    ("reused", "Existing bundle"),
+                    ("would_build", "Would build"),
+                    ("unrecorded", "Not recorded"),
+                ),
+                token_values=True,
+            ),
+        ),
+    )
+    filter_script = render_report_filter_script()
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TRTMC performance matrix</title>
 <style>
-body{{font-family:Arial,sans-serif;margin:28px;color:#1f2937}} h1{{margin-bottom:4px}}
-.meta{{color:#4b5563;margin:4px 0 18px}} .campaign-duration{{font-size:18px;margin:12px 0 18px}}
-.table-wrap{{overflow-x:auto}} table{{border-collapse:collapse;width:100%;min-width:1650px}}
-th,td{{border:1px solid #9ca3af;padding:7px;text-align:left;vertical-align:top}}
-th{{background:#e5e7eb}} tr:nth-child(even){{background:#f9fafb}} code{{font-size:12px}}
-.command-label{{font-weight:600;margin-top:8px}} pre{{margin:4px 0 10px;max-width:720px;white-space:pre-wrap;overflow-wrap:anywhere}}
+{COMMON_REPORT_STYLES}
+.table-wrap table{{min-width:1800px}}
+.command-label{{font-weight:650;margin-top:8px}} pre{{max-width:720px}}
 .light{{font-size:20px;text-align:center}} .timing-value{{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}}
-.timing-meta{{color:#6b7280;font-size:11px;margin-top:2px}} .scope-side{{font-size:11px;margin-bottom:7px;min-width:270px}}
+.scope-side{{font-size:11px;margin-bottom:7px;min-width:270px}}
 .scope-title{{font-size:12px;font-weight:700;margin-bottom:2px}}
-.filters{{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin:16px 0;padding:12px;background:#f3f4f6;border:1px solid #d1d5db}}
-.filters label{{display:flex;flex-direction:column;gap:4px;font-size:12px;font-weight:600}}
-.filters input,.filters select,.filters button{{box-sizing:border-box;min-height:34px;padding:6px 9px;border:1px solid #9ca3af;background:#fff;color:#1f2937}}
-.filters input{{min-width:260px}} .filters button{{cursor:pointer}} .filter-count{{margin-left:auto;font-size:13px;color:#4b5563}}
 </style></head><body>
+<header class="report-header">
+<p class="report-eyebrow">Performance report</p>
 <h1>TRTMC performance matrix</h1>
-<p class="meta">Generated {generated}. {family_count} families across {len(rows)} model-profile comparisons.{repeated_note}</p>
+<p class="purpose">TRTMC and reference latency at aligned public task boundaries.</p>
+</header>
+<p class="meta">Generated {generated}. {family_count} model types across {len(rows)} model comparisons.{repeated_note}</p>
 <p class="campaign-duration"><strong>Total campaign wall time:</strong> {campaign_duration} <span class="timing-meta">({campaign_seconds_label}; {campaign_started} → {campaign_finished})</span></p>
 <p class="meta">Release matrix coverage: {release_profiles} single-process profiles. {explicit_exclusion_label} and {excluded_l0_profiles} duplicate L0 profiles are excluded from the {ready_profiles} ready catalog profiles. {distributed_profiles} distributed profiles require a separate multi-process run and are outside this report. {other_profiles} other or unsupported profiles.</p>
 <p class="meta">Timing contracts were validated before execution for {preflight_count} comparisons. A row is classified only when its recorded TRTMC and reference policies match that contract.</p>
 <p class="meta">Times are the p50 wall time from the recorded timed samples. Measured scope states the exact recorded boundary and the work included and excluded on each side.</p>
 <p class="meta">Model-profile wall time spans the complete case from start to finish, including bundle preparation, GPU headroom waits, TRTMC and baseline commands, and orchestration overhead. It is reported for observability and is not used for traffic-light classification.</p>
 <p class="meta">{bundle_preparation_summary}</p>
-<p><strong>{summary}</strong></p>
-<div class="filters" aria-label="Report filters">
-<label>Search
-<input id="report-filter-search" type="search" placeholder="Family, operation, or model">
-</label>
-<label>Light
-<select id="report-filter-light"><option value="">All</option><option value="green">Green</option><option value="yellow">Yellow</option><option value="red">Red</option><option value="white">White</option></select>
-</label>
-<label>Bundle preparation
-<select id="report-filter-preparation"><option value="">All</option><option value="built">Built</option><option value="cache_hit">Cache hit</option><option value="reused">Existing bundle</option><option value="would_build">Would build</option><option value="unrecorded">Not recorded</option></select>
-</label>
-<button id="report-filter-reset" type="button">Reset</button>
-<span class="filter-count" id="report-filter-count">Showing {len(rows)} of {len(rows)} rows</span>
-</div>
-<div class="table-wrap"><table><thead><tr><th>Family</th><th>Operation</th><th>Model profile</th><th>Model-profile wall time</th><th>Baseline</th><th>TRTMC infer p50 (ms)</th><th>Baseline infer p50 (ms)</th><th>TRTMC bundle preparation</th><th>Measured scope</th><th>Light</th><th>Note</th><th>Commands</th></tr></thead>
+<div class="traffic-summary">{summary}</div>
+{report_filters}
+<div class="table-wrap"><table><thead><tr><th>Model type</th><th>Operation</th><th>Model</th><th>Task type</th><th>Model wall time</th><th>Baseline</th><th>TRTMC infer p50 (ms)</th><th>Baseline infer p50 (ms)</th><th>TRTMC bundle preparation</th><th>Measured scope</th><th>Status</th><th>Note</th><th>Commands</th></tr></thead>
 <tbody>{"".join(body)}</tbody></table></div>
 <p class="meta">Green: TRTMC is more than the configured margin faster. Yellow: within the margin. Red: TRTMC is more than the margin slower. White: not run, partial, or invalid comparison. Commands are the original recorded argv and must be run from the displayed working directory with the same model cache and dependencies.</p>
-<script>
-(() => {{
-  const search = document.getElementById("report-filter-search");
-  const light = document.getElementById("report-filter-light");
-  const preparation = document.getElementById("report-filter-preparation");
-  const reset = document.getElementById("report-filter-reset");
-  const count = document.getElementById("report-filter-count");
-  const rows = Array.from(document.querySelectorAll("tbody tr[data-filter-search]"));
-  const applyFilters = () => {{
-    const searchValue = search.value.trim().toLowerCase();
-    const lightValue = light.value;
-    const preparationValue = preparation.value;
-    let visible = 0;
-    for (const row of rows) {{
-      const matchesSearch = !searchValue || row.dataset.filterSearch.includes(searchValue);
-      const matchesLight = !lightValue || row.dataset.filterLight === lightValue;
-      const matchesPreparation = !preparationValue ||
-        row.dataset.filterPreparation.split(" ").includes(preparationValue);
-      row.hidden = !(matchesSearch && matchesLight && matchesPreparation);
-      if (!row.hidden) visible += 1;
-    }}
-    count.textContent = "Showing " + visible + " of " + rows.length + " rows";
-  }};
-  search.addEventListener("input", applyFilters);
-  light.addEventListener("change", applyFilters);
-  preparation.addEventListener("change", applyFilters);
-  reset.addEventListener("click", () => {{
-    search.value = "";
-    light.value = "";
-    preparation.value = "";
-    applyFilters();
-    search.focus();
-  }});
-}})();
-</script>
+{filter_script}
 </body></html>"""
 
 

--- a/tools/reporting_html.py
+++ b/tools/reporting_html.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared, dependency-free HTML primitives for standalone TRTMC reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+from typing import Iterable, Mapping, Sequence
+
+
+COMMON_REPORT_STYLES = """
+:root {
+  --bg: #f3f5f2;
+  --panel: #ffffff;
+  --panel-raised: #f8faf7;
+  --line: rgba(24, 39, 26, 0.10);
+  --line-strong: rgba(24, 39, 26, 0.18);
+  --text: #18201a;
+  --muted: #6c756e;
+  --green: #5c9600;
+  --green-bright: #76b900;
+  --green-dark: #315500;
+  --amber: #a96f00;
+  --danger: #b93434;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+html { background: var(--bg); }
+body {
+  min-width: 320px;
+  margin: 0;
+  padding: 28px;
+  color: var(--text);
+  background:
+    linear-gradient(rgba(24, 39, 26, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 39, 26, 0.018) 1px, transparent 1px),
+    radial-gradient(circle at 50% -20%, #e3eddd 0, var(--bg) 43%);
+  background-size: 48px 48px, 48px 48px, auto;
+  font-size: 14px;
+  line-height: 1.45;
+}
+button, input, select { font: inherit; }
+button:focus-visible, input:focus-visible, select:focus-visible, a:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--green-bright);
+  outline-offset: 2px;
+}
+.report-header { margin-bottom: 18px; }
+.report-eyebrow {
+  margin: 0 0 7px;
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+h1 { margin: 0 0 5px; font-size: clamp(25px, 3vw, 34px); line-height: 1.15; }
+.purpose, .meta, .summary { color: var(--muted); }
+.purpose { margin: 0; font-size: 15px; }
+.meta { margin: 5px 0 14px; }
+.summary { margin: 0 0 20px; }
+.campaign-duration { margin: 12px 0 18px; font-size: 18px; }
+.traffic-summary {
+  display: inline-flex;
+  gap: 16px;
+  align-items: center;
+  margin: 0 0 12px;
+  padding: 9px 13px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 8px 26px rgba(35, 48, 37, 0.07);
+  font-size: 16px;
+  font-weight: 700;
+}
+.filters {
+  position: sticky;
+  z-index: 10;
+  top: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+  margin: 16px 0;
+  padding: 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 10px 30px rgba(35, 48, 37, 0.09);
+  backdrop-filter: blur(14px);
+}
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.filters input, .filters select, .filters button {
+  min-height: 36px;
+  padding: 7px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  color: var(--text);
+  background: var(--panel);
+  font-size: 13px;
+  letter-spacing: normal;
+  text-transform: none;
+}
+.filters input { min-width: 250px; }
+.filters select { min-width: 145px; }
+.filters button { cursor: pointer; font-weight: 700; }
+.filters button:hover { border-color: rgba(92, 150, 0, 0.45); background: #f2f8ea; }
+.filter-count { margin: 0 0 8px auto; color: var(--muted); font-size: 13px; }
+.table-wrap {
+  width: 100%;
+  overflow: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: 0 14px 40px rgba(35, 48, 37, 0.08);
+}
+table { width: 100%; border-collapse: separate; border-spacing: 0; }
+th, td {
+  padding: 8px 10px;
+  border: 0;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+th:last-child, td:last-child { border-right: 0; }
+tbody tr:last-child td { border-bottom: 0; }
+th {
+  color: #3f4a42;
+  background: #edf1eb;
+  font-size: 12px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+tbody tr:nth-child(even) { background: var(--panel-raised); }
+tbody tr:hover { background: #f2f8ea; }
+a, summary { color: var(--green-dark); }
+summary { cursor: pointer; font-weight: 650; }
+pre {
+  margin: 4px 0 10px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f4f6f3;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+code { font-size: 12px; }
+.detail, .timing-meta { margin-top: 3px; color: var(--muted); font-size: 11px; }
+.unavailable { color: var(--muted); }
+@media (max-width: 720px) {
+  body { padding: 18px 12px; }
+  .filters { position: static; }
+  .filters label, .filters input, .filters select { width: 100%; min-width: 0; }
+  .filter-count { width: 100%; margin-left: 0; }
+}
+"""
+
+
+TASK_TYPE_BY_USER_CONTRACT = {
+    "multiple_choice_qa": "Text → Choice",
+    "continuation_parity": "Text → Text",
+    "code_completion": "Text → Code",
+    "translation": "Text → Text",
+    "seq2seq_output": "Text → Text",
+    "any-to-any": "Image + Text → Text",
+    "speech_response": "Audio → Audio",
+    "vl_answer": "Image + Text → Text",
+    "ocr_text": "Image → Text",
+    "exact_transcript": "Audio → Text",
+    "tts_audio": "Text → Audio",
+    "diffusion_image": "Text → Image",
+    "diffusion_video": "Text → Video",
+    "image-to-image": "Image + Text → Image",
+    "image_classification": "Image → Class",
+    "segmentation_mask": "Image → Mask",
+    "prompted_mask": "Image + Prompt → Mask",
+    "time_series_prediction_parity": "Time Series → Time Series",
+    "encoder_embedding_parity": "Text → Embedding",
+    "embedding_vector": "Text → Embedding",
+    "ranking_order": "Query + Documents → Ranking",
+    "diffusion_text_generation": "Text → Text",
+}
+
+TASK_TYPE_BY_TASK_STRATEGY = {
+    "text_generation_causal": "Text → Text",
+    "diffusion_text_generation": "Text → Text",
+    "vision_language_generation": "Image + Text → Text",
+    "text_to_audio": "Text → Audio",
+    "speech_to_speech": "Audio → Audio",
+    "speech_to_text": "Audio → Text",
+    "image_classification": "Image → Class",
+    "segmentation": "Image → Mask",
+    "prompted_segmentation": "Image + Prompt → Mask",
+    "neural_operator": "Time Series → Time Series",
+    "encoder_only_nlp": "Text → Embedding",
+    "embedding": "Text → Embedding",
+    "reranking": "Query + Documents → Ranking",
+}
+
+
+def task_type_label(
+    *,
+    user_contract: object = "",
+    task_strategy: object = "",
+    operation: object = "",
+    request: object = None,
+) -> str:
+    """Resolve the common user-facing task taxonomy for report rows."""
+    contract = str(user_contract or "")
+    if contract in TASK_TYPE_BY_USER_CONTRACT:
+        return TASK_TYPE_BY_USER_CONTRACT[contract]
+
+    strategy = str(task_strategy or "")
+    if strategy == "diffusion_media_generation":
+        request_fields = request if isinstance(request, Mapping) else {}
+        if request_fields.get("media_type") == "video" or request_fields.get(
+            "video_num_frames"
+        ):
+            return "Text → Video"
+        if request_fields.get("image_path"):
+            return "Image + Text → Image"
+        return "Text → Image"
+    if strategy == "omni_multimodal":
+        return (
+            "Text → Audio" if str(operation or "") == "generate_audio" else "Any → Any"
+        )
+    if strategy in TASK_TYPE_BY_TASK_STRATEGY:
+        return TASK_TYPE_BY_TASK_STRATEGY[strategy]
+
+    return {
+        "classify": "Image → Class",
+        "embed": "Text → Embedding",
+        "encode": "Text → Embedding",
+        "generate_audio": "Text → Audio",
+        "generate_image": "Text → Image",
+        "rerank": "Query + Documents → Ranking",
+        "segment": "Image → Mask",
+        "segment_prompted": "Image + Prompt → Mask",
+        "solve": "Time Series → Time Series",
+        "speak": "Audio → Audio",
+        "transcribe": "Audio → Text",
+    }.get(str(operation or ""), "")
+
+
+@dataclass(frozen=True)
+class ReportFilter:
+    """One exact-match select in the shared report filter bar."""
+
+    key: str
+    label: str
+    options: Sequence[str | tuple[str, str]]
+    all_label: str = "All"
+    token_values: bool = False
+
+
+def sorted_filter_values(values: Iterable[object]) -> tuple[str, ...]:
+    """Return stable, non-empty display values for a report select."""
+    return tuple(
+        sorted({str(value) for value in values if value is not None and str(value)})
+    )
+
+
+def _filter_id(key: str) -> str:
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", key):
+        raise ValueError(f"invalid report filter key: {key!r}")
+    return f"report-filter-{key}"
+
+
+def render_report_filters(
+    *,
+    row_count: int,
+    search_placeholder: str,
+    filters: Sequence[ReportFilter],
+) -> str:
+    """Render the common search/select/reset bar used by report tables."""
+    controls = [
+        "<label>Search\n"
+        f'<input id="report-filter-search" data-report-filter data-filter-key="search" '
+        f'type="search" placeholder="{html.escape(search_placeholder, quote=True)}">\n'
+        "</label>"
+    ]
+    for report_filter in filters:
+        control_id = _filter_id(report_filter.key)
+        mode = "tokens" if report_filter.token_values else "exact"
+        options = [f'<option value="">{html.escape(report_filter.all_label)}</option>']
+        for option in report_filter.options:
+            value, label = option if isinstance(option, tuple) else (option, option)
+            options.append(
+                f'<option value="{html.escape(str(value), quote=True)}">'
+                f"{html.escape(str(label))}</option>"
+            )
+        controls.append(
+            f"<label>{html.escape(report_filter.label)}\n"
+            f'<select id="{control_id}" data-report-filter '
+            f'data-filter-key="{html.escape(report_filter.key, quote=True)}" '
+            f'data-filter-mode="{mode}">{"".join(options)}</select>\n'
+            "</label>"
+        )
+    controls.extend(
+        [
+            '<button id="report-filter-reset" type="button">Reset</button>',
+            '<span class="filter-count" id="report-filter-count">'
+            f"Showing {row_count} of {row_count} rows</span>",
+        ]
+    )
+    return (
+        '<div class="filters" aria-label="Report filters">\n'
+        + "\n".join(controls)
+        + "\n</div>"
+    )
+
+
+def render_report_filter_script() -> str:
+    """Render shared dependency-free filtering behavior for annotated rows."""
+    return """<script>
+(() => {
+  const controls = Array.from(document.querySelectorAll("[data-report-filter]"));
+  const reset = document.getElementById("report-filter-reset");
+  const count = document.getElementById("report-filter-count");
+  const rows = Array.from(document.querySelectorAll("tbody tr[data-filter-search]"));
+  const applyFilters = () => {
+    let visible = 0;
+    for (const row of rows) {
+      const matches = controls.every((control) => {
+        const value = control.value.trim().toLowerCase();
+        if (!value) return true;
+        const key = control.dataset.filterKey;
+        const candidate = (row.getAttribute("data-filter-" + key) || "").toLowerCase();
+        if (key === "search") return candidate.includes(value);
+        if (control.dataset.filterMode === "tokens") {
+          return candidate.split(/\\s+/).includes(value);
+        }
+        return candidate === value;
+      });
+      row.hidden = !matches;
+      if (matches) visible += 1;
+    }
+    count.textContent = "Showing " + visible + " of " + rows.length + " rows";
+  };
+  for (const control of controls) {
+    control.addEventListener(control.type === "search" ? "input" : "change", applyFilters);
+  }
+  reset.addEventListener("click", () => {
+    for (const control of controls) control.value = "";
+    applyFilters();
+    document.getElementById("report-filter-search").focus();
+  });
+})();
+</script>"""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1885,6 +1885,22 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestUnitTiers.test_nightly_artifact_selector_tool",),
         ),
         ClassificationRule(
+            priority=483,
+            name="report_generation_tool",
+            matcher=_path_in(
+                {
+                    "tools/perf_matrix.py",
+                    "tools/reporting_html.py",
+                }
+            ),
+            resolver=_match_result(
+                "report_generation_tool", _no_models, ["tools"], False
+            ),
+            covered_by=(
+                "TestUnitTiers.test_report_generation_tool_triggers_tools_tier",
+            ),
+        ),
+        ClassificationRule(
             priority=485,
             name="model_ci_tool",
             matcher=_path_equals("tools/model_ci.py"),

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -131,7 +131,6 @@ no_impact tools/legal_headers.py # offline legal-header audit utility; no runtim
 no_impact tools/lance_reference.py # standalone pinned release-reference helper; focused performance-runner tests cover its behavior
 no_impact tools/nsys_to_layer_timing.py # developer utility script; no CI test impact is intentional
 no_impact tools/perf_compare.py # developer utility script; no CI test impact is intentional
-no_impact tools/perf_matrix.py # standalone performance-matrix orchestrator; focused tool tests cover its contracts and reporting
 no_impact tools/perfdb.py # developer utility script; no CI test impact is intentional
 no_impact tools/prepare_dpg_bench.py # offline dataset conversion utility; validation behavior is tested separately
 no_impact tools/profile_report.py # developer utility script; no CI test impact is intentional

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -40,6 +40,18 @@ from tensorrt_model_connect.python_profiles import (  # noqa: E402
     profile_env_var,
     resolve_profile_python,
 )
+from tensorrt_model_connect.benchmark.task_adapters import (  # noqa: E402
+    adapter_for_task_strategy,
+)
+from tensorrt_model_connect.benchmark.types import BenchmarkError  # noqa: E402
+from tools.reporting_html import (  # noqa: E402
+    COMMON_REPORT_STYLES,
+    TASK_TYPE_BY_USER_CONTRACT,
+    ReportFilter,
+    render_report_filter_script,
+    render_report_filters,
+    sorted_filter_values,
+)
 from tools.validation import catalog as validation_catalog  # noqa: E402
 from tools import trtmc_disagreements  # noqa: E402
 
@@ -55,31 +67,6 @@ NOT_COMPARED_DIRECTORY = "not-compared"
 LEGACY_E2E_REASON = (
     "E2E execution does not compare aligned reference and TRTMC outputs."
 )
-_TASK_TYPE_BY_USER_CONTRACT = {
-    "multiple_choice_qa": "Text → Choice",
-    "continuation_parity": "Text → Text",
-    "code_completion": "Text → Code",
-    "translation": "Text → Text",
-    "seq2seq_output": "Text → Text",
-    "any-to-any": "Image + Text → Text",
-    "speech_response": "Audio → Audio",
-    "vl_answer": "Image + Text → Text",
-    "ocr_text": "Image → Text",
-    "exact_transcript": "Audio → Text",
-    "tts_audio": "Text → Audio",
-    "diffusion_image": "Text → Image",
-    "diffusion_video": "Text → Video",
-    "image-to-image": "Image + Text → Image",
-    "image_classification": "Image → Class",
-    "segmentation_mask": "Image → Mask",
-    "prompted_mask": "Image + Prompt → Mask",
-    "time_series_prediction_parity": "Time Series → Time Series",
-    "encoder_embedding_parity": "Text → Embedding",
-    "ranking_order": "Query + Documents → Ranking",
-    "diffusion_text_generation": "Text → Text",
-}
-
-
 class ValidationError(RuntimeError):
     """The requested validation cannot be resolved or executed."""
 
@@ -218,7 +205,7 @@ def _suite_task_metadata(suite: Mapping[str, Any]) -> tuple[str, str]:
     user_contract = str(suite.get("user_contract", "") or "")
     task_type = str(suite.get("task_type", "") or "")
     if not task_type:
-        task_type = _TASK_TYPE_BY_USER_CONTRACT.get(user_contract, "")
+        task_type = TASK_TYPE_BY_USER_CONTRACT.get(user_contract, "")
     return task_type, user_contract
 
 
@@ -237,6 +224,45 @@ def _result_task_metadata(result: Mapping[str, Any]) -> tuple[str, str]:
         return task_type, user_contract
     workload = str(result.get("workload", "") or "")
     return _default_suite_task_metadata().get(workload, ("", user_contract))
+
+
+def _operation_for_task_strategy(task_strategy: str) -> str:
+    if not task_strategy:
+        return ""
+    try:
+        return adapter_for_task_strategy(task_strategy).operation
+    except BenchmarkError:
+        return ""
+
+
+@cache
+def _default_model_report_metadata() -> dict[str, tuple[str, str, str]]:
+    metadata = {}
+    for model in validation_catalog.load_manifest_records(DEFAULT_MODELS):
+        task_strategy = str(model.get("task_strategy", "") or "")
+        metadata[str(model["name"])] = (
+            str(model.get("family", "") or ""),
+            _operation_for_task_strategy(task_strategy),
+            task_strategy,
+        )
+    return metadata
+
+
+def _result_model_report_metadata(result: Mapping[str, Any]) -> tuple[str, str, str]:
+    fallback = _default_model_report_metadata().get(
+        str(result.get("model", "")),
+        ("", "", ""),
+    )
+    task_strategy = str(result.get("task_strategy", "") or fallback[2])
+    return (
+        str(result.get("family", "") or fallback[0]),
+        str(
+            result.get("operation", "")
+            or fallback[1]
+            or _operation_for_task_strategy(task_strategy)
+        ),
+        task_strategy,
+    )
 
 
 def ready_model_names(models_root: Path = DEFAULT_MODELS) -> tuple[str, ...]:
@@ -1233,9 +1259,13 @@ def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
         candidate = raw_result.get("precision_contract")
         precision_contract = dict(candidate) if isinstance(candidate, dict) else {}
     task_type, user_contract = _result_task_metadata(normalized)
+    family, operation, task_strategy = _result_model_report_metadata(normalized)
     normalized.update(
         {
             "schema_version": "trtmc.validation-result/v2",
+            "family": family,
+            "operation": operation,
+            "task_strategy": task_strategy,
             "task_type": task_type,
             "user_contract": user_contract,
             "execution": execution,
@@ -1297,6 +1327,9 @@ def _comparison_result(
     reference_environment: EnvironmentSelection,
     dataset_command: str,
     sample_limit: int = 0,
+    family: str = "",
+    operation: str = "",
+    task_strategy: str = "",
     task_type: str = "",
     user_contract: str = "",
 ) -> dict[str, Any]:
@@ -1332,6 +1365,9 @@ def _comparison_result(
         "schema_version": "trtmc.validation-result/v2",
         "model": binding.model,
         "workload": binding.workload,
+        "family": family,
+        "operation": operation,
+        "task_strategy": task_strategy,
         "task_type": task_type,
         "user_contract": user_contract,
         "executor": "trtmc_compare",
@@ -1380,6 +1416,8 @@ def run_binding(
 
     suite = suites[workload]
     task_type, user_contract = _suite_task_metadata(suite)
+    model = task_models[binding.model]
+    task_strategy = str(model.get("task_strategy", "") or "")
     dataset = (
         Path(arguments.dataset)
         if arguments.dataset
@@ -1401,6 +1439,9 @@ def run_binding(
         reference_environment=environment,
         dataset_command=dataset_command,
         sample_limit=int(arguments.limit or 0),
+        family=str(model.get("family", "") or ""),
+        operation=_operation_for_task_strategy(task_strategy),
+        task_strategy=task_strategy,
         task_type=task_type,
         user_contract=user_contract,
     )
@@ -2033,17 +2074,20 @@ def _traffic_light_counts(
 ) -> dict[str, int]:
     counts = {"green": 0, "yellow": 0, "red": 0, "white": 0}
     for result in results:
-        validation_status = str(result["validation"]["status"])
-        comparison_status = str(result["comparison"]["status"])
-        if validation_status == "skipped":
-            counts["yellow"] += 1
-        elif comparison_status == "agreement":
-            counts["green"] += 1
-        elif comparison_status == "disagreement":
-            counts["red"] += 1
-        else:
-            counts["white"] += 1
+        counts[_traffic_light_status(result)] += 1
     return counts
+
+
+def _traffic_light_status(result: Mapping[str, Any]) -> str:
+    validation_status = str(result["validation"]["status"])
+    comparison_status = str(result["comparison"]["status"])
+    if validation_status == "skipped":
+        return "yellow"
+    if comparison_status == "agreement":
+        return "green"
+    if comparison_status == "disagreement":
+        return "red"
+    return "white"
 
 
 def _report_rows(
@@ -2053,6 +2097,20 @@ def _report_rows(
 ) -> str:
     rows = []
     for result, path in zip(results, result_paths, strict=True):
+        family, operation, task_strategy = _result_model_report_metadata(result)
+        task_type, user_contract = _result_task_metadata(result)
+        status = _traffic_light_status(result)
+        search_filter = " ".join(
+            (
+                family,
+                operation,
+                str(result.get("model", "")),
+                task_strategy,
+                task_type,
+                user_contract,
+                str(result.get("workload") or ""),
+            )
+        ).lower()
         relative = path.relative_to(output)
         metadata = result.get("disagreements", {})
         artifact_name = (
@@ -2062,8 +2120,14 @@ def _report_rows(
         )
         artifact_relative = relative.parent / artifact_name
         rows.append(
-            "<tr>"
-            f"<td>{html.escape(str(result.get('model', '')))}</td>"
+            f'<tr data-filter-search="{html.escape(search_filter, quote=True)}" '
+            f'data-filter-model-type="{html.escape(family, quote=True)}" '
+            f'data-filter-operation="{html.escape(operation, quote=True)}" '
+            f'data-filter-task-type="{html.escape(task_type, quote=True)}" '
+            f'data-filter-status="{status}">'
+            f"<td><code>{html.escape(family or '—')}</code></td>"
+            f"<td><code>{html.escape(operation or '—')}</code></td>"
+            f"<td><code>{html.escape(str(result.get('model', '')))}</code></td>"
             f"<td>{_render_task_type(result)}</td>"
             f"<td>{html.escape(str(result.get('workload') or '—'))}</td>"
             f"<td>{_render_samples(result)}</td>"
@@ -2099,23 +2163,61 @@ def _report_document(
     execution_errors: int,
     traffic_light_counts: Mapping[str, int],
 ) -> str:
+    results = list(report.get("results", []))
     provenance = _report_provenance(report.get("run", {}))
     duration = _format_duration(report["summary"].get("duration_seconds"))
     duration_summary = f" · {html.escape(duration)} total duration" if duration else ""
+    filters = render_report_filters(
+        row_count=len(results),
+        search_placeholder="Model type, operation, model, task type, or workload",
+        filters=(
+            ReportFilter(
+                "model-type",
+                "Model type",
+                sorted_filter_values(
+                    _result_model_report_metadata(result)[0] for result in results
+                ),
+            ),
+            ReportFilter(
+                "operation",
+                "Operation",
+                sorted_filter_values(
+                    _result_model_report_metadata(result)[1] for result in results
+                ),
+            ),
+            ReportFilter(
+                "task-type",
+                "Task type",
+                sorted_filter_values(
+                    _result_task_metadata(result)[0] for result in results
+                ),
+            ),
+            ReportFilter(
+                "status",
+                "Status",
+                tuple(
+                    (status, label)
+                    for status, label in (
+                        ("green", "Green"),
+                        ("yellow", "Yellow"),
+                        ("red", "Red"),
+                        ("white", "White"),
+                    )
+                    if any(
+                        _traffic_light_status(result) == status for result in results
+                    )
+                ),
+            ),
+        ),
+    )
+    filter_script = render_report_filter_script()
     return f"""<!doctype html>
-<html lang="en"><head><meta charset="utf-8">
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TRTMC Reference Consistency Report</title>
 <style>
-body {{ font: 14px system-ui, sans-serif; margin: 32px; color: #202124; }}
-h1 {{ margin-bottom: 4px; }}
-.purpose {{ color: #5f6368; margin-bottom: 8px; }}
-.traffic-summary {{ font-size: 20px; font-weight: 650; margin: 14px 0 8px; }}
-.summary {{ color: #5f6368; margin-bottom: 24px; }}
-table {{ border-collapse: collapse; width: 100%; }}
-th, td {{ border: 1px solid #dadce0; padding: 8px 10px; text-align: left; }}
-th {{ background: #f8f9fa; }}
+{COMMON_REPORT_STYLES}
+.table-wrap table {{ min-width: 1900px; }}
 details {{ min-width: 210px; }}
-summary {{ cursor: pointer; color: #185abc; }}
 .commands {{ min-width: min(760px, 70vw); padding: 4px 0; }}
 .commands h4 {{ margin: 12px 0 4px; }}
 .failure-details {{ min-width: min(900px, 75vw); margin-bottom: 10px; }}
@@ -2131,9 +2233,6 @@ summary {{ cursor: pointer; color: #185abc; }}
 .failure-media img, .failure-media video {{ display: block; max-width: 360px;
                                            max-height: 280px; }}
 .failure-media audio {{ width: min(360px, 70vw); }}
-pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
-       background: #f8f9fa; border: 1px solid #dadce0; border-radius: 4px; }}
-.unavailable {{ color: #5f6368; }}
 .signal {{ display: inline-flex; align-items: center; gap: 7px; font-weight: 650;
            white-space: nowrap; }}
 .signal-light {{ width: 10px; height: 10px; border-radius: 50%;
@@ -2149,15 +2248,17 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 .signal-cached {{ color: #185abc; }}
 .signal-cached .signal-light {{ background: #1a73e8; box-shadow: 0 0 0 3px #e8f0fe; }}
 .signal-not_run, .signal-not_compared {{ color: #5f6368; }}
-.detail {{ color: #5f6368; font-size: 12px; margin-top: 4px; }}
 .metric {{ display: flex; justify-content: space-between; gap: 14px;
            font-variant-numeric: tabular-nums; font-size: 12px; }}
 .metric span {{ color: #5f6368; }}
 .metric.primary {{ font-size: 13px; }}
 .metric.primary span, .metric.primary strong {{ color: #202124; }}
 </style></head><body>
+<header class="report-header">
+<p class="report-eyebrow">Validation report</p>
 <h1>TRTMC Reference Consistency Report</h1>
-<div class="purpose">Accuracy and output agreement against the model reference.</div>
+<p class="purpose">Accuracy and output agreement against the model reference.</p>
+</header>
 <div class="traffic-summary" title="Agreement · Skipped · Disagreement · Not compared">
 🟢 {traffic_light_counts["green"]} &nbsp; 🟡 {traffic_light_counts["yellow"]} &nbsp;
 🔴 {traffic_light_counts["red"]} &nbsp; ⚪ {traffic_light_counts["white"]}
@@ -2169,10 +2270,12 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 {execution_errors} execution errors ·
 {report["summary"]["selected_samples"]} samples{duration_summary}<br>
 {html.escape(provenance)}</div>
-<table><thead><tr><th>Model</th><th>Task type</th><th>Workload</th><th>Samples</th><th>Execution</th>
+{filters}
+<div class="table-wrap"><table><thead><tr><th>Model type</th><th>Operation</th><th>Model</th><th>Task type</th><th>Workload</th><th>Samples</th><th>Execution</th>
 <th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
 <th>Validation</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
-<tbody>{rows}</tbody></table>
+<tbody>{rows}</tbody></table></div>
+{filter_script}
 </body></html>
 """
 


### PR DESCRIPTION
## Background

The reference-consistency and performance reports expose overlapping model data with different visual styles, field names, and filter controls. This makes the two report types harder to compare when they are viewed through the same report browser.

## Exit Criteria

- Both reports use the same visual tokens and responsive table/filter layout.
- Both reports expose Model type, Operation, Model, Task type, and Status with the same filter semantics.
- Report-specific evidence remains intact, and older result artifacts can recover missing task metadata without rerunning benchmarks.

## Implementation

- Add dependency-free shared HTML styling, filter rendering, and task taxonomy helpers.
- Enrich validation results with manifest family, operation, and task-strategy metadata; infer those fields for existing artifacts.
- Add task metadata to performance results and recover user contracts from manifests when rendering older results.
- Keep report-specific filters such as Bundle preparation while sharing Search, Model type, Operation, Task type, Status, Reset, and visible-row count.

## Validation

- `env PYTHONPATH=python:. pytest -q tests/tools/test_reporting_html.py tests/tools/test_trtmc_validate.py tests/tools/test_perf_matrix.py`: passed, 160 tests.
- `ruff check tools/reporting_html.py tools/trtmc_validate.py tools/perf_matrix.py tests/tools/test_reporting_html.py tests/tools/test_trtmc_validate.py tests/tools/test_perf_matrix.py`: passed.
- Re-rendered the supplied 105-row validation and performance artifacts: both expose the common filters and leading columns; all 102 overlapping models agree on Model type and Operation.

## Notes For Future Readers

- Start with `tools/reporting_html.py`, then review the two generator integrations.
- Task type is workload-specific. Validation may report Text → Choice while performance reports Text → Text for the same generation model; the shared taxonomy preserves that meaningful difference instead of forcing identical values.
