### PR TITLE
fix(ci): check internal CI trigger role

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -79,12 +79,14 @@ jobs:
           }
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
 
-          actor_permission="$(
+          # The legacy .permission field maps maintain to write. Use
+          # .role_name so maintainers remain distinct from write users.
+          actor_role="$(
             gh api --method GET \
               "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
-              --jq '.permission'
+              --jq '.role_name'
           )"
-          case "$actor_permission" in
+          case "$actor_role" in
             maintain|admin) ;;
             *)
               echo "::error::Only actors with maintain or admin access may dispatch CI."

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -207,7 +207,7 @@ def _run_internal_ci_snapshot(
     head_repo: str | None = "NVIDIA/TensorRT-Model-Connect",
     head_ref: str = "refactor/validation-engine",
     event_name: str = "pull_request_target",
-    actor_permission: str = "maintain",
+    actor_role: str = "maintain",
     max_attempts: int = 1,
     branch_available: bool = True,
     system_path: str | None = None,
@@ -228,7 +228,7 @@ endpoint = next(
     "",
 )
 if "/collaborators/" in endpoint:
-    print(os.environ["FAKE_ACTOR_PERMISSION"])
+    print(os.environ["FAKE_ACTOR_ROLE"])
 elif "/pulls/" in endpoint:
     pulls = json.loads(os.environ["FAKE_PULL_JSONS"])
     counter_path = os.environ["FAKE_PULL_COUNTER"]
@@ -289,7 +289,7 @@ else:
             "ACTOR": "trusted-maintainer",
             "EVENT_HEAD_SHA": event_head_sha,
             "EVENT_NAME": event_name,
-            "FAKE_ACTOR_PERMISSION": actor_permission,
+            "FAKE_ACTOR_ROLE": actor_role,
             "FAKE_BRANCH_COUNTER": str(tmp_path / "branch-counter"),
             "FAKE_BRANCH_AVAILABLE": "true" if branch_available else "false",
             "FAKE_BRANCH_HEAD_SHAS": json.dumps(branch_head_shas),
@@ -406,6 +406,8 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert dispatch_permissions.strip() == "statuses: write"
 
     assert "collaborators/$ACTOR/permission" in authorize
+    assert "--jq '.role_name'" in authorize
+    assert "--jq '.permission'" not in authorize
     assert "maintain|admin)" in authorize
     assert "write|maintain|admin)" not in authorize
     assert "Only actors with maintain or admin access" in authorize
@@ -619,7 +621,7 @@ def test_internal_ci_guard_only_allows_maintainers_and_admins(
             event_head_sha=head_sha,
             pr_head_sha=head_sha,
             branch_head_sha=head_sha,
-            actor_permission=permission,
+            actor_role=permission,
         )
         assert result.returncode == 0, result.stdout + result.stderr
 
@@ -630,7 +632,7 @@ def test_internal_ci_guard_only_allows_maintainers_and_admins(
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
         branch_head_sha=head_sha,
-        actor_permission="write",
+        actor_role="write",
     )
     assert result.returncode != 0
     assert "Only actors with maintain or admin access" in result.stdout + result.stderr


### PR DESCRIPTION
## Background

PR #714 exposed an authorization regression in the source-to-internal-CI bridge. GitHub's collaborator API maps the built-in Maintain role to `write` in the legacy `.permission` field, so valid maintainers were rejected before internal CI was dispatched.

## Exit Criteria

- Maintainers and admins can trigger internal CI.
- Users with only Write access remain unable to trigger internal CI.
- The workflow contract prevents authorization from reverting to the legacy `.permission` field.

## Implementation

- Authorize the trigger actor using the API response's `.role_name` field.
- Keep the accepted roles restricted to `maintain` and `admin`.
- Update the workflow test fixture and assert that `.permission` is not used for authorization.

## Validation

- `python -m pytest tests/tools/test_github_actions_ci.py -q`: passed, 69 tests.
- `git diff --check`: passed.
- `actionlint .github/workflows/internal-ci-bridge.yml`: not run because `actionlint` is not installed in the local environment.

## Notes For Future Readers

The REST endpoint path still ends in `/permission`; that endpoint returns both fields. The legacy `.permission` value collapses Maintain into `write`, while `.role_name` preserves the assigned role needed by this policy.
