### PR TITLE
feat(report-hub): add QA evidence workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,10 @@
 !.github/
 !.github/scripts/
 !.github/scripts/build-python-profiles.py
+!tools/
+!tools/__init__.py
+!tools/report_hub/
+!tools/report_hub/**
 
 **/__pycache__/
 **/*.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,6 @@ engines
 *.bundle
 *.ttrtb
 results.json
+report-hub.sqlite3*
 !**/Recording.wav
 worktrees/

--- a/tests/tools/test_report_hub.py
+++ b/tests/tools/test_report_hub.py
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.report_hub.app import ReportHubApplication
+from tools.report_hub.auth import AuthManager, AuthenticationError, Identity
+from tools.report_hub.config import Settings
+from tools.report_hub.domain import ConflictError, ReportHubError
+from tools.report_hub.normalize import normalize_report
+from tools.report_hub.integrations import IntegrationRegistry, PublishEnvelope
+from tools.report_hub.source import HttpEvidenceSource
+from tools.report_hub.storage import Store
+
+
+CATALOG = {
+    "schema_version": "trtmc.report-browser-index/v1",
+    "sources": {
+        "benchmark": {
+            "reports": [
+                {
+                    "folder": "accuracy-20260807-a1b2c3d4",
+                    "date": "2026-08-07",
+                    "updated_at": "2026-08-07T02:00:00Z",
+                    "_signature": "abc",
+                    "summary": {"total": 2, "passed": 1, "failed": 1, "other": 0},
+                },
+                {
+                    "folder": "accuracy-20260806-d4c3b2a1",
+                    "date": "2026-08-06",
+                    "updated_at": "2026-08-06T02:00:00Z",
+                    "_signature": "def",
+                    "summary": {"total": 1, "passed": 1, "failed": 0, "other": 0},
+                },
+            ]
+        },
+        "perf": {"reports": []},
+    },
+}
+
+VALIDATION_REPORT = {
+    "schema_version": "trtmc.validation-report/v2",
+    "results": [
+        {
+            "model": "qwen-test",
+            "family": "qwen",
+            "workload": "mmlu",
+            "operation": "generate",
+            "execution": {"status": "completed", "attempts": [{"error": ""}]},
+            "comparison": {
+                "status": "disagreement",
+                "primary_metric": {"name": "agreement", "value": 0.5},
+                "failures": [{"gate": "minimum", "actual": 0.5}],
+            },
+            "validation": {"status": "failed"},
+        },
+        {
+            "model": "t5-test",
+            "workload": "summary",
+            "execution": {"status": "completed"},
+            "comparison": {
+                "status": "agreement",
+                "primary_metric": {"name": "agreement", "value": 1.0},
+            },
+            "validation": {"status": "passed"},
+        },
+    ],
+}
+
+BENCHMARK_REPORT = {
+    "schema_version": "trtmc.benchmark-report/v1",
+    "runs": [
+        {
+            "run_id": "source-run",
+            "cells": [
+                {
+                    "model": "gpt-test",
+                    "name": "default",
+                    "operation": "generate",
+                    "status": "completed",
+                    "metrics": {
+                        "primary": {
+                            "name": "runtime_e2e_wall_ms.p50",
+                            "unit": "ms",
+                            "value": 12.5,
+                        },
+                        "sample_count": 20,
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+PERFORMANCE_REPORT = {
+    "schema_version": "trtmc.perf-matrix/v1",
+    "cases": [
+        {
+            "id": "nemotron.generate",
+            "model": "nemotron-test",
+            "family": "nemotron",
+            "operation": "generate",
+            "status": "red",
+            "workload_contract": {"testcase": "default"},
+            "baseline": {"metrics": {"latency_ms": {"p50": 100.0}}},
+            "candidate": {
+                "metrics": {
+                    "latency_ms": {"p50": 125.0},
+                    "primary": {"name": "runtime_e2e_wall_ms.p50", "value": 125.0},
+                }
+            },
+            "comparison": {
+                "baseline_over_trtmc_p50": 0.8,
+                "equivalence_margin_percent": 5.0,
+            },
+        }
+    ],
+}
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Store:
+    value = Store(tmp_path / "hub.sqlite3", retention_days=30)
+    value.initialize()
+    value.sync_catalog(CATALOG, actor="qa-user")
+    return value
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        database_path=tmp_path / "hub.sqlite3",
+        evidence_root_url="https://reports.example.test/root",
+        catalog_url="https://reports.example.test/root/catalog.json",
+        auth_mode="development",
+        dev_user="qa-user",
+        dev_role="admin",
+        secret="test-secret",
+        allowed_external_hosts=("github.com", "bugs.example.test"),
+    )
+
+
+def _run(store: Store, index: int = 0) -> dict[str, Any]:
+    return store.list_runs(source="benchmark")[index]
+
+
+def test_validation_and_benchmark_reports_normalize_to_stable_findings() -> None:
+    validation = normalize_report("benchmark", VALIDATION_REPORT)
+    benchmark = normalize_report("perf", BENCHMARK_REPORT)
+
+    assert [item.status for item in validation] == ["failed", "passed"]
+    assert validation[0].metric_name == "agreement"
+    assert validation[0].metric_value == 0.5
+    assert validation[0].finding_id == normalize_report("benchmark", VALIDATION_REPORT)[0].finding_id
+    assert benchmark[0].status == "passed"
+    assert benchmark[0].metric_value == 12.5
+    assert benchmark[0].details["sample_count"] == 20
+
+
+def test_performance_matrix_preserves_comparison_contract() -> None:
+    observation = normalize_report("perf", PERFORMANCE_REPORT)[0]
+
+    assert observation.status == "failed"
+    assert observation.metric_name == "baseline_over_trtmc_p50"
+    assert observation.metric_value == 0.8
+    assert observation.details["baseline_p50_ms"] == 100.0
+    assert observation.details["candidate_p50_ms"] == 125.0
+
+
+def test_unknown_report_schema_fails_closed() -> None:
+    with pytest.raises(ReportHubError, match="unsupported report schema"):
+        normalize_report("benchmark", {"schema_version": "unknown/v9"})
+
+
+def test_finding_identity_changes_with_metric_contract() -> None:
+    changed = json.loads(json.dumps(VALIDATION_REPORT))
+    changed["results"][0]["comparison"]["primary_metric"]["name"] = "exact_match_rate"
+
+    original_id = normalize_report("benchmark", VALIDATION_REPORT)[0].finding_id
+    changed_id = normalize_report("benchmark", changed)[0].finding_id
+
+    assert original_id != changed_id
+
+
+def test_catalog_sync_is_idempotent_and_never_restores_trashed_runs(store: Store) -> None:
+    run = _run(store)
+    trashed = store.trash_run(
+        run["id"],
+        reason="Superseded by complete run",
+        confirmation=run["folder"],
+        expected_version=run["version"],
+        actor="qa-user",
+    )
+
+    result = store.sync_catalog(CATALOG, actor="qa-user")
+
+    assert result == {"inserted": 0, "updated": 2}
+    assert store.get_run(run["id"])["lifecycle"] == "trashed"
+    assert store.get_run(run["id"])["version"] == trashed["version"]
+
+
+def test_trash_requires_exact_confirmation_and_supports_restore(store: Store) -> None:
+    run = _run(store)
+    with pytest.raises(ReportHubError, match="exactly match"):
+        store.trash_run(
+            run["id"],
+            reason="Duplicate",
+            confirmation="wrong-run",
+            expected_version=run["version"],
+            actor="qa-user",
+        )
+
+    trashed = store.trash_run(
+        run["id"],
+        reason="Duplicate",
+        confirmation=run["folder"],
+        expected_version=run["version"],
+        actor="qa-user",
+    )
+    with pytest.raises(ConflictError, match="changed"):
+        store.restore_run(run["id"], expected_version=run["version"], actor="qa-user")
+    restored = store.restore_run(
+        run["id"], expected_version=trashed["version"], actor="qa-user"
+    )
+
+    assert restored["lifecycle"] == "active"
+    assert restored["trashed_at"] is None
+    assert [event["action"] for event in store.audit_events(entity_id=run["id"])][:2] == [
+        "run.restored",
+        "run.trashed",
+    ]
+
+
+def test_restore_is_rejected_after_retention_expires(store: Store) -> None:
+    run = _run(store)
+    trashed = store.trash_run(
+        run["id"],
+        reason="Duplicate",
+        confirmation=run["folder"],
+        expected_version=run["version"],
+        actor="qa-user",
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ConflictError, match="retention window has expired"):
+        store.restore_run(
+            run["id"],
+            expected_version=trashed["version"],
+            actor="qa-user",
+            now=datetime(2026, 2, 2, tzinfo=timezone.utc),
+        )
+
+
+def test_purge_schedule_waits_for_retention_and_closed_findings(store: Store) -> None:
+    run = _run(store)
+    january = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    trashed = store.trash_run(
+        run["id"],
+        reason="Obsolete evidence",
+        confirmation=run["folder"],
+        expected_version=run["version"],
+        actor="qa-user",
+        now=january,
+    )
+    store.ingest_observations(
+        run["id"], normalize_report("benchmark", VALIDATION_REPORT), actor="qa-user"
+    )
+    with pytest.raises(ConflictError, match="retention"):
+        store.schedule_purge(
+            run["id"],
+            confirmation=run["folder"],
+            acknowledge_irreversible=True,
+            expected_version=trashed["version"],
+            actor="admin-user",
+            now=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        )
+    with pytest.raises(ConflictError, match="open findings"):
+        store.schedule_purge(
+            run["id"],
+            confirmation=run["folder"],
+            acknowledge_irreversible=True,
+            expected_version=trashed["version"],
+            actor="admin-user",
+            now=datetime(2026, 2, 2, tzinfo=timezone.utc),
+        )
+    for finding in store.list_findings(run_id=run["id"]):
+        store.update_triage(
+            finding["id"],
+            {
+                "status": "resolved",
+                "severity": "low",
+                "owner": "qa-user",
+                "note": "No longer actionable",
+                "tags": ["obsolete"],
+                "expected_version": 0,
+            },
+            actor="qa-user",
+        )
+    scheduled = store.schedule_purge(
+        run["id"],
+        confirmation=run["folder"],
+        acknowledge_irreversible=True,
+        expected_version=trashed["version"],
+        actor="admin-user",
+        now=datetime(2026, 2, 2, tzinfo=timezone.utc),
+    )
+    assert scheduled["lifecycle"] == "purge_scheduled"
+
+
+def test_triage_persists_across_multiple_run_observations(store: Store) -> None:
+    first, second = store.list_runs(source="benchmark")
+    observations = normalize_report("benchmark", VALIDATION_REPORT)
+    store.ingest_observations(first["id"], observations, actor="qa-user")
+    finding = store.list_findings(run_id=first["id"])[0]
+    saved = store.update_triage(
+        finding["id"],
+        {
+            "status": "investigating",
+            "severity": "high",
+            "owner": "qa-user",
+            "note": "Reproducing on a clean engine",
+            "tags": ["accuracy-regression"],
+            "expected_version": 0,
+        },
+        actor="qa-user",
+    )
+    store.ingest_observations(second["id"], observations, actor="qa-user")
+
+    same_finding = next(
+        item for item in store.list_findings(run_id=second["id"]) if item["id"] == finding["id"]
+    )
+    assert same_finding["triage"] == saved
+
+
+def test_auth_proxy_requires_identity_and_mutation_token(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings = Settings(**{**settings.__dict__, "auth_mode": "proxy"})
+    auth = AuthManager(settings)
+    with pytest.raises(AuthenticationError):
+        auth.authenticate({})
+    identity = auth.authenticate(
+        {settings.auth_user_header: "qa-user", settings.auth_role_header: "qa"}
+    )
+    with pytest.raises(ReportHubError, match="mutation token"):
+        auth.verify_mutation(identity, {})
+    auth.verify_mutation(identity, {"X-Report-Hub-CSRF": auth.csrf_token(identity)})
+
+
+def test_application_sync_analyze_and_update_triage(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    store = Store(settings.database_path)
+    store.initialize()
+
+    def loader(url: str, _maximum: int) -> dict[str, Any]:
+        return CATALOG if url.endswith("catalog.json") else VALIDATION_REPORT
+
+    application = ReportHubApplication(settings, store, HttpEvidenceSource(settings, loader=loader))
+    session = _json_response(application.handle("GET", "/api/v1/session", {}))
+    headers = {"X-Report-Hub-CSRF": session["csrf_token"]}
+    sync = application.handle("POST", "/api/v1/catalog/sync", headers, b"{}")
+    assert sync.status == 200
+    run = store.list_runs(source="benchmark")[0]
+    analyzed = _json_response(
+        application.handle("POST", f"/api/v1/runs/{run['id']}/analyze", headers, b"{}")
+    )
+    finding = analyzed["findings"][0]
+    triage_body = json.dumps(
+        {
+            "status": "investigating",
+            "severity": "high",
+            "owner": "qa-user",
+            "note": "Reproduced",
+            "tags": ["accuracy"],
+            "expected_version": 0,
+        }
+    ).encode()
+    response = application.handle(
+        "PUT", f"/api/v1/findings/{finding['id']}/triage", headers, triage_body
+    )
+    assert response.status == 200
+    assert _json_response(response)["triage"]["version"] == 1
+
+
+def test_external_github_link_is_repository_scoped(tmp_path: Path, store: Store) -> None:
+    settings = _settings(tmp_path)
+    application = ReportHubApplication(settings, store, HttpEvidenceSource(settings))
+    identity = Identity("qa-user", "qa")
+
+    with pytest.raises(ReportHubError, match="this repository"):
+        application._create_link(  # noqa: SLF001 - direct policy unit test
+            {
+                "system": "github",
+                "record_type": "issue",
+                "external_id": "42",
+                "url": "https://github.com/example/other/issues/42",
+            },
+            identity,
+            run_id=_run(store)["id"],
+        )
+
+
+def test_phase_zero_adapters_fail_closed_and_idempotency_is_persistent(store: Store) -> None:
+    adapter = IntegrationRegistry.phase_zero().get("devtest")
+    with pytest.raises(ReportHubError, match="write adapter is disabled"):
+        adapter.publish(PublishEnvelope("create_plan", "plan-1", "qa-user", {"name": "Nightly"}))
+
+    first = store.prepare_adapter_operation(
+        system="devtest",
+        operation="create_plan",
+        idempotency_key="plan-1",
+        request={"name": "Nightly"},
+        actor="qa-user",
+    )
+    replay = store.prepare_adapter_operation(
+        system="devtest",
+        operation="create_plan",
+        idempotency_key="plan-1",
+        request={"name": "Nightly"},
+        actor="qa-user",
+    )
+    assert first["replayed"] is False
+    assert replay["replayed"] is True
+    assert first["id"] == replay["id"]
+    with pytest.raises(ConflictError, match="different request"):
+        store.prepare_adapter_operation(
+            system="devtest",
+            operation="create_plan",
+            idempotency_key="plan-1",
+            request={"name": "Changed"},
+            actor="qa-user",
+        )
+
+
+def _json_response(response: Any) -> dict[str, Any]:
+    return json.loads(response.body.decode("utf-8"))

--- a/tools/report_hub/Dockerfile
+++ b/tools/report_hub/Dockerfile
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM python:3.12-slim
+
+RUN groupadd --system report-hub \
+    && useradd --system --gid report-hub --home-dir /app report-hub \
+    && mkdir -p /app/tools /var/lib/report-hub \
+    && chown -R report-hub:report-hub /app /var/lib/report-hub
+
+WORKDIR /app
+COPY --chown=report-hub:report-hub tools/__init__.py /app/tools/__init__.py
+COPY --chown=report-hub:report-hub tools/report_hub /app/tools/report_hub
+
+ENV PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    REPORT_HUB_DATABASE=/var/lib/report-hub/report-hub.sqlite3 \
+    REPORT_HUB_HOST=0.0.0.0 \
+    REPORT_HUB_PORT=4180
+
+USER report-hub
+EXPOSE 4180
+VOLUME ["/var/lib/report-hub"]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4180/api/v1/health', timeout=3)"]
+
+CMD ["python", "-m", "tools.report_hub"]

--- a/tools/report_hub/README.md
+++ b/tools/report_hub/README.md
@@ -1,0 +1,145 @@
+# TRTMC Report Hub
+
+Report Hub turns immutable accuracy and performance reports into an auditable QA
+workflow. It indexes `report.json`, preserves links to `report.html`, tracks one
+finding across repeated runs, and keeps human decisions separate from generated
+evidence.
+
+The UI has four workspaces:
+
+- **QA Findings** — normalize a run, filter failures, assign owner/severity/tags,
+  record conclusions, and associate repository work.
+- **Test Plan** — prepare a Hub-local plan and review coverage before any future
+  DevTest publication.
+- **Defect Handoff** — prepare a developer-ready brief and link a GitHub, NVBug,
+  or DevTest record after it exists.
+- **Trash** — hide a report from active views, restore it during retention, or
+  request a purge preflight after retention.
+
+## Evidence and authority
+
+`report.json`, `report.html`, logs, and artifacts remain immutable evidence in
+the report store. Report Hub stores only its catalog cache, normalized
+observations, findings, triage, drafts, links, lifecycle state, and audit events.
+
+Status values are not mirrored between systems. Hub owns QA triage; DevTest
+owns test execution; NVBug owns defect disposition; GitHub owns repository work.
+Conflicts should be shown to QA instead of silently overwriting either side.
+
+The service never changes a validation threshold and never writes back into a
+report. AI-generated suggestions belong in local drafts and still require a
+human decision.
+
+## Run locally
+
+Python 3.10 or newer is sufficient; the service has no third-party runtime
+dependencies.
+
+```bash
+python3 -m tools.report_hub \
+  --dev \
+  --database /tmp/report-hub.sqlite3 \
+  --evidence-root https://reports.example.test/trtmc
+```
+
+Development authentication is accepted only on a loopback bind. Open
+`http://127.0.0.1:4180`. Use a disposable database for development because its
+identity has the `admin` role.
+
+## Production configuration
+
+Run exactly one application instance behind the company authentication reverse
+proxy. The proxy must remove client-supplied identity headers and set trusted
+values itself.
+
+| Environment variable | Required | Purpose |
+| --- | --- | --- |
+| `REPORT_HUB_EVIDENCE_ROOT_URL` | yes | HTTP root containing `benchmark/`, `perf/`, and the catalog |
+| `REPORT_HUB_CATALOG_URL` | no | Override the default `report-browser/reports-index.json` location |
+| `REPORT_HUB_DATABASE` | yes | Persistent SQLite path |
+| `REPORT_HUB_SECRET` | yes | Random secret for per-user mutation tokens |
+| `REPORT_HUB_USER_HEADER` | no | Trusted user header; defaults to `X-Forwarded-User` |
+| `REPORT_HUB_ROLE_HEADER` | no | Trusted role header; defaults to `X-Report-Hub-Role` |
+| `REPORT_HUB_RETENTION_DAYS` | no | Trash retention; defaults to 30 days |
+| `REPORT_HUB_MAX_REPORT_BYTES` | no | Maximum JSON response; defaults to 8 MiB |
+| `REPORT_HUB_EXTERNAL_HOSTS` | no | Comma-separated HTTPS hosts allowed in manual links |
+
+Accepted roles are `viewer`, `qa`, and `admin`. A `qa` user can sync, analyze,
+triage, save drafts, link records, trash, and restore. Only `admin` can schedule
+a purge. The default bind is loopback so identity headers cannot be sent directly
+from another host.
+
+Build the isolated image from the repository root:
+
+```bash
+docker build -f tools/report_hub/Dockerfile -t trtmc-report-hub:local .
+docker run --rm \
+  --name trtmc-report-hub \
+  --network report-hub-internal \
+  -v report-hub-data:/var/lib/report-hub \
+  -e REPORT_HUB_EVIDENCE_ROOT_URL=https://reports.example.test/trtmc \
+  -e REPORT_HUB_SECRET=replace-with-a-random-secret \
+  trtmc-report-hub:local
+```
+
+Terminate TLS, authentication, body-size limits, request timeouts, and rate
+limits at the reverse proxy. Do not publish the application port directly.
+
+## Safe deletion
+
+The state sequence is:
+
+```text
+active -> trashed -> purge_scheduled -> purged
+            |                ^
+            +-- restore -----+
+```
+
+Moving to Trash requires a reason, exact folder-name confirmation, a valid QA
+identity, a mutation token, and the current record version. It changes Hub
+visibility only; evidence bytes are untouched. Catalog refresh never restores a
+trashed run.
+
+Purge scheduling additionally requires an admin, retention expiry, the exact
+folder name, an irreversibility acknowledgement, no open findings, and no
+external references. This release deliberately provides no physical storage
+worker, so it cannot permanently delete evidence. A future worker must resolve
+the constrained storage target, verify its checksum, use the approved storage
+tool, verify absence, and write the permanent tombstone.
+
+## External-system adoption
+
+All adapters fail closed in this release:
+
+1. **Hub only** — local triage, tags, plan/defect drafts, and manual links.
+2. **Link and read** — add authenticated read adapters and store snapshots with
+   their source revision and last-sync time.
+3. **Approved publish** — preview the exact mutation, require explicit human
+   approval, reserve a persistent idempotency key, publish once, and read the
+   created record back.
+
+`integrations.py` defines the adapter boundary. `Store.prepare_adapter_operation`
+rejects reuse of an idempotency key with a different request. A future adapter
+must use that reservation before a DevTest, NVBug, or GitHub mutation; enabling
+an adapter must be an explicit deployment change, never a fallback to raw REST.
+
+## Operations
+
+- Health check: `GET /api/v1/health` (does not require identity).
+- The first QA session syncs the catalog if the database is empty. Later syncs
+  are explicit and audited.
+- Back up SQLite using its online backup command, not a plain copy while the
+  service is writing: `sqlite3 DB_PATH '.backup BACKUP_PATH'`.
+- Back up the database before upgrades. Schema migrations fail closed when the
+  database is newer than the running service.
+- Keep the database volume encrypted and access-controlled; triage notes and
+  links may contain internal engineering context.
+- Restore tests should validate the database, audit sequence, Trash state, and
+  drafts—not only that the file can be opened.
+
+## Validation
+
+```bash
+python3 -m pytest -q tests/tools/test_report_hub.py
+python3 -m ruff check tools/report_hub tests/tools/test_report_hub.py
+```

--- a/tools/report_hub/__init__.py
+++ b/tools/report_hub/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRTMC Report Hub production service."""
+
+from .config import Settings
+from .storage import Store
+
+__all__ = ["Settings", "Store"]

--- a/tools/report_hub/__main__.py
+++ b/tools/report_hub/__main__.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run TRTMC Report Hub."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from pathlib import Path
+
+from .app import ReportHubApplication
+from .config import Settings
+from .server import serve
+from .source import HttpEvidenceSource
+from .storage import Store
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dev", action="store_true", help="use an explicit local development identity")
+    parser.add_argument("--host")
+    parser.add_argument("--port", type=int)
+    parser.add_argument("--database", type=Path)
+    parser.add_argument("--evidence-root")
+    parser.add_argument("--catalog-url")
+    arguments = parser.parse_args()
+
+    settings = Settings.from_environment(development=arguments.dev)
+    overrides: dict[str, object] = {}
+    if arguments.host:
+        overrides["bind_host"] = arguments.host
+    if arguments.port:
+        overrides["bind_port"] = arguments.port
+    if arguments.database:
+        overrides["database_path"] = arguments.database
+    if arguments.evidence_root:
+        overrides["evidence_root_url"] = arguments.evidence_root.rstrip("/")
+        if not arguments.catalog_url:
+            overrides["catalog_url"] = (
+                f"{arguments.evidence_root.rstrip('/')}/report-browser/reports-index.json"
+            )
+    if arguments.catalog_url:
+        overrides["catalog_url"] = arguments.catalog_url
+    settings = replace(settings, **overrides)
+    settings.validate()
+    if settings.auth_mode == "development" and settings.bind_host not in {"127.0.0.1", "::1", "localhost"}:
+        parser.error("development auth may only bind to a loopback address")
+
+    store = Store(settings.database_path, retention_days=settings.retention_days)
+    store.initialize()
+    application = ReportHubApplication(settings, store, HttpEvidenceSource(settings))
+    serve(application, settings.bind_host, settings.bind_port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/report_hub/app.py
+++ b/tools/report_hub/app.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-free HTTP application for Report Hub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import mimetypes
+from pathlib import Path
+import re
+from typing import Any, Mapping
+from urllib.parse import parse_qs, unquote, urlsplit
+
+from .auth import AuthManager, Identity
+from .config import Settings
+from .domain import ReportHubError
+from .integrations import IntegrationRegistry
+from .normalize import normalize_report
+from .source import HttpEvidenceSource
+from .storage import Store
+
+
+_ENTITY_ID = re.compile(r"^(?:run|finding)_[0-9a-f]{24}$")
+_GITHUB_PATH = re.compile(r"^/NVIDIA/TensorRT-Model-Connect/(?:issues|pull)/([1-9][0-9]*)/?$")
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    body: bytes
+    content_type: str = "application/json; charset=utf-8"
+    headers: tuple[tuple[str, str], ...] = ()
+
+    @classmethod
+    def json(cls, payload: Any, status: int = 200) -> "Response":
+        return cls(
+            status=status,
+            body=(json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+                "utf-8"
+            ),
+        )
+
+
+class ReportHubApplication:
+    def __init__(
+        self,
+        settings: Settings,
+        store: Store,
+        evidence: HttpEvidenceSource,
+        *,
+        static_root: Path | None = None,
+        integrations: IntegrationRegistry | None = None,
+    ):
+        self.settings = settings
+        self.store = store
+        self.evidence = evidence
+        self.auth = AuthManager(settings)
+        self.static_root = static_root or Path(__file__).with_name("static")
+        self.integrations = integrations or IntegrationRegistry.phase_zero()
+
+    def handle(
+        self,
+        method: str,
+        target: str,
+        headers: Mapping[str, str],
+        body: bytes = b"",
+    ) -> Response:
+        parsed = urlsplit(target)
+        path = parsed.path.rstrip("/") or "/"
+        if not path.startswith("/api/"):
+            return self._static(path)
+        try:
+            if path == "/api/v1/health" and method == "GET":
+                return Response.json({"ok": True, "schema_version": "trtmc.report-hub-health/v1"})
+            identity = self.auth.authenticate(headers)
+            if method in {"POST", "PUT", "PATCH", "DELETE"}:
+                self.auth.verify_mutation(identity, headers)
+            payload = self._payload(body) if body else {}
+            query = parse_qs(parsed.query)
+            return self._api(method, path, query, payload, identity)
+        except ReportHubError as error:
+            return Response.json(
+                {"error": {"code": error.code, "message": str(error)}}, status=error.status
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return Response.json(
+                {"error": {"code": "invalid_json", "message": "request body must be UTF-8 JSON"}},
+                status=400,
+            )
+
+    def _api(
+        self,
+        method: str,
+        path: str,
+        query: Mapping[str, list[str]],
+        payload: Mapping[str, Any],
+        identity: Identity,
+    ) -> Response:
+        if path == "/api/v1/session" and method == "GET":
+            return Response.json(
+                {
+                    "user": identity.user,
+                    "role": identity.role,
+                    "csrf_token": self.auth.csrf_token(identity),
+                    "auth_mode": self.settings.auth_mode,
+                }
+            )
+        if path == "/api/v1/integrations" and method == "GET":
+            return Response.json({"integrations": self.integrations.status()})
+        if path == "/api/v1/catalog/sync" and method == "POST":
+            self.auth.require_role(identity, "qa")
+            result = self.store.sync_catalog(self.evidence.fetch_catalog(), actor=identity.user)
+            return Response.json({"result": result}, status=200)
+        if path == "/api/v1/runs" and method == "GET":
+            source = _query_one(query, "source") or None
+            lifecycle = _query_one(query, "lifecycle") or "active"
+            return Response.json({"runs": self.store.list_runs(source=source, lifecycle=lifecycle)})
+        if path == "/api/v1/findings" and method == "GET":
+            run_id = _query_one(query, "run_id") or None
+            return Response.json({"findings": self.store.list_findings(run_id=run_id)})
+        if path == "/api/v1/audit" and method == "GET":
+            events = self.store.audit_events(
+                entity_type=_query_one(query, "entity_type") or None,
+                entity_id=_query_one(query, "entity_id") or None,
+                limit=_query_int(query, "limit", 100),
+            )
+            return Response.json({"events": events})
+
+        run_match = re.fullmatch(r"/api/v1/runs/([^/]+)(?:/(analyze|trash|restore|purge-schedule|test-plan|links))?", path)
+        if run_match:
+            run_id = _entity_id(run_match.group(1), "run")
+            action = run_match.group(2)
+            return self._run_api(method, run_id, action, payload, identity)
+
+        finding_match = re.fullmatch(
+            r"/api/v1/findings/([^/]+)(?:/(triage|defect-draft|links))?", path
+        )
+        if finding_match:
+            finding_id = _entity_id(finding_match.group(1), "finding")
+            action = finding_match.group(2)
+            return self._finding_api(method, finding_id, action, payload, identity)
+
+        return Response.json(
+            {"error": {"code": "not_found", "message": "API route was not found"}}, status=404
+        )
+
+    def _run_api(
+        self,
+        method: str,
+        run_id: str,
+        action: str | None,
+        payload: Mapping[str, Any],
+        identity: Identity,
+    ) -> Response:
+        if action is None and method == "GET":
+            run = self.store.get_run(run_id)
+            result = dict(run)
+            if run["lifecycle"] != "purged" and self.settings.evidence_root_url:
+                result["evidence"] = {
+                    "html_url": self.evidence.evidence_url(run["source"], run["folder"], "report.html")
+                }
+            return Response.json({"run": result})
+        if action == "analyze" and method == "POST":
+            self.auth.require_role(identity, "qa")
+            run = self.store.get_run(run_id)
+            document = self.evidence.fetch_report(run["source"], run["folder"])
+            count = self.store.ingest_observations(
+                run_id, normalize_report(run["source"], document.payload), actor=identity.user
+            )
+            return Response.json(
+                {
+                    "observations": count,
+                    "findings": self.store.list_findings(run_id=run_id),
+                    "evidence": {"json_url": document.json_url, "html_url": document.html_url},
+                }
+            )
+        if action == "trash" and method == "POST":
+            self.auth.require_role(identity, "qa")
+            run = self.store.trash_run(
+                run_id,
+                reason=payload.get("reason"),
+                confirmation=payload.get("confirmation"),
+                expected_version=_expected_version(payload),
+                actor=identity.user,
+            )
+            return Response.json({"run": run})
+        if action == "restore" and method == "POST":
+            self.auth.require_role(identity, "qa")
+            run = self.store.restore_run(
+                run_id, expected_version=_expected_version(payload), actor=identity.user
+            )
+            return Response.json({"run": run})
+        if action == "purge-schedule" and method == "POST":
+            self.auth.require_role(identity, "admin")
+            run = self.store.schedule_purge(
+                run_id,
+                confirmation=payload.get("confirmation"),
+                acknowledge_irreversible=payload.get("acknowledge_irreversible") is True,
+                expected_version=_expected_version(payload),
+                actor=identity.user,
+            )
+            return Response.json({"run": run})
+        if action == "test-plan":
+            if method == "GET":
+                return Response.json({"draft": self.store.get_draft("test_plan", run_id)})
+            if method == "PUT":
+                self.auth.require_role(identity, "qa")
+                data = payload.get("data")
+                if not isinstance(data, Mapping):
+                    raise ReportHubError("draft data must be an object")
+                draft = self.store.save_draft(
+                    "test_plan",
+                    run_id,
+                    data,
+                    expected_version=_expected_version(payload),
+                    actor=identity.user,
+                )
+                return Response.json({"draft": draft})
+        if action == "links":
+            if method == "GET":
+                return Response.json({"links": self.store.list_external_links(run_id=run_id)})
+            if method == "POST":
+                self.auth.require_role(identity, "qa")
+                link = self._create_link(payload, identity, run_id=run_id)
+                return Response.json({"link": link}, status=201)
+        return Response.json(
+            {"error": {"code": "method_not_allowed", "message": "method is not allowed"}},
+            status=405,
+        )
+
+    def _finding_api(
+        self,
+        method: str,
+        finding_id: str,
+        action: str | None,
+        payload: Mapping[str, Any],
+        identity: Identity,
+    ) -> Response:
+        if action is None and method == "GET":
+            return Response.json({"finding": self.store.get_finding(finding_id)})
+        if action == "triage" and method == "PUT":
+            self.auth.require_role(identity, "qa")
+            return Response.json(
+                {"triage": self.store.update_triage(finding_id, payload, actor=identity.user)}
+            )
+        if action == "defect-draft":
+            if method == "GET":
+                return Response.json({"draft": self.store.get_draft("defect", finding_id)})
+            if method == "PUT":
+                self.auth.require_role(identity, "qa")
+                data = payload.get("data")
+                if not isinstance(data, Mapping):
+                    raise ReportHubError("draft data must be an object")
+                draft = self.store.save_draft(
+                    "defect",
+                    finding_id,
+                    data,
+                    expected_version=_expected_version(payload),
+                    actor=identity.user,
+                )
+                return Response.json({"draft": draft})
+        if action == "links":
+            if method == "GET":
+                return Response.json({"links": self.store.list_external_links(finding_id=finding_id)})
+            if method == "POST":
+                self.auth.require_role(identity, "qa")
+                link = self._create_link(payload, identity, finding_id=finding_id)
+                return Response.json({"link": link}, status=201)
+        return Response.json(
+            {"error": {"code": "method_not_allowed", "message": "method is not allowed"}},
+            status=405,
+        )
+
+    def _create_link(
+        self,
+        payload: Mapping[str, Any],
+        identity: Identity,
+        *,
+        finding_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        system = str(payload.get("system", "")).lower()
+        url = str(payload.get("url", "")).strip()
+        self._validate_external_url(system, url)
+        return self.store.add_external_link(
+            finding_id=finding_id,
+            run_id=run_id,
+            system=system,
+            record_type=payload.get("record_type"),
+            external_id=payload.get("external_id"),
+            url=url,
+            actor=identity.user,
+        )
+
+    def _validate_external_url(self, system: str, url: str) -> None:
+        if not url:
+            return
+        parsed = urlsplit(url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ReportHubError("external link must use HTTPS")
+        hostname = parsed.hostname.lower()
+        if hostname not in self.settings.allowed_external_hosts:
+            raise ReportHubError("external link host is not allowed")
+        if system == "github" and (hostname != "github.com" or not _GITHUB_PATH.fullmatch(parsed.path)):
+            raise ReportHubError("GitHub link must target this repository's issue or pull request")
+
+    def _static(self, path: str) -> Response:
+        relative = unquote(path).lstrip("/") or "index.html"
+        candidate = (self.static_root / relative).resolve()
+        static_root = self.static_root.resolve()
+        if candidate != static_root and static_root not in candidate.parents:
+            return Response.json(
+                {"error": {"code": "not_found", "message": "file was not found"}}, status=404
+            )
+        if not candidate.is_file():
+            if "." in Path(relative).name:
+                return Response.json(
+                    {"error": {"code": "not_found", "message": "file was not found"}}, status=404
+                )
+            candidate = static_root / "index.html"
+        content_type = mimetypes.guess_type(candidate.name)[0] or "application/octet-stream"
+        cache = "public, max-age=3600" if candidate.name != "index.html" else "no-store"
+        return Response(
+            status=200,
+            body=candidate.read_bytes(),
+            content_type=f"{content_type}; charset=utf-8" if content_type.startswith("text/") else content_type,
+            headers=(("Cache-Control", cache),),
+        )
+
+    @staticmethod
+    def _payload(body: bytes) -> Mapping[str, Any]:
+        if len(body) > 128 * 1024:
+            raise ReportHubError("request body exceeds 128 KiB")
+        payload = json.loads(body.decode("utf-8"))
+        if not isinstance(payload, Mapping):
+            raise ReportHubError("request body must be a JSON object")
+        return payload
+
+
+def _query_one(query: Mapping[str, list[str]], key: str) -> str:
+    values = query.get(key, [])
+    return values[0] if values else ""
+
+
+def _query_int(query: Mapping[str, list[str]], key: str, default: int) -> int:
+    raw = _query_one(query, key)
+    try:
+        return int(raw) if raw else default
+    except ValueError as error:
+        raise ReportHubError(f"{key} must be an integer") from error
+
+
+def _expected_version(payload: Mapping[str, Any]) -> int:
+    value = payload.get("expected_version")
+    if not isinstance(value, int):
+        raise ReportHubError("expected_version must be an integer")
+    return value
+
+
+def _entity_id(value: str, prefix: str) -> str:
+    if not _ENTITY_ID.fullmatch(value) or not value.startswith(f"{prefix}_"):
+        raise ReportHubError(f"invalid {prefix} ID")
+    return value

--- a/tools/report_hub/auth.py
+++ b/tools/report_hub/auth.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trusted-proxy identity and per-user mutation tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+from typing import Mapping
+
+from .config import Settings
+from .domain import PermissionDeniedError, ReportHubError, require_text
+
+
+ROLE_RANK = {"viewer": 0, "qa": 1, "admin": 2}
+
+
+class AuthenticationError(ReportHubError):
+    status = 401
+    code = "authentication_required"
+
+
+@dataclass(frozen=True)
+class Identity:
+    user: str
+    role: str
+
+
+class AuthManager:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def authenticate(self, headers: Mapping[str, str]) -> Identity:
+        if self.settings.auth_mode == "development":
+            return Identity(self.settings.dev_user, self.settings.dev_role)
+        user = headers.get(self.settings.auth_user_header, "").strip()
+        role = headers.get(self.settings.auth_role_header, "").strip().lower()
+        if not user:
+            raise AuthenticationError("authenticated proxy identity is missing")
+        require_text(user, "user", maximum=160)
+        if role not in ROLE_RANK:
+            raise AuthenticationError("authenticated proxy role is missing or unsupported")
+        return Identity(user, role)
+
+    def require_role(self, identity: Identity, minimum: str) -> None:
+        if ROLE_RANK.get(identity.role, -1) < ROLE_RANK[minimum]:
+            raise PermissionDeniedError(f"{minimum} role is required")
+
+    def csrf_token(self, identity: Identity) -> str:
+        payload = f"report-hub/v1\0{identity.user}\0{identity.role}".encode("utf-8")
+        return hmac.new(self.settings.secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+    def verify_mutation(self, identity: Identity, headers: Mapping[str, str]) -> None:
+        supplied = headers.get("X-Report-Hub-CSRF", "")
+        if not supplied or not hmac.compare_digest(supplied, self.csrf_token(identity)):
+            raise PermissionDeniedError("valid Report Hub mutation token is required")

--- a/tools/report_hub/config.py
+++ b/tools/report_hub/config.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment-backed Report Hub configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+import secrets
+from urllib.parse import urlsplit
+
+
+@dataclass(frozen=True)
+class Settings:
+    database_path: Path
+    evidence_root_url: str = ""
+    catalog_url: str = ""
+    bind_host: str = "127.0.0.1"
+    bind_port: int = 4180
+    auth_mode: str = "proxy"
+    dev_user: str = ""
+    dev_role: str = "admin"
+    auth_user_header: str = "X-Forwarded-User"
+    auth_role_header: str = "X-Report-Hub-Role"
+    secret: str = ""
+    retention_days: int = 30
+    max_report_bytes: int = 8 * 1024 * 1024
+    request_timeout_seconds: float = 20.0
+    allowed_external_hosts: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_environment(cls, *, development: bool = False) -> "Settings":
+        root = os.environ.get("REPORT_HUB_EVIDENCE_ROOT_URL", "").rstrip("/")
+        catalog = os.environ.get("REPORT_HUB_CATALOG_URL", "")
+        if root and not catalog:
+            catalog = f"{root}/report-browser/reports-index.json"
+        auth_mode = "development" if development else os.environ.get("REPORT_HUB_AUTH_MODE", "proxy")
+        secret = os.environ.get("REPORT_HUB_SECRET", "")
+        if auth_mode == "development" and not secret:
+            secret = secrets.token_urlsafe(32)
+        return cls(
+            database_path=Path(os.environ.get("REPORT_HUB_DATABASE", "report-hub.sqlite3")),
+            evidence_root_url=root,
+            catalog_url=catalog,
+            bind_host=os.environ.get("REPORT_HUB_HOST", "127.0.0.1"),
+            bind_port=int(os.environ.get("REPORT_HUB_PORT", "4180")),
+            auth_mode=auth_mode,
+            dev_user=os.environ.get("REPORT_HUB_DEV_USER", "local-qa" if development else ""),
+            dev_role=os.environ.get("REPORT_HUB_DEV_ROLE", "admin"),
+            auth_user_header=os.environ.get("REPORT_HUB_USER_HEADER", "X-Forwarded-User"),
+            auth_role_header=os.environ.get("REPORT_HUB_ROLE_HEADER", "X-Report-Hub-Role"),
+            secret=secret,
+            retention_days=int(os.environ.get("REPORT_HUB_RETENTION_DAYS", "30")),
+            max_report_bytes=int(os.environ.get("REPORT_HUB_MAX_REPORT_BYTES", str(8 * 1024 * 1024))),
+            request_timeout_seconds=float(os.environ.get("REPORT_HUB_REQUEST_TIMEOUT", "20")),
+            allowed_external_hosts=tuple(
+                item.strip().lower()
+                for item in os.environ.get("REPORT_HUB_EXTERNAL_HOSTS", "github.com").split(",")
+                if item.strip()
+            ),
+        )
+
+    def validate(self) -> None:
+        if self.auth_mode not in {"proxy", "development"}:
+            raise ValueError("REPORT_HUB_AUTH_MODE must be proxy or development")
+        if self.auth_mode == "proxy" and not self.secret:
+            raise ValueError("REPORT_HUB_SECRET is required in proxy mode")
+        if self.auth_mode == "development" and not self.dev_user:
+            raise ValueError("development mode requires a development user")
+        if not 1 <= self.retention_days <= 3650:
+            raise ValueError("retention days must be between 1 and 3650")
+        if self.max_report_bytes < 1024:
+            raise ValueError("maximum report size must be at least 1024 bytes")
+        for name, value in (("evidence root", self.evidence_root_url), ("catalog", self.catalog_url)):
+            if not value:
+                continue
+            parsed = urlsplit(value)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError(f"{name} URL must use HTTP or HTTPS")

--- a/tools/report_hub/domain.py
+++ b/tools/report_hub/domain.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Domain types and validation shared by Report Hub adapters and storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any
+
+
+SAFE_FOLDER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+RUN_LIFECYCLES = {"active", "trashed", "purge_scheduled", "purged"}
+TRIAGE_STATUSES = {
+    "new",
+    "investigating",
+    "linked",
+    "monitoring",
+    "resolved",
+    "accepted_risk",
+}
+SEVERITIES = {"unassessed", "blocker", "high", "medium", "low"}
+EXTERNAL_SYSTEMS = {"github", "devtest", "nvbug"}
+
+
+class ReportHubError(Exception):
+    """Base class for errors safe to translate into an API response."""
+
+    status = 400
+    code = "invalid_request"
+
+
+class NotFoundError(ReportHubError):
+    status = 404
+    code = "not_found"
+
+
+class ConflictError(ReportHubError):
+    status = 409
+    code = "conflict"
+
+
+class PermissionDeniedError(ReportHubError):
+    status = 403
+    code = "permission_denied"
+
+
+class UpstreamError(ReportHubError):
+    status = 502
+    code = "upstream_error"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    canonical = json.dumps(parts, ensure_ascii=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"
+
+
+def require_folder(value: Any) -> str:
+    if not isinstance(value, str) or not SAFE_FOLDER.fullmatch(value):
+        raise ReportHubError("report folder contains unsupported characters")
+    return value
+
+
+def require_text(value: Any, field: str, *, maximum: int, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ReportHubError(f"{field} must be text")
+    cleaned = value.strip()
+    if not allow_empty and not cleaned:
+        raise ReportHubError(f"{field} is required")
+    if len(cleaned) > maximum:
+        raise ReportHubError(f"{field} exceeds {maximum} characters")
+    return cleaned
+
+
+def require_string_list(value: Any, field: str, *, maximum_items: int = 20) -> list[str]:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise ReportHubError(f"{field} must contain at most {maximum_items} values")
+    result: list[str] = []
+    for item in value:
+        cleaned = require_text(item, field, maximum=64)
+        if cleaned not in result:
+            result.append(cleaned)
+    return result
+
+
+@dataclass(frozen=True)
+class Observation:
+    finding_id: str
+    model: str
+    workload: str
+    family: str
+    operation: str
+    status: str
+    metric_name: str
+    metric_value: float | None
+    details: dict[str, Any]

--- a/tools/report_hub/integrations.py
+++ b/tools/report_hub/integrations.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""External-system adapter boundary.
+
+Phase 0 intentionally installs only disabled adapters. Future adapters must keep
+the same preview/approve/publish/read-back boundary and use Store's persistent
+idempotency reservation before performing a remote mutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from .domain import PermissionDeniedError
+
+
+@dataclass(frozen=True)
+class AdapterCapabilities:
+    system: str
+    mode: str
+    can_read: bool
+    can_publish: bool
+    message: str
+
+
+@dataclass(frozen=True)
+class PublishEnvelope:
+    operation: str
+    idempotency_key: str
+    actor: str
+    payload: Mapping[str, Any]
+
+
+class ExternalAdapter(Protocol):
+    capabilities: AdapterCapabilities
+
+    def read(self, external_id: str) -> Mapping[str, Any]: ...
+
+    def publish(self, envelope: PublishEnvelope) -> Mapping[str, Any]: ...
+
+
+class DisabledAdapter:
+    def __init__(self, capabilities: AdapterCapabilities):
+        self.capabilities = capabilities
+
+    def read(self, external_id: str) -> Mapping[str, Any]:
+        raise PermissionDeniedError(f"{self.capabilities.system} read adapter is disabled")
+
+    def publish(self, envelope: PublishEnvelope) -> Mapping[str, Any]:
+        raise PermissionDeniedError(f"{self.capabilities.system} write adapter is disabled")
+
+
+class IntegrationRegistry:
+    def __init__(self, adapters: Mapping[str, ExternalAdapter]):
+        self._adapters = dict(adapters)
+
+    @classmethod
+    def phase_zero(cls) -> "IntegrationRegistry":
+        specifications = (
+            AdapterCapabilities(
+                "github",
+                "manual_link",
+                False,
+                False,
+                "Issue and pull request links are stored locally.",
+            ),
+            AdapterCapabilities(
+                "devtest",
+                "local_draft",
+                False,
+                False,
+                "Test plan drafts remain in Hub until an approved adapter is configured.",
+            ),
+            AdapterCapabilities(
+                "nvbug",
+                "local_draft",
+                False,
+                False,
+                "Defect drafts remain in Hub; manual IDs can be linked after filing.",
+            ),
+        )
+        return cls({item.system: DisabledAdapter(item) for item in specifications})
+
+    def status(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "system": adapter.capabilities.system,
+                "mode": adapter.capabilities.mode,
+                "read": adapter.capabilities.can_read,
+                "write": adapter.capabilities.can_publish,
+                "message": adapter.capabilities.message,
+            }
+            for adapter in self._adapters.values()
+        ]
+
+    def get(self, system: str) -> ExternalAdapter:
+        return self._adapters[system]

--- a/tools/report_hub/normalize.py
+++ b/tools/report_hub/normalize.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalize supported report schemas into stable cross-run observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .domain import Observation, ReportHubError, stable_id
+
+
+def normalize_report(source: str, payload: Mapping[str, Any]) -> list[Observation]:
+    schema = str(payload.get("schema_version", ""))
+    if schema == "trtmc.validation-report/v2" or isinstance(payload.get("results"), list):
+        return _normalize_validation(source, payload)
+    if schema == "trtmc.perf-matrix/v1" or isinstance(payload.get("cases"), list):
+        return _normalize_performance(source, payload)
+    if schema == "trtmc.benchmark-report/v1" or isinstance(payload.get("runs"), list):
+        return _normalize_benchmark(source, payload)
+    raise ReportHubError(f"unsupported report schema: {schema or 'missing'}")
+
+
+def _normalize_validation(source: str, payload: Mapping[str, Any]) -> list[Observation]:
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        raise ReportHubError("validation report results must be a list")
+    observations: list[Observation] = []
+    for index, raw in enumerate(results):
+        if not isinstance(raw, Mapping):
+            continue
+        model = _text(raw.get("model") or raw.get("name"), f"case-{index + 1}")
+        workload = _text(
+            raw.get("workload")
+            or _nested(raw, "workload_contract", "testcase")
+            or _nested(raw, "resolved_settings", "testcase")
+            or raw.get("benchmark")
+            or raw.get("task"),
+            "unspecified",
+        )
+        comparison = raw.get("comparison") if isinstance(raw.get("comparison"), Mapping) else {}
+        metric = (
+            comparison.get("primary_metric")
+            if isinstance(comparison.get("primary_metric"), Mapping)
+            else {}
+        )
+        metric_value = metric.get("value", raw.get("value"))
+        metric_name = _text(metric.get("name") or raw.get("metric"), "validation")
+        observations.append(
+            Observation(
+                finding_id=stable_id("finding", source, model, workload, metric_name),
+                model=model,
+                workload=workload,
+                family=_text(raw.get("family"), model.split("-")[0]),
+                operation=_text(raw.get("operation") or raw.get("task_strategy"), "run"),
+                status=_validation_status(raw),
+                metric_name=metric_name,
+                metric_value=_number(metric_value),
+                details={
+                    "task_type": _text(raw.get("task_type") or raw.get("taskType"), ""),
+                    "failures": list(comparison.get("failures", []))
+                    if isinstance(comparison.get("failures"), list)
+                    else [],
+                    "error": _attempt_error(raw),
+                    "timestamp": raw.get("timestamp"),
+                },
+            )
+        )
+    return observations
+
+
+def _normalize_performance(source: str, payload: Mapping[str, Any]) -> list[Observation]:
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list):
+        raise ReportHubError("performance report cases must be a list")
+    observations: list[Observation] = []
+    for index, raw in enumerate(cases):
+        if not isinstance(raw, Mapping):
+            continue
+        model = _text(raw.get("model"), f"case-{index + 1}")
+        workload = _text(
+            _nested(raw, "workload_contract", "testcase")
+            or _nested(raw, "resolved_settings", "testcase")
+            or raw.get("id"),
+            "unspecified",
+        )
+        comparison = raw.get("comparison") if isinstance(raw.get("comparison"), Mapping) else {}
+        candidate_metrics = _nested(raw, "candidate", "metrics")
+        candidate_metrics = candidate_metrics if isinstance(candidate_metrics, Mapping) else {}
+        candidate_primary = (
+            candidate_metrics.get("primary")
+            if isinstance(candidate_metrics.get("primary"), Mapping)
+            else {}
+        )
+        baseline_latency = _nested(raw, "baseline", "metrics", "latency_ms", "p50")
+        candidate_latency = _nested(raw, "candidate", "metrics", "latency_ms", "p50")
+        ratio = comparison.get("baseline_over_trtmc_p50")
+        metric_name = "baseline_over_trtmc_p50" if _number(ratio) is not None else _text(
+            candidate_primary.get("name"), "runtime_e2e_wall_ms.p50"
+        )
+        metric_value = ratio if _number(ratio) is not None else candidate_primary.get(
+            "value", candidate_latency
+        )
+        observations.append(
+            Observation(
+                finding_id=stable_id("finding", source, model, workload, metric_name),
+                model=model,
+                workload=workload,
+                family=_text(raw.get("family"), model.split("-")[0]),
+                operation=_text(raw.get("operation") or raw.get("task_strategy"), "run"),
+                status=_performance_status(raw.get("status")),
+                metric_name=metric_name,
+                metric_value=_number(metric_value),
+                details={
+                    "task_type": _text(raw.get("task_type"), ""),
+                    "baseline_p50_ms": _number(baseline_latency),
+                    "candidate_p50_ms": _number(candidate_latency),
+                    "equivalence_margin_percent": _number(
+                        comparison.get("equivalence_margin_percent")
+                    ),
+                    "error": _text(raw.get("error"), ""),
+                },
+            )
+        )
+    return observations
+
+
+def _normalize_benchmark(source: str, payload: Mapping[str, Any]) -> list[Observation]:
+    runs = payload.get("runs", [])
+    if not isinstance(runs, list):
+        raise ReportHubError("benchmark report runs must be a list")
+    observations: list[Observation] = []
+    for run in runs:
+        if not isinstance(run, Mapping) or not isinstance(run.get("cells"), list):
+            continue
+        for index, cell in enumerate(run["cells"]):
+            if not isinstance(cell, Mapping):
+                continue
+            model = _text(cell.get("model"), f"case-{index + 1}")
+            workload = _text(cell.get("name") or cell.get("case"), "default")
+            metrics = cell.get("metrics") if isinstance(cell.get("metrics"), Mapping) else {}
+            primary = metrics.get("primary") if isinstance(metrics.get("primary"), Mapping) else {}
+            latency = metrics.get("latency_ms") if isinstance(metrics.get("latency_ms"), Mapping) else {}
+            metric_value = primary.get("value", latency.get("p50"))
+            metric_name = _text(primary.get("name"), "runtime_e2e_wall_ms.p50")
+            observations.append(
+                Observation(
+                    finding_id=stable_id("finding", source, model, workload, metric_name),
+                    model=model,
+                    workload=workload,
+                    family=model.split("-")[0],
+                    operation=_text(cell.get("operation"), "run"),
+                    status=_benchmark_status(cell.get("status")),
+                    metric_name=metric_name,
+                    metric_value=_number(metric_value),
+                    details={
+                        "unit": _text(primary.get("unit"), "ms"),
+                        "sample_count": metrics.get("sample_count"),
+                        "source_run_id": run.get("run_id"),
+                        "result_path": run.get("result_path"),
+                    },
+                )
+            )
+    return observations
+
+
+def _validation_status(raw: Mapping[str, Any]) -> str:
+    execution = str(_nested(raw, "execution", "status") or raw.get("execution_status") or "").lower()
+    validation = str(
+        _nested(raw, "validation", "status") or raw.get("validation_status") or raw.get("status") or ""
+    ).lower()
+    comparison = str(_nested(raw, "comparison", "status") or "").lower()
+    if execution and execution not in {"completed", "passed", "success"}:
+        return "error"
+    if validation in {"failed", "failure", "red"} or comparison in {"disagreement", "failed", "red"}:
+        return "failed"
+    if validation in {"passed", "pass", "green", "success"} or comparison in {"agreement", "passed", "green"}:
+        return "passed"
+    if validation in {"skipped", "unsupported", "yellow", "not_compared"}:
+        return "other"
+    return "other"
+
+
+def _benchmark_status(value: Any) -> str:
+    status = str(value or "").lower()
+    if status in {"completed", "passed", "success"}:
+        return "passed"
+    if status in {"failed", "failure"}:
+        return "failed"
+    if status in {"error", "aborted"}:
+        return "error"
+    return "other"
+
+
+def _performance_status(value: Any) -> str:
+    status = str(value or "").lower()
+    if status in {"green", "passed", "completed", "success"}:
+        return "passed"
+    if status in {"red", "failed", "failure", "regression"}:
+        return "failed"
+    if status in {"error", "aborted"}:
+        return "error"
+    return "other"
+
+
+def _nested(value: Mapping[str, Any], *keys: str) -> Any:
+    current: Any = value
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _text(value: Any, default: str) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else default
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _attempt_error(raw: Mapping[str, Any]) -> str:
+    execution = raw.get("execution")
+    attempts = execution.get("attempts") if isinstance(execution, Mapping) else None
+    if isinstance(attempts, list) and attempts and isinstance(attempts[-1], Mapping):
+        return _text(attempts[-1].get("error"), "")
+    return _text(raw.get("error") or raw.get("message"), "")

--- a/tools/report_hub/server.py
+++ b/tools/report_hub/server.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Threaded HTTP transport for the Report Hub application."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Type
+
+from .app import ReportHubApplication
+
+
+def handler_for(application: ReportHubApplication) -> Type[BaseHTTPRequestHandler]:
+    class ReportHubHandler(BaseHTTPRequestHandler):
+        server_version = "TRTMCReportHub/1"
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+            self._dispatch("GET")
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+            self._dispatch("POST")
+
+        def do_PUT(self) -> None:  # noqa: N802 - stdlib handler API
+            self._dispatch("PUT")
+
+        def _dispatch(self, method: str) -> None:
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self.send_error(HTTPStatus.BAD_REQUEST, "invalid Content-Length")
+                return
+            if length > 128 * 1024:
+                self.send_error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+                return
+            body = self.rfile.read(length) if length else b""
+            response = application.handle(method, self.path, self.headers, body)
+            self.send_response(response.status)
+            self.send_header("Content-Type", response.content_type)
+            self.send_header("Content-Length", str(len(response.body)))
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("Referrer-Policy", "same-origin")
+            self.send_header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; "
+                "connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+            )
+            for name, value in response.headers:
+                self.send_header(name, value)
+            self.end_headers()
+            self.wfile.write(response.body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            print(f"[report-hub] {self.address_string()} {format % args}")
+
+    return ReportHubHandler
+
+
+def serve(application: ReportHubApplication, host: str, port: int) -> None:
+    server = ThreadingHTTPServer((host, port), handler_for(application))
+    print(f"TRTMC Report Hub listening on http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/tools/report_hub/source.py
+++ b/tools/report_hub/source.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only HTTP adapter for the immutable report evidence store."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+from typing import Any, Callable
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .config import Settings
+from .domain import ReportHubError, UpstreamError, require_folder
+
+
+SOURCE_FILES = {
+    "benchmark": ("report.json",),
+    "perf": ("results.json", "report.json"),
+}
+
+
+@dataclass(frozen=True)
+class ReportDocument:
+    payload: Mapping[str, Any]
+    json_url: str
+    html_url: str
+
+
+class HttpEvidenceSource:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        loader: Callable[[str, int], Mapping[str, Any]] | None = None,
+    ):
+        self.settings = settings
+        self._loader = loader or self._load_json
+
+    def fetch_catalog(self) -> Mapping[str, Any]:
+        if not self.settings.catalog_url:
+            raise UpstreamError("report catalog URL is not configured")
+        payload = self._loader(self.settings.catalog_url, 2 * 1024 * 1024)
+        if payload.get("schema_version") != "trtmc.report-browser-index/v1":
+            raise UpstreamError("report catalog has an unsupported schema")
+        return payload
+
+    def fetch_report(self, source: str, folder: str) -> ReportDocument:
+        if source not in SOURCE_FILES:
+            raise ReportHubError("unsupported report source")
+        require_folder(folder)
+        if not self.settings.evidence_root_url:
+            raise UpstreamError("evidence root URL is not configured")
+        last_error: Exception | None = None
+        for filename in SOURCE_FILES[source]:
+            url = self.evidence_url(source, folder, filename)
+            try:
+                payload = self._loader(url, self.settings.max_report_bytes)
+                return ReportDocument(
+                    payload=payload,
+                    json_url=url,
+                    html_url=self.evidence_url(source, folder, "report.html"),
+                )
+            except UpstreamError as error:
+                last_error = error
+        raise UpstreamError(f"report evidence could not be read: {last_error}")
+
+    def evidence_url(self, source: str, folder: str, filename: str) -> str:
+        if source not in SOURCE_FILES:
+            raise ReportHubError("unsupported report source")
+        require_folder(folder)
+        if filename not in {*SOURCE_FILES[source], "report.html"}:
+            raise ReportHubError("unsupported evidence file")
+        quoted = urllib.parse.quote(folder, safe="")
+        return f"{self.settings.evidence_root_url.rstrip('/')}/{source}/{quoted}/{filename}"
+
+    def _load_json(self, url: str, maximum: int) -> Mapping[str, Any]:
+        request = urllib.request.Request(url, headers={"User-Agent": "TRTMC-Report-Hub/1"})
+        try:
+            with urllib.request.urlopen(request, timeout=self.settings.request_timeout_seconds) as response:
+                final_url = response.geturl()
+                if _origin(final_url) != _origin(url):
+                    raise UpstreamError("evidence request redirected to a different origin")
+                declared = response.headers.get("Content-Length")
+                if declared and int(declared) > maximum:
+                    raise UpstreamError("evidence document exceeds configured size limit")
+                raw = response.read(maximum + 1)
+        except urllib.error.HTTPError as error:
+            raise UpstreamError(f"evidence request failed with HTTP {error.code}") from error
+        except (urllib.error.URLError, TimeoutError, ValueError) as error:
+            raise UpstreamError(f"evidence request failed: {error}") from error
+        if len(raw) > maximum:
+            raise UpstreamError("evidence document exceeds configured size limit")
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise UpstreamError("evidence document is not valid UTF-8 JSON") from error
+        if not isinstance(payload, Mapping):
+            raise UpstreamError("evidence document must be a JSON object")
+        return payload
+
+
+def _origin(url: str) -> tuple[str, str]:
+    parsed = urllib.parse.urlsplit(url)
+    return parsed.scheme.lower(), parsed.netloc.lower()

--- a/tools/report_hub/static/app.js
+++ b/tools/report_hub/static/app.js
@@ -1,0 +1,686 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const app = document.querySelector("#app");
+
+const state = {
+  session: null,
+  integrations: [],
+  source: "benchmark",
+  runs: [],
+  selectedRunId: null,
+  findings: [],
+  selectedFindingId: null,
+  evidence: null,
+  filter: "failed",
+  query: "",
+  planDraft: null,
+  defectDraft: null,
+  links: [],
+  audit: [],
+  trash: [],
+  busy: false,
+  dialog: null,
+  toasts: [],
+};
+
+const routes = new Set(["findings", "test-plans", "defects", "trash"]);
+
+function route() {
+  const value = location.hash.replace(/^#\/?/, "") || "findings";
+  return routes.has(value) ? value : "findings";
+}
+
+function h(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function can(minimum) {
+  const rank = { viewer: 0, qa: 1, admin: 2 };
+  return rank[state.session?.role] >= rank[minimum];
+}
+
+function selectedRun() {
+  return state.runs.find((item) => item.id === state.selectedRunId) || null;
+}
+
+function selectedFinding() {
+  return state.findings.find((item) => item.id === state.selectedFindingId) || null;
+}
+
+async function api(path, options = {}) {
+  const headers = { Accept: "application/json" };
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (options.method && options.method !== "GET") {
+    headers["X-Report-Hub-CSRF"] = state.session?.csrf_token || "";
+  }
+  const response = await fetch(path, {
+    method: options.method || "GET",
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  let payload = {};
+  try {
+    payload = await response.json();
+  } catch (_error) {
+    // The status below still produces a useful transport error.
+  }
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || `Request failed with HTTP ${response.status}`);
+  }
+  return payload;
+}
+
+async function start() {
+  try {
+    state.session = await api("/api/v1/session");
+    const integrations = await api("/api/v1/integrations");
+    state.integrations = integrations.integrations || [];
+    await loadRuns({ syncIfEmpty: true });
+    window.addEventListener("hashchange", async () => {
+      await prepareRoute();
+      render();
+    });
+    await prepareRoute();
+    render();
+  } catch (error) {
+    app.innerHTML = `<main class="fatal"><h1>Report Hub unavailable</h1><p>${h(error.message)}</p></main>`;
+  }
+}
+
+async function loadRuns({ syncIfEmpty = false } = {}) {
+  let result = await api(`/api/v1/runs?source=${encodeURIComponent(state.source)}&lifecycle=active`);
+  if (!result.runs.length && syncIfEmpty && can("qa")) {
+    await api("/api/v1/catalog/sync", { method: "POST", body: {} });
+    result = await api(`/api/v1/runs?source=${encodeURIComponent(state.source)}&lifecycle=active`);
+  }
+  state.runs = result.runs;
+  if (!state.runs.some((item) => item.id === state.selectedRunId)) {
+    state.selectedRunId = state.runs[0]?.id || null;
+  }
+  if (state.selectedRunId) await loadFindings({ analyzeIfEmpty: syncIfEmpty });
+}
+
+async function loadFindings({ analyzeIfEmpty = false } = {}) {
+  if (!state.selectedRunId) {
+    state.findings = [];
+    return;
+  }
+  let result = await api(`/api/v1/findings?run_id=${encodeURIComponent(state.selectedRunId)}`);
+  if (!result.findings.length && analyzeIfEmpty && can("qa")) {
+    const analyzed = await api(`/api/v1/runs/${state.selectedRunId}/analyze`, {
+      method: "POST",
+      body: {},
+    });
+    result = { findings: analyzed.findings };
+    state.evidence = analyzed.evidence;
+  }
+  state.findings = result.findings || [];
+  if (!state.findings.some((item) => item.id === state.selectedFindingId)) {
+    state.selectedFindingId =
+      state.findings.find((item) => item.observation.status === "failed")?.id
+      || state.findings[0]?.id
+      || null;
+  }
+  await loadFindingContext();
+}
+
+async function loadFindingContext() {
+  const finding = selectedFinding();
+  if (!finding) {
+    state.links = [];
+    state.audit = [];
+    return;
+  }
+  const [links, audit] = await Promise.all([
+    api(`/api/v1/findings/${finding.id}/links`),
+    api(`/api/v1/audit?entity_type=finding&entity_id=${finding.id}&limit=12`),
+  ]);
+  state.links = links.links || [];
+  state.audit = audit.events || [];
+}
+
+async function prepareRoute() {
+  if (route() === "trash") {
+    const [trashed, scheduled] = await Promise.all([
+      api(`/api/v1/runs?source=${encodeURIComponent(state.source)}&lifecycle=trashed`),
+      api(`/api/v1/runs?source=${encodeURIComponent(state.source)}&lifecycle=purge_scheduled`),
+    ]);
+    state.trash = [...(trashed.runs || []), ...(scheduled.runs || [])];
+  }
+  if (route() === "test-plans" && state.selectedRunId) {
+    const result = await api(`/api/v1/runs/${state.selectedRunId}/test-plan`);
+    state.planDraft = result.draft;
+  }
+  if (route() === "defects" && state.selectedFindingId) {
+    const result = await api(`/api/v1/findings/${state.selectedFindingId}/defect-draft`);
+    state.defectDraft = result.draft;
+    await loadFindingContext();
+  }
+}
+
+function render() {
+  const activeRoute = route();
+  app.innerHTML = `
+    ${header(activeRoute)}
+    ${contextBar(activeRoute)}
+    ${activeRoute === "findings" ? findingsPage() : ""}
+    ${activeRoute === "test-plans" ? testPlanPage() : ""}
+    ${activeRoute === "defects" ? defectPage() : ""}
+    ${activeRoute === "trash" ? trashPage() : ""}
+    ${dialogMarkup()}
+    <div class="toast-stack">${state.toasts.map((toast) => `<div class="toast ${toast.kind}">${h(toast.message)}</div>`).join("")}</div>
+  `;
+  bindCommon();
+  if (activeRoute === "findings") bindFindings();
+  if (activeRoute === "test-plans") bindTestPlan();
+  if (activeRoute === "defects") bindDefect();
+  if (activeRoute === "trash") bindTrash();
+  bindDialog();
+}
+
+function header(activeRoute) {
+  const nav = [
+    ["findings", "QA Findings"],
+    ["test-plans", "Test Plan"],
+    ["defects", "Defect Handoff"],
+    ["trash", "Trash"],
+  ];
+  return `
+    <header class="topbar">
+      <div class="brand"><span class="brand-mark"></span><div><strong>TRTMC</strong><small>REPORT HUB</small></div></div>
+      <nav class="main-nav" aria-label="Primary">
+        ${nav.map(([key, label]) => `<a href="#/${key}" class="${activeRoute === key ? "is-active" : ""}">${label}</a>`).join("")}
+      </nav>
+      <div class="identity"><strong>${h(state.session.user)}</strong><small>${h(state.session.role)}</small></div>
+    </header>`;
+}
+
+function contextBar(activeRoute) {
+  const run = selectedRun();
+  return `
+    <section class="contextbar">
+      <div class="source-switch" aria-label="Evidence source">
+        <button data-source="benchmark" class="${state.source === "benchmark" ? "is-active" : ""}">Accuracy</button>
+        <button data-source="perf" class="${state.source === "perf" ? "is-active" : ""}">Performance</button>
+      </div>
+      <div class="run-control">
+        <label for="run-select">Evidence run</label>
+        <select id="run-select" ${state.runs.length ? "" : "disabled"}>
+          ${state.runs.length
+            ? state.runs.map((item) => `<option value="${h(item.id)}" ${item.id === state.selectedRunId ? "selected" : ""}>${h(item.date || "undated")} · ${h(item.folder)}</option>`).join("")
+            : `<option>No active runs indexed</option>`}
+        </select>
+      </div>
+      <div class="actions">
+        <button class="button" id="sync-catalog" ${can("qa") && !state.busy ? "" : "disabled"}>Refresh catalog</button>
+        ${activeRoute !== "trash" && run ? `<button class="button" id="open-evidence">Original report</button>` : ""}
+        ${activeRoute === "findings" && run ? `<button class="button danger" id="trash-run" ${can("qa") ? "" : "disabled"}>Move to Trash</button>` : ""}
+      </div>
+    </section>`;
+}
+
+function findingsPage() {
+  const run = selectedRun();
+  const summary = run?.summary || {};
+  const visible = filteredFindings();
+  const open = state.findings.filter((item) =>
+    ["failed", "error"].includes(item.observation.status)
+    && !["resolved", "accepted_risk"].includes(item.triage.status)
+  ).length;
+  return `
+    <main class="page">
+      <div class="page-title"><div><h1>QA Findings</h1><p>Evidence first. Human conclusions remain separate and auditable.</p></div>
+        ${run && can("qa") ? `<button class="button primary" id="analyze-run">Reload evidence</button>` : ""}
+      </div>
+      <section class="summary-grid">
+        ${summaryCard("Cases", summary.total ?? summary.cases ?? state.findings.length)}
+        ${summaryCard("Passed", summary.passed ?? 0)}
+        ${summaryCard("Failed", summary.failed ?? 0, "failed")}
+        ${summaryCard("Open triage", open, "attention")}
+      </section>
+      <section class="workspace">
+        <div class="panel">
+          <div class="panel-header"><div class="filters">
+            <input id="finding-query" type="search" value="${h(state.query)}" placeholder="Search model or workload" />
+            ${["failed", "all", "open", "resolved"].map((key) => `<button class="filter-chip ${state.filter === key ? "is-active" : ""}" data-filter="${key}">${key}</button>`).join("")}
+          </div><small>${visible.length} shown</small></div>
+          <div class="table-wrap">
+            ${visible.length ? findingsTable(visible) : `<div class="empty">${run ? "No findings match this view." : "Refresh the catalog to begin."}</div>`}
+          </div>
+        </div>
+        <aside class="panel">${findingDetail()}</aside>
+      </section>
+    </main>`;
+}
+
+function summaryCard(label, value, className = "") {
+  return `<div class="summary-card ${className}"><span>${h(label)}</span><strong>${h(value ?? 0)}</strong></div>`;
+}
+
+function filteredFindings() {
+  return state.findings.filter((item) => {
+    if (state.filter === "failed" && item.observation.status !== "failed") return false;
+    if (state.filter === "open" && ["resolved", "accepted_risk"].includes(item.triage.status)) return false;
+    if (state.filter === "resolved" && item.triage.status !== "resolved") return false;
+    if (!state.query) return true;
+    return `${item.model} ${item.workload} ${item.family} ${item.triage.tags.join(" ")}`
+      .toLowerCase()
+      .includes(state.query.toLowerCase());
+  });
+}
+
+function findingsTable(findings) {
+  return `<table><thead><tr><th>Model / workload</th><th>Result</th><th>Metric</th><th>Triage</th><th>Owner</th></tr></thead><tbody>
+    ${findings.map((item) => `<tr data-finding="${h(item.id)}" class="${item.id === state.selectedFindingId ? "is-selected" : ""}">
+      <td class="model-cell"><strong>${h(item.model)}</strong><small>${h(item.workload)}</small></td>
+      <td><span class="status ${h(item.observation.status)}">${h(item.observation.status)}</span></td>
+      <td>${metricValue(item.observation)}</td>
+      <td><span class="status ${h(item.triage.status)}">${h(item.triage.status)}</span></td>
+      <td>${h(item.triage.owner)}</td>
+    </tr>`).join("")}
+  </tbody></table>`;
+}
+
+function metricValue(observation) {
+  if (observation.metric_value === null || observation.metric_value === undefined) return "—";
+  const value = Number(observation.metric_value);
+  return `<strong>${h(Number.isFinite(value) ? value.toFixed(4) : observation.metric_value)}</strong><br><small>${h(observation.metric_name)}</small>`;
+}
+
+function findingDetail() {
+  const item = selectedFinding();
+  if (!item) return `<div class="detail-empty">Select a finding to review.</div>`;
+  const triage = item.triage;
+  return `
+    <div class="detail-title"><h2>${h(item.model)}</h2><p>${h(item.workload)}</p></div>
+    <div class="detail-section">
+      <h3>Observation</h3>
+      <div class="metric"><span>Result</span><span class="status ${h(item.observation.status)}">${h(item.observation.status)}</span></div>
+      <div class="metric"><span>Operation</span><strong>${h(item.observation.operation)}</strong></div>
+      <div class="metric"><span>${h(item.observation.metric_name)}</span><strong>${h(item.observation.metric_value ?? "—")}</strong></div>
+      ${item.observation.details.error ? `<div class="notice danger">${h(item.observation.details.error)}</div>` : ""}
+    </div>
+    <form class="detail-section" id="triage-form">
+      <h3>QA triage</h3>
+      <div class="form-grid">
+        ${selectField("triage-status", "Status", ["new", "investigating", "linked", "monitoring", "resolved", "accepted_risk"], triage.status)}
+        ${selectField("triage-severity", "Severity", ["unassessed", "blocker", "high", "medium", "low"], triage.severity)}
+        ${inputField("triage-owner", "Owner", triage.owner)}
+        ${inputField("triage-tags", "Tags", triage.tags.join(", "))}
+        <div class="field full"><label for="triage-note">QA note</label><textarea id="triage-note">${h(triage.note)}</textarea></div>
+      </div>
+      <div class="form-actions"><button class="button primary" ${can("qa") ? "" : "disabled"}>Save triage</button></div>
+    </form>
+    <div class="detail-section"><h3>Associations</h3>${linksMarkup(state.links)}</div>
+    <div class="detail-section"><h3>Recent audit</h3>${auditMarkup()}</div>`;
+}
+
+function testPlanPage() {
+  const run = selectedRun();
+  if (!run) return emptyPage("Test Plan", "Refresh the catalog and choose an evidence run.");
+  const data = state.planDraft?.data || {};
+  return `
+    <main class="page">
+      <div class="page-title"><div><h1>Test Plan</h1><p>Prepare locally; DevTest publication is a later approval gate.</p></div></div>
+      <div class="notice">This draft does not create or update DevTest records.</div>
+      <section class="wide-grid">
+        <form class="panel" id="plan-form">
+          <div class="panel-header"><h2>Run plan</h2><span class="status">local draft · v${h(state.planDraft?.version || 0)}</span></div>
+          <div class="panel-body form-grid">
+            ${inputField("plan-name", "Plan name", data.name || `${run.date || "Run"} ${state.source} validation`, true)}
+            ${inputField("plan-branch", "Branch / revision", data.branch || "", true)}
+            ${inputField("plan-platform", "Platform", data.platform || "GB300")}
+            ${inputField("plan-gpu", "GPU", data.gpu || "GB300")}
+            ${inputField("plan-os", "OS", data.os || "Linux")}
+            ${inputField("plan-driver", "Driver", data.driver || "")}
+            <div class="field full"><label for="plan-scope">Scope and coverage</label><textarea id="plan-scope">${h(data.scope || "")}</textarea></div>
+            <div class="field full"><label for="plan-exclusions">Exclusions / gates</label><textarea id="plan-exclusions">${h(data.exclusions || "")}</textarea></div>
+            <div class="field full"><div class="form-actions"><button class="button primary" ${can("qa") ? "" : "disabled"}>Save local draft</button></div></div>
+          </div>
+        </form>
+        <aside class="panel">
+          <div class="panel-header"><h2>Coverage check</h2><span class="status">${state.findings.length} cases</span></div>
+          <div class="panel-body">
+            <div class="checklist">
+              ${checkItem(Boolean(data.name), "Plan identity recorded")}
+              ${checkItem(Boolean(data.branch), "Branch or revision recorded")}
+              ${checkItem(Boolean(data.platform && data.gpu), "Execution platform recorded")}
+              ${checkItem(Boolean(data.scope), "Scope reviewed by QA")}
+            </div>
+          </div>
+          <div class="detail-section"><h3>DevTest adapter</h3><p class="notice">Disabled · local draft remains authoritative in Hub.</p></div>
+        </aside>
+      </section>
+    </main>`;
+}
+
+function defectPage() {
+  const finding = selectedFinding();
+  if (!finding) return emptyPage("Defect Handoff", "Analyze a run and select a finding first.");
+  const data = state.defectDraft?.data || {};
+  return `
+    <main class="page">
+      <div class="page-title"><div><h1>Defect Handoff</h1><p>${h(finding.model)} · ${h(finding.workload)}</p></div></div>
+      <section class="wide-grid">
+        <form class="panel" id="defect-form">
+          <div class="panel-header"><h2>Developer-ready brief</h2><span class="status">local draft · v${h(state.defectDraft?.version || 0)}</span></div>
+          <div class="panel-body form-grid">
+            ${inputField("defect-synopsis", "Synopsis", data.synopsis || `[Validation] ${finding.model}: ${finding.workload}`, true)}
+            ${selectField("defect-severity", "Proposed severity", ["unassessed", "blocker", "high", "medium", "low"], data.severity || finding.triage.severity)}
+            <div class="field full"><label for="defect-impact">Impact</label><textarea id="defect-impact">${h(data.impact || "")}</textarea></div>
+            <div class="field full"><label for="defect-repro">Reproduction</label><textarea id="defect-repro">${h(data.reproduction || "")}</textarea></div>
+            <div class="field full"><label for="defect-evidence">Evidence and comparison</label><textarea id="defect-evidence">${h(data.evidence || `${finding.observation.metric_name}: ${finding.observation.metric_value ?? "—"}`)}</textarea></div>
+            <div class="field full"><label for="defect-conclusion">QA conclusion / ask</label><textarea id="defect-conclusion">${h(data.conclusion || finding.triage.note)}</textarea></div>
+            <div class="field full"><div class="form-actions"><button class="button primary" ${can("qa") ? "" : "disabled"}>Save defect draft</button></div></div>
+          </div>
+        </form>
+        <aside class="panel">
+          <div class="panel-header"><h2>Preflight</h2><span class="status ${preflightReady(data, finding) ? "passed" : "other"}">${preflightReady(data, finding) ? "ready" : "incomplete"}</span></div>
+          <div class="panel-body checklist">
+            ${checkItem(Boolean(data.synopsis), "Clear synopsis")}
+            ${checkItem(Boolean(data.impact), "User or release impact")}
+            ${checkItem(Boolean(data.reproduction), "Reproduction path")}
+            ${checkItem(Boolean(data.evidence), "Comparable evidence")}
+            ${checkItem(finding.triage.owner !== "Unassigned", "QA owner")}
+          </div>
+          <div class="detail-section"><h3>Linked work</h3>${linksMarkup(state.links)}</div>
+          <form class="detail-section" id="link-form">
+            <h3>Add association</h3>
+            <div class="form-grid">
+              ${selectField("link-system", "System", ["github", "nvbug", "devtest"], "github")}
+              ${inputField("link-type", "Type", "issue")}
+              ${inputField("link-id", "ID", "", true)}
+              ${inputField("link-url", "HTTPS URL", "", true)}
+            </div>
+            <div class="form-actions"><button class="button" ${can("qa") ? "" : "disabled"}>Add link</button></div>
+          </form>
+          <div class="detail-section"><h3>Publication</h3><div class="notice">NVBug creation is disabled. Review here, file through the approved system, then link its ID.</div></div>
+        </aside>
+      </section>
+    </main>`;
+}
+
+function trashPage() {
+  return `
+    <main class="page">
+      <div class="page-title"><div><h1>Trash</h1><p>Hidden from active views and recoverable during retention.</p></div></div>
+      <div class="notice">Evidence bytes remain untouched. Permanent purge is a separate admin workflow and is not executed by this service.</div>
+      <section class="trash-list">
+        ${state.trash.length ? state.trash.map((run) => `<article class="trash-row">
+          <div><strong>${h(run.folder)}</strong><small>${h(run.source)} · ${run.lifecycle === "purge_scheduled" ? "purge scheduled" : `removed ${h(formatDate(run.trashed_at))} · recoverable until ${h(formatDate(run.purge_after))}`}</small><p>${h(run.purge_reason)}</p></div>
+          <div class="actions">${run.lifecycle === "trashed" ? `<button class="button" data-restore="${h(run.id)}" ${can("qa") ? "" : "disabled"}>Restore</button><button class="button danger" data-purge="${h(run.id)}" ${can("admin") ? "" : "disabled"}>Purge preflight</button>` : `<span class="status other">awaiting storage worker</span>`}</div>
+        </article>`).join("") : `<div class="panel empty">Trash is empty for this source.</div>`}
+      </section>
+    </main>`;
+}
+
+function emptyPage(title, message) {
+  return `<main class="page"><div class="page-title"><div><h1>${h(title)}</h1></div></div><div class="panel empty">${h(message)}</div></main>`;
+}
+
+function inputField(id, label, value, full = false) {
+  return `<div class="field ${full ? "full" : ""}"><label for="${id}">${h(label)}</label><input id="${id}" value="${h(value)}" /></div>`;
+}
+
+function selectField(id, label, options, selected) {
+  return `<div class="field"><label for="${id}">${h(label)}</label><select id="${id}">${options.map((value) => `<option value="${h(value)}" ${value === selected ? "selected" : ""}>${h(value)}</option>`).join("")}</select></div>`;
+}
+
+function checkItem(ready, label) {
+  return `<div class="check ${ready ? "is-ready" : ""}"><b>${ready ? "✓" : ""}</b><span>${h(label)}</span></div>`;
+}
+
+function preflightReady(data, finding) {
+  return Boolean(data.synopsis && data.impact && data.reproduction && data.evidence && finding.triage.owner !== "Unassigned");
+}
+
+function linksMarkup(links) {
+  if (!links.length) return `<p class="empty">No linked records.</p>`;
+  return `<div class="integration-list">${links.map((link) => `<div class="integration-card"><div><strong>${h(link.system)} · ${h(link.record_type)}</strong><p>${h(link.external_id)}</p></div>${link.url ? `<a class="button" href="${h(link.url)}" target="_blank" rel="noreferrer">Open</a>` : ""}</div>`).join("")}</div>`;
+}
+
+function auditMarkup() {
+  if (!state.audit.length) return `<p class="empty">No changes recorded.</p>`;
+  return state.audit.map((item) => `<div class="metric"><span>${h(item.action)} · ${h(item.actor)}</span><small>${h(formatDate(item.at))}</small></div>`).join("");
+}
+
+function dialogMarkup() {
+  const run = state.dialog?.run;
+  if (!run) return "";
+  if (state.dialog.type === "trash") {
+    return `<dialog id="action-dialog"><div class="dialog-head"><h2>Move report to Trash</h2></div><div class="dialog-body">
+      <div class="notice danger">This hides the run from active QA views. Original evidence is not deleted.</div>
+      <p>Type the exact folder name:</p><p><code>${h(run.folder)}</code></p>
+      <div class="field"><label for="dialog-reason">Reason</label><textarea id="dialog-reason"></textarea></div>
+      <div class="field"><label for="dialog-confirm">Folder name</label><input id="dialog-confirm" autocomplete="off" /></div>
+    </div><div class="dialog-actions"><button class="button" data-close-dialog>Cancel</button><button class="button danger" id="confirm-trash" disabled>Move to Trash</button></div></dialog>`;
+  }
+  return `<dialog id="action-dialog"><div class="dialog-head"><h2>Purge preflight</h2></div><div class="dialog-body">
+    <div class="notice danger">Scheduling is allowed only after retention expires and when no open findings or external references remain. This service never deletes NAS bytes.</div>
+    <p>Type the exact folder name:</p><p><code>${h(run.folder)}</code></p>
+    <div class="field"><label for="dialog-confirm">Folder name</label><input id="dialog-confirm" autocomplete="off" /></div>
+    <label class="check"><input type="checkbox" id="dialog-ack" /><span>I understand this schedules an irreversible storage operation.</span></label>
+  </div><div class="dialog-actions"><button class="button" data-close-dialog>Cancel</button><button class="button danger" id="confirm-purge" disabled>Schedule purge</button></div></dialog>`;
+}
+
+function bindCommon() {
+  document.querySelectorAll("[data-source]").forEach((button) => button.addEventListener("click", async () => {
+    if (state.source === button.dataset.source) return;
+    state.source = button.dataset.source;
+    state.selectedRunId = null;
+    state.selectedFindingId = null;
+    await withBusy(async () => {
+      await loadRuns();
+      await prepareRoute();
+    });
+  }));
+  document.querySelector("#run-select")?.addEventListener("change", async (event) => {
+    state.selectedRunId = event.target.value;
+    state.selectedFindingId = null;
+    await withBusy(async () => {
+      await loadFindings({ analyzeIfEmpty: true });
+      await prepareRoute();
+    });
+  });
+  document.querySelector("#sync-catalog")?.addEventListener("click", () => withBusy(async () => {
+    const result = await api("/api/v1/catalog/sync", { method: "POST", body: {} });
+    await loadRuns();
+    toast(`Catalog refreshed: ${result.result.inserted} new, ${result.result.updated} updated.`, "success");
+  }));
+  document.querySelector("#open-evidence")?.addEventListener("click", async () => {
+    try {
+      const result = await api(`/api/v1/runs/${state.selectedRunId}`);
+      window.open(result.run.evidence?.html_url, "_blank", "noopener,noreferrer");
+    } catch (error) { toast(error.message, "error"); }
+  });
+  document.querySelector("#trash-run")?.addEventListener("click", () => {
+    state.dialog = { type: "trash", run: selectedRun() };
+    render();
+  });
+}
+
+function bindFindings() {
+  document.querySelector("#analyze-run")?.addEventListener("click", () => withBusy(async () => {
+    const result = await api(`/api/v1/runs/${state.selectedRunId}/analyze`, { method: "POST", body: {} });
+    state.findings = result.findings;
+    state.evidence = result.evidence;
+    await loadFindingContext();
+    toast(`${result.observations} observations loaded.`, "success");
+  }));
+  document.querySelector("#finding-query")?.addEventListener("input", (event) => {
+    state.query = event.target.value;
+    render();
+    const input = document.querySelector("#finding-query");
+    input?.focus();
+    input?.setSelectionRange(state.query.length, state.query.length);
+  });
+  document.querySelectorAll("[data-filter]").forEach((button) => button.addEventListener("click", () => {
+    state.filter = button.dataset.filter;
+    render();
+  }));
+  document.querySelectorAll("[data-finding]").forEach((row) => row.addEventListener("click", async () => {
+    state.selectedFindingId = row.dataset.finding;
+    await withBusy(loadFindingContext);
+  }));
+  document.querySelector("#triage-form")?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const finding = selectedFinding();
+    await withBusy(async () => {
+      const result = await api(`/api/v1/findings/${finding.id}/triage`, {
+        method: "PUT",
+        body: {
+          status: value("triage-status"), severity: value("triage-severity"), owner: value("triage-owner"),
+          tags: value("triage-tags").split(",").map((item) => item.trim()).filter(Boolean),
+          note: value("triage-note"), expected_version: finding.triage.version,
+        },
+      });
+      finding.triage = result.triage;
+      await loadFindingContext();
+      toast("Triage saved.", "success");
+    });
+  });
+}
+
+function bindTestPlan() {
+  document.querySelector("#plan-form")?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    await withBusy(async () => {
+      const result = await api(`/api/v1/runs/${state.selectedRunId}/test-plan`, {
+        method: "PUT",
+        body: { expected_version: state.planDraft?.version || 0, data: {
+          name: value("plan-name"), branch: value("plan-branch"), platform: value("plan-platform"),
+          gpu: value("plan-gpu"), os: value("plan-os"), driver: value("plan-driver"),
+          scope: value("plan-scope"), exclusions: value("plan-exclusions"),
+          adoption_mode: "hub_only", selected_finding_ids: state.findings.map((item) => item.id),
+        } },
+      });
+      state.planDraft = result.draft;
+      toast("Test plan draft saved locally.", "success");
+    });
+  });
+}
+
+function bindDefect() {
+  document.querySelector("#defect-form")?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const finding = selectedFinding();
+    await withBusy(async () => {
+      const result = await api(`/api/v1/findings/${finding.id}/defect-draft`, {
+        method: "PUT",
+        body: { expected_version: state.defectDraft?.version || 0, data: {
+          synopsis: value("defect-synopsis"), severity: value("defect-severity"), impact: value("defect-impact"),
+          reproduction: value("defect-repro"), evidence: value("defect-evidence"), conclusion: value("defect-conclusion"),
+          publication_state: "local_draft",
+        } },
+      });
+      state.defectDraft = result.draft;
+      toast("Defect draft saved locally.", "success");
+    });
+  });
+  document.querySelector("#link-form")?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const finding = selectedFinding();
+    await withBusy(async () => {
+      await api(`/api/v1/findings/${finding.id}/links`, { method: "POST", body: {
+        system: value("link-system"), record_type: value("link-type"), external_id: value("link-id"), url: value("link-url"),
+      } });
+      await loadFindingContext();
+      toast("Association added.", "success");
+    });
+  });
+}
+
+function bindTrash() {
+  document.querySelectorAll("[data-restore]").forEach((button) => button.addEventListener("click", () => withBusy(async () => {
+    const run = state.trash.find((item) => item.id === button.dataset.restore);
+    await api(`/api/v1/runs/${run.id}/restore`, { method: "POST", body: { expected_version: run.version } });
+    await loadRuns();
+    await prepareRoute();
+    toast("Report restored to active views.", "success");
+  })));
+  document.querySelectorAll("[data-purge]").forEach((button) => button.addEventListener("click", () => {
+    state.dialog = { type: "purge", run: state.trash.find((item) => item.id === button.dataset.purge) };
+    render();
+  }));
+}
+
+function bindDialog() {
+  const dialog = document.querySelector("#action-dialog");
+  if (!dialog) return;
+  dialog.showModal();
+  dialog.querySelector("[data-close-dialog]")?.addEventListener("click", () => {
+    state.dialog = null;
+    render();
+  });
+  const confirmation = dialog.querySelector("#dialog-confirm");
+  if (state.dialog.type === "trash") {
+    const reason = dialog.querySelector("#dialog-reason");
+    const confirmButton = dialog.querySelector("#confirm-trash");
+    const update = () => { confirmButton.disabled = confirmation.value !== state.dialog.run.folder || !reason.value.trim(); };
+    confirmation.addEventListener("input", update);
+    reason.addEventListener("input", update);
+    confirmButton.addEventListener("click", () => withBusy(async () => {
+      const run = state.dialog.run;
+      await api(`/api/v1/runs/${run.id}/trash`, { method: "POST", body: {
+        reason: reason.value, confirmation: confirmation.value, expected_version: run.version,
+      } });
+      state.dialog = null;
+      await loadRuns();
+      toast("Report moved to Trash. Evidence was not deleted.", "success");
+    }));
+  } else {
+    const ack = dialog.querySelector("#dialog-ack");
+    const confirmButton = dialog.querySelector("#confirm-purge");
+    const update = () => { confirmButton.disabled = confirmation.value !== state.dialog.run.folder || !ack.checked; };
+    confirmation.addEventListener("input", update);
+    ack.addEventListener("change", update);
+    confirmButton.addEventListener("click", () => withBusy(async () => {
+      const run = state.dialog.run;
+      await api(`/api/v1/runs/${run.id}/purge-schedule`, { method: "POST", body: {
+        confirmation: confirmation.value, acknowledge_irreversible: ack.checked, expected_version: run.version,
+      } });
+      state.dialog = null;
+      await prepareRoute();
+      toast("Purge scheduled for an external storage worker.", "success");
+    }));
+  }
+}
+
+async function withBusy(action) {
+  if (state.busy) return;
+  state.busy = true;
+  render();
+  try {
+    await action();
+  } catch (error) {
+    toast(error.message, "error");
+  } finally {
+    state.busy = false;
+    render();
+  }
+}
+
+function toast(message, kind = "success") {
+  const item = { message, kind };
+  state.toasts.push(item);
+  render();
+  setTimeout(() => {
+    state.toasts = state.toasts.filter((candidate) => candidate !== item);
+    render();
+  }, 4200);
+}
+
+function value(id) { return document.querySelector(`#${id}`)?.value?.trim() || ""; }
+function formatDate(value) { return value ? new Date(value).toLocaleString() : "—"; }
+
+start();

--- a/tools/report_hub/static/index.html
+++ b/tools/report_hub/static/index.html
@@ -1,0 +1,24 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
+    <meta name="description" content="QA evidence, triage, test planning, and defect handoff." />
+    <title>TRTMC Report Hub</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <main class="boot">
+        <span class="spinner" aria-hidden="true"></span>
+        <strong>Opening report evidence…</strong>
+      </main>
+    </div>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/tools/report_hub/static/styles.css
+++ b/tools/report_hub/static/styles.css
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+  --nv-green: #76b900;
+  --black: #191919;
+  --surface-dark: #292929;
+  --surface-dark-2: #393939;
+  --canvas: #f4f5f6;
+  --panel: #ffffff;
+  --ink: #191919;
+  --muted: #65686c;
+  --line: #dfe1e4;
+  --line-strong: #c7cacf;
+  --danger: #e02828;
+  --danger-soft: #fff3f3;
+  --warning: #7a5100;
+  --warning-accent: #ffb43e;
+  --warning-soft: #fff8e9;
+  --green-soft: rgba(118, 185, 0, 0.11);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.07);
+  font-family: "NVIDIA Sans", Arial, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--canvas);
+  font-size: 15px;
+  line-height: 1.45;
+  text-rendering: optimizeLegibility;
+}
+
+* { box-sizing: border-box; }
+html, body { min-width: 320px; min-height: 100%; margin: 0; }
+body { background: var(--canvas); }
+button, input, select, textarea { font: inherit; }
+button, select { cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, a:focus-visible {
+  outline: 3px solid rgba(118, 185, 0, 0.42);
+  outline-offset: 2px;
+}
+
+.boot, .fatal {
+  display: grid;
+  min-height: 100vh;
+  place-content: center;
+  justify-items: center;
+  gap: 14px;
+}
+
+.spinner {
+  width: 30px;
+  height: 30px;
+  border: 3px solid #d4d6d9;
+  border-top-color: var(--nv-green);
+  border-radius: 50%;
+  animation: spin .75s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.topbar {
+  position: sticky;
+  z-index: 50;
+  top: 0;
+  display: grid;
+  grid-template-columns: 248px minmax(420px, 1fr) auto;
+  min-height: 70px;
+  color: #fff;
+  border-bottom: 3px solid var(--nv-green);
+  background: var(--black);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 22px;
+  border-right: 1px solid var(--surface-dark-2);
+}
+
+.brand-mark { width: 7px; height: 38px; background: var(--nv-green); }
+.brand strong { display: block; font-size: 19px; letter-spacing: .055em; }
+.brand small { display: block; margin-top: 3px; color: #aaa; font-size: 12px; letter-spacing: .12em; }
+
+.main-nav { display: flex; align-items: stretch; }
+.main-nav a {
+  position: relative;
+  display: grid;
+  min-width: 132px;
+  place-content: center;
+  padding: 0 20px;
+  color: #c3c3c3;
+  font-size: 13px;
+  font-weight: 750;
+}
+.main-nav a:hover { color: #fff; background: var(--surface-dark); }
+.main-nav a.is-active { color: #fff; background: var(--surface-dark); }
+.main-nav a.is-active::after {
+  position: absolute;
+  right: 20px;
+  bottom: 0;
+  left: 20px;
+  height: 3px;
+  background: var(--nv-green);
+  content: "";
+}
+
+.identity {
+  display: grid;
+  align-content: center;
+  min-width: 170px;
+  padding: 0 22px;
+  border-left: 1px solid var(--surface-dark-2);
+}
+.identity strong { font-size: 13px; }
+.identity small { color: #9b9b9b; font-size: 12px; text-transform: uppercase; }
+
+.contextbar {
+  display: grid;
+  grid-template-columns: auto minmax(320px, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  min-height: 72px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.source-switch { display: inline-flex; padding: 3px; border: 1px solid var(--line); background: #f3f3f3; }
+.source-switch button { padding: 9px 15px; border: 0; background: transparent; font-size: 13px; font-weight: 750; }
+.source-switch button.is-active { background: #fff; box-shadow: 0 1px 5px rgba(0,0,0,.09); }
+.source-switch button.is-active::before { color: var(--nv-green); content: "● "; }
+
+.run-control { min-width: 0; }
+.run-control label { display: block; margin-bottom: 4px; color: var(--muted); font-size: 12px; font-weight: 700; }
+.run-control select { width: 100%; min-height: 36px; padding: 6px 10px; border: 1px solid var(--line-strong); background: #fff; }
+
+.actions { display: flex; gap: 8px; align-items: center; }
+.button {
+  min-height: 36px;
+  padding: 7px 14px;
+  border: 1px solid var(--line-strong);
+  background: #fff;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 750;
+}
+.button:hover { border-color: #888; background: #fafafa; }
+.button.primary { border-color: var(--nv-green); background: var(--nv-green); color: #000; }
+.button.primary:hover { filter: brightness(.96); }
+.button.danger { border-color: #efb8b8; color: #b11919; background: #fff; }
+.button:disabled { cursor: not-allowed; opacity: .48; }
+.icon-button { width: 36px; padding: 0; }
+
+.page { padding: 22px 24px 40px; }
+.page-title { display: flex; justify-content: space-between; gap: 20px; align-items: end; margin-bottom: 16px; }
+.page-title h1 { margin: 0; font-size: 24px; line-height: 1.2; }
+.page-title p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
+
+.summary-grid { display: grid; grid-template-columns: repeat(4, minmax(130px, 1fr)); gap: 10px; margin-bottom: 16px; }
+.summary-card { padding: 15px 17px; border: 1px solid var(--line); background: var(--panel); }
+.summary-card span { display: block; color: var(--muted); font-size: 12px; font-weight: 700; text-transform: uppercase; }
+.summary-card strong { display: block; margin-top: 3px; font-size: 25px; }
+.summary-card.failed strong { color: var(--danger); }
+.summary-card.attention { border-top: 3px solid var(--warning-accent); }
+
+.workspace { display: grid; grid-template-columns: minmax(640px, 1.5fr) minmax(350px, .8fr); gap: 14px; align-items: start; }
+.panel { border: 1px solid var(--line); background: var(--panel); box-shadow: 0 2px 12px rgba(0,0,0,.025); }
+.panel-header { display: flex; justify-content: space-between; gap: 12px; align-items: center; min-height: 52px; padding: 10px 14px; border-bottom: 1px solid var(--line); }
+.panel-header h2 { margin: 0; font-size: 16px; }
+.panel-body { padding: 16px; }
+
+.filters { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.filters input { min-width: 220px; min-height: 34px; padding: 6px 10px; border: 1px solid var(--line); }
+.filter-chip { min-height: 32px; padding: 5px 10px; border: 1px solid var(--line); background: #fff; font-size: 12px; font-weight: 700; }
+.filter-chip.is-active { border-color: var(--black); background: var(--black); color: #fff; }
+
+.table-wrap { overflow: auto; }
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th { position: sticky; z-index: 2; top: 0; padding: 9px 12px; color: #555; background: #f3f4f5; text-align: left; white-space: nowrap; }
+td { padding: 11px 12px; border-top: 1px solid var(--line); vertical-align: top; }
+tbody tr { cursor: pointer; }
+tbody tr:hover { background: #fafafa; }
+tbody tr.is-selected { background: var(--green-soft); box-shadow: inset 4px 0 var(--nv-green); }
+.model-cell strong { display: block; font-size: 13px; }
+.model-cell small { color: var(--muted); font-size: 12px; }
+
+.status, .tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 23px;
+  padding: 2px 7px;
+  border: 1px solid var(--line-strong);
+  background: #f6f6f6;
+  font-size: 11px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+.status.failed, .status.blocker, .status.high { color: #aa1717; border-color: #efbcbc; background: var(--danger-soft); }
+.status.passed, .status.resolved, .status.linked { color: #315d00; border-color: #bedc9e; background: #f1f8e9; }
+.status.investigating, .status.medium, .status.other { color: var(--warning); border-color: #ebd092; background: var(--warning-soft); }
+.tag { margin: 2px 3px 2px 0; font-weight: 650; }
+
+.detail-empty, .empty { padding: 44px 24px; color: var(--muted); text-align: center; }
+.detail-title { padding: 16px; border-bottom: 1px solid var(--line); }
+.detail-title h2 { margin: 0 0 5px; font-size: 18px; }
+.detail-title p { margin: 0; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; }
+.detail-section { padding: 15px 16px; border-bottom: 1px solid var(--line); }
+.detail-section:last-child { border-bottom: 0; }
+.detail-section h3 { margin: 0 0 10px; font-size: 13px; text-transform: uppercase; letter-spacing: .055em; }
+.metric { display: grid; grid-template-columns: 1fr auto; gap: 10px; margin: 7px 0; font-size: 13px; }
+.metric span { color: var(--muted); }
+
+.form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 13px; }
+.field { display: grid; gap: 5px; }
+.field.full { grid-column: 1 / -1; }
+.field label { color: #4f5256; font-size: 12px; font-weight: 750; }
+.field input, .field select, .field textarea { width: 100%; min-height: 38px; padding: 8px 10px; border: 1px solid var(--line-strong); background: #fff; }
+.field textarea { min-height: 100px; resize: vertical; }
+.form-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+
+.wide-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(320px, .6fr); gap: 14px; align-items: start; }
+.integration-list { display: grid; gap: 8px; }
+.integration-card { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 12px; border: 1px solid var(--line); }
+.integration-card strong { text-transform: uppercase; font-size: 12px; }
+.integration-card p { margin: 3px 0 0; color: var(--muted); font-size: 12px; }
+
+.checklist { display: grid; gap: 8px; }
+.check { display: grid; grid-template-columns: 22px 1fr; gap: 8px; align-items: start; font-size: 13px; }
+.check b { display: grid; width: 20px; height: 20px; place-content: center; border: 1px solid var(--line-strong); }
+.check.is-ready b { border-color: var(--nv-green); background: var(--nv-green); color: #000; }
+
+.notice { margin-bottom: 14px; padding: 11px 13px; border-left: 4px solid var(--warning-accent); background: var(--warning-soft); font-size: 13px; }
+.notice.danger { border-left-color: var(--danger); background: var(--danger-soft); }
+.notice.success { border-left-color: var(--nv-green); background: var(--green-soft); }
+
+.trash-list { display: grid; gap: 10px; }
+.trash-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 16px; align-items: center; padding: 15px; border: 1px solid var(--line); background: #fff; }
+.trash-row strong { display: block; overflow-wrap: anywhere; }
+.trash-row small { color: var(--muted); }
+
+dialog { width: min(560px, calc(100vw - 32px)); padding: 0; border: 0; box-shadow: 0 26px 80px rgba(0,0,0,.28); }
+dialog::backdrop { background: rgba(25,25,25,.58); }
+.dialog-head { padding: 17px 19px; color: #fff; background: var(--black); border-bottom: 3px solid var(--nv-green); }
+.dialog-head h2 { margin: 0; font-size: 18px; }
+.dialog-body { padding: 18px 19px; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 13px 19px; border-top: 1px solid var(--line); background: #f5f5f5; }
+code { padding: 2px 5px; background: #eee; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; overflow-wrap: anywhere; }
+
+.toast-stack { position: fixed; z-index: 100; right: 20px; bottom: 20px; display: grid; gap: 8px; width: min(390px, calc(100vw - 40px)); }
+.toast { padding: 12px 14px; color: #fff; background: var(--black); box-shadow: var(--shadow); font-size: 13px; }
+.toast.error { border-left: 5px solid var(--danger); }
+.toast.success { border-left: 5px solid var(--nv-green); }
+
+@media (max-width: 1080px) {
+  .topbar { grid-template-columns: 210px 1fr; }
+  .identity { display: none; }
+  .main-nav a { min-width: auto; padding: 0 13px; }
+  .workspace, .wide-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 760px) {
+  .topbar { position: static; display: block; }
+  .brand { min-height: 60px; }
+  .main-nav { overflow-x: auto; min-height: 52px; }
+  .contextbar { grid-template-columns: 1fr; }
+  .actions { flex-wrap: wrap; }
+  .page { padding: 16px 12px 30px; }
+  .summary-grid { grid-template-columns: repeat(2, 1fr); }
+  .form-grid { grid-template-columns: 1fr; }
+  .field.full { grid-column: auto; }
+}

--- a/tools/report_hub/storage.py
+++ b/tools/report_hub/storage.py
@@ -1,0 +1,935 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite persistence for Report Hub state and audit history."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+from typing import Any
+
+from .domain import (
+    EXTERNAL_SYSTEMS,
+    SEVERITIES,
+    TRIAGE_STATUSES,
+    ConflictError,
+    NotFoundError,
+    Observation,
+    ReportHubError,
+    isoformat,
+    require_folder,
+    require_string_list,
+    require_text,
+    stable_id,
+    utc_now,
+)
+
+
+SCHEMA_VERSION = 1
+
+
+class Store:
+    def __init__(self, path: Path, *, retention_days: int = 30):
+        self.path = Path(path)
+        self.retention_days = retention_days
+
+    def initialize(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            current = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            if current > SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"database schema {current} is newer than supported schema {SCHEMA_VERSION}"
+                )
+            if current == 0:
+                connection.executescript(_SCHEMA)
+                connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def sync_catalog(self, catalog: Mapping[str, Any], *, actor: str) -> dict[str, int]:
+        sources = catalog.get("sources")
+        if not isinstance(sources, Mapping):
+            raise ReportHubError("report catalog sources must be an object")
+        now = isoformat(utc_now())
+        inserted = 0
+        updated = 0
+        with self._transaction() as connection:
+            for source in ("benchmark", "perf"):
+                group = sources.get(source, {})
+                reports = group.get("reports", []) if isinstance(group, Mapping) else []
+                if not isinstance(reports, list):
+                    raise ReportHubError(f"catalog source {source} reports must be a list")
+                for raw in reports:
+                    if not isinstance(raw, Mapping):
+                        continue
+                    folder = require_folder(raw.get("folder"))
+                    run_id = stable_id("run", source, folder)
+                    existing = connection.execute(
+                        "SELECT id FROM runs WHERE id = ?", (run_id,)
+                    ).fetchone()
+                    summary = raw.get("summary") if isinstance(raw.get("summary"), Mapping) else {}
+                    connection.execute(
+                        """
+                        INSERT INTO runs (
+                            id, source, folder, report_date, catalog_updated_at,
+                            signature, summary_json, lifecycle, version, created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?)
+                        ON CONFLICT(id) DO UPDATE SET
+                            report_date = excluded.report_date,
+                            catalog_updated_at = excluded.catalog_updated_at,
+                            signature = excluded.signature,
+                            summary_json = excluded.summary_json,
+                            updated_at = excluded.updated_at
+                        """,
+                        (
+                            run_id,
+                            source,
+                            folder,
+                            raw.get("date"),
+                            raw.get("updated_at"),
+                            raw.get("_signature"),
+                            _json(summary),
+                            now,
+                            now,
+                        ),
+                    )
+                    if existing:
+                        updated += 1
+                    else:
+                        inserted += 1
+            self._audit(
+                connection,
+                entity_type="catalog",
+                entity_id="report-catalog",
+                action="catalog.synced",
+                actor=actor,
+                before=None,
+                after={"inserted": inserted, "updated": updated},
+                at=now,
+            )
+        return {"inserted": inserted, "updated": updated}
+
+    def list_runs(self, *, source: str | None = None, lifecycle: str = "active") -> list[dict[str, Any]]:
+        clauses = ["lifecycle = ?"]
+        parameters: list[Any] = [lifecycle]
+        if source:
+            if source not in {"benchmark", "perf"}:
+                raise ReportHubError("unsupported report source")
+            clauses.append("source = ?")
+            parameters.append(source)
+        sql = f"SELECT * FROM runs WHERE {' AND '.join(clauses)} ORDER BY report_date DESC, folder DESC"
+        with self._connect() as connection:
+            return [self._run_dict(row) for row in connection.execute(sql, parameters)]
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        with self._connect() as connection:
+            row = connection.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+        if row is None:
+            raise NotFoundError("report run was not found")
+        return self._run_dict(row)
+
+    def trash_run(
+        self,
+        run_id: str,
+        *,
+        reason: str,
+        confirmation: str,
+        expected_version: int,
+        actor: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        reason = require_text(reason, "reason", maximum=500)
+        current_time = now or utc_now()
+        at = isoformat(current_time)
+        purge_after = isoformat(current_time + timedelta(days=self.retention_days))
+        with self._transaction() as connection:
+            before_row = self._locked_run(connection, run_id)
+            before = self._run_dict(before_row)
+            if before["lifecycle"] != "active":
+                raise ConflictError("only active reports can be moved to Trash")
+            if confirmation != before["folder"]:
+                raise ReportHubError("confirmation must exactly match the report folder")
+            if expected_version != before["version"]:
+                raise ConflictError("report changed; reload before deleting")
+            connection.execute(
+                """
+                UPDATE runs SET lifecycle = 'trashed', trashed_at = ?, purge_after = ?,
+                    purge_reason = ?, version = version + 1, updated_at = ?
+                WHERE id = ?
+                """,
+                (at, purge_after, reason, at, run_id),
+            )
+            after = self._run_dict(self._locked_run(connection, run_id))
+            self._audit(connection, "run", run_id, "run.trashed", actor, before, after, at)
+        return after
+
+    def restore_run(
+        self,
+        run_id: str,
+        *,
+        expected_version: int,
+        actor: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        current_time = now or utc_now()
+        at = isoformat(current_time)
+        with self._transaction() as connection:
+            before = self._run_dict(self._locked_run(connection, run_id))
+            if before["lifecycle"] != "trashed":
+                raise ConflictError("only reports in Trash can be restored")
+            if expected_version != before["version"]:
+                raise ConflictError("report changed; reload before restoring")
+            deadline = _parse_datetime(before["purge_after"])
+            if deadline is not None and current_time > deadline:
+                raise ConflictError("retention window has expired; report can no longer be restored")
+            connection.execute(
+                """
+                UPDATE runs SET lifecycle = 'active', trashed_at = NULL, purge_after = NULL,
+                    purge_reason = NULL, version = version + 1, updated_at = ? WHERE id = ?
+                """,
+                (at, run_id),
+            )
+            after = self._run_dict(self._locked_run(connection, run_id))
+            self._audit(connection, "run", run_id, "run.restored", actor, before, after, at)
+        return after
+
+    def schedule_purge(
+        self,
+        run_id: str,
+        *,
+        confirmation: str,
+        acknowledge_irreversible: bool,
+        expected_version: int,
+        actor: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        current_time = now or utc_now()
+        at = isoformat(current_time)
+        with self._transaction() as connection:
+            before = self._run_dict(self._locked_run(connection, run_id))
+            if before["lifecycle"] != "trashed":
+                raise ConflictError("only reports in Trash can be scheduled for purge")
+            if confirmation != before["folder"]:
+                raise ReportHubError("confirmation must exactly match the report folder")
+            if not acknowledge_irreversible:
+                raise ReportHubError("irreversibility acknowledgement is required")
+            if expected_version != before["version"]:
+                raise ConflictError("report changed; reload before scheduling purge")
+            deadline = _parse_datetime(before["purge_after"])
+            if deadline is None or current_time < deadline:
+                raise ConflictError("retention window has not expired")
+            references = connection.execute(
+                "SELECT COUNT(*) FROM external_links WHERE run_id = ? OR finding_id IN "
+                "(SELECT finding_id FROM observations WHERE run_id = ?)",
+                (run_id, run_id),
+            ).fetchone()[0]
+            open_findings = connection.execute(
+                """
+                SELECT COUNT(*) FROM observations o
+                LEFT JOIN triage t ON t.finding_id = o.finding_id
+                WHERE o.run_id = ? AND (
+                    (o.status IN ('failed', 'error')
+                        AND COALESCE(t.status, 'new') NOT IN ('resolved', 'accepted_risk'))
+                    OR (t.status IS NOT NULL AND t.status NOT IN ('resolved', 'accepted_risk'))
+                )
+                """,
+                (run_id,),
+            ).fetchone()[0]
+            if references or open_findings:
+                raise ConflictError(
+                    f"purge blocked by {references} external references and {open_findings} open findings"
+                )
+            connection.execute(
+                "UPDATE runs SET lifecycle = 'purge_scheduled', version = version + 1, updated_at = ? WHERE id = ?",
+                (at, run_id),
+            )
+            after = self._run_dict(self._locked_run(connection, run_id))
+            self._audit(connection, "run", run_id, "run.purge_scheduled", actor, before, after, at)
+        return after
+
+    def ingest_observations(
+        self,
+        run_id: str,
+        observations: Iterable[Observation],
+        *,
+        actor: str,
+    ) -> int:
+        run = self.get_run(run_id)
+        if run["lifecycle"] == "purged":
+            raise ConflictError("purged report evidence cannot be analyzed")
+        now = isoformat(utc_now())
+        count = 0
+        with self._transaction() as connection:
+            for observation in observations:
+                connection.execute(
+                    """
+                    INSERT INTO findings (
+                        id, source, model, workload, metric_contract, family, title,
+                        created_at, last_seen_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        family = excluded.family, title = excluded.title, last_seen_at = excluded.last_seen_at
+                    """,
+                    (
+                        observation.finding_id,
+                        run["source"],
+                        observation.model,
+                        observation.workload,
+                        observation.metric_name,
+                        observation.family,
+                        f"{observation.model} · {observation.workload}",
+                        now,
+                        now,
+                    ),
+                )
+                connection.execute(
+                    """
+                    INSERT INTO observations (
+                        run_id, finding_id, operation, status, metric_name, metric_value,
+                        details_json, observed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id, finding_id) DO UPDATE SET
+                        operation = excluded.operation, status = excluded.status,
+                        metric_name = excluded.metric_name, metric_value = excluded.metric_value,
+                        details_json = excluded.details_json, observed_at = excluded.observed_at
+                    """,
+                    (
+                        run_id,
+                        observation.finding_id,
+                        observation.operation,
+                        observation.status,
+                        observation.metric_name,
+                        observation.metric_value,
+                        _json(observation.details),
+                        now,
+                    ),
+                )
+                count += 1
+            self._audit(
+                connection,
+                "run",
+                run_id,
+                "run.analyzed",
+                actor,
+                None,
+                {"observations": count},
+                now,
+            )
+        return count
+
+    def list_findings(self, *, run_id: str | None = None) -> list[dict[str, Any]]:
+        parameters: list[Any] = []
+        run_join = ""
+        if run_id:
+            run_join = "JOIN observations selected ON selected.finding_id = f.id AND selected.run_id = ?"
+            parameters.append(run_id)
+        else:
+            run_join = """
+                LEFT JOIN observations selected ON selected.rowid = (
+                    SELECT latest.rowid FROM observations latest
+                    WHERE latest.finding_id = f.id
+                    ORDER BY latest.observed_at DESC, latest.run_id DESC LIMIT 1
+                )
+            """
+        sql = f"""
+            SELECT f.*,
+                COALESCE(t.status, 'new') AS triage_status,
+                COALESCE(t.severity, 'unassessed') AS severity,
+                COALESCE(t.owner, 'Unassigned') AS owner,
+                COALESCE(t.note, '') AS note,
+                COALESCE(t.tags_json, '[]') AS tags_json,
+                COALESCE(t.version, 0) AS triage_version,
+                t.updated_by AS triage_updated_by,
+                t.updated_at AS triage_updated_at,
+                selected.status AS observation_status,
+                selected.operation AS operation,
+                selected.metric_name AS metric_name,
+                selected.metric_value AS metric_value,
+                selected.details_json AS details_json
+            FROM findings f
+            {run_join}
+            LEFT JOIN triage t ON t.finding_id = f.id
+            ORDER BY f.last_seen_at DESC, f.title
+        """
+        with self._connect() as connection:
+            rows = connection.execute(sql, parameters).fetchall()
+        return [self._finding_dict(row) for row in rows]
+
+    def get_finding(self, finding_id: str) -> dict[str, Any]:
+        matches = [item for item in self.list_findings() if item["id"] == finding_id]
+        if not matches:
+            raise NotFoundError("finding was not found")
+        return matches[0]
+
+    def update_triage(
+        self,
+        finding_id: str,
+        payload: Mapping[str, Any],
+        *,
+        actor: str,
+    ) -> dict[str, Any]:
+        status = require_text(payload.get("status"), "status", maximum=32)
+        severity = require_text(payload.get("severity"), "severity", maximum=32)
+        owner = require_text(payload.get("owner", "Unassigned"), "owner", maximum=160)
+        note = require_text(payload.get("note", ""), "note", maximum=8000, allow_empty=True)
+        tags = require_string_list(payload.get("tags", []), "tags")
+        expected_version = payload.get("expected_version")
+        if not isinstance(expected_version, int):
+            raise ReportHubError("expected_version must be an integer")
+        if status not in TRIAGE_STATUSES:
+            raise ReportHubError("unsupported triage status")
+        if severity not in SEVERITIES:
+            raise ReportHubError("unsupported severity")
+        now = isoformat(utc_now())
+        with self._transaction() as connection:
+            finding = connection.execute("SELECT id FROM findings WHERE id = ?", (finding_id,)).fetchone()
+            if finding is None:
+                raise NotFoundError("finding was not found")
+            row = connection.execute("SELECT * FROM triage WHERE finding_id = ?", (finding_id,)).fetchone()
+            before = self._triage_dict(row) if row else None
+            current_version = int(row["version"]) if row else 0
+            if expected_version != current_version:
+                raise ConflictError("triage changed; reload before saving")
+            new_version = current_version + 1
+            connection.execute(
+                """
+                INSERT INTO triage (
+                    finding_id, status, severity, owner, note, tags_json, version, updated_by, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(finding_id) DO UPDATE SET
+                    status = excluded.status, severity = excluded.severity,
+                    owner = excluded.owner, note = excluded.note, tags_json = excluded.tags_json,
+                    version = excluded.version, updated_by = excluded.updated_by,
+                    updated_at = excluded.updated_at
+                """,
+                (finding_id, status, severity, owner, note, _json(tags), new_version, actor, now),
+            )
+            after = self._triage_dict(
+                connection.execute("SELECT * FROM triage WHERE finding_id = ?", (finding_id,)).fetchone()
+            )
+            self._audit(connection, "finding", finding_id, "triage.updated", actor, before, after, now)
+        return after
+
+    def add_external_link(
+        self,
+        *,
+        finding_id: str | None,
+        run_id: str | None,
+        system: str,
+        record_type: str,
+        external_id: str,
+        url: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        if bool(finding_id) == bool(run_id):
+            raise ReportHubError("link must target exactly one finding or run")
+        if system not in EXTERNAL_SYSTEMS:
+            raise ReportHubError("unsupported external system")
+        record_type = require_text(record_type, "record_type", maximum=64)
+        external_id = require_text(external_id, "external_id", maximum=160)
+        url = require_text(url, "url", maximum=2000, allow_empty=True)
+        link_id = stable_id("link", system, record_type, external_id, finding_id or "", run_id or "")
+        now = isoformat(utc_now())
+        with self._transaction() as connection:
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO external_links (
+                        id, finding_id, run_id, system, record_type, external_id, url,
+                        sync_status, created_by, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'manual', ?, ?, ?)
+                    """,
+                    (link_id, finding_id, run_id, system, record_type, external_id, url, actor, now, now),
+                )
+            except sqlite3.IntegrityError as error:
+                raise ConflictError("external link already exists or target is missing") from error
+            link = self._link_dict(
+                connection.execute("SELECT * FROM external_links WHERE id = ?", (link_id,)).fetchone()
+            )
+            self._audit(
+                connection,
+                "finding" if finding_id else "run",
+                finding_id or run_id or "",
+                "external_link.added",
+                actor,
+                None,
+                link,
+                now,
+            )
+        return link
+
+    def list_external_links(
+        self, *, finding_id: str | None = None, run_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        if bool(finding_id) == bool(run_id):
+            raise ReportHubError("provide exactly one finding or run")
+        field, value = ("finding_id", finding_id) if finding_id else ("run_id", run_id)
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"SELECT * FROM external_links WHERE {field} = ? ORDER BY created_at DESC", (value,)
+            ).fetchall()
+        return [self._link_dict(row) for row in rows]
+
+    def get_draft(self, kind: str, entity_id: str) -> dict[str, Any] | None:
+        table, field = _draft_table(kind)
+        with self._connect() as connection:
+            row = connection.execute(f"SELECT * FROM {table} WHERE {field} = ?", (entity_id,)).fetchone()
+        return self._draft_dict(row, field) if row else None
+
+    def save_draft(
+        self,
+        kind: str,
+        entity_id: str,
+        data: Mapping[str, Any],
+        *,
+        expected_version: int,
+        actor: str,
+    ) -> dict[str, Any]:
+        table, field = _draft_table(kind)
+        if len(_json(data)) > 64 * 1024:
+            raise ReportHubError("draft exceeds 64 KiB")
+        now = isoformat(utc_now())
+        with self._transaction() as connection:
+            parent_table = "runs" if kind == "test_plan" else "findings"
+            if connection.execute(f"SELECT id FROM {parent_table} WHERE id = ?", (entity_id,)).fetchone() is None:
+                raise NotFoundError(f"{parent_table[:-1]} was not found")
+            row = connection.execute(f"SELECT * FROM {table} WHERE {field} = ?", (entity_id,)).fetchone()
+            before = self._draft_dict(row, field) if row else None
+            current_version = int(row["version"]) if row else 0
+            if expected_version != current_version:
+                raise ConflictError("draft changed; reload before saving")
+            new_version = current_version + 1
+            connection.execute(
+                f"""
+                INSERT INTO {table} ({field}, data_json, version, updated_by, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT({field}) DO UPDATE SET data_json = excluded.data_json,
+                    version = excluded.version, updated_by = excluded.updated_by,
+                    updated_at = excluded.updated_at
+                """,
+                (entity_id, _json(data), new_version, actor, now),
+            )
+            after = self._draft_dict(
+                connection.execute(f"SELECT * FROM {table} WHERE {field} = ?", (entity_id,)).fetchone(),
+                field,
+            )
+            self._audit(
+                connection,
+                "run" if kind == "test_plan" else "finding",
+                entity_id,
+                f"{kind}.saved",
+                actor,
+                before,
+                after,
+                now,
+            )
+        return after
+
+    def audit_events(
+        self, *, entity_type: str | None = None, entity_id: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        parameters: list[Any] = []
+        if entity_type:
+            clauses.append("entity_type = ?")
+            parameters.append(entity_type)
+        if entity_id:
+            clauses.append("entity_id = ?")
+            parameters.append(entity_id)
+        parameters.append(max(1, min(limit, 500)))
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"SELECT * FROM audit_events {where} ORDER BY sequence DESC LIMIT ?", parameters
+            ).fetchall()
+        return [
+            {
+                "sequence": row["sequence"],
+                "entity_type": row["entity_type"],
+                "entity_id": row["entity_id"],
+                "action": row["action"],
+                "actor": row["actor"],
+                "at": row["at"],
+                "before": _loads(row["before_json"]),
+                "after": _loads(row["after_json"]),
+            }
+            for row in rows
+        ]
+
+    def prepare_adapter_operation(
+        self,
+        *,
+        system: str,
+        operation: str,
+        idempotency_key: str,
+        request: Mapping[str, Any],
+        actor: str,
+    ) -> dict[str, Any]:
+        if system not in EXTERNAL_SYSTEMS:
+            raise ReportHubError("unsupported external system")
+        operation = require_text(operation, "operation", maximum=80)
+        idempotency_key = require_text(idempotency_key, "idempotency_key", maximum=160)
+        request_json = _json(request) or "{}"
+        if len(request_json) > 64 * 1024:
+            raise ReportHubError("adapter request exceeds 64 KiB")
+        digest = hashlib.sha256(request_json.encode("utf-8")).hexdigest()
+        operation_id = stable_id("operation", system, idempotency_key)
+        now = isoformat(utc_now())
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT * FROM adapter_operations WHERE system = ? AND idempotency_key = ?",
+                (system, idempotency_key),
+            ).fetchone()
+            if row:
+                if row["request_sha256"] != digest or row["operation"] != operation:
+                    raise ConflictError("idempotency key was already used for a different request")
+                result = self._adapter_operation_dict(row)
+                result["replayed"] = True
+                return result
+            connection.execute(
+                """
+                INSERT INTO adapter_operations (
+                    id, system, operation, idempotency_key, request_sha256, request_json,
+                    status, actor, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'prepared', ?, ?, ?)
+                """,
+                (
+                    operation_id,
+                    system,
+                    operation,
+                    idempotency_key,
+                    digest,
+                    request_json,
+                    actor,
+                    now,
+                    now,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM adapter_operations WHERE id = ?", (operation_id,)
+            ).fetchone()
+            result = self._adapter_operation_dict(row)
+            result["replayed"] = False
+            self._audit(
+                connection,
+                "adapter_operation",
+                operation_id,
+                "adapter_operation.prepared",
+                actor,
+                None,
+                result,
+                now,
+            )
+            return result
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=10)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA busy_timeout = 10000")
+        return connection
+
+    def _transaction(self) -> _Transaction:
+        return _Transaction(self._connect())
+
+    @staticmethod
+    def _locked_run(connection: sqlite3.Connection, run_id: str) -> sqlite3.Row:
+        row = connection.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+        if row is None:
+            raise NotFoundError("report run was not found")
+        return row
+
+    @staticmethod
+    def _run_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "source": row["source"],
+            "folder": row["folder"],
+            "date": row["report_date"],
+            "catalog_updated_at": row["catalog_updated_at"],
+            "signature": row["signature"],
+            "summary": _loads(row["summary_json"]) or {},
+            "lifecycle": row["lifecycle"],
+            "trashed_at": row["trashed_at"],
+            "purge_after": row["purge_after"],
+            "purge_reason": row["purge_reason"],
+            "version": row["version"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    @staticmethod
+    def _finding_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "source": row["source"],
+            "model": row["model"],
+            "workload": row["workload"],
+            "metric_contract": row["metric_contract"],
+            "family": row["family"],
+            "title": row["title"],
+            "last_seen_at": row["last_seen_at"],
+            "observation": {
+                "status": row["observation_status"],
+                "operation": row["operation"],
+                "metric_name": row["metric_name"],
+                "metric_value": row["metric_value"],
+                "details": _loads(row["details_json"]) or {},
+            },
+            "triage": {
+                "status": row["triage_status"],
+                "severity": row["severity"],
+                "owner": row["owner"],
+                "note": row["note"],
+                "tags": _loads(row["tags_json"]) or [],
+                "version": row["triage_version"],
+                "updated_by": row["triage_updated_by"],
+                "updated_at": row["triage_updated_at"],
+            },
+        }
+
+    @staticmethod
+    def _triage_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "status": row["status"],
+            "severity": row["severity"],
+            "owner": row["owner"],
+            "note": row["note"],
+            "tags": _loads(row["tags_json"]) or [],
+            "version": row["version"],
+            "updated_by": row["updated_by"],
+            "updated_at": row["updated_at"],
+        }
+
+    @staticmethod
+    def _link_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "finding_id": row["finding_id"],
+            "run_id": row["run_id"],
+            "system": row["system"],
+            "record_type": row["record_type"],
+            "external_id": row["external_id"],
+            "url": row["url"],
+            "sync_status": row["sync_status"],
+            "snapshot": _loads(row["snapshot_json"]),
+            "last_synced_at": row["last_synced_at"],
+            "created_by": row["created_by"],
+            "created_at": row["created_at"],
+        }
+
+    @staticmethod
+    def _draft_dict(row: sqlite3.Row, field: str) -> dict[str, Any]:
+        return {
+            "entity_id": row[field],
+            "data": _loads(row["data_json"]) or {},
+            "version": row["version"],
+            "updated_by": row["updated_by"],
+            "updated_at": row["updated_at"],
+        }
+
+    @staticmethod
+    def _adapter_operation_dict(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "system": row["system"],
+            "operation": row["operation"],
+            "idempotency_key": row["idempotency_key"],
+            "request_sha256": row["request_sha256"],
+            "status": row["status"],
+            "response": _loads(row["response_json"]),
+            "actor": row["actor"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    @staticmethod
+    def _audit(
+        connection: sqlite3.Connection,
+        entity_type: str,
+        entity_id: str,
+        action: str,
+        actor: str,
+        before: Mapping[str, Any] | None,
+        after: Mapping[str, Any] | None,
+        at: str,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO audit_events (
+                entity_type, entity_id, action, actor, at, before_json, after_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (entity_type, entity_id, action, actor, at, _json(before), _json(after)),
+        )
+
+
+class _Transaction:
+    def __init__(self, connection: sqlite3.Connection):
+        self.connection = connection
+
+    def __enter__(self) -> sqlite3.Connection:
+        self.connection.execute("BEGIN IMMEDIATE")
+        return self.connection
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        try:
+            if exc_type is None:
+                self.connection.commit()
+            else:
+                self.connection.rollback()
+        finally:
+            self.connection.close()
+
+
+def _json(value: Any) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _loads(value: str | None) -> Any:
+    return json.loads(value) if value else None
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _draft_table(kind: str) -> tuple[str, str]:
+    if kind == "test_plan":
+        return "test_plan_drafts", "run_id"
+    if kind == "defect":
+        return "defect_drafts", "finding_id"
+    raise ReportHubError("unsupported draft kind")
+
+
+_SCHEMA = """
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE runs (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL CHECK (source IN ('benchmark', 'perf')),
+    folder TEXT NOT NULL,
+    report_date TEXT,
+    catalog_updated_at TEXT,
+    signature TEXT,
+    summary_json TEXT NOT NULL DEFAULT '{}',
+    lifecycle TEXT NOT NULL CHECK (lifecycle IN ('active', 'trashed', 'purge_scheduled', 'purged')),
+    trashed_at TEXT,
+    purge_after TEXT,
+    purge_reason TEXT,
+    version INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (source, folder)
+);
+
+CREATE TABLE findings (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    model TEXT NOT NULL,
+    workload TEXT NOT NULL,
+    metric_contract TEXT NOT NULL,
+    family TEXT NOT NULL,
+    title TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    UNIQUE (source, model, workload, metric_contract)
+);
+
+CREATE TABLE observations (
+    run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE RESTRICT,
+    finding_id TEXT NOT NULL REFERENCES findings(id) ON DELETE RESTRICT,
+    operation TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('passed', 'failed', 'error', 'other')),
+    metric_name TEXT NOT NULL,
+    metric_value REAL,
+    details_json TEXT NOT NULL DEFAULT '{}',
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (run_id, finding_id)
+);
+
+CREATE TABLE triage (
+    finding_id TEXT PRIMARY KEY REFERENCES findings(id) ON DELETE RESTRICT,
+    status TEXT NOT NULL CHECK (status IN ('new', 'investigating', 'linked', 'monitoring', 'resolved', 'accepted_risk')),
+    severity TEXT NOT NULL CHECK (severity IN ('unassessed', 'blocker', 'high', 'medium', 'low')),
+    owner TEXT NOT NULL,
+    note TEXT NOT NULL,
+    tags_json TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    updated_by TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE external_links (
+    id TEXT PRIMARY KEY,
+    finding_id TEXT REFERENCES findings(id) ON DELETE RESTRICT,
+    run_id TEXT REFERENCES runs(id) ON DELETE RESTRICT,
+    system TEXT NOT NULL CHECK (system IN ('github', 'devtest', 'nvbug')),
+    record_type TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    sync_status TEXT NOT NULL,
+    snapshot_json TEXT,
+    last_synced_at TEXT,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK ((finding_id IS NOT NULL) != (run_id IS NOT NULL)),
+    UNIQUE (system, record_type, external_id, finding_id, run_id)
+);
+
+CREATE TABLE test_plan_drafts (
+    run_id TEXT PRIMARY KEY REFERENCES runs(id) ON DELETE RESTRICT,
+    data_json TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    updated_by TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE defect_drafts (
+    finding_id TEXT PRIMARY KEY REFERENCES findings(id) ON DELETE RESTRICT,
+    data_json TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    updated_by TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE audit_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    at TEXT NOT NULL,
+    before_json TEXT,
+    after_json TEXT
+);
+
+CREATE TABLE adapter_operations (
+    id TEXT PRIMARY KEY,
+    system TEXT NOT NULL CHECK (system IN ('github', 'devtest', 'nvbug')),
+    operation TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_sha256 TEXT NOT NULL,
+    request_json TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('prepared', 'publishing', 'succeeded', 'failed')),
+    response_json TEXT,
+    actor TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (system, idempotency_key)
+);
+
+CREATE INDEX observations_finding_idx ON observations(finding_id, observed_at DESC);
+CREATE INDEX runs_lifecycle_idx ON runs(lifecycle, source, report_date DESC);
+CREATE INDEX audit_entity_idx ON audit_events(entity_type, entity_id, sequence DESC);
+"""


### PR DESCRIPTION
## Background

Accuracy and performance reports are currently useful as immutable evidence but do not provide a durable QA workflow across repeated runs. QA needs to preserve human triage, prepare developer communication, and safely remove obsolete runs from active views without making DevTest or NVBug a prerequisite.

## Exit Criteria

- Index supported accuracy and performance report schemas while preserving links to original evidence.
- Track findings, triage, tags, plan drafts, defect drafts, external links, and audit history across runs.
- Provide recoverable Trash semantics with typed confirmation, retention, optimistic locking, and admin-only purge scheduling.
- Keep DevTest, NVBug, and GitHub mutations disabled until approved adapters are deployed.

## Implementation

- Adds a dependency-free Python service with a versioned REST API, SQLite persistence, trusted-proxy identity, role checks, mutation tokens, security headers, and bounded evidence fetches.
- Normalizes validation, performance-matrix, and benchmark collection schemas into stable findings keyed by source, model, workload, and metric contract.
- Adds the NVIDIA gray-primary UI with QA Findings, Test Plan, Defect Handoff, and Trash workspaces.
- Adds local test-plan and defect drafts, repository-scoped GitHub link validation, fail-closed external adapter contracts, and persistent idempotency reservations for future publishing.
- Adds a non-root container image and deployment guidance. Original report bytes remain immutable; this release cannot physically delete storage evidence.

## Validation

- `python3 -m pytest -q tests/tools/test_report_hub.py tests/tools/test_public_source_hygiene.py`: passed, 16 tests.
- `python3 -m ruff check tools/report_hub tests/tools/test_report_hub.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `node --check tools/report_hub/static/app.js`: passed.
- `docker build -f tools/report_hub/Dockerfile -t trtmc-report-hub:smoke .`: passed; the built container health endpoint returned success.
- Playwright browser smoke through QA Findings, Test Plan, Defect Handoff, Trash, and Restore: passed with no console errors.

## Notes For Future Readers

- Review `domain.py`, `storage.py`, and `integrations.py` first for ownership and lifecycle rules, then `app.py`, and finally the static UI.
- SQLite schema v1 assumes one application writer. Back up through SQLite's online backup mechanism before upgrades.
- A future physical purge worker must add storage-target checksum, hold, baseline, and absence verification before it can turn a scheduled purge into a tombstone.
- Enabling an external adapter must remain an explicit deployment change with preview, approval, persistent idempotency, publish, and read-back stages.
