### PR TITLE
fix(tokenizer): honor CLIP Split behavior

### DIFF
--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -463,8 +463,9 @@ inline bool try_whitespace_run(char32_t cp, const char*& p, const char* end, con
     if (!is_whitespace(cp))
         return false;
 
-    // CLIP's Split pre-tokenizer retains regex matches and removes the gaps,
-    // so whitespace never reaches its ByteLevel pre-tokenizer.
+    // kClip is selected only for CLIP's Removed + inverted Split contract,
+    // which retains regex matches and removes the gaps. Whitespace therefore
+    // never reaches ByteLevel.
     if (variant == Variant::kClip) {
         scan_all_whitespace(p, end);
         return true;
@@ -1176,13 +1177,21 @@ class BpeTokenizer final : public ITokenizer {
         return std::stoi(regex.substr(comma + 1, close - comma - 1));
     }
 
-    // Classify a single Split regex string into a pre-tokenizer variant.
-    static pretok::Variant classify_split_regex(const std::string& regex, int& digit_group_out) {
+    // Classify one Split pre-tokenizer from both its pattern and contract.
+    static pretok::Variant classify_split(const nlohmann::json& split, int& digit_group_out) {
+        const auto regex = split["pattern"]["Regex"].get<std::string>();
         if ((regex.find("startoftext") != std::string::npos ||
              regex.find("endoftext") != std::string::npos) &&
             regex.find("\\p{L}") != std::string::npos &&
             regex.find("\\p{N}") != std::string::npos) {
-            return pretok::Variant::kClip;
+            const auto behavior = split.value("behavior", "");
+            const bool invert = split.value("invert", false);
+            if (behavior == "Removed" && invert)
+                return pretok::Variant::kClip;
+            if (behavior == "Isolated" && invert)
+                return pretok::Variant::kGpt2;
+            throw std::runtime_error("Unsupported CLIP Split contract: behavior=" + behavior +
+                                     ", invert=" + (invert ? "true" : "false"));
         }
         if (regex.find("[^\r\n") != std::string::npos ||
             regex.find("[^\\r\\n") != std::string::npos) {
@@ -1199,7 +1208,7 @@ class BpeTokenizer final : public ITokenizer {
         return pretok::Variant::kGpt2;
     }
 
-    // Detect variant from the Split regex inside a Sequence pre_tokenizer.
+    // Detect variant from the Split inside a Sequence pre_tokenizer.
     static pretok::Variant detect_split_variant(const nlohmann::json& pt, int& digit_group_out) {
         digit_group_out = 0;
         if (!pt.contains("pretokenizers"))
@@ -1209,8 +1218,7 @@ class BpeTokenizer final : public ITokenizer {
                 continue;
             if (!sub.contains("pattern") || !sub["pattern"].contains("Regex"))
                 continue;
-            return classify_split_regex(sub["pattern"]["Regex"].get<std::string>(),
-                                        digit_group_out);
+            return classify_split(sub, digit_group_out);
         }
         return pretok::Variant::kGpt2;
     }

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -1177,29 +1177,44 @@ class BpeTokenizer final : public ITokenizer {
         return std::stoi(regex.substr(comma + 1, close - comma - 1));
     }
 
+    static bool is_clip_split_regex(const std::string& regex) {
+        const bool has_boundary_token = regex.find("startoftext") != std::string::npos ||
+                                        regex.find("endoftext") != std::string::npos;
+        return has_boundary_token && regex.find("\\p{L}") != std::string::npos &&
+               regex.find("\\p{N}") != std::string::npos;
+    }
+
+    static pretok::Variant classify_clip_split(const nlohmann::json& split) {
+        const auto behavior = split.value("behavior", "");
+        const bool invert = split.value("invert", false);
+        if (behavior == "Removed" && invert)
+            return pretok::Variant::kClip;
+        if (behavior == "Isolated" && invert)
+            return pretok::Variant::kGpt2;
+        throw std::runtime_error("Unsupported CLIP Split contract: behavior=" + behavior +
+                                 ", invert=" + (invert ? "true" : "false"));
+    }
+
+    static bool is_qwen3_split_regex(const std::string& regex) {
+        return regex.find("[^\r\n") != std::string::npos ||
+               regex.find("[^\\r\\n") != std::string::npos;
+    }
+
+    static bool is_bloom_split_regex(const std::string& regex) {
+        return regex.find("[^(\\s") != std::string::npos ||
+               regex.find("[^(\\\\s") != std::string::npos;
+    }
+
     // Classify one Split pre-tokenizer from both its pattern and contract.
     static pretok::Variant classify_split(const nlohmann::json& split, int& digit_group_out) {
         const auto regex = split["pattern"]["Regex"].get<std::string>();
-        if ((regex.find("startoftext") != std::string::npos ||
-             regex.find("endoftext") != std::string::npos) &&
-            regex.find("\\p{L}") != std::string::npos &&
-            regex.find("\\p{N}") != std::string::npos) {
-            const auto behavior = split.value("behavior", "");
-            const bool invert = split.value("invert", false);
-            if (behavior == "Removed" && invert)
-                return pretok::Variant::kClip;
-            if (behavior == "Isolated" && invert)
-                return pretok::Variant::kGpt2;
-            throw std::runtime_error("Unsupported CLIP Split contract: behavior=" + behavior +
-                                     ", invert=" + (invert ? "true" : "false"));
-        }
-        if (regex.find("[^\r\n") != std::string::npos ||
-            regex.find("[^\\r\\n") != std::string::npos) {
+        if (is_clip_split_regex(regex))
+            return classify_clip_split(split);
+        if (is_qwen3_split_regex(regex)) {
             digit_group_out = parse_digit_group(regex);
             return pretok::Variant::kQwen3;
         }
-        if (regex.find("[^(\\s") != std::string::npos ||
-            regex.find("[^(\\\\s") != std::string::npos) {
+        if (is_bloom_split_regex(regex)) {
             return pretok::Variant::kBloom;
         }
         if (regex.find("\\s?[A-Za-z") != std::string::npos) {

--- a/tests/cpp/test_bpe_tokenizer.cpp
+++ b/tests/cpp/test_bpe_tokenizer.cpp
@@ -159,7 +159,7 @@ static const char* kClipNormalizedJson = R"({
     "end_of_word_suffix": "</w>",
     "vocab": {
       "e": 0, "a": 1, "r": 2,
-      "ea": 3, "r</w>": 4, "ear</w>": 5,
+      "ea": 3, "r</w>": 4, "ear</w>": 5, "\u0120": 6,
       "<|startoftext|>": 10, "<|endoftext|>": 11
     },
     "merges": ["e a", "ea r</w>"]
@@ -502,14 +502,24 @@ int main() {
         check(!ids.empty(), "null_end_of_word_suffix_encode");
     }
 
-    // === 7d. CLIP normalizer and whitespace-removing split ===
+    // === 7d. CLIP normalizer and Split behavior contract ===
     {
         std::cerr << "\n=== CLIP Normalization and Split ===\n";
 
         std::string clip_json(kClipNormalizedJson);
         auto tok = trtmc::CreateBpeTokenizer(clip_json.data(), clip_json.size(), true);
         auto ids = tok->encode("EAR   ear");
-        check(ids == std::vector<int32_t>({10, 5, 5, 11}), "clip_normalizer_and_split_encode");
+        check(ids == std::vector<int32_t>({10, 5, 5, 11}),
+              "clip_removed_split_discards_unmatched_whitespace");
+
+        const std::string removed = "\"behavior\": \"Removed\"";
+        const auto behavior = clip_json.find(removed);
+        check(behavior != std::string::npos, "clip_split_fixture_has_removed_behavior");
+        clip_json.replace(behavior, removed.size(), "\"behavior\": \"Isolated\"");
+        auto isolated = trtmc::CreateBpeTokenizer(clip_json.data(), clip_json.size(), true);
+        auto isolated_ids = isolated->encode("EAR   ear");
+        check(isolated_ids == std::vector<int32_t>({10, 5, 6, 5, 11}),
+              "clip_isolated_split_preserves_unmatched_whitespace");
     }
 
     // === 8. STRING merge format (StringMerge / SentencePiece style) ===

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -653,6 +653,37 @@ def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None
     assert result["unit_scope"] == "all"
 
 
+def test_tokenizer_platform_change_always_selects_known_consumers(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path, model_ids=("flux", "model_a", "sam3"))
+    _write(repo, "src/tokenizer/bpe_tokenizer.cpp", "// changed shared tokenizer\n")
+    head = _commit(repo, "change shared tokenizer")
+
+    result = _impact(repo, base, head, fallback_models=("model_a",))
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["flux", "model_a", "sam3"]
+    assert result["direct_models"] == ["flux", "sam3"]
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {
+        "include": [
+            {"model": "flux", "selection_kind": "direct"},
+            {"model": "model_a", "selection_kind": "fallback"},
+            {"model": "sam3", "selection_kind": "direct"},
+        ]
+    }
+    tokenizer_classification = next(
+        classification
+        for change in result["changes"]
+        for classification in change["classifications"]
+        if classification["path"] == "src/tokenizer/bpe_tokenizer.cpp"
+    )
+    assert tokenizer_classification == {
+        "path": "src/tokenizer/bpe_tokenizer.cpp",
+        "kind": "platform",
+        "consumer_models": ["flux", "sam3"],
+    }
+
+
 def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "python/tensorrt_model_connect/families/__init__.py", "# changed registry\n")

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -234,6 +234,13 @@ PLATFORM_PREFIXES = (
     "tests/",
     "third_party/",
 )
+
+# Broad platform changes still use a representative fallback matrix, but some
+# shared surfaces have known model consumers whose owned contracts must always
+# run. Keep this list narrow and evidence-based so a tokenizer change cannot be
+# certified only by unrelated fallback models.
+PLATFORM_CONSUMERS_BY_PREFIX = (("src/tokenizer/", frozenset({"flux", "sam3"})),)
+
 CI_OR_TOOLING_PREFIXES = (
     ".agents/",
     ".ci/",
@@ -641,6 +648,15 @@ def _merge_unit_scope(current: str, requested: str) -> str:
     return "all"
 
 
+def _platform_consumers(path: str, catalog: OwnershipCatalog) -> tuple[str, ...]:
+    known_models = set(catalog.models)
+    consumers: set[str] = set()
+    for prefix, models in PLATFORM_CONSUMERS_BY_PREFIX:
+        if path.startswith(prefix):
+            consumers.update(models & known_models)
+    return tuple(sorted(consumers))
+
+
 def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | None]:
     if path in MODEL_ROOT_PLATFORM_FILES:
         return "platform", None
@@ -973,7 +989,7 @@ def calculate_impact(
     )
     serialized_changes: list[dict[str, object]] = []
     for change in _diff_entries(repo_root, comparison_base, head_sha):
-        classifications: list[dict[str, str]] = []
+        classifications: list[dict[str, object]] = []
         path_catalogs = (
             (change.old_path, base_catalog),
             (change.new_path, head_catalog),
@@ -1000,6 +1016,10 @@ def calculate_impact(
             elif kind in {"platform", "ci_tooling", "unknown"}:
                 broad_change = True
                 unit_scope = _merge_unit_scope(unit_scope, "all")
+                consumers = _platform_consumers(path, head_catalog)
+                if consumers:
+                    affected.update(consumers)
+                    item["consumer_models"] = list(consumers)
             classifications.append(item)
         serialized_changes.append(
             {


### PR DESCRIPTION
## Why

Flux and SAM3 both consume the shared C++ BPE tokenizer, but the implementation classified `Split` behavior from the regex shape alone. It therefore conflated different tokenizer JSON contracts and mishandled SAM3's CLIP split behavior.

Model isolation did not prevent this because isolation removes sibling model-owned code, while the shared tokenizer remains intentionally present in each model projection. CI impact routing also did not explicitly select both known consumers for shared tokenizer changes.

This is a real shared-platform correctness and CI-coverage issue.

## What changed

- Interpret the complete tokenizer `Split` contract, including behavior and invert flags.
- Add generic C++ regression coverage for the CLIP/SAM3 form.
- Treat Flux and SAM3 as direct consumers when shared tokenizer sources change.
- Add impact-routing regression coverage for both consumers.

## Validation

- Baseline reproduction: the SAM3 tokenizer C++ check failed with the shared implementation.
- SAM3 GPU tokenizer test: passed.
- Generic BPE C++ test: passed.
- `tools/model_ci.py` tests: 74 passed.
- Ruff and diff checks: passed.

## Limitations

The explicit shared-consumer map must be updated if another model family adopts this tokenizer implementation.
