### PR TITLE
feat(mistral): add decode attention recipe

### DIFF
--- a/python/tensorrt_model_connect/families/mistral/default_decoder.py
+++ b/python/tensorrt_model_connect/families/mistral/default_decoder.py
@@ -446,6 +446,11 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
+            recipe_instance=(
+                f"decoder.layers.{layer_idx}.decode_attention"
+                if decoder_engine_role == "decode"
+                else None
+            ),
         )
 
         hidden_state = result["hidden"]
@@ -578,6 +583,7 @@ def _add_decoder_layer(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    recipe_instance: str | None = None,
     eps: float | None = None,
 ) -> dict[str, trt.ITensor]:
     """Add one standard decoder layer block. Returns hidden, present_k, present_v."""
@@ -604,6 +610,7 @@ def _add_decoder_layer(
         interleaved_rope=interleaved_rope,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
+        recipe_instance=recipe_instance,
     )
     attn_out = attn["attn_out"]
     present_k = attn["present_k"]

--- a/python/tensorrt_model_connect/families/mistral/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/mistral/graph_blocks.py
@@ -22,6 +22,7 @@ residual, DeepStack injection, MoE routing, etc.).
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -148,6 +149,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    recipe_instance: str | None = None,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -267,20 +269,30 @@ def add_attention_block(
         else:
             mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
 
-        context = graph_ops.add_attention_from_rows(
-            network,
-            q,
-            all_k.get_output(0),
-            all_v.get_output(0),
-            num_heads=num_heads,
-            head_dim=head_dim,
-            num_kv_heads=num_kv_heads,
-            q_seq=1,
-            kv_seq=kv_seq,
-            causal=False,
-            mask=mask_4d,
-            scale=attention_scale,
-        )
+        recipe = nullcontext()
+        if recipe_instance is not None:
+            from ...tvm_ffi.graph_build import graph_recipe_region
+
+            recipe = graph_recipe_region(
+                network,
+                "mistral.decode_attention_region@1",
+                recipe_instance,
+            )
+        with recipe:
+            context = graph_ops.add_attention_from_rows(
+                network,
+                q,
+                all_k.get_output(0),
+                all_v.get_output(0),
+                num_heads=num_heads,
+                head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                q_seq=1,
+                kv_seq=kv_seq,
+                causal=False,
+                mask=mask_4d,
+                scale=attention_scale,
+            )
     elif ffi_attention_kernel is not None:
         if num_kv_heads != num_heads:
             raise ValueError(

--- a/tests/e2e/models/mistral/test_mistral_builder_engine.py
+++ b/tests/e2e/models/mistral/test_mistral_builder_engine.py
@@ -8,8 +8,13 @@ Intent: Validate the Mistral family plugin weight loading and standard decoder k
 Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU required for engine build tests.
 Postconditions: All standard decoder weight keys are present with correct shapes and the engine builds successfully.
 """
+import pytest
+
 from tests.builder.family_plugin_tester import FamilyPluginTester
-from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
+from tests.builder.family_plugin_test_mixin import (
+    FamilyPluginTestMixin,
+    requires_trt,
+)
 
 
 class MistralPluginTester(FamilyPluginTester):
@@ -19,3 +24,52 @@ class MistralPluginTester(FamilyPluginTester):
 
 class TestMistralEngine(FamilyPluginTestMixin):
     tester_class = MistralPluginTester
+
+    @requires_trt
+    def test_decode_attention_recipe_is_selectable(self, tmp_path):
+        from tensorrt_model_connect.tvm_ffi import graph_build
+        from tensorrt_model_connect.tvm_ffi.graph_cli import select_recipe
+        from tensorrt_model_connect.tvm_ffi.graph_patch import load_snapshot
+
+        tester = MistralPluginTester()
+        config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+        config.raw["_decoder_engine_role"] = "decode"
+        snapshot_path = tmp_path / "mistral-decode.graph.json"
+
+        with pytest.raises(graph_build.GraphInspectionComplete):
+            with graph_build.inspect_graph(
+                snapshot_path,
+                engine_role="decode",
+                metadata={"decoder_engine_layout": "split"},
+            ):
+                with graph_build.engine_role("decode"):
+                    tester.get_plugin().build_engine(
+                        config,
+                        weights,
+                        tester.spec.max_cache_length,
+                        precision="fp16",
+                        verbose=False,
+                    )
+
+        snapshot = load_snapshot(snapshot_path)
+        recipes = snapshot.metadata["graph_recipes"]
+        assert len(recipes) == tester.spec.num_hidden_layers
+        recipe = recipes[0]
+        assert recipe["id"] == "mistral.decode_attention_region@1"
+        assert recipe["instance"] == "decoder.layers.0.decode_attention"
+        assert any(
+            "ATTENTION" in node.op
+            for node in snapshot.nodes
+            if node.id in recipe["node_ids"]
+        )
+
+        selection = select_recipe(
+            snapshot,
+            "mistral.decode_attention_region@1",
+            "decoder.layers.0.decode_attention",
+        )
+        assert len(selection.input_tensor_ids) == 4
+        assert len(selection.output_tensor_ids) == 1
+        assert selection.workspace_bytes == 0
+        assert selection.extra_args == ()
+        assert selection.output_shape_input is None


### PR DESCRIPTION
## Background

The TVM-FFI BYOK flow already supports family Recipes as syntax sugar over the ordinary TensorRT graph selector, but the Mistral family did not publish an attention Recipe. Kernel integrators therefore had to inspect and type raw node IDs for every Mistral graph.

## Exit Criteria

- A split-decode Mistral graph publishes one versioned attention Recipe instance per layer.
- The Recipe resolves through the existing `select_recipe()` path to a valid, single-output attention boundary.
- `trtmc build --recipe` produces a slot-ready bundle and ABI receipt without changing shared graph or runtime infrastructure.
- No compatible external kernel or performance claim is introduced in this PR.

## Implementation

- Pass a Recipe instance only while Mistral builds a split decode engine.
- Wrap the existing `add_attention_from_rows()` call with `graph_recipe_region()` under `mistral.decode_attention_region@1`; prefill and non-Recipe execution remain unchanged.
- Extend the existing synthetic Mistral builder integration test to capture the real TRT graph and select the recorded Recipe.

For `mistralai/Mistral-7B-Instruct-v0.1` checkpoint revision
`ec5deb64f2c6e6fa90c1abf74a91d5c93a9669ca`, FP16, and
`max_cache_length=256`, the measured layer-0 contract is:

- query: FP16 `[1, 4096]`
- concatenated key/value: two FP16 `[257, 1024]` tensors
- additive mask: FP16 `[1, 1, 1, 257]`
- context output: FP16 `[1, 4096]`

The selected region includes the existing query scale, TRT attention, and layout reshapes. It remains an ordinary graph selection; the Recipe adds no semantic map, runtime strategy, or kernel schema.

## Validation

- `python -m pytest tests/builder/test_graph_patch.py tests/builder/test_graph_cli.py tests/e2e/models/mistral/test_mistral_builder_engine.py::TestMistralEngine::test_decode_attention_recipe_is_selectable -q`: 25 passed in 1.53 seconds.

The exact real-model graph commands were:

```bash
./build/trtmc graph inspect \
  --engine-role decode \
  --snapshot artifacts/mistral-ffi-recipe/decode.graph.json \
  /workspace/users/yifeif/.cache/huggingface/hub/models--mistralai--Mistral-7B-Instruct-v0.1/snapshots/ec5deb64f2c6e6fa90c1abf74a91d5c93a9669ca \
  --precision fp16 \
  --max-cache-length 256 \
  --decoder-engine-layout split

./build/trtmc graph recipes \
  artifacts/mistral-ffi-recipe/decode.graph.json \
  | tee artifacts/mistral-ffi-recipe/recipes.txt

./build/trtmc graph select \
  artifacts/mistral-ffi-recipe/decode.graph.json \
  --nodes node:41 node:42 node:43 node:44 node:45 node:46 \
          node:47 node:48 node:49 node:50 node:51 \
  --binding-id mistral.decode_attention_region@1 \
  --workspace-bytes 0 \
  -o artifacts/mistral-ffi-recipe/manual-layer0.selection.json
```

These commands passed, published 32 Recipe instances, and selected layer 0
with four inputs, one output, zero workspace, and ABI SHA-256
`0504c686e9a7ddea2d1942098a2acbd9a1e2812e09213a94ecd9b9eda747fd50`.

- `./build/trtmc build /workspace/users/yifeif/.cache/huggingface/hub/models--mistralai--Mistral-7B-Instruct-v0.1/snapshots/ec5deb64f2c6e6fa90c1abf74a91d5c93a9669ca --precision fp16 --max-cache-length 256 --decoder-engine-layout split --recipe mistral.decode_attention_region@1 decoder.layers.0.decode_attention -o artifacts/mistral-ffi-recipe/mistral-slot.trtfb`: passed; prefill built in 179.2 seconds, decode in 230.3 seconds, and the bundle completed in 424.2 seconds.
- Bundle inspection: `kernel_slots.json` contains exactly `mistral.decode_attention_region@1` with the same ABI hash, and the Recipe receipt equals the ordinary manual selection receipt.
- Runtime DSO correctness and performance: not run. No existing DSO in the repository matches this FP16 explicit-mask ABI, and this focused PR intentionally does not add a new masked-attention kernel. It therefore makes no acceleration or no-regression claim.

## Notes For Future Readers

- Start review in `families/mistral/graph_blocks.py`, then check the decode-only instance plumbing and integration test.
- A kernel for this Recipe must consume the explicit additive mask and implement the exact receipt contract. Loading an unrelated FlashInfer DSO would not be a valid test.
- An ADR was intentionally skipped: this is a routine Recipe addition inside an existing family and does not change architecture, persisted configuration, runtime strategy, or shared FFI behavior.
