### PR TITLE
fix(sana-wm): warm reference license asset

### DIFF
--- a/python/tensorrt_model_connect/families/sana_wm/MODEL.toml
+++ b/python/tensorrt_model_connect/families/sana_wm/MODEL.toml
@@ -22,6 +22,9 @@ prefixes = [
 hf_warm_dependencies = [
   "stage-1-text-encoder|Efficient-Large-Model/gemma-2-2b-it",
 ]
+hf_warm_files = [
+  "official-reference-license|Efficient-Large-Model/SANA-WM_bidirectional|LICENSE",
+]
 hf_allow_patterns = [
   "README.md",
   "config.yaml",

--- a/tests/e2e/models/sana_wm/test_sana_wm_warm_hf_cache_metadata.py
+++ b/tests/e2e/models/sana_wm/test_sana_wm_warm_hf_cache_metadata.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
-from tensorrt_model_connect.families import family_hf_warm_dependencies
+from tensorrt_model_connect.families import (
+    family_hf_warm_dependencies,
+    family_hf_warm_files,
+)
 
 
 def test_sana_wm_stage1_text_encoder_dependency_is_family_owned() -> None:
@@ -15,3 +18,13 @@ def test_sana_wm_stage1_text_encoder_dependency_is_family_owned() -> None:
         dependencies["stage-1-text-encoder"]
         == "Efficient-Large-Model/gemma-2-2b-it"
     )
+
+
+def test_sana_wm_official_reference_license_is_warmed() -> None:
+    files = family_hf_warm_files("sana_wm")
+
+    assert (
+        "official-reference-license",
+        "Efficient-Large-Model/SANA-WM_bidirectional",
+        "LICENSE",
+    ) in files

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -275,6 +275,19 @@ def test_family_file_assets_are_metadata_driven() -> None:
             assert filename not in text
 
 
+def test_family_file_assets_are_scoped_to_selected_manifests() -> None:
+    text = WARM_HF_CACHE.read_text(encoding="utf-8")
+    selection_guard = (
+        "if filter_names is not None and name not in filter_names:\n"
+        "        continue"
+    )
+    family_assets = (
+        'file_assets.extend(_family_hf_warm_files(d.get("family", "")))'
+    )
+
+    assert text.index(selection_guard) < text.index(family_assets)
+
+
 def test_family_file_asset_guard_allows_global_filename_collisions() -> None:
     """A generic weight name is not itself family-specific hard-coding."""
     assert "pytorch_model.bin" in _literal_string_list("_HF_ALLOW_PATTERNS")

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -282,7 +282,7 @@ def test_family_file_assets_are_scoped_to_selected_manifests() -> None:
         "        continue"
     )
     family_assets = (
-        'file_assets.extend(_family_hf_warm_files(d.get("family", "")))'
+        'file_assets.extend(_family_hf_warm_file_specs(d.get("family", "")))'
     )
 
     assert text.index(selection_guard) < text.index(family_assets)


### PR DESCRIPTION
## Why

SANA-WM generated all expected TensorRT frames, but its offline official-reference process failed before comparison because the cached Hugging Face snapshot was missing `LICENSE`.

This is a real offline cache-completeness issue. It is not evidence of a TensorRT generation failure.

## What changed

- Declare the official-reference `LICENSE` file as a SANA-WM family warm-cache asset.
- Add metadata regression coverage for that exact dependency.
- Add a static regression proving family file assets remain scoped to selected manifests.

## Validation

- Nightly artifact inspection: TensorRT produced 320 frames; the official reference failed on the missing cached file.
- Warm-cache and SANA-WM focused tests: 41 passed.
- Family/model manifest validation: 78 models validated.
- Ruff and diff checks: passed.

## Limitations

An online cache rewarm and full GPU reference comparison were not rerun locally. The upstream SANA-WM manifest remains unpinned, so unrelated upstream drift is still possible.
