### PR TITLE
test(ci): make GPU lease timing deterministic

### DIFF
--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from tools.ci import gpu_lease as gpu_lease_module
 from tools.ci.context import CiContext
 from tools.ci.gpu_lease import GpuLease
 from tools.ci.model_reference_cache import ModelReferenceCacheWarmer
@@ -2653,7 +2654,20 @@ Node 3, zone  Movable
 
 def test_capacity_gated_lease_waits_for_memory_reclaim_without_requeueing(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Drive the short capacity settle window explicitly so host scheduling
+    # cannot turn the second memory sample into an unrelated GPU requeue.
+    clock = SimpleNamespace(now=0.0)
+
+    def advance_clock(seconds: float) -> None:
+        clock.now += seconds
+
+    monkeypatch.setattr(
+        gpu_lease_module,
+        "time",
+        SimpleNamespace(monotonic=lambda: clock.now, sleep=advance_clock),
+    )
     context = _fake_gpu_lease_context(
         tmp_path,
         "2, 284208, 184208, 100000\n3, 284208, 174208, 110000",


### PR DESCRIPTION
## Background

The GPU capacity lease test depended on a short wall-clock settle window. Under host scheduling delays, the allocator could correctly move to another GPU before the test inspected the original reservation lock, producing a timing-only failure.

## Exit Criteria

- Make the capacity-reclaim sequence deterministic without changing allocator behavior.
- Preserve the existing reservation-lock, queue, slot, and memory-admission assertions.

## Implementation

- Replace wall-clock progression in this test with a test-local monotonic clock.
- Advance the clock only through the allocator's existing sleep calls, so the two expected memory samples occur while the original GPU reservation remains held.

## Validation

- After the final rebase, `PYTHONPATH=python:. python -m pytest tests/tools/test_model_proof_runner.py::test_capacity_gated_lease_waits_for_memory_reclaim_without_requeueing -q -p no:cacheprovider`: 1 passed.
- After the final rebase, `PYTHONPATH=python:. python -m pytest tests/tools/test_model_proof_runner.py -q -p no:cacheprovider -k 'capacity_gated or capacity_gate'`: 12 passed.
- The isolated test also passed in 100 consecutive invocations, and the complete allocator suite passed with 17 tests on the same patch.
- Ruff and `git diff --check`: passed after the final rebase.
- Rebased without conflicts onto `main` at `11211d7351eb2e208deff873d16d6de5f7a25d0e`; the final diff remains one test file with 14 insertions.
- `trtmc/premerge/required`: passed for exact head `4541d0c19b58acd34ea8a28d0c953618529706e2`.
- CodeQL Python and JavaScript/TypeScript: passed for the same exact head.

## Notes For Future Readers

- This is test-only. It does not increase a timeout, modify production allocator code, or weaken any assertion.
- Review the virtual-clock setup together with the unchanged assertions in the same test.
