### PR TITLE
feat(llama): add decode attention recipe

### DIFF
--- a/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -671,6 +671,11 @@ def build_dual_profile_decoder_engine(
                 q_seq=None,
                 scale=attn_scale,
                 tag=f"{prefix}.attn",
+                recipe_instance=(
+                    f"decoder.layers.{layer_idx}.decode_attention"
+                    if profile_mode == "decode"
+                    else None
+                ),
             )
             context = native_attention["context"]
             present_k_outs.append(native_attention["present_k"])

--- a/python/tensorrt_model_connect/families/llama/graph_ops.py
+++ b/python/tensorrt_model_connect/families/llama/graph_ops.py
@@ -9,6 +9,7 @@ Tensor names and shapes must stay compatible with the C++ bundle runtime.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import nullcontext
 import math
 from typing import Any
 
@@ -978,6 +979,7 @@ def add_native_kv_cache_attention_from_rows(
     q_seq: int | None,
     scale: float | None = None,
     tag: str | None = None,
+    recipe_instance: str | None = None,
 ) -> dict[str, trt.ITensor]:
     """Update a user-owned KV cache and attend over its active prefix.
 
@@ -1063,19 +1065,30 @@ def add_native_kv_cache_attention_from_rows(
     ).get_output(0)
     q_scaled = network.add_cast(q_scaled, trt.bfloat16).get_output(0)
 
-    attention = network.add_attention_v2(
-        q_scaled,
-        updated_k,
-        updated_v,
-        trt.AttentionNormalizationOp.SOFTMAX,
-        trt.CausalMaskKind.LOWER_RIGHT,
-    )
-    if attention is None:
-        raise RuntimeError("TensorRT failed to create Llama native attention")
-    attention.decomposable = False
-    attention.key_value_lengths = key_value_lengths
-    if tag:
-        attention.name = tag
+    recipe = nullcontext()
+    if recipe_instance is not None:
+        from ...tvm_ffi.graph_build import graph_recipe_region
+
+        recipe = graph_recipe_region(
+            network,
+            "llama.decode_attention_region@1",
+            recipe_instance,
+            output_shape_input=0,
+        )
+    with recipe:
+        attention = network.add_attention_v2(
+            q_scaled,
+            updated_k,
+            updated_v,
+            trt.AttentionNormalizationOp.SOFTMAX,
+            trt.CausalMaskKind.LOWER_RIGHT,
+        )
+        if attention is None:
+            raise RuntimeError("TensorRT failed to create Llama native attention")
+        attention.decomposable = False
+        attention.key_value_lengths = key_value_lengths
+        if tag:
+            attention.name = tag
 
     context = reshape_heads_4d_to_rows(
         network,

--- a/tests/e2e/models/llama/test_llama_builder_engine.py
+++ b/tests/e2e/models/llama/test_llama_builder_engine.py
@@ -160,3 +160,56 @@ class TestLlamaEngine(FamilyPluginTestMixin):
         assert tuple(profile[2]) == (
             tester.spec.max_cache_length if role == "prefill" else 1,
         )
+
+    @requires_trt
+    def test_native_decode_records_attention_recipe(self, tmp_path):
+        """The Llama family publishes one exact decode-attention instance."""
+        from tensorrt_model_connect.tvm_ffi import graph_build
+        from tensorrt_model_connect.tvm_ffi.graph_cli import select_recipe
+        from tensorrt_model_connect.tvm_ffi.graph_patch import load_snapshot
+
+        tester = NativeLlamaPluginTester()
+        config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+        config.raw["_decoder_engine_role"] = "decode"
+        snapshot_path = tmp_path / "llama-decode.graph.json"
+
+        with pytest.raises(graph_build.GraphInspectionComplete):
+            with graph_build.inspect_graph(
+                snapshot_path,
+                engine_role="decode",
+                metadata={},
+            ):
+                with graph_build.engine_role("decode"):
+                    tester.get_plugin().build_engine(
+                        config,
+                        weights,
+                        tester.spec.max_cache_length,
+                        precision="bf16",
+                        verbose=False,
+                    )
+
+        snapshot = load_snapshot(snapshot_path)
+        recipes = snapshot.metadata["graph_recipes"]
+        assert len(recipes) == 1
+        recipe = recipes[0]
+        assert recipe["id"] == "llama.decode_attention_region@1"
+        assert recipe["instance"] == "decoder.layers.0.decode_attention"
+        selected_ops = [
+            node.op
+            for node in snapshot.nodes
+            if node.id in recipe["node_ids"]
+        ]
+        assert selected_ops
+        assert all("ATTENTION" in operation for operation in selected_ops)
+        assert recipe["workspace_bytes"] == 0
+        assert recipe["extra_args"] == []
+        assert recipe["output_shape_input"] == 0
+        selection = select_recipe(
+            snapshot,
+            "llama.decode_attention_region@1",
+            "decoder.layers.0.decode_attention",
+        )
+        assert selection.binding_id == "llama.decode_attention_region@1"
+        assert len(selection.input_tensor_ids) == 4
+        assert len(selection.output_tensor_ids) == 1
+        assert selection.output_shape_input == 0


### PR DESCRIPTION
## Background

The TVM-FFI BYOK flow already supports family-owned Recipes as syntax sugar over manual TensorRT graph selection, but the Llama family did not publish a known region. Kernel authors therefore had to inspect and type raw layer IDs even for Llama's qualified native decode attention.

## Exit Criteria

- A qualified Llama native decode graph publishes one versioned attention Recipe instance per layer.
- The Recipe selects the existing attention boundary through the shared graph validator and replacement path.
- Prefill and non-native Llama graph behavior remain unchanged.
- A compatible external TVM-FFI DSO can build, bind, run correctly, and meet the existing no-regression smoke gate.

## Implementation

- Record `llama.decode_attention_region@1` only for native `profile_mode == "decode"`, with instances named `decoder.layers.<N>.decode_attention`.
- Keep KV updates and FP32-scale-to-BF16 query rounding outside the region; the Recipe wraps only the native fused attention operation and declares that its dynamic output shape follows input 0.
- Add one focused TensorRT graph test that captures the family Recipe, verifies its attention-only nodes, and resolves it through the existing `select_recipe()` path.

The Recipe uses the existing graph-slot infrastructure and introduces no runtime path, schema, shared semantic map, or Direct Slot. An ADR was intentionally skipped because this is a routine addition to an existing family and architecture.

## Validation

- `cmake --build build -j 8`: passed (native CLI and TVM-FFI backend/plugin built).
- `ruff check python/tensorrt_model_connect/families/llama/graph_ops.py python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py tests/e2e/models/llama/test_llama_builder_engine.py`: passed.
- `PYTHONPATH=$PWD/python python -m pytest tests/builder/test_qwen_llama_native_kv_attention.py tests/e2e/models/llama/test_llama_native_kv_routing.py tests/e2e/models/llama/test_llama_builder_engine.py::TestLlamaEngine::test_native_decode_records_attention_recipe -q`: 34 passed.

The model used below was the exact cached Hugging Face revision
`47f17b2c73bbd07a4b643a0382970704d389f737`:

```bash
cd /workspace/tensorrt-model-connect
MODEL=/workspace/users/yifeif/.cache/huggingface/hub/models--nvidia--Llama-3.1-Minitron-4B-Depth-Base/snapshots/47f17b2c73bbd07a4b643a0382970704d389f737
export PYTHONPATH=$PWD/python
export HF_HUB_OFFLINE=1
```

### Graph capture and Recipe discovery

```bash
python -m tensorrt_model_connect graph inspect \
  --engine-role decode \
  --snapshot /tmp/llama-ffi-validation/minitron-decode.graph.json \
  "$MODEL" \
  --precision bf16 \
  --max-cache-length 131072 \
  --decoder-engine-layout split

python -m tensorrt_model_connect graph recipes \
  /tmp/llama-ffi-validation/minitron-decode.graph.json
```

This passed on GB300 / TensorRT 11.2 and reported exactly 16 instances, from
`decoder.layers.0.decode_attention` through
`decoder.layers.15.decode_attention`.

### Validation-only FlashInfer DSO export

The checked-in
`python/tensorrt_model_connect/families/qwen/kernels/export_flashinfer_decode_attention.py`
defaults to `KV_CAPACITY = 40960`. The Llama receipt below requires capacity
131072. I did **not** edit that exporter. For validation only, I imported the
module, assigned `exporter.KV_CAPACITY = 131072` in the temporary Python
process, and called its existing compile/link helpers:

```bash
python -m pip install \
  "nvidia-cutlass-dsl==4.5.0" \
  "apache-tvm-ffi==0.1.12" \
  "flashinfer-python==0.6.15"

git clone --branch v0.6.15 --depth 1 \
  https://github.com/flashinfer-ai/flashinfer.git \
  /tmp/flashinfer-llama-v0.6.15

git -C /tmp/flashinfer-llama-v0.6.15 apply \
  /workspace/tensorrt-model-connect/python/tensorrt_model_connect/families/qwen/kernels/flashinfer_device_kv_length.patch

mkdir -p /tmp/llama-ffi-validation
PYTHONPATH=/tmp/flashinfer-llama-v0.6.15:$PWD/python python - <<'PY'
from pathlib import Path

import torch

from tensorrt_model_connect.families.qwen.kernels import (
    export_flashinfer_decode_attention as exporter,
)

output = Path(
    "/tmp/llama-ffi-validation/llama-flashinfer-linear-c131072.so"
)
if output.exists():
    output.unlink()
torch.cuda.set_device(0)
exporter.KV_CAPACITY = 131072
exporter._link(exporter._compile(), output)
print(output)
PY
```

The generated DSO and this temporary parameter assignment are not part of the
PR. There is no checked-in exporter change or Llama-to-Qwen dependency.

### Slot-ready and native builds

```bash
export _TRTMC_INTERNAL_NATIVE_BIN_DIR=$PWD/build
export LD_LIBRARY_PATH=$PWD/build:$LD_LIBRARY_PATH

python -m tensorrt_model_connect build \
  "$MODEL" \
  --precision bf16 \
  --max-cache-length 131072 \
  --decoder-engine-layout split \
  --recipe llama.decode_attention_region@1 \
           decoder.layers.0.decode_attention \
  -o /tmp/llama-ffi-validation/minitron-slot.trtfb

python -m tensorrt_model_connect build \
  "$MODEL" \
  --precision bf16 \
  --max-cache-length 131072 \
  --decoder-engine-layout split \
  -o /tmp/llama-ffi-validation/minitron-native.trtfb
```

Both passed. The Recipe build also wrote
`/tmp/llama-ffi-validation/minitron-slot.selection.json`. Its ABI SHA was
`84d2c18ea1ad8add7d2c237a7766f6b7e6c7e4bbd3f1a217a1285cc360468996`.
The ordered contract was four inputs (`BF16 [1,32,-1,128]`, two
`BF16 [1,8,131072,128]`, and `INT32 [1]`) and one
`BF16 [1,32,-1,128]` output, with zero workspace and no fixed arguments.

### Binding and deterministic run

The generated DSO was copied to the validation manifest directory as follows:

```bash
mkdir -p artifacts/llama-ffi-validation
cp \
  /tmp/llama-ffi-validation/llama-flashinfer-linear-c131072.so \
  artifacts/llama-ffi-validation/kernel.so
```

The exact `artifacts/llama-ffi-validation/kernel-bindings.json` binding
manifest was:

```json
{
  "schema_version": 1,
  "bindings": [
    {
      "id": "llama.decode_attention_region@1",
      "abi_sha256": "84d2c18ea1ad8add7d2c237a7766f6b7e6c7e4bbd3f1a217a1285cc360468996",
      "library": "./kernel.so",
      "function": "run"
    }
  ]
}
```

```bash
export LD_LIBRARY_PATH=$PWD/build:/opt/venv/lib/python3.12/site-packages/tensorrt_libs:/usr/local/cuda/lib64

./build/trtmc run \
  /tmp/llama-ffi-validation/minitron-slot.trtfb \
  --kernel-bindings artifacts/llama-ffi-validation/kernel-bindings.json \
  --prompt "The capital of France is" \
  --max-new-tokens 16 \
  --greedy \
  --output /tmp/llama-ffi-validation/slot-output.jsonl

./build/trtmc run \
  /tmp/llama-ffi-validation/minitron-native.trtfb \
  --prompt "The capital of France is" \
  --max-new-tokens 16 \
  --greedy \
  --output /tmp/llama-ffi-validation/native-output.jsonl

diff -u \
  /tmp/llama-ffi-validation/native-output.jsonl \
  /tmp/llama-ffi-validation/slot-output.jsonl
```

The diff was empty: native and FFI produced exactly the same 16 token IDs.

### Short no-regression smoke

These are the exact two benchmark commands. Pair 1 ran native then FFI; pair 2
ran the same commands in reverse order.

```bash
./build/trtmc run \
  /tmp/llama-ffi-validation/minitron-native.trtfb \
  --prompt "The capital of France is" \
  --max-new-tokens 32 \
  --greedy \
  --warmup 1 \
  --benchmark 3

./build/trtmc run \
  /tmp/llama-ffi-validation/minitron-slot.trtfb \
  --kernel-bindings artifacts/llama-ffi-validation/kernel-bindings.json \
  --prompt "The capital of France is" \
  --max-new-tokens 32 \
  --greedy \
  --warmup 1 \
  --benchmark 3
```

Pair 1 measured native 518.18 vs FFI 526.65 tokens/s. Pair 2 measured FFI
526.64 vs native 521.63 tokens/s. Both passed the 0.98 no-regression gate. This
is a short functional smoke only; the small positive delta is **not** claimed
as qualified acceleration.

## Notes For Future Readers

- Review `graph_ops.py` first for the exact boundary, then the decode-only builder connection, then the graph test.
- The Recipe is intentionally available only when Llama enters its existing qualified native-KV route. That route currently requires BF16 split engines and `max_cache_length == max_position_embeddings`; configurations that fall back to the legacy graph do not advertise this Recipe.
- Validation reused the existing Qwen-shaped FlashInfer exporter only to produce an ABI-compatible test DSO with matching dimensions. The checked-in default remains capacity 40960; only the temporary validation process assigned capacity 131072. This PR ships no DSO or exporter change and creates no Llama-to-Qwen code or documentation dependency.
- The benchmark is a short functional no-regression receipt, not a general performance qualification across GPUs, model shapes, or context lengths.
