### PR TITLE
perf(olmo2): batch decoder prefill

### DIFF
--- a/python/tensorrt_model_connect/families/olmo2/graph_ops.py
+++ b/python/tensorrt_model_connect/families/olmo2/graph_ops.py
@@ -288,6 +288,21 @@ def reshape_heads_4d_to_rows(
     return out.get_output(0)
 
 
+def add_2d_mask_to_4d(
+    network: trt.INetworkDefinition,
+    mask_2d: trt.ITensor,
+) -> trt.ITensor:
+    """Reshape additive attention mask [Sq, K] to [1, 1, Sq, K]."""
+    mask_shape = network.add_shape(mask_2d).get_output(0)
+    ones = add_constant(
+        network, (2,), np.array([1, 1], dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([ones, mask_shape])
+    target.axis = 0
+    mask_4d = network.add_shuffle(mask_2d)
+    mask_4d.set_input(1, target.get_output(0))
+    return mask_4d.get_output(0)
+
+
 def add_apply_rope_native(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,

--- a/python/tensorrt_model_connect/families/olmo2/plugin.py
+++ b/python/tensorrt_model_connect/families/olmo2/plugin.py
@@ -49,6 +49,7 @@ class Olmo2Plugin:
 
     runtime_strategy = "olmo2_decoder_kv_cache"
     runtime_capabilities = {"decoder_kv"}
+    supports_split_decoder_roles = True
 
     def load_weights(
         self, model_dir: str, config: ModelConfig,
@@ -162,6 +163,16 @@ class Olmo2Plugin:
                 config, weights, max_cache_length,
                 verbose=verbose,
                 parallel_config=parallel)
+
+        if config.raw.get("_decoder_engine_role") == "prefill":
+            from .prefill_builder import build_olmo2_prefill_engine
+            return build_olmo2_prefill_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                verbose=verbose,
+            )
 
         import sys
         from tensorrt_model_connect import trt_compat

--- a/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
+++ b/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batched-prefill TensorRT engine for the OLMo-2 post-norm decoder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from . import graph_blocks, graph_ops
+
+if TYPE_CHECKING:
+    from .checkpoint_mapper import WeightDict
+    from .config import ModelConfig
+
+
+def _slice_last_row(network, tensor, width: int):
+    shape = network.add_shape(tensor).get_output(0)
+    row_shape = graph_ops.add_constant(
+        network, (2,), np.array([1, width], dtype=np.int64), dtype=np.int64)
+    start = network.add_elementwise(
+        shape, row_shape, trt_compat.get_trt().ElementWiseOperation.SUB).get_output(0)
+    size = graph_ops.add_constant(
+        network, (2,), np.array([1, width], dtype=np.int64), dtype=np.int64)
+    result = network.add_slice(tensor, start=(0, 0), shape=(0, 0), stride=(1, 1))
+    result.set_input(1, start)
+    result.set_input(2, size)
+    return result.get_output(0)
+
+
+def build_olmo2_prefill_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    verbose: bool = False,
+) -> bytes:
+    """Build one dynamic-Sq profile that consumes a prompt in one enqueue."""
+    trt = trt_compat.get_trt()
+    if precision == "fp16":
+        work_np_dtype, work_trt_dtype = np.float16, trt.float16
+    elif precision == "fp32":
+        work_np_dtype, work_trt_dtype = np.float32, trt.float32
+    else:
+        raise ValueError(f"Unsupported OLMo2 precision: {precision}")
+
+    attention_size = int(weights.get("_attention_size", config.attention_size))
+    mlp_size = int(weights.get("_mlp_size", config.intermediate_size))
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    num_heads = int(config.num_attention_heads)
+    num_kv_heads = int(config.num_key_value_heads)
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    max_prefill_length = max(1, int(max_cache_length))
+    opt_prefill_length = min(128, max_prefill_length)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_idx in range(num_layers):
+        cache_shape = (max_cache_length, kv_attention_size)
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            work_trt_dtype,
+            cache_shape,
+        ))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            work_trt_dtype,
+            cache_shape,
+        ))
+
+    profile = builder.create_optimization_profile()
+    profile.set_shape(
+        "token_id", (1,), (opt_prefill_length,), (max_prefill_length,))
+    profile.set_shape(
+        "position_id", (1,), (opt_prefill_length,), (max_prefill_length,))
+    profile.set_shape(
+        "attention_mask",
+        (1, max_cache_length + 1),
+        (opt_prefill_length, max_cache_length + opt_prefill_length),
+        (max_prefill_length, max_cache_length + max_prefill_length),
+    )
+    trt_config.add_optimization_profile(profile)
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype)
+    cos_table_np = graph_ops.make_rope_table_half_dim(
+        max_cache_length + max_prefill_length,
+        head_dim,
+        config.rope_theta,
+        True,
+    )
+    sin_table_np = graph_ops.make_rope_table_half_dim(
+        max_cache_length + max_prefill_length,
+        head_dim,
+        config.rope_theta,
+        False,
+    )
+    cos_tensor = graph_ops.add_constant(
+        network, cos_table_np.shape, cos_table_np, dtype=work_np_dtype)
+    sin_tensor = graph_ops.add_constant(
+        network, sin_table_np.shape, sin_table_np, dtype=work_np_dtype)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+    mask = attention_mask
+    if mask.dtype != work_trt_dtype:
+        mask = network.add_cast(mask, work_trt_dtype).get_output(0)
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, mask)
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        q = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, hidden, attention_size,
+            weights[f"{prefix}.w_q"], dtype=work_np_dtype)
+        k = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, hidden, kv_attention_size,
+            weights[f"{prefix}.w_k"], dtype=work_np_dtype)
+        v = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, hidden, kv_attention_size,
+            weights[f"{prefix}.w_v"], dtype=work_np_dtype)
+
+        q_norm = weights.get(f"{prefix}.q_norm")
+        if q_norm is not None:
+            q = graph_ops.add_rms_norm(
+                network, q, attention_size, q_norm, eps_tensor,
+                dtype=work_np_dtype)
+        k_norm = weights.get(f"{prefix}.k_norm")
+        if k_norm is not None:
+            k = graph_ops.add_rms_norm(
+                network, k, kv_attention_size, k_norm, eps_tensor,
+                dtype=work_np_dtype)
+
+        q = graph_ops.add_apply_rope_native(
+            network, q, num_heads, head_dim,
+            cos_tensor, sin_tensor, position_id, head_dim,
+            sequence_length=None)
+        k = graph_ops.add_apply_rope_native(
+            network, k, num_kv_heads, head_dim,
+            cos_tensor, sin_tensor, position_id, head_dim,
+            sequence_length=None)
+        present_k_outputs.append(k)
+        present_v_outputs.append(v)
+
+        all_k = network.add_concatenation([cache_k_inputs[layer_idx], k])
+        all_k.axis = 0
+        all_v = network.add_concatenation([cache_v_inputs[layer_idx], v])
+        all_v.axis = 0
+        context = graph_ops.add_attention_from_rows(
+            network,
+            q,
+            all_k.get_output(0),
+            all_v.get_output(0),
+            num_heads=num_heads,
+            head_dim=head_dim,
+            num_kv_heads=num_kv_heads,
+            q_seq=None,
+            kv_seq=None,
+            mask=mask_4d,
+            tag=f"{prefix}.attn",
+        )
+
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, context, attention_size, hidden,
+            weights[f"{prefix}.w_o"], dtype=work_np_dtype)
+        normed_attn = graph_ops.add_rms_norm(
+            network, attn_out, hidden,
+            weights[f"{prefix}.post_attn_norm"], eps_tensor,
+            dtype=work_np_dtype)
+        residual1 = network.add_elementwise(
+            hidden_state, normed_attn, trt.ElementWiseOperation.SUM).get_output(0)
+
+        mlp_out = graph_blocks.add_swiglu_mlp(
+            network,
+            residual1,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            mlp_size=mlp_size,
+            dtype=work_np_dtype,
+        )
+        normed_mlp = graph_ops.add_rms_norm(
+            network, mlp_out, hidden,
+            weights[f"{prefix}.post_ff_norm"], eps_tensor,
+            dtype=work_np_dtype)
+        hidden_state = network.add_elementwise(
+            residual1, normed_mlp, trt.ElementWiseOperation.SUM).get_output(0)
+
+    hidden_state = graph_ops.add_rms_norm(
+        network, hidden_state, hidden, weights["final_norm"], eps_tensor,
+        dtype=work_np_dtype)
+    last_hidden = _slice_last_row(network, hidden_state, hidden)
+    out_vocab = (
+        int(weights["w_out"].shape[1])
+        if isinstance(weights["w_out"], np.ndarray)
+        else vocab
+    )
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, last_hidden, hidden, out_vocab, weights["w_out"],
+        dtype=work_np_dtype)
+    logits = graph_ops.add_bias_sum(
+        network, logits, out_vocab, np.zeros(out_vocab, dtype=work_np_dtype),
+        dtype=work_np_dtype)
+    if logits.dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx, (present_k, present_v) in enumerate(
+        zip(present_k_outputs, present_v_outputs, strict=True)
+    ):
+        present_k.name = graph_ops.layer_tensor_name("present_k", layer_idx)
+        present_v.name = graph_ops.layer_tensor_name("present_v", layer_idx)
+        network.mark_output(present_k)
+        network.mark_output(present_v)
+
+    if verbose:
+        print(
+            "[trtmc build] Building OLMo2 batched-prefill engine "
+            f"(layers={num_layers}, hidden={hidden}, cache={max_cache_length}, "
+            f"opt_prefill={opt_prefill_length}, precision={precision}) ...",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("OLMo2 batched-prefill engine build failed")
+    return bytes(plan)

--- a/tests/e2e/models/olmo2/test_olmo2_build_engine_integration.py
+++ b/tests/e2e/models/olmo2/test_olmo2_build_engine_integration.py
@@ -105,3 +105,37 @@ class TestOlmo2BuildEngine:
 
         assert isinstance(engine, bytes)
         assert len(engine) > 0
+
+    def test_split_prefill_engine_has_dynamic_prompt_profile(self, tmp_path):
+        import tensorrt as trt
+
+        from tensorrt_model_connect.families.olmo2 import plugin
+
+        config = {
+            "model_type": "olmo2",
+            "vocab_size": self.VOCAB,
+            "hidden_size": self.HIDDEN,
+            "num_hidden_layers": self.LAYERS,
+            "num_attention_heads": self.HEADS,
+            "num_key_value_heads": self.KV_HEADS,
+            "intermediate_size": self.MLP,
+        }
+        tensors = self._make_tensors(
+            self.VOCAB, self.HIDDEN, self.LAYERS, self.HEADS, self.KV_HEADS, self.MLP)
+        _write_config(tmp_path, config)
+        _write_safetensors(tmp_path, tensors)
+
+        cfg = ModelConfig.from_dir(tmp_path)
+        cfg.raw["_decoder_engine_role"] = "prefill"
+        weights = plugin.load_weights(str(tmp_path), cfg)
+        plan = plugin.build_engine(
+            cfg, weights, max_cache_length=32, precision="fp32", verbose=False)
+
+        runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
+        engine = runtime.deserialize_cuda_engine(plan)
+
+        assert engine is not None
+        assert engine.num_optimization_profiles == 1
+        assert engine.get_tensor_shape("token_id") == (-1,)
+        assert engine.get_tensor_profile_shape("token_id", 0) == [
+            (1,), (32,), (32,)]

--- a/tests/e2e/models/olmo2/test_olmo2_builder_tp.py
+++ b/tests/e2e/models/olmo2/test_olmo2_builder_tp.py
@@ -30,6 +30,9 @@ class _Config:
     rope_theta = 10000.0
     rms_norm_eps = 1e-6
 
+    def __init__(self) -> None:
+        self.raw = {}
+
 
 def _weights() -> WeightDict:
     hidden = _Config.hidden_size
@@ -130,3 +133,41 @@ def test_olmo2_plugin_routes_parallel_builds(monkeypatch) -> None:
     assert calls["require"] == (parallel, "OLMo2 tensor-parallel builds")
     assert calls["build"]["max_cache_length"] == 256
     assert calls["build"]["kwargs"]["parallel_config"] == parallel
+
+
+def test_olmo2_plugin_routes_split_prefill_builds(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.olmo2.plugin")
+    prefill_builder = importlib.import_module(
+        "tensorrt_model_connect.families.olmo2.prefill_builder")
+
+    calls = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = {
+            "config": config,
+            "weights": weights,
+            "max_cache_length": max_cache_length,
+            "kwargs": kwargs,
+        }
+        return b"olmo2-prefill-plan"
+
+    monkeypatch.setattr(
+        prefill_builder, "build_olmo2_prefill_engine", fake_build)
+
+    config = _Config()
+    config.raw["_decoder_engine_role"] = "prefill"
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(),
+        max_cache_length=352,
+        precision="fp32",
+    )
+
+    assert plugin_module.plugin.supports_split_decoder_roles is True
+    assert result == b"olmo2-prefill-plan"
+    assert calls["build"]["max_cache_length"] == 352
+    assert calls["build"]["kwargs"] == {
+        "precision": "fp32",
+        "verbose": False,
+    }


### PR DESCRIPTION
## Background

OLMo2 used the single-token decoder engine for prompt prefill. A long prompt
therefore launched the decoder once per token and made `olmo2.generate` slower
than its Hugging Face reference even though the generated tokens agreed.

## Exit Criteria

- Prompt prefill uses a dynamic-length batched engine while decode remains a
  single-token engine.
- The split engines preserve OLMo2 post-norm residual semantics, RoPE, KV-cache
  outputs, and generated-token parity.
- The release performance case returns to green without changing its FP32
  precision contract.

## Implementation

- Add a family-owned dynamic prefill builder that consumes the complete prompt
  and emits last-token logits plus per-layer KV state.
- Route split `prefill` and `decode` build roles through the OLMo2 plugin while
  retaining the existing decoder and tensor-parallel paths.
- Add graph helpers and focused routing/integration tests for the split bundle.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q tests/e2e/models/olmo2/test_olmo2_builder_tp.py tests/e2e/models/olmo2/test_olmo2_build_engine_integration.py`:
  6 passed in the exact-head GB300 development container.
- `git diff --check github/main...HEAD`: passed.
- Exact head `aac6abcb` on GB300 with TensorRT 11.2: `olmo2.generate` was green;
  TRTMC p50 was 37.153 ms versus 105.996 ms for the compiled HF reference,
  and both produced the same eight token IDs.
- Targeted `mmlu_continuation_parity` validation: 10/10 exact match, token
  prefix agreement, and prediction agreement.

## Notes For Future Readers

- FP32 is intentional: the official checkpoint declares float32, and FP16
  diverged from the reference on the long MMLU prompt during diagnosis.
- Review the prefill graph first, then the small plugin routing change. Build
  time and engine size remain preparation costs outside measured latency.
