### PR TITLE
test(e2e): add native KV regression cases

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,14 @@ def pytest_addoption(parser):
             "--e2e-testcase",
             dict(action="append", default=[], help="Filter child testcases by exact name"),
         ),
+        (
+            "--e2e-category",
+            dict(
+                choices=("e2e", "regression"),
+                default=None,
+                help="Only run ordinary E2E or historical regression testcases",
+            ),
+        ),
         ("--e2e-artifacts-dir", dict(default=None, help="Artifacts output dir")),
         (
             "--e2e-core-only",

--- a/python/tensorrt_model_connect/benchmark/catalog.py
+++ b/python/tensorrt_model_connect/benchmark/catalog.py
@@ -116,6 +116,19 @@ class ManifestCatalog:
                     _catalog_entry(model, "invalid", str(exc), operation=adapter.operation)
                 )
                 continue
+            if all(
+                testcase.get("test_category", "e2e") == "regression"
+                for testcase in model.testcases
+            ):
+                entries.append(
+                    _catalog_entry(
+                        model,
+                        "regression",
+                        "requires explicit regression selection",
+                        operation=adapter.operation,
+                    )
+                )
+                continue
             entries.append(_catalog_entry(model, "ready", operation=adapter.operation))
         return tuple(sorted(entries, key=lambda item: (item.name, item.hf_id)))
 
@@ -193,6 +206,19 @@ class ManifestCatalog:
             raise BenchmarkError(f"model manifest has no testcases: {path}")
         if not all(isinstance(item, dict) for item in testcases):
             raise BenchmarkError(f"model manifest testcases must be objects: {path}")
+        test_categories = [
+            testcase.get("test_category", "e2e") for testcase in testcases
+        ]
+        invalid_categories = sorted(
+            repr(category)
+            for category in test_categories
+            if not isinstance(category, str) or category not in {"e2e", "regression"}
+        )
+        if invalid_categories:
+            raise BenchmarkError(
+                f"model manifest {path} has unsupported test categories: "
+                f"{invalid_categories}"
+            )
         distributed_runtime = raw.get("distributed_runtime", {})
         if not isinstance(distributed_runtime, Mapping):
             raise BenchmarkError(f"distributed_runtime in model manifest {path} must be an object")

--- a/python/tensorrt_model_connect/benchmark/cli.py
+++ b/python/tensorrt_model_connect/benchmark/cli.py
@@ -126,7 +126,9 @@ def _list_models(arguments: argparse.Namespace) -> int:
     print("  ".join(value.ljust(widths[index]) for index, value in enumerate(headers)))
     for row in rows:
         print("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
-    unavailable = [entry for entry in entries if entry.status != "ready"]
+    unavailable = [
+        entry for entry in entries if entry.status not in {"ready", "regression"}
+    ]
     if unavailable:
         print("\nUnavailable profiles:")
         for entry in unavailable:

--- a/python/tensorrt_model_connect/benchmark/task_adapters.py
+++ b/python/tensorrt_model_connect/benchmark/task_adapters.py
@@ -57,9 +57,42 @@ class TaskAdapter:
 
 
 def _prompt(testcase: Mapping[str, Any], operation: str, *, allow_empty: bool = False) -> str:
+    repeat = testcase.get("prompt_repeat")
+    if repeat is not None:
+        if not isinstance(repeat, Mapping):
+            raise BenchmarkError(f"{operation} testcase prompt_repeat must be an object")
+        unknown = sorted(set(repeat) - {"text", "separator", "count", "suffix"})
+        if unknown:
+            raise BenchmarkError(
+                f"{operation} testcase prompt_repeat has unsupported fields: {unknown}"
+            )
+        text = repeat.get("text")
+        count = repeat.get("count")
+        separator = repeat.get("separator", "")
+        suffix = repeat.get("suffix", "")
+        if not isinstance(text, str) or not text:
+            raise BenchmarkError(
+                f"{operation} testcase prompt_repeat.text must be a non-empty string"
+            )
+        if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+            raise BenchmarkError(
+                f"{operation} testcase prompt_repeat.count must be a positive integer"
+            )
+        if not isinstance(separator, str):
+            raise BenchmarkError(
+                f"{operation} testcase prompt_repeat.separator must be a string"
+            )
+        if not isinstance(suffix, str):
+            raise BenchmarkError(
+                f"{operation} testcase prompt_repeat.suffix must be a string"
+            )
+        return separator.join([text] * count) + suffix
+
     prompt = testcase.get("prompt", testcase.get("test_prompt"))
     if not isinstance(prompt, str) or (not prompt and not allow_empty):
-        raise BenchmarkError(f"{operation} testcase requires prompt/test_prompt")
+        raise BenchmarkError(
+            f"{operation} testcase requires prompt/test_prompt/prompt_repeat"
+        )
     return prompt
 
 

--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -2823,6 +2823,7 @@ def _proof_context(
         "gpu_slot_ids", "gpu_slots_per_device", "gpu_lease_evidence",
         "min_free_gpu_memory_mib", "gpu_memory_admission",
         "network", "plugin_search", "passed", "e2e_proof_kind",
+        "e2e_proof_kinds",
     ):
         if key in proof:
             context[key] = proof[key]
@@ -3235,22 +3236,46 @@ def validate_proof_context(
     if not selection.get("e2e_test") or not e2e_cases:
         issues.append("Test selection does not identify an E2E test and case")
 
+    supported_e2e_proof_kinds = {
+        "reference",
+        "snapshot_regression",
+        "functional_invariant",
+    }
     e2e_proof_kind = proof.get("e2e_proof_kind")
     if (
         not isinstance(e2e_proof_kind, str)
         or e2e_proof_kind
-        not in {
-            "reference",
-            "snapshot_regression",
-            "functional_invariant",
-        }
+        not in supported_e2e_proof_kinds | {"mixed"}
     ):
         issues.append("Final proof JSON has no valid E2E proof-kind classification")
+    raw_e2e_proof_kinds = proof.get("e2e_proof_kinds")
+    if raw_e2e_proof_kinds is None and e2e_proof_kind in supported_e2e_proof_kinds:
+        e2e_proof_kinds = [e2e_proof_kind]
+    elif (
+        isinstance(raw_e2e_proof_kinds, list)
+        and raw_e2e_proof_kinds
+        and all(isinstance(kind, str) for kind in raw_e2e_proof_kinds)
+        and raw_e2e_proof_kinds == sorted(set(raw_e2e_proof_kinds))
+        and set(raw_e2e_proof_kinds) <= supported_e2e_proof_kinds
+    ):
+        e2e_proof_kinds = raw_e2e_proof_kinds
+    else:
+        e2e_proof_kinds = []
+        issues.append("Final proof JSON has invalid per-case E2E proof kinds")
+    expected_e2e_proof_kind = (
+        e2e_proof_kinds[0]
+        if len(e2e_proof_kinds) == 1
+        else "mixed"
+    )
+    if e2e_proof_kinds and e2e_proof_kind != expected_e2e_proof_kind:
+        issues.append("Aggregate E2E proof kind does not match per-case proof kinds")
     if status.get("e2e_proof_kind") != e2e_proof_kind:
         issues.append("E2E proof kind does not match model-proof status")
+    if raw_e2e_proof_kinds is not None and status.get("e2e_proof_kinds") != e2e_proof_kinds:
+        issues.append("Per-case E2E proof kinds do not match model-proof status")
     e2e_reference = steps.get("e2e_reference")
     expected_reference_status = (
-        "passed" if e2e_proof_kind == "reference" else "skipped"
+        "passed" if "reference" in e2e_proof_kinds else "skipped"
     )
     if (
         not isinstance(e2e_reference, dict)
@@ -3324,6 +3349,17 @@ def render_proof_section(context: Dict[str, Any]) -> str:
             f"{admission.get('required_free_mib')} MiB required"
         )
     rows = []
+    e2e_proof_kinds = context.get("e2e_proof_kinds")
+    proof_kinds_summary = (
+        ", ".join(e2e_proof_kinds)
+        if isinstance(e2e_proof_kinds, list)
+        else None
+    )
+    reference_parity_claimed = (
+        "reference" in e2e_proof_kinds
+        if isinstance(e2e_proof_kinds, list)
+        else context.get("e2e_proof_kind") == "reference"
+    )
     fields = (
         ("Model ownership ID", context.get("model")),
         ("Pinned source revision", context.get("source_revision")),
@@ -3350,7 +3386,8 @@ def render_proof_section(context: Dict[str, Any]) -> str:
         ("Container network", context.get("network")),
         ("Plugin search", context.get("plugin_search")),
         ("E2E proof kind", context.get("e2e_proof_kind")),
-        ("E2E reference parity claimed", context.get("e2e_proof_kind") == "reference"),
+        ("E2E per-case proof kinds", proof_kinds_summary),
+        ("E2E reference parity claimed", reference_parity_claimed),
     )
     for label, value in fields:
         if value is None or value == "":

--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -3249,7 +3249,11 @@ def validate_proof_context(
     ):
         issues.append("Final proof JSON has no valid E2E proof-kind classification")
     raw_e2e_proof_kinds = proof.get("e2e_proof_kinds")
-    if raw_e2e_proof_kinds is None and e2e_proof_kind in supported_e2e_proof_kinds:
+    if (
+        raw_e2e_proof_kinds is None
+        and isinstance(e2e_proof_kind, str)
+        and e2e_proof_kind in supported_e2e_proof_kinds
+    ):
         e2e_proof_kinds = [e2e_proof_kind]
     elif (
         isinstance(raw_e2e_proof_kinds, list)

--- a/tests/builder/test_manifest_validation.py
+++ b/tests/builder/test_manifest_validation.py
@@ -24,8 +24,8 @@ try:
         load_all_manifests,
         load_manifest,
         load_model_manifest,
-        requires_threshold_sidecar,
     )
+    from tests.e2e_harness.threshold_policy import requires_threshold_sidecar
     from tests.e2e_harness.registry import (
         activate_model_plugins,
         get_comparator,

--- a/tests/builder/test_manifest_validation.py
+++ b/tests/builder/test_manifest_validation.py
@@ -24,6 +24,7 @@ try:
         load_all_manifests,
         load_manifest,
         load_model_manifest,
+        requires_threshold_sidecar,
     )
     from tests.e2e_harness.registry import (
         activate_model_plugins,
@@ -532,11 +533,15 @@ class TestManifestValidation:
         for manifest_path in sorted(models_dir.glob("*/manifests/*.json")):
             raw = json.loads(manifest_path.read_text(encoding="utf-8"))
             for testcase in raw["testcases"]:
-                testcase_paths[(manifest_path.parent.parent, testcase["name"])] = manifest_path
+                testcase_paths[(manifest_path.parent.parent, testcase["name"])] = (
+                    manifest_path,
+                    testcase,
+                )
         missing_sidecars = [
             f"{manifest.relative_to(models_dir).as_posix()}: {name}"
-            for (family_dir, name), manifest in testcase_paths.items()
-            if not (family_dir / "thresholds" / f"{name}.json").is_file()
+            for (family_dir, name), (manifest, testcase) in testcase_paths.items()
+            if requires_threshold_sidecar(testcase)
+            and not (family_dir / "thresholds" / f"{name}.json").is_file()
         ]
         missing_manifests = [
             path.relative_to(models_dir).as_posix()
@@ -548,6 +553,42 @@ class TestManifestValidation:
         assert not inline_thresholds
         assert not missing_sidecars
         assert not missing_manifests
+
+    @pytest.mark.parametrize(
+        ("testcase", "required"),
+        [
+            (
+                {
+                    "reference_backend": "invariant_only",
+                    "oracle_level": "L4_invariants",
+                    "user_contract": "runtime_invariants",
+                },
+                False,
+            ),
+            (
+                {
+                    "reference_backend": "invariant_only",
+                    "oracle_level": "L4_invariants",
+                    "user_contract": "sampling",
+                },
+                True,
+            ),
+            (
+                {
+                    "reference_backend": "hf_transformers",
+                    "oracle_level": "L1_external_reference",
+                    "user_contract": "continuation_parity",
+                },
+                True,
+            ),
+        ],
+    )
+    def test_threshold_sidecar_exemption_is_limited_to_runtime_invariants(
+        self,
+        testcase,
+        required,
+    ):
+        assert requires_threshold_sidecar(testcase) is required
 
     def test_repo_model_assets_are_local(self):
         """Model E2E manifests resolve data assets from their own folders."""

--- a/tests/e2e/models/llama/MODEL.toml
+++ b/tests/e2e/models/llama/MODEL.toml
@@ -8,6 +8,7 @@ test_manifests = [
   "manifests/minitron-4b-depth.json",
   "manifests/minitron-4b-width-l0.json",
   "manifests/minitron-4b-width.json",
+  "manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json",
   "manifests/nemotron-nano-4b.json",
   "manifests/tinyllama-1.1b.json",
 ]
@@ -15,6 +16,10 @@ test_manifests = [
 [e2e_defaults.text_generation_causal]
 reference_backend = "hf_transformers"
 oracle_level = "L1_external_reference"
+input_fields = [
+  { input = "prompt_repeat", manifest = "prompt_repeat" },
+  { input = "expected_prompt_tokens", manifest = "expected_prompt_tokens" },
+]
 stages = [
   { name = "full_generation", required = true },
 ]

--- a/tests/e2e/models/llama/e2e_plugins/contract.py
+++ b/tests/e2e/models/llama/e2e_plugins/contract.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 from tests.e2e_harness.contracts import (
     CompareResult,
+    E2ECase,
     MetricResult,
+    StageOutput,
     StageStatus,
+    ThresholdProfile,
 )
 # Model-owned contract helpers. Keep behavior here so contract semantics do not
 # drift across model families through shared harness code.
@@ -313,4 +316,107 @@ class LlamaChatInstructPlugin:
             f"Chat response diverged: NED={ned:.3f}",
         )
 
-plugin = [LlamaCausalContinuationPlugin(), LlamaChatInstructPlugin()]
+
+class LlamaNativeKvChunkedPrefillRegressionPlugin:
+    reference_families = ["llama_native_kv_chunked_prefill_regression"]
+    user_contract = "runtime_invariants"
+
+    def configure_reference(self, case: E2ECase) -> dict:
+        del case
+        return {}
+
+    def verify(
+        self,
+        trt_output: StageOutput,
+        ref_output: StageOutput,
+        case: E2ECase,
+        threshold: ThresholdProfile,
+    ):
+        del ref_output, threshold
+        stage = trt_output.stage_name
+        if stage != "full_generation":
+            return make_pass(stage, {}, f"{stage} completed")
+
+        data = trt_output.data or {}
+        cpp_meta = (trt_output.metadata or {}).get("cpp", {})
+        cpp_rc = int(data.get("cpp_returncode", -1))
+        token_ids = data.get("token_ids", [])
+        expected_generated = int(case.inputs.get("max_new_tokens", 0))
+        expected_prompt = int(case.inputs.get("expected_prompt_tokens", -1))
+        actual_prompt = int(data.get("prompt_token_count", -1))
+        decode_s = float(cpp_meta.get("trt_engine_decode_s", 0.0))
+        stderr = str(cpp_meta.get("stderr", ""))
+        expected_rows = int(case.metadata.get("expected_kv_cache_rows", -1))
+        expected_chunks = int(case.metadata.get("expected_prefill_chunks", -1))
+        expected_limit = int(case.metadata.get("expected_prefill_chunk_limit", -1))
+        cache_marker = f"KV cache rows={expected_rows} (bundle max={expected_rows}"
+        prefill_marker = 'label="prefill_engine_plan:prefill"'
+        chunk_plan_is_consistent = (
+            expected_limit > 0
+            and expected_chunks
+            == (expected_prompt + expected_limit - 1) // expected_limit
+        )
+        chunked_prefill_observed = chunk_plan_is_consistent and any(
+            prefill_marker in line and f"launches={expected_chunks}" in line
+            for line in stderr.splitlines()
+        )
+
+        checks = {
+            "runtime_returncode_ok": (
+                cpp_rc == 0,
+                f"cpp_returncode={cpp_rc}",
+            ),
+            "fixed_prompt_token_count": (
+                actual_prompt == expected_prompt,
+                f"expected={expected_prompt}, actual={actual_prompt}",
+            ),
+            "full_native_kv_capacity_loaded": (
+                cache_marker in stderr,
+                cache_marker,
+            ),
+            "chunked_prefill_executed": (
+                chunked_prefill_observed,
+                f"max_chunk={expected_limit}; {prefill_marker} with "
+                f"launches={expected_chunks}",
+            ),
+            "requested_tokens_generated": (
+                isinstance(token_ids, list) and len(token_ids) == expected_generated,
+                f"expected={expected_generated}, actual={len(token_ids) if isinstance(token_ids, list) else 'missing'}",
+            ),
+            "decode_step_executed": (
+                expected_generated >= 2 and decode_s > 0.0,
+                f"generated_tokens={expected_generated}, decode_s={decode_s}",
+            ),
+            "no_runtime_error_signature": (
+                not data.get("cpp_runtime_error"),
+                str(data.get("cpp_runtime_error") or "none detected"),
+            ),
+        }
+        metrics = {
+            name: MetricResult(
+                value=1.0 if passed else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=passed,
+                note=note,
+            )
+            for name, (passed, note) in checks.items()
+        }
+        rule = " AND ".join(checks)
+        if all(passed for passed, _note in checks.values()):
+            return make_pass(stage, metrics, rule)
+        failed = [name for name, (passed, _note) in checks.items() if not passed]
+        return make_fail(
+            stage,
+            metrics,
+            rule,
+            "Llama native KV chunked-prefill regression contract failed: "
+            + ", ".join(failed),
+        )
+
+
+plugin = [
+    LlamaCausalContinuationPlugin(),
+    LlamaChatInstructPlugin(),
+    LlamaNativeKvChunkedPrefillRegressionPlugin(),
+]

--- a/tests/e2e/models/llama/e2e_plugins/reference.py
+++ b/tests/e2e/models/llama/e2e_plugins/reference.py
@@ -6,9 +6,15 @@
 from __future__ import annotations
 
 from .references.hf_transformers import HfTransformersReference
+from .references.invariant_only import InvariantOnlyReference
 
 
 class LlamaHfTransformersReference(HfTransformersReference):
     """llama local reference for hf_transformers."""
 
-reference = LlamaHfTransformersReference()
+
+class LlamaInvariantOnlyReference(InvariantOnlyReference):
+    """llama local reference for invariant_only."""
+
+
+reference = [LlamaHfTransformersReference(), LlamaInvariantOnlyReference()]

--- a/tests/e2e/models/llama/e2e_plugins/references/invariant_only.py
+++ b/tests/e2e/models/llama/e2e_plugins/references/invariant_only.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-op reference output for Llama runtime-invariant contracts."""
+
+from __future__ import annotations
+
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+class InvariantOnlyReference:
+    """Let a contract validate TRT output without an external oracle."""
+
+    @property
+    def backend_name(self) -> str:
+        return "invariant_only"
+
+    def run_stage(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        del case, ctx
+        return StageOutput(
+            stage_name=stage.name,
+            data={"_invariant_only": True},
+            timing_s=0.0,
+            metadata={"source": "invariant_only"},
+        )
+
+
+plugin = InvariantOnlyReference()

--- a/tests/e2e/models/llama/e2e_plugins/runners/text_generation.py
+++ b/tests/e2e/models/llama/e2e_plugins/runners/text_generation.py
@@ -110,6 +110,75 @@ def _read_text_generation_sample(path: Path) -> dict:
     return {}
 
 
+def _prompt_from_case(case: E2ECase, ctx: RunContext | None = None) -> str:
+    repeat = case.inputs.get("prompt_repeat")
+    if isinstance(repeat, dict):
+        text = str(repeat["text"])
+        separator = str(repeat.get("separator", ""))
+        count = int(repeat["count"])
+        prompt = separator.join([text] * count) + str(repeat.get("suffix", ""))
+        if ctx is not None and ctx.artifacts_dir:
+            output_dir = Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / "resolved_prompt.txt").write_text(prompt, encoding="utf-8")
+        return prompt
+    return str(case.inputs.get("prompt", "The capital of France is"))
+
+
+def _count_prompt_tokens(
+    case: E2ECase,
+    ctx: RunContext,
+    prompt: str,
+) -> tuple[int, dict]:
+    python = ctx.runtime_python_path() or sys.executable
+    script = textwrap.dedent(
+        """\
+        import sys
+        from transformers import AutoTokenizer
+
+        revision = sys.argv[2] or None
+        tokenizer = AutoTokenizer.from_pretrained(
+            sys.argv[1],
+            revision=revision,
+            trust_remote_code=sys.argv[3] == "1",
+        )
+        print(len(tokenizer.encode(sys.stdin.read(), add_special_tokens=False)))
+        """
+    )
+    cmd = [
+        python,
+        "-c",
+        script,
+        case.hf_id,
+        case.hf_revision,
+        "1" if case.metadata.get("trust_remote_code") else "0",
+    ]
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    meta = {
+        "command": cmd,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Failed to count prompt tokens with the pinned model tokenizer: "
+            f"{result.stderr.strip()}"
+        )
+    try:
+        return int(result.stdout.strip()), meta
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Tokenizer returned an invalid prompt token count: {result.stdout!r}"
+        ) from exc
+
+
 def _ensure_distributed_runtime_env(
     case: E2ECase,
     ctx: RunContext,
@@ -355,8 +424,20 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run C++ binary inference and capture per-step logits via debug runner."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
+        prompt_token_count = None
+        prompt_validation_meta = None
+        if "expected_prompt_tokens" in case.inputs:
+            prompt_token_count, prompt_validation_meta = _count_prompt_tokens(
+                case, ctx, prompt
+            )
+            expected_prompt_tokens = int(case.inputs["expected_prompt_tokens"])
+            if prompt_token_count != expected_prompt_tokens:
+                raise RuntimeError(
+                    f"Prompt fixture token count changed: expected "
+                    f"{expected_prompt_tokens}, got {prompt_token_count}"
+                )
         has_contract = bool(case.reference_family and case.user_contract)
         is_acceptance = case.ci_lane == "acceptance"
 
@@ -375,6 +456,8 @@ class TextGenerationCausalRunner:
                 "prompt": prompt,
                 "runner_mode": "single_process_debug_generation",
             }
+            if prompt_token_count is not None:
+                data["prompt_token_count"] = prompt_token_count
             if logits_path:
                 data["logits_path"] = logits_path
             return StageOutput(
@@ -386,6 +469,7 @@ class TextGenerationCausalRunner:
                 metadata={
                     "cpp": {"skipped": "single_process_debug_generation"},
                     "debug_runner": debug_meta,
+                    "prompt_validation": prompt_validation_meta,
                 },
             )
 
@@ -414,6 +498,8 @@ class TextGenerationCausalRunner:
             "cpp_returncode": cpp_meta.get("effective_returncode", cpp_meta.get("returncode", -1)),
             "prompt": prompt,
         }
+        if prompt_token_count is not None:
+            data["prompt_token_count"] = prompt_token_count
         if cpp_meta.get("runtime_error_detected"):
             data["cpp_runtime_error"] = cpp_meta["runtime_error_detected"]
         if cpp_meta.get("token_ids") is not None:
@@ -438,7 +524,11 @@ class TextGenerationCausalRunner:
             text=cpp_text,
             logits=logits_path,
             timing_s=cpp_time + debug_time,
-            metadata={"cpp": cpp_meta, "debug_runner": debug_meta},
+            metadata={
+                "cpp": cpp_meta,
+                "debug_runner": debug_meta,
+                "prompt_validation": prompt_validation_meta,
+            },
         )
 
     # ------------------------------------------------------------------
@@ -450,7 +540,7 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run debug runner prefill phase only -- logits for each input token."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
 
         logits_path, elapsed, meta = self._run_debug_runner_logits(
             ctx, bundle_path, prompt, max_new_tokens=0, case=case, phase="prefill"
@@ -480,7 +570,7 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run debug runner decode phase only -- logits for generated tokens."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
 
         logits_path, elapsed, meta = self._run_debug_runner_logits(

--- a/tests/e2e/models/llama/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
@@ -1,0 +1,40 @@
+{
+  "name": "minitron-4b-width-regression-native-kv-chunked-prefill",
+  "hf_id": "nvidia/Llama-3.1-Minitron-4B-Width-Base",
+  "hf_revision": "5205ef7d36204947e3b973cb8b147a816ccd7e6a",
+  "bundle": "minitron-4b-width-regression-native-kv-chunked-prefill.bundle",
+  "family": "llama",
+  "runtime_strategy": "llama_decoder_kv_cache",
+  "task_strategy": "text_generation_causal",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "minitron-4b-width-regression-native-kv-chunked-prefill",
+      "test_category": "regression",
+      "ci_tier": "nightly_only",
+      "reference_backend": "invariant_only",
+      "oracle_level": "L4_invariants",
+      "reference_family": "llama_native_kv_chunked_prefill_regression",
+      "user_contract": "runtime_invariants",
+      "prompt_repeat": {
+        "text": "a",
+        "separator": " ",
+        "count": 32768,
+        "suffix": "\n"
+      },
+      "expected_prompt_tokens": 32769,
+      "expected_kv_cache_rows": 131072,
+      "expected_prefill_chunks": 2,
+      "expected_prefill_chunk_limit": 32768,
+      "max_new_tokens": 2,
+      "temperature": 0.0,
+      "top_k": 1,
+      "regression": {
+        "id": "llama-native-kv-full-context-chunked-prefill",
+        "issue": "https://github.com/NVIDIA/TensorRT-Model-Connect/pull/673",
+        "previous_failure": "The Llama native prefill path could only submit a prompt within the prefill engine's 32768-token profile in one call, so it could not exercise the model's larger 131072-token KV capacity.",
+        "prevents": "A model-only native Llama bundle building successfully for full context while prompts just above the 32768-token prefill profile fail instead of being split into multiple prefill calls and continuing through decode and clean teardown."
+      }
+    }
+  ]
+}

--- a/tests/e2e/models/llama/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
@@ -11,7 +11,7 @@
     {
       "name": "minitron-4b-width-regression-native-kv-chunked-prefill",
       "test_category": "regression",
-      "ci_tier": "nightly_only",
+      "ci_tier": "default",
       "reference_backend": "invariant_only",
       "oracle_level": "L4_invariants",
       "reference_family": "llama_native_kv_chunked_prefill_regression",

--- a/tests/e2e/models/llama/test_llama_build_contract.py
+++ b/tests/e2e/models/llama/test_llama_build_contract.py
@@ -44,7 +44,7 @@ def test_native_minitron_regression_exceeds_one_prefill_profile() -> None:
 
     assert case.hf_revision == "5205ef7d36204947e3b973cb8b147a816ccd7e6a"
     assert case.metadata["test_category"] == "regression"
-    assert case.metadata["ci_tier"] == "nightly_only"
+    assert case.metadata["ci_tier"] == "default"
     assert case.reference_backend == "invariant_only"
     assert case.oracle_level == "L4_invariants"
     assert case.reference_family == "llama_native_kv_chunked_prefill_regression"

--- a/tests/e2e/models/llama/test_llama_build_contract.py
+++ b/tests/e2e/models/llama/test_llama_build_contract.py
@@ -22,6 +22,7 @@ def test_native_minitron_manifests_use_family_build_defaults() -> None:
     for manifest_name in (
         "minitron-4b-width.json",
         "minitron-4b-width-l0.json",
+        "minitron-4b-width-regression-native-kv-chunked-prefill.json",
     ):
         manifest_path = Path(__file__).parent / "manifests" / manifest_name
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -31,6 +32,34 @@ def test_native_minitron_manifests_use_family_build_defaults() -> None:
         assert "max_cache_length" not in manifest, manifest_name
         assert "precision" not in case.metadata, manifest_name
         assert "max_cache_length" not in case.inputs, manifest_name
+
+
+def test_native_minitron_regression_exceeds_one_prefill_profile() -> None:
+    manifest_path = (
+        Path(__file__).parent
+        / "manifests"
+        / "minitron-4b-width-regression-native-kv-chunked-prefill.json"
+    )
+    case = load_manifest(manifest_path)
+
+    assert case.hf_revision == "5205ef7d36204947e3b973cb8b147a816ccd7e6a"
+    assert case.metadata["test_category"] == "regression"
+    assert case.metadata["ci_tier"] == "nightly_only"
+    assert case.reference_backend == "invariant_only"
+    assert case.oracle_level == "L4_invariants"
+    assert case.reference_family == "llama_native_kv_chunked_prefill_regression"
+    assert case.user_contract == "runtime_invariants"
+    assert case.inputs["prompt_repeat"] == {
+        "text": "a",
+        "separator": " ",
+        "count": 32768,
+        "suffix": "\n",
+    }
+    assert case.inputs["expected_prompt_tokens"] == 32769
+    assert case.metadata["expected_kv_cache_rows"] == 131072
+    assert case.metadata["expected_prefill_chunks"] == 2
+    assert case.metadata["expected_prefill_chunk_limit"] == 32768
+    assert case.inputs["max_new_tokens"] == 2
 
 
 def test_tinyllama_keeps_legacy_build_contract() -> None:

--- a/tests/e2e/models/llama/test_llama_native_kv_regression_contract.py
+++ b/tests/e2e/models/llama/test_llama_native_kv_regression_contract.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Llama native-KV chunked-prefill regression contract tests."""
+
+from pathlib import Path
+
+from tests.e2e.models.llama.e2e_plugins.contract import (
+    LlamaNativeKvChunkedPrefillRegressionPlugin,
+)
+from tests.e2e.models.llama.e2e_plugins.runners.text_generation import (
+    _prompt_from_case,
+)
+from tests.e2e_harness.contracts import StageOutput, ThresholdProfile
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def _case():
+    path = (
+        Path(__file__).with_name("manifests")
+        / "minitron-4b-width-regression-native-kv-chunked-prefill.json"
+    )
+    return load_manifest(path)
+
+
+def _reference_output() -> StageOutput:
+    return StageOutput(
+        stage_name="full_generation",
+        data={"_invariant_only": True},
+    )
+
+
+def test_repeat_prompt_fixture_is_deterministic() -> None:
+    prompt = _prompt_from_case(_case())
+
+    assert len(prompt.split()) == 32768
+    assert prompt.startswith("a a a")
+    assert prompt.endswith("a\n")
+
+
+def test_chunked_prefill_contract_requires_native_capacity_and_two_calls() -> None:
+    output = StageOutput(
+        stage_name="full_generation",
+        data={
+            "cpp_returncode": 0,
+            "prompt_token_count": 32769,
+            "token_ids": [17, 13],
+        },
+        metadata={
+            "cpp": {
+                "trt_engine_decode_s": 0.001,
+                "stderr": "\n".join(
+                    [
+                        "[trtmc] KV cache rows=131072 (bundle max=131072, row=1 B)",
+                        '[trtmc.engine_timing] label="prefill_engine_plan:prefill" '
+                        "execute_ms=953.48 launches=2",
+                    ]
+                ),
+            }
+        },
+    )
+
+    result = LlamaNativeKvChunkedPrefillRegressionPlugin().verify(
+        output,
+        _reference_output(),
+        _case(),
+        ThresholdProfile(task_strategy="text_generation_causal"),
+    )
+
+    assert result.passed
+
+
+def test_chunked_prefill_contract_rejects_single_prefill_call() -> None:
+    output = StageOutput(
+        stage_name="full_generation",
+        data={
+            "cpp_returncode": 0,
+            "prompt_token_count": 32769,
+            "token_ids": [17, 13],
+        },
+        metadata={
+            "cpp": {
+                "trt_engine_decode_s": 0.001,
+                "stderr": "\n".join(
+                    [
+                        "[trtmc] KV cache rows=131072 (bundle max=131072, row=1 B)",
+                        '[trtmc.engine_timing] label="prefill_engine_plan:prefill" '
+                        "execute_ms=953.48 launches=1",
+                    ]
+                ),
+            }
+        },
+    )
+
+    result = LlamaNativeKvChunkedPrefillRegressionPlugin().verify(
+        output,
+        _reference_output(),
+        _case(),
+        ThresholdProfile(task_strategy="text_generation_causal"),
+    )
+
+    assert not result.passed
+    assert "chunked_prefill_executed" in result.message

--- a/tests/e2e/models/qwen/MODEL.toml
+++ b/tests/e2e/models/qwen/MODEL.toml
@@ -6,6 +6,7 @@ plugin = "qwen"
 test_manifests = [
   "manifests/qwen3-0.6b-fp16-tp4.json",
   "manifests/qwen3-0.6b-fp16.json",
+  "manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json",
   "manifests/qwen3-0.6b-native-l0.json",
   "manifests/qwen3-0.6b-fp8-tp4.json",
   "manifests/qwen3-0.6b-fp8.json",
@@ -18,6 +19,12 @@ test_manifests = [
 [e2e_defaults.text_generation_causal]
 reference_backend = "hf_transformers"
 oracle_level = "L1_external_reference"
+preflight_asset_fields = ["prompt_file"]
+input_fields = [
+  { input = "prompt_file", manifest = "prompt_file" },
+  { input = "prompt_repeat", manifest = "prompt_repeat" },
+  { input = "expected_prompt_tokens", manifest = "expected_prompt_tokens" },
+]
 stages = [
   { name = "full_generation", required = true },
 ]

--- a/tests/e2e/models/qwen/e2e_plugins/contract.py
+++ b/tests/e2e/models/qwen/e2e_plugins/contract.py
@@ -309,4 +309,107 @@ class QwenSamplingPlugin:
             "Top-p sampling contract failed",
         )
 
-plugin = [QwenPostTrainedChatPlugin(), QwenSamplingPlugin()]
+
+class QwenNativeKvChunkedPrefillRegressionPlugin:
+    reference_families = ["qwen_native_kv_chunked_prefill_regression"]
+    user_contract = "runtime_invariants"
+
+    def configure_reference(self, case: E2ECase) -> dict:
+        del case
+        return {}
+
+    def verify(
+        self,
+        trt_output: StageOutput,
+        ref_output: StageOutput,
+        case: E2ECase,
+        threshold: ThresholdProfile,
+    ):
+        del ref_output, threshold
+        stage = trt_output.stage_name
+        if stage != "full_generation":
+            return make_pass(stage, {}, f"{stage} completed")
+
+        data = trt_output.data or {}
+        cpp_meta = (trt_output.metadata or {}).get("cpp", {})
+        cpp_rc = int(data.get("cpp_returncode", -1))
+        token_ids = data.get("token_ids", [])
+        expected_generated = int(case.inputs.get("max_new_tokens", 0))
+        expected_prompt = int(case.inputs.get("expected_prompt_tokens", -1))
+        actual_prompt = int(data.get("prompt_token_count", -1))
+        decode_s = float(cpp_meta.get("trt_engine_decode_s", 0.0))
+        stderr = str(cpp_meta.get("stderr", ""))
+        expected_rows = int(case.metadata.get("expected_kv_cache_rows", -1))
+        expected_chunks = int(case.metadata.get("expected_prefill_chunks", -1))
+        expected_limit = int(case.metadata.get("expected_prefill_chunk_limit", -1))
+        cache_marker = f"KV cache rows={expected_rows} (bundle max={expected_rows}"
+        prefill_marker = 'label="prefill_engine_plan:prefill"'
+        chunk_plan_is_consistent = (
+            expected_limit > 0
+            and expected_chunks
+            == (expected_prompt + expected_limit - 1) // expected_limit
+        )
+        chunked_prefill_observed = chunk_plan_is_consistent and any(
+            prefill_marker in line and f"launches={expected_chunks}" in line
+            for line in stderr.splitlines()
+        )
+
+        checks = {
+            "runtime_returncode_ok": (
+                cpp_rc == 0,
+                f"cpp_returncode={cpp_rc}",
+            ),
+            "fixed_prompt_token_count": (
+                actual_prompt == expected_prompt,
+                f"expected={expected_prompt}, actual={actual_prompt}",
+            ),
+            "full_native_kv_capacity_loaded": (
+                cache_marker in stderr,
+                cache_marker,
+            ),
+            "chunked_prefill_executed": (
+                chunked_prefill_observed,
+                f"max_chunk={expected_limit}; {prefill_marker} with "
+                f"launches={expected_chunks}",
+            ),
+            "requested_tokens_generated": (
+                isinstance(token_ids, list) and len(token_ids) == expected_generated,
+                f"expected={expected_generated}, actual={len(token_ids) if isinstance(token_ids, list) else 'missing'}",
+            ),
+            "decode_step_executed": (
+                expected_generated >= 2 and decode_s > 0.0,
+                f"generated_tokens={expected_generated}, decode_s={decode_s}",
+            ),
+            "no_runtime_error_signature": (
+                not data.get("cpp_runtime_error"),
+                str(data.get("cpp_runtime_error") or "none detected"),
+            ),
+        }
+        metrics = {
+            name: MetricResult(
+                value=1.0 if passed else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=passed,
+                note=note,
+            )
+            for name, (passed, note) in checks.items()
+        }
+        rule = " AND ".join(checks)
+        if all(passed for passed, _note in checks.values()):
+            return make_pass(stage, metrics, rule)
+        failed = [name for name, (passed, _note) in checks.items() if not passed]
+        return make_fail(
+            stage,
+            metrics,
+            rule,
+            "Qwen native-KV chunked-prefill regression contract failed: "
+            + ", ".join(failed),
+        )
+
+
+plugin = [
+    QwenPostTrainedChatPlugin(),
+    QwenSamplingPlugin(),
+    QwenNativeKvChunkedPrefillRegressionPlugin(),
+]

--- a/tests/e2e/models/qwen/e2e_plugins/runners/text_generation.py
+++ b/tests/e2e/models/qwen/e2e_plugins/runners/text_generation.py
@@ -121,6 +121,83 @@ def _expected_answers(case: E2ECase) -> list[str]:
     return [str(value) for value in raw_values if str(value).strip()]
 
 
+def _prompt_from_case(case: E2ECase, ctx: RunContext | None = None) -> str:
+    repeat = case.inputs.get("prompt_repeat")
+    if isinstance(repeat, dict):
+        text = str(repeat["text"])
+        separator = str(repeat.get("separator", ""))
+        count = int(repeat["count"])
+        prompt = separator.join([text] * count) + str(repeat.get("suffix", ""))
+        if ctx is not None and ctx.artifacts_dir:
+            output_dir = Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / "resolved_prompt.txt").write_text(prompt, encoding="utf-8")
+        return prompt
+
+    prompt_file = case.inputs.get("prompt_file")
+    if not prompt_file:
+        return str(case.inputs.get("prompt", "The capital of France is"))
+
+    path = Path(str(prompt_file))
+    if not path.is_file():
+        raise FileNotFoundError(f"Prompt fixture not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _count_prompt_tokens(
+    case: E2ECase,
+    ctx: RunContext,
+    prompt: str,
+) -> tuple[int, dict]:
+    python = ctx.runtime_python_path() or sys.executable
+    script = textwrap.dedent(
+        """\
+        import sys
+        from transformers import AutoTokenizer
+
+        revision = sys.argv[2] or None
+        tokenizer = AutoTokenizer.from_pretrained(
+            sys.argv[1],
+            revision=revision,
+            trust_remote_code=sys.argv[3] == "1",
+        )
+        print(len(tokenizer.encode(sys.stdin.read(), add_special_tokens=False)))
+        """
+    )
+    cmd = [
+        python,
+        "-c",
+        script,
+        case.hf_id,
+        case.hf_revision,
+        "1" if case.metadata.get("trust_remote_code") else "0",
+    ]
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    meta = {
+        "command": cmd,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Failed to count prompt tokens with the pinned model tokenizer: "
+            f"{result.stderr.strip()}"
+        )
+    try:
+        return int(result.stdout.strip()), meta
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Tokenizer returned an invalid prompt token count: {result.stdout!r}"
+        ) from exc
+
+
 def _ensure_distributed_runtime_env(
     case: E2ECase,
     ctx: RunContext,
@@ -366,8 +443,20 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run C++ binary inference and capture per-step logits via debug runner."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
+        prompt_token_count = None
+        prompt_validation_meta = None
+        if "expected_prompt_tokens" in case.inputs:
+            prompt_token_count, prompt_validation_meta = _count_prompt_tokens(
+                case, ctx, prompt
+            )
+            expected_prompt_tokens = int(case.inputs["expected_prompt_tokens"])
+            if prompt_token_count != expected_prompt_tokens:
+                raise RuntimeError(
+                    f"Prompt fixture token count changed: expected "
+                    f"{expected_prompt_tokens}, got {prompt_token_count}"
+                )
         has_contract = bool(case.reference_family and case.user_contract)
         is_acceptance = case.ci_lane == "acceptance"
 
@@ -386,6 +475,8 @@ class TextGenerationCausalRunner:
                 "prompt": prompt,
                 "runner_mode": "single_process_debug_generation",
             }
+            if prompt_token_count is not None:
+                data["prompt_token_count"] = prompt_token_count
             answers = _expected_answers(case)
             if answers:
                 data["expected_answers"] = answers
@@ -400,6 +491,7 @@ class TextGenerationCausalRunner:
                 metadata={
                     "cpp": {"skipped": "single_process_debug_generation"},
                     "debug_runner": debug_meta,
+                    "prompt_validation": prompt_validation_meta,
                 },
             )
 
@@ -428,6 +520,8 @@ class TextGenerationCausalRunner:
             "cpp_returncode": cpp_meta.get("effective_returncode", cpp_meta.get("returncode", -1)),
             "prompt": prompt,
         }
+        if prompt_token_count is not None:
+            data["prompt_token_count"] = prompt_token_count
         answers = _expected_answers(case)
         if answers:
             data["expected_answers"] = answers
@@ -455,7 +549,11 @@ class TextGenerationCausalRunner:
             text=cpp_text,
             logits=logits_path,
             timing_s=cpp_time + debug_time,
-            metadata={"cpp": cpp_meta, "debug_runner": debug_meta},
+            metadata={
+                "cpp": cpp_meta,
+                "debug_runner": debug_meta,
+                "prompt_validation": prompt_validation_meta,
+            },
         )
 
     # ------------------------------------------------------------------
@@ -467,7 +565,7 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run debug runner prefill phase only -- logits for each input token."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
 
         logits_path, elapsed, meta = self._run_debug_runner_logits(
             ctx, bundle_path, prompt, max_new_tokens=0, case=case, phase="prefill"
@@ -497,7 +595,7 @@ class TextGenerationCausalRunner:
     ) -> StageOutput:
         """Run debug runner decode phase only -- logits for generated tokens."""
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
-        prompt = case.inputs.get("prompt", "The capital of France is")
+        prompt = _prompt_from_case(case, ctx)
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
 
         logits_path, elapsed, meta = self._run_debug_runner_logits(

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
@@ -11,7 +11,7 @@
     {
       "name": "qwen3-0.6b-regression-native-kv-chunked-prefill",
       "test_category": "regression",
-      "ci_tier": "nightly_only",
+      "ci_tier": "default",
       "reference_backend": "invariant_only",
       "oracle_level": "L4_invariants",
       "reference_family": "qwen_native_kv_chunked_prefill_regression",

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
@@ -1,0 +1,40 @@
+{
+  "name": "qwen3-0.6b-regression-native-kv-chunked-prefill",
+  "hf_id": "Qwen/Qwen3-0.6B",
+  "hf_revision": "c1899de289a04d12100db370d81485cdf75e47ca",
+  "bundle": "qwen3-0.6b-regression-native-kv-chunked-prefill.bundle",
+  "family": "qwen",
+  "runtime_strategy": "qwen_decoder_kv_cache",
+  "task_strategy": "text_generation_causal",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "qwen3-0.6b-regression-native-kv-chunked-prefill",
+      "test_category": "regression",
+      "ci_tier": "nightly_only",
+      "reference_backend": "invariant_only",
+      "oracle_level": "L4_invariants",
+      "reference_family": "qwen_native_kv_chunked_prefill_regression",
+      "user_contract": "runtime_invariants",
+      "prompt_repeat": {
+        "text": "a",
+        "separator": " ",
+        "count": 32768,
+        "suffix": "\n"
+      },
+      "expected_prompt_tokens": 32769,
+      "expected_kv_cache_rows": 40960,
+      "expected_prefill_chunks": 2,
+      "expected_prefill_chunk_limit": 32768,
+      "max_new_tokens": 2,
+      "temperature": 0.0,
+      "top_k": 1,
+      "regression": {
+        "id": "qwen3-native-kv-full-context-chunked-prefill",
+        "issue": "https://github.com/NVIDIA/TensorRT-Model-Connect/pull/673",
+        "previous_failure": "The Qwen prefill path could only submit a prompt within the prefill engine's 32768-token profile in one call, so it could not progress through the model's larger 40960-token native KV capacity.",
+        "prevents": "A model-only Qwen build losing the BF16 native-KV route or failing to split a 32769-token prompt across the full 40960-token cache before decode and clean teardown."
+      }
+    }
+  ]
+}

--- a/tests/e2e/models/qwen/test_qwen_kv_cache_regression_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_kv_cache_regression_contract.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen native-KV chunked-prefill regression contract tests."""
+
+from pathlib import Path
+
+from tests.e2e.models.qwen.e2e_plugins.contract import (
+    QwenNativeKvChunkedPrefillRegressionPlugin,
+)
+from tests.e2e.models.qwen.e2e_plugins.runners.text_generation import (
+    _prompt_from_case,
+)
+from tests.e2e_harness.contracts import StageOutput, ThresholdProfile
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def _case():
+    path = (
+        Path(__file__).with_name("manifests")
+        / "qwen3-0.6b-regression-native-kv-chunked-prefill.json"
+    )
+    return load_manifest(path)
+
+
+def _reference_output() -> StageOutput:
+    return StageOutput(
+        stage_name="full_generation",
+        data={"_invariant_only": True},
+    )
+
+
+def test_repeat_prompt_fixture_is_deterministic() -> None:
+    prompt = _prompt_from_case(_case())
+
+    assert len(prompt.split()) == 32768
+    assert prompt.startswith("a a a")
+    assert prompt.endswith("a\n")
+
+
+def test_native_kv_contract_requires_full_capacity_chunking_and_decode() -> None:
+    output = StageOutput(
+        stage_name="full_generation",
+        data={
+            "cpp_returncode": 0,
+            "prompt_token_count": 32769,
+            "token_ids": [123, 456],
+        },
+        metadata={
+            "cpp": {
+                "trt_engine_decode_s": 0.001,
+                "stderr": "\n".join(
+                    [
+                        "[trtmc] KV cache rows=40960 (bundle max=40960, row=1 B)",
+                        '[trtmc.engine_timing] label="prefill_engine_plan:prefill" '
+                        "execute_ms=100 launches=2",
+                    ]
+                ),
+            }
+        },
+    )
+
+    result = QwenNativeKvChunkedPrefillRegressionPlugin().verify(
+        output,
+        _reference_output(),
+        _case(),
+        ThresholdProfile(task_strategy="text_generation_causal"),
+    )
+
+    assert result.passed
+
+
+def test_native_kv_contract_rejects_single_prefill_launch() -> None:
+    output = StageOutput(
+        stage_name="full_generation",
+        data={
+            "cpp_returncode": 0,
+            "prompt_token_count": 32769,
+            "token_ids": [123, 456],
+        },
+        metadata={
+            "cpp": {
+                "trt_engine_decode_s": 0.001,
+                "stderr": "\n".join(
+                    [
+                        "[trtmc] KV cache rows=40960 (bundle max=40960, row=1 B)",
+                        '[trtmc.engine_timing] label="prefill_engine_plan:prefill" '
+                        "execute_ms=100 launches=1",
+                    ]
+                ),
+            }
+        },
+    )
+
+    result = QwenNativeKvChunkedPrefillRegressionPlugin().verify(
+        output,
+        _reference_output(),
+        _case(),
+        ThresholdProfile(task_strategy="text_generation_causal"),
+    )
+
+    assert not result.passed
+    assert "chunked_prefill_executed" in result.message

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -53,7 +53,7 @@ def test_native_kv_regression_exceeds_one_prefill_profile() -> None:
     assert "precision" not in case.metadata
     assert "max_cache_length" not in case.inputs
     assert case.metadata["test_category"] == "regression"
-    assert case.metadata["ci_tier"] == "nightly_only"
+    assert case.metadata["ci_tier"] == "default"
     assert case.reference_backend == "invariant_only"
     assert case.oracle_level == "L4_invariants"
     assert case.reference_family == "qwen_native_kv_chunked_prefill_regression"

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -39,6 +39,54 @@ def test_fp16_manifest_keeps_legacy_build_contract() -> None:
     assert case.inputs["max_cache_length"] == 256
 
 
+def test_native_kv_regression_exceeds_one_prefill_profile() -> None:
+    manifest_path = (
+        Path(__file__).with_name("manifests")
+        / "qwen3-0.6b-regression-native-kv-chunked-prefill.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    case = load_manifest(manifest_path)
+
+    assert case.hf_revision == "c1899de289a04d12100db370d81485cdf75e47ca"
+    assert "precision" not in manifest
+    assert "max_cache_length" not in manifest
+    assert "precision" not in case.metadata
+    assert "max_cache_length" not in case.inputs
+    assert case.metadata["test_category"] == "regression"
+    assert case.metadata["ci_tier"] == "nightly_only"
+    assert case.reference_backend == "invariant_only"
+    assert case.oracle_level == "L4_invariants"
+    assert case.reference_family == "qwen_native_kv_chunked_prefill_regression"
+    assert case.user_contract == "runtime_invariants"
+    assert case.inputs["prompt_repeat"] == {
+        "text": "a",
+        "separator": " ",
+        "count": 32768,
+        "suffix": "\n",
+    }
+    assert case.inputs["expected_prompt_tokens"] == 32769
+    assert case.metadata["expected_kv_cache_rows"] == 40960
+    assert case.metadata["expected_prefill_chunks"] == 2
+    assert case.metadata["expected_prefill_chunk_limit"] == 32768
+    assert case.inputs["max_new_tokens"] == 2
+    assert case.inputs["temperature"] == 0.0
+    assert case.inputs["top_k"] == 1
+    assert case.metadata["regression"] == {
+        "id": "qwen3-native-kv-full-context-chunked-prefill",
+        "issue": "https://github.com/NVIDIA/TensorRT-Model-Connect/pull/673",
+        "previous_failure": (
+            "The Qwen prefill path could only submit a prompt within the "
+            "prefill engine's 32768-token profile in one call, so it could not "
+            "progress through the model's larger 40960-token native KV capacity."
+        ),
+        "prevents": (
+            "A model-only Qwen build losing the BF16 native-KV route or failing "
+            "to split a 32769-token prompt across the full 40960-token cache "
+            "before decode and clean teardown."
+        ),
+    }
+
+
 @pytest.mark.parametrize(
     "manifest_name",
     ["qwen3-0.6b-fp8.json", "qwen3-0.6b-fp8-tp4.json"],

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -62,6 +62,7 @@ _MODEL_ASSET_FIELDS = frozenset(
         "test_input_audio",
         "speech_reference_tokens",
         "golden_snapshot_path",
+        "prompt_file",
         "edit_condition_image",
         "fp8_scales",
         "elf_replay_artifact",
@@ -612,6 +613,9 @@ def _build_metadata(manifest: dict, defaults: dict[str, Any]) -> dict:
         "oracle_level",
         "prompt",
         "test_prompt",
+        "prompt_file",
+        "expected_prompt_tokens",
+        "prompt_repeat",
         "max_new_tokens",
         "max_cache_length",
         "precision",
@@ -657,6 +661,8 @@ def _build_metadata(manifest: dict, defaults: dict[str, Any]) -> dict:
         "determinism",
         "inputs",
         "metadata",
+        "test_category",
+        "regression",
         "reference_family",
         "user_contract",
         "ci_lane",
@@ -678,6 +684,10 @@ def _build_metadata(manifest: dict, defaults: dict[str, Any]) -> dict:
     for k, v in manifest.items():
         if k not in standard_fields:
             meta[k] = v
+
+    meta["test_category"] = manifest.get("test_category", "e2e")
+    if "regression" in manifest:
+        meta["regression"] = dict(manifest["regression"])
 
     # Explicitly propagate trust_remote_code to metadata so reference runners
     # can access it via case.metadata["trust_remote_code"].
@@ -839,6 +849,91 @@ def _validate_manifest(raw: dict, path: str) -> None:
         raise TypeError(
             f"Manifest {path!r}: 'hf_revision' must be a non-empty string"
         )
+
+    test_category = raw.get("test_category", "e2e")
+    if not isinstance(test_category, str) or test_category not in {
+        "e2e",
+        "regression",
+    }:
+        raise ValueError(
+            f"Manifest {path!r}: test_category must be 'e2e' or 'regression'"
+        )
+    regression = raw.get("regression")
+    if test_category == "regression":
+        if not isinstance(regression, dict):
+            raise TypeError(
+                f"Manifest {path!r}: regression testcases require a regression object"
+            )
+        required_regression_fields = (
+            "id",
+            "issue",
+            "previous_failure",
+            "prevents",
+        )
+        missing = [
+            field
+            for field in required_regression_fields
+            if not isinstance(regression.get(field), str)
+            or not regression[field].strip()
+        ]
+        if missing:
+            raise ValueError(
+                f"Manifest {path!r}: regression metadata is missing non-empty "
+                f"field(s): {missing}"
+            )
+    elif regression is not None:
+        raise ValueError(
+            f"Manifest {path!r}: regression metadata requires "
+            "test_category='regression'"
+        )
+
+    prompt_file = raw.get("prompt_file")
+    if prompt_file is not None and (
+        not isinstance(prompt_file, str) or not prompt_file.strip()
+    ):
+        raise TypeError(f"Manifest {path!r}: prompt_file must be a non-empty string")
+    expected_prompt_tokens = raw.get("expected_prompt_tokens")
+    if expected_prompt_tokens is not None:
+        if (
+            not isinstance(expected_prompt_tokens, int)
+            or isinstance(expected_prompt_tokens, bool)
+            or expected_prompt_tokens <= 0
+        ):
+            raise TypeError(
+                f"Manifest {path!r}: expected_prompt_tokens must be a positive integer"
+            )
+        if prompt_file is None and raw.get("prompt_repeat") is None:
+            raise ValueError(
+                f"Manifest {path!r}: expected_prompt_tokens requires prompt_file "
+                "or prompt_repeat"
+            )
+
+    prompt_repeat = raw.get("prompt_repeat")
+    if prompt_repeat is not None:
+        if not isinstance(prompt_repeat, dict):
+            raise TypeError(f"Manifest {path!r}: prompt_repeat must be an object")
+        unknown = set(prompt_repeat) - {"text", "separator", "count", "suffix"}
+        if unknown:
+            raise ValueError(
+                f"Manifest {path!r}: prompt_repeat has unsupported fields: "
+                f"{sorted(unknown)}"
+            )
+        text = prompt_repeat.get("text")
+        count = prompt_repeat.get("count")
+        if not isinstance(text, str) or not text:
+            raise TypeError(
+                f"Manifest {path!r}: prompt_repeat.text must be a non-empty string"
+            )
+        if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+            raise TypeError(
+                f"Manifest {path!r}: prompt_repeat.count must be a positive integer"
+            )
+        for field in ("separator", "suffix"):
+            value = prompt_repeat.get(field, "")
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Manifest {path!r}: prompt_repeat.{field} must be a string"
+                )
 
     # 3. Type checks for int fields
     for field_name in ("max_new_tokens", "max_cache_length"):

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -182,21 +182,6 @@ def _threshold_sidecar_path(
     return manifest_path.parent / "thresholds" / filename
 
 
-def requires_threshold_sidecar(testcase: dict[str, Any]) -> bool:
-    """Return whether a testcase consumes configurable numeric thresholds.
-
-    Fixed runtime-invariant contracts assert exact build and execution facts in
-    their model-owned verifier and deliberately ignore ``ThresholdProfile``.
-    Other invariant-only contracts may still use numeric quality or shape
-    thresholds, so the exemption stays intentionally narrow.
-    """
-    return not (
-        testcase.get("reference_backend") == "invariant_only"
-        and testcase.get("oracle_level") == "L4_invariants"
-        and testcase.get("user_contract") == "runtime_invariants"
-    )
-
-
 def _load_threshold_sidecar(
     manifest_path: Path,
     testcase_name: str | None = None,

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -182,6 +182,21 @@ def _threshold_sidecar_path(
     return manifest_path.parent / "thresholds" / filename
 
 
+def requires_threshold_sidecar(testcase: dict[str, Any]) -> bool:
+    """Return whether a testcase consumes configurable numeric thresholds.
+
+    Fixed runtime-invariant contracts assert exact build and execution facts in
+    their model-owned verifier and deliberately ignore ``ThresholdProfile``.
+    Other invariant-only contracts may still use numeric quality or shape
+    thresholds, so the exemption stays intentionally narrow.
+    """
+    return not (
+        testcase.get("reference_backend") == "invariant_only"
+        and testcase.get("oracle_level") == "L4_invariants"
+        and testcase.get("user_contract") == "runtime_invariants"
+    )
+
+
 def _load_threshold_sidecar(
     manifest_path: Path,
     testcase_name: str | None = None,

--- a/tests/e2e_harness/model_runner.py
+++ b/tests/e2e_harness/model_runner.py
@@ -80,6 +80,14 @@ def selected_testcases(
     if testcase_filters:
         cases = [case for case in cases if case.name in testcase_filters]
 
+    category_filter = config.getoption("--e2e-category", default=None)
+    if category_filter:
+        cases = [
+            case
+            for case in cases
+            if case.metadata.get("test_category", "e2e") == category_filter
+        ]
+
     excluded_ci_tiers = set(config.getoption("--e2e-exclude-ci-tier", default=[]) or [])
     if excluded_ci_tiers:
         cases = [

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -54,7 +54,7 @@ from .contracts import (
     StageStatus,
     ThresholdProfile,
 )
-from . import save_full_stderr
+from . import _case_artifact_dir, save_full_stderr
 from .python_profiles import profile_env_var
 from .runtime_strategy_metadata import runtime_strategy_requires_new_runtime_guard
 from .registry import (
@@ -795,6 +795,9 @@ def _build_repro_commands(
         )
     if case.hf_revision:
         build_parts.extend(["--model-revision", case.hf_revision])
+    precision = case.metadata.get("precision", "fp32")
+    if precision != "fp32":
+        build_parts.extend(["--precision", str(precision)])
     build_method = _manifest_build_method(case.metadata.get("build_args", {}))
     if build_method:
         build_parts.extend(["--method", build_method])
@@ -816,11 +819,38 @@ def _build_repro_commands(
                 ctx.binary_path,
                 "run",
                 bundle_path,
-                "--prompt",
-                _shell_quote(case.inputs.get("prompt", "")),
-                "--max-new-tokens",
-                str(case.inputs.get("max_new_tokens", 20)),
             ]
+            if case.inputs.get("prompt_file"):
+                infer_parts.extend(
+                    ["--prompts-file", _shell_quote(str(case.inputs["prompt_file"]))]
+                )
+            elif case.inputs.get("prompt_repeat") and ctx.artifacts_dir:
+                resolved_prompt = (
+                    Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+                    / "resolved_prompt.txt"
+                )
+                infer_parts.extend(
+                    ["--prompts-file", _shell_quote(str(resolved_prompt))]
+                )
+            else:
+                infer_parts.extend(
+                    ["--prompt", _shell_quote(str(case.inputs.get("prompt", "")))]
+                )
+            infer_parts.extend(
+                ["--max-new-tokens", str(case.inputs.get("max_new_tokens", 20))]
+            )
+            if case.inputs.get("temperature", 1.0) != 1.0:
+                infer_parts.extend(
+                    ["--temperature", str(case.inputs["temperature"])]
+                )
+            if case.inputs.get("top_p", 1.0) < 1.0 - 1e-6:
+                infer_parts.extend(["--top-p", str(case.inputs["top_p"])])
+            if case.inputs.get("min_p", 0.0) > 1e-6:
+                infer_parts.extend(["--min-p", str(case.inputs["min_p"])])
+            if case.inputs.get("top_k", 1) != 1:
+                infer_parts.extend(["--top-k", str(case.inputs["top_k"])])
+            if case.inputs.get("seed", -1) >= 0:
+                infer_parts.extend(["--seed", str(case.inputs["seed"])])
             runtime_cli_python = ctx.runtime_cli_hf_python()
             if runtime_cli_python:
                 infer_parts.extend(["--hf-python", runtime_cli_python])
@@ -841,6 +871,8 @@ def _build_repro_commands(
     ]
     if _distributed_runtime_config(case):
         rerun_parts.append("--multi-device-only")
+    if case.metadata.get("test_category") == "regression":
+        rerun_parts.extend(["--e2e-category", "regression"])
     repro["rerun_test"] = " ".join(rerun_parts)
 
     profile_exports: list[str] = []

--- a/tests/e2e_harness/threshold_policy.py
+++ b/tests/e2e_harness/threshold_policy.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repository policy for model-owned E2E threshold sidecars."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def requires_threshold_sidecar(testcase: dict[str, Any]) -> bool:
+    """Return whether a testcase consumes configurable numeric thresholds.
+
+    Fixed runtime-invariant contracts assert exact build and execution facts in
+    their model-owned verifier and deliberately ignore ``ThresholdProfile``.
+    Other invariant-only contracts may still use numeric quality or shape
+    thresholds, so the exemption stays intentionally narrow.
+    """
+    return not (
+        testcase.get("reference_backend") == "invariant_only"
+        and testcase.get("oracle_level") == "L4_invariants"
+        and testcase.get("user_contract") == "runtime_invariants"
+    )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -14,6 +14,9 @@ Usage:
     # Filter by strategy:
     pytest tests/test_e2e.py --e2e-task-strategy text_generation_causal
 
+    # Historical regressions only:
+    pytest tests/test_e2e.py --e2e-category regression
+
     # Core models only:
     pytest tests/test_e2e.py --e2e-core-only
 

--- a/tests/tools/test_e2e_repro_commands.py
+++ b/tests/tools/test_e2e_repro_commands.py
@@ -11,7 +11,10 @@ Postconditions: Generated repro commands contain correct binary subcommand, flag
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from tests.e2e_harness.contracts import E2ECase, RunContext
+from tests.e2e_harness.manifest_loader import load_manifest
 from tests.e2e_harness.orchestrator import _build_repro_commands
 from tests.e2e_harness.registry import (
     register_repro_command_provider,
@@ -243,3 +246,72 @@ def test_repro_commands_can_use_runner_owned_hook(tmp_path) -> None:
     cmd = repro["trt_inference"]
     assert " runner-owned-command " in f" {cmd} "
     assert "--case runner-owned-case" in cmd
+
+
+def test_qwen_native_kv_repro_preserves_model_only_build(tmp_path) -> None:
+    reset()
+    manifest = (
+        Path(__file__).resolve().parents[1]
+        / "e2e"
+        / "models"
+        / "qwen"
+        / "manifests"
+        / "qwen3-0.6b-regression-native-kv-chunked-prefill.json"
+    )
+    case = load_manifest(manifest)
+    ctx = RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        binary_path="./build/trtmc",
+        hf_python="/usr/bin/python3",
+        engine_dir=str(tmp_path),
+    )
+    bundle = str(tmp_path / case.bundle)
+
+    repro = _build_repro_commands(case, ctx, bundle, {})
+
+    assert "--max-cache-length" not in repro["build_bundle"]
+    assert "--precision" not in repro["build_bundle"]
+    assert f"--model-revision {case.hf_revision}" in repro["build_bundle"]
+    resolved_prompt = tmp_path / "artifacts" / case.name / "resolved_prompt.txt"
+    assert f"--prompts-file {resolved_prompt}" in repro["trt_inference"]
+    assert "--max-new-tokens 2" in repro["trt_inference"]
+    assert "--temperature 0.0" in repro["trt_inference"]
+    assert "--e2e-category regression" in repro["rerun_test_rebuild"]
+
+
+def test_llama_chunked_prefill_repro_preserves_model_only_build(tmp_path) -> None:
+    reset()
+    manifest = (
+        Path(__file__).resolve().parents[1]
+        / "e2e"
+        / "models"
+        / "llama"
+        / "manifests"
+        / "minitron-4b-width-regression-native-kv-chunked-prefill.json"
+    )
+    case = load_manifest(manifest)
+    ctx = RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        binary_path="./build/trtmc",
+        hf_python="/usr/bin/python3",
+        engine_dir=str(tmp_path),
+    )
+    bundle = str(tmp_path / case.bundle)
+
+    repro = _build_repro_commands(case, ctx, bundle, {})
+
+    assert "--max-cache-length" not in repro["build_bundle"]
+    assert "--precision" not in repro["build_bundle"]
+    assert f"--model-revision {case.hf_revision}" in repro["build_bundle"]
+    resolved_prompt = (
+        tmp_path
+        / "artifacts"
+        / case.name
+        / "resolved_prompt.txt"
+    )
+    assert f"--prompts-file {resolved_prompt}" in repro["trt_inference"]
+    assert "--max-new-tokens 2" in repro["trt_inference"]
+    assert "--temperature 0.0" in repro["trt_inference"]
+    assert "--e2e-category regression" in repro["rerun_test_rebuild"]

--- a/tests/tools/test_generate_report.py
+++ b/tests/tools/test_generate_report.py
@@ -2272,11 +2272,23 @@ class TestEvidenceCompleteness:
         status["steps"]["e2e_reference"] = {"status": "skipped"}
         assert mod.validate_proof_context(status, proof, selection) == []
 
+        proof["e2e_proof_kind"] = "mixed"
+        proof["e2e_proof_kinds"] = ["functional_invariant", "reference"]
+        status["e2e_proof_kind"] = "mixed"
+        status["e2e_proof_kinds"] = ["functional_invariant", "reference"]
         status["steps"]["e2e_reference"] = {"status": "passed"}
-        issues = mod.validate_proof_context(status, proof, selection)
-        assert any("e2e_reference must be skipped" in issue for issue in issues)
+        assert mod.validate_proof_context(status, proof, selection) == []
 
-        status["steps"]["e2e_reference"] = {"status": "skipped"}
+        rendered = mod.render_proof_section(mod._proof_context(status, proof, selection))
+        assert "E2E per-case proof kinds" in rendered
+        assert "functional_invariant, reference" in rendered
+
+        proof.pop("e2e_proof_kinds")
+        issues = mod.validate_proof_context(status, proof, selection)
+        assert any("per-case E2E proof kinds" in issue for issue in issues)
+        proof["e2e_proof_kinds"] = ["functional_invariant", "reference"]
+
+        status["steps"]["e2e_reference"] = {"status": "passed"}
         proof["min_free_gpu_memory_mib"] = True
         assert (
             "Proof has an invalid minimum free GPU memory value"

--- a/tests/tools/test_model_e2e_runner.py
+++ b/tests/tools/test_model_e2e_runner.py
@@ -78,6 +78,40 @@ def test_ci_tier_filters_children_without_changing_model_identity() -> None:
     assert [case.name for case in selected] == ["canary-1b-v2"]
 
 
+def test_category_filter_separates_e2e_from_historical_regressions() -> None:
+    qwen_dir = MODELS_DIR / "qwen"
+    regression = get_model_by_name(
+        "qwen3-0.6b-regression-native-kv-chunked-prefill", qwen_dir
+    )
+    ordinary = get_model_by_name("qwen3-0.6b-fp16", qwen_dir)
+    assert regression is not None
+    assert ordinary is not None
+
+    config = _Config(
+        **{
+            "--e2e-category": "regression",
+            "--e2e-exclude-ci-tier": [],
+        }
+    )
+    selected_regressions = model_runner.selected_testcases(
+        regression,
+        config=config,
+        case_matches_model=_case_matches,
+        is_multi_device_case=_is_multi_device,
+    )
+    selected_ordinary = model_runner.selected_testcases(
+        ordinary,
+        config=config,
+        case_matches_model=_case_matches,
+        is_multi_device_case=_is_multi_device,
+    )
+
+    assert [case.name for case in selected_regressions] == [
+        "qwen3-0.6b-regression-native-kv-chunked-prefill"
+    ]
+    assert selected_ordinary == []
+
+
 def test_platform_threshold_overrides_are_scoped_to_matching_platform() -> None:
     case = E2ECase(
         name="elf-b-owt-l0",

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -17,6 +17,8 @@ import json
 import re
 from pathlib import Path
 
+from tests.e2e_harness.manifest_loader import requires_threshold_sidecar
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUNTIME_MODELS = REPO_ROOT / "src" / "runtime" / "models"
@@ -9384,6 +9386,8 @@ def test_model_owned_e2e_assets_are_local_and_complete() -> None:
         for manifest in sorted((model_dir / "manifests").glob("*.json")):
             raw = json.loads(manifest.read_text(encoding="utf-8"))
             for testcase in raw.get("testcases", []):
+                if not requires_threshold_sidecar(testcase):
+                    continue
                 threshold = model_dir / "thresholds" / f"{testcase['name']}.json"
                 if not threshold.is_file():
                     violations.append(

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -17,7 +17,7 @@ import json
 import re
 from pathlib import Path
 
-from tests.e2e_harness.manifest_loader import requires_threshold_sidecar
+from tests.e2e_harness.threshold_policy import requires_threshold_sidecar
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -610,13 +610,14 @@ def test_qwen_premerge_selects_native_defaults_l0(tmp_path: Path) -> None:
     ]
 
 
-def test_qwen_nightly_keeps_production_cases(tmp_path: Path) -> None:
+def test_qwen_nightly_includes_production_and_regression_cases(tmp_path: Path) -> None:
     selection = _run_test_selection(tmp_path, "qwen", "nightly")
 
     assert selection["suite"] == "nightly"
     assert {case["name"] for case in selection["e2e_cases"]} == {
         "qwen3-0.6b-fp16",
         "qwen3-0.6b-fp8",
+        "qwen3-0.6b-regression-native-kv-chunked-prefill",
         "qwen3-0.6b-topp",
         "qwen3-4b-instruct-2507",
     }
@@ -1223,6 +1224,7 @@ def test_llama_nightly_model_proof_reserves_an_exclusive_gpu(tmp_path: Path) -> 
         "falcon3-1b": "exclusive_gpu",
         "minitron-4b-depth": "shared",
         "minitron-4b-width": "shared",
+        "minitron-4b-width-regression-native-kv-chunked-prefill": "shared",
         "nemotron-nano-4b": "shared",
         "tinyllama-1.1b": "shared",
     }

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -568,14 +568,19 @@ def test_premerge_selects_one_nested_l0_replacement(
     assert selection["e2e_cases"][0]["model"] == expected_case
 
 
-def test_every_owned_e2e_family_has_one_premerge_case(tmp_path: Path) -> None:
+def test_every_owned_e2e_family_has_one_premerge_smoke_case(tmp_path: Path) -> None:
     model_root = REPO_ROOT / "tests" / "e2e" / "models"
     families = sorted(path.parent.name for path in model_root.glob("*/MODEL.toml"))
 
     assert families
     for family in families:
         selection = _run_test_selection(tmp_path, family, "premerge")
-        assert len(selection["e2e_cases"]) == 1, family
+        smoke_cases = [
+            case
+            for case in selection["e2e_cases"]
+            if case["test_category"] != "regression"
+        ]
+        assert len(smoke_cases) == 1, family
         assert selection["e2e_cases"][0]["ci_tier"] != "nightly_only", family
 
 
@@ -588,26 +593,37 @@ def test_wan22_premerge_selects_standalone_l0_manifest(tmp_path: Path) -> None:
     assert "model_reference_cache" not in selection
 
 
-def test_qwen_premerge_selects_native_defaults_l0(tmp_path: Path) -> None:
-    selection = _run_test_selection(tmp_path, "qwen", "premerge")
+@pytest.mark.parametrize(
+    ("family", "smoke_case", "regression_case"),
+    (
+        (
+            "qwen",
+            "qwen3-0.6b-native-l0",
+            "qwen3-0.6b-regression-native-kv-chunked-prefill",
+        ),
+        (
+            "llama",
+            "minitron-4b-width-l0",
+            "minitron-4b-width-regression-native-kv-chunked-prefill",
+        ),
+    ),
+)
+def test_premerge_selects_smoke_and_native_kv_regression(
+    tmp_path: Path,
+    family: str,
+    smoke_case: str,
+    regression_case: str,
+) -> None:
+    selection = _run_test_selection(tmp_path, family, "premerge")
 
     assert selection["suite"] == "premerge"
-    assert [
-        (
-            case["name"],
-            case["model"],
-            case["manifest"],
-            case["ci_tier"],
-        )
-        for case in selection["e2e_cases"]
-    ] == [
-        (
-            "qwen3-0.6b-native-l0",
-            "qwen3-0.6b-native-l0",
-            "qwen3-0.6b-native-l0.json",
-            "l0_only",
-        )
+    assert [case["name"] for case in selection["e2e_cases"]] == [
+        smoke_case,
+        regression_case,
     ]
+    assert selection["e2e_cases"][0]["test_category"] == "e2e"
+    assert selection["e2e_cases"][1]["test_category"] == "regression"
+    assert selection["e2e_cases"][1]["ci_tier"] == "default"
 
 
 def test_qwen_nightly_includes_production_and_regression_cases(tmp_path: Path) -> None:
@@ -933,6 +949,22 @@ def test_selector_rejects_testcase_level_gpu_capacity(
             tmp_path,
             "convbert",
             "nightly",
+            projection_setup=configure,
+        )
+
+
+def test_selector_rejects_unknown_test_category(tmp_path: Path) -> None:
+    def configure(source: Path, _projection: dict[str, object]) -> None:
+        path = next((source / "tests/e2e/models/convbert/manifests").glob("*.json"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["testcases"][0]["test_category"] = "regresion"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CiError, match="test_category must be 'e2e' or 'regression'"):
+        _run_test_selection(
+            tmp_path,
+            "convbert",
+            "premerge",
             projection_setup=configure,
         )
 

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -27,7 +27,10 @@ from tools.ci.context import CiContext
 from tools.ci.gpu_lease import GpuLease
 from tools.ci.model_reference_cache import ModelReferenceCacheWarmer
 from tools.ci.model_proof import ModelProofRequest, ModelProofRunner, ModelReferenceCache
-from tools.ci.model_proof_inner import ModelProofInnerPipeline
+from tools.ci.model_proof_inner import (
+    ModelProofInnerPipeline,
+    _classify_e2e_proof_kinds,
+)
 from tools.ci.model_proof_selection import ModelProofSelector
 from tools.ci.process import CiError
 
@@ -1646,14 +1649,43 @@ def test_model_proof_enforces_one_full_bundle_build_per_selected_model() -> None
         assert contract in runner
 
     assert runner.index('"verify-builds"') < runner.index('"verify-results"')
-    assert runner.index('"verify-results"') < runner.index(
-        'result.get("proof_kind") for result in e2e_verification.get("results", [])'
+    verify_results_index = runner.index('"verify-results"')
+    assert verify_results_index < runner.index(
+        "e2e_proof_kind, e2e_proof_kinds = _classify_e2e_proof_kinds(",
+        verify_results_index,
     )
-    assert "if len(proof_kinds) != 1:" in runner
     assert 'self.status.fact("e2e_proof_kind", e2e_proof_kind)' in runner
+    assert 'self.status.fact("e2e_proof_kinds", e2e_proof_kinds)' in runner
     assert "self._python()" in runner
     assert '"pytest"' in runner
     assert 'self.source / str(payload["e2e_test"])' in runner
+
+
+@pytest.mark.parametrize(
+    ("proof_kinds", "expected_aggregate"),
+    (
+        (["reference"], "reference"),
+        (["functional_invariant"], "functional_invariant"),
+        (["reference", "functional_invariant"], "mixed"),
+    ),
+)
+def test_model_proof_classifies_single_and_mixed_e2e_oracles(
+    proof_kinds: list[str], expected_aggregate: str
+) -> None:
+    aggregate, ordered = _classify_e2e_proof_kinds(
+        {"results": [{"proof_kind": kind} for kind in proof_kinds]}
+    )
+
+    assert aggregate == expected_aggregate
+    assert ordered == sorted(proof_kinds)
+
+
+@pytest.mark.parametrize("results", ([], [{"proof_kind": "unknown"}]))
+def test_model_proof_rejects_missing_or_unknown_e2e_oracles(
+    results: list[dict[str, str]],
+) -> None:
+    with pytest.raises(CiError, match="invalid E2E proof kinds"):
+        _classify_e2e_proof_kinds({"results": results})
 
 
 def test_model_proof_report_assets_are_inside_the_positive_projection() -> None:

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -294,16 +294,23 @@ def test_catalog_exposes_every_declared_profile_and_family() -> None:
             declared = tomllib.load(stream)["test_manifests"]
         expected_manifests.extend(descriptor.parent / path for path in declared)
     expected_distributed = 0
+    expected_regressions = 0
     for manifest in expected_manifests:
         raw = json.loads(manifest.read_text(encoding="utf-8"))
-        expected_distributed += bool(raw.get("distributed_runtime", {}).get("enabled"))
+        distributed = bool(raw.get("distributed_runtime", {}).get("enabled"))
+        expected_distributed += distributed
+        expected_regressions += not distributed and all(
+            testcase.get("test_category", "e2e") == "regression"
+            for testcase in raw["testcases"]
+        )
 
     assert len(entries) == len(expected_manifests)
     assert len({entry.family for entry in entries}) == len(descriptors)
     assert sum(entry.status == "ready" for entry in entries) == (
-        len(expected_manifests) - expected_distributed
+        len(expected_manifests) - expected_distributed - expected_regressions
     )
     assert sum(entry.status == "distributed" for entry in entries) == expected_distributed
+    assert sum(entry.status == "regression" for entry in entries) == expected_regressions
     assert not [entry for entry in entries if entry.status in {"invalid", "unsupported"}]
 
 
@@ -320,7 +327,11 @@ def test_native_kv_regression_prompt_repeat_resolves_deterministically(
 ) -> None:
     model = ManifestCatalog().resolve(model_name)
     case = resolve_case(model, tmp_path / model.bundle_name)
+    entry = next(
+        entry for entry in ManifestCatalog().entries() if entry.name == model_name
+    )
 
+    assert entry.status == "regression"
     assert case.request["prompt"] == " ".join(["a"] * 32768) + "\n"
     assert case.sources["request.prompt"] == "model testcase"
 

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -308,6 +308,24 @@ def test_catalog_exposes_every_declared_profile_and_family() -> None:
 
 
 @pytest.mark.parametrize(
+    "model_name",
+    [
+        "minitron-4b-width-regression-native-kv-chunked-prefill",
+        "qwen3-0.6b-regression-native-kv-chunked-prefill",
+    ],
+)
+def test_native_kv_regression_prompt_repeat_resolves_deterministically(
+    tmp_path: Path,
+    model_name: str,
+) -> None:
+    model = ManifestCatalog().resolve(model_name)
+    case = resolve_case(model, tmp_path / model.bundle_name)
+
+    assert case.request["prompt"] == " ".join(["a"] * 32768) + "\n"
+    assert case.sources["request.prompt"] == "model testcase"
+
+
+@pytest.mark.parametrize(
     ("model_name", "operation"),
     [
         ("bark-small", "generate_audio"),

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -148,7 +148,7 @@ def test_dataset_path_rebases_mounted_defaults_under_dataset_root(tmp_path: Path
     )
 
 
-def test_validation_ready_models_exclude_l0_only_profiles():
+def test_validation_ready_models_exclude_l0_and_regression_profiles():
     records = validation_catalog.load_manifest_records(trtmc_validate.DEFAULT_MODELS)
     eligible = {
         str(record["name"])
@@ -156,10 +156,19 @@ def test_validation_ready_models_exclude_l0_only_profiles():
         if not record["requires_multi_device"] and not record.get("skip")
     }
     l0_only = {str(record["name"]) for record in records if record.get("ci_tier") == "l0_only"}
+    regressions = {
+        str(record["name"])
+        for record in records
+        if record.get("test_category") == "regression"
+    }
     selected = set(trtmc_validate.ready_model_names())
 
     assert l0_only
-    assert selected == eligible - l0_only
+    assert regressions == {
+        "minitron-4b-width-regression-native-kv-chunked-prefill",
+        "qwen3-0.6b-regression-native-kv-chunked-prefill",
+    }
+    assert selected == eligible - l0_only - regressions
 
 
 def test_catalog_defines_sample_limit_for_every_dataset_workload():

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -670,7 +670,8 @@ the producing class remains the source of truth for optional evidence fields.
       "source_revision": "<commit>",
       "suite": "premerge",
       "outcome": "passed",
-      "e2e_proof_kind": "reference",
+      "e2e_proof_kind": "mixed",
+      "e2e_proof_kinds": ["functional_invariant", "reference"],
       "steps": {
         "scratch_build": {"status": "passed", "evidence": "build.log"},
         "e2e_reference": {"status": "passed", "evidence": "e2e/junit.xml, e2e/*/result.json"},
@@ -682,8 +683,10 @@ the producing class remains the source of truth for optional evidence fields.
 
   The complete output also includes the single DSO audit, C++/Python JUnit,
   engine-build verification, `proof.json`, and the per-model HTML report.
-  `e2e_reference` is a parity claim only for exclusively L1/L2-selected
-  cases. L3 is reported as snapshot regression and L4 as a functional
+  `e2e_reference` passes when at least one selected case proves L1/L2
+  reference parity. When a proof combines reference and regression cases,
+  `e2e_proof_kind` is `mixed` and `e2e_proof_kinds` preserves every per-case
+  classification. L3 remains snapshot regression and L4 remains a functional
   invariant; neither is promoted to reference parity.
 - **Boundary:** It can see only the projected model and private resources. It
   cannot reach the network, peer model source, or host-wide cache; artifact

--- a/tools/ci/model_proof_inner.py
+++ b/tools/ci/model_proof_inner.py
@@ -24,6 +24,35 @@ from .selected_wheel import SelectedWheelRuntime
 from .validation import ValidationRunner
 
 
+_SUPPORTED_E2E_PROOF_KINDS = {
+    "functional_invariant",
+    "reference",
+    "snapshot_regression",
+}
+
+
+def _classify_e2e_proof_kinds(
+    verification: dict[str, object],
+) -> tuple[str, list[str]]:
+    results = verification.get("results")
+    raw_proof_kinds = (
+        [result.get("proof_kind") for result in results if isinstance(result, dict)]
+        if isinstance(results, list)
+        else []
+    )
+    if (
+        not raw_proof_kinds
+        or not all(isinstance(kind, str) for kind in raw_proof_kinds)
+        or not set(raw_proof_kinds) <= _SUPPORTED_E2E_PROOF_KINDS
+    ):
+        raise CiError(
+            f"Model proof found invalid E2E proof kinds: {raw_proof_kinds}"
+        )
+    proof_kinds = set(raw_proof_kinds)
+    ordered = sorted(proof_kinds)
+    return (ordered[0] if len(ordered) == 1 else "mixed"), ordered
+
+
 class ProofStatus:
     """Persist the status of each proof stage for strict HTML rendering."""
 
@@ -519,6 +548,7 @@ class ModelProofInnerPipeline:
             },
             "e2e_cases": self.selection.e2e_cases,
             "e2e_proof_kind": verification["e2e_proof_kind"],
+            "e2e_proof_kinds": verification["e2e_proof_kinds"],
             "engine_builds_per_model": verification["builds_per_model"],
             "engine_build_count": len(verification["records"]),
             "engine_build_verification": "engine-build-verification.json",
@@ -792,22 +822,24 @@ class ModelProofInnerPipeline:
         e2e_verification = json.loads(
             (self.artifacts / "e2e-verification.json").read_text(encoding="utf-8")
         )
-        proof_kinds = {result.get("proof_kind") for result in e2e_verification.get("results", [])}
-        if len(proof_kinds) != 1:
-            raise CiError(f"Model proof requires one E2E proof kind, found {proof_kinds}")
-        e2e_proof_kind = next(iter(proof_kinds))
+        e2e_proof_kind, e2e_proof_kinds = _classify_e2e_proof_kinds(
+            e2e_verification
+        )
         self.status.fact("e2e_proof_kind", e2e_proof_kind)
+        self.status.fact("e2e_proof_kinds", e2e_proof_kinds)
+        has_reference_proof = "reference" in e2e_proof_kinds
         self.status.step(
             "e2e_reference",
-            "passed" if e2e_proof_kind == "reference" else "skipped",
+            "passed" if has_reference_proof else "skipped",
             (
                 "e2e-verification.json (L1/L2 reference oracle)"
-                if e2e_proof_kind == "reference"
-                else f"not claimed: {e2e_proof_kind} oracle"
+                if has_reference_proof
+                else f"not claimed: {', '.join(e2e_proof_kinds)} oracle"
             ),
         )
         self.status.step("result_verification", "passed")
         verification["e2e_proof_kind"] = e2e_proof_kind
+        verification["e2e_proof_kinds"] = e2e_proof_kinds
         return verification
 
     def _finalize_report(self, validation_rc: int) -> int:

--- a/tools/ci/model_proof_selection.py
+++ b/tools/ci/model_proof_selection.py
@@ -246,6 +246,17 @@ class ModelProofSelector:
                 name = str(testcase.get("name") or "")
                 if not name:
                     raise CiError(f"E2E manifest has an unnamed testcase: {path}")
+                test_category = testcase.get(
+                    "test_category", data.get("test_category", "e2e")
+                )
+                if not isinstance(test_category, str) or test_category not in {
+                    "e2e",
+                    "regression",
+                }:
+                    raise CiError(
+                        "E2E manifest test_category must be 'e2e' or 'regression': "
+                        f"{path}"
+                    )
                 tier = str(testcase.get("ci_tier") or data.get("ci_tier") or "")
                 if tier == "multi_device":
                     continue
@@ -254,6 +265,7 @@ class ModelProofSelector:
                         "name": name,
                         "model": model,
                         "manifest": path.name,
+                        "test_category": test_category,
                         "ci_tier": tier,
                         "l0_replacement": str(testcase.get("l0_replacement") or ""),
                         "estimated_seconds": timing.get(name),
@@ -275,12 +287,20 @@ class ModelProofSelector:
         ]
         if not eligible:
             raise CiError(f"no premerge E2E case is available for {family}")
+        regressions = [
+            case for case in eligible if case["test_category"] == "regression"
+        ]
+        smoke_cases = [
+            case for case in eligible if case["test_category"] != "regression"
+        ]
         replacements = {
             case["l0_replacement"]
             for case in cases
             if case["ci_tier"] == "nightly_only" and case["l0_replacement"]
         }
-        candidates = [case for case in eligible if case["name"] in replacements] or eligible
+        candidates = [
+            case for case in smoke_cases if case["name"] in replacements
+        ] or smoke_cases
         priority = {"l0_only": 0, "contract_only": 1, "": 2}
         candidates.sort(
             key=lambda case: (
@@ -292,7 +312,7 @@ class ModelProofSelector:
                 case["model"],
             )
         )
-        return candidates[:1]
+        return candidates[:1] + regressions
 
     @staticmethod
     def _validate_lease(

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -58,6 +58,7 @@ harness_shared tests/e2e_harness/registry.py # shared E2E harness surface; broad
 harness_shared tests/e2e_harness/result_schema.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/runtime_config.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/runtime_strategy_metadata.py # shared E2E strategy metadata surface; broad E2E impact is intentional
+harness_shared tests/e2e_harness/threshold_policy.py # shared E2E threshold ownership policy; broad E2E impact is intentional
 harness_shared tests/e2e_harness/thresholds/__init__.py # shared E2E harness surface; broad E2E impact is intentional
 no_impact scripts/_build_fp8_onnx_monolithic.py # developer utility script; no CI test impact is intentional
 no_impact scripts/_inject_fp8_qdq_proto.py # developer utility script; no CI test impact is intentional

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -299,6 +299,7 @@ def ready_model_names(models_root: Path = DEFAULT_MODELS) -> tuple[str, ...]:
             if not model["requires_multi_device"]
             and not model.get("skip")
             and model.get("ci_tier") != "l0_only"
+            and model.get("test_category", "e2e") != "regression"
         )
     )
 

--- a/tools/validation/catalog.py
+++ b/tools/validation/catalog.py
@@ -146,6 +146,7 @@ def manifest_record(path: Path) -> dict[str, Any]:
             else {}
         ),
         "user_contract": user_contract,
+        "test_category": raw.get("test_category", "e2e"),
         "ci_tier": raw.get("ci_tier", "default"),
         "core": bool(raw.get("core", False)),
         "skip": raw.get("skip", ""),


### PR DESCRIPTION
## Background

PR #673 added full-context native TensorRT KV cache support for dense Qwen3 and Llama models. Existing short-prompt E2E cases do not cross the 32,768-token prefill profile boundary, so they cannot detect regressions in profile-bounded prefill chunking, shared full-capacity KV state, or teardown after long-context execution.

## Exit Criteria

- Regression cases are selectable independently from ordinary E2E coverage and do not enter Accuracy or Performance inventories.
- Qwen3-0.6B and Llama-3.1-Minitron-4B-Width exercise model-only native-KV builds with a 32,769-token prompt in both premerge and nightly model proof.
- Each case requires full model KV capacity, two prefill launches, decode execution, and clean teardown.
- The fixed prompt shape is verified with the tokenizer from the pinned Hugging Face revision.

## Implementation

- Add `test_category=regression` metadata and `--e2e-category regression` selection to the unified E2E harness.
- Add compact `prompt_repeat` fixtures so long deterministic prompts do not require large checked-in text files. The resolved prompt is retained with the case artifacts and used by generated reproduction commands.
- Add invariant-only native-KV contracts for Qwen and Llama. They verify the runtime return code, tokenizer count, full KV row count, expected prefill launch count, requested generated-token count, decode timing, and absence of runtime error signatures across the complete stderr stream.
- Keep one fast smoke case per affected family in premerge, then add every eligible regression case. Nightly continues to select all non-L0 production and regression cases.
- Allow one model-proof job to preserve mixed per-case oracle evidence: ordinary reference cases remain `reference`, L4 regressions remain `functional_invariant`, and the aggregate proof is reported as `mixed` without weakening either case-level criterion.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_model_proof_runner.py -k 'not test_distinct_explicit_hf_cache_paths_reach_both_containers' tests/tools/test_generate_report.py tests/builder/test_manifest_validation.py tests/e2e/models/qwen/test_qwen_manifest_contract.py tests/e2e/models/llama/test_llama_build_contract.py`: 337 passed, 1 environment-specific reflink test deselected.
- `python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 157 passed.
- Ruff and `git diff --check`: passed.
- Exact head `4c4b76e8`: `trtmc/premerge/required` passed.
- Exact head `4c4b76e8`, Qwen premerge model proof: the smoke case and `qwen3-0.6b-regression-native-kv-chunked-prefill` both passed build verification and E2E execution; the two-case E2E run completed in 344.70 seconds.
- Exact head `4c4b76e8`, Llama premerge model proof: the smoke case and `minitron-4b-width-regression-native-kv-chunked-prefill` both passed build verification and E2E execution; the two-case E2E run completed in 461.50 seconds.
- GB300, TensorRT 11.2, Qwen full rebuild and inference: passed. The model-only build selected 40,960 KV rows; a 32,769-token prompt produced two prefill launches, two generated tokens, decode timing, and clean teardown.
- GB300, TensorRT 11.2, Llama full build and inference: passed. The model-only build selected 131,072 KV rows; a 32,769-token prompt produced two prefill launches, two generated tokens, decode timing, and clean teardown.

## Notes For Future Readers

- Start review with the two manifests and family-owned contract plugins, then review model-proof selection and mixed-oracle evidence handling.
- These cases validate the native-KV runtime mechanism and safety invariants, not long-context semantic parity against Hugging Face.
- Both regression cases intentionally run in premerge and nightly. Do not change them back to `nightly_only` without changing that coverage decision.
