### PR TITLE
fix(packaging): sanitize nightly wheel build paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@
 cmake_minimum_required(VERSION 3.20)
 project(tensorrt_model_connect VERSION 0.1.0 LANGUAGES CXX)
 
+# Release wheels package build outputs directly. Keep CMake's automatically
+# generated build-tree RPATH entries relative to each ELF file.
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
 # Enable CUDA for runtime GPU kernels when a CUDA compiler is available.
 include(CheckLanguage)
 check_language(CUDA)
@@ -25,6 +29,8 @@ option(TRTMC_BUILD_BACKEND_TRT "Build standard TensorRT backend DSO" ON)
 option(TRTMC_BUILD_TESTS "Build C++ unit test executables" ON)
 option(TRTMC_BUILD_BENCHMARKS "Build benchmark executables" ON)
 option(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL "Enable optional libtorch-backed multinomial sampler" ON)
+option(TRTMC_DISTRIBUTABLE_BUILD
+       "Build distributable artifacts without embedding source/build paths" OFF)
 set(TRTMC_MODEL_PROOF_MODEL "" CACHE STRING
   "Require the source tree to contain exactly this runtime model (CI isolation proof mode).")
 set(TRTMC_TRT_BACKEND_ABI "" CACHE STRING
@@ -246,13 +252,13 @@ target_include_directories(trtmc_core SYSTEM PRIVATE
   ${PROJECT_SOURCE_DIR}/third_party/stb
 )
 
-target_compile_definitions(trtmc_core
-  PUBLIC
-    TRTMC_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"
-    TRTMC_VERSION_STRING=\"${PROJECT_VERSION}\"
-  PRIVATE
-    TRTMC_BINARY_DIR=\"${CMAKE_BINARY_DIR}\"
-)
+target_compile_definitions(trtmc_core PUBLIC TRTMC_VERSION_STRING=\"${PROJECT_VERSION}\")
+if(NOT TRTMC_DISTRIBUTABLE_BUILD)
+  target_compile_definitions(trtmc_core
+    PUBLIC TRTMC_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"
+    PRIVATE TRTMC_BINARY_DIR=\"${CMAKE_BINARY_DIR}\"
+  )
+endif()
 
 target_compile_options(trtmc_core
   PRIVATE

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 from conan import ConanFile
@@ -144,6 +145,20 @@ def _set_wheel_python_shebang(script: Path) -> None:
     script.write_text(f"#!python\n{body}", encoding="utf-8")
 
 
+def _set_wheel_runpath(path: Path, runpath: str) -> None:
+    """Replace build-tree RUNPATH entries with the wheel's runtime layout."""
+
+    try:
+        subprocess.run(
+            ["patchelf", "--set-rpath", runpath, str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ConanException(f"cannot set wheel RUNPATH for {path.name}: {exc}") from exc
+
+
 class TensorRTModelConnectConan(ConanFile):
     name = "tensorrt-model-connect"
     version = "0.1.0"
@@ -167,6 +182,9 @@ class TensorRTModelConnectConan(ConanFile):
         )
         toolchain.cache_variables["TRTMC_BUILD_BENCHMARKS"] = True
         toolchain.cache_variables["TRTMC_ENABLE_LIBTORCH_MULTINOMIAL"] = False
+        toolchain.cache_variables["TRTMC_DISTRIBUTABLE_BUILD"] = _env_flag(
+            "TRTMC_DISTRIBUTABLE_BUILD"
+        )
 
         for name in (
             "TRTMC_TRT_INCLUDE_DIR",
@@ -305,6 +323,18 @@ class TensorRTModelConnectConan(ConanFile):
             raise ConanException("TRTMC TensorRT backend DSO was not staged into the wheel package")
         if not model_plugins:
             raise ConanException("TRTMC model plugin DSOs were not staged into the wheel package")
+
+        for executable in (native, installed_script, benchmark_worker):
+            _set_wheel_runpath(executable, "$ORIGIN")
+        for core in (*package_cores, *script_cores):
+            _set_wheel_runpath(core, "$ORIGIN:/usr/local/cuda/lib64")
+        for backend in backends:
+            _set_wheel_runpath(
+                backend,
+                "$ORIGIN:$ORIGIN/../../tensorrt_libs:/usr/local/cuda/lib64",
+            )
+        for model_plugin in model_plugins:
+            _set_wheel_runpath(model_plugin, "$ORIGIN:/usr/local/cuda/lib64")
 
         for executable in (native, installed_script, benchmark_worker, benchmark_script):
             mode = executable.stat().st_mode

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1511,15 +1511,22 @@ def test_release_wheel_stages_core_runtime_and_uses_origin_rpath() -> None:
     pyproject = (REPO_ROOT / "pyproject.toml").read_text()
 
     assert "set_target_properties(trtmc PROPERTIES" in cmake
+    assert "set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)" in cmake
+    assert "TRTMC_DISTRIBUTABLE_BUILD" in cmake
+    assert 'toolchain.cache_variables["TRTMC_DISTRIBUTABLE_BUILD"]' in conanfile
     assert "BUILD_RPATH_USE_ORIGIN TRUE" in cmake
     assert 'INSTALL_RPATH "\\$ORIGIN"' in cmake
     assert '"libtrtmc_core.so*"' in conanfile
     assert "for destination in (package_bin, wheel_data_scripts):" in conanfile
     assert "TRTMC core DSO was not staged beside the wheel script" in conanfile
+    assert "_set_wheel_runpath" in conanfile
+    assert '"$ORIGIN:$ORIGIN/../../tensorrt_libs:/usr/local/cuda/lib64"' in conanfile
     assert "apache-tvm-ffi==0.1.12" in pyproject
     assert "script_cores" in script
     assert 'if "$ORIGIN" not in dynamic' in script
     assert "installed trtmc RUNPATH leaks the CI build directory" in script
+    assert '"TRTMC_DISTRIBUTABLE_BUILD": "1"' in script
+    assert "wheel embeds its CI checkout path" in script
 
 
 def test_ci_source_build_defaults_to_packaged_libtorch_mode() -> None:

--- a/tests/tools/test_optimized_runtime_packaging.py
+++ b/tests/tools/test_optimized_runtime_packaging.py
@@ -163,8 +163,35 @@ def _package(recipe_module, source: Path, tmp_path: Path) -> Path:
     recipe.source_folder = str(source)
     recipe.build_folder = str(build)
     recipe.package_folder = str(package)
-    recipe.package()
+    set_runpath = recipe_module._set_wheel_runpath
+    try:
+        # This source-staging fixture uses text placeholders instead of ELF
+        # build outputs. RUNPATH behavior has its own focused assertion below.
+        recipe_module._set_wheel_runpath = lambda _path, _runpath: None
+        recipe.package()
+    finally:
+        recipe_module._set_wheel_runpath = set_runpath
     return package / "tensorrt_model_connect"
+
+
+def test_wheel_runpath_rewrite_invokes_patchelf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recipe_module = _load_conan_recipe(monkeypatch)
+    binary = tmp_path / "libtrtmc_core.so"
+    binary.write_bytes(b"ELF fixture")
+    calls = []
+    monkeypatch.setattr(recipe_module.subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    recipe_module._set_wheel_runpath(binary, "$ORIGIN:/usr/local/cuda/lib64")
+
+    assert calls == [
+        (
+            (["patchelf", "--set-rpath", "$ORIGIN:/usr/local/cuda/lib64", str(binary)],),
+            {"check": True, "capture_output": True, "text": True},
+        )
+    ]
 
 
 def test_package_stages_a_model_owned_adapter_as_inert_source(

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -112,6 +112,17 @@ class WheelArchiveValidator:
             raise CiError(f"{wheel}: expected platform tag {self.platform}")
         with zipfile.ZipFile(wheel) as archive:
             names = set(archive.namelist())
+            repository_marker = str(self.context.repository.resolve()).encode()
+            leaked_entries = sorted(
+                name
+                for name in names
+                if not name.endswith("/") and repository_marker in archive.read(name)
+            )
+            if leaked_entries:
+                raise CiError(
+                    f"{wheel}: wheel embeds its CI checkout path in "
+                    f"{len(leaked_entries)} entries"
+                )
             if any(".data/purelib/" in name for name in names):
                 raise CiError(f"{wheel}: native wheel must not contain .data/purelib entries")
             binaries = [name for name in names if name.endswith("/bin/trtmc")]
@@ -322,6 +333,7 @@ class WheelPackageManager:
                     "TRTMC_CUDA_INCLUDE_DIR": cuda_include,
                     "TRTMC_CUDART_LIBRARY": cudart,
                     "TRTMC_CONAN_ENABLE_TEST_TARGETS": "1",
+                    "TRTMC_DISTRIBUTABLE_BUILD": "1",
                     "WHEEL_PYVER": tag,
                     "WHEEL_ABI": "none",
                     "WHEEL_ARCH": platform,


### PR DESCRIPTION
## Why

A final audit of staged nightly wheels found private CI checkout details embedded in native ELF payloads. No credentials were present, but those paths do not belong in a distributable wheel.

## What

- keep generated build-tree RPATH entries relative to each ELF
- omit source/build directory macros from distributable builds
- replace staged wheel RUNPATHs with the relocatable installed layout
- reject any wheel that still embeds its build checkout path

## Validation

- `python3 -m pytest tests/tools/test_github_actions_ci.py -q` (68 passed)
- `python3 -m py_compile conanfile.py tools/ci/package.py`
- `git diff --check`
