### PR TITLE
fix(docs): upgrade serialize-javascript

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15315,15 +15315,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16312,12 +16303,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/website/package.json
+++ b/website/package.json
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "@viz-js/viz": "3.28.0"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.7"
   }
 }


### PR DESCRIPTION
## Summary

- override the vulnerable transitive `serialize-javascript` dependency at `7.0.7`
- refresh the npm lockfile and remove its no-longer-needed `randombytes` dependency
- leave the remaining scanner-listed packages unchanged because current `main` already upgraded them to the recommended compatible versions or removed them with the Mermaid dependency chain

This resolves GHSA-5c6j-r48x-rmvq and GHSA-qj8w-gfj5-8c6v without upgrading Docusaurus-owned webpack plugins outside their supported dependency ranges.

## Validation

- `npm ci`
- `npm run test:model-support`
- `npm run build`
- `npm ls serialize-javascript websocket-driver svgo shell-quote launch-editor fast-uri lodash-es dagre-d3-es dompurify --all`
- filtered `npm audit --json` confirms none of the scanner-listed packages remain reported
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python3 -m pytest tests/tools/test_github_actions_ci.py -q -p no:cacheprovider` (68 passed)
- `git diff --check`