### PR TITLE
feat(distilbert): add residual-add FFI recipe

### DIFF
--- a/python/tensorrt_model_connect/families/distilbert/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/distilbert/encoder_builder.py
@@ -356,8 +356,15 @@ def _add_encoder_layer(
         dtype=dtype)
 
     # POST-norm: LayerNorm(hidden + attn_out)
-    residual1 = network.add_elementwise(
-        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    from ...tvm_ffi.graph_build import graph_recipe_region
+
+    with graph_recipe_region(
+        network,
+        "distilbert.attention_residual_add@1",
+        f"encoder.layers.{prefix.removeprefix('layer.')}.attention_residual_add",
+    ):
+        residual1 = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM)
     normed1 = _add_seq_layer_norm(
         network, residual1.get_output(0), hidden_size, seq_length,
         weights[f"{prefix}.post_attn_norm"],

--- a/tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py
+++ b/tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py
@@ -87,7 +87,7 @@ class TestDistilBERTBuildEngine:
             t[f"{p}.output_layer_norm.bias"] = _rand(hidden)
         return t
 
-    def test_build_engine_returns_bytes(self, tmp_path):
+    def _prepare_model(self, tmp_path):
         from tensorrt_model_connect.families.distilbert import plugin
 
         config = {
@@ -103,13 +103,67 @@ class TestDistilBERTBuildEngine:
             "dim": self.HIDDEN,
         }
         tensors = self._make_tensors(
-            self.VOCAB, self.HIDDEN, self.LAYERS, self.HEADS, self.INTERMEDIATE, self.MAX_POS)
+            self.VOCAB,
+            self.HIDDEN,
+            self.LAYERS,
+            self.HEADS,
+            self.INTERMEDIATE,
+            self.MAX_POS,
+        )
         _write_config(tmp_path, config)
         _write_safetensors(tmp_path, tensors)
 
         cfg = ModelConfig.from_dir(tmp_path)
-        weights = plugin.load_weights(str(tmp_path), cfg)
+        return plugin, cfg, plugin.load_weights(str(tmp_path), cfg)
+
+    def test_build_engine_returns_bytes(self, tmp_path):
+        plugin, cfg, weights = self._prepare_model(tmp_path)
         engine = plugin.build_engine(cfg, weights, max_cache_length=32, verbose=False)
 
         assert isinstance(engine, bytes)
         assert len(engine) > 0
+
+    def test_attention_residual_recipe_is_selectable(self, tmp_path):
+        from tensorrt_model_connect.tvm_ffi.graph_build import (
+            GraphInspectionComplete,
+            engine_role,
+            inspect_graph,
+        )
+        from tensorrt_model_connect.tvm_ffi.graph_cli import select_recipe
+        from tensorrt_model_connect.tvm_ffi.graph_patch import load_snapshot
+
+        plugin, cfg, weights = self._prepare_model(tmp_path)
+        snapshot_path = tmp_path / "decode.graph.json"
+
+        with pytest.raises(GraphInspectionComplete):
+            with inspect_graph(
+                snapshot_path,
+                engine_role="decode",
+                metadata={"decoder_engine_layout": "split"},
+            ):
+                with engine_role("decode"):
+                    plugin.build_engine(
+                        cfg, weights, max_cache_length=32, verbose=False)
+
+        snapshot = load_snapshot(snapshot_path)
+        recipes = snapshot.metadata["graph_recipes"]
+        assert len(recipes) == 1
+        recipe = recipes[0]
+        assert recipe["id"] == "distilbert.attention_residual_add@1"
+        assert recipe["instance"] == "encoder.layers.0.attention_residual_add"
+        assert len(recipe["node_ids"]) == 1
+        assert recipe["workspace_bytes"] == 0
+        assert recipe["extra_args"] == []
+        assert recipe["output_shape_input"] is None
+
+        selection = select_recipe(
+            snapshot,
+            "distilbert.attention_residual_add@1",
+            "encoder.layers.0.attention_residual_add",
+        )
+        assert len(selection.input_tensor_ids) == 2
+        assert len(selection.output_tensor_ids) == 1
+        selected = next(
+            node for node in snapshot.nodes if node.id == selection.node_ids[0]
+        )
+        assert selected.op.endswith("ElementWiseOperation.SUM")


### PR DESCRIPTION
## Background

The TVM-FFI tutorial already demonstrates manually selecting DistilBERT's first
attention residual add and replacing it with the supplied CuTe DSL kernel. Raw
TensorRT node IDs are graph receipts, so users currently have to rediscover this
known family boundary before following the example.

## Exit Criteria

- Each non-TP DistilBERT encoder layer records a versioned Recipe for its
  attention residual add. FFI graph slots remain TP=1.
- The Recipe uses the existing region validator and graph-patch path.
- The unchanged CuTe exporter accepts the Recipe receipt, and runtime output
  passes the tutorial's numerical gate.
- Shared FFI infrastructure, runtime behavior, and ordinary TRT graph
  construction remain unchanged.

## Implementation

- Record the existing one-node `hidden + attention_projection` SUM as
  `distilbert.attention_residual_add@1`, with instances such as
  `encoder.layers.0.attention_residual_add`.
- Keep the Recipe as syntax sugar over ordinary graph selection: zero workspace,
  no fixed arguments, and no output-shape override.
- Add one focused family integration test for capture, Recipe resolution, and
  the exact one-node SUM boundary.

## Validation

The commands below ran from the repository root in the isolated GB300 container.

```bash
export MODEL=/workspace/users/yifeif/.cache/huggingface/hub/models--distilbert--distilbert-base-uncased/snapshots/12040accade4e8a0f71eabdb258fecc2e7e948be
export WORK=/tmp/distilbert-recipe
export PYTHONPATH=python
export HF_HOME=/workspace/users/yifeif/.cache/huggingface
export LD_LIBRARY_PATH="$PWD/build:/opt/venv/lib/python3.12/site-packages/tensorrt_libs:/opt/venv/lib/python3.12/site-packages/tvm_ffi/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"

pytest -q \
  tests/builder/test_graph_patch.py \
  tests/builder/test_graph_cli.py \
  tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py

python -m tensorrt_model_connect graph inspect \
  --snapshot "$WORK/decode.graph.json" \
  --engine-role decode \
  "$MODEL" --precision fp16 --max-cache-length 256
python -m tensorrt_model_connect graph recipes "$WORK/decode.graph.json"

build/trtmc build "$MODEL" \
  --precision fp16 --max-cache-length 256 \
  --recipe distilbert.attention_residual_add@1 \
           encoder.layers.0.attention_residual_add \
  -o "$WORK/distilbert-slot-ready.trtfb"

python examples/byok/export_cutedsl_residual_add.py \
  --snapshot "$WORK/decode.graph.json" \
  --selection "$WORK/distilbert-slot-ready.selection.json" \
  --output "$WORK/residual-add-cutedsl.so"

printf '%s\n' \
  '{"schema_version":1,"bindings":[{"id":"distilbert.attention_residual_add@1","abi_sha256":"afba3e049f44f7f04109ac681925f839f0e95a3ce82723c866022230984cd040","library":"./residual-add-cutedsl.so","function":"run"}]}' \
  > "$WORK/kernel-bindings.json"

build/trtmc build "$MODEL" \
  --precision fp16 --max-cache-length 256 \
  -o "$WORK/distilbert-native.trtfb"

build/trtmc embed "$WORK/distilbert-native.trtfb" \
  --backend-dir build --model-plugin-dir build/models/distilbert \
  --prompt "The quick brown fox jumps over the lazy dog." \
  --hf-python /opt/venv/bin/python \
  > "$WORK/native.json" 2> "$WORK/native.stderr"

build/trtmc embed "$WORK/distilbert-slot-ready.trtfb" \
  --backend-dir build --model-plugin-dir build/models/distilbert \
  --kernel-bindings "$WORK/kernel-bindings.json" \
  --prompt "The quick brown fox jumps over the lazy dog." \
  --hf-python /opt/venv/bin/python \
  > "$WORK/byok.json" 2> "$WORK/byok.stderr"
```

Results:

- Focused tests: 26 passed.
- Real graph: six Recipe instances at nodes 49, 106, 163, 220, 277, and 334.
- Recipe build: passed; 127.5 MB bundle; fixed FP16
  `[256, 768] + [256, 768] -> [256, 768]`; ABI SHA
  `afba3e049f44f7f04109ac681925f839f0e95a3ce82723c866022230984cd040`.
- Unchanged CuTe exporter: passed against the Recipe-generated receipt.
- Runtime comparison: 196,608 values, maximum absolute difference `0.01563`,
  cosine similarity `0.999997682006`; the documented numerical gate passed.
- Exploratory timing ran six alternating fresh-process pairs with the same two
  `embed` commands above and took the median of
  `[trtmc.engine_timing] execute_ms`: native `1.991632 ms`, Recipe/CuTe
  `1.985472 ms`. Raw timing artifacts were not retained. These noisy samples
  are not a performance qualification or acceleration claim.
- Independent review:
  `ruff check --no-cache python/tensorrt_model_connect/families/distilbert/encoder_builder.py tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py`:
  passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- Review the Recipe scope in `encoder_builder.py` first, then the focused test.
- TP construction is untouched because FFI graph slots currently require TP=1.
- This reuses a teaching kernel. A production acceleration still needs a
  higher-work region and independent correctness and no-regression qualification.
- ADR intentionally skipped: this routine family Recipe adds no runtime strategy,
  schema, or architecture path.
