### PR TITLE
docs: streamline project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 > Build from a supported checkpoint, run through task-oriented C++ APIs, and
 > use the family-owned implementation as a blueprint for your own changes.
 
+## AI-native quick start
+
+Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
+prompt:
+
+```text
+/goal Clone https://github.com/NVIDIA/TensorRT-Model-Connect.git into a new TensorRT-Model-Connect directory in the current workspace. Detect the current GPU compute capability, modify the repository development Docker image, build and start the container, install TensorRT-Model-Connect, compile the CLI, TensorRT backend, and all native model DSOs only for that SM, then build and run an end-to-end Qwen/Qwen3-0.6B smoke test. Do not commit or push changes. Report the result of the test, show exact command, input and output of the inference run.
+```
+
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/) |
 [Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
 [Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
@@ -26,15 +35,6 @@ and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-start
 Developers compiling the native CLI, backends, or model DSOs should use the
 [Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
 guide.
-
-## AI-native quick start
-
-Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
-prompt:
-
-```text
-/goal Clone https://github.com/NVIDIA/TensorRT-Model-Connect.git into a new TensorRT-Model-Connect directory in the current workspace. Detect the current GPU compute capability, modify the repository development Docker image, build and start the container, install TensorRT-Model-Connect, compile the CLI, TensorRT backend, and all native model DSOs only for that SM, then build and run an end-to-end Qwen/Qwen3-0.6B smoke test. Do not commit or push changes. Report the result of the test, show exact command, input and output of the inference run.
-```
 
 ![TensorRT-Model-Connect build and runtime map](website/static/img/diagrams/trtmc-system-map.svg)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 > Build from a supported checkpoint, run through task-oriented C++ APIs, and
 > use the family-owned implementation as a blueprint for your own changes.
 
+[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/) |
+[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
+[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
+[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
+
 Build a deployment bundle from its canonical Hugging Face model ID, then run
 native inference in two commands:
 
@@ -15,7 +20,14 @@ trtmc run qwen3-0.6b.bundle \
   --greedy
 ```
 
-### AI-native quick start
+If `trtmc` is not installed, start with
+[System Requirements](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/environment-and-repro)
+and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/installation).
+Developers compiling the native CLI, backends, or model DSOs should use the
+[Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
+guide.
+
+## AI-native quick start
 
 Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
 prompt:
@@ -24,302 +36,58 @@ prompt:
 /goal Clone https://github.com/NVIDIA/TensorRT-Model-Connect.git into a new TensorRT-Model-Connect directory in the current workspace. Detect the current GPU compute capability, modify the repository development Docker image, build and start the container, install TensorRT-Model-Connect, compile the CLI, TensorRT backend, and all native model DSOs only for that SM, then build and run an end-to-end Qwen/Qwen3-0.6B smoke test. Do not commit or push changes. Report the result of the test, show exact command, input and output of the inference run.
 ```
 
-Set up the development environment first if `trtmc` is not installed; see
-[Installation and setup](#installation-and-setup).
-
 ![TensorRT-Model-Connect build and runtime map](website/static/img/diagrams/trtmc-system-map.svg)
 
-[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/) |
-[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
-[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
-[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
+## Why TensorRT-Model-Connect?
+
+- Start from a supported Hugging Face or local checkpoint and build TensorRT
+  engines without an intermediate ONNX export step.
+- Hand a versioned `.bundle` artifact from the Python-first build environment
+  to native C++ task APIs such as text generation, transcription, image and
+  video generation, segmentation, embedding, and forecasting.
+- Use model-family-owned builders, runtime pipelines, helper kernels, and
+  validation contracts as concrete blueprints for modification and
+  customization.
+- Keep native TensorRT execution and exactly qualified optimized-runtime
+  dispatch behind the same task-oriented application boundary.
+
+Read the [Project Overview](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/project-overview)
+for the architecture boundary, intended users, and comparison with other
+TensorRT integration paths.
 
 TensorRT-Model-Connect is a reference implementation. Users are responsible
 for trusting the checkpoints, bundles, native libraries, and local environment
 they provide when building or running models.
 
-## What is TensorRT-Model-Connect?
+## Explore the documentation
 
-TensorRT-Model-Connect (TRTMC) provides a common framework and a growing set of
-family-owned reference implementations for running different model families
-on TensorRT. Each implementation shows how to turn a supported Hugging Face or
-local checkpoint into a `.bundle` bundle and invoke it through task-oriented C++
-APIs. The implementations are intended both for straightforward deployment
-and as blueprints that developers can inspect, modify, extend, and customize.
-
-Python owns checkpoint resolution and TensorRT engine construction at build
-time. Native profiles execute model inference in C++ without PyTorch. A small
-number of hybrid profiles explicitly invoke a helper Python executable; their
-E2E manifests declare that runtime dependency.
-
-The `.bundle` bundle is the handoff between those environments. Native bundles
-resolve their matching model and TensorRT backend DSOs at runtime; exactly
-qualified optimized-runtime bundles can carry their implementation DSO. Both
-forms still require a compatible NVIDIA driver, CUDA/TensorRT cohort, dynamic
-loader, and system libraries.
-
-There is no intermediate ONNX export step. Applications load a bundle and call
-task APIs such as `generate()`, `transcribe()`, `generate_image()`,
-`embed()`, or `solve()` instead of maintaining conversion stages and
-model-specific application glue.
-
-## How does it fit into the TensorRT ecosystem?
-
-Choose the import path that matches the model boundary you already own. Each
-path targets TensorRT execution, but the development and deployment interfaces
-are different.
-
-| Starting point | Interface | When to use it |
-| --- | --- | --- |
-| Hugging Face or local checkpoint | **TensorRT-Model-Connect** | Start from a model-family reference implementation, build a `.bundle` bundle for native C++ task inference, and customize the implementation as needed. |
-| PyTorch model | **Torch-TensorRT** | Keep the model in the PyTorch ecosystem while compiling its execution with TensorRT. |
-| Portable framework interchange | **ONNX** | Use an exchange format when portability across originating frameworks is the primary requirement. |
-
-## Who is this for?
-
-TRTMC is designed for teams that:
-
-- want a working TensorRT reference implementation for a supported model
-  instead of starting its builder and runtime integration from scratch;
-- need inference in a C++ service, embedded application, robotics stack, or
-  edge system and want a concrete deployment blueprint to adapt;
-- want to study or customize model-specific builders, native runtime pipelines,
-  helper kernels, and integration boundaries;
-- want one versioned bundle boundary between a Python-first build environment
-  and a native application; or
-- need a common task API across text, vision, audio, diffusion, segmentation,
-  time-series, and other model families.
-
-TRTMC may not be the right boundary when inference already lives entirely in a
-Python/PyTorch deployment, or when ONNX is a required interchange artifact.
-
-## What problems does it solve?
-
-A conventional model-to-deployment path can accumulate several conversion and
-integration boundaries:
-
-```text
-PyTorch → ONNX or TorchScript → TensorRT → model-specific C++ integration
-```
-
-TRTMC reduces that path to:
-
-```text
-Hugging Face checkpoint → .bundle artifact → native C++ task API
-```
-
-| Traditional pain point | TRTMC boundary |
+| Goal | Start here |
 | --- | --- |
-| ONNX export failures and unsupported conversion gaps | Family-owned builders compile supported checkpoints directly with TensorRT APIs. |
-| Repeated model-specific application integration | Applications load a bundle and use a task-oriented runtime API. |
-| Validation across several conversion artifacts | Build, runtime, and E2E manifests identify one bundle contract and its evidence. |
-| Python framework dependencies in native inference paths | Native profiles execute model inference in C++; manifests explicitly flag hybrid profiles that require helper Python. |
-| Opaque deployment artifacts | `trtmc inspect` exposes bundle kind, model family, precision, runtime identity, and engines. |
-
-## Broad model coverage
-
-The current repository snapshot declares 78 Python family plugins, 79
-unique native runtime strategy keys, and 205 E2E model manifests. These are
-discovery counts, not a claim that every model is qualified on every platform.
-See [Model Support](website/docs/models-recipes/overview.md) for evidence
-levels and the generated inventory.
-
-The build-and-run design spans decoder and hybrid language models,
-encoder/embedding/reranking models, translation, vision-language and OCR,
-speech recognition and synthesis, diffusion image and video generation,
-segmentation, time-series forecasting, and neural operators.
-
-Each model-family reference implementation keeps its knowledge in family-owned
-builder, runtime, and E2E descriptors. These implementations serve as concrete
-blueprints for modification and customization rather than hiding model behavior
-behind a single generic integration. The repository also includes agent
-instructions and model-local validation contracts so contributors can extend
-one family without editing a hand-written global registry.
-
-## Installation and setup
-
-The development container supplies TensorRT, CUDA, Python, CMake, Ninja, and
-the declared Python execution profiles. Start with the repository already
-cloned and a terminal open at the checkout root. The host must have a
-working NVIDIA driver, Docker Engine with NVIDIA Container Toolkit support,
-network access, and enough disk space to build the image and model bundle. No
-other host directory is assumed.
-
-Build the development image for one target SM. `TORCH_CUDA_ARCH_LIST` uses the
-dotted compute-capability form; for example, build for SM103 with:
-
-```bash
-docker build \
-  --build-arg TRTMC_TORCH_CUDA_ARCH_LIST=10.3 \
-  --tag trtmc-dev-sm103 .
-```
-
-For SM110, use:
-
-```bash
-docker build \
-  --build-arg TRTMC_TORCH_CUDA_ARCH_LIST=11.0 \
-  --tag trtmc-dev-sm110 .
-```
-
-When a prebuilt development image is published, replace the corresponding
-local `docker build` with `docker pull`. Select the tag matching the target SM,
-then start the source-mounted container. This example continues with SM103.
-
-The host source path is resolved from Git, and `/src` is a container-local
-mount point created by Docker; neither path needs to be known in advance.
-
-```bash
-TRTMC_SM=103
-TRTMC_IMAGE="trtmc-dev-sm${TRTMC_SM}"
-TRTMC_SOURCE_DIR="$(git rev-parse --show-toplevel)"
-
-docker run --rm -it \
-  --gpus all \
-  --ipc=host \
-  --mount "type=bind,source=$TRTMC_SOURCE_DIR,target=/src" \
-  --workdir /src \
-  "$TRTMC_IMAGE" bash
-```
-
-### Native build configurations
-
-Inside the container, use the same SM number selected for the image. Install
-the editable Python builder once, then choose one native build configuration
-below. Change `TRTMC_SM=103` to `TRTMC_SM=110` when targeting SM110.
-
-```bash
-TRTMC_SM=103
-python -m pip install --no-deps -e . -C py-only=true
-```
-
-#### Default: standard TensorRT backend and all model DSOs
-
-**Use case:** first-time setup and general development across the supported
-model inventory. This is the recommended configuration for the Qwen smoke test
-below.
-
-```bash
-TRTMC_BUILD_DIR="build-sm${TRTMC_SM}"
-
-cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
-  -DTRTMC_BUILD_BACKEND_TRT=ON \
-  -DTRTMC_BUILD_BACKEND_RTX=OFF \
-  -DTRTMC_BUILD_TESTS=OFF \
-  -DTRTMC_BUILD_BENCHMARKS=OFF
-cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
-  trtmc \
-  trtmc_backend_trt \
-  trtmc_model_plugins
-
-export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
-"$TRTMC_BUILD_DIR/trtmc" version
-```
-
-The aggregate `trtmc_model_plugins` target builds every manifest-declared model
-DSO, but their CUDA code contains only the selected SM.
-
-#### Focused: one model DSO
-
-**Use case:** iterating on one runtime family when rebuilding every model DSO
-would add unnecessary compile time. The target name uses the runtime owner ID,
-not the Hugging Face repository ID or an internal test profile. For example,
-Qwen models use the `qwen` owner:
-
-```bash
-TRTMC_MODEL=qwen
-TRTMC_BUILD_DIR="build-sm${TRTMC_SM}-${TRTMC_MODEL}"
-
-cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
-  -DTRTMC_BUILD_BACKEND_TRT=ON \
-  -DTRTMC_BUILD_BACKEND_RTX=OFF \
-  -DTRTMC_BUILD_TESTS=OFF \
-  -DTRTMC_BUILD_BENCHMARKS=OFF
-cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
-  trtmc \
-  trtmc_backend_trt \
-  "trtmc_model_${TRTMC_MODEL}"
-
-export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
-"$TRTMC_BUILD_DIR/trtmc" version
-```
-
-Runtime owner IDs are the directory names under `src/runtime/models/`; each
-directory's `MODEL.toml` declares its output DSO and runtime strategies.
-
-#### Optional: TensorRT-RTX backend
-
-**Use case:** building and running native bundles explicitly created with
-`trtmc build --rtx`. Do not use this configuration for a standard TensorRT
-bundle.
-
-The generic development image includes the standard TensorRT SDK, not the
-optional TensorRT-RTX SDK. Before configuring this variant, install the
-matching `tensorrt_rtx` Python package, headers, and `libtensorrt_rtx.so` in
-the development environment. Set the two SDK directories explicitly; no
-installation path is assumed:
-
-```bash
-: "${TRTMC_RTX_INCLUDE_DIR:?Set this to the TensorRT-RTX include directory}"
-: "${TRTMC_RTX_LIBRARY_DIR:?Set this to the directory containing libtensorrt_rtx.so}"
-python -c "import tensorrt_rtx"
-
-TRTMC_BUILD_DIR="build-sm${TRTMC_SM}-rtx"
-cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
-  -DTRTMC_BUILD_BACKEND_TRT=OFF \
-  -DTRTMC_BUILD_BACKEND_RTX=ON \
-  -DTRTMC_RTX_INCLUDE_DIR="$TRTMC_RTX_INCLUDE_DIR" \
-  -DTRTMC_RTX_LIBRARY_DIR="$TRTMC_RTX_LIBRARY_DIR" \
-  -DTRTMC_BUILD_TESTS=OFF \
-  -DTRTMC_BUILD_BENCHMARKS=OFF
-cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
-  trtmc \
-  trtmc_backend_rtx \
-  trtmc_model_plugins
-```
-
-This emits `libtrtmc_backend_trt_rtx.so`. The Python package is also required
-when creating the matching bundle:
-
-```bash
-export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
-"$TRTMC_BUILD_DIR/trtmc" build Qwen/Qwen3-0.6B \
-  --rtx \
-  --output qwen3-0.6b-rtx.bundle
-```
-
-### Qwen smoke test
-
-After the recommended default build, run the basic end-to-end smoke test:
-
-```bash
-TRTMC_BUILD_DIR="build-sm${TRTMC_SM}"
-export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
-
-"$TRTMC_BUILD_DIR/trtmc" build Qwen/Qwen3-0.6B --output qwen3-0.6b.bundle
-"$TRTMC_BUILD_DIR/trtmc" run qwen3-0.6b.bundle \
-  --prompt "What is the capital of France? Answer in one word." \
-  --max-new-tokens 10 \
-  --greedy
-```
-
-The first command downloads the checkpoint and builds its platform-specific
-TensorRT engines. The smoke test succeeds when the second command completes
-and generates `Paris`. See
-[Getting Started](website/docs/getting-started/overview.md) for additional
-prerequisites and troubleshooting.
+| Complete the first Qwen inference | [Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
+| Select and install an environment | [Get Started](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/overview) |
+| Compile the CLI, backends, and model DSOs | [Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build) |
+| Find an exact checkpoint or model recipe | [Models & Recipes](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
+| Look up task and feature workflows | [User Guides](https://nvidia.github.io/TensorRT-Model-Connect/user-guides/overview) |
+| Learn through progressive labs and self-checks | [Tutorials](https://nvidia.github.io/TensorRT-Model-Connect/learning-path) |
+| Look up CLI, Python, C++, bundle, and config contracts | [Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview) |
+| Understand architecture or extend the repository | [Developer Guide](https://nvidia.github.io/TensorRT-Model-Connect/developer-guide/overview) |
+| Review compatibility, limitations, and lifecycle policy | [Release & Support](https://nvidia.github.io/TensorRT-Model-Connect/release-support/overview) |
+| Give a coding agent repository-specific guidance | [AI & Agent Guide](https://nvidia.github.io/TensorRT-Model-Connect/agent-guide) |
 
 ## Supported models
 
-See the [Supported Models documentation](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview/)
-for the complete checkpoint matrix, including Hugging Face architecture,
-TRTMC profile, precision, quantization, optimized-runtime dispatch, and the
-dated GB300 performance snapshot.
+The [Supported Models](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)
+page is the single source of truth for exact checkpoints, Hugging Face
+architectures, TRTMC profiles, precision, quantization, optimized-runtime
+dispatch, configuration, and qualification evidence.
+
+## Contributing and support
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing source or model
+  integration changes.
+- Report reproducible defects through
+  [GitHub Issues](https://github.com/NVIDIA/TensorRT-Model-Connect/issues).
+- Report security concerns according to [SECURITY.md](SECURITY.md).
+- TensorRT-Model-Connect is licensed under the terms in [LICENSE](LICENSE).
 
 <!-- Collaborative review anchor. -->

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -8,6 +8,11 @@ TensorRT-Model-Connect has three install paths:
 2. Build the wheel from source, then install it.
 3. Advanced Python-only editable install for developers.
 
+Developers who need the native CLI, backend DSOs, or model runtime DSOs should
+follow [Build from Source](source-build.md). That guide covers model-agnostic
+development images, target-SM selection, standard and TensorRT-RTX backends,
+and both aggregate and focused model-DSO builds.
+
 ## Requirements
 
 - Linux x86_64 or aarch64 with a compatible NVIDIA GPU for the selected build
@@ -148,19 +153,10 @@ to avoid dependency resolution:
 pip install --no-deps -e . -C py-only=true
 ```
 
-This editable install points Python at `python/tensorrt_model_connect/`. Use it
-with a separate source build when you need the native CLI:
-
-```bash
-cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
-  -DTRTMC_TRT_INCLUDE_DIR="${TRT_INC_DIR:-/usr/include/aarch64-linux-gnu}" \
-  -DTRTMC_TRT_LIBRARY="${TRT_LIB_DIR:-/usr/lib/aarch64-linux-gnu}/libnvinfer.so" \
-  -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include \
-  -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so
-cmake --build build -j
-
-./build/trtmc version
-```
+This editable install points Python at `python/tensorrt_model_connect/`. Pair it
+with [Build from Source](source-build.md) when you need the native CLI,
+backend, and model DSOs. That page keeps the target-SM and build-configuration
+commands in one canonical location.
 
 CI and release validation use the wheel path, not the Python-only editable
 install.

--- a/website/docs/getting-started/overview.md
+++ b/website/docs/getting-started/overview.md
@@ -21,10 +21,12 @@ internal architecture page.
 
 | Step | Page | You are done when |
 | --- | --- | --- |
-| 1 | [System Requirements](environment-and-repro.md) | You have selected a supported wheel or source-build path, the GPU is visible, and you understand the first model's resource boundary. |
-| 2 | [Installation](installation.md) | Either `trtmc version` or `./build/trtmc version` succeeds in the environment where you will build and run the model. |
-| 3 | [Quick Start](quick-start.md) | You have built and inspected `Qwen3-0.6B.bundle`, then received generated text from the native C++ runtime. |
-| 4 | [Learning Path](../learning-path.md) | You can choose the next tutorial without repeating the setup or first build. |
+| 1 | [Project Overview](project-overview.md) | You understand the checkpoint-to-bundle boundary and whether TRTMC is the right integration path. |
+| 2 | [System Requirements](environment-and-repro.md) | You have selected a supported wheel or source-build path, the GPU is visible, and you understand the first model's resource boundary. |
+| 3 | [Installation](installation.md) | Either `trtmc version` or the source-built CLI version command succeeds in the environment where you will build and run the model. |
+| 4 | [Build from Source](source-build.md) | Optional: you have compiled the CLI, selected backend, and required model DSOs for one target SM. |
+| 5 | [Quick Start](quick-start.md) | You have built and inspected `Qwen3-0.6B.bundle`, then received generated text from the native C++ runtime. |
+| 6 | [Learning Path](../learning-path.md) | You can choose the next tutorial without repeating the setup or first build. |
 
 Keep the [Glossary](glossary.md) open when a term is unfamiliar. You do not
 need to memorize it before starting.

--- a/website/docs/getting-started/project-overview.md
+++ b/website/docs/getting-started/project-overview.md
@@ -1,0 +1,117 @@
+---
+title: Project Overview
+description: What TensorRT-Model-Connect provides, who it serves, and where it fits in the TensorRT ecosystem.
+---
+
+TensorRT-Model-Connect (TRTMC) provides a common framework and a growing set of
+family-owned reference implementations for running diverse model families on
+TensorRT. Each implementation shows how to turn a supported Hugging Face or
+local checkpoint into a `.bundle` artifact and invoke it through task-oriented
+C++ APIs.
+
+The implementations support straightforward deployment, but they are also
+intended as blueprints that developers can inspect, modify, extend, and
+customize. Model behavior remains visible in family-owned builders, native
+runtime pipelines, helper kernels, configuration schemas, and validation
+contracts instead of being hidden behind a single generic integration.
+
+## The build and runtime boundary
+
+Python owns checkpoint resolution and TensorRT engine construction at build
+time. Native profiles execute model inference in C++ without PyTorch. A small
+number of hybrid profiles explicitly invoke a helper Python executable; their
+E2E manifests declare that runtime dependency.
+
+The `.bundle` artifact is the handoff between those environments:
+
+```text
+Hugging Face or local checkpoint
+  -> Python family resolution and TensorRT build
+  -> .bundle artifact
+  -> native C++ task API
+```
+
+Native bundles resolve their matching model and TensorRT backend DSOs at
+runtime. Exactly qualified optimized-runtime bundles can carry their own
+implementation DSO. Both forms still require a compatible NVIDIA driver,
+CUDA/TensorRT cohort, dynamic loader, and system libraries.
+
+There is no intermediate ONNX export step. Applications load a bundle and call
+task APIs such as `generate()`, `transcribe()`, `generate_image()`, `embed()`,
+or `solve()` instead of maintaining conversion stages and model-specific
+application glue.
+
+## Where it fits in the TensorRT ecosystem
+
+Choose the import path that matches the model boundary you already own. Each
+path targets TensorRT execution, but the development and deployment interfaces
+are different.
+
+| Starting point | Interface | When to use it |
+| --- | --- | --- |
+| Hugging Face or local checkpoint | **TensorRT-Model-Connect** | Start from a model-family reference implementation, build a `.bundle` for native C++ task inference, and customize the implementation as needed. |
+| PyTorch model | **Torch-TensorRT** | Keep the model in the PyTorch ecosystem while compiling its execution with TensorRT. |
+| Portable framework interchange | **ONNX** | Use an exchange format when portability across originating frameworks is the primary requirement. |
+
+TRTMC may not be the right boundary when inference already lives entirely in a
+Python/PyTorch deployment, or when ONNX is a required interchange artifact.
+
+## Who it is for
+
+TRTMC is designed for teams that:
+
+- want a working TensorRT reference implementation for a supported model
+  instead of starting its builder and runtime integration from scratch;
+- need inference in a C++ service, embedded application, robotics stack, or
+  edge system and want a concrete deployment blueprint to adapt;
+- want to study or customize model-specific builders, native runtime pipelines,
+  helper kernels, and integration boundaries;
+- want one versioned bundle boundary between a Python-first build environment
+  and a native application; or
+- need a common task API across text, vision, audio, diffusion, segmentation,
+  time-series, and other model families.
+
+## What it simplifies
+
+A conventional model-to-deployment path can accumulate several conversion and
+integration boundaries:
+
+```text
+PyTorch -> ONNX or TorchScript -> TensorRT -> model-specific C++ integration
+```
+
+TRTMC reduces that path to a family-owned build and a task-oriented runtime:
+
+| Traditional pain point | TRTMC boundary |
+| --- | --- |
+| ONNX export failures and unsupported conversion gaps | Family-owned builders compile supported checkpoints directly with TensorRT APIs. |
+| Repeated model-specific application integration | Applications load a bundle and use a task-oriented runtime API. |
+| Validation across several conversion artifacts | Build, runtime, and E2E manifests identify one bundle contract and its evidence. |
+| Python framework dependencies in native inference paths | Native profiles execute model inference in C++; manifests explicitly flag hybrid profiles that require helper Python. |
+| Opaque deployment artifacts | `trtmc inspect` exposes bundle kind, model family, precision, runtime identity, and engines. |
+
+## Model coverage and ownership
+
+The build-and-run design spans decoder and hybrid language models,
+encoder/embedding/reranking models, translation, vision-language and OCR,
+speech recognition and synthesis, diffusion image and video generation,
+segmentation, time-series forecasting, and neural operators.
+
+Each model-family implementation keeps its knowledge in family-owned builder,
+runtime, and E2E descriptors. The repository also includes agent instructions
+and model-local validation contracts so contributors can extend one family
+without editing a hand-written global registry.
+
+Declared inventory is not proof that every model passed on every platform. Use
+[Supported Models](../models-recipes/overview.md) for exact checkpoint IDs,
+architectures, configurations, and evidence levels.
+
+## Trust boundary
+
+TensorRT-Model-Connect is a reference implementation. Users are responsible
+for trusting the checkpoints, bundles, native libraries, and local environment
+they provide when building or running models. Continue with
+[System Requirements](environment-and-repro.md) before selecting an
+installation path.
+
+{/* Collaborative review anchor. */}

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -1,0 +1,202 @@
+---
+title: Build from Source
+description: Build the development image, CLI, TensorRT backend, and native model runtime DSOs for one target SM.
+---
+
+Use this path when you are developing the native CLI, a backend, or one or more
+model runtime DSOs. If you only need an installable release artifact, use the
+wheel paths in [Installation](installation.md) instead.
+
+Start with the repository already cloned and a terminal open at its root. The
+host needs a working NVIDIA driver, Docker Engine with NVIDIA Container Toolkit
+support, network access, and enough disk space to build the image and model
+bundles. No other host path is assumed.
+
+## 1. Select one target SM
+
+The development image is model-agnostic: it supplies TensorRT, CUDA, Python,
+CMake, Ninja, and the declared Python execution profiles. Select the compute
+capability needed by the target system rather than a model family.
+
+`TRTMC_TORCH_SM` uses the dotted compute-capability form required by
+`TORCH_CUDA_ARCH_LIST`. `TRTMC_SM` uses the integer form required by CMake. For
+example, build an image for SM103 with:
+
+```bash
+TRTMC_SM=103
+TRTMC_TORCH_SM=10.3
+TRTMC_IMAGE="trtmc-dev-sm${TRTMC_SM}"
+
+docker build \
+  --build-arg TRTMC_TORCH_CUDA_ARCH_LIST="$TRTMC_TORCH_SM" \
+  --tag "$TRTMC_IMAGE" .
+```
+
+For SM110, use the corresponding pair:
+
+```bash
+TRTMC_SM=110
+TRTMC_TORCH_SM=11.0
+TRTMC_IMAGE="trtmc-dev-sm${TRTMC_SM}"
+
+docker build \
+  --build-arg TRTMC_TORCH_CUDA_ARCH_LIST="$TRTMC_TORCH_SM" \
+  --tag "$TRTMC_IMAGE" .
+```
+
+The Docker build argument sets the architecture list used when Python CUDA
+extensions are compiled in the image or later in the container. The CMake
+configuration controls native CUDA code in TRTMC DSOs. Keep the two values
+aligned to the same compute capability.
+
+When a matching prebuilt development image is published, `docker pull` can
+replace `docker build`. The remaining source-mount and CMake steps are the
+same.
+
+## 2. Start the development container
+
+Choose the image tag created above. The source path is resolved from Git, and
+`/src` is a container-local mount point created by Docker; neither path needs
+to be known in advance.
+
+```bash
+TRTMC_SM=103
+TRTMC_IMAGE="trtmc-dev-sm${TRTMC_SM}"
+TRTMC_SOURCE_DIR="$(git rev-parse --show-toplevel)"
+
+docker run --rm -it \
+  --gpus all \
+  --ipc=host \
+  --mount "type=bind,source=$TRTMC_SOURCE_DIR,target=/src" \
+  --workdir /src \
+  "$TRTMC_IMAGE" bash
+```
+
+Run the remaining commands inside this container. Re-enter the same integer SM
+selected for the image, then install the editable Python builder once:
+
+```bash
+TRTMC_SM=103
+python -m pip install --no-deps -e . -C py-only=true
+```
+
+The editable install does not compile the native CLI or DSOs. Choose one of the
+native build configurations below for that work.
+
+## 3. Choose a native build configuration
+
+### Default: standard TensorRT backend and every model DSO
+
+**Use case:** first-time source setup and general development across the model
+inventory. This is the recommended configuration before following the Qwen
+Quick Start.
+
+```bash
+TRTMC_BUILD_DIR="build-sm${TRTMC_SM}"
+
+cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
+  -DTRTMC_BUILD_BACKEND_TRT=ON \
+  -DTRTMC_BUILD_BACKEND_RTX=OFF \
+  -DTRTMC_BUILD_TESTS=OFF \
+  -DTRTMC_BUILD_BENCHMARKS=OFF
+cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
+  trtmc \
+  trtmc_backend_trt \
+  trtmc_model_plugins
+
+export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
+"$TRTMC_BUILD_DIR/trtmc" version
+```
+
+The aggregate `trtmc_model_plugins` target builds every manifest-declared model
+DSO. Their native CUDA code contains only the selected SM.
+
+### Focused: one model DSO
+
+**Use case:** iterating on one runtime family when rebuilding every model DSO
+would add unnecessary compile time. The target name uses the runtime owner ID,
+not a Hugging Face repository ID or internal test profile. Qwen models, for
+example, use the `qwen` owner.
+
+```bash
+TRTMC_MODEL=qwen
+TRTMC_BUILD_DIR="build-sm${TRTMC_SM}-${TRTMC_MODEL}"
+
+cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
+  -DTRTMC_BUILD_BACKEND_TRT=ON \
+  -DTRTMC_BUILD_BACKEND_RTX=OFF \
+  -DTRTMC_BUILD_TESTS=OFF \
+  -DTRTMC_BUILD_BENCHMARKS=OFF
+cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
+  trtmc \
+  trtmc_backend_trt \
+  "trtmc_model_${TRTMC_MODEL}"
+
+export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
+"$TRTMC_BUILD_DIR/trtmc" version
+```
+
+Runtime owner IDs are directory names under `src/runtime/models/`. Each
+directory's `MODEL.toml` declares its output DSO and runtime strategies.
+
+### Optional: TensorRT-RTX backend
+
+**Use case:** building and running native bundles explicitly created with
+`trtmc build --rtx`. Do not use this configuration for a standard TensorRT
+bundle.
+
+The generic development image includes the standard TensorRT SDK, not the
+optional TensorRT-RTX SDK. Install the matching `tensorrt_rtx` Python package,
+headers, and `libtensorrt_rtx.so` before configuring this variant. Set the SDK
+directories explicitly; no installation path is assumed.
+
+```bash
+: "${TRTMC_RTX_INCLUDE_DIR:?Set this to the TensorRT-RTX include directory}"
+: "${TRTMC_RTX_LIBRARY_DIR:?Set this to the directory containing libtensorrt_rtx.so}"
+python -c "import tensorrt_rtx"
+
+TRTMC_BUILD_DIR="build-sm${TRTMC_SM}-rtx"
+cmake -S . -B "$TRTMC_BUILD_DIR" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_SM}-real" \
+  -DTRTMC_BUILD_BACKEND_TRT=OFF \
+  -DTRTMC_BUILD_BACKEND_RTX=ON \
+  -DTRTMC_RTX_INCLUDE_DIR="$TRTMC_RTX_INCLUDE_DIR" \
+  -DTRTMC_RTX_LIBRARY_DIR="$TRTMC_RTX_LIBRARY_DIR" \
+  -DTRTMC_BUILD_TESTS=OFF \
+  -DTRTMC_BUILD_BENCHMARKS=OFF
+cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
+  trtmc \
+  trtmc_backend_rtx \
+  trtmc_model_plugins
+```
+
+This emits `libtrtmc_backend_trt_rtx.so`. The Python package is also required
+when creating the matching bundle:
+
+```bash
+export TRTMC_MODEL_PLUGIN_DIR="$TRTMC_BUILD_DIR/models"
+"$TRTMC_BUILD_DIR/trtmc" build Qwen/Qwen3-0.6B \
+  --rtx \
+  --output qwen3-0.6b-rtx.bundle
+```
+
+## 4. Run the first inference
+
+After the default build, keep `TRTMC_MODEL_PLUGIN_DIR` exported and use the
+source-built executable for the canonical first-inference workflow:
+
+```bash
+export TRTMC="./build-sm${TRTMC_SM}/trtmc"
+```
+
+Continue with [Your First NLP Inference](quick-start.md), using `$TRTMC` for
+the build, inspect, and run commands. The [Build System](../architecture/build-system.md)
+reference explains the CLI, backend, and model target boundaries in more
+detail.
+
+{/* Collaborative review anchor. */}

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -61,6 +61,7 @@ entry path for that goal.
 
 | Goal | Start here |
 | --- | --- |
+| Understand the project boundary and intended users | [Project Overview](getting-started/project-overview.md) |
 | First successful NLP/text inference | [Getting Started](getting-started/overview.md) |
 | Exact model/checkpoint lookup | [Models & Recipes](models-recipes/overview.md) |
 | Task and feature lookup | [User Guides](user-guides/overview.md) |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -37,8 +37,10 @@ const sidebars = {
       label: 'Get Started',
       link: {type: 'doc', id: 'getting-started/overview'},
       items: [
+        'getting-started/project-overview',
         'getting-started/environment-and-repro',
         'getting-started/installation',
+        'getting-started/source-build',
         'getting-started/quick-start',
         'getting-started/troubleshooting'
       ]


### PR DESCRIPTION
## Background

The repository README had grown into a 325-line combined landing page and
source-build manual. More than half of it described Docker, target-SM, CMake,
backend, and model-DSO variants, which made the first-use path harder to scan
and duplicated the documentation site.

## Exit Criteria

- Preserve the two-command Qwen demo and AI-native quick start at the top of
  the README.
- Keep the README focused on project value, the shortest successful path, and
  links to canonical documentation.
- Move project positioning and source-build details into indexed documentation
  without dropping the supported build configurations.
- Keep model support and deeper guidance in their existing single-source-of-
  truth documentation.

## Implementation

- Reduced the README from 325 lines to 93 lines while retaining the Qwen smoke
  path, AI-native prompt, system diagram, core project value, documentation
  map, model-support link, and contribution/support entry points.
- Added a Project Overview page for the checkpoint-to-bundle boundary,
  intended users, TensorRT ecosystem comparison, model ownership, and trust
  boundary.
- Added a Build from Source page for model-agnostic development images,
  target-SM selection, source mounting, standard TensorRT and TensorRT-RTX
  backends, and aggregate or focused model-DSO builds.
- Indexed both pages in Get Started and linked them from the documentation
  home, installation page, and getting-started path.

## Validation

- `cd website && npm run build`: passed; verified 36 diagrams and generated
  the Docusaurus production site, including both new routes.
- `cd website && npm run test:model-support`: passed, 1 test with 0 failures.
- `git diff --check`: passed.
- Extracted the new README and source-build Bash fences and checked them with
  `bash -n`: passed.

## Notes For Future Readers

- Review the README first, then Project Overview, then Build from Source.
- Build from Source is now the canonical location for generic target-SM,
  backend, and model-DSO source-build commands; avoid copying those full
  command sets back into the README.
- This PR changes documentation only and does not claim target-hardware or
  model-parity validation.
