### PR TITLE
fix(qwen): allow decode attention fallback

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -731,6 +731,7 @@ def build_dual_profile_decoder_engine(
                 num_kv_heads=num_kv_heads,
                 q_seq=None,
                 scale=attn_scale, tag=f"{prefix}.attn",
+                allow_decomposition=(profile_mode == "decode"),
                 recipe_instance=(
                     f"decoder.layers.{layer_idx}.decode_attention"
                     if profile_mode == "decode"

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -1148,6 +1148,7 @@ def add_native_kv_cache_attention_from_rows(
     scale: float | None = None,
     tag: str | None = None,
     recipe_instance: str | None = None,
+    allow_decomposition: bool = False,
 ) -> dict[str, trt.ITensor]:
     """Update a user-owned KV cache and attend over its active prefix.
 
@@ -1160,6 +1161,10 @@ def add_native_kv_cache_attention_from_rows(
     Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The caller
     must bind each output to the same device address as its corresponding
     input, as required by TensorRT's KV-cache aliasing contract.
+
+    ``allow_decomposition`` lets TensorRT fall back to primitive attention
+    operations when no fused tactic is available. Keep it disabled for long
+    prefill shapes, where a decomposed score matrix can be prohibitively large.
     """
     if not hasattr(network, "add_kv_cache_update") or not hasattr(
         network, "add_attention_v2"
@@ -1254,10 +1259,7 @@ def add_native_kv_cache_attention_from_rows(
         )
         if attention is None:
             raise RuntimeError("TensorRT failed to create Qwen native attention")
-        # The prototype deliberately requires TensorRT's fused attention tactic.
-        # Unsupported dtype/head geometries fail at build time instead of silently
-        # falling back to a primitive graph with materially lower decode speed.
-        attention.decomposable = False
+        attention.decomposable = allow_decomposition
         attention.key_value_lengths = key_value_lengths
         if tag:
             attention.name = tag

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -61,7 +63,7 @@ class _FakeNetwork:
         return layer
 
 
-def _add_native_attention(monkeypatch, graph_ops, dtype):
+def _add_native_attention(monkeypatch, graph_ops, dtype, **kwargs):
     network = _FakeNetwork()
     heads, kv_heads, head_dim = 4, 2, 128
     tensors = {
@@ -96,6 +98,7 @@ def _add_native_attention(monkeypatch, graph_ops, dtype):
         num_kv_heads=kv_heads,
         head_dim=head_dim,
         q_seq=1,
+        **kwargs,
     )
     return network, tensors, result
 
@@ -152,6 +155,58 @@ def test_bf16_uses_exact_fp32_scale_before_fused_attention(
     assert attention[6].decomposable is False
     assert attention[6].key_value_lengths is tensors["lengths"]
     assert result["context"] is attention[6].get_output(0)
+
+
+@pytest.mark.parametrize("allow_decomposition", [False, True])
+def test_qwen_forwards_native_attention_decomposition_policy(
+    monkeypatch,
+    allow_decomposition,
+):
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.graph_ops"
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "add_constant",
+        lambda *_args, **_kwargs: _FakeTensor("scale", trt.float32),
+    )
+
+    network, _, _ = _add_native_attention(
+        monkeypatch,
+        graph_ops,
+        trt.bfloat16,
+        allow_decomposition=allow_decomposition,
+    )
+
+    attention = next(call for call in network.calls if call[0] == "attention")
+    assert attention[6].decomposable is allow_decomposition
+
+
+def test_qwen_builder_only_allows_decode_attention_decomposition():
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.graph_ops"
+    )
+    builder_path = Path(graph_ops.__file__).with_name(
+        "dual_profile_decoder_builder.py"
+    )
+    tree = ast.parse(builder_path.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_native_kv_cache_attention_from_rows"
+    ]
+
+    assert len(calls) == 1
+    decomposition_values = [
+        keyword.value
+        for keyword in calls[0].keywords
+        if keyword.arg == "allow_decomposition"
+    ]
+    assert len(decomposition_values) == 1
+    expected = ast.parse('profile_mode == "decode"', mode="eval").body
+    assert ast.dump(decomposition_values[0]) == ast.dump(expected)
 
 
 @pytest.mark.parametrize("module_name", _FAMILIES)


### PR DESCRIPTION
## Background

The default Qwen3-0.6B BF16 native-KV build uses a 40,960-token cache. On
SM86, TensorRT cannot find a dedicated fused-attention tactic for the long
decode shape, and the Qwen helper currently forbids primitive decomposition.
The same graph has fused tactic coverage on SM103.

This change adds a compatibility fallback for decode without weakening the
long-prefill guardrail.

## Exit Criteria

- Long prefill remains fused-only and fails closed if no fused tactic exists.
- Split decode permits TensorRT to decompose attention when necessary.
- The policy has no GPU, sequence-length, or TensorRT-version branches.
- Llama behavior and Qwen's portable FP16 path remain unchanged.

## Implementation

- Add an explicit `allow_decomposition` argument to the Qwen native-KV
  attention helper, defaulting to `False`.
- Enable it only when the Qwen builder is constructing the split decode
  profile. Prefill and legacy dual-profile builds remain fused-only.
- Cover the helper's explicit `False`/`True` forwarding, the shared Qwen/Llama
  fused-only default, and the decode-only builder policy.

## Validation

- `PYTHONPATH=python python -m pytest -q tests/builder/test_qwen_llama_native_kv_attention.py`: 7 passed in a TensorRT 11.2.0.113 GB300/SM103 container.
- `PYTHONPATH=python python -m pytest -q tests/e2e/models/qwen/test_qwen_native_kv_routing.py tests/tools/test_model_proof_runner.py`: 183 passed in the same container.
- `ruff check python/tensorrt_model_connect/families/qwen/graph_ops.py python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py tests/builder/test_qwen_llama_native_kv_attention.py`: passed.
- `git diff --check`: passed.
- `python3 tools/test_impact.py --files python/tensorrt_model_connect/families/qwen/graph_ops.py,python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py,tests/builder/test_qwen_llama_native_kv_attention.py --json`: selected the `builder` unit tier and Qwen model proofs, including `qwen3-0.6b-native-l0` and `qwen3-0.6b-regression-native-kv-chunked-prefill`.
- Exact-head `trtmc/premerge/required` on `84bf599b2fc3bb8fb7c587e9157807eb4a013842`: passed.
- CodeQL Python and JavaScript/TypeScript checks on the same head: passed.
- RTX 3090/SM86 full build, inspect, and run: not run in this workspace because no SM86 device is available; the handoff probe established that the exact long decode shape builds when decomposition is enabled.

## Notes For Future Readers

- TensorRT may still select a fused decode tactic when one is available;
  allowing decomposition does not force the primitive path.
- A decomposed SM86 decode is a compatibility path and may be slower than the
  fused path. Its latency should not be presented as fused-path parity.
- Do not enable this fallback globally: the maximum prefill profile can create
  a prohibitively large attention score matrix if decomposed.
