### PR TITLE
test(ci): validate fork multi-commit snapshot [do not merge]

### DIFF
--- a/website/docs/context/ci-smoke-fork-multicommit-a.md
+++ b/website/docs/context/ci-smoke-fork-multicommit-a.md
@@ -1,0 +1,8 @@
+---
+title: CI Smoke Probe - Fork Multi Commit A
+---
+
+This is the first commit marker for the temporary multi-commit pull-request
+probe.
+
+Probe: `fork-multicommit-a-140f71c`.

--- a/website/docs/context/ci-smoke-fork-multicommit-b.md
+++ b/website/docs/context/ci-smoke-fork-multicommit-b.md
@@ -1,0 +1,8 @@
+---
+title: CI Smoke Probe - Fork Multi Commit B
+---
+
+This is the second commit marker for the temporary multi-commit pull-request
+probe.
+
+Probe: `fork-multicommit-b-140f71c`.


### PR DESCRIPTION
## Background

Temporary CI smoke probe for a multi-commit maintainer fork PR. **Do not merge.**

## Exit Criteria

- CI pins a merge snapshot containing both commits.
- The required premerge status completes without direct access to the fork.

## Implementation

- Add two isolated documentation markers in two separate commits.
- Keep both files independent from the other parallel probes.

## Validation

- `python3 tools/model_ci.py impact --base 140f71cde3849405ad51e040d1c03dc1a7f08ce4 --head HEAD`: passed with both files, `mode=none`, zero models, and no unit tests.
- Commit-count and merge-base assertions passed: two commits on exact base `140f71cde3849405ad51e040d1c03dc1a7f08ce4`.
- `git diff --check 140f71cde3849405ad51e040d1c03dc1a7f08ce4..HEAD`: passed.

## Notes For Future Readers

- This PR is test infrastructure evidence only. Close it after the experiment; do not merge it.
