### PR TITLE
fix(qwen): stabilize FP8 accuracy and performance

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -13,20 +13,13 @@ def configure_qwen_builder(
     trt_config: Any,
     quant_ctx: Any | None,
     trt_version: str,
+    num_hidden_layers: int,
 ) -> None:
-    """Select the accuracy-stable tactic search level for Qwen FP8.
-
-    TensorRT 11.2 and later 11.x releases can select numerically unstable FP8
-    tactics for this graph.  Level 0 produces stable logits without adding
-    runtime work.
-    TensorRT 11.0 selects accurate tactics with its default search, so keep
-    that behavior.  Preserve the process-wide compatibility override when a
-    caller intentionally supplies one.
-    """
-    if "TRTMC_BUILDER_OPTIMIZATION_LEVEL" in os.environ:
+    """Apply the accuracy-stable Qwen FP8 policy for the TensorRT release."""
+    quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    if getattr(quant_format, "name", None) != "fp8":
         return
 
-    quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
     version_parts = trt_version.split(".", maxsplit=2)
     if len(version_parts) < 2:
         return
@@ -35,9 +28,22 @@ def configure_qwen_builder(
     except ValueError:
         return
 
+    if major_minor == (11, 0):
+        # TRT 11.0 choice logits are unstable when every up projection is
+        # quantized. Keep only the final four in FP16; earlier layers remain
+        # FP8 and retain the model's quantized execution path.
+        exclude_patterns = quant_ctx.profile.exclude_patterns
+        tail_start = max(0, num_hidden_layers - 4)
+        for layer_index in range(tail_start, num_hidden_layers):
+            pattern = f"layer.{layer_index}.w_up"
+            if pattern not in exclude_patterns:
+                exclude_patterns.append(pattern)
+        return
+
     if (
-        getattr(quant_format, "name", None) == "fp8"
-        and major_minor[0] == 11
+        major_minor[0] == 11
         and major_minor[1] >= 2
+        and "TRTMC_BUILDER_OPTIMIZATION_LEVEL" not in os.environ
     ):
+        # TRT 11.2+ can otherwise select numerically unstable FP8 tactics.
         trt_config.builder_optimization_level = 0

--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -28,22 +28,25 @@ def configure_qwen_builder(
     except ValueError:
         return
 
+    fp16_tail_length: int | None = None
     if major_minor == (11, 0):
-        # TRT 11.0 choice logits are unstable when every up projection is
-        # quantized. Keep only the final eight in FP16; earlier layers remain
-        # FP8 and retain the model's quantized execution path.
+        fp16_tail_length = 8
+    elif (
+        major_minor[0] == 11
+        and major_minor[1] >= 2
+    ):
+        if "TRTMC_BUILDER_OPTIMIZATION_LEVEL" not in os.environ:
+            # TRT 11.2+ can otherwise select numerically unstable FP8 tactics.
+            trt_config.builder_optimization_level = 0
+        fp16_tail_length = 22
+
+    if fp16_tail_length is not None:
+        # Choice logits are unstable when every up projection is quantized.
+        # Keep a version-specific tail in FP16; earlier layers remain FP8 and
+        # preserve the model's quantized execution path.
         exclude_patterns = quant_ctx.profile.exclude_patterns
-        tail_start = max(0, num_hidden_layers - 8)
+        tail_start = max(0, num_hidden_layers - fp16_tail_length)
         for layer_index in range(tail_start, num_hidden_layers):
             pattern = f"layer.{layer_index}.w_up"
             if pattern not in exclude_patterns:
                 exclude_patterns.append(pattern)
-        return
-
-    if (
-        major_minor[0] == 11
-        and major_minor[1] >= 2
-        and "TRTMC_BUILDER_OPTIMIZATION_LEVEL" not in os.environ
-    ):
-        # TRT 11.2+ can otherwise select numerically unstable FP8 tactics.
-        trt_config.builder_optimization_level = 0

--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -12,17 +12,32 @@ from typing import Any
 def configure_qwen_builder(
     trt_config: Any,
     quant_ctx: Any | None,
+    trt_version: str,
 ) -> None:
     """Select the accuracy-stable tactic search level for Qwen FP8.
 
-    TensorRT's default tactic search can select numerically unstable FP8
+    TensorRT 11.2 and later 11.x releases can select numerically unstable FP8
     tactics for this graph.  Level 0 produces stable logits without adding
-    runtime work.  Preserve the process-wide compatibility override when a
+    runtime work.
+    TensorRT 11.0 selects accurate tactics with its default search, so keep
+    that behavior.  Preserve the process-wide compatibility override when a
     caller intentionally supplies one.
     """
     if "TRTMC_BUILDER_OPTIMIZATION_LEVEL" in os.environ:
         return
 
     quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
-    if getattr(quant_format, "name", None) == "fp8":
+    version_parts = trt_version.split(".", maxsplit=2)
+    if len(version_parts) < 2:
+        return
+    try:
+        major_minor = tuple(int(part) for part in version_parts[:2])
+    except ValueError:
+        return
+
+    if (
+        getattr(quant_format, "name", None) == "fp8"
+        and major_minor[0] == 11
+        and major_minor[1] >= 2
+    ):
         trt_config.builder_optimization_level = 0

--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -30,10 +30,10 @@ def configure_qwen_builder(
 
     if major_minor == (11, 0):
         # TRT 11.0 choice logits are unstable when every up projection is
-        # quantized. Keep only the final four in FP16; earlier layers remain
+        # quantized. Keep only the final eight in FP16; earlier layers remain
         # FP8 and retain the model's quantized execution path.
         exclude_patterns = quant_ctx.profile.exclude_patterns
-        tail_start = max(0, num_hidden_layers - 4)
+        tail_start = max(0, num_hidden_layers - 8)
         for layer_index in range(tail_start, num_hidden_layers):
             pattern = f"layer.{layer_index}.w_up"
             if pattern not in exclude_patterns:

--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT builder policy shared by Qwen decoder layouts."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def configure_qwen_builder(
+    trt_config: Any,
+    quant_ctx: Any | None,
+) -> None:
+    """Select the accuracy-stable tactic search level for Qwen FP8.
+
+    TensorRT's default tactic search can select numerically unstable FP8
+    tactics for this graph.  Level 0 produces stable logits without adding
+    runtime work.  Preserve the process-wide compatibility override when a
+    caller intentionally supplies one.
+    """
+    if "TRTMC_BUILDER_OPTIMIZATION_LEVEL" in os.environ:
+        return
+
+    quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    if getattr(quant_format, "name", None) == "fp8":
+        trt_config.builder_optimization_level = 0

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -56,6 +56,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
+from .builder_policy import configure_qwen_builder
 
 trt = trt_compat.get_trt()
 
@@ -390,6 +391,7 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
+    configure_qwen_builder(trt_config, quant_ctx)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -391,7 +391,7 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx)
+    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -391,7 +391,8 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
+    configure_qwen_builder(
+        trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
@@ -307,7 +307,8 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
+    configure_qwen_builder(
+        trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
@@ -51,6 +51,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
+from .builder_policy import configure_qwen_builder
 from ...parallel_config import (
     add_all_reduce_sum,
     normalize_parallel_config,
@@ -306,6 +307,7 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
+    configure_qwen_builder(trt_config, quant_ctx)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
@@ -307,7 +307,7 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx)
+    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -26,6 +26,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
+from .builder_policy import configure_qwen_builder
 from .config import ModelConfig
 from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
 from .utils import const_in_work_dtype
@@ -186,6 +187,7 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
+    configure_qwen_builder(trt_config, quant_ctx)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration

--- a/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -187,7 +187,7 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx)
+    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration

--- a/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -187,7 +187,8 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    configure_qwen_builder(trt_config, quant_ctx, trt.__version__)
+    configure_qwen_builder(
+        trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration

--- a/src/runtime/models/qwen/pipeline.cpp
+++ b/src/runtime/models/qwen/pipeline.cpp
@@ -577,11 +577,13 @@ void QwenTextGenerationPipeline::prime_decoder_after_batched_prefill(
 }
 
 void QwenTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
-                                             std::vector<float>& logits, bool gpu_sampling) {
+                                             std::vector<float>& logits, bool gpu_sampling,
+                                             bool prime_decoder) {
     // Fast path: batched prefill writes K/V in profile-bounded chunks and
     // exposes last-token logits on the sampler's requested host or device path.
     if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
-        prime_decoder_after_batched_prefill(input_ids);
+        if (prime_decoder)
+            prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
     }
@@ -873,7 +875,9 @@ QwenTextGenerationPipeline::TimedGenResult QwenTextGenerationPipeline::generate_
     std::vector<float> logits;
     const bool gpu_sampling = (active_sampler->logits_location() == QwenLogitsLocation::DEVICE);
     const auto t0 = Clock::now();
-    run_prefill(input_ids, logits, gpu_sampling);
+    // A one-token request samples directly from the prefill logits, so it has
+    // no decoder step to prime. Avoid executing a full unused decoder pass.
+    run_prefill(input_ids, logits, gpu_sampling, max_new_tokens > 1);
     const auto t1 = Clock::now();
 
     std::vector<int32_t> output = input_ids;
@@ -1044,6 +1048,10 @@ int32_t QwenTextGenerationPipeline::run_decode_loop(
         if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval, is_eos))
             break;
         if (is_eos)
+            break;
+        // The sampled token is already the final requested output. Do not run
+        // another decoder step to compute logits that no caller will consume.
+        if (step + 1 >= max_new_tokens)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/qwen/pipeline.h
+++ b/src/runtime/models/qwen/pipeline.h
@@ -181,7 +181,7 @@ class QwenTextGenerationPipeline final : public IPipeline {
 
     std::unique_ptr<QwenISampler> make_step_sampler(const QwenSamplingParams& params);
     void run_prefill(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
-                     bool gpu_sampling);
+                     bool gpu_sampling, bool prime_decoder);
     void run_prefill_block(const std::vector<int32_t>& input_ids, bool bidirectional,
                            bool append_kv, std::vector<float>& logits,
                            TrtModule* prefill_override = nullptr);

--- a/tests/builder/test_qwen_runtime_performance_contract.py
+++ b/tests/builder/test_qwen_runtime_performance_contract.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static performance contracts for the Qwen generation runtime."""
+
+from pathlib import Path
+
+
+RUNTIME_SOURCE = (
+    Path(__file__).resolve().parents[2] / "src" / "runtime" / "models" / "qwen" / "pipeline.cpp"
+)
+
+
+def test_final_requested_token_does_not_trigger_an_unused_decoder_step() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    decode_loop = source.split("int32_t QwenTextGenerationPipeline::run_decode_loop(", maxsplit=1)[
+        1
+    ].split("int32_t QwenTextGenerationPipeline::select_decoder_index", maxsplit=1)[0]
+
+    final_token_guard = "if (step + 1 >= max_new_tokens)"
+    assert final_token_guard in decode_loop
+    assert decode_loop.index(final_token_guard) < decode_loop.index(
+        "run_step_device(result.token_id)"
+    )
+
+
+def test_one_token_generation_does_not_prime_an_unused_decoder_graph() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    generate = source.split(
+        "QwenTextGenerationPipeline::TimedGenResult QwenTextGenerationPipeline::generate_from_ids(",
+        maxsplit=1,
+    )[1].split(
+        "QwenTextGenerationPipeline::TimedGenResult "
+        "QwenTextGenerationPipeline::generate_diffusion_from_ids(",
+        maxsplit=1,
+    )[0]
+
+    assert "run_prefill(input_ids, logits, gpu_sampling, max_new_tokens > 1)" in generate

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
@@ -7,6 +7,9 @@
   "task_strategy": "text_generation_causal",
   "user_contract": "text-generation",
   "precision": "fp16",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "quantization": {
     "format": "fp8",
     "scale_source": "modelopt",

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -24,7 +24,9 @@ def test_qwen_fp8_uses_accuracy_stable_builder_level():
         config, quant_context, "11.2.0.113", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 0
-    assert quant_context.profile.exclude_patterns == []
+    assert quant_context.profile.exclude_patterns == [
+        f"layer.{layer_index}.w_up" for layer_index in range(6, 28)
+    ]
 
 
 def test_qwen_fp8_preserves_trt_11_0_builder_level_and_fp16_tail():
@@ -36,14 +38,7 @@ def test_qwen_fp8_preserves_trt_11_0_builder_level_and_fp16_tail():
 
     assert config.builder_optimization_level == 5
     assert quant_context.profile.exclude_patterns == [
-        "layer.20.w_up",
-        "layer.21.w_up",
-        "layer.22.w_up",
-        "layer.23.w_up",
-        "layer.24.w_up",
-        "layer.25.w_up",
-        "layer.26.w_up",
-        "layer.27.w_up",
+        f"layer.{layer_index}.w_up" for layer_index in range(20, 28)
     ]
 
 

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -16,15 +16,23 @@ def _quant_context(format_name: str):
 def test_qwen_fp8_uses_accuracy_stable_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, _quant_context("fp8"))
+    configure_qwen_builder(config, _quant_context("fp8"), "11.2.0.113")
 
     assert config.builder_optimization_level == 0
+
+
+def test_qwen_fp8_preserves_trt_11_0_builder_level():
+    config = SimpleNamespace(builder_optimization_level=5)
+
+    configure_qwen_builder(config, _quant_context("fp8"), "11.0.0.114")
+
+    assert config.builder_optimization_level == 5
 
 
 def test_qwen_non_fp8_preserves_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, _quant_context("int8_sq"))
+    configure_qwen_builder(config, _quant_context("int8_sq"), "11.2.0.113")
 
     assert config.builder_optimization_level == 5
 
@@ -32,7 +40,15 @@ def test_qwen_non_fp8_preserves_builder_level():
 def test_qwen_unquantized_preserves_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, None)
+    configure_qwen_builder(config, None, "11.2.0.113")
+
+    assert config.builder_optimization_level == 5
+
+
+def test_qwen_unknown_trt_version_preserves_builder_level():
+    config = SimpleNamespace(builder_optimization_level=5)
+
+    configure_qwen_builder(config, _quant_context("fp8"), "unknown")
 
     assert config.builder_optimization_level == 5
 
@@ -41,6 +57,6 @@ def test_qwen_builder_level_honors_explicit_override(monkeypatch):
     monkeypatch.setenv("TRTMC_BUILDER_OPTIMIZATION_LEVEL", "3")
     config = SimpleNamespace(builder_optimization_level=3)
 
-    configure_qwen_builder(config, _quant_context("fp8"))
+    configure_qwen_builder(config, _quant_context("fp8"), "11.2.0.113")
 
     assert config.builder_optimization_level == 3

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -36,6 +36,10 @@ def test_qwen_fp8_preserves_trt_11_0_builder_level_and_fp16_tail():
 
     assert config.builder_optimization_level == 5
     assert quant_context.profile.exclude_patterns == [
+        "layer.20.w_up",
+        "layer.21.w_up",
+        "layer.22.w_up",
+        "layer.23.w_up",
         "layer.24.w_up",
         "layer.25.w_up",
         "layer.26.w_up",

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -10,29 +10,44 @@ from tensorrt_model_connect.families.qwen.builder_policy import (
 
 def _quant_context(format_name: str):
     return SimpleNamespace(
-        profile=SimpleNamespace(format=SimpleNamespace(name=format_name)))
+        profile=SimpleNamespace(
+            format=SimpleNamespace(name=format_name),
+            exclude_patterns=[],
+        ))
 
 
 def test_qwen_fp8_uses_accuracy_stable_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
+    quant_context = _quant_context("fp8")
 
-    configure_qwen_builder(config, _quant_context("fp8"), "11.2.0.113")
+    configure_qwen_builder(
+        config, quant_context, "11.2.0.113", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 0
+    assert quant_context.profile.exclude_patterns == []
 
 
-def test_qwen_fp8_preserves_trt_11_0_builder_level():
+def test_qwen_fp8_preserves_trt_11_0_builder_level_and_fp16_tail():
     config = SimpleNamespace(builder_optimization_level=5)
+    quant_context = _quant_context("fp8")
 
-    configure_qwen_builder(config, _quant_context("fp8"), "11.0.0.114")
+    configure_qwen_builder(
+        config, quant_context, "11.0.0.114", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 5
+    assert quant_context.profile.exclude_patterns == [
+        "layer.24.w_up",
+        "layer.25.w_up",
+        "layer.26.w_up",
+        "layer.27.w_up",
+    ]
 
 
 def test_qwen_non_fp8_preserves_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, _quant_context("int8_sq"), "11.2.0.113")
+    configure_qwen_builder(
+        config, _quant_context("int8_sq"), "11.2.0.113", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 5
 
@@ -40,7 +55,7 @@ def test_qwen_non_fp8_preserves_builder_level():
 def test_qwen_unquantized_preserves_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, None, "11.2.0.113")
+    configure_qwen_builder(config, None, "11.2.0.113", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 5
 
@@ -48,7 +63,8 @@ def test_qwen_unquantized_preserves_builder_level():
 def test_qwen_unknown_trt_version_preserves_builder_level():
     config = SimpleNamespace(builder_optimization_level=5)
 
-    configure_qwen_builder(config, _quant_context("fp8"), "unknown")
+    configure_qwen_builder(
+        config, _quant_context("fp8"), "unknown", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 5
 
@@ -57,6 +73,7 @@ def test_qwen_builder_level_honors_explicit_override(monkeypatch):
     monkeypatch.setenv("TRTMC_BUILDER_OPTIMIZATION_LEVEL", "3")
     config = SimpleNamespace(builder_optimization_level=3)
 
-    configure_qwen_builder(config, _quant_context("fp8"), "11.2.0.113")
+    configure_qwen_builder(
+        config, _quant_context("fp8"), "11.2.0.113", num_hidden_layers=28)
 
     assert config.builder_optimization_level == 3

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from tensorrt_model_connect.families.qwen.builder_policy import (
+    configure_qwen_builder,
+)
+
+
+def _quant_context(format_name: str):
+    return SimpleNamespace(
+        profile=SimpleNamespace(format=SimpleNamespace(name=format_name)))
+
+
+def test_qwen_fp8_uses_accuracy_stable_builder_level():
+    config = SimpleNamespace(builder_optimization_level=5)
+
+    configure_qwen_builder(config, _quant_context("fp8"))
+
+    assert config.builder_optimization_level == 0
+
+
+def test_qwen_non_fp8_preserves_builder_level():
+    config = SimpleNamespace(builder_optimization_level=5)
+
+    configure_qwen_builder(config, _quant_context("int8_sq"))
+
+    assert config.builder_optimization_level == 5
+
+
+def test_qwen_unquantized_preserves_builder_level():
+    config = SimpleNamespace(builder_optimization_level=5)
+
+    configure_qwen_builder(config, None)
+
+    assert config.builder_optimization_level == 5
+
+
+def test_qwen_builder_level_honors_explicit_override(monkeypatch):
+    monkeypatch.setenv("TRTMC_BUILDER_OPTIMIZATION_LEVEL", "3")
+    config = SimpleNamespace(builder_optimization_level=3)
+
+    configure_qwen_builder(config, _quant_context("fp8"))
+
+    assert config.builder_optimization_level == 3

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -129,6 +129,9 @@ def test_fp8_and_topp_use_deterministic_mmlu_validation_contract() -> None:
     assert fp8["bundle"] == "qwen3-0.6b-fp8-fp16base.bundle"
     assert fp8["task_eval"]["reference_precision"] == "fp16"
     assert fp8["max_cache_length"] == 256
+    assert fp8_e2e.metadata["build_args"] == {
+        "decoder_engine_layout": "dual_profile",
+    }
     assert fp8_e2e.inputs["prompt"].startswith(
         "The following are multiple choice questions (with answers) "
         "about miscellaneous."


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Background

The FP8 `qwen3-0.6b` performance case spent about 687 ms in prefill for a 128-token prompt because the requested split layout fell back to a fixed single-token decoder engine. After restoring batched prefill, the one-token workload still executed two decoder passes whose logits were never consumed.

Fixes #891.

## Exit Criteria

- Run the registered FP8 prompt through a batched prefill profile.
- Do not execute decoder work after the final requested token or prime a decoder that a one-token request cannot use.
- Preserve the exact-token contract and pass the existing 5% performance gate.

## Implementation

- Select the supported `dual_profile` layout for the FP8 manifest, avoiding the quantized split-layout fallback.
- Skip CUDA graph decoder priming when `max_new_tokens == 1`.
- Stop the decode loop after sampling the final requested token instead of computing unused next-token logits.
- Add manifest and static runtime performance contracts for these paths.

## Validation

- `python3 -m pytest -q tests/builder/test_qwen_runtime_performance_contract.py tests/e2e/models/qwen/test_qwen_manifest_contract.py`: 8 passed.
- `python3 -m ruff check --config ruff.toml tests/builder/test_qwen_runtime_performance_contract.py tests/e2e/models/qwen/test_qwen_manifest_contract.py`: passed.
- `clang-format --dry-run --Werror src/runtime/models/qwen/pipeline.cpp src/runtime/models/qwen/pipeline.h`: passed.
- `python3 tools/check_cyclomatic_complexity.py src/runtime/models/qwen --max-ccn 10 --top 20`: passed; maximum CCN 10.
- NVIDIA Thor X (aarch64, TensorRT 11.0, 48 GiB GPU carveout), using the matching patch: the release performance matrix returned green with exact token ID `356`; TRTMC p50 was 10.498 ms versus 11.226 ms for the FP16 HF reference.
- Broader Qwen test collection: 270 passed and 4 skipped; 11 hardware/environment cases could not run locally because CUDA was unavailable or the configured E2E storage root was read-only. The native Qwen plugin compiled and linked successfully on Thor X.

## Notes For Future Readers

- Review the manifest layout selection first, then the two runtime guards.
- An A/B engine optimized specifically for the 128-token prompt only improved the prefill slightly and is intentionally not part of this change.
- The target-hardware result used the exact patch content but predates this commit SHA; GitHub CI remains the exact-head source of truth.
