### PR TITLE
fix(ci): bound release performance impact

### DIFF
--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -637,6 +637,33 @@ def test_impact_runs_units_for_test_consumed_docs(
     } == {expected_kind}
 
 
+def test_release_performance_config_runs_source_contracts_without_model_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "benchmarks/performance/release.yaml",
+        "entries:\n  - id: model-a.generate\n",
+    )
+    head = _commit(repo, "update release performance contract")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {"unit_tests"}
+
+
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -664,6 +664,34 @@ def test_release_performance_config_runs_source_contracts_without_model_fallback
     } == {"unit_tests"}
 
 
+@pytest.mark.parametrize(
+    "path",
+    (
+        "benchmarks/performance/baselines/task_reference.py",
+        "tools/perf_matrix.py",
+    ),
+)
+def test_release_performance_runtime_changes_keep_model_fallback(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# changed release performance runtime\n")
+    head = _commit(repo, "update release performance runtime")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {
+        "include": [{"model": "model_a", "selection_kind": "fallback"}]
+    }
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
 def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -142,9 +142,13 @@ BUILDER_UNIT_TEST_INPUT_EXACT = frozenset(
         "website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md",
     }
 )
-# Inputs consumed by the complete source-only tools/CI contract suite.
+# Inputs consumed by the complete source-only tools/CI contract suite. The
+# release performance matrix is declarative: representative premerge model
+# proofs do not execute it, while the source contracts validate its schema,
+# ready-model coverage, exclusions, and report accounting.
 FULL_UNIT_TEST_INPUT_EXACT = frozenset(
     {
+        "benchmarks/performance/release.yaml",
         "tools/ci/README.md",
     }
 )


### PR DESCRIPTION
## Background

The release performance suite keeps its temporary profile exclusions in `benchmarks/performance/release.yaml`. `tools/model_ci.py` did not classify that central declarative file, so every exclusion or matrix-accounting edit was treated as an unknown platform change. Premerge then selected five representative fallback GPU model proofs even though those proofs do not read or execute the release performance matrix.

This surfaced while repairing the missing MiniMax-H3 release-coverage contract in #834: the intended direct MiniMax proof expanded to MiniMax plus five unrelated fallback models.

## Root Cause

`benchmarks/performance/release.yaml` fell through to `kind=unknown`. With the private premerge bridge's fail-safe `--platform-change-policy fallback`, one unknown path adds the fixed fallback set.

The relevant behavior is instead certified by the complete source-only contract suite: it parses the release schema and enforces ready-model coverage, explicit-exclusion validity, uniqueness, family/operation alignment, and report accounting. Representative model proofs cannot certify any of those properties.

## Implementation

- Classify only `benchmarks/performance/release.yaml` as a full source-unit input.
- Keep performance runner and reference implementation changes fail-safe: `benchmarks/performance/baselines/task_reference.py` and `tools/perf_matrix.py` still select the representative fallback models.
- Keep selector changes themselves fail-safe. This PR changes `tools/model_ci.py`, so its own exact-head CI must run the existing fixed fallback set once; the selector does not self-exempt.

No model implementation, accuracy threshold, release exclusion, test passing criterion, workflow matrix, or fallback list changes in this PR.

## Validation

Base: `github/main@63c920304cb0236a995e933f49504e8f2f237317`.

- `python -m pytest tests/tools/test_model_ci.py -q -p no:cacheprovider`: `77 passed in 10.70s`.
- Frozen QA image `sha256:6e97af69eae7e9276e7f9061381edefd54a782ab6695c895117ecfff06188027`: the four new/adjacent impact cases passed in `4.05s`.
- `python -m pytest tests/tools/test_test_impact.py::TestUnitTiers::test_release_performance_triggers_tools_tier -q -p no:cacheprovider`: passed.
- `python tools/test_impact.py --validate`: passed with pre-existing stale-allowlist warnings.
- Ruff and `git diff --check`: passed.

## Runtime Bound

This selector PR deliberately retains the existing one-time five-model fallback because it modifies the selector itself. After it lands, a release-matrix-only change becomes `mode=unit`, runs the already-existing complete source-unit lane, selects zero model proofs, and adds no GPU fanout.

After rebasing #834 onto this change, its expected steady-state selection is one direct model (`minimax_h3`), no fallback models, `unit_scope=all`, and no C++ rebuild. Runtime or reference-runner code remains broad and continues to receive fallback protection.
