### PR TITLE
feat(stereo): add Fast Foundation Stereo

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -18,6 +18,11 @@ defaults:
     asset_loading_included: false
 
 excluded_profiles:
+  - model: fast-foundation-stereo
+    reason: >-
+      The exact baseline is owned by the supplied rectified-stereo fixture
+      archive and model-local L4 harness; the public release runner does not
+      yet provide an equivalent redistributable stereo reference workload.
   - model: minimax-h3-768p
     reason: >-
       The pinned Diffusers reference for MiniMax-H3 has not yet been integrated

--- a/examples/trtmc_benchmark_worker.cpp
+++ b/examples/trtmc_benchmark_worker.cpp
@@ -818,6 +818,61 @@ Json run_detect(trtmc::IPipeline& pipeline, const Json& request, const TimingCon
     };
 }
 
+std::vector<float> synthetic_stereo_image(int32_t height, int32_t width, int32_t pixel_shift) {
+    std::vector<float> pixels(static_cast<std::size_t>(height) * width * 3);
+    for (int32_t y = 0; y < height; ++y) {
+        for (int32_t x = 0; x < width; ++x) {
+            const int32_t source_x = std::min(x + pixel_shift, width - 1);
+            const auto offset = (static_cast<std::size_t>(y) * width + x) * 3;
+            pixels[offset] = static_cast<float>(source_x % 256) / 255.0F;
+            pixels[offset + 1] = static_cast<float>(y % 256) / 255.0F;
+            pixels[offset + 2] = static_cast<float>((source_x + y) % 256) / 255.0F;
+        }
+    }
+    return pixels;
+}
+
+Json run_disparity(trtmc::IPipeline& pipeline, const Json& request, const TimingConfig& timing) {
+    const int32_t height = optional_value<int32_t>(request, "height", 700);
+    const int32_t width = optional_value<int32_t>(request, "width", 700);
+    const int32_t pixel_shift = optional_value<int32_t>(request, "pixel_shift", 12);
+    if (height <= 0 || width <= 0 || pixel_shift < 0 || pixel_shift >= width) {
+        throw std::runtime_error("invalid synthetic stereo dimensions or pixel shift");
+    }
+    const auto left = synthetic_stereo_image(height, width, 0);
+    const auto right = synthetic_stereo_image(height, width, pixel_shift);
+    trtmc::StereoDisparityResult last;
+    const auto estimate = [&]() {
+        return pipeline.estimate_disparity(left.data(), right.data(), height, width);
+    };
+    for (int index = 0; index < timing.warmup; ++index) {
+        last = estimate();
+    }
+    Json observations = Json::array();
+    for (int index = 0; index < timing.iterations; ++index) {
+        const IterationTimer timer(timing.scope);
+        last = estimate();
+        const double measured_ms = timer.elapsed_ms();
+        observations.push_back({
+            {"iteration", index},
+            {"measured_wall_ms", measured_ms},
+            {"runtime_e2e_wall_ms", measured_ms},
+            {"stereo_pairs", 1},
+            {"disparity_pixels", last.disparity.size()},
+        });
+    }
+    return {
+        {"observations", std::move(observations)},
+        {"output_summary",
+         {
+             {"height", last.height},
+             {"width", last.width},
+             {"element_count", last.disparity.size()},
+             {"finite_sum", finite_sum(last.disparity)},
+         }},
+    };
+}
+
 Json run_rerank(trtmc::IPipeline& pipeline, const Json& request, const TimingConfig& timing) {
     const int warmup = timing.warmup;
     const int iterations = timing.iterations;
@@ -1010,6 +1065,7 @@ Json execute(const Json& request) {
         {"segment_prompted", run_segment_prompted},
         {"classify", run_classify},
         {"detect", run_detect},
+        {"disparity", run_disparity},
         {"rerank", run_rerank},
         {"encode", run_encode},
         {"embed", run_embed},

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -158,6 +158,12 @@ struct SegmentResult {
     int32_t width{0};
 };
 
+struct StereoDisparityResult {
+    std::vector<float> disparity; // [H, W] non-negative disparity in pixels
+    int32_t height{0};
+    int32_t width{0};
+};
+
 struct PromptedSegmentationResult {
     std::vector<float> masks;      // [num_masks, H, W], logits after postprocess
     std::vector<float> iou_scores; // [num_masks]
@@ -439,6 +445,20 @@ class IPipeline {
         (void)height;
         (void)width;
         throw std::runtime_error(std::string(pipeline_type()) + " does not support segment()");
+    }
+
+    // -- Stereo disparity --
+    // Images are rectified RGB HWC float values in [0, 1], with matching
+    // dimensions. The result preserves the input height and width.
+    virtual StereoDisparityResult estimate_disparity(const float* left_pixels,
+                                                     const float* right_pixels, int32_t height,
+                                                     int32_t width) {
+        (void)left_pixels;
+        (void)right_pixels;
+        (void)height;
+        (void)width;
+        throw std::runtime_error(std::string(pipeline_type()) +
+                                 " does not support estimate_disparity()");
     }
 
     virtual PromptedSegmentationResult segment_prompted(const float* image_pixels,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ test = ["pytest>=7.0", "torch>=2.0"]
 # Build-only dependency for official Wan checkpoints containing T5/VAE .pth
 # files. Kept out of the base install and never required by the C++ runtime.
 wan = ["torch>=2.0"]
+fast-foundation-stereo = [
+    "torch>=2.6",
+    "timm>=1.0",
+    "imageio>=2.31",
+    "opencv-python-headless>=4.8",
+]
 chronos = ["chronos-forecasting>=2.2.2"]
 # clip: required by tests/e2e/models/flux/e2e_plugins/comparators/clip_metrics.py for
 # CLIP-based semantic metrics on diffusion model outputs.  Gracefully skipped

--- a/python/tensorrt_model_connect/benchmark/operations.py
+++ b/python/tensorrt_model_connect/benchmark/operations.py
@@ -137,6 +137,13 @@ _OPERATIONS = (
         rate_metrics=(RateMetric("detected_images", "images_per_s"),),
     ),
     OperationSpec(
+        name="disparity",
+        rate_metrics=(
+            RateMetric("stereo_pairs", "stereo_pairs_per_s"),
+            RateMetric("disparity_pixels", "disparity_pixels_per_s"),
+        ),
+    ),
+    OperationSpec(
         name="rerank",
         rate_metrics=(RateMetric("documents", "documents_per_s"),),
     ),

--- a/python/tensorrt_model_connect/benchmark/task_adapters.py
+++ b/python/tensorrt_model_connect/benchmark/task_adapters.py
@@ -683,6 +683,36 @@ def _transcribe_request(testcase: Mapping[str, Any], model_root: Path) -> CaseRe
     )
 
 
+def _stereo_disparity_request(
+    testcase: Mapping[str, Any], _model_root: Path
+) -> CaseResolution:
+    height, height_source = _testcase_value(testcase, "stereo_height", 700)
+    width, width_source = _testcase_value(testcase, "stereo_width", 700)
+    pixel_shift, shift_source = _testcase_value(testcase, "stereo_pixel_shift", 12)
+    height = int(height)
+    width = int(width)
+    pixel_shift = int(pixel_shift)
+    if height <= 0 or width <= 0:
+        raise BenchmarkError("disparity testcase dimensions must be positive")
+    if pixel_shift < 0 or pixel_shift >= width:
+        raise BenchmarkError("disparity testcase pixel shift must be in [0, width)")
+    return _resolution(
+        {
+            "batch_size": 1,
+            "height": height,
+            "width": width,
+            "pixel_shift": pixel_shift,
+        },
+        {
+            "batch_size": _TASK_DEFAULT,
+            "height": height_source,
+            "width": width_source,
+            "pixel_shift": shift_source,
+        },
+        testcase=testcase,
+    )
+
+
 _TASK_ADAPTERS = (
     TaskAdapter(
         "text_generation_causal",
@@ -779,6 +809,12 @@ _TASK_ADAPTERS = (
         "transcribe",
         MeasurementSpec(warmup=1, iterations=10),
         _transcribe_request,
+    ),
+    TaskAdapter(
+        "stereo_disparity",
+        "disparity",
+        MeasurementSpec(warmup=3, iterations=100),
+        _stereo_disparity_request,
     ),
 )
 

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/MODEL.toml
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/MODEL.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "fast_foundation_stereo"
+plugin = "fast_foundation_stereo"
+module = "plugin"
+config_adapter = "model_config.py|config_from_dir"
+model_dir_adapter = "prepare_model.py|resolve_model_dir"
+hf_allow_patterns = [
+  "cfg.yaml",
+  "model_best_bp2_serialize.pth",
+]
+hf_required_files = [
+  "nvidia/c-fast-foundationstereo|model_best_bp2_serialize.pth",
+]
+aliases = [
+  "fast-foundation-stereo",
+  "fast_foundation_stereo",
+  "foundation_stereo_lite",
+]
+prefixes = [
+  "fast_foundation_stereo",
+]

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/__init__.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .plugin import FastFoundationStereoPlugin
+
+plugin = FastFoundationStereoPlugin()
+
+__all__ = ["FastFoundationStereoPlugin", "plugin"]

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/builder.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/builder.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ONNX-to-TensorRT builders for Fast Foundation Stereo's split graph."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+
+FEATURE_OUTPUT_NAMES = (
+    "features_left_04",
+    "features_left_08",
+    "features_left_16",
+    "features_left_32",
+    "features_right_04",
+    "stem_2x",
+)
+
+
+@contextmanager
+def _model_source_scope(model_root: Path):
+    old_cwd = Path.cwd()
+    source = str(model_root)
+    sys.path.insert(0, source)
+    os.chdir(model_root)
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
+        if sys.path and sys.path[0] == source:
+            sys.path.pop(0)
+
+
+def _load_model(model_root: Path, *, max_disparity: int, valid_iters: int):
+    import torch
+    from .prepare_model import (
+        configure_official_model_args,
+        install_official_io_import_shims,
+    )
+
+    install_official_io_import_shims()
+    checkpoint = model_root / "weights/23-36-37/model_best_bp2_serialize.pth"
+    model = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    configure_official_model_args(
+        model,
+        max_disparity=max_disparity,
+        valid_iters=valid_iters,
+    )
+    return model.cuda().eval()
+
+
+def _unwrap_compiled(function):
+    return getattr(function, "_torchdynamo_orig_callable", function)
+
+
+def _disable_compile_wrappers() -> None:
+    import core.foundation_stereo as foundation_stereo
+    import core.geometry as geometry
+    import core.submodule as submodule
+
+    submodule.build_concat_volume_optimized_pytorch = _unwrap_compiled(
+        submodule.build_concat_volume_optimized_pytorch
+    )
+    foundation_stereo.build_concat_volume_optimized_pytorch = (
+        submodule.build_concat_volume_optimized_pytorch
+    )
+    geometry.bilinear_sampler1d = _unwrap_compiled(geometry.bilinear_sampler1d)
+
+
+def _feature_onnx(model, *, fp16: bool) -> bytes:
+    import torch
+    from core.foundation_stereo import TrtFeatureRunner
+
+    class FeatureWrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.runner = TrtFeatureRunner(model)
+
+        def forward(self, left, right):
+            with torch.amp.autocast("cuda", enabled=fp16, dtype=torch.float16):
+                return self.runner(left, right)
+
+    image = torch.zeros((1, 3, 704, 704), device="cuda", dtype=torch.float32)
+    output = io.BytesIO()
+    torch.onnx.export(
+        FeatureWrapper().cuda().eval(),
+        (image, image),
+        output,
+        input_names=("left", "right"),
+        output_names=FEATURE_OUTPUT_NAMES,
+        opset_version=17,
+        dynamo=False,
+        do_constant_folding=True,
+    )
+    return output.getvalue()
+
+
+def _post_onnx(model, *, fp16: bool) -> bytes:
+    import torch
+    from core.foundation_stereo import TrtPostRunner
+
+    _disable_compile_wrappers()
+
+    class PostWrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.runner = TrtPostRunner(model)
+
+        def forward(
+            self,
+            features_left_04,
+            features_left_08,
+            features_left_16,
+            features_left_32,
+            features_right_04,
+            stem_2x,
+            gwc_volume,
+        ):
+            with torch.amp.autocast("cuda", enabled=fp16, dtype=torch.float16):
+                disparity = self.runner(
+                    features_left_04,
+                    features_left_08,
+                    features_left_16,
+                    features_left_32,
+                    features_right_04,
+                    stem_2x,
+                    gwc_volume,
+                )
+            return disparity.float()
+
+    dtype = torch.float16 if fp16 else torch.float32
+    inputs = (
+        torch.zeros((1, 224, 176, 176), device="cuda", dtype=dtype),
+        torch.zeros((1, 192, 88, 88), device="cuda", dtype=dtype),
+        torch.zeros((1, 320, 44, 44), device="cuda", dtype=dtype),
+        torch.zeros((1, 304, 22, 22), device="cuda", dtype=torch.float32),
+        torch.zeros((1, 224, 176, 176), device="cuda", dtype=dtype),
+        torch.zeros((1, 16, 352, 352), device="cuda", dtype=dtype),
+        torch.zeros((1, 8, 48, 176, 176), device="cuda", dtype=dtype),
+    )
+    output = io.BytesIO()
+    torch.onnx.export(
+        PostWrapper().cuda().eval(),
+        inputs,
+        output,
+        input_names=FEATURE_OUTPUT_NAMES + ("gwc_volume",),
+        output_names=("disp",),
+        opset_version=17,
+        dynamo=False,
+        do_constant_folding=True,
+    )
+    return output.getvalue()
+
+
+def _build_engine(
+    onnx_bytes: bytes,
+    *,
+    fp16: bool,
+    optimization_level: int,
+    auxiliary_streams: int,
+    workspace_gib: int,
+    verbose: bool,
+) -> bytes:
+    from tensorrt_model_connect import trt_compat
+
+    trt = trt_compat.get_trt()
+    logger = trt.Logger(trt.Logger.INFO if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    flags = trt_compat.network_creation_flags(explicit_batch=True)
+    network = builder.create_network(flags)
+    parser = trt.OnnxParser(network, logger)
+    if not parser.parse(onnx_bytes):
+        errors = "\n".join(str(parser.get_error(i)) for i in range(parser.num_errors))
+        raise RuntimeError(f"TensorRT failed to parse Fast Foundation Stereo ONNX:\n{errors}")
+
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_gib << 30)
+    if fp16:
+        _set_fp16_flag_if_supported(config, trt)
+    if hasattr(config, "builder_optimization_level"):
+        config.builder_optimization_level = optimization_level
+    if hasattr(config, "max_aux_streams"):
+        config.max_aux_streams = auxiliary_streams
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TensorRT failed to build Fast Foundation Stereo engine")
+    return bytes(plan)
+
+
+def _set_fp16_flag_if_supported(config, trt) -> None:
+    """Enable the legacy weakly typed FP16 policy when TensorRT exposes it."""
+    builder_flag = getattr(trt, "BuilderFlag", None)
+    fp16_flag = getattr(builder_flag, "FP16", None)
+    if fp16_flag is not None:
+        config.set_flag(fp16_flag)
+
+
+def _validate_precision(precision: str) -> bool:
+    if precision not in {"fp16", "fp32"}:
+        raise ValueError(
+            "Fast Foundation Stereo supports precision='fp16' or precision='fp32'; "
+            f"got {precision!r}"
+        )
+    return precision == "fp16"
+
+
+def build_feature_engine(
+    model_dir: str,
+    *,
+    precision: str,
+    max_disparity: int,
+    valid_iters: int,
+    verbose: bool = False,
+) -> bytes:
+    model_root = Path(model_dir).resolve()
+    fp16 = _validate_precision(precision)
+    with _model_source_scope(model_root):
+        model = _load_model(model_root, max_disparity=max_disparity, valid_iters=valid_iters)
+        onnx_bytes = _feature_onnx(model, fp16=fp16)
+        return _build_engine(
+            onnx_bytes,
+            fp16=fp16,
+            optimization_level=3,
+            auxiliary_streams=2,
+            workspace_gib=8,
+            verbose=verbose,
+        )
+
+
+def build_post_engine(
+    model_dir: str,
+    *,
+    precision: str,
+    max_disparity: int,
+    valid_iters: int,
+    verbose: bool = False,
+) -> bytes:
+    model_root = Path(model_dir).resolve()
+    fp16 = _validate_precision(precision)
+    with _model_source_scope(model_root):
+        model = _load_model(model_root, max_disparity=max_disparity, valid_iters=valid_iters)
+        onnx_bytes = _post_onnx(model, fp16=fp16)
+        return _build_engine(
+            onnx_bytes,
+            fp16=fp16,
+            optimization_level=3,
+            auxiliary_streams=2,
+            workspace_gib=8,
+            verbose=verbose,
+        )

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/model_config.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/model_config.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Config adapter for the standalone Fast Foundation Stereo package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_CHECKPOINT = Path("weights/23-36-37/model_best_bp2_serialize.pth")
+
+
+def config_from_dir(model_dir: str | Path) -> dict | None:
+    model_path = Path(model_dir)
+    required = (
+        model_path / "core/foundation_stereo.py",
+        model_path / "core/submodule.py",
+        model_path / _CHECKPOINT,
+    )
+    if not all(path.is_file() for path in required):
+        return None
+
+    benchmark: dict = {}
+    benchmark_path = model_path / "reference/benchmark_result.json"
+    if benchmark_path.is_file():
+        try:
+            loaded = json.loads(benchmark_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                benchmark = loaded
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    return {
+        "model_type": "fast_foundation_stereo",
+        "architectures": ["FastFoundationStereo"],
+        "runtime_strategy": "fast_foundation_stereo_disparity",
+        "vocab_size": 0,
+        "hidden_size": 0,
+        "num_hidden_layers": 0,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 1,
+        "stereo_input_height": 700,
+        "stereo_input_width": 700,
+        "stereo_engine_height": 704,
+        "stereo_engine_width": 704,
+        "stereo_max_disparity": int(benchmark.get("max_disp", 192)),
+        "stereo_valid_iters": int(benchmark.get("valid_iters", 8)),
+        "stereo_cv_groups": 8,
+        "stereo_normalize_gwc": True,
+        "stereo_post_engine_section": "fast_foundation_stereo_post_engine_plan",
+        "stereo_accuracy_metric": "flattened_cosine_similarity",
+        "stereo_min_cosine": 0.999,
+        "requires_tokenizer": False,
+    }

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/plugin.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/plugin.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo family plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+
+_CHECKPOINT = Path("weights/23-36-37/model_best_bp2_serialize.pth")
+_POST_SECTION = "fast_foundation_stereo_post_engine_plan"
+
+
+class ModelConfig(Protocol):
+    """The small builder-config surface consumed by this family."""
+
+    raw: dict
+
+
+class WeightDict(dict):
+    """Model-owned weight payload passed between the generic builder hooks."""
+
+
+class FastFoundationStereoPlugin:
+    name = "fast_foundation_stereo"
+    runtime_strategy = "fast_foundation_stereo_disparity"
+    requires_tokenizer = False
+
+    def matches(self, model_type: str) -> bool:
+        return (model_type or "").lower().replace("-", "_") in {
+            "fast_foundation_stereo",
+            "foundation_stereo_lite",
+        }
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> WeightDict:
+        del precision
+        model_path = Path(model_dir).resolve()
+        checkpoint = model_path / _CHECKPOINT
+        source = model_path / "core/foundation_stereo.py"
+        if not checkpoint.is_file() or not source.is_file():
+            raise FileNotFoundError(
+                "Fast Foundation Stereo requires core/foundation_stereo.py and "
+                f"{_CHECKPOINT.as_posix()} under {model_path}"
+            )
+        config.raw["_fast_foundation_stereo_model_dir"] = str(model_path)
+        return WeightDict({"_fast_foundation_stereo_model_dir": str(model_path)})
+
+    @staticmethod
+    def _model_dir(config: ModelConfig, weights: WeightDict) -> str:
+        model_dir = weights.get("_fast_foundation_stereo_model_dir") or config.raw.get(
+            "_fast_foundation_stereo_model_dir"
+        )
+        if not model_dir:
+            raise RuntimeError("Fast Foundation Stereo model directory was not loaded")
+        return str(model_dir)
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp16",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        del max_cache_length, quant_ctx
+        from .builder import build_feature_engine
+
+        return build_feature_engine(
+            self._model_dir(config, weights),
+            precision=precision,
+            max_disparity=int(config.raw.get("stereo_max_disparity", 192)),
+            valid_iters=int(config.raw.get("stereo_valid_iters", 8)),
+            verbose=verbose,
+        )
+
+    def build_extra_engines(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp16",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> dict[str, bytes]:
+        del max_cache_length, quant_ctx
+        from .builder import build_post_engine
+
+        return {
+            _POST_SECTION: build_post_engine(
+                self._model_dir(config, weights),
+                precision=precision,
+                max_disparity=int(config.raw.get("stereo_max_disparity", 192)),
+                valid_iters=int(config.raw.get("stereo_valid_iters", 8)),
+                verbose=verbose,
+            )
+        }
+
+
+plugin = FastFoundationStereoPlugin()

--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/prepare_model.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/prepare_model.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compose the official HF checkpoint with its pinned open-source model code."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import types
+import urllib.request
+from pathlib import Path
+
+
+_SOURCE_REVISION = "a290ba04c1b3ad1ec41a33974a157b2917b624d4"
+_SOURCE_SHA256 = "c11d945db0fb765c0bdf355311f986ab914ad2619133de3a26f84a3ecbddf6c9"
+_SOURCE_URL = f"https://github.com/NVlabs/Fast-FoundationStereo/archive/{_SOURCE_REVISION}.tar.gz"
+_NESTED_CHECKPOINT = Path("weights/23-36-37/model_best_bp2_serialize.pth")
+_FLAT_CHECKPOINT = Path("model_best_bp2_serialize.pth")
+
+
+def configure_official_model_args(
+    model,
+    *,
+    max_disparity: int,
+    valid_iters: int,
+) -> None:
+    """Apply the complete inference contract omitted by older checkpoints."""
+    model.args.max_disp = max_disparity
+    model.args.valid_iters = valid_iters
+    model.args.normalize = True
+
+
+def install_official_io_import_shims() -> None:
+    """Satisfy unused official visualization imports during model loading."""
+    if "imageio" not in sys.modules and importlib.util.find_spec("imageio") is None:
+        sys.modules["imageio"] = types.ModuleType("imageio")
+    if "cv2" not in sys.modules and importlib.util.find_spec("cv2") is None:
+        cv2 = types.ModuleType("cv2")
+        cv2.COLORMAP_TURBO = 20
+        sys.modules["cv2"] = cv2
+
+
+def _complete_source(root: Path) -> bool:
+    return all(
+        (root / relative).is_file()
+        for relative in (
+            "Utils.py",
+            "core/foundation_stereo.py",
+            "core/submodule.py",
+            "core/geometry.py",
+            "core/extractor.py",
+            "core/update.py",
+        )
+    )
+
+
+def _cache_root() -> Path:
+    configured = os.environ.get("TRTMC_FAST_FOUNDATION_STEREO_CACHE")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".cache/tensorrt_model_connect/fast_foundation_stereo"
+
+
+def _verified_source(*, local_files_only: bool = False) -> Path:
+    override = os.environ.get("TRTMC_FAST_FOUNDATION_STEREO_SOURCE_DIR")
+    if override:
+        source = Path(override).expanduser().resolve()
+        if not _complete_source(source):
+            raise FileNotFoundError(
+                "TRTMC_FAST_FOUNDATION_STEREO_SOURCE_DIR does not contain the "
+                "official Fast-FoundationStereo source tree"
+            )
+        return source
+
+    destination = _cache_root() / f"source-{_SOURCE_REVISION}"
+    if _complete_source(destination):
+        return destination
+    if local_files_only:
+        raise FileNotFoundError(
+            "Pinned Fast-FoundationStereo source is not present in the local cache; "
+            "prepare the model once without local-files-only"
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="fast-foundation-stereo-", dir=destination.parent
+    ) as temporary:
+        temporary_path = Path(temporary)
+        archive = temporary_path / "source.tar.gz"
+        urllib.request.urlretrieve(_SOURCE_URL, archive)
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        if digest != _SOURCE_SHA256:
+            raise RuntimeError(
+                "Fast-FoundationStereo source archive checksum mismatch: "
+                f"expected {_SOURCE_SHA256}, got {digest}"
+            )
+        extracted = temporary_path / "extracted"
+        extracted.mkdir()
+        prefix = f"Fast-FoundationStereo-{_SOURCE_REVISION}/"
+        with tarfile.open(archive, "r:gz") as source_archive:
+            for member in source_archive.getmembers():
+                if not member.name.startswith(prefix):
+                    continue
+                relative = member.name[len(prefix) :]
+                relative_path = Path(relative)
+                if relative_path.is_absolute() or ".." in relative_path.parts:
+                    continue
+                selected = relative in {
+                    "Utils.py",
+                    "LICENSE.txt",
+                } or relative.startswith("core/")
+                if not selected or member.issym() or member.islnk():
+                    continue
+                destination_path = extracted / relative_path
+                if member.isdir():
+                    destination_path.mkdir(parents=True, exist_ok=True)
+                    continue
+                if not member.isfile():
+                    continue
+                destination_path.parent.mkdir(parents=True, exist_ok=True)
+                source_file = source_archive.extractfile(member)
+                if source_file is None:
+                    raise RuntimeError(f"Failed to extract {relative} from source archive")
+                with source_file, destination_path.open("wb") as output_file:
+                    shutil.copyfileobj(source_file, output_file)
+        if not _complete_source(extracted):
+            raise RuntimeError("Pinned Fast-FoundationStereo archive is missing model source")
+        if destination.exists():
+            shutil.rmtree(destination)
+        extracted.rename(destination)
+    return destination
+
+
+def _link(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists() or destination.is_symlink():
+        destination.unlink()
+    destination.symlink_to(source)
+
+
+def resolve_model_dir(
+    model_dir: str | Path,
+    *,
+    local_files_only: bool = False,
+) -> Path | None:
+    """Stage the flat NVIDIA HF checkpoint beside pinned official source code."""
+    root = Path(model_dir).resolve()
+    if _complete_source(root) and (root / _NESTED_CHECKPOINT).is_file():
+        return None
+    checkpoint = root / _FLAT_CHECKPOINT
+    if not checkpoint.is_file():
+        return None
+
+    source = _verified_source(local_files_only=local_files_only)
+    identity = hashlib.sha256(str(root).encode()).hexdigest()[:16]
+    staged = _cache_root() / "staged" / identity
+    staged.mkdir(parents=True, exist_ok=True)
+    _link(source / "core", staged / "core")
+    _link(source / "Utils.py", staged / "Utils.py")
+    if (source / "LICENSE.txt").is_file():
+        _link(source / "LICENSE.txt", staged / "LICENSE.txt")
+    _link(checkpoint, staged / _NESTED_CHECKPOINT)
+    config = root / "cfg.yaml"
+    if config.is_file():
+        _link(config, staged / "cfg.yaml")
+    return staged

--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -103,6 +103,7 @@ _TASK_STRATEGY_TO_MODALITY = {
     # Kept explicit for forward-compatible manifests.  Unknown strategies
     # still receive the structured TRT/reference fallback renderer.
     "object_detection": "detection",
+    "stereo_disparity": "numeric",
 }
 
 

--- a/scripts/warm_hf_cache.py
+++ b/scripts/warm_hf_cache.py
@@ -111,6 +111,7 @@ _ENTRYPOINT_PATTERNS = [
 _WEIGHT_PATTERNS = [
     "*.safetensors",
     "*.bin",
+    "*.pth",
     "*.nemo",
     "model.npz",
     "elf_params.npz",

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -204,6 +204,8 @@ void print_usage() {
            "[--num-images N] [--prompts-file PATH] [--seed s0,s1,...]\n"
            "  trtmc encode          <bundle.bundle> --prompt \"text\" [--hf-python PATH]\n"
            "  trtmc segment         <bundle.bundle> --image PATH --output PATH [--hf-python PATH]\n"
+           "  trtmc disparity       <bundle.bundle> --image LEFT --right-image RIGHT "
+           "--output PATH\n"
            "  trtmc segment-prompted <bundle.bundle> --image PATH --output DIR "
            "[--point-x F] [--point-y F] [--background] [--prompt TEXT] [--hf-python PATH]\n"
            "  trtmc classify        <bundle.bundle> --image PATH [--benchmark N] [--warmup N]\n"
@@ -274,10 +276,10 @@ CliArgs parse_args(int argc, char** argv) {
     }
 
     static const char* known_cmds[] = {
-        "run",      "inspect", "generate-video", "segment",     "segment-prompted",
-        "classify", "detect",  "generate-audio", "serve-audio", "encode",
-        "embed",    "rerank",  "solve",          "speak",       "transcribe",
-        nullptr};
+        "run",        "inspect",  "generate-video", "segment",        "segment-prompted",
+        "disparity",  "classify", "detect",         "generate-audio", "serve-audio",
+        "encode",     "embed",    "rerank",         "solve",          "speak",
+        "transcribe", nullptr};
     bool valid = false;
     for (const char** p = known_cmds; *p; ++p)
         if (args.command == *p) {
@@ -485,6 +487,10 @@ CliArgs parse_args(int argc, char** argv) {
         }
         if (arg == "--image" && need_value(arg)) {
             args.image_path = argv[++i];
+            continue;
+        }
+        if (arg == "--right-image" && need_value(arg)) {
+            args.right_image_path = argv[++i];
             continue;
         }
         if (arg == "--lora-adapter" && need_value(arg)) {

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -21,6 +21,7 @@ struct CliArgs {
     std::string hf_python;
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;
+    std::string right_image_path;
     std::string lora_adapter_path;
     std::string lora_adapter_id{"default"};
     std::string output_dir;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -901,6 +901,43 @@ int cmd_segment(const CliArgs& args) {
     return EXIT_SUCCESS;
 }
 
+int cmd_disparity(const CliArgs& args) {
+    if (args.bundle_path.empty() || args.image_path.empty() || args.right_image_path.empty()) {
+        std::cerr << "Error: disparity requires bundle + --image + --right-image\n";
+        return EXIT_FAILURE;
+    }
+
+    const auto left = trtmc::io::read_image(args.image_path);
+    const auto right = trtmc::io::read_image(args.right_image_path);
+    if (left.empty() || right.empty()) {
+        std::cerr << "Error: failed to load stereo images\n";
+        return EXIT_FAILURE;
+    }
+    if (left.height != right.height || left.width != right.width) {
+        std::cerr << "Error: stereo image dimensions must match\n";
+        return EXIT_FAILURE;
+    }
+
+    auto pipeline = load_pipeline(args);
+    const auto result = pipeline->estimate_disparity(left.pixels.data(), right.pixels.data(),
+                                                     left.height, left.width);
+    const std::string out_path = args.output_dir.empty() ? "/tmp/disparity.f32" : args.output_dir;
+    std::ofstream output(out_path, std::ios::binary);
+    if (!output || result.disparity.empty()) {
+        std::cerr << "Error: failed to create disparity output: " << out_path << '\n';
+        return EXIT_FAILURE;
+    }
+    output.write(reinterpret_cast<const char*>(result.disparity.data()),
+                 static_cast<std::streamsize>(result.disparity.size() * sizeof(float)));
+    if (!output) {
+        std::cerr << "Error: failed to write disparity output: " << out_path << '\n';
+        return EXIT_FAILURE;
+    }
+    std::cout << "{\"output\":\"" << out_path << "\",\"height\":" << result.height
+              << ",\"width\":" << result.width << ",\"dtype\":\"float32\"}\n";
+    return EXIT_SUCCESS;
+}
+
 int cmd_classify(const CliArgs& args) {
     if (args.bundle_path.empty() || args.image_path.empty()) {
         std::cerr << "Error: classify requires bundle + --image\n";
@@ -1636,6 +1673,8 @@ int main(int argc, char** argv) {
             return cmd_encode(args);
         if (args.command == "segment")
             return cmd_segment(args);
+        if (args.command == "disparity")
+            return cmd_disparity(args);
         if (args.command == "segment-prompted")
             return cmd_segment_prompted(args);
         if (args.command == "classify")

--- a/src/runtime/models/fast_foundation_stereo/MODEL.toml
+++ b/src/runtime/models/fast_foundation_stereo/MODEL.toml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "fast_foundation_stereo"
+runtime_library = "libtrtmc_model_fast_foundation_stereo.so"
+runtime_plugins = ["plugin.cpp|register_fast_foundation_stereo_plugin"]
+runtime_strategies = ["fast_foundation_stereo_disparity"]
+runtime_tests = [
+  "test_fast_foundation_stereo_preprocess|test_fast_foundation_stereo_preprocess.cpp|trtmc_model_fast_foundation_stereo|_|_",
+  "test_fast_foundation_stereo_gwc|test_fast_foundation_stereo_gwc.cpp|trtmc_model_fast_foundation_stereo|_|REQUIRES_GPU",
+]

--- a/src/runtime/models/fast_foundation_stereo/gwc_kernel.cu
+++ b/src/runtime/models/fast_foundation_stereo/gwc_kernel.cu
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/fast_foundation_stereo/gwc_kernel.h"
+
+#include <cmath>
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+namespace {
+
+constexpr int kChannels = 224;
+constexpr int kGroups = 8;
+constexpr int kChannelsPerGroup = kChannels / kGroups;
+constexpr int kHeight = 176;
+constexpr int kWidth = 176;
+constexpr int kDisparities = 48;
+
+__global__ void group_norm_kernel(const __half* input, __half* norm) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const int count = kGroups * kHeight * kWidth;
+    if (index >= count)
+        return;
+    const int width_index = index % kWidth;
+    const int tmp = index / kWidth;
+    const int height_index = tmp % kHeight;
+    const int group = tmp / kHeight;
+    float sum = 0.0F;
+    for (int channel = 0; channel < kChannelsPerGroup; ++channel) {
+        const int channel_index = group * kChannelsPerGroup + channel;
+        const int input_index = (channel_index * kHeight + height_index) * kWidth + width_index;
+        const float value = __half2float(input[input_index]);
+        sum += value * value;
+    }
+    norm[index] = __float2half_rn(sqrtf(sum));
+}
+
+__global__ void gwc_kernel(const __half* reference, const __half* target,
+                           const __half* reference_norm, const __half* target_norm,
+                           __half* output) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    constexpr int count = kGroups * kDisparities * kHeight * kWidth;
+    if (index >= count)
+        return;
+
+    int remaining = index;
+    const int width_index = remaining % kWidth;
+    remaining /= kWidth;
+    const int height_index = remaining % kHeight;
+    remaining /= kHeight;
+    const int disparity = remaining % kDisparities;
+    const int group = remaining / kDisparities;
+    const int target_width = width_index - disparity;
+    if (target_width < 0) {
+        output[index] = __float2half(0.0F);
+        return;
+    }
+
+    float dot = 0.0F;
+    for (int channel = 0; channel < kChannelsPerGroup; ++channel) {
+        const int channel_index = group * kChannelsPerGroup + channel;
+        const int reference_index = (channel_index * kHeight + height_index) * kWidth + width_index;
+        const int target_index = (channel_index * kHeight + height_index) * kWidth + target_width;
+        dot += __half2float(reference[reference_index]) * __half2float(target[target_index]);
+    }
+    const int reference_norm_index = (group * kHeight + height_index) * kWidth + width_index;
+    const int target_norm_index = (group * kHeight + height_index) * kWidth + target_width;
+    const float denominator = __half2float(reference_norm[reference_norm_index]) *
+                                  __half2float(target_norm[target_norm_index]) +
+                              1.0e-5F;
+    output[index] = __float2half_rn(dot / denominator);
+}
+
+} // namespace
+
+cudaError_t launch_fast_foundation_stereo_gwc(const void* reference, const void* target,
+                                              void* reference_norm, void* target_norm, void* output,
+                                              cudaStream_t stream) {
+    constexpr int threads = 256;
+    constexpr int norm_count = kGroups * kHeight * kWidth;
+    constexpr int output_count = kGroups * kDisparities * kHeight * kWidth;
+    group_norm_kernel<<<(norm_count + threads - 1) / threads, threads, 0, stream>>>(
+        static_cast<const __half*>(reference), static_cast<__half*>(reference_norm));
+    group_norm_kernel<<<(norm_count + threads - 1) / threads, threads, 0, stream>>>(
+        static_cast<const __half*>(target), static_cast<__half*>(target_norm));
+    gwc_kernel<<<(output_count + threads - 1) / threads, threads, 0, stream>>>(
+        static_cast<const __half*>(reference), static_cast<const __half*>(target),
+        static_cast<const __half*>(reference_norm), static_cast<const __half*>(target_norm),
+        static_cast<__half*>(output));
+    return cudaGetLastError();
+}
+
+} // namespace trtmc

--- a/src/runtime/models/fast_foundation_stereo/gwc_kernel.h
+++ b/src/runtime/models/fast_foundation_stereo/gwc_kernel.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+cudaError_t launch_fast_foundation_stereo_gwc(const void* reference, const void* target,
+                                              void* reference_norm, void* target_norm, void* output,
+                                              cudaStream_t stream);
+
+} // namespace trtmc

--- a/src/runtime/models/fast_foundation_stereo/plugin.cpp
+++ b/src/runtime/models/fast_foundation_stereo/plugin.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bundle/bundle_format.h"
+#include "bundle/bundle_view.h"
+#include "runtime/models/fast_foundation_stereo/stereo_pipeline.h"
+#include "trtmc/runtime/pipeline_registry.h"
+#include "trtmc/runtime/trt_backend.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc {
+namespace {
+
+std::unique_ptr<ITrtModule> load_module(IBackend* backend, const std::vector<char>* plan,
+                                        const ModuleCreateOptions& options, const char* label) {
+    if (backend == nullptr || plan == nullptr || plan->empty())
+        throw std::runtime_error(std::string("Fast Foundation Stereo missing ") + label);
+    auto module = backend->create_module(plan->data(), plan->size(), options);
+    if (!module || !module->ok())
+        throw std::runtime_error(std::string("Fast Foundation Stereo failed to load ") + label);
+    return module;
+}
+
+} // namespace
+
+class FastFoundationStereoPlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions feature_options;
+        feature_options.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        feature_options.cuda_graphs = ctx.cuda_graphs;
+        auto feature = load_module(ctx.backend, find_section(ctx.bundle, "engine_plan"),
+                                   feature_options, "feature engine_plan");
+
+        ModuleCreateOptions post_options = feature_options;
+        post_options.stream = feature->stream();
+        auto post = load_module(ctx.backend,
+                                find_section(ctx.bundle, "fast_foundation_stereo_post_engine_plan"),
+                                post_options, "post engine plan");
+        return std::make_unique<FastFoundationStereoPipeline>(std::move(feature), std::move(post),
+                                                              ctx.bundle.info.model_id);
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_fast_foundation_stereo_plugin,
+                                       FastFoundationStereoPlugin,
+                                       "fast_foundation_stereo_disparity");
+
+} // namespace trtmc

--- a/src/runtime/models/fast_foundation_stereo/stereo_pipeline.cpp
+++ b/src/runtime/models/fast_foundation_stereo/stereo_pipeline.cpp
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/fast_foundation_stereo/stereo_pipeline.h"
+
+#include "runtime/models/fast_foundation_stereo/gwc_kernel.h"
+
+#include <algorithm>
+#include <cuda_runtime_api.h>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+
+#if !TRTMC_HAS_CUDA_KERNELS
+cudaError_t launch_fast_foundation_stereo_gwc(const void*, const void*, void*, void*, void*,
+                                              cudaStream_t) {
+    return cudaErrorNotSupported;
+}
+#endif
+
+namespace {
+
+constexpr int32_t kInputHeight = 700;
+constexpr int32_t kInputWidth = 700;
+constexpr int32_t kEngineHeight = 704;
+constexpr int32_t kEngineWidth = 704;
+constexpr int32_t kPadTop = 2;
+constexpr int32_t kPadLeft = 2;
+
+void check_cuda(const char* operation, cudaError_t status) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("FastFoundationStereoPipeline: ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+    }
+}
+
+Tensor input_tensor(std::vector<float>& data) {
+    Tensor tensor;
+    tensor.data = data.data();
+    tensor.shape = {1, 3, kEngineHeight, kEngineWidth};
+    tensor.dtype = DType::kFloat32;
+    return tensor;
+}
+
+} // namespace
+
+void prepare_fast_foundation_stereo_image(const float* pixels, int32_t height, int32_t width,
+                                          std::vector<float>& output) {
+    if (pixels == nullptr)
+        throw std::invalid_argument("Fast Foundation Stereo image pointer is null");
+    if (height != kInputHeight || width != kInputWidth) {
+        throw std::invalid_argument("Fast Foundation Stereo requires 700x700 rectified images");
+    }
+    output.resize(static_cast<std::size_t>(3) * kEngineHeight * kEngineWidth);
+    for (int32_t channel = 0; channel < 3; ++channel) {
+        for (int32_t y = 0; y < kEngineHeight; ++y) {
+            const int32_t source_y = std::clamp(y - kPadTop, 0, height - 1);
+            for (int32_t x = 0; x < kEngineWidth; ++x) {
+                const int32_t source_x = std::clamp(x - kPadLeft, 0, width - 1);
+                const auto source_index =
+                    (static_cast<std::size_t>(source_y) * width + source_x) * 3 + channel;
+                const auto output_index =
+                    (static_cast<std::size_t>(channel) * kEngineHeight + y) * kEngineWidth + x;
+                output[output_index] = pixels[source_index] * 255.0F;
+            }
+        }
+    }
+}
+
+FastFoundationStereoPipeline::FastFoundationStereoPipeline(std::unique_ptr<ITrtModule> feature,
+                                                           std::unique_ptr<ITrtModule> post,
+                                                           std::string model_id)
+    : feature_(std::move(feature)), post_(std::move(post)),
+      reference_norm_({1, 8, 176, 176}, DType::kFloat16, feature_ ? feature_->stream() : nullptr),
+      target_norm_({1, 8, 176, 176}, DType::kFloat16, feature_ ? feature_->stream() : nullptr),
+      gwc_({1, 8, 48, 176, 176}, DType::kFloat16, feature_ ? feature_->stream() : nullptr),
+      model_id_(std::move(model_id)) {
+    if (!feature_ || !feature_->ok() || !post_ || !post_->ok())
+        throw std::runtime_error("FastFoundationStereoPipeline: invalid engine module");
+    if (feature_->stream() != post_->stream())
+        throw std::runtime_error(
+            "FastFoundationStereoPipeline: engines must share one CUDA stream");
+    if (!reference_norm_.ok() || !target_norm_.ok() || !gwc_.ok())
+        throw std::runtime_error("FastFoundationStereoPipeline: failed to allocate GWC buffers");
+}
+
+void FastFoundationStereoPipeline::bind_post_inputs() {
+    static constexpr const char* names[] = {
+        "features_left_04", "features_left_08",  "features_left_16",
+        "features_left_32", "features_right_04", "stem_2x",
+    };
+    for (const char* name : names) {
+        void* pointer = feature_->device_ptr(name);
+        if (pointer == nullptr)
+            throw std::runtime_error(std::string("FastFoundationStereoPipeline: missing feature ") +
+                                     name);
+        post_->bind_external(name, pointer);
+    }
+    post_->bind_external("gwc_volume", gwc_.data());
+    post_inputs_bound_ = true;
+}
+
+StereoDisparityResult FastFoundationStereoPipeline::estimate_disparity(const float* left_pixels,
+                                                                       const float* right_pixels,
+                                                                       int32_t height,
+                                                                       int32_t width) {
+    prepare_fast_foundation_stereo_image(left_pixels, height, width, left_input_);
+    prepare_fast_foundation_stereo_image(right_pixels, height, width, right_input_);
+    feature_->forward_async(
+        {{"left", input_tensor(left_input_)}, {"right", input_tensor(right_input_)}});
+    if (!post_inputs_bound_)
+        bind_post_inputs();
+
+    check_cuda("GWC launch", launch_fast_foundation_stereo_gwc(
+                                 feature_->device_ptr("features_left_04"),
+                                 feature_->device_ptr("features_right_04"), reference_norm_.data(),
+                                 target_norm_.data(), gwc_.data(), feature_->stream()));
+    post_->forward_async({});
+
+    const auto* disparity = static_cast<const float*>(post_->device_ptr("disp"));
+    if (disparity == nullptr)
+        throw std::runtime_error("FastFoundationStereoPipeline: missing disparity output");
+    padded_output_.resize(static_cast<std::size_t>(kEngineHeight) * kEngineWidth);
+    check_cuda("disparity download", cudaMemcpyAsync(padded_output_.data(), disparity,
+                                                     padded_output_.size() * sizeof(float),
+                                                     cudaMemcpyDeviceToHost, post_->stream()));
+    post_->sync();
+
+    StereoDisparityResult result;
+    result.height = height;
+    result.width = width;
+    result.disparity.resize(static_cast<std::size_t>(height) * width);
+    for (int32_t y = 0; y < height; ++y) {
+        const auto* source =
+            padded_output_.data() + static_cast<std::size_t>(y + kPadTop) * kEngineWidth + kPadLeft;
+        auto* destination = result.disparity.data() + static_cast<std::size_t>(y) * width;
+        std::transform(source, source + width, destination,
+                       [](float value) { return std::max(value, 0.0F); });
+    }
+    return result;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/fast_foundation_stereo/stereo_pipeline.h
+++ b/src/runtime/models/fast_foundation_stereo/stereo_pipeline.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/device_tensor.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+void prepare_fast_foundation_stereo_image(const float* pixels, int32_t height, int32_t width,
+                                          std::vector<float>& output);
+
+class FastFoundationStereoPipeline final : public IPipeline {
+  public:
+    FastFoundationStereoPipeline(std::unique_ptr<ITrtModule> feature,
+                                 std::unique_ptr<ITrtModule> post, std::string model_id);
+
+    StereoDisparityResult estimate_disparity(const float* left_pixels, const float* right_pixels,
+                                             int32_t height, int32_t width) override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "FastFoundationStereoPipeline"; }
+
+  private:
+    void bind_post_inputs();
+
+    std::unique_ptr<ITrtModule> feature_;
+    std::unique_ptr<ITrtModule> post_;
+    DeviceTensor reference_norm_;
+    DeviceTensor target_norm_;
+    DeviceTensor gwc_;
+    std::vector<float> left_input_;
+    std::vector<float> right_input_;
+    std::vector<float> padded_output_;
+    std::string model_id_;
+    bool post_inputs_bound_{false};
+};
+
+} // namespace trtmc

--- a/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_gwc.cpp
+++ b/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_gwc.cpp
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/fast_foundation_stereo/gwc_kernel.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+constexpr int kChannels = 224;
+constexpr int kGroups = 8;
+constexpr int kHeight = 176;
+constexpr int kWidth = 176;
+constexpr int kDisparities = 48;
+
+std::size_t output_index(int group, int disparity, int height, int width) {
+    return (((static_cast<std::size_t>(group) * kDisparities + disparity) * kHeight + height) *
+            kWidth) +
+           width;
+}
+
+bool check_cuda(cudaError_t status, const char* operation) {
+    if (status == cudaSuccess)
+        return true;
+    std::cerr << "FAIL: " << operation << ": " << cudaGetErrorString(status) << '\n';
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const std::size_t feature_count = static_cast<std::size_t>(kChannels) * kHeight * kWidth;
+    const std::size_t norm_count = static_cast<std::size_t>(kGroups) * kHeight * kWidth;
+    const std::size_t output_count =
+        static_cast<std::size_t>(kGroups) * kDisparities * kHeight * kWidth;
+    std::vector<__half> ones(feature_count, __float2half(1.0F));
+
+    __half* reference = nullptr;
+    __half* target = nullptr;
+    __half* reference_norm = nullptr;
+    __half* target_norm = nullptr;
+    __half* output = nullptr;
+    bool ok =
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&reference), feature_count * sizeof(__half)),
+                   "reference alloc") &&
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&target), feature_count * sizeof(__half)),
+                   "target alloc") &&
+        check_cuda(
+            cudaMalloc(reinterpret_cast<void**>(&reference_norm), norm_count * sizeof(__half)),
+            "ref norm alloc") &&
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&target_norm), norm_count * sizeof(__half)),
+                   "target norm alloc") &&
+        check_cuda(cudaMalloc(reinterpret_cast<void**>(&output), output_count * sizeof(__half)),
+                   "output alloc");
+    if (ok) {
+        ok = check_cuda(cudaMemcpy(reference, ones.data(), feature_count * sizeof(__half),
+                                   cudaMemcpyHostToDevice),
+                        "reference upload") &&
+             check_cuda(cudaMemcpy(target, ones.data(), feature_count * sizeof(__half),
+                                   cudaMemcpyHostToDevice),
+                        "target upload") &&
+             check_cuda(trtmc::launch_fast_foundation_stereo_gwc(reference, target, reference_norm,
+                                                                 target_norm, output, nullptr),
+                        "GWC launch") &&
+             check_cuda(cudaDeviceSynchronize(), "GWC synchronize");
+    }
+
+    if (ok) {
+        __half valid_zero_disparity{};
+        __half invalid_shift{};
+        __half valid_shift{};
+        ok = check_cuda(cudaMemcpy(&valid_zero_disparity, output + output_index(0, 0, 0, 0),
+                                   sizeof(__half), cudaMemcpyDeviceToHost),
+                        "copy zero disparity") &&
+             check_cuda(cudaMemcpy(&invalid_shift, output + output_index(0, 47, 0, 46),
+                                   sizeof(__half), cudaMemcpyDeviceToHost),
+                        "copy invalid shift") &&
+             check_cuda(cudaMemcpy(&valid_shift, output + output_index(0, 47, 0, 47),
+                                   sizeof(__half), cudaMemcpyDeviceToHost),
+                        "copy valid shift");
+        if (std::fabs(__half2float(valid_zero_disparity) - 1.0F) > 1.0e-3F) {
+            std::cerr << "FAIL: zero-disparity correlation\n";
+            ok = false;
+        }
+        if (__half2float(invalid_shift) != 0.0F) {
+            std::cerr << "FAIL: invalid negative target coordinate was not zero\n";
+            ok = false;
+        }
+        if (std::fabs(__half2float(valid_shift) - 1.0F) > 1.0e-3F) {
+            std::cerr << "FAIL: shifted valid correlation\n";
+            ok = false;
+        }
+    }
+
+    cudaFree(output);
+    cudaFree(target_norm);
+    cudaFree(reference_norm);
+    cudaFree(target);
+    cudaFree(reference);
+    if (ok)
+        std::cout << "All Fast Foundation Stereo GWC tests passed\n";
+    return ok ? 0 : 1;
+}

--- a/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_preprocess.cpp
+++ b/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_preprocess.cpp
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/fast_foundation_stereo/stereo_pipeline.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+void check_close(float actual, float expected, const char* name) {
+    if (std::fabs(actual - expected) > 1.0e-6F) {
+        std::cerr << "FAIL: " << name << " actual=" << actual << " expected=" << expected << '\n';
+        ++failures;
+    }
+}
+
+void test_preprocess_matches_rgb_chw_replication_contract() {
+    constexpr int32_t height = 700;
+    constexpr int32_t width = 700;
+    std::vector<float> pixels(static_cast<std::size_t>(height) * width * 3, 0.0F);
+    pixels[0] = 0.25F;
+    pixels[1] = 0.5F;
+    pixels[2] = 1.0F;
+    const auto last = pixels.size() - 3;
+    pixels[last] = 0.75F;
+    pixels[last + 1] = 0.125F;
+    pixels[last + 2] = 0.625F;
+
+    std::vector<float> output;
+    trtmc::prepare_fast_foundation_stereo_image(pixels.data(), height, width, output);
+    check(output.size() == static_cast<std::size_t>(3) * 704 * 704,
+          "stereo preprocess output size");
+    if (output.size() != static_cast<std::size_t>(3) * 704 * 704)
+        return;
+
+    // Top-left padding replicates source pixel (0,0), then HWC becomes CHW.
+    check_close(output[0], 0.25F * 255.0F, "stereo red top-left replicate");
+    check_close(output[704 * 704], 0.5F * 255.0F, "stereo green top-left replicate");
+    check_close(output[2 * 704 * 704], 255.0F, "stereo blue top-left replicate");
+
+    const auto bottom_right = static_cast<std::size_t>(704) * 704 - 1;
+    check_close(output[bottom_right], 0.75F * 255.0F, "stereo red bottom-right replicate");
+    check_close(output[704 * 704 + bottom_right], 0.125F * 255.0F,
+                "stereo green bottom-right replicate");
+}
+
+void test_preprocess_rejects_invalid_input() {
+    std::vector<float> output;
+    bool null_threw = false;
+    try {
+        trtmc::prepare_fast_foundation_stereo_image(nullptr, 700, 700, output);
+    } catch (const std::invalid_argument&) {
+        null_threw = true;
+    }
+    check(null_threw, "stereo preprocess rejects null image");
+
+    float pixel = 0.0F;
+    bool shape_threw = false;
+    try {
+        trtmc::prepare_fast_foundation_stereo_image(&pixel, 699, 700, output);
+    } catch (const std::invalid_argument&) {
+        shape_threw = true;
+    }
+    check(shape_threw, "stereo preprocess rejects wrong shape");
+}
+
+} // namespace
+
+int main() {
+    test_preprocess_matches_rgb_chw_replication_contract();
+    test_preprocess_rejects_invalid_input();
+    if (failures == 0)
+        std::cout << "All Fast Foundation Stereo preprocess tests passed\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -174,6 +174,16 @@ void test_detect_parses_contract_flags() {
     check(args.conf_threshold > 0.41F && args.conf_threshold < 0.43F, "detect threshold");
 }
 
+void test_disparity_parses_stereo_images() {
+    auto args = parse({"trtmc", "disparity", "bundle.bundle", "--image", "left.png",
+                       "--right-image", "right.png", "--output", "disparity.f32"});
+    check(args.command == "disparity", "disparity command");
+    check(args.bundle_path == "bundle.bundle", "disparity bundle");
+    check(args.image_path == "left.png", "disparity left image");
+    check(args.right_image_path == "right.png", "disparity right image");
+    check(args.output_dir == "disparity.f32", "disparity output");
+}
+
 void test_inspect_and_config_flags() {
     auto args = parse({"trtmc", "inspect", "bundle.bundle", "--list-engines", "--config",
                        "profile.json", "--set", "audio.seed=7"});
@@ -445,6 +455,7 @@ int main() {
     test_run_parses_common_flags();
     test_diffusion_flags();
     test_detect_parses_contract_flags();
+    test_disparity_parses_stereo_images();
     test_inspect_and_config_flags();
     test_audio_and_solve_flags();
     test_canary_transcription_flags_and_batch();

--- a/tests/e2e/models/fast_foundation_stereo/MODEL.toml
+++ b/tests/e2e/models/fast_foundation_stereo/MODEL.toml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "fast_foundation_stereo"
+plugin = "fast_foundation_stereo"
+test_manifests = ["manifests/fast-foundation-stereo.json"]
+
+[model_reference_cache]
+repository = "https://github.com/NVlabs/Fast-FoundationStereo.git"
+revision = "a290ba04c1b3ad1ec41a33974a157b2917b624d4"
+relative_path = "fast_foundation_stereo/reference/Fast-FoundationStereo-a290ba04c1b3"
+entrypoint = "core/foundation_stereo.py"
+environment_variable = "TRTMC_FAST_FOUNDATION_STEREO_SOURCE_DIR"
+
+[e2e_defaults.stereo_disparity]
+reference_backend = "fast_foundation_stereo_torch"
+oracle_level = "L1_external_reference"
+stages = [{ name = "full_inference", required = true }]

--- a/tests/e2e/models/fast_foundation_stereo/analyze_ncu.py
+++ b/tests/e2e/models/fast_foundation_stereo/analyze_ncu.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Summarize Nsight Compute SpeedOfLight CSV exports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+def _load_samples(paths: list[Path]) -> list[dict[str, object]]:
+    samples: list[dict[str, object]] = []
+    for path in paths:
+        launches: dict[str, dict[str, object]] = {}
+        with path.open(newline="") as csv_file:
+            for row in csv.DictReader(csv_file):
+                launch = launches.setdefault(
+                    row["ID"],
+                    {
+                        "kernel": row["Kernel Name"],
+                        "source": path.name,
+                    },
+                )
+                metric_name = row["Metric Name"]
+                metric_value = row["Metric Value"]
+                if metric_name.startswith("Duration ("):
+                    launch["duration_us"] = float(metric_value)
+                elif metric_name.startswith("Memory Throughput ("):
+                    launch["memory_pct"] = float(metric_value)
+                elif metric_name.startswith("Compute (SM) Throughput ("):
+                    launch["compute_pct"] = float(metric_value)
+        samples.extend(launches.values())
+    return [
+        sample
+        for sample in samples
+        if {"duration_us", "memory_pct", "compute_pct"} <= sample.keys()
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("csv", nargs="+", type=Path)
+    parser.add_argument("--top", type=int, default=10)
+    args = parser.parse_args()
+
+    samples = _load_samples(args.csv)
+    total_duration = sum(float(sample["duration_us"]) for sample in samples)
+
+    def weighted(field: str) -> float:
+        return (
+            sum(float(sample["duration_us"]) * float(sample[field]) for sample in samples)
+            / total_duration
+        )
+
+    summary = {
+        "sampled_launches": len(samples),
+        "sampled_duration_us": total_duration,
+        "duration_weighted_compute_pct": weighted("compute_pct"),
+        "duration_weighted_memory_pct": weighted("memory_pct"),
+        "compute_limited_launches": sum(
+            float(sample["compute_pct"]) >= float(sample["memory_pct"]) for sample in samples
+        ),
+        "memory_limited_launches": sum(
+            float(sample["memory_pct"]) > float(sample["compute_pct"]) for sample in samples
+        ),
+        "launches_at_or_above_80_pct": sum(
+            max(float(sample["compute_pct"]), float(sample["memory_pct"])) >= 80.0
+            for sample in samples
+        ),
+        "max_compute_pct": max(float(sample["compute_pct"]) for sample in samples),
+        "max_memory_pct": max(float(sample["memory_pct"]) for sample in samples),
+        "top_duration_launches": sorted(
+            samples,
+            key=lambda sample: float(sample["duration_us"]),
+            reverse=True,
+        )[: args.top],
+    }
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/models/fast_foundation_stereo/benchmark.py
+++ b/tests/e2e/models/fast_foundation_stereo/benchmark.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark Torch and split TensorRT Fast Foundation Stereo backends."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import imageio.v2 as imageio
+import numpy as np
+import torch
+
+
+def percentile(values: list[float], q: float) -> float:
+    return float(np.percentile(np.asarray(values, dtype=np.float64), q))
+
+
+def list_images(directory: Path) -> dict[str, Path]:
+    suffixes = {".png", ".jpg", ".jpeg", ".bmp"}
+    return {
+        path.name: path
+        for path in sorted(directory.iterdir())
+        if path.is_file() and path.suffix.lower() in suffixes
+    }
+
+
+def select_pairs(
+    left_dir: Path, right_dir: Path, num_pairs: int, start_index: int
+) -> list[tuple[str, Path, Path]]:
+    left = list_images(left_dir)
+    right = list_images(right_dir)
+    names = sorted(set(left) & set(right))
+    selected = names[start_index : start_index + num_pairs]
+    if len(selected) != num_pairs:
+        raise RuntimeError(
+            f"need {num_pairs} paired images from index {start_index}, "
+            f"found {len(selected)}; left={len(left)}, right={len(right)}, "
+            f"paired={len(names)}"
+        )
+    return [(name, left[name], right[name]) for name in selected]
+
+
+def load_and_prepare(left_path, right_path, scale, device, input_padder):
+    left = imageio.imread(left_path)
+    right = imageio.imread(right_path)
+    if left.ndim == 2:
+        left = np.repeat(left[..., None], 3, axis=2)
+    if right.ndim == 2:
+        right = np.repeat(right[..., None], 3, axis=2)
+    left = np.ascontiguousarray(left[..., :3])
+    right = np.ascontiguousarray(right[..., :3])
+    if left.shape[:2] != right.shape[:2]:
+        raise ValueError(
+            f"image shape mismatch: {left_path}={left.shape}, {right_path}={right.shape}"
+        )
+
+    left = cv2.resize(left, fx=scale, fy=scale, dsize=None)
+    right = cv2.resize(right, dsize=(left.shape[1], left.shape[0]))
+    left_tensor = torch.as_tensor(left).to(device).float()[None].permute(0, 3, 1, 2)
+    right_tensor = torch.as_tensor(right).to(device).float()[None].permute(0, 3, 1, 2)
+    padder = input_padder(left_tensor.shape, divis_by=32, force_square=False)
+    left_tensor, right_tensor = padder.pad(left_tensor, right_tensor)
+    return left_tensor, right_tensor, padder, left.shape[:2]
+
+
+def summarize(values: list[float]) -> dict[str, float]:
+    return {
+        "mean_ms": float(np.mean(values)),
+        "median_ms": float(np.median(values)),
+        "p90_ms": percentile(values, 90),
+        "min_ms": float(np.min(values)),
+        "max_ms": float(np.max(values)),
+    }
+
+
+def cosine_similarity(actual: np.ndarray, expected: np.ndarray) -> float:
+    actual64 = actual.astype(np.float64, copy=False).reshape(-1)
+    expected64 = expected.astype(np.float64, copy=False).reshape(-1)
+    denominator = np.linalg.norm(actual64) * np.linalg.norm(expected64)
+    if denominator == 0:
+        return 1.0 if np.array_equal(actual64, expected64) else 0.0
+    return float(np.dot(actual64, expected64) / denominator)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("--backend", choices=("torch", "trt", "trt-single"), required=True)
+    parser.add_argument("--feature-engine", type=Path)
+    parser.add_argument("--post-engine", type=Path)
+    parser.add_argument("--engine", type=Path)
+    parser.add_argument("--cuda-graphs", action="store_true")
+    parser.add_argument("--input-root", type=Path)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--reference", type=Path)
+    parser.add_argument("--min-cosine", type=float, default=0.999)
+    parser.add_argument("--num-pairs", type=int, default=5)
+    parser.add_argument("--start-index", type=int, default=0)
+    parser.add_argument("--warmup-iters", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--scale", type=float, default=1.0)
+    parser.add_argument("--valid-iters", type=int, default=8)
+    parser.add_argument("--max-disp", type=int, default=192)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+    if args.num_pairs <= 0 or args.warmup_iters < 0 or args.iters <= 0:
+        raise ValueError("num-pairs and iters must be positive; warmup-iters cannot be negative")
+    if args.backend == "trt" and (not args.feature_engine or not args.post_engine):
+        parser.error("--feature-engine and --post-engine are required for --backend trt")
+    if args.backend == "trt-single" and not args.engine:
+        parser.error("--engine is required for --backend trt-single")
+
+    model_root = args.model_root.resolve()
+    os.chdir(model_root)
+    sys.path.insert(0, str(model_root))
+    from core.foundation_stereo import TrtRunner
+    from core.utils.utils import InputPadder
+    from Utils import AMP_DTYPE
+
+    input_root = (args.input_root or model_root / "rectified_stereo_rgb").resolve()
+    pairs = select_pairs(
+        input_root / "cam_1", input_root / "cam_0", args.num_pairs, args.start_index
+    )
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    checkpoint = model_root / "weights/23-36-37/model_best_bp2_serialize.pth"
+    model_init_start = time.perf_counter()
+    checkpoint_model = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    checkpoint_model.args.valid_iters = args.valid_iters
+    checkpoint_model.args.max_disp = args.max_disp
+    if args.backend == "torch":
+        model = checkpoint_model.cuda().eval()
+
+        def run_forward(left_tensor, right_tensor):
+            with torch.amp.autocast("cuda", enabled=True, dtype=AMP_DTYPE):
+                return model.forward(
+                    left_tensor,
+                    right_tensor,
+                    iters=args.valid_iters,
+                    test_mode=True,
+                    optimize_build_volume="pytorch1",
+                )
+
+    elif args.backend == "trt":
+        model = (
+            TrtRunner(
+                checkpoint_model.args,
+                str(args.feature_engine.resolve()),
+                str(args.post_engine.resolve()),
+            )
+            .cuda()
+            .eval()
+        )
+        del checkpoint_model
+
+        def run_forward(left_tensor, right_tensor):
+            return model(left_tensor, right_tensor)
+
+    else:
+        import tensorrt as trt
+
+        class SingleEngineRunner:
+            def __init__(self, engine_path: Path):
+                logger = trt.Logger(trt.Logger.WARNING)
+                runtime = trt.Runtime(logger)
+                self.engine = runtime.deserialize_cuda_engine(engine_path.read_bytes())
+                if self.engine is None:
+                    raise RuntimeError(f"failed to deserialize {engine_path}")
+                self.context = self.engine.create_execution_context()
+
+            @staticmethod
+            def torch_dtype(dtype):
+                mapping = {
+                    trt.DataType.FLOAT: torch.float32,
+                    trt.DataType.HALF: torch.float16,
+                    trt.DataType.BF16: torch.bfloat16,
+                    trt.DataType.INT32: torch.int32,
+                    trt.DataType.INT8: torch.int8,
+                    trt.DataType.BOOL: torch.bool,
+                }
+                return mapping[dtype]
+
+            def __call__(self, left_tensor, right_tensor):
+                inputs = {
+                    "left_image": left_tensor,
+                    "right_image": right_tensor,
+                }
+                for name, value in tuple(inputs.items()):
+                    expected = self.torch_dtype(self.engine.get_tensor_dtype(name))
+                    inputs[name] = value.to(expected).contiguous()
+                    self.context.set_input_shape(name, tuple(inputs[name].shape))
+
+                outputs = {}
+                for index in range(self.engine.num_io_tensors):
+                    name = self.engine.get_tensor_name(index)
+                    if self.engine.get_tensor_mode(name) != trt.TensorIOMode.OUTPUT:
+                        continue
+                    outputs[name] = torch.empty(
+                        tuple(self.context.get_tensor_shape(name)),
+                        device="cuda",
+                        dtype=self.torch_dtype(self.engine.get_tensor_dtype(name)),
+                    )
+                for name, value in {**inputs, **outputs}.items():
+                    self.context.set_tensor_address(name, int(value.data_ptr()))
+                if not self.context.execute_async_v3(torch.cuda.current_stream().cuda_stream):
+                    raise RuntimeError("TensorRT single-engine enqueue failed")
+                return outputs["disparity"]
+
+        model = SingleEngineRunner(args.engine.resolve())
+        mean = torch.tensor([123.675, 116.28, 103.53], device="cuda").view(1, 3, 1, 1)
+        std = torch.tensor([58.395, 57.12, 57.375], device="cuda").view(1, 3, 1, 1)
+
+        def run_forward(left_tensor, right_tensor):
+            return model((left_tensor - mean) / std, (right_tensor - mean) / std)
+
+    if args.backend.startswith("trt") and args.cuda_graphs:
+        eager_forward = run_forward
+        graph = None
+        static_left = torch.empty((1, 3, 704, 704), device="cuda")
+        static_right = torch.empty_like(static_left)
+        static_output = None
+
+        def run_forward(left_tensor, right_tensor):
+            nonlocal graph, static_output
+            static_left.copy_(left_tensor)
+            static_right.copy_(right_tensor)
+            if graph is None:
+                # TensorRT requires one successful enqueue after shapes and
+                # addresses are established before CUDA graph capture. The
+                # extra launches are warmup-only and outside timed samples.
+                for _ in range(3):
+                    static_output = eager_forward(static_left, static_right)
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    static_output = eager_forward(static_left, static_right)
+            graph.replay()
+            return static_output
+
+    torch.cuda.synchronize()
+    model_init_ms = (time.perf_counter() - model_init_start) * 1000.0
+    inference_stream = torch.cuda.Stream()
+
+    def run_one_iteration(save_output=False):
+        preprocess_start = time.perf_counter()
+        prepared = [
+            load_and_prepare(left, right, args.scale, "cuda", InputPadder)
+            for _, left, right in pairs
+        ]
+        torch.cuda.synchronize()
+        preprocess_ms = (time.perf_counter() - preprocess_start) * 1000.0
+
+        infer_start = time.perf_counter()
+        disparities = []
+        with torch.inference_mode():
+            for _, (left_tensor, right_tensor, padder, image_shape) in zip(pairs, prepared):
+                inference_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(inference_stream):
+                    disparity = run_forward(left_tensor, right_tensor)
+                torch.cuda.current_stream().wait_stream(inference_stream)
+                disparity = padder.unpad(disparity.float()).cpu().numpy().reshape(image_shape)
+                disparities.append(np.clip(disparity, 0, None).astype(np.float32))
+        torch.cuda.synchronize()
+        infer_ms = (time.perf_counter() - infer_start) * 1000.0
+        output = np.stack(disparities) if save_output else None
+        return preprocess_ms, infer_ms, preprocess_ms + infer_ms, output
+
+    for index in range(args.warmup_iters):
+        run_one_iteration()
+        print(f"warmup {index + 1}/{args.warmup_iters}")
+
+    preprocess_times = []
+    infer_times = []
+    total_times = []
+    first_output = None
+    for index in range(args.iters):
+        preprocess_ms, infer_ms, total_ms, output = run_one_iteration(index == 0)
+        preprocess_times.append(preprocess_ms)
+        infer_times.append(infer_ms)
+        total_times.append(total_ms)
+        if output is not None:
+            first_output = output
+
+    assert first_output is not None
+    output_path = args.out_dir / f"{args.backend}_disparity.npz"
+    np.savez_compressed(
+        output_path,
+        names=np.asarray([name for name, _, _ in pairs]),
+        disparity=first_output,
+    )
+
+    accuracy = None
+    accuracy_passed = None
+    if args.reference:
+        reference = np.load(args.reference)["disparity"]
+        if reference.shape != first_output.shape:
+            raise RuntimeError(
+                f"reference shape {reference.shape} != output shape {first_output.shape}"
+            )
+        pair_cosines = [
+            cosine_similarity(actual, expected) for actual, expected in zip(first_output, reference)
+        ]
+        accuracy = {
+            "global_cosine": cosine_similarity(first_output, reference),
+            "pair_cosines": pair_cosines,
+            "max_abs_error": float(np.max(np.abs(first_output - reference))),
+            "mean_abs_error": float(np.mean(np.abs(first_output - reference))),
+        }
+        # The supplied model contract compares the flattened [N, H, W] FP32
+        # disparity output. Pair-wise values are retained as diagnostics.
+        accuracy_passed = accuracy["global_cosine"] >= args.min_cosine
+
+    result = {
+        "backend": args.backend,
+        "model_root": str(model_root),
+        "input_root": str(input_root),
+        "num_pairs": args.num_pairs,
+        "start_index": args.start_index,
+        "warmup_iters": args.warmup_iters,
+        "iters": args.iters,
+        "scale": args.scale,
+        "valid_iters": args.valid_iters,
+        "max_disp": args.max_disp,
+        "cuda_graphs": args.cuda_graphs,
+        "model_init_ms": model_init_ms,
+        "preprocess_5_pairs": summarize(preprocess_times),
+        "infer_5_pairs": summarize(infer_times),
+        "total_5_pairs": summarize(total_times),
+        "preprocess_per_pair_ms": float(np.mean(preprocess_times) / args.num_pairs),
+        "infer_per_pair_ms": float(np.mean(infer_times) / args.num_pairs),
+        "total_per_pair_ms": float(np.mean(total_times) / args.num_pairs),
+        "output_file": str(output_path),
+        "accuracy": accuracy,
+        "minimum_cosine": args.min_cosine,
+        "accuracy_passed": accuracy_passed,
+    }
+    result_path = args.out_dir / "benchmark_result.json"
+    result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    if accuracy_passed is False:
+        raise RuntimeError(f"accuracy gate failed: {accuracy}; minimum cosine={args.min_cosine}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/__init__.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo model-owned E2E plugins."""

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparator.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparator.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo numeric disparity comparator."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+class StereoDisparityComparator:
+    @property
+    def task_strategy(self) -> str:
+        return "stereo_disparity"
+
+    def compare(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        disparity = trt.data.get("disparity")
+        if disparity is None:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.ERROR.value,
+                message="Native runtime produced no disparity tensor",
+            )
+        actual = np.asarray(disparity, dtype=np.float32)
+        reference = ref.data.get("disparity")
+        if reference is None:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.ERROR.value,
+                message="Official PyTorch reference produced no disparity tensor",
+            )
+        expected = np.asarray(reference, dtype=np.float32)
+        expected_shape = tuple(ref.data.get("expected_shape", (700, 700)))
+        shape_passed = actual.shape == expected.shape == expected_shape
+        finite_fraction = float(np.isfinite(actual).mean())
+        nonnegative_fraction = float((actual >= 0).mean())
+        if shape_passed:
+            actual64 = actual.astype(np.float64, copy=False).reshape(-1)
+            expected64 = expected.astype(np.float64, copy=False).reshape(-1)
+            denominator = np.linalg.norm(actual64) * np.linalg.norm(expected64)
+            cosine = (
+                float(np.dot(actual64, expected64) / denominator)
+                if denominator
+                else float(np.array_equal(actual64, expected64))
+            )
+        else:
+            cosine = 0.0
+        finite_threshold = threshold.metrics.get("finite_fraction", 1.0)
+        nonnegative_threshold = threshold.metrics.get("nonnegative_fraction", 1.0)
+        cosine_threshold = threshold.metrics.get("global_cosine", 0.999)
+        metrics = {
+            "shape": MetricResult(
+                value=1.0 if shape_passed else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=shape_passed,
+            ),
+            "finite_fraction": MetricResult(
+                value=finite_fraction,
+                threshold=finite_threshold,
+                operator=">=",
+                passed=finite_fraction >= finite_threshold,
+            ),
+            "nonnegative_fraction": MetricResult(
+                value=nonnegative_fraction,
+                threshold=nonnegative_threshold,
+                operator=">=",
+                passed=nonnegative_fraction >= nonnegative_threshold,
+            ),
+            "global_cosine": MetricResult(
+                value=cosine,
+                threshold=cosine_threshold,
+                operator=">=",
+                passed=cosine >= cosine_threshold,
+            ),
+        }
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule="shape, disparity invariants, and global cosine must pass",
+            message=(f"disparity shape={list(actual.shape)}, global cosine={cosine:.9f}"),
+        )
+
+
+comparator = StereoDisparityComparator()

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparators/__init__.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparators/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo model-owned comparator implementations."""

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/contracts.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/contracts.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable harness contract aliases for model-owned plugins."""
+
+from tests.e2e_harness.contracts import *  # noqa: F401,F403

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/reference.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/reference.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pinned official PyTorch reference for native stereo E2E coverage."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+from tensorrt_model_connect.families.fast_foundation_stereo.prepare_model import (
+    resolve_model_dir,
+)
+
+from .contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+def _checkpoint_snapshot(case: E2ECase, *, local_files_only: bool) -> Path:
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            case.hf_id,
+            revision=case.hf_revision or None,
+            allow_patterns=["cfg.yaml", "model_best_bp2_serialize.pth"],
+            local_files_only=local_files_only,
+        )
+    )
+
+
+class FastFoundationStereoTorchReference:
+    @property
+    def backend_name(self) -> str:
+        return "fast_foundation_stereo_torch"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name != "full_inference":
+            return StageOutput(
+                stage_name=stage.name,
+                data={"error": f"Unknown stage: {stage.name}"},
+            )
+        checkpoint = _checkpoint_snapshot(
+            case,
+            local_files_only=ctx.local_files_only,
+        )
+        staged = resolve_model_dir(
+            checkpoint,
+            local_files_only=ctx.local_files_only,
+        )
+        model_root = staged or checkpoint
+        artifact_dir = Path(ctx.artifacts_dir or "/tmp") / case.name
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        output_path = artifact_dir / "torch_disparity.npy"
+        script = Path(__file__).resolve().parents[1] / "official_reference.py"
+        command = [
+            ctx.reference_python_path() or sys.executable,
+            str(script),
+            "--model-root",
+            str(model_root),
+            "--output",
+            str(output_path),
+            "--pixel-shift",
+            str(int(case.inputs.get("pixel_shift", 12))),
+            "--valid-iters",
+            "8",
+            "--max-disp",
+            "192",
+        ]
+        started = time.monotonic()
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        elapsed = time.monotonic() - started
+        data: dict = {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        if result.returncode == 0 and output_path.is_file():
+            disparity = np.load(output_path, allow_pickle=False)
+            data.update(
+                disparity=disparity,
+                expected_shape=list(disparity.shape),
+                requires_finite=True,
+                requires_nonnegative=True,
+                output_path=str(output_path),
+            )
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            timing_s=elapsed,
+            metadata={
+                "backend": self.backend_name,
+                "command": command,
+                "returncode": result.returncode,
+                "stderr": result.stderr,
+            },
+        )
+
+
+reference = FastFoundationStereoTorchReference()

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/references/__init__.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/references/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo model-owned reference implementations."""

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/runner.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/runner.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native Fast Foundation Stereo E2E runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+
+from .contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+def _write_stereo_inputs(directory: Path, *, pixel_shift: int) -> tuple[Path, Path]:
+    from PIL import Image
+
+    if not 0 < pixel_shift < 700:
+        raise ValueError(f"pixel_shift must be in [1, 699], got {pixel_shift}")
+    directory.mkdir(parents=True, exist_ok=True)
+    y, x = np.mgrid[0:700, 0:700]
+    left = np.stack(((x % 256), (y % 256), ((x + y) % 256)), axis=-1).astype(np.uint8)
+    right = np.zeros_like(left)
+    right[:, :-pixel_shift] = left[:, pixel_shift:]
+    right[:, -pixel_shift:] = left[:, -1:]
+    left_path = directory / "left.png"
+    right_path = directory / "right.png"
+    Image.fromarray(left).save(left_path)
+    Image.fromarray(right).save(right_path)
+    return left_path, right_path
+
+
+class StereoDisparityRunner:
+    @property
+    def strategy_name(self) -> str:
+        return "stereo_disparity"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name != "full_inference":
+            return StageOutput(
+                stage_name=stage.name,
+                metadata={"error": f"Unknown stage: {stage.name}"},
+            )
+        artifact_dir = Path(ctx.artifacts_dir or "/tmp") / case.name
+        pixel_shift = int(case.inputs.get("pixel_shift", 12))
+        left_path, right_path = _write_stereo_inputs(
+            artifact_dir,
+            pixel_shift=pixel_shift,
+        )
+        output_path = artifact_dir / "disparity.f32"
+        bundle = case.bundle or f"{case.name}.bundle"
+        bundle_path = bundle if os.path.isabs(bundle) else os.path.join(ctx.engine_dir, bundle)
+        command = [
+            ctx.binary_path,
+            "disparity",
+            bundle_path,
+            "--image",
+            str(left_path),
+            "--right-image",
+            str(right_path),
+            "--output",
+            str(output_path),
+            "--cuda-graphs",
+        ]
+        if ctx.model_plugin_dir:
+            command.extend(("--model-plugin-dir", ctx.model_plugin_dir))
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        started = time.monotonic()
+        result = subprocess.run(command, capture_output=True, text=True, timeout=600, env=env)
+        elapsed = time.monotonic() - started
+        data: dict = {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        if result.returncode == 0 and output_path.is_file():
+            disparity = np.fromfile(output_path, dtype=np.float32)
+            if disparity.size == 700 * 700:
+                data.update(
+                    disparity=disparity.reshape(700, 700),
+                    output_shape=[700, 700],
+                    output_path=str(output_path),
+                )
+            try:
+                data["cli_output"] = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                pass
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            timing_s=elapsed,
+            metadata={"command": command},
+        )
+
+
+runner = StereoDisparityRunner()

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/runners/__init__.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/runners/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast Foundation Stereo model-owned runner implementations."""

--- a/tests/e2e/models/fast_foundation_stereo/manifests/fast-foundation-stereo.json
+++ b/tests/e2e/models/fast_foundation_stereo/manifests/fast-foundation-stereo.json
@@ -1,0 +1,26 @@
+{
+  "name": "fast-foundation-stereo",
+  "hf_id": "nvidia/c-fast-foundationstereo",
+  "hf_revision": "9b446878c81ddb27593036767b29b2859d46103e",
+  "bundle": "fast-foundation-stereo.bundle",
+  "family": "fast_foundation_stereo",
+  "runtime_strategy": "fast_foundation_stereo_disparity",
+  "task_strategy": "stereo_disparity",
+  "precision": "fp16",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "testcases": [
+    {
+      "name": "fast-foundation-stereo",
+      "trace_id": "IT-E2E-FFS-01",
+      "reference_backend": "fast_foundation_stereo_torch",
+      "reference_family": "stereo_disparity",
+      "user_contract": "stereo_disparity",
+      "oracle_level": "L1_external_reference",
+      "ci_tier": "default",
+      "inputs": {
+        "pixel_shift": 12
+      },
+      "notes": "Fixed 700x700 rectified stereo inference through the native C++ runtime. The pinned official PyTorch model receives the identical deterministic stereo pair; the gate requires shape, finiteness, non-negative disparity, and flattened FP32 cosine similarity >= 0.999."
+    }
+  ]
+}

--- a/tests/e2e/models/fast_foundation_stereo/official_reference.py
+++ b/tests/e2e/models/fast_foundation_stereo/official_reference.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the pinned official Fast-FoundationStereo PyTorch implementation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from tensorrt_model_connect.families.fast_foundation_stereo.prepare_model import (
+    configure_official_model_args,
+    install_official_io_import_shims,
+)
+
+
+def _synthetic_stereo(pixel_shift: int) -> tuple[np.ndarray, np.ndarray]:
+    if not 0 < pixel_shift < 700:
+        raise ValueError(f"pixel_shift must be in [1, 699], got {pixel_shift}")
+    y, x = np.mgrid[0:700, 0:700]
+    left = np.stack(((x % 256), (y % 256), ((x + y) % 256)), axis=-1).astype(np.uint8)
+    right = np.zeros_like(left)
+    right[:, :-pixel_shift] = left[:, pixel_shift:]
+    right[:, -pixel_shift:] = left[:, -1:]
+    return left, right
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--pixel-shift", type=int, default=12)
+    parser.add_argument("--valid-iters", type=int, default=8)
+    parser.add_argument("--max-disp", type=int, default=192)
+    arguments = parser.parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for the Fast-FoundationStereo reference")
+
+    model_root = arguments.model_root.resolve()
+    os.chdir(model_root)
+    sys.path.insert(0, str(model_root))
+    install_official_io_import_shims()
+    from core.utils.utils import InputPadder
+    from Utils import AMP_DTYPE
+
+    checkpoint = model_root / "weights/23-36-37/model_best_bp2_serialize.pth"
+    model = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    configure_official_model_args(
+        model,
+        max_disparity=arguments.max_disp,
+        valid_iters=arguments.valid_iters,
+    )
+    model = model.cuda().eval()
+
+    left, right = _synthetic_stereo(arguments.pixel_shift)
+    left_tensor = torch.as_tensor(left, device="cuda").float()[None].permute(0, 3, 1, 2)
+    right_tensor = torch.as_tensor(right, device="cuda").float()[None].permute(0, 3, 1, 2)
+    padder = InputPadder(left_tensor.shape, divis_by=32, force_square=False)
+    left_tensor, right_tensor = padder.pad(left_tensor, right_tensor)
+    with (
+        torch.inference_mode(),
+        torch.amp.autocast(
+            "cuda",
+            enabled=True,
+            dtype=AMP_DTYPE,
+        ),
+    ):
+        disparity = model.forward(
+            left_tensor,
+            right_tensor,
+            iters=arguments.valid_iters,
+            test_mode=True,
+            optimize_build_volume="pytorch1",
+        )
+    output = padder.unpad(disparity.float()).cpu().numpy().reshape(700, 700)
+    output = np.clip(output, 0, None).astype(np.float32)
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    np.save(arguments.output, output, allow_pickle=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/models/fast_foundation_stereo/performance/l4.json
+++ b/tests/e2e/models/fast_foundation_stereo/performance/l4.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": 1,
+  "receipt_kind": "l4_performance_and_roofline",
+  "measured_at": "2026-08-15 America/Los_Angeles",
+  "hardware": {
+    "node": "ipp2-2246",
+    "gpu": "NVIDIA L4",
+    "compute_capability": "8.9",
+    "memory_mib": 23034,
+    "power_limit_w": 72,
+    "driver": "595.58.03",
+    "tensorrt": "10.8.0.43"
+  },
+  "provenance": {
+    "supplied_archive_sha256": "8b8769aeeef47be494bccb0bf6593355da329ed45195a68fb2633154be492e4a",
+    "official_source_revision": "a290ba04c1b3ad1ec41a33974a157b2917b624d4",
+    "official_source_archive_sha256": "c11d945db0fb765c0bdf355311f986ab914ad2619133de3a26f84a3ecbddf6c9",
+    "checkpoint_hf_revision": "9b446878c81ddb27593036767b29b2859d46103e"
+  },
+  "protocol": {
+    "input_pairs": 5,
+    "input_shape": [700, 700, 3],
+    "engine_shape": [1, 3, 704, 704],
+    "warmup_iterations": 3,
+    "timed_iterations": 100,
+    "valid_iterations": 8,
+    "max_disparity": 192,
+    "accuracy_metric": "flattened_fp32_cosine_similarity",
+    "minimum_cosine": 0.999
+  },
+  "recorded_baseline": {
+    "preprocess_5_pairs_mean_ms": 133.45681335777044,
+    "inference_5_pairs_mean_ms": 631.8328293785453,
+    "total_5_pairs_mean_ms": 765.2896427363157
+  },
+  "l4_torch_reproduction": {
+    "preprocess_5_pairs_mean_ms": 79.91516468013288,
+    "inference_5_pairs_mean_ms": 685.3437921198929,
+    "total_5_pairs_mean_ms": 765.2589568000258,
+    "global_cosine": 1.0
+  },
+  "selected_tensorrt_configuration": {
+    "measurement_runtime": "official Python TrtRunner with the official Triton GWC kernel",
+    "native_runtime_boundary": "The C++ runtime uses the separately validated family-owned GWC CUDA kernel below.",
+    "precision": "weakly_typed_fp16_with_required_fp32_tensors",
+    "graph": "split_feature_gwc_post",
+    "builder_optimization_level": 3,
+    "workspace_gib": 8,
+    "maximum_auxiliary_streams": 2,
+    "actual_feature_auxiliary_streams": 2,
+    "actual_post_auxiliary_streams": 2,
+    "cuda_graphs": true,
+    "feature_engine_layers": 284,
+    "post_engine_layers": 697
+  },
+  "selected_tensorrt_sustained_runs": [
+    {
+      "preprocess_5_pairs_mean_ms": 77.40514166027424,
+      "inference_5_pairs_mean_ms": 326.32860979989346,
+      "total_5_pairs_mean_ms": 403.7337514601677,
+      "global_cosine": 0.999405287244333,
+      "accuracy_passed": true
+    },
+    {
+      "preprocess_5_pairs_mean_ms": 77.34481210020022,
+      "inference_5_pairs_mean_ms": 323.69157146014913,
+      "total_5_pairs_mean_ms": 401.03638356034935,
+      "global_cosine": 0.999405287244333,
+      "accuracy_passed": true
+    }
+  ],
+  "improvement_from_recorded_baseline_using_repeat": {
+    "inference_latency_reduction_percent": 48.76942817635419,
+    "inference_throughput_speedup": 1.9519594734221635,
+    "total_latency_reduction_percent": 47.596784123925694,
+    "total_throughput_speedup": 1.908279832224131
+  },
+  "roofline_sample": {
+    "tool": "Nsight Compute 2024.1.1",
+    "scope": "125 stratified post-engine kernel launches at offsets 0, 200, 400, and 600",
+    "sampled_duration_us": 6119.54,
+    "duration_weighted_compute_percent_of_peak": 58.21988569402276,
+    "duration_weighted_memory_percent_of_peak": 55.821482644120316,
+    "maximum_compute_percent_of_peak": 85.41,
+    "maximum_memory_percent_of_peak": 88.05,
+    "launches_at_or_above_80_percent_of_a_ceiling": 10,
+    "compute_limited_launches": 85,
+    "memory_limited_launches": 40,
+    "interpretation": "Dominant tensor-core and pooling/GEMM kernels reach the L4 compute or memory roof. Remaining batch-1 latency is distributed across small launches and reformat kernels; CUDA graphs reduce that launch overhead without changing model outputs."
+  },
+  "stage_gpu_time_ms_per_pair": {
+    "feature": 7.11487,
+    "groupwise_correlation": 1.99087,
+    "post": 56.71301,
+    "sum": 65.81875
+  },
+  "native_gwc_validation": {
+    "input": "deterministic random FP16 feature tensors with shape [1, 224, 176, 176]",
+    "production_math_flags": true,
+    "native_mean_ms": 0.8148294067382813,
+    "official_triton_mean_ms": 1.8557951354980469,
+    "cosine": 0.9999999403953552,
+    "maximum_absolute_error": 0.00048828125,
+    "mean_absolute_error": 2.5104574419287928e-08
+  },
+  "tuning_sweep_short_runs": [
+    {
+      "candidate": "selected_opt3_aux2_cuda_graphs",
+      "inference_5_pairs_mean_ms": 316.6116,
+      "global_cosine": 0.999405287244333
+    },
+    {
+      "candidate": "selected_opt3_aux2_no_cuda_graphs",
+      "inference_5_pairs_mean_ms": 327.27457609871635,
+      "global_cosine": 0.999405287244333
+    },
+    {
+      "candidate": "opt3_aux0",
+      "inference_5_pairs_mean_ms": 316.6310241991596,
+      "global_cosine": 0.999393157992395
+    },
+    {
+      "candidate": "opt3_aux1",
+      "inference_5_pairs_mean_ms": 316.9661971012829,
+      "global_cosine": 0.9994142748701115
+    },
+    {
+      "candidate": "opt3_aux4",
+      "inference_5_pairs_mean_ms": 326.0402198997326,
+      "global_cosine": 0.999389306161319
+    },
+    {
+      "candidate": "opt4_aux2",
+      "inference_5_pairs_mean_ms": 322.9438241003663,
+      "global_cosine": 0.9993751414938042
+    },
+    {
+      "candidate": "opt3_aux2_full_tiling",
+      "inference_5_pairs_mean_ms": 323.47987109969836,
+      "global_cosine": 0.99938988205566
+    },
+    {
+      "candidate": "single_engine_opt3",
+      "inference_5_pairs_mean_ms": 530.973,
+      "global_cosine": 0.999404645
+    }
+  ]
+}

--- a/tests/e2e/models/fast_foundation_stereo/profile_ncu.py
+++ b/tests/e2e/models/fast_foundation_stereo/profile_ncu.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Emit one profiler-delimited TensorRT post enqueue for Nsight Compute."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import torch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("feature_engine", type=Path)
+    parser.add_argument("post_engine", type=Path)
+    parser.add_argument("--warmup", type=int, default=3)
+    args = parser.parse_args()
+
+    root = args.model_root.resolve()
+    os.chdir(root)
+    sys.path.insert(0, str(root))
+    import tensorrt as trt
+    from core.foundation_stereo import TrtRunner
+    from core.submodule import build_gwc_volume_triton
+
+    checkpoint = root / "weights/23-36-37/model_best_bp2_serialize.pth"
+    checkpoint_model = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    checkpoint_model.args.valid_iters = 8
+    checkpoint_model.args.max_disp = 192
+    model = TrtRunner(checkpoint_model.args, str(args.feature_engine), str(args.post_engine)).cuda()
+    del checkpoint_model
+    left = torch.rand((1, 3, 704, 704), device="cuda") * 255
+    right = torch.rand_like(left) * 255
+    input_names = model.get_io_tensor_names(model.post_engine, trt.TensorIOMode.INPUT)
+
+    def prepare_inputs():
+        feature = model.run_trt(
+            model.feature_engine,
+            model.feature_context,
+            {"left": left, "right": right},
+        )
+        feature["gwc_volume"] = build_gwc_volume_triton(
+            feature["features_left_04"].half(),
+            feature["features_right_04"].half(),
+            48,
+            8,
+            normalize=True,
+        )
+        return {name: value for name, value in feature.items() if name in input_names}
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.inference_mode(), torch.cuda.stream(stream):
+        inputs = prepare_inputs()
+        for _ in range(args.warmup):
+            model.run_trt(model.post_engine, model.post_context, inputs)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    with torch.inference_mode(), torch.cuda.stream(stream):
+        torch.cuda.nvtx.range_push("ffs_post")
+        try:
+            model.run_trt(model.post_engine, model.post_context, inputs)
+            stream.synchronize()
+        finally:
+            torch.cuda.nvtx.range_pop()
+    print("profiled one post-engine enqueue")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/models/fast_foundation_stereo/runner.py
+++ b/tests/e2e/models/fast_foundation_stereo/runner.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E runner for the Fast Foundation Stereo family."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from tests.e2e_harness.model_runner import (
+    model_names_for_dir,
+    run_model_e2e as run_model_manifest_e2e,
+)
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_PROJECT_DIR = _MODEL_DIR.parents[3]
+
+
+def _resolve_binary(config) -> str:
+    configured = config.getoption("--trtmc-binary", default=None)
+    if configured:
+        return str(Path(configured).absolute())
+    default = _PROJECT_DIR / "build" / "trtmc"
+    return str(default) if default.is_file() else ""
+
+
+def _resolve_hf_python(config) -> str:
+    configured = config.getoption("--hf-python", default=None)
+    if configured:
+        return str(Path(configured).absolute())
+    venv = _PROJECT_DIR / ".venv" / "bin" / "python"
+    return str(venv) if venv.is_file() else sys.executable
+
+
+def _resolve_engine_dir(config) -> str:
+    configured = config.getoption("--engine-dir", default=None)
+    directory = (
+        Path(configured) if configured else Path("/mnt/storage/tensorrt-model-connect/engines")
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    return str(directory)
+
+
+def _resolve_model_plugin_dir(config) -> str:
+    configured = config.getoption("--model-plugin-dir", default=None)
+    return str(Path(configured).absolute()) if configured else ""
+
+
+def _resolve_artifacts_dir(config) -> str:
+    configured = config.getoption("--e2e-artifacts-dir", default=None)
+    if configured:
+        return str(Path(configured))
+    return str(Path("/tmp/e2e_artifacts") / _MODEL_DIR.name)
+
+
+@contextmanager
+def _model_plugin_dir_env(path: str):
+    previous = os.environ.get("TRTMC_MODEL_PLUGIN_DIR")
+    if path:
+        os.environ["TRTMC_MODEL_PLUGIN_DIR"] = path
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TRTMC_MODEL_PLUGIN_DIR", None)
+        else:
+            os.environ["TRTMC_MODEL_PLUGIN_DIR"] = previous
+
+
+def _resolve_ld_library_path() -> str:
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import importlib.util; s=importlib.util.find_spec('tensorrt_libs'); "
+                "print(s.submodule_search_locations[0])",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        trt_lib_dir = result.stdout.strip()
+    except Exception:
+        trt_lib_dir = ""
+    base = os.environ.get("LD_LIBRARY_PATH", "")
+    nccl_lib_dir = os.environ.get("TRTMC_NCCL_LIB_DIR", "")
+    return ":".join(
+        path for path in (nccl_lib_dir, trt_lib_dir, "/usr/local/cuda/lib64", base) if path
+    )
+
+
+def _load_waives(platform: str = "") -> dict[str, tuple[str, str]]:
+    del platform
+    return {}
+
+
+def _is_multi_device_case(case) -> bool:
+    metadata = case.metadata or {}
+    return str(metadata.get("ci_tier", "") or "") == "multi_device"
+
+
+def _parse_e2e_model_filters(values: list[str] | None) -> set[str]:
+    filters: set[str] = set()
+    for raw in values or []:
+        filters.update(item.strip() for item in str(raw).split(",") if item.strip())
+    return filters
+
+
+def _case_matches_e2e_model(case, filters: set[str]) -> bool:
+    if not filters:
+        return True
+    metadata = case.metadata or {}
+    fields = {
+        case.name,
+        case.family,
+        case.runtime_strategy,
+        case.task_strategy,
+        Path(case.hf_id).name if case.hf_id else "",
+        str(metadata.get("family", "")),
+        str(metadata.get("runtime_strategy", "")),
+    }
+    return bool(filters & {field for field in fields if field})
+
+
+def model_case_names(config=None) -> list[str]:
+    return model_names_for_dir(
+        config=config,
+        model_dir=_MODEL_DIR,
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+    )
+
+
+def run_model_e2e(case_name: str, request) -> None:
+    run_model_manifest_e2e(
+        model_name=case_name,
+        request=request,
+        model_dir=_MODEL_DIR,
+        load_waives=_load_waives,
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+        resolve_hf_python=_resolve_hf_python,
+        resolve_artifacts_dir=_resolve_artifacts_dir,
+        resolve_binary=_resolve_binary,
+        resolve_ld_library_path=_resolve_ld_library_path,
+        resolve_engine_dir=_resolve_engine_dir,
+        resolve_model_plugin_dir=_resolve_model_plugin_dir,
+        model_plugin_dir_env=_model_plugin_dir_env,
+    )

--- a/tests/e2e/models/fast_foundation_stereo/test_family.py
+++ b/tests/e2e/models/fast_foundation_stereo/test_family.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tests.e2e.models.fast_foundation_stereo.e2e_plugins.comparator import (
+    StereoDisparityComparator,
+)
+from tests.e2e_harness.contracts import StageOutput, StageSpec, ThresholdProfile
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.fast_foundation_stereo import (
+    FastFoundationStereoPlugin,
+)
+from tensorrt_model_connect.families.fast_foundation_stereo.builder import (
+    _set_fp16_flag_if_supported,
+)
+from tensorrt_model_connect.families.fast_foundation_stereo.model_config import (
+    config_from_dir,
+)
+from tensorrt_model_connect.families.fast_foundation_stereo.prepare_model import (
+    configure_official_model_args,
+    install_official_io_import_shims,
+    resolve_model_dir,
+)
+
+
+def _model_dir(tmp_path: Path) -> Path:
+    (tmp_path / "core").mkdir()
+    (tmp_path / "core/foundation_stereo.py").write_text("# source\n")
+    (tmp_path / "core/submodule.py").write_text("# source\n")
+    checkpoint = tmp_path / "weights/23-36-37/model_best_bp2_serialize.pth"
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_bytes(b"checkpoint")
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    (reference / "benchmark_result.json").write_text(
+        json.dumps({"max_disp": 192, "valid_iters": 8}), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_config_adapter_claims_only_complete_source_package(tmp_path: Path) -> None:
+    assert config_from_dir(tmp_path) is None
+    model_dir = _model_dir(tmp_path)
+    config = config_from_dir(model_dir)
+    assert config is not None
+    assert config["model_type"] == "fast_foundation_stereo"
+    assert config["runtime_strategy"] == "fast_foundation_stereo_disparity"
+    assert config["stereo_engine_height"] == 704
+    assert config["stereo_engine_width"] == 704
+    assert config["stereo_min_cosine"] == 0.999
+
+
+def test_plugin_owns_unique_strategy_and_skips_tokenizer() -> None:
+    plugin = FastFoundationStereoPlugin()
+    assert plugin.name == "fast_foundation_stereo"
+    assert plugin.runtime_strategy == "fast_foundation_stereo_disparity"
+    assert plugin.requires_tokenizer is False
+    assert plugin.matches("fast-foundation-stereo")
+    assert not plugin.matches("segformer")
+
+
+def test_official_io_import_shims_cover_only_missing_optional_modules(
+    monkeypatch,
+) -> None:
+    sentinel = object()
+    previous = {name: sys.modules.get(name, sentinel) for name in ("cv2", "imageio")}
+    for name in previous:
+        sys.modules.pop(name, None)
+    real_find_spec = importlib.util.find_spec
+    monkeypatch.setattr(
+        importlib.util,
+        "find_spec",
+        lambda name: None if name in previous else real_find_spec(name),
+    )
+
+    try:
+        install_official_io_import_shims()
+        assert sys.modules["cv2"].COLORMAP_TURBO == 20
+        assert sys.modules["imageio"].__name__ == "imageio"
+    finally:
+        for name, module in previous.items():
+            if module is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_official_model_args_include_normalized_gwc_contract() -> None:
+    model = SimpleNamespace(args=SimpleNamespace())
+
+    configure_official_model_args(
+        model,
+        max_disparity=192,
+        valid_iters=8,
+    )
+
+    assert model.args.max_disp == 192
+    assert model.args.valid_iters == 8
+    assert model.args.normalize is True
+
+
+def test_flat_hf_checkpoint_is_staged_with_pinned_source(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source"
+    for relative in (
+        "Utils.py",
+        "core/foundation_stereo.py",
+        "core/submodule.py",
+        "core/geometry.py",
+        "core/extractor.py",
+        "core/update.py",
+    ):
+        path = source / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# source\n", encoding="utf-8")
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model_best_bp2_serialize.pth").write_bytes(b"checkpoint")
+    (snapshot / "cfg.yaml").write_text("valid_iters: 8\n", encoding="utf-8")
+    monkeypatch.setenv("TRTMC_FAST_FOUNDATION_STEREO_SOURCE_DIR", str(source))
+    monkeypatch.setenv("TRTMC_FAST_FOUNDATION_STEREO_CACHE", str(tmp_path / "cache"))
+
+    staged = resolve_model_dir(snapshot)
+    assert staged is not None
+    assert (staged / "core/foundation_stereo.py").is_file()
+    assert (staged / "weights/23-36-37/model_best_bp2_serialize.pth").read_bytes() == b"checkpoint"
+    assert config_from_dir(staged) is not None
+
+
+def test_local_only_staging_requires_cached_pinned_source(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model_best_bp2_serialize.pth").write_bytes(b"checkpoint")
+    monkeypatch.delenv("TRTMC_FAST_FOUNDATION_STEREO_SOURCE_DIR", raising=False)
+    monkeypatch.setenv("TRTMC_FAST_FOUNDATION_STEREO_CACHE", str(tmp_path / "cache"))
+
+    with pytest.raises(FileNotFoundError, match="not present in the local cache"):
+        resolve_model_dir(snapshot, local_files_only=True)
+
+
+def test_plugin_builds_feature_and_family_owned_post_section(tmp_path: Path, monkeypatch) -> None:
+    model_dir = _model_dir(tmp_path)
+    raw = config_from_dir(model_dir)
+    assert raw is not None
+    config = ModelConfig.from_json(json.dumps(raw))
+    plugin = FastFoundationStereoPlugin()
+    weights = plugin.load_weights(str(model_dir), config, precision="fp16")
+
+    from tensorrt_model_connect.families.fast_foundation_stereo import builder
+
+    calls = []
+
+    def feature(model_dir, **kwargs):
+        calls.append(("feature", model_dir, kwargs))
+        return b"feature-plan"
+
+    def post(model_dir, **kwargs):
+        calls.append(("post", model_dir, kwargs))
+        return b"post-plan"
+
+    monkeypatch.setattr(builder, "build_feature_engine", feature)
+    monkeypatch.setattr(builder, "build_post_engine", post)
+    assert plugin.build_engine(config, weights, 1, precision="fp16") == b"feature-plan"
+    assert plugin.build_extra_engines(config, weights, 1, precision="fp16") == {
+        "fast_foundation_stereo_post_engine_plan": b"post-plan"
+    }
+    assert [call[0] for call in calls] == ["feature", "post"]
+    assert all(call[2]["max_disparity"] == 192 for call in calls)
+    assert all(call[2]["valid_iters"] == 8 for call in calls)
+
+
+def test_l4_performance_receipt_beats_baseline_and_passes_accuracy() -> None:
+    receipt = json.loads(
+        (Path(__file__).parent / "performance/l4.json").read_text()
+    )
+    baseline = receipt["recorded_baseline"]
+    selected = receipt["selected_tensorrt_sustained_runs"][-1]
+    protocol = receipt["protocol"]
+    roofline = receipt["roofline_sample"]
+
+    assert selected["inference_5_pairs_mean_ms"] < baseline["inference_5_pairs_mean_ms"]
+    assert selected["total_5_pairs_mean_ms"] < baseline["total_5_pairs_mean_ms"]
+    assert selected["global_cosine"] >= protocol["minimum_cosine"]
+    assert selected["accuracy_passed"] is True
+    assert (
+        max(
+            roofline["maximum_compute_percent_of_peak"],
+            roofline["maximum_memory_percent_of_peak"],
+        )
+        >= 80.0
+    )
+
+
+@pytest.mark.parametrize("exposes_fp16", [False, True])
+def test_fp16_builder_flag_is_optional_across_tensorrt_versions(
+    exposes_fp16: bool,
+) -> None:
+    calls = []
+    builder_flag = SimpleNamespace()
+    if exposes_fp16:
+        builder_flag.FP16 = "fp16"
+    config = SimpleNamespace(set_flag=calls.append)
+
+    _set_fp16_flag_if_supported(
+        config,
+        SimpleNamespace(BuilderFlag=builder_flag),
+    )
+
+    assert calls == (["fp16"] if exposes_fp16 else [])
+
+
+def test_disparity_comparator_gates_global_fp32_cosine() -> None:
+    expected = np.arange(16, dtype=np.float32).reshape(4, 4)
+    comparator = StereoDisparityComparator()
+    threshold = ThresholdProfile(
+        task_strategy="stereo_disparity",
+        metrics={
+            "finite_fraction": 1.0,
+            "global_cosine": 0.999,
+            "nonnegative_fraction": 1.0,
+        },
+    )
+    stage = StageSpec(name="full_inference")
+    reference = StageOutput(
+        stage_name=stage.name,
+        data={"disparity": expected, "expected_shape": [4, 4]},
+    )
+
+    passed = comparator.compare(
+        StageOutput(stage_name=stage.name, data={"disparity": expected.copy()}),
+        reference,
+        threshold,
+        stage,
+    )
+    failed = comparator.compare(
+        StageOutput(
+            stage_name=stage.name,
+            data={"disparity": np.flip(expected, axis=1).copy()},
+        ),
+        reference,
+        threshold,
+        stage,
+    )
+
+    assert passed.passed
+    assert passed.metrics["global_cosine"].value == pytest.approx(1.0)
+    assert not failed.passed
+    assert not failed.metrics["global_cosine"].passed

--- a/tests/e2e/models/fast_foundation_stereo/test_fast_foundation_stereo_e2e.py
+++ b/tests/e2e/models/fast_foundation_stereo/test_fast_foundation_stereo_e2e.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E entrypoint for the Fast Foundation Stereo family."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_RUNNER_PATH = Path(__file__).with_name("runner.py")
+_SPEC = importlib.util.spec_from_file_location(
+    f"{Path(__file__).resolve().parent.name}_e2e_runner",
+    _RUNNER_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_runner = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_runner)
+
+
+def pytest_generate_tests(metafunc):
+    if "case_name" in metafunc.fixturenames:
+        case_names = _runner.model_case_names(metafunc.config)
+        if not case_names:
+            pytest.skip("No model manifests selected", allow_module_level=True)
+        metafunc.parametrize("case_name", case_names)
+
+
+def test_model_e2e(case_name: str, request) -> None:
+    _runner.run_model_e2e(case_name, request)

--- a/tests/e2e/models/fast_foundation_stereo/thresholds/fast-foundation-stereo.json
+++ b/tests/e2e/models/fast_foundation_stereo/thresholds/fast-foundation-stereo.json
@@ -1,0 +1,7 @@
+{
+  "threshold_overrides": {
+    "finite_fraction": 1.0,
+    "global_cosine": 0.999,
+    "nonnegative_fraction": 1.0
+  }
+}

--- a/tests/e2e/models/fast_foundation_stereo/validation/fast-foundation-stereo.json
+++ b/tests/e2e/models/fast_foundation_stereo/validation/fast-foundation-stereo.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "trtmc.model-plugin-validation/v1",
+  "dataset": "Fast-FoundationStereo deterministic rectified pair",
+  "version": "1",
+  "requests": [
+    {
+      "sample_id": "fast-foundation-stereo-shift-12",
+      "testcase": "fast-foundation-stereo",
+      "stage": "full_inference",
+      "category": "synthetic-rectified-stereo",
+      "inputs": {
+        "pixel_shift": 12
+      }
+    }
+  ]
+}

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -318,5 +318,5 @@ def test_repository_registers_all_current_families() -> None:
 
     families = specialization.family_dirs(repo_root, ())
 
-    assert len(families) == 79
+    assert len(families) == 80
     assert any(family.name == "minimax_h3" for family in families)

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -33,6 +33,11 @@ MINIMAX_H3_EXCLUSION_REASON = (
     "The pinned Diffusers reference for MiniMax-H3 has not yet been integrated "
     "into the release performance runner."
 )
+FAST_FOUNDATION_STEREO_EXCLUSION_REASON = (
+    "The exact baseline is owned by the supplied rectified-stereo fixture "
+    "archive and model-local L4 harness; the public release runner does not "
+    "yet provide an equivalent redistributable stereo reference workload."
+)
 TASK_ADAPTERS = {
     "bark.generate_audio": "hf-transformers-tts",
     "canary.transcribe": "nemo-asr",
@@ -259,6 +264,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert len(raw_entries) == 77
     assert len(raw_additional) == 28
     assert excluded_profiles == {
+        "fast-foundation-stereo": FAST_FOUNDATION_STEREO_EXCLUSION_REASON,
         "minimax-h3-768p": MINIMAX_H3_EXCLUSION_REASON,
     }
     assert all(
@@ -1478,9 +1484,13 @@ def test_run_consolidates_results_and_records_replayable_commands(
     expected_catalog_coverage = {
         "total_profiles": len(catalog_entries),
         "ready_profiles": catalog_counts["ready"],
-        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles - 1,
-        "explicitly_excluded_profiles": 1,
+        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles - 2,
+        "explicitly_excluded_profiles": 2,
         "explicit_exclusions": [
+            {
+                "model": "fast-foundation-stereo",
+                "reason": FAST_FOUNDATION_STEREO_EXCLUSION_REASON,
+            },
             {
                 "model": "minimax-h3-768p",
                 "reason": MINIMAX_H3_EXCLUSION_REASON,
@@ -1525,7 +1535,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "76 model types" in report
     assert "105 model comparisons" in report
     assert "105 single-process profiles" in report
-    assert "1 explicitly excluded profile" in report
+    assert "2 explicitly excluded profiles" in report
     assert (
         f"{expected_catalog_coverage['excluded_l0_profiles']} duplicate L0 profiles are excluded"
     ) in report

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -164,6 +164,7 @@ def test_catalog_reuses_existing_model_manifests_for_different_tasks(tmp_path: P
         "chronos-bolt-tiny-official": ("solve", 50, 500),
         "nemotron-embed-vl-1b-v2": ("embed", 50, 500),
         "whisper-tiny-fp16": ("transcribe", 1, 10),
+        "fast-foundation-stereo": ("disparity", 3, 100),
     }
     for model_name, expected in expectations.items():
         case = resolve_case(catalog.resolve(model_name), _bundle(tmp_path, model_name))
@@ -183,6 +184,7 @@ def test_operation_registry_declares_supported_task_semantics() -> None:
         "segment_prompted",
         "classify",
         "detect",
+        "disparity",
         "rerank",
         "encode",
         "embed",
@@ -206,6 +208,7 @@ def test_operation_registry_declares_supported_task_semantics() -> None:
         "embedding": "embed",
         "neural_operator": "solve",
         "speech_to_text": "transcribe",
+        "stereo_disparity": "disparity",
     }
     assert operations["generate_image"].supports_batch is True
     assert operations["generate_image"].per_item_latency.result_name == "seconds_per_image_p50"
@@ -214,6 +217,10 @@ def test_operation_registry_declares_supported_task_semantics() -> None:
         "forecast_elements_per_s",
     ]
     assert operations["transcribe"].rate_metrics[0].inverse_result_name == "realtime_factor"
+    assert [metric.result_name for metric in operations["disparity"].rate_metrics] == [
+        "stereo_pairs_per_s",
+        "disparity_pixels_per_s",
+    ]
 
 
 def test_native_worker_has_a_runner_for_every_advertised_operation() -> None:

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -44,7 +44,7 @@ def test_model_workload_catalog_covers_every_ready_model():
         task_models=task_models,
     )
 
-    assert len(catalog["models"]) == len(ready_models) == 106
+    assert len(catalog["models"]) == len(ready_models) == 107
     assert sum("not_compared_reason" in spec for spec in catalog["models"].values()) == 0
     assert all("e2e" not in spec.get("workloads", []) for spec in catalog["models"].values())
     assert "reference_cache_identity" not in catalog["models"]["personaplex-7b"]
@@ -63,7 +63,7 @@ def test_model_workload_catalog_covers_every_ready_model():
     }
     assert len(qwen_identities) == 1
     bindings = trtmc_validate.resolve_bindings(catalog, catalog["models"])
-    assert len(bindings) == 106
+    assert len(bindings) == 107
     assert [
         binding.workload for binding in bindings if binding.model == "personaplex-7b"
     ] == ["full_duplex_bench_behavior_parity"]
@@ -188,6 +188,7 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     }
     assert min(catalog["sample_limits"].values()) >= 1
     assert {workload for workload, limit in catalog["sample_limits"].items() if limit == 1} == {
+        "fast_foundation_stereo_synthetic_parity",
         "minimax_h3_official_profile_parity",
         "seedtts_en_omni_audio_parity",
         "vbench_ti2v_official_profile_parity",
@@ -224,7 +225,45 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 106
+    assert len({model for model, _workload in bindings}) == 107
+
+
+def test_fast_foundation_stereo_catalog_uses_numeric_model_plugin_parity() -> None:
+    catalog = trtmc_validate.load_catalog()
+    suite = next(
+        value
+        for value in validation_catalog.load_suites()
+        if value["id"] == "fast_foundation_stereo_synthetic_parity"
+    )
+    model = next(
+        value
+        for value in validation_catalog.load_manifest_records(
+            trtmc_validate.DEFAULT_MODELS
+        )
+        if value["name"] == "fast-foundation-stereo"
+    )
+
+    assert catalog["models"]["fast-foundation-stereo"] == {
+        "workloads": ["fast_foundation_stereo_synthetic_parity"],
+    }
+    assert validation_catalog.suite_match_reason(suite, model) == (
+        True,
+        "selected",
+    )
+    assert suite["scoring"] == {"scorer": "model_plugin_parity"}
+    assert suite["gates"] == {"min_sample_pass_rate": 1.0}
+
+    dataset_path = trtmc_validate.REPO_ROOT / suite["dataset"]["default_path"]
+    dataset = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert dataset["requests"] == [
+        {
+            "sample_id": "fast-foundation-stereo-shift-12",
+            "testcase": "fast-foundation-stereo",
+            "stage": "full_inference",
+            "category": "synthetic-rectified-stereo",
+            "inputs": {"pixel_shift": 12},
+        }
+    ]
 
 
 def test_resolve_binding_requires_an_explicit_choice_for_multi_workload_model():

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -123,6 +123,7 @@ def _load_cache_helpers() -> dict:
         "_WEIGHT_PATTERNS": [
             "*.safetensors",
             "*.bin",
+            "*.pth",
             "*.nemo",
             "model.npz",
             "elf_params.npz",
@@ -312,6 +313,16 @@ def test_orbax_checkpoint_counts_as_complete_snapshot(tmp_path: Path) -> None:
     checkpoint.mkdir(parents=True)
     (snapshot / "ELF-B-de-en.yml").write_text("model: elf\n")
     (checkpoint / "manifest.ocdbt").write_bytes(b"checkpoint")
+
+    assert helpers["_snapshot_has_required_files"](snapshot)
+
+
+def test_pytorch_pth_checkpoint_counts_as_complete_snapshot(tmp_path: Path) -> None:
+    helpers = _load_cache_helpers()
+    snapshot = tmp_path / "snapshots" / "abc"
+    snapshot.mkdir(parents=True)
+    (snapshot / "cfg.yaml").write_text("valid_iters: 8\n")
+    (snapshot / "model_best_bp2_serialize.pth").write_bytes(b"checkpoint")
 
     assert helpers["_snapshot_has_required_files"](snapshot)
 

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -14,6 +14,7 @@ sample_limits:
   coco2017_prompted_segmentation: 20
   dpg_bench_diffusion_image: 5
   etth1_time_series_parity: 10
+  fast_foundation_stereo_synthetic_parity: 1
   flores200_en_fr_riva_translation_parity: 10
   gedit_bench_image_edit: 5
   humaneval_code_continuation_parity: 10
@@ -105,6 +106,8 @@ models:
     workloads: [mmlu_continuation_parity]
   falcon3-1b:
     workloads: [mmlu_continuation_parity]
+  fast-foundation-stereo:
+    workloads: [fast_foundation_stereo_synthetic_parity]
   flux-2-dev:
     workloads: [dpg_bench_diffusion_image]
     reference_cache_identity: flux-2-dev-dpg-v2

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1680,6 +1680,34 @@ suites:
       lane: local_only
       notes: GB300-only native-reference consistency.
 
+  - id: fast_foundation_stereo_synthetic_parity
+    description: >
+      Numeric disparity consistency on a repo-owned deterministic 700x700
+      rectified stereo pair. The pinned official PyTorch implementation and
+      native TRTMC runtime receive the same RGB tensors and must preserve the
+      model's flattened-FP32 cosine threshold of 0.999.
+    user_contract: stereo_disparity
+    default_model_names: [fast-foundation-stereo]
+    dataset:
+      kind: model_plugin_json
+      default_path: tests/e2e/models/fast_foundation_stereo/validation/fast-foundation-stereo.json
+    selectors:
+      model_names: [fast-foundation-stereo]
+      task_strategies: [stereo_disparity]
+      runtime_strategies: [fast_foundation_stereo_disparity]
+      user_contracts: [stereo_disparity]
+      families: [fast_foundation_stereo]
+    scoring:
+      scorer: model_plugin_parity
+    gates:
+      min_sample_pass_rate: 1.0
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        Single-GPU native-reference consistency. The model-owned threshold
+        sidecar supplies the 0.999 cosine gate without workload overrides.
+
   - id: mmmu_pro_vision_square_plugin_parity
     description: >
       Image-question output consistency on the same five distinct-subject

--- a/tools/reporting_html.py
+++ b/tools/reporting_html.py
@@ -195,6 +195,7 @@ TASK_TYPE_BY_USER_CONTRACT = {
     "embedding_vector": "Text → Embedding",
     "ranking_order": "Query + Documents → Ranking",
     "diffusion_text_generation": "Text → Text",
+    "stereo_disparity": "Stereo Images → Disparity",
 }
 
 TASK_TYPE_BY_TASK_STRATEGY = {
@@ -211,6 +212,7 @@ TASK_TYPE_BY_TASK_STRATEGY = {
     "encoder_only_nlp": "Text → Embedding",
     "embedding": "Text → Embedding",
     "reranking": "Query + Documents → Ranking",
+    "stereo_disparity": "Stereo Images → Disparity",
 }
 
 


### PR DESCRIPTION
## Background

Add isolated TensorRT Model Connect support for NVIDIA Fast Foundation Stereo and preserve the supplied model's accuracy while materially beating its recorded L4 baseline under the same five-pair protocol.

## Exit Criteria

- Build the official pinned checkpoint and source into a self-contained bundle without sharing another model family's runtime.
- Run fixed 700x700 rectified stereo inference through a native C++ disparity API and CLI.
- Retain flattened FP32 cosine similarity >= 0.999 against the official PyTorch reference.
- Beat the recorded five-pair L4 inference baseline using 3 warmups, 100 timed iterations, 8 update iterations, and max disparity 192.

## Implementation

- Adds a dedicated Python family that composes the pinned Hugging Face checkpoint with checksum-verified official source and builds split feature/post TensorRT engines.
- Uses the measured L4 configuration: an FP16 graph with required FP32 tensors, builder optimization level 3, 8 GiB workspace, two actual auxiliary streams, and CUDA graphs.
- Handles the TensorRT 10/11 precision-policy boundary without changing graph precision, and applies the official normalized-GWC inference contract omitted by the serialized checkpoint.
- Adds a native C++ stereo pipeline, optimized CUDA groupwise-correlation kernel, public disparity result API, and `trtmc disparity` command.
- Adds model-owned runtime/E2E manifests, pinned official PyTorch numeric-parity coverage, a repo-owned validation workload, an exact benchmark harness, Nsight Compute tooling, and a checked-in L4 performance receipt.

## Validation

- Exact head `1fda80a5dcc51dae7cabc1950d8941a0c3ef0cfa`: [private premerge run](https://github.com/NVIDIA-dev/TensorRT-Model-Connect-CI/actions/runs/31924496567) passed source quality, legal/ownership gates, units, all selected model proofs, combined report, and private verdict.
- Source-only units: 3294 Python passed, 1 skipped; 20 focused model tests passed with 137 deselected; 38/38 C++ tests passed.
- Isolated Fast Foundation Stereo proof built both engines, ran the native TensorRT 11.2 C++ disparity path, and passed the pinned official PyTorch L1 oracle: shape, finiteness, and non-negativity all passed; global cosine was 0.999995443 against the required 0.999.
- Focused local model/cache/reference validation: 64 passed. Ruff checks, legal-header checks, and diff checks passed.
- L4, exact 3-warmup/100-iteration repeat: 323.692 ms inference and 401.036 ms total for five pairs, with global cosine 0.999405 (pass). This is 48.77% lower inference latency and 47.60% lower total latency than the recorded baseline.
- Production-math native GWC comparison on L4: cosine 0.99999994 versus the official Triton kernel, 0.815 ms versus 1.856 ms; the new GPU contract test compiled and passed.
- Nsight Compute sampled 125 kernels across the post graph; peak sampled kernels reached 85.41% of the compute roof and 88.05% of the memory roof, with 10 launches at or above 80% of a ceiling.

## Notes For Future Readers

- The roofline statement is kernel-level, not a claim that the full batch-1 graph sustains 100% of peak. Duration-weighted sampled utilization was 58.22% compute and 55.82% memory; remaining latency is distributed across small launches and reformat kernels, with CUDA graphs reducing launch overhead.
- The L4 benchmark receipt uses TensorRT 10.8 on a 72 W NVIDIA L4. The exact-head private proof separately establishes current TensorRT 11.2 build/runtime compatibility and official-reference parity on GB300.
- Suggested review order: pinned source/checkpoint staging, split engine builder, native runtime/GWC kernel, then the L4 receipt and numeric E2E contract.
