### PR TITLE
fix(internlm): pin official tokenizer artifact

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -782,7 +782,16 @@ def _ensure_tokenizer_json(model_dir: Path, *, plugin=None) -> None:
     """
     tokenizer_path = model_dir / "tokenizer.json"
     rebuild_wordpiece = _wordpiece_tokenizer_needs_rebuild(model_dir)
+    family_ensure = getattr(plugin, "ensure_tokenizer_json", None)
     if tokenizer_path.exists() and not rebuild_wordpiece:
+        if callable(family_ensure):
+            kwargs = {}
+            if _call_supports_kwarg(family_ensure, "previous_error"):
+                kwargs["previous_error"] = None
+            if not bool(family_ensure(model_dir, **kwargs)):
+                raise RuntimeError(
+                    "family tokenizer validation rejected existing tokenizer.json"
+                )
         return
     if rebuild_wordpiece:
         print(
@@ -826,7 +835,6 @@ def _ensure_tokenizer_json(model_dir: Path, *, plugin=None) -> None:
     except Exception as e:
         slow_tokenizer_error = f"slow tokenizer conversion failed: {e}"
 
-    family_ensure = getattr(plugin, "ensure_tokenizer_json", None)
     if callable(family_ensure):
         kwargs = {}
         if _call_supports_kwarg(family_ensure, "previous_error"):

--- a/python/tensorrt_model_connect/families/__init__.py
+++ b/python/tensorrt_model_connect/families/__init__.py
@@ -446,6 +446,24 @@ def _metadata_triple(spec: str, field_name: str) -> tuple[str, str, str]:
     return first, second, third
 
 
+def _metadata_warm_file_spec(
+    spec: str,
+) -> tuple[str, str, str, str]:
+    parts = [part.strip() for part in spec.split("|")]
+    if len(parts) not in {3, 4} or any(not part for part in parts[:3]):
+        raise ValueError(
+            f"Invalid hf_warm_files entry {spec!r}; expected "
+            "'name|hf_id|filename[|revision]'"
+        )
+    if len(parts) == 3:
+        parts.append("")
+    elif not parts[3]:
+        raise ValueError(
+            f"Invalid hf_warm_files entry {spec!r}; revision must be non-empty"
+        )
+    return parts[0], parts[1], parts[2], parts[3]
+
+
 def _metadata_bool(value: str, field_name: str) -> bool:
     normalized = value.strip().lower()
     if normalized in {"1", "true", "yes", "on"}:
@@ -527,11 +545,22 @@ def family_hf_warm_dependencies(family: object) -> list[tuple[str, str]]:
 
 def family_hf_warm_files(family: object) -> list[tuple[str, str, str]]:
     """Return extra HF files for a matched family as ``(name, hf_id, filename)``."""
+    return [spec[:3] for spec in family_hf_warm_file_specs(family)]
+
+
+def family_hf_warm_file_specs(
+    family: object,
+) -> list[tuple[str, str, str, str]]:
+    """Return warm files as ``(name, hf_id, filename, revision)``.
+
+    Three-field metadata remains valid and produces an empty revision so
+    existing ``family_hf_warm_files`` consumers retain their original shape.
+    """
     metadata = _matching_family_metadata(family)
     if not metadata:
         return []
     return [
-        _metadata_triple(spec, "hf_warm_files")
+        _metadata_warm_file_spec(spec)
         for spec in metadata[0].hf_warm_files
     ]
 

--- a/python/tensorrt_model_connect/families/internlm/MODEL.toml
+++ b/python/tensorrt_model_connect/families/internlm/MODEL.toml
@@ -13,6 +13,9 @@ default_execution_profiles = [
   "runtime|internlm",
   "reference|internlm",
 ]
+hf_warm_files = [
+  "internlm-official-tokenizer-json|internlm/internlm2-step-prover|tokenizer.json|6c727046190546168bf3aba9a1d78d5fb325ff14",
+]
 aliases = [
   "internlm",
   "internlm2",

--- a/python/tensorrt_model_connect/families/internlm/tokenizer_json.py
+++ b/python/tensorrt_model_connect/families/internlm/tokenizer_json.py
@@ -1,11 +1,87 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""InternLM-owned fast-tokenizer serialization fallback."""
+"""Install InternLM's pinned official native tokenizer artifact."""
 
 from __future__ import annotations
 
+import hashlib
+import shutil
+import sys
+import tempfile
 from pathlib import Path
+
+
+PINNED_TOKENIZER_REPO_ID = "internlm/internlm2-step-prover"
+PINNED_TOKENIZER_REVISION = "6c727046190546168bf3aba9a1d78d5fb325ff14"
+PINNED_TOKENIZER_FILENAME = "tokenizer.json"
+PINNED_TOKENIZER_SHA256 = (
+    "1193d3a1aa3d9f74866287ca3c1f7bf64fe54dd6ecf015e751f13ebce509e411"
+)
+SOURCE_TOKENIZER_MODEL_SHA256 = (
+    "f868398fc4e05ee1e8aeba95ddf18ddcc45b8bce55d5093bead5bbf80429b48b"
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_sha256(path: Path, expected: str, label: str) -> None:
+    if not path.is_file():
+        raise RuntimeError(f"{label} is missing: {path}")
+    actual = _sha256_file(path)
+    if actual != expected:
+        raise RuntimeError(
+            f"{label} SHA256 mismatch: expected {expected}, got {actual}: {path}"
+        )
+
+
+def _matches_pinned_source(model_dir: Path) -> bool:
+    model_path = model_dir / "tokenizer.model"
+    return (
+        model_path.is_file()
+        and _sha256_file(model_path) == SOURCE_TOKENIZER_MODEL_SHA256
+    )
+
+
+def resolve_pinned_tokenizer_json(model_dir: str | Path) -> Path:
+    """Resolve and verify the official JSON without permitting network access."""
+    model_path = Path(model_dir) / "tokenizer.model"
+    _require_sha256(
+        model_path,
+        SOURCE_TOKENIZER_MODEL_SHA256,
+        "InternLM source tokenizer.model",
+    )
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        tokenizer_path = Path(
+            hf_hub_download(
+                repo_id=PINNED_TOKENIZER_REPO_ID,
+                filename=PINNED_TOKENIZER_FILENAME,
+                revision=PINNED_TOKENIZER_REVISION,
+                local_files_only=True,
+            )
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "pinned official InternLM tokenizer.json is unavailable in the "
+            f"local Hugging Face cache: {PINNED_TOKENIZER_REPO_ID}@"
+            f"{PINNED_TOKENIZER_REVISION}"
+        ) from exc
+
+    _require_sha256(
+        tokenizer_path,
+        PINNED_TOKENIZER_SHA256,
+        "pinned official InternLM tokenizer.json",
+    )
+    return tokenizer_path
 
 
 def ensure_tokenizer_json(
@@ -13,23 +89,63 @@ def ensure_tokenizer_json(
     *,
     previous_error: str | None = None,
 ) -> bool:
-    del previous_error
+    """Atomically install the verified pinned JSON beside the source model."""
     path = Path(model_dir)
-    if (path / "tokenizer.json").exists():
-        return True
+    tokenizer_path = path / PINNED_TOKENIZER_FILENAME
+    temporary_path: Path | None = None
+
+    # This family can match other InternLM checkpoints. Preserve their existing
+    # tokenizer contract and apply the pinned artifact only to the exact source
+    # model for which byte identity has been established.
+    if not _matches_pinned_source(path):
+        return tokenizer_path.is_file()
 
     try:
-        from transformers import AutoTokenizer
+        if tokenizer_path.exists():
+            _require_sha256(
+                tokenizer_path,
+                PINNED_TOKENIZER_SHA256,
+                "installed InternLM tokenizer.json",
+            )
+            return True
 
-        tokenizer = AutoTokenizer.from_pretrained(
-            str(path),
-            trust_remote_code=True,
-            use_fast=True,
+        pinned_path = resolve_pinned_tokenizer_json(path)
+        with tempfile.NamedTemporaryFile(
+            dir=path,
+            prefix=".trtmc-internlm-tokenizer-",
+            suffix=".json",
+            delete=False,
+        ) as output:
+            temporary_path = Path(output.name)
+            with pinned_path.open("rb") as source:
+                shutil.copyfileobj(source, output)
+
+        _require_sha256(
+            temporary_path,
+            PINNED_TOKENIZER_SHA256,
+            "copied InternLM tokenizer.json",
         )
-        if not getattr(tokenizer, "is_fast", False):
-            return False
-        tokenizer.save_pretrained(str(path))
-    except Exception:
-        return False
+        temporary_path.replace(tokenizer_path)
+        temporary_path = None
+        _require_sha256(
+            tokenizer_path,
+            PINNED_TOKENIZER_SHA256,
+            "installed InternLM tokenizer.json",
+        )
+        print(
+            "[trtmc build] Installed pinned official InternLM tokenizer.json",
+            file=sys.stderr,
+        )
+    except Exception as exc:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        detail = (
+            f"{previous_error}; pinned family tokenizer install failed: {exc}"
+            if previous_error
+            else f"pinned family tokenizer install failed: {exc}"
+        )
+        raise RuntimeError(
+            f"could not install tokenizer.json for {path}; {detail}"
+        ) from exc
 
-    return (path / "tokenizer.json").exists()
+    return tokenizer_path.is_file()

--- a/scripts/warm_hf_cache.py
+++ b/scripts/warm_hf_cache.py
@@ -151,6 +151,14 @@ def _family_hf_warm_files(family: object) -> list[tuple[str, str, str]]:
     return family_hf_warm_files(family)
 
 
+def _family_hf_warm_file_specs(
+    family: object,
+) -> list[tuple[str, str, str, str]]:
+    from tensorrt_model_connect.families import family_hf_warm_file_specs
+
+    return family_hf_warm_file_specs(family)
+
+
 _REQUIRED_FILES_BY_HF_ID = _load_family_hf_required_files_by_id()
 _HF_FAMILY_ALLOW_PATTERNS = _load_family_hf_allow_patterns()
 _HF_DOWNLOAD_PATTERNS = (
@@ -172,12 +180,18 @@ _DOWNLOAD_ATTEMPTS = 2
 _DEFAULT_ATTEMPT_TIMEOUT_SECONDS = 600.0
 
 
-def _is_hf_file_cached(hf_id: str, filename: str) -> bool:
+def _is_hf_file_cached(
+    hf_id: str,
+    filename: str,
+    revision: str = "",
+) -> bool:
     try:
+        revision_kwargs = {"revision": revision} if revision else {}
         hf_hub_download(
             hf_id,
             filename=filename,
             local_files_only=True,
+            **revision_kwargs,
         )
     except Exception:
         return False
@@ -281,7 +295,7 @@ if args.strict and filter_names is not None:
         sys.exit(1)
 
 entries: list[tuple[str, str, str, bool, bool]] = []
-file_assets: list[tuple[str, str, str]] = []
+file_assets: list[tuple[str, str, str, str]] = []
 for m in manifests:
     d = json.loads(m.read_text())
     name = d.get("name", m.stem)
@@ -314,7 +328,7 @@ for m in manifests:
             d.get("family", "")
         )
     )
-    file_assets.extend(_family_hf_warm_files(d.get("family", "")))
+    file_assets.extend(_family_hf_warm_file_specs(d.get("family", "")))
 deduped_entries: list[tuple[str, str, str, bool, bool]] = []
 entry_indexes: dict[tuple[str, str], int] = {}
 for name, hf_id, revision, gated, require_weights in entries:
@@ -333,15 +347,22 @@ for name, hf_id, revision, gated, require_weights in entries:
         old_require_weights or require_weights,
     )
 entries = deduped_entries
-deduped_file_assets: list[tuple[str, str, str]] = []
-seen_file_assets: set[tuple[str, str]] = set()
-for asset_name, asset_hf_id, filename in file_assets:
-    asset_key = (asset_hf_id, filename)
-    if asset_key in seen_file_assets:
-        continue
-    seen_file_assets.add(asset_key)
-    deduped_file_assets.append((asset_name, asset_hf_id, filename))
-file_assets = deduped_file_assets
+def _dedupe_file_assets(
+    assets: list[tuple[str, str, str, str]],
+) -> list[tuple[str, str, str, str]]:
+    deduped: list[tuple[str, str, str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for asset in assets:
+        asset_name, asset_hf_id, filename, revision = asset
+        asset_key = (asset_hf_id, filename, revision)
+        if asset_key in seen:
+            continue
+        seen.add(asset_key)
+        deduped.append((asset_name, asset_hf_id, filename, revision))
+    return deduped
+
+
+file_assets = _dedupe_file_assets(file_assets)
 
 
 def _is_cached(
@@ -654,11 +675,16 @@ def _warm_file(
     hf_id: str,
     filename: str,
     *,
+    revision: str = "",
     selective: bool,
     local_only: bool,
     timeout_seconds: float = _DEFAULT_ATTEMPT_TIMEOUT_SECONDS,
 ) -> tuple[str, str]:
-    if (selective or local_only) and _is_hf_file_cached(hf_id, filename):
+    if (selective or local_only) and _is_hf_file_cached(
+        hf_id,
+        filename,
+        revision=revision,
+    ):
         return "cached", ""
     if local_only:
         return "failed", "required file is not available in the local cache"
@@ -666,6 +692,7 @@ def _warm_file(
         "file",
         hf_id,
         timeout_seconds=timeout_seconds,
+        revision=revision,
         filename=filename,
     )
     return ("downloaded", detail) if local_path else ("failed", detail)
@@ -810,10 +837,14 @@ for i, (name, hf_id, revision, gated, require_weights) in enumerate(entries, 1):
 if file_assets and not stopped_early:
     print()
     print("Warming family file assets...")
-for i, (name, hf_id, filename) in enumerate(file_assets if not stopped_early else [], 1):
+for i, (name, hf_id, filename, revision) in enumerate(
+    file_assets if not stopped_early else [],
+    1,
+):
     status, detail = _warm_file(
         hf_id,
         filename,
+        revision=revision,
         selective=selective,
         local_only=args.local_only,
         timeout_seconds=args.attempt_timeout_seconds,
@@ -857,7 +888,7 @@ else:
 
 if args.emit_cache_repos and not warned:
     selected_repo_ids = [hf_id for _, hf_id, _, _, _ in entries]
-    selected_repo_ids.extend(hf_id for _, hf_id, _ in file_assets)
+    selected_repo_ids.extend(hf_id for _, hf_id, _, _ in file_assets)
     try:
         _write_cache_repository_manifest(
             pathlib.Path(args.emit_cache_repos),

--- a/tests/e2e/models/internlm/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/internlm/e2e_plugins/references/hf_transformers.py
@@ -9,6 +9,7 @@ per-step logits + generated text for comparison against TRT outputs.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -28,6 +29,61 @@ logger = logging.getLogger(__name__)
 
 PROJECT_DIR = Path(__file__).resolve().parents[6]
 E2E_DIR = PROJECT_DIR / "tests" / "e2e"
+
+_REFERENCE_TOKENIZER_REPO_ID = "internlm/internlm2-step-prover"
+_REFERENCE_TOKENIZER_REVISION = "6c727046190546168bf3aba9a1d78d5fb325ff14"
+_REFERENCE_TOKENIZER_FILENAME = "tokenizer.json"
+_REFERENCE_TOKENIZER_SHA256 = (
+    "1193d3a1aa3d9f74866287ca3c1f7bf64fe54dd6ecf015e751f13ebce509e411"
+)
+_REFERENCE_SOURCE_MODEL_SHA256 = (
+    "f868398fc4e05ee1e8aeba95ddf18ddcc45b8bce55d5093bead5bbf80429b48b"
+)
+
+
+def _reference_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_reference_tokenizer_json(model_dir: str | Path) -> Path | None:
+    """Resolve the target checkpoint's official tokenizer independently."""
+    model_path = Path(model_dir) / "tokenizer.model"
+    if (
+        not model_path.is_file()
+        or _reference_sha256(model_path) != _REFERENCE_SOURCE_MODEL_SHA256
+    ):
+        return None
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        tokenizer_path = Path(
+            hf_hub_download(
+                repo_id=_REFERENCE_TOKENIZER_REPO_ID,
+                filename=_REFERENCE_TOKENIZER_FILENAME,
+                revision=_REFERENCE_TOKENIZER_REVISION,
+                local_files_only=True,
+            )
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "pinned official InternLM reference tokenizer is unavailable in "
+            f"the local Hugging Face cache: {_REFERENCE_TOKENIZER_REPO_ID}@"
+            f"{_REFERENCE_TOKENIZER_REVISION}"
+        ) from exc
+
+    actual_sha256 = _reference_sha256(tokenizer_path)
+    if actual_sha256 != _REFERENCE_TOKENIZER_SHA256:
+        raise RuntimeError(
+            "pinned official InternLM reference tokenizer SHA256 mismatch: "
+            f"expected {_REFERENCE_TOKENIZER_SHA256}, got {actual_sha256}: "
+            f"{tokenizer_path}"
+        )
+    return tokenizer_path
 
 
 _PRECISION_TO_TORCH_DTYPE = {
@@ -328,6 +384,12 @@ class HfTransformersReference:
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
         model_ref = _resolve_cached_model_ref(hf_id)
+        resolved_tokenizer_path = _resolve_reference_tokenizer_json(model_ref)
+        tokenizer_path = (
+            str(resolved_tokenizer_path)
+            if resolved_tokenizer_path is not None
+            else None
+        )
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         contract_config = case.metadata.get("contract_config", {})
@@ -335,12 +397,14 @@ class HfTransformersReference:
         enable_thinking = contract_config.get("enable_thinking", True)
 
         script = textwrap.dedent(f"""\
-            import sys, numpy as np, torch
+            import json, sys, numpy as np, torch
+            from pathlib import Path
             from transformers import (
                 AutoModelForCausalLM,
                 AutoModelForSeq2SeqLM,
                 AutoTokenizer,
                 DynamicCache,
+                PreTrainedTokenizerFast,
             )
 
             if not hasattr(DynamicCache, "from_legacy_cache"):
@@ -352,6 +416,7 @@ class HfTransformersReference:
 
             hf_id = {hf_id!r}
             model_ref = {model_ref!r}
+            tokenizer_path = {tokenizer_path!r}
             prompt = {prompt!r}
             max_new_tokens = {max_new_tokens}
             trust_remote_code = {trust_remote_code!r}
@@ -363,8 +428,23 @@ class HfTransformersReference:
             def _np(t):
                 return t.detach().float().cpu().numpy()
 
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_ref, trust_remote_code=trust_remote_code)
+            if tokenizer_path is None:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
+            else:
+                tokenizer_dir = Path(model_ref)
+                tokenizer_config = json.loads(
+                    (tokenizer_dir / "tokenizer_config.json").read_text())
+                tokenizer = PreTrainedTokenizerFast(
+                    tokenizer_file=tokenizer_path,
+                    bos_token=tokenizer_config.get("bos_token"),
+                    eos_token=tokenizer_config.get("eos_token"),
+                    unk_token=tokenizer_config.get("unk_token"),
+                    pad_token=tokenizer_config.get("pad_token"),
+                    chat_template=tokenizer_config.get("chat_template"),
+                    clean_up_tokenization_spaces=tokenizer_config.get(
+                        "clean_up_tokenization_spaces", False),
+                )
             if use_chat_template:
                 messages = [{{"role": "user", "content": prompt}}]
                 try:

--- a/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
+++ b/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
@@ -85,4 +85,8 @@ def test_reference_profile_supports_current_internlm_dynamic_cache_api() -> None
     assert "huggingface-hub==0.26.5" in lock
     assert "tokenizers==0.20.3" in lock
     assert "transformers==4.46.3" in lock
+    assert "protobuf==" not in lock
+    assert "sentencepiece==" not in lock
+    assert "import google.protobuf" not in verify
+    assert "import sentencepiece" not in verify
     assert 'hasattr(DynamicCache, "get_max_cache_shape")' in verify

--- a/tests/e2e/models/internlm/test_internlm_reference_compat.py
+++ b/tests/e2e/models/internlm/test_internlm_reference_compat.py
@@ -3,9 +3,26 @@
 
 from __future__ import annotations
 
+import hashlib
+import importlib
 import inspect
+import sys
+import types
+from pathlib import Path
+
+import pytest
 
 from tests.e2e.models.internlm.e2e_plugins.references import hf_transformers
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _install_fake_hub(monkeypatch: pytest.MonkeyPatch, download) -> None:
+    module = types.ModuleType("huggingface_hub")
+    module.hf_hub_download = download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
 
 
 def test_reference_retries_chat_template_without_thinking_kwarg() -> None:
@@ -14,3 +31,86 @@ def test_reference_retries_chat_template_without_thinking_kwarg() -> None:
     )
     assert "except TypeError:" in source
     assert 'chat_kwargs.pop("enable_thinking", None)' in source
+
+
+def test_reference_uses_independently_pinned_fast_tokenizer() -> None:
+    source = inspect.getsource(
+        hf_transformers.HfTransformersReference._run_full_generation
+    )
+    module_source = inspect.getsource(hf_transformers)
+
+    assert "_resolve_reference_tokenizer_json(model_ref)" in source
+    assert "PreTrainedTokenizerFast" in source
+    assert "tokenizer_file=tokenizer_path" in source
+    assert 'tokenizer_dir / "tokenizer.json"' not in source
+    assert "if tokenizer_path is None:" in source
+    assert "AutoTokenizer.from_pretrained" in source
+    assert "families.internlm.tokenizer_json" not in module_source
+
+
+def test_reference_resolver_is_independent_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"target source model"
+    official_payload = b'{"official": true}'
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    artifact = tmp_path / "official-tokenizer.json"
+    artifact.write_bytes(official_payload)
+    monkeypatch.setattr(
+        hf_transformers,
+        "_REFERENCE_SOURCE_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    monkeypatch.setattr(
+        hf_transformers,
+        "_REFERENCE_TOKENIZER_SHA256",
+        _sha256(official_payload),
+    )
+    calls: list[dict[str, object]] = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs)
+        return str(artifact)
+
+    _install_fake_hub(monkeypatch, fake_download)
+    production_tokenizer = importlib.import_module(
+        "tensorrt_model_connect.families.internlm.tokenizer_json"
+    )
+
+    def product_resolver_must_not_run(*_args, **_kwargs):
+        raise AssertionError("reference must not call the production resolver")
+
+    monkeypatch.setattr(
+        production_tokenizer,
+        "resolve_pinned_tokenizer_json",
+        product_resolver_must_not_run,
+    )
+
+    assert hf_transformers._resolve_reference_tokenizer_json(tmp_path) == artifact
+    assert calls == [
+        {
+            "repo_id": hf_transformers._REFERENCE_TOKENIZER_REPO_ID,
+            "filename": hf_transformers._REFERENCE_TOKENIZER_FILENAME,
+            "revision": hf_transformers._REFERENCE_TOKENIZER_REVISION,
+            "local_files_only": True,
+        }
+    ]
+
+    artifact.write_bytes(b"tampered")
+    with pytest.raises(RuntimeError, match="reference tokenizer SHA256 mismatch"):
+        hf_transformers._resolve_reference_tokenizer_json(tmp_path)
+
+
+def test_reference_resolver_preserves_non_target_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "tokenizer.model").write_bytes(b"another InternLM source")
+
+    def unexpected_download(**_kwargs):
+        raise AssertionError("non-target reference must preserve AutoTokenizer fallback")
+
+    _install_fake_hub(monkeypatch, unexpected_download)
+
+    assert hf_transformers._resolve_reference_tokenizer_json(tmp_path) is None

--- a/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
+++ b/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
@@ -3,38 +3,417 @@
 
 from __future__ import annotations
 
+import hashlib
+import importlib
+import json
+import os
+import shutil
 import sys
 import types
+from pathlib import Path
 
-from tensorrt_model_connect.families.internlm.tokenizer_json import (
-    ensure_tokenizer_json,
+import pytest
+
+from tensorrt_model_connect.engine_builder import _ensure_tokenizer_json
+from tensorrt_model_connect.families import (
+    family_hf_warm_file_specs,
+    family_hf_warm_files,
+)
+
+tokenizer_json = importlib.import_module(
+    "tensorrt_model_connect.families.internlm.tokenizer_json"
 )
 
 
-def test_ensure_tokenizer_json_uses_trusted_fast_tokenizer(monkeypatch, tmp_path):
-    calls = {}
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
 
-    class FakeTokenizer:
-        is_fast = True
 
-        def save_pretrained(self, path):
-            (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+def _install_fake_hub(
+    monkeypatch: pytest.MonkeyPatch,
+    download,
+) -> None:
+    module = types.ModuleType("huggingface_hub")
+    module.hf_hub_download = download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
 
-    class FakeAutoTokenizer:
-        @staticmethod
-        def from_pretrained(path, **kwargs):
-            calls.update(path=path, **kwargs)
-            return FakeTokenizer()
 
-    monkeypatch.setitem(
-        sys.modules,
-        "transformers",
-        types.SimpleNamespace(AutoTokenizer=FakeAutoTokenizer),
+class _InternLMTokenizerPlugin:
+    @staticmethod
+    def ensure_tokenizer_json(model_dir, *, previous_error=None):
+        return tokenizer_json.ensure_tokenizer_json(
+            model_dir,
+            previous_error=previous_error,
+        )
+
+
+def test_internlm_declares_revisioned_official_tokenizer_warm_file() -> None:
+    expected_spec = (
+        "internlm-official-tokenizer-json",
+        tokenizer_json.PINNED_TOKENIZER_REPO_ID,
+        tokenizer_json.PINNED_TOKENIZER_FILENAME,
+        tokenizer_json.PINNED_TOKENIZER_REVISION,
     )
 
-    assert ensure_tokenizer_json(tmp_path)
-    assert calls == {
-        "path": str(tmp_path),
-        "trust_remote_code": True,
-        "use_fast": True,
+    assert family_hf_warm_file_specs("internlm") == [expected_spec]
+    assert family_hf_warm_files("internlm") == [expected_spec[:3]]
+
+
+def test_ensure_tokenizer_json_installs_verified_local_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"source tokenizer model"
+    official_payload = b'{"official": true}'
+    artifact = tmp_path / "cached-official-tokenizer.json"
+    artifact.write_bytes(official_payload)
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    calls: list[dict[str, object]] = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs)
+        return str(artifact)
+
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    monkeypatch.setattr(
+        tokenizer_json,
+        "PINNED_TOKENIZER_SHA256",
+        _sha256(official_payload),
+    )
+    _install_fake_hub(monkeypatch, fake_download)
+
+    assert tokenizer_json.ensure_tokenizer_json(tmp_path)
+    assert (tmp_path / "tokenizer.json").read_bytes() == official_payload
+    assert not list(tmp_path.glob(".trtmc-internlm-tokenizer-*.json"))
+    assert calls == [
+        {
+            "repo_id": tokenizer_json.PINNED_TOKENIZER_REPO_ID,
+            "filename": tokenizer_json.PINNED_TOKENIZER_FILENAME,
+            "revision": tokenizer_json.PINNED_TOKENIZER_REVISION,
+            "local_files_only": True,
+        }
+    ]
+
+
+def test_non_target_source_without_json_preserves_generic_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "tokenizer.model").write_bytes(b"wrong source")
+    downloads: list[dict[str, object]] = []
+    _install_fake_hub(
+        monkeypatch,
+        lambda **kwargs: downloads.append(kwargs),
+    )
+
+    assert not tokenizer_json.ensure_tokenizer_json(tmp_path)
+    assert downloads == []
+    assert not (tmp_path / "tokenizer.json").exists()
+
+
+def test_non_target_source_with_existing_json_remains_supported(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    existing_payload = b'{"version": "unrelated-valid-contract"}'
+    (tmp_path / "tokenizer.model").write_bytes(b"another InternLM source")
+    (tmp_path / "tokenizer.json").write_bytes(existing_payload)
+    downloads: list[dict[str, object]] = []
+    _install_fake_hub(
+        monkeypatch,
+        lambda **kwargs: downloads.append(kwargs),
+    )
+
+    _ensure_tokenizer_json(tmp_path, plugin=_InternLMTokenizerPlugin())
+
+    assert (tmp_path / "tokenizer.json").read_bytes() == existing_payload
+    assert downloads == []
+
+
+def test_pinned_tokenizer_hash_mismatch_is_gating(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"expected source"
+    artifact = tmp_path / "wrong-official-tokenizer.json"
+    artifact.write_bytes(b"wrong official JSON")
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    _install_fake_hub(
+        monkeypatch,
+        lambda **_kwargs: str(artifact),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "generic conversion failed; pinned family tokenizer install failed: "
+            "pinned official InternLM tokenizer.json SHA256 mismatch"
+        ),
+    ):
+        tokenizer_json.ensure_tokenizer_json(
+            tmp_path,
+            previous_error="generic conversion failed",
+        )
+
+    assert not (tmp_path / "tokenizer.json").exists()
+
+
+def test_builder_revalidates_existing_tokenizer_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"expected source"
+    official_payload = b"expected official JSON"
+    artifact = tmp_path / "cached-official-tokenizer.json"
+    artifact.write_bytes(official_payload)
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    (tmp_path / "tokenizer.json").write_bytes(b"stale tokenizer JSON")
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    monkeypatch.setattr(
+        tokenizer_json,
+        "PINNED_TOKENIZER_SHA256",
+        _sha256(official_payload),
+    )
+    _install_fake_hub(monkeypatch, lambda **_kwargs: str(artifact))
+
+    with pytest.raises(
+        RuntimeError,
+        match="installed InternLM tokenizer.json SHA256 mismatch",
+    ):
+        _ensure_tokenizer_json(
+            tmp_path,
+            plugin=_InternLMTokenizerPlugin(),
+        )
+
+
+def test_existing_target_json_validates_without_pinned_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"expected source"
+    official_payload = b"expected official JSON"
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    (tmp_path / "tokenizer.json").write_bytes(official_payload)
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    monkeypatch.setattr(
+        tokenizer_json,
+        "PINNED_TOKENIZER_SHA256",
+        _sha256(official_payload),
+    )
+
+    def unexpected_download(**_kwargs):
+        raise AssertionError("validated installed JSON must not require cache lookup")
+
+    _install_fake_hub(monkeypatch, unexpected_download)
+
+    _ensure_tokenizer_json(tmp_path, plugin=_InternLMTokenizerPlugin())
+
+
+def test_missing_pinned_tokenizer_never_falls_back_to_network_or_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"expected source"
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+
+    def missing(**kwargs):
+        assert kwargs["local_files_only"] is True
+        raise FileNotFoundError("not warmed")
+
+    _install_fake_hub(monkeypatch, missing)
+
+    with pytest.raises(RuntimeError, match="unavailable in the local Hugging Face cache"):
+        tokenizer_json.ensure_tokenizer_json(tmp_path)
+
+    assert not (tmp_path / "tokenizer.json").exists()
+
+
+@pytest.mark.skipif(
+    "TRTMC_MODEL_PROOF_GPU_ID" not in os.environ,
+    reason="real checkpoint artifact proof runs in the isolated model profile",
+)
+def test_real_checkpoint_uses_pinned_official_tokenizer_contract(
+    tmp_path: Path,
+) -> None:
+    """Validate official JSON plus math tokenizer config, not the broken slow path.
+
+    The official slow tokenizer cannot load this model's NUL piece. The oracle
+    here is the independently published, revision-pinned official JSON combined
+    with the exact math checkpoint's tokenizer_config contract.
+    """
+    from huggingface_hub import snapshot_download
+    from tokenizers import Tokenizer
+    from transformers import PreTrainedTokenizerFast
+
+    manifest = json.loads(
+        (
+            Path(__file__).with_name("manifests")
+            / "internlm2-1.8b.json"
+        ).read_text(encoding="utf-8")
+    )
+    snapshot = Path(
+        snapshot_download(
+            repo_id=manifest["hf_id"],
+            local_files_only=True,
+        )
+    )
+    for source in snapshot.iterdir():
+        if source.name == "model.safetensors" or source.is_dir():
+            continue
+        shutil.copy2(source, tmp_path / source.name, follow_symlinks=True)
+
+    _ensure_tokenizer_json(tmp_path, plugin=_InternLMTokenizerPlugin())
+
+    tokenizer_path = tmp_path / "tokenizer.json"
+    assert tokenizer_json._sha256_file(tokenizer_path) == (
+        tokenizer_json.PINNED_TOKENIZER_SHA256
+    )
+    backend = Tokenizer.from_file(str(tokenizer_path))
+    assert backend.get_vocab_size(with_added_tokens=True) == 92_544
+    assert {
+        alias: backend.token_to_id(alias)
+        for alias in (
+            "<|plugin|>",
+            "<|interpreter|>",
+            "<|action_end|>",
+            "<|action_start|>",
+            "<|im_end|>",
+            "<|im_start|>",
+        )
+    } == {
+        "<|plugin|>": 92_538,
+        "<|interpreter|>": 92_539,
+        "<|action_end|>": 92_540,
+        "<|action_start|>": 92_541,
+        "<|im_end|>": 92_542,
+        "<|im_start|>": 92_543,
     }
+
+    config = json.loads(
+        (tmp_path / "tokenizer_config.json").read_text(encoding="utf-8")
+    )
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_file=str(tokenizer_path),
+        bos_token=config.get("bos_token"),
+        eos_token=config.get("eos_token"),
+        unk_token=config.get("unk_token"),
+        pad_token=config.get("pad_token"),
+        chat_template=config.get("chat_template"),
+        clean_up_tokenization_spaces=config.get(
+            "clean_up_tokenization_spaces",
+            False,
+        ),
+    )
+
+    expected_single_ids = {
+        "The capital of France is": [1, 918, 6872, 446, 9760, 505],
+        "Hello, how are you?": [1, 9843, 328, 1392, 657, 629, 345],
+        "你好，世界！": [1, 77230, 60353, 68339, 60477],
+        "  leading  and\tinternal\nwhitespace  ": [
+            1,
+            387,
+            20858,
+            387,
+            568,
+            33437,
+            364,
+            1458,
+            36024,
+            387,
+        ],
+        "café naïve — 🚀": [
+            1,
+            1062,
+            283,
+            63000,
+            4477,
+            67656,
+            717,
+            262,
+            60656,
+            262,
+            243,
+            162,
+            157,
+            131,
+        ],
+        "": [1],
+    }
+    for text, expected_ids in expected_single_ids.items():
+        assert tokenizer.encode(text) == expected_ids
+        assert tokenizer.decode(
+            expected_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        ) == text
+
+    pair = tokenizer(
+        "Hello, how are you?",
+        "你好，世界！",
+        return_token_type_ids=True,
+    )
+    assert pair["input_ids"] == [
+        1,
+        9843,
+        328,
+        1392,
+        657,
+        629,
+        345,
+        1,
+        77230,
+        60353,
+        68339,
+        60477,
+    ]
+    assert pair["token_type_ids"] == [0] * 7 + [1] * 5
+
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "The capital of France is"}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    assert rendered == (
+        "<s><|im_start|>user\nThe capital of France is<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    assert tokenizer.encode(rendered, add_special_tokens=False) == [
+        1,
+        92543,
+        1008,
+        364,
+        918,
+        6872,
+        446,
+        9760,
+        505,
+        92542,
+        364,
+        92543,
+        525,
+        11353,
+        364,
+    ]

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -4642,6 +4642,7 @@ def test_cache_warm_uses_family_metadata() -> None:
         "family_hf_required_files_by_id",
         "family_hf_warm_dependencies",
         "family_hf_warm_files",
+        "family_hf_warm_file_specs",
     ):
         if helper not in warm_text:
             violations.append((WARM_HF_CACHE, 0, f"warm cache missing {helper}"))

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -29,6 +29,7 @@ DOWNLOAD_WORKER = REPO_ROOT / "scripts" / "hf_cache_download_worker.py"
 FAMILIES = REPO_ROOT / "python" / "tensorrt_model_connect" / "families"
 HELPER_FUNCTIONS = {
     "_component_has_weight",
+    "_dedupe_file_assets",
     "_cache_repository_manifest",
     "_diffusers_missing_weight_components",
     "_is_hf_file_cached",
@@ -257,10 +258,14 @@ def test_family_file_assets_are_metadata_driven() -> None:
     text = WARM_HF_CACHE.read_text()
     assert "_family_hf_warm_files" in text
     assert "family_hf_warm_files" in text
+    assert "_family_hf_warm_file_specs" in text
+    assert "family_hf_warm_file_specs" in text
     assert "Warming family file assets" in text
     global_allow_patterns = _literal_string_list("_HF_ALLOW_PATTERNS")
     for spec in _family_metadata_specs("hf_warm_files"):
-        asset_name, hf_id, filename = spec.split("|", 2)
+        parts = spec.split("|")
+        assert len(parts) in {3, 4}
+        asset_name, hf_id, filename = parts[:3]
         assert spec not in text
         assert asset_name not in text
         assert hf_id not in text
@@ -437,6 +442,14 @@ def test_cache_skip_and_worker_forward_pinned_revision(tmp_path: Path) -> None:
     )
     assert command[command.index("--revision") + 1] == revision
 
+    file_command = helpers["_worker_command"](
+        "file",
+        "org/model",
+        revision=revision,
+        filename="tokenizer.json",
+    )
+    assert file_command[file_command.index("--revision") + 1] == revision
+
 
 def test_cache_skip_rejects_unresolvable_local_revision() -> None:
     helpers = _load_cache_helpers()
@@ -530,16 +543,21 @@ def test_file_cache_and_local_only_paths_never_launch_worker() -> None:
     helpers["_run_download_attempts"] = (
         lambda _operation, hf_id, **_kwargs: downloads.append(hf_id)
     )
-    helpers["_is_hf_file_cached"] = lambda _hf_id, _filename: True
+    helpers["_is_hf_file_cached"] = (
+        lambda _hf_id, _filename, revision="": bool(revision)
+    )
 
     assert helpers["_warm_file"](
         "org/model",
         "weights.bin",
+        revision="0123456789abcdef",
         selective=True,
         local_only=False,
     ) == ("cached", "")
 
-    helpers["_is_hf_file_cached"] = lambda _hf_id, _filename: False
+    helpers["_is_hf_file_cached"] = (
+        lambda _hf_id, _filename, revision="": False
+    )
     status, detail = helpers["_warm_file"](
         "org/model",
         "weights.bin",
@@ -549,6 +567,51 @@ def test_file_cache_and_local_only_paths_never_launch_worker() -> None:
     assert status == "failed"
     assert "local cache" in detail
     assert downloads == []
+
+
+def test_file_warm_forwards_revision_to_local_lookup_and_worker() -> None:
+    helpers = _load_cache_helpers()
+    local_calls: list[tuple[str, str, str]] = []
+    worker_calls: list[dict] = []
+    revision = "0123456789abcdef0123456789abcdef01234567"
+
+    def fake_local(hf_id, filename, revision=""):
+        local_calls.append((hf_id, filename, revision))
+        return False
+
+    def fake_attempts(operation, hf_id, **kwargs):
+        worker_calls.append({"operation": operation, "hf_id": hf_id, **kwargs})
+        return "/tmp/tokenizer.json", ""
+
+    helpers["_is_hf_file_cached"] = fake_local
+    helpers["_run_download_attempts"] = fake_attempts
+
+    assert helpers["_warm_file"](
+        "org/model",
+        "tokenizer.json",
+        revision=revision,
+        selective=True,
+        local_only=False,
+    ) == ("downloaded", "")
+    assert local_calls == [("org/model", "tokenizer.json", revision)]
+    assert worker_calls == [
+        {
+            "operation": "file",
+            "hf_id": "org/model",
+            "timeout_seconds": 600.0,
+            "revision": revision,
+            "filename": "tokenizer.json",
+        }
+    ]
+
+
+def test_file_asset_dedup_includes_revision() -> None:
+    dedupe = _load_cache_helpers()["_dedupe_file_assets"]
+    first = ("first", "org/model", "tokenizer.json", "rev-a")
+    duplicate = ("duplicate", "org/model", "tokenizer.json", "rev-a")
+    other_revision = ("second", "org/model", "tokenizer.json", "rev-b")
+
+    assert dedupe([first, duplicate, other_revision]) == [first, other_revision]
 
 
 def test_download_attempts_retry_once_with_xet_disabled(tmp_path: Path) -> None:
@@ -719,6 +782,53 @@ def hf_hub_download(repo_id, *, filename):
     assert json.loads(completed.stdout) == {"path": environment[expected_path_env]}
 
 
+def test_download_worker_forwards_file_revision(tmp_path: Path) -> None:
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    _write_fake_hub_package(
+        tmp_path,
+        f"""
+import os
+
+def snapshot_download(*_args, **_kwargs):
+    raise RuntimeError("unexpected snapshot download")
+
+def hf_hub_download(repo_id, *, filename, revision):
+    assert repo_id == "org/model"
+    assert filename == "tokenizer.json"
+    assert revision == {revision!r}
+    return os.environ["FAKE_FILE_PATH"]
+""",
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(tmp_path)
+    environment["FAKE_FILE_PATH"] = str(tmp_path / "tokenizer.json")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(DOWNLOAD_WORKER),
+            "--operation",
+            "file",
+            "--repo-id",
+            "org/model",
+            "--filename",
+            "tokenizer.json",
+            "--revision",
+            revision,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=5,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "path": environment["FAKE_FILE_PATH"]
+    }
+
+
 def test_fail_fast_requires_fail_closed_mode_and_stops_after_two_attempts(
     tmp_path: Path,
 ) -> None:
@@ -875,12 +985,18 @@ def test_hf_file_cache_skip_uses_hf_local_resolution() -> None:
 
     helpers["hf_hub_download"] = fake_hf_hub_download
 
-    assert helpers["_is_hf_file_cached"]("org/model", "weights.bin")
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    assert helpers["_is_hf_file_cached"](
+        "org/model",
+        "weights.bin",
+        revision=revision,
+    )
     assert calls == [{
         "args": ("org/model",),
         "kwargs": {
             "filename": "weights.bin",
             "local_files_only": True,
+            "revision": revision,
         },
     }]
 


### PR DESCRIPTION
## Why

The InternLM nightly reference failed while loading its tokenizer, before model comparison. The checkpoint has no native `tokenizer.json`; the fast-tokenizer fallback treated its SentencePiece model as a different format, while the official slow tokenizer cannot load one embedded NUL piece.

This is a real tokenizer packaging and offline-cache issue, not evidence of a TensorRT inference mismatch.

## What changed

- Bind InternLM to an official `tokenizer.json` published from a repository whose `tokenizer.model` is byte-identical to the target checkpoint.
- Pin the artifact by full commit revision and verify both source-model and JSON SHA256 values before use.
- Warm and resolve that exact file through the existing offline HF cache path, with revision-aware file-asset metadata while preserving the old three-field API.
- Atomically install the verified artifact and revalidate an existing `tokenizer.json` instead of accepting it by filename alone.
- Make the reference independently resolve the pinned official artifact rather than consuming builder output.

## Validation

- Baseline reproduction: the exact Nightly profile failed in fast-tokenizer conversion before reference inference.
- Official artifact contract: 92,544 vocabulary entries, six InternLM aliases, single inputs, pair IDs/type IDs, and the manifest chat template all matched expected IDs.
- Exact pinned profile with the real cached checkpoint: 13 passed.
- Host regression set across builder, cache, family compatibility, and reference contracts: 262 passed, 1 skipped.
- Strict local-only warm check: both the model and pinned file were cached; zero network calls.
- Model manifest validation: 78 models validated.
- Ruff and diff checks: passed.

## Limitations

A full TensorRT GPU build and end-to-end reference inference were not rerun locally. The regression proves the tokenizer and offline-cache failure path that previously prevented that comparison from starting.
