### PR TITLE
fix(nemotron): align Hindi model in BF16

### DIFF
--- a/tests/e2e/models/nemotron/manifests/nemotron-hindi-4b.json
+++ b/tests/e2e/models/nemotron/manifests/nemotron-hindi-4b.json
@@ -5,7 +5,7 @@
   "family": "nemotron",
   "runtime_strategy": "nemotron_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
-  "precision": "fp32",
+  "precision": "bf16",
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
@@ -14,7 +14,7 @@
       "trace_id": "IT-E2E-NMHND-01",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "reference_precision": "fp32",
+      "reference_precision": "bf16",
       "prompt": "The capital of France is",
       "max_new_tokens": 20
     }

--- a/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
+++ b/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
@@ -13,5 +13,5 @@ def test_nemotron_hindi_reference_matches_bundle_precision() -> None:
     manifest_path = Path(__file__).with_name("manifests") / "nemotron-hindi-4b.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-    assert manifest["precision"] == "fp32"
+    assert manifest["precision"] == "bf16"
     assert manifest["testcases"][0]["reference_precision"] == manifest["precision"]


### PR DESCRIPTION
## Background

The Nemotron Hindi 4B manifest currently forces both the TensorRT bundle and its Hugging Face reference to FP32. The model and TRTMC path support BF16, so the conversion and comparison should remain aligned in BF16 without an FP32 fallback.

## Exit Criteria

- Build and execute `nemotron-hindi-4b` in BF16.
- Run the independent Hugging Face reference in BF16.
- Preserve the existing E2E, performance, and accuracy gates.

## Implementation

- Change the manifest bundle precision from `fp32` to `bf16`.
- Change the testcase reference precision from `fp32` to `bf16`.
- Update the model-owned contract test to require BF16 while retaining the invariant that candidate and reference precision match.

## Validation

- `PYTHONPATH=python python -m pytest -q tests/e2e/models/nemotron/test_nemotron_manifest_contract.py tests/tools/test_perf_matrix.py::test_task_reference_uses_manifest_reference_precision tests/tools/test_validation_engine.py::test_explicit_reference_dtype_must_match_engine_precision tests/tools/test_validation_engine.py::test_declared_native_reference_dtype_exception_is_recorded tests/tools/test_validation_engine.py::test_comparison_precision_overrides_both_candidate_and_reference tests/tools/test_validation_engine.py::test_validation_can_override_component_precision_without_changing_manifest tests/tools/test_validation_engine.py::test_quantized_reference_contract_records_candidate_and_base_precision`: 7 passed on the current head.
- Target-hardware E2E qualification: 1 passed; BF16 candidate and BF16 reference produced the same 20 generated token IDs, with normalized edit distance 0.0 and prefix match 1.0.
- Target-hardware `nemotron.generate` release performance qualification: green; BF16 candidate and BF16 reference token IDs matched exactly. Candidate p50 was 62.13 ms and reference p50 was 320.63 ms over 10 measured iterations after 3 warmups.
- Target-hardware `mmlu_continuation_parity` accuracy qualification: passed 10 samples with aligned BF16 precision, 0.9 tie-adjusted exact-match rate, and 0.9125 token-prefix agreement.

## Notes For Future Readers

- No FP16 or FP32 fallback is used by this manifest.
- Target-hardware proof was collected on the same two-file BF16 diff before rebasing onto the current `main`; the overlapping upstream change only standardized the bundle filename extension. The focused tests were rerun after the rebase on this PR head.
- Internal runtime paths and artifact links are intentionally omitted from this source PR.
