### PR TITLE
fix(ci): stabilize nightly model validation

### DIFF
--- a/tests/e2e/models/bark/manifests/bark-small.json
+++ b/tests/e2e/models/bark/manifests/bark-small.json
@@ -43,12 +43,12 @@
       "prompt": "Model Connect generates a clear audio sample for this test.",
       "max_new_tokens": 0,
       "determinism": {
-        "seed": 0
+        "seed": 42
       },
       "tts_probe_id": "probe_01_prompt_round_trip_sentence",
       "tts_probe_readiness": "ready_now",
       "tts_probe_purpose": "Cover Model Connect text prompt transport through generate-audio with a distinct sentence while reusing the existing bark-small bundle.",
-      "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. Golden Bark token checks are intentionally omitted because they are prompt-specific to the base bark-small case."
+      "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. Golden Bark token checks are intentionally omitted because they are prompt-specific to the base bark-small case. Seed 42 is pinned as the HF- and TensorRT-qualified sampling input for the unchanged TTS audio gate."
     },
     {
       "name": "bark-small-tts-probe02",
@@ -62,12 +62,12 @@
       "prompt": "Please pause, then continue speaking clearly.",
       "max_new_tokens": 0,
       "determinism": {
-        "seed": 0
+        "seed": 42
       },
       "tts_probe_id": "probe_02_comma_prompt_round_trip",
       "tts_probe_readiness": "ready_now",
       "tts_probe_purpose": "Cover Model Connect text prompt transport for a comma-bearing Bark TTS sentence while reusing the existing bark-small bundle.",
-      "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with comma punctuation -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. The prompt avoids numbers and abbreviations to keep ASR round-trip normalization stable."
+      "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with comma punctuation -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. Seed 42 is pinned as the HF- and TensorRT-qualified sampling input for the unchanged TTS audio gate."
     }
   ]
 }

--- a/tests/e2e/models/bark/test_bark_hf_reference.py
+++ b/tests/e2e/models/bark/test_bark_hf_reference.py
@@ -28,6 +28,16 @@ def test_bark_small_and_nightly_probes_use_fp32_reference() -> None:
     assert all(case.metadata["reference_precision"] == "fp32" for case in model.testcases)
 
 
+def test_bark_nightly_probes_pin_qualified_sampling_seed() -> None:
+    model = _bark_small_model()
+
+    assert {case.name: case.determinism.get("seed") for case in model.testcases} == {
+        "bark-small": 0,
+        "bark-small-tts-probe01": 42,
+        "bark-small-tts-probe02": 42,
+    }
+
+
 def test_bark_hf_reference_moves_model_and_inputs_to_available_device(
     monkeypatch,
     tmp_path: Path,
@@ -55,5 +65,6 @@ def test_bark_hf_reference_moves_model_and_inputs_to_available_device(
     assert "torch_dtype=torch.float32" in script
     assert "model.to(device)" in script
     assert 'value.to(device) if hasattr(value, "to") else value' in script
+    assert "seed = 42" in script
     assert "random.seed(seed)" in script
     assert "torch.cuda.manual_seed_all(seed)" in script

--- a/tests/e2e/models/magpie_tts/manifests/magpie-tts-357m.json
+++ b/tests/e2e/models/magpie_tts/manifests/magpie-tts-357m.json
@@ -92,7 +92,7 @@
       "ci_tier": "nightly_only",
       "l0_replacement": "magpie-tts-357m",
       "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base magpie-tts-357m case for the same text_to_audio_magpie runtime path.",
-      "prompt": "Say hello, then say goodbye.",
+      "prompt": "Hello, welcome to this audio test.",
       "max_new_tokens": 220,
       "runtime_config": {
         "audio_magpie": {

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
@@ -12,15 +12,15 @@
     "scale_source": "modelopt",
     "calibration_samples": 64
   },
-  "max_cache_length": 405,
+  "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [
     {
       "name": "qwen3-0.6b-fp8",
       "trace_id": "IT-E2E-QWN3-FP8-01",
-      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind the degree for the given field extension Q(sqrt(2), sqrt(3), sqrt(18)) over Q.\nA. 0\nB. 4\nC. 2\nD. 6\nAnswer:",
+      "prompt": "The following are multiple choice questions (with answers) about miscellaneous.\n\nHow many axles does a standard automobile have?\nA. one\nB. two\nC. four\nD. eight\nAnswer: B\n\nWhat place is named in the title of the 1979 live album by rock legends Cheap Trick?\nA. Budapest\nB. Budokan\nC. Bhutan\nD. Britain\nAnswer: B\n\nWho led the 1831 slave insurrection in SouthamptonVirginia?\nA. John Brown\nB. Dred Scott\nC. Nat Turner\nD. Harriet Tubman\nAnswer:",
       "expected_answers": [
-        "B"
+        "C"
       ],
       "task_eval": {
         "reference_backend": "hf_transformers",
@@ -33,7 +33,7 @@
         "enable_thinking": false
       },
       "max_new_tokens": 1,
-      "notes": "The canonical E2E prompt is QA MMLU sample 0, which distinguishes the supported FP16-based FP8 contract from the inaccurate BF16-based route without adding another engine build."
+      "notes": "The canonical E2E prompt is a fixed two-shot MMLU miscellaneous sample from the pinned cais/mmlu test split. It distinguishes the supported FP16-based FP8 contract from the inaccurate BF16-based route while preserving the existing logit and token agreement gates."
     }
   ]
 }

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -80,12 +80,12 @@ def test_fp8_and_topp_use_deterministic_mmlu_validation_contract() -> None:
     assert fp8["precision"] == "fp16"
     assert fp8["bundle"] == "qwen3-0.6b-fp8-fp16base.bundle"
     assert fp8["task_eval"]["reference_precision"] == "fp16"
-    assert fp8["max_cache_length"] == 405
+    assert fp8["max_cache_length"] == 256
     assert fp8_e2e.inputs["prompt"].startswith(
         "The following are multiple choice questions (with answers) "
-        "about abstract algebra."
+        "about miscellaneous."
     )
-    assert fp8_e2e.metadata["expected_answers"] == ["B"]
+    assert fp8_e2e.metadata["expected_answers"] == ["C"]
     assert fp8_e2e.inputs["max_new_tokens"] == 1
     assert fp8_e2e.metadata["contract_config"] == {
         "use_chat_template": False,

--- a/tests/tools/test_count_diffusion_frame_pairs.py
+++ b/tests/tools/test_count_diffusion_frame_pairs.py
@@ -71,6 +71,87 @@ def test_counts_frames_plus_ref_frames(tmp_path) -> None:
     assert pairs[0]["hf_image"].endswith("ref_frames/frame_0000.png")
 
 
+@pytest.mark.parametrize("duplicate_registration", [False, True])
+def test_registered_nested_frame_directories_are_preferred(
+    tmp_path, duplicate_registration
+) -> None:
+    model_dir = tmp_path / "artifacts" / "minimax-h3-768p"
+    _write_result(model_dir, case_name="minimax-h3-768p")
+    result_path = model_dir / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    trt_ref = "trt_native/frames"
+    hf_ref = "hf_reference/frames"
+    result["artifacts"] = {
+        "trt_frames": [trt_ref, trt_ref] if duplicate_registration else trt_ref,
+        "ref_frames": [hf_ref, hf_ref] if duplicate_registration else hf_ref,
+    }
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+    for dirname, payload in (
+        ("trt_native/frames", b"registered-trt"),
+        ("hf_reference/frames", b"registered-ref"),
+        ("frames", b"legacy-trt"),
+        ("hf_frames", b"legacy-ref"),
+    ):
+        frame_dir = model_dir / dirname
+        frame_dir.mkdir(parents=True)
+        (frame_dir / "frame_0000.png").write_bytes(payload)
+
+    pairs = discover_diffusion_frame_pairs(tmp_path / "artifacts")
+
+    assert len(pairs) == 1
+    assert pairs[0]["trt_image"].endswith(
+        "minimax-h3-768p/trt_native/frames/frame_0000.png"
+    )
+    assert pairs[0]["hf_image"].endswith(
+        "minimax-h3-768p/hf_reference/frames/frame_0000.png"
+    )
+
+
+def test_unsafe_registered_frame_paths_do_not_use_legacy_fallback(tmp_path) -> None:
+    artifacts_dir = tmp_path / "artifacts"
+    model_dir = artifacts_dir / "safe-case"
+    _write_result(model_dir, case_name="safe-case")
+    result_path = model_dir / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    result["artifacts"] = {
+        "trt_frames": "../outside-trt",
+        "ref_frames": "../outside-ref",
+    }
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+    _write_frame_pair(model_dir, "hf_frames")
+    for dirname in ("outside-trt", "outside-ref"):
+        outside = artifacts_dir / dirname
+        outside.mkdir()
+        (outside / "frame_0000.png").write_bytes(b"outside")
+
+    assert discover_diffusion_frame_pairs(artifacts_dir) == []
+    with pytest.raises(ValueError, match=r"missing=\['safe-case'\]"):
+        validate_complete_diffusion_frame_pairs(artifacts_dir)
+
+
+def test_registered_frame_symlink_escape_is_rejected(tmp_path) -> None:
+    artifacts_dir = tmp_path / "artifacts"
+    model_dir = artifacts_dir / "symlink-case"
+    _write_result(model_dir, case_name="symlink-case")
+    result_path = model_dir / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    result["artifacts"] = {
+        "trt_frames": "nested/trt",
+        "ref_frames": "nested/ref",
+    }
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+    outside = artifacts_dir / "outside.png"
+    outside.write_bytes(b"outside")
+    for dirname in ("nested/trt", "nested/ref"):
+        frame_dir = model_dir / dirname
+        frame_dir.mkdir(parents=True)
+        (frame_dir / "frame_0000.png").symlink_to(outside)
+
+    assert discover_diffusion_frame_pairs(artifacts_dir) == []
+    with pytest.raises(ValueError, match=r"missing=\['symlink-case'\]"):
+        validate_complete_diffusion_frame_pairs(artifacts_dir)
+
+
 def test_malformed_result_json_is_ignored(tmp_path) -> None:
     model_dir = tmp_path / "artifacts" / "broken"
     model_dir.mkdir(parents=True)

--- a/tools/count_diffusion_frame_pairs.py
+++ b/tools/count_diffusion_frame_pairs.py
@@ -12,13 +12,59 @@ from pathlib import Path
 from typing import Any
 
 
-def _frames_in(path: Path) -> list[Path]:
-    if not path.is_dir():
+def _safe_path(path: Path, root: Path, *, directory: bool) -> Path | None:
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if directory and not resolved.is_dir():
+        return None
+    if not directory and not resolved.is_file():
+        return None
+    return resolved
+
+
+def _frames_in(path: Path, root: Path) -> list[Path]:
+    safe_dir = _safe_path(path, root, directory=True)
+    if safe_dir is None:
         return []
-    frames = sorted(path.glob("frame_*.png"))
-    if frames:
-        return frames
-    return sorted(path.glob("*.png"))
+    candidates = sorted(safe_dir.glob("frame_*.png"))
+    if not candidates:
+        candidates = sorted(safe_dir.glob("*.png"))
+    return [
+        safe_frame
+        for frame in candidates
+        if (safe_frame := _safe_path(frame, root, directory=False)) is not None
+    ]
+
+
+def _registered_frame_dir(
+    result: dict[str, Any], model_dir: Path, key: str
+) -> tuple[bool, Path | None]:
+    artifacts = result.get("artifacts")
+    if not isinstance(artifacts, dict) or key not in artifacts:
+        return False, None
+    value = artifacts[key]
+    references = [value] if isinstance(value, str) else value
+    if not isinstance(references, list) or not references:
+        return True, None
+
+    directories: list[Path] = []
+    for reference in references:
+        if (
+            not isinstance(reference, str)
+            or not reference
+            or Path(reference).is_absolute()
+        ):
+            return True, None
+        safe_dir = _safe_path(model_dir / reference, model_dir, directory=True)
+        if safe_dir is None:
+            return True, None
+        if safe_dir not in directories:
+            directories.append(safe_dir)
+    return True, directories[0] if len(directories) == 1 else None
 
 
 def _select_frame(frames: list[Path]) -> Path | None:
@@ -86,10 +132,20 @@ def discover_diffusion_frame_pairs(artifacts_dir: Path) -> list[dict[str, Any]]:
             continue
 
         model_dir = result_path.parent
-        trt_frames = _frames_in(model_dir / "frames")
-        hf_frames = _frames_in(model_dir / "hf_frames")
-        if not hf_frames:
-            hf_frames = _frames_in(model_dir / "ref_frames")
+        trt_registered, trt_dir = _registered_frame_dir(
+            result, model_dir, "trt_frames"
+        )
+        trt_frames = _frames_in(trt_dir, model_dir) if trt_dir is not None else []
+        if not trt_registered:
+            trt_frames = _frames_in(model_dir / "frames", model_dir)
+        ref_registered, ref_dir = _registered_frame_dir(
+            result, model_dir, "ref_frames"
+        )
+        hf_frames = _frames_in(ref_dir, model_dir) if ref_dir is not None else []
+        if not ref_registered:
+            hf_frames = _frames_in(model_dir / "hf_frames", model_dir)
+        if not ref_registered and not hf_frames:
+            hf_frames = _frames_in(model_dir / "ref_frames", model_dir)
         if not trt_frames or len(trt_frames) != len(hf_frames):
             continue
         sample_count, expected_frame_count = _vlm_frame_contract(result)


### PR DESCRIPTION
## Background

The first exact-head Nightly after the Qwen FP8 precision fix exposed three validation gaps:

- The long Qwen FP8 MMLU canary was close enough to a decision boundary that valid execution tactics could flip its one-token answer.
- Magpie probe 02 used a sentence whose reference audio produced a timing-sensitive ASR transcript.
- MiniMax produced complete TRT and reference frames under registered nested directories, but the semantic collector only searched legacy directory names.

A later current-main Nightly exposed one inherited packaging gap: Whisper's new
manifest-owned audio input existed in source but was omitted from the installed
benchmark catalog, making the packaged Whisper profile invalid.
Frozen `main` now contains the generalized package fix in `c958c2d8a`, so the
overlapping PR commit was dropped during the final rebase rather than retaining
a second, weaker copy of the same change.

The same run also exposed an invalid deterministic Bark test vector: seed `0`
produced unintelligible audio for the two Nightly-only prompts in the Hugging
Face reference itself, so the probes could not satisfy their unchanged ASR
round-trip contract even with a correct TensorRT implementation.

These failures should be fixed without weakening any accuracy, transcript, or semantic-completeness requirement.

## Exit Criteria

- Qwen FP8 and Magpie probe 02 pass their existing model-owned acceptance gates with stable inputs.
- Every successful diffusion result contributes its declared TRT/reference frames to semantic certification.
- Bark's two Nightly-only prompt probes pass the existing ASR gate with one qualified deterministic seed in both the Hugging Face reference and TensorRT paths.
- The complete all-model Nightly passes on the exact PR head.
- No threshold or pass criterion is relaxed.

## Implementation

- Replace the plan-sensitive Qwen prompt with a fixed two-shot MMLU miscellaneous canary that still distinguishes the supported FP8 route from the known-bad route.
- Replace only Magpie probe 02's prompt with a stable punctuation-bearing sentence; keep its sampling configuration and NED gate unchanged.
- Make diffusion frame discovery honor each result's registered `trt_frames` and `ref_frames` paths, including duplicate registrations emitted as lists. Legacy directories remain supported when no registration exists, while unsafe or ambiguous registrations fail closed.
- Pin only the two Nightly-only Bark prompt probes to qualified seed `42`; keep the base Bark case at seed `0`, and add a Bark-owned contract test that guards the selected seed through the HF reference path.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_count_diffusion_frame_pairs.py tests/e2e/models/qwen/test_qwen_manifest_contract.py -q`: `22 passed`.
- Targeted tests in the pinned CI runtime covering the collector, Qwen FP8 contracts, Magpie contracts, diffusion CI wiring, and benchmark packaging: `47 passed`, with no failures or skips.
- Full isolated Qwen FP8 E2E with the current manifest: `1 passed`; production, debug, and HF all selected `C`, and every existing numerical/text gate passed.
- Full isolated Magpie probe 02 DUT plus reference E2E with the current manifest: `1 passed`; both ASR transcripts matched exactly with NED `0.0`.
- A/B replay against the original MiniMax failure artifact: the old collector reproduced the missing-case error; this change found one complete pair with `124` TRT and `124` reference frames.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_optimized_runtime_packaging.py -q`: `4 passed`; both wheel and source-distribution staging include an independently named audio input.
- Real PEP 517 source-distribution build: the Whisper long-form WAV was included byte-for-byte with its source SHA-256 (`166d138dc95c706e4eedbebb48f4ac4c8cb1b77ea796c0bc650da518308657e2`).
- Exact seed-`0` Bark reproduction: the Hugging Face reference itself failed the unchanged NED `0.15` gate for both probes (`0.763636` and `0.311111`), ruling out a TensorRT precision or runtime regression.
- Seed-`42` Bark qualification: both Hugging Face reference WAVs transcribed exactly, and two independent full E2E runs against the exact PR bundle produced exact transcripts for both TensorRT probes (`NED 0.0` in all cases).
- Bark-owned seed/reference/runner/build contract tests: `8 passed`.
- `python3 -m ruff check conanfile.py _pyproject_backend.py tools/count_diffusion_frame_pairs.py tests/tools/test_count_diffusion_frame_pairs.py tests/e2e/models/qwen/test_qwen_manifest_contract.py tests/tools/test_optimized_runtime_packaging.py`: passed.
- `ruff check tests/e2e/models/bark/test_bark_hf_reference.py`: passed.
- Rebased frozen-main contract suite covering the collector, generalized package asset validation, Qwen, Bark, and Magpie: `54 passed, 1 skipped`.
- Full pre-rebase exact-head Nightly `31229379274` on `5a5b25d10`: `92/92` jobs passed, including all model proofs, package coverage, diffusion semantic assessment, combined report, and verdict.
- `git diff --check github/main...HEAD`: passed.
- Post-rebase exact-head premerge `31235071390` on `2ca0927ec`: `8/8` model jobs, report, verdict, and exact-head status all passed.
- Post-rebase all-model Nightly `31235065911` on `2ca0927ec`: `92/92` jobs and `79/79` model proofs passed, including semantic assessment, combined report, and final verdict.

## Notes For Future Readers

- The Qwen FP8 precision implementation is already on `main`; this PR contains only the Nightly validation follow-up.
- The manifest-owned benchmark audio packaging fix is already on frozen `main` through `c958c2d8a`; it is intentionally absent from this PR's two-commit diff.
- Review the two manifest changes first, then the registered-artifact lookup and its fail-closed tests.
- Registered artifact paths are the source of truth. The legacy lookup exists only for older results that do not declare those paths.
