### PR TITLE
feat(stablelm): add full-context native KV cache

### DIFF
--- a/python/tensorrt_model_connect/families/stablelm/MODEL.toml
+++ b/python/tensorrt_model_connect/families/stablelm/MODEL.toml
@@ -12,6 +12,7 @@ prefixes = [
   "stablelm",
 ]
 debug_runner = "debug_runner.py|runner_from_bundle"
+default_build_route = "build_routing.py|prefer_native_default"
 debug_runtime_strategies = [
   "stablelm_decoder_kv_cache",
 ]

--- a/python/tensorrt_model_connect/families/stablelm/build_routing.py
+++ b/python/tensorrt_model_connect/families/stablelm/build_routing.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed routing contract for StableLM's TensorRT native KV path."""
+
+from __future__ import annotations
+
+import math
+import operator
+
+_INT32_MAX = (1 << 31) - 1
+_UINT64_MAX = (1 << 64) - 1
+
+
+class NativeKvCapability:
+    """Loader-safe capability result without importing TensorRT."""
+
+    __slots__ = ("applicable", "eligible", "reason")
+
+    def __init__(
+        self,
+        applicable: bool,
+        eligible: bool,
+        reason: str,
+    ) -> None:
+        self.applicable = applicable
+        self.eligible = eligible
+        self.reason = reason
+
+
+def _result(
+    *,
+    applicable: bool = True,
+    reasons: list[str] | tuple[str, ...] = (),
+) -> NativeKvCapability:
+    return NativeKvCapability(
+        applicable,
+        applicable and not reasons,
+        "; ".join(reasons) or "supported",
+    )
+
+
+def _raw(config: object) -> dict:
+    value = getattr(config, "raw", {})
+    return value if isinstance(value, dict) else {}
+
+
+def _integer(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(operator.index(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _positive(config: object, name: str) -> int:
+    value = _integer(getattr(config, name, None), name)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    if value > _INT32_MAX:
+        raise ValueError(f"{name} exceeds TensorRT's int32 dimension limit")
+    return value
+
+
+def resolved_head_dim(config: object) -> int:
+    """Return the explicit HF head width, or derive it when absent."""
+
+    raw = _raw(config)
+    explicit = raw.get("head_dim", getattr(config, "_head_dim", 0))
+    if explicit not in (None, 0):
+        head_dim = _integer(explicit, "head_dim")
+    else:
+        hidden = _positive(config, "hidden_size")
+        heads = _positive(config, "num_attention_heads")
+        if hidden % heads:
+            raise ValueError(
+                "hidden_size must be divisible by num_attention_heads when head_dim is absent"
+            )
+        head_dim = hidden // heads
+    if not 0 < head_dim <= _INT32_MAX:
+        raise ValueError("head_dim must be a positive TensorRT dimension")
+    return head_dim
+
+
+def resolved_rotary_dim(config: object) -> int:
+    """Return StableLM's active partial-RoPE width."""
+
+    head_dim = resolved_head_dim(config)
+    try:
+        factor = float(_raw(config).get("partial_rotary_factor", 0.25))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("partial_rotary_factor must be numeric") from exc
+    if not math.isfinite(factor) or not 0.0 < factor <= 1.0:
+        raise ValueError("partial_rotary_factor must be finite and in (0, 1]")
+    rotary_dim = int(head_dim * factor)
+    if rotary_dim < 2 or rotary_dim % 2:
+        raise ValueError(
+            "partial_rotary_factor must produce an even rotary dimension of at least 2"
+        )
+    return rotary_dim
+
+
+def _checked_product(label: str, *values: int) -> int:
+    product = 1
+    for value in values:
+        if value <= 0 or product > _UINT64_MAX // value:
+            raise ValueError(f"native StableLM KV {label} exceeds uint64")
+        product *= value
+    return product
+
+
+def native_kv_cache_geometry(
+    config: object,
+    capacity: int,
+    *,
+    element_bytes: int = 2,
+) -> tuple[int, int]:
+    """Return byte geometry for the required full-context FP16 cache."""
+
+    capacity = _integer(capacity, "max_cache_length")
+    context = _positive(config, "max_position_embeddings")
+    if capacity != context:
+        raise ValueError(
+            "native StableLM KV requires max_cache_length == "
+            f"max_position_embeddings ({context}), got {capacity}"
+        )
+    row_bytes = _checked_product(
+        "row size",
+        2,
+        _positive(config, "num_hidden_layers"),
+        _positive(config, "num_key_value_heads"),
+        resolved_head_dim(config),
+        _integer(element_bytes, "element_bytes"),
+    )
+    return row_bytes, _checked_product("cache size", capacity, row_bytes)
+
+
+def _enabled(value: object) -> bool:
+    return value not in (None, False, 0, "", (), [], {})
+
+
+def native_kv_architecture_capability(
+    config: object,
+) -> NativeKvCapability:
+    """Accept the dense StableLM-2 graph qualified by this family."""
+
+    model_type = str(getattr(config, "model_type", "")).lower()
+    if not model_type.startswith("stablelm"):
+        return _result(applicable=False)
+    if model_type != "stablelm":
+        return _result(reasons=["model_type must be exactly 'stablelm'"])
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if "max_position_embeddings" not in raw:
+        reasons.append(
+            "max_position_embeddings must be explicit in the HF config"
+        )
+    if tuple(getattr(config, "architectures", ()) or ()) != ("StableLmForCausalLM",):
+        reasons.append("architectures must contain exactly StableLmForCausalLM")
+
+    try:
+        dimensions = {
+            name: _positive(config, name)
+            for name in (
+                "vocab_size",
+                "hidden_size",
+                "intermediate_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "max_position_embeddings",
+            )
+        }
+        head_dim = resolved_head_dim(config)
+        if dimensions["hidden_size"] != (dimensions["num_attention_heads"] * head_dim):
+            reasons.append("hidden_size must equal num_attention_heads * head_dim")
+        if dimensions["num_key_value_heads"] != dimensions["num_attention_heads"]:
+            reasons.append(
+                "native StableLM currently requires MHA "
+                "(num_key_value_heads == num_attention_heads)"
+            )
+        if head_dim % 8 or head_dim > 128:
+            reasons.append(
+                "native StableLM attention requires head_dim to be an "
+                "integer multiple of 8 no larger than 128"
+            )
+        resolved_rotary_dim(config)
+    except ValueError as exc:
+        reasons.append(str(exc))
+
+    if str(getattr(config, "hidden_act", "")).lower() != "silu":
+        reasons.append("native StableLM requires hidden_act='silu'")
+    for name in ("rms_norm_eps", "rope_theta"):
+        try:
+            value = float(getattr(config, name))
+        except (TypeError, ValueError, OverflowError):
+            value = 0.0
+        if not math.isfinite(value) or value <= 0:
+            reasons.append(f"{name} must be finite and positive")
+    try:
+        partial_rotary = float(raw.get("partial_rotary_factor", 0.25))
+    except (TypeError, ValueError, OverflowError):
+        partial_rotary = 0.0
+    if "partial_rotary_factor" not in raw or partial_rotary != 0.25:
+        reasons.append("native StableLM requires partial_rotary_factor=0.25")
+    if raw.get("use_qkv_bias") is not True:
+        reasons.append("native StableLM requires use_qkv_bias=true")
+    if _enabled(raw.get("use_parallel_residual")):
+        reasons.append("native StableLM requires sequential residuals")
+
+    unsupported_flags = (
+        "is_encoder_decoder",
+        "rope_scaling",
+        "rope_parameters",
+        "sliding_window",
+        "use_sliding_window",
+        "interleaved_rope",
+        "rope_interleaved",
+        "num_experts",
+        "num_local_experts",
+        "num_experts_per_tok",
+    )
+    enabled = [name for name in unsupported_flags if _enabled(raw.get(name))]
+    if enabled:
+        reasons.append("unsupported StableLM fields: " + ", ".join(enabled))
+    if bool(getattr(config, "tie_word_embeddings", False)):
+        reasons.append("native StableLM requires an explicit untied output projection")
+    return _result(reasons=reasons)
+
+
+def native_kv_build_capability(
+    config: object,
+    *,
+    precision: str = "fp16",
+    max_cache_length: int | None = None,
+    parallel_enabled: bool | None = None,
+    dynamic_kv_cache: bool | None = None,
+    quantized: bool | None = None,
+    debug_layer_outputs: bool = False,
+) -> NativeKvCapability:
+    """Apply native deployment constraints after architecture routing."""
+
+    architecture = native_kv_architecture_capability(config)
+    if not architecture.eligible:
+        return architecture
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if str(precision).lower() != "fp16":
+        reasons.append("native StableLM requires FP16")
+    if str(raw.get("_decoder_engine_layout", "split")) != "split":
+        reasons.append("native StableLM requires split prefill/decode engines")
+    if raw.get("_rtx_build_requested"):
+        reasons.append("native StableLM requires the standard TensorRT backend")
+    if parallel_enabled or raw.get("_parallel_build_enabled"):
+        reasons.append("native StableLM does not support tensor parallel builds")
+    if dynamic_kv_cache or raw.get("_runtime_dynamic_kv_requested") or raw.get("dynamic_kv_cache"):
+        reasons.append("native StableLM uses one fixed physical KV capacity")
+    if quantized or raw.get("quantization_config") or raw.get("_quantized_build_requested"):
+        reasons.append("native StableLM does not support quantized builds")
+    if raw.get("_fp32_layers"):
+        reasons.append("native StableLM does not support FP32 layer overrides")
+    if debug_layer_outputs:
+        reasons.append("native StableLM does not support debug layer outputs")
+    try:
+        native_kv_cache_geometry(
+            config,
+            (
+                int(getattr(config, "max_position_embeddings"))
+                if max_cache_length is None
+                else max_cache_length
+            ),
+        )
+    except ValueError as exc:
+        reasons.append(str(exc))
+    return _result(reasons=reasons)
+
+
+def prefer_native_default(config: object) -> bool:
+    """Prefer native KV for supported StableLM architectures."""
+
+    return native_kv_architecture_capability(config).eligible

--- a/python/tensorrt_model_connect/families/stablelm/graph_ops.py
+++ b/python/tensorrt_model_connect/families/stablelm/graph_ops.py
@@ -417,6 +417,80 @@ def validate_native_rope_dim(
     return rotary_embedding_dim
 
 
+def make_native_active_rope_inv_freq(
+    head_dim: int,
+    rope_theta: float,
+    *,
+    rotary_dim: int | None = None,
+) -> np.ndarray:
+    """Return HF/Torch-exact frequencies for active-position RoPE."""
+    if rotary_dim is None:
+        rotary_dim = head_dim
+    rotary_dim = validate_native_rope_dim(rotary_dim)
+    if rotary_dim > int(head_dim):
+        raise ValueError("rotary_dim cannot exceed head_dim")
+    rope_theta = float(rope_theta)
+    if not np.isfinite(rope_theta) or rope_theta <= 0.0:
+        raise ValueError(
+            "TRT native StableLM RoPE requires rope_theta to be finite "
+            f"and positive; got {rope_theta}")
+    try:
+        import torch
+    except (ImportError, OSError) as exc:
+        raise RuntimeError(
+            "TensorRT native StableLM KV build requires PyTorch in the "
+            "Model Connect build environment to generate Hugging "
+            "Face-exact RoPE frequencies") from exc
+
+    with torch.no_grad():
+        exponents = (
+            torch.arange(0, rotary_dim, 2, dtype=torch.int64, device="cpu")
+            .to(dtype=torch.float32) / rotary_dim)
+        inv_freq = 1.0 / (rope_theta ** exponents)
+    return np.asarray(
+        inv_freq.detach().cpu().contiguous().numpy(), dtype=np.float32).copy()
+
+
+def add_active_rope_cache(
+    network: trt.INetworkDefinition,
+    position_id: trt.ITensor,
+    inv_freq: np.ndarray,
+    output_dtype: trt.DataType,
+) -> tuple[trt.ITensor, trt.ITensor]:
+    """Build ``[1, Sq, rotary_dim/2]`` cos/sin for active positions."""
+    inv_freq = np.asarray(inv_freq, dtype=np.float32)
+    if inv_freq.ndim != 1 or inv_freq.size == 0:
+        raise ValueError(
+            "active RoPE inverse frequencies must be a non-empty rank-1 array")
+
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    pos_col = network.add_shuffle(pos_float)
+    pos_col.reshape_dims = (-1, 1)
+    inv_freq_tensor = add_constant(
+        network, (1, int(inv_freq.size)), inv_freq.reshape(1, -1),
+        dtype=np.float32)
+    angles = network.add_elementwise(
+        pos_col.get_output(0), inv_freq_tensor,
+        trt.ElementWiseOperation.PROD).get_output(0)
+    cos_2d = network.add_unary(
+        angles, trt.UnaryOperation.COS).get_output(0)
+    sin_2d = network.add_unary(
+        angles, trt.UnaryOperation.SIN).get_output(0)
+
+    cos_3d = network.add_shuffle(cos_2d)
+    cos_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    sin_3d = network.add_shuffle(sin_2d)
+    sin_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    cos_cache = cos_3d.get_output(0)
+    sin_cache = sin_3d.get_output(0)
+    if cos_cache.dtype != output_dtype:
+        cos_cache = network.add_cast(
+            cos_cache, output_dtype).get_output(0)
+        sin_cache = network.add_cast(
+            sin_cache, output_dtype).get_output(0)
+    return cos_cache, sin_cache
+
+
 def make_rope_table_half_dim(
     max_cache_length: int,
     head_dim: int,
@@ -611,7 +685,7 @@ def add_apply_rope_native(
     head_dim: int,
     cos_cache_2d: trt.ITensor,
     sin_cache_2d: trt.ITensor,
-    position_id: trt.ITensor,
+    position_id: trt.ITensor | None,
     rotary_embedding_dim: int,
     interleaved: bool = False,
     sequence_length: int | None = 1,
@@ -649,11 +723,6 @@ def add_apply_rope_native(
     inp_4d = reshape_rows_to_heads_4d(
         network, inp, num_heads, head_dim, sequence_length)
 
-    # Reshape position_id [Sq] -> [1, Sq] (batch=1).
-    seq_dim = -1 if sequence_length is None else sequence_length
-    pos_2d = network.add_shuffle(position_id)
-    pos_2d.reshape_dims = (1, seq_dim)
-
     rope = network.add_rotary_embedding(
         inp_4d,
         cos_cache_2d,
@@ -661,10 +730,94 @@ def add_apply_rope_native(
         interleaved,
         rotary_embedding_dim,
     )
-    rope.set_input(3, pos_2d.get_output(0))
+    if position_id is not None:
+        seq_dim = -1 if sequence_length is None else sequence_length
+        pos_2d = network.add_shuffle(position_id)
+        pos_2d.reshape_dims = (1, seq_dim)
+        rope.set_input(3, pos_2d.get_output(0))
 
     return reshape_heads_4d_to_rows(
         network, rope.get_output(0), attention_size, sequence_length)
+
+
+def add_native_kv_cache_attention_from_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k_update: trt.ITensor,
+    v_update: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    q_seq: int | None,
+    scale: float | None = None,
+    tag: str | None = None,
+) -> dict[str, trt.ITensor]:
+    """Update a user-owned cache and attend over its active prefix."""
+    if not hasattr(network, "add_kv_cache_update") or not hasattr(
+            network, "add_attention_v2"):
+        raise RuntimeError(
+            "StableLM native KV cache requires TensorRT "
+            "add_kv_cache_update and add_attention_v2 support")
+
+    k_update_4d = reshape_rows_to_heads_4d(
+        network, k_update, num_kv_heads, head_dim, sequence_length=q_seq,
+        tag=None if tag is None else tag + ".k_update")
+    v_update_4d = reshape_rows_to_heads_4d(
+        network, v_update, num_kv_heads, head_dim, sequence_length=q_seq,
+        tag=None if tag is None else tag + ".v_update")
+    update_k = network.add_kv_cache_update(
+        cache_k, k_update_4d, cache_write_indices, trt.KVCacheMode.LINEAR)
+    update_v = network.add_kv_cache_update(
+        cache_v, v_update_4d, cache_write_indices, trt.KVCacheMode.LINEAR)
+    if update_k is None or update_v is None:
+        raise RuntimeError(
+            "TensorRT failed to create StableLM KV-cache update layers")
+    if tag:
+        update_k.name = tag + ".cache_k_update"
+        update_v.name = tag + ".cache_v_update"
+    updated_k = update_k.get_output(0)
+    updated_v = update_v.get_output(0)
+
+    q_4d = reshape_rows_to_heads_4d(
+        network, q, num_heads, head_dim, sequence_length=q_seq,
+        tag=None if tag is None else tag + ".q")
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    if q_4d.dtype != trt.float16:
+        raise ValueError("StableLM native KV attention requires FP16 queries")
+
+    q_scale_input = network.add_cast(q_4d, trt.float32).get_output(0)
+    scale_t = add_constant(
+        network, (1, 1, 1, 1), np.array([[[[scale]]]], dtype=np.float32),
+        dtype=np.float32)
+    q_scaled = network.add_elementwise(
+        q_scale_input, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    q_scaled = network.add_cast(q_scaled, trt.float16).get_output(0)
+
+    attention = network.add_attention_v2(
+        q_scaled, updated_k, updated_v,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        trt.CausalMaskKind.LOWER_RIGHT)
+    if attention is None:
+        raise RuntimeError("TensorRT failed to create StableLM native attention")
+    attention.decomposable = False
+    attention.key_value_lengths = key_value_lengths
+    if tag:
+        attention.name = tag
+
+    context = reshape_heads_4d_to_rows(
+        network, attention.get_output(0), num_heads * head_dim,
+        sequence_length=q_seq, tag=None if tag is None else tag + ".ctx")
+    return {
+        "context": context,
+        "present_k": updated_k,
+        "present_v": updated_v,
+    }
 
 
 def add_attention_core(

--- a/python/tensorrt_model_connect/families/stablelm/native_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/stablelm/native_decoder_builder.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native-only split prefill/decode builder for dense StableLM models."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from . import graph_ops
+from .build_routing import resolved_head_dim, resolved_rotary_dim
+from .utils import const_in_work_dtype, create_builder_context, norm_multi
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from .checkpoint_mapper import WeightDict
+    from .config import ModelConfig
+
+
+_NATIVE_PREFILL_CHUNK_TOKENS = 32768
+
+
+def _swiglu_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    matmul,
+    weights: "WeightDict",
+    prefix: str,
+    hidden: int,
+    mlp_size: int,
+) -> trt.ITensor:
+    gate = matmul(
+        inp,
+        hidden,
+        mlp_size,
+        weights[f"{prefix}.w_gate"],
+        f"{prefix}.w_gate",
+    )
+    up = matmul(
+        inp,
+        hidden,
+        mlp_size,
+        weights[f"{prefix}.w_up"],
+        f"{prefix}.w_up",
+    )
+    sigmoid = network.add_activation(
+        gate,
+        trt.ActivationType.SIGMOID,
+    )
+    swish = network.add_elementwise(
+        gate,
+        sigmoid.get_output(0),
+        trt.ElementWiseOperation.PROD,
+    )
+    gated = network.add_elementwise(
+        swish.get_output(0),
+        up,
+        trt.ElementWiseOperation.PROD,
+    )
+    return matmul(
+        gated.get_output(0),
+        mlp_size,
+        hidden,
+        weights[f"{prefix}.w_down"],
+        f"{prefix}.w_down",
+    )
+
+
+def build_native_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp16",
+    opt_prefill_length: int = 64,
+    max_prefill_length: int | None = None,
+    profile_mode: str,
+    verbose: bool = False,
+) -> bytes:
+    """Build one native-KV prefill or decode engine at full capacity."""
+
+    if precision != "fp16":
+        raise ValueError("native StableLM decoder requires FP16")
+    if profile_mode not in ("prefill", "decode"):
+        raise ValueError(
+            f"native StableLM profile_mode must be 'prefill' or 'decode', got {profile_mode!r}"
+        )
+
+    if max_prefill_length is None:
+        max_prefill_length = min(
+            max_cache_length,
+            _NATIVE_PREFILL_CHUNK_TOKENS,
+        )
+    max_prefill_length = max(
+        1,
+        min(max_prefill_length, max_cache_length),
+    )
+    opt_prefill_length = max(
+        1,
+        min(opt_prefill_length, max_prefill_length),
+    )
+
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    mlp_size = config.intermediate_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads
+    num_kv_heads = config.num_key_value_heads
+    head_dim = resolved_head_dim(config)
+    rotary_dim = resolved_rotary_dim(config)
+    attention_size = num_heads * head_dim
+    kv_attention_size = num_kv_heads * head_dim
+
+    inv_freq = graph_ops.make_native_active_rope_inv_freq(
+        head_dim,
+        config.rope_theta,
+        rotary_dim=rotary_dim,
+    )
+
+    builder_context = create_builder_context(
+        verbose=verbose,
+        workspace_bytes=16 << 30,
+    )
+    builder = builder_context.builder
+    network = builder_context.network
+    trt_config = builder_context.config
+    work_np_dtype = np.float16
+    work_trt_dtype = trt.float16
+
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    cache_write_indices = network.add_input(
+        "cache_write_indices",
+        trt.int32,
+        (1,),
+    )
+    key_value_lengths = network.add_input(
+        "key_value_lengths",
+        trt.int32,
+        (1,),
+    )
+
+    cache_shape = (
+        1,
+        num_kv_heads,
+        max_cache_length,
+        head_dim,
+    )
+    cache_k_inputs: list[trt.ITensor] = []
+    cache_v_inputs: list[trt.ITensor] = []
+    for layer_idx in range(num_layers):
+        cache_k_inputs.append(
+            network.add_input(
+                graph_ops.layer_tensor_name("cache_k", layer_idx),
+                work_trt_dtype,
+                cache_shape,
+            )
+        )
+        cache_v_inputs.append(
+            network.add_input(
+                graph_ops.layer_tensor_name("cache_v", layer_idx),
+                work_trt_dtype,
+                cache_shape,
+            )
+        )
+
+    profile = builder.create_optimization_profile()
+    if profile_mode == "prefill":
+        profile.set_shape(
+            "token_id",
+            (1,),
+            (opt_prefill_length,),
+            (max_prefill_length,),
+        )
+        profile.set_shape(
+            "position_id",
+            (1,),
+            (opt_prefill_length,),
+            (max_prefill_length,),
+        )
+    else:
+        profile.set_shape("token_id", (1,), (1,), (1,))
+        profile.set_shape("position_id", (1,), (1,), (1,))
+    trt_config.add_optimization_profile(profile)
+
+    embedding_table = const_in_work_dtype(
+        network,
+        (vocab, hidden),
+        weights["embedding"],
+        work_np_dtype,
+        work_trt_dtype,
+    )
+    cos_half, sin_half = graph_ops.add_active_rope_cache(
+        network,
+        position_id,
+        inv_freq,
+        work_trt_dtype,
+    )
+    eps_tensor = graph_ops.add_constant(
+        network,
+        (1, 1),
+        np.array([[config.rms_norm_eps]], dtype=np.float32),
+        dtype=np.float32,
+    )
+    attn_scale = float(1.0 / np.sqrt(head_dim))
+
+    def matmul(
+        lhs: trt.ITensor,
+        lhs_width: int,
+        rhs_width: int,
+        rhs_weights: np.ndarray,
+        _weight_name: str,
+    ) -> trt.ITensor:
+        if lhs.dtype != work_trt_dtype:
+            lhs = network.add_cast(
+                lhs,
+                work_trt_dtype,
+            ).get_output(0)
+        return graph_ops.add_matmul_rhs_constant(
+            network,
+            lhs,
+            lhs_width,
+            rhs_width,
+            rhs_weights,
+            dtype=work_np_dtype,
+        )
+
+    hidden_state = network.add_gather(
+        embedding_table,
+        token_id,
+        0,
+    ).get_output(0)
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(
+            hidden_state,
+            work_trt_dtype,
+        ).get_output(0)
+    present_k_outs: list[trt.ITensor] = []
+    present_v_outs: list[trt.ITensor] = []
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        normed = norm_multi(
+            network,
+            hidden_state,
+            hidden,
+            weights[f"{prefix}.input_norm"],
+            weights[f"{prefix}.input_norm_beta"],
+            eps_tensor,
+            "layernorm",
+            work_np_dtype,
+        )
+        q = matmul(
+            normed,
+            hidden,
+            attention_size,
+            weights[f"{prefix}.w_q"],
+            f"{prefix}.w_q",
+        )
+        k = matmul(
+            normed,
+            hidden,
+            kv_attention_size,
+            weights[f"{prefix}.w_k"],
+            f"{prefix}.w_k",
+        )
+        v = matmul(
+            normed,
+            hidden,
+            kv_attention_size,
+            weights[f"{prefix}.w_v"],
+            f"{prefix}.w_v",
+        )
+        q = graph_ops.add_bias_sum(
+            network,
+            q,
+            attention_size,
+            weights[f"{prefix}.q_bias"],
+            dtype=work_np_dtype,
+        )
+        k = graph_ops.add_bias_sum(
+            network,
+            k,
+            kv_attention_size,
+            weights[f"{prefix}.k_bias"],
+            dtype=work_np_dtype,
+        )
+        v = graph_ops.add_bias_sum(
+            network,
+            v,
+            kv_attention_size,
+            weights[f"{prefix}.v_bias"],
+            dtype=work_np_dtype,
+        )
+
+        q = graph_ops.add_apply_rope_native(
+            network,
+            q,
+            num_heads,
+            head_dim,
+            cos_half,
+            sin_half,
+            None,
+            rotary_dim,
+            False,
+            sequence_length=None,
+        )
+        k = graph_ops.add_apply_rope_native(
+            network,
+            k,
+            num_kv_heads,
+            head_dim,
+            cos_half,
+            sin_half,
+            None,
+            rotary_dim,
+            False,
+            sequence_length=None,
+        )
+
+        native_attention = graph_ops.add_native_kv_cache_attention_from_rows(
+            network,
+            q,
+            k,
+            v,
+            cache_k_inputs[layer_idx],
+            cache_v_inputs[layer_idx],
+            cache_write_indices,
+            key_value_lengths,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            q_seq=None,
+            scale=attn_scale,
+            tag=f"{prefix}.attn",
+        )
+        present_k_outs.append(native_attention["present_k"])
+        present_v_outs.append(native_attention["present_v"])
+
+        attn_out = matmul(
+            native_attention["context"],
+            attention_size,
+            hidden,
+            weights[f"{prefix}.w_o"],
+            f"{prefix}.w_o",
+        )
+        residual1 = network.add_elementwise(
+            hidden_state,
+            attn_out,
+            trt.ElementWiseOperation.SUM,
+        ).get_output(0)
+        norm2 = norm_multi(
+            network,
+            residual1,
+            hidden,
+            weights[f"{prefix}.post_attn_norm"],
+            weights[f"{prefix}.post_attn_norm_beta"],
+            eps_tensor,
+            "layernorm",
+            work_np_dtype,
+        )
+
+        mlp_out = _swiglu_mlp(
+            network,
+            norm2,
+            matmul=matmul,
+            weights=weights,
+            prefix=prefix,
+            hidden=hidden,
+            mlp_size=mlp_size,
+        )
+        hidden_state = network.add_elementwise(
+            residual1,
+            mlp_out,
+            trt.ElementWiseOperation.SUM,
+        ).get_output(0)
+
+    hidden_state = norm_multi(
+        network,
+        hidden_state,
+        hidden,
+        weights["final_norm"],
+        weights["final_norm_beta"],
+        eps_tensor,
+        "layernorm",
+        work_np_dtype,
+    )
+
+    shape_t = network.add_shape(hidden_state).get_output(0)
+    one_hidden = graph_ops.add_constant(
+        network,
+        (2,),
+        np.array([1, hidden], dtype=np.int64),
+        dtype=np.int64,
+    )
+    start_t = network.add_elementwise(
+        shape_t,
+        one_hidden,
+        trt.ElementWiseOperation.SUB,
+    ).get_output(0)
+    last_hidden_slice = network.add_slice(
+        hidden_state,
+        start=(0, 0),
+        shape=(0, 0),
+        stride=(1, 1),
+    )
+    last_hidden_slice.set_input(1, start_t)
+    last_hidden_slice.set_input(2, one_hidden)
+    last_hidden = last_hidden_slice.get_output(0)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network,
+        last_hidden,
+        hidden,
+        vocab,
+        weights["w_out"],
+        dtype=work_np_dtype,
+    )
+    logits = network.add_cast(
+        logits,
+        trt.float32,
+    ).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx, (present_k, present_v) in enumerate(zip(present_k_outs, present_v_outs)):
+        present_k.name = graph_ops.layer_tensor_name(
+            "present_k",
+            layer_idx,
+        )
+        present_v.name = graph_ops.layer_tensor_name(
+            "present_v",
+            layer_idx,
+        )
+        network.mark_output(present_k)
+        network.mark_output(present_v)
+
+    if verbose:
+        print(
+            f"[trtmc build] Building native StableLM {profile_mode} engine "
+            f"(layers={num_layers}, hidden={hidden}, heads={num_heads}, "
+            f"head_dim={head_dim}, rotary_dim={rotary_dim}, "
+            f"cache={max_cache_length}, max_prefill={max_prefill_length}, "
+            "precision=fp16) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError(f"native StableLM {profile_mode} engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/stablelm/native_kv_contract.py
+++ b/python/tensorrt_model_connect/families/stablelm/native_kv_contract.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mapped-weight contract for StableLM's TensorRT native KV graph."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from .build_routing import resolved_head_dim
+
+_LAYER_KEY = re.compile(r"^layer\.(\d+)\.")
+
+
+def _shape(value: object, name: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(dim) for dim in value.shape)
+    except (AttributeError, TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"native StableLM weight {name} has an invalid shape") from exc
+
+
+def _require(
+    weights: Mapping[str, object],
+    name: str,
+    expected: tuple[int, ...],
+) -> None:
+    if name not in weights:
+        raise ValueError(f"missing native StableLM weight {name}")
+    actual = _shape(weights[name], name)
+    if actual != expected:
+        raise ValueError(f"native StableLM weight {name} must have shape {expected}, got {actual}")
+
+
+def validate_native_kv_weights(
+    config: object,
+    weights: Mapping[str, object],
+) -> None:
+    """Validate mapped tensors once, before TensorRT graph construction."""
+
+    if not isinstance(weights, Mapping):
+        raise ValueError("native StableLM weights must be a mapping")
+
+    hidden = int(getattr(config, "hidden_size"))
+    vocab = int(getattr(config, "vocab_size"))
+    mlp = int(getattr(config, "intermediate_size"))
+    layers = int(getattr(config, "num_hidden_layers"))
+    heads = int(getattr(config, "num_attention_heads"))
+    kv_heads = int(getattr(config, "num_key_value_heads"))
+    head_dim = resolved_head_dim(config)
+    attention = heads * head_dim
+    kv_attention = kv_heads * head_dim
+
+    layer_indices: set[int] = set()
+    malformed: list[str] = []
+    for name in weights:
+        if not isinstance(name, str) or not name.startswith("layer."):
+            continue
+        match = _LAYER_KEY.match(name)
+        if match is None:
+            malformed.append(name)
+        else:
+            layer_indices.add(int(match.group(1)))
+    if malformed or layer_indices != set(range(layers)):
+        raise ValueError(
+            "native StableLM weights require continuous layer indices; "
+            f"malformed={sorted(malformed)}, found={sorted(layer_indices)}"
+        )
+
+    for name, expected in (
+        ("_attention_size", attention),
+        ("_kv_attention_size", kv_attention),
+        ("_mlp_size", mlp),
+    ):
+        if name in weights and int(weights[name]) != expected:
+            raise ValueError(f"native StableLM metadata {name} must be {expected}")
+
+    _require(weights, "embedding", (vocab, hidden))
+    _require(weights, "final_norm", (hidden,))
+    _require(weights, "final_norm_beta", (hidden,))
+    _require(weights, "w_out", (hidden, vocab))
+
+    for layer in range(layers):
+        prefix = f"layer.{layer}"
+        for suffix, expected in (
+            ("input_norm", (hidden,)),
+            ("input_norm_beta", (hidden,)),
+            ("w_q", (hidden, attention)),
+            ("w_k", (hidden, kv_attention)),
+            ("w_v", (hidden, kv_attention)),
+            ("q_bias", (attention,)),
+            ("k_bias", (kv_attention,)),
+            ("v_bias", (kv_attention,)),
+            ("w_o", (attention, hidden)),
+            ("post_attn_norm", (hidden,)),
+            ("post_attn_norm_beta", (hidden,)),
+            ("w_gate", (hidden, mlp)),
+            ("w_up", (hidden, mlp)),
+            ("w_down", (mlp, hidden)),
+        ):
+            _require(weights, f"{prefix}.{suffix}", expected)
+
+    forbidden = sorted(
+        name
+        for name in weights
+        if isinstance(name, str)
+        and (
+            name.endswith(".q_norm")
+            or name.endswith(".k_norm")
+            or name.endswith(".o_bias")
+            or name.endswith(".w_fc1")
+            or name.endswith(".w_fc2")
+            or name.endswith(".fc1_bias")
+            or name.endswith(".fc2_bias")
+            or name == "lm_head_bias"
+        )
+    )
+    if forbidden:
+        raise ValueError(
+            "native StableLM received unsupported mapped weights: " + ", ".join(forbidden)
+        )

--- a/python/tensorrt_model_connect/families/stablelm/plugin.py
+++ b/python/tensorrt_model_connect/families/stablelm/plugin.py
@@ -24,6 +24,7 @@ from .checkpoint_mapper import (
     _open_safetensors,
     _load_tensor,
     _has_tensor,
+    _target_np_dtype,
     _transpose_2d,
 )
 from ...parallel_config import (
@@ -31,6 +32,12 @@ from ...parallel_config import (
     require_tensorrt_11_for_tensor_parallel,
 )
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
+from .build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+)
+from .native_decoder_builder import build_native_decoder_engine
+from .native_kv_contract import validate_native_kv_weights
 from .standard_decoder_builder import build_standard_decoder_engine
 
 
@@ -43,8 +50,18 @@ class StableLMPlugin:
         mt = model_type.lower()
         return mt == "stablelm" or mt.startswith("stablelm")
 
+    def default_build_precision(self, config: ModelConfig) -> str:
+        return "fp16" if native_kv_architecture_capability(config).eligible else "fp32"
+
+    def default_max_cache_length(self, config: ModelConfig) -> int:
+        capability = native_kv_architecture_capability(config)
+        return int(config.max_position_embeddings) if capability.eligible else 256
+
+    def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
+        return not bool(config.raw.get("_quantized_build_requested"))
+
     def load_weights(
-        self, model_dir: str, config: ModelConfig,
+        self, model_dir: str, config: ModelConfig, *, precision: str = "fp32",
     ) -> WeightDict:
         model_dir_path = Path(model_dir)
         readers = _open_safetensors(model_dir_path)
@@ -53,13 +70,14 @@ class StableLMPlugin:
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers
         kv_attention_size = config.num_key_value_heads * config.head_dim
+        storage_dtype = _target_np_dtype(precision)
         weights = WeightDict()
 
         # Embedding
         embedding = _load_tensor(readers, "model.embed_tokens.weight")
         assert embedding.shape == (vocab, hidden), (
             f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
-        weights["embedding"] = embedding.astype(np.float32)
+        weights["embedding"] = embedding.astype(storage_dtype)
 
         mlp_size = 0
         attention_size = 0
@@ -78,10 +96,10 @@ class StableLMPlugin:
             post_norm_beta = _load_tensor(
                 readers, f"{hf_prefix}.post_attention_layernorm.bias")
 
-            weights[f"{prefix}.input_norm"] = input_norm.astype(np.float32)
-            weights[f"{prefix}.input_norm_beta"] = input_norm_beta.astype(np.float32)
-            weights[f"{prefix}.post_attn_norm"] = post_norm.astype(np.float32)
-            weights[f"{prefix}.post_attn_norm_beta"] = post_norm_beta.astype(np.float32)
+            weights[f"{prefix}.input_norm"] = input_norm.astype(storage_dtype)
+            weights[f"{prefix}.input_norm_beta"] = input_norm_beta.astype(storage_dtype)
+            weights[f"{prefix}.post_attn_norm"] = post_norm.astype(storage_dtype)
+            weights[f"{prefix}.post_attn_norm_beta"] = post_norm_beta.astype(storage_dtype)
 
             # Q/K/V projections (separate)
             q_raw = _load_tensor(
@@ -96,10 +114,10 @@ class StableLMPlugin:
             if attention_size == 0:
                 attention_size = q_raw.shape[0]
 
-            q_t = _transpose_2d(q_raw, "q_proj")
-            k_t = _transpose_2d(k_raw, "k_proj")
-            v_t = _transpose_2d(v_raw, "v_proj")
-            o_t = _transpose_2d(o_raw, "o_proj")
+            q_t = _transpose_2d(q_raw, "q_proj", precision)
+            k_t = _transpose_2d(k_raw, "k_proj", precision)
+            v_t = _transpose_2d(v_raw, "v_proj", precision)
+            o_t = _transpose_2d(o_raw, "o_proj", precision)
 
             # Keep compact GQA/MQA K/V
 
@@ -114,13 +132,13 @@ class StableLMPlugin:
             v_bias_key = f"{hf_prefix}.self_attn.v_proj.bias"
             if _has_tensor(readers, q_bias_key):
                 weights[f"{prefix}.q_bias"] = _load_tensor(
-                    readers, q_bias_key).astype(np.float32)
+                    readers, q_bias_key).astype(storage_dtype)
             if _has_tensor(readers, k_bias_key):
                 weights[f"{prefix}.k_bias"] = _load_tensor(
-                    readers, k_bias_key).astype(np.float32)
+                    readers, k_bias_key).astype(storage_dtype)
             if _has_tensor(readers, v_bias_key):
                 weights[f"{prefix}.v_bias"] = _load_tensor(
-                    readers, v_bias_key).astype(np.float32)
+                    readers, v_bias_key).astype(storage_dtype)
 
             # SwiGLU MLP (gate/up/down)
             gate_raw = _load_tensor(
@@ -132,30 +150,33 @@ class StableLMPlugin:
             if mlp_size == 0:
                 mlp_size = gate_raw.shape[0]
 
-            weights[f"{prefix}.w_gate"] = _transpose_2d(gate_raw, "gate_proj")
-            weights[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up_proj")
-            weights[f"{prefix}.w_down"] = _transpose_2d(down_raw, "down_proj")
+            weights[f"{prefix}.w_gate"] = _transpose_2d(
+                gate_raw, "gate_proj", precision)
+            weights[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up_proj", precision)
+            weights[f"{prefix}.w_down"] = _transpose_2d(
+                down_raw, "down_proj", precision)
 
         # Final LayerNorm
         final_norm_key = "model.norm.weight"
         if _has_tensor(readers, final_norm_key):
             weights["final_norm"] = _load_tensor(
-                readers, final_norm_key).astype(np.float32)
+                readers, final_norm_key).astype(storage_dtype)
         else:
-            weights["final_norm"] = np.ones(hidden, dtype=np.float32)
+            weights["final_norm"] = np.ones(hidden, dtype=storage_dtype)
 
         final_norm_beta_key = "model.norm.bias"
         if _has_tensor(readers, final_norm_beta_key):
             weights["final_norm_beta"] = _load_tensor(
-                readers, final_norm_beta_key).astype(np.float32)
+                readers, final_norm_beta_key).astype(storage_dtype)
 
         # LM head
         lm_head_key = "lm_head.weight"
         if _has_tensor(readers, lm_head_key):
             weights["w_out"] = _transpose_2d(
-                _load_tensor(readers, lm_head_key), "lm_head")
+                _load_tensor(readers, lm_head_key), "lm_head", precision)
         else:
-            weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied")
+            weights["w_out"] = _transpose_2d(
+                embedding.copy(), "embedding_tied", precision)
 
         weights["_attention_size"] = attention_size  # type: ignore[assignment]
         weights["_kv_attention_size"] = kv_attention_size  # type: ignore[assignment]
@@ -172,6 +193,31 @@ class StableLMPlugin:
     ) -> bytes:
         partial_rotary = config.raw.get("partial_rotary_factor", 1.0)
         parallel = normalize_parallel_config(parallel_config)
+        capability = native_kv_build_capability(
+            config,
+            precision=precision,
+            max_cache_length=max_cache_length,
+            parallel_enabled=parallel.enabled,
+            quantized=quant_ctx is not None,
+            debug_layer_outputs=debug_layer_outputs,
+        )
+        if capability.eligible:
+            validate_native_kv_weights(config, weights)
+            config.raw["_decoder_engine_layout_supported"] = True
+            config.raw["_native_kv_cache_metadata"] = {
+                "native_kv_contract_version": 1,
+                "native_kv_cache": True,
+            }
+            role = str(config.raw.get("_decoder_engine_role", ""))
+            if role not in ("prefill", "decode"):
+                raise ValueError(
+                    "native StableLM requires explicit split engine role "
+                    f"'prefill' or 'decode', got {role!r}")
+            return build_native_decoder_engine(
+                config, weights, max_cache_length, precision="fp16",
+                profile_mode=role, verbose=verbose)
+
+        config.raw.pop("_native_kv_cache_metadata", None)
         if parallel.enabled:
             require_tensorrt_11_for_tensor_parallel(
                 parallel, feature="StableLM tensor-parallel builds")
@@ -200,6 +246,10 @@ class StableLMPlugin:
             partial_rotary_factor=partial_rotary,
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict | None:
+        metadata = config.raw.get("_native_kv_cache_metadata")
+        return dict(metadata) if isinstance(metadata, dict) else None
 
 
 plugin = StableLMPlugin()

--- a/src/runtime/models/stablelm/MODEL.toml
+++ b/src/runtime/models/stablelm/MODEL.toml
@@ -5,5 +5,8 @@ id = "stablelm"
 runtime_library = "libtrtmc_model_stablelm.so"
 runtime_plugins = ["plugin.cpp|register_stablelm_plugin"]
 runtime_strategies = ["stablelm_decoder_kv_cache"]
+runtime_tests = [
+  "test_stablelm_native_kv_cache|test_stablelm_native_kv_cache.cpp|trtmc_model_stablelm,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
+]
 [validation_profiles]
 decoder_debug = ["stablelm_decoder_kv_cache"]

--- a/src/runtime/models/stablelm/kv_cache.cpp
+++ b/src/runtime/models/stablelm/kv_cache.cpp
@@ -25,6 +25,52 @@ int32_t round_up_rows(int32_t value, int32_t bucket, int32_t maximum) {
     return std::min(rounded, maximum);
 }
 
+void validate_native_scalar_input(TrtModule& module, const std::string& name) {
+    if (module.tensor_dtype(name) != DType::kInt32 ||
+        module.tensor_shape(name) != std::vector<int64_t>{1}) {
+        throw std::runtime_error("Stablelm native KV input '" + name + "' must be int32 [1]");
+    }
+}
+
+bool valid_native_cache_shape(const std::vector<int64_t>& shape, int32_t max_length,
+                              int32_t kv_dim) {
+    if (shape.size() != 4)
+        return false;
+    if (shape[0] != 1 || shape[2] != static_cast<int64_t>(max_length))
+        return false;
+    if (shape[1] <= 0 || shape[3] <= 0)
+        return false;
+    return shape[1] * shape[3] == kv_dim;
+}
+
+void validate_native_cache_pair(TrtModule& module, const std::string& cache_name,
+                                const std::string& present_name, int32_t max_length, int32_t kv_dim,
+                                DType cache_dtype) {
+    if (!module.has_input(cache_name) || !module.has_output(present_name)) {
+        throw std::runtime_error("Stablelm native KV engine is missing cache/present pair '" +
+                                 cache_name + "'/'" + present_name + "'");
+    }
+    const auto cache_shape = module.tensor_shape(cache_name);
+    const auto present_shape = module.tensor_shape(present_name);
+    if (!valid_native_cache_shape(cache_shape, max_length, kv_dim) ||
+        present_shape != cache_shape) {
+        throw std::runtime_error("Stablelm native KV cache/present tensors must share static "
+                                 "[1,Hkv,max_length,D] shape");
+    }
+    if (module.tensor_dtype(cache_name) != cache_dtype ||
+        module.tensor_dtype(present_name) != cache_dtype) {
+        throw std::runtime_error("Stablelm native KV cache dtype does not match model precision");
+    }
+}
+
+bool all_tensors_ok(const std::vector<DeviceTensor>& tensors) {
+    for (const auto& tensor : tensors) {
+        if (!tensor.ok())
+            return false;
+    }
+    return true;
+}
+
 } // namespace
 
 StablelmKvCache::StablelmKvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
@@ -47,6 +93,11 @@ StablelmKvCache::StablelmKvCache(int32_t num_layers, int32_t max_length, int32_t
             names_.present_v.push_back("present_v" + suffix);
         }
     }
+    const auto expected_names = static_cast<std::size_t>(num_layers);
+    if (names_.cache_k.size() != expected_names || names_.cache_v.size() != expected_names ||
+        names_.present_k.size() != expected_names || names_.present_v.size() != expected_names) {
+        throw std::invalid_argument("StablelmKvCache: per-layer tensor name count mismatch");
+    }
 
     cache_k_.reserve(static_cast<std::size_t>(num_layers));
     cache_v_.reserve(static_cast<std::size_t>(num_layers));
@@ -55,15 +106,103 @@ StablelmKvCache::StablelmKvCache(int32_t num_layers, int32_t max_length, int32_t
 
     for (int32_t i = 0; i < num_layers; ++i) {
         cache_k_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
+        if (!cache_k_.back().ok())
+            return;
         cache_v_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
-        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
-        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim}, cache_dtype_, stream);
+        if (!cache_v_.back().ok())
+            return;
     }
 
     // Pre-allocate mask buffer: [max_length + 1] for dense causal mask.
     mask_buf_.resize(static_cast<std::size_t>(max_length) + 1);
 
     reset();
+}
+
+bool StablelmKvCache::configure_binding_mode(TrtModule& module) {
+    const bool has_write_indices = module.has_input(names_.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(names_.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error(
+            "Stablelm native KV engine must expose both cache_write_indices and "
+            "key_value_lengths");
+    }
+
+    const bool native_mode = has_write_indices && has_kv_lengths;
+    if (binding_mode_initialized_ && native_mode != native_kv_update_enabled_) {
+        throw std::runtime_error(
+            "Stablelm prefill and decode engines use incompatible KV cache contracts");
+    }
+    binding_mode_initialized_ = true;
+    native_kv_update_enabled_ = native_mode;
+    if (native_mode)
+        validate_native_kv_contract(module);
+    return native_mode;
+}
+
+void StablelmKvCache::validate_native_kv_contract(TrtModule& module) const {
+    validate_native_scalar_input(module, names_.cache_write_indices);
+    validate_native_scalar_input(module, names_.key_value_lengths);
+
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        validate_native_cache_pair(module, names_.cache_k[li], names_.present_k[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+        validate_native_cache_pair(module, names_.cache_v[li], names_.present_v[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+    }
+}
+
+void StablelmKvCache::ensure_legacy_present_buffers() {
+    if (!present_k_.empty())
+        return;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        if (!present_k_.back().ok() || !present_v_.back().ok()) {
+            throw std::runtime_error("Stablelm legacy KV present-buffer allocation failed");
+        }
+    }
+}
+
+void StablelmKvCache::bind_native_cache(TrtModule& module) {
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        module.bind_external(names_.cache_k[li], cache_k_[li].data());
+        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (module.device_ptr(names_.cache_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.present_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.cache_v[li]) != cache_v_[li].data() ||
+            module.device_ptr(names_.present_v[li]) != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "Stablelm native KV engine did not preserve cache/present aliasing");
+        }
+    }
+}
+
+void StablelmKvCache::validate_native_aliases(const std::vector<const void*>& present_k,
+                                              const std::vector<const void*>& present_v) const {
+    if (static_cast<int32_t>(present_k.size()) != num_layers_ ||
+        static_cast<int32_t>(present_v.size()) != num_layers_) {
+        throw std::runtime_error("Stablelm native KV per-layer pointer count mismatch");
+    }
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        if (present_k[li] != cache_k_[li].data() || present_v[li] != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "Stablelm native prefill present tensors must alias the KV cache");
+        }
+    }
+}
+
+void StablelmKvCache::write_native_kv_inputs(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len > max_length_ - position_) {
+        throw std::runtime_error("Stablelm sequence exceeds the model's fixed KV cache capacity");
+    }
+    cache_write_index_ = position_;
+    key_value_length_ = position_ + seq_len;
+    inputs[names_.cache_write_indices] = Tensor{&cache_write_index_, {1}, DType::kInt32};
+    inputs[names_.key_value_lengths] = Tensor{&key_value_length_, {1}, DType::kInt32};
 }
 
 // Masked score constant is model-local.
@@ -199,6 +338,10 @@ void StablelmKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
     write_position_input(inputs, seq_len);
+    if (native_kv_update_enabled_) {
+        write_native_kv_inputs(inputs, seq_len);
+        return;
+    }
     if (seq_len > 1)
         write_batched_mask(inputs, seq_len);
     else
@@ -208,6 +351,11 @@ void StablelmKvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
 void StablelmKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len) {
     if (seq_len <= 0)
         seq_len = 1;
+    if (native_kv_update_enabled_) {
+        throw std::runtime_error(
+            "Stablelm native TensorRT KV cache supports causal attention only; "
+            "bidirectional block decoding is unsupported");
+    }
     write_position_input(inputs, seq_len);
     write_bidirectional_mask(inputs, seq_len);
 }
@@ -215,6 +363,13 @@ void StablelmKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_
 void StablelmKvCache::bind_to(TrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
+    ensure_legacy_present_buffers();
     // Enable dynamic row binding only when cache_k[0] itself is dynamic.
     // Static-shape engines with fixed [max_length, kv_dim] cache reject
     // setInputShape on cache inputs even when other inputs are dynamic.
@@ -241,7 +396,14 @@ void StablelmKvCache::bind_to(TrtModule& module) {
 }
 
 void StablelmKvCache::bind_cache_inputs(TrtModule& module) {
+    bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bound_cache_rows_ = max_length_;
+        bind_native_cache(module);
+        return;
+    }
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
         module.bind_external(names_.cache_k[li], cache_k_[li].data());
@@ -259,6 +421,11 @@ void StablelmKvCache::write_prefill_kv(const std::vector<const void*>& prefill_k
         static_cast<int32_t>(prefill_v.size()) != num_layers_) {
         throw std::runtime_error(
             "StablelmKvCache::write_prefill_kv: per-layer pointer count mismatch");
+    }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ = seq_len;
+        return;
     }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
@@ -284,6 +451,11 @@ void StablelmKvCache::append_prefill_kv(const std::vector<const void*>& prefill_
         throw std::runtime_error(
             "StablelmKvCache::append_prefill_kv: per-layer pointer count mismatch");
     }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ += seq_len;
+        return;
+    }
     const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
     const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
     const auto offset = static_cast<std::size_t>(position_) * row_bytes;
@@ -306,6 +478,15 @@ void StablelmKvCache::advance(int32_t n_tokens) {
     // n_tokens > 1 reserved for future batched prefill (TASK-10).
     assert(n_tokens == 1 && "StablelmKvCache::advance: only n_tokens==1 supported");
     (void)n_tokens;
+
+    if (native_kv_update_enabled_) {
+        if (position_ >= max_length_) {
+            throw std::runtime_error(
+                "Stablelm sequence exceeds the model's fixed KV cache capacity");
+        }
+        ++position_;
+        return;
+    }
 
     // Copy present K/V (single row) into cache at current position.
     // present_k_[layer] is [1, kv_dim] → copy to cache_k_[layer][position_, :]
@@ -345,6 +526,8 @@ void StablelmKvCache::reset() {
     // Reset only the logical sequence length. Attention masks hide every
     // stale cache row, and each present row is overwritten before use.
     position_ = 0;
+    cache_write_index_ = 0;
+    key_value_length_ = 0;
 }
 
 std::size_t StablelmKvCache::device_memory_bytes() const {
@@ -361,13 +544,13 @@ std::size_t StablelmKvCache::device_memory_bytes() const {
 }
 
 bool StablelmKvCache::ok() const {
-    if (cache_k_.size() != static_cast<std::size_t>(num_layers_))
+    const auto expected_layers = static_cast<std::size_t>(num_layers_);
+    if (cache_k_.size() != expected_layers)
         return false;
-    for (const auto& t : cache_k_) {
-        if (!t.ok())
-            return false;
-    }
-    return true;
+    if (cache_v_.size() != expected_layers)
+        return false;
+    return all_tensors_ok(cache_k_) && all_tensors_ok(cache_v_) && all_tensors_ok(present_k_) &&
+           all_tensors_ok(present_v_);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/stablelm/kv_cache.h
+++ b/src/runtime/models/stablelm/kv_cache.h
@@ -8,8 +8,9 @@
 // StablelmKvCache: autoregressive KV cache state manager.
 // HF equivalent: DynamicCache / past_key_values.
 //
-// Manages per-layer K/V device tensors, position tracking, and attention mask
-// construction. Binds directly to a TrtModule via bind_to().
+// Manages per-layer K/V device tensors and position tracking. Native TensorRT
+// KV engines update these buffers in place; legacy engines use present rows
+// plus an attention mask.
 
 #include "runtime/models/stablelm/inference_state.h"
 #include "trtmc/runtime/device_tensor.h"
@@ -30,6 +31,8 @@ struct StablelmKvCacheNames {
     std::vector<std::string> cache_v;
     std::vector<std::string> present_k;
     std::vector<std::string> present_v;
+    std::string cache_write_indices{"cache_write_indices"};
+    std::string key_value_lengths{"key_value_lengths"};
     std::string position_id{"position_id"};
     std::string attention_mask{"attention_mask"};
 };
@@ -52,7 +55,7 @@ class StablelmKvCache : public StablelmInferenceState {
     int32_t max_length() const override { return max_length_; }
     int32_t preferred_cache_rows() const override;
     int32_t num_layers() const override { return num_layers_; }
-    bool needs_attention_mask() const override { return true; }
+    bool needs_attention_mask() const override { return !native_kv_update_enabled_; }
     std::size_t device_memory_bytes() const override;
     const char* state_type() const override { return "dense_kv_cache"; }
     bool ok() const override;
@@ -67,9 +70,9 @@ class StablelmKvCache : public StablelmInferenceState {
     DeviceTensor& cache_k(int32_t layer) { return cache_k_[static_cast<std::size_t>(layer)]; }
     DeviceTensor& cache_v(int32_t layer) { return cache_v_[static_cast<std::size_t>(layer)]; }
 
-    // Write per-layer KV produced by a batched prefill engine into the cache
-    // at positions [0, seq_len). Device-to-device copy on this cache's stream;
-    // advances position_ to seq_len. Requires seq_len <= max_length.
+    // Complete a batched prefill and advance position_ to seq_len. Native
+    // TensorRT KV engines have already updated the aliased cache in place;
+    // legacy engines copy their per-layer outputs into the cache.
     void write_prefill_kv(const std::vector<const void*>& prefill_k,
                           const std::vector<const void*>& prefill_v, int32_t seq_len);
 
@@ -86,14 +89,18 @@ class StablelmKvCache : public StablelmInferenceState {
     // remain masked out by subsequent prepare_step calls.
     void set_position(int32_t position);
 
-    // Bind only the cache_k/v INPUT pointers to `module`. Used for the
-    // prefill TrtModule whose present_k/v outputs have shape (Sq, kv_dim)
-    // — too big for StablelmKvCache's single-row present buffer. The caller reads
-    // the prefill outputs directly from the module's own allocations and
-    // copies them via write_prefill_kv().
+    // Bind prefill KV tensors. Native TensorRT engines bind cache and present
+    // to the same full-capacity storage; legacy engines bind cache inputs only.
     void bind_cache_inputs(TrtModule& module);
 
   private:
+    bool configure_binding_mode(TrtModule& module);
+    void validate_native_kv_contract(TrtModule& module) const;
+    void validate_native_aliases(const std::vector<const void*>& present_k,
+                                 const std::vector<const void*>& present_v) const;
+    void ensure_legacy_present_buffers();
+    void bind_native_cache(TrtModule& module);
+    void write_native_kv_inputs(TensorMap& inputs, int32_t seq_len);
     void rebind_cache_rows(int32_t cache_rows);
     std::vector<int64_t> mask_shape_for_engine(int32_t mask_width, std::size_t mask_buf_size) const;
     void write_position_input(TensorMap& inputs, int32_t seq_len);
@@ -101,10 +108,11 @@ class StablelmKvCache : public StablelmInferenceState {
     void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
     void write_decode_mask(TensorMap& inputs);
 
-    std::vector<DeviceTensor> cache_k_;   // [num_layers], shape [max_length, kv_dim]
-    std::vector<DeviceTensor> cache_v_;   // [num_layers]
-    std::vector<DeviceTensor> present_k_; // [num_layers], shape [1, kv_dim] (single step output)
-    std::vector<DeviceTensor> present_v_; // [num_layers]
+    std::vector<DeviceTensor> cache_k_; // [num_layers], shape [max_length, kv_dim]
+    std::vector<DeviceTensor> cache_v_; // [num_layers]
+    // Legacy-only single-step outputs, allocated lazily when a legacy engine is bound.
+    std::vector<DeviceTensor> present_k_;
+    std::vector<DeviceTensor> present_v_;
     int32_t num_layers_{0};
     int32_t max_length_{0};
     int32_t kv_dim_{0};
@@ -113,7 +121,11 @@ class StablelmKvCache : public StablelmInferenceState {
     // Buffers owned by this object — Tensor.data in prepare_step() points here.
     std::vector<float> mask_buf_;
     std::vector<int32_t> pos_buf_vec_;
+    int32_t cache_write_index_{0};
+    int32_t key_value_length_{0};
     bool has_position_input_{false};
+    bool binding_mode_initialized_{false};
+    bool native_kv_update_enabled_{false};
     bool dynamic_binding_enabled_{false};
     int32_t bound_cache_rows_{0};
     DType cache_dtype_{DType::kFloat32};

--- a/src/runtime/models/stablelm/pipeline.cpp
+++ b/src/runtime/models/stablelm/pipeline.cpp
@@ -411,16 +411,109 @@ bool batched_prefill_supported(const TrtModule* prefill, const StablelmTextGenCo
                                int32_t sq, StablelmInferenceState* state) {
     if (prefill == nullptr || sq <= 0)
         return false;
-    if (cfg.prefill_max_length > 0 && sq > cfg.prefill_max_length)
-        return false;
     if (cfg.num_layers <= 0 || cfg.vocab_size <= 0)
         return false;
     return dynamic_cast<StablelmKvCache*>(state) != nullptr;
 }
+
+void validate_generation_capacity(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+                                  StablelmInferenceState* state, const TrtModule* prefill,
+                                  const TrtModule* decoder) {
+    const TrtModule* module = prefill != nullptr ? prefill : decoder;
+    if (module == nullptr || !module->has_input("cache_write_indices") ||
+        !module->has_input("key_value_lengths")) {
+        return;
+    }
+    const auto* kv = dynamic_cast<const StablelmKvCache*>(state);
+    if (kv == nullptr)
+        return;
+
+    const auto capacity = static_cast<std::size_t>(kv->max_length());
+    if (input_ids.size() > capacity ||
+        (max_new_tokens > 0 &&
+         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size())) {
+        throw std::runtime_error(
+            "Stablelm requested prompt and generation exceed the model's fixed KV cache capacity");
+    }
+}
+
+int32_t resolve_batched_prefill_chunk_limit(const StablelmKvCache& kv,
+                                            const StablelmTextGenConfig& config,
+                                            int32_t token_count) {
+    if (kv.needs_attention_mask()) {
+        if (config.prefill_max_length > 0 && token_count > config.prefill_max_length)
+            return 0;
+        return token_count;
+    }
+    if (config.prefill_max_length <= 0)
+        throw std::runtime_error("Stablelm native KV prefill engine has no valid profile capacity");
+    return config.prefill_max_length;
+}
 } // namespace
 
+void StablelmTextGenerationPipeline::run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                                                       StablelmKvCache& kv,
+                                                       const std::vector<const void*>& present_k,
+                                                       const std::vector<const void*>& present_v,
+                                                       std::vector<float>& logits,
+                                                       bool retain_device_logits) {
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = const_cast<int32_t*>(token_ids);
+    token_tensor.shape = {static_cast<int64_t>(chunk_size)};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+    state_->prepare_step(inputs, chunk_size);
+
+    TensorMap outputs = prefill_->forward(inputs);
+    auto logits_it = outputs.find(config_.logits_output_name);
+    if (logits_it == outputs.end()) {
+        throw std::runtime_error(
+            "StablelmTextGenerationPipeline: prefill module has no logits output");
+    }
+
+    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
+    const auto& logits_tensor = logits_it->second;
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab) {
+        throw std::runtime_error(
+            "StablelmTextGenerationPipeline: prefill logits are smaller than vocabulary");
+    }
+    logits.resize(vocab);
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+
+    if (retain_device_logits) {
+        const auto* device_logits =
+            static_cast<const float*>(prefill_->device_ptr(config_.logits_output_name));
+        if (device_logits == nullptr) {
+            throw std::runtime_error(
+                "StablelmTextGenerationPipeline: prefill logits have no device buffer");
+        }
+        d_logits_ptr_ = device_logits + logits_offset;
+    }
+    kv.append_prefill_kv(present_k, present_v, chunk_size);
+}
+
+void StablelmTextGenerationPipeline::log_batched_prefill(int32_t token_count, int32_t chunk_count,
+                                                         int32_t chunk_limit) const {
+    if (!config_.log_runtime_stats)
+        return;
+
+    std::cerr << "[trtmc] Batched prefill (";
+    if (!config_.prefill_log_label.empty())
+        std::cerr << config_.prefill_log_label;
+    else
+        std::cerr << "profile " << config_.prefill_profile_index;
+    std::cerr << "): " << token_count << " tokens in " << chunk_count << " call";
+    if (chunk_count != 1)
+        std::cerr << 's';
+    std::cerr << " (max chunk=" << chunk_limit << ")\n";
+}
+
 bool StablelmTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
-                                                         std::vector<float>& logits) {
+                                                         std::vector<float>& logits,
+                                                         bool retain_device_logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     if (!batched_prefill_supported(prefill_.get(), config_, sq, state_.get()))
         return false;
@@ -430,41 +523,28 @@ bool StablelmTextGenerationPipeline::run_prefill_batched(const std::vector<int32
     // decode module(s), so we rebind the cache_k/cache_v inputs onto the
     // prefill execution context before running.
     kv->bind_cache_inputs(*prefill_);
-
-    TensorMap inputs;
-    Tensor tok_t;
-    tok_t.data = const_cast<int32_t*>(input_ids.data());
-    tok_t.shape = {static_cast<int64_t>(sq)};
-    tok_t.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = tok_t;
-    state_->prepare_step(inputs, sq);
-
-    TensorMap outputs = prefill_->forward(inputs);
-    auto logits_it = outputs.find(config_.logits_output_name);
-    if (logits_it == outputs.end())
-        return false;
-
-    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
-    const auto& lt = logits_it->second;
-    if (static_cast<std::size_t>(lt.numel()) < vocab)
-        return false;
-    logits.resize(vocab);
-    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
-    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
+    if (sq > kv->max_length()) {
+        throw std::runtime_error("Stablelm sequence exceeds the model's fixed KV cache capacity");
+    }
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
         return false;
-    kv->write_prefill_kv(pk, pv, sq);
-    if (config_.log_runtime_stats) {
-        std::cerr << "[trtmc] Batched prefill (";
-        if (!config_.prefill_log_label.empty()) {
-            std::cerr << config_.prefill_log_label;
-        } else {
-            std::cerr << "profile " << config_.prefill_profile_index;
-        }
-        std::cerr << "): " << sq << " tokens in one call\n";
+
+    const int32_t chunk_limit = resolve_batched_prefill_chunk_limit(*kv, config_, sq);
+    if (chunk_limit <= 0)
+        return false;
+
+    int32_t chunk_count = 0;
+    for (int32_t start = 0; start < sq;) {
+        const int32_t chunk_size = std::min(chunk_limit, sq - start);
+        run_prefill_chunk(input_ids.data() + start, chunk_size, *kv, pk, pv, logits,
+                          retain_device_logits);
+        ++chunk_count;
+        start += chunk_size;
     }
+
+    log_batched_prefill(sq, chunk_count, chunk_limit);
     return true;
 }
 
@@ -492,9 +572,9 @@ void StablelmTextGenerationPipeline::prime_decoder_after_batched_prefill(
 
 void StablelmTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                                  std::vector<float>& logits, bool gpu_sampling) {
-    // Fast path: batched prefill engine writes K/V for the whole prompt in
-    // one forward and returns last-token logits on host.
-    if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
+    // Fast path: batched prefill writes K/V in profile-bounded chunks and
+    // exposes last-token logits on the sampler's requested host or device path.
+    if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
         prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
@@ -605,6 +685,7 @@ void StablelmTextGenerationPipeline::reset_generation_context() {
     using Clock = std::chrono::steady_clock;
     const auto start = Clock::now();
     state_->reset();
+    d_logits_ptr_ = nullptr;
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
         decoder_ctx.module->reset_execution_context();
@@ -759,6 +840,8 @@ StablelmTextGenerationPipeline::TimedGenResult StablelmTextGenerationPipeline::g
     using Clock = std::chrono::steady_clock;
     if (max_new_tokens == 0 || input_ids.empty())
         return TimedGenResult{input_ids, 0.0, 0.0};
+    validate_generation_capacity(input_ids, max_new_tokens, state_.get(), prefill_.get(),
+                                 decoders_.front().module.get());
 
     const std::string mode = resolve_generation_mode(cfg);
     if (mode == "diffusion" || mode == "dlm")

--- a/src/runtime/models/stablelm/pipeline.h
+++ b/src/runtime/models/stablelm/pipeline.h
@@ -42,9 +42,8 @@ struct StablelmTextGenConfig {
 
     // Batched-prefill plumbing — populated when the bundle ships with a
     // dedicated prefill optimization profile. The runtime forwards the
-    // whole prompt through `prefill_module` once (writing per-layer K/V
-    // into the shared cache via write_prefill_kv) before falling back to
-    // the per-token decode loop.
+    // prompt through `prefill_module` in one or more profile-bounded chunks
+    // before falling back to the per-token decode loop.
     std::string present_k_pattern{"present_k_{i}"};
     std::string present_v_pattern{"present_v_{i}"};
     int32_t prefill_max_length{0};
@@ -190,7 +189,13 @@ class StablelmTextGenerationPipeline final : public IPipeline {
                            TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
-    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
+                             bool retain_device_logits);
+    void run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size, StablelmKvCache& kv,
+                           const std::vector<const void*>& present_k,
+                           const std::vector<const void*>& present_v, std::vector<float>& logits,
+                           bool retain_device_logits);
+    void log_batched_prefill(int32_t token_count, int32_t chunk_count, int32_t chunk_limit) const;
     void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,

--- a/src/runtime/models/stablelm/plugin.cpp
+++ b/src/runtime/models/stablelm/plugin.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cuda_runtime_api.h>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -69,13 +70,27 @@ int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
 }
 
 int32_t cache_row_dim_from_module(const TrtModule& module, const std::string& tensor_name) {
-    const int32_t static_dim = dim_at(module.tensor_shape(tensor_name), 1);
+    const auto row_dim = [](const std::vector<int64_t>& shape) -> int32_t {
+        if (shape.size() == 2)
+            return dim_at(shape, 1);
+        if (shape.size() == 4) {
+            const int32_t heads = dim_at(shape, 1);
+            const int32_t head_dim = dim_at(shape, 3);
+            if (heads > 0 && head_dim > 0 &&
+                heads <= std::numeric_limits<int32_t>::max() / head_dim) {
+                return heads * head_dim;
+            }
+        }
+        return -1;
+    };
+
+    const int32_t static_dim = row_dim(module.tensor_shape(tensor_name));
     if (static_dim > 0)
         return static_dim;
     const int32_t profile_count = module.optimization_profile_count();
     for (int32_t profile_idx = 0; profile_idx < profile_count; ++profile_idx) {
-        const int32_t profile_dim = dim_at(
-            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax), 1);
+        const int32_t profile_dim = row_dim(
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax));
         if (profile_dim > 0)
             return profile_dim;
     }
@@ -125,13 +140,16 @@ int32_t profile_token_max_length(const TrtModule& module, const std::string& tok
 
 int32_t profile_cache_rows(const TrtModule& module, const std::string& cache_name,
                            int32_t profile_idx, int32_t fallback_rows) {
-    const int32_t static_rows = dim_at(module.tensor_shape(cache_name), 0);
+    const auto cache_rows = [](const std::vector<int64_t>& shape) {
+        return dim_at(shape, shape.size() == 4 ? 2 : 0);
+    };
+    const int32_t static_rows = cache_rows(module.tensor_shape(cache_name));
     if (static_rows > 0)
         return static_rows;
 
     if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
-        const int32_t max_rows = dim_at(
-            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax), 0);
+        const int32_t max_rows = cache_rows(
+            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax));
         if (max_rows > 0)
             return max_rows;
     }
@@ -194,47 +212,121 @@ std::string format_bytes(std::uint64_t bytes) {
     return oss.str();
 }
 
-KvCacheRuntimeSizing
-resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& module,
+bool engine_uses_native_kv_updates(const TrtModule& module, const StablelmKvCacheNames& kv_names) {
+    const bool has_write_indices = module.has_input(kv_names.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(kv_names.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error(
+            "Stablelm native KV engine must expose both cache_write_indices and "
+            "key_value_lengths");
+    }
+    return has_write_indices;
+}
+
+void validate_native_kv_marker(const std::string& config_json, bool engine_uses_native_kv) {
+    const bool declares_native_kv = extract_json_bool(config_json, "native_kv_cache", false);
+    const bool has_version =
+        config_json.find("\"native_kv_contract_version\"") != std::string::npos;
+    if (!declares_native_kv && !has_version && !engine_uses_native_kv)
+        return;
+    if (!declares_native_kv || !engine_uses_native_kv ||
+        extract_json_int(config_json, "native_kv_contract_version", 0) != 1) {
+        throw std::runtime_error("Stablelm native KV metadata does not match the engine contract");
+    }
+}
+
+bool validate_native_kv_runtime(const PipelineContext& ctx, const TrtModule& module,
                                 const StablelmKvCacheNames& kv_names, DType cache_dtype,
-                                const StablelmTriAttentionConfig& tri_cfg, int32_t kv_dim) {
-    KvCacheRuntimeSizing sizing;
-    const auto elem_bytes = static_cast<std::uint64_t>(dtype_size(cache_dtype));
-    sizing.row_bytes = static_cast<std::uint64_t>(ctx.config.num_layers) *
-                       static_cast<std::uint64_t>(kv_dim) * elem_bytes * 2ULL;
-    if (sizing.row_bytes == 0)
-        throw std::runtime_error("Computed zero bytes per KV row");
+                                const StablelmTriAttentionConfig& tri_cfg,
+                                const TensorParallelRuntimeConfig& tp_cfg) {
+    const bool native_kv = engine_uses_native_kv_updates(module, kv_names);
+    validate_native_kv_marker(ctx.config_json, native_kv);
+    if (!native_kv)
+        return false;
 
-    const int32_t bundle_max_rows = ctx.config.max_cache_length;
-    sizing.runtime_rows = bundle_max_rows;
-    sizing.cache_bytes = static_cast<std::uint64_t>(bundle_max_rows) * sizing.row_bytes;
+    if (cache_dtype != DType::kFloat16 || tri_cfg.enabled || tp_cfg.enabled) {
+        throw std::runtime_error(
+            "Stablelm native KV requires FP16, single-GPU, non-TriAttention runtime");
+    }
+    if (ctx.config.head_dim <= 0) {
+        throw std::runtime_error("Stablelm native KV requires a positive head_dim");
+    }
+    const std::vector<int64_t> expected_shape{1, ctx.config.num_kv_heads,
+                                              ctx.config.max_cache_length, ctx.config.head_dim};
+    if (module.tensor_shape(kv_names.cache_k.front()) != expected_shape) {
+        throw std::runtime_error("Stablelm native KV cache shape does not match bundle geometry");
+    }
+    return true;
+}
 
-    if (ctx.kv_cache_size_bytes == 0)
-        return sizing;
+std::uint64_t checked_multiply(std::uint64_t lhs, std::uint64_t rhs) {
+    if (lhs != 0 && rhs > std::numeric_limits<std::uint64_t>::max() / lhs)
+        throw std::overflow_error("Stablelm native KV byte accounting overflow");
+    return lhs * rhs;
+}
 
+void admit_native_kv_allocation(const PipelineContext& ctx, bool native_kv,
+                                const KvCacheRuntimeSizing& sizing) {
+    if (!native_kv)
+        return;
+
+    std::size_t free_bytes = 0;
+    std::size_t total_bytes = 0;
+    const cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Stablelm native KV CUDA memory query failed: ") +
+                                 cudaGetErrorString(status));
+    }
+
+    constexpr std::uint64_t kTwoGiB = 2ULL << 30;
+    const auto free = static_cast<std::uint64_t>(free_bytes);
+    const auto total = static_cast<std::uint64_t>(total_bytes);
+    const auto reserve = std::max(kTwoGiB, total / 10);
+    const auto available = free > reserve ? free - reserve : 0;
+    if (sizing.cache_bytes > available) {
+        throw std::runtime_error(
+            "Stablelm native KV cache admission failed before allocation: capacity=" +
+            std::to_string(ctx.config.max_cache_length) +
+            " tokens, required=" + format_bytes(sizing.cache_bytes) +
+            ", free=" + format_bytes(free) + ", reserve=" + format_bytes(reserve));
+    }
+}
+
+void reject_native_kv_size_override(const PipelineContext& ctx) {
+    if (ctx.kv_cache_size_bytes != 0) {
+        throw std::invalid_argument(
+            "Stablelm native TensorRT KV cache allocates the model's complete fixed "
+            "capacity; kv_cache_size_bytes is not supported");
+    }
+}
+
+void apply_runtime_kv_size_override(const PipelineContext& ctx, const TrtModule& module,
+                                    const StablelmKvCacheNames& kv_names,
+                                    const StablelmTriAttentionConfig& tri_cfg,
+                                    int32_t bundle_max_rows, KvCacheRuntimeSizing& sizing) {
     if (!cache_input_supports_runtime_rows(module, kv_names.cache_k.front())) {
         throw std::runtime_error(
             "This bundle was not built with runtime-resizable KV cache support. "
             "Rebuild with trtmc build --dynamic-kv-cache to use --kv-cache-size.");
     }
 
-    const std::uint64_t requested_rows_u64 = ctx.kv_cache_size_bytes / sizing.row_bytes;
-    if (requested_rows_u64 == 0) {
+    const std::uint64_t requested_rows = ctx.kv_cache_size_bytes / sizing.row_bytes;
+    if (requested_rows == 0) {
         throw std::runtime_error("--kv-cache-size is smaller than one KV row (" +
                                  format_bytes(sizing.row_bytes) + ")");
     }
 
-    std::uint64_t runtime_rows_u64 = requested_rows_u64;
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(bundle_max_rows)) {
-        runtime_rows_u64 = static_cast<std::uint64_t>(bundle_max_rows);
+    std::uint64_t runtime_rows = requested_rows;
+    if (runtime_rows > static_cast<std::uint64_t>(bundle_max_rows)) {
+        runtime_rows = static_cast<std::uint64_t>(bundle_max_rows);
         sizing.clamped_to_bundle_max = true;
     }
-    if (runtime_rows_u64 > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
+    if (runtime_rows > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max())) {
         throw std::runtime_error("Resolved KV cache rows exceed int32 runtime limits");
     }
 
-    sizing.runtime_rows = static_cast<int32_t>(runtime_rows_u64);
-    sizing.cache_bytes = runtime_rows_u64 * sizing.row_bytes;
+    sizing.runtime_rows = static_cast<int32_t>(runtime_rows);
+    sizing.cache_bytes = runtime_rows * sizing.row_bytes;
     sizing.override_applied = true;
 
     if (tri_cfg.enabled && sizing.runtime_rows < tri_cfg.kv_budget) {
@@ -244,7 +336,33 @@ resolve_kv_cache_runtime_sizing(const PipelineContext& ctx, const TrtModule& mod
             " rows, but this TriAttention bundle needs at least " +
             std::to_string(tri_cfg.kv_budget) + " rows (" + format_bytes(minimum_bytes) + ")");
     }
+}
 
+KvCacheRuntimeSizing resolve_kv_cache_runtime_sizing(
+    const PipelineContext& ctx, const TrtModule& module, const StablelmKvCacheNames& kv_names,
+    DType cache_dtype, const StablelmTriAttentionConfig& tri_cfg, int32_t kv_dim, bool native_kv) {
+    KvCacheRuntimeSizing sizing;
+    const int32_t bundle_max_rows = ctx.config.max_cache_length;
+    if (ctx.config.num_layers <= 0 || kv_dim <= 0 || bundle_max_rows <= 0)
+        throw std::runtime_error("Stablelm KV geometry must be positive");
+    sizing.row_bytes = checked_multiply(
+        checked_multiply(checked_multiply(static_cast<std::uint64_t>(ctx.config.num_layers),
+                                          static_cast<std::uint64_t>(kv_dim)),
+                         static_cast<std::uint64_t>(dtype_size(cache_dtype))),
+        2);
+    sizing.runtime_rows = bundle_max_rows;
+    sizing.cache_bytes =
+        checked_multiply(static_cast<std::uint64_t>(bundle_max_rows), sizing.row_bytes);
+
+    if (native_kv) {
+        reject_native_kv_size_override(ctx);
+        return sizing;
+    }
+
+    if (ctx.kv_cache_size_bytes == 0)
+        return sizing;
+
+    apply_runtime_kv_size_override(ctx, module, kv_names, tri_cfg, bundle_max_rows, sizing);
     return sizing;
 }
 
@@ -279,9 +397,11 @@ class DecoderPlugin final : public IPipelinePlugin {
             throw std::runtime_error("No decoder engine profiles were loaded");
         TrtModule& metadata_module = *profile_modules.modules.front().module;
 
+        const bool native_kv = validate_native_kv_runtime(ctx, metadata_module, kv_names,
+                                                          cache_dtype, tri_cfg, tp_runtime.config);
         const int32_t kv_dim = cache_row_dim_from_module(metadata_module, kv_names.cache_k.front());
-        const auto sizing = resolve_kv_cache_runtime_sizing(ctx, metadata_module, kv_names,
-                                                            cache_dtype, tri_cfg, kv_dim);
+        const auto sizing = resolve_kv_cache_runtime_sizing(
+            ctx, metadata_module, kv_names, cache_dtype, tri_cfg, kv_dim, native_kv);
 
         const auto decode_profile_roles = detect_decoder_profile_roles(
             metadata_module, io.token_id, kv_names.cache_k.front(), ctx.config.max_cache_length);
@@ -302,6 +422,10 @@ class DecoderPlugin final : public IPipelinePlugin {
                 prefill_module = std::move(split_prefill_module);
         }
 
+        // Split prefill deserialization can consume additional execution-context
+        // memory. Admit the KV allocation against the free memory that remains
+        // after every engine/context needed by this pipeline has been loaded.
+        admit_native_kv_allocation(ctx, native_kv, sizing);
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
         log_kv_cache_sizing(ctx, sizing, state.get());
@@ -309,9 +433,8 @@ class DecoderPlugin final : public IPipelinePlugin {
         StablelmTextGenConfig tgc;
         populate_text_gen_config(ctx, tgc, io, decoders.front(), ctx.runtime_config);
         apply_chat_template_format(ctx.bundle, tgc);
-        // Wire batched prefill: the pipeline forwards the whole prompt
-        // through `prefill_module` (TRT optimization profile 0) and copies
-        // per-layer K/V into the shared cache via write_prefill_kv.
+        // Wire batched prefill. Native TensorRT KV engines update the shared
+        // aliased cache in place; legacy engines copy prefill outputs into it.
         tgc.prefill_max_length = prefill_max_length;
         tgc.prefill_profile_index = prefill_profile_idx;
         tgc.prefill_log_label = std::move(prefill_log_label);

--- a/tests/cpp/models/stablelm/test_stablelm_native_kv_cache.cpp
+++ b/tests/cpp/models/stablelm/test_stablelm_native_kv_cache.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../../native_kv_cache_contract_test.h"
+#include "runtime/backend/trt_module_impl.h"
+#include "runtime/models/stablelm/kv_cache.h"
+#include "runtime/models/stablelm/pipeline.h"
+
+#include <NvInfer.h>
+#include <cstring>
+#include <cuda_runtime_api.h>
+
+#if NV_TENSORRT_MAJOR >= 11
+namespace {
+
+int test_trt_external_alias() {
+    trtmc::TrtLogger logger;
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(logger));
+    if (!builder)
+        return 1;
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    if (!network || !config)
+        return 1;
+    auto* cache =
+        network->addInput("cache", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4{1, 1, 4, 1});
+    auto* update =
+        network->addInput("update", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4{1, 1, 2, 1});
+    auto* index = network->addInput("index", nvinfer1::DataType::kINT32, nvinfer1::Dims{1, {1}});
+    if (!cache || !update || !index)
+        return 1;
+    auto* layer =
+        network->addKVCacheUpdate(*cache, *update, *index, nvinfer1::KVCacheMode::kLINEAR);
+    if (!layer)
+        return 1;
+    layer->getOutput(0)->setName("present");
+    network->markOutput(*layer->getOutput(0));
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+    auto runtime = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(logger));
+    if (!plan || !runtime)
+        return 1;
+    auto engine = trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        runtime->deserializeCudaEngine(plan->data(), plan->size()));
+    const char* alias = engine ? engine->getAliasedInputTensor("present") : nullptr;
+    if (!alias || std::strcmp(alias, "cache") != 0)
+        return 1;
+    cudaStream_t stream = nullptr;
+    void* storage = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess ||
+        cudaMalloc(&storage, 4 * sizeof(float)) != cudaSuccess)
+        return 1;
+    float values[4]{1, 2, 3, 4};
+    float replacement[2]{7, 8};
+    int32_t write_index[1]{1};
+    cudaMemcpy(storage, values, sizeof(values), cudaMemcpyHostToDevice);
+    int failures = 0;
+    {
+        trtmc::TrtModuleImpl module(engine.get(), engine->createExecutionContext(), stream);
+        module.bind_external("cache", storage);
+        if (!module.ok() || module.device_ptr("cache") != storage ||
+            module.device_ptr("present") != storage)
+            ++failures;
+        module.forward(
+            {{"update", trtmc::Tensor{replacement, {1, 1, 2, 1}, trtmc::DType::kFloat32}},
+             {"index", trtmc::Tensor{write_index, {1}, trtmc::DType::kInt32}}});
+        cudaMemcpy(values, storage, sizeof(values), cudaMemcpyDeviceToHost);
+        if (values[0] != 1 || values[1] != 7 || values[2] != 8 || values[3] != 4)
+            ++failures;
+    }
+    cudaFree(storage);
+    cudaStreamDestroy(stream);
+    return failures;
+}
+
+} // namespace
+#endif
+
+int main() {
+    int failures =
+        trtmc::test::run_native_kv_contract_tests<trtmc::StablelmTextGenerationPipeline,
+                                                  trtmc::StablelmKvCache,
+                                                  trtmc::StablelmTextGenConfig>("Stablelm");
+#if NV_TENSORRT_MAJOR >= 11
+    failures += test_trt_external_alias();
+#endif
+    return failures;
+}

--- a/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
+++ b/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
@@ -7,7 +7,6 @@
   "runtime_strategy": "stablelm_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
-  "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [
     {

--- a/tests/e2e/models/stablelm/test_stablelm_native_kv_routing.py
+++ b/tests/e2e/models/stablelm/test_stablelm_native_kv_routing.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only contracts for StableLM's TensorRT native KV path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.families.stablelm.build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+    native_kv_cache_geometry,
+    prefer_native_default,
+    resolved_head_dim,
+    resolved_rotary_dim,
+)
+from tensorrt_model_connect.families.stablelm.config import ModelConfig
+from tensorrt_model_connect.families.stablelm.native_kv_contract import (
+    validate_native_kv_weights,
+)
+
+
+def _config(*, raw_updates: dict | None = None, **overrides) -> ModelConfig:
+    values = {
+        "model_type": "stablelm",
+        "architectures": ["StableLmForCausalLM"],
+        "vocab_size": 100352,
+        "hidden_size": 2048,
+        "intermediate_size": 5632,
+        "num_hidden_layers": 24,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 32,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 10000.0,
+        "max_position_embeddings": 4096,
+        "hidden_act": "silu",
+        "tie_word_embeddings": False,
+        "_head_dim": 0,
+    }
+    values.update(overrides)
+    raw = {
+        "_decoder_engine_layout": "split",
+        "max_position_embeddings": values["max_position_embeddings"],
+        "partial_rotary_factor": 0.25,
+        "use_qkv_bias": True,
+    }
+    raw.update(raw_updates or {})
+    values["raw"] = raw
+    return ModelConfig(**values)
+
+
+def test_stablelm_2_1_6b_uses_full_context_native_kv():
+    config = _config()
+
+    architecture = native_kv_architecture_capability(config)
+    build = native_kv_build_capability(config)
+    row_bytes, cache_bytes = native_kv_cache_geometry(config, 4096)
+
+    assert architecture.eligible, architecture.reason
+    assert build.eligible, build.reason
+    assert prefer_native_default(config)
+    assert resolved_head_dim(config) == 64
+    assert resolved_rotary_dim(config) == 16
+    assert row_bytes == 2 * 24 * 32 * 64 * 2
+    assert cache_bytes == 4096 * row_bytes
+
+
+def test_native_graph_uses_update_and_fused_attention_without_concat():
+    family_dir = Path(__file__).resolve().parents[4] / (
+        "python/tensorrt_model_connect/families/stablelm"
+    )
+    builder = (family_dir / "native_decoder_builder.py").read_text()
+    graph_ops = (family_dir / "graph_ops.py").read_text()
+
+    assert "add_native_kv_cache_attention_from_rows" in builder
+    assert "add_kv_cache_update" in graph_ops
+    assert "add_attention_v2" in graph_ops
+    assert "attention.decomposable = False" in graph_ops
+    assert "add_concatenation([cache_" not in builder
+
+
+@pytest.mark.parametrize(
+    ("overrides", "raw_updates", "reason"),
+    [
+        ({"model_type": "stablelm2"}, {}, "model_type"),
+        ({"architectures": ["OtherForCausalLM"]}, {}, "architectures"),
+        ({"hidden_size": 2049}, {}, "divisible"),
+        ({"num_key_value_heads": 8}, {}, "requires MHA"),
+        ({"hidden_act": "gelu"}, {}, "hidden_act"),
+        ({"tie_word_embeddings": True}, {}, "untied"),
+        ({}, {"partial_rotary_factor": 0.5}, "partial_rotary_factor=0.25"),
+        ({}, {"use_qkv_bias": False}, "use_qkv_bias=true"),
+        ({}, {"use_parallel_residual": True}, "sequential residuals"),
+        ({}, {"rope_scaling": {"type": "linear"}}, "unsupported"),
+    ],
+)
+def test_architecture_variants_fail_closed(overrides, raw_updates, reason):
+    decision = native_kv_architecture_capability(_config(raw_updates=raw_updates, **overrides))
+
+    assert decision.applicable
+    assert not decision.eligible
+    assert reason in decision.reason
+    assert not prefer_native_default(_config(raw_updates=raw_updates, **overrides))
+
+
+def test_foreign_model_type_is_not_applicable():
+    decision = native_kv_architecture_capability(_config(model_type="llama"))
+
+    assert not decision.applicable
+    assert not decision.eligible
+
+
+def test_missing_context_limit_does_not_use_the_parser_default():
+    config = _config()
+    config.raw.pop("max_position_embeddings")
+
+    decision = native_kv_architecture_capability(config)
+
+    assert not decision.eligible
+    assert "max_position_embeddings must be explicit" in decision.reason
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "raw_updates", "reason"),
+    [
+        ({"precision": "fp32"}, {}, "FP16"),
+        ({"precision": "bf16"}, {}, "FP16"),
+        ({"max_cache_length": 4095}, {}, "max_cache_length"),
+        ({"parallel_enabled": True}, {}, "tensor parallel"),
+        ({"dynamic_kv_cache": True}, {}, "fixed physical"),
+        ({"quantized": True}, {}, "quantized"),
+        ({"debug_layer_outputs": True}, {}, "debug"),
+        ({}, {"_fp32_layers": ["layer.0"]}, "FP32 layer"),
+        ({}, {"_decoder_engine_layout": "dual_profile"}, "split"),
+        ({}, {"_rtx_build_requested": True}, "standard TensorRT"),
+    ],
+)
+def test_unqualified_build_modes_use_the_legacy_route(kwargs, raw_updates, reason):
+    decision = native_kv_build_capability(
+        _config(raw_updates=raw_updates),
+        **kwargs,
+    )
+
+    assert not decision.eligible
+    assert reason in decision.reason
+
+
+@dataclass
+class _Tensor:
+    shape: tuple[int, ...]
+
+
+def _small_config(*, role: str = "prefill") -> ModelConfig:
+    return _config(
+        vocab_size=32,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        raw_updates={"_decoder_engine_role": role},
+    )
+
+
+def _weights(config: ModelConfig) -> dict[str, object]:
+    hidden = config.hidden_size
+    attention = config.num_attention_heads * resolved_head_dim(config)
+    kv_attention = config.num_key_value_heads * resolved_head_dim(config)
+    mlp = config.intermediate_size
+    weights: dict[str, object] = {
+        "embedding": _Tensor((config.vocab_size, hidden)),
+        "final_norm": _Tensor((hidden,)),
+        "final_norm_beta": _Tensor((hidden,)),
+        "w_out": _Tensor((hidden, config.vocab_size)),
+        "_attention_size": attention,
+        "_kv_attention_size": kv_attention,
+        "_mlp_size": mlp,
+    }
+    for name, shape in (
+        ("input_norm", (hidden,)),
+        ("input_norm_beta", (hidden,)),
+        ("w_q", (hidden, attention)),
+        ("w_k", (hidden, kv_attention)),
+        ("w_v", (hidden, kv_attention)),
+        ("q_bias", (attention,)),
+        ("k_bias", (kv_attention,)),
+        ("v_bias", (kv_attention,)),
+        ("w_o", (attention, hidden)),
+        ("post_attn_norm", (hidden,)),
+        ("post_attn_norm_beta", (hidden,)),
+        ("w_gate", (hidden, mlp)),
+        ("w_up", (hidden, mlp)),
+        ("w_down", (mlp, hidden)),
+    ):
+        weights[f"layer.0.{name}"] = _Tensor(shape)
+    return weights
+
+
+def test_weight_contract_rejects_missing_shape_and_foreign_weights():
+    config = _small_config()
+    weights = _weights(config)
+    validate_native_kv_weights(config, weights)
+
+    missing = dict(weights)
+    missing.pop("layer.0.w_k")
+    with pytest.raises(ValueError, match="missing.*w_k"):
+        validate_native_kv_weights(config, missing)
+
+    wrong_shape = dict(weights)
+    wrong_shape["layer.0.w_q"] = _Tensor((63, 64))
+    with pytest.raises(ValueError, match="must have shape"):
+        validate_native_kv_weights(config, wrong_shape)
+
+    foreign = dict(weights)
+    foreign["layer.0.o_bias"] = _Tensor((64,))
+    with pytest.raises(ValueError, match="unsupported mapped weights"):
+        validate_native_kv_weights(config, foreign)
+
+
+def test_plugin_builds_only_the_requested_native_split_role(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module("tensorrt_model_connect.families.stablelm.plugin")
+    config = _small_config(role="decode")
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"plan"
+
+    monkeypatch.setattr(plugin_module, "build_native_decoder_engine", _build)
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+    )
+
+    assert result == b"plan"
+    assert captured["kwargs"]["profile_mode"] == "decode"
+    assert captured["kwargs"]["precision"] == "fp16"
+    assert plugin_module.plugin.get_bundle_config_overrides(config) == {
+        "native_kv_contract_version": 1,
+        "native_kv_cache": True,
+    }
+
+
+def test_explicit_non_native_options_preserve_the_legacy_builder(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module("tensorrt_model_connect.families.stablelm.plugin")
+    config = _small_config(role="decode")
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(plugin_module, "build_standard_decoder_engine", _build)
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        64,
+        precision="fp16",
+    )
+
+    assert result == b"legacy-plan"
+    assert captured["args"][2] == 64
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None


### PR DESCRIPTION
## Background
StableLM still used the legacy dense-mask KV path and its acceptance manifest pinned cache capacity to 384 tokens. Qwen and Llama already establish the full-context TensorRT native KV contract that this family can reuse without introducing new shared runtime plumbing.

## Exit Criteria
- Route the qualified StableLM-2 decoder to FP16 split prefill/decode engines at its full 4096-token context.
- Update a state-owned cache in place with TensorRT native KV update and fused attention layers.
- Preserve the existing legacy route for unsupported StableLM variants and build modes.
- Match the pinned Hugging Face FP16 reference exactly on the family acceptance case.

## Implementation
- Add a fail-closed StableLM-2 architecture/build capability contract and mapped-weight validation.
- Add a family-owned native builder for LayerNorm, partial RoPE, QKV bias, sequential residuals, and SwiGLU.
- Extend the StableLM runtime with cache/present alias validation, native scalar inputs, chunked prefill, fixed-capacity admission, and legacy compatibility.
- Remove the 384-token manifest override so the qualified model uses max_position_embeddings.

## Validation
- TensorRT-aware routing tests: 27 passed.
- Existing StableLM weight mapping and engine builder regressions: 15 passed.
- C++/GPU native KV contract: 1 passed on NVIDIA GB300 with TensorRT 11.2.0.113.
- Pinned StableLM-2 1.6B build: 4096-token FP16 split bundle; prefill 96.7 s, decode 103.9 s, 217.2 s total.
- Pinned L1 external-reference E2E: 20 of 20 generated tokens exact, token agreement 1.0, normalized edit distance 0.0.

## Notes
This follows the Qwen/Llama fixed physical full-context native KV contract. It does not add runtime-sized cache allocation or accept kv_cache_size_bytes overrides. Native routing is intentionally limited to the qualified StableLmForCausalLM FP16 MHA geometry; quantization, tensor parallelism, sliding windows, scaled RoPE, and other variants retain the legacy path.