### PR TITLE
feat(skills): guide checkout environment setup

### DIFF
--- a/plugins/trtmc-agent-skills/skills/setup-trtmc-environment/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/setup-trtmc-environment/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: setup-trtmc-environment
+description: >-
+  Prepare a TensorRT-Model-Connect development or deployment-validation
+  environment from a fresh checkout on an unfamiliar host. Use before builds,
+  tests, packaging, or runtime work when no working repo environment is known.
+---
+
+# Set Up The Environment
+
+Start from the checkout, not from existing container names or machine-specific
+workspace conventions.
+
+1. Find the repository root with `git rev-parse --show-toplevel`.
+2. Read the current environment guide, `Dockerfile`, and matching
+   `scripts/docker_build_*.sh` / `scripts/docker_run_*.sh`. Treat them as the
+   source of truth; do not copy assumptions from another host.
+3. Inspect the host as needed (`uname`, `docker info`, `nvidia-smi`, free disk)
+   and select a repo-supported path. If none matches, explain the gap and stop.
+   Do not install drivers or reconfigure the container runtime without separate
+   authorization.
+4. Build the selected repo image when it is missing or stale, using the repo's
+   build path. Do not prebuild unrelated model-family reference profiles.
+5. Start a fresh container from that image with this checkout mounted
+   read-write for development or read-only for deployment validation. Choose
+   paths and names for this checkout; do not reuse, migrate, or remove unrelated
+   containers.
+6. Verify the checkout mount, required GPU visibility, and TensorRT import, then
+   run the requested build, test, packaging, or runtime command.
+
+Keep model-specific dependencies on demand and follow each family's own lock
+and verification files. Report setup evidence separately from compilation,
+tests, model parity, performance, and production-deployment evidence.


### PR DESCRIPTION
## Background

Agents need a checkout-first way to prepare a development or
deployment-validation environment on an unfamiliar host. The earlier version
of this PR added a profile schema and orchestration tool, which made the skill
more prescriptive and complex than the task requires.

## Exit Criteria

- Start from the current checkout and host instead of machine-specific
  container or workspace conventions.
- Use the environment paths already declared by the repository and build the
  selected image when it is missing or stale.
- Leave implementation choices to the agent while protecting unrelated
  containers, host configuration, model-specific dependencies, and evidence
  boundaries.

## Implementation

- Add one 33-line `SKILL.md` with a high-freedom workflow.
- Direct the agent to inspect the current docs, Dockerfile, scripts, and host
  capabilities before choosing a supported path.
- Keep model-family dependencies on demand and distinguish development mounts
  from read-only deployment-validation mounts.

No tool, profile schema, auxiliary metadata, CI rule, test fixture, or docs
change is added.

## Validation

- Skill Creator `quick_validate.py`: passed.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_test_impact.py -q`:
  257 passed.
- Referenced environment guide, Dockerfile, and build/run script patterns:
  present in the current checkout.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- The skill intentionally describes constraints and a decision process instead
  of encoding the current host matrix in a second source of truth.
- PR #804 is unchanged by this PR.
