### PR TITLE
perf(minimax-h3): add native first-block caching

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -955,6 +955,7 @@ def build_bundle(
             verbose=verbose, t0=t0,
             fp8_scales=fp8_scales, save_fp8_scales=save_fp8_scales,
             rtx=rtx,
+            family_build_options=family_build_options,
             diffusion_overrides=diffusion_overrides,
             build_timing=build_timing,
             parallel_config=parallel,
@@ -1614,6 +1615,7 @@ def _build_diffusion_bundle(
     fp8_scales: dict | None = None,
     save_fp8_scales: str | None = None,
     rtx: bool = False,
+    family_build_options: dict | None = None,
     diffusion_overrides: dict | None = None,
     build_timing: dict | None = None,
     parallel_config: ParallelConfig | None = None,
@@ -1647,6 +1649,7 @@ def _build_diffusion_bundle(
     config = ModelConfig(model_type=model_type, raw=dict(pipeline_config))
     config.raw["max_cache_length"] = max_cache_length
     config.raw["_fp32_layers"] = sorted(set(fp32_layers or ()))
+    config.raw["_family_build_options"] = dict(family_build_options or {})
     if diffusion_overrides:
         config.raw.update(diffusion_overrides)
     config.raw["_source_model_ref"] = getattr(

--- a/python/tensorrt_model_connect/families/minimax_h3/config.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/config.py
@@ -25,6 +25,41 @@ DEFAULT_WORKSPACE_LIMIT_BYTES = {
     "vae_tile_decoder.plan": VAE_TILE_DECODER_DEFAULT_WORKSPACE_BYTES,
 }
 
+FIRST_BLOCK_CACHE_DENOISER_PLAN_FILENAMES = (
+    "denoiser_head.plan",
+    "denoiser_tail.plan",
+    "denoiser_finish.plan",
+)
+
+
+def native_plan_filenames(*, first_block_cache: bool) -> tuple[str, ...]:
+    """Return the exact plan set selected by the native denoiser profile."""
+
+    if not isinstance(first_block_cache, bool):
+        raise ValueError("MiniMax-H3 first_block_cache must be a boolean")
+    denoiser_plans = (
+        FIRST_BLOCK_CACHE_DENOISER_PLAN_FILENAMES if first_block_cache else ("denoiser.plan",)
+    )
+    return (
+        "text_encoder.plan",
+        "adaln_precompute.plan",
+        *denoiser_plans,
+        "vae_tile_decoder.plan",
+    )
+
+
+def default_workspace_limit_bytes(*, first_block_cache: bool) -> dict[str, int]:
+    """Return per-plan tactic workspace limits for one denoiser layout."""
+
+    return {
+        filename: (
+            DENOISER_DEFAULT_WORKSPACE_BYTES
+            if filename.startswith("denoiser_") or filename == "denoiser.plan"
+            else DEFAULT_WORKSPACE_LIMIT_BYTES[filename]
+        )
+        for filename in native_plan_filenames(first_block_cache=first_block_cache)
+    }
+
 
 def resolve_workspace_bytes(workspace_bytes: int | None, *, default_bytes: int) -> int:
     """Resolve a positive tactic-workspace limit without silently coercing values."""
@@ -58,6 +93,7 @@ class MiniMaxH3Config:
     padded_sequence_length: int = 38247
     max_timestep_count: int = 4
     context_parallel_size: int = 1
+    first_block_cache: bool = False
 
     @property
     def sequence_length(self) -> int:
@@ -91,6 +127,8 @@ class MiniMaxH3Config:
             raise ValueError("MiniMax-H3 single-device profile requires no packed-sequence padding")
         if self.rope_freq_dim * 6 > self.head_dim:
             raise ValueError("MiniMax-H3 rotary channels exceed head_dim")
+        if not isinstance(self.first_block_cache, bool):
+            raise ValueError("MiniMax-H3 first_block_cache must be a boolean")
 
 
 SOL_ENGINE_1344X768_124F = MiniMaxH3Config()

--- a/python/tensorrt_model_connect/families/minimax_h3/dit_builder.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/dit_builder.py
@@ -24,25 +24,8 @@ from .config import (
 trt = trt_compat.get_trt()
 
 
-def checkpoint_keys(
-    profile: MiniMaxH3Config = SOL_ENGINE_1344X768_124F,
-) -> tuple[str, ...]:
-    """Checkpoint tensors used by the recurrent DiT plan, excluding AdaLN."""
-
-    names = [
-        "proj_in.weight",
-        "proj_in.bias",
-        "audio_proj_in.weight",
-        "audio_proj_in.bias",
-        "context_embedder.weight",
-        "context_embedder.bias",
-        "token_refiner.final_norm.weight",
-        "norm_out.norm.weight",
-        "proj_out.weight",
-        "proj_out.bias",
-        "audio_proj_out.weight",
-        "audio_proj_out.bias",
-    ]
+def _refiner_checkpoint_keys(profile: MiniMaxH3Config) -> tuple[str, ...]:
+    names: list[str] = []
     for index in range(profile.num_refiner_layers):
         prefix = f"token_refiner.refiner_blocks.{index}"
         names.extend(
@@ -57,7 +40,12 @@ def checkpoint_keys(
                 f"{prefix}.ff.net.2.weight",
             ]
         )
-    for index in range(profile.num_layers):
+    return tuple(names)
+
+
+def _block_checkpoint_keys(indices) -> tuple[str, ...]:
+    names: list[str] = []
+    for index in indices:
         prefix = f"transformer_blocks.{index}"
         names.extend(
             [
@@ -72,6 +60,58 @@ def checkpoint_keys(
             ]
         )
     return tuple(names)
+
+
+def head_checkpoint_keys(
+    profile: MiniMaxH3Config = SOL_ENGINE_1344X768_124F,
+) -> tuple[str, ...]:
+    """Weights used by packing, token refinement, and transformer block zero."""
+
+    return (
+        "proj_in.weight",
+        "proj_in.bias",
+        "audio_proj_in.weight",
+        "audio_proj_in.bias",
+        "context_embedder.weight",
+        "context_embedder.bias",
+        "token_refiner.final_norm.weight",
+        *_refiner_checkpoint_keys(profile),
+        *_block_checkpoint_keys(range(1)),
+    )
+
+
+def tail_checkpoint_keys(
+    profile: MiniMaxH3Config = SOL_ENGINE_1344X768_124F,
+) -> tuple[str, ...]:
+    """Weights used by transformer blocks one through the final block."""
+
+    return _block_checkpoint_keys(range(1, profile.num_layers))
+
+
+def finish_checkpoint_keys(
+    profile: MiniMaxH3Config = SOL_ENGINE_1344X768_124F,
+) -> tuple[str, ...]:
+    """Weights used by the final norm and modality-specific projections."""
+
+    return (
+        "norm_out.norm.weight",
+        "proj_out.weight",
+        "proj_out.bias",
+        "audio_proj_out.weight",
+        "audio_proj_out.bias",
+    )
+
+
+def checkpoint_keys(
+    profile: MiniMaxH3Config = SOL_ENGINE_1344X768_124F,
+) -> tuple[str, ...]:
+    """Checkpoint tensors used by all DiT plans, excluding AdaLN."""
+
+    return (
+        *head_checkpoint_keys(profile),
+        *tail_checkpoint_keys(profile),
+        *finish_checkpoint_keys(profile),
+    )
 
 
 def _slice_modulation(network, selected, index: int, rows: int, width: int):
@@ -233,18 +273,147 @@ def _refine_text(network, text, weights, profile: MiniMaxH3Config):
     )
 
 
-def build_dit_engine(
-    weights: dict,
-    profile: MiniMaxH3Config,
-    *,
-    verbose: bool = False,
-    consume_weights: bool = False,
-    workspace_bytes: int | None = None,
-) -> bytes:
-    """Build the full-sequence single-device H3 TensorRT plan."""
+def _packed_hidden(network, video, audio, text, weights, profile: MiniMaxH3Config):
+    """Project and pack text | audio | video exactly like the Diffusers model."""
 
-    profile.validate()
+    text_hidden = _refine_text(network, text, weights, profile)
+    audio_hidden = op.linear(
+        network, audio, weights["audio_proj_in.weight"], weights["audio_proj_in.bias"], bf16=False
+    )
+    audio_hidden = op.cast(network, audio_hidden, trt.bfloat16)
+    video_hidden = op.linear(
+        network, video, weights["proj_in.weight"], weights["proj_in.bias"], bf16=False
+    )
+    video_hidden = op.cast(network, video_hidden, trt.bfloat16)
+    packed = network.add_concatenation((text_hidden, audio_hidden, video_hidden))
+    packed.axis = 0
+    return packed.get_output(0)
+
+
+def _transformer_block(
+    network,
+    hidden,
+    block_modulation,
+    adaln_indices,
+    cos,
+    sin,
+    weights,
+    profile: MiniMaxH3Config,
+    index: int,
+):
+    """Add one native H3 transformer block and return its residual stream."""
+
     rows = profile.sequence_length
+    prefix = f"transformer_blocks.{index}"
+    selected = op.gather_rows(network, block_modulation, adaln_indices)
+    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+        _slice_modulation(network, selected, part, rows, profile.hidden_size) for part in range(6)
+    )
+    normalized = op.rms_norm(
+        network,
+        hidden,
+        weights[f"{prefix}.norm1.weight"],
+        profile.hidden_size,
+        profile.norm_eps,
+    )
+    normalized = op.modulate(network, normalized, shift_msa, scale_msa)
+    update = _attention_block(
+        network,
+        normalized,
+        weights,
+        prefix,
+        profile,
+        rows,
+        cos=cos,
+        sin=sin,
+    )
+    hidden = op.gated_residual(network, hidden, update, gate_msa)
+
+    normalized = op.rms_norm(
+        network,
+        hidden,
+        weights[f"{prefix}.norm2.weight"],
+        profile.hidden_size,
+        profile.norm_eps,
+    )
+    normalized = op.modulate(network, normalized, shift_mlp, scale_mlp)
+    update = op.swiglu(
+        network,
+        normalized,
+        weights[f"{prefix}.ff.net.0.proj.weight"],
+        weights[f"{prefix}.ff.net.2.weight"],
+        profile.ffn_dim,
+    )
+    return op.gated_residual(network, hidden, update, gate_mlp)
+
+
+def _final_hidden(network, hidden, timestep_indices, final_modulation, weights, profile):
+    rows = profile.sequence_length
+    selected = op.gather_rows(network, final_modulation, timestep_indices)
+    final_shift = _slice_modulation(network, selected, 0, rows, profile.hidden_size)
+    final_scale = _slice_modulation(network, selected, 1, rows, profile.hidden_size)
+    hidden = op.rms_norm(
+        network, hidden, weights["norm_out.norm.weight"], profile.hidden_size, profile.norm_eps
+    )
+    hidden = op.modulate(network, hidden, final_shift, final_scale)
+    return op.cast(network, hidden, trt.float32)
+
+
+def _mark_full_velocity_outputs(network, hidden, weights):
+    """Preserve the original monolithic plan's full packed-sequence outputs."""
+
+    video_all = op.linear(
+        network, hidden, weights["proj_out.weight"], weights["proj_out.bias"], bf16=False
+    )
+    audio_all = op.linear(
+        network,
+        hidden,
+        weights["audio_proj_out.weight"],
+        weights["audio_proj_out.bias"],
+        bf16=False,
+    )
+    video_all.name = "video_velocity"
+    audio_all.name = "audio_velocity"
+    network.mark_output(video_all)
+    network.mark_output(audio_all)
+
+
+def _mark_sliced_velocity_outputs(network, hidden, weights, profile: MiniMaxH3Config):
+    """Project only rows consumed by the audio and video scheduler updates."""
+
+    audio_hidden = network.add_slice(
+        hidden,
+        (profile.text_rows, 0),
+        (profile.audio_rows, profile.hidden_size),
+        (1, 1),
+    ).get_output(0)
+    video_hidden = network.add_slice(
+        hidden,
+        (profile.text_rows + profile.audio_rows, 0),
+        (profile.video_rows, profile.hidden_size),
+        (1, 1),
+    ).get_output(0)
+    video = op.linear(
+        network,
+        video_hidden,
+        weights["proj_out.weight"],
+        weights["proj_out.bias"],
+        bf16=False,
+    )
+    audio = op.linear(
+        network,
+        audio_hidden,
+        weights["audio_proj_out.weight"],
+        weights["audio_proj_out.bias"],
+        bf16=False,
+    )
+    video.name = "video_velocity"
+    audio.name = "audio_velocity"
+    network.mark_output(video)
+    network.mark_output(audio)
+
+
+def _native_builder(verbose: bool, workspace_bytes: int | None):
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
@@ -256,8 +425,48 @@ def build_dit_engine(
         default_bytes=DENOISER_DEFAULT_WORKSPACE_BYTES,
     )
     # Hugging Face keeps TF32 disabled for the FP32 input/output projections.
-    # Match that contract while retaining native TensorRT GEMMs.
     config.clear_flag(trt.BuilderFlag.TF32)
+    return logger, builder, network, config
+
+
+def _serialize(
+    *,
+    logger,
+    builder,
+    network,
+    config,
+    weights: dict,
+    consume_weights: bool,
+    label: str,
+) -> bytes:
+    try:
+        plan = builder.build_serialized_network(network, config)
+    finally:
+        op.release_weight_buffers(network)
+        if consume_weights:
+            weights.clear()
+    if plan is None:
+        raise RuntimeError(f"TensorRT failed to build MiniMax-H3 {label} engine")
+    del network, config, builder, logger
+    gc.collect()
+    return bytes(plan)
+
+
+def build_dit_engine(
+    weights: dict,
+    profile: MiniMaxH3Config,
+    *,
+    verbose: bool = False,
+    consume_weights: bool = False,
+    workspace_bytes: int | None = None,
+) -> bytes:
+    """Build the full-sequence single-device H3 TensorRT plan."""
+
+    profile.validate()
+    if profile.first_block_cache:
+        raise ValueError("MiniMax-H3 first_block_cache profile requires the split DiT builders")
+    rows = profile.sequence_length
+    logger, builder, network, config = _native_builder(verbose, workspace_bytes)
 
     video = network.add_input(
         "video_hidden_states", trt.float32, (profile.video_rows, profile.video_patch_dim)
@@ -285,88 +494,26 @@ def build_dit_engine(
     # The public single-device FL2VA profile is packed as text | audio | video.
     # Projection, text refinement, packing, and full-sequence attention all
     # remain native TensorRT operations on one device.
-    text_hidden = _refine_text(network, text, weights, profile)
-    audio_hidden = op.linear(
-        network, audio, weights["audio_proj_in.weight"], weights["audio_proj_in.bias"], bf16=False
-    )
-    audio_hidden = op.cast(network, audio_hidden, trt.bfloat16)
-    video_hidden = op.linear(
-        network, video, weights["proj_in.weight"], weights["proj_in.bias"], bf16=False
-    )
-    video_hidden = op.cast(network, video_hidden, trt.bfloat16)
-    packed = network.add_concatenation((text_hidden, audio_hidden, video_hidden))
-    packed.axis = 0
-    hidden = packed.get_output(0)
+    hidden = _packed_hidden(network, video, audio, text, weights, profile)
 
     cos, sin = _rope_tables(network, positions, profile, rows)
     # Pristine Diffusers packs exactly 38,247 rows on one device, so its
     # attention mask is None. Preserve that contract without synthetic padding.
     for index in range(profile.num_layers):
-        prefix = f"transformer_blocks.{index}"
-        selected = op.gather_rows(network, block_modulations[index], adaln_indices)
-        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
-            _slice_modulation(network, selected, part, rows, profile.hidden_size)
-            for part in range(6)
-        )
-        normalized = op.rms_norm(
+        hidden = _transformer_block(
             network,
             hidden,
-            weights[f"{prefix}.norm1.weight"],
-            profile.hidden_size,
-            profile.norm_eps,
-        )
-        normalized = op.modulate(network, normalized, shift_msa, scale_msa)
-        update = _attention_block(
-            network,
-            normalized,
+            block_modulations[index],
+            adaln_indices,
+            cos,
+            sin,
             weights,
-            prefix,
             profile,
-            rows,
-            cos=cos,
-            sin=sin,
+            index,
         )
-        hidden = op.gated_residual(network, hidden, update, gate_msa)
 
-        normalized = op.rms_norm(
-            network,
-            hidden,
-            weights[f"{prefix}.norm2.weight"],
-            profile.hidden_size,
-            profile.norm_eps,
-        )
-        normalized = op.modulate(network, normalized, shift_mlp, scale_mlp)
-        update = op.swiglu(
-            network,
-            normalized,
-            weights[f"{prefix}.ff.net.0.proj.weight"],
-            weights[f"{prefix}.ff.net.2.weight"],
-            profile.ffn_dim,
-        )
-        hidden = op.gated_residual(network, hidden, update, gate_mlp)
-
-    selected = op.gather_rows(network, final_modulation, timestep_indices)
-    final_shift = _slice_modulation(network, selected, 0, rows, profile.hidden_size)
-    final_scale = _slice_modulation(network, selected, 1, rows, profile.hidden_size)
-    hidden = op.rms_norm(
-        network, hidden, weights["norm_out.norm.weight"], profile.hidden_size, profile.norm_eps
-    )
-    hidden = op.modulate(network, hidden, final_shift, final_scale)
-    hidden = op.cast(network, hidden, trt.float32)
-    video_all = op.linear(
-        network, hidden, weights["proj_out.weight"], weights["proj_out.bias"], bf16=False
-    )
-    audio_all = op.linear(
-        network,
-        hidden,
-        weights["audio_proj_out.weight"],
-        weights["audio_proj_out.bias"],
-        bf16=False,
-    )
-    video_all.name = "video_velocity"
-    audio_all.name = "audio_velocity"
-    network.mark_output(video_all)
-    network.mark_output(audio_all)
+    hidden = _final_hidden(network, hidden, timestep_indices, final_modulation, weights, profile)
+    _mark_full_velocity_outputs(network, hidden, weights)
 
     op.validate_native_network(
         network,
@@ -379,14 +526,230 @@ def build_dit_engine(
         f"packed={profile.sequence_length}, devices=1",
         file=sys.stderr,
     )
-    try:
-        plan = builder.build_serialized_network(network, config)
-    finally:
-        op.release_weight_buffers(network)
-        if consume_weights:
-            weights.clear()
-    if plan is None:
-        raise RuntimeError("TensorRT failed to build MiniMax-H3 DiT engine")
-    del network, config, builder
-    gc.collect()
-    return bytes(plan)
+    return _serialize(
+        logger=logger,
+        builder=builder,
+        network=network,
+        config=config,
+        weights=weights,
+        consume_weights=consume_weights,
+        label="DiT",
+    )
+
+
+def _require_first_block_cache_profile(profile: MiniMaxH3Config) -> None:
+    profile.validate()
+    if not profile.first_block_cache:
+        raise ValueError("MiniMax-H3 split DiT plans require profile.first_block_cache=True")
+
+
+def build_dit_head_engine(
+    weights: dict,
+    profile: MiniMaxH3Config,
+    *,
+    verbose: bool = False,
+    consume_weights: bool = False,
+    workspace_bytes: int | None = None,
+) -> bytes:
+    """Build packing, text refinement, block zero, and the native cache metric."""
+
+    _require_first_block_cache_profile(profile)
+    rows = profile.sequence_length
+    logger, builder, network, config = _native_builder(verbose, workspace_bytes)
+    video = network.add_input(
+        "video_hidden_states", trt.float32, (profile.video_rows, profile.video_patch_dim)
+    )
+    audio = network.add_input(
+        "audio_hidden_states", trt.float32, (profile.audio_rows, profile.audio_in_channels)
+    )
+    text = network.add_input(
+        "encoder_hidden_states", trt.float32, (profile.text_rows, profile.text_dim)
+    )
+    positions = network.add_input("position_ids", trt.float32, (rows, 3))
+    adaln_indices = network.add_input("adaln_indices", trt.int32, (rows,))
+    block_modulation = network.add_input(
+        "block_modulation_0",
+        trt.bfloat16,
+        (profile.adaln_table_rows, 6, profile.hidden_size),
+    )
+    previous_head_residual = network.add_input(
+        "previous_head_residual", trt.bfloat16, (rows, profile.hidden_size)
+    )
+
+    pre_block_hidden = _packed_hidden(network, video, audio, text, weights, profile)
+    cos, sin = _rope_tables(network, positions, profile, rows)
+    head_hidden = _transformer_block(
+        network,
+        pre_block_hidden,
+        block_modulation,
+        adaln_indices,
+        cos,
+        sin,
+        weights,
+        profile,
+        0,
+    )
+    head_residual = network.add_elementwise(
+        head_hidden, pre_block_hidden, trt.ElementWiseOperation.SUB
+    ).get_output(0)
+
+    # This is the FirstBlockCache decision used by Sol-Engine/Diffusers:
+    # sum(abs(current - previous)) / max(sum(abs(previous)), eps). Keep the
+    # large tensors in BF16 and expose only the one-element FP32 result.
+    delta = network.add_elementwise(
+        head_residual, previous_head_residual, trt.ElementWiseOperation.SUB
+    ).get_output(0)
+    delta_abs = network.add_unary(delta, trt.UnaryOperation.ABS).get_output(0)
+    previous_abs = network.add_unary(previous_head_residual, trt.UnaryOperation.ABS).get_output(0)
+    delta_abs = op.cast(network, delta_abs, trt.float32)
+    previous_abs = op.cast(network, previous_abs, trt.float32)
+    reduce_axes = (1 << 0) | (1 << 1)
+    numerator = network.add_reduce(
+        delta_abs, trt.ReduceOperation.SUM, reduce_axes, True
+    ).get_output(0)
+    denominator = network.add_reduce(
+        previous_abs, trt.ReduceOperation.SUM, reduce_axes, True
+    ).get_output(0)
+    epsilon = op.constant(network, np.full((1, 1), 1.0e-8, dtype=np.float32))
+    denominator = network.add_elementwise(
+        denominator, epsilon, trt.ElementWiseOperation.MAX
+    ).get_output(0)
+    metric = network.add_elementwise(
+        numerator, denominator, trt.ElementWiseOperation.DIV
+    ).get_output(0)
+    metric_shape = network.add_shuffle(metric)
+    metric_shape.reshape_dims = (1,)
+    cache_metric = metric_shape.get_output(0)
+
+    head_hidden.name = "head_hidden"
+    head_residual.name = "head_residual"
+    cache_metric.name = "cache_metric"
+    network.mark_output(head_hidden)
+    network.mark_output(head_residual)
+    network.mark_output(cache_metric)
+    op.validate_native_network(
+        network,
+        expected_attentions=profile.num_refiner_layers + 1,
+        label="DiT FirstBlockCache head",
+    )
+    print(
+        f"[minimax-h3] building native DiT cache head: packed={rows}, devices=1",
+        file=sys.stderr,
+    )
+    return _serialize(
+        logger=logger,
+        builder=builder,
+        network=network,
+        config=config,
+        weights=weights,
+        consume_weights=consume_weights,
+        label="DiT FirstBlockCache head",
+    )
+
+
+def build_dit_tail_engine(
+    weights: dict,
+    profile: MiniMaxH3Config,
+    *,
+    verbose: bool = False,
+    consume_weights: bool = False,
+    workspace_bytes: int | None = None,
+) -> bytes:
+    """Build blocks one through 49 and expose their reusable total residual."""
+
+    _require_first_block_cache_profile(profile)
+    rows = profile.sequence_length
+    logger, builder, network, config = _native_builder(verbose, workspace_bytes)
+    head_hidden = network.add_input("head_hidden", trt.bfloat16, (rows, profile.hidden_size))
+    positions = network.add_input("position_ids", trt.float32, (rows, 3))
+    adaln_indices = network.add_input("adaln_indices", trt.int32, (rows,))
+    block_modulations = {
+        index: network.add_input(
+            f"block_modulation_{index}",
+            trt.bfloat16,
+            (profile.adaln_table_rows, 6, profile.hidden_size),
+        )
+        for index in range(1, profile.num_layers)
+    }
+    cos, sin = _rope_tables(network, positions, profile, rows)
+    hidden = head_hidden
+    for index in range(1, profile.num_layers):
+        hidden = _transformer_block(
+            network,
+            hidden,
+            block_modulations[index],
+            adaln_indices,
+            cos,
+            sin,
+            weights,
+            profile,
+            index,
+        )
+    tail_residual = network.add_elementwise(
+        hidden, head_hidden, trt.ElementWiseOperation.SUB
+    ).get_output(0)
+    tail_residual.name = "tail_residual"
+    network.mark_output(tail_residual)
+    op.validate_native_network(
+        network,
+        expected_attentions=profile.num_layers - 1,
+        label="DiT FirstBlockCache tail",
+    )
+    print(
+        f"[minimax-h3] building native DiT cache tail: blocks=1-{profile.num_layers - 1}, "
+        f"packed={rows}, devices=1",
+        file=sys.stderr,
+    )
+    return _serialize(
+        logger=logger,
+        builder=builder,
+        network=network,
+        config=config,
+        weights=weights,
+        consume_weights=consume_weights,
+        label="DiT FirstBlockCache tail",
+    )
+
+
+def build_dit_finish_engine(
+    weights: dict,
+    profile: MiniMaxH3Config,
+    *,
+    verbose: bool = False,
+    consume_weights: bool = False,
+    workspace_bytes: int | None = None,
+) -> bytes:
+    """Apply a selected tail residual, final norm, and consumed-row projections."""
+
+    _require_first_block_cache_profile(profile)
+    rows = profile.sequence_length
+    logger, builder, network, config = _native_builder(verbose, workspace_bytes)
+    head_hidden = network.add_input("head_hidden", trt.bfloat16, (rows, profile.hidden_size))
+    tail_residual = network.add_input("tail_residual", trt.bfloat16, (rows, profile.hidden_size))
+    timestep_indices = network.add_input("timestep_indices", trt.int32, (rows,))
+    final_modulation = network.add_input(
+        "final_modulation", trt.bfloat16, (profile.max_timestep_count, 2, profile.hidden_size)
+    )
+    hidden = network.add_elementwise(
+        head_hidden, tail_residual, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    hidden = _final_hidden(network, hidden, timestep_indices, final_modulation, weights, profile)
+    _mark_sliced_velocity_outputs(network, hidden, weights, profile)
+    op.validate_native_network(
+        network,
+        expected_attentions=0,
+        label="DiT FirstBlockCache finish",
+    )
+    print(
+        f"[minimax-h3] building native DiT cache finish: packed={rows}, devices=1",
+        file=sys.stderr,
+    )
+    return _serialize(
+        logger=logger,
+        builder=builder,
+        network=network,
+        config=config,
+        weights=weights,
+        consume_weights=consume_weights,
+        label="DiT FirstBlockCache finish",
+    )

--- a/python/tensorrt_model_connect/families/minimax_h3/plugin.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/plugin.py
@@ -87,7 +87,7 @@ def _fixed_profile(raw: dict):
 
 
 def _first_block_cache_threshold(raw: dict) -> float:
-    value = raw.get("first_block_cache_threshold", 0.08)
+    value = raw.get("first_block_cache_threshold", 0.025)
     if isinstance(value, bool):
         raise ValueError("MiniMax-H3 first_block_cache_threshold must be finite and positive")
     try:

--- a/python/tensorrt_model_connect/families/minimax_h3/plugin.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/plugin.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import gc
 import hashlib
 import json
+import math
 import os
+from dataclasses import replace
 from pathlib import Path
 
 from .checkpoint import (
@@ -16,7 +18,10 @@ from .checkpoint import (
     numpy_state,
     validate_component_key_partition,
 )
-from .config import DEFAULT_WORKSPACE_LIMIT_BYTES, SOL_ENGINE_1344X768_124F
+from .config import (
+    SOL_ENGINE_1344X768_124F,
+    default_workspace_limit_bytes,
+)
 from .provenance import (
     builder_source_sha256,
     checkpoint_snapshot_record,
@@ -40,6 +45,16 @@ def _build_source_revision() -> str:
     )
 
 
+def _effective_build_config(raw: dict) -> dict:
+    family_options = raw.get("_family_build_options", {})
+    minimax_options = (
+        family_options.get("minimax_h3", {}) if isinstance(family_options, dict) else {}
+    )
+    if not isinstance(minimax_options, dict):
+        raise ValueError("minimax_h3 build options must be an object")
+    return {**raw, **minimax_options}
+
+
 def _fixed_profile(raw: dict):
     expected = {
         "text_rows": SOL_ENGINE_1344X768_124F.text_rows,
@@ -54,7 +69,36 @@ def _fixed_profile(raw: dict):
     }
     if mismatches:
         raise ValueError(f"Unsupported MiniMax-H3 packed-row profile: {mismatches}")
-    return SOL_ENGINE_1344X768_124F
+    explicit_flag = raw.get("first_block_cache")
+    mode = raw.get(
+        "denoiser_cache_mode",
+        "first_block" if explicit_flag is True else "monolithic",
+    )
+    if mode not in ("monolithic", "first_block"):
+        raise ValueError(f"Unsupported MiniMax-H3 denoiser_cache_mode: {mode!r}")
+    if explicit_flag is not None and not isinstance(explicit_flag, bool):
+        raise ValueError("MiniMax-H3 first_block_cache must be a boolean")
+    mode_flag = mode == "first_block"
+    if explicit_flag is not None and explicit_flag != mode_flag:
+        raise ValueError("MiniMax-H3 cache mode and first_block_cache flag disagree")
+    if not mode_flag:
+        return SOL_ENGINE_1344X768_124F
+    return replace(SOL_ENGINE_1344X768_124F, first_block_cache=True)
+
+
+def _first_block_cache_threshold(raw: dict) -> float:
+    value = raw.get("first_block_cache_threshold", 0.08)
+    if isinstance(value, bool):
+        raise ValueError("MiniMax-H3 first_block_cache_threshold must be finite and positive")
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "MiniMax-H3 first_block_cache_threshold must be finite and positive"
+        ) from error
+    if not math.isfinite(threshold) or threshold <= 0.0:
+        raise ValueError("MiniMax-H3 first_block_cache_threshold must be finite and positive")
+    return threshold
 
 
 class MiniMaxH3Plugin:
@@ -126,23 +170,70 @@ class MiniMaxH3Plugin:
         if mode != "single" or cp_size != 1:
             raise ValueError("MiniMax-H3 requires parallel.mode=single and cp_size=1")
 
-        raw = getattr(config, "raw", {})
+        raw = _effective_build_config(getattr(config, "raw", {}))
         profile = _fixed_profile(raw)
         profile.validate()
+        workspace_limits = default_workspace_limit_bytes(
+            first_block_cache=profile.first_block_cache
+        )
         source_revision = _build_source_revision()
         snapshot = checkpoint_snapshot_record(Path(weights["_model_dir"]))
         from .adaln_builder import build_adaln_precompute_engine
         from .adaln_builder import checkpoint_keys as adaln_checkpoint_keys
-        from .dit_builder import build_dit_engine, checkpoint_keys as dit_checkpoint_keys
+        from .dit_builder import (
+            build_dit_engine,
+            build_dit_finish_engine,
+            build_dit_head_engine,
+            build_dit_tail_engine,
+            checkpoint_keys as dit_checkpoint_keys,
+            finish_checkpoint_keys,
+            head_checkpoint_keys,
+            tail_checkpoint_keys,
+        )
         from .text_encoder_builder import (
             build_text_encoder_engine,
             checkpoint_keys as text_encoder_checkpoint_keys,
         )
 
-        validate_component_key_partition(
-            weights["_transformer_dir"],
-            (adaln_checkpoint_keys(profile), dit_checkpoint_keys(profile)),
-        )
+        if profile.first_block_cache:
+            denoiser_specs = (
+                (
+                    "denoiser_head",
+                    "denoiser_head.plan",
+                    build_dit_head_engine,
+                    head_checkpoint_keys(profile),
+                ),
+                (
+                    "denoiser_tail",
+                    "denoiser_tail.plan",
+                    build_dit_tail_engine,
+                    tail_checkpoint_keys(profile),
+                ),
+                (
+                    "denoiser_finish",
+                    "denoiser_finish.plan",
+                    build_dit_finish_engine,
+                    finish_checkpoint_keys(profile),
+                ),
+            )
+            checkpoint_groups = (
+                adaln_checkpoint_keys(profile),
+                *(spec[3] for spec in denoiser_specs),
+            )
+        else:
+            denoiser_specs = (
+                (
+                    "denoiser",
+                    "denoiser.plan",
+                    build_dit_engine,
+                    dit_checkpoint_keys(profile),
+                ),
+            )
+            checkpoint_groups = (
+                adaln_checkpoint_keys(profile),
+                dit_checkpoint_keys(profile),
+            )
+        validate_component_key_partition(weights["_transformer_dir"], checkpoint_groups)
 
         text_state = load_selected_component_state_dict(
             weights["_text_encoder_dir"], text_encoder_checkpoint_keys()
@@ -154,7 +245,7 @@ class MiniMaxH3Plugin:
             sequence_length=profile.text_rows,
             verbose=verbose,
             consume_weights=True,
-            workspace_bytes=DEFAULT_WORKSPACE_LIMIT_BYTES["text_encoder.plan"],
+            workspace_bytes=workspace_limits["text_encoder.plan"],
         )
         del text_weights
         gc.collect()
@@ -169,25 +260,33 @@ class MiniMaxH3Plugin:
             profile,
             verbose=verbose,
             consume_weights=True,
-            workspace_bytes=DEFAULT_WORKSPACE_LIMIT_BYTES["adaln_precompute.plan"],
+            workspace_bytes=workspace_limits["adaln_precompute.plan"],
         )
         del adaln_weights
         gc.collect()
 
-        dit_state = load_selected_component_state_dict(
-            weights["_transformer_dir"], dit_checkpoint_keys(profile)
-        )
-        dit_weights = numpy_state(dit_state)
-        del dit_state
-        denoiser_plan = build_dit_engine(
-            dit_weights,
-            profile,
-            verbose=verbose,
-            consume_weights=True,
-            workspace_bytes=DEFAULT_WORKSPACE_LIMIT_BYTES["denoiser.plan"],
-        )
-        del dit_weights
-        gc.collect()
+        denoiser_components = {}
+        plan_sha256 = {
+            "text_encoder.plan": hashlib.sha256(text_encoder_plan).hexdigest(),
+            "adaln_precompute.plan": hashlib.sha256(adaln_plan).hexdigest(),
+        }
+        for component_name, filename, denoiser_builder, selected_keys in denoiser_specs:
+            dit_state = load_selected_component_state_dict(
+                weights["_transformer_dir"], selected_keys
+            )
+            dit_weights = numpy_state(dit_state)
+            del dit_state
+            denoiser_plan = denoiser_builder(
+                dit_weights,
+                profile,
+                verbose=verbose,
+                consume_weights=True,
+                workspace_bytes=workspace_limits[filename],
+            )
+            del dit_weights
+            gc.collect()
+            denoiser_components[component_name] = denoiser_plan
+            plan_sha256[filename] = hashlib.sha256(denoiser_plan).hexdigest()
 
         from .vae_builder import (
             build_vae_tile_decoder_engine,
@@ -201,21 +300,16 @@ class MiniMaxH3Plugin:
             vae_weights,
             verbose=verbose,
             consume_weights=True,
-            workspace_bytes=DEFAULT_WORKSPACE_LIMIT_BYTES["vae_tile_decoder.plan"],
+            workspace_bytes=workspace_limits["vae_tile_decoder.plan"],
         )
         tokenizer_json = (Path(weights["_tokenizer_dir"]) / "tokenizer.json").read_bytes()
 
-        plan_sha256 = {
-            "text_encoder.plan": hashlib.sha256(text_encoder_plan).hexdigest(),
-            "adaln_precompute.plan": hashlib.sha256(adaln_plan).hexdigest(),
-            "denoiser.plan": hashlib.sha256(denoiser_plan).hexdigest(),
-            "vae_tile_decoder.plan": hashlib.sha256(vae_decoder_plan).hexdigest(),
-        }
+        plan_sha256["vae_tile_decoder.plan"] = hashlib.sha256(vae_decoder_plan).hexdigest()
 
         return {
             "text_encoder": text_encoder_plan,
             "adaln_precompute": adaln_plan,
-            "denoiser": denoiser_plan,
+            **denoiser_components,
             "vae_decoder": vae_decoder_plan,
             "profile": profile,
             # Text/VAE paths remain explicit so follow-on native component
@@ -228,7 +322,7 @@ class MiniMaxH3Plugin:
                 "source_revision": source_revision,
                 "builder_source_sha256": builder_source_sha256(),
                 "checkpoint_inventory_sha256": snapshot["inventory_sha256"],
-                "workspace_limit_bytes": dict(DEFAULT_WORKSPACE_LIMIT_BYTES),
+                "workspace_limit_bytes": workspace_limits,
                 "plan_sha256": plan_sha256,
             },
         }
@@ -237,16 +331,27 @@ class MiniMaxH3Plugin:
         self, components: dict, *, parallel_config=None
     ) -> list[tuple[str, bytes]]:
         del parallel_config
-        return [
+        shared = [
             ("text_encoder_plan", components["text_encoder"]),
             ("adaln_precompute_plan", components["adaln_precompute"]),
-            ("denoiser_plan", components["denoiser"]),
+        ]
+        if components["profile"].first_block_cache:
+            denoiser = [
+                ("denoiser_head_plan", components["denoiser_head"]),
+                ("denoiser_tail_plan", components["denoiser_tail"]),
+                ("denoiser_finish_plan", components["denoiser_finish"]),
+            ]
+        else:
+            denoiser = [("denoiser_plan", components["denoiser"])]
+        return [
+            *shared,
+            *denoiser,
             ("vae_tile_decoder_plan", components["vae_decoder"]),
             ("tokenizer.json", components["tokenizer_json"]),
         ]
 
     def diffusion_bundle_config(self, config, *, components: dict) -> dict:
-        raw = getattr(config, "raw", {})
+        raw = _effective_build_config(getattr(config, "raw", {}))
         profile = components["profile"]
         fixed_request = {
             "video_height": 768,
@@ -264,7 +369,15 @@ class MiniMaxH3Plugin:
         provenance = components.get("provenance")
         if not isinstance(provenance, dict):
             raise ValueError("MiniMax-H3 components are missing exact build provenance")
-        validate_workspace_limit_bytes(provenance.get("workspace_limit_bytes"))
+        validate_workspace_limit_bytes(provenance.get("workspace_limit_bytes"), profile=profile)
+        if profile.first_block_cache:
+            denoiser_sections = [
+                "denoiser_head_plan",
+                "denoiser_tail_plan",
+                "denoiser_finish_plan",
+            ]
+        else:
+            denoiser_sections = ["denoiser_plan"]
         return {
             "checkpoint_revision": "48d93ede732756e404a3b1b2f3b3a9b5a22f6cfc",
             **provenance,
@@ -280,10 +393,13 @@ class MiniMaxH3Plugin:
                 "lazy_sections": [
                     "text_encoder_plan",
                     "adaln_precompute_plan",
-                    "denoiser_plan",
+                    *denoiser_sections,
                     "vae_tile_decoder_plan",
                 ],
             },
+            "first_block_cache": profile.first_block_cache,
+            "denoiser_cache_mode": ("first_block" if profile.first_block_cache else "monolithic"),
+            "first_block_cache_threshold": _first_block_cache_threshold(raw),
             "text_rows": profile.text_rows,
             "audio_rows": profile.audio_rows,
             "video_rows": profile.video_rows,

--- a/python/tensorrt_model_connect/families/minimax_h3/provenance.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/provenance.py
@@ -15,6 +15,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from .config import native_plan_filenames
+
 CHECKPOINT_REVISION = "48d93ede732756e404a3b1b2f3b3a9b5a22f6cfc"
 CHECKPOINT_REPOSITORY = "MiniMaxAI/MiniMax-H3"
 HF_CACHE_REPOSITORY = "models--MiniMaxAI--MiniMax-H3"
@@ -33,12 +35,8 @@ DIFFUSERS_REFERENCE_ARCHIVE_SHA256 = (
     "372c820aece801258bd4cea2458a2b85ad536e9262d7b0bbcdd450eda2d664a9"
 )
 DIFFUSERS_REFERENCE_CONTAINER_ROOT = "/work/reference-private"
-PLAN_FILENAMES = (
-    "text_encoder.plan",
-    "adaln_precompute.plan",
-    "denoiser.plan",
-    "vae_tile_decoder.plan",
-)
+PLAN_FILENAMES = native_plan_filenames(first_block_cache=False)
+FIRST_BLOCK_CACHE_PLAN_FILENAMES = native_plan_filenames(first_block_cache=True)
 _REQUIRED_SNAPSHOT_FILES = (
     "modular_model_index.json",
     "scheduler/scheduler_config.json",
@@ -107,12 +105,26 @@ def _validate_record_object(record: object, label: str) -> tuple[int, str]:
     return expected_size, expected_sha
 
 
-def validate_workspace_limit_bytes(record: object) -> dict[str, int]:
+def plan_filenames_for_profile(profile) -> tuple[str, ...]:
+    return native_plan_filenames(first_block_cache=profile.first_block_cache)
+
+
+def validate_workspace_limit_bytes(
+    record: object, *, profile=None, first_block_cache: bool | None = None
+) -> dict[str, int]:
     """Validate the exact per-plan TensorRT tactic-workspace provenance."""
 
-    if not isinstance(record, dict) or set(record) != set(PLAN_FILENAMES):
+    if profile is not None and first_block_cache is not None:
+        raise ValueError("MiniMax-H3 workspace validation received two profile selectors")
+    if profile is not None:
+        first_block_cache = profile.first_block_cache
+    selected = False if first_block_cache is None else first_block_cache
+    if not isinstance(selected, bool):
+        raise ValueError("MiniMax-H3 first_block_cache selector must be a boolean")
+    expected = native_plan_filenames(first_block_cache=selected)
+    if not isinstance(record, dict) or set(record) != set(expected):
         raise ValueError(
-            "MiniMax-H3 workspace_limit_bytes must cover exactly all four native plans"
+            "MiniMax-H3 workspace_limit_bytes must cover exactly the selected native plans"
         )
     for filename, value in record.items():
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
@@ -624,12 +636,13 @@ def _validate_build_receipt_metadata(
     for key, value in expected.items():
         if receipt.get(key) != value:
             raise ValueError(f"MiniMax-H3 build receipt does not match current {key}")
-    validate_workspace_limit_bytes(receipt.get("workspace_limit_bytes"))
+    selected_plans = plan_filenames_for_profile(profile)
+    validate_workspace_limit_bytes(receipt.get("workspace_limit_bytes"), profile=profile)
     snapshot_record = validate_checkpoint_snapshot_record(receipt.get("checkpoint_snapshot"))
     components = receipt.get("components")
-    if not isinstance(components, dict) or set(components) != set(PLAN_FILENAMES):
-        raise ValueError("MiniMax-H3 build receipt must cover exactly all four native plans")
-    for filename in PLAN_FILENAMES:
+    if not isinstance(components, dict) or set(components) != set(selected_plans):
+        raise ValueError("MiniMax-H3 build receipt must cover exactly the selected native plans")
+    for filename in selected_plans:
         _validate_record_object(components.get(filename), filename)
     assets = receipt.get("assets")
     tokenizer_record = assets.get("tokenizer.json") if isinstance(assets, dict) else None
@@ -657,7 +670,7 @@ def validate_build_receipt(
     current_snapshot = checkpoint_snapshot_record(snapshot)
     if recorded_snapshot != current_snapshot:
         raise ValueError("MiniMax-H3 build receipt does not match current checkpoint_snapshot")
-    for filename in PLAN_FILENAMES:
+    for filename in plan_filenames_for_profile(profile):
         validate_record(
             plans_dir / filename,
             components.get(filename),
@@ -679,7 +692,7 @@ def validate_component_build_receipt(
     profile,
     hash_file: bool,
 ) -> tuple[str, dict, dict]:
-    if component not in PLAN_FILENAMES:
+    if component not in plan_filenames_for_profile(profile):
         raise ValueError(f"Unknown MiniMax-H3 native component: {component}")
     source_sha, components, snapshot_record = _validate_build_receipt_metadata(
         receipt,
@@ -753,13 +766,24 @@ def validate_native_bundle_config(bundle: Path, *, source_revision: str) -> dict
     inventory_sha = config.get("checkpoint_inventory_sha256")
     if not isinstance(inventory_sha, str) or _SHA256.fullmatch(inventory_sha) is None:
         raise ValueError("MiniMax-H3 bundle config has an invalid checkpoint inventory SHA256")
+    cache_mode = config.get("denoiser_cache_mode", "monolithic")
+    if cache_mode not in ("monolithic", "first_block"):
+        raise ValueError("MiniMax-H3 bundle config has an invalid denoiser cache mode")
+    first_block_cache = cache_mode == "first_block"
+    selected_plans = native_plan_filenames(first_block_cache=first_block_cache)
     plan_sha = config.get("plan_sha256")
-    if not isinstance(plan_sha, dict) or set(plan_sha) != set(PLAN_FILENAMES):
-        raise ValueError("MiniMax-H3 bundle config must identify exactly all four native plans")
+    if not isinstance(plan_sha, dict) or set(plan_sha) != set(selected_plans):
+        raise ValueError("MiniMax-H3 bundle config must identify exactly the selected native plans")
     if any(
         not isinstance(value, str) or _SHA256.fullmatch(value) is None
         for value in plan_sha.values()
     ):
         raise ValueError("MiniMax-H3 bundle config has an invalid native plan SHA256")
-    validate_workspace_limit_bytes(config.get("workspace_limit_bytes"))
+    if not isinstance(config.get("first_block_cache", False), bool):
+        raise ValueError("MiniMax-H3 bundle config has an invalid first_block_cache flag")
+    if config.get("first_block_cache", False) != first_block_cache:
+        raise ValueError("MiniMax-H3 bundle cache mode and profile flag disagree")
+    validate_workspace_limit_bytes(
+        config.get("workspace_limit_bytes"), first_block_cache=first_block_cache
+    )
     return config

--- a/python/tensorrt_model_connect/families/minimax_h3/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/runtime_config_schema.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time settings for the MiniMax-H3 native TensorRT bundle."""
+
+from __future__ import annotations
+
+import math
+
+from tensorrt_model_connect.runtime_config import (
+    ConfigField,
+    Layer,
+    Schema,
+    register_schema,
+)
+
+
+# The build CLI currently contributes ``--config`` / ``--set`` values at
+# SESSION_REQUEST priority before forwarding them as opaque family options.
+_BUILD = frozenset({Layer.BUILD_TIME, Layer.BUNDLE_DEFAULT, Layer.SESSION_REQUEST})
+
+
+SCHEMA = Schema(
+    namespace="minimax_h3",
+    fields=(
+        ConfigField(
+            name="first_block_cache",
+            type_tag="bool",
+            default=False,
+            allowed_layers=_BUILD,
+        ),
+        ConfigField(
+            name="first_block_cache_threshold",
+            type_tag="double",
+            default=0.08,
+            allowed_layers=_BUILD,
+            validator=lambda value: (
+                isinstance(value, float) and math.isfinite(value) and value > 0.0
+            ),
+        ),
+    ),
+)
+
+
+register_schema(SCHEMA)

--- a/python/tensorrt_model_connect/families/minimax_h3/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/runtime_config_schema.py
@@ -32,7 +32,7 @@ SCHEMA = Schema(
         ConfigField(
             name="first_block_cache_threshold",
             type_tag="double",
-            default=0.08,
+            default=0.025,
             allowed_layers=_BUILD,
             validator=lambda value: (
                 isinstance(value, float) and math.isfinite(value) and value > 0.0

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
@@ -143,7 +143,7 @@ def test_plugin_bundle_config_preserves_exact_provenance() -> None:
     assert result["workspace_limit_bytes"] == DEFAULT_WORKSPACE_LIMIT_BYTES
     assert result["first_block_cache"] is False
     assert result["denoiser_cache_mode"] == "monolithic"
-    assert result["first_block_cache_threshold"] == 0.08
+    assert result["first_block_cache_threshold"] == 0.025
     assert result["bundle_loading"] == {
         "mode": "staged",
         "eager_sections": ["tokenizer.json", "config.json"],

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_family.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 import tomllib
@@ -12,12 +13,15 @@ import pytest
 
 from tensorrt_model_connect.families.minimax_h3.config import (
     DEFAULT_WORKSPACE_LIMIT_BYTES,
+    FIRST_BLOCK_CACHE_DENOISER_PLAN_FILENAMES,
     MiniMaxH3Config,
     SOL_ENGINE_1344X768_124F,
+    default_workspace_limit_bytes,
 )
 from tensorrt_model_connect.families.minimax_h3.plugin import (
     MiniMaxH3Plugin,
     _build_source_revision,
+    _effective_build_config,
     _fixed_profile,
 )
 
@@ -34,6 +38,7 @@ def test_sol_engine_profile_matches_public_packed_shape() -> None:
     assert profile.padded_sequence_length // profile.context_parallel_size == 38247
     assert profile.attention_size == 7168
     assert profile.video_patch_dim == 96
+    assert profile.first_block_cache is False
 
 
 def test_invalid_single_device_contract_fails_closed() -> None:
@@ -42,6 +47,8 @@ def test_invalid_single_device_contract_fails_closed() -> None:
             MiniMaxH3Config(padded_sequence_length=padded_rows).validate()
     with pytest.raises(ValueError, match="context_parallel_size=1"):
         MiniMaxH3Config(context_parallel_size=4).validate()
+    with pytest.raises(ValueError, match="must be a boolean"):
+        MiniMaxH3Config(first_block_cache=1).validate()
 
 
 def test_manifest_discovers_both_public_pipeline_names() -> None:
@@ -88,8 +95,28 @@ def test_plugin_fails_closed_on_unqualified_profile_or_source(monkeypatch) -> No
     monkeypatch.setenv("TRTMC_MINIMAX_H3_SOURCE_REVISION", "A" * 40)
     assert _build_source_revision() == "a" * 40
     assert _fixed_profile({}) is SOL_ENGINE_1344X768_124F
+    assert _fixed_profile({"first_block_cache": True}).first_block_cache is True
+    assert _fixed_profile({"denoiser_cache_mode": "first_block"}).first_block_cache is True
+    with pytest.raises(ValueError, match="disagree"):
+        _fixed_profile({"denoiser_cache_mode": "first_block", "first_block_cache": False})
     with pytest.raises(ValueError, match="packed-row profile"):
         _fixed_profile({"video_rows": 1})
+
+
+def test_namespaced_build_options_select_first_block_cache() -> None:
+    raw = _effective_build_config(
+        {
+            "_family_build_options": {
+                "minimax_h3": {
+                    "first_block_cache": True,
+                    "first_block_cache_threshold": 0.05,
+                }
+            }
+        }
+    )
+
+    assert _fixed_profile(raw).first_block_cache is True
+    assert raw["first_block_cache_threshold"] == 0.05
 
 
 def test_plugin_bundle_config_preserves_exact_provenance() -> None:
@@ -114,6 +141,9 @@ def test_plugin_bundle_config_preserves_exact_provenance() -> None:
     assert result["seed"] == 7
     assert result["context_parallel_size"] == 1
     assert result["workspace_limit_bytes"] == DEFAULT_WORKSPACE_LIMIT_BYTES
+    assert result["first_block_cache"] is False
+    assert result["denoiser_cache_mode"] == "monolithic"
+    assert result["first_block_cache_threshold"] == 0.08
     assert result["bundle_loading"] == {
         "mode": "staged",
         "eager_sections": ["tokenizer.json", "config.json"],
@@ -128,6 +158,72 @@ def test_plugin_bundle_config_preserves_exact_provenance() -> None:
         MiniMaxH3Plugin().diffusion_bundle_config(
             SimpleNamespace(raw={"video_width": 1}),
             components={"profile": SOL_ENGINE_1344X768_124F, "provenance": provenance},
+        )
+
+
+def test_plugin_emits_first_block_cache_sections_and_profile() -> None:
+    profile = replace(SOL_ENGINE_1344X768_124F, first_block_cache=True)
+    workspaces = default_workspace_limit_bytes(first_block_cache=True)
+    provenance = {
+        "source_revision": "a" * 40,
+        "builder_source_sha256": "b" * 64,
+        "checkpoint_inventory_sha256": "c" * 64,
+        "workspace_limit_bytes": workspaces,
+        "plan_sha256": {filename: "d" * 64 for filename in workspaces},
+    }
+    components = {
+        "profile": profile,
+        "provenance": provenance,
+        "text_encoder": b"text",
+        "adaln_precompute": b"adaln",
+        "denoiser_head": b"head",
+        "denoiser_tail": b"tail",
+        "denoiser_finish": b"finish",
+        "vae_decoder": b"vae",
+        "tokenizer_json": b"{}",
+    }
+    sections = dict(MiniMaxH3Plugin().diffusion_bundle_sections(components))
+    assert tuple(sections) == (
+        "text_encoder_plan",
+        "adaln_precompute_plan",
+        "denoiser_head_plan",
+        "denoiser_tail_plan",
+        "denoiser_finish_plan",
+        "vae_tile_decoder_plan",
+        "tokenizer.json",
+    )
+    config = MiniMaxH3Plugin().diffusion_bundle_config(
+        SimpleNamespace(
+            raw={
+                "first_block_cache": True,
+                "first_block_cache_threshold": 0.08,
+            }
+        ),
+        components=components,
+    )
+    assert config["first_block_cache"] is True
+    assert config["denoiser_cache_mode"] == "first_block"
+    assert config["first_block_cache_threshold"] == 0.08
+    assert config["bundle_loading"]["lazy_sections"][2:5] == [
+        "denoiser_head_plan",
+        "denoiser_tail_plan",
+        "denoiser_finish_plan",
+    ]
+    assert set(config["workspace_limit_bytes"]) == {
+        "text_encoder.plan",
+        "adaln_precompute.plan",
+        *FIRST_BLOCK_CACHE_DENOISER_PLAN_FILENAMES,
+        "vae_tile_decoder.plan",
+    }
+    with pytest.raises(ValueError, match="finite and positive"):
+        MiniMaxH3Plugin().diffusion_bundle_config(
+            SimpleNamespace(
+                raw={
+                    "first_block_cache": True,
+                    "first_block_cache_threshold": float("nan"),
+                }
+            ),
+            components=components,
         )
 
     malformed_provenance = dict(provenance)
@@ -172,4 +268,8 @@ def test_sol_lossless_optimizations_are_structural() -> None:
     assert 'network.add_input("rank"' not in dit
     assert "layer.mask" not in ops
     assert "SolAttn" not in "\n".join((adaln, dit, ops))
-    assert "FirstBlockCache" not in "\n".join((adaln, dit, ops))
+    assert "build_dit_head_engine" in dit
+    assert "build_dit_tail_engine" in dit
+    assert "build_dit_finish_engine" in dit
+    assert "cache_metric" in dit
+    assert "FirstBlockCacheConfig" not in "\n".join((adaln, dit, ops))

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_provenance.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_provenance.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,8 @@ from tensorrt_model_connect.families.minimax_h3 import provenance
 from tensorrt_model_connect.families.minimax_h3.config import (
     DEFAULT_WORKSPACE_LIMIT_BYTES,
     SOL_ENGINE_1344X768_124F,
+    default_workspace_limit_bytes,
+    native_plan_filenames,
 )
 from tensorrt_model_connect.families.minimax_h3.provenance import (
     CHECKPOINT_REVISION,
@@ -207,6 +210,44 @@ def test_complete_native_build_receipt_is_accepted(tmp_path: Path) -> None:
     _validate(receipt, plans, snapshot, tokenizer)
 
 
+def test_first_block_cache_build_receipt_selects_exact_split_plans(tmp_path: Path) -> None:
+    receipt, plans, snapshot, tokenizer = _receipt(tmp_path)
+    profile = replace(SOL_ENGINE_1344X768_124F, first_block_cache=True)
+    selected = native_plan_filenames(first_block_cache=True)
+    components = {}
+    for index, filename in enumerate(selected, start=1):
+        path = plans / filename
+        if not path.exists():
+            path.write_bytes(bytes([index]) * index)
+        components[filename] = file_record(path)
+    receipt["profile"] = serialized_profile(profile)
+    receipt["workspace_limit_bytes"] = default_workspace_limit_bytes(first_block_cache=True)
+    receipt["components"] = components
+    validate_build_receipt(
+        receipt,
+        plans_dir=plans,
+        snapshot=snapshot,
+        tokenizer=tokenizer,
+        build_helper=BUILD_HELPER,
+        source_revision=SOURCE_REVISION,
+        profile=profile,
+        hash_files=True,
+    )
+
+    receipt["components"]["denoiser.plan"] = {"bytes": 1, "sha256": "0" * 64}
+    with pytest.raises(ValueError, match="selected native plans"):
+        validate_build_receipt(
+            receipt,
+            plans_dir=plans,
+            snapshot=snapshot,
+            tokenizer=tokenizer,
+            build_helper=BUILD_HELPER,
+            source_revision=SOURCE_REVISION,
+            profile=profile,
+            hash_files=False,
+        )
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -230,7 +271,7 @@ def test_native_build_receipt_rejects_incomplete_or_invalid_artifacts(tmp_path: 
     receipt, plans, snapshot, tokenizer = _receipt(tmp_path)
     incomplete = copy.deepcopy(receipt)
     incomplete["components"].pop(PLAN_FILENAMES[0])
-    with pytest.raises(ValueError, match="all four"):
+    with pytest.raises(ValueError, match="selected native plans"):
         _validate(incomplete, plans, snapshot, tokenizer)
 
     malformed = copy.deepcopy(receipt)

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_trt_builders.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_trt_builders.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import ml_dtypes
 import numpy as np
 import pytest
@@ -22,7 +24,16 @@ from tensorrt_model_connect.families.minimax_h3.config import (  # noqa: E402
     VAE_TILE_DECODER_DEFAULT_WORKSPACE_BYTES,
     resolve_workspace_bytes,
 )
-from tensorrt_model_connect.families.minimax_h3.dit_builder import build_dit_engine  # noqa: E402
+from tensorrt_model_connect.families.minimax_h3.dit_builder import (  # noqa: E402
+    build_dit_engine,
+    build_dit_finish_engine,
+    build_dit_head_engine,
+    build_dit_tail_engine,
+    checkpoint_keys as dit_checkpoint_keys,
+    finish_checkpoint_keys,
+    head_checkpoint_keys,
+    tail_checkpoint_keys,
+)
 from tensorrt_model_connect.families.minimax_h3 import graph_ops as op  # noqa: E402
 from tensorrt_model_connect.families.minimax_h3.text_encoder_builder import (  # noqa: E402
     build_text_encoder_engine,
@@ -162,6 +173,29 @@ def test_workspace_limit_uses_default_or_exact_override() -> None:
         op.configure_workspace(RejectingConfig(), 8 << 30, default_bytes=64 << 30)
 
 
+def test_first_block_cache_checkpoint_partitions_are_exact() -> None:
+    profile = replace(SOL_ENGINE_1344X768_124F, first_block_cache=True)
+    head = set(head_checkpoint_keys(profile))
+    tail = set(tail_checkpoint_keys(profile))
+    finish = set(finish_checkpoint_keys(profile))
+    assert head
+    assert tail
+    assert finish
+    assert not (head & tail or head & finish or tail & finish)
+    assert head | tail | finish == set(dit_checkpoint_keys(profile))
+    assert "transformer_blocks.0.norm1.weight" in head
+    assert "transformer_blocks.1.norm1.weight" in tail
+    assert "norm_out.norm.weight" in finish
+
+
+def test_split_builders_require_explicit_first_block_cache_profile() -> None:
+    for builder in (build_dit_head_engine, build_dit_tail_engine, build_dit_finish_engine):
+        with pytest.raises(ValueError, match="first_block_cache=True"):
+            builder({}, SOL_ENGINE_1344X768_124F)
+    with pytest.raises(ValueError, match="requires the split DiT builders"):
+        build_dit_engine({}, replace(SOL_ENGINE_1344X768_124F, first_block_cache=True))
+
+
 @pytest.mark.gpu
 def test_tiny_native_h3_graphs_serialize() -> None:
     profile = MiniMaxH3Config(
@@ -188,6 +222,30 @@ def test_tiny_native_h3_graphs_serialize() -> None:
     weights = _weights(profile)
     assert build_adaln_precompute_engine(weights, profile, workspace_bytes=1 << 30)
     assert build_dit_engine(weights, profile, workspace_bytes=1 << 30)
+
+    split_profile = replace(profile, num_layers=2, first_block_cache=True)
+    split_weights = _weights(split_profile)
+    head_plan = build_dit_head_engine(split_weights, split_profile, workspace_bytes=1 << 30)
+    tail_plan = build_dit_tail_engine(split_weights, split_profile, workspace_bytes=1 << 30)
+    finish_plan = build_dit_finish_engine(split_weights, split_profile, workspace_bytes=1 << 30)
+    assert head_plan and tail_plan and finish_plan
+
+    runtime_logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(runtime_logger)
+    expected = (
+        (head_plan, {"head_hidden", "head_residual", "cache_metric"}),
+        (tail_plan, {"tail_residual"}),
+        (finish_plan, {"video_velocity", "audio_velocity"}),
+    )
+    for plan, expected_outputs in expected:
+        engine = runtime.deserialize_cuda_engine(plan)
+        assert engine is not None
+        outputs = {
+            engine.get_tensor_name(index)
+            for index in range(engine.num_io_tensors)
+            if engine.get_tensor_mode(engine.get_tensor_name(index)) == trt.TensorIOMode.OUTPUT
+        }
+        assert outputs == expected_outputs
 
 
 @pytest.mark.gpu

--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -484,7 +484,7 @@ void TrtModuleImpl::bind_alias_outputs_or_invalidate(const std::vector<std::stri
     }
 }
 
-void TrtModuleImpl::reset_alias_cuda_graph_if_rebound(void* previous_ptr, void* ptr) {
+void TrtModuleImpl::reset_cuda_graph_if_rebound(void* previous_ptr, void* ptr) {
     if (previous_ptr != ptr && use_cuda_graph_ && cuda_graph_)
         cuda_graph_->reset();
 }
@@ -510,7 +510,7 @@ void TrtModuleImpl::bind_alias_group(const std::string& input_name, void* ptr) {
 
     bind_alias_outputs_or_invalidate(outputs->second, ptr);
 
-    reset_alias_cuda_graph_if_rebound(input->second.d_ptr, ptr);
+    reset_cuda_graph_if_rebound(input->second.d_ptr, ptr);
     input->second.d_ptr = ptr;
     input->second.is_external = true;
     for (const auto& output_name : outputs->second) {
@@ -883,18 +883,27 @@ void TrtModuleImpl::bind_external(const std::string& name, void* external_device
     }
 
     auto& entry = it->second;
+    if (external_device_ptr == nullptr)
+        throw std::invalid_argument("External buffer for '" + name + "' is null");
+    if (external_device_ptr == entry.d_ptr)
+        return;
 
-    // Free our own buffer if we allocated it
-    if (entry.d_ptr && !entry.is_external) {
-        cudaFree(entry.d_ptr);
-    }
+    // Bind the candidate before changing ownership. If TensorRT rejects the
+    // address, the module must retain both its previous context binding and its
+    // still-live owned buffer.
+    BufferEntry candidate = entry;
+    candidate.d_ptr = external_device_ptr;
+    candidate.is_external = true;
+    if (!bind_tensor_address(name, candidate))
+        throw std::runtime_error("TensorRT rejected external buffer for '" + name + "'");
 
-    entry.d_ptr = external_device_ptr;
-    entry.is_external = true;
-
-    // Update execution context binding
-    if (ctx_ && external_device_ptr)
-        bind_tensor_address(name, entry);
+    void* const previous_ptr = entry.d_ptr;
+    const bool free_previous =
+        previous_ptr != nullptr && !entry.is_external && previous_ptr != external_device_ptr;
+    reset_cuda_graph_if_rebound(previous_ptr, external_device_ptr);
+    entry = std::move(candidate);
+    if (free_previous)
+        cudaFree(previous_ptr);
 }
 
 } // namespace trtmc

--- a/src/runtime/backend/trt_module_impl.h
+++ b/src/runtime/backend/trt_module_impl.h
@@ -112,7 +112,7 @@ class TrtModuleImpl final : public ITrtModule {
     bool should_allocate_input(const std::string& name, std::size_t nbytes) const;
     void validate_alias_outputs_exist(const std::vector<std::string>& output_names) const;
     void bind_alias_outputs_or_invalidate(const std::vector<std::string>& output_names, void* ptr);
-    void reset_alias_cuda_graph_if_rebound(void* previous_ptr, void* ptr);
+    void reset_cuda_graph_if_rebound(void* previous_ptr, void* ptr);
     void validate_alias_groups_bound() const;
     void free_buffers();
     void detect_dynamic_shapes(nvinfer1::ICudaEngine* engine, int32_t num_io);

--- a/src/runtime/models/minimax_h3/MODEL.toml
+++ b/src/runtime/models/minimax_h3/MODEL.toml
@@ -10,4 +10,5 @@ runtime_tests = [
   "test_minimax_h3_config_schema|test_minimax_h3_config_schema.cpp|trtmc_model_minimax_h3|_|_",
   "test_minimax_h3_math|test_minimax_h3_math.cpp|trtmc_model_minimax_h3|_|_",
   "test_minimax_h3_cuda_rng|test_minimax_h3_cuda_rng.cpp|trtmc_model_minimax_h3|_|REQUIRES_GPU",
+  "test_minimax_h3_trt_module_bind_external|test_minimax_h3_trt_module_bind_external.cpp|trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/minimax_h3/MODEL.toml
+++ b/src/runtime/models/minimax_h3/MODEL.toml
@@ -4,8 +4,10 @@
 id = "minimax_h3"
 runtime_library = "libtrtmc_model_minimax_h3.so"
 runtime_plugins = ["plugin.cpp|register_minimax_h3_plugin"]
+runtime_config_schemas = ["config_schema.cpp|register_minimax_h3_schema"]
 runtime_strategies = ["diffusion_minimax_h3"]
 runtime_tests = [
+  "test_minimax_h3_config_schema|test_minimax_h3_config_schema.cpp|trtmc_model_minimax_h3|_|_",
   "test_minimax_h3_math|test_minimax_h3_math.cpp|trtmc_model_minimax_h3|_|_",
   "test_minimax_h3_cuda_rng|test_minimax_h3_cuda_rng.cpp|trtmc_model_minimax_h3|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/minimax_h3/config_schema.cpp
+++ b/src/runtime/models/minimax_h3/config_schema.cpp
@@ -26,7 +26,7 @@ Schema make_minimax_h3_schema() {
     return Schema{
         "minimax_h3",
         {
-            ConfigField{"first_block_cache_threshold", "double", std::any{0.08}, session,
+            ConfigField{"first_block_cache_threshold", "double", std::any{0.025}, session,
                         is_positive_finite_double},
         },
     };

--- a/src/runtime/models/minimax_h3/config_schema.cpp
+++ b/src/runtime/models/minimax_h3/config_schema.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/minimax_h3/config_schema.h"
+
+#include <any>
+#include <cmath>
+#include <set>
+
+namespace trtmc::config::schemas {
+namespace {
+
+bool is_positive_finite_double(const std::any& value) {
+    if (value.type() != typeid(double))
+        return false;
+    const double parsed = std::any_cast<double>(value);
+    return std::isfinite(parsed) && parsed > 0.0;
+}
+
+} // namespace
+
+Schema make_minimax_h3_schema() {
+    const std::set<Layer> session = {Layer::SessionRequest, Layer::PlatformProfile};
+    return Schema{
+        "minimax_h3",
+        {
+            ConfigField{"first_block_cache_threshold", "double", std::any{0.08}, session,
+                        is_positive_finite_double},
+        },
+    };
+}
+
+REGISTER_CONFIG_SCHEMA_FACTORY_WITH_MANIFEST(register_minimax_h3_schema, make_minimax_h3_schema);
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/minimax_h3/config_schema.h
+++ b/src/runtime/models/minimax_h3/config_schema.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/config/schema_registry.h"
+
+namespace trtmc::config::schemas {
+
+Schema make_minimax_h3_schema();
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/minimax_h3/pipeline.cpp
+++ b/src/runtime/models/minimax_h3/pipeline.cpp
@@ -552,6 +552,17 @@ void validate_generate_config(const GenerateConfig& cfg) {
             "MiniMax-H3 native profile is fixed at 124 frames, 768x1344, 50 grid points");
 }
 
+struct DenoiserStats {
+    int32_t full_steps{0};
+    int32_t skipped_steps{0};
+};
+
+bool device_tensors_ready(std::initializer_list<const DeviceTensor*> tensors) {
+    return std::all_of(tensors.begin(), tensors.end(), [](const DeviceTensor* tensor) {
+        return tensor != nullptr && tensor->ok();
+    });
+}
+
 } // namespace
 
 struct MiniMaxH3Pipeline::ResidentState {
@@ -575,7 +586,453 @@ struct MiniMaxH3Pipeline::ResidentState {
     std::unique_ptr<ITrtModule> denoiser_tail;
     std::unique_ptr<ITrtModule> denoiser_finish;
     std::unique_ptr<ITrtModule> vae;
+
+    void load_text_embeddings(const std::string& requested_prompt, ITokenizer& tokenizer,
+                              const MiniMaxH3ModuleLoader& loader, cudaStream_t stream);
+    void load_modulations(const MiniMaxH3Schedule& video_schedule,
+                          const MiniMaxH3Schedule& audio_schedule,
+                          const MiniMaxH3ModuleLoader& loader, cudaStream_t stream);
+    bool prepare_denoiser(const MiniMaxH3ModuleLoader& loader, cudaStream_t stream,
+                          bool first_block_cache);
+    DenoiserStats run_denoiser(bool first_block_cache, DenoiserMetadata& metadata,
+                               const MiniMaxH3Schedule& video_schedule,
+                               const MiniMaxH3Schedule& audio_schedule,
+                               std::vector<float>& video_rows_host,
+                               std::vector<float>& audio_rows_host, float cache_threshold,
+                               cudaStream_t stream);
+    bool prepare_vae(const MiniMaxH3ModuleLoader& loader, cudaStream_t stream,
+                     bool first_block_cache);
+    std::vector<float> decode_vae(bool first_block_cache, const std::vector<float>& latent,
+                                  std::size_t expected_pixels, cudaStream_t stream);
+
+    bool denoiser_is_resident(bool first_block_cache) const;
+    void load_first_block_cache_denoiser(const MiniMaxH3ModuleLoader& loader, cudaStream_t stream);
+    DenoiserStats run_first_block_cache_denoiser(DenoiserMetadata& metadata,
+                                                 const MiniMaxH3Schedule& video_schedule,
+                                                 const MiniMaxH3Schedule& audio_schedule,
+                                                 std::vector<float>& video_rows_host,
+                                                 std::vector<float>& audio_rows_host,
+                                                 float cache_threshold, cudaStream_t stream);
+    DenoiserStats run_monolithic_denoiser(DenoiserMetadata& metadata,
+                                          const MiniMaxH3Schedule& video_schedule,
+                                          const MiniMaxH3Schedule& audio_schedule,
+                                          std::vector<float>& video_rows_host,
+                                          std::vector<float>& audio_rows_host);
+    bool vae_is_resident(bool first_block_cache) const;
+    void load_first_block_cache_vae(const MiniMaxH3ModuleLoader& loader, cudaStream_t stream);
+    std::vector<float> decode_first_block_cache_vae(std::size_t expected_pixels,
+                                                    cudaStream_t stream);
+    std::vector<float> decode_monolithic_vae(const std::vector<float>& latent,
+                                             std::size_t expected_pixels);
 };
+
+void MiniMaxH3Pipeline::ResidentState::load_text_embeddings(const std::string& requested_prompt,
+                                                            ITokenizer& tokenizer,
+                                                            const MiniMaxH3ModuleLoader& loader,
+                                                            cudaStream_t stream) {
+    // The text encoder is the largest plan. Drop resident execution modules
+    // before loading it so prompt changes retain the previous peak-memory
+    // behavior on smaller devices.
+    denoiser.reset();
+    denoiser_head.reset();
+    denoiser_tail.reset();
+    denoiser_finish.reset();
+    head_hidden.reset();
+    head_residual.reset();
+    previous_head_residual.reset();
+    tail_residual.reset();
+    video_rows.reset();
+    audio_rows.reset();
+    video_velocity.reset();
+    audio_velocity.reset();
+    vae.reset();
+    vae_latent_tiles.reset();
+    vae_decoded_tiles.reset();
+    vae_overlap.reset();
+    frame_major_rgb.reset();
+    prompt.clear();
+    text_embeddings.clear();
+    const auto ids = tokenizer.encode(requested_prompt);
+    if (ids.size() != kTextRows)
+        throw std::invalid_argument(
+            "MiniMax-H3 GB300 profile requires exactly 537 prompt tokens; got " +
+            std::to_string(ids.size()));
+    auto module = loader("text_encoder_plan", stream);
+    module->set_timing_label("text_encoder_plan");
+    TensorMap inputs;
+    inputs.emplace("input_ids",
+                   Tensor{const_cast<int32_t*>(ids.data()), {kTextRows}, DType::kInt32});
+    const auto outputs = module->forward(inputs);
+    text_embeddings = copy_float(require_output(outputs, "encoder_hidden_states"),
+                                 static_cast<std::size_t>(kTextRows) * kTextDim, "text encoder");
+    module->sync();
+    prompt = requested_prompt;
+}
+
+void MiniMaxH3Pipeline::ResidentState::load_modulations(const MiniMaxH3Schedule& video_schedule,
+                                                        const MiniMaxH3Schedule& audio_schedule,
+                                                        const MiniMaxH3ModuleLoader& loader,
+                                                        cudaStream_t stream) {
+    auto module = loader("adaln_precompute_plan", stream);
+    module->set_timing_label("adaln_precompute_plan");
+    modulations = precompute_modulations(*module, video_schedule, audio_schedule);
+    module->sync();
+}
+
+bool MiniMaxH3Pipeline::ResidentState::denoiser_is_resident(bool first_block_cache) const {
+    if (!first_block_cache)
+        return denoiser != nullptr;
+    return denoiser_head != nullptr && denoiser_tail != nullptr && denoiser_finish != nullptr &&
+           device_tensors_ready({head_hidden.get(), head_residual.get(),
+                                 previous_head_residual.get(), tail_residual.get(),
+                                 video_rows.get(), audio_rows.get(), video_velocity.get(),
+                                 audio_velocity.get()});
+}
+
+void MiniMaxH3Pipeline::ResidentState::load_first_block_cache_denoiser(
+    const MiniMaxH3ModuleLoader& loader, cudaStream_t stream) {
+    auto head = loader("denoiser_head_plan", stream);
+    auto tail = loader("denoiser_tail_plan", stream);
+    auto finish = loader("denoiser_finish_plan", stream);
+    head->set_timing_label("denoiser_head_plan");
+    tail->set_timing_label("denoiser_tail_plan");
+    finish->set_timing_label("denoiser_finish_plan");
+
+    DeviceTensor new_head_hidden({kSequenceRows, kHidden}, DType::kBFloat16, stream);
+    DeviceTensor new_head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream);
+    DeviceTensor new_previous_head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream);
+    DeviceTensor new_tail_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream);
+    DeviceTensor new_video_rows({kVideoRows, kPatchDim}, DType::kFloat32, stream);
+    DeviceTensor new_audio_rows({kAudioRows, kAudioChannels}, DType::kFloat32, stream);
+    DeviceTensor new_video_velocity({kVideoRows, kPatchDim}, DType::kFloat32, stream);
+    DeviceTensor new_audio_velocity({kAudioRows, kAudioChannels}, DType::kFloat32, stream);
+    if (!device_tensors_ready({&new_head_hidden, &new_head_residual, &new_previous_head_residual,
+                               &new_tail_residual, &new_video_rows, &new_audio_rows,
+                               &new_video_velocity, &new_audio_velocity}))
+        throw std::runtime_error("MiniMax-H3 failed to allocate FirstBlockCache buffers");
+
+    auto resident_head_hidden = std::make_unique<DeviceTensor>(std::move(new_head_hidden));
+    auto resident_head_residual = std::make_unique<DeviceTensor>(std::move(new_head_residual));
+    auto resident_previous_head_residual =
+        std::make_unique<DeviceTensor>(std::move(new_previous_head_residual));
+    auto resident_tail_residual = std::make_unique<DeviceTensor>(std::move(new_tail_residual));
+    auto resident_video_rows = std::make_unique<DeviceTensor>(std::move(new_video_rows));
+    auto resident_audio_rows = std::make_unique<DeviceTensor>(std::move(new_audio_rows));
+    auto resident_video_velocity = std::make_unique<DeviceTensor>(std::move(new_video_velocity));
+    auto resident_audio_velocity = std::make_unique<DeviceTensor>(std::move(new_audio_velocity));
+
+    bind_external_checked(*head, "head_hidden", resident_head_hidden->data(), false,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*head, "head_residual", resident_head_residual->data(), false,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*head, "previous_head_residual", resident_previous_head_residual->data(),
+                          true, DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*head, "video_hidden_states", resident_video_rows->data(), true,
+                          DType::kFloat32, {kVideoRows, kPatchDim});
+    bind_external_checked(*head, "audio_hidden_states", resident_audio_rows->data(), true,
+                          DType::kFloat32, {kAudioRows, kAudioChannels});
+    bind_external_checked(*tail, "head_hidden", resident_head_hidden->data(), true,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*tail, "tail_residual", resident_tail_residual->data(), false,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*finish, "head_hidden", resident_head_hidden->data(), true,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*finish, "tail_residual", resident_tail_residual->data(), true,
+                          DType::kBFloat16, {kSequenceRows, kHidden});
+    bind_external_checked(*finish, "video_velocity", resident_video_velocity->data(), false,
+                          DType::kFloat32, {kVideoRows, kPatchDim});
+    bind_external_checked(*finish, "audio_velocity", resident_audio_velocity->data(), false,
+                          DType::kFloat32, {kAudioRows, kAudioChannels});
+
+    denoiser_head = std::move(head);
+    denoiser_tail = std::move(tail);
+    denoiser_finish = std::move(finish);
+    head_hidden = std::move(resident_head_hidden);
+    head_residual = std::move(resident_head_residual);
+    previous_head_residual = std::move(resident_previous_head_residual);
+    tail_residual = std::move(resident_tail_residual);
+    video_rows = std::move(resident_video_rows);
+    audio_rows = std::move(resident_audio_rows);
+    video_velocity = std::move(resident_video_velocity);
+    audio_velocity = std::move(resident_audio_velocity);
+}
+
+bool MiniMaxH3Pipeline::ResidentState::prepare_denoiser(const MiniMaxH3ModuleLoader& loader,
+                                                        cudaStream_t stream,
+                                                        bool first_block_cache) {
+    const bool resident_hit = denoiser_is_resident(first_block_cache);
+    if (resident_hit)
+        return true;
+    if (first_block_cache) {
+        load_first_block_cache_denoiser(loader, stream);
+    } else {
+        denoiser = loader("denoiser_plan", stream);
+        denoiser->set_timing_label("denoiser_plan");
+    }
+    return false;
+}
+
+DenoiserStats MiniMaxH3Pipeline::ResidentState::run_first_block_cache_denoiser(
+    DenoiserMetadata& metadata, const MiniMaxH3Schedule& video_schedule,
+    const MiniMaxH3Schedule& audio_schedule, std::vector<float>& video_rows_host,
+    std::vector<float>& audio_rows_host, float cache_threshold, cudaStream_t stream) {
+    DenoiserStats stats;
+    auto& head = *denoiser_head;
+    auto& tail = *denoiser_tail;
+    auto& finish = *denoiser_finish;
+    head.reset_execution_context();
+    tail.reset_execution_context();
+    finish.reset_execution_context();
+    if (cudaMemsetAsync(previous_head_residual->data(), 0, previous_head_residual->nbytes(),
+                        stream) != cudaSuccess)
+        throw std::runtime_error("MiniMax-H3 failed to reset FirstBlockCache state");
+    if (!video_rows->copy_from_host(video_rows_host.data()) ||
+        !audio_rows->copy_from_host(audio_rows_host.data()))
+        throw std::runtime_error("MiniMax-H3 failed to upload FirstBlockCache latents");
+
+    for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
+        auto& modulation = modulations[step];
+        TensorMap head_inputs;
+        head_inputs.emplace("encoder_hidden_states",
+                            Tensor{text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
+        head_inputs.emplace("position_ids",
+                            Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
+        head_inputs.emplace("adaln_indices",
+                            Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
+        append_block_modulation_inputs(head_inputs, modulation, 0, 1);
+        const auto head_outputs = head.forward(head_inputs);
+        const float metric =
+            copy_float(require_output(head_outputs, "cache_metric"), 1, "cache metric")[0];
+        const bool compute_tail = step == 0 || !std::isfinite(metric) || metric > cache_threshold;
+
+        if (compute_tail) {
+            TensorMap tail_inputs;
+            tail_inputs.emplace(
+                "position_ids",
+                Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
+            tail_inputs.emplace(
+                "adaln_indices",
+                Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
+            append_block_modulation_inputs(tail_inputs, modulation, 1, kLayers);
+            tail.forward_async(tail_inputs);
+            if (!previous_head_residual->copy_from(*head_residual))
+                throw std::runtime_error("MiniMax-H3 failed to update FirstBlockCache state");
+            ++stats.full_steps;
+        } else {
+            ++stats.skipped_steps;
+        }
+
+        TensorMap finish_inputs;
+        finish_inputs.emplace(
+            "timestep_indices",
+            Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
+        append_final_modulation_input(finish_inputs, modulation);
+        finish.forward_async(finish_inputs);
+        minimax_h3::scheduler_step_cuda_async(
+            static_cast<float*>(video_rows->data()),
+            static_cast<const float*>(video_velocity->data()), video_rows_host.size(),
+            video_schedule.timesteps[step], video_schedule.sigmas[step],
+            video_schedule.sigmas[step + 1], stream);
+        minimax_h3::scheduler_step_cuda_async(
+            static_cast<float*>(audio_rows->data()),
+            static_cast<const float*>(audio_velocity->data()), audio_rows_host.size(),
+            audio_schedule.timesteps[step], audio_schedule.sigmas[step],
+            audio_schedule.sigmas[step + 1], stream);
+        std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
+                  << video_schedule.timesteps.size() << " cache_metric=" << metric
+                  << " compute_tail=" << static_cast<int>(compute_tail) << '\n';
+    }
+    finish.sync();
+    return stats;
+}
+
+DenoiserStats MiniMaxH3Pipeline::ResidentState::run_monolithic_denoiser(
+    DenoiserMetadata& metadata, const MiniMaxH3Schedule& video_schedule,
+    const MiniMaxH3Schedule& audio_schedule, std::vector<float>& video_rows_host,
+    std::vector<float>& audio_rows_host) {
+    DenoiserStats stats;
+    auto& module = *denoiser;
+    module.reset_execution_context();
+    for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
+        TensorMap inputs;
+        inputs.emplace("video_hidden_states",
+                       Tensor{video_rows_host.data(), {kVideoRows, kPatchDim}, DType::kFloat32});
+        inputs.emplace(
+            "audio_hidden_states",
+            Tensor{audio_rows_host.data(), {kAudioRows, kAudioChannels}, DType::kFloat32});
+        inputs.emplace("encoder_hidden_states",
+                       Tensor{text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
+        inputs.emplace("position_ids",
+                       Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
+        inputs.emplace("adaln_indices",
+                       Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
+        inputs.emplace("timestep_indices",
+                       Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
+        append_modulation_inputs(inputs, modulations[step]);
+        const auto outputs = module.forward(inputs);
+        auto video_all =
+            copy_float(require_output(outputs, "video_velocity"),
+                       static_cast<std::size_t>(kSequenceRows) * kPatchDim, "video velocity");
+        auto audio_all =
+            copy_float(require_output(outputs, "audio_velocity"),
+                       static_cast<std::size_t>(kSequenceRows) * kAudioChannels, "audio velocity");
+        const auto video_begin =
+            video_all.begin() + static_cast<std::ptrdiff_t>(kTextRows + kAudioRows) * kPatchDim;
+        std::vector<float> video_velocity_host(video_begin, video_begin + video_rows_host.size());
+        const auto audio_begin =
+            audio_all.begin() + static_cast<std::ptrdiff_t>(kTextRows) * kAudioChannels;
+        std::vector<float> audio_velocity_host(audio_begin, audio_begin + audio_rows_host.size());
+        minimax_h3_scheduler_step(video_rows_host.data(), video_velocity_host.data(),
+                                  video_rows_host.size(), video_schedule.timesteps[step],
+                                  video_schedule.sigmas[step], video_schedule.sigmas[step + 1]);
+        minimax_h3_scheduler_step(audio_rows_host.data(), audio_velocity_host.data(),
+                                  audio_rows_host.size(), audio_schedule.timesteps[step],
+                                  audio_schedule.sigmas[step], audio_schedule.sigmas[step + 1]);
+        ++stats.full_steps;
+        std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
+                  << video_schedule.timesteps.size() << '\n';
+    }
+    module.sync();
+    return stats;
+}
+
+DenoiserStats MiniMaxH3Pipeline::ResidentState::run_denoiser(
+    bool first_block_cache, DenoiserMetadata& metadata, const MiniMaxH3Schedule& video_schedule,
+    const MiniMaxH3Schedule& audio_schedule, std::vector<float>& video_rows_host,
+    std::vector<float>& audio_rows_host, float cache_threshold, cudaStream_t stream) {
+    if (first_block_cache) {
+        return run_first_block_cache_denoiser(metadata, video_schedule, audio_schedule,
+                                              video_rows_host, audio_rows_host, cache_threshold,
+                                              stream);
+    }
+    return run_monolithic_denoiser(metadata, video_schedule, audio_schedule, video_rows_host,
+                                   audio_rows_host);
+}
+
+bool MiniMaxH3Pipeline::ResidentState::vae_is_resident(bool first_block_cache) const {
+    if (!first_block_cache)
+        return vae != nullptr;
+    return vae != nullptr && device_tensors_ready({vae_latent_tiles.get(), vae_decoded_tiles.get(),
+                                                   vae_overlap.get(), frame_major_rgb.get()});
+}
+
+void MiniMaxH3Pipeline::ResidentState::load_first_block_cache_vae(
+    const MiniMaxH3ModuleLoader& loader, cudaStream_t stream) {
+    auto module = loader("vae_tile_decoder_plan", stream);
+    module->set_timing_label("vae_tile_decoder_plan");
+    DeviceTensor latent_tiles(
+        {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize},
+        DType::kFloat32, stream);
+    DeviceTensor decoded_tiles({kTileBatch, 3, kTileFrames, kTileSize, kTileSize}, DType::kFloat32,
+                               stream);
+    DeviceTensor overlap({3, 5, kOutputHeight, kOutputWidth}, DType::kFloat32, stream);
+    DeviceTensor output_pixels({kOutputFrames, kOutputHeight, kOutputWidth, 3}, DType::kFloat32,
+                               stream);
+    if (!device_tensors_ready({&latent_tiles, &decoded_tiles, &overlap, &output_pixels}))
+        throw std::runtime_error("MiniMax-H3 failed to allocate CUDA VAE buffers");
+
+    auto resident_latent_tiles = std::make_unique<DeviceTensor>(std::move(latent_tiles));
+    auto resident_decoded_tiles = std::make_unique<DeviceTensor>(std::move(decoded_tiles));
+    auto resident_overlap = std::make_unique<DeviceTensor>(std::move(overlap));
+    auto resident_frame_major_rgb = std::make_unique<DeviceTensor>(std::move(output_pixels));
+    bind_external_checked(
+        *module, "latent_tiles", resident_latent_tiles->data(), true, DType::kFloat32,
+        {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize});
+    bind_external_checked(*module, "decoded_tiles", resident_decoded_tiles->data(), false,
+                          DType::kFloat32, {kTileBatch, 3, kTileFrames, kTileSize, kTileSize});
+
+    vae = std::move(module);
+    vae_latent_tiles = std::move(resident_latent_tiles);
+    vae_decoded_tiles = std::move(resident_decoded_tiles);
+    vae_overlap = std::move(resident_overlap);
+    frame_major_rgb = std::move(resident_frame_major_rgb);
+}
+
+bool MiniMaxH3Pipeline::ResidentState::prepare_vae(const MiniMaxH3ModuleLoader& loader,
+                                                   cudaStream_t stream, bool first_block_cache) {
+    const bool resident_hit = vae_is_resident(first_block_cache);
+    if (resident_hit)
+        return true;
+    if (first_block_cache) {
+        load_first_block_cache_vae(loader, stream);
+    } else {
+        vae = loader("vae_tile_decoder_plan", stream);
+        vae->set_timing_label("vae_tile_decoder_plan");
+    }
+    return false;
+}
+
+std::vector<float>
+MiniMaxH3Pipeline::ResidentState::decode_first_block_cache_vae(std::size_t expected_pixels,
+                                                               cudaStream_t stream) {
+    auto& module = *vae;
+    module.reset_execution_context();
+    const auto latent_normalization = vae_latent_normalization();
+    const auto pixel_normalization = vae_pixel_normalization();
+    TensorMap no_inputs;
+    for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
+        minimax_h3::extract_vae_tiles_cuda_async(static_cast<const float*>(video_rows->data()),
+                                                 static_cast<float*>(vae_latent_tiles->data()),
+                                                 clip_index, latent_normalization, stream);
+        module.forward_async(no_inputs);
+        minimax_h3::assemble_vae_clip_cuda_async(
+            static_cast<const float*>(vae_decoded_tiles->data()),
+            static_cast<float*>(vae_overlap->data()), static_cast<float*>(frame_major_rgb->data()),
+            clip_index, pixel_normalization, stream);
+        std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
+    }
+    module.sync();
+    std::vector<float> pixels(expected_pixels);
+    if (!frame_major_rgb->copy_to_host(pixels.data()))
+        throw std::runtime_error("MiniMax-H3 failed to download CUDA VAE output");
+    return pixels;
+}
+
+std::vector<float>
+MiniMaxH3Pipeline::ResidentState::decode_monolithic_vae(const std::vector<float>& latent,
+                                                        std::size_t expected_pixels) {
+    std::vector<float> video(expected_pixels);
+    std::size_t decoded_frames = 0;
+    std::vector<float> overlap;
+    std::vector<float> clip;
+    auto& module = *vae;
+    module.reset_execution_context();
+    constexpr std::size_t output_count =
+        static_cast<std::size_t>(kTileBatch) * 3 * kTileFrames * kTileSize * kTileSize;
+    for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
+        auto latent_tiles = extract_tiles(latent, clip_index);
+        TensorMap inputs;
+        inputs.emplace("latent_tiles", Tensor{latent_tiles.data(),
+                                              {kTileBatch, kLatentChannels, kTileInputFrames,
+                                               kTileLatentSize, kTileLatentSize},
+                                              DType::kFloat32});
+        const auto outputs = module.forward(inputs);
+        const Tensor decoded_tiles = require_output(outputs, "decoded_tiles");
+        if (decoded_tiles.numel() != output_count)
+            throw std::runtime_error("MiniMax-H3 invalid VAE decoded tiles output");
+        stitch_spatial_tiles(decoded_tiles, clip);
+        write_temporal_chunk(video, decoded_frames, clip, overlap);
+        decoded_frames += 17;
+        update_trailing_overlap(clip, overlap);
+        std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
+    }
+    module.sync();
+    write_final_overlap(video, decoded_frames, overlap);
+    decoded_frames += 5;
+    if (video.size() != expected_pixels || decoded_frames != kOutputFrames)
+        throw std::runtime_error("MiniMax-H3 VAE produced the wrong video geometry");
+    postprocess_video(video);
+    return to_frame_major_rgb(video);
+}
+
+std::vector<float> MiniMaxH3Pipeline::ResidentState::decode_vae(bool first_block_cache,
+                                                                const std::vector<float>& latent,
+                                                                std::size_t expected_pixels,
+                                                                cudaStream_t stream) {
+    if (first_block_cache)
+        return decode_first_block_cache_vae(expected_pixels, stream);
+    return decode_monolithic_vae(latent, expected_pixels);
+}
 
 MiniMaxH3Schedule make_minimax_h3_schedule(int32_t grid_points, float shift) {
     if (grid_points < 2 || shift <= 0.0F)
@@ -637,58 +1094,16 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
 
     const bool text_cache_hit = resident_->prompt == prompt && !resident_->text_embeddings.empty();
     const auto text_begin = Clock::now();
-    if (!text_cache_hit) {
-        // The text encoder is the largest plan. Drop resident execution modules
-        // before loading it so prompt changes retain the previous peak-memory
-        // behavior on smaller devices.
-        resident_->denoiser.reset();
-        resident_->denoiser_head.reset();
-        resident_->denoiser_tail.reset();
-        resident_->denoiser_finish.reset();
-        resident_->head_hidden.reset();
-        resident_->head_residual.reset();
-        resident_->previous_head_residual.reset();
-        resident_->tail_residual.reset();
-        resident_->video_rows.reset();
-        resident_->audio_rows.reset();
-        resident_->video_velocity.reset();
-        resident_->audio_velocity.reset();
-        resident_->vae.reset();
-        resident_->vae_latent_tiles.reset();
-        resident_->vae_decoded_tiles.reset();
-        resident_->vae_overlap.reset();
-        resident_->frame_major_rgb.reset();
-        resident_->prompt.clear();
-        resident_->text_embeddings.clear();
-        const auto ids = tokenizer_->encode(prompt);
-        if (ids.size() != kTextRows)
-            throw std::invalid_argument(
-                "MiniMax-H3 GB300 profile requires exactly 537 prompt tokens; got " +
-                std::to_string(ids.size()));
-        auto module = loader_("text_encoder_plan", stream_);
-        module->set_timing_label("text_encoder_plan");
-        TensorMap inputs;
-        inputs.emplace("input_ids",
-                       Tensor{const_cast<int32_t*>(ids.data()), {kTextRows}, DType::kInt32});
-        const auto outputs = module->forward(inputs);
-        resident_->text_embeddings =
-            copy_float(require_output(outputs, "encoder_hidden_states"),
-                       static_cast<std::size_t>(kTextRows) * kTextDim, "text encoder");
-        module->sync();
-        resident_->prompt = prompt;
-    }
+    if (!text_cache_hit)
+        resident_->load_text_embeddings(prompt, *tokenizer_, loader_, stream_);
     const auto text_end = Clock::now();
 
     const auto video_schedule = make_minimax_h3_schedule(kSteps, 12.0F);
     const auto audio_schedule = make_minimax_h3_schedule(kSteps, 3.0F);
     const bool adaln_cache_hit = !resident_->modulations.empty();
     const auto adaln_begin = Clock::now();
-    if (!adaln_cache_hit) {
-        auto module = loader_("adaln_precompute_plan", stream_);
-        module->set_timing_label("adaln_precompute_plan");
-        resident_->modulations = precompute_modulations(*module, video_schedule, audio_schedule);
-        module->sync();
-    }
+    if (!adaln_cache_hit)
+        resident_->load_modulations(video_schedule, audio_schedule, loader_, stream_);
     const auto adaln_end = Clock::now();
 
     auto video_tensor =
@@ -703,207 +1118,10 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
 
     const auto denoiser_begin = Clock::now();
     const bool denoiser_resident_hit =
-        first_block_cache_
-            ? resident_->denoiser_head != nullptr && resident_->denoiser_tail != nullptr &&
-                  resident_->denoiser_finish != nullptr && resident_->head_hidden != nullptr &&
-                  resident_->head_hidden->ok() && resident_->head_residual != nullptr &&
-                  resident_->head_residual->ok() && resident_->previous_head_residual != nullptr &&
-                  resident_->previous_head_residual->ok() && resident_->tail_residual != nullptr &&
-                  resident_->tail_residual->ok() && resident_->video_rows != nullptr &&
-                  resident_->video_rows->ok() && resident_->audio_rows != nullptr &&
-                  resident_->audio_rows->ok() && resident_->video_velocity != nullptr &&
-                  resident_->video_velocity->ok() && resident_->audio_velocity != nullptr &&
-                  resident_->audio_velocity->ok()
-            : resident_->denoiser != nullptr;
-    if (first_block_cache_ && !denoiser_resident_hit) {
-        auto head = loader_("denoiser_head_plan", stream_);
-        auto tail = loader_("denoiser_tail_plan", stream_);
-        auto finish = loader_("denoiser_finish_plan", stream_);
-        head->set_timing_label("denoiser_head_plan");
-        tail->set_timing_label("denoiser_tail_plan");
-        finish->set_timing_label("denoiser_finish_plan");
-
-        DeviceTensor head_hidden({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
-        DeviceTensor head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
-        DeviceTensor previous_head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
-        DeviceTensor tail_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
-        DeviceTensor video_rows_device({kVideoRows, kPatchDim}, DType::kFloat32, stream_);
-        DeviceTensor audio_rows_device({kAudioRows, kAudioChannels}, DType::kFloat32, stream_);
-        DeviceTensor video_velocity({kVideoRows, kPatchDim}, DType::kFloat32, stream_);
-        DeviceTensor audio_velocity({kAudioRows, kAudioChannels}, DType::kFloat32, stream_);
-        if (!head_hidden.ok() || !head_residual.ok() || !previous_head_residual.ok() ||
-            !tail_residual.ok() || !video_rows_device.ok() || !audio_rows_device.ok() ||
-            !video_velocity.ok() || !audio_velocity.ok())
-            throw std::runtime_error("MiniMax-H3 failed to allocate FirstBlockCache buffers");
-
-        auto resident_head_hidden = std::make_unique<DeviceTensor>(std::move(head_hidden));
-        auto resident_head_residual = std::make_unique<DeviceTensor>(std::move(head_residual));
-        auto resident_previous_head_residual =
-            std::make_unique<DeviceTensor>(std::move(previous_head_residual));
-        auto resident_tail_residual = std::make_unique<DeviceTensor>(std::move(tail_residual));
-        auto resident_video_rows = std::make_unique<DeviceTensor>(std::move(video_rows_device));
-        auto resident_audio_rows = std::make_unique<DeviceTensor>(std::move(audio_rows_device));
-        auto resident_video_velocity = std::make_unique<DeviceTensor>(std::move(video_velocity));
-        auto resident_audio_velocity = std::make_unique<DeviceTensor>(std::move(audio_velocity));
-
-        bind_external_checked(*head, "head_hidden", resident_head_hidden->data(), false,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*head, "head_residual", resident_head_residual->data(), false,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*head, "previous_head_residual",
-                              resident_previous_head_residual->data(), true, DType::kBFloat16,
-                              {kSequenceRows, kHidden});
-        bind_external_checked(*head, "video_hidden_states", resident_video_rows->data(), true,
-                              DType::kFloat32, {kVideoRows, kPatchDim});
-        bind_external_checked(*head, "audio_hidden_states", resident_audio_rows->data(), true,
-                              DType::kFloat32, {kAudioRows, kAudioChannels});
-        bind_external_checked(*tail, "head_hidden", resident_head_hidden->data(), true,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*tail, "tail_residual", resident_tail_residual->data(), false,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*finish, "head_hidden", resident_head_hidden->data(), true,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*finish, "tail_residual", resident_tail_residual->data(), true,
-                              DType::kBFloat16, {kSequenceRows, kHidden});
-        bind_external_checked(*finish, "video_velocity", resident_video_velocity->data(), false,
-                              DType::kFloat32, {kVideoRows, kPatchDim});
-        bind_external_checked(*finish, "audio_velocity", resident_audio_velocity->data(), false,
-                              DType::kFloat32, {kAudioRows, kAudioChannels});
-
-        resident_->denoiser_head = std::move(head);
-        resident_->denoiser_tail = std::move(tail);
-        resident_->denoiser_finish = std::move(finish);
-        resident_->head_hidden = std::move(resident_head_hidden);
-        resident_->head_residual = std::move(resident_head_residual);
-        resident_->previous_head_residual = std::move(resident_previous_head_residual);
-        resident_->tail_residual = std::move(resident_tail_residual);
-        resident_->video_rows = std::move(resident_video_rows);
-        resident_->audio_rows = std::move(resident_audio_rows);
-        resident_->video_velocity = std::move(resident_video_velocity);
-        resident_->audio_velocity = std::move(resident_audio_velocity);
-    } else if (!first_block_cache_ && !resident_->denoiser) {
-        resident_->denoiser = loader_("denoiser_plan", stream_);
-        resident_->denoiser->set_timing_label("denoiser_plan");
-    }
-    int32_t full_denoiser_steps = 0;
-    int32_t skipped_denoiser_steps = 0;
-    if (first_block_cache_) {
-        auto& head = *resident_->denoiser_head;
-        auto& tail = *resident_->denoiser_tail;
-        auto& finish = *resident_->denoiser_finish;
-        head.reset_execution_context();
-        tail.reset_execution_context();
-        finish.reset_execution_context();
-        if (cudaMemsetAsync(resident_->previous_head_residual->data(), 0,
-                            resident_->previous_head_residual->nbytes(), stream_) != cudaSuccess)
-            throw std::runtime_error("MiniMax-H3 failed to reset FirstBlockCache state");
-        if (!resident_->video_rows->copy_from_host(video_rows.data()) ||
-            !resident_->audio_rows->copy_from_host(audio_rows.data()))
-            throw std::runtime_error("MiniMax-H3 failed to upload FirstBlockCache latents");
-
-        for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
-            auto& modulation = resident_->modulations[step];
-            TensorMap head_inputs;
-            head_inputs.emplace(
-                "encoder_hidden_states",
-                Tensor{resident_->text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
-            head_inputs.emplace(
-                "position_ids",
-                Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
-            head_inputs.emplace(
-                "adaln_indices",
-                Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
-            append_block_modulation_inputs(head_inputs, modulation, 0, 1);
-            const auto head_outputs = head.forward(head_inputs);
-            const float metric =
-                copy_float(require_output(head_outputs, "cache_metric"), 1, "cache metric")[0];
-            const bool compute_tail =
-                step == 0 || !std::isfinite(metric) || metric > cache_threshold_;
-
-            if (compute_tail) {
-                TensorMap tail_inputs;
-                tail_inputs.emplace(
-                    "position_ids",
-                    Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
-                tail_inputs.emplace(
-                    "adaln_indices",
-                    Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
-                append_block_modulation_inputs(tail_inputs, modulation, 1, kLayers);
-                tail.forward_async(tail_inputs);
-                if (!resident_->previous_head_residual->copy_from(*resident_->head_residual))
-                    throw std::runtime_error("MiniMax-H3 failed to update FirstBlockCache state");
-                ++full_denoiser_steps;
-            } else {
-                ++skipped_denoiser_steps;
-            }
-
-            TensorMap finish_inputs;
-            finish_inputs.emplace(
-                "timestep_indices",
-                Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
-            append_final_modulation_input(finish_inputs, modulation);
-            finish.forward_async(finish_inputs);
-            minimax_h3::scheduler_step_cuda_async(
-                static_cast<float*>(resident_->video_rows->data()),
-                static_cast<const float*>(resident_->video_velocity->data()), video_rows.size(),
-                video_schedule.timesteps[step], video_schedule.sigmas[step],
-                video_schedule.sigmas[step + 1], stream_);
-            minimax_h3::scheduler_step_cuda_async(
-                static_cast<float*>(resident_->audio_rows->data()),
-                static_cast<const float*>(resident_->audio_velocity->data()), audio_rows.size(),
-                audio_schedule.timesteps[step], audio_schedule.sigmas[step],
-                audio_schedule.sigmas[step + 1], stream_);
-            std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
-                      << video_schedule.timesteps.size() << " cache_metric=" << metric
-                      << " compute_tail=" << (compute_tail ? 1 : 0) << '\n';
-        }
-        finish.sync();
-    } else {
-        auto& module = *resident_->denoiser;
-        module.reset_execution_context();
-        for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
-            TensorMap inputs;
-            inputs.emplace("video_hidden_states",
-                           Tensor{video_rows.data(), {kVideoRows, kPatchDim}, DType::kFloat32});
-            inputs.emplace(
-                "audio_hidden_states",
-                Tensor{audio_rows.data(), {kAudioRows, kAudioChannels}, DType::kFloat32});
-            inputs.emplace(
-                "encoder_hidden_states",
-                Tensor{resident_->text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
-            inputs.emplace("position_ids",
-                           Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
-            inputs.emplace("adaln_indices",
-                           Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
-            inputs.emplace(
-                "timestep_indices",
-                Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
-            append_modulation_inputs(inputs, resident_->modulations[step]);
-            const auto outputs = module.forward(inputs);
-            auto video_all =
-                copy_float(require_output(outputs, "video_velocity"),
-                           static_cast<std::size_t>(kSequenceRows) * kPatchDim, "video velocity");
-            auto audio_all = copy_float(require_output(outputs, "audio_velocity"),
-                                        static_cast<std::size_t>(kSequenceRows) * kAudioChannels,
-                                        "audio velocity");
-            const auto video_begin =
-                video_all.begin() + static_cast<std::ptrdiff_t>(kTextRows + kAudioRows) * kPatchDim;
-            std::vector<float> video_velocity(video_begin, video_begin + video_rows.size());
-            const auto audio_begin =
-                audio_all.begin() + static_cast<std::ptrdiff_t>(kTextRows) * kAudioChannels;
-            std::vector<float> audio_velocity(audio_begin, audio_begin + audio_rows.size());
-            minimax_h3_scheduler_step(video_rows.data(), video_velocity.data(), video_rows.size(),
-                                      video_schedule.timesteps[step], video_schedule.sigmas[step],
-                                      video_schedule.sigmas[step + 1]);
-            minimax_h3_scheduler_step(audio_rows.data(), audio_velocity.data(), audio_rows.size(),
-                                      audio_schedule.timesteps[step], audio_schedule.sigmas[step],
-                                      audio_schedule.sigmas[step + 1]);
-            ++full_denoiser_steps;
-            std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
-                      << video_schedule.timesteps.size() << '\n';
-        }
-        module.sync();
-    }
+        resident_->prepare_denoiser(loader_, stream_, first_block_cache_);
+    const DenoiserStats denoiser_stats =
+        resident_->run_denoiser(first_block_cache_, metadata, video_schedule, audio_schedule,
+                                video_rows, audio_rows, cache_threshold_, stream_);
     const auto denoiser_end = Clock::now();
     audio_rows.clear();
     audio_rows.shrink_to_fit();
@@ -917,110 +1135,9 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
     video_rows.shrink_to_fit();
     const std::size_t expected_pixels =
         static_cast<std::size_t>(3) * kOutputFrames * kOutputHeight * kOutputWidth;
-    std::vector<float> pixels;
     const auto vae_begin = Clock::now();
-    const bool vae_resident_hit =
-        first_block_cache_
-            ? resident_->vae != nullptr && resident_->vae_latent_tiles != nullptr &&
-                  resident_->vae_latent_tiles->ok() && resident_->vae_decoded_tiles != nullptr &&
-                  resident_->vae_decoded_tiles->ok() && resident_->vae_overlap != nullptr &&
-                  resident_->vae_overlap->ok() && resident_->frame_major_rgb != nullptr &&
-                  resident_->frame_major_rgb->ok()
-            : resident_->vae != nullptr;
-    if (first_block_cache_) {
-        if (!vae_resident_hit) {
-            auto module = loader_("vae_tile_decoder_plan", stream_);
-            module->set_timing_label("vae_tile_decoder_plan");
-            DeviceTensor latent_tiles(
-                {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize},
-                DType::kFloat32, stream_);
-            DeviceTensor decoded_tiles({kTileBatch, 3, kTileFrames, kTileSize, kTileSize},
-                                       DType::kFloat32, stream_);
-            DeviceTensor overlap({3, 5, kOutputHeight, kOutputWidth}, DType::kFloat32, stream_);
-            DeviceTensor frame_major_rgb({kOutputFrames, kOutputHeight, kOutputWidth, 3},
-                                         DType::kFloat32, stream_);
-            if (!latent_tiles.ok() || !decoded_tiles.ok() || !overlap.ok() || !frame_major_rgb.ok())
-                throw std::runtime_error("MiniMax-H3 failed to allocate CUDA VAE buffers");
-
-            auto resident_latent_tiles = std::make_unique<DeviceTensor>(std::move(latent_tiles));
-            auto resident_decoded_tiles = std::make_unique<DeviceTensor>(std::move(decoded_tiles));
-            auto resident_overlap = std::make_unique<DeviceTensor>(std::move(overlap));
-            auto resident_frame_major_rgb =
-                std::make_unique<DeviceTensor>(std::move(frame_major_rgb));
-            bind_external_checked(
-                *module, "latent_tiles", resident_latent_tiles->data(), true, DType::kFloat32,
-                {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize});
-            bind_external_checked(*module, "decoded_tiles", resident_decoded_tiles->data(), false,
-                                  DType::kFloat32,
-                                  {kTileBatch, 3, kTileFrames, kTileSize, kTileSize});
-
-            resident_->vae = std::move(module);
-            resident_->vae_latent_tiles = std::move(resident_latent_tiles);
-            resident_->vae_decoded_tiles = std::move(resident_decoded_tiles);
-            resident_->vae_overlap = std::move(resident_overlap);
-            resident_->frame_major_rgb = std::move(resident_frame_major_rgb);
-        }
-
-        auto& module = *resident_->vae;
-        module.reset_execution_context();
-        const auto latent_normalization = vae_latent_normalization();
-        const auto pixel_normalization = vae_pixel_normalization();
-        TensorMap no_inputs;
-        for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
-            minimax_h3::extract_vae_tiles_cuda_async(
-                static_cast<const float*>(resident_->video_rows->data()),
-                static_cast<float*>(resident_->vae_latent_tiles->data()), clip_index,
-                latent_normalization, stream_);
-            module.forward_async(no_inputs);
-            minimax_h3::assemble_vae_clip_cuda_async(
-                static_cast<const float*>(resident_->vae_decoded_tiles->data()),
-                static_cast<float*>(resident_->vae_overlap->data()),
-                static_cast<float*>(resident_->frame_major_rgb->data()), clip_index,
-                pixel_normalization, stream_);
-            std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
-        }
-        module.sync();
-        pixels.resize(expected_pixels);
-        if (!resident_->frame_major_rgb->copy_to_host(pixels.data()))
-            throw std::runtime_error("MiniMax-H3 failed to download CUDA VAE output");
-    } else {
-        if (!resident_->vae) {
-            resident_->vae = loader_("vae_tile_decoder_plan", stream_);
-            resident_->vae->set_timing_label("vae_tile_decoder_plan");
-        }
-        std::vector<float> video(expected_pixels);
-        std::size_t decoded_frames = 0;
-        std::vector<float> overlap;
-        std::vector<float> clip;
-        auto& module = *resident_->vae;
-        module.reset_execution_context();
-        constexpr std::size_t output_count =
-            static_cast<std::size_t>(kTileBatch) * 3 * kTileFrames * kTileSize * kTileSize;
-        for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
-            auto latent_tiles = extract_tiles(latent, clip_index);
-            TensorMap inputs;
-            inputs.emplace("latent_tiles", Tensor{latent_tiles.data(),
-                                                  {kTileBatch, kLatentChannels, kTileInputFrames,
-                                                   kTileLatentSize, kTileLatentSize},
-                                                  DType::kFloat32});
-            const auto outputs = module.forward(inputs);
-            const Tensor decoded_tiles = require_output(outputs, "decoded_tiles");
-            if (decoded_tiles.numel() != output_count)
-                throw std::runtime_error("MiniMax-H3 invalid VAE decoded tiles output");
-            stitch_spatial_tiles(decoded_tiles, clip);
-            write_temporal_chunk(video, decoded_frames, clip, overlap);
-            decoded_frames += 17;
-            update_trailing_overlap(clip, overlap);
-            std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
-        }
-        module.sync();
-        write_final_overlap(video, decoded_frames, overlap);
-        decoded_frames += 5;
-        if (video.size() != expected_pixels || decoded_frames != kOutputFrames)
-            throw std::runtime_error("MiniMax-H3 VAE produced the wrong video geometry");
-        postprocess_video(video);
-        pixels = to_frame_major_rgb(video);
-    }
+    const bool vae_resident_hit = resident_->prepare_vae(loader_, stream_, first_block_cache_);
+    auto pixels = resident_->decode_vae(first_block_cache_, latent, expected_pixels, stream_);
     const auto vae_end = Clock::now();
     latent.clear();
     latent.shrink_to_fit();
@@ -1032,14 +1149,14 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
               << " denoiser_ms=" << milliseconds(denoiser_begin, denoiser_end)
               << " vae_decoder_ms=" << milliseconds(vae_begin, vae_end)
               << " total_ms=" << milliseconds(total_begin, total_end)
-              << " text_cache_hit=" << (text_cache_hit ? 1 : 0)
-              << " adaln_cache_hit=" << (adaln_cache_hit ? 1 : 0)
-              << " denoiser_resident_hit=" << (denoiser_resident_hit ? 1 : 0)
-              << " vae_resident_hit=" << (vae_resident_hit ? 1 : 0)
-              << " first_block_cache=" << (first_block_cache_ ? 1 : 0)
+              << " text_cache_hit=" << static_cast<int>(text_cache_hit)
+              << " adaln_cache_hit=" << static_cast<int>(adaln_cache_hit)
+              << " denoiser_resident_hit=" << static_cast<int>(denoiser_resident_hit)
+              << " vae_resident_hit=" << static_cast<int>(vae_resident_hit)
+              << " first_block_cache=" << static_cast<int>(first_block_cache_)
               << " cache_threshold=" << cache_threshold_
-              << " full_denoiser_steps=" << full_denoiser_steps
-              << " skipped_denoiser_steps=" << skipped_denoiser_steps << '\n';
+              << " full_denoiser_steps=" << denoiser_stats.full_steps
+              << " skipped_denoiser_steps=" << denoiser_stats.skipped_steps << '\n';
     ImageResult result;
     result.height = kOutputHeight;
     result.width = kOutputWidth;

--- a/src/runtime/models/minimax_h3/pipeline.cpp
+++ b/src/runtime/models/minimax_h3/pipeline.cpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -79,6 +80,20 @@ constexpr std::array<float, 3> kPixelStd = {0.229F, 0.224F, 0.225F};
 constexpr std::size_t kVideoLatentCount =
     static_cast<std::size_t>(kLatentChannels) * kLatentFrames * kLatentHeight * kLatentWidth;
 constexpr std::size_t kAudioCount = static_cast<std::size_t>(kAudioRows) * kAudioChannels;
+
+minimax_h3::VaeLatentNormalization vae_latent_normalization() {
+    minimax_h3::VaeLatentNormalization result{};
+    std::copy(kLatentMean.begin(), kLatentMean.end(), result.mean);
+    std::copy(kLatentStd.begin(), kLatentStd.end(), result.std);
+    return result;
+}
+
+minimax_h3::VaePixelNormalization vae_pixel_normalization() {
+    minimax_h3::VaePixelNormalization result{};
+    std::copy(kPixelMean.begin(), kPixelMean.end(), result.mean);
+    std::copy(kPixelStd.begin(), kPixelStd.end(), result.std);
+    return result;
+}
 
 struct RawTensor {
     std::vector<std::byte> bytes;
@@ -307,6 +322,32 @@ void append_modulation_inputs(TensorMap& inputs, StepModulation& modulation) {
                                               modulation.final.dtype});
 }
 
+void append_block_modulation_inputs(TensorMap& inputs, StepModulation& modulation,
+                                    int32_t first_layer, int32_t end_layer) {
+    for (int32_t layer = first_layer; layer < end_layer; ++layer) {
+        const std::string name = "block_modulation_" + std::to_string(layer);
+        auto& value = modulation.blocks[layer];
+        inputs.emplace(name, Tensor{value.bytes.data(), value.shape, value.dtype});
+    }
+}
+
+void append_final_modulation_input(TensorMap& inputs, StepModulation& modulation) {
+    inputs.emplace("final_modulation", Tensor{modulation.final.bytes.data(), modulation.final.shape,
+                                              modulation.final.dtype});
+}
+
+void bind_external_checked(ITrtModule& module, const char* name, void* pointer, bool is_input,
+                           DType dtype, std::initializer_list<int64_t> shape) {
+    const bool direction_matches = is_input ? module.has_input(name) : module.has_output(name);
+    const std::vector<int64_t> expected_shape(shape);
+    if (pointer == nullptr || !direction_matches || module.tensor_dtype(name) != dtype ||
+        module.tensor_shape(name) != expected_shape)
+        throw std::runtime_error(std::string("MiniMax-H3 split plan ABI mismatch for ") + name);
+    module.bind_external(name, pointer);
+    if (module.device_ptr(name) != pointer)
+        throw std::runtime_error(std::string("MiniMax-H3 external binding failed for ") + name);
+}
+
 void denormalize_latents(std::vector<float>& latent) {
     const std::size_t per_channel =
         static_cast<std::size_t>(kLatentFrames) * kLatentHeight * kLatentWidth;
@@ -352,9 +393,8 @@ std::vector<float> extract_tiles(const std::vector<float>& latent, int32_t clip)
     return result;
 }
 
-void stitch_one_spatial_tile(const std::vector<float>& tiles, std::vector<float>& clip,
-                             int32_t tile_y, int32_t tile_x, int32_t kept_height,
-                             int32_t kept_width) {
+void stitch_one_spatial_tile(const float* tiles, std::vector<float>& clip, int32_t tile_y,
+                             int32_t tile_x, int32_t kept_height, int32_t kept_width) {
     const int32_t tile = tile_y * 7 + tile_x;
     const auto tile_value = [&](int32_t source_tile, int32_t channel, int32_t frame, int32_t y,
                                 int32_t x) {
@@ -397,93 +437,83 @@ void stitch_one_spatial_tile(const std::vector<float>& tiles, std::vector<float>
     }
 }
 
-std::vector<float> stitch_spatial_tiles(const std::vector<float>& tiles) {
+void stitch_spatial_tiles(const Tensor& tiles, std::vector<float>& clip) {
     const std::size_t one_tile = static_cast<std::size_t>(3) * kTileFrames * kTileSize * kTileSize;
-    if (tiles.size() != static_cast<std::size_t>(kTileCount) * one_tile)
+    if (tiles.dtype != DType::kFloat32 || tiles.data == nullptr ||
+        tiles.numel() != static_cast<std::size_t>(kTileCount) * one_tile)
         throw std::runtime_error("MiniMax-H3 decoded VAE tile count is invalid");
-    std::vector<float> clip(static_cast<std::size_t>(3) * kTileFrames * kOutputHeight *
-                            kOutputWidth);
+    const auto* values = static_cast<const float*>(tiles.data);
+    clip.resize(static_cast<std::size_t>(3) * kTileFrames * kOutputHeight * kOutputWidth);
     for (int32_t tile_y = 0; tile_y < 4; ++tile_y) {
         const int32_t kept_height =
             tile_y < 3 ? kTileSize - kTileHeightOverlaps[tile_y] : kTileSize;
         for (int32_t tile_x = 0; tile_x < 7; ++tile_x) {
             const int32_t kept_width =
                 tile_x < 6 ? kTileSize - kTileWidthOverlaps[tile_x] : kTileSize;
-            stitch_one_spatial_tile(tiles, clip, tile_y, tile_x, kept_height, kept_width);
+            stitch_one_spatial_tile(values, clip, tile_y, tile_x, kept_height, kept_width);
         }
     }
-    return clip;
 }
 
-void append_temporal_chunk(std::vector<float>& video, const std::vector<float>& clip,
-                           const std::vector<float>& previous_overlap) {
+void write_temporal_chunk(std::vector<float>& video, std::size_t old_frames,
+                          const std::vector<float>& clip,
+                          const std::vector<float>& previous_overlap) {
     constexpr int32_t chunk_frames = 17;
     constexpr int32_t pre_padding = 3;
     constexpr int32_t overlap_frames = 5;
     const std::size_t plane = static_cast<std::size_t>(kOutputHeight) * kOutputWidth;
-    const std::size_t old_frames = video.size() / (3 * plane);
-    std::vector<float> expanded(static_cast<std::size_t>(3) * (old_frames + chunk_frames) * plane);
+    if (video.size() != static_cast<std::size_t>(3) * kOutputFrames * plane ||
+        old_frames + chunk_frames > kOutputFrames)
+        throw std::invalid_argument("MiniMax-H3 temporal output buffer is invalid");
     for (int32_t channel = 0; channel < 3; ++channel) {
-        if (old_frames > 0) {
-            std::copy_n(video.begin() + static_cast<std::ptrdiff_t>(channel * old_frames * plane),
-                        old_frames * plane,
-                        expanded.begin() + static_cast<std::ptrdiff_t>(
-                                               channel * (old_frames + chunk_frames) * plane));
-        }
         for (int32_t frame = 0; frame < chunk_frames; ++frame) {
             const auto source =
                 (static_cast<std::size_t>(channel) * kTileFrames + pre_padding + frame) * plane;
-            const auto target = (static_cast<std::size_t>(channel) * (old_frames + chunk_frames) +
-                                 old_frames + frame) *
+            const auto target = (static_cast<std::size_t>(channel) * kOutputFrames + old_frames +
+                                 static_cast<std::size_t>(frame)) *
                                 plane;
             if (!previous_overlap.empty() && frame < overlap_frames) {
                 const float weight_b = static_cast<float>(frame) / overlap_frames;
                 const auto prior =
                     (static_cast<std::size_t>(channel) * overlap_frames + frame) * plane;
                 for (std::size_t pixel = 0; pixel < plane; ++pixel)
-                    expanded[target + pixel] = previous_overlap[prior + pixel] * (1.0F - weight_b) +
-                                               clip[source + pixel] * weight_b;
+                    video[target + pixel] = previous_overlap[prior + pixel] * (1.0F - weight_b) +
+                                            clip[source + pixel] * weight_b;
             } else {
                 std::copy_n(clip.begin() + static_cast<std::ptrdiff_t>(source), plane,
-                            expanded.begin() + static_cast<std::ptrdiff_t>(target));
+                            video.begin() + static_cast<std::ptrdiff_t>(target));
             }
         }
     }
-    video.swap(expanded);
 }
 
-std::vector<float> trailing_overlap(const std::vector<float>& clip) {
+void update_trailing_overlap(const std::vector<float>& clip, std::vector<float>& result) {
     constexpr int32_t overlap_frames = 5;
     constexpr int32_t start = 23;
     const std::size_t plane = static_cast<std::size_t>(kOutputHeight) * kOutputWidth;
-    std::vector<float> result(static_cast<std::size_t>(3) * overlap_frames * plane);
+    result.resize(static_cast<std::size_t>(3) * overlap_frames * plane);
     for (int32_t channel = 0; channel < 3; ++channel) {
         const auto source = (static_cast<std::size_t>(channel) * kTileFrames + start) * plane;
         const auto target = static_cast<std::size_t>(channel) * overlap_frames * plane;
         std::copy_n(clip.begin() + static_cast<std::ptrdiff_t>(source), overlap_frames * plane,
                     result.begin() + static_cast<std::ptrdiff_t>(target));
     }
-    return result;
 }
 
-void append_final_overlap(std::vector<float>& video, const std::vector<float>& overlap) {
+void write_final_overlap(std::vector<float>& video, std::size_t old_frames,
+                         const std::vector<float>& overlap) {
     constexpr int32_t overlap_frames = 5;
     const std::size_t plane = static_cast<std::size_t>(kOutputHeight) * kOutputWidth;
-    const std::size_t old_frames = video.size() / (3 * plane);
-    std::vector<float> expanded(static_cast<std::size_t>(3) * (old_frames + overlap_frames) *
-                                plane);
+    if (video.size() != static_cast<std::size_t>(3) * kOutputFrames * plane ||
+        old_frames + overlap_frames != kOutputFrames ||
+        overlap.size() != static_cast<std::size_t>(3) * overlap_frames * plane)
+        throw std::invalid_argument("MiniMax-H3 final temporal overlap is invalid");
     for (int32_t channel = 0; channel < 3; ++channel) {
-        std::copy_n(video.begin() + static_cast<std::ptrdiff_t>(channel * old_frames * plane),
-                    old_frames * plane,
-                    expanded.begin() + static_cast<std::ptrdiff_t>(
-                                           channel * (old_frames + overlap_frames) * plane));
         std::copy_n(overlap.begin() + static_cast<std::ptrdiff_t>(channel * overlap_frames * plane),
                     overlap_frames * plane,
-                    expanded.begin() +
-                        static_cast<std::ptrdiff_t>(
-                            (channel * (old_frames + overlap_frames) + old_frames) * plane));
+                    video.begin() + static_cast<std::ptrdiff_t>(
+                                        (channel * kOutputFrames + old_frames) * plane));
     }
-    video.swap(expanded);
 }
 
 void postprocess_video(std::vector<float>& video) {
@@ -524,6 +554,29 @@ void validate_generate_config(const GenerateConfig& cfg) {
 
 } // namespace
 
+struct MiniMaxH3Pipeline::ResidentState {
+    std::string prompt;
+    std::vector<float> text_embeddings;
+    std::vector<StepModulation> modulations;
+    std::unique_ptr<DeviceTensor> head_hidden;
+    std::unique_ptr<DeviceTensor> head_residual;
+    std::unique_ptr<DeviceTensor> previous_head_residual;
+    std::unique_ptr<DeviceTensor> tail_residual;
+    std::unique_ptr<DeviceTensor> video_rows;
+    std::unique_ptr<DeviceTensor> audio_rows;
+    std::unique_ptr<DeviceTensor> video_velocity;
+    std::unique_ptr<DeviceTensor> audio_velocity;
+    std::unique_ptr<DeviceTensor> vae_latent_tiles;
+    std::unique_ptr<DeviceTensor> vae_decoded_tiles;
+    std::unique_ptr<DeviceTensor> vae_overlap;
+    std::unique_ptr<DeviceTensor> frame_major_rgb;
+    std::unique_ptr<ITrtModule> denoiser;
+    std::unique_ptr<ITrtModule> denoiser_head;
+    std::unique_ptr<ITrtModule> denoiser_tail;
+    std::unique_ptr<ITrtModule> denoiser_finish;
+    std::unique_ptr<ITrtModule> vae;
+};
+
 MiniMaxH3Schedule make_minimax_h3_schedule(int32_t grid_points, float shift) {
     if (grid_points < 2 || shift <= 0.0F)
         throw std::invalid_argument("MiniMax-H3 schedule arguments are invalid");
@@ -556,15 +609,21 @@ void minimax_h3_scheduler_step(float* sample, const float* velocity, std::size_t
 }
 
 MiniMaxH3Pipeline::MiniMaxH3Pipeline(MiniMaxH3ModuleLoader loader,
-                                     std::unique_ptr<ITokenizer> tokenizer, std::string model_id)
-    : loader_(std::move(loader)), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id)) {
+                                     std::unique_ptr<ITokenizer> tokenizer, std::string model_id,
+                                     bool first_block_cache, float cache_threshold)
+    : loader_(std::move(loader)), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id)),
+      resident_(std::make_unique<ResidentState>()), first_block_cache_(first_block_cache),
+      cache_threshold_(cache_threshold) {
     if (!loader_ || !tokenizer_)
         throw std::invalid_argument("MiniMax-H3 pipeline requires a loader and tokenizer");
+    if (!std::isfinite(cache_threshold_) || cache_threshold_ <= 0.0F)
+        throw std::invalid_argument("MiniMax-H3 cache threshold must be finite and positive");
     if (cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking) != cudaSuccess)
         throw std::runtime_error("MiniMax-H3 failed to create its CUDA stream");
 }
 
 MiniMaxH3Pipeline::~MiniMaxH3Pipeline() {
+    resident_.reset();
     if (stream_ != nullptr)
         cudaStreamDestroy(stream_);
 }
@@ -576,33 +635,58 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
     const int64_t seed = cfg.seed >= 0 ? cfg.seed : 0;
     const auto total_begin = Clock::now();
 
-    const auto ids = tokenizer_->encode(prompt);
-    if (ids.size() != kTextRows)
-        throw std::invalid_argument(
-            "MiniMax-H3 GB300 profile requires exactly 537 prompt tokens; got " +
-            std::to_string(ids.size()));
-    std::vector<float> text_embeddings;
+    const bool text_cache_hit = resident_->prompt == prompt && !resident_->text_embeddings.empty();
     const auto text_begin = Clock::now();
-    {
+    if (!text_cache_hit) {
+        // The text encoder is the largest plan. Drop resident execution modules
+        // before loading it so prompt changes retain the previous peak-memory
+        // behavior on smaller devices.
+        resident_->denoiser.reset();
+        resident_->denoiser_head.reset();
+        resident_->denoiser_tail.reset();
+        resident_->denoiser_finish.reset();
+        resident_->head_hidden.reset();
+        resident_->head_residual.reset();
+        resident_->previous_head_residual.reset();
+        resident_->tail_residual.reset();
+        resident_->video_rows.reset();
+        resident_->audio_rows.reset();
+        resident_->video_velocity.reset();
+        resident_->audio_velocity.reset();
+        resident_->vae.reset();
+        resident_->vae_latent_tiles.reset();
+        resident_->vae_decoded_tiles.reset();
+        resident_->vae_overlap.reset();
+        resident_->frame_major_rgb.reset();
+        resident_->prompt.clear();
+        resident_->text_embeddings.clear();
+        const auto ids = tokenizer_->encode(prompt);
+        if (ids.size() != kTextRows)
+            throw std::invalid_argument(
+                "MiniMax-H3 GB300 profile requires exactly 537 prompt tokens; got " +
+                std::to_string(ids.size()));
         auto module = loader_("text_encoder_plan", stream_);
+        module->set_timing_label("text_encoder_plan");
         TensorMap inputs;
         inputs.emplace("input_ids",
                        Tensor{const_cast<int32_t*>(ids.data()), {kTextRows}, DType::kInt32});
         const auto outputs = module->forward(inputs);
-        text_embeddings =
+        resident_->text_embeddings =
             copy_float(require_output(outputs, "encoder_hidden_states"),
                        static_cast<std::size_t>(kTextRows) * kTextDim, "text encoder");
         module->sync();
+        resident_->prompt = prompt;
     }
     const auto text_end = Clock::now();
 
     const auto video_schedule = make_minimax_h3_schedule(kSteps, 12.0F);
     const auto audio_schedule = make_minimax_h3_schedule(kSteps, 3.0F);
-    std::vector<StepModulation> modulations;
+    const bool adaln_cache_hit = !resident_->modulations.empty();
     const auto adaln_begin = Clock::now();
-    {
+    if (!adaln_cache_hit) {
         auto module = loader_("adaln_precompute_plan", stream_);
-        modulations = precompute_modulations(*module, video_schedule, audio_schedule);
+        module->set_timing_label("adaln_precompute_plan");
+        resident_->modulations = precompute_modulations(*module, video_schedule, audio_schedule);
         module->sync();
     }
     const auto adaln_end = Clock::now();
@@ -618,8 +702,165 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
     auto metadata = make_denoiser_metadata();
 
     const auto denoiser_begin = Clock::now();
-    {
-        auto module = loader_("denoiser_plan", stream_);
+    const bool denoiser_resident_hit =
+        first_block_cache_
+            ? resident_->denoiser_head != nullptr && resident_->denoiser_tail != nullptr &&
+                  resident_->denoiser_finish != nullptr && resident_->head_hidden != nullptr &&
+                  resident_->head_hidden->ok() && resident_->head_residual != nullptr &&
+                  resident_->head_residual->ok() && resident_->previous_head_residual != nullptr &&
+                  resident_->previous_head_residual->ok() && resident_->tail_residual != nullptr &&
+                  resident_->tail_residual->ok() && resident_->video_rows != nullptr &&
+                  resident_->video_rows->ok() && resident_->audio_rows != nullptr &&
+                  resident_->audio_rows->ok() && resident_->video_velocity != nullptr &&
+                  resident_->video_velocity->ok() && resident_->audio_velocity != nullptr &&
+                  resident_->audio_velocity->ok()
+            : resident_->denoiser != nullptr;
+    if (first_block_cache_ && !denoiser_resident_hit) {
+        auto head = loader_("denoiser_head_plan", stream_);
+        auto tail = loader_("denoiser_tail_plan", stream_);
+        auto finish = loader_("denoiser_finish_plan", stream_);
+        head->set_timing_label("denoiser_head_plan");
+        tail->set_timing_label("denoiser_tail_plan");
+        finish->set_timing_label("denoiser_finish_plan");
+
+        DeviceTensor head_hidden({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
+        DeviceTensor head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
+        DeviceTensor previous_head_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
+        DeviceTensor tail_residual({kSequenceRows, kHidden}, DType::kBFloat16, stream_);
+        DeviceTensor video_rows_device({kVideoRows, kPatchDim}, DType::kFloat32, stream_);
+        DeviceTensor audio_rows_device({kAudioRows, kAudioChannels}, DType::kFloat32, stream_);
+        DeviceTensor video_velocity({kVideoRows, kPatchDim}, DType::kFloat32, stream_);
+        DeviceTensor audio_velocity({kAudioRows, kAudioChannels}, DType::kFloat32, stream_);
+        if (!head_hidden.ok() || !head_residual.ok() || !previous_head_residual.ok() ||
+            !tail_residual.ok() || !video_rows_device.ok() || !audio_rows_device.ok() ||
+            !video_velocity.ok() || !audio_velocity.ok())
+            throw std::runtime_error("MiniMax-H3 failed to allocate FirstBlockCache buffers");
+
+        auto resident_head_hidden = std::make_unique<DeviceTensor>(std::move(head_hidden));
+        auto resident_head_residual = std::make_unique<DeviceTensor>(std::move(head_residual));
+        auto resident_previous_head_residual =
+            std::make_unique<DeviceTensor>(std::move(previous_head_residual));
+        auto resident_tail_residual = std::make_unique<DeviceTensor>(std::move(tail_residual));
+        auto resident_video_rows = std::make_unique<DeviceTensor>(std::move(video_rows_device));
+        auto resident_audio_rows = std::make_unique<DeviceTensor>(std::move(audio_rows_device));
+        auto resident_video_velocity = std::make_unique<DeviceTensor>(std::move(video_velocity));
+        auto resident_audio_velocity = std::make_unique<DeviceTensor>(std::move(audio_velocity));
+
+        bind_external_checked(*head, "head_hidden", resident_head_hidden->data(), false,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*head, "head_residual", resident_head_residual->data(), false,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*head, "previous_head_residual",
+                              resident_previous_head_residual->data(), true, DType::kBFloat16,
+                              {kSequenceRows, kHidden});
+        bind_external_checked(*head, "video_hidden_states", resident_video_rows->data(), true,
+                              DType::kFloat32, {kVideoRows, kPatchDim});
+        bind_external_checked(*head, "audio_hidden_states", resident_audio_rows->data(), true,
+                              DType::kFloat32, {kAudioRows, kAudioChannels});
+        bind_external_checked(*tail, "head_hidden", resident_head_hidden->data(), true,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*tail, "tail_residual", resident_tail_residual->data(), false,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*finish, "head_hidden", resident_head_hidden->data(), true,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*finish, "tail_residual", resident_tail_residual->data(), true,
+                              DType::kBFloat16, {kSequenceRows, kHidden});
+        bind_external_checked(*finish, "video_velocity", resident_video_velocity->data(), false,
+                              DType::kFloat32, {kVideoRows, kPatchDim});
+        bind_external_checked(*finish, "audio_velocity", resident_audio_velocity->data(), false,
+                              DType::kFloat32, {kAudioRows, kAudioChannels});
+
+        resident_->denoiser_head = std::move(head);
+        resident_->denoiser_tail = std::move(tail);
+        resident_->denoiser_finish = std::move(finish);
+        resident_->head_hidden = std::move(resident_head_hidden);
+        resident_->head_residual = std::move(resident_head_residual);
+        resident_->previous_head_residual = std::move(resident_previous_head_residual);
+        resident_->tail_residual = std::move(resident_tail_residual);
+        resident_->video_rows = std::move(resident_video_rows);
+        resident_->audio_rows = std::move(resident_audio_rows);
+        resident_->video_velocity = std::move(resident_video_velocity);
+        resident_->audio_velocity = std::move(resident_audio_velocity);
+    } else if (!first_block_cache_ && !resident_->denoiser) {
+        resident_->denoiser = loader_("denoiser_plan", stream_);
+        resident_->denoiser->set_timing_label("denoiser_plan");
+    }
+    int32_t full_denoiser_steps = 0;
+    int32_t skipped_denoiser_steps = 0;
+    if (first_block_cache_) {
+        auto& head = *resident_->denoiser_head;
+        auto& tail = *resident_->denoiser_tail;
+        auto& finish = *resident_->denoiser_finish;
+        head.reset_execution_context();
+        tail.reset_execution_context();
+        finish.reset_execution_context();
+        if (cudaMemsetAsync(resident_->previous_head_residual->data(), 0,
+                            resident_->previous_head_residual->nbytes(), stream_) != cudaSuccess)
+            throw std::runtime_error("MiniMax-H3 failed to reset FirstBlockCache state");
+        if (!resident_->video_rows->copy_from_host(video_rows.data()) ||
+            !resident_->audio_rows->copy_from_host(audio_rows.data()))
+            throw std::runtime_error("MiniMax-H3 failed to upload FirstBlockCache latents");
+
+        for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
+            auto& modulation = resident_->modulations[step];
+            TensorMap head_inputs;
+            head_inputs.emplace(
+                "encoder_hidden_states",
+                Tensor{resident_->text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
+            head_inputs.emplace(
+                "position_ids",
+                Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
+            head_inputs.emplace(
+                "adaln_indices",
+                Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
+            append_block_modulation_inputs(head_inputs, modulation, 0, 1);
+            const auto head_outputs = head.forward(head_inputs);
+            const float metric =
+                copy_float(require_output(head_outputs, "cache_metric"), 1, "cache metric")[0];
+            const bool compute_tail =
+                step == 0 || !std::isfinite(metric) || metric > cache_threshold_;
+
+            if (compute_tail) {
+                TensorMap tail_inputs;
+                tail_inputs.emplace(
+                    "position_ids",
+                    Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
+                tail_inputs.emplace(
+                    "adaln_indices",
+                    Tensor{metadata.adaln_indices.data(), {kSequenceRows}, DType::kInt32});
+                append_block_modulation_inputs(tail_inputs, modulation, 1, kLayers);
+                tail.forward_async(tail_inputs);
+                if (!resident_->previous_head_residual->copy_from(*resident_->head_residual))
+                    throw std::runtime_error("MiniMax-H3 failed to update FirstBlockCache state");
+                ++full_denoiser_steps;
+            } else {
+                ++skipped_denoiser_steps;
+            }
+
+            TensorMap finish_inputs;
+            finish_inputs.emplace(
+                "timestep_indices",
+                Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
+            append_final_modulation_input(finish_inputs, modulation);
+            finish.forward_async(finish_inputs);
+            minimax_h3::scheduler_step_cuda_async(
+                static_cast<float*>(resident_->video_rows->data()),
+                static_cast<const float*>(resident_->video_velocity->data()), video_rows.size(),
+                video_schedule.timesteps[step], video_schedule.sigmas[step],
+                video_schedule.sigmas[step + 1], stream_);
+            minimax_h3::scheduler_step_cuda_async(
+                static_cast<float*>(resident_->audio_rows->data()),
+                static_cast<const float*>(resident_->audio_velocity->data()), audio_rows.size(),
+                audio_schedule.timesteps[step], audio_schedule.sigmas[step],
+                audio_schedule.sigmas[step + 1], stream_);
+            std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
+                      << video_schedule.timesteps.size() << " cache_metric=" << metric
+                      << " compute_tail=" << (compute_tail ? 1 : 0) << '\n';
+        }
+        finish.sync();
+    } else {
+        auto& module = *resident_->denoiser;
+        module.reset_execution_context();
         for (std::size_t step = 0; step < video_schedule.timesteps.size(); ++step) {
             TensorMap inputs;
             inputs.emplace("video_hidden_states",
@@ -627,8 +868,9 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
             inputs.emplace(
                 "audio_hidden_states",
                 Tensor{audio_rows.data(), {kAudioRows, kAudioChannels}, DType::kFloat32});
-            inputs.emplace("encoder_hidden_states",
-                           Tensor{text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
+            inputs.emplace(
+                "encoder_hidden_states",
+                Tensor{resident_->text_embeddings.data(), {kTextRows, kTextDim}, DType::kFloat32});
             inputs.emplace("position_ids",
                            Tensor{metadata.positions.data(), {kSequenceRows, 3}, DType::kFloat32});
             inputs.emplace("adaln_indices",
@@ -636,8 +878,8 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
             inputs.emplace(
                 "timestep_indices",
                 Tensor{metadata.timestep_indices.data(), {kSequenceRows}, DType::kInt32});
-            append_modulation_inputs(inputs, modulations[step]);
-            const auto outputs = module->forward(inputs);
+            append_modulation_inputs(inputs, resident_->modulations[step]);
+            const auto outputs = module.forward(inputs);
             auto video_all =
                 copy_float(require_output(outputs, "video_velocity"),
                            static_cast<std::size_t>(kSequenceRows) * kPatchDim, "video velocity");
@@ -656,28 +898,102 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
             minimax_h3_scheduler_step(audio_rows.data(), audio_velocity.data(), audio_rows.size(),
                                       audio_schedule.timesteps[step], audio_schedule.sigmas[step],
                                       audio_schedule.sigmas[step + 1]);
+            ++full_denoiser_steps;
             std::cerr << "[minimax-h3] denoiser " << (step + 1) << '/'
                       << video_schedule.timesteps.size() << '\n';
         }
-        module->sync();
+        module.sync();
     }
     const auto denoiser_end = Clock::now();
-    modulations.clear();
-    modulations.shrink_to_fit();
-    text_embeddings.clear();
-    text_embeddings.shrink_to_fit();
     audio_rows.clear();
     audio_rows.shrink_to_fit();
 
-    auto latent = unpatchify_video(video_rows);
+    std::vector<float> latent;
+    if (!first_block_cache_) {
+        latent = unpatchify_video(video_rows);
+        denormalize_latents(latent);
+    }
     video_rows.clear();
     video_rows.shrink_to_fit();
-    denormalize_latents(latent);
-    std::vector<float> video;
-    std::vector<float> overlap;
+    const std::size_t expected_pixels =
+        static_cast<std::size_t>(3) * kOutputFrames * kOutputHeight * kOutputWidth;
+    std::vector<float> pixels;
     const auto vae_begin = Clock::now();
-    {
-        auto module = loader_("vae_tile_decoder_plan", stream_);
+    const bool vae_resident_hit =
+        first_block_cache_
+            ? resident_->vae != nullptr && resident_->vae_latent_tiles != nullptr &&
+                  resident_->vae_latent_tiles->ok() && resident_->vae_decoded_tiles != nullptr &&
+                  resident_->vae_decoded_tiles->ok() && resident_->vae_overlap != nullptr &&
+                  resident_->vae_overlap->ok() && resident_->frame_major_rgb != nullptr &&
+                  resident_->frame_major_rgb->ok()
+            : resident_->vae != nullptr;
+    if (first_block_cache_) {
+        if (!vae_resident_hit) {
+            auto module = loader_("vae_tile_decoder_plan", stream_);
+            module->set_timing_label("vae_tile_decoder_plan");
+            DeviceTensor latent_tiles(
+                {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize},
+                DType::kFloat32, stream_);
+            DeviceTensor decoded_tiles({kTileBatch, 3, kTileFrames, kTileSize, kTileSize},
+                                       DType::kFloat32, stream_);
+            DeviceTensor overlap({3, 5, kOutputHeight, kOutputWidth}, DType::kFloat32, stream_);
+            DeviceTensor frame_major_rgb({kOutputFrames, kOutputHeight, kOutputWidth, 3},
+                                         DType::kFloat32, stream_);
+            if (!latent_tiles.ok() || !decoded_tiles.ok() || !overlap.ok() || !frame_major_rgb.ok())
+                throw std::runtime_error("MiniMax-H3 failed to allocate CUDA VAE buffers");
+
+            auto resident_latent_tiles = std::make_unique<DeviceTensor>(std::move(latent_tiles));
+            auto resident_decoded_tiles = std::make_unique<DeviceTensor>(std::move(decoded_tiles));
+            auto resident_overlap = std::make_unique<DeviceTensor>(std::move(overlap));
+            auto resident_frame_major_rgb =
+                std::make_unique<DeviceTensor>(std::move(frame_major_rgb));
+            bind_external_checked(
+                *module, "latent_tiles", resident_latent_tiles->data(), true, DType::kFloat32,
+                {kTileBatch, kLatentChannels, kTileInputFrames, kTileLatentSize, kTileLatentSize});
+            bind_external_checked(*module, "decoded_tiles", resident_decoded_tiles->data(), false,
+                                  DType::kFloat32,
+                                  {kTileBatch, 3, kTileFrames, kTileSize, kTileSize});
+
+            resident_->vae = std::move(module);
+            resident_->vae_latent_tiles = std::move(resident_latent_tiles);
+            resident_->vae_decoded_tiles = std::move(resident_decoded_tiles);
+            resident_->vae_overlap = std::move(resident_overlap);
+            resident_->frame_major_rgb = std::move(resident_frame_major_rgb);
+        }
+
+        auto& module = *resident_->vae;
+        module.reset_execution_context();
+        const auto latent_normalization = vae_latent_normalization();
+        const auto pixel_normalization = vae_pixel_normalization();
+        TensorMap no_inputs;
+        for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
+            minimax_h3::extract_vae_tiles_cuda_async(
+                static_cast<const float*>(resident_->video_rows->data()),
+                static_cast<float*>(resident_->vae_latent_tiles->data()), clip_index,
+                latent_normalization, stream_);
+            module.forward_async(no_inputs);
+            minimax_h3::assemble_vae_clip_cuda_async(
+                static_cast<const float*>(resident_->vae_decoded_tiles->data()),
+                static_cast<float*>(resident_->vae_overlap->data()),
+                static_cast<float*>(resident_->frame_major_rgb->data()), clip_index,
+                pixel_normalization, stream_);
+            std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
+        }
+        module.sync();
+        pixels.resize(expected_pixels);
+        if (!resident_->frame_major_rgb->copy_to_host(pixels.data()))
+            throw std::runtime_error("MiniMax-H3 failed to download CUDA VAE output");
+    } else {
+        if (!resident_->vae) {
+            resident_->vae = loader_("vae_tile_decoder_plan", stream_);
+            resident_->vae->set_timing_label("vae_tile_decoder_plan");
+        }
+        std::vector<float> video(expected_pixels);
+        std::size_t decoded_frames = 0;
+        std::vector<float> overlap;
+        std::vector<float> clip;
+        auto& module = *resident_->vae;
+        module.reset_execution_context();
         constexpr std::size_t output_count =
             static_cast<std::size_t>(kTileBatch) * 3 * kTileFrames * kTileSize * kTileSize;
         for (int32_t clip_index = 0; clip_index < 7; ++clip_index) {
@@ -687,28 +1003,27 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
                                                   {kTileBatch, kLatentChannels, kTileInputFrames,
                                                    kTileLatentSize, kTileLatentSize},
                                                   DType::kFloat32});
-            const auto outputs = module->forward(inputs);
-            auto decoded_tiles = copy_float(require_output(outputs, "decoded_tiles"), output_count,
-                                            "VAE decoded tiles");
-            auto clip = stitch_spatial_tiles(decoded_tiles);
-            append_temporal_chunk(video, clip, overlap);
-            overlap = trailing_overlap(clip);
+            const auto outputs = module.forward(inputs);
+            const Tensor decoded_tiles = require_output(outputs, "decoded_tiles");
+            if (decoded_tiles.numel() != output_count)
+                throw std::runtime_error("MiniMax-H3 invalid VAE decoded tiles output");
+            stitch_spatial_tiles(decoded_tiles, clip);
+            write_temporal_chunk(video, decoded_frames, clip, overlap);
+            decoded_frames += 17;
+            update_trailing_overlap(clip, overlap);
             std::cerr << "[minimax-h3] VAE clip " << (clip_index + 1) << "/7\n";
         }
-        module->sync();
+        module.sync();
+        write_final_overlap(video, decoded_frames, overlap);
+        decoded_frames += 5;
+        if (video.size() != expected_pixels || decoded_frames != kOutputFrames)
+            throw std::runtime_error("MiniMax-H3 VAE produced the wrong video geometry");
+        postprocess_video(video);
+        pixels = to_frame_major_rgb(video);
     }
     const auto vae_end = Clock::now();
     latent.clear();
     latent.shrink_to_fit();
-    append_final_overlap(video, overlap);
-    const std::size_t expected_pixels =
-        static_cast<std::size_t>(3) * kOutputFrames * kOutputHeight * kOutputWidth;
-    if (video.size() != expected_pixels)
-        throw std::runtime_error("MiniMax-H3 VAE produced the wrong video geometry");
-    postprocess_video(video);
-    auto pixels = to_frame_major_rgb(video);
-    video.clear();
-    video.shrink_to_fit();
 
     const auto total_end = Clock::now();
     std::cerr << std::fixed << std::setprecision(3)
@@ -716,7 +1031,15 @@ ImageResult MiniMaxH3Pipeline::generate_image(const std::string& prompt,
               << " adaln_ms=" << milliseconds(adaln_begin, adaln_end)
               << " denoiser_ms=" << milliseconds(denoiser_begin, denoiser_end)
               << " vae_decoder_ms=" << milliseconds(vae_begin, vae_end)
-              << " total_ms=" << milliseconds(total_begin, total_end) << '\n';
+              << " total_ms=" << milliseconds(total_begin, total_end)
+              << " text_cache_hit=" << (text_cache_hit ? 1 : 0)
+              << " adaln_cache_hit=" << (adaln_cache_hit ? 1 : 0)
+              << " denoiser_resident_hit=" << (denoiser_resident_hit ? 1 : 0)
+              << " vae_resident_hit=" << (vae_resident_hit ? 1 : 0)
+              << " first_block_cache=" << (first_block_cache_ ? 1 : 0)
+              << " cache_threshold=" << cache_threshold_
+              << " full_denoiser_steps=" << full_denoiser_steps
+              << " skipped_denoiser_steps=" << skipped_denoiser_steps << '\n';
     ImageResult result;
     result.height = kOutputHeight;
     result.width = kOutputWidth;

--- a/src/runtime/models/minimax_h3/pipeline.h
+++ b/src/runtime/models/minimax_h3/pipeline.h
@@ -33,7 +33,8 @@ void minimax_h3_scheduler_step(float* sample, const float* velocity, std::size_t
 class MiniMaxH3Pipeline final : public IPipeline {
   public:
     MiniMaxH3Pipeline(MiniMaxH3ModuleLoader loader, std::unique_ptr<ITokenizer> tokenizer,
-                      std::string model_id);
+                      std::string model_id, bool first_block_cache = false,
+                      float cache_threshold = 0.08F);
     ~MiniMaxH3Pipeline() override;
 
     bool supports_image_generation() const override { return true; }
@@ -42,11 +43,16 @@ class MiniMaxH3Pipeline final : public IPipeline {
     const char* pipeline_type() const override { return "MiniMaxH3Pipeline"; }
 
   private:
+    struct ResidentState;
+
     MiniMaxH3ModuleLoader loader_;
     std::unique_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
     cudaStream_t stream_{nullptr};
     std::mutex generation_mutex_;
+    std::unique_ptr<ResidentState> resident_;
+    bool first_block_cache_{false};
+    float cache_threshold_{0.08F};
 };
 
 } // namespace trtmc

--- a/src/runtime/models/minimax_h3/pipeline.h
+++ b/src/runtime/models/minimax_h3/pipeline.h
@@ -34,7 +34,7 @@ class MiniMaxH3Pipeline final : public IPipeline {
   public:
     MiniMaxH3Pipeline(MiniMaxH3ModuleLoader loader, std::unique_ptr<ITokenizer> tokenizer,
                       std::string model_id, bool first_block_cache = false,
-                      float cache_threshold = 0.08F);
+                      float cache_threshold = 0.025F);
     ~MiniMaxH3Pipeline() override;
 
     bool supports_image_generation() const override { return true; }
@@ -52,7 +52,7 @@ class MiniMaxH3Pipeline final : public IPipeline {
     std::mutex generation_mutex_;
     std::unique_ptr<ResidentState> resident_;
     bool first_block_cache_{false};
-    float cache_threshold_{0.08F};
+    float cache_threshold_{0.025F};
 };
 
 } // namespace trtmc

--- a/src/runtime/models/minimax_h3/plugin.cpp
+++ b/src/runtime/models/minimax_h3/plugin.cpp
@@ -6,6 +6,7 @@
 #include "bundle/bundle_format.h"
 #include "bundle/bundle_view.h"
 #include "runtime/models/minimax_h3/pipeline.h"
+#include "trtmc/config/config_bundle.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "trtmc/runtime/trt_backend.h"
 #include "trtmc/tokenizer.h"
@@ -13,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -24,17 +26,27 @@ namespace {
 
 using SectionMap = std::unordered_map<std::string, BundleSectionInfo>;
 
-SectionMap index_sections(const BundleInfo& info) {
-    constexpr std::array<const char*, 4> names = {"text_encoder_plan", "adaln_precompute_plan",
-                                                  "denoiser_plan", "vae_tile_decoder_plan"};
+SectionMap index_sections(const BundleInfo& info, bool first_block_cache) {
+    constexpr std::array<const char*, 4> monolithic_names = {
+        "text_encoder_plan", "adaln_precompute_plan", "denoiser_plan", "vae_tile_decoder_plan"};
+    constexpr std::array<const char*, 6> first_block_cache_names = {
+        "text_encoder_plan",  "adaln_precompute_plan", "denoiser_head_plan",
+        "denoiser_tail_plan", "denoiser_finish_plan",  "vae_tile_decoder_plan"};
     SectionMap sections;
-    for (const char* name : names) {
+    const auto add_section = [&](const char* name) {
         const auto it =
             std::find_if(info.sections.begin(), info.sections.end(),
                          [name](const BundleSectionInfo& item) { return item.name == name; });
         if (it == info.sections.end() || it->size == 0)
             throw std::runtime_error(std::string("MiniMax-H3 bundle is missing ") + name);
         sections.emplace(name, *it);
+    };
+    if (first_block_cache) {
+        for (const char* name : first_block_cache_names)
+            add_section(name);
+    } else {
+        for (const char* name : monolithic_names)
+            add_section(name);
     }
     return sections;
 }
@@ -66,7 +78,26 @@ class MiniMaxH3Plugin final : public IPipelinePlugin {
         const int32_t vae_tile_batch = extract_json_int(ctx.config_json, "vae_tile_batch", 28);
         if (vae_tile_batch != 28)
             throw std::runtime_error("MiniMax-H3 requires vae_tile_batch=28");
-        auto sections = index_sections(ctx.bundle.info);
+        const std::string cache_mode =
+            extract_json_string(ctx.config_json, "denoiser_cache_mode", "monolithic");
+        if (cache_mode != "monolithic" && cache_mode != "first_block")
+            throw std::runtime_error("MiniMax-H3 bundle has an invalid denoiser_cache_mode");
+        const bool first_block_cache =
+            extract_json_bool(ctx.config_json, "first_block_cache", false);
+        if (first_block_cache != (cache_mode == "first_block"))
+            throw std::runtime_error("MiniMax-H3 bundle cache mode and profile flag disagree");
+        float cache_threshold =
+            extract_json_float(ctx.config_json, "first_block_cache_threshold", 0.08F);
+        if (ctx.runtime_config != nullptr &&
+            ctx.runtime_config->source_of("minimax_h3", "first_block_cache_threshold") !=
+                config::Layer::SchemaDefault) {
+            cache_threshold = static_cast<float>(
+                ctx.runtime_config->get<double>("minimax_h3", "first_block_cache_threshold"));
+        }
+        if (!std::isfinite(cache_threshold) || cache_threshold <= 0.0F)
+            throw std::runtime_error(
+                "MiniMax-H3 first_block_cache_threshold must be finite and positive");
+        auto sections = index_sections(ctx.bundle.info, first_block_cache);
         const std::string bundle_path = ctx.bundle_path;
         const std::string runtime_cache = ctx.runtime_cache_path;
         IBackend* const backend = ctx.backend;
@@ -85,7 +116,8 @@ class MiniMaxH3Plugin final : public IPipelinePlugin {
             return backend->create_module(plan.data(), plan.size(), options);
         };
         return std::make_unique<MiniMaxH3Pipeline>(std::move(loader), load_tokenizer(ctx.bundle),
-                                                   ctx.bundle.info.model_id);
+                                                   ctx.bundle.info.model_id, first_block_cache,
+                                                   cache_threshold);
     }
 };
 

--- a/src/runtime/models/minimax_h3/plugin.cpp
+++ b/src/runtime/models/minimax_h3/plugin.cpp
@@ -26,6 +26,11 @@ namespace {
 
 using SectionMap = std::unordered_map<std::string, BundleSectionInfo>;
 
+struct CacheConfig {
+    bool enabled{false};
+    float threshold{0.08F};
+};
+
 SectionMap index_sections(const BundleInfo& info, bool first_block_cache) {
     constexpr std::array<const char*, 4> monolithic_names = {
         "text_encoder_plan", "adaln_precompute_plan", "denoiser_plan", "vae_tile_decoder_plan"};
@@ -61,63 +66,70 @@ std::unique_ptr<ITokenizer> load_tokenizer(const BundleFile& bundle) {
     return tokenizer;
 }
 
+void validate_profile(const PipelineContext& ctx) {
+    if (ctx.backend == nullptr)
+        throw std::runtime_error("MiniMax-H3 requires the TensorRT backend");
+    if (extract_json_int(ctx.config_json, "context_parallel_size", 1) != 1)
+        throw std::runtime_error("MiniMax-H3 requires context_parallel_size=1");
+    if (extract_json_int(ctx.config_json, "padded_sequence_length", 38247) != 38247)
+        throw std::runtime_error("MiniMax-H3 requires 38247 unpadded sequence rows");
+    if (extract_json_int(ctx.config_json, "vae_tile_batch", 28) != 28)
+        throw std::runtime_error("MiniMax-H3 requires vae_tile_batch=28");
+}
+
+CacheConfig load_cache_config(const PipelineContext& ctx) {
+    CacheConfig result;
+    const std::string mode =
+        extract_json_string(ctx.config_json, "denoiser_cache_mode", "monolithic");
+    if (mode != "monolithic" && mode != "first_block")
+        throw std::runtime_error("MiniMax-H3 bundle has an invalid denoiser_cache_mode");
+    result.enabled = extract_json_bool(ctx.config_json, "first_block_cache", false);
+    if (result.enabled != (mode == "first_block"))
+        throw std::runtime_error("MiniMax-H3 bundle cache mode and profile flag disagree");
+    result.threshold =
+        extract_json_float(ctx.config_json, "first_block_cache_threshold", result.threshold);
+    if (ctx.runtime_config != nullptr &&
+        ctx.runtime_config->source_of("minimax_h3", "first_block_cache_threshold") !=
+            config::Layer::SchemaDefault) {
+        result.threshold = static_cast<float>(
+            ctx.runtime_config->get<double>("minimax_h3", "first_block_cache_threshold"));
+    }
+    if (!std::isfinite(result.threshold) || result.threshold <= 0.0F)
+        throw std::runtime_error(
+            "MiniMax-H3 first_block_cache_threshold must be finite and positive");
+    return result;
+}
+
+MiniMaxH3ModuleLoader make_module_loader(const PipelineContext& ctx, SectionMap sections) {
+    const std::string bundle_path = ctx.bundle_path;
+    const std::string runtime_cache = ctx.runtime_cache_path;
+    IBackend* const backend = ctx.backend;
+    const bool cuda_graphs = ctx.cuda_graphs;
+    return [sections = std::move(sections), bundle_path, runtime_cache, backend,
+            cuda_graphs](const std::string& name, cudaStream_t stream) {
+        const auto it = sections.find(name);
+        if (it == sections.end())
+            throw std::runtime_error("Unknown MiniMax-H3 plan section: " + name);
+        auto plan = ReadBundleSection(bundle_path, it->second);
+        ModuleCreateOptions options;
+        options.stream = stream;
+        options.runtime_cache_path = runtime_cache.c_str();
+        options.cuda_graphs = cuda_graphs;
+        return backend->create_module(plan.data(), plan.size(), options);
+    };
+}
+
 } // namespace
 
 class MiniMaxH3Plugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
-        if (ctx.backend == nullptr)
-            throw std::runtime_error("MiniMax-H3 requires the TensorRT backend");
-        const int32_t cp_size = extract_json_int(ctx.config_json, "context_parallel_size", 1);
-        if (cp_size != 1)
-            throw std::runtime_error("MiniMax-H3 requires context_parallel_size=1");
-        const int32_t sequence_rows =
-            extract_json_int(ctx.config_json, "padded_sequence_length", 38247);
-        if (sequence_rows != 38247)
-            throw std::runtime_error("MiniMax-H3 requires 38247 unpadded sequence rows");
-        const int32_t vae_tile_batch = extract_json_int(ctx.config_json, "vae_tile_batch", 28);
-        if (vae_tile_batch != 28)
-            throw std::runtime_error("MiniMax-H3 requires vae_tile_batch=28");
-        const std::string cache_mode =
-            extract_json_string(ctx.config_json, "denoiser_cache_mode", "monolithic");
-        if (cache_mode != "monolithic" && cache_mode != "first_block")
-            throw std::runtime_error("MiniMax-H3 bundle has an invalid denoiser_cache_mode");
-        const bool first_block_cache =
-            extract_json_bool(ctx.config_json, "first_block_cache", false);
-        if (first_block_cache != (cache_mode == "first_block"))
-            throw std::runtime_error("MiniMax-H3 bundle cache mode and profile flag disagree");
-        float cache_threshold =
-            extract_json_float(ctx.config_json, "first_block_cache_threshold", 0.08F);
-        if (ctx.runtime_config != nullptr &&
-            ctx.runtime_config->source_of("minimax_h3", "first_block_cache_threshold") !=
-                config::Layer::SchemaDefault) {
-            cache_threshold = static_cast<float>(
-                ctx.runtime_config->get<double>("minimax_h3", "first_block_cache_threshold"));
-        }
-        if (!std::isfinite(cache_threshold) || cache_threshold <= 0.0F)
-            throw std::runtime_error(
-                "MiniMax-H3 first_block_cache_threshold must be finite and positive");
-        auto sections = index_sections(ctx.bundle.info, first_block_cache);
-        const std::string bundle_path = ctx.bundle_path;
-        const std::string runtime_cache = ctx.runtime_cache_path;
-        IBackend* const backend = ctx.backend;
-        const bool cuda_graphs = ctx.cuda_graphs;
-        MiniMaxH3ModuleLoader loader = [sections = std::move(sections), bundle_path, runtime_cache,
-                                        backend,
-                                        cuda_graphs](const std::string& name, cudaStream_t stream) {
-            const auto it = sections.find(name);
-            if (it == sections.end())
-                throw std::runtime_error("Unknown MiniMax-H3 plan section: " + name);
-            auto plan = ReadBundleSection(bundle_path, it->second);
-            ModuleCreateOptions options;
-            options.stream = stream;
-            options.runtime_cache_path = runtime_cache.c_str();
-            options.cuda_graphs = cuda_graphs;
-            return backend->create_module(plan.data(), plan.size(), options);
-        };
+        validate_profile(ctx);
+        const CacheConfig cache = load_cache_config(ctx);
+        auto loader = make_module_loader(ctx, index_sections(ctx.bundle.info, cache.enabled));
         return std::make_unique<MiniMaxH3Pipeline>(std::move(loader), load_tokenizer(ctx.bundle),
-                                                   ctx.bundle.info.model_id, first_block_cache,
-                                                   cache_threshold);
+                                                   ctx.bundle.info.model_id, cache.enabled,
+                                                   cache.threshold);
     }
 };
 

--- a/src/runtime/models/minimax_h3/plugin.cpp
+++ b/src/runtime/models/minimax_h3/plugin.cpp
@@ -28,7 +28,7 @@ using SectionMap = std::unordered_map<std::string, BundleSectionInfo>;
 
 struct CacheConfig {
     bool enabled{false};
-    float threshold{0.08F};
+    float threshold{0.025F};
 };
 
 SectionMap index_sections(const BundleInfo& info, bool first_block_cache) {

--- a/src/runtime/models/minimax_h3/torch_cuda_normal.cu
+++ b/src/runtime/models/minimax_h3/torch_cuda_normal.cu
@@ -5,11 +5,14 @@
 
 #include "runtime/models/minimax_h3/torch_cuda_normal.h"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <cuda_runtime_api.h>
 #include <limits>
 #include <stdexcept>
+#include <string>
 
 namespace trtmc::minimax_h3 {
 namespace {
@@ -21,6 +24,28 @@ constexpr uint32_t kUpperMask = 0x80000000U;
 constexpr uint32_t kLowerMask = 0x7fffffffU;
 constexpr float kUniformScale = 1.0F / 16777216.0F;
 constexpr double kPi = 3.14159265358979323846;
+constexpr uint32_t kSchedulerBlockSize = 256;
+constexpr uint32_t kSchedulerMaxBlocks = 4096;
+constexpr int32_t kVaeTileRows = 4;
+constexpr int32_t kVaeTileColumns = 7;
+constexpr int32_t kVaeTileCount = kVaeTileRows * kVaeTileColumns;
+constexpr int32_t kVaeLatentChannels = 24;
+constexpr int32_t kVaeTileInputFrames = 7;
+constexpr int32_t kVaeTileLatentSize = 16;
+constexpr int32_t kVaePatchHeight = 2;
+constexpr int32_t kVaePatchWidth = 2;
+constexpr int32_t kVaePatchDim = 96;
+constexpr int32_t kVaeLatentHeight = 48;
+constexpr int32_t kVaeLatentWidth = 84;
+constexpr int32_t kVaeTileFrames = 28;
+constexpr int32_t kVaeTileSize = 256;
+constexpr int32_t kVaeOutputChannels = 3;
+constexpr int32_t kVaeOutputHeight = 768;
+constexpr int32_t kVaeOutputWidth = 1344;
+constexpr int32_t kVaeChunkFrames = 17;
+constexpr int32_t kVaeTemporalOverlapFrames = 5;
+constexpr int32_t kVaeTemporalPrePadding = 3;
+constexpr int32_t kVaeTrailingOverlapStart = 23;
 
 // This is PyTorch's at::mt19937 engine, not std::mt19937. The state transition
 // and low-24-bit uniform mapping are part of torch.Generator CPU determinism.
@@ -86,6 +111,277 @@ void normal_fill_16(float* values) {
     }
 }
 
+__global__ void scheduler_step_kernel(float* sample, const float* velocity, int64_t count,
+                                      float sigma_from_timestep, float ratio) {
+    const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    for (int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; index < count;
+         index += stride) {
+        const float current = sample[index];
+        const float denoised = current + sigma_from_timestep * velocity[index];
+        sample[index] = ratio * current + (1.0F - ratio) * denoised;
+    }
+}
+
+__device__ __forceinline__ int32_t latent_y_start(int32_t tile_y) {
+    switch (tile_y) {
+    case 0:
+        return 0;
+    case 1:
+        return 10;
+    case 2:
+        return 21;
+    default:
+        return 32;
+    }
+}
+
+__device__ __forceinline__ int32_t latent_x_start(int32_t tile_x) {
+    switch (tile_x) {
+    case 0:
+        return 0;
+    case 1:
+        return 11;
+    case 2:
+        return 22;
+    case 3:
+        return 33;
+    case 4:
+        return 44;
+    case 5:
+        return 56;
+    default:
+        return 68;
+    }
+}
+
+__device__ __forceinline__ int32_t output_y_start(int32_t tile_y) {
+    switch (tile_y) {
+    case 0:
+        return 0;
+    case 1:
+        return 160;
+    case 2:
+        return 336;
+    default:
+        return 512;
+    }
+}
+
+__device__ __forceinline__ int32_t output_x_start(int32_t tile_x) {
+    switch (tile_x) {
+    case 0:
+        return 0;
+    case 1:
+        return 176;
+    case 2:
+        return 352;
+    case 3:
+        return 528;
+    case 4:
+        return 704;
+    case 5:
+        return 896;
+    default:
+        return 1088;
+    }
+}
+
+__device__ __forceinline__ int32_t height_overlap(int32_t boundary) {
+    return boundary == 0 ? 96 : 80;
+}
+
+__device__ __forceinline__ int32_t width_overlap(int32_t boundary) {
+    return boundary < 4 ? 80 : 64;
+}
+
+__global__ void extract_vae_tiles_kernel(const float* video_rows, float* latent_tiles,
+                                         int32_t clip_index, VaeLatentNormalization normalization,
+                                         int64_t count) {
+    const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    for (int64_t linear = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         linear < count; linear += stride) {
+        int64_t remaining = linear;
+        const int32_t x = static_cast<int32_t>(remaining % kVaeTileLatentSize);
+        remaining /= kVaeTileLatentSize;
+        const int32_t y = static_cast<int32_t>(remaining % kVaeTileLatentSize);
+        remaining /= kVaeTileLatentSize;
+        const int32_t frame = static_cast<int32_t>(remaining % kVaeTileInputFrames);
+        remaining /= kVaeTileInputFrames;
+        const int32_t channel = static_cast<int32_t>(remaining % kVaeLatentChannels);
+        const int32_t tile = static_cast<int32_t>(remaining / kVaeLatentChannels);
+
+        const int32_t latent_frame = clip_index * kVaeTemporalOverlapFrames + frame;
+        const int32_t latent_y = latent_y_start(tile / kVaeTileColumns) + y;
+        const int32_t latent_x = latent_x_start(tile % kVaeTileColumns) + x;
+        const int32_t patch_row =
+            ((latent_frame * (kVaeLatentHeight / kVaePatchHeight) + latent_y / kVaePatchHeight) *
+                 (kVaeLatentWidth / kVaePatchWidth) +
+             latent_x / kVaePatchWidth);
+        const int32_t patch_column = channel * kVaePatchHeight * kVaePatchWidth +
+                                     (latent_y % kVaePatchHeight) * kVaePatchWidth +
+                                     latent_x % kVaePatchWidth;
+        const float value =
+            video_rows[static_cast<int64_t>(patch_row) * kVaePatchDim + patch_column];
+        latent_tiles[linear] = value * normalization.std[channel] + normalization.mean[channel];
+    }
+}
+
+__device__ __forceinline__ int32_t output_tile_y(int32_t y) {
+    if (y < 160)
+        return 0;
+    if (y < 336)
+        return 1;
+    if (y < 512)
+        return 2;
+    return 3;
+}
+
+__device__ __forceinline__ int32_t output_tile_x(int32_t x) {
+    if (x < 176)
+        return 0;
+    if (x < 352)
+        return 1;
+    if (x < 528)
+        return 2;
+    if (x < 704)
+        return 3;
+    if (x < 896)
+        return 4;
+    if (x < 1088)
+        return 5;
+    return 6;
+}
+
+__device__ __forceinline__ float decoded_tile_value(const float* decoded_tiles, int32_t tile,
+                                                    int32_t channel, int32_t frame, int32_t y,
+                                                    int32_t x) {
+    const int64_t index =
+        ((((static_cast<int64_t>(tile) * kVaeOutputChannels + channel) * kVaeTileFrames + frame) *
+              kVaeTileSize +
+          y) *
+             kVaeTileSize +
+         x);
+    return decoded_tiles[index];
+}
+
+__device__ __forceinline__ float spatially_stitched_value(const float* decoded_tiles,
+                                                          int32_t channel, int32_t frame,
+                                                          int32_t output_y, int32_t output_x) {
+    const int32_t tile_y = output_tile_y(output_y);
+    const int32_t tile_x = output_tile_x(output_x);
+    const int32_t tile = tile_y * kVaeTileColumns + tile_x;
+    const int32_t y = output_y - output_y_start(tile_y);
+    const int32_t x = output_x - output_x_start(tile_x);
+    float value = decoded_tile_value(decoded_tiles, tile, channel, frame, y, x);
+
+    // Match stitch_one_spatial_tile exactly: vertical ownership/blend first,
+    // followed by the horizontal blend from the left tile.
+    if (tile_y > 0 && y < height_overlap(tile_y - 1)) {
+        const int32_t overlap = height_overlap(tile_y - 1);
+        const float weight_b = static_cast<float>(y) / overlap;
+        const float upper = decoded_tile_value(decoded_tiles, tile - kVaeTileColumns, channel,
+                                               frame, kVaeTileSize - overlap + y, x);
+        value = upper * (1.0F - weight_b) + value * weight_b;
+    }
+    if (tile_x > 0 && x < width_overlap(tile_x - 1)) {
+        const int32_t overlap = width_overlap(tile_x - 1);
+        const float weight_b = static_cast<float>(x) / overlap;
+        const float left = decoded_tile_value(decoded_tiles, tile - 1, channel, frame, y,
+                                              kVaeTileSize - overlap + x);
+        value = left * (1.0F - weight_b) + value * weight_b;
+    }
+    return value;
+}
+
+__device__ __forceinline__ float normalize_pixel(float value, int32_t channel,
+                                                 VaePixelNormalization normalization) {
+    value = value * normalization.std[channel] + normalization.mean[channel];
+    if (value < 0.0F)
+        value = 0.0F;
+    else if (value > 1.0F)
+        value = 1.0F;
+    return value;
+}
+
+__global__ void assemble_vae_chunk_kernel(const float* decoded_tiles, const float* overlap,
+                                          float* frame_major_rgb, int32_t clip_index,
+                                          VaePixelNormalization normalization, int64_t count) {
+    const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    for (int64_t linear = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         linear < count; linear += stride) {
+        int64_t remaining = linear;
+        const int32_t output_x = static_cast<int32_t>(remaining % kVaeOutputWidth);
+        remaining /= kVaeOutputWidth;
+        const int32_t output_y = static_cast<int32_t>(remaining % kVaeOutputHeight);
+        remaining /= kVaeOutputHeight;
+        const int32_t frame = static_cast<int32_t>(remaining % kVaeChunkFrames);
+        const int32_t channel = static_cast<int32_t>(remaining / kVaeChunkFrames);
+
+        float value = spatially_stitched_value(decoded_tiles, channel,
+                                               kVaeTemporalPrePadding + frame, output_y, output_x);
+        if (clip_index > 0 && frame < kVaeTemporalOverlapFrames) {
+            const int64_t overlap_index =
+                (((static_cast<int64_t>(channel) * kVaeTemporalOverlapFrames + frame) *
+                      kVaeOutputHeight +
+                  output_y) *
+                     kVaeOutputWidth +
+                 output_x);
+            const float weight_b = static_cast<float>(frame) / kVaeTemporalOverlapFrames;
+            value = overlap[overlap_index] * (1.0F - weight_b) + value * weight_b;
+        }
+        value = normalize_pixel(value, channel, normalization);
+        const int32_t output_frame = clip_index * kVaeChunkFrames + frame;
+        const int64_t output_index =
+            (((static_cast<int64_t>(output_frame) * kVaeOutputHeight + output_y) * kVaeOutputWidth +
+              output_x) *
+                 kVaeOutputChannels +
+             channel);
+        frame_major_rgb[output_index] = value;
+    }
+}
+
+__global__ void update_vae_overlap_kernel(const float* decoded_tiles, float* overlap,
+                                          float* frame_major_rgb, int32_t clip_index,
+                                          VaePixelNormalization normalization, int64_t count) {
+    const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    for (int64_t linear = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         linear < count; linear += stride) {
+        int64_t remaining = linear;
+        const int32_t output_x = static_cast<int32_t>(remaining % kVaeOutputWidth);
+        remaining /= kVaeOutputWidth;
+        const int32_t output_y = static_cast<int32_t>(remaining % kVaeOutputHeight);
+        remaining /= kVaeOutputHeight;
+        const int32_t frame = static_cast<int32_t>(remaining % kVaeTemporalOverlapFrames);
+        const int32_t channel = static_cast<int32_t>(remaining / kVaeTemporalOverlapFrames);
+
+        const float value = spatially_stitched_value(
+            decoded_tiles, channel, kVaeTrailingOverlapStart + frame, output_y, output_x);
+        overlap[linear] = value;
+        if (clip_index == 6) {
+            const int32_t output_frame = kVaeChunkFrames * 7 + frame;
+            const int64_t output_index =
+                (((static_cast<int64_t>(output_frame) * kVaeOutputHeight + output_y) *
+                      kVaeOutputWidth +
+                  output_x) *
+                     kVaeOutputChannels +
+                 channel);
+            frame_major_rgb[output_index] = normalize_pixel(value, channel, normalization);
+        }
+    }
+}
+
+uint32_t launch_grid(std::size_t count) {
+    const std::size_t requested_blocks =
+        count / kSchedulerBlockSize + (count % kSchedulerBlockSize != 0 ? 1U : 0U);
+    return static_cast<uint32_t>(std::min<std::size_t>(requested_blocks, kSchedulerMaxBlocks));
+}
+
+void check_kernel_launch(const char* label) {
+    const cudaError_t status = cudaGetLastError();
+    if (status != cudaSuccess)
+        throw std::runtime_error(std::string(label) + " failed: " + cudaGetErrorString(status));
+}
+
 } // namespace
 
 uint64_t torch_cuda_normal_consumed_offset(std::size_t count) {
@@ -117,6 +413,57 @@ std::vector<float> torch_cuda_normal(std::size_t count, uint64_t seed, uint64_t 
         std::memcpy(output.data() + count - 16, tail, sizeof(tail));
     }
     return output;
+}
+
+void scheduler_step_cuda_async(float* sample, const float* velocity, std::size_t count,
+                               float timestep, float sigma, float sigma_next, cudaStream_t stream) {
+    if (sample == nullptr || velocity == nullptr || !(sigma > 0.0F))
+        throw std::invalid_argument("MiniMax-H3 CUDA scheduler received invalid inputs");
+    if (count > static_cast<std::size_t>(std::numeric_limits<int64_t>::max()))
+        throw std::overflow_error("MiniMax-H3 CUDA scheduler tensor is too large");
+    if (count == 0)
+        return;
+
+    const uint32_t grid = launch_grid(count);
+    const float sigma_from_timestep = 1.0F - timestep;
+    const float ratio = sigma_next / sigma;
+    scheduler_step_kernel<<<grid, kSchedulerBlockSize, 0, stream>>>(
+        sample, velocity, static_cast<int64_t>(count), sigma_from_timestep, ratio);
+    check_kernel_launch("MiniMax-H3 CUDA scheduler launch");
+}
+
+void extract_vae_tiles_cuda_async(const float* video_rows, float* latent_tiles, int32_t clip_index,
+                                  VaeLatentNormalization normalization, cudaStream_t stream) {
+    if (video_rows == nullptr || latent_tiles == nullptr || stream == nullptr || clip_index < 0 ||
+        clip_index >= 7)
+        throw std::invalid_argument("MiniMax-H3 CUDA VAE extraction received invalid inputs");
+    constexpr std::size_t count = static_cast<std::size_t>(kVaeTileCount) * kVaeLatentChannels *
+                                  kVaeTileInputFrames * kVaeTileLatentSize * kVaeTileLatentSize;
+    extract_vae_tiles_kernel<<<launch_grid(count), kSchedulerBlockSize, 0, stream>>>(
+        video_rows, latent_tiles, clip_index, normalization, static_cast<int64_t>(count));
+    check_kernel_launch("MiniMax-H3 CUDA VAE extraction launch");
+}
+
+void assemble_vae_clip_cuda_async(const float* decoded_tiles, float* overlap,
+                                  float* frame_major_rgb, int32_t clip_index,
+                                  VaePixelNormalization normalization, cudaStream_t stream) {
+    if (decoded_tiles == nullptr || overlap == nullptr || frame_major_rgb == nullptr ||
+        stream == nullptr || clip_index < 0 || clip_index >= 7)
+        throw std::invalid_argument("MiniMax-H3 CUDA VAE assembly received invalid inputs");
+    constexpr std::size_t chunk_count = static_cast<std::size_t>(kVaeOutputChannels) *
+                                        kVaeChunkFrames * kVaeOutputHeight * kVaeOutputWidth;
+    assemble_vae_chunk_kernel<<<launch_grid(chunk_count), kSchedulerBlockSize, 0, stream>>>(
+        decoded_tiles, overlap, frame_major_rgb, clip_index, normalization,
+        static_cast<int64_t>(chunk_count));
+    check_kernel_launch("MiniMax-H3 CUDA VAE chunk assembly launch");
+
+    constexpr std::size_t overlap_count = static_cast<std::size_t>(kVaeOutputChannels) *
+                                          kVaeTemporalOverlapFrames * kVaeOutputHeight *
+                                          kVaeOutputWidth;
+    update_vae_overlap_kernel<<<launch_grid(overlap_count), kSchedulerBlockSize, 0, stream>>>(
+        decoded_tiles, overlap, frame_major_rgb, clip_index, normalization,
+        static_cast<int64_t>(overlap_count));
+    check_kernel_launch("MiniMax-H3 CUDA VAE overlap assembly launch");
 }
 
 } // namespace trtmc::minimax_h3

--- a/src/runtime/models/minimax_h3/torch_cuda_normal.h
+++ b/src/runtime/models/minimax_h3/torch_cuda_normal.h
@@ -6,14 +6,49 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cuda_runtime_api.h>
 #include <vector>
 
 namespace trtmc::minimax_h3 {
+
+struct VaeLatentNormalization {
+    float mean[24];
+    float std[24];
+};
+
+struct VaePixelNormalization {
+    float mean[3];
+    float std[3];
+};
 
 // Matches torch.randn(..., generator=torch.Generator().manual_seed(seed)) for
 // contiguous float32 CPU tensors on AArch64. Calls are deliberately separate so
 // video consumes the generator before audio, matching HF and Sol H3.
 std::vector<float> torch_cuda_normal(std::size_t count, uint64_t seed, uint64_t offset = 0);
 uint64_t torch_cuda_normal_consumed_offset(std::size_t count);
+
+// Enqueue the MiniMax-H3 data-ward Euler update on `stream`, modifying the
+// device-resident FP32 sample in place. Both pointers must be non-null (also for
+// a zero count) and remain valid until the stream reaches this work; sigma must
+// be positive. The function does not synchronize, so successful return only
+// means CUDA accepted the launch. Invalid host arguments throw
+// std::invalid_argument/std::overflow_error, while launch failures throw
+// std::runtime_error. A zero count with valid pointers is a no-op.
+void scheduler_step_cuda_async(float* sample, const float* velocity, std::size_t count,
+                               float timestep, float sigma, float sigma_next, cudaStream_t stream);
+
+// Extract one fixed-profile VAE tile batch directly from the denoiser's patched
+// video rows. The kernel also applies the checkpoint latent mean/std transform,
+// so no full latent unpatch is materialized on either host or device.
+void extract_vae_tiles_cuda_async(const float* video_rows, float* latent_tiles, int32_t clip_index,
+                                  VaeLatentNormalization normalization, cudaStream_t stream);
+
+// Spatially stitch one fixed-profile VAE output, assemble its 17 temporal
+// frames (plus the final 5-frame tail for clip six), apply pixel normalization,
+// clamp, and write frame-major RGB. `overlap` stores the previous clip's raw
+// five-frame spatial overlap and is updated after it has been consumed.
+void assemble_vae_clip_cuda_async(const float* decoded_tiles, float* overlap,
+                                  float* frame_major_rgb, int32_t clip_index,
+                                  VaePixelNormalization normalization, cudaStream_t stream);
 
 } // namespace trtmc::minimax_h3

--- a/tests/builder/test_max_batch_size_cli.py
+++ b/tests/builder/test_max_batch_size_cli.py
@@ -259,5 +259,5 @@ def test_diffusion_family_build_options_reach_plugin(monkeypatch, tmp_path):
 
     assert plugin.calls[0]["family_build_options"]["minimax_h3"] == {
         "first_block_cache": True,
-        "first_block_cache_threshold": 0.08,
+        "first_block_cache_threshold": 0.025,
     }

--- a/tests/builder/test_max_batch_size_cli.py
+++ b/tests/builder/test_max_batch_size_cli.py
@@ -251,7 +251,7 @@ def test_diffusion_family_build_options_reach_plugin(monkeypatch, tmp_path):
     """Schema-resolved ``--set`` values must survive diffusion dispatch."""
     plugin = _install_stub_plugin(monkeypatch)
     model_dir = _make_fake_diffusion_model_dir(tmp_path)
-    output = tmp_path / "out.trtfb"
+    output = tmp_path / "out.bundle"
     args = _build_args(model_dir, output, max_batch_size=1)
     args.set_flags = ["minimax_h3.first_block_cache=true"]
 

--- a/tests/builder/test_max_batch_size_cli.py
+++ b/tests/builder/test_max_batch_size_cli.py
@@ -88,6 +88,7 @@ class _FakeDiffusionPlugin:
             "dit_mbs": dit_mbs,
             "te_mbs": te_mbs,
             "vae_mbs": vae_mbs,
+            "family_build_options": config.raw.get("_family_build_options", {}),
         })
         out = {
             "text_encoders": [("fake_te", b"te-plan")],
@@ -244,3 +245,19 @@ def test_max_batch_size_four_records_envelope(monkeypatch, tmp_path):
     assert plugin.calls[0]["vae_mbs"] == 1  # VAE always slices
     assert plugin.tokenizer_add_special_calls == 1
     assert plugin.tokenizer_section_calls == 1
+
+
+def test_diffusion_family_build_options_reach_plugin(monkeypatch, tmp_path):
+    """Schema-resolved ``--set`` values must survive diffusion dispatch."""
+    plugin = _install_stub_plugin(monkeypatch)
+    model_dir = _make_fake_diffusion_model_dir(tmp_path)
+    output = tmp_path / "out.trtfb"
+    args = _build_args(model_dir, output, max_batch_size=1)
+    args.set_flags = ["minimax_h3.first_block_cache=true"]
+
+    assert cli._cmd_build(args) == 0
+
+    assert plugin.calls[0]["family_build_options"]["minimax_h3"] == {
+        "first_block_cache": True,
+        "first_block_cache_threshold": 0.08,
+    }

--- a/tests/cpp/models/minimax_h3/test_minimax_h3_config_schema.cpp
+++ b/tests/cpp/models/minimax_h3/test_minimax_h3_config_schema.cpp
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/config/cli_support.h"
+#include "trtmc/config/config_bundle.h"
+#include "trtmc/config/schema_registry.h"
+#include "trtmc/runtime/pipeline_plugin_loader.h"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+template <typename Callable>
+void check_invalid(Callable&& callable, const char* label) {
+    try {
+        callable();
+        check(false, label);
+    } catch (const std::invalid_argument&) {
+    }
+}
+
+} // namespace
+
+int main() {
+    using trtmc::config::ConfigBundle;
+    using trtmc::config::Layer;
+    using trtmc::config::SchemaRegistry;
+
+    auto& schemas = SchemaRegistry::instance();
+    check(schemas.lookup("minimax_h3") == nullptr, "minimax_h3 schema absent from core");
+
+    trtmc::load_model_plugin_for_strategy("diffusion_minimax_h3");
+    const auto* schema = schemas.lookup("minimax_h3");
+    check(schema != nullptr, "MiniMax-H3 plugin registers model-owned schema");
+    check(schema != nullptr && schema->fields.size() == 1, "MiniMax-H3 schema field count");
+
+    const ConfigBundle defaults = ConfigBundle::build({}, schemas);
+    check(defaults.source_of("minimax_h3", "first_block_cache_threshold") == Layer::SchemaDefault,
+          "cache threshold default retains SchemaDefault provenance");
+    check(std::abs(defaults.get<double>("minimax_h3", "first_block_cache_threshold") - 0.08) <
+              1.0e-12,
+          "cache threshold schema default");
+
+    const ConfigBundle overridden = trtmc::config::resolve_cli_config(
+        "", {"minimax_h3.first_block_cache_threshold=0.05"}, {}, schemas);
+    check(overridden.source_of("minimax_h3", "first_block_cache_threshold") ==
+              Layer::SessionRequest,
+          "qualified cache threshold records session provenance");
+    check(std::abs(overridden.get<double>("minimax_h3", "first_block_cache_threshold") - 0.05) <
+              1.0e-12,
+          "qualified cache threshold reaches resolved config");
+
+    check_invalid(
+        [&] {
+            (void)trtmc::config::resolve_cli_config("", {"first_block_cache_threshold=0.05"}, {},
+                                                    schemas);
+        },
+        "unqualified cache threshold fails closed");
+    for (const std::string& value : {"0", "-0.01", "nan", "inf"}) {
+        check_invalid(
+            [&] {
+                (void)trtmc::config::resolve_cli_config(
+                    "", {"minimax_h3.first_block_cache_threshold=" + value}, {}, schemas);
+            },
+            "non-positive or non-finite cache threshold fails closed");
+    }
+
+    if (failures > 0) {
+        std::cerr << failures << " MiniMax-H3 config schema test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/minimax_h3/test_minimax_h3_config_schema.cpp
+++ b/tests/cpp/models/minimax_h3/test_minimax_h3_config_schema.cpp
@@ -52,7 +52,7 @@ int main() {
     const ConfigBundle defaults = ConfigBundle::build({}, schemas);
     check(defaults.source_of("minimax_h3", "first_block_cache_threshold") == Layer::SchemaDefault,
           "cache threshold default retains SchemaDefault provenance");
-    check(std::abs(defaults.get<double>("minimax_h3", "first_block_cache_threshold") - 0.08) <
+    check(std::abs(defaults.get<double>("minimax_h3", "first_block_cache_threshold") - 0.025) <
               1.0e-12,
           "cache threshold schema default");
 

--- a/tests/cpp/models/minimax_h3/test_minimax_h3_cuda_rng.cpp
+++ b/tests/cpp/models/minimax_h3/test_minimax_h3_cuda_rng.cpp
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "runtime/models/minimax_h3/pipeline.h"
 #include "runtime/models/minimax_h3/torch_cuda_normal.h"
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <cuda_runtime_api.h>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace {
@@ -26,6 +32,222 @@ uint64_t update_fnv1a(uint64_t hash, const std::vector<float>& values) {
         hash *= 1099511628211ULL;
     }
     return hash;
+}
+
+void check_cuda(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess)
+        throw std::runtime_error(std::string(operation) + " failed: " + cudaGetErrorString(status));
+}
+
+void test_scheduler_matches_cpu() {
+    // Exceeds the production launch cap so the grid-stride path is covered.
+    constexpr std::size_t count = 1100003;
+    constexpr float timestep = 0.421875F;
+    constexpr float sigma = 0.578125F;
+    constexpr float sigma_next = 0.53125F;
+    std::vector<float> sample(count);
+    std::vector<float> velocity(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        sample[index] = static_cast<float>(static_cast<int32_t>(index % 211U) - 105) / 19.0F;
+        velocity[index] =
+            static_cast<float>(static_cast<int32_t>((index * 37U) % 307U) - 153) / 23.0F;
+    }
+    std::vector<float> expected = sample;
+    trtmc::minimax_h3_scheduler_step(expected.data(), velocity.data(), count, timestep, sigma,
+                                     sigma_next);
+
+    cudaStream_t stream = nullptr;
+    float* device_sample = nullptr;
+    float* device_velocity = nullptr;
+    check_cuda(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), "cudaStreamCreate");
+    try {
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&device_sample), count * sizeof(float)),
+                   "sample cudaMalloc");
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&device_velocity), count * sizeof(float)),
+                   "velocity cudaMalloc");
+        check_cuda(cudaMemcpyAsync(device_sample, sample.data(), count * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream),
+                   "sample cudaMemcpyAsync");
+        check_cuda(cudaMemcpyAsync(device_velocity, velocity.data(), count * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream),
+                   "velocity cudaMemcpyAsync");
+        trtmc::minimax_h3::scheduler_step_cuda_async(device_sample, device_velocity, count,
+                                                     timestep, sigma, sigma_next, stream);
+        check_cuda(cudaMemcpyAsync(sample.data(), device_sample, count * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream),
+                   "result cudaMemcpyAsync");
+        check_cuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+    } catch (...) {
+        cudaFree(device_velocity);
+        cudaFree(device_sample);
+        cudaStreamDestroy(stream);
+        throw;
+    }
+    check_cuda(cudaFree(device_velocity), "velocity cudaFree");
+    check_cuda(cudaFree(device_sample), "sample cudaFree");
+    check_cuda(cudaStreamDestroy(stream), "cudaStreamDestroy");
+
+    for (std::size_t index = 0; index < count; ++index) {
+        const float tolerance = 2.0e-6F + 2.0e-6F * std::abs(expected[index]);
+        if (!std::isfinite(sample[index]) ||
+            std::abs(sample[index] - expected[index]) > tolerance) {
+            throw std::runtime_error("CUDA scheduler differs from CPU at index " +
+                                     std::to_string(index));
+        }
+    }
+}
+
+void test_scheduler_rejects_invalid_inputs() {
+    float* const dummy = reinterpret_cast<float*>(static_cast<uintptr_t>(1));
+    const auto rejects_invalid = [](auto&& operation) {
+        try {
+            operation();
+        } catch (const std::invalid_argument&) {
+            return true;
+        }
+        return false;
+    };
+    if (!rejects_invalid([&] {
+            trtmc::minimax_h3::scheduler_step_cuda_async(nullptr, dummy, 1, 0.25F, 0.75F, 0.5F,
+                                                         nullptr);
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::scheduler_step_cuda_async(dummy, nullptr, 1, 0.25F, 0.75F, 0.5F,
+                                                         nullptr);
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::scheduler_step_cuda_async(dummy, dummy, 1, 0.25F, 0.0F, 0.5F,
+                                                         nullptr);
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::scheduler_step_cuda_async(dummy, dummy, 1, 0.25F, -0.75F, 0.5F,
+                                                         nullptr);
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::scheduler_step_cuda_async(
+                dummy, dummy, 1, 0.25F, std::numeric_limits<float>::quiet_NaN(), 0.5F, nullptr);
+        })) {
+        throw std::runtime_error("CUDA scheduler accepted invalid inputs");
+    }
+
+    trtmc::minimax_h3::scheduler_step_cuda_async(dummy, dummy, 0, 0.25F, 0.75F, 0.5F, nullptr);
+
+    if constexpr (std::numeric_limits<std::size_t>::max() >
+                  static_cast<std::size_t>(std::numeric_limits<int64_t>::max())) {
+        try {
+            trtmc::minimax_h3::scheduler_step_cuda_async(
+                dummy, dummy, static_cast<std::size_t>(std::numeric_limits<int64_t>::max()) + 1U,
+                0.25F, 0.75F, 0.5F, nullptr);
+        } catch (const std::overflow_error&) {
+            return;
+        }
+        throw std::runtime_error("CUDA scheduler accepted an overflowing tensor size");
+    }
+}
+
+void test_cuda_vae_tile_extraction() {
+    constexpr int32_t video_rows_count = 37296;
+    constexpr int32_t patch_dim = 96;
+    constexpr int32_t tile_count = 28;
+    constexpr int32_t channels = 24;
+    constexpr int32_t frames = 7;
+    constexpr int32_t tile_size = 16;
+    const std::size_t video_count = static_cast<std::size_t>(video_rows_count) * patch_dim;
+    const std::size_t tile_values =
+        static_cast<std::size_t>(tile_count) * channels * frames * tile_size * tile_size;
+    std::vector<float> video_rows(video_count);
+    for (int32_t row = 0; row < video_rows_count; ++row) {
+        for (int32_t column = 0; column < patch_dim; ++column)
+            video_rows[static_cast<std::size_t>(row) * patch_dim + column] =
+                static_cast<float>(row * 128 + column);
+    }
+    std::vector<float> tiles(tile_values);
+    trtmc::minimax_h3::VaeLatentNormalization normalization{};
+    for (int32_t channel = 0; channel < channels; ++channel) {
+        normalization.mean[channel] = static_cast<float>(channel) * 0.25F;
+        normalization.std[channel] = 0.5F;
+    }
+
+    cudaStream_t stream = nullptr;
+    float* device_video = nullptr;
+    float* device_tiles = nullptr;
+    check_cuda(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), "cudaStreamCreate");
+    try {
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&device_video), video_count * sizeof(float)),
+                   "VAE video cudaMalloc");
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&device_tiles), tile_values * sizeof(float)),
+                   "VAE tiles cudaMalloc");
+        check_cuda(cudaMemcpyAsync(device_video, video_rows.data(), video_count * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream),
+                   "VAE video cudaMemcpyAsync");
+        trtmc::minimax_h3::extract_vae_tiles_cuda_async(device_video, device_tiles, 6,
+                                                        normalization, stream);
+        check_cuda(cudaMemcpyAsync(tiles.data(), device_tiles, tile_values * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream),
+                   "VAE tiles cudaMemcpyAsync");
+        check_cuda(cudaStreamSynchronize(stream), "VAE extraction cudaStreamSynchronize");
+    } catch (...) {
+        cudaFree(device_tiles);
+        cudaFree(device_video);
+        cudaStreamDestroy(stream);
+        throw;
+    }
+    check_cuda(cudaFree(device_tiles), "VAE tiles cudaFree");
+    check_cuda(cudaFree(device_video), "VAE video cudaFree");
+    check_cuda(cudaStreamDestroy(stream), "VAE cudaStreamDestroy");
+
+    const auto check_sample = [&](int32_t tile, int32_t channel, int32_t frame, int32_t y,
+                                  int32_t x, int32_t latent_y_start, int32_t latent_x_start) {
+        const int32_t latent_frame = 6 * 5 + frame;
+        const int32_t latent_y = latent_y_start + y;
+        const int32_t latent_x = latent_x_start + x;
+        const int32_t row = ((latent_frame * 24 + latent_y / 2) * 42 + latent_x / 2);
+        const int32_t column = channel * 4 + (latent_y % 2) * 2 + latent_x % 2;
+        const float source = video_rows[static_cast<std::size_t>(row) * patch_dim + column];
+        const float expected = source * normalization.std[channel] + normalization.mean[channel];
+        const std::size_t target =
+            ((((static_cast<std::size_t>(tile) * channels + channel) * frames + frame) * tile_size +
+              y) *
+                 tile_size +
+             x);
+        if (tiles[target] != expected)
+            throw std::runtime_error("CUDA VAE tile extraction index mismatch");
+    };
+    check_sample(0, 0, 0, 0, 0, 0, 0);
+    check_sample(8, 7, 3, 5, 9, 10, 11);
+    check_sample(27, 23, 6, 15, 15, 32, 68);
+}
+
+void test_cuda_vae_helpers_reject_invalid_inputs() {
+    trtmc::minimax_h3::VaeLatentNormalization latent_normalization{};
+    trtmc::minimax_h3::VaePixelNormalization pixel_normalization{};
+    float* const dummy = reinterpret_cast<float*>(static_cast<uintptr_t>(1));
+    const auto rejects_invalid = [](auto&& operation) {
+        try {
+            operation();
+        } catch (const std::invalid_argument&) {
+            return true;
+        }
+        return false;
+    };
+    if (!rejects_invalid([&] {
+            trtmc::minimax_h3::extract_vae_tiles_cuda_async(nullptr, dummy, 0, latent_normalization,
+                                                            reinterpret_cast<cudaStream_t>(1));
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::extract_vae_tiles_cuda_async(dummy, dummy, 7, latent_normalization,
+                                                            reinterpret_cast<cudaStream_t>(1));
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::assemble_vae_clip_cuda_async(
+                nullptr, dummy, dummy, 0, pixel_normalization, reinterpret_cast<cudaStream_t>(1));
+        }) ||
+        !rejects_invalid([&] {
+            trtmc::minimax_h3::assemble_vae_clip_cuda_async(
+                dummy, dummy, dummy, -1, pixel_normalization, reinterpret_cast<cudaStream_t>(1));
+        })) {
+        throw std::runtime_error("CUDA VAE helper accepted invalid inputs");
+    }
 }
 
 } // namespace
@@ -60,6 +282,15 @@ int main() {
     if (hash != 0xb68438da31d3c096ULL) {
         std::cerr << "FAIL: H3 full video+audio torch.randn hash mismatch actual=0x" << std::hex
                   << hash << std::dec << '\n';
+        ++failures;
+    }
+    try {
+        test_scheduler_matches_cpu();
+        test_scheduler_rejects_invalid_inputs();
+        test_cuda_vae_tile_extraction();
+        test_cuda_vae_helpers_reject_invalid_inputs();
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: " << error.what() << '\n';
         ++failures;
     }
     return failures == 0 ? 0 : 1;

--- a/tests/cpp/models/minimax_h3/test_minimax_h3_trt_module_bind_external.cpp
+++ b/tests/cpp/models/minimax_h3/test_minimax_h3_trt_module_bind_external.cpp
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/backend/trt_module_impl.h"
+#include "runtime/core/trt_common.h"
+
+#include <NvInfer.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace trtmc {
+
+class TrtModuleImplTestPeer {
+  public:
+    static nvinfer1::IExecutionContext* release_execution_context(TrtModuleImpl& module) {
+        return std::exchange(module.ctx_, nullptr);
+    }
+
+    static bool binding_is_external(const TrtModuleImpl& module, const std::string& name) {
+        return module.buffers_.at(name).is_external;
+    }
+};
+
+} // namespace trtmc
+
+namespace {
+
+int failures = 0;
+trtmc::TrtLogger g_logger;
+
+void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
+    if (!builder)
+        return nullptr;
+
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 20);
+
+    auto* input = network->addInput("x", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{1, {4}});
+    if (!input)
+        return nullptr;
+    auto* identity = network->addIdentity(*input);
+    if (!identity)
+        return nullptr;
+    auto* output = identity->getOutput(0);
+    output->setName("y");
+    network->markOutput(*output);
+
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+    if (!plan)
+        return nullptr;
+    auto runtime = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(g_logger));
+    if (!runtime)
+        return nullptr;
+    return trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        runtime->deserializeCudaEngine(plan->data(), plan->size()));
+}
+
+void test_bind_external_failure_preserves_owned_buffer() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto* ctx = engine->createExecutionContext();
+    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+    auto* const old_ptr = module.device_ptr("x");
+    check(old_ptr != nullptr, "failed external bind: original buffer exists");
+
+    void* ext_ptr = nullptr;
+    cudaMalloc(&ext_ptr, 16);
+    check(ext_ptr != nullptr, "failed external bind: external alloc ok");
+
+    // A missing execution context makes the TensorRT address update fail.
+    // The binding operation must not publish ext_ptr or free old_ptr.
+    auto* detached_ctx = trtmc::TrtModuleImplTestPeer::release_execution_context(module);
+    bool rejected = false;
+    try {
+        module.bind_external("x", ext_ptr);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    check(rejected, "failed external bind: rejection is surfaced");
+    check(module.device_ptr("x") == old_ptr,
+          "failed external bind: original buffer remains published");
+    check(cudaMemset(old_ptr, 0, 16) == cudaSuccess,
+          "failed external bind: original owned buffer remains live");
+
+    delete detached_ctx;
+    cudaFree(ext_ptr);
+    cudaStreamDestroy(stream);
+}
+
+void test_bind_external_same_owned_pointer_preserves_ownership() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    {
+        auto* ctx = engine->createExecutionContext();
+        trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+        auto* const owned_ptr = module.device_ptr("x");
+        check(owned_ptr != nullptr, "same-pointer external bind: original buffer exists");
+        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
+              "same-pointer external bind: original buffer is owned");
+
+        module.bind_external("x", owned_ptr);
+
+        check(module.device_ptr("x") == owned_ptr,
+              "same-pointer external bind: device pointer is unchanged");
+        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
+              "same-pointer external bind: ownership is preserved");
+    }
+    cudaStreamDestroy(stream);
+}
+
+} // namespace
+
+int main() {
+    test_bind_external_failure_preserves_owned_buffer();
+    test_bind_external_same_owned_pointer_preserves_ownership();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/cpp/test_trt_module.cpp
+++ b/tests/cpp/test_trt_module.cpp
@@ -42,6 +42,8 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 static int failures = 0;
@@ -55,6 +57,21 @@ static void check(bool condition, const char* test_name) {
 
 // Process-wide logger (TRT requires a single logger for all objects).
 static trtmc::TrtLogger g_logger;
+
+namespace trtmc {
+
+class TrtModuleImplTestPeer {
+  public:
+    static nvinfer1::IExecutionContext* release_execution_context(TrtModuleImpl& module) {
+        return std::exchange(module.ctx_, nullptr);
+    }
+
+    static bool binding_is_external(const TrtModuleImpl& module, const std::string& name) {
+        return module.buffers_.at(name).is_external;
+    }
+};
+
+} // namespace trtmc
 
 // Build a tiny TRT engine: identity mapping input[4] → output[4] (float32)
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
@@ -315,6 +332,68 @@ static void test_bind_external() {
     cudaStreamDestroy(stream);
 }
 
+static void test_bind_external_failure_preserves_owned_buffer() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto* ctx = engine->createExecutionContext();
+    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+    auto* const old_ptr = module.device_ptr("x");
+    check(old_ptr != nullptr, "failed external bind: original buffer exists");
+
+    void* ext_ptr = nullptr;
+    cudaMalloc(&ext_ptr, 16);
+    check(ext_ptr != nullptr, "failed external bind: external alloc ok");
+
+    // A missing execution context makes the TensorRT address update fail.
+    // The binding operation must not publish ext_ptr or free old_ptr.
+    auto* detached_ctx = trtmc::TrtModuleImplTestPeer::release_execution_context(module);
+    bool rejected = false;
+    try {
+        module.bind_external("x", ext_ptr);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    check(rejected, "failed external bind: rejection is surfaced");
+    check(module.device_ptr("x") == old_ptr,
+          "failed external bind: original buffer remains published");
+    check(cudaMemset(old_ptr, 0, 16) == cudaSuccess,
+          "failed external bind: original owned buffer remains live");
+
+    delete detached_ctx;
+    cudaFree(ext_ptr);
+    cudaStreamDestroy(stream);
+}
+
+static void test_bind_external_same_owned_pointer_preserves_ownership() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    {
+        auto* ctx = engine->createExecutionContext();
+        trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+        auto* const owned_ptr = module.device_ptr("x");
+        check(owned_ptr != nullptr, "same-pointer external bind: original buffer exists");
+        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
+              "same-pointer external bind: original buffer is owned");
+
+        module.bind_external("x", owned_ptr);
+
+        check(module.device_ptr("x") == owned_ptr,
+              "same-pointer external bind: device pointer is unchanged");
+        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
+              "same-pointer external bind: ownership is preserved");
+    }
+    cudaStreamDestroy(stream);
+}
+
 static void test_unique_ptr_ownership() {
     // Modules now live behind unique_ptr<ITrtModule> — verify ownership transfer
     auto engine = build_identity_engine();
@@ -488,6 +567,8 @@ int main() {
     test_introspection();
     test_device_ptr();
     test_bind_external();
+    test_bind_external_failure_preserves_owned_buffer();
+    test_bind_external_same_owned_pointer_preserves_ownership();
     test_unique_ptr_ownership();
     test_keep_alive();
     test_forward_device();

--- a/tests/cpp/test_trt_module.cpp
+++ b/tests/cpp/test_trt_module.cpp
@@ -42,8 +42,6 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
-#include <stdexcept>
-#include <utility>
 #include <vector>
 
 static int failures = 0;
@@ -57,21 +55,6 @@ static void check(bool condition, const char* test_name) {
 
 // Process-wide logger (TRT requires a single logger for all objects).
 static trtmc::TrtLogger g_logger;
-
-namespace trtmc {
-
-class TrtModuleImplTestPeer {
-  public:
-    static nvinfer1::IExecutionContext* release_execution_context(TrtModuleImpl& module) {
-        return std::exchange(module.ctx_, nullptr);
-    }
-
-    static bool binding_is_external(const TrtModuleImpl& module, const std::string& name) {
-        return module.buffers_.at(name).is_external;
-    }
-};
-
-} // namespace trtmc
 
 // Build a tiny TRT engine: identity mapping input[4] → output[4] (float32)
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
@@ -332,68 +315,6 @@ static void test_bind_external() {
     cudaStreamDestroy(stream);
 }
 
-static void test_bind_external_failure_preserves_owned_buffer() {
-    auto engine = build_identity_engine();
-    if (!engine)
-        return;
-
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-
-    auto* ctx = engine->createExecutionContext();
-    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
-    auto* const old_ptr = module.device_ptr("x");
-    check(old_ptr != nullptr, "failed external bind: original buffer exists");
-
-    void* ext_ptr = nullptr;
-    cudaMalloc(&ext_ptr, 16);
-    check(ext_ptr != nullptr, "failed external bind: external alloc ok");
-
-    // A missing execution context makes the TensorRT address update fail.
-    // The binding operation must not publish ext_ptr or free old_ptr.
-    auto* detached_ctx = trtmc::TrtModuleImplTestPeer::release_execution_context(module);
-    bool rejected = false;
-    try {
-        module.bind_external("x", ext_ptr);
-    } catch (const std::runtime_error&) {
-        rejected = true;
-    }
-    check(rejected, "failed external bind: rejection is surfaced");
-    check(module.device_ptr("x") == old_ptr,
-          "failed external bind: original buffer remains published");
-    check(cudaMemset(old_ptr, 0, 16) == cudaSuccess,
-          "failed external bind: original owned buffer remains live");
-
-    delete detached_ctx;
-    cudaFree(ext_ptr);
-    cudaStreamDestroy(stream);
-}
-
-static void test_bind_external_same_owned_pointer_preserves_ownership() {
-    auto engine = build_identity_engine();
-    if (!engine)
-        return;
-
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-    {
-        auto* ctx = engine->createExecutionContext();
-        trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
-        auto* const owned_ptr = module.device_ptr("x");
-        check(owned_ptr != nullptr, "same-pointer external bind: original buffer exists");
-        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
-              "same-pointer external bind: original buffer is owned");
-
-        module.bind_external("x", owned_ptr);
-
-        check(module.device_ptr("x") == owned_ptr,
-              "same-pointer external bind: device pointer is unchanged");
-        check(!trtmc::TrtModuleImplTestPeer::binding_is_external(module, "x"),
-              "same-pointer external bind: ownership is preserved");
-    }
-    cudaStreamDestroy(stream);
-}
-
 static void test_unique_ptr_ownership() {
     // Modules now live behind unique_ptr<ITrtModule> — verify ownership transfer
     auto engine = build_identity_engine();
@@ -567,8 +488,6 @@ int main() {
     test_introspection();
     test_device_ptr();
     test_bind_external();
-    test_bind_external_failure_preserves_owned_buffer();
-    test_bind_external_same_owned_pointer_preserves_ownership();
     test_unique_ptr_ownership();
     test_keep_alive();
     test_forward_device();

--- a/tests/e2e/models/minimax_h3/MODEL.toml
+++ b/tests/e2e/models/minimax_h3/MODEL.toml
@@ -25,6 +25,7 @@ input_fields = [
   { input = "fps", manifest = "fps" },
 ]
 build_cli_args = [
+  { flag = "--set", value = "minimax_h3.first_block_cache=true" },
   { flag = "--video-height", input = "video_height" },
   { flag = "--video-width", input = "video_width" },
   { flag = "--video-num-frames", input = "video_num_frames" },

--- a/tests/e2e/models/minimax_h3/benchmark_native_runtime.py
+++ b/tests/e2e/models/minimax_h3/benchmark_native_runtime.py
@@ -1,0 +1,724 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark warm MiniMax-H3 requests and prove the observed residency boundary.
+
+The shared benchmark worker keeps one ``IPipeline`` alive for warmup and measured
+requests.  This harness parses H3 cache-hit markers instead of assuming that
+TensorRT modules are resident.  Request-local modules yield per-request engine
+timings; resident modules yield only a variant aggregate because the shared
+runtime has no per-request timing snapshot API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import statistics
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from tensorrt_model_connect.families.minimax_h3.provenance import (
+    CHECKPOINT_REVISION,
+    atomic_write_json,
+    file_identity,
+    stable_file_record,
+    validate_file_identity,
+    validate_native_bundle_config,
+    validate_source_revision,
+)
+
+
+STAGES = ("text_encoder", "adaln", "denoiser", "vae_decoder")
+PERF_PATTERN = re.compile(
+    r"\[minimax-h3\.perf\] text_encoder_ms=(?P<text_encoder>[0-9.]+) "
+    r"adaln_ms=(?P<adaln>[0-9.]+) denoiser_ms=(?P<denoiser>[0-9.]+) "
+    r"vae_decoder_ms=(?P<vae_decoder>[0-9.]+) total_ms=(?P<total>[0-9.]+)"
+    r"(?P<annotations>[^\n]*)"
+)
+ENGINE_PATTERN = re.compile(
+    r'\[trtmc\.engine_timing\] label="[^"]*" execute_ms=(?P<execute>[0-9.]+) '
+    r"launches=(?P<launches>[0-9]+)"
+)
+BACKEND_PATTERN = re.compile(
+    r"\[trtmc\] Backend loaded: [^\n]* \((?P<dso>libtrtmc_backend_[^)]+\.so)\)"
+)
+CUDA_GRAPH_FAILURE = "[cuda_graph] Capture failed"
+ANNOTATION_PATTERN = re.compile(r"(?P<name>[a-z][a-z0-9_]*)=(?P<value>[^ ]+)")
+CACHE_THRESHOLD_CONFIG_KEY = "minimax_h3.first_block_cache_threshold"
+
+
+def evict_file_pages(path: Path) -> dict[str, bool | str]:
+    """Best-effort eviction of clean cache pages for one file only."""
+
+    posix_fadvise = getattr(os, "posix_fadvise", None)
+    dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+    if posix_fadvise is None or dontneed is None:
+        return {"supported": False, "attempted": False, "succeeded": False}
+
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+        try:
+            posix_fadvise(descriptor, 0, 0, dontneed)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        return {
+            "supported": True,
+            "attempted": True,
+            "succeeded": False,
+            "error": f"{type(error).__name__}: {error}",
+        }
+    return {"supported": True, "attempted": True, "succeeded": True}
+
+
+def resolve_trt_backend_dso(executable: Path, bundle_config: dict) -> Path:
+    """Resolve the exact adjacent backend DSO selected by the runtime loader."""
+
+    if bundle_config.get("engine_backend") != "trt":
+        raise ValueError("MiniMax-H3 native evidence requires engine_backend=trt")
+    abi = bundle_config.get("trt_abi")
+    match = re.fullmatch(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", str(abi))
+    if match is None:
+        raise ValueError("MiniMax-H3 bundle config has an invalid TensorRT ABI")
+    names = (
+        f"libtrtmc_backend_trt_{match.group('major')}_{match.group('minor')}.so",
+        "libtrtmc_backend_trt.so",
+    )
+    for name in names:
+        candidate = executable.parent / name
+        if candidate.is_file():
+            return candidate.resolve(strict=True)
+    raise FileNotFoundError(
+        "MiniMax-H3 could not bind the adjacent TensorRT backend DSO: "
+        + ", ".join(str(executable.parent / name) for name in names)
+    )
+
+
+def _canonical_sha256(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        raise ValueError("MiniMax-H3 benchmark cannot summarize an empty sample set")
+    return float(statistics.median(values))
+
+
+def _summary(requests: list[dict[str, Any]]) -> dict[str, float | int]:
+    summary: dict[str, float | int] = {
+        "samples": len(requests),
+        "median_public_pipeline_call_wall_ms": _median(
+            [item["public_pipeline_call_wall_ms"] for item in requests]
+        ),
+        "median_pipeline_total_ms": _median([item["pipeline_total_ms"] for item in requests]),
+        "median_host_prepost_and_output_assembly_ms": _median(
+            [item["host_prepost_and_output_assembly_ms"] for item in requests]
+        ),
+    }
+    if all("engine_execute" in item for item in requests):
+        summary["median_engine_execute_ms"] = _median(
+            [item["engine_execute"]["total_ms"] for item in requests]
+        )
+        summary["median_stage_non_engine_ms"] = _median(
+            [item["stage_non_engine"]["total_ms"] for item in requests]
+        )
+    return summary
+
+
+def _annotation_value(name: str, raw: str) -> bool | int | float | str:
+    if name.endswith("_hit") and raw in {"0", "1"}:
+        return raw == "1"
+    try:
+        return int(raw)
+    except ValueError:
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+
+
+def _perf_annotations(perf: dict[str, str]) -> dict[str, bool | int | float | str]:
+    return {
+        match.group("name"): _annotation_value(match.group("name"), match.group("value"))
+        for match in ANNOTATION_PATTERN.finditer(perf.get("annotations", ""))
+    }
+
+
+def _request_timing(
+    perf: dict[str, str],
+    engine_group: list[dict[str, str]] | None,
+    *,
+    iteration: int,
+    public_wall_ms: float | None,
+) -> dict[str, Any]:
+    stage_wall = {stage + "_ms": float(perf[stage]) for stage in STAGES}
+    stage_wall["total_ms"] = sum(stage_wall.values())
+    pipeline_total_ms = float(perf["total"])
+    result: dict[str, Any] = {
+        "iteration": iteration,
+        "pipeline_total_ms": pipeline_total_ms,
+        "stage_wall": stage_wall,
+        "runtime_annotations": _perf_annotations(perf),
+        # This is deliberately not called output-assembly time: it also contains
+        # tokenization, RNG, patch/unpatch, scheduler, and other host work.
+        "host_prepost_and_output_assembly_ms": pipeline_total_ms - stage_wall["total_ms"],
+    }
+    if engine_group is not None:
+        engine_execute = {
+            stage + "_ms": float(engine["execute"])
+            for stage, engine in zip(STAGES, engine_group, strict=True)
+        }
+        engine_execute["total_ms"] = sum(engine_execute.values())
+        result["engine_execute"] = engine_execute
+        result["engine_launches"] = {
+            stage: int(engine["launches"])
+            for stage, engine in zip(STAGES, engine_group, strict=True)
+        }
+        stage_non_engine = {
+            stage + "_ms": stage_wall[stage + "_ms"] - engine_execute[stage + "_ms"]
+            for stage in STAGES
+        }
+        stage_non_engine["total_ms"] = sum(stage_non_engine.values())
+        # Module creation/deserialization, transfers, and stage-local host work
+        # cannot be split further with the current runtime timing surface.
+        result["stage_non_engine"] = stage_non_engine
+    if public_wall_ms is not None:
+        result["public_pipeline_call_wall_ms"] = public_wall_ms
+        result["worker_call_overhead_ms"] = public_wall_ms - pipeline_total_ms
+    return result
+
+
+def parse_worker_evidence(
+    result: dict[str, Any],
+    log_text: str,
+    *,
+    warmup: int,
+    iterations: int,
+    cuda_graphs: bool,
+    cache_threshold: float | None = None,
+    expected_backend_dso_name: str | None = None,
+) -> dict[str, Any]:
+    """Bind worker observations to H3 stage and TensorRT engine timings."""
+
+    if result.get("status") != "completed":
+        raise ValueError("MiniMax-H3 benchmark worker did not complete")
+    if result.get("operation") != "generate_image":
+        raise ValueError("MiniMax-H3 benchmark worker used the wrong operation")
+    if result.get("warmup") != warmup or result.get("iterations") != iterations:
+        raise ValueError("MiniMax-H3 benchmark worker changed the measurement count")
+    observations = result.get("observations")
+    if not isinstance(observations, list) or len(observations) != iterations:
+        raise ValueError("MiniMax-H3 benchmark worker returned the wrong observation count")
+
+    perf_matches = [match.groupdict() for match in PERF_PATTERN.finditer(log_text)]
+    engine_matches = [match.groupdict() for match in ENGINE_PATTERN.finditer(log_text)]
+    request_count = warmup + iterations
+    if len(perf_matches) != request_count:
+        raise ValueError(
+            "MiniMax-H3 benchmark log has "
+            f"{len(perf_matches)} pipeline timings for {request_count} requests"
+        )
+    if not engine_matches:
+        raise ValueError("MiniMax-H3 benchmark log has no TensorRT engine timing evidence")
+    loaded_backends = [match.group("dso") for match in BACKEND_PATTERN.finditer(log_text)]
+    if expected_backend_dso_name is not None and loaded_backends != [expected_backend_dso_name]:
+        raise ValueError(
+            "MiniMax-H3 benchmark runtime did not load the provenance-bound TensorRT backend DSO"
+        )
+    capture_failures = log_text.count(CUDA_GRAPH_FAILURE)
+    if cuda_graphs and capture_failures:
+        raise ValueError(
+            f"MiniMax-H3 CUDA graph capture failed {capture_failures} time(s); "
+            "the requested variant is not a CUDA graph result"
+        )
+
+    per_request_engine_timings = len(engine_matches) == request_count * len(STAGES)
+    all_requests = []
+    for index, perf in enumerate(perf_matches):
+        begin = index * len(STAGES)
+        all_requests.append(
+            _request_timing(
+                perf,
+                engine_matches[begin : begin + len(STAGES)] if per_request_engine_timings else None,
+                iteration=index,
+                public_wall_ms=None,
+            )
+        )
+
+    measured_requests = []
+    for iteration, (timing, observation) in enumerate(
+        zip(all_requests[warmup:], observations, strict=True)
+    ):
+        if observation.get("iteration") != iteration:
+            raise ValueError("MiniMax-H3 benchmark observation order is invalid")
+        wall = observation.get("measured_wall_ms")
+        if not isinstance(wall, (int, float)):
+            raise ValueError("MiniMax-H3 benchmark observation has no measured wall time")
+        item = dict(timing)
+        item["iteration"] = iteration
+        item["public_pipeline_call_wall_ms"] = float(wall)
+        item["worker_call_overhead_ms"] = float(wall) - item["pipeline_total_ms"]
+        measured_requests.append(item)
+
+    first_request = all_requests[0]
+    engine_timing_scope = "per_request"
+    aggregate_engine = None
+    if not per_request_engine_timings:
+        engine_timing_scope = "variant_aggregate"
+        aggregate_engine = {
+            "entries": [
+                {
+                    "execute_ms": float(item["execute"]),
+                    "launches": int(item["launches"]),
+                }
+                for item in engine_matches
+            ],
+            "total_ms": sum(float(item["execute"]) for item in engine_matches),
+            "total_launches": sum(int(item["launches"]) for item in engine_matches),
+            "requests_included": request_count,
+            "per_request_values_available": False,
+        }
+    cache_fields = (
+        "text_cache_hit",
+        "adaln_cache_hit",
+        "denoiser_resident_hit",
+        "vae_resident_hit",
+    )
+    cache_markers_available = all(
+        all(field in item["runtime_annotations"] for field in cache_fields) for item in all_requests
+    )
+    measured_cache_hits = (
+        all(
+            all(item["runtime_annotations"][field] is True for field in cache_fields)
+            for item in all_requests[warmup:]
+        )
+        if cache_markers_available and warmup > 0
+        else None
+    )
+    if cache_markers_available and warmup > 0 and not measured_cache_hits:
+        raise ValueError("MiniMax-H3 measured warm requests did not hit all resident caches")
+    if cache_threshold is not None:
+        observed_thresholds = [
+            item["runtime_annotations"].get("cache_threshold") for item in all_requests
+        ]
+        if any(not isinstance(value, (int, float)) for value in observed_thresholds):
+            raise ValueError(
+                "MiniMax-H3 benchmark requested a cache threshold but the runtime did not report it"
+            )
+        if any(
+            not math.isclose(float(value), cache_threshold, rel_tol=0.0, abs_tol=1.0e-9)
+            for value in observed_thresholds
+        ):
+            raise ValueError(
+                "MiniMax-H3 runtime cache threshold does not match the requested override"
+            )
+    cold_start = {
+        "pipeline_factory_load_ms": float(result["load_ms"]),
+        "pipeline_factory_load_includes_plan_deserialization": False,
+        "first_request": first_request,
+        "plan_deserialization_separately_instrumented": False,
+        "plan_deserialization_included_in": "first_request.stage_wall",
+    }
+    return {
+        "cuda_graphs_requested": cuda_graphs,
+        "cuda_graph_capture_failures_observed": capture_failures,
+        "pipeline_factory_load_ms": float(result["load_ms"]),
+        "pipeline_factory_load_includes_plan_deserialization": False,
+        "warmup_requests": warmup,
+        "measured_requests_are_pipeline_warm": warmup > 0,
+        "engine_timing_scope": engine_timing_scope,
+        "aggregate_engine_execute": aggregate_engine,
+        "cache_markers_available": cache_markers_available,
+        "measured_requests_hit_all_resident_caches": measured_cache_hits,
+        "cache_threshold_override": cache_threshold,
+        "loaded_backend_dso": loaded_backends[0] if loaded_backends else None,
+        "cold_start": cold_start,
+        "first_request": first_request,
+        "requests": measured_requests,
+        "summary": _summary(measured_requests),
+        "output_summary": result.get("output_summary", {}),
+    }
+
+
+def build_worker_request(
+    *,
+    bundle: Path,
+    plugin_dir: Path,
+    prompt: str,
+    seed: int,
+    source_revision: str,
+    cuda_graphs: bool,
+    warmup: int,
+    iterations: int,
+    cache_threshold: float | None = None,
+) -> dict[str, Any]:
+    workload = {
+        "prompt": prompt,
+        "seed": seed,
+        "height": 768,
+        "width": 1344,
+        "video_height": 768,
+        "video_width": 1344,
+        "video_num_frames": 124,
+        "num_inference_steps": 50,
+        "media_type": "video",
+        "batch_size": 1,
+    }
+    runtime: dict[str, Any] = {
+        "cuda_graphs": cuda_graphs,
+        "model_plugin_search_paths": [str(plugin_dir)],
+    }
+    if cache_threshold is not None:
+        runtime["config"] = {CACHE_THRESHOLD_CONFIG_KEY: cache_threshold}
+    identity = {
+        "source_revision": source_revision,
+        "bundle_path": str(bundle),
+        "workload": workload,
+        "runtime": runtime,
+        "measurement": {"warmup": warmup, "iterations": iterations},
+    }
+    return {
+        "schema_version": 1,
+        "case_name": f"minimax-h3-cuda-graphs-{'on' if cuda_graphs else 'off'}",
+        "case_digest": _canonical_sha256(identity),
+        "bundle": str(bundle),
+        "operation": "generate_image",
+        "request": workload,
+        "runtime": runtime,
+        "measurement": {
+            "warmup": warmup,
+            "iterations": iterations,
+            "timing_scope": "public_pipeline_call_wall",
+            "asset_loading_included": False,
+        },
+    }
+
+
+def _worker_metadata(worker: Path) -> dict[str, Any]:
+    completed = subprocess.run(
+        [str(worker), "--metadata"], capture_output=True, text=True, check=False, timeout=10
+    )
+    if completed.returncode:
+        raise RuntimeError(f"MiniMax-H3 benchmark worker metadata failed: {completed.stderr}")
+    try:
+        metadata = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("MiniMax-H3 benchmark worker returned invalid metadata") from error
+    if metadata.get("schema_version") != "trtmc.benchmark-worker-metadata/v1":
+        raise RuntimeError("MiniMax-H3 benchmark worker metadata schema is unsupported")
+    return metadata
+
+
+def _run_variant(
+    *,
+    worker: Path,
+    backend_dso_name: str,
+    bundle: Path,
+    plugin_dir: Path,
+    prompt: str,
+    seed: int,
+    source_revision: str,
+    cuda_graphs: bool,
+    warmup: int,
+    iterations: int,
+    cache_threshold: float | None,
+    timeout_s: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    name = "cuda_graphs_on" if cuda_graphs else "cuda_graphs_off"
+    variant_dir = output_dir / name
+    variant_dir.mkdir()
+    request = build_worker_request(
+        bundle=bundle,
+        plugin_dir=plugin_dir,
+        prompt=prompt,
+        seed=seed,
+        source_revision=source_revision,
+        cuda_graphs=cuda_graphs,
+        warmup=warmup,
+        iterations=iterations,
+        cache_threshold=cache_threshold,
+    )
+    request_path = variant_dir / "worker_request.json"
+    result_path = variant_dir / "worker_result.json"
+    log_path = variant_dir / "worker.log"
+    atomic_write_json(request_path, request)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "TRTMC_MODEL_PLUGIN_DIR": str(plugin_dir),
+            "TRTMC_MODEL_PLUGIN_STRICT": "1",
+            "WORLD_SIZE": "1",
+            "RANK": "0",
+        }
+    )
+    command = [str(worker), "--request", str(request_path), "--output", str(result_path)]
+    bundle_page_cache_eviction = evict_file_pages(bundle)
+    started = time.perf_counter()
+    with log_path.open("w", encoding="utf-8") as log:
+        completed = subprocess.run(
+            command,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=timeout_s,
+            env=environment,
+        )
+    process_wall_s = time.perf_counter() - started
+    if not result_path.is_file():
+        raise RuntimeError(
+            f"MiniMax-H3 benchmark worker exited {completed.returncode} without a result; "
+            f"see {log_path}"
+        )
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    if completed.returncode or result.get("status") != "completed":
+        raise RuntimeError(
+            f"MiniMax-H3 benchmark worker failed: {result.get('error', completed.returncode)}; "
+            f"see {log_path}"
+        )
+    if result.get("case_digest") != request["case_digest"]:
+        raise RuntimeError("MiniMax-H3 benchmark worker returned the wrong case digest")
+    evidence = parse_worker_evidence(
+        result,
+        log_path.read_text(encoding="utf-8", errors="replace"),
+        warmup=warmup,
+        iterations=iterations,
+        cuda_graphs=cuda_graphs,
+        cache_threshold=cache_threshold,
+        expected_backend_dso_name=backend_dso_name,
+    )
+    evidence.update(
+        {
+            "process_wall_s": process_wall_s,
+            "runtime_request": request["runtime"],
+            "worker_request": stable_file_record(request_path, "worker request")[0],
+            "worker_result": stable_file_record(result_path, "worker result")[0],
+            "worker_log": stable_file_record(log_path, "worker log")[0],
+            "bundle_page_cache_eviction": bundle_page_cache_eviction,
+            "command": command,
+        }
+    )
+    return evidence
+
+
+def _variants(mode: str) -> tuple[bool, ...]:
+    if mode == "off":
+        return (False,)
+    if mode == "on":
+        return (True,)
+    if mode == "both":
+        return (False, True)
+    raise ValueError(f"Unsupported CUDA graph mode: {mode}")
+
+
+def _comparison(variants: list[dict[str, Any]]) -> dict[str, float] | None:
+    by_mode = {item["cuda_graphs_requested"]: item for item in variants}
+    if set(by_mode) != {False, True}:
+        return None
+    off = by_mode[False]["summary"]["median_public_pipeline_call_wall_ms"]
+    on = by_mode[True]["summary"]["median_public_pipeline_call_wall_ms"]
+    return {
+        "cuda_graphs_off_median_ms": off,
+        "cuda_graphs_on_median_ms": on,
+        "cuda_graphs_on_minus_off_ms": on - off,
+        "cuda_graphs_on_over_off": on / off,
+    }
+
+
+def _residency_contract(variants: list[dict[str, Any]]) -> dict[str, Any]:
+    markers_available = all(item["cache_markers_available"] for item in variants)
+    warm_hits = (
+        all(item["measured_requests_hit_all_resident_caches"] is True for item in variants)
+        if markers_available
+        else None
+    )
+    return {
+        "worker_process_reused_within_variant": True,
+        "pipeline_instance_reused_across_requests": True,
+        "cache_markers_available": markers_available,
+        "measured_requests_hit_all_resident_caches": warm_hits,
+        "engine_modules_reused_across_requests": warm_hits,
+        "evidence": (
+            "per-request text_cache_hit, adaln_cache_hit, denoiser_resident_hit, and "
+            "vae_resident_hit markers"
+            if markers_available
+            else "runtime predates the explicit MiniMax-H3 cache-hit timing markers"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--prompt-file", required=True)
+    parser.add_argument("--worker", required=True)
+    parser.add_argument("--plugin-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument(
+        "--cuda-graphs",
+        nargs="?",
+        const="on",
+        default="both",
+        choices=("off", "on", "both"),
+        help="benchmark CUDA graphs off, on, or both (bare flag means on)",
+    )
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iterations", type=int, default=2)
+    parser.add_argument(
+        "--cache-threshold",
+        type=float,
+        default=None,
+        help=f"override runtime.config.{CACHE_THRESHOLD_CONFIG_KEY}",
+    )
+    parser.add_argument("--timeout-s", type=int, default=7200)
+    args = parser.parse_args()
+    if args.warmup < 0 or args.iterations < 1 or args.timeout_s < 1:
+        raise ValueError("warmup must be non-negative; iterations and timeout must be positive")
+    if args.cache_threshold is not None and (
+        not math.isfinite(args.cache_threshold) or args.cache_threshold <= 0.0
+    ):
+        raise ValueError("cache threshold must be a positive finite number")
+
+    source_revision = validate_source_revision(args.source_revision)
+    bundle = Path(args.bundle).resolve(strict=True)
+    bundle_identity = file_identity(bundle)
+    prompt_path = Path(args.prompt_file).resolve(strict=True)
+    worker = Path(args.worker).resolve(strict=True)
+    plugin_dir = Path(args.plugin_dir).resolve(strict=True)
+    plugin = (plugin_dir / "libtrtmc_model_minimax_h3.so").resolve(strict=True)
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists():
+        raise FileExistsError(f"MiniMax-H3 benchmark output already exists: {output_dir}")
+    output_dir.mkdir(parents=True)
+
+    prompt_spec = json.loads(prompt_path.read_text(encoding="utf-8"))
+    if not isinstance(prompt_spec.get("prompt"), str) or not prompt_spec["prompt"]:
+        raise ValueError("MiniMax-H3 benchmark prompt must be a non-empty string")
+    if not isinstance(prompt_spec.get("seed"), int) or isinstance(prompt_spec["seed"], bool):
+        raise ValueError("MiniMax-H3 benchmark seed must be an integer")
+
+    # Read the bundle's own pinned source first so already-qualified engines can
+    # be benchmarked by a newer harness without misattributing their build.
+    from tensorrt_model_connect.families.minimax_h3.provenance import load_bundle_config
+
+    unvalidated_config = load_bundle_config(bundle)
+    bundle_source_revision = validate_source_revision(unvalidated_config.get("source_revision", ""))
+    bundle_config = validate_native_bundle_config(bundle, source_revision=bundle_source_revision)
+    backend = resolve_trt_backend_dso(worker, bundle_config)
+    prompt_record, prompt_identity = stable_file_record(prompt_path, "prompt file")
+    worker_record, worker_identity = stable_file_record(worker, "benchmark worker")
+    backend_record, backend_identity = stable_file_record(backend, "TensorRT backend")
+    plugin_record, plugin_identity = stable_file_record(plugin, "MiniMax-H3 model plugin")
+    script_path = Path(__file__).resolve()
+    script_record, script_identity = stable_file_record(script_path, "benchmark harness")
+    metadata = _worker_metadata(worker)
+
+    variant_receipts = [
+        _run_variant(
+            worker=worker,
+            backend_dso_name=backend.name,
+            bundle=bundle,
+            plugin_dir=plugin_dir,
+            prompt=prompt_spec["prompt"],
+            seed=int(prompt_spec["seed"]),
+            source_revision=source_revision,
+            cuda_graphs=enabled,
+            warmup=args.warmup,
+            iterations=args.iterations,
+            cache_threshold=args.cache_threshold,
+            timeout_s=args.timeout_s,
+            output_dir=output_dir,
+        )
+        for enabled in _variants(args.cuda_graphs)
+    ]
+
+    validate_file_identity(bundle, bundle_identity, "native bundle")
+    validate_file_identity(prompt_path, prompt_identity, "prompt file")
+    validate_file_identity(worker, worker_identity, "benchmark worker")
+    validate_file_identity(backend, backend_identity, "TensorRT backend")
+    validate_file_identity(plugin, plugin_identity, "MiniMax-H3 model plugin")
+    validate_file_identity(script_path, script_identity, "benchmark harness")
+    receipt = {
+        "schema_version": "trtmc.minimax-h3-native-runtime-benchmark/v1",
+        "status": "passed",
+        "backend": "tensorrt_native_single_device",
+        "source_revision": source_revision,
+        "bundle_source_revision": bundle_source_revision,
+        "checkpoint_revision": CHECKPOINT_REVISION,
+        "checkpoint_inventory_sha256": bundle_config["checkpoint_inventory_sha256"],
+        "builder_source_sha256": bundle_config["builder_source_sha256"],
+        "plan_sha256": bundle_config["plan_sha256"],
+        "workspace_limit_bytes": bundle_config["workspace_limit_bytes"],
+        "inputs": {
+            "bundle": {"path": str(bundle), **bundle_identity},
+            "prompt_file": prompt_record,
+            "worker": worker_record,
+            "trt_backend": backend_record,
+            "model_plugin": plugin_record,
+            "benchmark_harness": script_record,
+        },
+        "worker_metadata": metadata,
+        "workload": {
+            "prompt": prompt_spec["prompt"],
+            "seed": int(prompt_spec["seed"]),
+            "height": 768,
+            "width": 1344,
+            "num_frames": 124,
+            "num_inference_steps": 50,
+            "batch_size": 1,
+        },
+        "measurement": {
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "timing_scope": "public_pipeline_call_wall",
+            "variant_process_isolation": True,
+            "variant_order": [item["cuda_graphs_requested"] for item in variant_receipts],
+            "cache_threshold_override": args.cache_threshold,
+        },
+        "residency_contract": _residency_contract(variant_receipts),
+        "timing_boundaries": {
+            "pipeline_factory_load": (
+                "creates the pipeline/tokenizer but does not deserialize the four lazy plans"
+            ),
+            "stage_wall": (
+                "includes plan read/deserialization, engine execution, transfers, and "
+                "stage-local host work"
+            ),
+            "engine_execute": "CUDA event time around TensorRT enqueue or CUDA graph launch",
+            "stage_non_engine": (
+                "available only for request-local engines; resident engine timing is emitted "
+                "only as a whole-variant aggregate and is never divided into synthetic samples"
+            ),
+            "output_assembly": {
+                "separately_instrumented": False,
+                "included_in": "host_prepost_and_output_assembly_ms",
+                "reason": (
+                    "the current H3 pipeline exposes only four stage walls and total request wall; "
+                    "exact output assembly requires pipeline/runtime instrumentation"
+                ),
+            },
+            "png_encoding": "not executed by the benchmark worker",
+        },
+        "host": {"hostname": platform.node(), "platform": platform.platform()},
+        "world_size": 1,
+        "collective_transport": "none",
+        "variants": variant_receipts,
+        "comparison": _comparison(variant_receipts),
+    }
+    atomic_write_json(output_dir / "benchmark_receipt.json", receipt)
+    print(json.dumps(receipt, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/models/minimax_h3/build_native_components.py
+++ b/tests/e2e/models/minimax_h3/build_native_components.py
@@ -10,6 +10,7 @@ import gc
 import hashlib
 import json
 import time
+from dataclasses import replace
 from pathlib import Path
 
 from tensorrt_model_connect.families.minimax_h3.checkpoint import (
@@ -18,8 +19,8 @@ from tensorrt_model_connect.families.minimax_h3.checkpoint import (
     validate_component_key_partition,
 )
 from tensorrt_model_connect.families.minimax_h3.config import (
-    DEFAULT_WORKSPACE_LIMIT_BYTES,
     SOL_ENGINE_1344X768_124F,
+    default_workspace_limit_bytes,
 )
 from tensorrt_model_connect.families.minimax_h3.provenance import (
     CHECKPOINT_REVISION,
@@ -57,13 +58,16 @@ def _positive_workspace_gib(raw: str) -> int:
     return value
 
 
-def _workspace_limits(workspace_gib: int | None) -> dict[str, int]:
+def _workspace_limits(
+    workspace_gib: int | None, *, first_block_cache: bool = False
+) -> dict[str, int]:
+    defaults = default_workspace_limit_bytes(first_block_cache=first_block_cache)
     if workspace_gib is None:
-        return dict(DEFAULT_WORKSPACE_LIMIT_BYTES)
+        return defaults
     if not isinstance(workspace_gib, int) or isinstance(workspace_gib, bool) or workspace_gib <= 0:
         raise ValueError("workspace_gib must be a positive integer")
     workspace_bytes = workspace_gib << 30
-    return {filename: workspace_bytes for filename in DEFAULT_WORKSPACE_LIMIT_BYTES}
+    return {filename: workspace_bytes for filename in defaults}
 
 
 def _validate_resume_identity(previous: object, current: dict) -> None:
@@ -92,6 +96,11 @@ def main() -> int:
     parser.add_argument("--source-revision", required=True)
     parser.add_argument("--cp-size", type=int, default=1, choices=(1,))
     parser.add_argument(
+        "--first-block-cache",
+        action="store_true",
+        help="Build native head/tail/finish denoiser plans for FirstBlockCache.",
+    )
+    parser.add_argument(
         "--workspace-gib",
         type=_positive_workspace_gib,
         help="Override the TensorRT tactic workspace for every component (GiB).",
@@ -112,14 +121,16 @@ def main() -> int:
     output = Path(args.output_dir)
     output.mkdir(parents=True, exist_ok=True)
     source_revision = validate_source_revision(args.source_revision)
-    profile_values = {
-        **SOL_ENGINE_1344X768_124F.__dict__,
-        "context_parallel_size": args.cp_size,
-    }
-    profile = SOL_ENGINE_1344X768_124F.__class__(**profile_values)
+    profile = replace(
+        SOL_ENGINE_1344X768_124F,
+        context_parallel_size=args.cp_size,
+        first_block_cache=args.first_block_cache,
+    )
     receipt_path = output / "build_receipt.json"
     tokenizer = model / "tokenizer" / "tokenizer.json"
-    workspace_limit_bytes = _workspace_limits(args.workspace_gib)
+    workspace_limit_bytes = _workspace_limits(
+        args.workspace_gib, first_block_cache=profile.first_block_cache
+    )
     receipt = {
         "checkpoint_revision": CHECKPOINT_REVISION,
         "checkpoint_snapshot": checkpoint_snapshot_record(model),
@@ -192,15 +203,34 @@ def main() -> int:
     )
     from tensorrt_model_connect.families.minimax_h3.dit_builder import (
         build_dit_engine,
+        build_dit_finish_engine,
+        build_dit_head_engine,
+        build_dit_tail_engine,
         checkpoint_keys as dit_keys,
+        finish_checkpoint_keys,
+        head_checkpoint_keys,
+        tail_checkpoint_keys,
     )
 
     build_adaln = should_build("adaln_precompute", "adaln_precompute.plan")
-    build_denoiser = should_build("denoiser", "denoiser.plan")
-    if build_adaln or build_denoiser:
-        validate_component_key_partition(
-            model / "transformer", (adaln_keys(profile), dit_keys(profile))
+    if profile.first_block_cache:
+        denoiser_specs = (
+            ("denoiser_head.plan", build_dit_head_engine, head_checkpoint_keys(profile)),
+            ("denoiser_tail.plan", build_dit_tail_engine, tail_checkpoint_keys(profile)),
+            ("denoiser_finish.plan", build_dit_finish_engine, finish_checkpoint_keys(profile)),
         )
+    else:
+        denoiser_specs = (("denoiser.plan", build_dit_engine, dit_keys(profile)),)
+    build_denoiser = any(
+        should_build("denoiser", filename) for filename, _builder, _keys in denoiser_specs
+    )
+    if build_adaln or build_denoiser:
+        checkpoint_groups = (
+            (adaln_keys(profile), *(keys for _filename, _builder, keys in denoiser_specs))
+            if profile.first_block_cache
+            else (adaln_keys(profile), dit_keys(profile))
+        )
+        validate_component_key_partition(model / "transformer", checkpoint_groups)
     if build_adaln:
         state = load_selected_component_state_dict(model / "transformer", adaln_keys(profile))
         weights = numpy_state(state)
@@ -217,20 +247,23 @@ def main() -> int:
         del weights, plan
         gc.collect()
     if build_denoiser:
-        state = load_selected_component_state_dict(model / "transformer", dit_keys(profile))
-        weights = numpy_state(state)
-        del state
-        started = time.perf_counter()
-        plan = build_dit_engine(
-            weights,
-            profile,
-            consume_weights=True,
-            workspace_bytes=workspace_limit_bytes["denoiser.plan"],
-        )
-        _write(output, "denoiser.plan", plan, time.perf_counter() - started, receipt)
-        checkpoint_receipt()
-        del weights, plan
-        gc.collect()
+        for filename, denoiser_builder, selected_keys in denoiser_specs:
+            if not should_build("denoiser", filename):
+                continue
+            state = load_selected_component_state_dict(model / "transformer", selected_keys)
+            weights = numpy_state(state)
+            del state
+            started = time.perf_counter()
+            plan = denoiser_builder(
+                weights,
+                profile,
+                consume_weights=True,
+                workspace_bytes=workspace_limit_bytes[filename],
+            )
+            _write(output, filename, plan, time.perf_counter() - started, receipt)
+            checkpoint_receipt()
+            del weights, plan
+            gc.collect()
 
     from tensorrt_model_connect.families.minimax_h3.vae_builder import (
         build_vae_tile_decoder_engine,

--- a/tests/e2e/models/minimax_h3/e2e_plugins/__init__.py
+++ b/tests/e2e/models/minimax_h3/e2e_plugins/__init__.py
@@ -24,6 +24,14 @@ _PLAN_FILENAMES = {
     "denoiser.plan",
     "vae_tile_decoder.plan",
 }
+_FIRST_BLOCK_CACHE_PLAN_FILENAMES = {
+    "text_encoder.plan",
+    "adaln_precompute.plan",
+    "denoiser_head.plan",
+    "denoiser_tail.plan",
+    "denoiser_finish.plan",
+    "vae_tile_decoder.plan",
+}
 
 
 def artifact_dir(ctx: RunContext, case: E2ECase, name: str) -> Path:
@@ -97,9 +105,18 @@ def source_revision(case: E2ECase, ctx: RunContext) -> str:
         raise ValueError("MiniMax-H3 E2E bundle does not use the unpadded sequence")
     if config.get("vae_tile_batch") != 28:
         raise ValueError("MiniMax-H3 E2E bundle does not decode all spatial tiles in one batch")
+    cache_mode = config.get("denoiser_cache_mode", "monolithic")
+    if cache_mode not in ("monolithic", "first_block"):
+        raise ValueError("MiniMax-H3 E2E bundle has an invalid denoiser cache mode")
+    first_block_cache = config.get("first_block_cache", False)
+    if not isinstance(first_block_cache, bool) or first_block_cache != (
+        cache_mode == "first_block"
+    ):
+        raise ValueError("MiniMax-H3 E2E bundle cache profile is inconsistent")
+    expected_plans = _FIRST_BLOCK_CACHE_PLAN_FILENAMES if first_block_cache else _PLAN_FILENAMES
     plan_sha = config.get("plan_sha256")
-    if not isinstance(plan_sha, dict) or set(plan_sha) != _PLAN_FILENAMES:
-        raise ValueError("MiniMax-H3 bundle does not identify exactly all four native plans")
+    if not isinstance(plan_sha, dict) or set(plan_sha) != expected_plans:
+        raise ValueError("MiniMax-H3 bundle does not identify the selected native plans")
     if any(_SHA256.fullmatch(str(value)) is None for value in plan_sha.values()):
         raise ValueError("MiniMax-H3 bundle contains an invalid native plan SHA256")
 

--- a/tests/e2e/models/minimax_h3/native_reference.py
+++ b/tests/e2e/models/minimax_h3/native_reference.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import platform
 import re
@@ -33,10 +34,69 @@ PERF_PATTERN = re.compile(
     r"vae_decoder_ms=(?P<vae>[0-9.]+) total_ms=(?P<total>[0-9.]+)"
 )
 ENGINE_PATTERN = re.compile(
-    r'\[trtmc\.engine_timing\] label="engine" execute_ms=(?P<execute>[0-9.]+) '
+    r'\[trtmc\.engine_timing\] label="(?P<label>[^"]+)" execute_ms=(?P<execute>[0-9.]+) '
     r"launches=(?P<launches>[0-9]+)"
 )
-ENGINE_STAGES = ("text_encoder", "adaln", "denoiser", "vae_decoder")
+BACKEND_PATTERN = re.compile(
+    r"\[trtmc\] Backend loaded: [^\n]* \((?P<dso>libtrtmc_backend_[^)]+\.so)\)"
+)
+CACHE_THRESHOLD_PATTERN = re.compile(
+    r"\[minimax-h3\.perf\][^\n]* cache_threshold=(?P<threshold>[0-9.]+)"
+)
+CACHE_THRESHOLD_CONFIG_KEY = "minimax_h3.first_block_cache_threshold"
+
+
+def evict_file_pages(path: Path) -> dict[str, bool | str]:
+    """Best-effort eviction of clean cache pages for one file only."""
+
+    posix_fadvise = getattr(os, "posix_fadvise", None)
+    dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+    if posix_fadvise is None or dontneed is None:
+        return {"supported": False, "attempted": False, "succeeded": False}
+
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+        try:
+            posix_fadvise(descriptor, 0, 0, dontneed)
+        finally:
+            os.close(descriptor)
+    except OSError as error:
+        return {
+            "supported": True,
+            "attempted": True,
+            "succeeded": False,
+            "error": f"{type(error).__name__}: {error}",
+        }
+    return {"supported": True, "attempted": True, "succeeded": True}
+
+
+def cache_threshold_cli_args(value: float | None) -> list[str]:
+    if value is None:
+        return []
+    return ["--set", f"{CACHE_THRESHOLD_CONFIG_KEY}={value:.9g}"]
+
+
+def resolve_trt_backend_dso(executable: Path, bundle_config: dict) -> Path:
+    """Resolve the exact adjacent backend DSO selected by the runtime loader."""
+
+    if bundle_config.get("engine_backend") != "trt":
+        raise ValueError("MiniMax-H3 native evidence requires engine_backend=trt")
+    abi = bundle_config.get("trt_abi")
+    match = re.fullmatch(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", str(abi))
+    if match is None:
+        raise ValueError("MiniMax-H3 bundle config has an invalid TensorRT ABI")
+    names = (
+        f"libtrtmc_backend_trt_{match.group('major')}_{match.group('minor')}.so",
+        "libtrtmc_backend_trt.so",
+    )
+    for name in names:
+        candidate = executable.parent / name
+        if candidate.is_file():
+            return candidate.resolve(strict=True)
+    raise FileNotFoundError(
+        "MiniMax-H3 could not bind the adjacent TensorRT backend DSO: "
+        + ", ".join(str(executable.parent / name) for name in names)
+    )
 
 
 def main() -> int:
@@ -47,7 +107,21 @@ def main() -> int:
     parser.add_argument("--plugin-dir", required=True)
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--source-revision", required=True)
+    parser.add_argument(
+        "--cuda-graphs",
+        action="store_true",
+        help="forward CUDA graph enablement to the native TRTMC runtime",
+    )
+    parser.add_argument(
+        "--cache-threshold",
+        type=float,
+        help=f"override {CACHE_THRESHOLD_CONFIG_KEY} for this visual run",
+    )
     args = parser.parse_args()
+    if args.cache_threshold is not None and (
+        not math.isfinite(args.cache_threshold) or args.cache_threshold <= 0.0
+    ):
+        raise ValueError("cache threshold must be finite and positive")
     source_revision = validate_source_revision(args.source_revision)
     bundle = Path(args.bundle).resolve(strict=True)
     bundle_identity = file_identity(bundle)
@@ -65,10 +139,12 @@ def main() -> int:
     if not isinstance(prompt_spec.get("seed"), int) or isinstance(prompt_spec["seed"], bool):
         raise ValueError("MiniMax-H3 prompt file must contain an integer seed")
     bundle_config = validate_native_bundle_config(bundle, source_revision=source_revision)
+    backend = resolve_trt_backend_dso(trtf, bundle_config)
     script_path = Path(__file__).resolve()
     bound_paths = {
         "bundle": bundle,
         "trtf": trtf,
+        "trt_backend": backend,
         "plugin": plugin,
         "prompt_file": prompt_path,
         "native_reference": script_path,
@@ -115,11 +191,15 @@ def main() -> int:
         "--width",
         "1344",
     ]
+    if args.cuda_graphs:
+        command.append("--cuda-graphs")
+    command.extend(cache_threshold_cli_args(args.cache_threshold))
     environment = os.environ.copy()
     environment["TRTMC_MODEL_PLUGIN_DIR"] = str(plugin_dir)
     environment["TRTMC_PNG_WRITE_WORKERS"] = "8"
     environment["WORLD_SIZE"] = "1"
     environment["RANK"] = "0"
+    bundle_page_cache_eviction = evict_file_pages(bundle)
     started = time.perf_counter()
     stdout_path = output / "native_stdout.txt"
     stderr_path = output / "native_stderr.txt"
@@ -145,16 +225,30 @@ def main() -> int:
     np.save(frames_path, frames)
     frames_record, _ = stable_file_record(frames_path, "native decoded frames")
     native_stderr = stderr_path.read_text()
+    loaded_backends = [match.group("dso") for match in BACKEND_PATTERN.finditer(native_stderr)]
+    if loaded_backends != [backend.name]:
+        raise RuntimeError(
+            "Native H3 runtime did not load the provenance-bound TensorRT backend DSO"
+        )
     matches = [match.groupdict() for match in PERF_PATTERN.finditer(native_stderr)]
     perf = {name + "_ms": float(value) for name, value in matches[-1].items()} if matches else {}
+    threshold_matches = [
+        float(match.group("threshold")) for match in CACHE_THRESHOLD_PATTERN.finditer(native_stderr)
+    ]
+    effective_cache_threshold = threshold_matches[-1] if threshold_matches else None
+    if args.cache_threshold is not None and (
+        effective_cache_threshold is None
+        or not math.isclose(
+            effective_cache_threshold, args.cache_threshold, rel_tol=0.0, abs_tol=1e-6
+        )
+    ):
+        raise RuntimeError("Native H3 runtime did not apply the requested cache threshold")
     engine_matches = [match.groupdict() for match in ENGINE_PATTERN.finditer(native_stderr)]
-    engine_execute = {}
-    if len(engine_matches) >= len(ENGINE_STAGES):
-        selected = engine_matches[-len(ENGINE_STAGES) :]
-        engine_execute = {
-            f"{stage}_ms": float(match["execute"])
-            for stage, match in zip(ENGINE_STAGES, selected, strict=True)
-        }
+    engine_execute: dict[str, float] = {}
+    if engine_matches:
+        for match in engine_matches:
+            name = f"{match['label']}_ms"
+            engine_execute[name] = engine_execute.get(name, 0.0) + float(match["execute"])
         engine_execute["total_ms"] = sum(engine_execute.values())
     receipt = {
         "backend": "tensorrt_native_single_device",
@@ -168,13 +262,18 @@ def main() -> int:
         "inputs": inputs,
         "workload": workload,
         "world_size": 1,
+        "cuda_graphs_requested": args.cuda_graphs,
+        "cache_threshold_override": args.cache_threshold,
+        "effective_cache_threshold": effective_cache_threshold,
         "wall_s": elapsed,
         "runtime": perf,
         "engine_execute": engine_execute,
+        "loaded_backend_dso": loaded_backends[0],
         "runtime_includes_plan_deserialization": True,
         "collective_transport": "none",
         "shape": list(frames.shape),
         "frames": frames_record,
+        "bundle_page_cache_eviction": bundle_page_cache_eviction,
         "host": platform.node(),
         "command": command,
     }

--- a/tests/e2e/models/minimax_h3/pack_native_bundle.py
+++ b/tests/e2e/models/minimax_h3/pack_native_bundle.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -30,6 +31,14 @@ PLAN_SECTIONS = {
     "denoiser_plan": "denoiser.plan",
     "vae_tile_decoder_plan": "vae_tile_decoder.plan",
 }
+FIRST_BLOCK_CACHE_PLAN_SECTIONS = {
+    "text_encoder_plan": "text_encoder.plan",
+    "adaln_precompute_plan": "adaln_precompute.plan",
+    "denoiser_head_plan": "denoiser_head.plan",
+    "denoiser_tail_plan": "denoiser_tail.plan",
+    "denoiser_finish_plan": "denoiser_finish.plan",
+    "vae_tile_decoder_plan": "vae_tile_decoder.plan",
+}
 EAGER_BUNDLE_SECTIONS = ("tokenizer.json", "config.json")
 LAZY_BUNDLE_SECTIONS = tuple(PLAN_SECTIONS)
 
@@ -47,13 +56,13 @@ def _target_metadata() -> tuple[str, str, str]:
     return trt_version, trt_abi, gpu_name
 
 
-def _bundle_loading_policy() -> dict[str, object]:
+def _bundle_loading_policy(plan_sections=PLAN_SECTIONS) -> dict[str, object]:
     """Keep only metadata resident; H3 loads one large plan at a time."""
 
     return {
         "mode": "staged",
         "eager_sections": list(EAGER_BUNDLE_SECTIONS),
-        "lazy_sections": list(LAZY_BUNDLE_SECTIONS),
+        "lazy_sections": list(plan_sections),
     }
 
 
@@ -63,11 +72,18 @@ def main() -> int:
     parser.add_argument("--model-path", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--source-revision", required=True)
+    parser.add_argument(
+        "--first-block-cache",
+        action="store_true",
+        help="Package split head/tail/finish plans instead of denoiser.plan.",
+    )
     args = parser.parse_args()
     plans = Path(args.plans_dir)
     model = Path(args.model_path)
     output = Path(args.output)
     source_revision = validate_source_revision(args.source_revision)
+    profile = replace(SOL_ENGINE_1344X768_124F, first_block_cache=args.first_block_cache)
+    plan_sections = FIRST_BLOCK_CACHE_PLAN_SECTIONS if profile.first_block_cache else PLAN_SECTIONS
     trt_version, trt_abi, gpu_name = _target_metadata()
     receipt_path = plans / "build_receipt.json"
     if not receipt_path.is_file():
@@ -81,12 +97,12 @@ def main() -> int:
         tokenizer=tokenizer,
         build_helper=Path(__file__).with_name("build_native_components.py"),
         source_revision=source_revision,
-        profile=SOL_ENGINE_1344X768_124F,
+        profile=profile,
         hash_files=False,
     )
 
     sections: list[BundleSection] = []
-    for section_name, filename in PLAN_SECTIONS.items():
+    for section_name, filename in plan_sections.items():
         path = plans / filename
         sections.append(
             _bundle_section_from_file(
@@ -107,7 +123,7 @@ def main() -> int:
         "engine_backend": "trt",
         "trt_version": trt_version,
         "trt_abi": trt_abi,
-        "bundle_loading": _bundle_loading_policy(),
+        "bundle_loading": _bundle_loading_policy(plan_sections),
         "tokenizer_add_special_tokens": 0,
         "checkpoint_revision": CHECKPOINT_REVISION,
         "source_revision": source_revision,
@@ -116,8 +132,11 @@ def main() -> int:
         "checkpoint_inventory_sha256": snapshot_record["inventory_sha256"],
         "workspace_limit_bytes": dict(receipt["workspace_limit_bytes"]),
         "plan_sha256": {
-            filename: recorded[filename]["sha256"] for filename in PLAN_SECTIONS.values()
+            filename: recorded[filename]["sha256"] for filename in plan_sections.values()
         },
+        "first_block_cache": profile.first_block_cache,
+        "denoiser_cache_mode": "first_block" if profile.first_block_cache else "monolithic",
+        "first_block_cache_threshold": 0.08,
         "height": 768,
         "width": 1344,
         "num_frames": 124,

--- a/tests/e2e/models/minimax_h3/pack_native_bundle.py
+++ b/tests/e2e/models/minimax_h3/pack_native_bundle.py
@@ -136,7 +136,7 @@ def main() -> int:
         },
         "first_block_cache": profile.first_block_cache,
         "denoiser_cache_mode": "first_block" if profile.first_block_cache else "monolithic",
-        "first_block_cache_threshold": 0.08,
+        "first_block_cache_threshold": 0.025,
         "height": 768,
         "width": 1344,
         "num_frames": 124,

--- a/tests/e2e/models/minimax_h3/test_benchmark_native_runtime.py
+++ b/tests/e2e/models/minimax_h3/test_benchmark_native_runtime.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).with_name("benchmark_native_runtime.py")
+SPEC = importlib.util.spec_from_file_location("minimax_h3_benchmark_native_runtime", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_resolve_trt_backend_dso_matches_runtime_candidate_order(tmp_path: Path) -> None:
+    executable = tmp_path / "trtmc_benchmark_worker"
+    executable.write_bytes(b"binary")
+    unversioned = tmp_path / "libtrtmc_backend_trt.so"
+    versioned = tmp_path / "libtrtmc_backend_trt_11_2.so"
+    unversioned.write_bytes(b"unversioned")
+    versioned.write_bytes(b"versioned")
+    config = {"engine_backend": "trt", "trt_abi": "11.2"}
+
+    assert MODULE.resolve_trt_backend_dso(executable, config) == versioned.resolve()
+    versioned.unlink()
+    assert MODULE.resolve_trt_backend_dso(executable, config) == unversioned.resolve()
+
+
+def test_resolve_trt_backend_dso_fails_closed(tmp_path: Path) -> None:
+    executable = tmp_path / "trtmc_benchmark_worker"
+    executable.write_bytes(b"binary")
+
+    with pytest.raises(ValueError, match="engine_backend=trt"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "rtx", "trt_abi": "11.2"})
+    with pytest.raises(ValueError, match="invalid TensorRT ABI"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "trt", "trt_abi": "latest"})
+    with pytest.raises(FileNotFoundError, match="adjacent TensorRT backend"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "trt", "trt_abi": "11.2"})
+
+
+def test_file_page_eviction_is_portable_when_advice_constant_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(MODULE.os, "POSIX_FADV_DONTNEED", raising=False)
+
+    def fail_open(*_args, **_kwargs) -> int:
+        raise AssertionError("file should not be opened without POSIX_FADV_DONTNEED")
+
+    monkeypatch.setattr(MODULE.os, "open", fail_open)
+
+    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+        "supported": False,
+        "attempted": False,
+        "succeeded": False,
+    }
+
+
+def test_file_page_eviction_reports_open_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_open(*_args, **_kwargs) -> int:
+        raise OSError("open rejected")
+
+    monkeypatch.setattr(MODULE.os, "posix_fadvise", lambda *_args: None, raising=False)
+    monkeypatch.setattr(MODULE.os, "POSIX_FADV_DONTNEED", 4, raising=False)
+    monkeypatch.setattr(MODULE.os, "open", fail_open)
+
+    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+        "supported": True,
+        "attempted": True,
+        "succeeded": False,
+        "error": "OSError: open rejected",
+    }
+
+
+def _request_log(*, requests: int, cuda_graph_failure: bool = False, resident: bool = False) -> str:
+    lines: list[str] = []
+    for index in range(requests):
+        if not resident:
+            for stage_index in range(4):
+                lines.append(
+                    '[trtmc.engine_timing] label="engine" '
+                    f"execute_ms={10 + index + stage_index:.6f} launches={stage_index + 1}"
+                )
+        cache_markers = (
+            f" text_cache_hit={int(index > 0)} adaln_cache_hit={int(index > 0)}"
+            f" denoiser_resident_hit={int(index > 0)} vae_resident_hit={int(index > 0)}"
+            " cache_threshold=0.08 full_steps=40 skipped_steps=9"
+            if resident
+            else ""
+        )
+        lines.append(
+            "[minimax-h3.perf] "
+            f"text_encoder_ms={21 + index:.3f} "
+            f"adaln_ms={22 + index:.3f} "
+            f"denoiser_ms={23 + index:.3f} "
+            f"vae_decoder_ms={24 + index:.3f} total_ms={100 + index:.3f}{cache_markers}"
+        )
+    if resident:
+        for stage_index in range(4):
+            lines.append(
+                '[trtmc.engine_timing] label="engine" '
+                f"execute_ms={30 + stage_index:.6f} launches={requests * (stage_index + 1)}"
+            )
+    if cuda_graph_failure:
+        lines.append("[cuda_graph] Capture failed, disabling CUDA Graphs")
+    return "\n".join(lines)
+
+
+def _worker_result(*, warmup: int, iterations: int) -> dict:
+    return {
+        "status": "completed",
+        "operation": "generate_image",
+        "warmup": warmup,
+        "iterations": iterations,
+        "load_ms": 7.5,
+        "observations": [
+            {"iteration": index, "measured_wall_ms": 110.0 + index} for index in range(iterations)
+        ],
+        "output_summary": {
+            "height": 768,
+            "width": 1344,
+            "num_frames": 124,
+        },
+    }
+
+
+def test_worker_request_forwards_cuda_graphs_and_fixed_workload(tmp_path: Path) -> None:
+    request = MODULE.build_worker_request(
+        bundle=tmp_path / "h3.trtfb",
+        plugin_dir=tmp_path / "plugins",
+        prompt="prompt",
+        seed=0,
+        source_revision="a" * 40,
+        cuda_graphs=True,
+        warmup=1,
+        iterations=2,
+    )
+
+    assert request["operation"] == "generate_image"
+    assert request["runtime"] == {
+        "cuda_graphs": True,
+        "model_plugin_search_paths": [str(tmp_path / "plugins")],
+    }
+    assert request["request"]["video_num_frames"] == 124
+    assert request["request"]["num_inference_steps"] == 50
+    assert request["measurement"]["warmup"] == 1
+    assert request["measurement"]["iterations"] == 2
+
+
+def test_worker_request_forwards_optional_cache_threshold(tmp_path: Path) -> None:
+    request = MODULE.build_worker_request(
+        bundle=tmp_path / "h3.trtfb",
+        plugin_dir=tmp_path / "plugins",
+        prompt="prompt",
+        seed=0,
+        source_revision="a" * 40,
+        cuda_graphs=False,
+        warmup=1,
+        iterations=2,
+        cache_threshold=0.05,
+    )
+
+    assert request["runtime"]["config"] == {"minimax_h3.first_block_cache_threshold": 0.05}
+
+    default_request = MODULE.build_worker_request(
+        bundle=tmp_path / "h3.trtfb",
+        plugin_dir=tmp_path / "plugins",
+        prompt="prompt",
+        seed=0,
+        source_revision="a" * 40,
+        cuda_graphs=False,
+        warmup=1,
+        iterations=2,
+    )
+    assert "config" not in default_request["runtime"]
+    assert request["case_digest"] != default_request["case_digest"]
+
+
+def test_parse_worker_evidence_separates_pipeline_and_engine_boundaries() -> None:
+    backend = "libtrtmc_backend_trt_11_2.so"
+    evidence = MODULE.parse_worker_evidence(
+        _worker_result(warmup=1, iterations=2),
+        f"[trtmc] Backend loaded: TensorRT ({backend})\n" + _request_log(requests=3),
+        warmup=1,
+        iterations=2,
+        cuda_graphs=False,
+        expected_backend_dso_name=backend,
+    )
+
+    assert evidence["pipeline_factory_load_ms"] == 7.5
+    assert evidence["pipeline_factory_load_includes_plan_deserialization"] is False
+    assert evidence["loaded_backend_dso"] == backend
+    assert evidence["measured_requests_are_pipeline_warm"] is True
+    assert evidence["first_request"]["pipeline_total_ms"] == 100.0
+    assert [item["pipeline_total_ms"] for item in evidence["requests"]] == [101.0, 102.0]
+    assert evidence["requests"][0]["public_pipeline_call_wall_ms"] == 110.0
+    assert evidence["requests"][0]["engine_execute"]["total_ms"] == 50.0
+    assert evidence["requests"][0]["stage_wall"]["total_ms"] == 94.0
+    assert evidence["requests"][0]["stage_non_engine"]["total_ms"] == 44.0
+    assert evidence["requests"][0]["host_prepost_and_output_assembly_ms"] == 7.0
+    assert evidence["summary"]["samples"] == 2
+    assert evidence["cold_start"]["plan_deserialization_separately_instrumented"] is False
+    assert evidence["cold_start"]["plan_deserialization_included_in"] == (
+        "first_request.stage_wall"
+    )
+
+
+@pytest.mark.parametrize(
+    "backend_log",
+    [
+        "",
+        "[trtmc] Backend loaded: TensorRT (libtrtmc_backend_trt.so)\n",
+        (
+            "[trtmc] Backend loaded: TensorRT (libtrtmc_backend_trt_11_2.so)\n"
+            "[trtmc] Backend loaded: TensorRT (libtrtmc_backend_trt_11_2.so)\n"
+        ),
+    ],
+)
+def test_parse_worker_evidence_rejects_unbound_backend_log(backend_log: str) -> None:
+    with pytest.raises(ValueError, match="provenance-bound TensorRT backend"):
+        MODULE.parse_worker_evidence(
+            _worker_result(warmup=0, iterations=1),
+            backend_log + _request_log(requests=1),
+            warmup=0,
+            iterations=1,
+            cuda_graphs=False,
+            expected_backend_dso_name="libtrtmc_backend_trt_11_2.so",
+        )
+
+
+def test_parse_worker_evidence_rejects_cuda_graph_fallback() -> None:
+    with pytest.raises(ValueError, match="CUDA graph capture failed"):
+        MODULE.parse_worker_evidence(
+            _worker_result(warmup=0, iterations=1),
+            _request_log(requests=1, cuda_graph_failure=True),
+            warmup=0,
+            iterations=1,
+            cuda_graphs=True,
+        )
+
+
+def test_parse_worker_evidence_preserves_resident_engine_aggregate() -> None:
+    evidence = MODULE.parse_worker_evidence(
+        _worker_result(warmup=1, iterations=2),
+        _request_log(requests=3, resident=True),
+        warmup=1,
+        iterations=2,
+        cuda_graphs=False,
+        cache_threshold=0.08,
+    )
+
+    assert evidence["engine_timing_scope"] == "variant_aggregate"
+    assert evidence["aggregate_engine_execute"] == {
+        "entries": [
+            {"execute_ms": 30.0, "launches": 3},
+            {"execute_ms": 31.0, "launches": 6},
+            {"execute_ms": 32.0, "launches": 9},
+            {"execute_ms": 33.0, "launches": 12},
+        ],
+        "total_ms": 126.0,
+        "total_launches": 30,
+        "requests_included": 3,
+        "per_request_values_available": False,
+    }
+    assert evidence["cache_markers_available"] is True
+    assert evidence["measured_requests_hit_all_resident_caches"] is True
+    assert evidence["cache_threshold_override"] == 0.08
+    assert "engine_execute" not in evidence["requests"][0]
+    assert evidence["requests"][0]["runtime_annotations"] == {
+        "text_cache_hit": True,
+        "adaln_cache_hit": True,
+        "denoiser_resident_hit": True,
+        "vae_resident_hit": True,
+        "cache_threshold": 0.08,
+        "full_steps": 40,
+        "skipped_steps": 9,
+    }
+
+
+def test_receipt_rejects_unapplied_cache_threshold_override() -> None:
+    with pytest.raises(ValueError, match="does not match the requested override"):
+        MODULE.parse_worker_evidence(
+            _worker_result(warmup=1, iterations=1),
+            _request_log(requests=2, resident=True),
+            warmup=1,
+            iterations=1,
+            cuda_graphs=False,
+            cache_threshold=0.05,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [("off", (False,)), ("on", (True,)), ("both", (False, True))],
+)
+def test_cuda_graph_variant_selection(mode: str, expected: tuple[bool, ...]) -> None:
+    assert MODULE._variants(mode) == expected
+
+
+def test_partial_engine_timings_remain_a_variant_aggregate() -> None:
+    lines = _request_log(requests=2).splitlines()
+    malformed_log = "\n".join(lines[1:])
+    evidence = MODULE.parse_worker_evidence(
+        _worker_result(warmup=1, iterations=1),
+        malformed_log,
+        warmup=1,
+        iterations=1,
+        cuda_graphs=False,
+    )
+
+    assert evidence["engine_timing_scope"] == "variant_aggregate"
+    assert evidence["aggregate_engine_execute"]["per_request_values_available"] is False

--- a/tests/e2e/models/minimax_h3/test_benchmark_native_runtime.py
+++ b/tests/e2e/models/minimax_h3/test_benchmark_native_runtime.py
@@ -52,7 +52,7 @@ def test_file_page_eviction_is_portable_when_advice_constant_is_unavailable(
 
     monkeypatch.setattr(MODULE.os, "open", fail_open)
 
-    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+    assert MODULE.evict_file_pages(Path("model.bundle")) == {
         "supported": False,
         "attempted": False,
         "succeeded": False,
@@ -67,7 +67,7 @@ def test_file_page_eviction_reports_open_failure(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(MODULE.os, "POSIX_FADV_DONTNEED", 4, raising=False)
     monkeypatch.setattr(MODULE.os, "open", fail_open)
 
-    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+    assert MODULE.evict_file_pages(Path("model.bundle")) == {
         "supported": True,
         "attempted": True,
         "succeeded": False,
@@ -129,7 +129,7 @@ def _worker_result(*, warmup: int, iterations: int) -> dict:
 
 def test_worker_request_forwards_cuda_graphs_and_fixed_workload(tmp_path: Path) -> None:
     request = MODULE.build_worker_request(
-        bundle=tmp_path / "h3.trtfb",
+        bundle=tmp_path / "h3.bundle",
         plugin_dir=tmp_path / "plugins",
         prompt="prompt",
         seed=0,
@@ -152,7 +152,7 @@ def test_worker_request_forwards_cuda_graphs_and_fixed_workload(tmp_path: Path) 
 
 def test_worker_request_forwards_optional_cache_threshold(tmp_path: Path) -> None:
     request = MODULE.build_worker_request(
-        bundle=tmp_path / "h3.trtfb",
+        bundle=tmp_path / "h3.bundle",
         plugin_dir=tmp_path / "plugins",
         prompt="prompt",
         seed=0,
@@ -166,7 +166,7 @@ def test_worker_request_forwards_optional_cache_threshold(tmp_path: Path) -> Non
     assert request["runtime"]["config"] == {"minimax_h3.first_block_cache_threshold": 0.05}
 
     default_request = MODULE.build_worker_request(
-        bundle=tmp_path / "h3.trtfb",
+        bundle=tmp_path / "h3.bundle",
         plugin_dir=tmp_path / "plugins",
         prompt="prompt",
         seed=0,

--- a/tests/e2e/models/minimax_h3/test_build_native_components.py
+++ b/tests/e2e/models/minimax_h3/test_build_native_components.py
@@ -11,7 +11,10 @@ from types import ModuleType
 
 import pytest
 
-from tensorrt_model_connect.families.minimax_h3.config import DEFAULT_WORKSPACE_LIMIT_BYTES
+from tensorrt_model_connect.families.minimax_h3.config import (
+    DEFAULT_WORKSPACE_LIMIT_BYTES,
+    default_workspace_limit_bytes,
+)
 from tests.e2e.models.minimax_h3.build_native_components import (
     _positive_workspace_gib,
     _validate_resume_identity,
@@ -29,6 +32,16 @@ def test_workspace_limits_preserve_defaults_or_apply_exact_override() -> None:
     assert _workspace_limits(None) == DEFAULT_WORKSPACE_LIMIT_BYTES
     assert _workspace_limits(8) == {filename: 8 << 30 for filename in DEFAULT_WORKSPACE_LIMIT_BYTES}
     assert _positive_workspace_gib("8") == 8
+    split_defaults = default_workspace_limit_bytes(first_block_cache=True)
+    assert _workspace_limits(None, first_block_cache=True) == split_defaults
+    assert set(split_defaults) == {
+        "text_encoder.plan",
+        "adaln_precompute.plan",
+        "denoiser_head.plan",
+        "denoiser_tail.plan",
+        "denoiser_finish.plan",
+        "vae_tile_decoder.plan",
+    }
 
 
 @pytest.mark.parametrize("raw", ["0", "-1", "1.5", "bad"])
@@ -56,7 +69,10 @@ def test_resume_identity_binds_workspace_limits() -> None:
         _validate_resume_identity(previous, current)
 
 
-def test_main_passes_cli_workspace_to_every_builder(tmp_path: Path, monkeypatch, capsys) -> None:
+@pytest.mark.parametrize("first_block_cache", [False, True])
+def test_main_passes_cli_workspace_to_every_builder(
+    tmp_path: Path, monkeypatch, capsys, first_block_cache: bool
+) -> None:
     from tests.e2e.models.minimax_h3 import build_native_components
 
     model = tmp_path / "model"
@@ -66,21 +82,31 @@ def test_main_passes_cli_workspace_to_every_builder(tmp_path: Path, monkeypatch,
     output = tmp_path / "plans"
     observed = {}
     module_specs = {
-        "text_encoder_builder": ("build_text_encoder_engine", "text_encoder.plan"),
-        "adaln_builder": ("build_adaln_precompute_engine", "adaln_precompute.plan"),
-        "dit_builder": ("build_dit_engine", "denoiser.plan"),
-        "vae_builder": ("build_vae_tile_decoder_engine", "vae_tile_decoder.plan"),
+        "text_encoder_builder": (("build_text_encoder_engine", "text_encoder.plan"),),
+        "adaln_builder": (("build_adaln_precompute_engine", "adaln_precompute.plan"),),
+        "dit_builder": (
+            ("build_dit_engine", "denoiser.plan"),
+            ("build_dit_head_engine", "denoiser_head.plan"),
+            ("build_dit_tail_engine", "denoiser_tail.plan"),
+            ("build_dit_finish_engine", "denoiser_finish.plan"),
+        ),
+        "vae_builder": (("build_vae_tile_decoder_engine", "vae_tile_decoder.plan"),),
     }
     package = "tensorrt_model_connect.families.minimax_h3"
-    for module_name, (builder_name, plan_name) in module_specs.items():
+    for module_name, builders in module_specs.items():
         fake_module = ModuleType(f"{package}.{module_name}")
         fake_module.checkpoint_keys = lambda *_args: ()
+        if module_name == "dit_builder":
+            fake_module.head_checkpoint_keys = lambda *_args: ()
+            fake_module.tail_checkpoint_keys = lambda *_args: ()
+            fake_module.finish_checkpoint_keys = lambda *_args: ()
+        for builder_name, plan_name in builders:
 
-        def fake_builder(*_args, _plan_name=plan_name, workspace_bytes=None, **_kwargs):
-            observed[_plan_name] = workspace_bytes
-            return _plan_name.encode()
+            def fake_builder(*_args, _plan_name=plan_name, workspace_bytes=None, **_kwargs):
+                observed[_plan_name] = workspace_bytes
+                return _plan_name.encode()
 
-        setattr(fake_module, builder_name, fake_builder)
+            setattr(fake_module, builder_name, fake_builder)
         monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
 
     monkeypatch.setattr(
@@ -99,25 +125,29 @@ def test_main_passes_cli_workspace_to_every_builder(tmp_path: Path, monkeypatch,
         "validate_component_key_partition",
         lambda *_args: None,
     )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "build_native_components.py",
-            "--model-path",
-            str(model),
-            "--output-dir",
-            str(output),
-            "--source-revision",
-            "1" * 40,
-            "--workspace-gib",
-            "8",
-        ],
-    )
+    argv = [
+        "build_native_components.py",
+        "--model-path",
+        str(model),
+        "--output-dir",
+        str(output),
+        "--source-revision",
+        "1" * 40,
+        "--workspace-gib",
+        "8",
+    ]
+    if first_block_cache:
+        argv.append("--first-block-cache")
+    monkeypatch.setattr(sys, "argv", argv)
 
     assert build_native_components.main() == 0
-    assert observed == {filename: 8 << 30 for filename in DEFAULT_WORKSPACE_LIMIT_BYTES}
+    expected_limits = {
+        filename: 8 << 30
+        for filename in default_workspace_limit_bytes(first_block_cache=first_block_cache)
+    }
+    assert observed == expected_limits
     receipt = json.loads((output / "build_receipt.json").read_text())
     assert receipt["workspace_limit_bytes"] == observed
-    assert set(receipt["components"]) == set(DEFAULT_WORKSPACE_LIMIT_BYTES)
+    assert set(receipt["components"]) == set(expected_limits)
+    assert receipt["profile"]["first_block_cache"] is first_block_cache
     capsys.readouterr()

--- a/tests/e2e/models/minimax_h3/test_native_reference.py
+++ b/tests/e2e/models/minimax_h3/test_native_reference.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import tomllib
+
+import pytest
+
+
+SCRIPT = Path(__file__).with_name("native_reference.py")
+SPEC = importlib.util.spec_from_file_location("minimax_h3_native_reference", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_cache_threshold_cli_args_are_model_namespaced() -> None:
+    assert MODULE.cache_threshold_cli_args(None) == []
+    assert MODULE.cache_threshold_cli_args(0.05) == [
+        "--set",
+        "minimax_h3.first_block_cache_threshold=0.05",
+    ]
+
+
+def test_canonical_build_selects_first_block_cache() -> None:
+    model_config = tomllib.loads(SCRIPT.with_name("MODEL.toml").read_text())
+    assert {
+        "flag": "--set",
+        "value": "minimax_h3.first_block_cache=true",
+    } in model_config["e2e_defaults"]["diffusion_media_generation"]["build_cli_args"]
+
+
+def test_resolve_trt_backend_dso_matches_runtime_candidate_order(tmp_path: Path) -> None:
+    executable = tmp_path / "trtf"
+    executable.write_bytes(b"binary")
+    unversioned = tmp_path / "libtrtmc_backend_trt.so"
+    versioned = tmp_path / "libtrtmc_backend_trt_11_2.so"
+    unversioned.write_bytes(b"unversioned")
+    versioned.write_bytes(b"versioned")
+    config = {"engine_backend": "trt", "trt_abi": "11.2"}
+
+    assert MODULE.resolve_trt_backend_dso(executable, config) == versioned.resolve()
+    versioned.unlink()
+    assert MODULE.resolve_trt_backend_dso(executable, config) == unversioned.resolve()
+
+
+def test_resolve_trt_backend_dso_fails_closed(tmp_path: Path) -> None:
+    executable = tmp_path / "trtf"
+    executable.write_bytes(b"binary")
+
+    with pytest.raises(ValueError, match="engine_backend=trt"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "rtx", "trt_abi": "11.2"})
+    with pytest.raises(ValueError, match="invalid TensorRT ABI"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "trt", "trt_abi": "latest"})
+    with pytest.raises(FileNotFoundError, match="adjacent TensorRT backend"):
+        MODULE.resolve_trt_backend_dso(executable, {"engine_backend": "trt", "trt_abi": "11.2"})
+
+
+def test_file_page_eviction_is_portable_when_posix_fadvise_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(MODULE.os, "posix_fadvise", raising=False)
+
+    def fail_open(*_args, **_kwargs) -> int:
+        raise AssertionError("file should not be opened without posix_fadvise")
+
+    monkeypatch.setattr(MODULE.os, "open", fail_open)
+
+    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+        "supported": False,
+        "attempted": False,
+        "succeeded": False,
+    }
+
+
+def test_file_page_eviction_advises_exact_file_and_closes_descriptor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = tmp_path / "bundle.trtfb"
+    bundle.write_bytes(b"bundle")
+    calls: list[tuple[int, int, int, int]] = []
+
+    def record_fadvise(descriptor: int, offset: int, length: int, advice: int) -> None:
+        calls.append((descriptor, offset, length, advice))
+
+    monkeypatch.setattr(MODULE.os, "posix_fadvise", record_fadvise, raising=False)
+    monkeypatch.setattr(MODULE.os, "POSIX_FADV_DONTNEED", 4, raising=False)
+
+    result = MODULE.evict_file_pages(bundle)
+
+    assert result == {"supported": True, "attempted": True, "succeeded": True}
+    assert len(calls) == 1
+    descriptor, offset, length, advice = calls[0]
+    assert (offset, length, advice) == (0, 0, 4)
+    with pytest.raises(OSError):
+        os.fstat(descriptor)
+
+
+def test_file_page_eviction_reports_failure_and_closes_descriptor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle = tmp_path / "bundle.trtfb"
+    bundle.write_bytes(b"bundle")
+    descriptors: list[int] = []
+    real_open = MODULE.os.open
+
+    def record_open(path: Path, flags: int) -> int:
+        descriptor = real_open(path, flags)
+        descriptors.append(descriptor)
+        return descriptor
+
+    def fail_fadvise(*_args) -> None:
+        raise OSError("advice rejected")
+
+    monkeypatch.setattr(MODULE.os, "open", record_open)
+    monkeypatch.setattr(MODULE.os, "posix_fadvise", fail_fadvise, raising=False)
+    monkeypatch.setattr(MODULE.os, "POSIX_FADV_DONTNEED", 4, raising=False)
+
+    result = MODULE.evict_file_pages(bundle)
+
+    assert result == {
+        "supported": True,
+        "attempted": True,
+        "succeeded": False,
+        "error": "OSError: advice rejected",
+    }
+    with pytest.raises(OSError):
+        os.fstat(descriptors[0])

--- a/tests/e2e/models/minimax_h3/test_native_reference.py
+++ b/tests/e2e/models/minimax_h3/test_native_reference.py
@@ -70,7 +70,7 @@ def test_file_page_eviction_is_portable_when_posix_fadvise_is_unavailable(
 
     monkeypatch.setattr(MODULE.os, "open", fail_open)
 
-    assert MODULE.evict_file_pages(Path("bundle.trtfb")) == {
+    assert MODULE.evict_file_pages(Path("model.bundle")) == {
         "supported": False,
         "attempted": False,
         "succeeded": False,
@@ -80,7 +80,7 @@ def test_file_page_eviction_is_portable_when_posix_fadvise_is_unavailable(
 def test_file_page_eviction_advises_exact_file_and_closes_descriptor(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    bundle = tmp_path / "bundle.trtfb"
+    bundle = tmp_path / "model.bundle"
     bundle.write_bytes(b"bundle")
     calls: list[tuple[int, int, int, int]] = []
 
@@ -103,7 +103,7 @@ def test_file_page_eviction_advises_exact_file_and_closes_descriptor(
 def test_file_page_eviction_reports_failure_and_closes_descriptor(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    bundle = tmp_path / "bundle.trtfb"
+    bundle = tmp_path / "model.bundle"
     bundle.write_bytes(b"bundle")
     descriptors: list[int] = []
     real_open = MODULE.os.open

--- a/tests/e2e/models/minimax_h3/test_pack_native_bundle.py
+++ b/tests/e2e/models/minimax_h3/test_pack_native_bundle.py
@@ -9,7 +9,12 @@ import json
 from pathlib import Path
 import sys
 
-from tensorrt_model_connect.families.minimax_h3.provenance import PLAN_FILENAMES
+import pytest
+
+from tensorrt_model_connect.families.minimax_h3.provenance import (
+    FIRST_BLOCK_CACHE_PLAN_FILENAMES,
+    PLAN_FILENAMES,
+)
 from tests.e2e.models.minimax_h3 import pack_native_bundle
 
 
@@ -71,16 +76,29 @@ def test_staged_loading_partitions_every_bundle_section() -> None:
         "config.json",
     }
     assert not set(policy["eager_sections"]) & set(policy["lazy_sections"])
+    split = pack_native_bundle._bundle_loading_policy(
+        pack_native_bundle.FIRST_BLOCK_CACHE_PLAN_SECTIONS
+    )
+    assert split["lazy_sections"][2:5] == [
+        "denoiser_head_plan",
+        "denoiser_tail_plan",
+        "denoiser_finish_plan",
+    ]
+    assert set(split["lazy_sections"]) == set(pack_native_bundle.FIRST_BLOCK_CACHE_PLAN_SECTIONS)
 
 
-def test_packer_preserves_validated_workspace_mapping(tmp_path: Path, monkeypatch, capsys) -> None:
+@pytest.mark.parametrize("first_block_cache", [False, True])
+def test_packer_preserves_validated_workspace_mapping(
+    tmp_path: Path, monkeypatch, capsys, first_block_cache: bool
+) -> None:
     plans = tmp_path / "plans"
     plans.mkdir()
     recorded = {}
-    for filename in PLAN_FILENAMES:
+    selected_plans = FIRST_BLOCK_CACHE_PLAN_FILENAMES if first_block_cache else PLAN_FILENAMES
+    for filename in selected_plans:
         (plans / filename).write_bytes(filename.encode())
         recorded[filename] = {"bytes": len(filename), "sha256": "a" * 64}
-    workspace_limits = {filename: 8 << 30 for filename in PLAN_FILENAMES}
+    workspace_limits = {filename: 8 << 30 for filename in selected_plans}
     (plans / "build_receipt.json").write_text(
         json.dumps(
             {
@@ -112,22 +130,24 @@ def test_packer_preserves_validated_workspace_mapping(tmp_path: Path, monkeypatc
         captured.update(json.loads(config_section.data))
 
     monkeypatch.setattr(pack_native_bundle, "write_bundle", capture_bundle)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "pack_native_bundle.py",
-            "--plans-dir",
-            str(plans),
-            "--model-path",
-            str(model),
-            "--output",
-            str(tmp_path / "model.bundle"),
-            "--source-revision",
-            "1" * 40,
-        ],
-    )
+    argv = [
+        "pack_native_bundle.py",
+        "--plans-dir",
+        str(plans),
+        "--model-path",
+        str(model),
+        "--output",
+        str(tmp_path / "model.bundle"),
+        "--source-revision",
+        "1" * 40,
+    ]
+    if first_block_cache:
+        argv.append("--first-block-cache")
+    monkeypatch.setattr(sys, "argv", argv)
 
     assert pack_native_bundle.main() == 0
     assert captured["workspace_limit_bytes"] == workspace_limits
+    assert captured["first_block_cache"] is first_block_cache
+    assert captured["denoiser_cache_mode"] == ("first_block" if first_block_cache else "monolithic")
+    assert captured["first_block_cache_threshold"] == 0.08
     capsys.readouterr()

--- a/tests/e2e/models/minimax_h3/test_pack_native_bundle.py
+++ b/tests/e2e/models/minimax_h3/test_pack_native_bundle.py
@@ -149,5 +149,5 @@ def test_packer_preserves_validated_workspace_mapping(
     assert captured["workspace_limit_bytes"] == workspace_limits
     assert captured["first_block_cache"] is first_block_cache
     assert captured["denoiser_cache_mode"] == ("first_block" if first_block_cache else "monolithic")
-    assert captured["first_block_cache_threshold"] == 0.08
+    assert captured["first_block_cache_threshold"] == 0.025
     capsys.readouterr()


### PR DESCRIPTION
## Background

The native single-device MiniMax-H3 pipeline executed all 50 DiT blocks at every
denoising step and repeatedly paid model-residency, transfer, scheduler, and VAE
assembly costs. This change applies the first-block residual caching strategy
used by SOL-engine to the TensorRT-native path and keeps the hot pipeline state
on device.

The scope is single-device inference only. Context parallelism, including CP4,
is not part of this change.

## Exit Criteria

- [x] Add an opt-in first-block cached bundle/runtime path while preserving the
  existing monolithic path.
- [x] Keep the text encoder, AdaLN, DiT, and VAE networks in TensorRT-native
  plans, with remaining scheduler and media assembly work device-resident.
- [x] Support a model-owned, validated cache-threshold override and CUDA graphs.
- [x] Route the optimized layout through canonical `trtmc build` and H3 E2E.
- [x] Preserve visually coherent generation without requiring pixel identity.
- [x] Record a lower GB300 wall than the available single-device SOL-engine
  hot-path result while the optimized output passes the requested human-visible
  quality criterion.
- [x] Finish the Thor visual-coherence review and record its final frame/contact-
  sheet evidence. Thor performance evidence is captured at worker level but is
  not a canonical root-harness receipt; see Validation.

## Implementation

- Split the DiT into TensorRT-native head, tail, and finish plans. The head runs
  block 0 and computes an FP32 residual-change metric; the tail contains blocks
  1-49; the finish plan reconstructs the final video and audio velocities.
- Commit cached residual state only after a full denoiser step. Skipped steps
  reuse the last committed tail residual.
- Keep same-prompt text embeddings, AdaLN modulations, denoiser modules, VAE
  module, latents, and velocities resident across requests.
- Move scheduler updates, VAE tile extraction, spatial/temporal assembly,
  normalization, and clamping to asynchronous CUDA paths.
- Add the model-owned `minimax_h3.first_block_cache_threshold` setting with a
  finite, positive default of `0.025`; the qualified fast path uses an explicit
  `0.20` override.
- Forward schema-backed family build options through diffusion dispatch so
  canonical H3 builds can select the split layout with
  `--set minimax_h3.first_block_cache=true`.
- Extend build, packaging, provenance, visual-reference, and benchmark tooling
  for the split plan set, exact backend-DSO binding, cache-residency evidence,
  and scoped bundle page-cache eviction.
- Make external TensorRT buffer rebinding transactional. Failed bindings retain
  the previous owned buffer; successful pointer changes invalidate captured
  CUDA graphs; same-pointer binds preserve ownership.

## Validation

PR review head after rebase and premerge repair:
`a699291b30d6e4fc5fee76e555277f657c6b871d` on top of
`github/main@ba98f3a1fa06e209c27543b8e41246a665c0fe2d`.

The GB300 performance and visual artifacts below remain bound to the pre-rebase
exact source `a8650c75eb641412f67dd22f6d9bc2554b6f50f3` on top of
`github/main@63c920304cb0236a995e933f49504e8f2f237317`. The branch was rebased
over the already-merged Nemotron fix from #838, MiniMax-H3 coverage contracts
from #834, and the latest checkout-guidance change from #829. A focused
premerge repair then decomposed the H3 pipeline/plugin orchestration to satisfy
the source-complexity contract and moved the external-binding regressions from
the fail-closed shared test surface into the H3-owned test target. The branch
was subsequently rebased over #832's deterministic GPU-lease test and #839's
repository-wide `.bundle` format standardization. The latter required one
mechanical conflict resolution and removal of nine legacy suffixes from H3
test fixtures; the resulting tree retains the new `BUNDLE` container contract.
None of these changes relaxed a validation criterion. The measured artifacts
are implementation qualification evidence, not exact-head performance
receipts for `a699291b`.

Exact-head static, unit, and build gates:

- Full CI-equivalent source-quality pipeline: passed, including lint, format,
  architecture contracts, and `157 passed`. Repository maximum cyclomatic
  complexity is 10; `MiniMaxH3Pipeline::generate_image` is 6 and
  `MiniMaxH3Plugin::create` is 1.
- H3/config Python suite: `168 passed` (one duplicate registry test was removed
  upstream by #834):
  `PYTHONPATH=python python -m pytest -q python/tensorrt_model_connect/families/minimax_h3/tests tests/e2e/models/minimax_h3/test_build_native_components.py tests/e2e/models/minimax_h3/test_pack_native_bundle.py tests/e2e/models/minimax_h3/test_benchmark_native_runtime.py tests/e2e/models/minimax_h3/test_native_reference.py tests/builder/test_max_batch_size_cli.py tests/builder/test_config_cli_support.py tests/builder/test_config_schema_registry.py tests/builder/test_config_schemas_crosslang.py`.
- Exact model-catalog validation and impact selection: passed. The new
  external-binding regression is classified as MiniMax-H3-owned; the shared
  `tests/cpp/test_trt_module.cpp` is unchanged from `github/main`.
- Model-CI policy tests: `76 passed` after the #839 rebase.
- GB300 container build of the H3 runtime plus affected C++ tests: passed.
  The rebase-sensitive config-schema and owned external-binding tests passed
  `2/2`; the H3 runtime and all three requested targets built successfully.
- Repository search confirms no tracked `.trtfb` spelling was reintroduced;
  H3 packing uses the shared post-#839 bundle writer and `model.bundle` fixtures.
- `git diff --check`: passed.

The first exact-head internal premerge run identified one model-proof failure:
the original `0.08` schema default was too aggressive for the repository's
unchanged low-frequency visual gate. It executed 16 full and 33 cached-tail
steps; temporal correlation passed at `0.991126`, while low-frequency
correlation (`0.705103` minimum, `0.783873` mean) missed the existing `0.8` and
`0.9` thresholds. All source-quality, ownership, unit, and fallback-model jobs
passed. An independent SOL/PyTorch FBC run at `0.08` against the same reference
missed the gate by a similar margin, supporting threshold calibration rather
than an implementation-specific accuracy repair.

GB300 calibration against that exact CI reference selected `0.025` as the
strongest measured default with useful quality headroom. With the existing
split TensorRT bundle, it executed 37 full and 12 cached-tail steps and passed
the unchanged gate: low-frequency correlation was `0.891602` minimum and
`0.940719` mean, temporal correlation was `0.998244`, PSNR was `19.5483`, and
MAE was `0.044903`. This calibration run is diagnostic evidence from the
existing split bundle. An intermediate exact-head run at `c7b168a6` passed all
six model proofs but became historical when #839 advanced `main`.

The final exact-head internal run at `a699291b` rebuilt and consumed a
121,486,510,405-byte post-#839 `.bundle` through the canonical single-device
path. Its six TensorRT-native plans included the denoiser head, tail, and finish
plans, with no collective. The effective threshold was the schema default
`0.025` with no override; it executed 37 full and 12 cached-tail steps. The
unchanged visual gate passed with low-frequency correlation `0.893068` minimum
and `0.940782` mean, brightness correlation `0.999486`, and temporal
correlation `0.998639`; PSNR `19.5728` and MAE `0.044755` remain diagnostics.
The H3 E2E suite passed `16/16`, all five fallback model proofs passed, and
source quality, ownership, unit, combined report, private verdict, and exact
source-status publication all succeeded. This is the final merge-authority
receipt for the PR head.

The canonical GB300 bundle was built through `trtmc build` from the pre-rebase
exact source above. Its builder-source digest is
`3cedd79c1590e21a100e78d9295835f523e9226191c4d0ba2f4c1874f174b488`,
its bundle digest is
`8e30a6a63acd25a5990a273fd4763f4a7996500d742ba708efe74a5dd4cbf7f7`,
and its config records TensorRT 11.2, CP=1, FBC enabled, threshold `0.20`, and
the exact six-plan split set.

GB300 performance qualification used one warmup followed by two measured calls
of the same pipeline and prompt at 768x1344, 124 frames, 50 inference steps,
seed 0, CUDA graphs enabled, and threshold `0.20`.

- Public pipeline-call wall samples: `23.169925s`, `23.195442s`
- Median public pipeline-call wall: `23.182683s`
- Cache behavior per measured request: 8 full steps, 41 skipped steps
- Text, AdaLN, denoiser, and VAE resident-cache markers: all hit
- CUDA graph capture failures: 0
- Recorded SOL-engine result for the same prompt, shape, steps, seed, and one-GPU
  workload: `41.951s` hot denoise-plus-decode and `44.116s` total, with cache
  threshold `0.08`.
- Raw ratio against the SOL hot component: `1.8096x`, or `44.74%` lower wall.
  The optimized path measures a broader public pipeline-call boundary but uses
  cache threshold `0.20`; this is a directional result, not a strict
  apples-to-apples A/B.
- Prior merged [PR #815](https://github.com/NVIDIA/TensorRT-Model-Connect/pull/815)
  same-workload `torch.compile` baseline: `119.865525s`. That result was measured
  after compile/warmup with PyTorch `2.12.0+cu130` and
  `max-autotune-no-cudagraphs`, from source `469abbab65a4657b0742dfaac158187c15ee3278`.
- Raw cross-run ratio against that prior compiled request: `5.1705x`. It was not
  co-measured from the exact `a8650c75` source and is not presented as an
  exact-source A/B.

The measured GB300 wall is a warm same-process, same-pipeline, same-prompt call.
It includes host pre/post-processing and output assembly, excludes PNG encoding,
and excludes cold TensorRT plan deserialization. The SOL artifact and the prior
compiled baseline use the same pinned workload, but only the raw timing ratios
above are claimed; they did not pass through one shared timing and quality gate.

The exact-source GB300 visual run produced 124 finite RGB frames at 768x1344
with the same seed and threshold. Dense early/mid, transition, and ending
contact sheets were manually reviewed: the bridge, fleet charge, flash, captain
close-up, and ending remained coherent, with no black frames, frozen sequence,
anatomical collapse, or broken scene transition. Pixel identity and minor high-
frequency or cut-timing differences were not acceptance criteria.

Thor worker-level performance qualification used the same 768x1344, 124-frame,
50-step, seed-0 workload with CUDA graphs enabled and threshold `0.20`. One
warmup preceded two measured hot same-process calls.

- Public worker wall samples: `362.152826953s`, `367.800573329s`
- Median public worker wall: `364.976700141s` (`6.082945min`)
- Cache behavior per measured request: 8 full steps, 41 skipped steps
- Text, AdaLN, denoiser, and VAE resident-cache markers: all hit
- CUDA graph capture failures: 0
- The repository's `parse_worker_evidence` validation passed for the completed
  worker result; supplementary evidence is recorded in
  `results/benchmark-fbc020-graphs-on/benchmark_worker_evidence.json`.
- The official root `benchmark_receipt.json` was not emitted. Its final bundle-
  identity gate observed an SSHFS inode change. The supplementary evidence shows
  unchanged byte size and mtime, and the bundle configuration remained parseable,
  but the identity gate still failed. These values are therefore reported as
  worker-level evidence, not as a canonical root-harness pass.
- After benchmark and visual completion, a direct storage-side SHA-256 pass over
  the 121,487,603,011-byte bundle produced
  `9d3097f07f6701c6ef76b57293dda58a08ed849b7064eaed665d08ffe3160554`.
  This is supplemental content-integrity evidence; it does not replace the
  missing canonical root-harness receipt.

The previously recorded Thor baseline used a cold fresh process, the monolithic
four-plan path, and PNG output. Its timing boundary is not comparable to this
hot worker measurement, so no Thor speedup or latency-reduction claim is made.

Thor visual qualification passed:

- Output: 124 finite RGB frames with shape `[124, 768, 1344, 3]`
- Frame-manifest digest:
  `a61ef4819248dce98111f5d57a3d5cfdd36be84614f6b38573fe5fc817fd0ab0`
- Contact-sheet digest:
  `6593eeab301804bd17979c12075dfb747419aceaaf00dc1698cbcb1004ae5df8`
- Cache behavior: 8 full steps, 41 skipped steps
- CUDA graph capture failures: 0
- Visual-only wall: `2401.917790556s`; page-cache state was unspecified, so
  this value is not a performance result and is excluded from comparisons.
- Visual telemetry over 2408 seconds: RAM peak `119051/125710MB`, GPU
  temperature peak `85.218C`, approximate VIN mean `48.163W`, VIN peak
  `168.186W`, and approximate VIN energy `32.215Wh`.
- Manual contact-sheet review found coherent bridge, fleet-charge, white-flash,
  captain close-up, and eyes-closed ending sequences, with no black frames,
  frozen sequence, structural collapse, or broken scene transition. Minor
  detail differences remain within the visual acceptance criterion.

## Notes For Future Readers

- First-block caching is opt-in; monolithic bundles retain their existing
  behavior.
- The tuned explicit `0.20` threshold is qualified for this workload and human
  visual gate. The conservative schema default is `0.025` and passes the
  repository's unchanged automated visual gate in GB300 calibration.
- Review the split TensorRT builders first, then resident runtime state and CUDA
  helpers, followed by bundle/provenance handling and the benchmark harness.
- Generated plans, bundles, frames, and benchmark receipts are qualification
  artifacts and are not committed.
- Keep the pre-rebase GB300 receipt boundary explicit after the review rebase;
  do not describe the performance numbers as exact-head `a699291b` results.
- #839 changed the repository bundle container contract and suffix. Historical
  qualification artifacts remain evidence for their recorded source, but they
  cannot be made current by renaming; current-head use requires a fresh build
  or repack with the new writer.
- The Thor bundle metadata records source
  `928dc5aea6543785d09991d0746c20ee65036937`. Runtime binaries were rebuilt after
  later branch synchronization, but the bundle provenance remains bound to
  `928dc5`; treat the Thor evidence as branch-development qualification and do
  not describe it as an exact `a8650c75` source receipt.
- Keep the Thor worker/root evidence distinction visible. Do not convert the
  worker numbers into a canonical benchmark-pass claim, and do not compare them
  directly with the historical cold monolithic run.
- The Thor visual-only wall is retained for provenance, but its unspecified
  page-cache state makes it unsuitable for performance comparisons.
