### PR TITLE
fix(deps): resolve remaining security alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN pip install "apache-tvm-ffi==0.1.12"
 
 # Core Python deps
 RUN pip install \
-    "transformers==5.2.0" \
+    "transformers==5.5.0" \
     tokenizers \
     safetensors \
     sentencepiece \
@@ -120,10 +120,10 @@ RUN pip install \
 # the torch installation already present in this image for GPU inference.
 RUN pip install "open-clip-torch>=2.20"
 
-# NeMo currently declares transformers~=4.57; force the runtime pin we need.
+# NeMo currently declares transformers~=4.57; force the secure runtime pin we need.
 RUN pip install "nemo_toolkit[tts]==2.7.0" && \
-    pip install --upgrade "transformers==5.2.0" && \
-    python3 -c "import transformers; assert transformers.__version__ == '5.2.0', transformers.__version__" && \
+    pip install --upgrade "transformers==5.5.0" && \
+    python3 -c "import transformers; assert transformers.__version__ == '5.5.0', transformers.__version__" && \
     python3 -c "import diffusers, ftfy; print('deps_ok', diffusers.__version__)"
 
 # Upgrade NeMo to a main-branch SHA that ships

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN pip install "apache-tvm-ffi==0.1.12"
 
 # Core Python deps
 RUN pip install \
-    "transformers==5.5.0" \
+    "transformers==5.5.4" \
     tokenizers \
     safetensors \
     sentencepiece \
@@ -122,8 +122,8 @@ RUN pip install "open-clip-torch>=2.20"
 
 # NeMo currently declares transformers~=4.57; force the secure runtime pin we need.
 RUN pip install "nemo_toolkit[tts]==2.7.0" && \
-    pip install --upgrade "transformers==5.5.0" && \
-    python3 -c "import transformers; assert transformers.__version__ == '5.5.0', transformers.__version__" && \
+    pip install --upgrade "transformers==5.5.4" && \
+    python3 -c "import transformers; assert transformers.__version__ == '5.5.4', transformers.__version__" && \
     python3 -c "import diffusers, ftfy; print('deps_ok', diffusers.__version__)"
 
 # Upgrade NeMo to a main-branch SHA that ships

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ml_dtypes>=0.4",
     "onnx>=1.16",
     "onnxscript>=0.2",
-    "transformers>=4.40",
+    "transformers>=5.5.0",
     "huggingface_hub>=0.23",
     "sentencepiece>=0.1.99",
     "tensorrt==11.1.0.106; platform_machine == 'aarch64'",
@@ -34,7 +34,7 @@ test = ["pytest>=7.0", "torch>=2.0"]
 # Build-only dependency for official Wan checkpoints containing T5/VAE .pth
 # files. Kept out of the base install and never required by the C++ runtime.
 wan = ["torch>=2.0"]
-chronos = ["chronos-forecasting>=2.2.2"]
+chronos = ["chronos-forecasting>=2.3.1"]
 # clip: required by tests/e2e/models/flux/e2e_plugins/comparators/clip_metrics.py for
 # CLIP-based semantic metrics on diffusion model outputs.  Gracefully skipped
 # at runtime when absent, but all CLIP gates become no-ops without it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ml_dtypes>=0.4",
     "onnx>=1.16",
     "onnxscript>=0.2",
-    "transformers>=5.5.0",
+    "transformers>=5.5.4",
     "huggingface_hub>=0.23",
     "sentencepiece>=0.1.99",
     "tensorrt==11.1.0.106; platform_machine == 'aarch64'",

--- a/python/tensorrt_model_connect/deepseek_ocr_reference_compat.py
+++ b/python/tensorrt_model_connect/deepseek_ocr_reference_compat.py
@@ -1,0 +1,571 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Portions of the cache, RoPE, and eager-attention compatibility behavior are
+# adapted from Hugging Face Transformers v4.46.3 `cache_utils.py` and
+# `models/llama/modeling_llama.py`.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+
+"""Transformers v5 adapters for the pinned DeepSeek-OCR-2 reference.
+
+The exact upstream source was authored against Transformers 4.46.3. The
+reference runs in its own Python process, so this module restores only the
+removed import, config, call, and cache surfaces that source consumes. The
+adapter retains the pinned Transformers 5.5.4 package while preserving the
+v4 eager operation order where BF16 GPU arithmetic is observably different.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+from importlib.metadata import version
+import math
+from typing import Any
+
+
+_SUPPORTED_TRANSFORMERS_VERSION = "5.5.4"
+_COMPAT_STATE_ATTRIBUTE = "_trtmc_deepseek_ocr_compat_state"
+_CONFIG_COMPAT_ATTRIBUTE = "_trtmc_deepseek_ocr_v4_config_compat"
+_QWEN_CONFIG_COMPAT_ATTRIBUTE = "_trtmc_deepseek_ocr_qwen_config_compat"
+_QWEN_MODEL_COMPAT_ATTRIBUTE = "_trtmc_deepseek_ocr_qwen_model_compat"
+DEEPSEEK_OCR_REFERENCE_REVISION = "aaa02f3811945a91062062994c5c4a3f4c0af2b0"
+
+
+@dataclass(frozen=True)
+class DeepSeekOcrTransformersCompat:
+    """Types installed into the isolated DeepSeek reference process."""
+
+    eager_attention_type: type
+    flash_attention_type: type
+    dynamic_cache_type: type
+
+
+def configure_deepseek_ocr_legacy_generation_cache(model: Any) -> None:
+    """Keep the pinned remote model's v4 tuple-cache generation path."""
+    model_type = type(model)
+    if model_type.__name__ != "DeepseekOCR2ForCausalLM" or not model_type.__module__.startswith(
+        "transformers_modules."
+    ):
+        raise RuntimeError(
+            "DeepSeek-OCR generation cache compatibility received an unexpected model type: "
+            f"{model_type.__module__}.{model_type.__name__}"
+        )
+
+    @classmethod
+    def supports_default_dynamic_cache(cls) -> bool:
+        del cls
+        return False
+
+    model_type._supports_default_dynamic_cache = supports_default_dynamic_cache
+    if model_type._supports_default_dynamic_cache():
+        raise RuntimeError("DeepSeek-OCR v5 dynamic-cache initialization remained enabled")
+
+    original_prepare = model_type.prepare_inputs_for_generation
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        **kwargs,
+    ):
+        prepared = original_prepare(
+            self,
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        prepared_ids = prepared.get("input_ids")
+        if past_key_values is not None and prepared_ids is not None:
+            if isinstance(past_key_values, tuple):
+                cached = past_key_values[0][0].shape[-2]
+            else:
+                cached = past_key_values.get_seq_length()
+            if cached and prepared_ids.shape[1] == input_ids.shape[1] > 1:
+                raise RuntimeError(
+                    "DeepSeek-OCR generation did not trim cached input tokens: "
+                    f"cache={type(past_key_values).__name__}, cached={cached}, "
+                    f"input={input_ids.shape[1]}, prepared={prepared_ids.shape[1]}, "
+                    f"mask={getattr(attention_mask, 'shape', None)}"
+                )
+            for name in ("position_ids", "cache_position"):
+                value = prepared.get(name)
+                if value is not None and value.shape[-1] > prepared_ids.shape[1]:
+                    prepared[name] = value[..., -prepared_ids.shape[1] :]
+        return prepared
+
+    model_type.prepare_inputs_for_generation = prepare_inputs_for_generation
+
+
+def configure_deepseek_ocr_rotary_embeddings(
+    model: Any,
+    compat: DeepSeekOcrTransformersCompat,
+) -> tuple[int, int]:
+    """Materialize v5 RoPE buffers skipped by the remote-code meta loader."""
+    language_layers = 0
+    visual_encoders = 0
+    for _, module in model.named_modules():
+        is_language_attention = isinstance(module, compat.eager_attention_type)
+        module_type = type(module)
+        is_visual_encoder = (
+            module_type.__name__ == "CustomQwen2ModelInner"
+            and module_type.__module__.startswith("transformers_modules.")
+        )
+        if not is_language_attention and not is_visual_encoder:
+            continue
+
+        rotary = getattr(module, "rotary_emb", None)
+        config = getattr(module, "config", None)
+        if rotary is None or config is None:
+            raise RuntimeError(
+                "Pinned DeepSeek-OCR module is missing its rotary embedding or config: "
+                f"{module_type.__module__}.{module_type.__name__}"
+            )
+        parameter = next(module.parameters(), None)
+        device = parameter.device if parameter is not None else None
+        module.rotary_emb = type(rotary)(config=config, device=device)
+        inv_freq = module.rotary_emb.inv_freq
+        if inv_freq.device.type == "meta" or not bool((inv_freq > 0).all().item()):
+            raise RuntimeError(
+                "Pinned DeepSeek-OCR rotary frequencies were not materialized safely"
+            )
+        if is_language_attention:
+            language_layers += 1
+        else:
+            visual_encoders += 1
+
+    if language_layers == 0 or visual_encoders != 1:
+        raise RuntimeError(
+            "Pinned DeepSeek-OCR rotary module count mismatch: "
+            f"language={language_layers}, visual={visual_encoders}"
+        )
+    return language_layers, visual_encoders
+
+
+def _build_legacy_dynamic_cache(cache_base_type: type, torch) -> type:
+    """Build the small v4 dynamic cache consumed by the pinned remote source."""
+
+    class DeepSeekOcrLegacyDynamicCache(cache_base_type):
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            super().__init__(layers=[])
+            self._seen_tokens = 0
+            self.key_cache = []
+            self.value_cache = []
+
+        def __getitem__(self, layer_idx):
+            if layer_idx >= len(self):
+                raise KeyError(f"Cache has {len(self)} layers; cannot access layer {layer_idx}")
+            return self.key_cache[layer_idx], self.value_cache[layer_idx]
+
+        def __iter__(self):
+            return iter(zip(self.key_cache, self.value_cache))
+
+        def __len__(self):
+            return len(self.key_cache)
+
+        def update(self, key_states, value_states, layer_idx, cache_kwargs=None):
+            del cache_kwargs
+            if layer_idx == 0:
+                self._seen_tokens += key_states.shape[-2]
+            while len(self.key_cache) < layer_idx:
+                self.key_cache.append([])
+                self.value_cache.append([])
+            if len(self.key_cache) == layer_idx:
+                self.key_cache.append(key_states)
+                self.value_cache.append(value_states)
+            elif len(self.key_cache[layer_idx]) == 0:
+                self.key_cache[layer_idx] = key_states
+                self.value_cache[layer_idx] = value_states
+            else:
+                self.key_cache[layer_idx] = torch.cat(
+                    (self.key_cache[layer_idx], key_states), dim=-2
+                )
+                self.value_cache[layer_idx] = torch.cat(
+                    (self.value_cache[layer_idx], value_states), dim=-2
+                )
+            return self.key_cache[layer_idx], self.value_cache[layer_idx]
+
+        def get_seq_length(self, layer_idx=0):
+            if layer_idx >= len(self.key_cache) or len(self.key_cache[layer_idx]) == 0:
+                return 0
+            return self.key_cache[layer_idx].shape[-2]
+
+        def get_max_cache_shape(self):
+            return None
+
+        def get_max_length(self):
+            return None
+
+        def get_usable_length(self, new_seq_length, layer_idx=0):
+            del new_seq_length
+            return self.get_seq_length(layer_idx)
+
+        @property
+        def seen_tokens(self):
+            return self._seen_tokens
+
+        def to_legacy_cache(self):
+            return tuple(zip(self.key_cache, self.value_cache))
+
+        @classmethod
+        def from_legacy_cache(cls, past_key_values=None):
+            cache = cls()
+            if past_key_values is not None:
+                for layer_idx, (key_states, value_states) in enumerate(past_key_values):
+                    cache.update(key_states, value_states, layer_idx)
+            return cache
+
+        def reorder_cache(self, beam_indices):
+            for layer_idx in range(len(self)):
+                device_indices = beam_indices.to(self.key_cache[layer_idx].device)
+                self.key_cache[layer_idx] = self.key_cache[layer_idx].index_select(
+                    0, device_indices
+                )
+                self.value_cache[layer_idx] = self.value_cache[layer_idx].index_select(
+                    0, device_indices
+                )
+
+    DeepSeekOcrLegacyDynamicCache.__name__ = "DynamicCache"
+    DeepSeekOcrLegacyDynamicCache.__qualname__ = "DynamicCache"
+    DeepSeekOcrLegacyDynamicCache.__module__ = "transformers.cache_utils"
+    return DeepSeekOcrLegacyDynamicCache
+
+
+def _install_config_compat(pretrained_config_type: type) -> None:
+    """Keep v4 inherited remote-config construction and token attributes."""
+    if getattr(pretrained_config_type, _CONFIG_COMPAT_ATTRIBUTE, False):
+        return
+
+    original_post_init = pretrained_config_type.__post_init__
+
+    def post_init(self, **kwargs):
+        token_ids = {
+            name: kwargs[name]
+            for name in ("pad_token_id", "bos_token_id", "eos_token_id")
+            if name in kwargs
+        }
+        original_post_init(self, **kwargs)
+        for name, value in token_ids.items():
+            setattr(self, name, value)
+
+    # Transformers 5 dataclass-wraps a remote subclass with no local __init__,
+    # which bypasses its inherited custom constructor. The pinned source relies
+    # on normal Python inheritance to retain DeepseekV2Config's v4 defaults.
+    def legacy_init_subclass(cls, *args, **kwargs):
+        del cls, args, kwargs
+
+    pretrained_config_type.__post_init__ = post_init
+    pretrained_config_type.__init_subclass__ = classmethod(legacy_init_subclass)
+    setattr(pretrained_config_type, _CONFIG_COMPAT_ATTRIBUTE, True)
+
+
+def _install_qwen_config_compat(qwen_config_type: type) -> None:
+    """Keep the requested Qwen vision-encoder layer count under v5 strict config."""
+    if getattr(qwen_config_type, _QWEN_CONFIG_COMPAT_ATTRIBUTE, False):
+        return
+
+    original_init = qwen_config_type.__init__
+
+    def init(self, *args, **kwargs):
+        if not args and "num_hidden_layers" in kwargs and "layer_types" not in kwargs:
+            kwargs["layer_types"] = ["full_attention"] * int(kwargs["num_hidden_layers"])
+        original_init(self, *args, **kwargs)
+
+    qwen_config_type.__init__ = init
+    setattr(qwen_config_type, _QWEN_CONFIG_COMPAT_ATTRIBUTE, True)
+
+
+def _install_qwen_model_compat(qwen_model_type: type) -> None:
+    """Route the pinned visual encoder through its source-owned custom mask."""
+    if getattr(qwen_model_type, _QWEN_MODEL_COMPAT_ATTRIBUTE, False):
+        return
+
+    original_forward = qwen_model_type.forward
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        use_cache=None,
+        **kwargs,
+    ):
+        model_type = type(self)
+        is_pinned_visual_encoder = (
+            model_type.__name__ == "CustomQwen2ModelInner"
+            and model_type.__module__.startswith("transformers_modules.")
+        )
+        token_type_ids = getattr(self, "_current_token_type_ids", None)
+        if is_pinned_visual_encoder:
+            if inputs_embeds is None or token_type_ids is None:
+                raise RuntimeError(
+                    "Pinned DeepSeek-OCR Qwen2 visual encoder requires inputs_embeds "
+                    "and token_type_ids"
+                )
+            if set(self.config.layer_types) != {"full_attention"}:
+                raise RuntimeError(
+                    "Pinned DeepSeek-OCR Qwen2 visual encoder requires full-attention layers"
+                )
+            custom_mask = self._update_causal_mask(
+                attention_mask,
+                inputs_embeds,
+                kwargs.get("cache_position"),
+                past_key_values,
+                kwargs.get("output_attentions"),
+            )
+            attention_mask = {"full_attention": custom_mask}
+
+        return original_forward(
+            self,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+    qwen_model_type.forward = forward
+    setattr(qwen_model_type, _QWEN_MODEL_COMPAT_ATTRIBUTE, True)
+
+
+def install_deepseek_ocr_transformers_compat() -> DeepSeekOcrTransformersCompat:
+    """Install the exact legacy surfaces required by DeepSeek-OCR-2."""
+    installed_version = version("transformers")
+    if installed_version != _SUPPORTED_TRANSFORMERS_VERSION:
+        raise RuntimeError(
+            "DeepSeek-OCR compatibility requires Transformers "
+            f"{_SUPPORTED_TRANSFORMERS_VERSION}, found {installed_version}"
+        )
+
+    modeling_llama = importlib.import_module("transformers.models.llama.modeling_llama")
+    existing = getattr(modeling_llama, _COMPAT_STATE_ATTRIBUTE, None)
+    if existing is not None:
+        return existing
+
+    cache_utils = importlib.import_module("transformers.cache_utils")
+    configuration_utils = importlib.import_module("transformers.configuration_utils")
+    import_utils = importlib.import_module("transformers.utils.import_utils")
+    torch = importlib.import_module("torch")
+    if not hasattr(import_utils, "is_torch_fx_available"):
+
+        def is_torch_fx_available() -> bool:
+            return hasattr(torch, "fx")
+
+        import_utils.is_torch_fx_available = is_torch_fx_available
+
+    _install_config_compat(configuration_utils.PreTrainedConfig)
+    dynamic_cache_type = _build_legacy_dynamic_cache(cache_utils.Cache, torch)
+    cache_utils.DynamicCache = dynamic_cache_type
+    qwen_configuration = importlib.import_module("transformers.models.qwen2.configuration_qwen2")
+    _install_qwen_config_compat(qwen_configuration.Qwen2Config)
+    qwen_modeling = importlib.import_module("transformers.models.qwen2.modeling_qwen2")
+    _install_qwen_model_compat(qwen_modeling.Qwen2Model)
+
+    current_attention_type = modeling_llama.LlamaAttention
+    current_rotary_type = modeling_llama.LlamaRotaryEmbedding
+    repeat_kv = modeling_llama.repeat_kv
+
+    def apply_rotary_pos_emb(query, key, cos, sin):
+        """Use the pinned v4 eager RoPE operations, without v5 kernel dispatch."""
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+
+        def rotate_half(value):
+            first = value[..., : value.shape[-1] // 2]
+            second = value[..., value.shape[-1] // 2 :]
+            return torch.cat((-second, first), dim=-1)
+
+        return (
+            (query * cos) + (rotate_half(query) * sin),
+            (key * cos) + (rotate_half(key) * sin),
+        )
+
+    class DeepSeekOcrEagerLlamaAttention(current_attention_type):
+        """Translate the v4 call contract to Transformers 5 eager attention."""
+
+        _trtmc_deepseek_ocr_eager_compat = True
+
+        def __init__(self, config, layer_idx=None):
+            if getattr(config, "pretraining_tp", None) != 1:
+                raise RuntimeError("Pinned DeepSeek-OCR requires pretraining_tp=1")
+            if getattr(config, "_attn_implementation", None) != "eager":
+                raise RuntimeError("Pinned DeepSeek-OCR requires eager attention")
+            super().__init__(config=config, layer_idx=layer_idx)
+            self.hidden_size = config.hidden_size
+            self.num_heads = config.num_attention_heads
+            self.num_key_value_heads = config.num_key_value_heads
+            self.rotary_emb = current_rotary_type(config=config)
+
+        def forward(
+            self,
+            hidden_states,
+            attention_mask=None,
+            position_ids=None,
+            past_key_value=None,
+            output_attentions=False,
+            use_cache=False,
+            cache_position=None,
+            position_embeddings=None,
+            **kwargs,
+        ):
+            del use_cache
+            batch_size, query_length, _ = hidden_states.size()
+            query_states = self.q_proj(hidden_states)
+            key_states = self.k_proj(hidden_states)
+            value_states = self.v_proj(hidden_states)
+            query_states = query_states.view(
+                batch_size, query_length, self.num_heads, self.head_dim
+            ).transpose(1, 2)
+            key_states = key_states.view(
+                batch_size, query_length, self.num_key_value_heads, self.head_dim
+            ).transpose(1, 2)
+            value_states = value_states.view(
+                batch_size, query_length, self.num_key_value_heads, self.head_dim
+            ).transpose(1, 2)
+
+            if position_embeddings is None:
+                if position_ids is None:
+                    raise RuntimeError(
+                        "DeepSeek-OCR eager attention requires explicit position_ids"
+                    )
+                position_embeddings = self.rotary_emb(value_states, position_ids)
+            cos, sin = position_embeddings
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+            key_length = query_length
+            previous_length = 0
+            if past_key_value is not None:
+                previous_length = past_key_value.get_usable_length(query_length, self.layer_idx)
+                key_length += previous_length
+                cache_kwargs = {
+                    "sin": sin,
+                    "cos": cos,
+                    "cache_position": cache_position,
+                }
+                key_states, value_states = past_key_value.update(
+                    key_states,
+                    value_states,
+                    self.layer_idx,
+                    cache_kwargs,
+                )
+            if attention_mask is not None:
+                if attention_mask.shape[-1] != key_length:
+                    raise RuntimeError(
+                        "DeepSeek-OCR eager mask/cache mismatch before attention: "
+                        f"layer={self.layer_idx}, query={query_length}, "
+                        f"previous={previous_length}, mask={attention_mask.shape[-1]}"
+                    )
+                attention_mask = attention_mask[..., :key_length]
+
+            del kwargs
+            key_states = repeat_kv(key_states, self.num_key_value_groups)
+            value_states = repeat_kv(value_states, self.num_key_value_groups)
+            # Keep v4's division operation: folding this into a reciprocal
+            # multiply changes BF16 GPU logits and the qualified OCR output.
+            weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
+                self.head_dim
+            )
+            if attention_mask is not None:
+                weights = weights + attention_mask
+            weights = torch.nn.functional.softmax(weights, dim=-1, dtype=torch.float32).to(
+                query_states.dtype
+            )
+            weights = torch.nn.functional.dropout(
+                weights,
+                p=self.attention_dropout,
+                training=self.training,
+            )
+            output = torch.matmul(weights, value_states)
+            expected_shape = (
+                batch_size,
+                self.num_heads,
+                query_length,
+                self.head_dim,
+            )
+            if output.size() != expected_shape:
+                raise RuntimeError(
+                    "DeepSeek-OCR eager attention output shape mismatch: "
+                    f"expected={expected_shape}, found={tuple(output.size())}"
+                )
+            output = output.transpose(1, 2).contiguous()
+            output = output.reshape(batch_size, query_length, -1)
+            output = self.o_proj(output)
+            if not output_attentions:
+                weights = None
+            return output, weights, past_key_value
+
+    class DeepSeekOcrFlashAttentionCompat(DeepSeekOcrEagerLlamaAttention):
+        """Import-compatible marker; selecting it is rejected before inference."""
+
+        _trtmc_deepseek_ocr_flash_compat = True
+
+    DeepSeekOcrEagerLlamaAttention.__name__ = "LlamaAttention"
+    DeepSeekOcrEagerLlamaAttention.__qualname__ = "LlamaAttention"
+    DeepSeekOcrEagerLlamaAttention.__module__ = modeling_llama.__name__
+    DeepSeekOcrFlashAttentionCompat.__name__ = "LlamaFlashAttention2"
+    DeepSeekOcrFlashAttentionCompat.__qualname__ = "LlamaFlashAttention2"
+    DeepSeekOcrFlashAttentionCompat.__module__ = modeling_llama.__name__
+
+    modeling_llama.LlamaAttention = DeepSeekOcrEagerLlamaAttention
+    modeling_llama.LlamaFlashAttention2 = DeepSeekOcrFlashAttentionCompat
+    state = DeepSeekOcrTransformersCompat(
+        eager_attention_type=DeepSeekOcrEagerLlamaAttention,
+        flash_attention_type=DeepSeekOcrFlashAttentionCompat,
+        dynamic_cache_type=dynamic_cache_type,
+    )
+    setattr(modeling_llama, _COMPAT_STATE_ATTRIBUTE, state)
+    return state
+
+
+def assert_deepseek_ocr_eager_attention(
+    model: Any,
+    compat: DeepSeekOcrTransformersCompat,
+) -> int:
+    """Fail closed unless the loaded model selected pinned eager MHA layers."""
+    config = getattr(model, "config", None)
+    implementation = getattr(config, "_attn_implementation", None)
+    if implementation != "eager":
+        raise RuntimeError(
+            f"DeepSeek-OCR reference must use eager attention; loaded {implementation!r}"
+        )
+    if not callable(getattr(model, "named_modules", None)):
+        raise RuntimeError("DeepSeek-OCR reference model cannot be inspected")
+
+    eager_modules: list[tuple[str, Any]] = []
+    flash_modules: list[str] = []
+    for name, module in model.named_modules():
+        if isinstance(module, compat.flash_attention_type):
+            flash_modules.append(name)
+        elif isinstance(module, compat.eager_attention_type):
+            eager_modules.append((name, module))
+    if flash_modules:
+        raise RuntimeError(
+            "DeepSeek-OCR selected unsupported flash-attention compatibility "
+            f"layers: {flash_modules}"
+        )
+    if not eager_modules:
+        raise RuntimeError("DeepSeek-OCR did not instantiate the pinned eager MHA compatibility")
+
+    expected_layer_counts: set[int] = set()
+    for name, module in eager_modules:
+        module_config = getattr(module, "config", None)
+        if getattr(module_config, "_attn_implementation", None) != "eager":
+            raise RuntimeError(f"DeepSeek-OCR layer {name!r} is not configured for eager attention")
+        if getattr(module_config, "use_mla", None) is not False:
+            raise RuntimeError(f"DeepSeek-OCR layer {name!r} did not select pinned MHA mode")
+        expected_layer_counts.add(int(module_config.num_hidden_layers))
+    if expected_layer_counts != {len(eager_modules)}:
+        raise RuntimeError(
+            "DeepSeek-OCR eager attention layer count mismatch: "
+            f"expected {sorted(expected_layer_counts)}, found {len(eager_modules)}"
+        )
+    return len(eager_modules)

--- a/python/tensorrt_model_connect/families/chronos_bolt/python_profile_requirements/chronos.lock.txt
+++ b/python/tensorrt_model_connect/families/chronos_bolt/python_profile_requirements/chronos.lock.txt
@@ -1,6 +1,6 @@
-chronos-forecasting==2.2.2
-transformers==4.57.6
+chronos-forecasting==2.3.1
+transformers==5.5.0
 tokenizers==0.22.2
-huggingface_hub==0.36.2
+huggingface_hub==1.26.0
 accelerate==1.13.0
 einops==0.8.1

--- a/python/tensorrt_model_connect/families/chronos_bolt/python_profile_requirements/chronos.lock.txt
+++ b/python/tensorrt_model_connect/families/chronos_bolt/python_profile_requirements/chronos.lock.txt
@@ -1,6 +1,6 @@
 chronos-forecasting==2.3.1
-transformers==5.5.0
+transformers==5.5.4
 tokenizers==0.22.2
-huggingface_hub==1.26.0
+huggingface_hub==1.5.0
 accelerate==1.13.0
 einops==0.8.1

--- a/python/tensorrt_model_connect/families/chronos_bolt/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/chronos_bolt/python_profile_verify.py
@@ -1,8 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import version
+
 import chronos
 import transformers
+
+assert version("chronos-forecasting") == "2.3.1"
+assert version("huggingface-hub") == "1.5.0"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"
 
 config = transformers.T5Config(
     d_model=16,
@@ -25,8 +32,4 @@ config.chronos_config = {
     "use_reg_token": True,
 }
 chronos.chronos_bolt.ChronosBoltModelForForecasting(config).eval()
-print(
-    f"chronos={chronos.__version__} "
-    f"transformers={transformers.__version__} "
-    "chronos_bolt_ctor=ok"
-)
+print(f"chronos={chronos.__version__} transformers={transformers.__version__} chronos_bolt_ctor=ok")

--- a/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_requirements/deepseek_ocr.lock.txt
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_requirements/deepseek_ocr.lock.txt
@@ -1,6 +1,6 @@
 addict==2.4.0
 easydict==1.13
 einops==0.8.1
-huggingface-hub==0.26.5
-tokenizers==0.20.3
-transformers==4.46.3
+huggingface-hub==1.26.0
+tokenizers==0.22.2
+transformers==5.5.0

--- a/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_requirements/deepseek_ocr.lock.txt
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_requirements/deepseek_ocr.lock.txt
@@ -1,6 +1,6 @@
 addict==2.4.0
 easydict==1.13
 einops==0.8.1
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 tokenizers==0.22.2
-transformers==5.5.0
+transformers==5.5.4

--- a/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_verify.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import transformers
-from transformers.models.llama.modeling_llama import LlamaFlashAttention2
+from transformers.cache_utils import DynamicCache
+from transformers.models.llama.modeling_llama import LlamaAttention
 
-assert transformers.__version__ == "4.46.3"
-assert LlamaFlashAttention2 is not None
+assert transformers.__version__ == "5.5.0"
+assert hasattr(DynamicCache, "get_max_cache_shape")
+assert LlamaAttention is not None
 print(f"transformers={transformers.__version__}")

--- a/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/python_profile_verify.py
@@ -1,11 +1,176 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import transformers
-from transformers.cache_utils import DynamicCache
-from transformers.models.llama.modeling_llama import LlamaAttention
+"""Verify the pinned DeepSeek-OCR-2 reference on patched Transformers."""
 
-assert transformers.__version__ == "5.5.0"
-assert hasattr(DynamicCache, "get_max_cache_shape")
-assert LlamaAttention is not None
-print(f"transformers={transformers.__version__}")
+from importlib.metadata import version
+from types import SimpleNamespace
+
+import torch
+import transformers
+
+from tensorrt_model_connect.deepseek_ocr_reference_compat import (
+    assert_deepseek_ocr_eager_attention,
+    install_deepseek_ocr_transformers_compat,
+)
+
+
+assert version("huggingface-hub") == "1.5.0"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"
+
+compat = install_deepseek_ocr_transformers_compat()
+from transformers.models.llama.modeling_llama import (  # noqa: E402
+    LlamaAttention,
+    LlamaFlashAttention2,
+)
+
+assert LlamaAttention is compat.eager_attention_type
+assert LlamaFlashAttention2 is compat.flash_attention_type
+
+from transformers.configuration_utils import PreTrainedConfig  # noqa: E402
+
+
+class LegacyConfig(PreTrainedConfig):
+    def __init__(self, inherited_default=17, **kwargs):
+        self.inherited_default = inherited_default
+        super().__init__(**kwargs)
+
+
+class LegacyConfigChild(LegacyConfig):
+    pass
+
+
+legacy_config = LegacyConfigChild(pad_token_id=None, bos_token_id=0, eos_token_id=1)
+assert legacy_config.inherited_default == 17
+assert legacy_config.pad_token_id is None
+assert legacy_config.bos_token_id == 0
+assert legacy_config.eos_token_id == 1
+
+from transformers import Qwen2Config  # noqa: E402
+from transformers.models.qwen2.modeling_qwen2 import Qwen2Model  # noqa: E402
+
+
+qwen_config = Qwen2Config(num_hidden_layers=3, _attn_implementation="sdpa")
+assert qwen_config.num_hidden_layers == 3
+assert qwen_config.layer_types == ["full_attention"] * 3
+assert qwen_config._attn_implementation == "sdpa"
+
+
+class CustomQwen2ModelInner(Qwen2Model):
+    def forward(self, *, inputs_embeds, token_type_ids, attention_mask=None, **kwargs):
+        self._current_token_type_ids = token_type_ids
+        return super().forward(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+
+    def _update_causal_mask(
+        self,
+        attention_mask,
+        input_tensor,
+        cache_position,
+        past_key_values,
+        output_attentions,
+    ):
+        del attention_mask, cache_position, past_key_values, output_attentions
+        self._legacy_mask_called = True
+        batch_size, sequence_length = input_tensor.shape[:2]
+        return torch.zeros(
+            (batch_size, 1, sequence_length, sequence_length),
+            dtype=input_tensor.dtype,
+            device=input_tensor.device,
+        )
+
+
+vision_config = Qwen2Config(
+    hidden_size=8,
+    num_hidden_layers=1,
+    num_attention_heads=2,
+    num_key_value_heads=2,
+    intermediate_size=16,
+    max_position_embeddings=16,
+    vocab_size=16,
+    _attn_implementation="sdpa",
+    use_cache=False,
+)
+vision_model = CustomQwen2ModelInner(vision_config).eval()
+CustomQwen2ModelInner.__module__ = "transformers_modules.deepseek_ocr.deepencoderv2"
+vision_inputs = torch.randn(1, 4, vision_config.hidden_size)
+vision_token_types = torch.zeros((1, 4), dtype=torch.long)
+vision_output = vision_model(
+    inputs_embeds=vision_inputs,
+    token_type_ids=vision_token_types,
+    use_cache=False,
+)
+assert vision_output.last_hidden_state.shape == vision_inputs.shape
+assert vision_model._legacy_mask_called
+
+config = SimpleNamespace(
+    _attn_implementation="eager",
+    attention_bias=False,
+    attention_dropout=0.0,
+    hidden_size=8,
+    max_position_embeddings=16,
+    num_attention_heads=2,
+    num_hidden_layers=1,
+    num_key_value_heads=2,
+    pretraining_tp=1,
+    rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+    rope_theta=10000.0,
+    use_mla=False,
+)
+torch.manual_seed(7)
+attention = compat.eager_attention_type(config, layer_idx=0).eval().to(torch.bfloat16)
+cache = compat.dynamic_cache_type.from_legacy_cache()
+hidden_states = torch.randn(1, 3, config.hidden_size).to(torch.bfloat16)
+position_ids = torch.arange(3).unsqueeze(0)
+output, weights, returned_cache = attention(
+    hidden_states,
+    position_ids=position_ids,
+    past_key_value=cache,
+    use_cache=True,
+)
+assert output.shape == hidden_states.shape
+expected_first_token = torch.tensor(
+    [
+        -0.123046875,
+        0.06640625,
+        0.0194091796875,
+        -0.02880859375,
+        0.0279541015625,
+        0.058349609375,
+        -0.1923828125,
+        0.0439453125,
+    ],
+    dtype=torch.float32,
+)
+assert torch.equal(output[0, 0].float(), expected_first_token)
+assert weights is None
+assert returned_cache is cache
+assert cache.seen_tokens == 3
+assert cache.get_usable_length(1) == 3
+assert cache.get_max_length() is None
+legacy_cache = cache.to_legacy_cache()
+assert len(legacy_cache) == 1
+assert compat.dynamic_cache_type.from_legacy_cache(legacy_cache).seen_tokens == 3
+
+
+class TinyEagerModel(torch.nn.Module):
+    def __init__(self, attention_module):
+        super().__init__()
+        self.config = config
+        self.attention = attention_module
+
+
+assert assert_deepseek_ocr_eager_attention(TinyEagerModel(attention), compat) == 1
+flash_model = TinyEagerModel(compat.flash_attention_type(config, layer_idx=0))
+try:
+    assert_deepseek_ocr_eager_attention(flash_model, compat)
+except RuntimeError as error:
+    assert "unsupported flash-attention" in str(error)
+else:
+    raise AssertionError("flash-attention compatibility selection was accepted")
+
+print("transformers=5.5.4 deepseek_ocr_eager_compat=ok")

--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
@@ -8,6 +8,6 @@ import tokenizers
 import transformers
 
 
-assert transformers.__version__ == "4.44.2"
-assert tokenizers.__version__ == "0.19.1"
-assert huggingface_hub.__version__ == "0.24.7"
+assert transformers.__version__ == "5.5.0"
+assert tokenizers.__version__ == "0.22.2"
+assert huggingface_hub.__version__ == "1.26.0"

--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
@@ -3,11 +3,11 @@
 
 """Verify the official PyTorch ELF reference environment."""
 
-import huggingface_hub
-import tokenizers
+from importlib.metadata import version
+
 import transformers
 
 
-assert transformers.__version__ == "5.5.0"
-assert tokenizers.__version__ == "0.22.2"
-assert huggingface_hub.__version__ == "1.26.0"
+assert version("huggingface-hub") == "1.5.0"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"

--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-huggingface-hub==0.24.7
-tokenizers==0.19.1
-transformers==4.44.2
+huggingface-hub==1.26.0
+tokenizers==0.22.2
+transformers==5.5.0

--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 tokenizers==0.22.2
-transformers==5.5.0
+transformers==5.5.4

--- a/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
@@ -1,4 +1,4 @@
 einops==0.8.1
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 tokenizers==0.22.2
-transformers==5.5.0
+transformers==5.5.4

--- a/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
@@ -1,4 +1,4 @@
 einops==0.8.1
-huggingface-hub==0.26.5
-tokenizers==0.20.3
-transformers==4.46.3
+huggingface-hub==1.26.0
+tokenizers==0.22.2
+transformers==5.5.0

--- a/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
@@ -1,10 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import version
+
 import einops
 import transformers
 from transformers.cache_utils import DynamicCache
 
-assert hasattr(DynamicCache, "get_max_cache_shape")
-assert transformers.__version__ == "5.5.0"
+
+if not hasattr(DynamicCache, "from_legacy_cache"):
+
+    @classmethod
+    def _from_legacy_cache(cls, past_key_values=None):
+        return cls(past_key_values) if past_key_values else cls()
+
+    DynamicCache.from_legacy_cache = _from_legacy_cache
+
+assert version("einops") == "0.8.1"
+assert version("huggingface-hub") == "1.5.0"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"
+assert callable(DynamicCache.get_max_cache_shape)
+assert isinstance(DynamicCache.from_legacy_cache(), DynamicCache)
 print(f"einops={einops.__version__} transformers={transformers.__version__}")

--- a/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
@@ -5,6 +5,6 @@ import einops
 import transformers
 from transformers.cache_utils import DynamicCache
 
-assert hasattr(DynamicCache, "from_legacy_cache")
 assert hasattr(DynamicCache, "get_max_cache_shape")
+assert transformers.__version__ == "5.5.0"
 print(f"einops={einops.__version__} transformers={transformers.__version__}")

--- a/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
@@ -1,8 +1,8 @@
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 imageio==2.34.0
 numpy==1.26.4
 opencv-python-headless==4.8.1.78
 scikit-learn==1.5.0
 scipy==1.12.0
 tokenizers==0.22.2
-transformers==5.5.0
+transformers==5.5.4

--- a/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
@@ -1,9 +1,8 @@
-flash-attn==2.8.3
-huggingface-hub==0.29.1
+huggingface-hub==1.26.0
 imageio==2.34.0
 numpy==1.26.4
-opencv-python-headless==4.7.0.72
-scikit-learn==1.4.2
+opencv-python-headless==4.8.1.78
+scikit-learn==1.5.0
 scipy==1.12.0
-tokenizers==0.21.4
-transformers==4.49.0
+tokenizers==0.22.2
+transformers==5.5.0

--- a/python/tensorrt_model_connect/families/lance/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/lance/python_profile_verify.py
@@ -15,21 +15,19 @@ try:
 except metadata.PackageNotFoundError:
     pass
 else:
-    raise AssertionError("the vulnerable flash-attn distribution must not be installed")
-assert metadata.version("huggingface-hub") == "1.26.0"
+    raise AssertionError("the flash-attn distribution must not be installed")
+assert metadata.version("huggingface-hub") == "1.5.0"
 assert metadata.version("imageio") == "2.34.0"
 assert metadata.version("numpy") == "1.26.4"
 assert metadata.version("opencv-python-headless") == "4.8.1.78"
 assert metadata.version("scikit-learn") == "1.5.0"
 assert metadata.version("scipy") == "1.12.0"
 assert metadata.version("tokenizers") == "0.22.2"
-assert metadata.version("transformers") == "5.5.0"
+assert metadata.version("transformers") == "5.5.4"
 assert callable(cv2.imread)
 assert callable(imageio.imread)
 assert numpy.__version__ == "1.26.4"
 assert scipy.__version__ == "1.12.0"
 assert sklearn.__version__ == "1.5.0"
 assert hasattr(DynamicCache, "get_max_cache_shape")
-print(
-    f"transformers={metadata.version('transformers')}"
-)
+print(f"transformers={metadata.version('transformers')}")

--- a/python/tensorrt_model_connect/families/lance/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/lance/python_profile_verify.py
@@ -8,26 +8,28 @@ import imageio
 import numpy
 import scipy
 import sklearn
-from flash_attn import flash_attn_varlen_func
-from transformers.cache_utils import SlidingWindowCache
+from transformers.cache_utils import DynamicCache
 
-assert metadata.version("flash-attn") == "2.8.3"
-assert metadata.version("huggingface-hub") == "0.29.1"
+try:
+    metadata.version("flash-attn")
+except metadata.PackageNotFoundError:
+    pass
+else:
+    raise AssertionError("the vulnerable flash-attn distribution must not be installed")
+assert metadata.version("huggingface-hub") == "1.26.0"
 assert metadata.version("imageio") == "2.34.0"
 assert metadata.version("numpy") == "1.26.4"
-assert metadata.version("opencv-python-headless") == "4.7.0.72"
-assert metadata.version("scikit-learn") == "1.4.2"
+assert metadata.version("opencv-python-headless") == "4.8.1.78"
+assert metadata.version("scikit-learn") == "1.5.0"
 assert metadata.version("scipy") == "1.12.0"
-assert metadata.version("tokenizers") == "0.21.4"
-assert metadata.version("transformers") == "4.49.0"
+assert metadata.version("tokenizers") == "0.22.2"
+assert metadata.version("transformers") == "5.5.0"
 assert callable(cv2.imread)
 assert callable(imageio.imread)
 assert numpy.__version__ == "1.26.4"
 assert scipy.__version__ == "1.12.0"
-assert sklearn.__version__ == "1.4.2"
-assert callable(flash_attn_varlen_func)
-assert SlidingWindowCache is not None
+assert sklearn.__version__ == "1.5.0"
+assert hasattr(DynamicCache, "get_max_cache_shape")
 print(
-    f"flash-attn={metadata.version('flash-attn')} "
     f"transformers={metadata.version('transformers')}"
 )

--- a/python/tensorrt_model_connect/families/nemotron_h/python_profile_requirements/nemotron_h_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/nemotron_h/python_profile_requirements/nemotron_h_reference.lock.txt
@@ -1,13 +1,13 @@
 apache-tvm-ffi==0.1.9
 causal-conv1d==1.6.2.post1
-huggingface-hub==0.31.4
+huggingface-hub==1.26.0
 mamba-ssm==2.3.2.post1
 nvidia-cutlass-dsl==4.6.0.dev0
 nvidia-cutlass-dsl-libs-base==4.6.0.dev0
 protobuf==6.33.6
 quack-kernels==0.5.3
 tilelang==0.1.8
-tokenizers==0.21.1
+tokenizers==0.22.2
 torch-c-dlpack-ext==0.1.5
-transformers==4.48.3
+transformers==5.5.0
 z3-solver==4.15.4.0

--- a/python/tensorrt_model_connect/families/nemotron_h/python_profile_requirements/nemotron_h_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/nemotron_h/python_profile_requirements/nemotron_h_reference.lock.txt
@@ -1,6 +1,6 @@
 apache-tvm-ffi==0.1.9
 causal-conv1d==1.6.2.post1
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 mamba-ssm==2.3.2.post1
 nvidia-cutlass-dsl==4.6.0.dev0
 nvidia-cutlass-dsl-libs-base==4.6.0.dev0
@@ -9,5 +9,5 @@ quack-kernels==0.5.3
 tilelang==0.1.8
 tokenizers==0.22.2
 torch-c-dlpack-ext==0.1.5
-transformers==5.5.0
+transformers==5.5.4
 z3-solver==4.15.4.0

--- a/python/tensorrt_model_connect/families/nemotron_h/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/python_profile_verify.py
@@ -10,7 +10,7 @@ import transformers
 from mamba_ssm.ops.triton.layernorm_gated import rmsnorm_fn  # noqa: F401
 
 
-assert transformers.__version__ == "4.48.3"
+assert transformers.__version__ == "5.5.0"
 assert version("causal-conv1d") == "1.6.2.post1"
 assert version("mamba-ssm") == "2.3.2.post1"
 print(

--- a/python/tensorrt_model_connect/families/nemotron_h/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/python_profile_verify.py
@@ -10,10 +10,13 @@ import transformers
 from mamba_ssm.ops.triton.layernorm_gated import rmsnorm_fn  # noqa: F401
 
 
-assert transformers.__version__ == "5.5.0"
+assert version("huggingface-hub") == "1.5.0"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"
 assert version("causal-conv1d") == "1.6.2.post1"
 assert version("mamba-ssm") == "2.3.2.post1"
 print(
     f"transformers={transformers.__version__} "
     f"causal-conv1d={version('causal-conv1d')} "
-    f"mamba-ssm={version('mamba-ssm')}")
+    f"mamba-ssm={version('mamba-ssm')}"
+)

--- a/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_requirements/phi4_multimodal.lock.txt
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_requirements/phi4_multimodal.lock.txt
@@ -1,6 +1,6 @@
 accelerate==1.3.0
 backoff==2.2.1
-huggingface-hub==0.28.1
+huggingface-hub==1.26.0
 peft==0.13.2
-tokenizers==0.21.4
-transformers==4.48.2
+tokenizers==0.22.2
+transformers==5.5.0

--- a/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_requirements/phi4_multimodal.lock.txt
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_requirements/phi4_multimodal.lock.txt
@@ -1,6 +1,6 @@
 accelerate==1.3.0
 backoff==2.2.1
-huggingface-hub==1.26.0
+huggingface-hub==1.5.0
 peft==0.13.2
 tokenizers==0.22.2
-transformers==5.5.0
+transformers==5.5.4

--- a/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_verify.py
@@ -3,8 +3,9 @@
 
 import backoff
 import transformers
-from transformers.cache_utils import SlidingWindowCache
+from transformers.cache_utils import DynamicCache, StaticCache
 
-assert transformers.__version__ == "4.48.2"
-assert SlidingWindowCache is not None
+assert transformers.__version__ == "5.5.0"
+assert hasattr(DynamicCache, "get_max_cache_shape")
+assert StaticCache is not None
 print(f"backoff={backoff.__version__} transformers={transformers.__version__}")

--- a/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/python_profile_verify.py
@@ -1,11 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import backoff
-import transformers
-from transformers.cache_utils import DynamicCache, StaticCache
+from importlib.metadata import version
 
-assert transformers.__version__ == "5.5.0"
-assert hasattr(DynamicCache, "get_max_cache_shape")
-assert StaticCache is not None
+import backoff
+import peft
+import transformers
+from transformers.cache_utils import SlidingWindowCache
+
+
+assert version("huggingface-hub") == "1.5.0"
+assert version("peft") == "0.13.2"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4"
+assert peft.__version__ == "0.13.2"
+assert SlidingWindowCache is not None
 print(f"backoff={backoff.__version__} transformers={transformers.__version__}")

--- a/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-transformers==5.5.0
+huggingface-hub==1.5.0
 rouge-score==0.1.2
 sacrebleu==2.5.1
+tokenizers==0.22.2
+transformers==5.5.4

--- a/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-transformers==5.2.0
+transformers==5.5.0
 rouge-score==0.1.2
 sacrebleu==2.5.1

--- a/python/tensorrt_model_connect/python_profiles.toml
+++ b/python/tensorrt_model_connect/python_profiles.toml
@@ -13,7 +13,7 @@ system_site_packages = true
 verification_script = """
 from importlib.metadata import version
 import transformers
-assert transformers.__version__ == "5.2.0", transformers.__version__
+assert transformers.__version__ == "5.5.0", transformers.__version__
 assert version("rouge-score") == "0.1.2"
 assert version("sacrebleu") == "2.5.1"
 """

--- a/python/tensorrt_model_connect/python_profiles.toml
+++ b/python/tensorrt_model_connect/python_profiles.toml
@@ -13,9 +13,11 @@ system_site_packages = true
 verification_script = """
 from importlib.metadata import version
 import transformers
-assert transformers.__version__ == "5.5.0", transformers.__version__
+assert version("huggingface-hub") == "1.5.0"
 assert version("rouge-score") == "0.1.2"
 assert version("sacrebleu") == "2.5.1"
+assert version("tokenizers") == "0.22.2"
+assert transformers.__version__ == "5.5.4", transformers.__version__
 """
 
 [reference_backend_defaults.golden_snapshot]

--- a/tests/e2e/models/deepseek_ocr/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/deepseek_ocr/e2e_plugins/references/hf_transformers.py
@@ -21,9 +21,7 @@ class DeepSeekOcrHfReference:
     def backend_name(self) -> str:
         return "hf_transformers"
 
-    def run_stage(
-        self, case: E2ECase, stage: StageSpec, ctx: RunContext
-    ) -> StageOutput:
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
         if stage.name != "full_generation":
             return StageOutput(
                 stage_name=stage.name,
@@ -35,24 +33,29 @@ class DeepSeekOcrHfReference:
         cmd = [
             ctx.reference_python_path() or "python3",
             str(script),
-            "--model", case.hf_id,
-            "--image", str(case.inputs.get("image", "")),
-            "--prompt", str(case.inputs.get("prompt", "")),
+            "--model",
+            case.hf_id,
+            "--revision",
+            case.hf_revision,
+            "--image",
+            str(case.inputs.get("image", "")),
+            "--prompt",
+            str(case.inputs.get("prompt", "")),
         ]
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
 
         started = time.monotonic()
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=1800)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=1800)
         elapsed = time.monotonic() - started
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
-                result.stderr, ctx.artifacts_dir or "", "hf_transformers", case.name)
+                result.stderr, ctx.artifacts_dir or "", "hf_transformers", case.name
+            )
             message = (
-                f"DeepSeek-OCR Hugging Face reference failed "
-                f"(rc={result.returncode}): {truncated}")
+                f"DeepSeek-OCR Hugging Face reference failed (rc={result.returncode}): {truncated}"
+            )
             if log_path:
                 message += f" (full stderr: {log_path})"
             raise RuntimeError(message)

--- a/tests/e2e/models/deepseek_ocr/hf_reference.py
+++ b/tests/e2e/models/deepseek_ocr/hf_reference.py
@@ -8,10 +8,198 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import tempfile
 
 import torch
+import torch.nn.functional as F
 from transformers import AutoModel, AutoTokenizer
+
+
+def _install_transformers_5_legacy_model_compat() -> None:
+    """Bridge only the cache/import APIs used by the pinned upstream model code."""
+    from transformers.cache_utils import Cache, DynamicCache
+    import transformers.models.llama.modeling_llama as llama
+    import transformers.utils.import_utils as import_utils
+
+    if not hasattr(Cache, "get_usable_length"):
+        def get_usable_length(self, new_seq_length, layer_idx=0):
+            previous = self.get_seq_length(layer_idx)
+            maximum = self.get_max_cache_shape()
+            if maximum is None or maximum < 0:
+                return previous
+            if previous + new_seq_length > maximum:
+                return max(0, maximum - new_seq_length)
+            return previous
+
+        Cache.get_usable_length = get_usable_length
+    if not hasattr(Cache, "get_max_length"):
+        def get_max_length(self):
+            maximum = self.get_max_cache_shape()
+            return None if maximum is None or maximum < 0 else maximum
+
+        Cache.get_max_length = get_max_length
+    if not hasattr(Cache, "seen_tokens"):
+        Cache.seen_tokens = property(lambda self: self.get_seq_length())
+    if not hasattr(DynamicCache, "to_legacy_cache"):
+        def to_legacy_cache(self):
+            return tuple((layer.keys, layer.values) for layer in self.layers)
+
+        DynamicCache.to_legacy_cache = to_legacy_cache
+    if not hasattr(DynamicCache, "from_legacy_cache"):
+        @classmethod
+        def from_legacy_cache(cls, past_key_values=None):
+            cache = cls()
+            for layer_idx, (key_states, value_states) in enumerate(
+                past_key_values or ()
+            ):
+                cache.update(key_states, value_states, layer_idx)
+            return cache
+
+        DynamicCache.from_legacy_cache = from_legacy_cache
+    if not hasattr(llama, "LlamaFlashAttention2"):
+        from transformers.models.llama.configuration_llama import LlamaConfig
+
+        class _LlamaAttentionCompat(torch.nn.Module):
+            """Transformers 4.46 eager attention contract used by DeepSeek-OCR-2."""
+
+            def __init__(self, config, layer_idx=None):
+                super().__init__()
+                self.config = config
+                self.layer_idx = layer_idx
+                self.attention_dropout = config.attention_dropout
+                self.hidden_size = config.hidden_size
+                self.num_heads = config.num_attention_heads
+                self.head_dim = self.hidden_size // self.num_heads
+                self.num_key_value_heads = config.num_key_value_heads
+                self.num_key_value_groups = (
+                    self.num_heads // self.num_key_value_heads
+                )
+                self.q_proj = torch.nn.Linear(
+                    self.hidden_size,
+                    self.num_heads * self.head_dim,
+                    bias=config.attention_bias,
+                )
+                self.k_proj = torch.nn.Linear(
+                    self.hidden_size,
+                    self.num_key_value_heads * self.head_dim,
+                    bias=config.attention_bias,
+                )
+                self.v_proj = torch.nn.Linear(
+                    self.hidden_size,
+                    self.num_key_value_heads * self.head_dim,
+                    bias=config.attention_bias,
+                )
+                self.o_proj = torch.nn.Linear(
+                    self.num_heads * self.head_dim,
+                    self.hidden_size,
+                    bias=config.attention_bias,
+                )
+                if getattr(config, "rope_scaling", None) is not None:
+                    raise ValueError(
+                        "DeepSeek-OCR-2 compatibility expects unscaled RoPE"
+                    )
+                rope_config = LlamaConfig(
+                    hidden_size=config.hidden_size,
+                    num_attention_heads=config.num_attention_heads,
+                    num_key_value_heads=config.num_key_value_heads,
+                    max_position_embeddings=config.max_position_embeddings,
+                    rope_parameters={
+                        "rope_theta": getattr(config, "rope_theta", 10000.0),
+                        "rope_type": "default",
+                    },
+                )
+                self.rotary_emb = llama.LlamaRotaryEmbedding(rope_config)
+
+            def forward(
+                self,
+                hidden_states,
+                attention_mask=None,
+                position_ids=None,
+                past_key_value=None,
+                output_attentions=False,
+                use_cache=False,
+                cache_position=None,
+                position_embeddings=None,
+                **kwargs,
+            ):
+                del use_cache, kwargs
+                batch_size, query_length, _ = hidden_states.size()
+                query_states = self.q_proj(hidden_states)
+                key_states = self.k_proj(hidden_states)
+                value_states = self.v_proj(hidden_states)
+                query_states = query_states.view(
+                    batch_size, query_length, self.num_heads, self.head_dim
+                ).transpose(1, 2)
+                key_states = key_states.view(
+                    batch_size,
+                    query_length,
+                    self.num_key_value_heads,
+                    self.head_dim,
+                ).transpose(1, 2)
+                value_states = value_states.view(
+                    batch_size,
+                    query_length,
+                    self.num_key_value_heads,
+                    self.head_dim,
+                ).transpose(1, 2)
+
+                if position_embeddings is None:
+                    cos, sin = self.rotary_emb(value_states, position_ids)
+                else:
+                    cos, sin = position_embeddings
+                query_states, key_states = llama.apply_rotary_pos_emb(
+                    query_states, key_states, cos, sin
+                )
+                if past_key_value is not None:
+                    cache_kwargs = {
+                        "sin": sin,
+                        "cos": cos,
+                        "cache_position": cache_position,
+                    }
+                    key_states, value_states = past_key_value.update(
+                        key_states,
+                        value_states,
+                        self.layer_idx,
+                        cache_kwargs,
+                    )
+                key_states = llama.repeat_kv(
+                    key_states, self.num_key_value_groups
+                )
+                value_states = llama.repeat_kv(
+                    value_states, self.num_key_value_groups
+                )
+                attention_weights = torch.matmul(
+                    query_states, key_states.transpose(2, 3)
+                ) / math.sqrt(self.head_dim)
+                if attention_mask is not None:
+                    attention_weights = attention_weights + attention_mask[
+                        :, :, :, : key_states.shape[-2]
+                    ]
+                attention_weights = F.softmax(
+                    attention_weights, dim=-1, dtype=torch.float32
+                ).to(query_states.dtype)
+                attention_weights = F.dropout(
+                    attention_weights,
+                    p=self.attention_dropout,
+                    training=self.training,
+                )
+                attention_output = torch.matmul(
+                    attention_weights, value_states
+                )
+                attention_output = attention_output.transpose(1, 2).contiguous()
+                attention_output = attention_output.reshape(
+                    batch_size, query_length, -1
+                )
+                attention_output = self.o_proj(attention_output)
+                if not output_attentions:
+                    attention_weights = None
+                return attention_output, attention_weights, past_key_value
+
+        llama.LlamaAttention = _LlamaAttentionCompat
+        llama.LlamaFlashAttention2 = _LlamaAttentionCompat
+    if not hasattr(import_utils, "is_torch_fx_available"):
+        import_utils.is_torch_fx_available = lambda: False
 
 
 def main() -> int:
@@ -20,6 +208,8 @@ def main() -> int:
     parser.add_argument("--image", required=True)
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
+
+    _install_transformers_5_legacy_model_compat()
 
     tokenizer = AutoTokenizer.from_pretrained(
         args.model, trust_remote_code=True)

--- a/tests/e2e/models/deepseek_ocr/hf_reference.py
+++ b/tests/e2e/models/deepseek_ocr/hf_reference.py
@@ -8,218 +8,61 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
+import re
 import tempfile
 
 import torch
-import torch.nn.functional as F
 from transformers import AutoModel, AutoTokenizer
 
-
-def _install_transformers_5_legacy_model_compat() -> None:
-    """Bridge only the cache/import APIs used by the pinned upstream model code."""
-    from transformers.cache_utils import Cache, DynamicCache
-    import transformers.models.llama.modeling_llama as llama
-    import transformers.utils.import_utils as import_utils
-
-    if not hasattr(Cache, "get_usable_length"):
-        def get_usable_length(self, new_seq_length, layer_idx=0):
-            previous = self.get_seq_length(layer_idx)
-            maximum = self.get_max_cache_shape()
-            if maximum is None or maximum < 0:
-                return previous
-            if previous + new_seq_length > maximum:
-                return max(0, maximum - new_seq_length)
-            return previous
-
-        Cache.get_usable_length = get_usable_length
-    if not hasattr(Cache, "get_max_length"):
-        def get_max_length(self):
-            maximum = self.get_max_cache_shape()
-            return None if maximum is None or maximum < 0 else maximum
-
-        Cache.get_max_length = get_max_length
-    if not hasattr(Cache, "seen_tokens"):
-        Cache.seen_tokens = property(lambda self: self.get_seq_length())
-    if not hasattr(DynamicCache, "to_legacy_cache"):
-        def to_legacy_cache(self):
-            return tuple((layer.keys, layer.values) for layer in self.layers)
-
-        DynamicCache.to_legacy_cache = to_legacy_cache
-    if not hasattr(DynamicCache, "from_legacy_cache"):
-        @classmethod
-        def from_legacy_cache(cls, past_key_values=None):
-            cache = cls()
-            for layer_idx, (key_states, value_states) in enumerate(
-                past_key_values or ()
-            ):
-                cache.update(key_states, value_states, layer_idx)
-            return cache
-
-        DynamicCache.from_legacy_cache = from_legacy_cache
-    if not hasattr(llama, "LlamaFlashAttention2"):
-        from transformers.models.llama.configuration_llama import LlamaConfig
-
-        class _LlamaAttentionCompat(torch.nn.Module):
-            """Transformers 4.46 eager attention contract used by DeepSeek-OCR-2."""
-
-            def __init__(self, config, layer_idx=None):
-                super().__init__()
-                self.config = config
-                self.layer_idx = layer_idx
-                self.attention_dropout = config.attention_dropout
-                self.hidden_size = config.hidden_size
-                self.num_heads = config.num_attention_heads
-                self.head_dim = self.hidden_size // self.num_heads
-                self.num_key_value_heads = config.num_key_value_heads
-                self.num_key_value_groups = (
-                    self.num_heads // self.num_key_value_heads
-                )
-                self.q_proj = torch.nn.Linear(
-                    self.hidden_size,
-                    self.num_heads * self.head_dim,
-                    bias=config.attention_bias,
-                )
-                self.k_proj = torch.nn.Linear(
-                    self.hidden_size,
-                    self.num_key_value_heads * self.head_dim,
-                    bias=config.attention_bias,
-                )
-                self.v_proj = torch.nn.Linear(
-                    self.hidden_size,
-                    self.num_key_value_heads * self.head_dim,
-                    bias=config.attention_bias,
-                )
-                self.o_proj = torch.nn.Linear(
-                    self.num_heads * self.head_dim,
-                    self.hidden_size,
-                    bias=config.attention_bias,
-                )
-                if getattr(config, "rope_scaling", None) is not None:
-                    raise ValueError(
-                        "DeepSeek-OCR-2 compatibility expects unscaled RoPE"
-                    )
-                rope_config = LlamaConfig(
-                    hidden_size=config.hidden_size,
-                    num_attention_heads=config.num_attention_heads,
-                    num_key_value_heads=config.num_key_value_heads,
-                    max_position_embeddings=config.max_position_embeddings,
-                    rope_parameters={
-                        "rope_theta": getattr(config, "rope_theta", 10000.0),
-                        "rope_type": "default",
-                    },
-                )
-                self.rotary_emb = llama.LlamaRotaryEmbedding(rope_config)
-
-            def forward(
-                self,
-                hidden_states,
-                attention_mask=None,
-                position_ids=None,
-                past_key_value=None,
-                output_attentions=False,
-                use_cache=False,
-                cache_position=None,
-                position_embeddings=None,
-                **kwargs,
-            ):
-                del use_cache, kwargs
-                batch_size, query_length, _ = hidden_states.size()
-                query_states = self.q_proj(hidden_states)
-                key_states = self.k_proj(hidden_states)
-                value_states = self.v_proj(hidden_states)
-                query_states = query_states.view(
-                    batch_size, query_length, self.num_heads, self.head_dim
-                ).transpose(1, 2)
-                key_states = key_states.view(
-                    batch_size,
-                    query_length,
-                    self.num_key_value_heads,
-                    self.head_dim,
-                ).transpose(1, 2)
-                value_states = value_states.view(
-                    batch_size,
-                    query_length,
-                    self.num_key_value_heads,
-                    self.head_dim,
-                ).transpose(1, 2)
-
-                if position_embeddings is None:
-                    cos, sin = self.rotary_emb(value_states, position_ids)
-                else:
-                    cos, sin = position_embeddings
-                query_states, key_states = llama.apply_rotary_pos_emb(
-                    query_states, key_states, cos, sin
-                )
-                if past_key_value is not None:
-                    cache_kwargs = {
-                        "sin": sin,
-                        "cos": cos,
-                        "cache_position": cache_position,
-                    }
-                    key_states, value_states = past_key_value.update(
-                        key_states,
-                        value_states,
-                        self.layer_idx,
-                        cache_kwargs,
-                    )
-                key_states = llama.repeat_kv(
-                    key_states, self.num_key_value_groups
-                )
-                value_states = llama.repeat_kv(
-                    value_states, self.num_key_value_groups
-                )
-                attention_weights = torch.matmul(
-                    query_states, key_states.transpose(2, 3)
-                ) / math.sqrt(self.head_dim)
-                if attention_mask is not None:
-                    attention_weights = attention_weights + attention_mask[
-                        :, :, :, : key_states.shape[-2]
-                    ]
-                attention_weights = F.softmax(
-                    attention_weights, dim=-1, dtype=torch.float32
-                ).to(query_states.dtype)
-                attention_weights = F.dropout(
-                    attention_weights,
-                    p=self.attention_dropout,
-                    training=self.training,
-                )
-                attention_output = torch.matmul(
-                    attention_weights, value_states
-                )
-                attention_output = attention_output.transpose(1, 2).contiguous()
-                attention_output = attention_output.reshape(
-                    batch_size, query_length, -1
-                )
-                attention_output = self.o_proj(attention_output)
-                if not output_attentions:
-                    attention_weights = None
-                return attention_output, attention_weights, past_key_value
-
-        llama.LlamaAttention = _LlamaAttentionCompat
-        llama.LlamaFlashAttention2 = _LlamaAttentionCompat
-    if not hasattr(import_utils, "is_torch_fx_available"):
-        import_utils.is_torch_fx_available = lambda: False
+from tensorrt_model_connect.deepseek_ocr_reference_compat import (
+    DEEPSEEK_OCR_REFERENCE_REVISION,
+    assert_deepseek_ocr_eager_attention,
+    configure_deepseek_ocr_legacy_generation_cache,
+    configure_deepseek_ocr_rotary_embeddings,
+    install_deepseek_ocr_transformers_compat,
+)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
+    parser.add_argument("--revision", required=True)
     parser.add_argument("--image", required=True)
     parser.add_argument("--prompt", required=True)
     args = parser.parse_args()
+    if not re.fullmatch(r"[0-9a-f]{40}", args.revision):
+        parser.error("--revision must be an exact 40-character commit SHA")
+    if args.revision != DEEPSEEK_OCR_REFERENCE_REVISION:
+        parser.error(
+            "--revision must match the qualified DeepSeek-OCR-2 reference "
+            f"{DEEPSEEK_OCR_REFERENCE_REVISION}"
+        )
 
-    _install_transformers_5_legacy_model_compat()
+    compat = install_deepseek_ocr_transformers_compat()
 
     tokenizer = AutoTokenizer.from_pretrained(
-        args.model, trust_remote_code=True)
+        args.model,
+        revision=args.revision,
+        code_revision=args.revision,
+        trust_remote_code=True,
+    )
     model = AutoModel.from_pretrained(
         args.model,
+        revision=args.revision,
+        code_revision=args.revision,
         trust_remote_code=True,
         use_safetensors=True,
         torch_dtype=torch.bfloat16,
         attn_implementation="eager",
-    ).eval().cuda()
+    ).eval()
+    eager_attention_layers = assert_deepseek_ocr_eager_attention(model, compat)
+    rotary_language_layers, rotary_visual_encoders = configure_deepseek_ocr_rotary_embeddings(
+        model, compat
+    )
+    if rotary_language_layers != eager_attention_layers or rotary_visual_encoders != 1:
+        raise RuntimeError("DeepSeek-OCR rotary compatibility coverage mismatch")
+    configure_deepseek_ocr_legacy_generation_cache(model)
+    model = model.cuda()
 
     prompt = args.prompt
     if "<image>" not in prompt:
@@ -238,7 +81,15 @@ def main() -> int:
             eval_mode=True,
         )
 
-    print(json.dumps({"text": str(text or "")}, ensure_ascii=False))
+    print(
+        json.dumps(
+            {
+                "text": str(text or ""),
+                "eager_attention_layers": eager_attention_layers,
+            },
+            ensure_ascii=False,
+        )
+    )
     return 0
 
 

--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
@@ -42,7 +42,7 @@
           "ocr_mode": true
         }
       },
-      "notes": "The reference runs the official BF16 model.infer path in the family-owned Transformers 4.46.3 profile and preserves the original OCR prompt and full-text contract. TensorRT uses the checkpoint's official 768-pixel single-view query table, resized SAM position embedding, and mixed image/query attention policy. Decoder layers 6-11 and selector 12's embedding/final-logit boundary remain FP32 to preserve runtime stability. The official TensorRT 11.1.0.106 result requires requalification before this acceptance result is treated as portable to that release."
+      "notes": "The reference runs the official BF16 model.infer path in the family-owned Transformers 5.5.0 profile and preserves the original OCR prompt and full-text contract. TensorRT uses the checkpoint's official 768-pixel single-view query table, resized SAM position embedding, and mixed image/query attention policy. Decoder layers 6-11 and selector 12's embedding/final-logit boundary remain FP32 to preserve runtime stability. The official TensorRT 11.1.0.106 result requires requalification before this acceptance result is treated as portable to that release."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
@@ -1,6 +1,7 @@
 {
   "name": "deepseek-ocr",
   "hf_id": "deepseek-ai/DeepSeek-OCR-2",
+  "hf_revision": "aaa02f3811945a91062062994c5c4a3f4c0af2b0",
   "bundle": "deepseek-ocr.bundle",
   "family": "deepseek_ocr",
   "runtime_strategy": "deepseek_ocr_vision_language",
@@ -42,7 +43,7 @@
           "ocr_mode": true
         }
       },
-      "notes": "The reference runs the official BF16 model.infer path in the family-owned Transformers 5.5.0 profile and preserves the original OCR prompt and full-text contract. TensorRT uses the checkpoint's official 768-pixel single-view query table, resized SAM position embedding, and mixed image/query attention policy. Decoder layers 6-11 and selector 12's embedding/final-logit boundary remain FP32 to preserve runtime stability. The official TensorRT 11.1.0.106 result requires requalification before this acceptance result is treated as portable to that release."
+      "notes": "The reference runs the official BF16 model.infer path at the pinned remote-source revision through the family-owned Transformers 5.5.4 compatibility adapter and preserves the original OCR prompt and full-text contract. TensorRT uses the checkpoint's official 768-pixel single-view query table, resized SAM position embedding, and mixed image/query attention policy. Decoder layers 6-11 and selector 12's embedding/final-logit boundary remain FP32 to preserve runtime stability. The official TensorRT 11.1.0.106 result requires requalification before this acceptance result is treated as portable to that release."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_transformers_compat.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_transformers_compat.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed contracts for the pinned DeepSeek-OCR reference shim."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_model_connect.deepseek_ocr_reference_compat import (
+    DEEPSEEK_OCR_REFERENCE_REVISION,
+    DeepSeekOcrTransformersCompat,
+    assert_deepseek_ocr_eager_attention,
+    configure_deepseek_ocr_rotary_embeddings,
+)
+
+
+class _PositiveInvFreq:
+    device = SimpleNamespace(type="cpu")
+
+    def __gt__(self, value):
+        assert value == 0
+        return self
+
+    def all(self):
+        return self
+
+    def item(self):
+        return True
+
+    def tolist(self):
+        return [1.0]
+
+
+class _Parameter:
+    device = SimpleNamespace(type="cpu")
+
+
+class _RotaryEmbedding:
+    def __init__(self, *, config, device=None):
+        del config, device
+        self.inv_freq = _PositiveInvFreq()
+
+
+class _EagerAttention:
+    def __init__(self, *, implementation: str = "eager", use_mla: bool = False):
+        self.config = SimpleNamespace(
+            _attn_implementation=implementation,
+            num_hidden_layers=1,
+            use_mla=use_mla,
+        )
+        self.rotary_emb = _RotaryEmbedding(config=self.config)
+        self._parameter = _Parameter()
+
+    def parameters(self):
+        return iter((self._parameter,))
+
+
+class _FlashAttention(_EagerAttention):
+    pass
+
+
+class _Model:
+    def __init__(self, module, *, implementation: str = "eager"):
+        self.config = SimpleNamespace(_attn_implementation=implementation)
+        self.module = module
+
+    def named_modules(self):
+        return (("", self), ("language.layers.0.self_attn", self.module))
+
+
+class CustomQwen2ModelInner:
+    __module__ = "transformers_modules.deepseek_ocr.deepencoderv2"
+
+    def __init__(self):
+        self.config = SimpleNamespace()
+        self.rotary_emb = _RotaryEmbedding(config=self.config)
+        self._parameter = _Parameter()
+
+    def parameters(self):
+        return iter((self._parameter,))
+
+
+class _RotaryModel:
+    def __init__(self):
+        self.language = _EagerAttention()
+        self.visual = CustomQwen2ModelInner()
+
+    def named_modules(self):
+        return (
+            ("", self),
+            ("language.layers.0.self_attn", self.language),
+            ("vision.qwen2", self.visual),
+        )
+
+
+_COMPAT = DeepSeekOcrTransformersCompat(
+    eager_attention_type=_EagerAttention,
+    flash_attention_type=_FlashAttention,
+    dynamic_cache_type=object,
+)
+
+
+def test_eager_attention_guard_accepts_only_the_pinned_mha_shape() -> None:
+    assert assert_deepseek_ocr_eager_attention(_Model(_EagerAttention()), _COMPAT) == 1
+
+
+@pytest.mark.parametrize(
+    ("model", "message"),
+    [
+        (
+            _Model(_EagerAttention(), implementation="flash_attention_2"),
+            "must use eager attention",
+        ),
+        (
+            _Model(_FlashAttention()),
+            "unsupported flash-attention",
+        ),
+        (
+            _Model(_EagerAttention(implementation="flash_attention_2")),
+            "not configured for eager attention",
+        ),
+        (
+            _Model(_EagerAttention(use_mla=True)),
+            "did not select pinned MHA mode",
+        ),
+    ],
+)
+def test_eager_attention_guard_fails_closed(model, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        assert_deepseek_ocr_eager_attention(model, _COMPAT)
+
+
+def test_rotary_compat_rematerializes_exact_language_and_visual_modules() -> None:
+    model = _RotaryModel()
+    old_language = model.language.rotary_emb
+    old_visual = model.visual.rotary_emb
+
+    assert configure_deepseek_ocr_rotary_embeddings(model, _COMPAT) == (1, 1)
+    assert model.language.rotary_emb is not old_language
+    assert model.visual.rotary_emb is not old_visual
+    assert model.language.rotary_emb.inv_freq.tolist() == [1.0]
+    assert model.visual.rotary_emb.inv_freq.tolist() == [1.0]
+
+
+def test_reference_installs_compat_before_loading_exact_remote_source() -> None:
+    model_root = Path(__file__).resolve().parent
+    script = (model_root / "hf_reference.py").read_text(encoding="utf-8")
+    wrapper = (model_root / "e2e_plugins/references/hf_transformers.py").read_text(encoding="utf-8")
+
+    assert script.index("install_deepseek_ocr_transformers_compat()") < script.index(
+        "AutoTokenizer.from_pretrained"
+    )
+    guard_call = "eager_attention_layers = assert_deepseek_ocr_eager_attention"
+    rotary_call = (
+        "rotary_language_layers, rotary_visual_encoders = configure_deepseek_ocr_rotary_embeddings"
+    )
+    assert script.index("AutoModel.from_pretrained") < script.index(guard_call)
+    assert script.index(guard_call) < script.index(rotary_call)
+    assert script.index(rotary_call) < script.index("model.cuda()")
+    assert 'attn_implementation="eager"' in script
+    assert "revision=args.revision" in script
+    assert '"--revision",\n            case.hf_revision,' in wrapper
+    assert DEEPSEEK_OCR_REFERENCE_REVISION == ("aaa02f3811945a91062062994c5c4a3f4c0af2b0")

--- a/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
+++ b/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
@@ -5,9 +5,6 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
-
 from tests.e2e.models.deepseek_ocr.e2e_plugins.contract import DeepseekOcrVLQAPlugin
 from tests.e2e_harness.contracts import (
     E2ECase,
@@ -16,50 +13,6 @@ from tests.e2e_harness.contracts import (
     StageStatus,
     ThresholdProfile,
 )
-
-
-def test_secure_transformers_preserves_deepseek_eager_attention_contract() -> None:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            """
-from types import SimpleNamespace
-import torch
-from tests.e2e.models.deepseek_ocr import hf_reference
-
-hf_reference._install_transformers_5_legacy_model_compat()
-from transformers.models.llama.modeling_llama import LlamaAttention
-config = SimpleNamespace(
-    hidden_size=16,
-    num_attention_heads=2,
-    num_key_value_heads=2,
-    max_position_embeddings=32,
-    attention_dropout=0.0,
-    attention_bias=False,
-    rope_scaling=None,
-    rope_theta=10000.0,
-)
-attention = LlamaAttention(config=config, layer_idx=0)
-hidden = torch.randn(1, 3, 16)
-mask = torch.zeros(1, 1, 3, 3)
-position_ids = torch.arange(3).unsqueeze(0)
-output, weights, cache = attention(
-    hidden,
-    attention_mask=mask,
-    position_ids=position_ids,
-    output_attentions=True,
-)
-assert output.shape == (1, 3, 16)
-assert weights.shape == (1, 2, 3, 3)
-assert cache is None
-""",
-        ],
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, result.stderr
 
 
 def _case(

--- a/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
+++ b/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 from tests.e2e.models.deepseek_ocr.e2e_plugins.contract import DeepseekOcrVLQAPlugin
 from tests.e2e_harness.contracts import (
     E2ECase,
@@ -13,6 +16,50 @@ from tests.e2e_harness.contracts import (
     StageStatus,
     ThresholdProfile,
 )
+
+
+def test_secure_transformers_preserves_deepseek_eager_attention_contract() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+from types import SimpleNamespace
+import torch
+from tests.e2e.models.deepseek_ocr import hf_reference
+
+hf_reference._install_transformers_5_legacy_model_compat()
+from transformers.models.llama.modeling_llama import LlamaAttention
+config = SimpleNamespace(
+    hidden_size=16,
+    num_attention_heads=2,
+    num_key_value_heads=2,
+    max_position_embeddings=32,
+    attention_dropout=0.0,
+    attention_bias=False,
+    rope_scaling=None,
+    rope_theta=10000.0,
+)
+attention = LlamaAttention(config=config, layer_idx=0)
+hidden = torch.randn(1, 3, 16)
+mask = torch.zeros(1, 1, 3, 3)
+position_ids = torch.arange(3).unsqueeze(0)
+output, weights, cache = attention(
+    hidden,
+    attention_mask=mask,
+    position_ids=position_ids,
+    output_attentions=True,
+)
+assert output.shape == (1, 3, 16)
+assert weights.shape == (1, 2, 3, 3)
+assert cache is None
+""",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _case(

--- a/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
@@ -67,12 +67,12 @@ def test_elf_reference_profile_pins_upstream_transformers_version() -> None:
         encoding="utf-8"
     )
 
-    assert "transformers==4.44.2" in lock
-    assert "tokenizers==0.19.1" in lock
-    assert "huggingface-hub==0.24.7" in lock
-    assert 'transformers.__version__ == "4.44.2"' in verify
-    assert 'tokenizers.__version__ == "0.19.1"' in verify
-    assert 'huggingface_hub.__version__ == "0.24.7"' in verify
+    assert "transformers==5.5.0" in lock
+    assert "tokenizers==0.22.2" in lock
+    assert "huggingface-hub==1.26.0" in lock
+    assert 'transformers.__version__ == "5.5.0"' in verify
+    assert 'tokenizers.__version__ == "0.22.2"' in verify
+    assert 'huggingface_hub.__version__ == "1.26.0"' in verify
 
 
 def _rand(*shape: int) -> np.ndarray:

--- a/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
@@ -67,12 +67,12 @@ def test_elf_reference_profile_pins_upstream_transformers_version() -> None:
         encoding="utf-8"
     )
 
-    assert "transformers==5.5.0" in lock
+    assert "transformers==5.5.4" in lock
     assert "tokenizers==0.22.2" in lock
-    assert "huggingface-hub==1.26.0" in lock
-    assert 'transformers.__version__ == "5.5.0"' in verify
-    assert 'tokenizers.__version__ == "0.22.2"' in verify
-    assert 'huggingface_hub.__version__ == "1.26.0"' in verify
+    assert "huggingface-hub==1.5.0" in lock
+    assert 'transformers.__version__ == "5.5.4"' in verify
+    assert 'version("tokenizers") == "0.22.2"' in verify
+    assert 'version("huggingface-hub") == "1.5.0"' in verify
 
 
 def _rand(*shape: int) -> np.ndarray:

--- a/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
@@ -35,9 +35,9 @@ def test_elf_reference_profile_pins_inference_only_dependencies() -> None:
     }
 
     assert requirements == {
-        "huggingface-hub==1.26.0",
+        "huggingface-hub==1.5.0",
         "tokenizers==0.22.2",
-        "transformers==5.5.0",
+        "transformers==5.5.4",
     }
     assert default_execution_profiles(family="elf_flow") == {
         "build": "elf_flow",

--- a/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
@@ -35,9 +35,9 @@ def test_elf_reference_profile_pins_inference_only_dependencies() -> None:
     }
 
     assert requirements == {
-        "huggingface-hub==0.24.7",
-        "tokenizers==0.19.1",
-        "transformers==4.44.2",
+        "huggingface-hub==1.26.0",
+        "tokenizers==0.22.2",
+        "transformers==5.5.0",
     }
     assert default_execution_profiles(family="elf_flow") == {
         "build": "elf_flow",

--- a/tests/e2e/models/internlm/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/internlm/e2e_plugins/references/hf_transformers.py
@@ -407,10 +407,21 @@ class HfTransformersReference:
                 PreTrainedTokenizerFast,
             )
 
+            if not hasattr(DynamicCache, "to_legacy_cache"):
+                def _to_legacy_cache(self):
+                    return tuple((layer.keys, layer.values) for layer in self.layers)
+
+                DynamicCache.to_legacy_cache = _to_legacy_cache
+
             if not hasattr(DynamicCache, "from_legacy_cache"):
                 @classmethod
                 def _from_legacy_cache(cls, past_key_values=None):
-                    return cls(past_key_values) if past_key_values else cls()
+                    cache = cls()
+                    for layer_idx, (key_states, value_states) in enumerate(
+                        past_key_values or ()
+                    ):
+                        cache.update(key_states, value_states, layer_idx)
+                    return cache
 
                 DynamicCache.from_legacy_cache = _from_legacy_cache
 

--- a/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
+++ b/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
@@ -82,9 +82,9 @@ def test_reference_profile_supports_current_internlm_dynamic_cache_api() -> None
     ).read_text(encoding="utf-8")
     verify = (_FAMILY_DIR / "python_profile_verify.py").read_text(encoding="utf-8")
 
-    assert "huggingface-hub==0.26.5" in lock
-    assert "tokenizers==0.20.3" in lock
-    assert "transformers==4.46.3" in lock
+    assert "huggingface-hub==1.26.0" in lock
+    assert "tokenizers==0.22.2" in lock
+    assert "transformers==5.5.0" in lock
     assert "protobuf==" not in lock
     assert "sentencepiece==" not in lock
     assert "import google.protobuf" not in verify

--- a/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
+++ b/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
@@ -82,11 +82,12 @@ def test_reference_profile_supports_current_internlm_dynamic_cache_api() -> None
     ).read_text(encoding="utf-8")
     verify = (_FAMILY_DIR / "python_profile_verify.py").read_text(encoding="utf-8")
 
-    assert "huggingface-hub==1.26.0" in lock
+    assert "huggingface-hub==1.5.0" in lock
     assert "tokenizers==0.22.2" in lock
-    assert "transformers==5.5.0" in lock
+    assert "transformers==5.5.4" in lock
     assert "protobuf==" not in lock
     assert "sentencepiece==" not in lock
     assert "import google.protobuf" not in verify
     assert "import sentencepiece" not in verify
-    assert 'hasattr(DynamicCache, "get_max_cache_shape")' in verify
+    assert "callable(DynamicCache.get_max_cache_shape)" in verify
+    assert "isinstance(DynamicCache.from_legacy_cache(), DynamicCache)" in verify

--- a/tests/e2e/models/lance/e2e_plugins/references/lance_image_compat/flash_attn/__init__.py
+++ b/tests/e2e/models/lance/e2e_plugins/references/lance_image_compat/flash_attn/__init__.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safe PyTorch fallback for Lance's image-only variable-length attention.
+
+The pinned upstream image reference imports ``flash_attn_varlen_func``
+unconditionally. The compiled ``flash-attn`` distribution also ships training
+checkpoint helpers affected by CVE-2026-31253, so the reference exposes only
+the inference primitive it needs and delegates that operation to PyTorch SDPA.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def flash_attn_varlen_func(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float = 0.0,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+    softcap: float = 0.0,
+    alibi_slopes: torch.Tensor | None = None,
+    deterministic: bool = False,
+    return_attn_probs: bool = False,
+    block_table: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute the subset of packed attention used by Lance image inference."""
+    del max_seqlen_q, max_seqlen_k, deterministic
+    if dropout_p != 0.0:
+        raise ValueError("Lance's image reference supports inference dropout only")
+    if window_size != (-1, -1):
+        raise ValueError("Lance's image reference does not request windowed attention")
+    if softcap != 0.0 or alibi_slopes is not None or block_table is not None:
+        raise ValueError("Lance's image reference received unsupported attention options")
+    if return_attn_probs:
+        raise ValueError("Lance's image reference does not expose attention probabilities")
+    if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
+        raise ValueError("packed attention inputs must have shape [tokens, heads, dim]")
+
+    q_offsets = cu_seqlens_q.detach().cpu().tolist()
+    k_offsets = cu_seqlens_k.detach().cpu().tolist()
+    if len(q_offsets) != len(k_offsets) or len(q_offsets) < 2:
+        raise ValueError("packed attention offsets must describe matching batches")
+    if q_offsets[0] != 0 or k_offsets[0] != 0:
+        raise ValueError("packed attention offsets must start at zero")
+    if any(not isinstance(offset, int) for offset in (*q_offsets, *k_offsets)):
+        raise ValueError("packed attention offsets must be integers")
+
+    outputs: list[torch.Tensor] = []
+    for index in range(len(q_offsets) - 1):
+        q_start, q_end = q_offsets[index : index + 2]
+        k_start, k_end = k_offsets[index : index + 2]
+        q_length = q_end - q_start
+        k_length = k_end - k_start
+        if q_length < 0 or k_length < 0:
+            raise ValueError("packed attention offsets must be nondecreasing")
+        if causal and q_length != k_length:
+            raise ValueError("causal packed attention requires equal query/key lengths")
+
+        q_slice = query[q_start:q_end].transpose(0, 1)
+        k_slice = key[k_start:k_end].transpose(0, 1)
+        v_slice = value[k_start:k_end].transpose(0, 1)
+        output = F.scaled_dot_product_attention(
+            q_slice,
+            k_slice,
+            v_slice,
+            dropout_p=0.0,
+            is_causal=causal,
+            scale=softmax_scale,
+        )
+        outputs.append(output.transpose(0, 1))
+
+    if q_offsets[-1] != query.shape[0] or k_offsets[-1] != key.shape[0]:
+        raise ValueError("packed attention offsets must cover every input token")
+    return torch.cat(outputs, dim=0)
+
+
+__all__ = ["flash_attn_varlen_func"]

--- a/tests/e2e/models/lance/e2e_plugins/references/lance_image_compat/sitecustomize.py
+++ b/tests/e2e/models/lance/e2e_plugins/references/lance_image_compat/sitecustomize.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep Transformers from treating Lance's local fallback as flash-attn."""
+
+from __future__ import annotations
+
+import transformers.utils as transformers_utils
+import transformers.cache_utils as cache_utils
+import transformers.utils.import_utils as import_utils
+
+
+def _compiled_flash_attn_is_unavailable() -> bool:
+    return False
+
+
+for name in (
+    "is_flash_attn_2_available",
+    "is_flash_attn_3_available",
+    "is_flash_attn_4_available",
+):
+    setattr(import_utils, name, _compiled_flash_attn_is_unavailable)
+    setattr(transformers_utils, name, _compiled_flash_attn_is_unavailable)
+
+Cache = cache_utils.Cache
+DynamicCache = cache_utils.DynamicCache
+if not hasattr(Cache, "get_usable_length"):
+    def _get_usable_length(self, new_seq_length, layer_idx=0):
+        previous = self.get_seq_length(layer_idx)
+        maximum = self.get_max_cache_shape()
+        if maximum is None or maximum < 0:
+            return previous
+        if previous + new_seq_length > maximum:
+            return max(0, maximum - new_seq_length)
+        return previous
+
+    Cache.get_usable_length = _get_usable_length
+if not hasattr(DynamicCache, "to_legacy_cache"):
+    def _to_legacy_cache(self):
+        return tuple((layer.keys, layer.values) for layer in self.layers)
+
+    DynamicCache.to_legacy_cache = _to_legacy_cache
+if not hasattr(DynamicCache, "from_legacy_cache"):
+    @classmethod
+    def _from_legacy_cache(cls, past_key_values=None):
+        cache = cls()
+        for layer_idx, (key_states, value_states) in enumerate(
+            past_key_values or ()
+        ):
+            cache.update(key_states, value_states, layer_idx)
+        return cache
+
+    DynamicCache.from_legacy_cache = _from_legacy_cache
+if not hasattr(cache_utils, "SlidingWindowCache"):
+    class _LegacySlidingWindowCache:
+        pass
+
+    cache_utils.SlidingWindowCache = _LegacySlidingWindowCache

--- a/tests/e2e/models/lance/test_lance_official_reference.py
+++ b/tests/e2e/models/lance/test_lance_official_reference.py
@@ -66,6 +66,56 @@ def test_lance_image_reference_provides_decord_import_without_video_support() ->
     assert environment["PYTHONPATH"].endswith(":/existing/python/path")
 
 
+def test_lance_image_reference_uses_safe_pytorch_packed_attention() -> None:
+    environment = lance_official._image_reference_environment(os.environ)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import torch
+import torch.nn.functional as F
+from flash_attn import flash_attn_varlen_func
+
+torch.manual_seed(7)
+query = torch.randn(5, 2, 4)
+key = torch.randn(5, 2, 4)
+value = torch.randn(5, 2, 4)
+offsets = torch.tensor([0, 2, 5], dtype=torch.int32)
+actual = flash_attn_varlen_func(query, key, value, offsets, offsets, 3, 3)
+expected = torch.cat([
+    F.scaled_dot_product_attention(
+        query[start:end].transpose(0, 1),
+        key[start:end].transpose(0, 1),
+        value[start:end].transpose(0, 1),
+        dropout_p=0.0,
+    ).transpose(0, 1)
+    for start, end in ((0, 2), (2, 5))
+])
+torch.testing.assert_close(actual, expected)
+
+for invalid_offsets, message in (
+    (torch.tensor([1, 2, 5], dtype=torch.int32), "start at zero"),
+    (torch.tensor([0.0, 2.0, 5.0]), "must be integers"),
+):
+    try:
+        flash_attn_varlen_func(
+            query, key, value, invalid_offsets, invalid_offsets, 3, 3
+        )
+    except ValueError as error:
+        assert message in str(error)
+    else:
+        raise AssertionError(f"invalid offsets were accepted: {invalid_offsets}")
+""",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_lance_image_reference_keeps_upstream_visual_generation_contract(
     monkeypatch,
     tmp_path: Path,

--- a/tests/e2e/models/lance/test_lance_python_profiles.py
+++ b/tests/e2e/models/lance/test_lance_python_profiles.py
@@ -13,12 +13,12 @@ def test_lance_reference_profile_pins_upstream_transformers_stack() -> None:
         / "lance_reference.lock.txt"
     ).read_text(encoding="utf-8")
 
-    assert "flash-attn==2.8.3" in requirements
-    assert "huggingface-hub==0.29.1" in requirements
+    assert "flash-attn==" not in requirements
+    assert "huggingface-hub==1.26.0" in requirements
     assert "imageio==2.34.0" in requirements
     assert "numpy==1.26.4" in requirements
-    assert "opencv-python-headless==4.7.0.72" in requirements
-    assert "scikit-learn==1.4.2" in requirements
+    assert "opencv-python-headless==4.8.1.78" in requirements
+    assert "scikit-learn==1.5.0" in requirements
     assert "scipy==1.12.0" in requirements
-    assert "tokenizers==0.21.4" in requirements
-    assert "transformers==4.49.0" in requirements
+    assert "tokenizers==0.22.2" in requirements
+    assert "transformers==5.5.0" in requirements

--- a/tests/e2e/models/lance/test_lance_python_profiles.py
+++ b/tests/e2e/models/lance/test_lance_python_profiles.py
@@ -14,11 +14,11 @@ def test_lance_reference_profile_pins_upstream_transformers_stack() -> None:
     ).read_text(encoding="utf-8")
 
     assert "flash-attn==" not in requirements
-    assert "huggingface-hub==1.26.0" in requirements
+    assert "huggingface-hub==1.5.0" in requirements
     assert "imageio==2.34.0" in requirements
     assert "numpy==1.26.4" in requirements
     assert "opencv-python-headless==4.8.1.78" in requirements
     assert "scikit-learn==1.5.0" in requirements
     assert "scipy==1.12.0" in requirements
     assert "tokenizers==0.22.2" in requirements
-    assert "transformers==5.5.0" in requirements
+    assert "transformers==5.5.4" in requirements

--- a/tests/e2e/models/minimax_h3/hf_reference.py
+++ b/tests/e2e/models/minimax_h3/hf_reference.py
@@ -31,13 +31,13 @@ from tensorrt_model_connect.families.minimax_h3.provenance import (
 
 DIFFUSERS_REVISION = "abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc"
 TRANSFORMERS_COMPAT_REVISION = "bed02e1faee69e866e382f835b4f7b0a3c7b8431"
-BASE_TRANSFORMERS_VERSION = "5.5.0"
+BASE_TRANSFORMERS_VERSION = "5.5.4"
 BASE_TRANSFORMERS_ENTRYPOINT = Path(
     "/opt/venv/lib/python3.12/site-packages/transformers/__init__.py"
 )
 BASE_TRANSFORMERS_ENTRYPOINT_RECORD = {
     "bytes": 40505,
-    "sha256": "460fadeb41958b1b47d7df8769b5f0ca3f46554ab733f52cf03a2b92d55d899a",
+    "sha256": "9efd2360b4a0b2e1165dceebc90a5c899a1360bf719157bb27512cae4e929ccd",
 }
 EXPECTED_NUM_FRAMES = 124
 

--- a/tests/e2e/models/minimax_h3/hf_reference.py
+++ b/tests/e2e/models/minimax_h3/hf_reference.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from types import MethodType
 
 import numpy as np
 import torch
@@ -32,13 +31,13 @@ from tensorrt_model_connect.families.minimax_h3.provenance import (
 
 DIFFUSERS_REVISION = "abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc"
 TRANSFORMERS_COMPAT_REVISION = "bed02e1faee69e866e382f835b4f7b0a3c7b8431"
-BASE_TRANSFORMERS_VERSION = "5.2.0"
+BASE_TRANSFORMERS_VERSION = "5.5.0"
 BASE_TRANSFORMERS_ENTRYPOINT = Path(
     "/opt/venv/lib/python3.12/site-packages/transformers/__init__.py"
 )
 BASE_TRANSFORMERS_ENTRYPOINT_RECORD = {
-    "bytes": 38424,
-    "sha256": "91b2c544c6848f4ce8213c770aaa705ce682ee656c995f4ce58352c4b7368ee7",
+    "bytes": 40505,
+    "sha256": "460fadeb41958b1b47d7df8769b5f0ca3f46554ab733f52cf03a2b92d55d899a",
 }
 EXPECTED_NUM_FRAMES = 124
 
@@ -152,7 +151,7 @@ def qualified_transformers_source(entrypoint: Path, version: str) -> dict:
     if entrypoint_record != BASE_TRANSFORMERS_ENTRYPOINT_RECORD:
         raise ValueError("MiniMax-H3 immutable base Transformers entrypoint mismatch")
     return {
-        "qualification": "immutable_base_5_2_plus_local_shim",
+        "qualification": "immutable_base_5_5",
         "version": version,
         "entrypoint": str(entrypoint),
         "entrypoint_record": entrypoint_record,
@@ -186,17 +185,8 @@ def _processor_method_identity(processor) -> tuple[object, object]:
 
 def prepare_processor_compat(processor, transformers_source: dict) -> tuple[str | None, tuple]:
     qualification = transformers_source.get("qualification")
-    if qualification == "immutable_base_5_2_plus_local_shim":
-        if hasattr(processor, "create_mm_token_type_ids"):
-            raise ValueError(
-                "MiniMax-H3 immutable Transformers base unexpectedly provides "
-                "create_mm_token_type_ids"
-            )
-        processor.create_mm_token_type_ids = MethodType(create_mm_token_type_ids, processor)
-        identity = _processor_method_identity(processor)
-        if identity != (processor, create_mm_token_type_ids):
-            raise ValueError("MiniMax-H3 could not bind its local processor compatibility helper")
-        return "local-create-mm-token-type-ids-for-transformers-5.2.0", identity
+    if qualification == "immutable_base_5_5":
+        return None, _processor_method_identity(processor)
     if qualification != "clean_git_checkout":
         raise ValueError("MiniMax-H3 Transformers source has an unknown qualification")
     return None, _processor_method_identity(processor)

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
@@ -334,17 +334,17 @@ def test_transformers_base_qualification_is_exact_and_honest(
 ) -> None:
     entrypoint = tmp_path / "immutable" / "transformers" / "__init__.py"
     entrypoint.parent.mkdir(parents=True)
-    entrypoint.write_text('__version__ = "5.5.0"\n', encoding="utf-8")
+    entrypoint.write_text('__version__ = "5.5.4"\n', encoding="utf-8")
     monkeypatch.setattr(hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT", entrypoint)
     monkeypatch.setattr(
         hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT_RECORD", file_record(entrypoint)
     )
 
-    record = hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
+    record = hf_reference.qualified_transformers_source(entrypoint, "5.5.4")
 
     assert record == {
         "qualification": "immutable_base_5_5",
-        "version": "5.5.0",
+        "version": "5.5.4",
         "entrypoint": str(entrypoint),
         "entrypoint_record": file_record(entrypoint),
     }
@@ -354,7 +354,7 @@ def test_transformers_base_qualification_is_exact_and_honest(
 
     entrypoint.write_text('__version__ = "5.2.x"\n', encoding="utf-8")
     with pytest.raises(ValueError, match="entrypoint mismatch"):
-        hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
+        hf_reference.qualified_transformers_source(entrypoint, "5.5.4")
 
 
 def test_secure_base_uses_transformers_processor_helper() -> None:

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
@@ -9,7 +9,7 @@ import importlib
 import json
 import subprocess
 from pathlib import Path
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -334,40 +334,43 @@ def test_transformers_base_qualification_is_exact_and_honest(
 ) -> None:
     entrypoint = tmp_path / "immutable" / "transformers" / "__init__.py"
     entrypoint.parent.mkdir(parents=True)
-    entrypoint.write_text('__version__ = "5.2.0"\n', encoding="utf-8")
+    entrypoint.write_text('__version__ = "5.5.0"\n', encoding="utf-8")
     monkeypatch.setattr(hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT", entrypoint)
     monkeypatch.setattr(
         hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT_RECORD", file_record(entrypoint)
     )
 
-    record = hf_reference.qualified_transformers_source(entrypoint, "5.2.0")
+    record = hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
 
     assert record == {
-        "qualification": "immutable_base_5_2_plus_local_shim",
-        "version": "5.2.0",
+        "qualification": "immutable_base_5_5",
+        "version": "5.5.0",
         "entrypoint": str(entrypoint),
         "entrypoint_record": file_record(entrypoint),
     }
     assert "revision" not in record
     with pytest.raises(ValueError, match="version mismatch"):
-        hf_reference.qualified_transformers_source(entrypoint, "5.2.1")
+        hf_reference.qualified_transformers_source(entrypoint, "5.5.1")
 
     entrypoint.write_text('__version__ = "5.2.x"\n', encoding="utf-8")
     with pytest.raises(ValueError, match="entrypoint mismatch"):
-        hf_reference.qualified_transformers_source(entrypoint, "5.2.0")
+        hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
 
 
-def test_local_processor_compat_is_bound_and_stable() -> None:
+def test_secure_base_uses_transformers_processor_helper() -> None:
     processor = SimpleNamespace(
         image_token_ids=[10, 11],
         video_token_id=20,
         audio_token_ids=[30],
     )
-    source = {"qualification": "immutable_base_5_2_plus_local_shim"}
+    processor.create_mm_token_type_ids = MethodType(
+        hf_reference.create_mm_token_type_ids, processor
+    )
+    source = {"qualification": "immutable_base_5_5"}
 
     label, identity = hf_reference.prepare_processor_compat(processor, source)
 
-    assert label == "local-create-mm-token-type-ids-for-transformers-5.2.0"
+    assert label is None
     assert processor.create_mm_token_type_ids([[0, 10, 20, 30, 11]]) == [[0, 1, 2, 3, 1]]
     hf_reference.validate_processor_method_unchanged(processor, identity)
 

--- a/tests/e2e/models/nemotron_h/manifests/nemotron-h-nano-9b.json
+++ b/tests/e2e/models/nemotron_h/manifests/nemotron-h-nano-9b.json
@@ -1,6 +1,7 @@
 {
   "name": "nemotron-h-nano-9b",
   "hf_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+  "hf_revision": "6533e8de2c68e4536bf7c411d7a3ce5734111476",
   "bundle": "nemotron-h-nano-9b.bundle",
   "family": "nemotron_h",
   "runtime_strategy": "nemotron_h_hybrid_mamba_attention",
@@ -24,7 +25,7 @@
           "enable_thinking": false
         }
       },
-      "notes": "The reference runs the checkpoint's documented original PyTorch implementation in BF16 with Transformers 5.5.0, causal-conv1d 1.6.2.post1, and mamba-ssm 2.3.2.post1. TensorRT projections, transformer layers, final normalization, and LM head run in FP16 with FP32 GEMM accumulation. Mamba softplus and recurrent state accumulation remain FP32 to avoid checkpoint-scale overflow. The family-owned grouped RMSNorm fallback is used only when the official kernels are unavailable."
+      "notes": "The reference runs the checkpoint's documented original PyTorch implementation in BF16 with Transformers 5.5.4, causal-conv1d 1.6.2.post1, and mamba-ssm 2.3.2.post1. TensorRT projections, transformer layers, final normalization, and LM head run in FP16 with FP32 GEMM accumulation. Mamba softplus and recurrent state accumulation remain FP32 to avoid checkpoint-scale overflow. The family-owned grouped RMSNorm fallback is used only when the official kernels are unavailable."
     }
   ]
 }

--- a/tests/e2e/models/nemotron_h/manifests/nemotron-h-nano-9b.json
+++ b/tests/e2e/models/nemotron_h/manifests/nemotron-h-nano-9b.json
@@ -24,7 +24,7 @@
           "enable_thinking": false
         }
       },
-      "notes": "The reference runs the checkpoint's documented original PyTorch implementation in BF16 with Transformers 4.48.3, causal-conv1d 1.6.2.post1, and mamba-ssm 2.3.2.post1. TensorRT projections, transformer layers, final normalization, and LM head run in FP16 with FP32 GEMM accumulation. Mamba softplus and recurrent state accumulation remain FP32 to avoid checkpoint-scale overflow. The family-owned grouped RMSNorm fallback is used only when the official kernels are unavailable."
+      "notes": "The reference runs the checkpoint's documented original PyTorch implementation in BF16 with Transformers 5.5.0, causal-conv1d 1.6.2.post1, and mamba-ssm 2.3.2.post1. TensorRT projections, transformer layers, final normalization, and LM head run in FP16 with FP32 GEMM accumulation. Mamba softplus and recurrent state accumulation remain FP32 to avoid checkpoint-scale overflow. The family-owned grouped RMSNorm fallback is used only when the official kernels are unavailable."
     }
   ]
 }

--- a/tests/e2e/models/phi4_multimodal/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/phi4_multimodal/e2e_plugins/references/hf_transformers.py
@@ -882,11 +882,46 @@ class HfTransformersReference:
         script = textwrap.dedent(f"""\
             import sys, torch
             from transformers import AutoProcessor
+            from transformers.cache_utils import Cache, DynamicCache
+            import transformers.cache_utils as cache_utils
             from PIL import Image
             from {__name__} import (
                 _decode_vl_generated_text,
                 _vl_prompt_has_image_placeholder,
             )
+
+            if not hasattr(Cache, "get_usable_length"):
+                def _get_usable_length(self, new_seq_length, layer_idx=0):
+                    previous = self.get_seq_length(layer_idx)
+                    maximum = self.get_max_cache_shape()
+                    if maximum is None or maximum < 0:
+                        return previous
+                    if previous + new_seq_length > maximum:
+                        return max(0, maximum - new_seq_length)
+                    return previous
+
+                Cache.get_usable_length = _get_usable_length
+            if not hasattr(DynamicCache, "to_legacy_cache"):
+                def _to_legacy_cache(self):
+                    return tuple((layer.keys, layer.values) for layer in self.layers)
+
+                DynamicCache.to_legacy_cache = _to_legacy_cache
+            if not hasattr(DynamicCache, "from_legacy_cache"):
+                @classmethod
+                def _from_legacy_cache(cls, past_key_values=None):
+                    cache = cls()
+                    for layer_idx, (key_states, value_states) in enumerate(
+                        past_key_values or ()
+                    ):
+                        cache.update(key_states, value_states, layer_idx)
+                    return cache
+
+                DynamicCache.from_legacy_cache = _from_legacy_cache
+            if not hasattr(cache_utils, "SlidingWindowCache"):
+                class _LegacySlidingWindowCache:
+                    pass
+
+                cache_utils.SlidingWindowCache = _LegacySlidingWindowCache
 
             hf_id = {hf_id!r}
             model_ref = {model_ref!r}

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -931,6 +931,17 @@ class TestModelOwnedAdapterIsolation:
             assert expected_tier in match.unit_tiers
 
 class TestFamilyPlugin:
+    def test_root_reference_compat_is_family_owned(self, imap):
+        """A root reference adapter maps only to its named family."""
+        match = test_impact.classify_file(
+            "python/tensorrt_model_connect/decoder_family_reference_compat.py",
+            imap,
+        )
+
+        assert match.rule == "family_reference_compat"
+        assert sorted(match.models) == ["decoder-large", "decoder-small"]
+        assert "decoder-peer" not in match.models
+
     def test_family_only_change(self, imap):
         """families/decoder_family/plugin.py -> exactly decoder_family models."""
         match = test_impact.classify_file(

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -47,7 +47,7 @@ class EnvironmentVerifier:
                 "-c",
                 "import transformers, sys; "
                 "print(f'python={sys.executable} transformers={transformers.__version__}'); "
-                "assert transformers.__version__ == '5.5.0', transformers.__version__",
+                "assert transformers.__version__ == '5.2.0', transformers.__version__",
             ]
         )
         binary = self.context.repository / "build" / "trtmc"

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -47,7 +47,7 @@ class EnvironmentVerifier:
                 "-c",
                 "import transformers, sys; "
                 "print(f'python={sys.executable} transformers={transformers.__version__}'); "
-                "assert transformers.__version__ == '5.2.0', transformers.__version__",
+                "assert transformers.__version__ == '5.5.0', transformers.__version__",
             ]
         )
         binary = self.context.repository / "build" / "trtmc"

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1386,6 +1386,18 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             ),
         ),
         ClassificationRule(
+            priority=85,
+            name="family_reference_compat",
+            matcher=_regex_rule(
+                r"python/tensorrt_model_connect/"
+                r"([A-Za-z]\w*)_reference_compat\.py$"
+            ),
+            resolver=_match_result("family_reference_compat", _family_models),
+            covered_by=(
+                "TestFamilyPlugin.test_root_reference_compat_is_family_owned",
+            ),
+        ),
+        ClassificationRule(
             priority=90,
             name="specialized_builder",
             matcher=_regex_rule(

--- a/website/docs/getting-started/build-and-run.md
+++ b/website/docs/getting-started/build-and-run.md
@@ -144,7 +144,7 @@ path; the manifest notes that the FP16 attention path does not satisfy its
 framework-reference accuracy contract.
 
 On its first build, the CLI may materialize the family-owned `chronos` Python
-profile, which pins `chronos-forecasting==2.2.2`. The build therefore needs the
+profile, which pins `chronos-forecasting==2.3.1`. The build therefore needs the
 TensorRT/CUDA GPU environment plus access to the checkpoint and Python
 packages, or populated caches. The resulting bundle runs through the native
 `chronos_bolt_trt` C++/TensorRT strategy and does not invoke that Python profile

--- a/website/docs/tutorials/intermediate/diffusion-and-time-series.md
+++ b/website/docs/tutorials/intermediate/diffusion-and-time-series.md
@@ -174,7 +174,7 @@ builds on this page. Chronos-Bolt also declares a build-time Python profile
 named `chronos`. On first use, the CLI materializes the pinned dependencies
 from
 `python/tensorrt_model_connect/families/chronos_bolt/python_profile_requirements/chronos.lock.txt`,
-including `chronos-forecasting==2.2.2`. That step needs package access or a
+including `chronos-forecasting==2.3.1`. That step needs package access or a
 pre-populated profile/cache. A successful build exits with status 0 and creates
 `/tmp/chronos-bolt-tiny-official.bundle`.
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,10 +12,14 @@
         "@docusaurus/preset-classic": "3.10.2",
         "@mdx-js/react": "^3.1.0",
         "clsx": "^2.1.1",
+        "image-size": "file:vendor/safe-image-size",
         "prism-react-renderer": "^2.4.1"
       },
       "devDependencies": {
         "@viz-js/viz": "3.28.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@11ty/gray-matter": {
@@ -9702,16 +9706,8 @@
       }
     },
     "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
+      "resolved": "vendor/safe-image-size",
+      "link": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -15315,15 +15311,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16312,12 +16299,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -17737,13 +17724,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {
@@ -18374,6 +18364,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "vendor/safe-image-size": {
+      "name": "image-size",
+      "version": "2.0.3",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "tensorrt-model-connect-docs",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "npm run diagrams:check && docusaurus build",
     "clear": "docusaurus clear",
@@ -9,16 +12,22 @@
     "diagrams:check": "node scripts/render-diagrams.mjs --check",
     "serve": "docusaurus serve",
     "start": "docusaurus start --host 0.0.0.0",
-    "test:model-support": "node --test plugins/model-support-inventory/index.test.js"
+    "test:model-support": "node --test plugins/model-support-inventory/index.test.js",
+    "test:safe-image-size": "node --test vendor/safe-image-size/fromFile.test.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.1",
+    "image-size": "file:vendor/safe-image-size",
     "prism-react-renderer": "^2.4.1"
   },
   "devDependencies": {
     "@viz-js/viz": "3.28.0"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.5",
+    "uuid": "11.1.1"
   }
 }

--- a/website/vendor/safe-image-size/fromFile.js
+++ b/website/vendor/safe-image-size/fromFile.js
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+"use strict";
+
+const { open } = require("node:fs/promises");
+
+const MAX_SVG_BYTES = 1024 * 1024;
+const NUMBER = "[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?";
+const DIMENSION_RE = new RegExp(`^(${NUMBER})(?:px)?$`, "i");
+const VIEWBOX_RE = new RegExp(
+  `^\\s*(${NUMBER})[\\s,]+(${NUMBER})[\\s,]+(${NUMBER})[\\s,]+(${NUMBER})\\s*$`,
+  "i",
+);
+
+function positiveFinite(value, field) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new TypeError(`SVG ${field} must be a positive finite number`);
+  }
+  return parsed;
+}
+
+function attribute(openingTag, name) {
+  const match = openingTag.match(
+    new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, "i"),
+  );
+  return match ? (match[1] ?? match[2]) : undefined;
+}
+
+function explicitDimension(openingTag, name) {
+  const raw = attribute(openingTag, name);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const match = raw.trim().match(DIMENSION_RE);
+  if (!match) {
+    return undefined;
+  }
+  return positiveFinite(match[1], name);
+}
+
+function svgDimensions(source) {
+  const prefix = source.slice(0, MAX_SVG_BYTES).toString("utf8");
+  const start = prefix.search(/<svg(?:\s|>)/i);
+  if (start < 0) {
+    throw new TypeError("Only SVG images are supported by this documentation site");
+  }
+  const end = prefix.indexOf(">", start);
+  if (end < 0) {
+    throw new TypeError("SVG opening tag is incomplete");
+  }
+
+  const openingTag = prefix.slice(start, end + 1);
+  const width = explicitDimension(openingTag, "width");
+  const height = explicitDimension(openingTag, "height");
+  if (width !== undefined && height !== undefined) {
+    return { height, width, type: "svg" };
+  }
+
+  const viewBox = attribute(openingTag, "viewBox");
+  const match = viewBox?.match(VIEWBOX_RE);
+  if (!match) {
+    throw new TypeError("SVG must declare positive width/height or a valid viewBox");
+  }
+  return {
+    height: positiveFinite(match[4], "viewBox height"),
+    width: positiveFinite(match[3], "viewBox width"),
+    type: "svg",
+  };
+}
+
+async function imageSizeFromFile(path) {
+  const file = await open(path, "r");
+  try {
+    const stats = await file.stat();
+    if (!stats.isFile()) {
+      throw new TypeError("Image path must identify a regular file");
+    }
+    if (stats.size <= 0 || stats.size > MAX_SVG_BYTES) {
+      throw new TypeError(`SVG size must be between 1 and ${MAX_SVG_BYTES} bytes`);
+    }
+
+    const source = Buffer.alloc(stats.size);
+    const { bytesRead } = await file.read(source, 0, stats.size, 0);
+    if (bytesRead !== stats.size) {
+      throw new Error("Could not read the complete SVG");
+    }
+    return svgDimensions(source);
+  } finally {
+    await file.close();
+  }
+}
+
+module.exports = { imageSizeFromFile };

--- a/website/vendor/safe-image-size/fromFile.js
+++ b/website/vendor/safe-image-size/fromFile.js
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 "use strict";
 

--- a/website/vendor/safe-image-size/fromFile.test.js
+++ b/website/vendor/safe-image-size/fromFile.test.js
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+"use strict";
+
+const assert = require("node:assert/strict");
+const { mkdtemp, rm, writeFile } = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { imageSizeFromFile } = require("./fromFile.js");
+
+async function withFixture(contents, callback) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "trtmc-image-size-"));
+  const fixture = path.join(root, "fixture.img");
+  try {
+    await writeFile(fixture, contents);
+    await callback(fixture);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("reads explicit SVG dimensions", async () => {
+  await withFixture(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1508"></svg>',
+    async (fixture) => {
+      assert.deepEqual(await imageSizeFromFile(fixture), {
+        height: 1508,
+        width: 1200,
+        type: "svg",
+      });
+    },
+  );
+});
+
+test("uses a valid viewBox when explicit dimensions are absent", async () => {
+  await withFixture('<svg viewBox="0 0 64 32"></svg>', async (fixture) => {
+    assert.deepEqual(await imageSizeFromFile(fixture), {
+      height: 32,
+      width: 64,
+      type: "svg",
+    });
+  });
+});
+
+test("rejects unsupported binary formats without looping", async () => {
+  const vulnerableSamples = [
+    Buffer.from([0x69, 0x63, 0x6e, 0x73, 0, 0, 0, 8, 0x69, 0x63, 0x30, 0, 0, 0, 0, 0]),
+    Buffer.from([0, 0, 0, 0, 0x6a, 0x78, 0x6c, 0x70]),
+    Buffer.from([0, 0, 0, 0, 0x69, 0x73, 0x70, 0x65]),
+  ];
+  for (const sample of vulnerableSamples) {
+    await withFixture(sample, async (fixture) => {
+      await assert.rejects(imageSizeFromFile(fixture), /Only SVG images are supported/);
+    });
+  }
+});
+
+test("rejects oversized inputs before reading them", async () => {
+  await withFixture(Buffer.alloc(1024 * 1024 + 1, 0x20), async (fixture) => {
+    await assert.rejects(imageSizeFromFile(fixture), /SVG size must be between/);
+  });
+});

--- a/website/vendor/safe-image-size/fromFile.test.js
+++ b/website/vendor/safe-image-size/fromFile.test.js
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 "use strict";
 

--- a/website/vendor/safe-image-size/package.json
+++ b/website/vendor/safe-image-size/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "image-size",
+  "version": "2.0.3",
+  "description": "Bounded SVG-only image-size adapter for the TensorRT Model Connect documentation site",
+  "license": "Apache-2.0",
+  "main": "fromFile.js",
+  "exports": {
+    "./fromFile": "./fromFile.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}


### PR DESCRIPTION
## Background

GitHub reports 103 Dependabot alerts on `main` (29 high, 68 moderate, and 6 low). They come from vulnerable website transitive packages and pinned Python reference profiles, including Transformers releases used by multiple official model references.

## Exit Criteria

- Every open GitHub package alert is addressed in the affected Python locks or website dependency tree.
- Official reference paths remain importable and preserve their model-specific behavior on the secure dependency baseline.
- The current PR head passes `trtmc/premerge/required` and the exact-head Nightly gate before this PR is marked ready.

## Implementation

- Upgrade the shared and family-owned Python profiles to Transformers 5.5.4 and compatible tokenizers, Hugging Face Hub, Chronos, OpenCV, and scikit-learn releases.
- Add narrow Transformers 5 compatibility adapters for the pinned DeepSeek-OCR-2, InternLM, Phi-4 Multimodal, Lance, and MiniMax-H3 reference paths.
- Remove the vulnerable `flash-attn` distribution from Lance. Its image-only inference reference now exposes only the packed attention primitive it uses, implemented with PyTorch SDPA and fail-closed option validation.
- Override vulnerable `serialize-javascript` and `uuid` website transitives. Since `image-size` has no patched upstream release, replace it with a bounded SVG-only adapter matching this documentation site's actual inputs.
- Declare Node 20 as the documentation baseline, matching the Pages workflow and the upgraded dependencies.

## Validation

- Refreshed all 103 open Dependabot alerts (29 high, 68 medium, and 6 low) and mapped every advisory/manifest pair to the patched version or the bounded local `image-size` replacement in this PR.
- `npm ci && npm audit --audit-level=low && npm run test:safe-image-size && npm run test:model-support && npm run build` under Node 20: passed; 0 vulnerabilities, 7 tests passed, and the production site built successfully.
- `npm run start -- --port 3099` under Node 20 plus an HTTP request to the generated site: passed; webpack compiled and the page returned HTTP 200.
- The exact-source CI image was built and verified with all 11 declared prebuilt Python profiles, including the compiled Nemotron-H profile.
- Security-change-focused CPU/contract pytest selection inside that immutable image with networking disabled and the source mounted read-only: 106 passed, 3 deselected. One unmarked Phi-4 TensorRT-builder case was explicitly left to GPU CI rather than weakening its assertion or marker.
- `tests/tools/test_test_impact.py`: 258 passed; the new root-level reference adapter maps only to its owning DeepSeek-OCR family.
- All changed Python files passed Ruff.
- `python3 tools/test_impact.py --validate`: passed for 207 models, 12 core models, and 79 families.
- Legal-header validation and `git diff --check` passed.

## Notes For Future Readers

- Review the dependency/profile pins first, then the scoped reference compatibility adapters, followed by the Lance and documentation-site replacements.
- Local CPU validation does not replace GPU qualification. Exact-head premerge and Nightly remain required before this draft is marked ready.
- Dependabot alerts on the default branch are expected to remain open until this fix is merged.
