### PR TITLE
ci(github): suppress dispatch deployments

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -115,7 +115,9 @@ jobs:
     name: Internal CI dispatch
     needs: authorize
     runs-on: ubuntu-24.04
-    environment: ci-dispatch
+    environment:
+      name: ci-dispatch
+      deployment: false
     timeout-minutes: 5
     permissions: {}
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -226,10 +226,28 @@ def test_source_workflow_inventory_does_not_repeat_premerge_after_merge() -> Non
     assert "actions/workflows/premerge.yml/dispatches" not in pages
 
 
+def test_only_pages_workflow_creates_deployment_objects() -> None:
+    deployments = []
+    workflows = REPO_ROOT / ".github" / "workflows"
+    for path in sorted((*workflows.glob("*.yml"), *workflows.glob("*.yaml"))):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in workflow["jobs"].items():
+            environment = job.get("environment")
+            if environment is None:
+                continue
+            if isinstance(environment, str):
+                deployments.append((path.name, job_name, environment))
+            elif environment.get("deployment", True):
+                deployments.append((path.name, job_name, environment["name"]))
+
+    assert deployments == [("pages.yml", "deploy", "github-pages")]
+
+
 def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     workflow = (
         REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"
     ).read_text(encoding="utf-8")
+    workflow_config = yaml.safe_load(workflow)
     authorize = workflow.split("\n  authorize:", maxsplit=1)[1].split(
         "\n  dispatch:", maxsplit=1
     )[0]
@@ -290,7 +308,10 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "always() && github.event_name == 'pull_request_target'" in authorize
 
     assert "needs: authorize" in dispatch
-    assert "environment: ci-dispatch" in dispatch
+    assert workflow_config["jobs"]["dispatch"]["environment"] == {
+        "name": "ci-dispatch",
+        "deployment": False,
+    }
     secret_references = set(re.findall(r"secrets\.([A-Z][A-Z0-9_]*)", workflow))
     assert secret_references == {
         "TRTMC_CI_DISPATCH_TOKEN",


### PR DESCRIPTION
## Background

The Internal CI bridge uses the protected `ci-dispatch` environment for its dispatch secrets. GitHub creates a Deployment object by default whenever a job references an environment, so every CI dispatch currently adds a non-deployment entry to the repository's deployment history.

## Exit Criteria

- Stop Internal CI dispatches from creating Deployment objects.
- Preserve the existing `ci-dispatch` environment secrets and branch policy.
- Keep GitHub Pages as the only Source workflow environment that creates automatic Deployment objects.
- Leave existing deployment history unchanged.

## Implementation

- Set `deployment: false` on the `ci-dispatch` job environment while retaining the environment name and secret boundary.
- Add a regression test that enumerates every Source workflow job environment and requires `pages.yml` / `deploy` / `github-pages` to be the only tuple allowed to create automatic Deployment objects.
- Update the existing bridge contract test to require the exact non-deploying environment configuration.

## Validation

- `python3 -m pytest tests/tools/test_github_actions_ci.py -q`: 61 passed.
- `python3 -m ruff check tests/tools/test_github_actions_ci.py`: passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- GitHub documents that `deployment: false` retains environment secrets, variables, and compatible protection rules without creating a Deployment object: [Using environments without deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments).
- Existing `ci-dispatch` deployment records are intentionally retained; deleting audit history is outside this PR.
- A `pull_request_target` run for this PR would use the workflow from the base branch, where deployment suppression is not yet active. The first live no-new-deployment verification is therefore post-merge; this PR should not add the one-shot Internal CI label merely to test this change.
