### PR TITLE
docs(onboarding): clarify wheel quick start

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -14,8 +14,8 @@ Release wheels currently support aarch64 only. x86_64 wheels are planned; use
 
 ## Install a release wheel
 
-This first-time path uses Python 3.12. Download the aarch64 `py312` `.whl`
-asset from the [latest GitHub release](https://github.com/NVIDIA/TensorRT-Model-Connect/releases/latest).
+This first-time path uses Python 3.12. Download the aarch64 `+trt111` `py312`
+`.whl` asset from the [latest GitHub release](https://github.com/NVIDIA/TensorRT-Model-Connect/releases/latest).
 If no matching wheel is published, use the source path instead.
 
 ```bash
@@ -26,7 +26,7 @@ WHEEL=/path/to/downloaded-wheel.whl
 python -m pip install "$WHEEL"
 ```
 
-Python 3.10 users can instead use the `py310` wheel and corresponding
+Python 3.10 users can instead use the `+trt111` `py310` wheel and corresponding
 `python3.10` commands. Keep this virtual environment active and continue to
 [Quick Start](quick-start.md), where the CLI is checked once.
 

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -29,8 +29,7 @@ trtmc build Qwen/Qwen3-0.6B \
 
 The bounded cache profile is intended for the first portable native-attention
 build. The first build may download model files and compile TensorRT engines.
-`qwen3-0.6b.bundle` is the runnable output; the neighboring
-`qwen3-0.6b.effective_config.json` file is diagnostic only.
+`qwen3-0.6b.bundle` is the runnable output.
 
 ## 3. Inspect the bundle
 


### PR DESCRIPTION
## Background

The first published wheel release contains both TensorRT 11.1 and 11.2 assets for each supported Python version, while Getting Started only tells users to choose by Python tag. A clean wheel Quick Start also confirmed that the build step produces the bundle but not the diagnostic effective-config sidecar described beside it.

## Exit Criteria

- The documented TensorRT 11.1 newcomer path identifies the matching wheel profile.
- Quick Start describes only the artifact guaranteed by its build command.
- Source builds, packaging, and runtime behavior remain unchanged.

## Implementation

- Name the `+trt111` profile for both Python 3.12 and Python 3.10 wheel selection.
- Remove the config-sidecar sentence from the minimal Qwen build step.

## Validation

- Published `tensorrt_model_connect-0.1.0+trt111-py312-none-manylinux_2_39_aarch64.whl`: checksum matched `SHA256SUMS`; metadata and runtime resolved TensorRT 11.1.0.106.
- Clean Python 3.12 virtual environment: wheel installation and `pip check` passed.
- `trtmc build Qwen/Qwen3-0.6B --precision bf16 --max-cache-length 16384 --output qwen3-0.6b.bundle`: passed on GB300 in 191.22 seconds.
- `trtmc inspect ./qwen3-0.6b.bundle` and `trtmc inspect ./qwen3-0.6b.bundle --list-engines`: passed with BF16, cache length 16384, and two engine plans.
- Documented `trtmc run`: passed in 5.83 seconds, loaded `libtrtmc_backend_trt_11_1.so`, and returned `Paris`.
- `python3 -m pytest tests/tools/test_check_doc_file_references.py -q`: 8 passed.
- `npm run build` in `website/`: passed after `npm ci`; verified 34 diagrams and generated the production site.
- `git diff --check`: passed.

## Notes For Future Readers

- Review `installation.md` first, then the one-line deletion in `quick-start.md`.
- This intentionally keeps the first-run path short instead of adding release-manifest, checksum, or sidecar lifecycle instructions.
