### PR TITLE
fix(nemotron-h): honor all EOS token IDs

### DIFF
--- a/src/runtime/models/nemotron_h/pipeline.cpp
+++ b/src/runtime/models/nemotron_h/pipeline.cpp
@@ -26,14 +26,27 @@ inline double elapsed_ms(TimePoint start, TimePoint end) {
 
 namespace trtmc {
 
+namespace {
+
+RecurrentGenConfig normalize_eos_token_ids(RecurrentGenConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
+} // namespace
+
 RecurrentPipeline::RecurrentPipeline(std::unique_ptr<TrtModule> decoder,
                                      std::unique_ptr<NemotronHInferenceState> state,
                                      RecurrentGenConfig config, cudaStream_t stream,
                                      const char* name, std::shared_ptr<ITokenizer> tokenizer,
                                      std::string model_id_str,
                                      std::unique_ptr<NemotronHISampler> sampler)
-    : decoder_(std::move(decoder)), state_(std::move(state)), config_(config), stream_(stream),
-      name_(name), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+    : decoder_(std::move(decoder)), state_(std::move(state)),
+      config_(normalize_eos_token_ids(std::move(config))), stream_(stream), name_(name),
+      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       sampler_(std::move(sampler)) {
     if (!decoder_ || !decoder_->ok())
         throw std::runtime_error(std::string(name_) + ": invalid decoder module");
@@ -64,9 +77,8 @@ TextResult RecurrentPipeline::generate(const std::string& prompt, const Generate
 
     auto input_ids = encode_prompt(*tokenizer_, config_, prompt, cfg);
     int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
-    auto sp = nemotron_h_sampling_params_from_config(cfg, eos);
+    auto sp = nemotron_h_sampling_params_from_config(cfg, config_.id_eos_ids);
     auto output_ids = generate_from_ids(input_ids, max_new, sp);
 
     std::vector<int32_t> new_tokens(
@@ -79,8 +91,7 @@ TextResult RecurrentPipeline::generate(const std::string& prompt, const Generate
 RecurrentPipeline::GenerationResult
 RecurrentPipeline::generate_ids(const std::vector<int32_t>& input_ids, const GenerateConfig& cfg) {
     int32_t max_new = cfg.max_new_tokens;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    auto sp = nemotron_h_sampling_params_from_config(cfg, eos);
+    auto sp = nemotron_h_sampling_params_from_config(cfg, config_.id_eos_ids);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
 }
 

--- a/src/runtime/models/nemotron_h/pipeline.h
+++ b/src/runtime/models/nemotron_h/pipeline.h
@@ -26,6 +26,7 @@ struct RecurrentGenConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
     int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
     bool has_position_input{false};
     std::string chat_template_format{};
 };

--- a/src/runtime/models/nemotron_h/plugin_helpers.cpp
+++ b/src/runtime/models/nemotron_h/plugin_helpers.cpp
@@ -319,6 +319,7 @@ RecurrentGenConfig make_recurrent_gen_config(const BaseConfig& cfg) {
     rgc.vocab_size = cfg.vocab_size;
     rgc.id_bos = cfg.id_bos;
     rgc.id_eos = cfg.id_eos;
+    rgc.id_eos_ids = cfg.id_eos_ids;
     return rgc;
 }
 

--- a/src/runtime/models/nemotron_h/sampler.cpp
+++ b/src/runtime/models/nemotron_h/sampler.cpp
@@ -17,10 +17,18 @@
 
 namespace trtmc {
 
+bool nemotron_h_is_eos_token(const NemotronHSamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
 namespace {
 
 NemotronHSampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
-                                         int32_t eos_token_id) {
+                                         const NemotronHSamplingParams& params) {
     NemotronHSampleResult result;
     const float* best = logits;
     for (int32_t i = 1; i < vocab_size; ++i) {
@@ -29,7 +37,7 @@ NemotronHSampleResult argmax_over_logits(const float* logits, int32_t vocab_size
     }
     result.token_id = static_cast<int32_t>(best - logits);
     result.logprob = *best;
-    result.is_eos = (result.token_id == eos_token_id);
+    result.is_eos = nemotron_h_is_eos_token(params, result.token_id);
     return result;
 }
 
@@ -166,10 +174,10 @@ class NemotronHGreedySampler final : public NemotronHISampler {
         if (vocab_size <= 0 || logits == nullptr) {
             NemotronHSampleResult result;
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = nemotron_h_is_eos_token(params, 0);
             return result;
         }
-        return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+        return argmax_over_logits(logits, vocab_size, params);
     }
 
     NemotronHLogitsLocation logits_location() const override {
@@ -189,12 +197,12 @@ class NemotronHTopKSampler final : public NemotronHISampler {
         NemotronHSampleResult result;
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = nemotron_h_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
 
@@ -210,7 +218,7 @@ class NemotronHTopKSampler final : public NemotronHISampler {
                 result.token_id = dist.indices[static_cast<std::size_t>(i)];
                 result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(i)],
                                                    std::numeric_limits<float>::min()));
-                result.is_eos = (result.token_id == params.eos_token_id);
+                result.is_eos = nemotron_h_is_eos_token(params, result.token_id);
                 return result;
             }
         }
@@ -218,7 +226,7 @@ class NemotronHTopKSampler final : public NemotronHISampler {
         result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
         result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(dist.keep - 1)],
                                            std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = nemotron_h_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -235,16 +243,26 @@ class NemotronHTopKSampler final : public NemotronHISampler {
 
 } // namespace
 
-NemotronHSamplingParams nemotron_h_sampling_params_from_config(const GenerateConfig& cfg,
-                                                               int32_t default_eos) {
+NemotronHSamplingParams
+nemotron_h_sampling_params_from_config(const GenerateConfig& cfg,
+                                       const std::vector<int32_t>& default_eos_token_ids) {
     NemotronHSamplingParams p;
     p.temperature = cfg.temperature;
     p.top_k = cfg.top_k;
     p.top_p = cfg.top_p;
     p.min_p = cfg.min_p;
     p.seed = cfg.seed;
-    p.eos_token_id = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : default_eos;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
     return p;
+}
+
+NemotronHSamplingParams nemotron_h_sampling_params_from_config(const GenerateConfig& cfg,
+                                                               int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return nemotron_h_sampling_params_from_config(cfg, defaults);
 }
 
 std::unique_ptr<NemotronHISampler>

--- a/src/runtime/models/nemotron_h/sampler.h
+++ b/src/runtime/models/nemotron_h/sampler.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace trtmc {
 
@@ -20,6 +21,7 @@ struct NemotronHSamplingParams {
     float repetition_penalty{1.0F};
     int32_t seed{-1};
     int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
 };
 
 enum class NemotronHLogitsLocation {
@@ -43,8 +45,13 @@ class NemotronHISampler {
     virtual void reset() {}
 };
 
+NemotronHSamplingParams
+nemotron_h_sampling_params_from_config(const GenerateConfig& cfg,
+                                       const std::vector<int32_t>& default_eos_token_ids);
 NemotronHSamplingParams nemotron_h_sampling_params_from_config(const GenerateConfig& cfg,
                                                                int32_t default_eos = -1);
+
+bool nemotron_h_is_eos_token(const NemotronHSamplingParams& params, int32_t token_id);
 
 std::unique_ptr<NemotronHISampler> create_nemotron_h_sampler(const NemotronHSamplingParams& params);
 

--- a/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
+++ b/tests/cpp/models/nemotron_h/test_nemotron_h_recurrent_pipeline.cpp
@@ -25,6 +25,7 @@
 #include "runtime/models/nemotron_h/hybrid_state.h"
 #include "runtime/models/nemotron_h/kv_cache.h"
 #include "runtime/models/nemotron_h/pipeline.h"
+#include "runtime/models/nemotron_h/plugin_helpers.h"
 #include "runtime/models/nemotron_h/recurrent_state.h"
 #include "trtmc/runtime/trt_module.h"
 // pipeline_interface.h was removed; GenerateConfig is in trtmc/pipeline.h
@@ -84,8 +85,12 @@ class RecordingTokenizer final : public trtmc::ITokenizer {
     mutable std::string last_text;
 };
 
-// Mock decoder: token_id[1] → logits[4] = constant [0.1, 0.2, 0.9, 0.3]
-static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_decoder() {
+// Mock decoder defaults to token_id[1] → logits[4] = [0.1, 0.2, 0.9, 0.3].
+// Tests can select a different vocabulary size and winning token.
+static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_decoder(int32_t winning_token = 2,
+                                                                     int32_t vocab_size = 4) {
+    if (winning_token < 0 || winning_token >= vocab_size)
+        return nullptr;
     auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
     if (!builder)
         return nullptr;
@@ -94,9 +99,11 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_decoder() {
     config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 20);
 
     auto* inp = network->addInput("token_id", nvinfer1::DataType::kINT32, nvinfer1::Dims{1, {1}});
-    float const_logits[4] = {0.1f, 0.2f, 0.9f, 0.3f};
+    std::vector<float> const_logits(static_cast<std::size_t>(vocab_size), 0.1F);
+    const_logits[static_cast<std::size_t>(winning_token)] = 0.9F;
     auto* cst = network->addConstant(
-        nvinfer1::Dims{1, {4}}, nvinfer1::Weights{nvinfer1::DataType::kFLOAT, const_logits, 4});
+        nvinfer1::Dims{1, {vocab_size}},
+        nvinfer1::Weights{nvinfer1::DataType::kFLOAT, const_logits.data(), vocab_size});
     cst->getOutput(0)->setName("logits");
     network->markOutput(*cst->getOutput(0));
 
@@ -202,6 +209,58 @@ static void test_mamba_pipeline() {
     check(result.token_ids[1] == 2, "mamba: generated token = 2 (eos)");
 
     cudaStreamDestroy(stream);
+}
+
+static std::vector<int32_t> generate_with_model_eos_ids(int32_t winning_token,
+                                                        int32_t request_eos_token_id = -1) {
+    auto engine = build_mock_decoder(winning_token, 13);
+    if (!engine) {
+        std::cerr << "SKIP: can't build multi-EOS engine\n";
+        return {};
+    }
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
+                                                         engine->createExecutionContext(), stream);
+    std::vector<trtmc::NemotronHRecurrentState::TensorSpec> specs = {
+        {"conv_state", {12}},
+        {"ssm_state", {32}},
+    };
+    auto state = std::make_unique<trtmc::NemotronHRecurrentState>(1, specs, stream);
+
+    trtmc::BaseConfig base;
+    base.vocab_size = 13;
+    base.id_eos = 2;
+    base.id_eos_ids = {2, 11, 12};
+    auto config = trtmc::make_recurrent_gen_config(base);
+
+    trtmc::GenerateConfig generate_config;
+    generate_config.max_new_tokens = 3;
+    generate_config.eos_token_id = request_eos_token_id;
+
+    std::vector<int32_t> token_ids;
+    {
+        trtmc::RecurrentPipeline pipeline(std::move(module), std::move(state), std::move(config),
+                                          stream, "NemotronHPipeline");
+        token_ids = pipeline.generate_ids({1}, generate_config).token_ids;
+    }
+    cudaStreamDestroy(stream);
+    return token_ids;
+}
+
+static void test_nemotron_h_multi_eos_stopping() {
+    const auto eos_12 = generate_with_model_eos_ids(12);
+    check(eos_12.size() == 2, "multi-EOS: token 12 stops generation");
+    check(eos_12.size() >= 2 && eos_12[1] == 12, "multi-EOS: token 12 is emitted");
+
+    const auto eos_2 = generate_with_model_eos_ids(2);
+    check(eos_2.size() == 2, "multi-EOS: token 2 still stops generation");
+
+    const auto scalar_override = generate_with_model_eos_ids(12, 3);
+    check(scalar_override.size() == 4,
+          "multi-EOS: explicit scalar override replaces model EOS IDs");
 }
 
 static void test_rwkv_pipeline() {
@@ -369,6 +428,7 @@ int main() {
     test_argmax_recurrent();
     test_recurrent_state_updates_in_place();
     test_mamba_pipeline();
+    test_nemotron_h_multi_eos_stopping();
     test_rwkv_pipeline();
     test_hybrid_pipeline();
     test_generate_applies_chat_template();


### PR DESCRIPTION
## Why

Nemotron-H model configuration may declare more than one EOS token, but the recurrent runtime retained and checked only one ID. Generation could therefore continue after producing another valid EOS token.

This is a real runtime correctness issue.

## What changed

- Preserve the complete configured EOS ID set through recurrent configuration and pipeline setup.
- Stop greedy and top-k generation when the sampled token matches any configured EOS ID.
- Keep the scalar request-level EOS override behavior intact.
- Add regression coverage for primary EOS, secondary EOS, and request override behavior.

## Validation

- Baseline reproduction: generation did not stop on a secondary configured EOS ID.
- Focused Nemotron-H C++ suite: 3/3 tests passed.
- Format and diff checks: passed.

## Limitations

Validation covered the recurrent pipeline and sampler in the project test container. A full model GPU E2E run was not repeated for this draft.
