### PR TITLE
fix(ci): budget GPU capacity probe queue yields

### DIFF
--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -2271,6 +2271,7 @@ def test_explicit_runner_gpu_id_still_acquires_a_slot_lease(tmp_path: Path) -> N
     assert (tmp_path / "gpu-locks" / "gpu-7-slot-0.lock").is_file()
 
 
+@pytest.mark.model_proof_allocator
 def test_capacity_gated_exclusive_lease_skips_a_memory_busy_gpu(
     tmp_path: Path,
 ) -> None:
@@ -2278,6 +2279,7 @@ def test_capacity_gated_exclusive_lease_skips_a_memory_busy_gpu(
         tmp_path,
         "2, 284208, 184208, 100000\n3, 284208, 34208, 250000",
     )
+    context.env["FAKE_NVIDIA_SMI_DELAY_SECONDS"] = "0.25"
     artifacts = tmp_path / "artifacts"
     lease = GpuLease(
         context,

--- a/tools/ci/gpu_lease.py
+++ b/tools/ci/gpu_lease.py
@@ -48,6 +48,8 @@ class FileLock:
 class GpuLease:
     """Hold one shared slot or every slot of one GPU until explicitly released."""
 
+    CAPACITY_REQUEUE_DELAY_SECONDS = 1.0
+
     LOCK_FILE_PATTERNS = (
         "allocator.lock",
         "admission-{scope}.enqueue.lock",
@@ -483,7 +485,13 @@ class GpuLease:
             return True
         assert self.gpu_id is not None
         now = time.monotonic()
-        settle_deadline = now + max(0.0, deadline - now) / max(1, candidates_remaining)
+        requeue_budget = (
+            max(0, candidates_remaining - 1) * self.CAPACITY_REQUEUE_DELAY_SECONDS
+        )
+        settle_budget = max(0.0, deadline - now - requeue_budget) / max(
+            1, candidates_remaining
+        )
+        settle_deadline = now + settle_budget
         settle_poll_interval = max(0.25, min(5.0, self.poll_interval))
         while time.monotonic() < settle_deadline:
             try:
@@ -865,7 +873,12 @@ class GpuLease:
     def _requeue_after_capacity_rejection(self, deadline: float) -> bool:
         self._release_ticket()
         print("Yielding the GPU admission queue after a memory-capacity rejection")
-        time.sleep(min(1.0, max(0.0, deadline - time.monotonic())))
+        time.sleep(
+            min(
+                self.CAPACITY_REQUEUE_DELAY_SECONDS,
+                max(0.0, deadline - time.monotonic()),
+            )
+        )
         if time.monotonic() >= deadline:
             return False
         try:


### PR DESCRIPTION
## Why

The nightly package job could reject one busy GPU and then time out before it had enough budget to probe the next eligible GPU. The allocator used one global deadline but did not reserve the fixed queue-yield interval between capacity candidates.

This is a real CI reliability issue: an available GPU can be missed solely because probe latency plus the fixed requeue sleep consumes the deadline.

## What changed

- Reserve the capacity-rejection queue yield before spending the remaining deadline on settle polling.
- Use one shared constant for the queue-yield interval.
- Make the allocator regression reproduce the failure with delayed `nvidia-smi` probes.

## Validation

- Baseline reproduction: the delayed-probe scenario timed out after rejecting GPU 2 and never selected eligible GPU 3.
- Fixed reproduction: the same scenario selected GPU 3 and passed.
- Model-proof allocator marker suite: 17 passed.
- Capacity and GPU-NUMA focused suites: 31 passed.
- Builder coverage gate: passed.
- Ruff and diff checks: passed.

## Limitations

The regression uses deterministic simulated probe latency. It does not reproduce every possible real host scheduling delay.
