### PR TITLE
fix(deps): upgrade Transformers runtime to 5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN pip install "apache-tvm-ffi==0.1.12"
 
 # Core Python deps
 RUN pip install \
-    "transformers==5.2.0" \
+    "transformers==5.5.0" \
     tokenizers \
     safetensors \
     sentencepiece \
@@ -122,8 +122,8 @@ RUN pip install "open-clip-torch>=2.20"
 
 # NeMo currently declares transformers~=4.57; force the runtime pin we need.
 RUN pip install "nemo_toolkit[tts]==2.7.0" && \
-    pip install --upgrade "transformers==5.2.0" && \
-    python3 -c "import transformers; assert transformers.__version__ == '5.2.0', transformers.__version__" && \
+    pip install --upgrade "transformers==5.5.0" && \
+    python3 -c "import transformers; assert transformers.__version__ == '5.5.0', transformers.__version__" && \
     python3 -c "import diffusers, ftfy; print('deps_ok', diffusers.__version__)"
 
 # Upgrade NeMo to a main-branch SHA that ships

--- a/python/tensorrt_model_connect/families/locateanything/transformers_compat.py
+++ b/python/tensorrt_model_connect/families/locateanything/transformers_compat.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transformers compatibility for the pinned LocateAnything remote code."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+
+_ATTENTION_METHOD = "_check_and_adjust_attn_implementation"
+
+
+def install_remote_attention_compat(model_class: type[Any]) -> int:
+    """Accept the Transformers 5.5 attention keyword in pinned remote classes.
+
+    The pinned LocateAnything overrides predate ``allow_all_kernels``.  Keep
+    their original behavior, including the conservative default for remote
+    kernels, while accepting the new optional keyword passed by Transformers.
+    """
+    module = sys.modules.get(model_class.__module__)
+    if module is None:
+        raise RuntimeError(f"LocateAnything remote module {model_class.__module__!r} is not loaded")
+
+    remote_package = model_class.__module__.rsplit(".", 1)[0]
+    roots = (
+        model_class,
+        getattr(module, "Qwen2ForCausalLM", None),
+        getattr(module, "Qwen3ForCausalLM", None),
+    )
+    patched = 0
+    seen: set[type[Any]] = set()
+    for root in roots:
+        if not isinstance(root, type):
+            continue
+        for candidate in root.__mro__:
+            if candidate in seen or not candidate.__module__.startswith(remote_package):
+                continue
+            seen.add(candidate)
+            original = candidate.__dict__.get(_ATTENTION_METHOD)
+            if original is None or getattr(original, "_trtmc_transformers_55", False):
+                continue
+            setattr(candidate, _ATTENTION_METHOD, _accept_allow_all_kernels(original))
+            patched += 1
+    return patched
+
+
+def _accept_allow_all_kernels(original: Callable[..., Any]) -> Callable[..., Any]:
+    def compatible(
+        self: Any,
+        attn_implementation: str | None,
+        is_init_check: bool = False,
+        allow_all_kernels: bool = False,
+    ) -> str:
+        # The pinned implementation cannot opt into unverified kernels.  Ignore
+        # the new opt-in instead of broadening its existing security behavior.
+        del allow_all_kernels
+        return original(self, attn_implementation, is_init_check)
+
+    compatible._trtmc_transformers_55 = True  # type: ignore[attr-defined]
+    return compatible

--- a/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-transformers==5.2.0
+transformers==5.5.0
 rouge-score==0.1.2
 sacrebleu==2.5.1

--- a/python/tensorrt_model_connect/python_profiles.toml
+++ b/python/tensorrt_model_connect/python_profiles.toml
@@ -13,7 +13,7 @@ system_site_packages = true
 verification_script = """
 from importlib.metadata import version
 import transformers
-assert transformers.__version__ == "5.2.0", transformers.__version__
+assert transformers.__version__ == "5.5.0", transformers.__version__
 assert version("rouge-score") == "0.1.2"
 assert version("sacrebleu") == "2.5.1"
 """

--- a/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
+++ b/tests/e2e/models/internlm/test_internlm_tokenizer_json.py
@@ -40,6 +40,8 @@ def _install_fake_hub(
 
 
 class _InternLMTokenizerPlugin:
+    tokenizer_json_conversion_policy = "family_first"
+
     @staticmethod
     def ensure_tokenizer_json(model_dir, *, previous_error=None):
         return tokenizer_json.ensure_tokenizer_json(

--- a/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
@@ -893,10 +893,14 @@ class HfTransformersReference:
             from pathlib import Path
 
             import torch
+            from tensorrt_model_connect.families.locateanything.transformers_compat import (
+                install_remote_attention_compat,
+            )
             from tensorrt_model_connect.families.locateanything.vl_debug_runner import (
                 preprocess_image_inputs_for_trt,
             )
             from transformers import AutoConfig, AutoModel, AutoTokenizer, PretrainedConfig
+            from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
             if torch.cuda.is_available():
                 # Avoid Thor PyTorch/cuDNN sublibrary mismatches in HF reference conv2d.
@@ -1120,6 +1124,9 @@ class HfTransformersReference:
             _install_tied_weight_compat()
             config = _load_locateanything_config(model_ref)
             tokenizer = _load_locateanything_tokenizer(model_ref)
+            remote_model_class = get_class_from_dynamic_module(
+                config.auto_map["AutoModel"], model_ref, local_files_only=True)
+            install_remote_attention_compat(remote_model_class)
             model = AutoModel.from_pretrained(
                 model_ref, config=config, trust_remote_code=trust_remote_code,
                 torch_dtype={torch_dtype_expr})

--- a/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
+++ b/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
@@ -6,9 +6,14 @@
 from __future__ import annotations
 
 import subprocess
+import sys
+import types
 
 import huggingface_hub
 
+from tensorrt_model_connect.families.locateanything.transformers_compat import (
+    install_remote_attention_compat,
+)
 from tests.e2e.models.locateanything.e2e_plugins.references import (
     hf_transformers as locateanything_hf_transformers,
 )
@@ -93,6 +98,8 @@ def test_vl_reference_uses_manual_processor(monkeypatch, tmp_path) -> None:
     assert "DynamicCache.from_legacy_cache" in script
     assert "get_expanded_tied_weights_keys" in script
     assert "model.embed_tokens.weight" in script
+    assert "get_class_from_dynamic_module" in script
+    assert "install_remote_attention_compat" in script
     assert "torch.backends.cudnn.enabled = False" in script
     assert "def _load_locateanything_config" in script
     assert "def _load_locateanything_raw_config" in script
@@ -116,3 +123,64 @@ def test_vl_reference_uses_manual_processor(monkeypatch, tmp_path) -> None:
     assert out.text == "found"
     assert out.metadata["reference_variant"] == "locateanything_manual_processor"
     assert out.logits is None
+
+
+def test_remote_attention_compat_accepts_transformers_55_keyword(monkeypatch) -> None:
+    calls: list[tuple[str | None, bool, bool]] = []
+
+    class NativePreTrainedModel:
+        def _check_and_adjust_attn_implementation(
+            self,
+            attn_implementation,
+            is_init_check=False,
+            allow_all_kernels=False,
+        ):
+            calls.append((attn_implementation, is_init_check, allow_all_kernels))
+            return attn_implementation
+
+    class LocateAnythingPreTrainedModel(NativePreTrainedModel):
+        def _check_and_adjust_attn_implementation(self, attn_implementation, is_init_check=False):
+            if attn_implementation == "magi":
+                return "magi"
+            return super()._check_and_adjust_attn_implementation(attn_implementation, is_init_check)
+
+    class LocateAnythingForConditionalGeneration(LocateAnythingPreTrainedModel):
+        pass
+
+    class Qwen2PreTrainedModel(NativePreTrainedModel):
+        def _check_and_adjust_attn_implementation(self, attn_implementation, is_init_check=False):
+            return super()._check_and_adjust_attn_implementation(attn_implementation, is_init_check)
+
+    class Qwen2ForCausalLM(Qwen2PreTrainedModel):
+        pass
+
+    module_name = "transformers_modules.test_locateanything.modeling_locateanything"
+    for remote_class in (
+        LocateAnythingPreTrainedModel,
+        LocateAnythingForConditionalGeneration,
+        Qwen2PreTrainedModel,
+        Qwen2ForCausalLM,
+    ):
+        remote_class.__module__ = module_name
+    remote_module = types.ModuleType(module_name)
+    remote_module.Qwen2ForCausalLM = Qwen2ForCausalLM
+    monkeypatch.setitem(sys.modules, module_name, remote_module)
+
+    assert install_remote_attention_compat(LocateAnythingForConditionalGeneration) == 2
+    assert (
+        LocateAnythingForConditionalGeneration()._check_and_adjust_attn_implementation(
+            "sdpa", is_init_check=True, allow_all_kernels=True
+        )
+        == "sdpa"
+    )
+    assert (
+        Qwen2ForCausalLM()._check_and_adjust_attn_implementation("eager", allow_all_kernels=True)
+        == "eager"
+    )
+    assert (
+        LocateAnythingForConditionalGeneration()._check_and_adjust_attn_implementation(
+            "magi", allow_all_kernels=True
+        )
+        == "magi"
+    )
+    assert calls == [("sdpa", True, False), ("eager", False, False)]

--- a/tests/e2e/models/minimax_h3/hf_reference.py
+++ b/tests/e2e/models/minimax_h3/hf_reference.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from types import MethodType
 
 import numpy as np
 import torch
@@ -32,13 +31,13 @@ from tensorrt_model_connect.families.minimax_h3.provenance import (
 
 DIFFUSERS_REVISION = "abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc"
 TRANSFORMERS_COMPAT_REVISION = "bed02e1faee69e866e382f835b4f7b0a3c7b8431"
-BASE_TRANSFORMERS_VERSION = "5.2.0"
+BASE_TRANSFORMERS_VERSION = "5.5.0"
 BASE_TRANSFORMERS_ENTRYPOINT = Path(
     "/opt/venv/lib/python3.12/site-packages/transformers/__init__.py"
 )
 BASE_TRANSFORMERS_ENTRYPOINT_RECORD = {
-    "bytes": 38424,
-    "sha256": "91b2c544c6848f4ce8213c770aaa705ce682ee656c995f4ce58352c4b7368ee7",
+    "bytes": 40505,
+    "sha256": "460fadeb41958b1b47d7df8769b5f0ca3f46554ab733f52cf03a2b92d55d899a",
 }
 EXPECTED_NUM_FRAMES = 124
 
@@ -152,7 +151,7 @@ def qualified_transformers_source(entrypoint: Path, version: str) -> dict:
     if entrypoint_record != BASE_TRANSFORMERS_ENTRYPOINT_RECORD:
         raise ValueError("MiniMax-H3 immutable base Transformers entrypoint mismatch")
     return {
-        "qualification": "immutable_base_5_2_plus_local_shim",
+        "qualification": "immutable_base_5_5_with_native_processor_helper",
         "version": version,
         "entrypoint": str(entrypoint),
         "entrypoint_record": entrypoint_record,
@@ -177,6 +176,26 @@ def create_mm_token_type_ids(processor, input_ids):
     return result
 
 
+def _processor_compat_probe(processor) -> list[list[int]]:
+    token_ids = set()
+    for name in ("image", "video", "audio"):
+        for attribute in (f"{name}_token_ids", f"{name}_ids"):
+            values = getattr(processor, attribute, None)
+            if values is None:
+                continue
+            if not isinstance(values, (list, tuple, np.ndarray)):
+                values = [values]
+            token_ids.update(int(value) for value in values if value is not None)
+        value = getattr(processor, f"{name}_token_id", None)
+        if value is not None:
+            token_ids.add(int(value))
+
+    neutral_id = 0
+    while neutral_id in token_ids:
+        neutral_id += 1
+    return [[neutral_id, *sorted(token_ids)]]
+
+
 def _processor_method_identity(processor) -> tuple[object, object]:
     method = getattr(processor, "create_mm_token_type_ids", None)
     if not callable(method):
@@ -186,17 +205,17 @@ def _processor_method_identity(processor) -> tuple[object, object]:
 
 def prepare_processor_compat(processor, transformers_source: dict) -> tuple[str | None, tuple]:
     qualification = transformers_source.get("qualification")
-    if qualification == "immutable_base_5_2_plus_local_shim":
-        if hasattr(processor, "create_mm_token_type_ids"):
-            raise ValueError(
-                "MiniMax-H3 immutable Transformers base unexpectedly provides "
-                "create_mm_token_type_ids"
-            )
-        processor.create_mm_token_type_ids = MethodType(create_mm_token_type_ids, processor)
+    if qualification == "immutable_base_5_5_with_native_processor_helper":
         identity = _processor_method_identity(processor)
-        if identity != (processor, create_mm_token_type_ids):
-            raise ValueError("MiniMax-H3 could not bind its local processor compatibility helper")
-        return "local-create-mm-token-type-ids-for-transformers-5.2.0", identity
+        probe = _processor_compat_probe(processor)
+        native_result = processor.create_mm_token_type_ids(probe)
+        local_result = create_mm_token_type_ids(processor, probe)
+        if native_result != local_result:
+            raise ValueError(
+                "MiniMax-H3 native create_mm_token_type_ids is not semantically "
+                "equivalent to the local compatibility helper"
+            )
+        return "native-create-mm-token-type-ids-for-transformers-5.5.0", identity
     if qualification != "clean_git_checkout":
         raise ValueError("MiniMax-H3 Transformers source has an unknown qualification")
     return None, _processor_method_identity(processor)

--- a/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
+++ b/tests/e2e/models/minimax_h3/test_minimax_h3_reference_source.py
@@ -9,7 +9,7 @@ import importlib
 import json
 import subprocess
 from pathlib import Path
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -334,46 +334,78 @@ def test_transformers_base_qualification_is_exact_and_honest(
 ) -> None:
     entrypoint = tmp_path / "immutable" / "transformers" / "__init__.py"
     entrypoint.parent.mkdir(parents=True)
-    entrypoint.write_text('__version__ = "5.2.0"\n', encoding="utf-8")
+    entrypoint.write_text('__version__ = "5.5.0"\n', encoding="utf-8")
     monkeypatch.setattr(hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT", entrypoint)
     monkeypatch.setattr(
         hf_reference, "BASE_TRANSFORMERS_ENTRYPOINT_RECORD", file_record(entrypoint)
     )
 
-    record = hf_reference.qualified_transformers_source(entrypoint, "5.2.0")
+    record = hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
 
     assert record == {
-        "qualification": "immutable_base_5_2_plus_local_shim",
-        "version": "5.2.0",
+        "qualification": "immutable_base_5_5_with_native_processor_helper",
+        "version": "5.5.0",
         "entrypoint": str(entrypoint),
         "entrypoint_record": file_record(entrypoint),
     }
     assert "revision" not in record
     with pytest.raises(ValueError, match="version mismatch"):
-        hf_reference.qualified_transformers_source(entrypoint, "5.2.1")
+        hf_reference.qualified_transformers_source(entrypoint, "5.5.1")
 
-    entrypoint.write_text('__version__ = "5.2.x"\n', encoding="utf-8")
+    entrypoint.write_text('__version__ = "5.5.x"\n', encoding="utf-8")
     with pytest.raises(ValueError, match="entrypoint mismatch"):
-        hf_reference.qualified_transformers_source(entrypoint, "5.2.0")
+        hf_reference.qualified_transformers_source(entrypoint, "5.5.0")
 
 
-def test_local_processor_compat_is_bound_and_stable() -> None:
+def _native_create_mm_token_type_ids(processor, input_ids):
+    result = []
+    for tokenizer_input in input_ids:
+        tokenizer_input = np.asarray(tokenizer_input)
+        token_types = np.zeros_like(tokenizer_input)
+        token_types[np.isin(tokenizer_input, processor.image_ids)] = 1
+        token_types[np.isin(tokenizer_input, processor.video_ids)] = 2
+        token_types[np.isin(tokenizer_input, processor.audio_ids)] = 3
+        result.append(token_types.tolist())
+    return result
+
+
+def _processor_with_native_helper() -> SimpleNamespace:
     processor = SimpleNamespace(
         image_token_ids=[10, 11],
         video_token_id=20,
         audio_token_ids=[30],
+        image_ids=[10, 11],
+        video_ids=[20],
+        audio_ids=[30],
     )
-    source = {"qualification": "immutable_base_5_2_plus_local_shim"}
+    processor.create_mm_token_type_ids = MethodType(_native_create_mm_token_type_ids, processor)
+    return processor
+
+
+def test_native_processor_compat_is_equivalent_and_stable() -> None:
+    processor = _processor_with_native_helper()
+    source = {"qualification": "immutable_base_5_5_with_native_processor_helper"}
 
     label, identity = hf_reference.prepare_processor_compat(processor, source)
 
-    assert label == "local-create-mm-token-type-ids-for-transformers-5.2.0"
+    assert label == "native-create-mm-token-type-ids-for-transformers-5.5.0"
     assert processor.create_mm_token_type_ids([[0, 10, 20, 30, 11]]) == [[0, 1, 2, 3, 1]]
     hf_reference.validate_processor_method_unchanged(processor, identity)
 
     processor.create_mm_token_type_ids = lambda _inputs: []
     with pytest.raises(ValueError, match="changed during the run"):
         hf_reference.validate_processor_method_unchanged(processor, identity)
+
+
+def test_native_processor_compat_rejects_semantic_drift() -> None:
+    processor = _processor_with_native_helper()
+    processor.image_ids = [12]
+
+    with pytest.raises(ValueError, match="not semantically equivalent"):
+        hf_reference.prepare_processor_compat(
+            processor,
+            {"qualification": "immutable_base_5_5_with_native_processor_helper"},
+        )
 
 
 def test_git_transformers_requires_its_own_processor_helper() -> None:

--- a/tests/tools/test_diff_vl.py
+++ b/tests/tools/test_diff_vl.py
@@ -11,7 +11,11 @@ Postconditions: Family-owned handlers are discovered and cosine similarity match
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import numpy as np
+import pytest
 
 
 class TestFamilyHandlerDispatch:
@@ -23,6 +27,49 @@ class TestFamilyHandlerDispatch:
         mod = importlib.import_module("diff_vl")
         assert mod._find_family_diff_vl_handler("example_decoder") is None
         assert mod._find_family_diff_vl_handler("generic_text") is None
+
+
+class TestAutoVisionModelClass:
+    """Test Transformers 5.5 model class selection and legacy fallback."""
+
+    def test_prefers_current_image_text_api(self, monkeypatch):
+        import diff_vl
+
+        transformers = ModuleType("transformers")
+        current_class = object()
+        transformers.AutoModelForImageTextToText = current_class
+        transformers.AutoModelForVision2Seq = object()
+        monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+        assert diff_vl._get_auto_vision_model_class() is current_class
+
+    def test_falls_back_when_current_api_is_unavailable(self, monkeypatch):
+        import diff_vl
+
+        transformers = ModuleType("transformers")
+        legacy_class = object()
+        transformers.AutoModelForVision2Seq = legacy_class
+        monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+        assert diff_vl._get_auto_vision_model_class() is legacy_class
+
+    def test_does_not_mask_current_api_import_errors(self, monkeypatch):
+        import diff_vl
+
+        class BrokenTransformersModule(ModuleType):
+            def __getattr__(self, name):
+                if name == "AutoModelForImageTextToText":
+                    raise ImportError("current API dependency failed")
+                if name == "AutoModelForVision2Seq":
+                    raise AssertionError("legacy fallback must not be used")
+                raise AttributeError(name)
+
+        monkeypatch.setitem(
+            sys.modules, "transformers", BrokenTransformersModule("transformers")
+        )
+
+        with pytest.raises(ImportError, match="current API dependency failed"):
+            diff_vl._get_auto_vision_model_class()
 
 
 class TestCosineSimilarity:

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -48,7 +48,7 @@ class EnvironmentVerifier:
                 "-c",
                 "import transformers, sys; "
                 "print(f'python={sys.executable} transformers={transformers.__version__}'); "
-                "assert transformers.__version__ == '5.2.0', transformers.__version__",
+                "assert transformers.__version__ == '5.5.0', transformers.__version__",
             ]
         )
         binary = self.context.repository / "build" / "trtmc"

--- a/tools/diff_vl.py
+++ b/tools/diff_vl.py
@@ -105,6 +105,16 @@ def _find_family_diff_vl_handler(model_type: str) -> ModuleType | None:
     return None
 
 
+def _get_auto_vision_model_class():
+    """Return the current Transformers auto class with legacy fallback."""
+    import transformers
+
+    try:
+        return transformers.AutoModelForImageTextToText
+    except AttributeError:
+        return transformers.AutoModelForVision2Seq
+
+
 def _read_bundle_header(bundle_path: str) -> dict:
     with open(bundle_path, "rb") as f:
         magic = f.read(8)
@@ -163,15 +173,16 @@ def _get_hf_vision_features_generic(
     image_path: str,
     fixed_image_size: int = 448,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Generic HF vision feature extraction using AutoModelForVision2Seq."""
+    """Generic HF vision feature extraction using a Transformers auto model."""
     import torch
     from PIL import Image
 
     print(f"[diff_vl] Loading HF generic VL model {model_id} ...", file=sys.stderr)
-    from transformers import AutoModelForVision2Seq, AutoProcessor
+    from transformers import AutoProcessor
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model = AutoModelForVision2Seq.from_pretrained(
+    model_class = _get_auto_vision_model_class()
+    model = model_class.from_pretrained(
         model_id, torch_dtype=torch.float32, device_map=device,
         trust_remote_code=True)
     model.eval()


### PR DESCRIPTION
## Background

The shared CI runtime and `reference_common` profile currently pin Transformers 5.2. Upgrading them to 5.5 exposes compatibility changes in the LocateAnything remote attention hook, the MiniMax-H3 multimodal processor helper, and the vision-language auto-model API.

## Exit Criteria

- The shared runtime and reference profile install and verify exactly Transformers 5.5.0.
- Existing model proof and reference-comparison semantics remain unchanged.
- Family-owned isolated profiles keep their independently certified exact versions; this is not a blanket rewrite of every profile.

## Implementation

- Upgrade the Docker runtime, `reference_common` lock, and CI version verifiers to Transformers 5.5.0.
- Adapt LocateAnything's pinned remote model class to the 5.5 attention API while preserving its conservative kernel policy.
- Requalify MiniMax-H3 against the immutable 5.5 entrypoint and verify the native multimodal token helper against the existing semantic oracle.
- Prefer `AutoModelForImageTextToText`, with a narrow compatibility fallback for older Transformers versions.
- Keep InternLM's test fixture aligned with the production `family_first` tokenizer conversion policy.

No comparator, tolerance, required stage, case list, skip, or passing criterion is relaxed.

## Validation

- Local target-hardware model proof for the same patch content: 79/79 model owners and 146/146 E2E cases passed; 951 proof steps passed with no failed or error step.
- Rebased exact head: focused Transformers compatibility tests passed (`42 passed, 1 skipped`).
- Rebased exact head: CI runtime and Python-profile contract tests passed (`78 passed`).
- `ruff check` passed for all changed Python files.
- `git diff --check github/main...HEAD` passed.

## Notes For Future Readers

- Review the version pins first, then the three compatibility boundaries: LocateAnything, MiniMax-H3, and `tools/diff_vl.py`.
- A clean image build is intentionally left to the required exact-head CI; the PR should remain draft until that result is available.
