### PR TITLE
docs: add help routes and second review anchors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Bug report
+description: Report reproducible behavior that differs from the documented contract
+title: "Bug: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve TensorRT-Model-Connect. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Select the boundary where the first failure appears.
+      options:
+        - Installation or source build
+        - Model resolution or TensorRT engine build
+        - Bundle creation or inspection
+        - Runtime loading or dispatch
+        - Inference output or task execution
+        - Validation or benchmarking
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: TensorRT-Model-Connect version
+      description: Provide a release, tag, or full commit SHA.
+      placeholder: "Full commit SHA or release tag"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation_method
+    attributes:
+      label: Installation method
+      multiple: true
+      options:
+        - Development container
+        - Python package or wheel
+        - Source build outside the development container
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model and revision
+      description: Provide the exact Hugging Face model ID and revision, or identify the local checkpoint without uploading restricted artifacts.
+      placeholder: "Qwen/Qwen3-0.6B at <revision>, or not model-specific"
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the OS, GPU and compute capability, driver, CUDA, TensorRT, container image or package version, and relevant dependency versions.
+      placeholder: |
+        OS:
+        GPU and compute capability:
+        Driver:
+        CUDA:
+        TensorRT:
+        Container image or package:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Provide the smallest commands, configuration, and input that reproduce the issue. Redact secrets and private URLs.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Observed and expected behavior
+      description: Describe what happened, what you expected, and where the behavior differs from documentation or another stated contract.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste the first relevant error and nearby context. Do not include credentials, private URLs, or proprietary logs.
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched open and closed issues and found no duplicate.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true
+        - label: I removed secrets, credentials, private URLs, and restricted artifacts.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,8 @@ body:
       value: |
         Thanks for helping improve TensorRT-Model-Connect. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
 
+        If the implementation appears correct but the documentation is incorrect, unclear, or missing, use the [documentation request form](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new?template=documentation_request.yml).
+
   - type: dropdown
     id: area
     attributes:
@@ -61,10 +63,10 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Include the OS, GPU and compute capability, driver, CUDA, TensorRT, container image or package version, and relevant dependency versions.
+      description: Include the OS, GPU, driver, CUDA, TensorRT, container image or package version, and relevant dependency versions.
       placeholder: |
         OS:
-        GPU and compute capability:
+        GPU:
         Driver:
         CUDA:
         TensorRT:
@@ -82,10 +84,18 @@ body:
       required: true
 
   - type: textarea
-    id: behavior
+    id: observed_behavior
     attributes:
-      label: Observed and expected behavior
-      description: Describe what happened, what you expected, and where the behavior differs from documentation or another stated contract.
+      label: Observed behavior
+      description: Describe what happened and where the behavior differs from documentation or another stated contract.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: Read the help and issue-filing guide
+    url: https://nvidia.github.io/TensorRT-Model-Connect/release-support/get-help
+    about: Choose a support route and collect the evidence maintainers need.
+  - name: Report a security vulnerability
+    url: https://www.nvidia.com/en-us/security/report-vulnerability/
+    about: Report suspected vulnerabilities privately to NVIDIA PSIRT, not in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Documentation request
+description: Report incorrect, unclear, or missing documentation
+title: "Docs: "
+labels: ["documentation"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the TensorRT-Model-Connect documentation. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Request type
+      options:
+        - Correct or update existing documentation
+        - Clarify existing documentation
+        - Add missing documentation
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Blocking current usage
+        - High
+        - Medium
+        - Low or nice to have
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the relevant page or source file and include a heading or line number when possible.
+      placeholder: "https://nvidia.github.io/TensorRT-Model-Connect/..."
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or missing content
+      description: Explain what is incorrect, unclear, or absent and how it affects the reader.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification and search performed
+      description: List the implementation, command help, tests, or other docs you checked before filing.
+
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested correction
+      description: Propose wording, structure, commands, or references if you have a specific fix.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched open and closed documentation issues and found no duplicate.
+          required: true
+        - label: I identified what I verified and any runtime or hardware checks I did not run.
+          required: true
+        - label: I removed secrets, private/internal evidence, personal paths, and restricted artifacts.
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -23,18 +23,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      options:
-        - Blocking current usage
-        - High
-        - Medium
-        - Low or nice to have
-    validations:
-      required: true
-
   - type: input
     id: location
     attributes:
@@ -68,8 +56,6 @@ body:
       label: Submission checks
       options:
         - label: I searched open and closed documentation issues and found no duplicate.
-          required: true
-        - label: I identified what I verified and any runtime or hardware checks I did not run.
           required: true
         - label: I removed secrets, private/internal evidence, personal paths, and restricted artifacts.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for proposing an improvement. Describe the user problem and evidence boundary before prescribing an implementation. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
+        Thanks for proposing an improvement. Describe the problem you are trying to solve, the end goal you want to achieve, and where TensorRT-Model-Connect falls short today before prescribing an implementation. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
 
   - type: dropdown
     id: request_type
@@ -24,23 +24,11 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      options:
-        - Blocking a current use case
-        - High
-        - Medium
-        - Low or nice to have
-    validations:
-      required: true
-
   - type: textarea
     id: problem
     attributes:
       label: Problem and use case
-      description: Explain the user problem, who encounters it, and why existing behavior is insufficient.
+      description: Explain the end goal, who encounters the problem, and where TensorRT-Model-Connect falls short today.
     validations:
       required: true
 
@@ -76,8 +64,6 @@ body:
       label: Submission checks
       options:
         - label: I searched open and closed issues and found no duplicate request.
-          required: true
-        - label: I identified which claims require source, hardware, parity, or performance evidence.
           required: true
         - label: I removed secrets, private/internal evidence, personal paths, and restricted artifacts.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Feature request
+description: Request a new model, capability, improvement, or behavior change
+title: "Feature: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Describe the user problem and evidence boundary before prescribing an implementation. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Request type
+      options:
+        - New model or checkpoint support
+        - New capability
+        - Improvement to existing behavior
+        - Change to an existing contract
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Blocking a current use case
+        - High
+        - Medium
+        - Low or nice to have
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and use case
+      description: Explain the user problem, who encounters it, and why existing behavior is insufficient.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed outcome
+      description: Describe the behavior or acceptance criteria you want, without assuming a specific implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: model_target
+    attributes:
+      label: Model and target details
+      description: For model requests, include the exact model ID/revision, task, precision, target GPU, and expected runtime path.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe existing models, tools, workarounds, or APIs you evaluated.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add public references, examples, compatibility constraints, or performance and quality requirements.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched open and closed issues and found no duplicate request.
+          required: true
+        - label: I identified which claims require source, hardware, parity, or performance evidence.
+          required: true
+        - label: I removed secrets, private/internal evidence, personal paths, and restricted artifacts.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Question
+description: Ask for help using or understanding TensorRT-Model-Connect
+title: "Question: "
+labels: ["question"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search the documentation and existing issues before asking. Do not disclose suspected security vulnerabilities here; report them privately through https://www.nvidia.com/en-us/security/report-vulnerability/. Do not include secrets, credentials, private URLs, internal CI logs or artifacts, package coordinates, runner details, personal paths, proprietary logs, or restricted model assets.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Topic
+      options:
+        - Installation or source build
+        - Model support or engine build
+        - Bundle or runtime usage
+        - Task API or inference behavior
+        - Validation, benchmarking, or qualification
+        - Architecture or contribution guidance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: State the goal, the point where you are blocked, and the specific answer you need.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What have you tried?
+      description: Link the docs you followed and include relevant commands, configuration, and results.
+
+  - type: input
+    id: version
+    attributes:
+      label: TensorRT-Model-Connect version
+      description: Provide a release, tag, or full commit SHA when the question depends on repository behavior.
+
+  - type: input
+    id: model
+    attributes:
+      label: Model and revision
+      description: Provide the exact model ID/revision when the question is model-specific.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: Include OS, GPU, driver, CUDA, TensorRT, and installation method when they affect the question.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched the documentation and open and closed issues first.
+          required: true
+        - label: This question contains no secrets, private URLs, or restricted artifacts.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,4 +43,4 @@
   `plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md` directly and
   follow it.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/ASSET_LICENSES.md
+++ b/ASSET_LICENSES.md
@@ -122,3 +122,5 @@ licensed and is attributed in `NOTICE`.
 | `elf-b-owt-replay/sampling_steps.f32` | `fc47f743709eb080e0c060422c1a39fb55e44d5e7a2f5f9fa3437ca7b269be12` |
 | `elf-b-xsum-replay/initial_latents.f32` | `5153428af20ad73e2ba40e72a7d7cbd5dd10bf4cc7026bbdaad91fb12ae4ddd0` |
 | `elf-b-xsum-replay/sampling_steps.f32` | `79c790d0590ebf5d1838da98ed968b0e7c6b4309d56d50890ae3b0e025cc982e` |
+
+<!-- Collaborative review anchor: batch 2. -->

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ dispatch, configuration, and qualification evidence.
 - Report security concerns according to [SECURITY.md](SECURITY.md).
 - TensorRT-Model-Connect is licensed under the terms in [LICENSE](LICENSE).
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/README.md
+++ b/README.md
@@ -91,13 +91,22 @@ page is the single source of truth for exact checkpoints, Hugging Face
 architectures, TRTMC profiles, precision, quantization, optimized-runtime
 dispatch, configuration, and qualification evidence.
 
-## Contributing and support
+## Get help and file an issue
+
+Start with [Get Help and File an Issue](https://nvidia.github.io/TensorRT-Model-Connect/release-support/get-help)
+to choose the right support route and collect the model, environment, command,
+and log details maintainers need. Use the
+[issue chooser](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new/choose)
+for usage questions, reproducible bugs, feature or model requests, and
+documentation corrections.
+
+Do not disclose suspected security vulnerabilities in a public issue. Follow
+[SECURITY.md](SECURITY.md) to report them privately to NVIDIA PSIRT.
+
+## Contributing
 
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing source or model
   integration changes.
-- Report reproducible defects through
-  [GitHub Issues](https://github.com/NVIDIA/TensorRT-Model-Connect/issues).
-- Report security concerns according to [SECURITY.md](SECURITY.md).
 - TensorRT-Model-Connect is licensed under the terms in [LICENSE](LICENSE).
 
 <!-- Collaborative review anchor: batch 2. -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,4 +22,4 @@ include:
 For non-security bugs, feature requests, and documentation issues, use this
 repository's GitHub issue tracker.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -338,4 +338,4 @@ TTS, VLM, embedding, reranking, vision, time-series, Qwen3-Omni, PersonaPlex, EL
 Lance, or SANA-WM workloads. Do not silently substitute HF eager for a declared
 torch.compile entry.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/debug-trt-mismatch/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/debug-trt-mismatch/SKILL.md
@@ -200,4 +200,4 @@ details, and package coordinates private. Source PRs may cite only the
 sanitized exact-head `trtmc/premerge/required` status and public reproduction
 evidence.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
@@ -364,4 +364,4 @@ State the baseline and target SHA, corrected facts and source paths, exact
 checks and outcomes, unrun evidence tiers, known baseline gaps, and PR URLs.
 “No change” is valid when the current documentation matches current evidence.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/fp16-trt-network/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/fp16-trt-network/SKILL.md
@@ -163,4 +163,4 @@ Compare FP32 and low-precision artifacts with the same implementation path.
 Use `$debug-trt-mismatch` for the first divergent token, layer, stage, or
 runtime boundary. Report checks that were not run on target hardware.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/optimize-model-precision/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/optimize-model-precision/SKILL.md
@@ -186,4 +186,4 @@ Provide the full matrix, exact commands, artifact paths and hashes, objective
 comparison, selected configuration, failures and first divergent boundaries,
 code changes, and unrun target-hardware or broad-regression checks.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
@@ -331,4 +331,4 @@ current status/check URLs and states, action, validation, mergeability/review
 state, blockers, residual risk, and whether a branch was pushed or merged. An
 unchanged pending state is normal during monitoring.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/profile-model/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/profile-model/SKILL.md
@@ -192,4 +192,4 @@ contract, raw artifact paths, p50 and other suite-owned statistics, output
 equivalence, observed bottleneck, comparison limitations, and the next
 evidence-backed experiment.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/setup-trtmc-environment/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/setup-trtmc-environment/SKILL.md
@@ -31,3 +31,5 @@ workspace conventions.
 Keep model-specific dependencies on demand and follow each family's own lock
 and verification files. Report setup evidence separately from compilation,
 tests, model parity, performance, and production-deployment evidence.
+
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/submit-github-bug-issue/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/submit-github-bug-issue/SKILL.md
@@ -209,4 +209,4 @@ File one issue per root cause. Do not bundle unrelated failures into a single
 issue just because they came from the same QA report. If several cases share the
 same root cause, include them as affected scope/evidence in one issue.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
@@ -197,4 +197,4 @@ Report the PR URL and number, draft state, pushed head SHA, validation evidence,
 initial exact-head CI state, and any dependency or unrun gate. Hand monitoring
 and any merge work to `$pr-babysitter`; this skill never merges.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/transform-model/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/transform-model/SKILL.md
@@ -193,4 +193,4 @@ runtime/bundle path, build and validation commands, artifact hashes/paths,
 comparison metrics, target hardware, performance evidence if claimed, and
 unrun or blocked gates.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md
@@ -135,4 +135,4 @@ Before returning a message, verify:
   repository-banned terms.
 - Future-reader notes capture any review order, limitation, or maintenance warning that is not obvious from the diff.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/plugins/trtmc-agent-skills/skills/write-git-messages/references/source-notes.md
+++ b/plugins/trtmc-agent-skills/skills/write-git-messages/references/source-notes.md
@@ -18,4 +18,4 @@ Use these notes when a user asks why the skill recommends a format or when local
 - A good PR title often becomes the squash merge title, so it should be written with the same care as a commit summary.
 - Local repository convention wins over generic style unless it is unclear, missing, or explicitly being replaced.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/python/tensorrt_model_connect/families/qwen/kernels/README.md
+++ b/python/tensorrt_model_connect/families/qwen/kernels/README.md
@@ -52,4 +52,4 @@ This is a POC of the integration boundary, not a vendored FlashInfer fork. The
 small optional-length change should live upstream before this becomes a
 supported built-in kernel.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/cabi/README.md
+++ b/src/cabi/README.md
@@ -19,4 +19,4 @@ Current ownership:
 `bundle/README.md` is an ownership note only; no C-linkage bundle-helper
 implementation remains in that subdirectory.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/cabi/api/README.md
+++ b/src/cabi/api/README.md
@@ -6,6 +6,9 @@ subset with C linkage, not a C-compatible public header or complete stable C
 ABI: it exposes `trtmc::IPipeline*` and `std::uint64_t`, and it has no exported
 pipeline-destroy function.
 
+Before 1.0, this ABI is not guaranteed to remain stable across
+TensorRT-Model-Connect versions.
+
 Focus areas:
 
 - Pipeline option and handle validation with thread-local error reporting.

--- a/src/cabi/api/README.md
+++ b/src/cabi/api/README.md
@@ -19,4 +19,4 @@ Bundle parsing itself lives under `src/bundle/`. Optimized-runtime hosting
 lives under `src/runtime/providers/`; native runtime-strategy resolution and
 model-plugin loading live under `src/runtime/registry/`.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/cabi/bundle/README.md
+++ b/src/cabi/bundle/README.md
@@ -16,4 +16,4 @@ Current owners:
 Keep new model-specific engine setup and tokenizer policy under the owning
 `src/runtime/models/<family>/` directory.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/core/README.md
+++ b/src/runtime/core/README.md
@@ -23,4 +23,4 @@ sampling, masks, and KV-cache policy are model-owned under
 under `src/runtime/providers/` to verify and load their embedded implementation
 DSO.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/audio/README.md
+++ b/src/runtime/domains/audio/README.md
@@ -5,4 +5,4 @@ lives in `include/trtmc/trtmc_io.hpp`; model-specific feature extraction,
 post-processing, and audio runtime behavior live under each owning model family
 in `src/runtime/models/<family>/`.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/diffusion/README.md
+++ b/src/runtime/domains/diffusion/README.md
@@ -22,4 +22,4 @@ How to understand:
 There is no shared `diffusion_types.h`; each model that needs such a contract
 owns a family-prefixed type header.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/encoder/README.md
+++ b/src/runtime/domains/encoder/README.md
@@ -14,4 +14,4 @@ Use each model's `MODEL.toml` as the discovery source, then read its
 Keep pooling, preprocessing, tensor binding, and output semantics with the
 owning model rather than adding a generic backend here.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/multimodal/README.md
+++ b/src/runtime/domains/multimodal/README.md
@@ -11,4 +11,4 @@ How to understand:
 2. Inspect model-owned `src/runtime/models/<family>/pipeline.*` files for
    end-to-end vision-language decode behavior.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/perception/README.md
+++ b/src/runtime/domains/perception/README.md
@@ -4,4 +4,4 @@ Behavior-bearing perception helpers are model-owned under `src/runtime/models/`.
 Keep preprocessing, postprocessing, prompt encoding, and model-default structs in
 the owning model folder.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/src/runtime/domains/recurrent/README.md
+++ b/src/runtime/domains/recurrent/README.md
@@ -10,4 +10,4 @@ Current recurrent contract owners:
 - `src/runtime/models/nemotron_h/nemotron_h_recurrent_step_contracts.h`
 - `src/runtime/models/qwen3_5/qwen3_5_recurrent_step_contracts.h`
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/assets/README.md
+++ b/tests/assets/README.md
@@ -1,4 +1,4 @@
 Small images used by documentation/tutorial commands, E2E impact validation,
 and manual testing.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/e2e/models/canary/data/asr_probes/README.md
+++ b/tests/e2e/models/canary/data/asr_probes/README.md
@@ -18,4 +18,4 @@ intended to benchmark ASR model quality.
 Use `manifest.json` for detailed purpose and notes. Re-run
 `generate_asr_probe_inputs.py` from this directory to regenerate the WAVs.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/e2e/models/nemotron_speech_streaming/data/asr_probes/README.md
+++ b/tests/e2e/models/nemotron_speech_streaming/data/asr_probes/README.md
@@ -18,4 +18,4 @@ intended to benchmark ASR model quality.
 Use `manifest.json` for detailed purpose and notes. Re-run
 `generate_asr_probe_inputs.py` from this directory to regenerate the WAVs.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/e2e/models/whisper/data/README.md
+++ b/tests/e2e/models/whisper/data/README.md
@@ -17,3 +17,5 @@ SHA-256:
 ```text
 166d138dc95c706e4eedbebb48f4ac4c8cb1b77ea796c0bc650da518308657e2
 ```
+
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/e2e/models/whisper/data/asr_probes/README.md
+++ b/tests/e2e/models/whisper/data/asr_probes/README.md
@@ -18,4 +18,4 @@ intended to benchmark ASR model quality.
 Use `manifest.json` for detailed purpose and notes. Re-run
 `generate_asr_probe_inputs.py` from this directory to regenerate the WAVs.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -131,3 +131,5 @@ See `benchmarks/performance/README.md` for the L4T TensorRT 11 bare-metal build.
 
 Each Accuracy `MODEL=SUITE` binding has its own engine directory. Perf bundles
 remain independent from Accuracy engines.
+
+<!-- Collaborative review anchor: batch 2. -->

--- a/tests/tools/test_github_issue_templates.py
+++ b/tests/tools/test_github_issue_templates.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+TEMPLATE_DIRECTORY = REPOSITORY / ".github" / "ISSUE_TEMPLATE"
+EXPECTED_FORMS = {
+    "bug_report.yml": ("bug", "Bug: "),
+    "documentation_request.yml": ("documentation", "Docs: "),
+    "feature_request.yml": ("enhancement", "Feature: "),
+    "question.yml": ("question", "Question: "),
+}
+SUPPORTED_BODY_TYPES = {"checkboxes", "dropdown", "input", "markdown", "textarea"}
+FORBIDDEN_TEMPLATE_TEXT = (
+    "__PROJECT__",
+    "__THIS PROJECT__",
+    "__PROJECT_NAME__",
+    "___PROJECT___",
+    "jarmak-nv",
+    "rapids-repo-template",
+    "PLC-OSS-Template",
+    "print_env.sh",
+)
+
+
+def _load_yaml(path: Path) -> dict:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict), f"{path} must contain a YAML object"
+    return value
+
+
+def test_issue_template_inventory_is_intentional() -> None:
+    filenames = {path.name for path in TEMPLATE_DIRECTORY.iterdir() if path.is_file()}
+    assert filenames == {*EXPECTED_FORMS, "config.yml"}
+    assert not {name for name in filenames if "security" in name.lower()}
+
+
+@pytest.mark.parametrize(("filename", "expected"), EXPECTED_FORMS.items())
+def test_issue_form_structure(filename: str, expected: tuple[str, str]) -> None:
+    expected_label, expected_title = expected
+    form = _load_yaml(TEMPLATE_DIRECTORY / filename)
+
+    assert isinstance(form.get("name"), str) and form["name"]
+    assert isinstance(form.get("description"), str) and form["description"]
+    assert form.get("title") == expected_title
+    assert form.get("labels") == [expected_label]
+
+    body = form.get("body")
+    assert isinstance(body, list) and body
+    assert any(item.get("type") != "markdown" for item in body)
+    ids: list[str] = []
+    for item in body:
+        assert isinstance(item, dict)
+        item_type = item.get("type")
+        assert item_type in SUPPORTED_BODY_TYPES
+        attributes = item.get("attributes")
+        assert isinstance(attributes, dict)
+        if item_type == "markdown":
+            assert isinstance(attributes.get("value"), str) and attributes["value"]
+            continue
+
+        item_id = item.get("id")
+        assert isinstance(item_id, str) and item_id
+        ids.append(item_id)
+        assert isinstance(attributes.get("label"), str) and attributes["label"]
+
+        validations = item.get("validations", {})
+        assert isinstance(validations, dict)
+        if "required" in validations:
+            assert isinstance(validations["required"], bool)
+
+    assert len(ids) == len(set(ids)), f"{filename} contains duplicate field IDs"
+    assert "security" not in form["labels"]
+
+    source = (TEMPLATE_DIRECTORY / filename).read_text(encoding="utf-8")
+    assert "https://www.nvidia.com/en-us/security/report-vulnerability/" in source
+    assert "internal CI logs or artifacts" in source
+    assert "restricted model assets" in source
+
+
+def test_issue_chooser_routes_help_and_security_reports() -> None:
+    config = _load_yaml(TEMPLATE_DIRECTORY / "config.yml")
+    assert config.get("blank_issues_enabled") is False
+
+    links = config.get("contact_links")
+    assert isinstance(links, list)
+    urls = {link["url"] for link in links}
+    assert "https://nvidia.github.io/TensorRT-Model-Connect/release-support/get-help" in urls
+    assert "https://www.nvidia.com/en-us/security/report-vulnerability/" in urls
+
+
+def test_issue_templates_have_no_upstream_placeholders() -> None:
+    combined = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(TEMPLATE_DIRECTORY.glob("*.yml"))
+    )
+    for forbidden in FORBIDDEN_TEMPLATE_TEXT:
+        assert forbidden not in combined

--- a/tests/tools/test_github_issue_templates.py
+++ b/tests/tools/test_github_issue_templates.py
@@ -36,6 +36,18 @@ def _load_yaml(path: Path) -> dict:
     return value
 
 
+def _body_items_by_id(form: dict) -> dict[str, dict]:
+    return {
+        item["id"]: item
+        for item in form["body"]
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+
+
+def _checkbox_labels(item: dict) -> list[str]:
+    return [option["label"] for option in item["attributes"]["options"]]
+
+
 def test_issue_template_inventory_is_intentional() -> None:
     filenames = {path.name for path in TEMPLATE_DIRECTORY.iterdir() if path.is_file()}
     assert filenames == {*EXPECTED_FORMS, "config.yml"}
@@ -103,3 +115,40 @@ def test_issue_templates_have_no_upstream_placeholders() -> None:
     )
     for forbidden in FORBIDDEN_TEMPLATE_TEXT:
         assert forbidden not in combined
+
+
+def test_issue_forms_preserve_reviewed_intake_contracts() -> None:
+    bug_path = TEMPLATE_DIRECTORY / "bug_report.yml"
+    bug = _load_yaml(bug_path)
+    bug_items = _body_items_by_id(bug)
+    bug_source = bug_path.read_text(encoding="utf-8")
+
+    assert (
+        "https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new"
+        "?template=documentation_request.yml"
+    ) in bug_source
+    assert "compute capability" not in str(
+        bug_items["environment"]["attributes"]
+    ).lower()
+    assert "behavior" not in bug_items
+    for item_id in ("observed_behavior", "expected_behavior"):
+        assert bug_items[item_id]["validations"]["required"] is True
+
+    documentation = _load_yaml(TEMPLATE_DIRECTORY / "documentation_request.yml")
+    documentation_items = _body_items_by_id(documentation)
+    assert "priority" not in documentation_items
+    assert not any(
+        "runtime or hardware checks" in label
+        for label in _checkbox_labels(documentation_items["terms"])
+    )
+
+    feature_path = TEMPLATE_DIRECTORY / "feature_request.yml"
+    feature = _load_yaml(feature_path)
+    feature_items = _body_items_by_id(feature)
+    feature_source = feature_path.read_text(encoding="utf-8")
+    assert "priority" not in feature_items
+    assert "evidence boundary" not in feature_source
+    assert not any(
+        "which claims require" in label
+        for label in _checkbox_labels(feature_items["terms"])
+    )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1445,11 +1445,16 @@ class TestNoImpact:
         assert match.rule == "no_impact"
         assert match.models == []
 
-    def test_github_ci_config_triggers_tools_tier(self, imap):
-        """.github workflows should validate CI tooling without selecting E2E."""
-        match = test_impact.classify_file(
-            ".github/workflows/internal-ci-bridge.yml", imap
-        )
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/ISSUE_TEMPLATE/bug_report.yml",
+            ".github/workflows/internal-ci-bridge.yml",
+        ],
+    )
+    def test_github_ci_config_triggers_tools_tier(self, imap, path):
+        """.github configuration should validate tools without selecting E2E."""
+        match = test_impact.classify_file(path, imap)
         assert match.rule == "github_ci_config"
         assert match.models == []
         assert match.unit_tiers == ["tools"]

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -413,4 +413,4 @@ model-name:
 
 Do not use `e2e` as a validation workload.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -788,4 +788,4 @@ login, cleanup, and artifact safeguards. Some low-level developer test engines
 also remain shell commands behind Python classes. Pipeline decisions, ordering,
 selection, isolation, and certification belong in this package.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tools/validation/README.md
+++ b/tools/validation/README.md
@@ -68,4 +68,4 @@ A new workload is complete only when it has:
 Models without that complete contract stay visible as `not_compared`; E2E
 execution is never reported as reference consistency.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/tools/validation/README.md
+++ b/tools/validation/README.md
@@ -26,8 +26,9 @@ python tools/trtmc_validate.py gpt2-125m
 python tools/trtmc_validate.py --all --dry-run
 ```
 
-Nightly CI calls `engine.py` directly for reviewed ETTh1 preparation and
-evaluation. No validation path invokes a legacy task-eval CLI.
+Nightly CI calls `engine.py` directly for reviewed preparation and evaluation
+of the hourly Electricity Transformer Temperature (`ETTh1`) dataset. No
+validation path invokes a legacy task-eval CLI.
 
 ## Contracts
 

--- a/website/data/model-support-matrix.md
+++ b/website/data/model-support-matrix.md
@@ -81,10 +81,10 @@ SPDX-License-Identifier: Apache-2.0
 | `Qwen/Qwen-Image-2512` | `qwen-image-2512` | `BF16` | None | — | 🟢 Green |
 | `Qwen/Qwen-Image-Edit-2511` | `qwen-image-edit-2511` | `BF16` | None | — | 🟢 Green |
 | `Qwen/Qwen2.5-VL-3B-Instruct` | `qwen25vl-3b` | `FP16` | None | TensorRT Edge-LLM<br />Qualified TRTMC dispatch target: Coming soon | 🟢 Green |
-| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-fp16` | `FP16` | None | TensorRT Edge-LLM<br />Qualified dispatch tuple: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional tuples: Coming soon | 🟢 Green |
-| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-fp8` | `BF16` | `format=fp8`<br />`scale_source=modelopt`<br />`calibration_samples=64` | TensorRT Edge-LLM<br />Qualified dispatch tuple: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional tuples: Coming soon | 🟢 Green |
-| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-topp` | `FP16` | None | TensorRT Edge-LLM<br />Qualified dispatch tuple: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional tuples: Coming soon | 🟢 Green |
-| `Qwen/Qwen3-4B-Instruct-2507` | `qwen3-4b-instruct-2507` | `FP16` | None | TensorRT Edge-LLM<br />Qualified dispatch tuple: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional tuples: Coming soon | 🟢 Green |
+| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-fp16` | `FP16` | None | TensorRT Edge-LLM<br />Qualified TRTMC dispatch target: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional dispatch targets: Coming soon | 🟢 Green |
+| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-fp8` | `BF16` | `format=fp8`<br />`scale_source=modelopt`<br />`calibration_samples=64` | TensorRT Edge-LLM<br />Qualified TRTMC dispatch target: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional dispatch targets: Coming soon | 🟢 Green |
+| `Qwen/Qwen3-0.6B` | `qwen3-0.6b-topp` | `FP16` | None | TensorRT Edge-LLM<br />Qualified TRTMC dispatch target: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional dispatch targets: Coming soon | 🟢 Green |
+| `Qwen/Qwen3-4B-Instruct-2507` | `qwen3-4b-instruct-2507` | `FP16` | None | TensorRT Edge-LLM<br />Qualified TRTMC dispatch target: Linux x86_64, NVIDIA A100 80GB PCIe (SM80), FP16<br />Additional dispatch targets: Coming soon | 🟢 Green |
 | `Qwen/Qwen3-30B-A3B` | `qwen3-moe-30b-a3b` | `FP16` | None | — | 🟢 Green |
 | `amd-quark/tiny-random-qwen3_moe` | `qwen3-moe-tiny-random` | `FP16` | None | — | 🟢 Green |
 | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | `qwen3-omni-30b-a3b-instruct` | `BF16` | None | — | 🔴 Red |

--- a/website/data/model-support-matrix.md
+++ b/website/data/model-support-matrix.md
@@ -112,3 +112,5 @@ SPDX-License-Identifier: Apache-2.0
 | `FacebookAI/xlm-roberta-base` | `xlm-roberta-base` | `FP16` | None | — | 🟢 Green |
 | `xlnet/xlnet-base-cased` | `xlnet-base` | `FP16` | None | — | 🟢 Green |
 | `Tongyi-MAI/Z-Image-Turbo` | `z-image-turbo` | `FP16`<br />FP32 layers: `2, 3, 4, 7, 8` | None | — | 🔴 Red |
+
+<!-- Collaborative review anchor: batch 2. -->

--- a/website/diagram-sources/README.md
+++ b/website/diagram-sources/README.md
@@ -69,4 +69,4 @@ exception:
   website color modes; and
 - a nearby figure caption in the Markdown page explaining what to notice.
 
-<!-- Collaborative review anchor. -->
+<!-- Collaborative review anchor: batch 2. -->

--- a/website/docs/agent-guide.md
+++ b/website/docs/agent-guide.md
@@ -78,3 +78,5 @@ documentation.
 
 The agent should use [Build from Source](getting-started/source-build.md) and
 [Quick Start](getting-started/quick-start.md), not invent a parallel setup.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -293,4 +293,4 @@ batch and automatically chunks additional inputs:
 See [Configurable Canary Decoding](/tutorials/intermediate/canary-decoding)
 for bounds, batch output, and local checkpoint examples.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/api/cpp-api.md
+++ b/website/docs/api/cpp-api.md
@@ -436,4 +436,4 @@ consumed during creation. The current implementation does not consume the
 legacy `max_new_tokens` or `image_path` fields; generation settings belong on
 the request API.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/api/overview.md
+++ b/website/docs/api/overview.md
@@ -34,4 +34,4 @@ Hugging Face model or local model directory
   -> task-specific output
 ```
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/api/python-builder.md
+++ b/website/docs/api/python-builder.md
@@ -175,4 +175,4 @@ diffusion component/bundle ownership, and FP8 calibration behavior. Treat the
 live protocol as the source of truth instead of copying its complete optional
 surface into downstream integrations.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/build-pipeline.md
+++ b/website/docs/architecture/build-pipeline.md
@@ -154,4 +154,4 @@ Both routes call the common bundle serializer, but their payloads differ:
 Continue with [Bundle Format](bundle-format.md) for the physical container and
 [Runtime Lifecycle](runtime-lifecycle.md) for load-time behavior.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/build-system.md
+++ b/website/docs/architecture/build-system.md
@@ -157,4 +157,4 @@ to that build. Run-time success additionally depends on:
 Use [Validation Design](validation-design.md) to choose evidence beyond
 successful compilation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/bundle-format.md
+++ b/website/docs/architecture/bundle-format.md
@@ -197,4 +197,4 @@ kernel-binding parameter.
 Continue with [Runtime Lifecycle](runtime-lifecycle.md) to see how these
 identities drive pipeline construction.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/overview.md
+++ b/website/docs/architecture/overview.md
@@ -104,4 +104,4 @@ parity from the existence of a family package alone.
 | Native plugin loading | `src/runtime/registry/pipeline_plugin_loader.cpp` |
 | Optimized implementation loading | `src/runtime/providers/optimized_runtime_host.cpp` |
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/runtime-lifecycle.md
+++ b/website/docs/architecture/runtime-lifecycle.md
@@ -166,4 +166,4 @@ support. Use bundle inspection plus the owning build/profile contract.
 | Backend abstraction | `include/trtmc/runtime/trt_backend.h`, `include/trtmc/runtime/trt_module.h` |
 | Model pipelines | `src/runtime/models/<owner>/` |
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/runtime-plugins.md
+++ b/website/docs/architecture/runtime-plugins.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 Runtime plugin dispatch and request flow are documented in Runtime Lifecycle.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/units-and-ownership.md
+++ b/website/docs/architecture/units-and-ownership.md
@@ -126,4 +126,4 @@ code elsewhere:
 
 For implementation recipes, continue to [Extend the Project](../extend/overview.md).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/architecture/validation-design.md
+++ b/website/docs/architecture/validation-design.md
@@ -127,4 +127,4 @@ The canonical evidence sources are:
 - `tools/model_ci.py`
 - `tools/test_impact.py`
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/adr/README.md
+++ b/website/docs/context/adr/README.md
@@ -53,4 +53,4 @@ family.
 The `doc-sync` and `submit-github-pr` skills maintain this index as part of
 their documentation and PR workflows.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/architecture-decision-records.md
+++ b/website/docs/context/architecture-decision-records.md
@@ -13,4 +13,4 @@ import {Redirect} from '@docusaurus/router';
 The Architecture Decision Records index moved to the
 [current ADR index](./adr/).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/config-registry-status.md
+++ b/website/docs/context/config-registry-status.md
@@ -1080,4 +1080,4 @@ Commit chain:
   After Phase 3 closes, parallelize Phase 4 across clusters (Cluster A
   is the big one — 17 TriAttention fields + codegen).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/model-plugin-encapsulation-plan.md
+++ b/website/docs/context/model-plugin-encapsulation-plan.md
@@ -378,4 +378,4 @@ The migration is done when:
 - pytestE2E can load only that model plugin through `trtmc` and reproduce the
   saved `origin/main` user-contract result for that model
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/optimized-runtime-family-adapter-plan.md
+++ b/website/docs/context/optimized-runtime-family-adapter-plan.md
@@ -572,4 +572,4 @@ profile declarations retain their exact semantic qualification snapshot.
 - Qualification logs, comparison output, benchmark results, and generated
   engines remain external artifacts and must not be committed as proof.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/traceability-and-safety.md
+++ b/website/docs/context/traceability-and-safety.md
@@ -119,4 +119,4 @@ Before publishing a normative traceability matrix or compliance claim:
 Until those criteria are met, use model manifests as a partial E2E evidence
 index and describe repository-wide traceability as incomplete.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/context/triattention-native-cpp-worklog.md
+++ b/website/docs/context/triattention-native-cpp-worklog.md
@@ -2406,4 +2406,4 @@ Result:
 So the sparse exact sampler preserves the already-proven dense parity behavior
 while avoiding the expensive full-vocab scatter plus `at::multinomial` call.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/developer-guide/overview.md
+++ b/website/docs/developer-guide/overview.md
@@ -39,3 +39,5 @@ The native and platform-specialized paths are separate implementation
 boundaries. Users normally interact with the same bundle/task API; advanced
 developers use the provider/profile metadata and runtime lifecycle pages to
 understand which backend owns execution.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/add-config-schema.md
+++ b/website/docs/extend/add-config-schema.md
@@ -103,4 +103,4 @@ effect.
    `MODEL.toml` and build that model DSO.
 5. Verify the effective-config artifact and the user-visible behavior.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/add-model-family.md
+++ b/website/docs/extend/add-model-family.md
@@ -300,4 +300,4 @@ evidence and retain the validator's artifacts separately. In either flow, the
 evidence—not the presence of the three descriptors alone—is the acceptance
 signal.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/add-optimized-runtime.md
+++ b/website/docs/extend/add-optimized-runtime.md
@@ -112,4 +112,4 @@ See the
 [optimized-runtime design record](../context/optimized-runtime-family-adapter-plan.md)
 for rationale and historical implementation detail.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/add-runtime-strategy.md
+++ b/website/docs/extend/add-runtime-strategy.md
@@ -135,4 +135,4 @@ The final evidence should prove descriptor consistency, model-DSO loading,
 plugin construction, the public task method, and comparison against the
 manifest's declared oracle.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -116,4 +116,4 @@ maintainer who has repository `maintain` or `admin` permission. Private CI
 repository details,
 runner information, logs, artifacts, and URLs are not public documentation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/model-validation.md
+++ b/website/docs/extend/model-validation.md
@@ -165,4 +165,4 @@ For branch, pull-request, and one-shot `run-internal-ci` handling, follow
 [Contributing](contributing.md). CI success does not widen the evidence boundary
 beyond the jobs and models that actually ran.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/extend/overview.md
+++ b/website/docs/extend/overview.md
@@ -67,4 +67,4 @@ The [Developer Guide](../developer-guide/overview.md) and
 these extension points. Historical migration plans and worklogs are project
 records, not current contributor runbooks.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/config-and-backends.md
+++ b/website/docs/features/config-and-backends.md
@@ -185,4 +185,4 @@ $TRTMC run /tmp/optimized.bundle \
 Check the selected implementation's qualification contract before passing
 provider-specific options such as CUDA graphs.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/model-families.md
+++ b/website/docs/features/model-families.md
@@ -86,4 +86,4 @@ The current example is the Qwen TensorRT Edge-LLM adapter with three qualified
 Qwen3/A100 SM80/FP16 profiles. These profiles do not add native strategy keys
 or claim support for arbitrary Qwen checkpoints and targets.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/multi-device.md
+++ b/website/docs/features/multi-device.md
@@ -210,3 +210,5 @@ does not prove that all ranks completed without a TensorRT or NCCL error.
 
 For complete commands and two worked models, see
 [Run Inference on Multiple GPUs](../tutorials/advanced/multi-device-inference.md).
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/overview.md
+++ b/website/docs/features/overview.md
@@ -94,4 +94,4 @@ declared. A support claim needs the evidence appropriate to its level:
 See [Model Support](../models-recipes/overview.md) for the live inventory
 and [Testing Reference](../reference/testing.md) for the validation boundary.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/quantization.md
+++ b/website/docs/features/quantization.md
@@ -228,4 +228,4 @@ image/video health and reference comparisons for diffusion, waveform or ASR
 checks for audio, and numerical error metrics for time-series models. A generic
 unit test of the shared format core is not model qualification.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/runtime-strategies.md
+++ b/website/docs/features/runtime-strategies.md
@@ -45,4 +45,4 @@ The task strategy lets generic runners and comparators share a user contract.
 The runtime strategy keeps pipeline code, state, samplers, helpers, and
 dependencies owned by the model.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/sampling.md
+++ b/website/docs/features/sampling.md
@@ -80,4 +80,4 @@ The E2E test covers the user-visible sampling contract, not device placement.
 The CPU/host-side implementation constraint is covered by the sampler interface
 and unit tests.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/triattention.md
+++ b/website/docs/features/triattention.md
@@ -139,4 +139,4 @@ The dated implementation investigation is retained in the
 its temporary paths and benchmark numbers are historical evidence, not a
 current runbook.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/features/tvm-ffi.md
+++ b/website/docs/features/tvm-ffi.md
@@ -2,9 +2,10 @@
 title: TVM FFI Kernel Bridge
 ---
 
-Model Connect can replace one selected TensorRT graph region with a TVM-FFI
-kernel. The TensorRT engine fixes the region boundary; the external kernel DSO
-is chosen when a new pipeline loads.
+Model Connect can replace one selected TensorRT graph region with an
+[Apache TVM FFI](https://tvm.apache.org/ffi/) kernel. The TensorRT engine fixes
+the region boundary; the external kernel DSO is chosen when a new pipeline
+loads.
 
 There are two ways to select the region:
 

--- a/website/docs/features/tvm-ffi.md
+++ b/website/docs/features/tvm-ffi.md
@@ -160,4 +160,4 @@ with the DSO, so the kernel author must implement the ordered contract exactly.
 For a complete worked example, see
 [Bring Your Own Kernel with TVM FFI](../tutorials/advanced/bring-your-own-kernel.md).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/build-and-run.md
+++ b/website/docs/getting-started/build-and-run.md
@@ -146,4 +146,4 @@ floating-point forecast values. See
 [Diffusion, Vision, and Time-Series Pipelines](../tutorials/intermediate/diffusion-and-time-series.md)
 for the input/output mental model and dependency boundaries.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/environment-and-repro.md
+++ b/website/docs/getting-started/environment-and-repro.md
@@ -61,4 +61,4 @@ continue to [Installation](installation.md).
 | CMake cannot find CUDA or TensorRT | Use the repository source container. |
 | TensorRT reports an ABI mismatch | Build and run in a compatible TensorRT cohort. |
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/glossary.md
+++ b/website/docs/getting-started/glossary.md
@@ -66,4 +66,4 @@ provider profile; otherwise it needs extension work.
 
 It is not fully portable across every GPU, CUDA, and TensorRT version once an engine has been built. The bundle records compatibility metadata, and the runtime checks that metadata before execution.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/inference-fundamentals.md
+++ b/website/docs/getting-started/inference-fundamentals.md
@@ -212,4 +212,4 @@ After this page:
 - Use [Beginner Text Generation](../tutorials/beginner/text-generation.md) to follow every step of decoder inference.
 - Use [Architecture Overview](../architecture/overview.md) to map these concepts to the actual source files.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -39,4 +39,4 @@ Continue in the source container prepared by
 Do not mix a wheel, backend DSO, bundle, or TensorRT library from another
 architecture or TensorRT cohort.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/overview.md
+++ b/website/docs/getting-started/overview.md
@@ -20,4 +20,4 @@ request. It does not qualify every model or hardware profile on that machine.
 
 After the first run, continue to [Learning Path](../learning-path.md).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/project-overview.md
+++ b/website/docs/getting-started/project-overview.md
@@ -114,4 +114,4 @@ they provide when building or running models. Continue with
 [System Requirements](environment-and-repro.md) before selecting an
 installation path.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -63,4 +63,4 @@ error. If it does not, keep the first error and use
 Continue with [Learning Path](../learning-path.md) or choose another model from
 [Model Support](../models-recipes/overview.md).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -75,4 +75,4 @@ This path skips CI-only Python profiles and unrelated model DSOs. Continue to
 advanced backend options belong in the
 [Build System](../architecture/build-system.md) reference.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/getting-started/troubleshooting.md
+++ b/website/docs/getting-started/troubleshooting.md
@@ -35,3 +35,5 @@ Complete error:
 For failures after the first smoke test, use
 [Troubleshooting](../release-support/troubleshooting.md) and the task-specific
 User Guide.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -107,4 +107,4 @@ After Getting Started:
 4. use [Developer Guide](developer-guide/overview.md) only when you need
    source-level ownership or contribution instructions.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/learning-path.md
+++ b/website/docs/learning-path.md
@@ -169,4 +169,4 @@ implementation is the goal.
 runtime strategy and DSO owner, public API boundary, tests, E2E manifest, and
 documentation that form the vertical slice of your change.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/models-recipes/model-recipes.md
+++ b/website/docs/models-recipes/model-recipes.md
@@ -21,3 +21,5 @@ maintained by hand. Use
 [Supported Models](overview.md) for the retained release-support snapshot.
 
 <ModelRecipeTaskIndex />
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/models-recipes/overview.md
+++ b/website/docs/models-recipes/overview.md
@@ -83,3 +83,5 @@ Platform specializations will roll out in phases aligned with model coverage
 available in TensorRT Edge-LLM and TensorRT-Model-Connect releases. Each batch
 must document the exact qualified model, target, precision, and configuration
 tuple.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/operations/model-e2e-task-prompt.md
+++ b/website/docs/operations/model-e2e-task-prompt.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 The current model contribution validation workflow moved to Extend.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/benchmarking.md
+++ b/website/docs/reference/benchmarking.md
@@ -463,4 +463,4 @@ hashes `test_image` the same way. Packaged default audio, image, and FP8 scale
 assets are copied from the canonical E2E model directory with the catalog
 snapshot.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/documentation-research.md
+++ b/website/docs/reference/documentation-research.md
@@ -43,4 +43,4 @@ Applied rules:
 - The visual style favors technical documentation over marketing: square corners, light borders, neutral surfaces, concise tables, and NVIDIA-green accents.
 - Source-derived counts and strategy names are taken from the current checkout, not copied from older wiki text.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/e2e-l0-replacements.md
+++ b/website/docs/reference/e2e-l0-replacements.md
@@ -55,4 +55,4 @@ This table is a checked snapshot of non-self replacements declared by
 `PYTHONPATH=python:. python3 tools/test_impact.py --validate` after changing a
 replacement.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/profiling.md
+++ b/website/docs/reference/profiling.md
@@ -145,4 +145,4 @@ no repository-supported conversion command for that trace.
 - Retain JSON artifacts with the tested commit, GPU, TensorRT version, and
   exact command when using results as qualification evidence.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/source-layout.md
+++ b/website/docs/reference/source-layout.md
@@ -16,7 +16,7 @@ physical names usually match, but their link is the exact
 `runtime_strategy`, not filename equality: current builder/E2E owners
 `magpie_tts` and `wan_t2v` map to runtime owners `magpie` and `wan`,
 respectively. At this revision, all three trees contain 79 descriptors. The E2E
-descriptors declare 207 JSON manifests; runtime descriptors declare 80 unique
+descriptors declare 209 JSON manifests; runtime descriptors declare 80 unique
 strategy keys because one runtime owner exposes two strategies. Treat these
 numbers as a checked snapshot, not a constant: the descriptor files are the
 source of truth.

--- a/website/docs/reference/source-layout.md
+++ b/website/docs/reference/source-layout.md
@@ -97,4 +97,4 @@ new changes; do not present the command as a passing consistency check.
 Use `tools/test_impact.py` for change selection. Do not infer ownership from an
 old document count or from a removed shared runtime directory.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -293,4 +293,4 @@ Compilation is not parity. A single-model E2E is not broad regression proof.
 Performance results are not qualification evidence unless the run also records
 the exact commit, hardware, inputs, artifacts, and comparison baseline.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/compatibility.md
+++ b/website/docs/release-support/compatibility.md
@@ -22,3 +22,5 @@ model revision × build configuration × bundle contract × runtime implementati
 The [Supported Models](../models-recipes/overview.md) page lists declared
 checkpoint/configuration contracts. A current target-hardware E2E result is the
 evidence required for a verified target claim.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/deprecation-policy.md
+++ b/website/docs/release-support/deprecation-policy.md
@@ -18,3 +18,5 @@ A future deprecation should include:
 Do not weaken validation criteria to preserve a deprecated path. If a test no
 longer represents the intended contract, change the contract and test through
 normal human review with a migration note.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/get-help.md
+++ b/website/docs/release-support/get-help.md
@@ -1,0 +1,75 @@
+---
+title: Get Help and File an Issue
+description: Choose the right support route and provide enough evidence for maintainers to reproduce and triage a request.
+---
+
+Use the route that matches what you need. Public issues are visible to
+everyone, so remove credentials, private URLs, proprietary logs, and
+license-restricted model artifacts before submitting anything.
+
+:::danger Security vulnerabilities
+
+Do not open a public issue for a suspected vulnerability. Follow the
+[security policy](https://github.com/NVIDIA/TensorRT-Model-Connect/blob/main/SECURITY.md)
+to report it privately to NVIDIA PSIRT.
+
+:::
+
+## Choose an issue type
+
+| Need | Route |
+| --- | --- |
+| Help using or understanding TensorRT-Model-Connect | [Ask a question](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new?template=question.yml) |
+| Reproducible behavior that differs from the documented contract | [Report a bug](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new?template=bug_report.yml) |
+| A new model, capability, or improvement | [Request a feature](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new?template=feature_request.yml) |
+| Incorrect, unclear, or missing documentation | [Request a documentation change](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new?template=documentation_request.yml) |
+| Unsure which route applies | [Open the issue chooser](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new/choose) |
+
+Questions receive best-effort help from maintainers and the community. The
+question form does not create a support SLA or establish that an unqualified
+model, configuration, or target is supported.
+
+## Before filing
+
+1. Check the [supported-model inventory](../models-recipes/overview.md) for the
+   exact checkpoint, profile, precision, runtime path, and evidence level.
+2. Check [Known Issues](known-issues.md), this section's
+   [Troubleshooting](troubleshooting.md), and
+   [First-run Troubleshooting](../getting-started/troubleshooting.md).
+3. Search [open and closed issues](https://github.com/NVIDIA/TensorRT-Model-Connect/issues?q=is%3Aissue)
+   for the same model, error, or requested behavior. Add evidence to an
+   existing issue instead of opening a duplicate.
+4. Reduce failures to the smallest command, configuration, and input that still
+   reproduces the behavior. Preserve the first error rather than retrying with
+   unrelated flags.
+
+## Information maintainers need
+
+Include the evidence that applies to your request:
+
+- the TensorRT-Model-Connect release, tag, or full commit SHA;
+- installation method and exact container image or package version;
+- operating system, GPU model and compute capability, driver, CUDA, and
+  TensorRT versions;
+- exact Hugging Face model ID and revision, or a description of the local
+  checkpoint without uploading restricted artifacts;
+- exact commands and relevant configuration, with secrets redacted;
+- expected behavior, observed behavior, and the first relevant error or log;
+- a minimal reproducer and whether the problem also occurs with the documented
+  model-owned manifest; and
+- for performance reports, the timing boundary, warmup, sample count, workload,
+  and output-quality gate.
+
+A command being accepted by a parser, a family being registered, and a model
+being qualified on an exact hardware/software tuple are different evidence
+levels. State what you verified and what you did not run.
+
+## Contributing a fix
+
+If you plan to submit a change, read
+[CONTRIBUTING.md](https://github.com/NVIDIA/TensorRT-Model-Connect/blob/main/CONTRIBUTING.md)
+and the [Developer Guide](../developer-guide/overview.md). Link the issue from
+the pull request so reviewers can connect the proposed implementation to the
+reported behavior and exit criteria.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/get-help.md
+++ b/website/docs/release-support/get-help.md
@@ -49,8 +49,7 @@ Include the evidence that applies to your request:
 
 - the TensorRT-Model-Connect release, tag, or full commit SHA;
 - installation method and exact container image or package version;
-- operating system, GPU model and compute capability, driver, CUDA, and
-  TensorRT versions;
+- operating system, GPU model, driver, CUDA, and TensorRT versions;
 - exact Hugging Face model ID and revision, or a description of the local
   checkpoint without uploading restricted artifacts;
 - exact commands and relevant configuration, with secrets redacted;

--- a/website/docs/release-support/known-issues.md
+++ b/website/docs/release-support/known-issues.md
@@ -24,3 +24,5 @@ description: Current boundaries that users must account for when interpreting fe
 
 Use the current source, exact manifest, and test evidence when this page and a
 newer implementation differ.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/migration-guide.md
+++ b/website/docs/release-support/migration-guide.md
@@ -17,3 +17,5 @@ Future migration entries should be organized by `from → to` and state:
 
 Historical design plans and worklogs are not migration instructions unless a
 released contract links them explicitly.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/overview.md
+++ b/website/docs/release-support/overview.md
@@ -22,3 +22,5 @@ site must not imply that unreleased APIs belong to a stable numbered release.
 
 Support claims remain exact: model ID/revision, configuration, runtime path,
 target, software cohort, and evidence level all matter.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/overview.md
+++ b/website/docs/release-support/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Release & Support
-description: Compatibility, known limitations, troubleshooting, release history, migration, and deprecation policy.
+description: Help, issue filing, compatibility, known limitations, troubleshooting, release history, migration, and deprecation policy.
 ---
 
 This section defines how to interpret the documentation over time.
@@ -13,6 +13,7 @@ site must not imply that unreleased APIs belong to a stable numbered release.
 
 | Question | Page |
 | --- | --- |
+| How do I get help or file an actionable issue? | [Get Help and File an Issue](get-help.md) |
 | Which artifact/software combinations are meaningful? | [Compatibility](compatibility.md) |
 | Which boundaries are known today? | [Limitations / Known Issues](known-issues.md) |
 | How do I diagnose a failure after first run? | [Troubleshooting](troubleshooting.md) |

--- a/website/docs/release-support/release-notes.md
+++ b/website/docs/release-support/release-notes.md
@@ -16,3 +16,5 @@ When the first release is published, this page should record:
 - links to the immutable versioned documentation snapshot and migration notes.
 
 Do not use branch commit history as a substitute for release notes.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/troubleshooting.md
+++ b/website/docs/release-support/troubleshooting.md
@@ -22,4 +22,8 @@ For a new installation, start with
 result, reproduce the exact model-owned manifest before opening a generalized
 framework issue.
 
+When the failure is reproducible, follow [Get Help and File an Issue](get-help.md)
+to select the right issue form and include the exact environment, model
+revision, commands, expected behavior, observed behavior, and first error.
+
 {/* Collaborative review anchor: batch 2. */}

--- a/website/docs/release-support/troubleshooting.md
+++ b/website/docs/release-support/troubleshooting.md
@@ -21,3 +21,5 @@ For a new installation, start with
 [First-run Troubleshooting](../getting-started/troubleshooting.md). For a model
 result, reproduce the exact model-owned manifest before opening a generalized
 framework issue.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/advanced/bring-your-own-kernel.md
+++ b/website/docs/tutorials/advanced/bring-your-own-kernel.md
@@ -774,4 +774,4 @@ no-regression gates. The success criterion is not “the DSO loaded”; it is
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/advanced/multi-device-inference.md
+++ b/website/docs/tutorials/advanced/multi-device-inference.md
@@ -327,3 +327,5 @@ assets. A skipped preflight is not a passing model result.
    without error before the model-owned output oracle can establish success.
 
 </details>
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
+++ b/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
@@ -244,4 +244,4 @@ When reporting a result, always include:
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/advanced/validation-and-benchmarking.md
+++ b/website/docs/tutorials/advanced/validation-and-benchmarking.md
@@ -223,4 +223,4 @@ The input is part of the benchmark. A one-token prompt, a 2K-token prompt, a sin
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/beginner/bring-your-own-kernel.md
+++ b/website/docs/tutorials/beginner/bring-your-own-kernel.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 This advanced tutorial moved to
 [Advanced: Bring Your Own Kernel](../advanced/bring-your-own-kernel.md).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/beginner/inspect-bundles.md
+++ b/website/docs/tutorials/beginner/inspect-bundles.md
@@ -232,4 +232,4 @@ Before leaving the tutorial, write short answers to these prompts:
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/beginner/text-generation.md
+++ b/website/docs/tutorials/beginner/text-generation.md
@@ -95,4 +95,4 @@ For exact CLI options, use the [CLI Reference](/api/cli-reference). For parity
 and performance work, continue to
 [Validation and Benchmarking](/tutorials/advanced/validation-and-benchmarking).
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/intermediate/canary-decoding.md
+++ b/website/docs/tutorials/intermediate/canary-decoding.md
@@ -203,4 +203,4 @@ sizes, excessive output lengths, and invalid duration values throw
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/intermediate/diffusion-and-time-series.md
+++ b/website/docs/tutorials/intermediate/diffusion-and-time-series.md
@@ -252,4 +252,4 @@ evidence.
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/tutorials/intermediate/multimodal-and-speech.md
+++ b/website/docs/tutorials/intermediate/multimodal-and-speech.md
@@ -226,4 +226,4 @@ Text-to-audio is a good example of why `IPipeline` has task-specific methods. Th
 
 </details>
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/unit-design/building-blocks.md
+++ b/website/docs/unit-design/building-blocks.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 The source-unit map and public contract table moved to Units and Ownership.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/unit-design/cpp-runtime.md
+++ b/website/docs/unit-design/cpp-runtime.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 Native and optimized load paths are documented in Runtime Lifecycle.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/unit-design/overview.md
+++ b/website/docs/unit-design/overview.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 Architecture and Unit Design now share one canonical documentation area.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/unit-design/python-builder.md
+++ b/website/docs/unit-design/python-builder.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 Family discovery and build behavior are documented in Build Pipeline.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/unit-design/testing.md
+++ b/website/docs/unit-design/testing.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 
 Test ownership and evidence boundaries are documented in Validation Design.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/build-a-bundle.md
+++ b/website/docs/user-guides/build-a-bundle.md
@@ -51,3 +51,5 @@ Record at least:
 Run [Inspect a Bundle](inspect-a-bundle.md) before inference. The
 [CLI Reference](../api/cli-reference.md#trtmc-build) is the source for the
 complete option inventory.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/configure-runtime.md
+++ b/website/docs/user-guides/configure-runtime.md
@@ -32,3 +32,5 @@ schema catalog and backend/cache behavior. Use
 [Quantization](../features/quantization.md) and
 [Multi-Device Execution](../features/multi-device.md) for their model-owned
 build contracts.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/image-video-generation.md
+++ b/website/docs/user-guides/image-video-generation.md
@@ -41,3 +41,5 @@ Hugging Face image or video task.
 
 For the denoising-loop and task-result mental model, follow the
 [Diffusion, Vision, and Time-Series Tutorial](../tutorials/intermediate/diffusion-and-time-series.md).
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/inspect-a-bundle.md
+++ b/website/docs/user-guides/inspect-a-bundle.md
@@ -29,3 +29,5 @@ the default search path.
 
 For a guided artifact-debugging lab, use
 [Inspect Bundles](../tutorials/beginner/inspect-bundles.md).
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/multimodal-speech.md
+++ b/website/docs/user-guides/multimodal-speech.md
@@ -48,3 +48,5 @@ organized by the corresponding Hugging Face multimodal or audio task.
 For concept-first labs covering preprocessing, engine components, streaming
 state, and typed results, follow [Multimodal and Speech](../tutorials/intermediate/multimodal-and-speech.md)
 and [Canary Decoding](../tutorials/intermediate/canary-decoding.md).
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/overview.md
+++ b/website/docs/user-guides/overview.md
@@ -33,3 +33,5 @@ know the concept and need every option or API field.
 The supported-model inventory is separate from these instructions. Confirm an
 exact checkpoint/configuration in [Models & Recipes](../models-recipes/overview.md)
 before treating a generic command as a support claim.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/run-inference.md
+++ b/website/docs/user-guides/run-inference.md
@@ -30,3 +30,5 @@ Shared loading controls such as `--backend-dir`, `--model-plugin-dir`,
 `--runtime-cache`, `--config`, and `--set` have execution-path-specific
 meaning. Read [Configure Runtime Behavior](configure-runtime.md) before using
 one as a generic fix.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/text-generation.md
+++ b/website/docs/user-guides/text-generation.md
@@ -37,3 +37,5 @@ Use [Sampling Reference](../features/sampling.md) for algorithm semantics,
 [CLI Reference](../api/cli-reference.md#runtime-commands) for every accepted
 option, and the [Text Generation Tutorial](../tutorials/beginner/text-generation.md)
 for a progressive lab with exercises.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/time-series.md
+++ b/website/docs/user-guides/time-series.md
@@ -27,3 +27,5 @@ oracle from an exact manifest in the
 [Time Series Forecasting recipes](/models-recipes/model-recipes/tasks/time-series-forecasting).
 Success is a zero exit status plus an output vector whose shape and values pass
 the model-owned comparator; a plausible vector alone is not parity evidence.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/user-guides/validate-benchmark.md
+++ b/website/docs/user-guides/validate-benchmark.md
@@ -31,3 +31,5 @@ Use [Testing Reference](../reference/testing.md) and
 [Benchmarking Reference](../reference/benchmarking.md) for command details.
 The [Validation and Benchmarking Tutorial](../tutorials/advanced/validation-and-benchmarking.md)
 is the course-style lab.
+
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Adding-a-Model-Family.md
+++ b/website/docs/wiki/Adding-a-Model-Family.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 Use the maintained contributor guide to add and validate a model family.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md
+++ b/website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md
@@ -31,4 +31,4 @@ contracts.
 the canonical [Quantization](/features/quantization) page for the complete
 workflow and current command examples.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Architecture-Extensibility-Assessment.md
+++ b/website/docs/wiki/Architecture-Extensibility-Assessment.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 Current extension boundaries and contributor routes are documented in Extend
 the Project.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Architecture-Overview.md
+++ b/website/docs/wiki/Architecture-Overview.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 This archived overview moved to the maintained architecture documentation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Dynamic-Design.md
+++ b/website/docs/wiki/Dynamic-Design.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 The build and request sequences are now part of the maintained architecture
 documentation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/FP8-Quantization-Guide.md
+++ b/website/docs/wiki/FP8-Quantization-Guide.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 FP8 commands, ownership, and evidence requirements moved to Quantization.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/HF-vs-TRT-Comparison.md
+++ b/website/docs/wiki/HF-vs-TRT-Comparison.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 The comparison and inference concepts moved to Inference Fundamentals.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Home.md
+++ b/website/docs/wiki/Home.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 The former Wiki index has been integrated into the maintained documentation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/ISO-26262-Compliance.md
+++ b/website/docs/wiki/ISO-26262-Compliance.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 The safety disclaimer and traceability gaps moved to the maintained
 Traceability and Safety Status page.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Pipeline-Deep-Dive.md
+++ b/website/docs/wiki/Pipeline-Deep-Dive.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 Pipeline construction and plugin dispatch are documented in Runtime Lifecycle.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Runtime-Target-Architecture.md
+++ b/website/docs/wiki/Runtime-Target-Architecture.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 Native and optimized runtime dispatch are documented in Runtime Lifecycle.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Source-Layout.md
+++ b/website/docs/wiki/Source-Layout.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 The repository map moved to the maintained Source Layout page.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Static-Design.md
+++ b/website/docs/wiki/Static-Design.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 The static design material is now part of the maintained architecture
 documentation.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/TRT-Internals.md
+++ b/website/docs/wiki/TRT-Internals.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 TensorRT build, bundle, and runtime boundaries are documented in Architecture.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Testing-and-Validation.md
+++ b/website/docs/wiki/Testing-and-Validation.md
@@ -11,4 +11,4 @@ import {Redirect} from '@docusaurus/router';
 
 The maintained commands and evidence model are in the Testing Reference.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/docs/wiki/Traceability-Matrix.md
+++ b/website/docs/wiki/Traceability-Matrix.md
@@ -12,4 +12,4 @@ import {Redirect} from '@docusaurus/router';
 The measured traceability and safety status moved to a single maintained
 context page.
 
-{/* Collaborative review anchor. */}
+{/* Collaborative review anchor: batch 2. */}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -177,6 +177,7 @@ const sidebars = {
       link: {type: 'doc', id: 'release-support/overview'},
       collapsed: true,
       items: [
+        'release-support/get-help',
         'release-support/compatibility',
         'release-support/known-issues',
         'release-support/troubleshooting',

--- a/website/src/components/ModelSupportInventory/index.js
+++ b/website/src/components/ModelSupportInventory/index.js
@@ -114,7 +114,9 @@ function CellLines({lines}) {
 function OptimizedRuntimeDispatch({lines}) {
   if (lines.length === 0 || lines[0] === '—') return <>No</>;
   const qualified = lines.some(
-    (line) => line.startsWith('Qualified dispatch tuple:') && !line.endsWith('Coming soon')
+    (line) =>
+      line.startsWith('Qualified TRTMC dispatch target:') &&
+      !line.endsWith('Coming soon')
   );
   const status = qualified ? 'Yes' : 'Coming soon';
   return (


### PR DESCRIPTION
## Background

PR #817 created a repository-wide collaborative documentation review surface,
but the documentation set has grown since that review. This second batch
refreshes the non-rendering anchors for a new round of inline review and adds a
clear public path for getting help or filing an actionable issue.

The issue intake was adapted from the latest
[PLC OSS template at `092cf91e`](https://github.com/NVIDIA-GitHub-Management/PLC-OSS-Template/commit/092cf91e258035ecc0c9aae3c16d37873e328de7),
with stale placeholders and project-specific RAPIDS assumptions replaced by
TensorRT-Model-Connect terminology, evidence requirements, and security
boundaries.

## Exit Criteria

- Every currently tracked Markdown or MDX document has exactly one batch-two
  review anchor, except the byte-pinned `CONTRIBUTING.md`.
- Users can find a canonical help and issue-filing guide from the README and
  Release & Support navigation.
- The issue chooser offers repository-specific bug, feature/model,
  documentation, and question forms using existing labels.
- Public forms reject security disclosures, secrets, internal CI material, and
  restricted assets; suspected vulnerabilities route privately to NVIDIA
  PSIRT.
- Documentation, issue-form structure, legal headers, test-impact rules, and
  the production site build validate locally.

## Implementation

- Refresh the collaborative review anchors to batch two and cover Markdown
  files introduced since the first review, including the file added on current
  `main` during this rebase.
- Add `Get Help and File an Issue` as the canonical Release & Support page and
  link it from the README, section overview, troubleshooting page, and sidebar.
- Link the first reader-facing Apache TVM FFI mention to the official upstream
  documentation, following the reference pattern used by the CUTLASS guide.
- Add YAML issue forms for reproducible bugs, feature/model requests,
  documentation requests, and best-effort usage questions.
- Disable blank issues and add direct help-guide and private NVIDIA PSIRT
  routes in the issue chooser.
- Add structural tests for the exact form inventory, field IDs, labels,
  security routing, public-evidence hygiene, and removal of upstream template
  placeholders.
- Classify `.github/ISSUE_TEMPLATE/**` changes in the existing tools unit-test
  tier.
- Refresh the source-layout snapshot from 207 to the current 209 E2E manifests,
  as detected after rebasing.

## Validation

- Rebased onto `github/main@8c6f717170e66d07eeba15b2205f043558837fbd`.
- `git diff --check github/main..HEAD`: passed.
- Anchor inventory: passed; 146 of 147 tracked Markdown/MDX files contain
  exactly one batch-two anchor, with only `CONTRIBUTING.md` excluded.
- `python3 -m pytest tests/tools/test_github_issue_templates.py tests/tools/test_test_impact.py tests/tools/test_public_source_hygiene.py -q`:
  passed, 275 tests.
- `ruff check tests/tools/test_github_issue_templates.py tests/tools/test_test_impact.py`:
  passed.
- `python3 tools/legal_headers.py --check`: passed, 0 findings.
- `python3 tools/check_doc_file_references.py --strict website/docs`: passed;
  107 documents, 221 path references, 0 errors, and 0 warnings.
- `python3 tools/model_ci.py validate`: passed for the current 79-model
  ownership inventory.
- `python3 tools/test_impact.py --validate`: passed with existing
  fallback/core-coverage warnings.
- `npm --prefix website run test:model-support`: passed, 1 test.
- `npm --prefix website run build`: passed; 34 diagrams verified and the
  Docusaurus production build completed.

## Validation Boundary

- The complete `tests/tools` suite was attempted on the bare host but could not
  finish collection because that environment lacks the installed project,
  TensorRT, PyTorch, and Pillow. The directly changed and relevant tests above
  passed.
- GPU execution, model parity, performance, and qualification were not run
  because this change is limited to documentation and GitHub issue intake.
- `CONTRIBUTING.md` remains byte-for-byte unchanged, and
  `website/docs/context/.last_scan_sha` remains unchanged because this is not a
  completed semantic doc-sync audit.

## Review Order

1. Help and issue-filing guidance.
2. Issue chooser and four YAML forms.
3. Form/test-impact tests.
4. Repository-wide batch-two review anchors.


