### PR TITLE
[Accuracy] Align Lance X2T with official reference

### DIFF
--- a/python/tensorrt_model_connect/families/lance/default_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_decoder.py
@@ -66,6 +66,7 @@ def build_standard_decoder_engine(
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
     embed_input: bool = False,
+    round_rope_inv_freq_to_bf16: bool = False,
     verbose: bool = False,
     debug_layer_outputs: bool = False,
     hidden_state_output: bool = False,
@@ -153,6 +154,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             embed_input=embed_input,
+            round_rope_inv_freq_to_bf16=round_rope_inv_freq_to_bf16,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
@@ -169,6 +171,13 @@ def build_standard_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
     dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
+    rope_scaling = config.raw.get("rope_scaling") or {}
+    raw_mrope_section = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict) else None)
+    mrope_section = (
+        tuple(int(value) for value in raw_mrope_section)
+        if raw_mrope_section is not None else None)
     dynamic_kv_opt_rows = int(config.raw.get("_dynamic_kv_opt_length", max_cache_length))
     dynamic_kv_opt_rows = max(1, min(dynamic_kv_opt_rows, max_cache_length))
     raw_profile_rows = config.raw.get("_dynamic_kv_profile_rows")
@@ -209,6 +218,9 @@ def build_standard_decoder_engine(
     # ---------------------------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))
+    mrope_position_ids = (
+        network.add_input("mrope_position_ids", trt.int32, (3,))
+        if mrope_section is not None else None)
     attention_mask = network.add_input(
         "attention_mask", trt.float32,
         (1, -1) if dynamic_kv_cache else (1, attention_window))
@@ -303,17 +315,29 @@ def build_standard_decoder_engine(
 
     if position_type == "rope":
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        if mrope_section is not None:
+            if len(mrope_section) != 3 or any(value <= 0 for value in mrope_section):
+                raise ValueError(
+                    "rope_scaling.mrope_section must contain three positive integers")
+            if sum(mrope_section) != rotary_embedding_dim // 2:
+                raise ValueError(
+                    "rope_scaling.mrope_section must sum to half the rotary dimension; "
+                    f"got {mrope_section} for rotary dimension {rotary_embedding_dim}")
         cos_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            round_inv_freq_to_bf16=round_rope_inv_freq_to_bf16)
         sin_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            round_inv_freq_to_bf16=round_rope_inv_freq_to_bf16)
+        rope_storage_dtype = (
+            np.float32 if round_rope_inv_freq_to_bf16 else work_np_dtype)
         cos_half_tensor = graph_ops.add_constant(
-            network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
+            network, cos_half_np.shape, cos_half_np, dtype=rope_storage_dtype)
         cos_half_tensor = _cast_work_dtype(cos_half_tensor)
         sin_half_tensor = graph_ops.add_constant(
-            network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
+            network, sin_half_np.shape, sin_half_np, dtype=rope_storage_dtype)
         sin_half_tensor = _cast_work_dtype(sin_half_tensor)
     elif position_type == "learned":
         pos_embed_np = weights["position_embedding"]
@@ -450,6 +474,8 @@ def build_standard_decoder_engine(
             sin_half_tensor=sin_half_tensor,
             rotary_embedding_dim=rotary_embedding_dim,
             interleaved_rope=interleaved_rope,
+            mrope_position_ids=mrope_position_ids,
+            mrope_section=mrope_section,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
         )
@@ -582,6 +608,8 @@ def _add_decoder_layer(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    mrope_position_ids: trt.ITensor | None = None,
+    mrope_section: tuple[int, int, int] | None = None,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     eps: float | None = None,
@@ -608,6 +636,8 @@ def _add_decoder_layer(
         sin_half_tensor=sin_half_tensor,
         rotary_embedding_dim=rotary_embedding_dim,
         interleaved_rope=interleaved_rope,
+        mrope_position_ids=mrope_position_ids,
+        mrope_section=mrope_section,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
     )

--- a/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
@@ -162,6 +162,7 @@ def build_dual_profile_decoder_engine(
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
     embed_input: bool = False,
+    round_rope_inv_freq_to_bf16: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -227,6 +228,23 @@ def build_dual_profile_decoder_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    rope_scaling = config.raw.get("rope_scaling") or {}
+    raw_mrope_section = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict) else None)
+    mrope_section = (
+        tuple(int(value) for value in raw_mrope_section)
+        if raw_mrope_section is not None else None)
+    if mrope_section is not None:
+        if position_type != "rope":
+            raise ValueError("mRoPE requires position_type='rope'")
+        if len(mrope_section) != 3 or any(value <= 0 for value in mrope_section):
+            raise ValueError(
+                "rope_scaling.mrope_section must contain three positive integers")
+        if sum(mrope_section) != rotary_embedding_dim // 2:
+            raise ValueError(
+                "rope_scaling.mrope_section must sum to half the rotary dimension; "
+                f"got {mrope_section} for rotary dimension {rotary_embedding_dim}")
 
     builder_context = create_builder_context(
         verbose=verbose,
@@ -246,6 +264,9 @@ def build_dual_profile_decoder_engine(
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
+    mrope_position_ids = (
+        network.add_input("mrope_position_ids", trt.int32, (3, -1))
+        if mrope_section is not None else None)
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
     input_embed_tensor = None
     use_input_embed_tensor = None
@@ -288,6 +309,10 @@ def build_dual_profile_decoder_engine(
         min_sq = opt_sq if fixed else 1
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        if mrope_position_ids is not None:
+            prof.set_shape(
+                "mrope_position_ids",
+                (3, min_sq), (3, opt_sq), (3, max_sq))
         prof.set_shape(
             "attention_mask",
             (min_sq, max_cache_length + min_sq),
@@ -365,16 +390,29 @@ def build_dual_profile_decoder_engine(
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
         cos_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            round_inv_freq_to_bf16=round_rope_inv_freq_to_bf16)
         sin_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
-        cos_half_table = _const_in_work_dtype(
-            network, cos_half_np.shape, cos_half_np,
-            work_np_dtype, work_trt_dtype)
-        sin_half_table = _const_in_work_dtype(
-            network, sin_half_np.shape, sin_half_np,
-            work_np_dtype, work_trt_dtype)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            round_inv_freq_to_bf16=round_rope_inv_freq_to_bf16)
+        if round_rope_inv_freq_to_bf16:
+            cos_half_table = graph_ops.add_constant(
+                network, cos_half_np.shape, cos_half_np, dtype=np.float32)
+            sin_half_table = graph_ops.add_constant(
+                network, sin_half_np.shape, sin_half_np, dtype=np.float32)
+            if work_trt_dtype != trt.float32:
+                cos_half_table = network.add_cast(
+                    cos_half_table, work_trt_dtype).get_output(0)
+                sin_half_table = network.add_cast(
+                    sin_half_table, work_trt_dtype).get_output(0)
+        else:
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np,
+                work_np_dtype, work_trt_dtype)
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np,
+                work_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -527,16 +565,26 @@ def build_dual_profile_decoder_engine(
         # Position embedding (RoPE only; learned was applied above and ALiBi
         # is added into the attention mask).
         if position_type == "rope":
-            q = graph_ops.add_apply_rope_native(
-                network, q, num_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
-                rotary_embedding_dim, interleaved_rope,
-                sequence_length=None)
-            k = graph_ops.add_apply_rope_native(
-                network, k, num_kv_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
-                rotary_embedding_dim, interleaved_rope,
-                sequence_length=None)
+            if mrope_position_ids is not None and mrope_section is not None:
+                q = graph_ops.add_apply_mrope_native_sequence(
+                    network, q, num_heads, head_dim,
+                    cos_half_table, sin_half_table, mrope_position_ids,
+                    mrope_section, rotary_embedding_dim, interleaved_rope)
+                k = graph_ops.add_apply_mrope_native_sequence(
+                    network, k, num_kv_heads, head_dim,
+                    cos_half_table, sin_half_table, mrope_position_ids,
+                    mrope_section, rotary_embedding_dim, interleaved_rope)
+            else:
+                q = graph_ops.add_apply_rope_native(
+                    network, q, num_heads, head_dim,
+                    cos_half_table, sin_half_table, position_id,
+                    rotary_embedding_dim, interleaved_rope,
+                    sequence_length=None)
+                k = graph_ops.add_apply_rope_native(
+                    network, k, num_kv_heads, head_dim,
+                    cos_half_table, sin_half_table, position_id,
+                    rotary_embedding_dim, interleaved_rope,
+                    sequence_length=None)
 
         # Present K / V (this step's raw K / V), shape (Sq, attn_size).
         present_k_outs.append(k)

--- a/python/tensorrt_model_connect/families/lance/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/lance/graph_blocks.py
@@ -146,6 +146,8 @@ def add_attention_block(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    mrope_position_ids: trt.ITensor | None = None,
+    mrope_section: tuple[int, int, int] | None = None,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     sequence_length: int | None = 1,
@@ -222,14 +224,27 @@ def add_attention_block(
                 "TRT native IRotaryEmbeddingLayer")
         rope_dim = rotary_embedding_dim or head_dim
         rope_dim = graph_ops.validate_native_rope_dim(rope_dim)
-        q = graph_ops.add_apply_rope_native(
-            network, q, num_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope, sequence_length=sequence_length)
-        k = graph_ops.add_apply_rope_native(
-            network, k, num_kv_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope, sequence_length=sequence_length)
+        if mrope_position_ids is not None and mrope_section is not None:
+            if sequence_length != 1:
+                raise ValueError(
+                    "legacy mRoPE attention requires a single-token profile")
+            q = graph_ops.add_apply_mrope_native(
+                network, q, num_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, mrope_position_ids,
+                mrope_section, rope_dim, interleaved_rope)
+            k = graph_ops.add_apply_mrope_native(
+                network, k, num_kv_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, mrope_position_ids,
+                mrope_section, rope_dim, interleaved_rope)
+        else:
+            q = graph_ops.add_apply_rope_native(
+                network, q, num_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, position_id,
+                rope_dim, interleaved_rope, sequence_length=sequence_length)
+            k = graph_ops.add_apply_rope_native(
+                network, k, num_kv_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, position_id,
+                rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k

--- a/python/tensorrt_model_connect/families/lance/graph_ops.py
+++ b/python/tensorrt_model_connect/families/lance/graph_ops.py
@@ -681,6 +681,7 @@ def make_rope_table_half_dim(
     cosine: bool,
     partial_rotary_factor: float = 1.0,
     interleaved: bool = False,
+    round_inv_freq_to_bf16: bool = False,
 ) -> np.ndarray:
     """Build a RoPE cos/sin table of shape [max_cache_length, rotary_ndims // 2].
 
@@ -697,6 +698,9 @@ def make_rope_table_half_dim(
         partial_rotary_factor: Fraction of head dims that rotate (default 1.0).
         interleaved:      If True, adjacent-pair frequencies (CodeGen/GPT-J).
                           If False, half-split frequencies (LLaMA/Qwen).
+        round_inv_freq_to_bf16: Match Lance's official BF16 reference, whose
+            ``model.to(torch.bfloat16)`` call converts the registered
+            ``inv_freq`` buffer before positions are applied.
 
     Returns:
         Float32 array [max_cache_length, rotary_ndims // 2].
@@ -708,17 +712,27 @@ def make_rope_table_half_dim(
     if max_cache_length <= 0 or rope_theta <= 0.0:
         return np.full((max(max_cache_length, 1), max(half, 1)),
                        default, dtype=np.float32)
-    table = np.full((max_cache_length, half), default, dtype=np.float32)
-    for pos in range(max_cache_length):
-        for d in range(half):
-            # For both interleaved and rotate-half the frequency index is d
-            # (the distinction only affects which input pair is rotated; the
-            # freq assignment per half-dim is the same).
-            exponent = (2.0 * d) / rotary_ndims
-            inv_freq = rope_theta ** (-exponent)
-            angle = pos * inv_freq
-            table[pos, d] = np.cos(angle) if cosine else np.sin(angle)
-    return table
+    # Match PyTorch's default RoPE initialization in float32.  For both
+    # interleaved and rotate-half layouts the frequency index is ``d``; only
+    # the input pairing differs.
+    exponents = (
+        np.arange(0, rotary_ndims, 2, dtype=np.float32)
+        / np.float32(rotary_ndims)
+    )
+    inv_freq = np.float32(1.0) / np.power(
+        np.float32(rope_theta), exponents, dtype=np.float32)
+    if round_inv_freq_to_bf16:
+        # NumPy has no portable bfloat16 dtype.  Round float32 to BF16 using
+        # round-to-nearest-even, retain it as float32, and then calculate the
+        # phase exactly as the official reference does after model.to(bf16).
+        bits = inv_freq.view(np.uint32)
+        rounding_bias = np.uint32(0x7FFF) + ((bits >> 16) & np.uint32(1))
+        inv_freq = ((bits + rounding_bias) & np.uint32(0xFFFF0000)).view(
+            np.float32)
+    positions = np.arange(max_cache_length, dtype=np.float32)[:, None]
+    angles = positions * inv_freq[None, :]
+    return (np.cos(angles) if cosine else np.sin(angles)).astype(
+        np.float32, copy=False)
 
 
 def reshape_rows_to_heads_4d(
@@ -949,6 +963,96 @@ def add_apply_rope_native_sequence(
     )
     return reshape_heads_4d_to_rows(
         network, rope.get_output(0), attention_size, sequence_length)
+
+
+def add_apply_mrope_native(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    position_ids: trt.ITensor,
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    interleaved: bool = False,
+) -> trt.ITensor:
+    """Apply Lance/Qwen2.5-VL temporal/height/width RoPE to one token."""
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    sections = tuple(int(value) for value in mrope_section)
+    if len(sections) != 3 or any(value <= 0 for value in sections):
+        raise ValueError("mrope_section must contain three positive integers")
+    if sum(sections) != rotary_embedding_dim // 2:
+        raise ValueError(
+            "mrope_section must sum to half the rotary embedding dimension; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+
+    def build_cache(cache: trt.ITensor) -> trt.ITensor:
+        selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        offset = 0
+        parts = []
+        for axis, width in enumerate(sections):
+            part = network.add_slice(
+                selected, start=(axis, offset), shape=(1, width), stride=(1, 1))
+            parts.append(part.get_output(0))
+            offset += width
+        joined = network.add_concatenation(parts)
+        joined.axis = 1
+        shaped = network.add_shuffle(joined.get_output(0))
+        shaped.reshape_dims = (1, 1, rotary_embedding_dim // 2)
+        return shaped.get_output(0)
+
+    return add_apply_rope_native_sequence(
+        network, inp, num_heads, head_dim,
+        build_cache(cos_cache_2d), build_cache(sin_cache_2d),
+        rotary_embedding_dim, interleaved, sequence_length=1)
+
+
+def add_apply_mrope_native_sequence(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    position_ids: trt.ITensor,
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    interleaved: bool = False,
+) -> trt.ITensor:
+    """Apply Lance/Qwen2.5-VL mRoPE to a runtime-dynamic sequence."""
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    sections = tuple(int(value) for value in mrope_section)
+    if len(sections) != 3 or any(value <= 0 for value in sections):
+        raise ValueError("mrope_section must contain three positive integers")
+    half_dim = rotary_embedding_dim // 2
+    if sum(sections) != half_dim:
+        raise ValueError(
+            "mrope_section must sum to half the rotary embedding dimension; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+
+    def build_cache(cache: trt.ITensor) -> trt.ITensor:
+        selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        offset = 0
+        parts = []
+        for axis, width in enumerate(sections):
+            axis_index = add_constant(
+                network, (1,), np.array([axis], dtype=np.int32), dtype=np.int32)
+            axis_values = network.add_gather(selected, axis_index, 0).get_output(0)
+            column_indices = add_constant(
+                network, (width,), np.arange(offset, offset + width, dtype=np.int32),
+                dtype=np.int32)
+            part = network.add_gather(axis_values, column_indices, 2)
+            parts.append(part.get_output(0))
+            offset += width
+        joined = network.add_concatenation(parts)
+        joined.axis = 2
+        return joined.get_output(0)
+
+    return add_apply_rope_native_sequence(
+        network, inp, num_heads, head_dim,
+        build_cache(cos_cache_2d), build_cache(sin_cache_2d),
+        rotary_embedding_dim, interleaved, sequence_length=None)
 
 
 def _add_decomposed_attention_core(

--- a/python/tensorrt_model_connect/families/lance/plugin.py
+++ b/python/tensorrt_model_connect/families/lance/plugin.py
@@ -96,6 +96,7 @@ class LancePlugin:
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision,
             verbose=verbose, quant_ctx=quant_ctx, embed_input=True,
+            round_rope_inv_freq_to_bf16=(precision == "bf16"),
             debug_layer_outputs=debug_layer_outputs,
         )
 

--- a/src/runtime/models/lance/image_preprocessor.cpp
+++ b/src/runtime/models/lance/image_preprocessor.cpp
@@ -443,6 +443,56 @@ LancePreprocessedImage lance_load_and_preprocess_image(const std::string& image_
     return lance_preprocess_decoded_image(lance_decode_image_rgb(image_path), config);
 }
 
+LanceMropePositions lance_build_mrope_positions(const std::vector<int32_t>& input_ids,
+                                                int32_t image_token_id, int32_t num_image_features,
+                                                int32_t grid_height, int32_t grid_width) {
+    LanceMropePositions result;
+    result.token_positions.resize(input_ids.size());
+
+    const auto fill_text_positions = [&result, &input_ids]() {
+        for (std::size_t i = 0; i < input_ids.size(); ++i) {
+            const int32_t position = static_cast<int32_t>(i);
+            result.token_positions[i] = {position, position, position};
+        }
+        result.next_position = static_cast<int32_t>(input_ids.size());
+    };
+
+    const auto image_begin = std::find(input_ids.begin(), input_ids.end(), image_token_id);
+    const bool valid_grid =
+        grid_height > 0 && grid_width > 0 && grid_height * grid_width == num_image_features;
+    if (image_begin == input_ids.end() || !valid_grid) {
+        fill_text_positions();
+        return result;
+    }
+
+    const std::size_t image_offset =
+        static_cast<std::size_t>(std::distance(input_ids.begin(), image_begin));
+    const std::size_t image_end = image_offset + static_cast<std::size_t>(num_image_features);
+    if (image_end > input_ids.size()) {
+        fill_text_positions();
+        return result;
+    }
+
+    for (std::size_t i = 0; i < image_offset; ++i) {
+        const int32_t position = static_cast<int32_t>(i);
+        result.token_positions[i] = {position, position, position};
+    }
+
+    const int32_t vision_base = static_cast<int32_t>(image_offset);
+    for (int32_t i = 0; i < num_image_features; ++i) {
+        result.token_positions[image_offset + static_cast<std::size_t>(i)] = {
+            vision_base, vision_base + i / grid_width, vision_base + i % grid_width};
+    }
+
+    int32_t text_position = vision_base + std::max(grid_height, grid_width);
+    for (std::size_t i = image_end; i < input_ids.size(); ++i) {
+        result.token_positions[i] = {text_position, text_position, text_position};
+        ++text_position;
+    }
+    result.next_position = text_position;
+    return result;
+}
+
 std::string lance_format_prompt(const std::string& user_prompt,
                                 const LancePreprocessConfig& config) {
     // Build image_pads string: repeat image_token_str num_image_pad_tokens times

--- a/src/runtime/models/lance/image_preprocessor.h
+++ b/src/runtime/models/lance/image_preprocessor.h
@@ -7,6 +7,7 @@
 
 #include "runtime/models/lance/decoded_image.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -43,6 +44,17 @@ struct LancePreprocessedImage {
     int32_t width{0};
     bool ok{false};
 };
+
+struct LanceMropePositions {
+    std::vector<std::array<int32_t, 3>> token_positions;
+    int32_t next_position{0};
+};
+
+// Build the temporal/height/width positions used by Lance's Qwen2.5-VL
+// understanding decoder. grid_height/grid_width are post-merge dimensions.
+LanceMropePositions lance_build_mrope_positions(const std::vector<int32_t>& input_ids,
+                                                int32_t image_token_id, int32_t num_image_features,
+                                                int32_t grid_height, int32_t grid_width);
 
 // Load and preprocess a single image for the vision encoder.
 // Dispatches to the appropriate strategy based on config.preprocessor_type:

--- a/src/runtime/models/lance/kv_cache.cpp
+++ b/src/runtime/models/lance/kv_cache.cpp
@@ -126,6 +126,15 @@ void LanceKvCache::write_position_input(TensorMap& inputs, int32_t seq_len) {
     pos_t.shape = {static_cast<int64_t>(seq_len)};
     pos_t.dtype = DType::kInt32;
     inputs[names_.position_id] = pos_t;
+
+    if (has_mrope_position_input_ && seq_len == 1) {
+        mrope_pos_buf_.fill(position_);
+        Tensor mrope_t;
+        mrope_t.data = mrope_pos_buf_.data();
+        mrope_t.shape = {3};
+        mrope_t.dtype = DType::kInt32;
+        inputs["mrope_position_ids"] = mrope_t;
+    }
 }
 
 void LanceKvCache::write_batched_mask(TensorMap& inputs, int32_t seq_len) {
@@ -145,6 +154,41 @@ void LanceKvCache::write_batched_mask(TensorMap& inputs, int32_t seq_len) {
             mask_buf_[row + static_cast<std::size_t>(max_length_) + static_cast<std::size_t>(j)] =
                 0.0f;
     }
+    Tensor mask_t;
+    mask_t.data = mask_buf_.data();
+    mask_t.shape = {static_cast<int64_t>(seq_len), static_cast<int64_t>(kv_len)};
+    mask_t.dtype = DType::kFloat32;
+    inputs[names_.attention_mask] = mask_t;
+}
+
+void LanceKvCache::write_segmented_prefill_mask(TensorMap& inputs, int32_t seq_len,
+                                                int32_t block_start, int32_t block_end) {
+    block_start = std::max(0, std::min(block_start, seq_len));
+    block_end = std::max(block_start, std::min(block_end, seq_len));
+    if (block_start == block_end) {
+        write_batched_mask(inputs, seq_len);
+        return;
+    }
+
+    // Start from the standard causal prompt mask. Queries inside the visual
+    // block additionally see the entire visual block, matching Lance's
+    // official [causal, full, causal] segment contract.
+    const int32_t valid = std::max(0, std::min(position_, max_length_));
+    const int32_t kv_len = max_length_ + seq_len;
+    const std::size_t total = static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(kv_len);
+    mask_buf_.assign(total, kMaskedScore);
+    for (int32_t i = 0; i < seq_len; ++i) {
+        const std::size_t row = static_cast<std::size_t>(i) * static_cast<std::size_t>(kv_len);
+        for (int32_t j = 0; j < valid; ++j)
+            mask_buf_[row + static_cast<std::size_t>(j)] = 0.0F;
+        for (int32_t j = 0; j <= i; ++j)
+            mask_buf_[row + static_cast<std::size_t>(max_length_ + j)] = 0.0F;
+        if (i >= block_start && i < block_end) {
+            for (int32_t j = block_start; j < block_end; ++j)
+                mask_buf_[row + static_cast<std::size_t>(max_length_ + j)] = 0.0F;
+        }
+    }
+
     Tensor mask_t;
     mask_t.data = mask_buf_.data();
     mask_t.shape = {static_cast<int64_t>(seq_len), static_cast<int64_t>(kv_len)};
@@ -212,9 +256,19 @@ void LanceKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len
     write_bidirectional_mask(inputs, seq_len);
 }
 
+void LanceKvCache::prepare_prefill_with_bidirectional_block(TensorMap& inputs, int32_t seq_len,
+                                                            int32_t block_start,
+                                                            int32_t block_end) {
+    if (seq_len <= 0)
+        seq_len = 1;
+    write_position_input(inputs, seq_len);
+    write_segmented_prefill_mask(inputs, seq_len, block_start, block_end);
+}
+
 void LanceKvCache::bind_to(TrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    has_mrope_position_input_ = module.has_input("mrope_position_ids");
     // Enable dynamic row binding only when cache_k[0] itself is dynamic.
     // Static-shape engines with fixed [max_length, kv_dim] cache reject
     // setInputShape on cache inputs even when other inputs are dynamic.
@@ -242,6 +296,7 @@ void LanceKvCache::bind_to(TrtModule& module) {
 
 void LanceKvCache::bind_cache_inputs(TrtModule& module) {
     has_position_input_ = module.has_input(names_.position_id);
+    has_mrope_position_input_ = module.has_input("mrope_position_ids");
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
         module.bind_external(names_.cache_k[li], cache_k_[li].data());

--- a/src/runtime/models/lance/kv_cache.h
+++ b/src/runtime/models/lance/kv_cache.h
@@ -14,6 +14,7 @@
 #include "runtime/models/lance/inference_state.h"
 #include "trtmc/runtime/device_tensor.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -77,6 +78,11 @@ class LanceKvCache : public LanceInferenceState {
     // to one another while still seeing the valid prefix cache.
     void prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len);
 
+    // Prepare a causal prompt with one bidirectional sub-block. Lance's
+    // official x2t path uses this for the vision_start/image/vision_end span.
+    void prepare_prefill_with_bidirectional_block(TensorMap& inputs, int32_t seq_len,
+                                                  int32_t block_start, int32_t block_end);
+
     // Append batched present K/V at the current position. Used after causal
     // block verification in diffusion-style text decoders.
     void append_prefill_kv(const std::vector<const void*>& prefill_k,
@@ -98,6 +104,8 @@ class LanceKvCache : public LanceInferenceState {
     std::vector<int64_t> mask_shape_for_engine(int32_t mask_width, std::size_t mask_buf_size) const;
     void write_position_input(TensorMap& inputs, int32_t seq_len);
     void write_batched_mask(TensorMap& inputs, int32_t seq_len);
+    void write_segmented_prefill_mask(TensorMap& inputs, int32_t seq_len, int32_t block_start,
+                                      int32_t block_end);
     void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
     void write_decode_mask(TensorMap& inputs);
 
@@ -113,7 +121,9 @@ class LanceKvCache : public LanceInferenceState {
     // Buffers owned by this object — Tensor.data in prepare_step() points here.
     std::vector<float> mask_buf_;
     std::vector<int32_t> pos_buf_vec_;
+    std::array<int32_t, 3> mrope_pos_buf_{};
     bool has_position_input_{false};
+    bool has_mrope_position_input_{false};
     bool dynamic_binding_enabled_{false};
     int32_t bound_cache_rows_{0};
     DType cache_dtype_{DType::kFloat32};

--- a/src/runtime/models/lance/pipeline.cpp
+++ b/src/runtime/models/lance/pipeline.cpp
@@ -215,6 +215,37 @@ std::pair<int32_t, int32_t> find_lance_vision_attention_block(const std::vector<
     return {first_index - 1, last_index + 2};
 }
 
+struct LanceVlMropeContext {
+    bool enabled = false;
+    LanceMropePositions positions;
+
+    const LanceMropePositions* prefill_positions() const { return enabled ? &positions : nullptr; }
+
+    const std::array<int32_t, 3>* token_position(std::size_t index) const {
+        return enabled ? &positions.token_positions[index] : nullptr;
+    }
+
+    int32_t decode_position() const { return enabled ? positions.next_position : -1; }
+};
+
+LanceVlMropeContext make_lance_vl_mrope_context(const TrtModule& text_decoder,
+                                                const std::vector<int32_t>& input_ids,
+                                                int32_t image_token_id, int32_t num_features,
+                                                const LancePreprocessConfig& preprocess) {
+    LanceVlMropeContext context;
+    context.enabled = text_decoder.has_input("mrope_position_ids");
+    if (!context.enabled)
+        return context;
+
+    int32_t merged_grid = 0;
+    if (preprocess.patch_size > 0 && preprocess.merge_size > 0) {
+        merged_grid = preprocess.fixed_image_size / (preprocess.patch_size * preprocess.merge_size);
+    }
+    context.positions = lance_build_mrope_positions(input_ids, image_token_id, num_features,
+                                                    merged_grid, merged_grid);
+    return context;
+}
+
 void add_vl_prefill_base_inputs(TensorMap& inputs, LanceInferenceState& state,
                                 const std::vector<int32_t>& input_ids,
                                 VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
@@ -519,30 +550,22 @@ std::vector<int32_t> LancePipeline::generate_vl_from_ids(
     reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
-    const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
-    const int32_t merged_grid = vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
-                                    ? vl_preprocess_.fixed_image_size /
-                                          (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
-                                    : 0;
-    const auto mrope = use_mrope
-                           ? lance_build_mrope_positions(input_ids, config_.image_token_id,
-                                                         num_features, merged_grid, merged_grid)
-                           : LanceMropePositions{};
+    const auto mrope = make_lance_vl_mrope_context(
+        *text_decoder_, input_ids, config_.image_token_id, num_features, vl_preprocess_);
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
-                                feature_dim, use_mrope ? &mrope : nullptr, logits)) {
+                                feature_dim, mrope.prefill_positions(), logits)) {
         int32_t feature_index = 0;
         for (std::size_t index = 0; index < input_ids.size(); ++index) {
             const auto tid = input_ids[index];
-            const auto* position = use_mrope ? &mrope.token_positions[index] : nullptr;
             run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                                 feature_index, position, logits);
+                                 feature_index, mrope.token_position(index), logits);
         }
     }
     state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens,
-                       use_mrope ? mrope.next_position : -1);
+                       mrope.decode_position());
     return output;
 }
 

--- a/src/runtime/models/lance/pipeline.cpp
+++ b/src/runtime/models/lance/pipeline.cpp
@@ -197,6 +197,24 @@ bool valid_vl_features(const std::vector<float>& image_features, int32_t num_fea
     return image_features.size() >= required;
 }
 
+std::pair<int32_t, int32_t> find_lance_vision_attention_block(const std::vector<int32_t>& input_ids,
+                                                              int32_t image_token_id) {
+    const auto first = std::find(input_ids.begin(), input_ids.end(), image_token_id);
+    if (first == input_ids.end())
+        return {-1, -1};
+    auto last = first;
+    while (last + 1 != input_ids.end() && *(last + 1) == image_token_id)
+        ++last;
+
+    const auto first_index = static_cast<int32_t>(std::distance(input_ids.begin(), first));
+    const auto last_index = static_cast<int32_t>(std::distance(input_ids.begin(), last));
+    // The official full-attention segment includes vision_start and
+    // vision_end around the contiguous image placeholder run.
+    if (first_index == 0 || last_index + 1 >= static_cast<int32_t>(input_ids.size()))
+        return {-1, -1};
+    return {first_index - 1, last_index + 2};
+}
+
 void add_vl_prefill_base_inputs(TensorMap& inputs, LanceInferenceState& state,
                                 const std::vector<int32_t>& input_ids,
                                 VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
@@ -227,6 +245,25 @@ bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
                               {sequence_length, feature_dim},
                               DType::kFloat32};
     }
+    return true;
+}
+
+bool add_lance_mrope_prefill_input(TrtModule& prefill, const std::vector<int32_t>& input_ids,
+                                   const LanceMropePositions* mrope, int32_t sequence_length,
+                                   std::vector<int32_t>& positions, TensorMap& inputs) {
+    if (!prefill.has_input("mrope_position_ids"))
+        return true;
+    if (mrope == nullptr || mrope->token_positions.size() != input_ids.size())
+        return false;
+    positions.resize(static_cast<std::size_t>(3 * sequence_length));
+    for (int32_t token_index = 0; token_index < sequence_length; ++token_index) {
+        for (int32_t axis = 0; axis < 3; ++axis) {
+            positions[static_cast<std::size_t>(axis * sequence_length + token_index)] =
+                mrope->token_positions[static_cast<std::size_t>(token_index)]
+                                      [static_cast<std::size_t>(axis)];
+        }
+    }
+    inputs["mrope_position_ids"] = Tensor{positions.data(), {3, sequence_length}, DType::kInt32};
     return true;
 }
 
@@ -482,24 +519,37 @@ std::vector<int32_t> LancePipeline::generate_vl_from_ids(
     reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
+    const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
+    const int32_t merged_grid = vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
+                                    ? vl_preprocess_.fixed_image_size /
+                                          (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
+                                    : 0;
+    const auto mrope = use_mrope
+                           ? lance_build_mrope_positions(input_ids, config_.image_token_id,
+                                                         num_features, merged_grid, merged_grid)
+                           : LanceMropePositions{};
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
-                                feature_dim, logits)) {
+                                feature_dim, use_mrope ? &mrope : nullptr, logits)) {
         int32_t feature_index = 0;
-        for (const auto& tid : input_ids)
+        for (std::size_t index = 0; index < input_ids.size(); ++index) {
+            const auto tid = input_ids[index];
+            const auto* position = use_mrope ? &mrope.token_positions[index] : nullptr;
             run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                                 feature_index, logits);
+                                 feature_index, position, logits);
+        }
     }
     state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
-    run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
+    run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens,
+                       use_mrope ? mrope.next_position : -1);
     return output;
 }
 
 bool LancePipeline::run_vl_prefill_batched(
     const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
     const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
-    int32_t feature_dim, std::vector<float>& logits) {
+    int32_t feature_dim, const LanceMropePositions* mrope, std::vector<float>& logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     auto* kv_cache =
         eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
@@ -515,6 +565,13 @@ bool LancePipeline::run_vl_prefill_batched(
 
     TensorMap inputs;
     add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    const auto [vision_start, vision_end] =
+        find_lance_vision_attention_block(input_ids, config_.image_token_id);
+    if (vision_start >= 0)
+        kv_cache->prepare_prefill_with_bidirectional_block(inputs, sq, vision_start, vision_end);
+    std::vector<int32_t> mrope_positions;
+    if (!add_lance_mrope_prefill_input(*prefill_, input_ids, mrope, sq, mrope_positions, inputs))
+        return false;
     if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
         return false;
 
@@ -533,10 +590,12 @@ bool LancePipeline::run_vl_prefill_batched(
 void LancePipeline::run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                                          const std::vector<std::vector<float>>& deepstack_features,
                                          int32_t num_features, int32_t feature_dim,
-                                         int32_t& feature_index, std::vector<float>& logits) {
+                                         int32_t& feature_index,
+                                         const std::array<int32_t, 3>* mrope_position,
+                                         std::vector<float>& logits) {
     const bool use_image_embed = token_id == config_.image_token_id && feature_index < num_features;
     if (!use_image_embed) {
-        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
+        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, mrope_position, logits);
         return;
     }
 
@@ -545,31 +604,42 @@ void LancePipeline::run_vl_prefill_token(int32_t token_id, const std::vector<flo
     const auto deepstack_embeds =
         select_deepstack_feature_pointers(deepstack_features, feature_index, feature_dim);
     run_text_step_with_embed(token_id, embed, 1.0F, deepstack_embeds,
-                             deepstack_embeds.empty() ? 0.0F : 1.0F, logits);
+                             deepstack_embeds.empty() ? 0.0F : 1.0F, mrope_position, logits);
     ++feature_index;
 }
 
 void LancePipeline::run_vl_decode_loop(LanceISampler* sampler, const LanceSamplingParams& params,
                                        std::vector<int32_t>& output, std::vector<float>& logits,
-                                       int32_t max_new_tokens) {
+                                       int32_t max_new_tokens, int32_t mrope_position) {
     const int32_t vocab_size = static_cast<int32_t>(logits.size());
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         LanceSampleResult result = sampler->sample(logits.data(), vocab_size, params);
         output.push_back(result.token_id);
         if (result.is_eos)
             break;
-        run_text_step(result.token_id, logits);
+        run_text_step(result.token_id, logits, mrope_position);
+        if (mrope_position >= 0)
+            ++mrope_position;
     }
 }
 
-void LancePipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
+void LancePipeline::run_text_step(int32_t token_id, std::vector<float>& logits,
+                                  int32_t mrope_position) {
+    if (mrope_position < 0 || !text_decoder_->has_input("mrope_position_ids")) {
+        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, nullptr, logits);
+        return;
+    }
+    std::array<int32_t, 3> position{};
+    position.fill(mrope_position);
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, &position, logits);
 }
 
 void LancePipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
                                              float use_input_embed,
                                              const std::vector<const float*>& deepstack_embeds,
-                                             float deepstack_active, std::vector<float>& logits) {
+                                             float deepstack_active,
+                                             const std::array<int32_t, 3>* mrope_position,
+                                             std::vector<float>& logits) {
     TensorMap inputs;
 
     Tensor token_t;
@@ -579,6 +649,11 @@ void LancePipeline::run_text_step_with_embed(int32_t token_id, const float* inpu
     inputs["token_id"] = token_t;
 
     state_->prepare_step(inputs);
+
+    if (mrope_position != nullptr && text_decoder_->has_input("mrope_position_ids")) {
+        inputs["mrope_position_ids"] =
+            Tensor{const_cast<int32_t*>(mrope_position->data()), {3}, DType::kInt32};
+    }
 
     std::vector<float> zero_embed;
     std::vector<float> zero_deepstack;

--- a/src/runtime/models/lance/pipeline.h
+++ b/src/runtime/models/lance/pipeline.h
@@ -97,24 +97,27 @@ class LancePipeline final : public IPipeline {
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
+                              const std::array<int32_t, 3>* mrope_position,
                               std::vector<float>& logits);
 
     bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
                                 const std::vector<float>& image_features,
                                 const std::vector<std::vector<float>>& deepstack_features,
                                 int32_t num_features, int32_t feature_dim,
-                                std::vector<float>& logits);
+                                const LanceMropePositions* mrope, std::vector<float>& logits);
 
     void run_vl_decode_loop(LanceISampler* sampler, const LanceSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,
-                            int32_t max_new_tokens);
+                            int32_t max_new_tokens, int32_t mrope_position = -1);
 
-    void run_text_step(int32_t token_id, std::vector<float>& logits);
+    void run_text_step(int32_t token_id, std::vector<float>& logits, int32_t mrope_position = -1);
 
     // Run a text step with optional vision embedding override.
     void run_text_step_with_embed(int32_t token_id, const float* input_embed, float use_input_embed,
                                   const std::vector<const float*>& deepstack_embeds,
-                                  float deepstack_active, std::vector<float>& logits);
+                                  float deepstack_active,
+                                  const std::array<int32_t, 3>* mrope_position,
+                                  std::vector<float>& logits);
 
     // Run vision encoder on preprocessed image inputs.
     bool run_vision_encoder(const LancePreprocessedImage& preprocessed,

--- a/tests/cpp/models/lance/test_lance_vl_pipeline.cpp
+++ b/tests/cpp/models/lance/test_lance_vl_pipeline.cpp
@@ -61,12 +61,15 @@ struct CountingTextStats {
     int32_t calls{0};
     std::unordered_map<std::string, std::vector<int64_t>> shapes;
     std::unordered_map<std::string, std::vector<float>> float_values;
+    std::unordered_map<std::string, std::vector<int32_t>> int_values;
 };
 
 class CountingTextModule final : public trtmc::ITrtModule {
   public:
-    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream,
+                       bool has_mrope_input = false)
         : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          has_mrope_input_(has_mrope_input),
           present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
                              : trtmc::DeviceTensor{}),
           present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
@@ -76,12 +79,17 @@ class CountingTextModule final : public trtmc::ITrtModule {
         ++stats_->calls;
         stats_->shapes.clear();
         stats_->float_values.clear();
+        stats_->int_values.clear();
         for (const auto& [name, tensor] : inputs) {
             stats_->shapes[name] = tensor.shape;
             if (tensor.dtype == trtmc::DType::kFloat32) {
                 const auto* begin = static_cast<const float*>(tensor.data);
                 stats_->float_values[name] =
                     std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            } else if (tensor.dtype == trtmc::DType::kInt32) {
+                const auto* begin = static_cast<const int32_t*>(tensor.data);
+                stats_->int_values[name] = std::vector<int32_t>(
+                    begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
             }
         }
         return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
@@ -99,7 +107,8 @@ class CountingTextModule final : public trtmc::ITrtModule {
     bool has_input(const std::string& name) const override {
         return name == "token_id" || name == "position_id" || name == "attention_mask" ||
                name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
-               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0" ||
+               (name == "mrope_position_ids" && has_mrope_input_);
     }
     bool has_output(const std::string& name) const override {
         return name == "logits" || name == "present_k_0" || name == "present_v_0";
@@ -134,6 +143,7 @@ class CountingTextModule final : public trtmc::ITrtModule {
     std::shared_ptr<CountingTextStats> stats_;
     bool prefill_{false};
     cudaStream_t stream_{nullptr};
+    bool has_mrope_input_{false};
     mutable trtmc::DeviceTensor present_k_;
     mutable trtmc::DeviceTensor present_v_;
     std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
@@ -141,10 +151,16 @@ class CountingTextModule final : public trtmc::ITrtModule {
 
 class FakeSequenceVisionModule final : public trtmc::ITrtModule {
   public:
+    explicit FakeSequenceVisionModule(int32_t feature_count = 1)
+        : feature_count_(feature_count),
+          features_(static_cast<std::size_t>(feature_count) * 4, 1.0F),
+          deepstack_(static_cast<std::size_t>(feature_count) * 4, 2.0F) {}
+
     trtmc::TensorMap forward(const trtmc::TensorMap&) override {
-        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+        return {{"image_features",
+                 trtmc::Tensor{features_.data(), {feature_count_, 4}, trtmc::DType::kFloat32}},
                 {"deepstack_features_0",
-                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+                 trtmc::Tensor{deepstack_.data(), {feature_count_, 4}, trtmc::DType::kFloat32}}};
     }
     trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
     void forward_device_async(const trtmc::DeviceTensorMap&) override {}
@@ -177,8 +193,9 @@ class FakeSequenceVisionModule final : public trtmc::ITrtModule {
     void keep_alive(std::shared_ptr<void>) override {}
 
   private:
-    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
-    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+    int32_t feature_count_{1};
+    std::vector<float> features_;
+    std::vector<float> deepstack_;
 };
 
 // ---------------------------------------------------------------------------
@@ -187,6 +204,16 @@ class FakeSequenceVisionModule final : public trtmc::ITrtModule {
 class VLFixedTokenizer : public trtmc::ITokenizer {
   public:
     std::vector<int32_t> encode(const std::string&) const override { return {1, 2, 3}; }
+    std::string decode(const std::vector<int32_t>&) const override { return "out"; }
+    int32_t id_for_token(std::string_view) const override { return 0; }
+    std::string token_for_id(int32_t) const override { return ""; }
+};
+
+class VLBlockTokenizer : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override {
+        return {9, 8, 1, 1, 1, 1, 7, 6};
+    }
     std::string decode(const std::vector<int32_t>&) const override { return "out"; }
     int32_t id_for_token(std::string_view) const override { return 0; }
     std::string token_for_id(int32_t) const override { return ""; }
@@ -758,6 +785,65 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_full_attention_for_vision_block() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream, true);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream, true);
+    auto vision = std::make_unique<FakeSequenceVisionModule>(4);
+    auto cache = std::make_unique<trtmc::LanceKvCache>(1, 8, 4, stream);
+
+    trtmc::LanceConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::LancePreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.patch_size = 1;
+    vl_pp.merge_size = 2;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLBlockTokenizer>();
+    trtmc::LancePipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                  vl_pp, stream, tokenizer, "", nullptr, std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    const auto& mask = prefill_stats->float_values["attention_mask"];
+    constexpr int32_t width = 16;
+    auto value = [&mask](int32_t row, int32_t column) {
+        return mask[static_cast<std::size_t>(row * width + column)];
+    };
+    check(prefill_stats->shapes["attention_mask"] == std::vector<int64_t>({8, width}),
+          "vision block mask: shape");
+    check(value(0, 9) < -1000.0F, "vision block mask: causal prefix remains causal");
+    check(value(1, 14) == 0.0F, "vision block mask: first vision query sees block future");
+    check(value(1, 15) < -1000.0F, "vision block mask: vision query cannot see later text");
+    check(value(6, 9) == 0.0F, "vision block mask: vision end sees block start");
+    check(value(7, 15) == 0.0F, "vision block mask: later text remains causal");
+    check(prefill_stats->shapes["mrope_position_ids"] == std::vector<int64_t>({3, 8}),
+          "vision mrope: shape");
+    check(prefill_stats->int_values["mrope_position_ids"] ==
+              std::vector<int32_t>(
+                  {0, 1, 2, 2, 2, 2, 4, 5, 0, 1, 2, 2, 3, 3, 4, 5, 0, 1, 2, 3, 2, 3, 4, 5}),
+          "vision mrope: temporal height width positions");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -807,6 +893,7 @@ int main() {
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
     test_vl_sequence_prefill_uses_one_text_launch();
+    test_vl_sequence_prefill_uses_full_attention_for_vision_block();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/e2e/models/lance/test_lance_builder.py
+++ b/tests/e2e/models/lance/test_lance_builder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import importlib
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
@@ -29,6 +30,52 @@ def test_lance_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> No
 
     assert result == b"lance-dual-profile-plan"
     assert calls["build"][3]["embed_input"] is True
+
+
+def test_lance_bf16_build_rounds_rope_inv_freq_like_official_reference(
+    monkeypatch,
+) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.lance.plugin")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["kwargs"] = kwargs
+        return b"lance-bf16-plan"
+
+    monkeypatch.setattr(module, "build_standard_decoder_engine", fake_build)
+    result = module.LancePlugin().build_engine(
+        SimpleNamespace(), {}, 512, precision="bf16")
+
+    assert result == b"lance-bf16-plan"
+    assert calls["kwargs"]["round_rope_inv_freq_to_bf16"] is True
+
+
+def test_lance_rope_table_can_match_bf16_inv_freq_buffer() -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.lance.graph_ops")
+    regular = module.make_rope_table_half_dim(
+        388, 128, 1_000_000.0, True)
+    official_bf16 = module.make_rope_table_half_dim(
+        388,
+        128,
+        1_000_000.0,
+        True,
+        round_inv_freq_to_bf16=True,
+    )
+
+    # Position zero is invariant; later positions expose the BF16 frequency
+    # quantization performed by the official reference's model.to(bfloat16).
+    np.testing.assert_array_equal(official_bf16[0], regular[0])
+    assert np.max(np.abs(official_bf16[387] - regular[387])) > 0.25
+    np.testing.assert_allclose(
+        official_bf16[387, :4],
+        np.array(
+            [-0.83420676, -0.92246085, 0.92788374, 0.06237314],
+            dtype=np.float32,
+        ),
+        atol=1e-6,
+    )
 
 
 def test_lance_vl_config_matches_official_x2t_image_framing() -> None:


### PR DESCRIPTION
## Summary

- match the official Lance BF16 rotary-frequency conversion
- apply bidirectional attention within the visual token segment
- generate and bind Lance temporal/height/width mRoPE positions
- cover the segmented mask, mRoPE positions, and BF16 RoPE contract

## Root cause

TRTMC and the pinned official Lance reference used the same checkpoint, image
tensor, prompt tokens, BF16 precision, and deterministic decoding. The decoder
still differed in three model semantics:

1. The official model converts its registered `inv_freq` buffer to BF16 before
   computing RoPE phases; TRTMC retained the original FP32 frequencies.
2. The official x2t path gives the visual segment full attention while keeping
   text causal; TRTMC used a causal mask for the entire prompt.
3. The official Qwen2.5-VL decoder applies temporal/height/width mRoPE to image
   tokens; TRTMC used one linear position axis.

## Verification

- Lance model-owned user contract: 1 passed
- `trtmc-validate`: 5/5 MMMU-Pro Vision samples agree with the official reference
- `trtmc-bench`: default case completed (1 warmup, 10 measured iterations)
- Lance C++ pipeline regression test passed
- Lance builder/manifest/preparation tests: 7 passed
- C++ formatting and `git diff --check` passed

Fixes #766
