### PR TITLE
fix(package): include benchmark audio assets

### DIFF
--- a/_pyproject_backend.py
+++ b/_pyproject_backend.py
@@ -93,7 +93,7 @@ def _append_benchmark_catalog_to_sdist(sdist_path: Path) -> None:
         for index, testcase in enumerate(raw.get("testcases", [])):
             if not isinstance(testcase, dict):
                 continue
-            for field in ("test_image", "prompt_file"):
+            for field in ("test_image", "prompt_file", "test_input_audio"):
                 if field in testcase:
                     references.append((f"testcases[{index}].{field}", testcase[field]))
         for field, declared in references:

--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,7 @@ def _stage_benchmark_catalog(recipe: ConanFile, source_folder: str | Path, packa
         for index, testcase in enumerate(raw.get("testcases", [])):
             if not isinstance(testcase, dict):
                 continue
-            for field in ("test_image", "prompt_file"):
+            for field in ("test_image", "prompt_file", "test_input_audio"):
                 if field in testcase:
                     references.append((f"testcases[{index}].{field}", testcase[field]))
         for field, declared in references:

--- a/tests/tools/test_optimized_runtime_packaging.py
+++ b/tests/tools/test_optimized_runtime_packaging.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import fnmatch
 import importlib.util
+import json
 import shutil
 import sys
 import tarfile
@@ -19,6 +20,32 @@ from _pyproject_backend import _append_benchmark_catalog_to_sdist
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _manifest_audio_assets(manifest: Path) -> tuple[Path, ...]:
+    """Return every local transcription input declared by one manifest."""
+
+    raw = json.loads(manifest.read_text(encoding="utf-8"))
+    family = manifest.parent.parent.resolve()
+    source_prefix = Path("tests/e2e/models") / family.name
+    assets: set[Path] = set()
+    for testcase in raw.get("testcases", []):
+        declared = testcase.get("test_input_audio") if isinstance(testcase, dict) else None
+        if declared is None:
+            continue
+        assert isinstance(declared, str) and declared
+        path = Path(declared).expanduser()
+        candidate = path if path.is_absolute() else family / path
+        if (
+            not candidate.is_file()
+            and not path.is_absolute()
+            and path.is_relative_to(source_prefix)
+        ):
+            candidate = family / path.relative_to(source_prefix)
+        resolved = candidate.resolve()
+        assert resolved.is_relative_to(family) and resolved.is_file()
+        assets.add(resolved)
+    return tuple(sorted(assets))
 
 
 def _load_conan_recipe(monkeypatch: pytest.MonkeyPatch):
@@ -122,7 +149,8 @@ def _package(recipe_module, source: Path, tmp_path: Path) -> Path:
     (catalog_family / "manifests/example.json").write_text(
         '{"fp8_scales": "data/fp8-scales.json", '
         '"testcases": [{"test_image": "data/test_img.jpeg", '
-        '"prompt_file": "data/prompt.txt"}]}\n',
+        '"prompt_file": "data/prompt.txt", '
+        '"test_input_audio": "data/transcription.wav"}]}\n',
         encoding="utf-8",
     )
     (catalog_family / "data").mkdir()
@@ -130,6 +158,7 @@ def _package(recipe_module, source: Path, tmp_path: Path) -> Path:
     (catalog_family / "data/fp8-scales.json").write_text("{}\n", encoding="utf-8")
     (catalog_family / "data/test_img.jpeg").write_bytes(b"test-image")
     (catalog_family / "data/prompt.txt").write_text("test prompt\n", encoding="utf-8")
+    (catalog_family / "data/transcription.wav").write_bytes(b"RIFF-transcription-audio")
     recipe = recipe_module.TensorRTModelConnectConan()
     recipe.source_folder = str(source)
     recipe.build_folder = str(build)
@@ -193,6 +222,7 @@ def test_package_stages_a_model_owned_adapter_as_inert_source(
     assert (catalog / "data/fp8-scales.json").is_file()
     assert (catalog / "data/test_img.jpeg").is_file()
     assert (catalog / "data/prompt.txt").is_file()
+    assert (catalog / "data/transcription.wav").is_file()
 
 
 def test_package_stages_the_complete_canonical_benchmark_catalog(
@@ -217,10 +247,18 @@ def test_package_stages_the_complete_canonical_benchmark_catalog(
     )
     assert (installed / "gpt2/manifests/distilgpt2.json").is_file()
     assert (installed / "whisper/data/Recording.wav").is_file()
+    assert (installed / "whisper/data/librispeech-test-clean-6930-75918-0003.wav").is_file()
     assert (installed / "flux/data/flux2-fp8-scales.json").is_file()
     assert (installed / "qwen_image/data/test_img.jpeg").is_file()
     assert (installed / "sana_wm/assets/demo_0.png").is_file()
     assert (installed / "sana_wm/assets/demo_0.txt").is_file()
+    missing_audio_assets = [
+        asset.relative_to(source).as_posix()
+        for manifest in source.glob("*/manifests/*.json")
+        for asset in _manifest_audio_assets(manifest)
+        if not (installed / asset.relative_to(source)).is_file()
+    ]
+    assert not missing_audio_assets
 
 
 def test_sdist_appends_only_the_minimal_benchmark_catalog(
@@ -237,7 +275,8 @@ def test_sdist_appends_only_the_minimal_benchmark_catalog(
     (family / "manifests/example.json").write_text(
         '{"fp8_scales": "data/fp8-scales.json", '
         '"testcases": [{"test_image": "data/test_img.jpeg", '
-        '"prompt_file": "data/prompt.txt"}]}\n',
+        '"prompt_file": "data/prompt.txt", '
+        '"test_input_audio": "data/transcription.wav"}]}\n',
         encoding="utf-8",
     )
     (family / "data").mkdir()
@@ -245,6 +284,7 @@ def test_sdist_appends_only_the_minimal_benchmark_catalog(
     (family / "data/fp8-scales.json").write_text("{}\n", encoding="utf-8")
     (family / "data/test_img.jpeg").write_bytes(b"test-image")
     (family / "data/prompt.txt").write_text("test prompt\n", encoding="utf-8")
+    (family / "data/transcription.wav").write_bytes(b"RIFF-transcription-audio")
     (family / "data/not-a-benchmark-input.bin").write_bytes(b"large fixture")
     archive = tmp_path / "example-0.1.0.tar.gz"
     with tarfile.open(archive, "w:gz") as destination:
@@ -262,6 +302,7 @@ def test_sdist_appends_only_the_minimal_benchmark_catalog(
     assert f"{prefix}/data/fp8-scales.json" in names
     assert f"{prefix}/data/test_img.jpeg" in names
     assert f"{prefix}/data/prompt.txt" in names
+    assert f"{prefix}/data/transcription.wav" in names
     assert f"{prefix}/data/not-a-benchmark-input.bin" not in names
 
 

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -61,7 +61,17 @@ class InstalledWheelValidator:
             raise CiError("wheel did not install trtmc-bench on PATH")
         if not benchmark_catalog.is_dir():
             raise CiError(f"packaged benchmark catalog is missing under {benchmark_catalog}")
-        benchmark_model = ManifestCatalog(benchmark_catalog).resolve("distilgpt2")
+        catalog = ManifestCatalog(benchmark_catalog)
+        catalog_entries = catalog.entries()
+        unusable_entries = [
+            entry for entry in catalog_entries if entry.status in {"invalid", "unsupported"}
+        ]
+        if unusable_entries:
+            details = "; ".join(
+                f"{entry.name} ({entry.status}): {entry.reason}" for entry in unusable_entries
+            )
+            raise CiError(f"packaged benchmark catalog has unusable entries: {details}")
+        benchmark_model = catalog.resolve("distilgpt2")
         if not backends:
             raise CiError(f"packaged TensorRT backend DSO is missing under {native_dir}")
         print(f"installed_wheel={wheel}")
@@ -71,6 +81,7 @@ class InstalledWheelValidator:
         print(f"installed_trtmc_bench={benchmark_script}")
         print(f"packaged_benchmark_worker={benchmark_worker}")
         print(f"packaged_benchmark_catalog={benchmark_catalog}")
+        print(f"packaged_benchmark_catalog_entries={len(catalog_entries)}")
         print(f"packaged_benchmark_smoke_model={benchmark_model.name}")
         for backend in backends:
             print(f"packaged_backend={backend}")


### PR DESCRIPTION
## Background

Nightly run 31220958514 failed in `3 / Coverage and wheel package`. Both Python 3.10 and 3.12 wheels built, passed archive audit, and uploaded successfully; the failure occurred later when the Python builder/tools suite ran against the installed Python 3.12 wheel. Eight catalog and benchmark tests failed before the coverage thresholds were evaluated.

The regression was exposed when PR #697 (commit 56901bd291c528e6addc5a8274fb8336070703e8) changed the first `whisper-tiny-fp16` testcase from `data/Recording.wav` to `data/librispeech-test-clean-6930-75918-0003.wav`. The wheel and sdist catalog packagers discovered `fp8_scales`, `test_image`, and `prompt_file`, but not testcase `test_input_audio`; the wheel only retained the previously hard-coded `Recording.wav`. As a result, the installed catalog classified `whisper-tiny-fp16` as invalid and downstream catalog/performance-matrix assertions failed.

Premerge did run the relevant source tests for PR #697, but the source checkout contained the referenced WAV. The package regression tests only asserted the old hard-coded audio asset, and the installed-wheel validator resolved only `distilgpt2`, so neither check proved that every packaged catalog entry remained usable.

## Exit Criteria

- Wheel and sdist packaging include every local asset referenced by testcase `test_input_audio`.
- Installed-wheel validation fails when any packaged catalog entry is invalid or unsupported.
- Regression coverage checks both a synthetic transcription asset and every audio asset referenced by the canonical catalog.
- Coverage thresholds remain unchanged and no additional CI job or model execution is added.

## Implementation

- Teach both Conan wheel staging and the PEP 517 sdist backend to collect `test_input_audio` alongside the existing manifest asset fields.
- Validate all 207 installed benchmark catalog entries before the existing `distilgpt2` smoke resolution.
- Extend optimized-runtime packaging tests to cover wheel staging, canonical catalog completeness, and sdist staging for transcription audio.

## Validation

- Red reproduction on main at e1553e8d653987a5c2d7cfa2ed3427c2886f423d: the added packaging regressions failed in three places because transcription audio was absent.
- Focused regression after the fix and after rebasing onto current main 68c43a2f: `4 passed in 0.40s`.
- Exact nightly package path in the pinned CI runtime image built and audited both cp310 and cp312 manylinux wheels. The installed-wheel validator reported `packaged_benchmark_catalog_entries=207` and completed successfully.
- The exact eight tests that failed in nightly now pass against the freshly installed wheel: `8 passed in 3.29s`.
- Full installed-wheel `python-builder` stage completed with exit code 0. Coverage was line 73.90% and branch 60.38%, above the unchanged 38% and 25% gates.
- Ruff passed for all changed Python files, and `git diff --check` is clean.

The focused regression adds about 0.4 seconds to an existing test file. The stronger catalog validation runs inside the existing wheel-validation stage; this PR adds no CI lane, no model build, and no GPU work. The package stage now reports 26 WAV assets and the generated wheels remain approximately 38 MiB each.

## Notes For Future Readers

The `70.4%` total printed in the failed nightly log was not a coverage-threshold failure. Pytest returned nonzero because of the eight functional failures, so the threshold check was never reached. This change intentionally preserves the existing thresholds and makes the package contract fail at the installed catalog boundary instead.
