### PR TITLE
test(minimax-h3): enforce coverage contracts

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -17,6 +17,12 @@ defaults:
     input_preparation_included: true
     asset_loading_included: false
 
+excluded_profiles:
+  - model: minimax-h3-768p
+    reason: >-
+      The pinned Diffusers reference for MiniMax-H3 has not yet been integrated
+      into the release performance runner.
+
 entries:
   - id: albert.encode
     family: albert

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
@@ -10,7 +10,6 @@ import tomllib
 
 import pytest
 
-from tensorrt_model_connect.families import find_diffusion_plugin, load_plugin_by_id
 from tensorrt_model_connect.families.minimax_h3.config import (
     DEFAULT_WORKSPACE_LIMIT_BYTES,
     MiniMaxH3Config,
@@ -65,14 +64,6 @@ def test_manifest_discovers_both_public_pipeline_names() -> None:
         "vae/**",
         "audio_vae/**",
     }
-
-
-def test_family_registry_loads_native_plugin_for_public_pipelines() -> None:
-    plugin = load_plugin_by_id("minimax_h3")
-    assert plugin is not None
-    assert plugin.name == "minimax_h3"
-    for pipeline_class in ("MiniMaxH3ModularPipeline", "MiniMaxH3Pipeline"):
-        assert find_diffusion_plugin(pipeline_class) is plugin
 
 
 def test_plugin_aliases_are_exact() -> None:

--- a/tests/builder/test_repository_contracts.py
+++ b/tests/builder/test_repository_contracts.py
@@ -6,6 +6,9 @@
 from tests.tools.test_family_source_isolation import (
     test_family_imports_resolve_without_sibling_or_unapproved_shared_modules as _check_family_isolation,
 )
+from tests.tools.test_family_specialization import (
+    test_repository_registers_all_current_families as _check_family_inventory,
+)
 from tests.tools.test_perf_matrix import (
     test_release_suite_covers_every_non_l0_ready_model_profile as _check_release_coverage,
 )
@@ -24,3 +27,7 @@ def test_ready_models_have_release_performance_coverage_or_exclusion() -> None:
 
 def test_family_sources_remain_isolated() -> None:
     _check_family_isolation()
+
+
+def test_repository_family_inventory_is_current() -> None:
+    _check_family_inventory()

--- a/tests/builder/test_repository_contracts.py
+++ b/tests/builder/test_repository_contracts.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run repository-wide ready-model contracts in every builder lane."""
+
+from tests.tools.test_family_source_isolation import (
+    test_family_imports_resolve_without_sibling_or_unapproved_shared_modules as _check_family_isolation,
+)
+from tests.tools.test_perf_matrix import (
+    test_release_suite_covers_every_non_l0_ready_model_profile as _check_release_coverage,
+)
+from tests.tools.test_trtmc_validate import (
+    test_model_workload_catalog_covers_every_ready_model as _check_validation_coverage,
+)
+
+
+def test_ready_models_have_validation_workloads() -> None:
+    _check_validation_coverage()
+
+
+def test_ready_models_have_release_performance_coverage_or_exclusion() -> None:
+    _check_release_coverage()
+
+
+def test_family_sources_remain_isolated() -> None:
+    _check_family_isolation()

--- a/tests/e2e/models/minimax_h3/e2e_plugins/reference.py
+++ b/tests/e2e/models/minimax_h3/e2e_plugins/reference.py
@@ -12,6 +12,10 @@ import subprocess
 import sys
 import time
 
+from tensorrt_model_connect.families.minimax_h3.provenance import (
+    validate_source_revision,
+)
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
@@ -34,6 +38,14 @@ _DIFFUSERS_REPO_ENV = "TRTMC_MINIMAX_H3_DIFFUSERS_REPO"
 _FAMILY_MANIFEST = (
     PROJECT_DIR / "python" / "tensorrt_model_connect" / "families" / "minimax_h3" / "MODEL.toml"
 )
+
+
+def _reference_source_revision(case: E2ECase, ctx: RunContext) -> str:
+    if case.metadata.get("validation_sample_id"):
+        return validate_source_revision(
+            str(case.metadata.get("reference_source_revision", ""))
+        )
+    return source_revision(case, ctx)
 
 
 def _reference_environment(ctx: RunContext) -> dict[str, str]:
@@ -122,7 +134,7 @@ class MiniMaxH3HfReference:
         validate_fixed_profile(case)
         output_dir = artifact_dir(ctx, case, "hf_reference")
         python = ctx.reference_python_path() or sys.executable
-        revision = source_revision(case, ctx)
+        revision = _reference_source_revision(case, ctx)
         command = [
             python,
             str(MODEL_DIR / "hf_reference.py"),

--- a/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
+++ b/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
@@ -9,7 +9,7 @@
   "precision": "bf16",
   "reference_precision": "bf16",
   "e2e_parallel_resource": "exclusive_gpu",
-  "e2e_min_free_gpu_memory_mib": 280000,
+  "e2e_min_free_gpu_memory_mib": 184320,
   "build_timeout_s": 14400,
   "build_args": {
     "parallel": {

--- a/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
+++ b/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
@@ -9,7 +9,7 @@
   "precision": "bf16",
   "reference_precision": "bf16",
   "e2e_parallel_resource": "exclusive_gpu",
-  "e2e_min_free_gpu_memory_mib": 240000,
+  "e2e_min_free_gpu_memory_mib": 280000,
   "build_timeout_s": 14400,
   "build_args": {
     "parallel": {

--- a/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
+++ b/tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json
@@ -9,6 +9,7 @@
   "precision": "bf16",
   "reference_precision": "bf16",
   "e2e_parallel_resource": "exclusive_gpu",
+  "e2e_min_free_gpu_memory_mib": 240000,
   "build_timeout_s": 14400,
   "build_args": {
     "parallel": {

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
@@ -54,7 +54,7 @@ def pytest_generate_tests(metafunc):
 def test_minimax_h3_manifest_is_truthful_single_device_contract() -> None:
     manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
-    assert manifest["e2e_min_free_gpu_memory_mib"] == 280000
+    assert manifest["e2e_min_free_gpu_memory_mib"] == 184320
 
     model = load_model_manifest(_MANIFEST_PATH)
     assert model.name == "minimax-h3-768p"

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
@@ -52,6 +52,10 @@ def pytest_generate_tests(metafunc):
 
 
 def test_minimax_h3_manifest_is_truthful_single_device_contract() -> None:
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+    assert manifest["e2e_min_free_gpu_memory_mib"] == 240000
+
     model = load_model_manifest(_MANIFEST_PATH)
     assert model.name == "minimax-h3-768p"
     assert model.family == "minimax_h3"

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
@@ -21,6 +21,7 @@ from tests.e2e.models.minimax_h3.e2e_plugins.reference import (
     _model_snapshot,
     _reference_allow_patterns,
 )
+from tensorrt_model_connect.families import find_diffusion_plugin, load_plugin_by_id
 from tensorrt_model_connect.families.minimax_h3.provenance import file_record
 from tests.e2e_harness.contracts import RunContext, StageOutput, StageSpec, ThresholdProfile
 from tests.e2e_harness.manifest_loader import load_model_manifest
@@ -84,6 +85,14 @@ def test_minimax_h3_plugins_cover_native_reference_and_comparison() -> None:
     assert get_runner("diffusion_media_generation") is not None
     assert get_reference("hf_diffusers") is not None
     assert get_comparator("diffusion_media_generation") is not None
+
+
+def test_family_registry_loads_native_plugin_for_public_pipelines() -> None:
+    plugin = load_plugin_by_id("minimax_h3")
+    assert plugin is not None
+    assert plugin.name == "minimax_h3"
+    for pipeline_class in ("MiniMaxH3ModularPipeline", "MiniMaxH3Pipeline"):
+        assert find_diffusion_plugin(pipeline_class) is plugin
 
 
 def test_minimax_h3_reference_resolves_complete_family_snapshot_offline(

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_e2e.py
@@ -54,7 +54,7 @@ def pytest_generate_tests(metafunc):
 def test_minimax_h3_manifest_is_truthful_single_device_contract() -> None:
     manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
-    assert manifest["e2e_min_free_gpu_memory_mib"] == 240000
+    assert manifest["e2e_min_free_gpu_memory_mib"] == 280000
 
     model = load_model_manifest(_MANIFEST_PATH)
     assert model.name == "minimax-h3-768p"

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
@@ -94,6 +94,34 @@ def test_reference_environment_prioritizes_pinned_diffusers(
     assert environment["PYTHONDONTWRITEBYTECODE"] == "1"
 
 
+def test_model_plugin_reference_uses_validation_revision_without_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = SimpleNamespace(
+        metadata={
+            "validation_sample_id": "fixed-profile",
+            "reference_source_revision": "a" * 40,
+        }
+    )
+    ctx = RunContext(case=case)
+    monkeypatch.setattr(
+        reference,
+        "source_revision",
+        lambda *_args: pytest.fail("validation reference must not require a bundle"),
+    )
+
+    revision = reference._reference_source_revision(case, ctx)
+
+    assert revision == "a" * 40
+
+
+def test_model_plugin_reference_requires_exact_validation_revision() -> None:
+    case = SimpleNamespace(metadata={"validation_sample_id": "fixed-profile"})
+
+    with pytest.raises(ValueError, match="lowercase 40-character Git SHA"):
+        reference._reference_source_revision(case, RunContext(case=case))
+
+
 def test_reference_evidence_is_resolved_from_context_and_passed_explicitly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/e2e/models/minimax_h3/validation/minimax-h3-768p.json
+++ b/tests/e2e/models/minimax_h3/validation/minimax-h3-768p.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "trtmc.model-plugin-validation/v1",
+  "dataset": "MiniMax-H3 pinned 768p T2VA profile",
+  "version": "1",
+  "requests": [
+    {
+      "sample_id": "minimax-h3-768p-official-profile",
+      "testcase": "minimax-h3-768p",
+      "stage": "end_to_end",
+      "category": "official-profile",
+      "inputs": {}
+    }
+  ]
+}

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -318,4 +318,5 @@ def test_repository_registers_all_current_families() -> None:
 
     families = specialization.family_dirs(repo_root, ())
 
-    assert len(families) == 78
+    assert len(families) == 79
+    assert any(family.name == "minimax_h3" for family in families)

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -637,6 +637,33 @@ def test_impact_runs_units_for_test_consumed_docs(
     } == {expected_kind}
 
 
+def test_release_performance_config_runs_source_contracts_without_model_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "benchmarks/performance/release.yaml",
+        "entries:\n  - id: model-a.generate\n",
+    )
+    head = _commit(repo, "update release performance contract")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {"unit_tests"}
+
+
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -664,6 +664,34 @@ def test_release_performance_config_runs_source_contracts_without_model_fallback
     } == {"unit_tests"}
 
 
+@pytest.mark.parametrize(
+    "path",
+    (
+        "benchmarks/performance/baselines/task_reference.py",
+        "tools/perf_matrix.py",
+    ),
+)
+def test_release_performance_runtime_changes_keep_model_fallback(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# changed release performance runtime\n")
+    head = _commit(repo, "update release performance runtime")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {
+        "include": [{"model": "model_a", "selection_kind": "fallback"}]
+    }
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -826,8 +826,8 @@ def test_minimax_h3_selection_requires_native_runtime_capacity(tmp_path: Path) -
     selection = _run_test_selection(tmp_path, "minimax_h3", "premerge")
 
     assert selection["resource_class"] == "exclusive_gpu"
-    assert selection["min_free_gpu_memory_mib"] == 240000
-    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {240000}
+    assert selection["min_free_gpu_memory_mib"] == 280000
+    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {280000}
 
 
 def test_selection_without_a_capacity_requirement_normalizes_to_zero(

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -822,6 +822,14 @@ def test_qwen3_omni_selection_requires_clean_gpu_capacity(tmp_path: Path) -> Non
     assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {280000}
 
 
+def test_minimax_h3_selection_requires_native_runtime_capacity(tmp_path: Path) -> None:
+    selection = _run_test_selection(tmp_path, "minimax_h3", "premerge")
+
+    assert selection["resource_class"] == "exclusive_gpu"
+    assert selection["min_free_gpu_memory_mib"] == 240000
+    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {240000}
+
+
 def test_selection_without_a_capacity_requirement_normalizes_to_zero(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -826,8 +826,8 @@ def test_minimax_h3_selection_requires_native_runtime_capacity(tmp_path: Path) -
     selection = _run_test_selection(tmp_path, "minimax_h3", "premerge")
 
     assert selection["resource_class"] == "exclusive_gpu"
-    assert selection["min_free_gpu_memory_mib"] == 280000
-    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {280000}
+    assert selection["min_free_gpu_memory_mib"] == 184320
+    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {184320}
 
 
 def test_selection_without_a_capacity_requirement_normalizes_to_zero(

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -23,6 +23,10 @@ from tools import perf_matrix
 REPOSITORY = Path(__file__).resolve().parents[2]
 SUITE = REPOSITORY / "benchmarks/performance/release.yaml"
 GB300_ENVIRONMENT = REPOSITORY / "benchmarks/performance/environments/gb300.yaml"
+MINIMAX_H3_EXCLUSION_REASON = (
+    "The pinned Diffusers reference for MiniMax-H3 has not yet been integrated "
+    "into the release performance runner."
+)
 TASK_ADAPTERS = {
     "bark.generate_audio": "hf-transformers-tts",
     "canary.transcribe": "nemo-asr",
@@ -248,7 +252,9 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert len(cases) == 105
     assert len(raw_entries) == 77
     assert len(raw_additional) == 28
-    assert excluded_profiles == {}
+    assert excluded_profiles == {
+        "minimax-h3-768p": MINIMAX_H3_EXCLUSION_REASON,
+    }
     assert all(
         set(entry["workload"]) <= {"testcase", "request", "runtime"}
         for entry in raw_entries
@@ -256,7 +262,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert all(entry["workload"].get("testcase") for entry in raw_entries)
     assert all(entry.get("model") and entry.get("inherit") for entry in raw_additional)
     assert not any("priority" in entry for entry in raw_entries)
-    assert {case["model"] for case in cases} == ready_profiles
+    assert {case["model"] for case in cases} == ready_profiles - set(excluded_profiles)
     assert not any(perf_matrix._is_l0_profile(case["model"]) for case in cases)
     assert len({(case["family"], case["operation"]) for case in cases}) == 77
     assert len({case["family"] for case in cases}) == 76
@@ -1265,9 +1271,14 @@ def test_run_consolidates_results_and_records_replayable_commands(
     expected_catalog_coverage = {
         "total_profiles": len(catalog_entries),
         "ready_profiles": catalog_counts["ready"],
-        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles,
-        "explicitly_excluded_profiles": 0,
-        "explicit_exclusions": [],
+        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles - 1,
+        "explicitly_excluded_profiles": 1,
+        "explicit_exclusions": [
+            {
+                "model": "minimax-h3-768p",
+                "reason": MINIMAX_H3_EXCLUSION_REASON,
+            }
+        ],
         "excluded_l0_profiles": excluded_l0_profiles,
         "distributed_profiles": catalog_counts["distributed"],
         "other_profiles": sum(
@@ -1307,7 +1318,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "76 model types" in report
     assert "105 model comparisons" in report
     assert "105 single-process profiles" in report
-    assert "0 explicitly excluded profiles" in report
+    assert "1 explicitly excluded profile" in report
     assert (
         f"{expected_catalog_coverage['excluded_l0_profiles']} duplicate L0 profiles are excluded"
     ) in report

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -45,7 +45,7 @@ def test_model_workload_catalog_covers_every_ready_model():
         task_models=task_models,
     )
 
-    assert len(catalog["models"]) == len(ready_models) == 105
+    assert len(catalog["models"]) == len(ready_models) == 106
     assert sum(
         "not_compared_reason" in spec for spec in catalog["models"].values()
     ) == 0
@@ -71,6 +71,59 @@ def test_model_workload_catalog_covers_every_ready_model():
         )
     }
     assert len(qwen_identities) == 1
+
+
+def test_minimax_h3_catalog_uses_model_owned_official_profile() -> None:
+    catalog = trtmc_validate.load_catalog()
+    suites = validation_catalog.load_suites()
+    suite = next(
+        value
+        for value in suites
+        if value["id"] == "minimax_h3_official_profile_parity"
+    )
+    model = next(
+        value
+        for value in validation_catalog.load_manifest_records(
+            trtmc_validate.DEFAULT_MODELS
+        )
+        if value["name"] == "minimax-h3-768p"
+    )
+
+    assert catalog["models"]["minimax-h3-768p"] == {
+        "default": "minimax_h3_official_profile_parity",
+        "workloads": ["minimax_h3_official_profile_parity"],
+    }
+    assert validation_catalog.suite_match_reason(suite, model) == (
+        True,
+        "selected",
+    )
+    assert suite["dataset"] == {
+        "kind": "model_plugin_json",
+        "default_path": (
+            "tests/e2e/models/minimax_h3/validation/minimax-h3-768p.json"
+        ),
+    }
+    assert suite["scoring"] == {"scorer": "model_plugin_parity"}
+    assert suite["gates"] == {"min_sample_pass_rate": 1.0}
+
+    dataset_path = trtmc_validate.REPO_ROOT / suite["dataset"]["default_path"]
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert dataset["requests"] == [
+        {
+            "sample_id": "minimax-h3-768p-official-profile",
+            "testcase": "minimax-h3-768p",
+            "stage": "end_to_end",
+            "category": "official-profile",
+            "inputs": {},
+        }
+    ]
+    resolved = validation_catalog.resolve_suite_for_model(suite, model)
+    assert resolved["generation"] == {
+        "video_num_frames": 124,
+        "video_height": 768,
+        "video_width": 1344,
+        "num_inference_steps": 50,
+    }
 
 
 def test_validation_ready_models_exclude_l0_only_profiles():
@@ -109,6 +162,7 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
         for workload, limit in catalog["sample_limits"].items()
         if limit == 1
     } == {
+        "minimax_h3_official_profile_parity",
         "seedtts_en_omni_audio_parity",
         "vbench_ti2v_official_profile_parity",
     }
@@ -148,7 +202,7 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 105
+    assert len({model for model, _workload in bindings}) == 106
 
 
 def test_resolve_binding_defaults_and_rejects_undeclared_workload():

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -22,7 +22,30 @@ from PIL import Image
 
 from tools import prepare_media_validation_datasets as prepare_media
 from tools import prepare_full_duplex_bench_validation as prepare_fdb
+from tools import trtmc_reference
+from tools.reference import plugin_reference
 from tools.validation import engine as validation_engine
+
+
+def _write_bundle_config(path: Path, config: dict[str, Any]) -> None:
+    config_data = json.dumps(config).encode("utf-8")
+    header_data = json.dumps(
+        {
+            "sections": {
+                "config.json": {
+                    "offset": 0,
+                    "size": len(config_data),
+                }
+            }
+        }
+    ).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b"TRTFB\x00\x01\x00"
+        + struct.pack("<Q", len(header_data))
+        + header_data
+        + config_data
+    )
 
 
 def test_full_duplex_bench_scorer_runs_in_reference_environment(
@@ -2324,6 +2347,139 @@ def test_non_gpt_oss_mmlu_model_keeps_suite_defaults() -> None:
     assert validation_engine.effective_validation_config(suite, model) == {}
 
 
+def test_reference_source_revision_current_resolves_to_exact_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revision = "a" * 40
+    monkeypatch.setattr(
+        validation_engine,
+        "_current_source_revision",
+        lambda: revision,
+    )
+
+    resolved = validation_engine.resolve_reference_source_revision(
+        {
+            "reference_source_revision": "current",
+            "reference_precision": "bf16",
+        }
+    )
+
+    assert resolved == {
+        "reference_source_revision": revision,
+        "reference_precision": "bf16",
+    }
+
+
+def test_reference_source_revision_current_fails_closed_without_exact_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "TRTMC_VALIDATION_SOURCE_REVISION",
+        "TRTMC_ENGINE_BUILD_REVISION",
+        "GITHUB_SHA",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        validation_engine.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="not-an-exact-sha\n",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="cannot resolve current validation source revision as an exact Git SHA",
+    ):
+        validation_engine.resolve_reference_source_revision(
+            {"reference_source_revision": "current"}
+        )
+
+
+def test_current_source_revision_prefers_exact_ci_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRTMC_VALIDATION_SOURCE_REVISION", "A" * 40)
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", "B" * 40)
+    monkeypatch.setenv("GITHUB_SHA", "C" * 40)
+    monkeypatch.setattr(
+        validation_engine.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("exact CI revision must avoid git fallback"),
+    )
+
+    assert validation_engine._current_source_revision() == "a" * 40
+
+
+def test_model_plugin_reference_cache_key_tracks_resolved_source_revision(
+    tmp_path: Path,
+) -> None:
+    def reference_key(name: str, revision: str) -> str:
+        work_dir = tmp_path / name
+        work_dir.mkdir()
+        (work_dir / "answers.json").write_text(
+            json.dumps({"requests": [{"sample_id": "one"}]}),
+            encoding="utf-8",
+        )
+        (work_dir / "prompts.jsonl").write_text(
+            json.dumps({"sample_id": "one", "prompt": "hello"}) + "\n",
+            encoding="utf-8",
+        )
+        (work_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "dataset_kind": "model_plugin_json",
+                    "files": {
+                        "answers": str(work_dir / "answers.json"),
+                        "prompts": str(work_dir / "prompts.jsonl"),
+                    },
+                    "task_eval": {
+                        "model_manifest": "tests/e2e/models/example.json",
+                        "reference_source_revision": revision,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        arguments = trtmc_reference.build_parser().parse_args(
+            [
+                "run",
+                "--model",
+                "org/model",
+                "--family",
+                "example",
+                "--work-dir",
+                str(work_dir),
+                "--reference-cache-identity",
+                "example-reference-v1",
+            ]
+        )
+        return trtmc_reference.reference_key(arguments)[0]
+
+    assert reference_key("first", "a" * 40) != reference_key("second", "b" * 40)
+
+
+def test_plugin_reference_injects_source_revision_into_case_metadata() -> None:
+    case = SimpleNamespace(metadata={})
+
+    plugin_reference._apply_reference_task_metadata(
+        case,
+        {
+            "task_eval": {
+                "reference_precision": "bf16",
+                "reference_source_revision": "a" * 40,
+            }
+        },
+    )
+
+    assert case.metadata == {
+        "reference_precision": "bf16",
+        "reference_source_revision": "a" * 40,
+    }
+
+
 @pytest.mark.parametrize(
     ("model_name", "prompt_token_limit"),
     [
@@ -4053,6 +4209,148 @@ def test_ensure_bundle_applies_selected_cuda_device_to_build(
     )
 
     assert captured["cuda_visible_devices"] == "selected-device"
+
+
+def test_ensure_bundle_reuses_matching_source_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revision = "a" * 40
+    bundle = tmp_path / "shared" / "model.trtfb"
+    _write_bundle_config(bundle, {"source_revision": revision})
+    monkeypatch.setattr(
+        validation_engine,
+        "bundle_inspection",
+        lambda *_args: {"Precision": "fp32"},
+    )
+    monkeypatch.setattr(
+        validation_engine.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("matching bundle must be reused"),
+    )
+
+    result, built = validation_engine.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        replace_existing=True,
+        expected_source_revision=revision,
+    )
+
+    assert result == bundle
+    assert built is False
+
+
+def test_ensure_bundle_rebuilds_mismatched_source_revision_with_expected_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_revision = "a" * 40
+    bundle = tmp_path / "shared" / "model.trtfb"
+    _write_bundle_config(bundle, {"source_revision": "b" * 40})
+    monkeypatch.setattr(
+        validation_engine,
+        "bundle_inspection",
+        lambda *_args: {"Precision": "fp32"},
+    )
+
+    def fake_run(command, **kwargs):
+        assert not bundle.exists()
+        assert kwargs["env"]["TRTMC_ENGINE_BUILD_REVISION"] == expected_revision
+        _write_bundle_config(bundle, {"source_revision": expected_revision})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+
+    result, built = validation_engine.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        replace_existing=True,
+        expected_source_revision=expected_revision,
+    )
+
+    assert result == bundle
+    assert built is True
+    assert validation_engine._bundle_source_revision(bundle) == expected_revision
+
+
+def test_source_bound_bundle_preserves_existing_file_without_replace_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_revision = "a" * 40
+    existing_revision = "b" * 40
+    bundle = tmp_path / "shared" / "model.trtfb"
+    _write_bundle_config(bundle, {"source_revision": existing_revision})
+    monkeypatch.setattr(
+        validation_engine,
+        "bundle_inspection",
+        lambda *_args: {"Precision": "fp32"},
+    )
+
+    def fake_run(_command, **kwargs):
+        assert bundle.is_file()
+        assert kwargs["env"]["TRTMC_ENGINE_BUILD_REVISION"] == expected_revision
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Bundle build failed"):
+        validation_engine.ensure_bundle(
+            {
+                "name": "model",
+                "hf_id": "org/model",
+                "precision": "fp32",
+            },
+            bundle_path=bundle,
+            trtmc_binary="trtmc",
+            replace_existing=False,
+            expected_source_revision=expected_revision,
+        )
+
+    assert validation_engine._bundle_source_revision(bundle) == existing_revision
+
+
+def test_ensure_bundle_rejects_wrong_source_revision_after_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_revision = "a" * 40
+    bundle = tmp_path / "shared" / "model.trtfb"
+
+    def fake_run(command, **kwargs):
+        assert kwargs["env"]["TRTMC_ENGINE_BUILD_REVISION"] == expected_revision
+        _write_bundle_config(bundle, {"source_revision": "b" * 40})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        RuntimeError,
+        match="produced source_revision .* expected",
+    ):
+        validation_engine.ensure_bundle(
+            {
+                "name": "model",
+                "hf_id": "org/model",
+                "precision": "fp32",
+            },
+            bundle_path=bundle,
+            trtmc_binary="trtmc",
+            replace_existing=True,
+            expected_source_revision=expected_revision,
+        )
+
+    assert not bundle.exists()
 
 
 def test_ensure_bundle_removes_partial_replacement_after_failed_build(
@@ -6145,6 +6443,56 @@ def test_eval_one_model_passes_model_manifest_to_diffusion_prepare(
 
     assert captured["model_manifest"] == model["manifest"]
     assert captured["family"] == "flux"
+
+
+def test_eval_resolves_reference_source_revision_before_preparing_cache_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revision = "a" * 40
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(),
+        "minimax_h3_official_profile_parity",
+    )
+    model = {
+        "name": "minimax-h3-768p",
+        "manifest": "tests/e2e/models/minimax_h3/manifests/minimax-h3-768p.json",
+        "hf_id": "MiniMaxAI/MiniMax-H3",
+        "bundle": "minimax-h3-768p.trtfb",
+        "family": "minimax_h3",
+        "task_eval": {},
+    }
+    captured: dict[str, Any] = {}
+
+    class Prepared(Exception):
+        pass
+
+    def fake_prepare(**kwargs):
+        captured.update(kwargs["validation_config"])
+        raise Prepared
+
+    monkeypatch.setattr(
+        validation_engine,
+        "_current_source_revision",
+        lambda: revision,
+    )
+    monkeypatch.setattr(validation_engine, "prepare_task_dataset", fake_prepare)
+
+    with pytest.raises(Prepared):
+        validation_engine.eval_one_model(
+            suite=suite,
+            model=model,
+            args=argparse.Namespace(
+                work_root=str(tmp_path / "work"),
+                dataset=str(tmp_path / "minimax-h3-768p.json"),
+                limit=1,
+                subject="",
+                sample_seed=None,
+            ),
+        )
+
+    assert captured["reference_source_revision"] == revision
+    assert captured["model_manifest"] == model["manifest"]
 
 
 def test_flux_validation_build_command_preserves_diffusion_shape(tmp_path: Path) -> None:

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -27,6 +27,7 @@ sample_limits:
   mmlu_generation_mode_parity: 8
   mmmu_pro_vision_plugin_parity: 5
   mmmu_pro_vision_square_plugin_parity: 5
+  minimax_h3_official_profile_parity: 1
   newstest2019_en_ru_marian_translation_parity: 10
   ocrbench_v2_unified: 5
   openwebtext_elf_diffusion_text: 5
@@ -180,6 +181,9 @@ models:
   marian-en-ru:
     default: newstest2019_en_ru_marian_translation_parity
     workloads: [newstest2019_en_ru_marian_translation_parity]
+  minimax-h3-768p:
+    default: minimax_h3_official_profile_parity
+    workloads: [minimax_h3_official_profile_parity]
   minitron-4b-depth:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1687,6 +1687,34 @@ suites:
       lane: local_only
       notes: GB300-only native-reference consistency.
 
+  - id: minimax_h3_official_profile_parity
+    description: >
+      MiniMax-H3 consistency at the pinned native 1344x768, 124-frame,
+      50-step T2VA profile. The single repo-owned request deliberately selects
+      the model-owned testcase without overriding its prompt, seed, geometry,
+      or comparison thresholds.
+    user_contract: diffusion_video
+    default_model_names: [minimax-h3-768p]
+    dataset:
+      kind: model_plugin_json
+      default_path: tests/e2e/models/minimax_h3/validation/minimax-h3-768p.json
+    selectors:
+      model_names: [minimax-h3-768p]
+      task_strategies: [diffusion_media_generation]
+      runtime_strategies: [diffusion_minimax_h3]
+      user_contracts: [diffusion_video]
+      families: [minimax_h3]
+    scoring:
+      scorer: model_plugin_parity
+    gates:
+      min_sample_pass_rate: 1.0
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        GB300-only full-profile validation. The model-owned comparator keeps
+        the checked-in visual thresholds; this suite adds no threshold override.
+
   - id: mmlu_generation_mode_parity
     description: >
       Deterministic MMLU-Pro output consistency across AR, diffusion,

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1704,6 +1704,10 @@ suites:
       runtime_strategies: [diffusion_minimax_h3]
       user_contracts: [diffusion_video]
       families: [minimax_h3]
+    model_overrides:
+      by_model:
+        minimax-h3-768p:
+          reference_source_revision: current
     scoring:
       scorer: model_plugin_parity
     gates:

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -142,9 +142,13 @@ BUILDER_UNIT_TEST_INPUT_EXACT = frozenset(
         "website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md",
     }
 )
-# Inputs consumed by the complete source-only tools/CI contract suite.
+# Inputs consumed by the complete source-only tools/CI contract suite. The
+# release performance matrix is declarative: representative premerge model
+# proofs do not execute it, while the source contracts validate its schema,
+# ready-model coverage, exclusions, and report accounting.
 FULL_UNIT_TEST_INPUT_EXACT = frozenset(
     {
+        "benchmarks/performance/release.yaml",
         "tools/ci/README.md",
     }
 )

--- a/tools/reference/plugin_reference.py
+++ b/tools/reference/plugin_reference.py
@@ -223,15 +223,22 @@ def _model_manifest_path(manifest: Mapping[str, Any]) -> Path:
     return manifest_path if manifest_path.is_absolute() else REPO_ROOT / manifest_path
 
 
+def _apply_reference_task_metadata(
+    case: Any,
+    manifest: Mapping[str, Any],
+) -> None:
+    task_config = manifest.get("task_eval", {})
+    if not isinstance(task_config, Mapping):
+        return
+    for name in ("reference_precision", "reference_source_revision"):
+        value = str(task_config.get(name, "") or "")
+        if value:
+            case.metadata[name] = value
+
+
 def _load_reference_plugin(manifest: Mapping[str, Any]) -> tuple[Any, Any]:
     case = load_manifest(_model_manifest_path(manifest))
-    task_config = manifest.get("task_eval", {})
-    if isinstance(task_config, Mapping):
-        reference_precision = str(
-            task_config.get("reference_precision", "") or ""
-        )
-        if reference_precision:
-            case.metadata["reference_precision"] = reference_precision
+    _apply_reference_task_metadata(case, manifest)
     activate_model_plugins(str(case.metadata.get("model_test_dir", "") or ""))
     reference = get_reference(case.reference_backend)
     if reference is None:
@@ -693,13 +700,7 @@ def _run_model_plugin(
             prompt_row,
             source_index=source_index,
         )
-        task_config = manifest.get("task_eval", {})
-        if isinstance(task_config, Mapping):
-            reference_precision = str(
-                task_config.get("reference_precision", "") or ""
-            )
-            if reference_precision:
-                case.metadata["reference_precision"] = reference_precision
+        _apply_reference_task_metadata(case, manifest)
         activate_model_plugins(str(case.metadata.get("model_test_dir", "") or ""))
         reference = get_reference(case.reference_backend)
         if reference is None:

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -370,6 +370,70 @@ def _deep_merge_mappings(*values: Any) -> dict[str, Any]:
     return merged
 
 
+_EXACT_SOURCE_REVISION = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _current_source_revision() -> str:
+    for name in (
+        "TRTMC_VALIDATION_SOURCE_REVISION",
+        "TRTMC_ENGINE_BUILD_REVISION",
+        "GITHUB_SHA",
+    ):
+        configured = os.environ.get(name, "").strip().lower()
+        if not configured:
+            continue
+        if _EXACT_SOURCE_REVISION.fullmatch(configured) is None:
+            raise ValueError(f"{name} must be an exact Git SHA")
+        return configured
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise ValueError(
+            "cannot resolve current validation source revision"
+        ) from error
+    revision = result.stdout.strip().lower()
+    if result.returncode != 0 or _EXACT_SOURCE_REVISION.fullmatch(revision) is None:
+        detail = result.stderr.strip() or revision or "git rev-parse returned no revision"
+        raise ValueError(
+            "cannot resolve current validation source revision as an exact Git SHA: "
+            f"{detail}"
+        )
+    return revision
+
+
+def resolve_reference_source_revision(
+    validation_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve source-bound reference contracts before preparing cache inputs."""
+
+    resolved = copy.deepcopy(dict(validation_config))
+    configured = resolved.get("reference_source_revision")
+    if configured is None:
+        return resolved
+    if not isinstance(configured, str) or not configured.strip():
+        raise ValueError(
+            "validation.reference_source_revision must be 'current' or an exact Git SHA"
+        )
+    revision = (
+        _current_source_revision()
+        if configured.strip() == "current"
+        else configured.strip().lower()
+    )
+    if _EXACT_SOURCE_REVISION.fullmatch(revision) is None:
+        raise ValueError(
+            "validation.reference_source_revision must resolve to an exact Git SHA; "
+            f"got {configured!r}"
+        )
+    resolved["reference_source_revision"] = revision
+    return resolved
+
+
 def effective_validation_config(
     suite: dict[str, Any], model: dict[str, Any]
 ) -> dict[str, Any]:
@@ -8987,6 +9051,19 @@ def _bundle_can_be_reused(
     return not bundle_abi or not runtime_abi or bundle_abi == runtime_abi
 
 
+def _bundle_source_revision(bundle_path: Path) -> str:
+    try:
+        config = json.loads(
+            _read_bundle_section(bundle_path, "config.json").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return ""
+    if not isinstance(config, dict):
+        return ""
+    revision = str(config.get("source_revision", "") or "").strip().lower()
+    return revision if _EXACT_SOURCE_REVISION.fullmatch(revision) else ""
+
+
 def _remove_bundle_before_or_after_replacement(
     bundle_path: Path,
     replace_existing: bool,
@@ -9006,7 +9083,14 @@ def ensure_bundle(
     extra_build_args: list[str] | None = None,
     log_path: Path | None = None,
     cuda_visible_devices: str = "",
+    expected_source_revision: str = "",
 ) -> tuple[Path, bool]:
+    expected_source_revision = str(expected_source_revision or "").strip().lower()
+    if (
+        expected_source_revision
+        and _EXACT_SOURCE_REVISION.fullmatch(expected_source_revision) is None
+    ):
+        raise ValueError("expected_source_revision must be an exact Git SHA")
     expected_precision = _canonical_reference_precision(
         model.get("precision", "fp32"),
         field="TRTMC base precision",
@@ -9018,6 +9102,9 @@ def ensure_bundle(
             max_cache_length=max_cache_length,
             expected_precision=expected_precision,
             allow_unknown=not replace_existing,
+        ) and (
+            not expected_source_revision
+            or _bundle_source_revision(bundle_path) == expected_source_revision
         ):
             return bundle_path, False
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
@@ -9035,9 +9122,12 @@ def ensure_bundle(
     log_path = log_path or bundle_path.with_suffix(".build.log")
     log_path.parent.mkdir(parents=True, exist_ok=True)
     build_env = None
-    if cuda_visible_devices:
+    if cuda_visible_devices or expected_source_revision:
         build_env = os.environ.copy()
-        build_env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+        if cuda_visible_devices:
+            build_env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+        if expected_source_revision:
+            build_env["TRTMC_ENGINE_BUILD_REVISION"] = expected_source_revision
     with log_path.open("w", encoding="utf-8") as log_f:
         log_f.write(f"$ {shlex.join(cmd)}\n")
         log_f.flush()
@@ -9056,6 +9146,15 @@ def ensure_bundle(
         )
         raise RuntimeError(
             f"Bundle build failed for {model['name']} rc={proc.returncode}; see {log_path}"
+        )
+    actual_source_revision = (
+        _bundle_source_revision(bundle_path) if expected_source_revision else ""
+    )
+    if expected_source_revision and actual_source_revision != expected_source_revision:
+        _remove_bundle_before_or_after_replacement(bundle_path, replace_existing)
+        raise RuntimeError(
+            f"Bundle build for {model['name']} produced source_revision "
+            f"{actual_source_revision or '<missing>'}, expected {expected_source_revision}"
         )
     return bundle_path, True
 
@@ -10832,7 +10931,9 @@ def eval_one_model(
     reference_backend = reference_mode or str(
         model.get("reference_backend", "hf_transformers") or "hf_transformers"
     )
-    validation_config = effective_validation_config(suite, model)
+    validation_config = resolve_reference_source_revision(
+        effective_validation_config(suite, model)
+    )
     model = apply_comparison_precision(model, validation_config)
     suite_reference = suite.get("reference", {})
     if isinstance(suite_reference, dict) and suite_reference:
@@ -10962,6 +11063,9 @@ def eval_one_model(
         extra_build_args=args.extra_build_arg,
         log_path=work_dir / "build.log",
         cuda_visible_devices=args.cuda_visible_devices,
+        expected_source_revision=str(
+            validation_config.get("reference_source_revision", "") or ""
+        ),
     )
 
     if (


### PR DESCRIPTION
## Context

The historical QA dashboard run `trtmc-validate-gb300-2-20260726-c8291be0-all105` was produced from Source revision `c8291be0390705ca1cdcccdff83e251e7d7e1767` and contains 105 rows. It predates MiniMax-H3, so this PR does **not** claim that MiniMax was one of that run's failing models. MiniMax-H3 was added to `main` later by #815; the missing contracts below then became a shared current-`main` blocker for the rebased model-accuracy PRs.

MiniMax-H3 onboarding was incomplete in four repository-wide contracts:

- the validation catalog did not contain `minimax-h3-768p`;
- release-performance accounting neither ran nor explicitly excluded it;
- a package-registry assertion inside the family source violated family isolation; and
- the strict family inventory still expected 78 families after the repository had 79.

The model-owned premerge lane selected `tests/builder/`, while the canonical coverage, performance, isolation, and inventory assertions lived under `tests/tools/`. That topology let a model land without those contracts being exercised by its normal premerge projection.

The first validation registration also exposed an execution cycle: a clean-engine reference tried to obtain Source provenance from a bundle before that bundle existed. Exact-head model proof then exposed a separate resource-contract gap: `exclusive_gpu` acquired cooperative lock slots but, with no free-memory requirement, could start on a device without enough capacity to deserialize the first TensorRT plan.

## What changed

- Added a one-sample, model-owned validation profile for the existing pinned `minimax-h3-768p` contract: checkpoint `48d93ede732756e404a3b1b2f3b3a9b5a22f6cfc`, Diffusers reference `abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc`, the manifest prompt, seed 0, 1344x768, 124 frames, 50 steps, 24 fps, and BF16 candidate/reference execution.
- Resolved `reference_source_revision: current` to an exact lowercase Source SHA before reference-cache preparation. The same SHA is part of the reference-cache identity, is passed into a clean bundle build, and is verified on both bundle reuse and after a rebuild. Missing or mismatched provenance fails closed.
- Added an explicit MiniMax release-performance exclusion until the pinned Diffusers reference is integrated into the release runner. This records the unsupported path; it does not relax a timing or accuracy threshold.
- Moved the package-registry assertion out of the family source and kept the family-isolation allowlist unchanged.
- Added builder-owned wrappers for validation coverage, performance coverage/exclusion, family source isolation, and the strict 79-family inventory.
- Classified a declarative `tests/performance/release.yaml`-only change as source-contract-only. Changes to selector/runtime/performance-runtime code retain the fixed fallback set.
- Declared `exclusive_gpu` plus `184320 MiB` of required free capacity for MiniMax. The value is based on the successful identical HF reference's measured `144177.109 MiB` peak plus about 39.2 GiB of headroom. Admission also rejects active compute processes. The manifest value and selector propagation are both locked by tests.

No visual comparison threshold was added, removed, or weakened.

## Reproduction and investigation

- The initial exact-head source lane caught the four current-`main` onboarding omissions once the builder wrappers were present, including the stale 78-versus-79 family inventory.
- A clean-engine run showed that reading provenance from a not-yet-built bundle made the validation row non-runnable. Resolving the exact Source SHA before cache/build preparation removes that cycle without bypassing provenance checks.
- On head `ce933d8857d2e22ca9160bacacd0532af9e9f23c`, one model-proof attempt failed during TensorRT build; the next built a 121 GB bundle and then failed while deserializing the first native plan because the manifest had `min_free_gpu_memory_mib=0`. Native inference, HF reference, and comparison correctly did not run after that failure.
- The stale `82d5b025d2ff39bb1b1135c3c82de38184baa33d` diagnostic run returned `rc=1` from the TensorRT text-encoder builder without an OOM, SIGKILL, disk-pressure, or deeper TensorRT error in its artifact. It was superseded by the current head and is not used as merge evidence.
- The current exact head passed from a clean scratch build through native execution, pinned HF reference, and all-frame comparison. That result, not a stale or partially completed run, is the readiness evidence below.

## Exact-head validation

Source head: `529e2e0210f29b0eaa0867d110c5051da834f780`

- [Private premerge run 31089031941](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31089031941): **PASS**
  - source-only Python: `3036 passed, 1 skipped`;
  - projected Python: `17 passed, 128 deselected`;
  - source-only C++: `38/38 passed`;
  - MiniMax family Python: `88 passed`;
  - MiniMax E2E: `16 passed in 1505.22s`;
  - DeepSeek-V2, LTX-Video, Whisper, PatchTSMixer, and SegFormer fixed fallbacks: all passed.
- [MiniMax artifact 8963534728](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31089031941/artifacts/8963534728): exact-head receipt verified
  - exclusive GPU 0, all four lease slots, no network access;
  - capacity admission: `184320 MiB` required, `280607 MiB` effective free observed;
  - clean bundle build: one invocation, one attempt, `rc=0`, 843.27s, 121,486,206,616 bytes;
  - native and HF receipts both bind Source `529e2e...` and checkpoint `48d93e...`;
  - both produced exactly 124 finite RGB frames at 1344x768;
  - minimum/mean low-frequency correlation: `0.907871 / 0.939423` against `>= 0.8 / >= 0.9`;
  - brightness-profile correlation: `0.999868` against `>= 0.95`;
  - maximum frame-brightness absolute error: `0.013277` against `<= 0.08`;
  - temporal-activity correlation: `0.999447` against `>= 0.9`;
  - maximum temporal-activity absolute error: `0.007833` against `<= 0.05`;
  - frame-contrast ratios remained inside `[0.7, 1.4]`;
  - PSNR `19.4489 dB` and MAE `0.04554436` remain diagnostic, as defined by the unchanged model contract.
- [CodeQL run 31088989028](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/31088989028): JavaScript/TypeScript and Python both passed.
- `trtmc/premerge/required`: exact-head success, published from the private verdict above.
- Ruff and `git diff --check`: passed.

The current PR changes shared selection contracts, so its one-time exact-head run intentionally selected one direct MiniMax proof plus five fixed fallback models. The full private run completed in about 34 minutes; it did not fan out to all models.

Steady-state cost is bounded:

- the added builder wrappers are source-only checks;
- a future `release.yaml`-only change runs unit/all with zero GPU model proofs;
- a MiniMax-owned change selects one direct MiniMax proof; and
- shared selector/runtime or performance-runtime changes retain the existing fixed five-model fallback rather than an all-model fanout.

The GPU capacity check adds no model execution. It waits for a suitable exclusive device before the expensive build, avoiding a late native-start OOM after spending roughly 14-20 minutes building the bundle.

## Follow-up boundary

Remove the release-performance exclusion only after the pinned Diffusers checkout is wired into the release runner and validated on target hardware. Do not replace exact-source binding with a cache bypass, move the registry assertion back into the family package, or weaken the model-owned visual thresholds.
