### PR TITLE
docs(readme): refresh landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ documentation.
 
 ## Build a Deployment Bundle
 
-**This manual workflow starts after TensorRT-Model-Connect is fully set up; it
-is not part of the AI Native QuickStart above.**
+Once your environment is ready, use this workflow to build a deployment bundle
+from a supported Hugging Face model and run native inference.
 
 If `trtmc` is not installed, start with
 [System Requirements](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/environment-and-repro)
@@ -34,9 +34,6 @@ and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-start
 Developers compiling the native CLI, backends, or model DSOs should use the
 [Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
 guide.
-
-Build a deployment bundle from its canonical Hugging Face model ID, then run
-native inference in two commands:
 
 ```bash
 trtmc build Qwen/Qwen3-0.6B \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1>TensorRT-Model-Connect</h1>
 
-<h4>A collection of C++ reference implementations for diverse AI models on NVIDIA TensorRT, continuously expanded through an agentic workflow.</h4>
+<p><strong>A collection of C++ reference implementations for diverse AI models on NVIDIA TensorRT, continuously expanded through an agentic workflow.</strong></p>
 
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# TensorRT-Model-Connect
+<div align="center">
 
-> Reference implementations for deploying diverse model families on TensorRT.
-> Build from a supported checkpoint, run through task-oriented C++ APIs, and
-> use the family-owned implementation as a blueprint for your own changes.
+<h1>TensorRT-Model-Connect</h1>
 
-## AI-native quick start
+<h4>A collection of C++ reference implementations for diverse AI models on NVIDIA TensorRT, continuously expanded through an agentic workflow.</h4>
+
+[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
+
+</div>
+
+## AI Native QuickStart
 
 Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
 prompt:
@@ -19,10 +23,17 @@ exact commands, bundle path, inference output, and any deviation from the
 documentation.
 ```
 
-[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/) |
-[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
-[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
-[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
+## Build a Deployment Bundle
+
+**This manual workflow starts after TensorRT-Model-Connect is fully set up; it
+is not part of the AI Native QuickStart above.**
+
+If `trtmc` is not installed, start with
+[System Requirements](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/environment-and-repro)
+and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/installation).
+Developers compiling the native CLI, backends, or model DSOs should use the
+[Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
+guide.
 
 Build a deployment bundle from its canonical Hugging Face model ID, then run
 native inference in two commands:
@@ -42,13 +53,6 @@ trtmc run ./qwen3-0.6b.bundle \
   --top-p 0.8 \
   --seed 42
 ```
-
-If `trtmc` is not installed, start with
-[System Requirements](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/environment-and-repro)
-and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/installation).
-Developers compiling the native CLI, backends, or model DSOs should use the
-[Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
-guide.
 
 ## What is TensorRT-Model-Connect?
 **TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 </div>
 
-## AI Native QuickStart
+## 🤖 AI Native QuickStart
 
 Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
 prompt:
@@ -23,7 +23,7 @@ exact commands, bundle path, inference output, and any deviation from the
 documentation.
 ```
 
-## Build a Deployment Bundle
+## 📦 Build a Deployment Bundle
 
 Once your environment is ready, use this workflow to build a deployment bundle
 from a supported Hugging Face model and run native inference.
@@ -76,7 +76,7 @@ TensorRT-Model-Connect is a reference implementation. Users are responsible
 for trusting the checkpoints, bundles, native libraries, and local environment
 they provide when building or running models.
 
-## Explore the documentation
+## 📚 Explore the documentation
 
 | Goal | Start here |
 | --- | --- |


### PR DESCRIPTION
## Background

The README landing section mixed project identity, the AI-native prompt, navigation links, and bundle commands without a clear visual or workflow boundary. This refresh follows the centered-header pattern used by the TensorRT-LLM README while preserving TensorRT-Model-Connect's existing entry points and keeping visual cues restrained.

## Exit Criteria

- Center the project title, concise subtitle, and primary documentation links at the top.
- Keep the AI Native QuickStart prompt intact.
- Present the bundle build/run commands as a clear workflow for a ready environment.
- Add a small amount of visual emphasis without decorating every section.

## Implementation

- Add a centered header containing the title, an agentic-workflow subtitle, and the four existing documentation links.
- Render the subtitle as emphasized prose so the page keeps a valid `h1` to `h2` heading hierarchy.
- Retain the existing agent prompt under its own `AI Native QuickStart` section.
- Add a `Build a Deployment Bundle` heading, describe the user outcome, and place setup guidance before the commands.
- Add one semantic emoji to each of the three action-oriented entry points; keep the remaining headings, prose, and list markup plain.

## Validation

- GitHub Markdown API rendering: confirmed the centered header, `h1` to `h2` hierarchy, three emoji headings, and subsequent sections render normally.
- `python3 -m pytest tests/tools/test_check_doc_file_references.py -q`: 8 passed.
- `git diff --check`: passed.

## Notes For Future Readers

- The compact top navigation and the detailed documentation table serve different levels of discovery and are intentionally both retained.
- Emoji are intentionally limited to three single heading cues, consistent with [GitHub's guidance on thoughtful placement and accessibility](https://github.blog/developer-skills/github/5-tips-for-making-your-github-profile-page-accessible/).
- This is a README-only presentation and onboarding change; runtime and documentation-site behavior are unchanged.
