### PR TITLE
build(package): include release legal files

### DIFF
--- a/ASSET_LICENSES.md
+++ b/ASSET_LICENSES.md
@@ -1,8 +1,10 @@
 # Asset Licenses
 
-This file records the provenance and redistribution terms for non-code assets
-that have been reviewed for inclusion in TensorRT Model Connect. Assets not
-listed here require separate review.
+This file records explicit provenance and redistribution terms for
+third-party, maintainer-supplied, and binary or media assets. Repository-authored
+source, configuration, benchmark metadata, and generated golden data are
+distributed under the project license unless stated otherwise. Third-party or
+externally sourced assets not listed here require separate review.
 
 ## Shared vehicle test photograph
 
@@ -22,3 +24,101 @@ inclusion and redistribution in this repository under the Apache License 2.0:
 - `tests/e2e/models/timm_vit/data/test_img.jpeg`
 
 SHA-256: `d68cb42a55f79e51f71b78cf7d726f01c80a0e2dab8674da6f68361cce004cbc`
+
+## Project-created image fixtures
+
+The following images were created for TensorRT Model Connect testing and are
+distributed under the Apache License 2.0 with the rest of the project:
+
+- `tests/assets/test_image.jpg` — synthetic two-color image fixture;
+  SHA-256 `d321e0168fc3678faca52c73dffafc80e729f125432cbcaf51f24c5044931c98`
+- `tests/assets/test_scene.jpg` — synthetic geometric scene fixture;
+  SHA-256 `e1d5893d77507c36b5c7703a3ad1532abc7c2f226f1bb121fa44c08797756363`
+- `tests/e2e/models/deepseek_ocr/data/orc_test_img.jpeg` — screenshot of
+  project source text created for OCR regression testing; SHA-256
+  `d27d4e33afb8e820916b19bffc4c94f1f626536cc3375b5fafeee684b0a3b9b3`
+
+## Maintainer voice recording and derived ASR probes
+
+The project maintainer recorded and supplied the original human-voice fixture
+and authorized its inclusion and redistribution under the Apache License 2.0.
+Byte-identical copies are stored at:
+
+- `tests/e2e/models/canary/data/Recording.wav`
+- `tests/e2e/models/nemotron_speech_streaming/data/Recording.wav`
+- `tests/e2e/models/whisper/data/Recording.wav`
+
+SHA-256: `fe14352b6b83009d4e344613fc05b17c0a89a94b0c8502c8422c637928263ca4`
+
+The WAV files below each corresponding `data/asr_probes/` directory are
+deterministic transformations of that recording produced by the checked-in
+`generate_asr_probe_inputs.py` script. The same relative probe has the same
+content in all three model families:
+
+| Probe | SHA-256 |
+|---|---|
+| `probe_01_clean_48k_stereo_baseline.wav` | `fe14352b6b83009d4e344613fc05b17c0a89a94b0c8502c8422c637928263ca4` |
+| `probe_02_clean_16k_mono_no_resample.wav` | `794b1d96d9c28cf39746b37e806b1f1e012b6904526536d1f5b1dec8477e430f` |
+| `probe_03_clean_48k_mono_resample.wav` | `dc544108da2b91863a7503695c8af023097601436af4d95cbb948f466e313add` |
+| `probe_04_clean_48k_stereo_gain_skew.wav` | `fc2cb56ce769d4b92441a4f8483a65aa65767f8b89d4c06be8c9fb15421e03d7` |
+| `probe_05_low_volume_48k_stereo.wav` | `fae8e228584dc68f7f406c98c2a7e04a35fcc5919713fc2e6dd1ff71b1fb3d4c` |
+| `probe_06_leading_trailing_silence_48k_stereo.wav` | `7d10e274ccc476f581ed6767d4bed075fdf599e4f4d9e42ca25391415cca4545` |
+| `probe_08_noisy_48k_stereo_snr20.wav` | `2e10d12b6d35c871f29d3559fa0975fac81912f0f04a3d6519de315766b9be28` |
+
+The PersonaPlex fixture contains the same maintainer-owned spoken recording,
+converted to mono 24 kHz float32 for official-reference regression tests:
+
+- `tests/e2e/models/personaplex/data/Recording.wav`; SHA-256
+  `6d5dc6d3b696db0d97d1e45679c81198cb1c9187d5056bb6673ef205dbd4d2e7`
+
+The following NumPy array is project-generated golden model output for that
+fixture and is distributed under the Apache License 2.0:
+
+- `tests/e2e/models/personaplex/data/personaplex_recording_official_tokens_greedy.npy`;
+  SHA-256 `1f9cbce7a20d09a65069eaa521c3bc5c492f00b27f2d32a4b5c12d1de5a9618c`
+
+## LibriSpeech accuracy fixture
+
+`tests/e2e/models/whisper/data/librispeech-test-clean-6930-75918-0003.wav`
+is utterance `6930-75918-0003` from the LibriSpeech `test-clean` split,
+distributed by OpenSLR as SLR12 under the Creative Commons Attribution 4.0
+International license. LibriSpeech was prepared by Vassil Panayotov with the
+assistance of Daniel Povey and is derived from LibriVox public-domain
+audiobooks.
+
+- Source and attribution: https://www.openslr.org/12/
+- License: https://creativecommons.org/licenses/by/4.0/
+- SHA-256: `166d138dc95c706e4eedbebb48f4ac4c8cb1b77ea796c0bc650da518308657e2`
+
+## SANA world-model fixtures
+
+The following files are unmodified copies from NVlabs/Sana revision
+`59629fdf790850797cb657bad014fce432bd713d`, which is distributed under the
+Apache License 2.0:
+
+- Upstream: https://github.com/NVlabs/Sana/tree/59629fdf790850797cb657bad014fce432bd713d
+- `tests/e2e/models/sana_wm/assets/demo_0.png`; SHA-256
+  `632754d1cb85bb5d04dc0f81709065892f80fba133d065ad4edd14c1f141d626`
+- `tests/e2e/models/sana_wm/assets/demo_0.txt`; SHA-256
+  `e6e573dac5002554b0be2bc444b41f77e842f9b35da39984166861273d975901`
+- `tests/e2e/models/sana_wm/assets/demo_0_intrinsics.npy`; SHA-256
+  `ae21429541b5a61a386322f2e3dd71ab1d1b104aaf44f04d8d20a2c47d97ea1f`
+
+## ELF numerical replay fixtures
+
+The `.f32` files below `tests/e2e/models/elf_flow/data/` are numerical replay
+tensors exported for this project from the official ELF evaluator at revision
+`1f38c80457d33c95020efdaaf9463823c569c786`. They are distributed as project
+test data under the Apache License 2.0. The upstream ELF implementation is MIT
+licensed and is attributed in `NOTICE`.
+
+| Relative path below `tests/e2e/models/elf_flow/data/` | SHA-256 |
+|---|---|
+| `elf-b-de-en-replay/condition_latents.f32` | `9f6083ed8fd0084d0e16ba8616d82fe2412bb4092919a24f661056629113885d` |
+| `elf-b-de-en-replay/condition_mask.f32` | `45c048edf5f982926c32922ce9c0c55f3118cb572ea2434cdb0d0816b746ff5b` |
+| `elf-b-de-en-replay/initial_latents.f32` | `3840d5e8eabe062c866b67cbe72524ee2b43a162c8ee83da6cf66de471faa18a` |
+| `elf-b-de-en-replay/sampling_steps.f32` | `995a97d5841b0f032c17da2eab4ffd1669ee19bf7598abaa5e27a27f0b164779` |
+| `elf-b-owt-replay/initial_latents.f32` | `1d8142e76339ecb1463237a9c84d395c274b63cabe53fde78e01f7da30cd3a38` |
+| `elf-b-owt-replay/sampling_steps.f32` | `fc47f743709eb080e0c060422c1a39fb55e44d5e7a2f5f9fa3437ca7b269be12` |
+| `elf-b-xsum-replay/initial_latents.f32` | `5153428af20ad73e2ba40e72a7d7cbd5dd10bf4cc7026bbdaad91fb12ae4ddd0` |
+| `elf-b-xsum-replay/sampling_steps.f32` | `79c790d0590ebf5d1838da98ed968b0e7c6b4309d56d50890ae3b0e025cc982e` |

--- a/NOTICE
+++ b/NOTICE
@@ -50,7 +50,7 @@ SOFTWARE.
 nlohmann/json
 -------------------------------------------------------------------------------
 
-This product compiles and redistributes nlohmann/json, version 3.11.3:
+This product includes compiled portions of nlohmann/json, version 3.11.3:
 
   https://github.com/nlohmann/json/tree/v3.11.3
 

--- a/NOTICE
+++ b/NOTICE
@@ -47,6 +47,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -------------------------------------------------------------------------------
+nlohmann/json
+-------------------------------------------------------------------------------
+
+This product compiles and redistributes nlohmann/json, version 3.11.3:
+
+  https://github.com/nlohmann/json/tree/v3.11.3
+
+MIT License
+
+Copyright (c) 2013-2022 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
 ELF
 -------------------------------------------------------------------------------
 

--- a/_pyproject_backend.py
+++ b/_pyproject_backend.py
@@ -9,6 +9,7 @@ import hashlib
 import io
 import json
 import re
+import shutil
 import tarfile
 import tempfile
 import zipfile
@@ -225,6 +226,8 @@ def _project_metadata() -> dict[str, Any]:
         "name": project["name"],
         "version": project["version"],
         "description": project.get("description", ""),
+        "license": project.get("license"),
+        "license-files": project.get("license-files", []),
         "requires-python": project.get("requires-python"),
         "dependencies": project.get("dependencies", []),
         "optional-dependencies": project.get("optional-dependencies", {}),
@@ -239,17 +242,22 @@ def _write_dist_info(parent: Path) -> Path:
     dist_info.mkdir(parents=True, exist_ok=True)
     (dist_info / "METADATA").write_text(_metadata_text(project), encoding="utf-8")
     (dist_info / "WHEEL").write_text(_wheel_text(), encoding="utf-8")
+    _copy_license_files(dist_info, project)
     return dist_info
 
 
 def _metadata_text(project: dict[str, Any]) -> str:
     lines = [
-        "Metadata-Version: 2.1",
+        "Metadata-Version: 2.4",
         f"Name: {project['name']}",
         f"Version: {project['version']}",
     ]
     if project["description"]:
         lines.append(f"Summary: {project['description']}")
+    if project.get("license"):
+        lines.append(f"License-Expression: {project['license']}")
+    for license_file in project.get("license-files", []):
+        lines.append(f"License-File: {license_file}")
     if project["requires-python"]:
         lines.append(f"Requires-Python: {project['requires-python']}")
     for dependency in project["dependencies"]:
@@ -263,6 +271,18 @@ def _metadata_text(project: dict[str, Any]) -> str:
             )
     lines.append("")
     return "\n".join(lines)
+
+
+def _copy_license_files(dist_info: Path, project: dict[str, Any]) -> None:
+    repository = Path.cwd().resolve()
+    destination = dist_info / "licenses"
+    for relative in project.get("license-files", []):
+        source = (repository / relative).resolve()
+        if not source.is_relative_to(repository) or not source.is_file():
+            raise FileNotFoundError(f"license file is missing or outside the project: {relative}")
+        target = destination / source.relative_to(repository)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
 
 
 def _dependency_with_extra_marker(dependency: str, extra: str) -> str:
@@ -288,9 +308,10 @@ def _write_editable_wheel(wheel_path: Path, dist_info: Path, dist_info_name: str
     source_path = (Path.cwd() / _PYTHON_SOURCE_ROOT).resolve()
     pth_name = "__editable__.tensorrt_model_connect.pth"
     entries: list[tuple[str, bytes]] = [(pth_name, f"{source_path}\n".encode())]
-    for path in sorted(dist_info.iterdir()):
+    for path in sorted(dist_info.rglob("*")):
         if path.is_file() and path.name != "RECORD":
-            entries.append((f"{dist_info_name}/{path.name}", path.read_bytes()))
+            relative = path.relative_to(dist_info).as_posix()
+            entries.append((f"{dist_info_name}/{relative}", path.read_bytes()))
 
     records: list[tuple[str, str, str]] = []
     with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as wheel:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ name = "tensorrt-model-connect"
 version = "0.1.0"
 description = "TensorRT-Model-Connect builder for HuggingFace models and .bundle artifacts"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "ASSET_LICENSES.md"]
 requires-python = ">=3.10"
 dependencies = [
     "safetensors>=0.4",

--- a/tests/tools/test_release_package_legal.py
+++ b/tests/tools/test_release_package_legal.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import tomllib
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+import pytest
+
+import _pyproject_backend as backend
+from tools import model_ci
+from tools.ci.package import RELEASE_LEGAL_FILES, WheelArchiveValidator
+from tools.ci.process import CiError
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Context:
+    repository = REPOSITORY_ROOT
+
+
+def _validate_legal_payload(wheel: Path) -> None:
+    validator = WheelArchiveValidator(_Context(), "manylinux_2_39_aarch64")
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        validator._validate_legal_payload(
+            wheel,
+            archive,
+            names,
+            metadata_name,
+            archive.read(metadata_name).decode(),
+        )
+
+
+def _synthetic_wheel(
+    path: Path,
+    *,
+    metadata: str,
+    omitted: str | None = None,
+    stale: str | None = None,
+) -> Path:
+    dist_info = "tensorrt_model_connect-0.1.0.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(f"{dist_info}/METADATA", metadata)
+        for relative in RELEASE_LEGAL_FILES:
+            if relative == omitted:
+                continue
+            content = b"stale\n" if relative == stale else (REPOSITORY_ROOT / relative).read_bytes()
+            archive.writestr(f"{dist_info}/licenses/{relative}", content)
+    return path
+
+
+def test_pyproject_declares_pep639_release_legal_files() -> None:
+    with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as source:
+        project = tomllib.load(source)["project"]
+
+    assert project["license"] == "Apache-2.0"
+    assert tuple(project["license-files"]) == RELEASE_LEGAL_FILES
+    assert "ASSET_LICENSES.md" in model_ci.PLATFORM_PROJECTION_EXACT
+    assert "ASSET_LICENSES.md" in model_ci.LEGAL_OR_DOC_EXACT
+
+
+def test_python_only_editable_wheel_contains_release_legal_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPOSITORY_ROOT)
+    filename = backend.build_editable(str(tmp_path), {"py-only": "true"})
+    wheel = tmp_path / filename
+
+    _validate_legal_payload(wheel)
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_name = next(
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        )
+        metadata = Parser().parsestr(archive.read(metadata_name).decode())
+        assert metadata["Metadata-Version"] == "2.4"
+        assert metadata["License-Expression"] == "Apache-2.0"
+        assert sorted(metadata.get_all("License-File")) == sorted(RELEASE_LEGAL_FILES)
+
+
+def test_wheel_legal_validator_rejects_missing_file(tmp_path: Path) -> None:
+    metadata = backend._metadata_text(backend._project_metadata())
+    wheel = _synthetic_wheel(
+        tmp_path / "missing.whl",
+        metadata=metadata,
+        omitted="NOTICE",
+    )
+
+    with pytest.raises(CiError, match="packaged legal file is missing"):
+        _validate_legal_payload(wheel)
+
+
+def test_wheel_legal_validator_rejects_stale_file(tmp_path: Path) -> None:
+    metadata = backend._metadata_text(backend._project_metadata())
+    wheel = _synthetic_wheel(
+        tmp_path / "stale.whl",
+        metadata=metadata,
+        stale="ASSET_LICENSES.md",
+    )
+
+    with pytest.raises(CiError, match="packaged legal file is stale"):
+        _validate_legal_payload(wheel)
+
+
+def test_wheel_legal_validator_rejects_missing_metadata_declaration(tmp_path: Path) -> None:
+    metadata = backend._metadata_text(backend._project_metadata()).replace(
+        "License-File: NOTICE\n", ""
+    )
+    wheel = _synthetic_wheel(tmp_path / "metadata.whl", metadata=metadata)
+
+    with pytest.raises(CiError, match="package metadata must declare legal files"):
+        _validate_legal_payload(wheel)

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import sys
 import zipfile
+from email.parser import Parser
 from pathlib import Path
 
 from .context import CiContext
@@ -23,6 +24,7 @@ from .process import CiError
 
 WHEEL_BUILD_STATE = "wheel-build.json"
 WHEEL_INSTALL_STATE = "wheel-installed.json"
+RELEASE_LEGAL_FILES = ("LICENSE", "NOTICE", "ASSET_LICENSES.md")
 
 
 class InstalledWheelValidator:
@@ -174,9 +176,17 @@ class WheelArchiveValidator:
             backends = [
                 name for name in names if "/bin/libtrtmc_backend" in name and name.endswith(".so")
             ]
-            metadata = archive.read(
-                next(name for name in names if name.endswith(".dist-info/METADATA"))
-            ).decode()
+            metadata_entries = sorted(
+                name for name in names if name.endswith(".dist-info/METADATA")
+            )
+            if len(metadata_entries) != 1:
+                raise CiError(
+                    f"{wheel}: expected exactly one .dist-info/METADATA entry, "
+                    f"found {len(metadata_entries)}"
+                )
+            metadata_name = metadata_entries[0]
+            metadata = archive.read(metadata_name).decode()
+            self._validate_legal_payload(wheel, archive, names, metadata_name, metadata)
             wheel_metadata = archive.read(
                 next(name for name in names if name.endswith(".dist-info/WHEEL"))
             ).decode()
@@ -240,6 +250,35 @@ class WheelArchiveValidator:
             ]
         ):
             print(f"  {entry}")
+
+    def _validate_legal_payload(
+        self,
+        wheel: Path,
+        archive: zipfile.ZipFile,
+        names: set[str],
+        metadata_name: str,
+        metadata_text: str,
+    ) -> None:
+        metadata = Parser().parsestr(metadata_text)
+        if metadata.get("Metadata-Version") != "2.4":
+            raise CiError(f"{wheel}: package metadata must use Metadata-Version 2.4")
+        if metadata.get("License-Expression") != "Apache-2.0":
+            raise CiError(f"{wheel}: package metadata must declare Apache-2.0")
+        declared = metadata.get_all("License-File", [])
+        if sorted(declared) != sorted(RELEASE_LEGAL_FILES):
+            raise CiError(
+                f"{wheel}: package metadata must declare legal files "
+                f"{', '.join(RELEASE_LEGAL_FILES)}"
+            )
+
+        dist_info = metadata_name.rsplit("/", maxsplit=1)[0]
+        for relative in RELEASE_LEGAL_FILES:
+            member = f"{dist_info}/licenses/{relative}"
+            if member not in names:
+                raise CiError(f"{wheel}: packaged legal file is missing: {member}")
+            source = self.context.repository / relative
+            if not source.is_file() or archive.read(member) != source.read_bytes():
+                raise CiError(f"{wheel}: packaged legal file is stale: {relative}")
 
 
 class WheelPackageManager:

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -50,6 +50,7 @@ PLATFORM_PROJECTION_EXACT = frozenset(
     {
         ".clang-format",
         ".github/scripts/write-model-proof-fallback-report.py",
+        "ASSET_LICENSES.md",
         "CMakeLists.txt",
         "Dockerfile",
         "LICENSE",
@@ -122,6 +123,7 @@ PLATFORM_PROJECTION_PREFIXES = (
 LEGAL_OR_DOC_EXACT = frozenset(
     {
         "AGENTS.md",
+        "ASSET_LICENSES.md",
         "CODEOWNERS",
         "CONTRIBUTING.md",
         "LICENSE",


### PR DESCRIPTION
## Background

The nightly release path currently produces wheels with Metadata-Version 2.1 and no packaged license, notice, or asset-attribution files. That makes the wheel payload inconsistent with the Apache-2.0 source distribution and allows future nightly releases to repeat the omission.

## Exit Criteria

- Wheel and sdist metadata declare Apache-2.0 using PEP 639.
- `LICENSE`, `NOTICE`, and `ASSET_LICENSES.md` are included in the standard package locations.
- The nightly package stage rejects wheels with missing, undeclared, or stale legal files.
- Shipped test assets and compiled third-party headers have explicit provenance and attribution.

## Implementation

- Declare the project license and release legal-file set in `pyproject.toml`; the pinned `conan-py-build` backend now places them under `.dist-info/licenses/` for wheels and at the sdist root.
- Keep the Python-only editable backend consistent by emitting Metadata-Version 2.4 and copying the same legal payload.
- Extend the existing final wheel archive validator to check metadata, members, and byte-for-byte source parity before release artifacts are accepted.
- Include `ASSET_LICENSES.md` in isolated model source projections.
- Document the provenance of project images, maintainer recordings and derived probes, LibriSpeech, SANA, PersonaPlex, and ELF fixtures, and add the missing nlohmann/json MIT notice.

## Validation

- `python3 -m pytest -q tests/tools/test_release_package_legal.py tests/tools/test_optimized_runtime_packaging.py tests/tools/test_model_ci.py tests/tools/test_github_actions_ci.py`: 154 passed.
- `python3 tools/legal_headers.py --check`: 0 findings.
- `python3 -m ruff check _pyproject_backend.py tools/ci/package.py tools/model_ci.py tests/tools/test_release_package_legal.py`: passed.
- Pinned `conan-py-build==0.4.3` metadata and sdist hooks were executed in a clean temporary environment: Metadata-Version 2.4, Apache-2.0 expression, all three License-File headers, `.dist-info/licenses/` payload, sdist root files, and PKG-INFO were verified.
- A native TensorRT wheel was not built locally; the existing package stage builds it and now runs the new archive validator before artifact publication.

## Notes For Future Readers

- Review `ASSET_LICENSES.md` and `NOTICE` first, then `pyproject.toml` and the focused validator/test changes.
- No Internal CI or nightly workflow change is required; the release path already consumes the Source packaging code and `WheelArchiveValidator`.
