### PR TITLE
feat(skills): add Model Connect container runner

### DIFF
--- a/.github/workflows/legal.yml
+++ b/.github/workflows/legal.yml
@@ -80,3 +80,6 @@ jobs:
 
       - name: Check all tracked source headers
         run: python tools/legal_headers.py --check
+
+      - name: Check repository identity terminology
+        run: python tools/check_legacy_project_references.py

--- a/plugins/trtmc-agent-skills/skills/trtmc-agent-container/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/trtmc-agent-container/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: trtmc-agent-container
+description: >-
+  Find, provision, and use the TensorRT-Model-Connect development container
+  that mounts the current checkout. Use for CMake builds, C++ tests, pytest,
+  smoke tests, or other commands that require the repository CUDA, TensorRT,
+  and Python environment. Reuses an existing matching container without
+  renaming it; when none exists, rebuilds the standard development image from
+  the current checkout and starts a new isolated container automatically.
+---
+
+# TRTMC Agent Container
+
+Use the bundled runner instead of hand-writing container discovery and
+provisioning commands.
+
+## Quick Start
+
+From anywhere inside a TensorRT-Model-Connect checkout:
+
+```bash
+RUNNER=plugins/trtmc-agent-skills/skills/trtmc-agent-container/scripts/trtmc_agent_container.py
+python3 "$RUNNER" ensure --pretty
+python3 "$RUNNER" run -- cmake --build build -j8
+python3 "$RUNNER" run -- ctest --test-dir build --output-on-failure
+```
+
+`run` calls `ensure` automatically. Calling `ensure` explicitly is useful when
+the user asks to prepare or inspect the environment before running work.
+
+## Discovery And Provisioning Contract
+
+1. Resolve the current repository root and reject unrelated repositories.
+2. Inspect container mounts and reuse a single container that mounts this exact
+   checkout. The container name is not used as proof of ownership.
+3. Prefer the standard workspace name when more than one candidate exists.
+   Stop on unresolved ambiguity instead of guessing.
+4. Start a stopped matching container without renaming or recreating it.
+5. When no matching container exists:
+   - run `scripts/docker_build_gb300.sh` from the current checkout to rebuild
+     `trtmc-dev-gb300:latest`;
+   - start a detached container named `trtmc-dev-gb300-agent-N` for an
+     `agent-N` checkout, or `trtmc-dev-gb300` otherwise;
+   - mount the checkout at `/workspace/tensorrt-model-connect`.
+6. Run the requested command from the mounted repository root.
+
+Existing containers are never renamed, removed, or migrated by this skill.
+
+## Common Commands
+
+```bash
+python3 "$RUNNER" run -- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+python3 "$RUNNER" run -- cmake --build build -j8
+python3 "$RUNNER" run -- ctest --test-dir build --output-on-failure -R <regex>
+python3 "$RUNNER" run -- python3 -m pytest tests/builder -q
+python3 "$RUNNER" run -- ./scripts/validate_family.sh <model-id>
+```
+
+Use `resolve --pretty` for read-only discovery. Use `run --print-only -- ...`
+to inspect the resulting `docker exec` command without creating or starting a
+container.
+
+## Overrides
+
+- `TRTMC_CONTAINER_NAME`: require or create a specific container name.
+- `TRTMC_CONTAINER_WORKDIR`: set the mount destination for a newly created
+  container, or require that destination on a reused container.
+- `TRTMC_CONTAINER_IMAGE`: use an already-built custom development image. The
+  automatic image build applies to the standard image only.
+- `TRTMC_STORAGE_ROOT`: override shared engine/cache storage.
+- `TRTMC_HF_CACHE`: override the Hugging Face cache mounted into the container.
+
+## Guardrails
+
+- Do not use this skill outside TensorRT-Model-Connect.
+- Do not choose a container solely because its name looks plausible.
+- Do not reuse a container whose mount source does not resolve to the current
+  checkout.
+- Do not delete or rename an existing container to repair discovery.
+- If multiple non-standard containers mount the same checkout, require
+  `TRTMC_CONTAINER_NAME` instead of guessing.
+- Treat image construction and container creation as environment preparation,
+  not as evidence that a build, test, GPU workload, or model proof passed.

--- a/plugins/trtmc-agent-skills/skills/trtmc-agent-container/agents/openai.yaml
+++ b/plugins/trtmc-agent-skills/skills/trtmc-agent-container/agents/openai.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+interface:
+  display_name: "TRTMC Container Runner"
+  short_description: "Run Model Connect builds and tests in the matching container"
+  default_prompt: "Use $trtmc-agent-container to find or create the matching TensorRT-Model-Connect dev container, then run the requested build or test command."

--- a/plugins/trtmc-agent-skills/skills/trtmc-agent-container/scripts/trtmc_agent_container.py
+++ b/plugins/trtmc-agent-skills/skills/trtmc-agent-container/scripts/trtmc_agent_container.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+DEFAULT_CONTAINER_IMAGE = "trtmc-dev-gb300:latest"
+DEFAULT_CONTAINER_PREFIX = "trtmc-dev-gb300"
+DEFAULT_CONTAINER_WORKDIR = "/workspace/tensorrt-model-connect"
+AGENT_PATTERN = re.compile(r"^agent-(\d+)$")
+SAFE_NAME_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class Mount:
+    source: str
+    destination: str
+
+
+@dataclass(frozen=True)
+class ContainerRecord:
+    name: str
+    image: str
+    running: bool
+    mounts: tuple[Mount, ...]
+
+
+@dataclass(frozen=True)
+class ContainerContext:
+    repo_root: str
+    workspace_id: str | None
+    expected_container_name: str
+    container_name: str
+    container_workdir: str
+    container_image: str
+    state: str
+    created: bool = False
+
+
+def _default_runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def _real_path(value: str | Path) -> str:
+    return os.path.realpath(os.fspath(value))
+
+
+def find_repo_root(start: Path) -> Path:
+    resolved = start.resolve()
+    for candidate in (resolved, *resolved.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise RuntimeError(f"no Git repository found above {resolved}")
+
+
+def verify_repo_identity(repo_root: Path) -> None:
+    required = (
+        repo_root / ".agents" / "plugins" / "marketplace.json",
+        repo_root / "python" / "tensorrt_model_connect",
+        repo_root / "scripts" / "docker_build_gb300.sh",
+    )
+    missing = [str(path.relative_to(repo_root)) for path in required if not path.exists()]
+    if missing:
+        joined = ", ".join(missing)
+        raise RuntimeError(
+            f"{repo_root} is not a TensorRT-Model-Connect checkout; missing: {joined}"
+        )
+
+
+def _safe_workspace_id(value: str) -> str:
+    safe = SAFE_NAME_PATTERN.sub("-", value.strip()).strip("-.")
+    if not safe:
+        raise RuntimeError("workspace identifier does not contain a safe container-name character")
+    return safe
+
+
+def detect_workspace_id(repo_root: Path) -> str | None:
+    marker = repo_root / ".workspace_id"
+    if marker.is_file():
+        value = marker.read_text(encoding="utf-8").strip()
+        if value:
+            return _safe_workspace_id(value)
+
+    for part in repo_root.parts:
+        match = AGENT_PATTERN.fullmatch(part)
+        if match:
+            return f"agent-{match.group(1)}"
+    return None
+
+
+def expected_container_name(workspace_id: str | None) -> str:
+    override = os.environ.get("TRTMC_CONTAINER_NAME", "").strip()
+    if override:
+        return _safe_workspace_id(override)
+    if workspace_id:
+        return f"{DEFAULT_CONTAINER_PREFIX}-{workspace_id}"
+    return DEFAULT_CONTAINER_PREFIX
+
+
+def _completed_error(command: Sequence[str], result: subprocess.CompletedProcess[str]) -> RuntimeError:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+    return RuntimeError(f"{' '.join(command)} failed: {detail}")
+
+
+class ContainerManager:
+    def __init__(self, repo_root: Path, runner: CommandRunner = _default_runner):
+        self.repo_root = repo_root.resolve()
+        verify_repo_identity(self.repo_root)
+        self.runner = runner
+        self.workspace_id = detect_workspace_id(self.repo_root)
+        self.name_overridden = bool(os.environ.get("TRTMC_CONTAINER_NAME", "").strip())
+        self.expected_name = expected_container_name(self.workspace_id)
+        self.image = os.environ.get("TRTMC_CONTAINER_IMAGE", DEFAULT_CONTAINER_IMAGE)
+        self.requested_workdir = os.environ.get(
+            "TRTMC_CONTAINER_WORKDIR", DEFAULT_CONTAINER_WORKDIR
+        )
+
+    def _run(self, command: Sequence[str], *, require_success: bool = True) -> subprocess.CompletedProcess[str]:
+        result = self.runner(tuple(command))
+        if require_success and result.returncode != 0:
+            raise _completed_error(command, result)
+        return result
+
+    def list_containers(self) -> list[ContainerRecord]:
+        ids_result = self._run(("docker", "ps", "-aq"))
+        ids = [line.strip() for line in ids_result.stdout.splitlines() if line.strip()]
+        if not ids:
+            return []
+
+        inspect_result = self._run(("docker", "inspect", *ids))
+        payload = json.loads(inspect_result.stdout)
+        records: list[ContainerRecord] = []
+        for item in payload:
+            mounts = tuple(
+                Mount(
+                    source=str(mount.get("Source", "")),
+                    destination=str(mount.get("Destination", "")),
+                )
+                for mount in item.get("Mounts", [])
+                if mount.get("Source") and mount.get("Destination")
+            )
+            records.append(
+                ContainerRecord(
+                    name=str(item.get("Name", "")).lstrip("/"),
+                    image=str(item.get("Config", {}).get("Image", "")),
+                    running=bool(item.get("State", {}).get("Running", False)),
+                    mounts=mounts,
+                )
+            )
+        return records
+
+    def _repo_mount(self, container: ContainerRecord) -> Mount | None:
+        repo_path = _real_path(self.repo_root)
+        matches = [mount for mount in container.mounts if _real_path(mount.source) == repo_path]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise RuntimeError(
+                f"container {container.name} mounts {self.repo_root} more than once"
+            )
+        mount = matches[0]
+        explicit_workdir = os.environ.get("TRTMC_CONTAINER_WORKDIR", "").strip()
+        if explicit_workdir and mount.destination != explicit_workdir:
+            raise RuntimeError(
+                f"container {container.name} mounts the checkout at {mount.destination}, "
+                f"not requested {explicit_workdir}"
+            )
+        return mount
+
+    def _select(self, containers: Sequence[ContainerRecord]) -> tuple[ContainerRecord | None, str]:
+        by_name = {container.name: container for container in containers}
+        named = by_name.get(self.expected_name)
+        if named is not None:
+            mount = self._repo_mount(named)
+            if mount is None:
+                raise RuntimeError(
+                    f"container name {self.expected_name} is already used by another checkout"
+                )
+            return named, mount.destination
+
+        matches: list[tuple[ContainerRecord, Mount]] = []
+        for container in containers:
+            mount = self._repo_mount(container)
+            if mount is not None:
+                matches.append((container, mount))
+
+        if self.name_overridden and matches:
+            names = ", ".join(sorted(container.name for container, _mount in matches))
+            raise RuntimeError(
+                f"requested container {self.expected_name} does not exist, but this "
+                f"checkout is already mounted by: {names}"
+            )
+        if len(matches) == 1:
+            container, mount = matches[0]
+            return container, mount.destination
+        if len(matches) > 1:
+            names = ", ".join(sorted(container.name for container, _mount in matches))
+            raise RuntimeError(
+                f"multiple containers mount {self.repo_root}: {names}; "
+                "set TRTMC_CONTAINER_NAME explicitly"
+            )
+        return None, self.requested_workdir
+
+    def resolve(self) -> ContainerContext:
+        container, workdir = self._select(self.list_containers())
+        if container is None:
+            return ContainerContext(
+                repo_root=str(self.repo_root),
+                workspace_id=self.workspace_id,
+                expected_container_name=self.expected_name,
+                container_name=self.expected_name,
+                container_workdir=workdir,
+                container_image=self.image,
+                state="missing",
+            )
+        return ContainerContext(
+            repo_root=str(self.repo_root),
+            workspace_id=self.workspace_id,
+            expected_container_name=self.expected_name,
+            container_name=container.name,
+            container_workdir=workdir,
+            container_image=container.image,
+            state="running" if container.running else "stopped",
+        )
+
+    def _build_image(self) -> None:
+        if self.image != DEFAULT_CONTAINER_IMAGE:
+            self._run(("docker", "image", "inspect", self.image))
+            return
+        build_script = self.repo_root / "scripts" / "docker_build_gb300.sh"
+        self._run(("bash", str(build_script)))
+        self._run(("docker", "image", "inspect", self.image))
+
+    def _create_container(self, workdir: str) -> None:
+        storage_root = Path(
+            os.environ.get("TRTMC_STORAGE_ROOT", str(Path.home() / ".cache" / "trtmc"))
+        ).expanduser().resolve()
+        hf_cache = Path(
+            os.environ.get(
+                "TRTMC_HF_CACHE",
+                os.environ.get(
+                    "HF_HOME", str(Path.home() / ".cache" / "huggingface")
+                )
+                + "/hub",
+            )
+        ).expanduser().resolve()
+        engine_dir = storage_root / "engines"
+        engine_dir.mkdir(parents=True, exist_ok=True)
+        hf_cache.mkdir(parents=True, exist_ok=True)
+
+        command = (
+            "docker",
+            "run",
+            "-d",
+            "--gpus",
+            "all",
+            "-v",
+            f"{self.repo_root}:{workdir}",
+            "-v",
+            f"{storage_root}:{storage_root}",
+            "-v",
+            f"{hf_cache}:/root/.cache/huggingface/hub",
+            "-e",
+            f"ENGINE_DIR={engine_dir}",
+            "-w",
+            workdir,
+            "--name",
+            self.expected_name,
+            self.image,
+            "sleep",
+            "infinity",
+        )
+        self._run(command)
+
+    def ensure(self) -> ContainerContext:
+        context = self.resolve()
+        if context.state == "running":
+            return context
+        if context.state == "stopped":
+            self._run(("docker", "start", context.container_name))
+            return ContainerContext(**{**asdict(context), "state": "running"})
+
+        self._build_image()
+        self._create_container(context.container_workdir)
+        return ContainerContext(
+            **{
+                **asdict(context),
+                "state": "running",
+                "container_image": self.image,
+                "created": True,
+            }
+        )
+
+
+def build_docker_exec(context: ContainerContext, command: Sequence[str]) -> list[str]:
+    escaped = " ".join(shlex.quote(part) for part in command)
+    shell_command = f"cd {shlex.quote(context.container_workdir)} && exec {escaped}"
+    return ["docker", "exec", context.container_name, "bash", "-lc", shell_command]
+
+
+def _print_context(context: ContainerContext, pretty: bool) -> None:
+    print(json.dumps(asdict(context), indent=2 if pretty else None, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Find or provision the dev container for the current TensorRT-Model-Connect checkout."
+    )
+    parser.add_argument("--cwd", help="override the path used to find the repository")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    resolve = subparsers.add_parser("resolve", help="inspect container mapping without mutation")
+    resolve.add_argument("--pretty", action="store_true")
+
+    ensure = subparsers.add_parser("ensure", help="start or provision the matching container")
+    ensure.add_argument("--pretty", action="store_true")
+
+    run = subparsers.add_parser("run", help="ensure a container and run a command in it")
+    run.add_argument("--print-only", action="store_true")
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        repo_root = find_repo_root(Path(args.cwd or os.getcwd()))
+        manager = ContainerManager(repo_root)
+        if args.subcommand == "resolve":
+            _print_context(manager.resolve(), args.pretty)
+            return 0
+        if args.subcommand == "ensure":
+            _print_context(manager.ensure(), args.pretty)
+            return 0
+
+        command = list(args.command)
+        if command and command[0] == "--":
+            command = command[1:]
+        if not command:
+            raise RuntimeError("no command provided after 'run --'")
+        context = manager.resolve() if args.print_only else manager.ensure()
+        docker_command = build_docker_exec(context, command)
+        if args.print_only:
+            print(" ".join(shlex.quote(part) for part in docker_command))
+            return 0
+        return subprocess.run(docker_command, check=False).returncode
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_check_legacy_project_references.py
+++ b/tests/tools/test_check_legacy_project_references.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import check_legacy_project_references as checker
+
+
+def test_scan_paths_rejects_retired_project_slug(tmp_path: Path) -> None:
+    document = tmp_path / "guide.md"
+    document.write_text("use " + "trt" + "-transformers for this task\n", encoding="utf-8")
+
+    findings = checker.scan_paths(tmp_path, [document])
+
+    assert [(finding.path, finding.line, finding.kind) for finding in findings] == [
+        ("guide.md", 1, "retired project slug")
+    ]
+
+
+def test_scan_paths_rejects_singular_full_project_name(tmp_path: Path) -> None:
+    document = tmp_path / "guide.md"
+    document.write_text(
+        "use " + "TensorRT" + " Transformer for this task\n", encoding="utf-8"
+    )
+
+    findings = checker.scan_paths(tmp_path, [document])
+
+    assert len(findings) == 1
+    assert findings[0].kind == "retired full project display name"
+
+
+def test_scan_paths_rejects_retired_container_prefix_case_insensitively(
+    tmp_path: Path,
+) -> None:
+    document = tmp_path / "guide.md"
+    document.write_text("TRTF" + "-DEV-GB300-AGENT-2\n", encoding="utf-8")
+
+    findings = checker.scan_paths(tmp_path, [document])
+
+    assert len(findings) == 1
+    assert findings[0].kind == "retired container prefix"
+
+
+def test_scan_paths_checks_tracked_path_names(tmp_path: Path) -> None:
+    directory = tmp_path / ("trt" + "-transformers-notes")
+    directory.mkdir()
+    document = directory / "README.md"
+    document.write_text("current text\n", encoding="utf-8")
+
+    findings = checker.scan_paths(tmp_path, [document])
+
+    assert len(findings) == 1
+    assert findings[0].line == 0
+    assert findings[0].kind == "retired project slug"
+
+
+def test_scan_paths_allows_bundle_extension(tmp_path: Path) -> None:
+    document = tmp_path / "bundle.md"
+    document.write_text("the output is model.trtfb\n", encoding="utf-8")
+
+    assert checker.scan_paths(tmp_path, [document]) == []
+
+
+def test_scan_paths_ignores_binary_files(tmp_path: Path) -> None:
+    binary = tmp_path / "artifact.bin"
+    binary.write_bytes(b"\x00" + ("trt" + "-transformers").encode())
+
+    assert checker.scan_paths(tmp_path, [binary]) == []

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1892,6 +1892,23 @@ class TestUnitTiers:
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "plugins/trtmc-agent-skills/skills/trtmc-agent-container/"
+            "scripts/trtmc_agent_container.py",
+            "tools/check_legacy_project_references.py",
+        ],
+    )
+    def test_repository_automation_tool_triggers_tools_tier(self, imap, path):
+        """Repository automation edits run tools tests without model E2E."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "repository_automation_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
     def test_nightly_artifact_selector_tool(self, imap):
         """Retry artifact selection runs its tooling contracts, not model E2E."""
         match = test_impact.classify_file("tools/select_latest_attempt_artifact.py", imap)

--- a/tests/tools/test_trtmc_agent_container_skill.py
+++ b/tests/tools/test_trtmc_agent_container_skill.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Sequence
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "trtmc-agent-skills"
+    / "skills"
+    / "trtmc-agent-container"
+    / "scripts"
+    / "trtmc_agent_container.py"
+)
+
+
+def _load_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("trtmc_agent_container_skill", RUNNER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner_module = _load_runner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_container_overrides(monkeypatch) -> None:
+    for name in (
+        "TRTMC_CONTAINER_IMAGE",
+        "TRTMC_CONTAINER_NAME",
+        "TRTMC_CONTAINER_WORKDIR",
+        "TRTMC_HF_CACHE",
+        "TRTMC_STORAGE_ROOT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _repo(tmp_path: Path, agent: str = "agent-8") -> Path:
+    repo = tmp_path / "workspaces" / agent / "TensorRT-Model-Connect"
+    (repo / ".git").mkdir(parents=True)
+    (repo / ".agents" / "plugins").mkdir(parents=True)
+    (repo / ".agents" / "plugins" / "marketplace.json").write_text("{}\n")
+    (repo / "python" / "tensorrt_model_connect").mkdir(parents=True)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "docker_build_gb300.sh").write_text("#!/bin/sh\n")
+    return repo
+
+
+def _completed(command: Sequence[str], code: int = 0, output: str = ""):
+    return subprocess.CompletedProcess(tuple(command), code, stdout=output, stderr="")
+
+
+def _container_payload(
+    *, name: str, repo: Path, destination: str, running: bool
+) -> str:
+    return json.dumps(
+        [
+            {
+                "Name": f"/{name}",
+                "Config": {"Image": "trtmc-dev-gb300:latest"},
+                "State": {"Running": running},
+                "Mounts": [
+                    {"Source": str(repo), "Destination": destination},
+                ],
+            }
+        ]
+    )
+
+
+def test_expected_name_uses_agent_workspace(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path, "agent-12")
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+
+    manager = runner_module.ContainerManager(
+        repo, runner=lambda command: _completed(command, output="")
+    )
+
+    assert manager.workspace_id == "agent-12"
+    assert manager.expected_name == "trtmc-dev-gb300-agent-12"
+
+
+def test_ensure_reuses_matching_mount_without_renaming(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+    calls: list[tuple[str, ...]] = []
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        calls.append(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="abc\n")
+        if command == ("docker", "inspect", "abc"):
+            return _completed(
+                command,
+                output=_container_payload(
+                    name="custom-model-connect-container",
+                    repo=repo,
+                    destination="/workspace/current-checkout",
+                    running=True,
+                ),
+            )
+        raise AssertionError(command)
+
+    context = runner_module.ContainerManager(repo, runner=fake).ensure()
+
+    assert context.container_name == "custom-model-connect-container"
+    assert context.container_workdir == "/workspace/current-checkout"
+    assert context.created is False
+    assert not any(command[:2] == ("docker", "run") for command in calls)
+
+
+def test_ensure_starts_stopped_matching_container(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+    calls: list[tuple[str, ...]] = []
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        calls.append(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="abc\n")
+        if command == ("docker", "inspect", "abc"):
+            return _completed(
+                command,
+                output=_container_payload(
+                    name="custom-stopped-container",
+                    repo=repo,
+                    destination="/workspace/current-checkout",
+                    running=False,
+                ),
+            )
+        if command == ("docker", "start", "custom-stopped-container"):
+            return _completed(command, output="custom-stopped-container\n")
+        raise AssertionError(command)
+
+    context = runner_module.ContainerManager(repo, runner=fake).ensure()
+
+    assert context.state == "running"
+    assert ("docker", "start", "custom-stopped-container") in calls
+
+
+def test_ensure_rebuilds_standard_image_then_creates_container(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _repo(tmp_path)
+    storage = tmp_path / "storage"
+    cache = tmp_path / "hf-cache"
+    monkeypatch.setenv("TRTMC_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_HF_CACHE", str(cache))
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+    calls: list[tuple[str, ...]] = []
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        calls.append(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="")
+        if command == ("docker", "image", "inspect", "trtmc-dev-gb300:latest"):
+            return _completed(command)
+        if command == ("bash", str(repo / "scripts" / "docker_build_gb300.sh")):
+            return _completed(command)
+        if command[:3] == ("docker", "run", "-d"):
+            return _completed(command, output="new-container-id\n")
+        raise AssertionError(command)
+
+    context = runner_module.ContainerManager(repo, runner=fake).ensure()
+
+    assert context.created is True
+    assert context.container_name == "trtmc-dev-gb300-agent-8"
+    build_command = ("bash", str(repo / "scripts" / "docker_build_gb300.sh"))
+    assert build_command in calls
+    assert next(index for index, value in enumerate(calls) if value == build_command) < next(
+        index for index, value in enumerate(calls) if value[:3] == ("docker", "run", "-d")
+    )
+
+
+def test_ensure_uses_existing_custom_image_without_rebuilding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setenv("TRTMC_STORAGE_ROOT", str(tmp_path / "storage"))
+    monkeypatch.setenv("TRTMC_HF_CACHE", str(tmp_path / "cache"))
+    monkeypatch.setenv("TRTMC_CONTAINER_IMAGE", "example.invalid/custom:latest")
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+    calls: list[tuple[str, ...]] = []
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        calls.append(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="")
+        if command == (
+            "docker",
+            "image",
+            "inspect",
+            "example.invalid/custom:latest",
+        ):
+            return _completed(command)
+        if command[:3] == ("docker", "run", "-d"):
+            return _completed(command)
+        raise AssertionError(command)
+
+    runner_module.ContainerManager(repo, runner=fake).ensure()
+
+    assert not any(command[0] == "bash" for command in calls)
+
+
+def test_resolve_rejects_ambiguous_mount_ownership(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.delenv("TRTMC_CONTAINER_NAME", raising=False)
+
+    payload = json.dumps(
+        [
+            json.loads(
+                _container_payload(
+                    name=name,
+                    repo=repo,
+                    destination=f"/workspace/{name}",
+                    running=True,
+                )
+            )[0]
+            for name in ("candidate-a", "candidate-b")
+        ]
+    )
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="a\nb\n")
+        if command == ("docker", "inspect", "a", "b"):
+            return _completed(command, output=payload)
+        raise AssertionError(command)
+
+    with pytest.raises(RuntimeError, match="multiple containers mount"):
+        runner_module.ContainerManager(repo, runner=fake).resolve()
+
+
+def test_explicit_name_does_not_silently_select_another_container(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.setenv("TRTMC_CONTAINER_NAME", "requested-container")
+
+    def fake(command: Sequence[str]):
+        command = tuple(command)
+        if command == ("docker", "ps", "-aq"):
+            return _completed(command, output="abc\n")
+        if command == ("docker", "inspect", "abc"):
+            return _completed(
+                command,
+                output=_container_payload(
+                    name="different-container",
+                    repo=repo,
+                    destination="/workspace/current-checkout",
+                    running=True,
+                ),
+            )
+        raise AssertionError(command)
+
+    with pytest.raises(RuntimeError, match="requested container"):
+        runner_module.ContainerManager(repo, runner=fake).resolve()
+
+
+def test_build_docker_exec_quotes_command_and_uses_discovered_workdir() -> None:
+    context = runner_module.ContainerContext(
+        repo_root="/host/repo",
+        workspace_id="agent-8",
+        expected_container_name="trtmc-dev-gb300-agent-8",
+        container_name="custom-container",
+        container_workdir="/workspace/current checkout",
+        container_image="trtmc-dev-gb300:latest",
+        state="running",
+    )
+
+    command = runner_module.build_docker_exec(context, ["python3", "-c", "print('ok')"])
+
+    assert command[:3] == ["docker", "exec", "custom-container"]
+    assert "cd '/workspace/current checkout'" in command[-1]
+    assert "exec python3 -c" in command[-1]

--- a/tools/check_legacy_project_references.py
+++ b/tools/check_legacy_project_references.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reject retired repository and development-container terminology."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class LegacyReference:
+    path: str
+    line: int
+    kind: str
+
+
+def legacy_terms() -> tuple[tuple[str, str], ...]:
+    # Keep the retired spellings out of the checker itself so a whole-repo
+    # scan can include this file without an allowlist.
+    return (
+        ("retired project slug", "trt" + "-transformer"),
+        ("retired project display name", "trt" + " transformer"),
+        ("retired full project slug", "tensorrt" + "-transformer"),
+        ("retired full project display name", "tensorrt" + " transformer"),
+        ("retired container prefix", "trtf" + "-dev"),
+        ("retired container skill", "trtf" + "-agent-container"),
+        ("retired container override", "trtf" + "_container_workdir"),
+    )
+
+
+def tracked_paths(repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        ("git", "ls-files", "-z"),
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git ls-files failed: {detail or result.returncode}")
+    return [
+        repo_root / value.decode("utf-8", errors="surrogateescape")
+        for value in result.stdout.split(b"\0")
+        if value
+    ]
+
+
+def scan_paths(repo_root: Path, paths: Iterable[Path]) -> list[LegacyReference]:
+    findings: list[LegacyReference] = []
+    terms = tuple((kind, term.casefold()) for kind, term in legacy_terms())
+
+    for path in paths:
+        if not path.is_file():
+            continue
+        relative = path.relative_to(repo_root).as_posix()
+        folded_path = relative.casefold()
+        for kind, term in terms:
+            if term in folded_path:
+                findings.append(LegacyReference(relative, 0, kind))
+
+        data = path.read_bytes()
+        if b"\0" in data[:8192]:
+            continue
+        try:
+            content = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            folded_line = line.casefold()
+            for kind, term in terms:
+                if term in folded_line:
+                    findings.append(LegacyReference(relative, line_number, kind))
+    return findings
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check tracked files for retired project/container terminology."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (default: parent of tools/)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    try:
+        findings = scan_paths(repo_root, tracked_paths(repo_root))
+    except (OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if findings:
+        for finding in findings:
+            location = f"{finding.path}:{finding.line}" if finding.line else finding.path
+            print(f"{location}: {finding.kind}")
+        print(f"FAILED: found {len(findings)} retired project/container reference(s)")
+        return 1
+
+    print("No retired project/container references found in tracked files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1876,6 +1876,23 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestE2EDataFiles.test_data_file_maps_to_manifest_users",),
         ),
         ClassificationRule(
+            priority=482,
+            name="repository_automation_tool",
+            matcher=_path_in(
+                {
+                    "plugins/trtmc-agent-skills/skills/trtmc-agent-container/"
+                    "scripts/trtmc_agent_container.py",
+                    "tools/check_legacy_project_references.py",
+                }
+            ),
+            resolver=_match_result(
+                "repository_automation_tool", _no_models, ["tools"], False
+            ),
+            covered_by=(
+                "TestUnitTiers.test_repository_automation_tool_triggers_tools_tier",
+            ),
+        ),
+        ClassificationRule(
             priority=484,
             name="nightly_artifact_selector_tool",
             matcher=_path_equals("tools/select_latest_attempt_artifact.py"),

--- a/website/docs/getting-started/environment-and-repro.md
+++ b/website/docs/getting-started/environment-and-repro.md
@@ -80,6 +80,8 @@ cd TensorRT-Model-Connect
 repository mounted at `/workspace/tensorrt-model-connect`, the Hugging Face
 cache mounted from the host, and GPU access requested through Docker. Keep that
 shell open for the source-install and Quick Start commands.
+In parallel agent workspaces, the matching container may be named
+`trtmc-dev-gb300-agent-N` instead of `trtmc-dev-gb300`.
 
 :::warning Host versus container
 Source-build commands in this site assume you are inside that container. A

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -39,6 +39,7 @@ PYTHONPATH=python:. python3 -m pytest \
 PYTHONPATH=python:. python3 tools/model_ci.py validate
 PYTHONPATH=python:. python3 tools/test_impact.py --validate
 python3 tools/check_doc_file_references.py --strict website/docs
+python3 tools/check_legacy_project_references.py
 npm --prefix website ci
 npm --prefix website run build
 git diff --check
@@ -48,7 +49,9 @@ Install `numpy`, `Pillow`, `pytest`, and `PyYAML` first if the Python
 environment does not provide them. `npm ci` uses
 `website/package-lock.json` and replaces that workspace's installed dependency
 tree; use Node 20 to match `.github/workflows/pages.yml`. The reference checker
-validates repository-relative paths and selected numeric claims. The
+validates repository-relative paths and selected numeric claims. The repository
+identity checker rejects retired project and development-container terminology
+from every tracked text file. The
 runtime-strategy checker compares native descriptors, source, tests, and runner
 commands. A successful Docusaurus build proves that this site is buildable; it
 does not by itself prove every documented behavior or command.


### PR DESCRIPTION
## Summary

- add a repo-local container skill that discovers ownership by exact checkout mount
- preserve and reuse existing containers without renaming, removing, or migrating them
- rebuild the standard development image from the current checkout before creating a missing container
- replace the remaining stale documentation name and add an always-run repository terminology guard

## Validation

- Rebased onto `github/main` at `0ac3b5f861c7bd7f1a6bfb472b46ad38a1a30ce0`; that SHA is an ancestor of the current head `0b98565dda085615f90b7554f142701ace6314df`.
- `git diff --check github/main..HEAD`: passed on the rebased head.
- `python3 tools/check_legacy_project_references.py --repo-root .`: passed; no retired project or container references were found in tracked files.
- Strict documentation-reference checks passed for the container skill, Getting Started, and Reference docs.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_check_legacy_project_references.py tests/tools/test_trtmc_agent_container_skill.py tests/tools/test_test_impact.py tests/tools/test_github_actions_ci.py -q`: 338 passed.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed (205 models, 12 core, 78 families); it retained existing allowlist/core-strategy warnings.
- Exact-head CI: not re-triggered after this rebase; the current head has no GitHub check/status rollup. Results from the prior head are intentionally not claimed.

## Architecture decision

No ADR is needed. This changes repository-local development automation and CI validation, not product runtime architecture or a public API.