### PR TITLE
fix(phi4-multimodal): stabilize FP16 vision parity

### DIFF
--- a/python/tensorrt_model_connect/families/phi4_multimodal/graph_ops.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/graph_ops.py
@@ -25,6 +25,23 @@ def _cast_back_to_trt_dtype(
         return tensor
     return network.add_cast(tensor, target_dtype).get_output(0)
 
+
+def _add_matrix_multiply_with_fp32_accumulation(
+    network: trt.INetworkDefinition,
+    lhs: trt.ITensor,
+    lhs_op: trt.MatrixOperation,
+    rhs: trt.ITensor,
+    rhs_op: trt.MatrixOperation,
+) -> trt.ITensor:
+    """Evaluate an FP16-input matrix multiply in FP32, then restore FP16."""
+    output_dtype = lhs.dtype
+    if lhs.dtype == trt.float16 and rhs.dtype == trt.float16:
+        lhs = network.add_cast(lhs, trt.float32).get_output(0)
+        rhs = network.add_cast(rhs, trt.float32).get_output(0)
+    output = network.add_matrix_multiply(lhs, lhs_op, rhs, rhs_op).get_output(0)
+    return _cast_back_to_trt_dtype(network, output, output_dtype)
+
+
 def layer_tensor_name(stem: str, layer: int) -> str:
     return f"{stem}_{layer}"
 
@@ -48,6 +65,7 @@ def add_matmul_rhs_constant(
     rhs_width: int,
     rhs_weights: np.ndarray,
     dtype: np.dtype = np.float32,
+    fp32_accumulation: bool = False,
 ) -> trt.ITensor:
     """Matrix multiply: lhs @ rhs_constant.  rhs is [lhs_width, rhs_width]."""
     rank = len(tuple(lhs.shape))
@@ -63,6 +81,12 @@ def add_matmul_rhs_constant(
         dtype=dtype,
     )
     rhs = _cast_back_to_trt_dtype(network, rhs, lhs.dtype)
+    if fp32_accumulation:
+        return _add_matrix_multiply_with_fp32_accumulation(
+            network,
+            lhs, trt.MatrixOperation.NONE,
+            rhs, trt.MatrixOperation.NONE,
+        )
     mm = network.add_matrix_multiply(
         lhs, trt.MatrixOperation.NONE,
         rhs, trt.MatrixOperation.NONE,
@@ -297,9 +321,14 @@ def add_gelu_erf(
 ) -> trt.ITensor:
     """GELU (exact, erf-based): 0.5 * x * (1 + erf(x / sqrt(2))).
 
-    Constants are cast to ``inp.dtype`` for the same STRONGLY_TYPED reason
-    documented on ``add_gelu_new``.
+    Torch's CUDA GELU evaluates the transcendental path in FP32 for FP16
+    inputs, then rounds the result back to the input dtype. Preserve that
+    boundary instead of evaluating ``erf`` and its surrounding arithmetic in
+    FP16, where small per-layer errors compound through the vision tower.
     """
+    output_dtype = inp.dtype
+    if inp.dtype != trt.float32:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
     target_dtype = inp.dtype
     const_shape = (1,) * max(1, len(tuple(inp.shape)))
 
@@ -321,7 +350,7 @@ def add_gelu_erf(
     result = network.add_elementwise(
         half_x.get_output(0), one_plus_erf.get_output(0),
         trt.ElementWiseOperation.PROD)
-    return result.get_output(0)
+    return _cast_back_to_trt_dtype(network, result.get_output(0), output_dtype)
 
 
 def add_activation(
@@ -395,6 +424,7 @@ def add_layer_norm_native(
     beta: np.ndarray,
     eps: float,
     dtype: np.dtype = np.float32,
+    fp32_compute: bool = False,
 ) -> trt.ITensor:
     """LayerNorm via TRT native INormalizationLayer (add_normalization_v2).
 
@@ -414,7 +444,14 @@ def add_layer_norm_native(
         beta:        Bias weights [hidden_size].
         eps:         Numerical stability epsilon (scalar, not a tensor).
         dtype:       Storage dtype for gamma/beta constants before TRT cast.
+        fp32_compute: Cast input and parameters to FP32 for the normalization,
+                      then restore the input dtype at the output boundary.
     """
+    output_dtype = inp.dtype
+    if fp32_compute and inp.dtype != trt.float32:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+        dtype = np.float32
+
     inp_shape = getattr(inp, "shape", None)
     rank = len(tuple(inp_shape)) if inp_shape is not None else 2
     param_shape = (
@@ -434,7 +471,7 @@ def add_layer_norm_native(
     # attribute. Keep the TRT 10 hint, and let TRT 11 infer the precision.
     if hasattr(norm, "compute_precision"):
         norm.compute_precision = trt.float32
-    return norm.get_output(0)
+    return _cast_back_to_trt_dtype(network, norm.get_output(0), output_dtype)
 
 
 def validate_native_rope_dim(
@@ -920,6 +957,53 @@ def _add_attention_core_explicit(
     context = network.add_matrix_multiply(
         probs_t, trt.MatrixOperation.NONE,
         v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
+def add_siglip_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    mask: trt.ITensor | None,
+    scale: float,
+) -> trt.ITensor:
+    """Match the checkpoint's eager SigLIP attention precision boundaries.
+
+    QK and PV are evaluated through FP32 tensors and rounded to FP16 outputs.
+    Scaling and masking remain FP16 operations, and softmax alone is explicitly
+    evaluated in FP32 before its probabilities are rounded back to FP16.
+    """
+    output_dtype = q_4d.dtype
+    scores = _add_matrix_multiply_with_fp32_accumulation(
+        network,
+        q_4d, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE,
+    )
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, scores.dtype)
+    scores = network.add_elementwise(
+        scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+    if mask is not None:
+        if mask.dtype != scores.dtype:
+            mask = network.add_cast(mask, scores.dtype).get_output(0)
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    if scores.dtype != trt.float32:
+        scores = network.add_cast(scores, trt.float32).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    probs_t = _cast_back_to_trt_dtype(
+        network, probs.get_output(0), output_dtype)
+
+    context = _add_matrix_multiply_with_fp32_accumulation(
+        network,
+        probs_t, trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE,
+    )
     return _cast_back_to_trt_dtype(network, context, output_dtype)
 
 

--- a/python/tensorrt_model_connect/families/phi4_multimodal/phi4mm_vision_builder.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/phi4mm_vision_builder.py
@@ -93,7 +93,8 @@ def _linear(network, inp, weight, bias, work_np_dtype):
     out_features, in_features = weight.shape
     result = graph_ops.add_matmul_rhs_constant(
         network, inp, in_features, out_features, weight.T,
-        dtype=work_np_dtype)
+        dtype=work_np_dtype,
+        fp32_accumulation=work_np_dtype == np.float16)
     if bias is not None:
         result = graph_ops.add_bias_sum(
             network, result, out_features, np.asarray(bias),
@@ -114,7 +115,7 @@ def _build_encoder_layer(
         network, hidden, _EMBED_DIM,
         _require(weights, f"{prefix}.layer_norm1.weight"),
         _require(weights, f"{prefix}.layer_norm1.bias"),
-        1.0e-6, dtype=work_np_dtype)
+        1.0e-6, dtype=work_np_dtype, fp32_compute=True)
 
     q = _linear(
         network, normed,
@@ -139,9 +140,11 @@ def _build_encoder_layer(
         layer.second_transpose = trt.Permutation([0, 2, 1, 3])
         return layer.get_output(0)
 
-    context = graph_ops.add_attention_core(
+    context = graph_ops.add_siglip_attention_core(
         network, as_heads(q), as_heads(k), as_heads(v),
-        mask=attention_mask, scale=_HEAD_DIM ** -0.5)
+        mask=attention_mask,
+        scale=_HEAD_DIM ** -0.5,
+    )
     context_rows = network.add_shuffle(context)
     context_rows.first_transpose = trt.Permutation([0, 2, 1, 3])
     context_rows.reshape_dims = (
@@ -158,7 +161,7 @@ def _build_encoder_layer(
         network, hidden, _EMBED_DIM,
         _require(weights, f"{prefix}.layer_norm2.weight"),
         _require(weights, f"{prefix}.layer_norm2.bias"),
-        1.0e-6, dtype=work_np_dtype)
+        1.0e-6, dtype=work_np_dtype, fp32_compute=True)
     mlp = _linear(
         network, normed,
         _require(weights, f"{prefix}.mlp.fc1.weight"),
@@ -266,14 +269,19 @@ def build_phi4mm_vision_engine(
     batched = network.add_shuffle(work_input)
     batched.reshape_dims = (_NUM_CROPS, 3, _CROP_SIZE, _CROP_SIZE)
 
+    patch_input = batched.get_output(0)
+    patch_np_dtype = work_np_dtype
+    if precision == "fp16":
+        patch_input = _cast(network, patch_input, trt.float32)
+        patch_np_dtype = np.float32
     patch_weight = np.asarray(
         _require(weights, "img_processor.embeddings.patch_embedding.weight"),
-        dtype=work_np_dtype)
+        dtype=patch_np_dtype)
     patch_bias = np.asarray(
         _require(weights, "img_processor.embeddings.patch_embedding.bias"),
-        dtype=work_np_dtype)
+        dtype=patch_np_dtype)
     patch = network.add_convolution_nd(
-        batched.get_output(0), _EMBED_DIM, (_PATCH_SIZE, _PATCH_SIZE),
+        patch_input, _EMBED_DIM, (_PATCH_SIZE, _PATCH_SIZE),
         trt.Weights(np.ascontiguousarray(patch_weight)),
         trt.Weights(np.ascontiguousarray(patch_bias)))
     patch.stride_nd = (_PATCH_SIZE, _PATCH_SIZE)
@@ -281,6 +289,7 @@ def build_phi4mm_vision_engine(
     rows.first_transpose = trt.Permutation([0, 2, 3, 1])
     rows.reshape_dims = (
         _NUM_CROPS, _GRID_SIZE * _GRID_SIZE, _EMBED_DIM)
+    patch_rows = _cast(network, rows.get_output(0), work_trt_dtype)
 
     position = const_in_work_dtype(
         network, (_NUM_CROPS, _GRID_SIZE * _GRID_SIZE, _EMBED_DIM),
@@ -288,7 +297,7 @@ def build_phi4mm_vision_engine(
             weights, "img_processor.embeddings.position_embedding.weight")),
         work_np_dtype, work_trt_dtype)
     hidden = network.add_elementwise(
-        rows.get_output(0), position, trt.ElementWiseOperation.SUM).get_output(0)
+        patch_rows, position, trt.ElementWiseOperation.SUM).get_output(0)
     attention_mask = const_in_work_dtype(
         network,
         (_NUM_CROPS, 1, _GRID_SIZE * _GRID_SIZE, _GRID_SIZE * _GRID_SIZE),

--- a/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
+++ b/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
@@ -59,6 +59,231 @@ def test_phi4_multimodal_embed_input_dispatches_to_dual_profile_builder(monkeypa
     assert kwargs["partial_rotary_factor"] == 0.75
 
 
+def test_phi4_fp16_matmul_can_request_fp32_accumulation(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.phi4_multimodal.graph_ops")
+    matrix_inputs: list[tuple[object, object]] = []
+
+    class FakeTensor:
+        def __init__(self, dtype: object) -> None:
+            self.dtype = dtype
+            self.shape = (1, 4)
+
+    class FakeLayer:
+        def __init__(self, output: object) -> None:
+            self.output = output
+
+        def get_output(self, index: int) -> object:
+            assert index == 0
+            return self.output
+
+    class FakeNetwork:
+        def add_cast(self, tensor: FakeTensor, dtype: object) -> FakeLayer:
+            return FakeLayer(FakeTensor(dtype))
+
+        def add_matrix_multiply(
+            self,
+            lhs: FakeTensor,
+            lhs_op: object,
+            rhs: FakeTensor,
+            rhs_op: object,
+        ) -> FakeLayer:
+            del lhs_op, rhs_op
+            matrix_inputs.append((lhs.dtype, rhs.dtype))
+            return FakeLayer(FakeTensor(lhs.dtype))
+
+    monkeypatch.setattr(
+        module,
+        "add_constant",
+        lambda network, shape, values, dtype: FakeTensor(module.trt.float16),
+    )
+    output = module.add_matmul_rhs_constant(
+        FakeNetwork(),
+        FakeTensor(module.trt.float16),
+        4,
+        4,
+        np.ones((4, 4), dtype=np.float16),
+        dtype=np.float16,
+        fp32_accumulation=True,
+    )
+
+    assert matrix_inputs == [(module.trt.float32, module.trt.float32)]
+    assert output.dtype == module.trt.float16
+
+
+def test_phi4_vision_linear_requests_fp32_accumulation(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.phi4_multimodal.phi4mm_vision_builder")
+    calls: list[dict[str, object]] = []
+
+    def fake_matmul(*args, **kwargs):
+        del args
+        calls.append(kwargs)
+        return "matmul"
+
+    monkeypatch.setattr(module.graph_ops, "add_matmul_rhs_constant", fake_matmul)
+    monkeypatch.setattr(
+        module.graph_ops, "add_bias_sum",
+        lambda network, result, width, bias, dtype: result,
+    )
+
+    result = module._linear(
+        "network",
+        "input",
+        np.ones((3, 4), dtype=np.float32),
+        np.zeros(3, dtype=np.float32),
+        np.float16,
+    )
+
+    assert result == "matmul"
+    assert calls == [{"dtype": np.float16, "fp32_accumulation": True}]
+
+
+def test_phi4_siglip_attention_preserves_fp16_score_boundaries(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.phi4_multimodal.graph_ops")
+    accumulation_calls: list[tuple[object, object]] = []
+    elementwise_dtypes: list[tuple[object, object]] = []
+
+    class FakeTensor:
+        def __init__(self, dtype: object) -> None:
+            self.dtype = dtype
+
+    class FakeLayer:
+        def __init__(self, output: FakeTensor) -> None:
+            self.output = output
+            self.axes = 0
+
+        def get_output(self, index: int) -> FakeTensor:
+            assert index == 0
+            return self.output
+
+    class FakeNetwork:
+        def add_cast(self, tensor: FakeTensor, dtype: object) -> FakeLayer:
+            return FakeLayer(FakeTensor(dtype))
+
+        def add_matrix_multiply(
+            self,
+            lhs: FakeTensor,
+            lhs_op: object,
+            rhs: FakeTensor,
+            rhs_op: object,
+        ) -> FakeLayer:
+            del lhs_op, rhs, rhs_op
+            return FakeLayer(FakeTensor(lhs.dtype))
+
+        def add_elementwise(
+            self, lhs: FakeTensor, rhs: FakeTensor, operation: object,
+        ) -> FakeLayer:
+            del operation
+            elementwise_dtypes.append((lhs.dtype, rhs.dtype))
+            return FakeLayer(FakeTensor(lhs.dtype))
+
+        def add_softmax(self, tensor: FakeTensor) -> FakeLayer:
+            assert tensor.dtype == module.trt.float32
+            return FakeLayer(FakeTensor(tensor.dtype))
+
+    monkeypatch.setattr(
+        module,
+        "_scalar_constant_for_trt_dtype",
+        lambda network, shape, value, dtype: FakeTensor(dtype),
+    )
+
+    def fake_accumulation(network, lhs, lhs_op, rhs, rhs_op):
+        del network, lhs_op, rhs_op
+        accumulation_calls.append((lhs.dtype, rhs.dtype))
+        return FakeTensor(lhs.dtype)
+
+    monkeypatch.setattr(
+        module,
+        "_add_matrix_multiply_with_fp32_accumulation",
+        fake_accumulation,
+    )
+    half = module.trt.float16
+    output = module.add_siglip_attention_core(
+        FakeNetwork(),
+        FakeTensor(half),
+        FakeTensor(half),
+        FakeTensor(half),
+        mask=FakeTensor(half),
+        scale=8 ** -0.5,
+    )
+
+    assert accumulation_calls == [(half, half), (half, half)]
+    assert elementwise_dtypes[0] == (half, half)
+    assert output.dtype == half
+
+
+def test_phi4_vision_norm_and_gelu_compute_in_fp32(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.phi4_multimodal.graph_ops")
+    normalization_dtypes: list[tuple[object, object, object]] = []
+    unary_dtypes: list[object] = []
+
+    class FakeTensor:
+        def __init__(self, dtype: object) -> None:
+            self.dtype = dtype
+            self.shape = (1, 4)
+
+    class FakeLayer:
+        def __init__(self, output: FakeTensor) -> None:
+            self.output = output
+            self.epsilon = 0.0
+
+        def get_output(self, index: int) -> FakeTensor:
+            assert index == 0
+            return self.output
+
+    class FakeNetwork:
+        def add_cast(self, tensor: FakeTensor, dtype: object) -> FakeLayer:
+            return FakeLayer(FakeTensor(dtype))
+
+        def add_elementwise(
+            self, lhs: FakeTensor, rhs: FakeTensor, operation: object,
+        ) -> FakeLayer:
+            del rhs, operation
+            return FakeLayer(FakeTensor(lhs.dtype))
+
+        def add_unary(self, tensor: FakeTensor, operation: object) -> FakeLayer:
+            del operation
+            unary_dtypes.append(tensor.dtype)
+            return FakeLayer(FakeTensor(tensor.dtype))
+
+        def add_normalization_v2(
+            self, inp: FakeTensor, gamma: FakeTensor, beta: FakeTensor, axes: int,
+        ) -> FakeLayer:
+            del axes
+            normalization_dtypes.append((inp.dtype, gamma.dtype, beta.dtype))
+            return FakeLayer(FakeTensor(inp.dtype))
+
+    monkeypatch.setattr(
+        module,
+        "add_constant",
+        lambda network, shape, values, dtype: FakeTensor(
+            module.trt.float32 if dtype is np.float32 else module.trt.float16),
+    )
+    half = module.trt.float16
+    network = FakeNetwork()
+    norm = module.add_layer_norm_native(
+        network,
+        FakeTensor(half),
+        4,
+        np.ones(4, dtype=np.float32),
+        np.zeros(4, dtype=np.float32),
+        1.0e-6,
+        dtype=np.float16,
+        fp32_compute=True,
+    )
+    gelu = module.add_gelu_erf(
+        network, FakeTensor(half), dtype=np.float16)
+
+    assert normalization_dtypes == [
+        (module.trt.float32, module.trt.float32, module.trt.float32)]
+    assert unary_dtypes == [module.trt.float32]
+    assert norm.dtype == half
+    assert gelu.dtype == half
+
+
 def _rand(*shape: int) -> np.ndarray:
     return RNG.randn(*shape).astype(np.float32)
 


### PR DESCRIPTION
## Background

Phi-4 Multimodal's FP16 vision engine accumulated tactic-dependent numerical drift through the SigLIP tower. On the fixed MMMU-Pro Vision slice, independently built plans could therefore flip `mmmu_pro_vision_000005` between the Hugging Face reference answer `I` and `J`, despite identical prompt tokens and image tensors.

Closes #764

## Exit Criteria

- [x] Preserve the Hugging Face eager SigLIP precision boundaries in the TensorRT vision graph.
- [x] Produce bit-identical vision features across independent engine builds.
- [x] Match the FP16 Hugging Face reference on all five fixed MMMU-Pro Vision samples without relaxing the 100% agreement gate.

## Implementation

- Evaluate the FP16 patch convolution and vision linear matrix multiplies through FP32 compute, then restore FP16 at their output boundaries.
- Add a SigLIP-specific eager attention path with FP16 scale/mask boundaries and FP32 softmax.
- Evaluate vision LayerNorm and exact GELU in FP32 before restoring FP16.
- Add focused regression coverage for the matmul, attention, normalization, and GELU precision contracts.

## Validation

- `PYTHONPATH=/workspace/trtmc/python /opt/venv/bin/python -m pytest -q tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py` — PASS, 21 tests.
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_model_plugin_encapsulation_static.py` — PASS, 157 tests.
- `ruff check python/tensorrt_model_connect/families/phi4_multimodal/graph_ops.py python/tensorrt_model_connect/families/phi4_multimodal/phi4mm_vision_builder.py tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py` — PASS.
- Two independent full bundle builds produced bit-identical `[721, 3072]` vision features (`sha256: 34d47d929ed3493fe5e5d276d5057fb65c7a2f1acece1610a0f7ee6d0b6588a6`).
- `tools/trtmc_compare.py --suite mmmu_pro_vision_plugin_parity --limit 5 ...` — PASS, 5/5 samples with token agreement rate 1.0; `mmmu_pro_vision_000005` matched reference output `I`.

## Notes For Future Readers

The disputed sample's dataset label remains `J`; this change fixes deterministic agreement with the official FP16 Hugging Face execution path, which emits `I`. The parity gate remains unchanged.
