### PR TITLE
docs(readme): lead with two-command inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,30 @@
 
 <h1>TensorRT-Model-Connect</h1>
 
-<p><strong>A collection of C++ reference implementations for diverse AI models on NVIDIA TensorRT, continuously expanded through an agentic workflow.</strong></p>
+<p><strong>Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
 
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
 
 </div>
 
-## 🤖 AI Native QuickStart
+## Example Code
+
+```bash
+trtmc build Qwen/Qwen3-0.6B -o qwen3-0.6b.bundle
+trtmc run ./qwen3-0.6b.bundle --prompt "What is the capital of France? Answer in one word." --chat-template --no-thinking
+# Generated text: Paris
+```
+
+The same bundle works from
+[C++](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api):
+
+```cpp
+auto pipeline = trtmc::load("./qwen3-0.6b.bundle");
+std::cout << pipeline->generate("What is the capital of France? Answer in one word.").text << '\n';
+```
+
+<details>
+<summary><strong>🤖 AI-Native QuickStart</strong></summary>
 
 Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
 prompt:
@@ -23,43 +40,7 @@ exact commands, bundle path, inference output, and any deviation from the
 documentation.
 ```
 
-## 📦 Build a Deployment Bundle
-
-Once your environment is ready, use this workflow to build a deployment bundle
-from a supported Hugging Face model and run native inference.
-
-If `trtmc` is not installed, start with
-[System Requirements](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/environment-and-repro)
-and [Installation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/installation).
-Developers compiling the native CLI, backends, or model DSOs should use the
-[Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build)
-guide.
-
-```bash
-trtmc build Qwen/Qwen3-0.6B \
-  --precision bf16 \
-  --max-cache-length 16384 \
-  --output qwen3-0.6b.bundle
-trtmc run ./qwen3-0.6b.bundle \
-  --prompt "What is the capital of France? Answer in one word." \
-  --chat-template \
-  --no-thinking \
-  --max-new-tokens 64 \
-  --temperature 0.7 \
-  --top-k 20 \
-  --top-p 0.8 \
-  --seed 42
-
-# Generated text: Paris
-```
-
-Native applications can use the same bundle through the
-[C++ API](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api):
-
-```cpp
-auto pipeline = trtmc::load("./qwen3-0.6b.bundle");
-std::cout << pipeline->generate("What is the capital of France? Answer in one word.").text << '\n';
-```
+</details>
 
 ## What is TensorRT-Model-Connect?
 **TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.

--- a/README.md
+++ b/README.md
@@ -28,26 +28,6 @@ std::cout << pipeline->generate("What is the capital of France? Answer in one wo
 **TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.
 <img width="1318" height="1088" alt="MC-what-it-is" src="https://github.com/user-attachments/assets/85850b96-5a30-4531-bcec-98e00883dedb" />
 
-## Getting Started
-
-**Recommended Quick Start: AI-Native**
-
-Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
-prompt:
-
-```text
-/goal Use the current TensorRT-Model-Connect checkout, or clone
-https://github.com/NVIDIA/TensorRT-Model-Connect.git if none is provided. Read
-AGENTS.md, then follow website/docs/getting-started/source-build.md and
-website/docs/getting-started/quick-start.md exactly. Do not modify source,
-tests, Dockerfiles, git history, or remote state. Report the selected GPU,
-exact commands, bundle path, inference output, and any deviation from the
-documentation.
-```
-
-Want to know more? See the
-[Quick Start documentation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start).
-
 ## Why TensorRT-Model-Connect?
 
 - Start from a supported Hugging Face or local checkpoint and build TensorRT
@@ -68,6 +48,26 @@ TensorRT integration paths.
 TensorRT-Model-Connect is a reference implementation. Users are responsible
 for trusting the checkpoints, bundles, native libraries, and local environment
 they provide when building or running models.
+
+## Getting Started
+
+**Recommended Quick Start: AI-Native**
+
+Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
+prompt:
+
+```text
+/goal Use the current TensorRT-Model-Connect checkout, or clone
+https://github.com/NVIDIA/TensorRT-Model-Connect.git if none is provided. Read
+AGENTS.md, then follow website/docs/getting-started/source-build.md and
+website/docs/getting-started/quick-start.md exactly. Do not modify source,
+tests, Dockerfiles, git history, or remote state. Report the selected GPU,
+exact commands, bundle path, inference output, and any deviation from the
+documentation.
+```
+
+Want to know more? See the
+[Quick Start documentation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start).
 
 ## 📚 Explore the documentation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ trtmc run ./qwen3-0.6b.bundle \
   --top-k 20 \
   --top-p 0.8 \
   --seed 42
+
+# Generated text: Paris
+```
+
+Native applications can use the same bundle through the
+[C++ API](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api):
+
+```cpp
+auto pipeline = trtmc::load("./qwen3-0.6b.bundle");
+std::cout << pipeline->generate("What is the capital of France? Answer in one word.").text << '\n';
 ```
 
 ## What is TensorRT-Model-Connect?

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ auto pipeline = trtmc::load("./qwen3-0.6b.bundle");
 std::cout << pipeline->generate("What is the capital of France? Answer in one word.").text << '\n';
 ```
 
-<details>
-<summary><strong>🤖 AI-Native QuickStart</strong></summary>
+## What is TensorRT-Model-Connect?
+**TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.
+<img width="1318" height="1088" alt="MC-what-it-is" src="https://github.com/user-attachments/assets/85850b96-5a30-4531-bcec-98e00883dedb" />
+
+## Getting Started
+
+**Recommended Quick Start: AI-Native**
 
 Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
 prompt:
@@ -40,11 +45,8 @@ exact commands, bundle path, inference output, and any deviation from the
 documentation.
 ```
 
-</details>
-
-## What is TensorRT-Model-Connect?
-**TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.
-<img width="1318" height="1088" alt="MC-what-it-is" src="https://github.com/user-attachments/assets/85850b96-5a30-4531-bcec-98e00883dedb" />
+Want to know more? See the
+[Quick Start documentation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start).
 
 ## Why TensorRT-Model-Connect?
 


### PR DESCRIPTION
## Background

The README should lead with what users can accomplish, make the first inference result concrete, and keep the recommended AI-native path easy to find.

## Exit Criteria

- Lead with the user outcome: a supported Hugging Face model running end-to-end TensorRT inference in two commands.
- Show the generated result and the native C++ entry point without turning the README into a tutorial.
- Present AI-Native QuickStart as the visible recommended Getting Started path and route readers to the full guide.

## Implementation

- Replaced the descriptive subtitle with a benefit-led two-command deployment statement.
- Reduced the Qwen example to one build command, one run command, and `# Generated text: Paris`; only the stable output path and Qwen chat semantics remain explicit.
- Kept a two-line C++ example linked to the full API documentation.
- Added a visible `Getting Started` section after the complete `Why TensorRT-Model-Connect?` section, labeled AI-Native as the recommended quick start, and linked the complete Quick Start documentation.

## Validation

- `git diff --check github/main...HEAD`: passed.
- `bash -n /tmp/trtmc_readme_commands.sh`: passed for the exact README command block.
- `c++ -std=c++17 -fsyntax-only -Iinclude /tmp/trtmc_readme_cpp_snippet.cpp`: passed for a wrapper containing the exact README C++ lines and required includes.
- `python3 -m pytest tests/builder/test_cli.py::test_default_bundle_path_uses_model_name -q`: passed (`1 passed`).
- `python3 -c 'from pathlib import Path; s=Path("README.md").read_text(); assert "<details>" not in s; assert s.index("## What is TensorRT-Model-Connect?") < s.index("## Why TensorRT-Model-Connect?") < s.index("## Getting Started") < s.index("## 📚 Explore the documentation"); assert "Recommended Quick Start: AI-Native" in s'`: passed.
- `test -f website/docs/getting-started/quick-start.md`: passed.
- GPU inference was not rerun; the representative `Paris` result is backed by the canonical quick start and Qwen E2E manifests.

## Notes For Future Readers

- Machine-dependent timing lines are intentionally omitted; the comment shows generated text only.
- The C++ example demonstrates the same bundle and public API shape, not full parity with every CLI decoding flag.
