### PR TITLE
fix(models): disable Bark and ELF timing caches

### DIFF
--- a/tests/e2e/models/bark/manifests/bark-small.json
+++ b/tests/e2e/models/bark/manifests/bark-small.json
@@ -9,14 +9,11 @@
   "reference_precision": "fp32",
   "e2e_parallel_resource": "exclusive_gpu",
   "build_env": {
-    "TRTMC_BARK_TIMING_CACHE_MODE": "verified",
-    "TRTMC_BARK_TIMING_CACHE_PATH": {
-      "required_from_env": true,
-      "path_like": true
-    },
-    "TRTMC_BARK_TIMING_CACHE_SHA256": {
-      "required_from_env": true
-    }
+    "TRTMC_TRT_TIMING_CACHE_PATH": "",
+    "TRTMC_TRT_TIMING_CACHE_DIR": "",
+    "TRTMC_BARK_TIMING_CACHE_MODE": "off",
+    "TRTMC_BARK_TIMING_CACHE_PATH": "",
+    "TRTMC_BARK_TIMING_CACHE_SHA256": ""
   },
   "max_cache_length": 1024,
   "trust_remote_code": false,

--- a/tests/e2e/models/bark/test_bark_build_contract.py
+++ b/tests/e2e/models/bark/test_bark_build_contract.py
@@ -53,7 +53,7 @@ def test_large_acceptance_build_has_a_precision_matched_l0() -> None:
     assert replacement_threshold == small_threshold
 
 
-def test_acceptance_build_requires_an_injected_verified_timing_cache() -> None:
+def test_acceptance_build_disables_timing_caches() -> None:
     model_dir = Path(__file__).parent
     manifest_path = model_dir / "manifests" / "bark-small.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -61,12 +61,9 @@ def test_acceptance_build_requires_an_injected_verified_timing_cache() -> None:
 
     assert manifest["precision"] == "fp16"
     assert build_env == {
-        "TRTMC_BARK_TIMING_CACHE_MODE": "verified",
-        "TRTMC_BARK_TIMING_CACHE_PATH": {
-            "required_from_env": True,
-            "path_like": True,
-        },
-        "TRTMC_BARK_TIMING_CACHE_SHA256": {
-            "required_from_env": True,
-        },
+        "TRTMC_TRT_TIMING_CACHE_PATH": "",
+        "TRTMC_TRT_TIMING_CACHE_DIR": "",
+        "TRTMC_BARK_TIMING_CACHE_MODE": "off",
+        "TRTMC_BARK_TIMING_CACHE_PATH": "",
+        "TRTMC_BARK_TIMING_CACHE_SHA256": "",
     }

--- a/tests/e2e/models/elf_flow/manifests/elf-b-owt-l0.json
+++ b/tests/e2e/models/elf_flow/manifests/elf-b-owt-l0.json
@@ -14,14 +14,8 @@
     "TRTMC_TRT_TIMING_CACHE_PATH": "",
     "TRTMC_TRT_TIMING_CACHE_DIR": "",
     "TRTMC_ELF_TIMING_CACHE_GENERATE": "0",
-    "TRTMC_ELF_TIMING_CACHE_PATH": {
-      "required_from_env": true,
-      "path_like": true
-    },
-    "TRTMC_ELF_TIMING_CACHE_METADATA_PATH": {
-      "required_from_env": true,
-      "path_like": true
-    }
+    "TRTMC_ELF_TIMING_CACHE_PATH": "",
+    "TRTMC_ELF_TIMING_CACHE_METADATA_PATH": ""
   },
   "max_cache_length": 1024,
   "testcases": [

--- a/tests/e2e/models/elf_flow/test_elf_flow_contract.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_contract.py
@@ -699,11 +699,5 @@ def test_elf_l0_manifests_use_upstream_replay_contract() -> None:
             assert build_env["TRTMC_TRT_TIMING_CACHE_PATH"] == ""
             assert build_env["TRTMC_TRT_TIMING_CACHE_DIR"] == ""
             assert build_env["TRTMC_ELF_TIMING_CACHE_GENERATE"] == "0"
-            assert build_env["TRTMC_ELF_TIMING_CACHE_PATH"] == {
-                "required_from_env": True,
-                "path_like": True,
-            }
-            assert build_env["TRTMC_ELF_TIMING_CACHE_METADATA_PATH"] == {
-                "required_from_env": True,
-                "path_like": True,
-            }
+            assert build_env["TRTMC_ELF_TIMING_CACHE_PATH"] == ""
+            assert build_env["TRTMC_ELF_TIMING_CACHE_METADATA_PATH"] == ""


### PR DESCRIPTION
## Background

The `bark-small` and `elf-b-owt-l0` acceptance manifests require environment-provided timing-cache artifacts. That makes model proof depend on external cache packaging even though both models can satisfy their existing correctness and quality gates without those caches.

## Exit Criteria

- Neither acceptance case reads or writes a model-specific or generic TensorRT timing cache.
- Existing parity, accuracy, and quality thresholds remain unchanged.
- The optional timing-cache implementation remains available to other profiles.

## Implementation

- Disable Bark's model-owned cache mode and blank its model-specific and generic cache selectors.
- Blank ELF's model-specific cache paths while retaining its existing precision and builder settings.
- Update only the two model-owned build-contract tests.

## Validation

- Targeted model, manifest, orchestrator, and benchmark tests: **175 passed**.
- Public source hygiene and model-proof runner tests: **147 passed**.
- Ruff and JSON validation passed.
- GB300 cold rebuilds with intentionally invalid cache paths:
  - Bark: **3/3 passed** with unchanged ASR/audio gates.
  - ELF: **3/3 passed** with token agreement `1.0` and text NED `0.0002163` on every run.
  - No sentinel cache path was created or consumed.

## Notes

Without a verified timing cache, Bark output may vary across tactic selections. All three cold builds remained inside the existing user-visible quality threshold; this change does not weaken that threshold.
