### PR TITLE
ci: simplify internal premerge dispatch

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -46,16 +46,12 @@ jobs:
     outputs:
       pr_number: ${{ steps.snapshot.outputs.pr_number }}
       head_sha: ${{ steps.snapshot.outputs.head_sha }}
-      guard_code: ${{ steps.snapshot.outputs.guard_code }}
-      pr_head_sha: ${{ steps.snapshot.outputs.pr_head_sha }}
-      branch_head_sha: ${{ steps.snapshot.outputs.branch_head_sha }}
 
     steps:
       # This trusted workflow reads PR metadata only. It never checks out or
       # executes the pull-request head.
       - name: Capture the exact pull-request head
         id: snapshot
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
@@ -64,19 +60,6 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          head_sha=""
-          branch_sha=""
-          fail_guard() {
-            local code="$1"
-            local message="$2"
-            {
-              echo "guard_code=$code"
-              echo "pr_head_sha=${head_sha:-${EVENT_HEAD_SHA:-}}"
-              echo "branch_head_sha=${branch_sha:-}"
-            } >> "$GITHUB_OUTPUT"
-            echo "::error::$code: $message"
-            exit 1
-          }
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
 
           # The legacy .permission field maps maintain to write. Use
@@ -98,67 +81,24 @@ jobs:
             [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           fi
 
-          max_attempts="${HEAD_SYNC_MAX_ATTEMPTS:-6}"
-          retry_delay="${HEAD_SYNC_RETRY_DELAY_SECONDS:-10}"
-          [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]
-          [[ "$retry_delay" =~ ^[0-9]+$ ]]
-          head_sha=""
-          branch_sha=""
-          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-            pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
-            state="$(jq -er '.state' <<<"$pull")"
-            base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
-            base_ref="$(jq -er '.base.ref' <<<"$pull")"
-            head_sha="$(jq -er '.head.sha' <<<"$pull")"
-            head_repo="$(jq -r '.head.repo.full_name // empty' <<<"$pull")"
-            head_ref="$(jq -r '.head.ref // empty' <<<"$pull")"
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -er '.state' <<<"$pull")"
+          base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
+          base_ref="$(jq -er '.base.ref' <<<"$pull")"
+          head_sha="$(jq -er '.head.sha' <<<"$pull")"
 
-            test "$state" = "open"
-            test "$base_repo" = "$GITHUB_REPOSITORY"
-            test "$base_ref" = "main"
-            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-            if [ -z "$head_repo" ] || [ -z "$head_ref" ]; then
-              fail_guard HEAD_SOURCE_UNAVAILABLE \
-                "PR source repository or branch is unavailable."
-            fi
-            [[ "$head_repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
-            head_ref_uri="$(jq -rn --arg value "$head_ref" '$value | @uri')"
-            if ! branch_sha="$(
-              gh api --method GET \
-                "/repos/$head_repo/branches/$head_ref_uri" \
-                --jq '.commit.sha'
-            )"; then
-              fail_guard HEAD_SOURCE_UNAVAILABLE \
-                "Cannot read source branch $head_repo:$head_ref."
-            fi
-            [[ "$branch_sha" =~ ^[0-9a-f]{40}$ ]]
-            if [ "$head_sha" = "$branch_sha" ]; then
-              break
-            fi
-            if [ "$attempt" -lt "$max_attempts" ]; then
-              sleep "$retry_delay"
-            fi
-          done
+          test "$state" = "open"
+          test "$base_repo" = "$GITHUB_REPOSITORY"
+          test "$base_ref" = "main"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
           if [ "$EVENT_NAME" = "pull_request_target" ] \
             && [ "$head_sha" != "$EVENT_HEAD_SHA" ]; then
-            if [ "$head_sha" = "$branch_sha" ]; then
-              fail_guard TRIGGER_SUPERSEDED \
-                "PR head advanced from trigger $EVENT_HEAD_SHA to $head_sha. Re-add the label for the current head."
-            else
-              fail_guard HEAD_MOVING_OR_STALE \
-                "Trigger $EVENT_HEAD_SHA, PR metadata $head_sha, and source branch $branch_sha do not agree."
-            fi
-          fi
-          if [ "$head_sha" != "$branch_sha" ]; then
-            fail_guard PR_TRACKING_REF_STALE \
-              "PR metadata head $head_sha differs from source branch $branch_sha."
+            echo "::error::The CI trigger was superseded by a newer PR head."
+            exit 1
           fi
           {
-            echo "guard_code=OK"
             echo "pr_number=$PR_NUMBER"
             echo "head_sha=$head_sha"
-            echo "pr_head_sha=$head_sha"
-            echo "branch_head_sha=$branch_sha"
           } >> "$GITHUB_OUTPUT"
 
       - name: Consume the trusted trigger label
@@ -171,144 +111,15 @@ jobs:
           gh api --silent --method DELETE \
             "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
 
-      - name: Enforce trusted head guard
-        if: ${{ always() && steps.snapshot.outcome == 'failure' }}
-        env:
-          GUARD_CODE: ${{ steps.snapshot.outputs.guard_code }}
-        run: |
-          echo "::error::Internal CI authorization failed: ${GUARD_CODE:-UNKNOWN}."
-          exit 1
-
-  report-guard-failure:
-    name: Report pull-request head guard failure
-    needs: authorize
-    if: >-
-      always() &&
-      needs.authorize.result == 'failure' &&
-      needs.authorize.outputs.guard_code != '' &&
-      needs.authorize.outputs.guard_code != 'OK'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      issues: write
-      pull-requests: read
-      statuses: write
-
-    steps:
-      - name: Publish stale-head diagnostic
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.authorize.outputs.pr_number || github.event.pull_request.number || inputs.pr_number }}
-          GUARD_CODE: ${{ needs.authorize.outputs.guard_code }}
-          PR_HEAD_SHA: ${{ needs.authorize.outputs.pr_head_sha }}
-          BRANCH_HEAD_SHA: ${{ needs.authorize.outputs.branch_head_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
-          [[ "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          if [ -n "$BRANCH_HEAD_SHA" ]; then
-            [[ "$BRANCH_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          fi
-
-          case "$GUARD_CODE" in
-            PR_TRACKING_REF_STALE)
-              description="FAIL: stale PR tracking ref"
-              title="PR tracking ref is stale"
-              recovery="Refresh the PR base to main without changing it, wait for the PR head to match the source branch, then add run-internal-ci again."
-              ;;
-            TRIGGER_SUPERSEDED)
-              description="FAIL: CI trigger superseded"
-              title="CI trigger was superseded by a newer push"
-              recovery="Wait for the PR head to match the source branch, then add run-internal-ci again. A base refresh is not normally required."
-              ;;
-            HEAD_MOVING_OR_STALE)
-              description="FAIL: PR head is moving or stale"
-              title="PR head sources do not agree"
-              recovery="Wait for branch activity to settle and retry. If PR metadata remains behind the source branch, refresh the PR base to main."
-              ;;
-            HEAD_SOURCE_UNAVAILABLE)
-              description="FAIL: PR source branch unavailable"
-              title="PR source branch is unavailable"
-              recovery="Restore an accessible source repository and branch, then add run-internal-ci again."
-              ;;
-            *)
-              echo "::error::Unsupported head guard code: $GUARD_CODE"
-              exit 1
-              ;;
-          esac
-
-          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          status_failure=""
-          if ! gh api --silent --method POST \
-              "/repos/$GITHUB_REPOSITORY/statuses/$PR_HEAD_SHA" \
-              -f state=failure \
-              -f context=trtmc/premerge/required \
-              -f description="$description" \
-              -f target_url="$run_url"; then
-            status_failure="The required failure status could not be published; inspect the Source guard run."
-            echo "::error::$status_failure"
-          fi
-
-          marker="<!-- trtmc-pr-head-guard -->"
-          body="$marker
-          **$title**
-
-          - PR metadata: \`$PR_HEAD_SHA\`
-          - Source branch: \`${BRANCH_HEAD_SHA:-unavailable}\`
-          - Guard result: \`$GUARD_CODE\`
-
-          $recovery
-
-          ${status_failure:+$status_failure
-
-          }
-          [Source guard run]($run_url)"
-          comments="$(
-            gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100"
-          )"
-          comment_id="$(
-            jq -r --arg marker "$marker" \
-              '[.[] | select(.body | contains($marker)) | .id][0] // empty' \
-              <<<"$comments"
-          )"
-          if [ -n "$comment_id" ]; then
-            gh api --silent --method PATCH \
-              "/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
-              -f body="$body"
-          else
-            gh api --silent --method POST \
-              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-              -f body="$body"
-          fi
-          if [ -n "$status_failure" ]; then
-            exit 1
-          fi
-
   dispatch:
     name: Internal CI dispatch
     needs: authorize
     runs-on: ubuntu-24.04
     environment: ci-dispatch
     timeout-minutes: 5
-    permissions:
-      statuses: write
+    permissions: {}
 
     steps:
-      - name: Mark the exact source head pending
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          gh api --silent --method POST \
-            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-            -f state=pending \
-            -f context=trtmc/premerge/required \
-            -f description="PENDING: TensorRT-Model-Connect premerge" \
-            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"
-
       - name: Dispatch internal premerge CI
         env:
           # Fine-grained PAT scoped only to the internal CI repository with
@@ -339,18 +150,3 @@ jobs:
           gh api --silent --method POST \
             "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches" \
             --input "$payload"
-
-      - name: Fail closed if dispatch is not accepted
-        if: ${{ failure() }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          gh api --silent --method POST \
-            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-            -f state=failure \
-            -f context=trtmc/premerge/required \
-            -f description="FAIL: TensorRT-Model-Connect premerge dispatch" \
-            -f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -110,106 +110,13 @@ def _internal_ci_snapshot_script() -> str:
     )
 
 
-def _internal_ci_guard_report_script() -> str:
-    workflow = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
-            encoding="utf-8"
-        )
-    )
-    steps = workflow["jobs"]["report-guard-failure"]["steps"]
-    return next(
-        step["run"]
-        for step in steps
-        if step["name"] == "Publish stale-head diagnostic"
-    )
-
-
-def _run_internal_ci_guard_report(
-    tmp_path: Path,
-    *,
-    guard_code: str,
-    pr_head_sha: str,
-    branch_head_sha: str,
-    existing_comment_id: int | None = None,
-    status_available: bool = True,
-) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    _write_fake_jq(fake_bin)
-    fake_log = tmp_path / "gh-calls.jsonl"
-    fake_gh = fake_bin / "gh"
-    fake_gh.write_text(
-        """#!/usr/bin/env python3
-import json
-import os
-import sys
-
-with open(os.environ["FAKE_GH_LOG"], "a", encoding="utf-8") as output:
-    output.write(json.dumps(sys.argv[1:]) + "\\n")
-if any("/statuses/" in argument for argument in sys.argv[1:]):
-    if os.environ["FAKE_STATUS_AVAILABLE"] != "true":
-        raise SystemExit(4)
-if any("/comments?per_page=" in argument for argument in sys.argv[1:]):
-    comment_id = os.environ.get("FAKE_EXISTING_COMMENT_ID", "")
-    if comment_id:
-        print(json.dumps([
-            {
-                "id": int(comment_id),
-                "body": "<!-- trtmc-pr-head-guard -->\\nold diagnostic",
-            }
-        ]))
-    else:
-        print("[]")
-""",
-        encoding="utf-8",
-    )
-    fake_gh.chmod(0o755)
-    environment = os.environ.copy()
-    environment.update(
-        {
-            "BRANCH_HEAD_SHA": branch_head_sha,
-            "FAKE_EXISTING_COMMENT_ID": (
-                "" if existing_comment_id is None else str(existing_comment_id)
-            ),
-            "FAKE_GH_LOG": str(fake_log),
-            "FAKE_STATUS_AVAILABLE": "true" if status_available else "false",
-            "GH_TOKEN": "test-token",
-            "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
-            "GITHUB_RUN_ID": "30612451909",
-            "GITHUB_SERVER_URL": "https://github.com",
-            "GUARD_CODE": guard_code,
-            "PATH": f"{fake_bin}:{environment['PATH']}",
-            "PR_HEAD_SHA": pr_head_sha,
-            "PR_NUMBER": "715",
-        }
-    )
-    result = subprocess.run(
-        ["bash", "-c", _internal_ci_guard_report_script()],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    calls = [
-        json.loads(line)
-        for line in fake_log.read_text(encoding="utf-8").splitlines()
-    ]
-    return result, calls
-
-
 def _run_internal_ci_snapshot(
     tmp_path: Path,
     *,
     event_head_sha: str,
-    pr_head_sha: str | tuple[str, ...],
-    branch_head_sha: str | tuple[str, ...],
-    head_repo: str | None = "NVIDIA/TensorRT-Model-Connect",
-    head_ref: str = "refactor/validation-engine",
+    pr_head_sha: str,
     event_name: str = "pull_request_target",
     actor_role: str = "maintain",
-    max_attempts: int = 1,
-    branch_available: bool = True,
     system_path: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     fake_bin = tmp_path / "bin"
@@ -230,32 +137,7 @@ endpoint = next(
 if "/collaborators/" in endpoint:
     print(os.environ["FAKE_ACTOR_ROLE"])
 elif "/pulls/" in endpoint:
-    pulls = json.loads(os.environ["FAKE_PULL_JSONS"])
-    counter_path = os.environ["FAKE_PULL_COUNTER"]
-    try:
-        index = int(open(counter_path, encoding="utf-8").read())
-    except FileNotFoundError:
-        index = 0
-    with open(counter_path, "w", encoding="utf-8") as counter:
-        counter.write(str(index + 1))
-    print(json.dumps(pulls[min(index, len(pulls) - 1)]))
-elif "/branches/" in endpoint:
-    expected = f"/repos/{os.environ['FAKE_EXPECTED_HEAD_REPO']}/branches/"
-    if expected not in endpoint:
-        print(f"wrong head repository endpoint: {endpoint}", file=sys.stderr)
-        raise SystemExit(3)
-    if os.environ["FAKE_BRANCH_AVAILABLE"] != "true":
-        print("branch not found", file=sys.stderr)
-        raise SystemExit(4)
-    sequence = json.loads(os.environ["FAKE_BRANCH_HEAD_SHAS"])
-    counter_path = os.environ["FAKE_BRANCH_COUNTER"]
-    try:
-        index = int(open(counter_path, encoding="utf-8").read())
-    except FileNotFoundError:
-        index = 0
-    with open(counter_path, "w", encoding="utf-8") as counter:
-        counter.write(str(index + 1))
-    print(sequence[min(index, len(sequence) - 1)])
+    print(os.environ["FAKE_PULL_JSON"])
 else:
     print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
     raise SystemExit(2)
@@ -264,43 +146,25 @@ else:
     )
     fake_gh.chmod(0o755)
     output = tmp_path / "github-output"
-    pr_head_shas = [pr_head_sha] if isinstance(pr_head_sha, str) else list(pr_head_sha)
-    pulls = [
-        {
-            "state": "open",
-            "base": {
-                "ref": "main",
-                "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
-            },
-            "head": {
-                "sha": sha,
-                "ref": head_ref,
-                "repo": None if head_repo is None else {"full_name": head_repo},
-            },
-        }
-        for sha in pr_head_shas
-    ]
+    pull = {
+        "state": "open",
+        "base": {
+            "ref": "main",
+            "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
+        },
+        "head": {"sha": pr_head_sha},
+    }
     environment = os.environ.copy()
-    branch_head_shas = (
-        [branch_head_sha] if isinstance(branch_head_sha, str) else list(branch_head_sha)
-    )
     environment.update(
         {
             "ACTOR": "trusted-maintainer",
             "EVENT_HEAD_SHA": event_head_sha,
             "EVENT_NAME": event_name,
             "FAKE_ACTOR_ROLE": actor_role,
-            "FAKE_BRANCH_COUNTER": str(tmp_path / "branch-counter"),
-            "FAKE_BRANCH_AVAILABLE": "true" if branch_available else "false",
-            "FAKE_BRANCH_HEAD_SHAS": json.dumps(branch_head_shas),
-            "FAKE_EXPECTED_HEAD_REPO": head_repo or "",
-            "FAKE_PULL_COUNTER": str(tmp_path / "pull-counter"),
-            "FAKE_PULL_JSONS": json.dumps(pulls),
+            "FAKE_PULL_JSON": json.dumps(pull),
             "GH_TOKEN": "test-token",
             "GITHUB_OUTPUT": str(output),
             "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
-            "HEAD_SYNC_MAX_ATTEMPTS": str(max_attempts),
-            "HEAD_SYNC_RETRY_DELAY_SECONDS": "0",
             "PATH": f"{fake_bin}:{system_path or environment['PATH']}",
             "PR_NUMBER": "715",
         }
@@ -367,18 +231,12 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
         REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"
     ).read_text(encoding="utf-8")
     authorize = workflow.split("\n  authorize:", maxsplit=1)[1].split(
-        "\n  report-guard-failure:", maxsplit=1
-    )[0]
-    report = workflow.split("\n  report-guard-failure:", maxsplit=1)[1].split(
         "\n  dispatch:", maxsplit=1
     )[0]
     dispatch = workflow.split("\n  dispatch:", maxsplit=1)[1]
     authorize_permissions = authorize.split(
         "    permissions:", maxsplit=1
     )[1].split("\n    outputs:", maxsplit=1)[0]
-    report_permissions = report.split("    permissions:", maxsplit=1)[1].split(
-        "\n\n", maxsplit=1
-    )[0]
     dispatch_permissions = dispatch.split("    permissions:", maxsplit=1)[1].split(
         "\n\n", maxsplit=1
     )[0]
@@ -395,10 +253,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "github.ref == 'refs/heads/main'" in workflow
     assert "permissions: {}" in workflow
     assert authorize_permissions.strip() == "contents: read\n      pull-requests: write"
-    assert report_permissions.strip() == (
-        "issues: write\n      pull-requests: read\n      statuses: write"
-    )
-    assert dispatch_permissions.strip() == "statuses: write"
+    assert dispatch_permissions.strip() == "{}"
 
     assert "collaborators/$ACTOR/permission" in authorize
     assert "--jq '.role_name'" in authorize
@@ -414,11 +269,9 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert 'test "$base_repo" = "$GITHUB_REPOSITORY"' in authorize
     assert 'test "$base_ref" = "main"' in authorize
     assert 'if [ "$EVENT_NAME" = "pull_request_target" ]; then' in authorize
-    assert '"/repos/$head_repo/branches/$head_ref_uri"' in authorize
-    assert "PR_TRACKING_REF_STALE" in authorize
-    assert "TRIGGER_SUPERSEDED" in authorize
-    assert "HEAD_MOVING_OR_STALE" in authorize
-    assert "HEAD_SOURCE_UNAVAILABLE" in authorize
+    assert '"/repos/$head_repo/branches/$head_ref_uri"' not in authorize
+    assert "head_repo" not in authorize
+    assert "head_ref" not in authorize
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert 'echo "head_sha=$head_sha"' in authorize
     assert "pr_number=$PR_NUMBER" in authorize
@@ -435,13 +288,6 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     ) in authorize
     assert "gh api --silent --method DELETE" in authorize
     assert "always() && github.event_name == 'pull_request_target'" in authorize
-
-    assert "needs: authorize" in report
-    assert "needs.authorize.result == 'failure'" in report
-    assert "/statuses/$PR_HEAD_SHA" in report
-    assert "/issues/$PR_NUMBER/comments" in report
-    assert "<!-- trtmc-pr-head-guard -->" in report
-    assert "secrets." not in report
 
     assert "needs: authorize" in dispatch
     assert "environment: ci-dispatch" in dispatch
@@ -462,6 +308,9 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "private_ci_bridge.py" not in workflow
     assert "self-hosted" not in workflow
     assert "secrets: inherit" not in workflow
+    assert "report-guard-failure" not in workflow
+    assert "/statuses/" not in workflow
+    assert "/comments" not in workflow
     assert (
         "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/"
         "actions/workflows/premerge.yml/dispatches"
@@ -472,49 +321,17 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert 'echo "$PRIVATE_CI_' not in dispatch
     assert "GITHUB_STEP_SUMMARY" not in dispatch
 
-    assert (
-        dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") == 3
-    )
-    assert "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" in dispatch
-    assert "/repos/$GITHUB_REPOSITORY/statuses/$MERGE_SHA" not in dispatch
-    assert "-f state=pending" in dispatch
-    assert "-f state=failure" in dispatch
-    assert dispatch.count("-f context=trtmc/premerge/required") == 2
-    assert '-f description="PENDING: TensorRT-Model-Connect premerge"' in dispatch
-    assert (
-        '-f description="FAIL: TensorRT-Model-Connect premerge dispatch"'
-    ) in dispatch
-    assert dispatch.count(
-        '-f target_url="https://github.com/$GITHUB_REPOSITORY/tree/$HEAD_SHA/tests"'
-    ) == 2
-    assert dispatch.index("/statuses/$HEAD_SHA") < dispatch.index(
-        "actions/workflows/premerge.yml/dispatches"
-    )
+    assert dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") == 1
 
     assert 'ref: "main"' in dispatch
     for name in ("pr_number", "head_sha"):
         assert f"{name}: ${name}" in dispatch
     assert "umask 077" in dispatch
     assert 'trap \'rm -f "$payload"\' EXIT' in dispatch
-    assert 'if: ${{ failure() }}' in dispatch
+    assert 'if: ${{ failure() }}' not in dispatch
 
 
-def test_internal_ci_guard_rejects_stale_pr_tracking_head(tmp_path: Path) -> None:
-    old_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    branch_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result = _run_internal_ci_snapshot(
-        tmp_path,
-        event_head_sha=old_head,
-        pr_head_sha=old_head,
-        branch_head_sha=branch_head,
-    )
-
-    assert result.returncode != 0
-    assert "PR_TRACKING_REF_STALE" in result.stdout + result.stderr
-
-
-def test_internal_ci_guard_classifies_a_new_push_after_label(
+def test_internal_ci_bridge_rejects_a_new_push_after_label(
     tmp_path: Path,
 ) -> None:
     event_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
@@ -524,52 +341,13 @@ def test_internal_ci_guard_classifies_a_new_push_after_label(
         tmp_path,
         event_head_sha=event_head,
         pr_head_sha=current_head,
-        branch_head_sha=current_head,
     )
 
     assert result.returncode != 0
-    assert "TRIGGER_SUPERSEDED" in result.stdout + result.stderr
-    assert "PR_TRACKING_REF_STALE" not in result.stdout + result.stderr
+    assert "superseded by a newer PR head" in result.stdout + result.stderr
 
 
-def test_internal_ci_guard_rereads_pr_metadata_while_waiting_for_sync(
-    tmp_path: Path,
-) -> None:
-    event_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    current_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result = _run_internal_ci_snapshot(
-        tmp_path,
-        event_head_sha=event_head,
-        pr_head_sha=(event_head, current_head),
-        branch_head_sha=(current_head, current_head),
-        max_attempts=2,
-    )
-
-    assert result.returncode != 0
-    assert "TRIGGER_SUPERSEDED" in result.stdout + result.stderr
-    assert "PR_TRACKING_REF_STALE" not in result.stdout + result.stderr
-
-
-def test_internal_ci_guard_classifies_three_disagreeing_heads(
-    tmp_path: Path,
-) -> None:
-    event_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    pr_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-    branch_head = "e76caa69b5b0a70e6db6096f1952ba6429cb32cc"
-
-    result = _run_internal_ci_snapshot(
-        tmp_path,
-        event_head_sha=event_head,
-        pr_head_sha=pr_head,
-        branch_head_sha=branch_head,
-    )
-
-    assert result.returncode != 0
-    assert "HEAD_MOVING_OR_STALE" in result.stdout + result.stderr
-
-
-def test_internal_ci_guard_reports_an_unavailable_head_repository(
+def test_internal_ci_bridge_uses_upstream_pr_metadata_without_fork_access(
     tmp_path: Path,
 ) -> None:
     head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
@@ -578,32 +356,12 @@ def test_internal_ci_guard_reports_an_unavailable_head_repository(
         tmp_path,
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
-        head_repo=None,
-    )
-
-    assert result.returncode != 0
-    assert "HEAD_SOURCE_UNAVAILABLE" in result.stdout + result.stderr
-
-
-def test_internal_ci_guard_accepts_an_accessible_fork_branch(
-    tmp_path: Path,
-) -> None:
-    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result = _run_internal_ci_snapshot(
-        tmp_path,
-        event_head_sha=head_sha,
-        pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
-        head_repo="external-contributor/TensorRT-Model-Connect",
-        head_ref="feature/validation-fix",
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_internal_ci_guard_only_allows_maintainers_and_admins(
+def test_internal_ci_bridge_only_allows_maintainers_and_admins(
     tmp_path: Path,
 ) -> None:
     head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
@@ -615,7 +373,6 @@ def test_internal_ci_guard_only_allows_maintainers_and_admins(
             run_dir,
             event_head_sha=head_sha,
             pr_head_sha=head_sha,
-            branch_head_sha=head_sha,
             actor_role=permission,
         )
         assert result.returncode == 0, result.stdout + result.stderr
@@ -626,32 +383,13 @@ def test_internal_ci_guard_only_allows_maintainers_and_admins(
         write_dir,
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
         actor_role="write",
     )
     assert result.returncode != 0
     assert "Only actors with maintain or admin access" in result.stdout + result.stderr
 
 
-def test_internal_ci_guard_reports_an_inaccessible_fork_branch(
-    tmp_path: Path,
-) -> None:
-    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result = _run_internal_ci_snapshot(
-        tmp_path,
-        event_head_sha=head_sha,
-        pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
-        head_repo="external-contributor/TensorRT-Model-Connect",
-        branch_available=False,
-    )
-
-    assert result.returncode != 0
-    assert "HEAD_SOURCE_UNAVAILABLE" in result.stdout + result.stderr
-
-
-def test_internal_ci_guard_protects_manual_dispatch_without_event_head(
+def test_internal_ci_bridge_protects_manual_dispatch_without_event_head(
     tmp_path: Path,
 ) -> None:
     head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
@@ -660,14 +398,13 @@ def test_internal_ci_guard_protects_manual_dispatch_without_event_head(
         tmp_path,
         event_head_sha="",
         pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
         event_name="workflow_dispatch",
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_internal_ci_guard_tests_do_not_depend_on_host_jq(tmp_path: Path) -> None:
+def test_internal_ci_bridge_tests_do_not_depend_on_host_jq(tmp_path: Path) -> None:
     head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
     tool_bin = tmp_path / "system-bin"
     tool_bin.mkdir()
@@ -679,14 +416,13 @@ def test_internal_ci_guard_tests_do_not_depend_on_host_jq(tmp_path: Path) -> Non
         tmp_path,
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
-        branch_head_sha=head_sha,
         system_path=str(tool_bin),
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_internal_ci_trigger_label_is_consumed_after_guard_failure() -> None:
+def test_internal_ci_trigger_label_is_always_consumed() -> None:
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
             encoding="utf-8"
@@ -702,72 +438,6 @@ def test_internal_ci_trigger_label_is_consumed_after_guard_failure() -> None:
         "${{ always() && github.event_name == 'pull_request_target' }}"
     )
     assert step["env"]["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
-
-
-def test_internal_ci_guard_failure_is_visible_on_the_pull_request(
-    tmp_path: Path,
-) -> None:
-    pr_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    branch_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result, calls = _run_internal_ci_guard_report(
-        tmp_path,
-        guard_code="PR_TRACKING_REF_STALE",
-        pr_head_sha=pr_head,
-        branch_head_sha=branch_head,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    serialized = json.dumps(calls)
-    assert f"/statuses/{pr_head}" in serialized
-    assert "trtmc/premerge/required" in serialized
-    assert "FAIL: stale PR tracking ref" in serialized
-    assert f"PR metadata: `{pr_head}`" in serialized
-    assert f"Source branch: `{branch_head}`" in serialized
-    assert "Refresh the PR base" in serialized
-    assert "/issues/715/comments" in serialized
-    assert re.search(r"NVIDIA-[A-Za-z0-9-]+", serialized) is None
-
-
-def test_internal_ci_guard_updates_its_existing_diagnostic_comment(
-    tmp_path: Path,
-) -> None:
-    pr_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    branch_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result, calls = _run_internal_ci_guard_report(
-        tmp_path,
-        guard_code="PR_TRACKING_REF_STALE",
-        pr_head_sha=pr_head,
-        branch_head_sha=branch_head,
-        existing_comment_id=123456,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    serialized = json.dumps(calls)
-    assert "/issues/comments/123456" in serialized
-    assert "--method\", \"PATCH" in serialized
-    assert not any(
-        "/issues/715/comments" in " ".join(call) and "POST" in call for call in calls
-    )
-
-
-def test_internal_ci_guard_comments_even_when_failure_status_cannot_be_posted(
-    tmp_path: Path,
-) -> None:
-    pr_head = "f7b48712c82318ded4e41c0dd7003379e1790198"
-    branch_head = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
-
-    result, calls = _run_internal_ci_guard_report(
-        tmp_path,
-        guard_code="PR_TRACKING_REF_STALE",
-        pr_head_sha=pr_head,
-        branch_head_sha=branch_head,
-        status_available=False,
-    )
-
-    assert result.returncode != 0
-    assert "/issues/715/comments" in json.dumps(calls)
 
 
 def test_ci_orchestration_uses_the_class_based_python_entrypoint() -> None:


### PR DESCRIPTION
## Background
The public Internal CI bridge currently verifies contributor fork branches and publishes guard diagnostics and statuses itself. That requires access to repositories outside the Source repository and gives the public bridge responsibilities beyond trusted dispatch.

## Exit Criteria
- The Source workflow authorizes only maintainers or admins and captures the current open PR head targeting `main`.
- The Source workflow never checks out PR code, queries contributor forks, publishes CI statuses, or posts diagnostic comments.
- The private workflow dispatch still receives the PR number and approved PR head SHA.

## Implementation
- Read the current PR head from the upstream pull request metadata and reject a label event superseded by a newer head.
- Keep one-shot label consumption and the protected private workflow dispatch.
- Remove fork branch synchronization, public guard reporting, and public status publication from the Source bridge.
- Simplify the bridge contract tests to enforce this narrow boundary.

## Validation
- `python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_model_ci.py tests/tools/test_test_impact.py -q`: passed, 393 tests.
- Parsed every workflow YAML file and ran `bash -n` over every `run` block: passed.
- `git diff --check`: passed.

## Notes For Future Readers
- Merge NVIDIA-dev/TensorRT-Model-Connect-CI#28 before this bridge simplification so dispatched runs test the pinned PR merge snapshot.
- The required status remains generic and is published by trusted private CI to the approved PR head.
