### PR TITLE
test(wan): isolate official source environment

### DIFF
--- a/tests/e2e/models/wan2_2_ti2v/test_wan22_official_reference.py
+++ b/tests/e2e/models/wan2_2_ti2v/test_wan22_official_reference.py
@@ -39,6 +39,11 @@ _NATIVE_ACCEPTANCE = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _isolate_declared_official_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(wan22_official.OFFICIAL_SOURCE_ENV, raising=False)
+
+
 def _write_png(path: Path, width: int, height: int, value: int = 0) -> None:
     def chunk(kind: bytes, payload: bytes) -> bytes:
         return (


### PR DESCRIPTION
## Background

Wan model proof declares `TRTMC_WAN_REFERENCE_REPO` for the pinned official source checkout. The official-reference contract tests that exercise the `TRTMC_STORAGE_ROOT` fallback did not isolate that runner-provided variable, so the external checkout could override each test's temporary source tree.

## Exit Criteria

- Keep the official source tests hermetic with or without a runner-injected declared checkout.
- Preserve the production precedence of `TRTMC_WAN_REFERENCE_REPO` over the storage-root fallback.

## Implementation

- Clear the declared official-source variable at the test boundary with an autouse fixture.
- Keep the explicit declared-checkout test responsible for setting the variable it validates.

## Validation

- `TRTMC_WAN_REFERENCE_REPO=<pinned-checkout> python3 -m pytest tests/e2e/models/wan2_2_ti2v/test_wan22_official_reference.py -q`: 10 passed.
- Nightly-selected Wan Python test files in the matching CI runtime: 83 passed.
- `git diff --check`: passed.

## Notes For Future Readers

- This is test isolation only; the Wan resolver and model manifest are unchanged.
