### PR TITLE
fix(qwen-moe): reserve clean nightly GPU

### DIFF
--- a/tests/e2e/models/qwen_moe/manifests/qwen3-moe-30b-a3b.json
+++ b/tests/e2e/models/qwen_moe/manifests/qwen3-moe-30b-a3b.json
@@ -5,6 +5,8 @@
   "family": "qwen_moe",
   "runtime_strategy": "qwen_moe_decoder_moe",
   "task_strategy": "text_generation_causal",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "e2e_min_free_gpu_memory_mib": 122880,
   "precision": "fp16",
   "max_cache_length": 128,
   "trust_remote_code": false,

--- a/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
+++ b/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
@@ -5,9 +5,18 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def test_qwen3_moe_30b_requires_clean_gpu_capacity() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "qwen3-moe-30b-a3b.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+    assert manifest["e2e_min_free_gpu_memory_mib"] == 122880
 
 
 def test_tiny_random_qwen3_moe_does_not_infer_an_hf_contract() -> None:

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -823,6 +823,14 @@ def test_qwen3_omni_selection_requires_clean_gpu_capacity(tmp_path: Path) -> Non
     assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {280000}
 
 
+def test_qwen_moe_selection_requires_clean_gpu_capacity(tmp_path: Path) -> None:
+    selection = _run_test_selection(tmp_path, "qwen_moe", "nightly")
+
+    assert selection["resource_class"] == "exclusive_gpu"
+    assert selection["min_free_gpu_memory_mib"] == 122880
+    assert {case["min_free_gpu_memory_mib"] for case in selection["e2e_cases"]} == {122880}
+
+
 def test_minimax_h3_selection_requires_native_runtime_capacity(tmp_path: Path) -> None:
     selection = _run_test_selection(tmp_path, "minimax_h3", "premerge")
 


### PR DESCRIPTION
## Summary

Reserve an exclusive GPU with 120 GiB of free-memory headroom for the Qwen3-30B-A3B Nightly proof.

This is a model-owned resource-contract fix. It does not change TensorRT build behavior or relax any comparison threshold.

## Root cause

Nightly run `31169529135`, job `92839441939`, ran Qwen3-30B-A3B as a shared-GPU job with no free-memory admission gate. The job loaded weights, then the first `trt.Builder(logger)` call returned `nullptr`; engine compilation never started and no bundle was produced.

The exact failing source revision `c3608b73056587e3b8081e1c389aa3760e583020`, pinned runtime image, and Hugging Face snapshot complete successfully when sufficient GPU headroom is available. This rules out a stable model/source failure and, together with the missing resource gate, measured footprint, and Builder failure point, strongly supports GPU contention as the failure class. The original artifact did not preserve a memory snapshot, so it cannot prove the precise internal TensorRT failure mechanism.

The clean shared-GPU proof measured a worst GPU-memory increment of `99,682 MiB`. A 20% margin is `119,618 MiB`; the manifest rounds this up to `122,880 MiB` (120 GiB).

## Fix

- Declare `exclusive_gpu` for Qwen3-30B-A3B.
- Require `122,880 MiB` free GPU memory before starting the isolated proof.
- Lock both values with model-manifest and proof-selection contract tests.

## Validation

- Full source-only model-proof runner: `148 passed`.
- Exact-head Nightly proof on GPU 1 acquired all four slots with `165,167 MiB` free at admission.
- Engine build passed with no recovery and produced a `61,084,713,425`-byte bundle.
- Native runtime, FP32 reference, and comparator all passed; both generated `Jupiter`, with exact match `1.0`.
- Final model-proof status: `passed`, exit code `0`.
- `git diff --check github/main...HEAD`: passed.

The generic allocator candidate-switch/fairness fix is tracked in #842. That PR prevents a capacity-gated exclusive job from waiting on a busy first candidate while another GPU becomes free; this PR owns the Qwen-MoE resource requirement itself.
