### PR TITLE
fix(m2m_100): retain TensorRT constant buffers

### DIFF
--- a/python/tensorrt_model_connect/families/m2m_100/graph_ops.py
+++ b/python/tensorrt_model_connect/families/m2m_100/graph_ops.py
@@ -8,11 +8,39 @@ Tensor names and shapes must stay compatible with the C++ bundle runtime.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
+from functools import wraps
+from typing import Callable, ParamSpec, TypeVar
+
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
 
 trt = trt_compat.get_trt()
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_CONSTANT_BUFFERS: ContextVar[list[np.ndarray] | None] = ContextVar(
+    "m2m_100_constant_buffers",
+    default=None,
+)
+
+
+def retain_constant_buffers(build: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Keep NumPy-owned TensorRT constant buffers alive for one engine build."""
+
+    @wraps(build)
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        if _CONSTANT_BUFFERS.get() is not None:
+            return build(*args, **kwargs)
+
+        token = _CONSTANT_BUFFERS.set([])
+        try:
+            return build(*args, **kwargs)
+        finally:
+            _CONSTANT_BUFFERS.reset(token)
+
+    return wrapped
 
 
 def _cast_back_to_trt_dtype(
@@ -37,7 +65,13 @@ def add_constant(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Add a constant tensor in the given *dtype* (default float32)."""
-    weights = trt.Weights(np.ascontiguousarray(values, dtype=dtype))
+    buffers = _CONSTANT_BUFFERS.get()
+    if buffers is None:
+        raise RuntimeError("M2M-100 constants must be created inside an engine build")
+
+    buffer = np.ascontiguousarray(values, dtype=dtype)
+    buffers.append(buffer)
+    weights = trt.Weights(buffer)
     layer = network.add_constant(shape, weights)
     return layer.get_output(0)
 

--- a/python/tensorrt_model_connect/families/m2m_100/plugin.py
+++ b/python/tensorrt_model_connect/families/m2m_100/plugin.py
@@ -41,6 +41,16 @@ from . import graph_blocks
 
 
 trt = trt_compat.get_trt()
+_PROCESS_LOGGERS: dict[bool, trt.Logger] = {}
+
+
+def _get_process_logger(*, verbose: bool) -> trt.Logger:
+    """Return the logger that must outlive every TensorRT builder in this process."""
+    logger = _PROCESS_LOGGERS.get(verbose)
+    if logger is None:
+        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+        _PROCESS_LOGGERS[verbose] = logger
+    return logger
 
 
 def _make_sinusoidal_pos_embed(
@@ -243,6 +253,7 @@ class M2M100Plugin:
 
         return weights
 
+    @graph_ops.retain_constant_buffers
     def build_engine(
         self,
         config: ModelConfig,
@@ -274,7 +285,7 @@ class M2M100Plugin:
         # This determines the encoder output dimension the decoder cross-attends to.
         max_source_length = 128
 
-        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+        logger = _get_process_logger(verbose=verbose)
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
@@ -481,6 +492,7 @@ class M2M100Plugin:
         }
 
 
+@graph_ops.retain_constant_buffers
 def _build_m2m100_encoder(
     config,
     weights,
@@ -504,7 +516,7 @@ def _build_m2m100_encoder(
     else:
         raise ValueError(f"Unsupported M2M-100 precision {precision!r}; expected fp32 or fp16")
 
-    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    logger = _get_process_logger(verbose=verbose)
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()

--- a/tests/e2e/models/m2m_100/test_m2m_100_graph_ops_lifetime.py
+++ b/tests/e2e/models/m2m_100/test_m2m_100_graph_ops_lifetime.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for M2M-100 TensorRT constant buffer lifetime."""
+
+from __future__ import annotations
+
+import gc
+import importlib
+from types import SimpleNamespace
+import weakref
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.families.m2m_100 import graph_ops
+
+
+plugin = importlib.import_module("tensorrt_model_connect.families.m2m_100.plugin")
+
+
+class _FakeLayer:
+    def get_output(self, _index: int) -> object:
+        return object()
+
+
+class _FakeNetwork:
+    def __init__(self) -> None:
+        self.weights: list[object] = []
+
+    def add_constant(self, _shape: tuple[int, ...], weights: object) -> _FakeLayer:
+        self.weights.append(weights)
+        return _FakeLayer()
+
+
+def test_fp16_constant_buffer_lives_until_engine_build_finishes(monkeypatch) -> None:
+    buffer_refs: list[weakref.ReferenceType[np.ndarray]] = []
+
+    class _WeakWeights:
+        def __init__(self, values: np.ndarray) -> None:
+            buffer_refs.append(weakref.ref(values))
+
+    monkeypatch.setattr(
+        graph_ops,
+        "trt",
+        SimpleNamespace(Weights=_WeakWeights),
+    )
+    network = _FakeNetwork()
+    values = np.arange(4, dtype=np.float32)
+
+    @graph_ops.retain_constant_buffers
+    def _build_engine() -> bytes:
+        graph_ops.add_constant(network, (4,), values, dtype=np.float16)
+        gc.collect()
+        assert buffer_refs[0]() is not None
+        return b"plan"
+
+    assert _build_engine() == b"plan"
+
+    gc.collect()
+
+    assert buffer_refs[0]() is None
+
+
+def test_constant_buffer_is_released_when_engine_build_raises(monkeypatch) -> None:
+    buffer_refs: list[weakref.ReferenceType[np.ndarray]] = []
+
+    class _WeakWeights:
+        def __init__(self, values: np.ndarray) -> None:
+            buffer_refs.append(weakref.ref(values))
+
+    monkeypatch.setattr(
+        graph_ops,
+        "trt",
+        SimpleNamespace(Weights=_WeakWeights),
+    )
+    network = _FakeNetwork()
+    values = np.arange(4, dtype=np.float32)
+
+    @graph_ops.retain_constant_buffers
+    def _build_engine() -> None:
+        graph_ops.add_constant(network, (4,), values, dtype=np.float16)
+        raise RuntimeError("build failed")
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        _build_engine()
+
+    gc.collect()
+
+    assert buffer_refs[0]() is None
+
+
+def test_process_logger_is_reused_and_retained(monkeypatch) -> None:
+    created: list[object] = []
+
+    class _FakeLogger:
+        VERBOSE = 1
+        WARNING = 2
+
+        def __init__(self, severity: int) -> None:
+            self.severity = severity
+            created.append(self)
+
+    monkeypatch.setattr(plugin, "trt", SimpleNamespace(Logger=_FakeLogger))
+    monkeypatch.setattr(plugin, "_PROCESS_LOGGERS", {})
+
+    first = plugin._get_process_logger(verbose=False)
+    logger_ref = weakref.ref(first)
+    del first
+    gc.collect()
+
+    second = plugin._get_process_logger(verbose=True)
+    third = plugin._get_process_logger(verbose=False)
+
+    assert logger_ref() is third
+    assert created == [third, second]
+    assert third.severity == _FakeLogger.WARNING
+    assert second.severity == _FakeLogger.VERBOSE


### PR DESCRIPTION
## Background

A fresh exact-main nightly exposed a nondeterministic M2M-100 crash while TensorRT serialized the FP16 decoder immediately after the FP32 integration build. Controlled local runs could both pass and reproduce the same SIGSEGV on the same GPU, ruling out a deterministic graph regression or stable device fault.

A forced-GC reproducer showed the source defect directly: converting FP32 weights to contiguous FP16 arrays created temporary NumPy buffers that were reclaimed after `add_constant()` returned, while TensorRT still retained pointers to their storage for serialization.

## Exit Criteria

- Keep every TensorRT constant backing array alive through decoder and encoder serialization.
- Release retained arrays on both successful and exceptional build exits.
- Preserve warning and verbose logger behavior without changing graph precision, acceptance criteria, or shared builder code.

## Implementation

- Adds an M2M-100 build scope that retains converted constant buffers for the lifetime of one engine build and always clears the scope in `finally`.
- Uses process-lifetime TensorRT loggers keyed by verbosity so builders never outlive their logger and existing verbosity semantics remain intact.
- Adds model-owned forced-GC regression tests for success cleanup, exception cleanup, and logger lifetime.

## Validation

- Exact pre-fix source with the pinned CI runtime: reproduced the original FP32-pass/FP16-SIGSEGV sequence; separate runs on the same device also passed, confirming nondeterminism.
- `/opt/venv/bin/python -m pytest tests/e2e/models/m2m_100/test_m2m_100_graph_ops_lifetime.py -v -p no:cacheprovider`: 3 passed in the pinned CI image.
- `python3 -m tools.ci model-proof --model m2m_100 --revision 26601c73358018cd818e4024851a59f4f3021895 --suite nightly`: passed on an official exclusive GPU lease; scratch build, C++ test, all 15 model-owned Python tests, FP32 then FP16 builds, engine/result verification, and the full NLLB E2E all passed. The validated commit and this PR head share Git tree `b882140bc7a9594b6350666c058d7dea4f5e5240`; only the author email metadata was amended before push.
- `python3 tools/legal_headers.py --check`: 0 findings.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- Review `graph_ops.py` first for the lifetime boundary, then `plugin.py` for decoder/encoder adoption, and finally the forced-GC tests.
- The keepalive is family-owned and context-local; it does not change other model builders or relax any CI gate.
