### PR TITLE
fix(perf): align PixArt reference component precision

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -1199,6 +1199,69 @@ def _load_reranking(
     return Session(invoke, _resolved_revision(arguments, model), "transformers")
 
 
+_PIXART_TRTMC_MIXED_PRECISION = "pixart_fp16_dit_fp32_t5"
+
+
+def _diffusion_component_precision_contract(
+    arguments: argparse.Namespace,
+    options: Mapping[str, Any],
+) -> str:
+    contract = str(options.get("component_precision_contract", "") or "")
+    if not contract:
+        return ""
+    if contract != _PIXART_TRTMC_MIXED_PRECISION:
+        raise ValueError(f"unsupported diffusion component precision contract: {contract}")
+    if arguments.family != "pixart" or arguments.precision != "fp16":
+        raise ValueError(
+            f"{contract} requires family=pixart and precision=fp16"
+        )
+    return contract
+
+
+def _cast_floating_tensors(value: Any, dtype: Any, torch_module: Any) -> Any:
+    if isinstance(value, torch_module.Tensor):
+        return value.to(dtype=dtype) if value.is_floating_point() else value
+    if isinstance(value, tuple):
+        return tuple(
+            _cast_floating_tensors(item, dtype, torch_module) for item in value
+        )
+    if isinstance(value, list):
+        return [
+            _cast_floating_tensors(item, dtype, torch_module) for item in value
+        ]
+    if isinstance(value, dict):
+        return {
+            key: _cast_floating_tensors(item, dtype, torch_module)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _configure_diffusion_component_precision(
+    pipeline: Any,
+    arguments: argparse.Namespace,
+    options: Mapping[str, Any],
+    torch_module: Any,
+) -> None:
+    contract = _diffusion_component_precision_contract(arguments, options)
+    if not contract:
+        return
+
+    def fp16_transformer_inputs(_module: Any, args: Any, kwargs: Any) -> Any:
+        return (
+            _cast_floating_tensors(args, torch_module.float16, torch_module),
+            _cast_floating_tensors(kwargs, torch_module.float16, torch_module),
+        )
+
+    def fp32_transformer_output(_module: Any, _args: Any, output: Any) -> Any:
+        return _cast_floating_tensors(output, torch_module.float32, torch_module)
+
+    pipeline.transformer.register_forward_pre_hook(
+        fp16_transformer_inputs, with_kwargs=True
+    )
+    pipeline.transformer.register_forward_hook(fp32_transformer_output)
+
+
 def _diffusion_pipeline(
     arguments: argparse.Namespace,
     torch_module: Any,
@@ -1248,6 +1311,23 @@ def _diffusion_pipeline(
             continue
         try:
             load_options: dict[str, Any] = {}
+            component_contract = _diffusion_component_precision_contract(
+                arguments, options
+            )
+            if component_contract == _PIXART_TRTMC_MIXED_PRECISION:
+                from transformers import T5EncoderModel
+
+                load_options["text_encoder"] = T5EncoderModel.from_pretrained(
+                    model_source,
+                    subfolder="text_encoder",
+                    torch_dtype=torch_module.float32,
+                    **(
+                        {"revision": requested_revision}
+                        if requested_revision and model_source == model_id
+                        else {}
+                    ),
+                    local_files_only=arguments.local_files_only,
+                )
             if arguments.family == "wan2_2_ti2v":
                 vae_class = getattr(diffusers, "AutoencoderKLWan", None)
                 if vae_class is None:
@@ -1292,6 +1372,7 @@ def _load_diffusers(
     from PIL import Image
 
     pipeline = _diffusion_pipeline(arguments, torch, options)
+    _configure_diffusion_component_precision(pipeline, arguments, options, torch)
     if bool(options.get("cpu_offload", False)) and hasattr(pipeline, "enable_model_cpu_offload"):
         pipeline.enable_model_cpu_offload()
     else:

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -663,6 +663,10 @@ entries:
       reference_backend: hf_diffusers
       timing_scope: task-pipeline-call-wall
       output_contract: media-shape
+      adapter_options:
+        # Match the Accuracy/TRTMC component contract: FP32 T5 encoder,
+        # FP16 DiT inputs, and FP32 DiT outputs/scheduler bindings.
+        component_precision_contract: pixart_fp16_dit_fp32_t5
   - id: qwen.generate
     family: qwen
     operation: generate

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -1765,6 +1765,10 @@ def test_suite_has_explicit_eager_and_task_reference_rows() -> None:
     assert rows["deepseek_ocr.generate"]["baseline"]["output_contract"] == "ocr-text"
     assert rows["locateanything.generate"]["baseline"]["output_contract"] == "localization"
     assert rows["qwen_vl.generate"]["baseline"]["output_contract"] == "normalized-text"
+    assert rows["pixart.generate_image"]["baseline"]["adapter_options"] == {
+        "component_precision_contract": "pixart_fp16_dit_fp32_t5"
+    }
+    assert "adapter_options" not in rows["flux.generate_image"]["baseline"]
     assert not any(row["baseline"]["runner"] == "unsupported" for row in rows.values())
     assert {
         case_id: row["baseline"].get("adapter")
@@ -2698,6 +2702,92 @@ def test_wan22_diffusers_adapter_uses_pinned_conversion_and_fp32_vae(
     assert captured["pipeline_kwargs"]["torch_dtype"] == "bf16"
     assert captured["pipeline_kwargs"]["revision"] == "diffusers-revision"
     assert isinstance(captured["pipeline_kwargs"]["vae"], FakeVae)
+
+
+def test_pixart_diffusers_adapter_matches_trtmc_component_precision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    captured: dict[str, object] = {}
+
+    class FakeTextEncoder:
+        @classmethod
+        def from_pretrained(cls, model, **kwargs):
+            captured.update(text_encoder_model=model, text_encoder_kwargs=kwargs)
+            return cls()
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model, **kwargs):
+            captured.update(pipeline_model=model, pipeline_kwargs=kwargs)
+            return cls()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "diffusers",
+        Namespace(PixArtSigmaPipeline=FakePipeline, DiffusionPipeline=FakePipeline),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        Namespace(T5EncoderModel=FakeTextEncoder),
+    )
+    arguments = Namespace(
+        family="pixart",
+        local_files_only=False,
+        model="PixArt-alpha/PixArt-Sigma-XL-2-1024-MS",
+        precision="fp16",
+        revision="snapshot",
+        trust_remote_code=False,
+    )
+    torch_module = Namespace(float16="fp16", float32="fp32", bfloat16="bf16")
+    options = {"component_precision_contract": "pixart_fp16_dit_fp32_t5"}
+
+    runner["_diffusion_pipeline"](arguments, torch_module, options)
+
+    assert captured["text_encoder_model"] == arguments.model
+    assert captured["text_encoder_kwargs"] == {
+        "subfolder": "text_encoder",
+        "torch_dtype": "fp32",
+        "revision": "snapshot",
+        "local_files_only": False,
+    }
+    assert captured["pipeline_model"] == arguments.model
+    assert captured["pipeline_kwargs"]["torch_dtype"] == "fp16"
+    assert isinstance(captured["pipeline_kwargs"]["text_encoder"], FakeTextEncoder)
+
+
+def test_pixart_component_precision_registers_fp16_input_and_fp32_output_hooks() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+
+    class FakeTransformer:
+        def __init__(self) -> None:
+            self.pre_hook = None
+            self.post_hook = None
+            self.with_kwargs = False
+
+        def register_forward_pre_hook(self, hook, *, with_kwargs=False):
+            self.pre_hook = hook
+            self.with_kwargs = with_kwargs
+
+        def register_forward_hook(self, hook):
+            self.post_hook = hook
+
+    transformer = FakeTransformer()
+    pipeline = Namespace(transformer=transformer)
+    arguments = Namespace(family="pixart", precision="fp16")
+    torch_module = Namespace(float16="fp16", float32="fp32", Tensor=object)
+
+    runner["_configure_diffusion_component_precision"](
+        pipeline,
+        arguments,
+        {"component_precision_contract": "pixart_fp16_dit_fp32_t5"},
+        torch_module,
+    )
+
+    assert transformer.with_kwargs is True
+    assert callable(transformer.pre_hook)
+    assert callable(transformer.post_hook)
 
 
 def test_cached_snapshot_path_keeps_snapshot_parent_for_symlinked_marker(


### PR DESCRIPTION
## Background

The PixArt Accuracy path uses the model's mixed-precision component contract: the T5 text encoder remains FP32, while the DiT and VAE execute in FP16 with FP32 scheduler-facing DiT outputs. The generic Diffusers performance reference previously converted the entire pipeline to FP16, so Accuracy and performance were not measuring the same precision contract.

## Exit Criteria

- Make the PixArt performance reference use the same component precision contract as Accuracy/TRTMC.
- Scope the behavior to the PixArt performance entry without changing other Diffusers models.
- Cover component loading, input/output casting hooks, and suite placement with tests.
- Validate the complete PixArt performance case on GB300.

## Implementation

- Add an opt-in `pixart_fp16_dit_fp32_t5` Diffusers adapter contract.
- Load the PixArt T5 encoder in FP32 while keeping the pipeline's DiT and VAE in FP16.
- Cast DiT inputs to FP16 and scheduler-facing DiT outputs back to FP32.
- Enable the contract only for `pixart.generate_image` in the release performance suite.
- Add regression coverage for model loading, hook registration, and suite scoping.

## Validation

- `python -m pytest tests/tools/test_perf_matrix.py -q` — 108 passed.
- `python -m pytest tests/e2e/models/pixart/test_pixart_hf_reference.py tests/e2e/models/pixart/test_pixart_parity.py tests/tools/test_perf_matrix.py -q` — 115 passed.
- GB300 formal model check at commit `7ee422cf7d8e97542e986b4f453972d00854823f` — Green; TRTMC p50 511.842 ms, aligned Diffusers reference p50 812.888 ms (warmup 3, iterations 10).

## Notes

- This change aligns the reference precision contract; it does not alter the TensorRT PixArt engine precision or comparison thresholds.
- Other Diffusers performance entries retain their existing behavior.
