### PR TITLE
fix(perf): stabilize task reference execution

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -479,6 +479,32 @@ def _load_tts(
     return Session(invoke, revision, framework, reference_dependencies=dependencies)
 
 
+def _load_nemo_asr_reference_model(
+    arguments: argparse.Namespace,
+    *,
+    device: Any,
+) -> Any:
+    if (
+        arguments.family == "nemotron_speech_streaming"
+        and "nemotron-3.5-asr-streaming" in arguments.model.lower()
+    ):
+        from tools.reference.speech import load_nemotron35_asr_model
+
+        return load_nemotron35_asr_model(
+            model=arguments.model,
+            revision=arguments.revision or "",
+            local_files_only=arguments.local_files_only,
+            device=str(device),
+        )
+
+    import nemo.collections.asr as nemo_asr
+
+    return nemo_asr.models.ASRModel.from_pretrained(
+        arguments.model,
+        map_location="cpu",
+    )
+
+
 def _load_asr(
     arguments: argparse.Namespace,
     request: Mapping[str, Any],
@@ -494,14 +520,9 @@ def _load_asr(
     device = torch.device("cuda")
 
     if arguments.family in {"canary", "nemotron_speech_streaming"}:
-        import nemo.collections.asr as nemo_asr
         from tools.validation.engine import _transcription_text
 
-        model = (
-            nemo_asr.models.ASRModel.from_pretrained(arguments.model, map_location="cpu")
-            .eval()
-            .to(device)
-        )
+        model = _load_nemo_asr_reference_model(arguments, device=device).eval().to(device)
         reference_dtype = _torch_dtype(torch, arguments.precision)
         autocast_dtype = reference_dtype if arguments.precision != "fp32" else torch.float16
         temporary = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)

--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -244,6 +244,49 @@ def _snapshot_revision(path: str | Path) -> str:
     return ""
 
 
+def _load_sam3_processor(
+    transformers: Any,
+    model: str,
+    processor_kwargs: Mapping[str, Any],
+) -> Any:
+    """Load SAM3's processor, including Meta's processor_config-only snapshot."""
+    try:
+        return transformers.Sam3Processor.from_pretrained(model, **processor_kwargs)
+    except (OSError, ValueError) as processor_error:
+        model_path = Path(model)
+        if model_path.is_dir():
+            processor_config_path = model_path / "processor_config.json"
+        else:
+            try:
+                from huggingface_hub import try_to_load_from_cache
+
+                cached_path = try_to_load_from_cache(
+                    model,
+                    "processor_config.json",
+                    revision=str(processor_kwargs.get("revision") or "main"),
+                )
+            except Exception:  # noqa: BLE001 - preserve the original processor error
+                raise processor_error
+            processor_config_path = Path(cached_path) if isinstance(cached_path, str) else Path()
+        if not processor_config_path.is_file():
+            raise processor_error
+
+        processor_config = json.loads(processor_config_path.read_text(encoding="utf-8"))
+        image_processor_kwargs = processor_config.get("image_processor")
+        if not isinstance(image_processor_kwargs, dict):
+            raise processor_error
+        image_processor_kwargs = dict(image_processor_kwargs)
+        image_processor_kwargs.pop("image_processor_type", None)
+        image_processor_kwargs.pop("processor_class", None)
+        image_processor = transformers.Sam3ImageProcessorFast(**image_processor_kwargs)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(model, **processor_kwargs)
+        return transformers.Sam3Processor(
+            image_processor,
+            tokenizer,
+            target_size=processor_config.get("target_size"),
+        )
+
+
 def _cached_snapshot_revision(repo_id: str, requested: str | None) -> str:
     try:
         from huggingface_hub import scan_cache_dir
@@ -1743,7 +1786,7 @@ def _load_vision(
             return {"mask_count": int(masks.shape[0]), **_tensor_summary(masks)}
 
     elif arguments.family == "sam3":
-        processor = transformers.Sam3Processor.from_pretrained(arguments.model, **processor_kwargs)
+        processor = _load_sam3_processor(transformers, arguments.model, processor_kwargs)
         model = transformers.Sam3Model.from_pretrained(arguments.model, **kwargs).eval().to(device)
         inputs = _to_device(
             processor(

--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -548,6 +548,15 @@ def _load_nemo_asr_reference_model(
     )
 
 
+def _disable_nemo_asr_cuda_graphs(model: Any) -> bool:
+    """Disable NeMo's optional RNNT CUDA Graph decoder when available."""
+    decoding = getattr(getattr(model, "decoding", None), "decoding", None)
+    disable_cuda_graphs = getattr(decoding, "disable_cuda_graphs", None)
+    if not callable(disable_cuda_graphs):
+        return False
+    return bool(disable_cuda_graphs())
+
+
 def _load_asr(
     arguments: argparse.Namespace,
     request: Mapping[str, Any],
@@ -566,6 +575,7 @@ def _load_asr(
         from tools.validation.engine import _transcription_text
 
         model = _load_nemo_asr_reference_model(arguments, device=device).eval().to(device)
+        _disable_nemo_asr_cuda_graphs(model)
         reference_dtype = _torch_dtype(torch, arguments.precision)
         autocast_dtype = reference_dtype if arguments.precision != "fp32" else torch.float16
         temporary = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -2079,6 +2079,78 @@ def test_candidate_preflight_rejects_an_unavailable_build_python_profile(
         perf_matrix._candidate_build_python_profile({"model": {"family": "example"}})
 
 
+def test_candidate_preflight_requires_modelopt_for_auto_fp8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        perf_matrix,
+        "_run_command",
+        lambda argv, _environment, timeout: calls.append((argv, timeout))
+        or {
+            "exit_code": 1,
+            "stderr_tail": "ModuleNotFoundError: No module named 'modelopt'",
+        },
+    )
+
+    with pytest.raises(
+        perf_matrix.PerfMatrixError,
+        match="candidate build Python profile 'base' is missing nvidia-modelopt",
+    ):
+        perf_matrix._candidate_build_dependency_preflight(
+            {
+                "model": {
+                    "build": {
+                        "quantization": {
+                            "format": "fp8",
+                            "scale_source": "modelopt",
+                        }
+                    }
+                }
+            },
+            profile="base",
+            python="/profile/python",
+            timeout_seconds=30,
+        )
+
+    assert calls == [
+        (
+            [
+                "/profile/python",
+                "-c",
+                "import modelopt.torch.quantization",
+            ],
+            30,
+        )
+    ]
+
+
+def test_candidate_preflight_skips_modelopt_for_non_calibrated_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        perf_matrix,
+        "_run_command",
+        lambda *_args, **_kwargs: pytest.fail("dependency probe must not run"),
+    )
+
+    perf_matrix._candidate_build_dependency_preflight(
+        {
+            "model": {
+                "build": {
+                    "quantization": {
+                        "format": "fp8",
+                        "scale_source": "precomputed",
+                    }
+                }
+            }
+        },
+        profile="base",
+        python="/profile/python",
+        timeout_seconds=30,
+    )
+
+
 def test_seq2seq_token_framing_is_explicit_and_exact() -> None:
     runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/hf_transformers.py"))
     normalize = runner["_normalize_seq2seq_tokens"]

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -2371,6 +2371,22 @@ def test_nemotron35_perf_reference_uses_archive_compatible_loader(monkeypatch) -
     }
 
 
+def test_nemo_asr_perf_reference_disables_rnnt_cuda_graphs() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    calls = 0
+
+    class GreedyDecoder:
+        def disable_cuda_graphs(self) -> bool:
+            nonlocal calls
+            calls += 1
+            return True
+
+    model = Namespace(decoding=Namespace(decoding=GreedyDecoder()))
+
+    assert runner["_disable_nemo_asr_cuda_graphs"](model) is True
+    assert calls == 1
+
+
 def test_vlm_adapter_routes_non_generic_families_to_owned_loaders() -> None:
     runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
     deepseek = object()

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -2472,6 +2472,67 @@ def test_sam3_reference_reports_source_image_dimensions(
     assert session.invoke() == {"num_masks": 2, "height": 4, "width": 6}
 
 
+def test_sam3_reference_falls_back_to_processor_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    processor_config = snapshot / "processor_config.json"
+    processor_config.write_text(
+        json.dumps(
+            {
+                "target_size": 1008,
+                "image_processor": {
+                    "image_processor_type": "Sam3ImageProcessorFast",
+                    "size": {"height": 1008, "width": 1008},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeProcessor:
+        def __init__(self, image_processor, tokenizer, *, target_size):
+            self.image_processor = image_processor
+            self.tokenizer = tokenizer
+            self.target_size = target_size
+
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            raise OSError("preprocessor_config.json is absent")
+
+    class FakeImageProcessor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            return "tokenizer"
+
+    fake_transformers = Namespace(
+        AutoTokenizer=FakeTokenizer,
+        Sam3ImageProcessorFast=FakeImageProcessor,
+        Sam3Processor=FakeProcessor,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        Namespace(try_to_load_from_cache=lambda *_args, **_kwargs: str(processor_config)),
+    )
+
+    processor = runner["_load_sam3_processor"](
+        fake_transformers,
+        "facebook/sam3",
+        {"local_files_only": True, "revision": "pinned"},
+    )
+
+    assert processor.target_size == 1008
+    assert processor.tokenizer == "tokenizer"
+    assert processor.image_processor.kwargs == {"size": {"height": 1008, "width": 1008}}
+
+
 def test_locateanything_fallback_tokenizer_supports_batch_decode(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -2261,6 +2261,44 @@ def test_task_reference_runner_measures_loaded_public_operation(
     }
 
 
+def test_nemotron35_perf_reference_uses_archive_compatible_loader(monkeypatch) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    from tools.reference import speech
+
+    expected = object()
+    captured: dict[str, object] = {}
+
+    def load_compatible(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(
+        speech,
+        "load_nemotron35_asr_model",
+        load_compatible,
+        raising=False,
+    )
+    arguments = Namespace(
+        family="nemotron_speech_streaming",
+        model="nvidia/nemotron-3.5-asr-streaming-0.6b",
+        revision="model-revision",
+        local_files_only=True,
+    )
+
+    model = runner["_load_nemo_asr_reference_model"](
+        arguments,
+        device="cuda",
+    )
+
+    assert model is expected
+    assert captured == {
+        "model": "nvidia/nemotron-3.5-asr-streaming-0.6b",
+        "revision": "model-revision",
+        "local_files_only": True,
+        "device": "cuda",
+    }
+
+
 def test_vlm_adapter_routes_non_generic_families_to_owned_loaders() -> None:
     runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
     deepseek = object()

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -108,6 +108,64 @@ def test_tts_transcriber_passes_local_files_only_once(monkeypatch) -> None:
     }
 
 
+def test_tts_transcriber_limits_cuda_memory(monkeypatch) -> None:
+    load_calls: list[dict[str, object]] = []
+    transcribe_calls: list[dict[str, object]] = []
+    loaded_processor = SimpleNamespace(
+        tokenizer=object(),
+        feature_extractor=SimpleNamespace(sampling_rate=16000),
+    )
+
+    class FakeTranscriber:
+        feature_extractor = SimpleNamespace(sampling_rate=16000)
+
+        def __call__(self, _waveforms, **kwargs):
+            transcribe_calls.append(kwargs)
+            return [{"text": "hello"}, {"text": "world"}]
+
+    class FakeModelLoader:
+        @staticmethod
+        def from_pretrained(_model_id: str, **kwargs):
+            load_calls.append(kwargs)
+            return object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: True),
+            float16="fp16",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoModelForSpeechSeq2Seq=FakeModelLoader,
+            AutoProcessor=SimpleNamespace(
+                from_pretrained=lambda *_args, **_kwargs: loaded_processor
+            ),
+            pipeline=lambda *_args, **_kwargs: FakeTranscriber(),
+        ),
+    )
+    monkeypatch.setattr(speech, "_read_wav_float32", lambda _path: ([0.0], 16000))
+    monkeypatch.setattr(
+        speech,
+        "_resample_audio",
+        lambda audio, _source_rate, _target_rate: audio,
+    )
+
+    result = speech._transcribe_tts(
+        SimpleNamespace(device="cuda", local_files_only=True),
+        [Path("one.wav"), Path("two.wav")],
+        "openai/whisper-large-v3-turbo",
+    )
+
+    assert result == ["hello", "world"]
+    assert load_calls == [{"local_files_only": True, "torch_dtype": "fp16"}]
+    assert transcribe_calls == [{"batch_size": 1}]
+
+
 def _prepare_work(path: Path, *, model_manifest: str = "") -> None:
     path.mkdir(parents=True)
     (path / "answers.json").write_text(

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -1179,6 +1179,36 @@ def _candidate_build_python_profile(resolved: Mapping[str, Any]) -> tuple[str, s
     return profile, python
 
 
+def _candidate_build_dependency_preflight(
+    resolved: Mapping[str, Any],
+    *,
+    profile: str,
+    python: str,
+    timeout_seconds: int,
+) -> None:
+    model = resolved.get("model", {})
+    build = model.get("build", {}) if isinstance(model, Mapping) else {}
+    quantization = build.get("quantization", {}) if isinstance(build, Mapping) else {}
+    if not isinstance(quantization, Mapping) or (
+        str(quantization.get("format", "")).strip().lower(),
+        str(quantization.get("scale_source", "")).strip().lower(),
+    ) != ("fp8", "modelopt"):
+        return
+
+    command = _run_command(
+        [python, "-c", "import modelopt.torch.quantization"],
+        _command_environment(),
+        timeout_seconds,
+    )
+    if command["exit_code"] != 0:
+        detail = str(command.get("stderr_tail", "")).strip()
+        suffix = f": {detail}" if detail else ""
+        raise PerfMatrixError(
+            f"candidate build Python profile {profile!r} is missing "
+            f"nvidia-modelopt required for automatic FP8 calibration{suffix}"
+        )
+
+
 def _command_environment() -> dict[str, str]:
     environment = dict(os.environ)
     existing = environment.get("PYTHONPATH", "")
@@ -1238,7 +1268,13 @@ def _resolve_candidate(
         raise PerfMatrixError(
             f"case {case['id']} includes asset loading but resolves no timed asset path"
         )
-    profile, _ = _candidate_build_python_profile(value)
+    profile, python = _candidate_build_python_profile(value)
+    _candidate_build_dependency_preflight(
+        value,
+        profile=profile,
+        python=python,
+        timeout_seconds=options.timeout_seconds,
+    )
     value["_candidate_build_python_profile"] = profile
     command.pop("stdout", None)
     return value, argv, command

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -466,6 +466,25 @@ def _load_nemotron35_model(
     return torch, model
 
 
+def load_nemotron35_asr_model(
+    *,
+    model: str,
+    device: str,
+    revision: str = "",
+    local_files_only: bool = False,
+) -> Any:
+    """Load Nemotron 3.5 through its archive-compatible NeMo model class."""
+    arguments = argparse.Namespace(
+        model=model,
+        model_revision=revision,
+        local_files_only=local_files_only,
+        device=device,
+    )
+    archive = _resolve_nemotron35_archive(arguments)
+    _torch, loaded = _load_nemotron35_model(arguments, archive)
+    return loaded
+
+
 def _load_nemo_asr_model(arguments: argparse.Namespace, nemo_asr: Any) -> Any:
     if arguments.local_files_only:
         archive = _resolve_nemo_archive(

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -690,14 +690,16 @@ def _transcribe_tts(
         pipeline,
     )
 
-    device = (
-        0
-        if arguments.device.startswith("cuda") and torch.cuda.is_available()
-        else -1
-    )
+    use_cuda = arguments.device.startswith("cuda") and torch.cuda.is_available()
+    device = 0 if use_cuda else -1
+    model_kwargs: dict[str, Any] = {
+        "local_files_only": arguments.local_files_only,
+    }
+    if use_cuda:
+        model_kwargs["torch_dtype"] = torch.float16
     model = AutoModelForSpeechSeq2Seq.from_pretrained(
         model_id,
-        local_files_only=arguments.local_files_only,
+        **model_kwargs,
     )
     processor = AutoProcessor.from_pretrained(
         model_id,
@@ -715,7 +717,7 @@ def _transcribe_tts(
     for path in wav_paths:
         audio, sample_rate = _read_wav_float32(str(path))
         waveforms.append(_resample_audio(audio, sample_rate, target_rate))
-    outputs = transcriber(waveforms, batch_size=min(8, len(waveforms)))
+    outputs = transcriber(waveforms, batch_size=1 if use_cuda else min(8, len(waveforms)))
     if isinstance(outputs, Mapping):
         outputs = [outputs]
     return [_transcription_text(output).strip() for output in outputs]


### PR DESCRIPTION
## Background

Thor X qualification exposed reference paths that worked on the development image but failed in clean, architecture-specific Python profiles. The failures prevented valid performance comparisons for Nemotron speech, SAM3, ModelOpt-calibrated models, and TTS validation.

## Exit Criteria

- Reference adapters load pinned model assets compatibly in self-contained profiles.
- Missing ModelOpt calibration support fails during preflight with an actionable error.
- NeMo RNNT references avoid the CUDA-graph path that crashes on L4T Thor.
- TTS transcription does not retain unnecessary GPU state between samples.

## Implementation

- Load Nemotron 3.5 archives through a compatibility path that preserves the pinned NeMo contract.
- Preflight `nvidia-modelopt` before automatic FP8 calibration.
- Load the SAM3 processor configuration required by its reference pipeline.
- Bound TTS transcription lifetime and release per-sample reference state.
- Disable NeMo RNNT CUDA graphs for the qualified reference comparison path.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_perf_matrix.py tests/tools/test_trtmc_reference.py`: 157 passed.
- Ruff over every changed Python file: passed.
- `git diff --check 75e25af7..2e5feb36`: passed.
- ThorX-2, TensorRT 11.0, `nemotron-3.5-asr-streaming-0.6b`: green; TRTMC p50 62.285 ms, NeMo p50 396.174 ms, baseline/TRTMC ratio 6.361x.
- ThorX-2, TensorRT 11.0, `sam3`: green; TRTMC p50 185.998 ms, reference p50 1385.879 ms, ratio 7.451x.
- ThorX-1, TensorRT 11.0, `magpie-tts-357m`: Accuracy passed with HF and bundle accuracy 1.0.

## Notes For Future Readers

- This PR is based directly on GitHub `main` at `75e25af7`; it does not contain #856 or #870.
- `nemotron-speech-streaming-en-0.6b` remains an explicit Thor framework limitation: several GPU RNNT paths crash natively in the installed PyTorch/cuDNN stack. A mixed GPU-encoder/CPU-decoder fallback works, but it is intentionally not reported as a GPU performance baseline.
- Review the adapter changes in `benchmarks/performance/baselines/task_reference.py` and `tools/reference/speech.py` first, followed by the preflight and regression tests.
