### PR TITLE
fix(validation): harden artifact and GPU provenance

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -793,6 +793,16 @@ def _ensure_tokenizer_json(model_dir: Path, *, plugin=None) -> None:
                     "family tokenizer validation rejected existing tokenizer.json"
                 )
         return
+    family_first = (
+        getattr(plugin, "tokenizer_json_conversion_policy", "")
+        == "family_first"
+    )
+    if family_first and callable(family_ensure):
+        kwargs = {}
+        if _call_supports_kwarg(family_ensure, "previous_error"):
+            kwargs["previous_error"] = None
+        if bool(family_ensure(model_dir, **kwargs)):
+            return
     if rebuild_wordpiece:
         print(
             "[trtmc build] Rebuilding undersized WordPiece tokenizer.json "

--- a/python/tensorrt_model_connect/families/internlm/plugin.py
+++ b/python/tensorrt_model_connect/families/internlm/plugin.py
@@ -43,6 +43,7 @@ class InternLMPlugin:
     name = "internlm"
     runtime_strategy = "internlm_decoder_kv_cache"
     runtime_capabilities = {"decoder_kv"}
+    tokenizer_json_conversion_policy = "family_first"
 
     def matches(self, model_type: str) -> bool:
         return model_type.lower().startswith("internlm")

--- a/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
+++ b/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
@@ -19,6 +19,7 @@ from tensorrt_model_connect.families import (
     family_hf_warm_file_specs,
     family_hf_warm_files,
 )
+from tensorrt_model_connect.families.internlm.plugin import InternLMPlugin
 
 tokenizer_json = importlib.import_module(
     "tensorrt_model_connect.families.internlm.tokenizer_json"
@@ -97,6 +98,53 @@ def test_ensure_tokenizer_json_installs_verified_local_artifact(
             "local_files_only": True,
         }
     ]
+
+
+def test_internlm_uses_pinned_tokenizer_before_generic_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_payload = b"source tokenizer model"
+    official_payload = b'{"official": true}'
+    artifact = tmp_path / "cached-official-tokenizer.json"
+    artifact.write_bytes(official_payload)
+    (tmp_path / "tokenizer.model").write_bytes(source_payload)
+    generic_calls: list[Path] = []
+
+    class FakeBackendTokenizer:
+        @staticmethod
+        def save(path):
+            generic_calls.append(Path(path))
+            Path(path).write_bytes(b'{"generic": true}')
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(path, use_fast=False):
+            assert Path(path) == tmp_path
+            assert use_fast is False
+            return types.SimpleNamespace(backend_tokenizer=FakeBackendTokenizer())
+
+    monkeypatch.setattr(
+        tokenizer_json,
+        "SOURCE_TOKENIZER_MODEL_SHA256",
+        _sha256(source_payload),
+    )
+    monkeypatch.setattr(
+        tokenizer_json,
+        "PINNED_TOKENIZER_SHA256",
+        _sha256(official_payload),
+    )
+    _install_fake_hub(monkeypatch, lambda **_kwargs: str(artifact))
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        types.SimpleNamespace(AutoTokenizer=FakeAutoTokenizer),
+    )
+
+    _ensure_tokenizer_json(tmp_path, plugin=InternLMPlugin())
+
+    assert generic_calls == []
+    assert (tmp_path / "tokenizer.json").read_bytes() == official_payload
 
 
 def test_non_target_source_without_json_preserves_generic_fallback(

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -229,8 +229,23 @@ def test_reference_cache_identity_shares_equivalent_trtmc_variants(
     cache_dir = tmp_path / "cache"
     first = tmp_path / "first"
     second = tmp_path / "second"
-    _prepare_work(first, model_manifest="manifests/model-fp16.json")
-    _prepare_work(second, model_manifest="manifests/model-fp8.json")
+    model_dir = tmp_path / "model"
+    manifest_dir = model_dir / "manifests"
+    plugins_dir = model_dir / "e2e_plugins"
+    manifest_dir.mkdir(parents=True)
+    plugins_dir.mkdir()
+    fp16_manifest = manifest_dir / "model-fp16.json"
+    fp8_manifest = manifest_dir / "model-fp8.json"
+    fp16_manifest.write_text('{"precision": "fp16"}', encoding="utf-8")
+    fp8_manifest.write_text('{"precision": "fp8"}', encoding="utf-8")
+    (plugins_dir / "reference.py").write_text("REFERENCE = 1\n", encoding="utf-8")
+    _prepare_work(first, model_manifest=str(fp16_manifest))
+    _prepare_work(second, model_manifest=str(fp8_manifest))
+    for work_dir in (first, second):
+        manifest_path = work_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["dataset_kind"] = "diffusion_prompt_json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     calls = 0
 
     def fake_reference(args) -> None:
@@ -358,6 +373,83 @@ def test_reference_cache_keeps_variant_manifests_separate_without_identity(
     second_key, _ = trtmc_reference.reference_key(_args(second, cache_dir))
 
     assert first_key != second_key
+
+
+def test_plugin_reference_cache_key_tracks_model_owned_implementation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    model_dir = tmp_path / "z_image"
+    manifest_path = model_dir / "manifests" / "z-image-turbo.json"
+    reference_path = (
+        model_dir / "e2e_plugins" / "references" / "hf_diffusers.py"
+    )
+    manifest_path.parent.mkdir(parents=True)
+    reference_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "z-image-turbo",
+                "testcases": [
+                    {
+                        "name": "z-image-turbo",
+                        "reference_precision": "fp16",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    reference_path.write_text("REFERENCE_DTYPE = 'fp16'\n", encoding="utf-8")
+
+    def prepare_work(name: str) -> Path:
+        work_dir = tmp_path / name
+        _prepare_work(work_dir, model_manifest=str(manifest_path))
+        work_manifest_path = work_dir / "manifest.json"
+        work_manifest = json.loads(
+            work_manifest_path.read_text(encoding="utf-8")
+        )
+        work_manifest["dataset_kind"] = "diffusion_prompt_json"
+        work_manifest_path.write_text(
+            json.dumps(work_manifest),
+            encoding="utf-8",
+        )
+        return work_dir
+
+    calls = 0
+
+    def fake_reference(args) -> None:
+        nonlocal calls
+        calls += 1
+        Path(args.work_dir, "hf_predictions.json").write_text(
+            json.dumps(
+                {"responses": [{"sample_id": "one", "output_text": "A"}]}
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        trtmc_reference,
+        "_run_reference_inference",
+        fake_reference,
+    )
+
+    first = prepare_work("first")
+    assert trtmc_reference.run_reference(_args(first, cache_dir)) == "generated"
+    model_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    model_manifest["testcases"][0]["reference_precision"] = "bf16"
+    manifest_path.write_text(json.dumps(model_manifest), encoding="utf-8")
+    second = prepare_work("second")
+    assert trtmc_reference.run_reference(_args(second, cache_dir)) == "generated"
+    reference_path.write_text("REFERENCE_DTYPE = 'bf16'\n", encoding="utf-8")
+    third = prepare_work("third")
+    assert trtmc_reference.run_reference(_args(third, cache_dir)) == "generated"
+    fourth = prepare_work("fourth")
+    assert trtmc_reference.run_reference(_args(fourth, cache_dir)) == "reused"
+
+    assert calls == 3
+    assert len(list(cache_dir.iterdir())) == 3
 
 
 def test_reference_cache_key_changes_with_inference_setting(

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -457,7 +457,11 @@ def test_all_supervisor_applies_model_failure_policy(
         "_run_supervised_binding_with_retries",
         run_worker,
     )
-    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "write_run_metadata",
+        lambda output, **_kwargs: output,
+    )
     monkeypatch.setattr(
         trtmc_validate,
         "finalize_run_metadata",
@@ -595,7 +599,11 @@ def test_all_supervisor_records_not_compared_without_launching_worker(
         "_run_supervised_binding_with_retries",
         unexpected_worker,
     )
-    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "write_run_metadata",
+        lambda output, **_kwargs: output,
+    )
     monkeypatch.setattr(
         trtmc_validate,
         "finalize_run_metadata",
@@ -809,6 +817,19 @@ def test_single_ci_case_writes_stable_result_and_exit_code(
     )
     binding = trtmc_validate.Binding("model-a", "workload-a")
     catalog = {"sample_limits": {"workload-a": 5}}
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_runtime_gpu_devices",
+        lambda _visible: [
+            {
+                "cuda_logical_index": 0,
+                "nvidia_smi_index": 0,
+                "uuid": "GPU-test",
+                "name": "NVIDIA test GPU",
+                "pci_bus_id": "00000000:01:00.0",
+            }
+        ],
+    )
 
     def run_binding(binding, *, arguments, task_models, suites):
         result = {
@@ -2267,21 +2288,200 @@ def test_report_does_not_treat_shared_task_failure_as_disagreement(tmp_path):
 
 def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
     monkeypatch.setenv("TRTMC_VALIDATION_SOURCE_REVISION", "abc123")
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
     monkeypatch.setattr(
         trtmc_validate.sys,
         "argv",
         ["tools/trtmc_validate.py", "model-a"],
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_runtime_gpu_devices",
+        lambda visible: [
+            {
+                "cuda_logical_index": 0,
+                "nvidia_smi_index": 0,
+                "uuid": "GPU-7980c63d",
+                "name": "NVIDIA GB300",
+                "pci_bus_id": "00000009:06:00.0",
+            }
+        ],
     )
 
     path = trtmc_validate.write_run_metadata(tmp_path)
     metadata = json.loads(path.read_text(encoding="utf-8"))
 
     assert metadata["source_revision"] == "abc123"
-    assert metadata["cuda_visible_devices"] == "1"
+    assert metadata["cuda_visible_devices"] == "0"
+    assert metadata["gpu_devices"] == [
+        {
+            "cuda_logical_index": 0,
+            "nvidia_smi_index": 0,
+            "uuid": "GPU-7980c63d",
+            "name": "NVIDIA GB300",
+            "pci_bus_id": "00000009:06:00.0",
+        }
+    ]
     assert metadata["command"] == "tools/trtmc_validate.py model-a"
     assert metadata["finished_at"] is None
     assert metadata["duration_seconds"] is None
+
+
+def test_run_metadata_prefers_cli_gpu_selector_over_parent_environment(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    received = []
+
+    def resolve(visible):
+        received.append(visible)
+        return [
+            {
+                "cuda_logical_index": 0,
+                "nvidia_smi_index": 1,
+                "uuid": "GPU-gb300",
+                "name": "NVIDIA GB300",
+                "pci_bus_id": "00000009:06:00.0",
+            }
+        ]
+
+    monkeypatch.setattr(trtmc_validate, "_runtime_gpu_devices", resolve)
+
+    path = trtmc_validate.write_run_metadata(
+        tmp_path,
+        cuda_visible_devices="1",
+    )
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+
+    assert received == ["1"]
+    assert metadata["cuda_visible_devices"] == "1"
+    assert metadata["gpu_devices"][0]["uuid"] == "GPU-gb300"
+
+
+def test_cuda_visible_device_ordinal_resolves_to_stable_gpu_identity():
+    inventory = [
+        {
+            "nvidia_smi_index": 0,
+            "uuid": "GPU-rtx",
+            "name": "NVIDIA RTX PRO 6000",
+            "pci_bus_id": "00000004:01:00.0",
+        },
+        {
+            "nvidia_smi_index": 1,
+            "uuid": "GPU-gb300",
+            "name": "NVIDIA GB300",
+            "pci_bus_id": "00000009:06:00.0",
+        },
+    ]
+
+    assert trtmc_validate._resolve_cuda_devices("1", inventory) == [
+        {
+            "cuda_logical_index": 0,
+            "nvidia_smi_index": 1,
+            "uuid": "GPU-gb300",
+            "name": "NVIDIA GB300",
+            "pci_bus_id": "00000009:06:00.0",
+        }
+    ]
+
+
+def test_nvidia_smi_inventory_records_stable_gpu_identity(monkeypatch):
+    command = []
+
+    def fake_run(args, **kwargs):
+        command.extend(args)
+        assert kwargs == {
+            "check": False,
+            "capture_output": True,
+            "text": True,
+            "timeout": 10,
+        }
+        return trtmc_validate.subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(
+                "0, GPU-ae3e92b4, NVIDIA RTX PRO 6000, 00000004:01:00.0\n"
+                "1, GPU-7980c63d, NVIDIA GB300, 00000009:06:00.0\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(trtmc_validate.subprocess, "run", fake_run)
+
+    assert trtmc_validate._query_nvidia_smi_gpus() == [
+        {
+            "nvidia_smi_index": 0,
+            "uuid": "GPU-ae3e92b4",
+            "name": "NVIDIA RTX PRO 6000",
+            "pci_bus_id": "00000004:01:00.0",
+        },
+        {
+            "nvidia_smi_index": 1,
+            "uuid": "GPU-7980c63d",
+            "name": "NVIDIA GB300",
+            "pci_bus_id": "00000009:06:00.0",
+        },
+    ]
+    assert command == [
+        "nvidia-smi",
+        "--query-gpu=index,uuid,name,pci.bus_id",
+        "--format=csv,noheader,nounits",
+    ]
+
+
+def test_run_metadata_rejects_missing_gpu_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_runtime_gpu_devices",
+        lambda _visible: [],
+    )
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="GPU identity",
+    ):
+        trtmc_validate.write_run_metadata(tmp_path)
+
+    assert not (tmp_path / "run.json").exists()
+
+
+def test_report_provenance_disambiguates_process_local_cuda_ordinal():
+    provenance = trtmc_validate._report_provenance(
+        {
+            "source_revision": "abc123",
+            "hostname": "container-id",
+            "cuda_visible_devices": "0",
+            "gpu_devices": [
+                {
+                    "cuda_logical_index": 0,
+                    "nvidia_smi_index": 0,
+                    "uuid": "GPU-7980c63d",
+                    "name": "NVIDIA GB300",
+                    "pci_bus_id": "00000009:06:00.0",
+                }
+            ],
+        }
+    )
+
+    assert "GPU logical 0=NVIDIA GB300" in provenance
+    assert "uuid=GPU-7980c63d" in provenance
+    assert "pci=00000009:06:00.0" in provenance
+    assert "runtime-nvidia-smi-index=0" in provenance
+    assert "CUDA_VISIBLE_DEVICES(process-local)=0" in provenance
+
+
+def test_report_provenance_marks_legacy_gpu_identity_as_missing():
+    provenance = trtmc_validate._report_provenance(
+        {
+            "hostname": "legacy-container-id",
+            "cuda_visible_devices": "0",
+        }
+    )
+
+    assert "GPU identity=not recorded" in provenance
+    assert "CUDA_VISIBLE_DEVICES(process-local)=0" in provenance
 
 
 def test_run_metadata_preserves_campaign_start_when_results_exist(
@@ -2306,6 +2506,19 @@ def test_run_metadata_preserves_campaign_start_when_results_exist(
         trtmc_validate,
         "_utc_now",
         lambda: datetime(2026, 7, 25, 2, 0, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_runtime_gpu_devices",
+        lambda _visible: [
+            {
+                "cuda_logical_index": 0,
+                "nvidia_smi_index": 0,
+                "uuid": "GPU-test",
+                "name": "NVIDIA test GPU",
+                "pci_bus_id": "00000000:01:00.0",
+            }
+        ],
     )
 
     path = trtmc_validate.write_run_metadata(tmp_path)

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -55,6 +55,12 @@ setup validation failed before the case could run. Requesting a model that is
 explicitly marked not compared also writes
 `<output>/<model>/not-compared/comparison.json` and returns `2`.
 
+`run.json` records each runtime-visible GPU's model, UUID, and PCI bus address.
+The report labels `CUDA_VISIBLE_DEVICES` as a process-local selector because a
+container may renumber a host GPU to logical device `0`. Validation refuses to
+start when it cannot resolve that selector to stable GPU identity, preventing
+an ambiguous report from being published.
+
 Dataset-backed workloads use the task-specific sample limits declared in
 `model_workloads.yaml`. Fast encoder and classification workloads use larger
 slices, while generation-heavy image, video, and audio workloads use smaller

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -33,6 +33,7 @@ from tools.validation.artifacts import (  # noqa: E402
 CACHE_SCHEMA = "trtmc.reference-cache/v1"
 CACHE_IMPLEMENTATION = 1
 REFERENCE_CACHE_IDENTITY_IMPLEMENTATION = 2
+MODEL_OWNED_REFERENCE_IDENTITY_IMPLEMENTATION = 1
 _CACHE_METADATA = "reference.json"
 _WORK_METADATA = "hf_cache.json"
 _NATIVE_RUN_LOG = "hf_native_run.log"
@@ -158,6 +159,64 @@ def _hash_file(
             hasher.update(chunk)
 
 
+def _model_owned_reference_identity(args: argparse.Namespace) -> str:
+    work_manifest_path = Path(args.work_dir).resolve() / "manifest.json"
+    if not work_manifest_path.is_file():
+        return ""
+    try:
+        work_manifest = json.loads(
+            work_manifest_path.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return ""
+    dataset_kind = str(work_manifest.get("dataset_kind", "") or "")
+    if dataset_kind not in _NATIVE_PLUGIN_DATASET_KINDS:
+        return ""
+    task_config = work_manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    manifest_ref = str(task_config.get("model_manifest", "") or "")
+    if not manifest_ref:
+        return ""
+    model_manifest = Path(manifest_ref)
+    if not model_manifest.is_absolute():
+        model_manifest = REPO_ROOT / model_manifest
+    if not model_manifest.is_file():
+        return ""
+
+    model_root = (
+        model_manifest.parent.parent
+        if model_manifest.parent.name == "manifests"
+        else model_manifest.parent
+    )
+    sources: list[tuple[str, Path]] = []
+    if not str(getattr(args, "reference_cache_identity", "") or ""):
+        sources.append((f"manifest/{model_manifest.name}", model_manifest))
+    owner_manifest = model_root / "MODEL.toml"
+    if owner_manifest.is_file():
+        sources.append(("MODEL.toml", owner_manifest))
+    plugins_root = model_root / "e2e_plugins"
+    if plugins_root.is_dir():
+        sources.extend(
+            (
+                f"e2e_plugins/{path.relative_to(plugins_root).as_posix()}",
+                path,
+            )
+            for path in sorted(plugins_root.rglob("*.py"))
+            if path.is_file()
+        )
+
+    if not sources:
+        return ""
+    hasher = hashlib.sha256()
+    for label, path in sources:
+        hasher.update(label.encode())
+        hasher.update(b"\0")
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    return hasher.hexdigest()
+
+
 def _settings(args: argparse.Namespace) -> dict[str, Any]:
     native_runner = _native_reference_runner(args)
     settings = {
@@ -185,6 +244,14 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
         "min_p": args.min_p,
         "seed": args.seed,
     }
+    model_owned_reference_identity = _model_owned_reference_identity(args)
+    if model_owned_reference_identity:
+        settings["model_owned_reference_identity"] = (
+            model_owned_reference_identity
+        )
+        settings["model_owned_reference_identity_implementation"] = (
+            MODEL_OWNED_REFERENCE_IDENTITY_IMPLEMENTATION
+        )
     reference_cache_identity = str(
         getattr(args, "reference_cache_identity", "") or ""
     )

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -1512,13 +1513,122 @@ def _campaign_started_at(output: Path, fallback: str) -> str:
     return started_at
 
 
-def write_run_metadata(output: Path) -> Path:
+def _query_nvidia_smi_gpus() -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,uuid,name,pci.bus_id",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ValidationError(f"could not query GPU identity: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit code {result.returncode}"
+        raise ValidationError(f"could not query GPU identity: {detail}")
+
+    inventory: list[dict[str, Any]] = []
+    for row in csv.reader(result.stdout.splitlines()):
+        values = [value.strip() for value in row]
+        if len(values) != 4:
+            raise ValidationError("nvidia-smi returned malformed GPU identity data")
+        try:
+            index = int(values[0])
+        except ValueError as exc:
+            raise ValidationError(
+                "nvidia-smi returned a non-numeric GPU index"
+            ) from exc
+        uuid, name, pci_bus_id = values[1:]
+        if not uuid or not name or not pci_bus_id:
+            raise ValidationError("nvidia-smi returned incomplete GPU identity data")
+        inventory.append(
+            {
+                "nvidia_smi_index": index,
+                "uuid": uuid,
+                "name": name,
+                "pci_bus_id": pci_bus_id,
+            }
+        )
+    return inventory
+
+
+def _resolve_cuda_devices(
+    cuda_visible_devices: str,
+    inventory: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    visible = cuda_visible_devices.strip()
+    if visible.lower() in {"-1", "none", "void"}:
+        return []
+    selectors = (
+        [str(device["nvidia_smi_index"]) for device in inventory]
+        if not visible or visible.lower() == "all"
+        else [selector.strip() for selector in visible.split(",")]
+    )
+    if not selectors or any(not selector for selector in selectors):
+        raise ValidationError("CUDA_VISIBLE_DEVICES contains an empty selector")
+
+    resolved: list[dict[str, Any]] = []
+    for logical_index, selector in enumerate(selectors):
+        if selector.isdigit():
+            matches = [
+                device
+                for device in inventory
+                if int(device["nvidia_smi_index"]) == int(selector)
+            ]
+        else:
+            matches = [
+                device
+                for device in inventory
+                if str(device["uuid"]) == selector
+                or str(device["uuid"]).startswith(selector)
+            ]
+        if len(matches) != 1:
+            raise ValidationError(
+                "CUDA_VISIBLE_DEVICES selector does not resolve to exactly one "
+                f"GPU identity: {selector}"
+            )
+        device = dict(matches[0])
+        device["cuda_logical_index"] = logical_index
+        resolved.append(device)
+    return resolved
+
+
+def _runtime_gpu_devices(cuda_visible_devices: str) -> list[dict[str, Any]]:
+    return _resolve_cuda_devices(
+        cuda_visible_devices,
+        _query_nvidia_smi_gpus(),
+    )
+
+
+def write_run_metadata(
+    output: Path,
+    *,
+    cuda_visible_devices: str | None = None,
+) -> Path:
     started_at = _campaign_started_at(output, _utc_now().isoformat())
+    effective_cuda_visible_devices = (
+        cuda_visible_devices.strip()
+        if cuda_visible_devices is not None and cuda_visible_devices.strip()
+        else os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    )
+    gpu_devices = _runtime_gpu_devices(effective_cuda_visible_devices)
+    if not gpu_devices:
+        raise ValidationError(
+            "GPU identity is unavailable; refusing to write ambiguous run metadata"
+        )
     metadata = {
         "schema_version": "trtmc.validation-run/v1",
         "source_revision": _source_revision(),
         "hostname": platform.node(),
-        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        "cuda_visible_devices": effective_cuda_visible_devices,
+        "nvidia_visible_devices": os.environ.get("NVIDIA_VISIBLE_DEVICES", ""),
+        "gpu_identity_source": "nvidia-smi",
+        "gpu_devices": gpu_devices,
         "command": shlex.join(sys.argv),
         "started_at": started_at,
         "finished_at": None,
@@ -1543,10 +1653,44 @@ def finalize_run_metadata(output: Path) -> Path:
 
 
 def _report_provenance(run: Mapping[str, Any]) -> str:
-    fields = (
+    fields = [
         ("source", run.get("source_revision")),
         ("host", run.get("hostname")),
-        ("CUDA_VISIBLE_DEVICES", run.get("cuda_visible_devices")),
+    ]
+    gpu_devices = run.get("gpu_devices", [])
+    if isinstance(gpu_devices, Sequence) and not isinstance(
+        gpu_devices, (str, bytes)
+    ):
+        for device in gpu_devices:
+            if not isinstance(device, Mapping):
+                continue
+            logical_index = device.get("cuda_logical_index")
+            identity = [str(device.get("name", "") or "unknown GPU")]
+            for label, key in (
+                ("uuid", "uuid"),
+                ("pci", "pci_bus_id"),
+                ("runtime-nvidia-smi-index", "nvidia_smi_index"),
+            ):
+                value = device.get(key)
+                if value not in (None, ""):
+                    identity.append(f"{label}={value}")
+            details = "; ".join(identity[1:])
+            display = identity[0] + (f" ({details})" if details else "")
+            fields.append(
+                (
+                    f"GPU logical {logical_index}",
+                    display,
+                )
+            )
+    if run.get("cuda_visible_devices") and not any(
+        name.startswith("GPU logical ") for name, _ in fields
+    ):
+        fields.append(("GPU identity", "not recorded"))
+    fields.append(
+        (
+            "CUDA_VISIBLE_DEVICES(process-local)",
+            run.get("cuda_visible_devices"),
+        )
     )
     return " · ".join(f"{name}={value}" for name, value in fields if value)
 
@@ -2824,7 +2968,10 @@ def _run_all_bindings(
     catalog: Mapping[str, Any],
 ) -> int:
     _prepare_run_directories(arguments)
-    write_run_metadata(arguments.output)
+    write_run_metadata(
+        arguments.output,
+        cuda_visible_devices=arguments.cuda_visible_devices,
+    )
     failed = False
     not_compared = False
     for binding in bindings:
@@ -2885,7 +3032,10 @@ def _run_bindings(
 ) -> int:
     _prepare_run_directories(arguments)
     if not arguments.model_worker:
-        write_run_metadata(arguments.output)
+        write_run_metadata(
+            arguments.output,
+            cuda_visible_devices=arguments.cuda_visible_devices,
+        )
     failed = False
     not_compared = False
     for binding in bindings:


### PR DESCRIPTION
## Background

Validation could publish or consume misleading artifacts in three framework paths: InternLM could run generic tokenizer conversion before its verified family artifact hook, native plugin reference changes could reuse stale Hugging Face outputs, and reports exposed only a process-local CUDA ordinal without stable GPU identity.

## Exit Criteria

- Prefer the verified InternLM tokenizer artifact before generic conversion.
- Invalidate native plugin reference caches when model-owned manifests or reference implementations change, while preserving explicit cache identity sharing.
- Record stable runtime GPU identity and refuse to create ambiguous run metadata.

## Implementation

- Add an opt-in family-first tokenizer conversion policy and enable it for InternLM.
- Hash the selected model manifest, owner `MODEL.toml`, and model-owned `e2e_plugins` Python sources into native reference cache settings.
- Resolve `CUDA_VISIBLE_DEVICES` through `nvidia-smi`, persist GPU model/UUID/PCI identity in `run.json`, and render the selector explicitly as process-local in reports.

## Validation

- `env PYTHONPATH="$PWD/python:$PWD" python -m pytest -q tests/e2e/models/internlm/test_internlm_tokenizer_json.py`: 9 passed, 1 skipped.
- `env PYTHONPATH="$PWD/python:$PWD" python -m pytest -q tests/tools/test_trtmc_reference.py`: 41 passed.
- `env PYTHONPATH="$PWD/python:$PWD" python -m pytest -q tests/tools/test_trtmc_validate.py -k 'not test_model_workload_catalog_covers_every_ready_model'`: 76 passed, 1 deselected.
- `ruff check` on all changed Python files: passed.
- Targeted `trtmc_validate.py z-image-turbo dpg_bench_diffusion_image` at head `74baa219e` on NVIDIA GB300: 5/5 passed when generating a new healthy reference, then 5/5 passed while reusing the same new cache key.

The unfiltered validator test file currently reports 76 passed and one base-branch failure because `minimax-h3-768p` is marked ready on `main` but is not present in the validation catalog.

## Notes For Future Readers

- Review the commits in order: tokenizer artifact precedence, GPU run provenance, then reference cache identity.
- `CUDA_VISIBLE_DEVICES=0` is a process-local selector inside a container; the stable model, UUID, and PCI fields identify the actual runtime GPU.
- The Minimax-H3 catalog gap is intentionally not hidden by weakening the catalog audit and is outside this PR's scope.
