### PR TITLE
[Accuracy] Align FLUX scheduling and text conditioning

### DIFF
--- a/python/tensorrt_model_connect/families/flux/mistral_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/flux/mistral_encoder_builder.py
@@ -27,6 +27,24 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 
+# Transformers Mistral applies ``rotate_half`` (first half paired with the
+# second half), not adjacent-pair GPT-J/CodeGen RoPE.
+_MISTRAL_ROPE_INTERLEAVED = False
+
+
+def _decoder_layers_for_hidden_states(
+    hidden_state_indices: list[int] | tuple[int, ...], num_layers: int
+) -> tuple[int, ...]:
+    """Map Transformers hidden-state indices to decoder-layer indices."""
+    indices = tuple(int(index) for index in hidden_state_indices)
+    if any(index < 1 or index > num_layers for index in indices):
+        raise ValueError(
+            "Mistral hidden-state indices must be between 1 and "
+            f"num_layers={num_layers}, got {indices}"
+        )
+    return tuple(index - 1 for index in indices)
+
+
 trt = trt_compat.get_trt()
 
 if TYPE_CHECKING:
@@ -159,9 +177,8 @@ def build_mistral_encoder_engine(
 ) -> bytes:
     """Build Mistral 3 encoder TRT engine plan.
 
-    Runs all layers as a single forward pass with bidirectional attention
-    (no causal mask).  Extracts hidden states from specified layers and
-    concatenates them along the feature dimension.
+    Runs all layers as a single causal forward pass. Extracts hidden states
+    from specified layers and concatenates them along the feature dimension.
 
     Args:
         weights: Weight dict from load_mistral_encoder_weights.
@@ -173,22 +190,27 @@ def build_mistral_encoder_engine(
         num_layers: Number of transformer layers.
         vocab_size: Vocabulary size.
         max_seq_len: Maximum input sequence length.
-        extract_layers: Layer indices (0-based) whose hidden states are
-            extracted and concatenated for the output.
+        extract_layers: Transformers ``hidden_states`` indices whose tensors
+            are extracted and concatenated. Hidden state 0 is the embedding
+            input, so hidden state N is the output of decoder layer N - 1.
         eps: RMSNorm epsilon.
         verbose: Enable TRT builder verbose logging.
 
     Returns:
         Serialized TRT engine plan bytes.
     """
+    decoder_extract_layers = _decoder_layers_for_hidden_states(
+        extract_layers, num_layers)
     q_size = num_heads * head_dim
     kv_size = num_kv_heads * head_dim
     concat_dim = len(extract_layers) * hidden_size
 
     rope_cos_half_np = graph_ops.make_rope_table_half_dim(
-        max_seq_len, head_dim, rope_theta, True, interleaved=True)
+        max_seq_len, head_dim, rope_theta, True,
+        interleaved=_MISTRAL_ROPE_INTERLEAVED)
     rope_sin_half_np = graph_ops.make_rope_table_half_dim(
-        max_seq_len, head_dim, rope_theta, False, interleaved=True)
+        max_seq_len, head_dim, rope_theta, False,
+        interleaved=_MISTRAL_ROPE_INTERLEAVED)
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -309,11 +331,13 @@ def build_mistral_encoder_engine(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             rope_cos_half, rope_sin_half, rope_position_ids,
-            head_dim, interleaved=True, sequence_length=max_seq_len)
+            head_dim, interleaved=_MISTRAL_ROPE_INTERLEAVED,
+            sequence_length=max_seq_len)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             rope_cos_half, rope_sin_half, rope_position_ids,
-            head_dim, interleaved=True, sequence_length=max_seq_len)
+            head_dim, interleaved=_MISTRAL_ROPE_INTERLEAVED,
+            sequence_length=max_seq_len)
 
         context_flat = graph_ops.add_attention_from_rows(
             network,
@@ -379,7 +403,7 @@ def build_mistral_encoder_engine(
             trt.ElementWiseOperation.SUM).get_output(0)
 
         # Extract hidden state if this layer is in the extraction list
-        if layer_idx in extract_layers:
+        if layer_idx in decoder_extract_layers:
             extracted.append(hidden)
 
     # --- Final RMSNorm ---

--- a/python/tensorrt_model_connect/families/flux/plugin.py
+++ b/python/tensorrt_model_connect/families/flux/plugin.py
@@ -855,9 +855,19 @@ class FluxPlugin:
     def diffusion_tokenizer_add_special_tokens(
         self, model_dir_path, *, detect_tokenizer_add_special_tokens,
     ) -> bool:
+        import json
         from pathlib import Path
 
         model_dir = Path(model_dir_path)
+        transformer_config = model_dir / "transformer" / "config.json"
+        if transformer_config.exists():
+            try:
+                if _is_flux2(json.loads(transformer_config.read_text())):
+                    # The FLUX.2 chat template already contains its BOS token.
+                    # Applying the tokenizer post-processor adds a second BOS.
+                    return False
+            except (OSError, ValueError, TypeError):
+                pass
         for tok_subdir in ("tokenizer_2", "tokenizer"):
             tok_dir = model_dir / tok_subdir
             if tok_dir.is_dir():

--- a/python/tensorrt_model_connect/families/flux/plugin.py
+++ b/python/tensorrt_model_connect/families/flux/plugin.py
@@ -183,12 +183,20 @@ class FluxPlugin:
         if transformer_config_path.exists():
             tc = json.loads(transformer_config_path.read_text())
             weights["_transformer_config"] = tc
+            config.raw["_transformer_config"] = tc
 
         # Read VAE config for latent_channels and patch_size
         vae_config_path = model_path / "vae" / "config.json"
         if vae_config_path.exists():
             vc = json.loads(vae_config_path.read_text())
             weights["_vae_config"] = vc
+            config.raw["_vae_config"] = vc
+
+        scheduler_config_path = model_path / "scheduler" / "scheduler_config.json"
+        if scheduler_config_path.exists():
+            scheduler_config = json.loads(scheduler_config_path.read_text())
+            weights["_scheduler_config"] = scheduler_config
+            config.raw["_scheduler_config"] = scheduler_config
 
         # Read text_encoder config for Mistral detection
         te_config_path = model_path / "text_encoder" / "config.json"
@@ -910,6 +918,7 @@ class FluxPlugin:
     def _get_flux1_diffusion_config(self, config: ModelConfig, tc: dict) -> dict:
         """Diffusion config for FLUX.1 variants."""
         guidance_embeds = tc.get("guidance_embeds", False)
+        scheduler = config.raw.get("_scheduler_config", {})
 
         img_h = config.raw.get("image_height", self._IMAGE_HEIGHT)
         img_w = config.raw.get("image_width", self._IMAGE_WIDTH)
@@ -920,10 +929,16 @@ class FluxPlugin:
             "num_inference_steps": config.raw.get(
                 "num_inference_steps", 28 if guidance_embeds else 4),
             "guidance_scale": 3.5 if guidance_embeds else 0.0,
-            "flow_shift": 3.0,
-            "use_dynamic_shifting": 1,
-            "base_shift": 0.5,
-            "max_shift": 1.15,
+            "flow_shift": float(scheduler.get("shift", 1.0)),
+            "use_dynamic_shifting": int(bool(
+                scheduler.get("use_dynamic_shifting", False))),
+            "base_shift": float(scheduler.get("base_shift", 0.5)),
+            "max_shift": float(scheduler.get("max_shift", 1.15)),
+            "base_image_seq_len": int(
+                scheduler.get("base_image_seq_len", 256)),
+            "max_image_seq_len": int(
+                scheduler.get("max_image_seq_len", 4096)),
+            "shift_terminal": float(scheduler.get("shift_terminal") or 0.0),
             "image_height": img_h,
             "image_width": img_w,
             "video_height": img_h,
@@ -952,6 +967,7 @@ class FluxPlugin:
         """Diffusion config for FLUX.2 variants."""
         img_h = config.raw.get("image_height", self._IMAGE_HEIGHT)
         img_w = config.raw.get("image_width", self._IMAGE_WIDTH)
+        scheduler = config.raw.get("_scheduler_config", {})
 
         vc = config.raw.get("_vae_config", {})
         vae_latent_ch = vc.get("latent_channels", self._FLUX2_VAE_LATENT_CHANNELS)
@@ -966,10 +982,16 @@ class FluxPlugin:
             "scheduler": "flow_match_euler",
             "num_inference_steps": config.raw.get("num_inference_steps", 28),
             "guidance_scale": 3.5,
-            "flow_shift": 3.0,
-            "use_dynamic_shifting": 1,
-            "base_shift": 0.5,
-            "max_shift": 1.15,
+            "flow_shift": float(scheduler.get("shift", 3.0)),
+            "use_dynamic_shifting": int(bool(
+                scheduler.get("use_dynamic_shifting", True))),
+            "base_shift": float(scheduler.get("base_shift", 0.5)),
+            "max_shift": float(scheduler.get("max_shift", 1.15)),
+            "base_image_seq_len": int(
+                scheduler.get("base_image_seq_len", 256)),
+            "max_image_seq_len": int(
+                scheduler.get("max_image_seq_len", 4096)),
+            "shift_terminal": float(scheduler.get("shift_terminal") or 0.0),
             "image_height": img_h,
             "image_width": img_w,
             "video_height": img_h,

--- a/python/tensorrt_model_connect/families/flux/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/flux/tests/test_family.py
@@ -73,27 +73,38 @@ def test_matches_and_build_engine_not_supported() -> None:
         plugin.build_engine(_cfg(), {}, 16)
 
 
-def test_load_weights_reads_optional_dirs_and_transformer_config(tmp_path) -> None:
-    """Intent: cover load_weights success branch with optional subdirs and config JSON.
+def test_load_weights_reads_component_configs(tmp_path) -> None:
+    """Intent: cover load_weights success branch with component config JSON.
 
-    Preconditions: model_index.json, transformer/config.json, and selected subdirs exist.
-    Postconditions: output WeightDict includes discovered directories and parsed transformer config.
+    Preconditions: model index and component configs exist.
+    Postconditions: weights and runtime config retain checkpoint-owned component settings.
     """
     model_dir = tmp_path / "flux"
     (model_dir / "transformer").mkdir(parents=True)
     (model_dir / "text_encoder").mkdir(parents=True)
     (model_dir / "vae").mkdir(parents=True)
+    (model_dir / "scheduler").mkdir(parents=True)
     (model_dir / "model_index.json").write_text("{}")
     (model_dir / "transformer" / "config.json").write_text(
         json.dumps({"num_attention_heads": 3, "guidance_embeds": True})
     )
+    (model_dir / "vae" / "config.json").write_text(
+        json.dumps({"latent_channels": 16})
+    )
+    (model_dir / "scheduler" / "scheduler_config.json").write_text(
+        json.dumps({"shift": 1.0, "use_dynamic_shifting": False})
+    )
 
-    weights = flux_mod.plugin.load_weights(str(model_dir), _cfg())
+    config = _cfg()
+    weights = flux_mod.plugin.load_weights(str(model_dir), config)
 
     assert weights["_model_format"] == "diffusers"
     assert "_text_encoder_dir" in weights
     assert "_text_encoder_2_dir" not in weights
     assert weights["_transformer_config"]["num_attention_heads"] == 3
+    assert weights["_vae_config"]["latent_channels"] == 16
+    assert weights["_scheduler_config"]["shift"] == 1.0
+    assert config.raw["_scheduler_config"]["use_dynamic_shifting"] is False
     assert weights["_vae_dir"].endswith("vae")
 
 
@@ -1023,6 +1034,31 @@ def test_get_diffusion_config_guidance_toggle() -> None:
     assert fast["num_inference_steps"] == 4
     assert fast["guidance_scale"] == 0.0
     assert fast["guidance_embeds"] == 0
+
+
+def test_get_diffusion_config_uses_checkpoint_scheduler() -> None:
+    """Intent: preserve the checkpoint's FlowMatchEuler trajectory.
+
+    Preconditions: FLUX.1-schnell declares its shipped scheduler settings.
+    Postconditions: the bundle config does not substitute Flux.2 shifting.
+    """
+    config = _cfg(
+        _transformer_config={"guidance_embeds": False},
+        _scheduler_config={
+            "shift": 1.0,
+            "use_dynamic_shifting": False,
+            "base_image_seq_len": 128,
+            "max_image_seq_len": 2048,
+        },
+    )
+
+    diffusion = flux_mod.plugin.get_diffusion_config(config)
+
+    assert diffusion["flow_shift"] == 1.0
+    assert diffusion["use_dynamic_shifting"] == 0
+    assert diffusion["base_image_seq_len"] == 128
+    assert diffusion["max_image_seq_len"] == 2048
+    assert diffusion["shift_terminal"] == 0.0
 
 
 def test_serialize_flux_preprocessor_guidance_key_control() -> None:

--- a/python/tensorrt_model_connect/families/flux/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/flux/tests/test_family.py
@@ -56,6 +56,46 @@ def _decode_blob(blob: bytes) -> tuple[dict[str, dict], bytes]:
     return index, payload
 
 
+def test_mistral_hidden_state_indices_map_to_preceding_decoder_layers() -> None:
+    from tensorrt_model_connect.families.flux.mistral_encoder_builder import (
+        _MISTRAL_ROPE_INTERLEAVED,
+        _decoder_layers_for_hidden_states,
+    )
+
+    assert _decoder_layers_for_hidden_states((10, 20, 30), 40) == (9, 19, 29)
+    assert _MISTRAL_ROPE_INTERLEAVED is False
+    with pytest.raises(ValueError, match="between 1 and num_layers=40"):
+        _decoder_layers_for_hidden_states((0, 20, 30), 40)
+
+
+def test_flux2_chat_template_does_not_add_a_second_bos(tmp_path) -> None:
+    transformer = tmp_path / "transformer"
+    transformer.mkdir()
+    (transformer / "config.json").write_text(
+        json.dumps({"_class_name": "Flux2Transformer2DModel"})
+    )
+
+    assert not flux_mod.plugin.diffusion_tokenizer_add_special_tokens(
+        tmp_path,
+        detect_tokenizer_add_special_tokens=lambda _path: True,
+    )
+
+
+def test_flux1_preserves_detected_tokenizer_special_tokens(tmp_path) -> None:
+    transformer = tmp_path / "transformer"
+    transformer.mkdir()
+    (transformer / "config.json").write_text(
+        json.dumps({"_class_name": "FluxTransformer2DModel"})
+    )
+    tokenizer = tmp_path / "tokenizer"
+    tokenizer.mkdir()
+
+    assert flux_mod.plugin.diffusion_tokenizer_add_special_tokens(
+        tmp_path,
+        detect_tokenizer_add_special_tokens=lambda path: path == tokenizer,
+    )
+
+
 def test_matches_and_build_engine_not_supported() -> None:
     """Intent: verify FLUX model aliases and explicit build_engine rejection.
 

--- a/src/runtime/models/flux/flux_clip_helpers.h
+++ b/src/runtime/models/flux/flux_clip_helpers.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace trtmc::diffusion::flux_clip {
+
+inline std::vector<int32_t> pad_and_truncate_ids(const std::vector<int32_t>& input_ids,
+                                                 std::size_t sequence_length, int32_t pad_token_id,
+                                                 int32_t eos_token_id) {
+    std::vector<int32_t> padded(sequence_length, std::max(pad_token_id, 0));
+    const auto copy_length = std::min(sequence_length, input_ids.size());
+    std::copy_n(input_ids.begin(), copy_length, padded.begin());
+    if (input_ids.size() > sequence_length && eos_token_id >= 0 && !padded.empty()) {
+        padded.back() = eos_token_id;
+    }
+    return padded;
+}
+
+} // namespace trtmc::diffusion::flux_clip

--- a/src/runtime/models/flux/flux_rope_helpers.h
+++ b/src/runtime/models/flux/flux_rope_helpers.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace trtmc {
+namespace diffusion {
+namespace flux_rope {
+
+inline int32_t axis_position(std::size_t axis, int32_t temporal_pos, int32_t height_pos,
+                             int32_t width_pos, int32_t sequence_pos) {
+    switch (axis) {
+    case 0:
+        return temporal_pos;
+    case 1:
+        return height_pos;
+    case 2:
+        return width_pos;
+    case 3:
+        return sequence_pos;
+    default:
+        return 0;
+    }
+}
+
+} // namespace flux_rope
+} // namespace diffusion
+} // namespace trtmc

--- a/src/runtime/models/flux/flux_text_helpers.h
+++ b/src/runtime/models/flux/flux_text_helpers.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/tokenizer.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace trtmc::diffusion::flux_text {
+
+struct PaddedTextInputs {
+    std::vector<int32_t> input_ids;
+    std::vector<float> attention_mask;
+    std::size_t valid_tokens{0};
+};
+
+inline int32_t resolve_pad_token_id(ITokenizer* tokenizer, bool is_flux2) {
+    if (!is_flux2 || tokenizer == nullptr) {
+        return 0;
+    }
+    try {
+        const int32_t pad_id = tokenizer->id_for_token("<pad>");
+        return pad_id >= 0 ? pad_id : 0;
+    } catch (const std::exception&) {
+        return 0;
+    }
+}
+
+inline PaddedTextInputs prepare_inputs(const std::vector<int32_t>& input_ids, int32_t seq_len,
+                                       int32_t pad_token_id) {
+    if (seq_len <= 0) {
+        throw std::invalid_argument("FLUX text sequence length must be positive");
+    }
+    PaddedTextInputs prepared;
+    prepared.input_ids.assign(static_cast<std::size_t>(seq_len), pad_token_id);
+    prepared.attention_mask.assign(static_cast<std::size_t>(seq_len), -1e9F);
+    prepared.valid_tokens = std::min(static_cast<std::size_t>(seq_len), input_ids.size());
+    std::copy_n(input_ids.begin(), prepared.valid_tokens, prepared.input_ids.begin());
+    std::fill_n(prepared.attention_mask.begin(), prepared.valid_tokens, 0.0F);
+    return prepared;
+}
+
+inline void clear_padding_rows(std::vector<float>& embeddings,
+                               const std::vector<std::size_t>& valid_tokens, int32_t seq_len,
+                               int32_t embedding_dim, bool preserve_padding_rows) {
+    if (preserve_padding_rows) {
+        return;
+    }
+    const auto seq = static_cast<std::size_t>(seq_len);
+    const auto dim = static_cast<std::size_t>(embedding_dim);
+    for (std::size_t batch = 0; batch < valid_tokens.size(); ++batch) {
+        const auto first_padding = std::min(valid_tokens[batch], seq);
+        auto* first = embeddings.data() + (batch * seq + first_padding) * dim;
+        std::fill(first, embeddings.data() + (batch + 1) * seq * dim, 0.0F);
+    }
+}
+
+} // namespace trtmc::diffusion::flux_text

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -14,6 +14,7 @@
 #include "runtime/models/flux/pipeline.h"
 
 #include "runtime/models/flux/flux_batch_utils.h"
+#include "runtime/models/flux/flux_clip_helpers.h"
 #include "runtime/models/flux/flux_denoising_step_seam.h"
 #include "runtime/models/flux/flux_generation_plan.h"
 #include "runtime/models/flux/gpu_matmul.h"
@@ -78,15 +79,6 @@ void cpu_silu_inplace(float* data, std::size_t count) {
 // ---------------------------------------------------------------------------
 // CLIP helpers
 // ---------------------------------------------------------------------------
-
-std::vector<int32_t> make_clip_padded_ids(const std::vector<int32_t>& input_ids,
-                                          int32_t pad_token_id) {
-    std::vector<int32_t> padded(static_cast<std::size_t>(kFluxClipSeqLen),
-                                std::max(pad_token_id, 0));
-    const auto copy_len = std::min(static_cast<std::size_t>(kFluxClipSeqLen), input_ids.size());
-    std::copy_n(input_ids.begin(), copy_len, padded.begin());
-    return padded;
-}
 
 int32_t find_first_token(const std::vector<int32_t>& ids, int32_t token_id) {
     for (int32_t i = 0; i < kFluxClipSeqLen; ++i) {
@@ -742,7 +734,8 @@ bool FluxPipeline::run_clip_encoder(const std::vector<int32_t>& input_ids,
     int32_t clip_pad_token_id = 0;
     detect_clip_special_tokens(clip_tokenizer_.get(), clip_eos_token_id, clip_pad_token_id);
 
-    const auto padded = make_clip_padded_ids(input_ids, clip_pad_token_id);
+    const auto padded = diffusion::flux_clip::pad_and_truncate_ids(
+        input_ids, static_cast<std::size_t>(kFluxClipSeqLen), clip_pad_token_id, clip_eos_token_id);
 
     // Build input TensorMap
     TensorMap inputs;
@@ -751,23 +744,24 @@ bool FluxPipeline::run_clip_encoder(const std::vector<int32_t>& input_ids,
 
     auto outputs = clip_module->forward(inputs);
 
-    // Check if pooled_output is directly available from the engine
-    if (outputs.count("pooled_output")) {
-        auto& pooled_tensor = outputs.at("pooled_output");
-        const auto* data = static_cast<const float*>(pooled_tensor.data);
-        pooled_output.assign(data, data + pooled_tensor.numel());
+    // HF CLIP pools the first EOS position. The engine's legacy pooled output
+    // is fixed to the last sequence row, which differs whenever EOS padding is
+    // present. Prefer the full hidden states so runtime can match HF exactly.
+    if (outputs.count("text_embeddings")) {
+        auto& text_emb_tensor = outputs.at("text_embeddings");
+        const auto* clip_hidden = static_cast<const float*>(text_emb_tensor.data);
+        const auto clip_hidden_size =
+            static_cast<std::size_t>(kFluxClipSeqLen) * static_cast<std::size_t>(kFluxClipDim);
+        std::vector<float> clip_hidden_vec(clip_hidden, clip_hidden + clip_hidden_size);
+
+        const int32_t pool_idx = select_clip_pool_index(padded, clip_eos_token_id);
+        copy_clip_pooled_row(clip_hidden_vec, pool_idx, pooled_output);
         return true;
     }
 
-    // Fallback: manually extract pooled row from text_embeddings at EOS position
-    auto& text_emb_tensor = outputs.at("text_embeddings");
-    const auto* clip_hidden = static_cast<const float*>(text_emb_tensor.data);
-    const auto clip_hidden_size =
-        static_cast<std::size_t>(kFluxClipSeqLen) * static_cast<std::size_t>(kFluxClipDim);
-    std::vector<float> clip_hidden_vec(clip_hidden, clip_hidden + clip_hidden_size);
-
-    const int32_t pool_idx = select_clip_pool_index(padded, clip_eos_token_id);
-    copy_clip_pooled_row(clip_hidden_vec, pool_idx, pooled_output);
+    auto& pooled_tensor = outputs.at("pooled_output");
+    const auto* data = static_cast<const float*>(pooled_tensor.data);
+    pooled_output.assign(data, data + pooled_tensor.numel());
     return true;
 }
 
@@ -800,9 +794,10 @@ bool FluxPipeline::run_t5_encoder(int32_t encoder_idx, const std::vector<int32_t
     }
 
     TensorMap inputs;
-    inputs["input_ids"] = Tensor{padded_ids.data(), {static_cast<int64_t>(seq_len)}, DType::kInt32};
+    inputs["input_ids"] =
+        Tensor{padded_ids.data(), {1, static_cast<int64_t>(seq_len)}, DType::kInt32};
     inputs["attention_mask"] =
-        Tensor{mask.data(), {static_cast<int64_t>(seq_len)}, DType::kFloat32};
+        Tensor{mask.data(), {1, static_cast<int64_t>(seq_len)}, DType::kFloat32};
 
     auto outputs = te->forward(inputs);
 

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -17,6 +17,8 @@
 #include "runtime/models/flux/flux_clip_helpers.h"
 #include "runtime/models/flux/flux_denoising_step_seam.h"
 #include "runtime/models/flux/flux_generation_plan.h"
+#include "runtime/models/flux/flux_rope_helpers.h"
+#include "runtime/models/flux/flux_text_helpers.h"
 #include "runtime/models/flux/gpu_matmul.h"
 
 #include <algorithm>
@@ -780,24 +782,16 @@ bool FluxPipeline::run_t5_encoder(int32_t encoder_idx, const std::vector<int32_t
     const int32_t seq_len = config_.text_seq_len;
     const int32_t te_dim = config_.text_encoder_dim;
 
-    // Pad input_ids to seq_len
-    std::vector<int32_t> padded_ids(static_cast<std::size_t>(seq_len), 0);
-    const auto copy_len = std::min(static_cast<std::size_t>(seq_len), input_ids.size());
-    std::copy_n(input_ids.begin(), copy_len, padded_ids.begin());
-
-    // Build attention mask: 0.0 for real tokens, -1e9 for padding
-    std::vector<float> mask(static_cast<std::size_t>(seq_len), -1e9F);
-    for (int32_t i = 0; i < seq_len; ++i) {
-        if (padded_ids[static_cast<std::size_t>(i)] != 0) {
-            mask[static_cast<std::size_t>(i)] = 0.0F;
-        }
-    }
+    const bool is_flux2 = !weights_.vae_bn_mean.empty();
+    const int32_t pad_token_id =
+        diffusion::flux_text::resolve_pad_token_id(tokenizer_.get(), is_flux2);
+    auto prepared = diffusion::flux_text::prepare_inputs(input_ids, seq_len, pad_token_id);
 
     TensorMap inputs;
     inputs["input_ids"] =
-        Tensor{padded_ids.data(), {1, static_cast<int64_t>(seq_len)}, DType::kInt32};
+        Tensor{prepared.input_ids.data(), {1, static_cast<int64_t>(seq_len)}, DType::kInt32};
     inputs["attention_mask"] =
-        Tensor{mask.data(), {1, static_cast<int64_t>(seq_len)}, DType::kFloat32};
+        Tensor{prepared.attention_mask.data(), {1, static_cast<int64_t>(seq_len)}, DType::kFloat32};
 
     auto outputs = te->forward(inputs);
 
@@ -806,14 +800,11 @@ bool FluxPipeline::run_t5_encoder(int32_t encoder_idx, const std::vector<int32_t
     const auto* emb_data = static_cast<const float*>(emb_tensor.data);
     text_embeddings.assign(emb_data, emb_data + emb_size);
 
-    // Zero out padding token embeddings
-    for (int32_t i = 0; i < seq_len; ++i) {
-        if (padded_ids[static_cast<std::size_t>(i)] == 0) {
-            float* row = text_embeddings.data() +
-                         static_cast<std::size_t>(i) * static_cast<std::size_t>(te_dim);
-            std::fill_n(row, static_cast<std::size_t>(te_dim), 0.0F);
-        }
-    }
+    // Diffusers feeds FLUX.2's full Mistral output to the denoiser, including
+    // padded query rows. Preserve those rows while retaining FLUX.1's legacy
+    // zero-padding contract.
+    diffusion::flux_text::clear_padding_rows(text_embeddings, {prepared.valid_tokens}, seq_len,
+                                             te_dim, is_flux2);
 
     return true;
 }
@@ -926,22 +917,21 @@ bool FluxPipeline::run_t5_encoder_batch(int32_t encoder_idx,
     const int32_t seq_len = config_.text_seq_len;
     const int32_t te_dim = config_.text_encoder_dim;
 
-    std::vector<int32_t> padded_ids(static_cast<std::size_t>(B) * static_cast<std::size_t>(seq_len),
-                                    0);
-    std::vector<float> mask(static_cast<std::size_t>(B) * static_cast<std::size_t>(seq_len), -1e9F);
+    const bool is_flux2 = !weights_.vae_bn_mean.empty();
+    const int32_t pad_token_id =
+        diffusion::flux_text::resolve_pad_token_id(tokenizer_.get(), is_flux2);
+    std::vector<int32_t> padded_ids;
+    std::vector<float> mask;
+    std::vector<std::size_t> valid_tokens;
+    padded_ids.reserve(static_cast<std::size_t>(B) * static_cast<std::size_t>(seq_len));
+    mask.reserve(static_cast<std::size_t>(B) * static_cast<std::size_t>(seq_len));
+    valid_tokens.reserve(static_cast<std::size_t>(B));
     for (int32_t b = 0; b < B; ++b) {
         const auto& ids = batch_input_ids[static_cast<std::size_t>(b)];
-        const auto copy_len = std::min(static_cast<std::size_t>(seq_len), ids.size());
-        std::copy_n(ids.begin(), copy_len,
-                    padded_ids.begin() +
-                        static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len));
-        for (int32_t i = 0; i < seq_len; ++i) {
-            const auto idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len) +
-                             static_cast<std::size_t>(i);
-            if (padded_ids[idx] != 0) {
-                mask[idx] = 0.0F;
-            }
-        }
+        auto prepared = diffusion::flux_text::prepare_inputs(ids, seq_len, pad_token_id);
+        padded_ids.insert(padded_ids.end(), prepared.input_ids.begin(), prepared.input_ids.end());
+        mask.insert(mask.end(), prepared.attention_mask.begin(), prepared.attention_mask.end());
+        valid_tokens.push_back(prepared.valid_tokens);
     }
 
     TensorMap inputs;
@@ -958,20 +948,8 @@ bool FluxPipeline::run_t5_encoder_batch(int32_t encoder_idx,
     const auto* emb_data = static_cast<const float*>(emb_tensor.data);
     text_embeddings_batch.assign(emb_data, emb_data + emb_size);
 
-    // Zero out padding token embeddings sample-by-sample.
-    for (int32_t b = 0; b < B; ++b) {
-        for (int32_t i = 0; i < seq_len; ++i) {
-            const auto pad_idx = static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len) +
-                                 static_cast<std::size_t>(i);
-            if (padded_ids[pad_idx] == 0) {
-                float* row = text_embeddings_batch.data() +
-                             (static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len) +
-                              static_cast<std::size_t>(i)) *
-                                 static_cast<std::size_t>(te_dim);
-                std::fill_n(row, static_cast<std::size_t>(te_dim), 0.0F);
-            }
-        }
-    }
+    diffusion::flux_text::clear_padding_rows(text_embeddings_batch, valid_tokens, seq_len, te_dim,
+                                             is_flux2);
     return true;
 }
 
@@ -1184,20 +1162,13 @@ void FluxPipeline::compute_flux_rope(int32_t h_patches, int32_t w_patches, int32
         axes = {16, 56, 56}; // FLUX.1 default
     }
 
-    auto encode_pos = [&](float* cos_row, float* sin_row, int32_t text_pos, int32_t h_pos,
-                          int32_t w_pos) {
+    auto encode_pos = [&](float* cos_row, float* sin_row, int32_t temporal_pos, int32_t h_pos,
+                          int32_t w_pos, int32_t sequence_pos) {
         int32_t offset = 0;
         for (std::size_t ax = 0; ax < axes.size(); ++ax) {
             const int32_t ax_dim = axes[ax];
-            // Determine position value for this axis
-            int32_t pos = 0;
-            if (ax == 0)
-                pos = text_pos;
-            else if (ax == 1)
-                pos = h_pos;
-            else if (ax == 2)
-                pos = w_pos;
-            // axes[3+] default to position 0 (identity rotation for image tokens)
+            const int32_t pos =
+                diffusion::flux_rope::axis_position(ax, temporal_pos, h_pos, w_pos, sequence_pos);
 
             for (int32_t i = 0; i < ax_dim / 2; ++i) {
                 const float freq = 1.0F / std::pow(theta, 2.0F * static_cast<float>(i) /
@@ -1212,12 +1183,13 @@ void FluxPipeline::compute_flux_rope(int32_t h_patches, int32_t w_patches, int32
         }
     };
 
-    // Text tokens: ALL positions are (0, 0, 0) -- identity rotation
+    // FLUX.2 text positions are (T=0, H=0, W=0, L=token index).
+    // FLUX.1 has three axes, so the sequence coordinate is ignored.
     for (int32_t t = 0; t < text_seq_len; ++t) {
         encode_pos(
             cos_out.data() + static_cast<std::size_t>(t) * static_cast<std::size_t>(head_dim),
             sin_out.data() + static_cast<std::size_t>(t) * static_cast<std::size_t>(head_dim), 0, 0,
-            0);
+            0, t);
     }
 
     // Image tokens: position (0, h, w)
@@ -1227,7 +1199,7 @@ void FluxPipeline::compute_flux_rope(int32_t h_patches, int32_t w_patches, int32
             encode_pos(
                 cos_out.data() + static_cast<std::size_t>(idx) * static_cast<std::size_t>(head_dim),
                 sin_out.data() + static_cast<std::size_t>(idx) * static_cast<std::size_t>(head_dim),
-                0, h, w);
+                0, h, w, 0);
         }
     }
 }
@@ -1395,7 +1367,6 @@ bool FluxPipeline::run_denoising(const diffusion::FluxGenerationPlan& plan,
 
     FlowMatchEulerState scheduler = diffusion::make_flux_scheduler_state(plan);
     log_flux_dynamic_shift(scheduler);
-
     if (!run_flux_denoising_loop(scheduler, num_inference_steps, latents, hidden, denoiser_output,
                                  pack_latents_fn, unpack_velocity_fn, compute_temb, embed_hidden,
                                  run_denoiser_fn)) {
@@ -1763,7 +1734,6 @@ bool FluxPipeline::run_flux_denoising_loop_batch(
 
     FlowMatchEulerState scheduler = diffusion::make_flux_scheduler_state(plan);
     log_flux_dynamic_shift(scheduler);
-
     // Per-sample temb for FLUX.1 (depends on pooled_output). For FLUX.2 we
     // just pass the raw scalar timestep; the engine carries the temb MLP.
     const float guidance_scale = plan.guidance_scale;

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -160,7 +160,7 @@ static const ByteEncoderTables& byte_tables() {
 
 namespace pretok {
 
-enum class Variant { kGpt2, kQwen3, kBloom, kDeepSeek };
+enum class Variant { kGpt2, kQwen3, kBloom, kDeepSeek, kClip };
 
 // ── Character classification ──
 
@@ -243,6 +243,9 @@ inline bool is_newline(char32_t cp) {
 // Qwen3: any char except CR, LF, letter, digit
 // DeepSeek: any whitespace (\s?)
 inline bool is_prefix(char32_t cp, Variant v) {
+    if (v == Variant::kClip) {
+        return false;
+    }
     if (v == Variant::kQwen3) {
         return !is_newline(cp) && !is_letter(cp) && !is_digit(cp);
     }
@@ -460,6 +463,13 @@ inline bool try_whitespace_run(char32_t cp, const char*& p, const char* end, con
     if (!is_whitespace(cp))
         return false;
 
+    // CLIP's Split pre-tokenizer retains regex matches and removes the gaps,
+    // so whitespace never reaches its ByteLevel pre-tokenizer.
+    if (variant == Variant::kClip) {
+        scan_all_whitespace(p, end);
+        return true;
+    }
+
     // Qwen3: \s*[\r\n]+ — newline sequences take priority
     if (variant == Variant::kQwen3 && has_newline_in_ws(cp, p, end)) {
         scan_qwen3_newline_chunk(cp, p, end);
@@ -484,7 +494,7 @@ inline bool try_simple_run(char32_t cp, const char*& p, const char* end, const c
         if (variant == Variant::kQwen3) {
             if (digit_group > 1)
                 scan_digits(p, end, digit_group - 1);
-        } else {
+        } else if (variant != Variant::kClip) {
             scan_digits(p, end);
         }
         result.emplace_back(start, p);
@@ -596,12 +606,13 @@ class BpeTokenizer final : public ITokenizer {
     }
 
     void encode_segment(const std::string& text, std::vector<int32_t>& result) const {
+        const auto normalized = normalize_text(text);
         if (mIsSentencePiece) {
-            encode_sentencepiece(text, result);
+            encode_sentencepiece(normalized, result);
         } else if (mIsMetaspace) {
-            encode_metaspace(text, result);
+            encode_metaspace(normalized, result);
         } else {
-            encode_bytelevel(text, result);
+            encode_bytelevel(normalized, result);
         }
     }
 
@@ -660,6 +671,36 @@ class BpeTokenizer final : public ITokenizer {
     BpeTokenizer() = default;
 
     enum class DecoderType { kByteLevel, kMetaspace, kSequence };
+
+    std::string normalize_text(const std::string& text) const {
+        if (!mNormalizeLowercase && !mNormalizeWhitespace) {
+            return text;
+        }
+
+        std::string normalized;
+        normalized.reserve(text.size());
+        const char* cursor = text.data();
+        const char* end = cursor + text.size();
+        bool previous_was_whitespace = false;
+        while (cursor < end) {
+            const char* char_start = cursor;
+            const char32_t cp = read_utf8(cursor, end);
+            if (mNormalizeWhitespace && pretok::is_whitespace(cp)) {
+                if (!previous_was_whitespace) {
+                    normalized.push_back(' ');
+                }
+                previous_was_whitespace = true;
+                continue;
+            }
+            previous_was_whitespace = false;
+            if (mNormalizeLowercase && cp >= 'A' && cp <= 'Z') {
+                normalized.push_back(static_cast<char>(cp - 'A' + 'a'));
+            } else {
+                normalized.append(char_start, cursor);
+            }
+        }
+        return normalized;
+    }
 
     // ─── Added token segmentation ───
 
@@ -1137,6 +1178,12 @@ class BpeTokenizer final : public ITokenizer {
 
     // Classify a single Split regex string into a pre-tokenizer variant.
     static pretok::Variant classify_split_regex(const std::string& regex, int& digit_group_out) {
+        if ((regex.find("startoftext") != std::string::npos ||
+             regex.find("endoftext") != std::string::npos) &&
+            regex.find("\\p{L}") != std::string::npos &&
+            regex.find("\\p{N}") != std::string::npos) {
+            return pretok::Variant::kClip;
+        }
         if (regex.find("[^\r\n") != std::string::npos ||
             regex.find("[^\\r\\n") != std::string::npos) {
             digit_group_out = parse_digit_group(regex);
@@ -1337,6 +1384,7 @@ class BpeTokenizer final : public ITokenizer {
             return;
         auto& norm = j["normalizer"];
         std::string norm_type = norm.value("type", "");
+        detect_text_normalizers(norm);
         if (normalizer_sequence_prepends(norm, norm_type)) {
             mSentencePiecePrependAlways = true;
         } else if (normalizer_replaces_space_with_sentence_piece(norm, norm_type)) {
@@ -1344,6 +1392,26 @@ class BpeTokenizer final : public ITokenizer {
             // first token. Preserve the old prepend-if-missing behavior for
             // Metaspace-style SentencePiece models.
             mSentencePiecePrependIfMissing = false;
+        }
+    }
+
+    void detect_text_normalizers(const nlohmann::json& normalizer) {
+        const std::string type = normalizer.value("type", "");
+        if (type == "Sequence" && normalizer.contains("normalizers")) {
+            for (const auto& child : normalizer["normalizers"]) {
+                detect_text_normalizers(child);
+            }
+            return;
+        }
+        if (type == "Lowercase") {
+            mNormalizeLowercase = true;
+            return;
+        }
+        if (type == "Replace" && normalizer.contains("pattern") &&
+            normalizer["pattern"].contains("Regex") &&
+            normalizer["pattern"]["Regex"].get<std::string>() == "\\s+" &&
+            normalizer.value("content", "") == " ") {
+            mNormalizeWhitespace = true;
         }
     }
 
@@ -1448,6 +1516,8 @@ class BpeTokenizer final : public ITokenizer {
         false; // true for Normalizer Prepend, false for Metaspace first
     bool mSentencePiecePrependIfMissing = true;
     bool mByteFallback = false;
+    bool mNormalizeLowercase = false;
+    bool mNormalizeWhitespace = false;
     std::string mEndOfWordSuffix;
 
     // Post-processor: BOS/EOS token IDs to add when add_special_tokens=true

--- a/tests/cpp/models/flux/test_flux_pipeline.cpp
+++ b/tests/cpp/models/flux/test_flux_pipeline.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "runtime/models/flux/flux_clip_helpers.h"
 #include "runtime/models/flux/pipeline.h"
 
 #include <iostream>
@@ -43,11 +44,25 @@ void test_flux_with_custom_config() {
           "FluxPipeline custom config pipeline_type");
 }
 
+void test_clip_padding_preserves_eos_when_truncated() {
+    using trtmc::diffusion::flux_clip::pad_and_truncate_ids;
+
+    check(pad_and_truncate_ids({10, 1, 11}, 5, 11, 11) == std::vector<int32_t>({10, 1, 11, 11, 11}),
+          "CLIP short input pads with EOS");
+    check(pad_and_truncate_ids({10, 1, 2, 3, 11}, 5, 11, 11) ==
+              std::vector<int32_t>({10, 1, 2, 3, 11}),
+          "CLIP exact input preserves EOS");
+    check(pad_and_truncate_ids({10, 1, 2, 3, 4, 11}, 5, 11, 11) ==
+              std::vector<int32_t>({10, 1, 2, 3, 11}),
+          "CLIP truncated input restores EOS");
+}
+
 } // namespace
 
 int main() {
     test_flux_construction();
     test_flux_with_custom_config();
+    test_clip_padding_preserves_eos_when_truncated();
     if (failures > 0) {
         std::cerr << failures << " flux pipeline test(s) FAILED\n";
     }

--- a/tests/cpp/models/flux/test_flux_pipeline.cpp
+++ b/tests/cpp/models/flux/test_flux_pipeline.cpp
@@ -4,14 +4,27 @@
  */
 
 #include "runtime/models/flux/flux_clip_helpers.h"
+#include "runtime/models/flux/flux_rope_helpers.h"
+#include "runtime/models/flux/flux_text_helpers.h"
 #include "runtime/models/flux/pipeline.h"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 
 namespace {
 
 int failures = 0;
+
+class PadTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override { return {}; }
+    std::string decode(const std::vector<int32_t>&) const override { return {}; }
+    int32_t id_for_token(std::string_view token) const override {
+        return token == "<pad>" ? 11 : -1;
+    }
+    std::string token_for_id(int32_t) const override { return {}; }
+};
 
 void check(bool condition, const char* name) {
     if (!condition) {
@@ -57,12 +70,54 @@ void test_clip_padding_preserves_eos_when_truncated() {
           "CLIP truncated input restores EOS");
 }
 
+void test_flux2_text_padding_matches_tokenizer_contract() {
+    using trtmc::diffusion::flux_text::clear_padding_rows;
+    using trtmc::diffusion::flux_text::prepare_inputs;
+    using trtmc::diffusion::flux_text::resolve_pad_token_id;
+
+    PadTokenizer tokenizer;
+    check(resolve_pad_token_id(&tokenizer, true) == 11, "FLUX.2 resolves tokenizer pad id");
+    check(resolve_pad_token_id(&tokenizer, false) == 0, "FLUX.1 retains legacy pad id");
+
+    const auto prepared = prepare_inputs({12, 0, 13}, 5, 11);
+    check(prepared.input_ids == std::vector<int32_t>({12, 0, 13, 11, 11}),
+          "FLUX.2 text uses tokenizer pad id");
+    check(prepared.attention_mask == std::vector<float>({0.0F, 0.0F, 0.0F, -1e9F, -1e9F}),
+          "FLUX.2 text mask follows input length rather than token value");
+
+    std::vector<float> embeddings(10, 1.0F);
+    clear_padding_rows(embeddings, {3}, 5, 2, true);
+    check(std::all_of(embeddings.begin(), embeddings.end(),
+                      [](float value) { return value == 1.0F; }),
+          "FLUX.2 preserves padded query embeddings");
+    clear_padding_rows(embeddings, {3}, 5, 2, false);
+    check(embeddings ==
+              std::vector<float>({1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F}),
+          "FLUX.1 clears padded query embeddings");
+}
+
+void test_flux2_rope_coordinates_match_diffusers_contract() {
+    using trtmc::diffusion::flux_rope::axis_position;
+
+    check(axis_position(0, 0, 0, 0, 17) == 0, "FLUX.2 text temporal coordinate");
+    check(axis_position(1, 0, 0, 0, 17) == 0, "FLUX.2 text height coordinate");
+    check(axis_position(2, 0, 0, 0, 17) == 0, "FLUX.2 text width coordinate");
+    check(axis_position(3, 0, 0, 0, 17) == 17, "FLUX.2 text sequence coordinate");
+
+    check(axis_position(0, 0, 5, 7, 0) == 0, "FLUX.2 image temporal coordinate");
+    check(axis_position(1, 0, 5, 7, 0) == 5, "FLUX.2 image height coordinate");
+    check(axis_position(2, 0, 5, 7, 0) == 7, "FLUX.2 image width coordinate");
+    check(axis_position(3, 0, 5, 7, 0) == 0, "FLUX.2 image sequence coordinate");
+}
+
 } // namespace
 
 int main() {
     test_flux_construction();
     test_flux_with_custom_config();
     test_clip_padding_preserves_eos_when_truncated();
+    test_flux2_text_padding_matches_tokenizer_contract();
+    test_flux2_rope_coordinates_match_diffusers_contract();
     if (failures > 0) {
         std::cerr << failures << " flux pipeline test(s) FAILED\n";
     }

--- a/tests/cpp/test_bpe_tokenizer.cpp
+++ b/tests/cpp/test_bpe_tokenizer.cpp
@@ -130,6 +130,55 @@ static const char* kClipEndOfWordJson = R"({
   }
 })";
 
+static const char* kClipNormalizedJson = R"({
+  "normalizer": {
+    "type": "Sequence",
+    "normalizers": [
+      {"type": "NFC"},
+      {"type": "Replace", "pattern": {"Regex": "\\s+"}, "content": " "},
+      {"type": "Lowercase"}
+    ]
+  },
+  "pre_tokenizer": {
+    "type": "Sequence",
+    "pretokenizers": [
+      {
+        "type": "Split",
+        "pattern": {
+          "Regex": "<\\|startoftext\\|>|<\\|endoftext\\|>|'s|'t|'re|'ve|'m|'ll|'d|[\\p{L}]+|[\\p{N}]|[^\\s\\p{L}\\p{N}]+"
+        },
+        "behavior": "Removed",
+        "invert": true
+      },
+      {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true,
+       "use_regex": true}
+    ]
+  },
+  "model": {
+    "type": "BPE",
+    "end_of_word_suffix": "</w>",
+    "vocab": {
+      "e": 0, "a": 1, "r": 2,
+      "ea": 3, "r</w>": 4, "ear</w>": 5,
+      "<|startoftext|>": 10, "<|endoftext|>": 11
+    },
+    "merges": ["e a", "ea r</w>"]
+  },
+  "added_tokens": [
+    {"id": 10, "content": "<|startoftext|>", "special": true},
+    {"id": 11, "content": "<|endoftext|>", "special": true}
+  ],
+  "post_processor": {
+    "type": "RobertaProcessing",
+    "sep": ["<|endoftext|>", 11],
+    "cls": ["<|startoftext|>", 10],
+    "trim_offsets": false,
+    "add_prefix_space": false
+  },
+  "decoder": {"type": "ByteLevel", "add_prefix_space": true,
+              "trim_offsets": true, "use_regex": true}
+})";
+
 // HF BPE tokenizers commonly serialize a present-but-null end_of_word_suffix.
 static const char* kNullEndOfWordSuffixJson = R"({
   "model": {
@@ -451,6 +500,16 @@ int main() {
         check(tok != nullptr, "null_end_of_word_suffix_create");
         auto ids = tok->encode("hello");
         check(!ids.empty(), "null_end_of_word_suffix_encode");
+    }
+
+    // === 7d. CLIP normalizer and whitespace-removing split ===
+    {
+        std::cerr << "\n=== CLIP Normalization and Split ===\n";
+
+        std::string clip_json(kClipNormalizedJson);
+        auto tok = trtmc::CreateBpeTokenizer(clip_json.data(), clip_json.size(), true);
+        auto ids = tok->encode("EAR   ear");
+        check(ids == std::vector<int32_t>({10, 5, 5, 11}), "clip_normalizer_and_split_encode");
     }
 
     // === 8. STRING merge format (StringMerge / SentencePiece style) ===

--- a/tests/e2e/models/flux/e2e_plugins/references/hf_diffusers.py
+++ b/tests/e2e/models/flux/e2e_plugins/references/hf_diffusers.py
@@ -128,6 +128,7 @@ class HfDiffusersReference:
             "fp32": "torch.float32",
         }.get(reference_precision, "torch.float32")
         guidance_scale = case.inputs.get("guidance_scale")
+        max_sequence_length = case.inputs.get("max_cache_length")
         python = ctx.reference_python_path() or sys.executable
         initial_latents = ensure_initial_latents(case, ctx)
 
@@ -153,6 +154,7 @@ image_height = {image_height}
 image_width = {image_width}
 model_type = {model_type!r}
 guidance_scale = {guidance_scale!r}
+max_sequence_length = {max_sequence_length!r}
 frames_dir = {frames_dir!r}
 reference_torch_dtype = {reference_torch_dtype}
 initial_latents_path = {str(initial_latents.path)!r}
@@ -199,6 +201,8 @@ else:
     kwargs["latents"] = hf_latents
 if model_type in ("flux.2", "flux2"):
     kwargs["guidance_scale"] = 3.5 if guidance_scale is None else guidance_scale
+    if max_sequence_length is not None:
+        kwargs["max_sequence_length"] = int(max_sequence_length)
 output = pipe(**kwargs)
 frames = output.images
 

--- a/tests/e2e/models/flux/test_flux_hf_diffusers_reference.py
+++ b/tests/e2e/models/flux/test_flux_hf_diffusers_reference.py
@@ -75,3 +75,38 @@ def test_flux_reference_honors_nested_validation_precision(monkeypatch, tmp_path
     script = cmd[cmd.index("-c") + 1]
     assert "reference_torch_dtype = torch.float16" in script
     assert "unpacked_latents.to(dtype=reference_torch_dtype)" in script
+
+
+def test_flux2_reference_honors_declared_text_sequence_length(monkeypatch, tmp_path):
+    case = E2ECase(
+        name="flux-2-dev",
+        hf_id="black-forest-labs/FLUX.2-dev",
+        family="flux",
+        runtime_strategy="diffusion_flux",
+        bundle="flux-2-dev.trtfb",
+        inputs={
+            "image_height": 384,
+            "image_width": 384,
+            "max_cache_length": 256,
+        },
+        metadata={"model_type": "flux.2"},
+    )
+    context = RunContext(case=case, artifacts_dir=str(tmp_path))
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="Generated 1 frames\n", stderr=""
+        )
+
+    monkeypatch.setattr(hf_diffusers.subprocess, "run", fake_run)
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), context
+    )
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    script = cmd[cmd.index("-c") + 1]
+    assert "max_sequence_length = 256" in script
+    assert 'kwargs["max_sequence_length"] = int(max_sequence_length)' in script

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -61,6 +61,10 @@ def test_model_workload_catalog_covers_every_ready_model():
         catalog["models"]["flux-2-dev"]["reference_cache_identity"]
         == catalog["models"]["flux-2-dev-fp8"]["reference_cache_identity"]
     )
+    assert (
+        catalog["models"]["flux-2-dev"]["reference_cache_identity"]
+        == "flux-2-dev-dpg-v2"
+    )
     qwen_identities = {
         catalog["models"][name]["reference_cache_identity"]
         for name in (

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -132,11 +132,11 @@ models:
   flux-2-dev:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
-    reference_cache_identity: flux-2-dev-dpg-v1
+    reference_cache_identity: flux-2-dev-dpg-v2
   flux-2-dev-fp8:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
-    reference_cache_identity: flux-2-dev-dpg-v1
+    reference_cache_identity: flux-2-dev-dpg-v2
   flux-schnell:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]


### PR DESCRIPTION
## Background

The FLUX validation workload exposed two independent reference-parity gaps. FLUX.1 used the wrong scheduler and CLIP tokenization details, while FLUX.2 diverged in its Mistral conditioning and denoiser position IDs. The affected models must pass their model-owned user contract, standard `trtmc-validate`, and standard `trtmc-bench` without relaxing accuracy thresholds.

## Exit Criteria

- `flux-schnell`, `flux-2-dev`, and `flux-2-dev-fp8` pass their standard accuracy workloads.
- Each affected model passes the model-owned E2E user contract and completes `trtmc-bench`.
- Reference and TRTMC inputs/settings are aligned; validation thresholds remain unchanged.

## Implementation

- Load each FLUX checkpoint's FlowMatchEuler scheduler settings instead of applying FLUX.2 defaults to every variant.
- Honor CLIP lowercase, whitespace-removing BPE, EOS truncation, and EOS pooling semantics.
- Pass rank-correct T5 inputs to TensorRT.
- Align FLUX.2 with Diffusers by avoiding duplicate BOS insertion, using the model pad token and length-based attention mask, preserving padded Mistral query rows, and forwarding the configured reference sequence length.
- Map Transformers hidden-state indices to the correct Mistral decoder layers and use Mistral's rotate-half RoPE convention.
- Generate FLUX.2 denoiser text position IDs as `(0, 0, 0, token_index)`.
- Version the FLUX.2 reference-cache identity so stale references cannot mask the corrected input contract.

Fixes #797.
Fixes #798.
Fixes #800.
Fixes #801.

## Validation

- `python -m pytest python/tensorrt_model_connect/families/flux/tests tests/e2e/models/flux/test_flux_hf_diffusers_reference.py tests/tools/test_trtmc_validate.py`: passed (89 tests in the focused combined run).
- `python -m pytest tests/e2e/models/flux`: passed all 54 non-hardware model-owned tests; hardware cases were exercised separately on GB300.
- `test_flux_generation_plan` and `test_flux_pipeline`: passed on GB300.
- `python tools/trtmc_validate.py flux-schnell dpg_bench_diffusion_image ...`: passed 5/5; mean TRTMC/HF image CLIP cosine 0.9195 and mean SSIM 0.6333.
- `python -m pytest tests/e2e/models/flux/test_flux_e2e.py --e2e-model flux-schnell ...`: passed 1/1.
- `scripts/trtmc-bench run --model flux-schnell ...`: completed; p50 431.153 ms, p95 436.366 ms.
- `python tools/trtmc_validate.py flux-2-dev dpg_bench_diffusion_image ...`: passed 5/5; mean image cosine 0.9847, minimum 0.9703, mean SSIM 0.9209.
- `python -m pytest tests/e2e/models/flux/test_flux_e2e.py --e2e-model flux-2-dev ...`: passed 1/1.
- `scripts/trtmc-bench run --model flux-2-dev ...`: completed; p50 7919.251 ms, p95 7940.087 ms.
- `python tools/trtmc_validate.py flux-2-dev-fp8 dpg_bench_diffusion_image ...`: passed 5/5; mean image cosine 0.9690 and mean SSIM 0.7932.
- `python -m pytest tests/e2e/models/flux/test_flux_e2e.py --e2e-model flux-2-dev-fp8 ...`: passed 1/1.
- `scripts/trtmc-bench run --model flux-2-dev-fp8 ...`: completed; p50 4914.389 ms, p95 4929.608 ms.
- `ruff check` for changed Python files, `clang-format --dry-run --Werror` for changed C++ files, and `git diff --check`: passed.

## Notes For Future Readers

- Review the Mistral encoder and FLUX runtime input preparation first; they contain the core accuracy corrections. The reference adapter and cache-identity change enforce the same contract in validation.
- FLUX.2 FP8 intentionally compares a quantized TRTMC denoiser against the unquantized BF16 Diffusers reference; the precision contract records this explicitly.
- No comparison thresholds or pass criteria changed.
