### PR TITLE
test(elf): constrain optional plugin hook mocks

### DIFF
--- a/tests/e2e/models/elf_flow/test_elf_flow_bundle_packaging.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_bundle_packaging.py
@@ -8,7 +8,39 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-from tensorrt_model_connect.engine_builder import build_bundle
+from tensorrt_model_connect.engine_builder import (
+    _tokenizer_json_bundle_override_from_plugin,
+    build_bundle,
+)
+from tensorrt_model_connect.families.elf_flow.plugin import ELFPlugin
+
+
+def _elf_plugin_mock() -> MagicMock:
+    """Return an ELF-shaped mock without fabricating optional plugin hooks."""
+    mock_plugin = MagicMock(spec=ELFPlugin)
+    mock_plugin.name = "elf"
+    mock_plugin.runtime_strategy = "elf_flow"
+    mock_plugin.load_weights.return_value = {}
+    mock_plugin.build_engine.return_value = b"PLAN"
+    mock_plugin.get_bundle_config_overrides.return_value = {
+        "runtime_strategy": "elf_flow",
+        "model_type": "elf",
+        "elf_max_length": 1024,
+        "elf_max_input_length": 0,
+        "elf_text_encoder_dim": 512,
+        "elf_input_dim": 1024,
+        "elf_denoiser_noise_scale": 2.0,
+    }
+    del mock_plugin.build_extra_engines
+    return mock_plugin
+
+
+def test_elf_mock_does_not_fabricate_optional_tokenizer_override(tmp_path):
+    """ELF has no tokenizer override hook, so the builder takes its no-hook path."""
+    mock_plugin = _elf_plugin_mock()
+
+    assert not hasattr(mock_plugin, "tokenizer_json_bundle_override")
+    assert _tokenizer_json_bundle_override_from_plugin(mock_plugin, tmp_path) is None
 
 
 def test_yaml_only_elf_synthesizes_config_json_section(tmp_path):
@@ -30,27 +62,7 @@ def test_yaml_only_elf_synthesizes_config_json_section(tmp_path):
     )
     output_path = str(tmp_path / "output.trtfb")
 
-    mock_plugin = MagicMock()
-    mock_plugin.name = "elf"
-    mock_plugin.runtime_strategy = "elf_flow"
-    mock_plugin.load_weights.return_value = {}
-    mock_plugin.build_engine.return_value = b"PLAN"
-    mock_plugin.get_bundle_config_overrides.return_value = {
-        "runtime_strategy": "elf_flow",
-        "model_type": "elf",
-        "elf_max_length": 1024,
-        "elf_max_input_length": 0,
-        "elf_text_encoder_dim": 512,
-        "elf_input_dim": 1024,
-        "elf_denoiser_noise_scale": 2.0,
-    }
-
-    del mock_plugin.build_vision_engine
-    del mock_plugin.build_extra_engines
-    del mock_plugin.embed_input
-    del mock_plugin.get_vl_config
-    del mock_plugin.get_segmentation_config
-    del mock_plugin.get_audio_config
+    mock_plugin = _elf_plugin_mock()
 
     with patch(
         "tensorrt_model_connect.engine_builder.find_plugin",


### PR DESCRIPTION
## Why

The ELF nightly test used an unconstrained `MagicMock` as a plugin. That mock silently fabricated an optional tokenizer hook which the real ELF plugin does not implement, so packaging tried to use a mock return value as tokenizer bytes.

This is a real test-fixture issue, not an ELF production-runtime defect.

## What changed

- Constrain the test double to the real `ELFPlugin` interface.
- Add a regression proving the mock cannot fabricate the optional tokenizer hook.
- Preserve the existing YAML-only packaging coverage.

## Validation

- Baseline reproduction: packaging raised `TypeError` because the fabricated hook returned a `MagicMock` instead of bytes or `None`.
- Focused ELF packaging tests: 2 passed.
- Broader selected nightly Python tests: 50 passed, 2 skipped.
- Existing tokenizer override test: passed.
- Ruff and diff checks: passed.

## Limitations

The full ELF E2E directory was not rerun because the sandbox could not resolve an unrelated JAX dependency. The changed test path and neighboring contract tests passed locally.
