### PR TITLE
fix(nemotron): retain Hindi model in FP32

### DIFF
--- a/tests/e2e/models/nemotron/manifests/nemotron-hindi-4b.json
+++ b/tests/e2e/models/nemotron/manifests/nemotron-hindi-4b.json
@@ -5,7 +5,7 @@
   "family": "nemotron",
   "runtime_strategy": "nemotron_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "precision": "fp16",
+  "precision": "fp32",
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
+++ b/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nemotron-owned manifest contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_nemotron_hindi_reference_matches_bundle_precision() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "nemotron-hindi-4b.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["precision"] == "fp32"
+    assert manifest["testcases"][0]["reference_precision"] == manifest["precision"]


### PR DESCRIPTION
## Background

The GB300 release performance campaign began validating each testcase at its declared reference precision. `nemotron-hindi-4b` then produced different greedy tokens from its FP32 reference: the first nine generated tokens matched, but FP16 diverged afterward, so the performance comparison failed closed instead of reporting a misleading speedup.

## Exit Criteria

- The canonical Nemotron Hindi bundle uses a precision that preserves exact generated-token parity with its declared FP32 reference.
- The model-owned contract prevents candidate and reference precision from drifting apart again.
- The prompt, reference implementation, output contract, and performance thresholds remain unchanged.

## Implementation

- Retain `nemotron-hindi-4b` in FP32.
- Add a focused manifest regression requiring the canonical precision to be FP32 and to match the testcase reference precision.

## Validation

- Fail-before focused regression: `1 failed`; the prior manifest declared FP16 while the test required FP32 parity.
- `PYTHONPATH=python python -m pytest -q tests/e2e/models/nemotron/test_nemotron_manifest_contract.py`: `1 passed` on exact head `d8ac48ae597368e1888df31c930058e3196589ff`.
- `PYTHONPATH=python python tools/model_ci.py impact --base github/main --head HEAD`: selected only the direct `nemotron` model on exact head.
- GB300 FP32 diagnostic using the campaign source binary and this manifest-only precision change: the candidate and existing FP32 reference matched all 20 generated token IDs and the complete text. Candidate p50 was `87.848522 ms`; reference p50 was `275.112637 ms`.
- `PYTHONPATH=python python -m pytest -q tests/tools/test_perf_matrix.py tests/e2e/models/nemotron/test_nemotron_manifest_contract.py`: `89 passed`, `4 failed`. All four failures reproduce an unrelated current-`main` release-suite coverage gap for newly added `minimax-h3-768p`.
- `PYTHONPATH=python python -m pytest -q tests/e2e/models/nemotron/test_nemotron_builder_engine.py`: `10 passed`, `3 failed` because the local host has no CUDA device. The real GB300 build and measurement above passed.
- `git diff --check`: passed.

## Notes For Future Readers

- The GB300 proof used source `99e8aa607449d5f92a8b1f2b61e20cc68ba839a6` plus a temporary manifest that differs from this PR only in the model name and FP32 precision. No Nemotron runtime source changed between that campaign revision and this PR base, but this is not an exact-head GPU replay; current-head CI remains authoritative.
- No engine, model weight, benchmark artifact, prompt, reference precision, or threshold is committed here.
