### PR TITLE
perf(dinov3): fuse QKV and rotary paths

### DIFF
--- a/python/tensorrt_model_connect/families/dinov3/graph_ops.py
+++ b/python/tensorrt_model_connect/families/dinov3/graph_ops.py
@@ -169,15 +169,19 @@ def apply_patch_rope(
     dtype: np.dtype,
 ):
     """Apply HF DINOv3's axial 2D RoPE only to the patch-token suffix."""
+    batch = int(tensor.shape[0])
     num_patches = grid_h * grid_w
     prefix = slice_tensor(
-        network, tensor, (0, 0, 0, 0), (1, num_heads, num_prefix_tokens, head_dim)
+        network,
+        tensor,
+        (0, 0, 0, 0),
+        (batch, num_heads, num_prefix_tokens, head_dim),
     )
     patches = slice_tensor(
         network,
         tensor,
         (0, 0, num_prefix_tokens, 0),
-        (1, num_heads, num_patches, head_dim),
+        (batch, num_heads, num_patches, head_dim),
     )
 
     coords_h = (np.arange(grid_h, dtype=np.float32) + 0.5) / float(grid_h)
@@ -199,7 +203,7 @@ def apply_patch_rope(
     direct = _elementwise(network, patches, cos_tensor, trt.ElementWiseOperation.PROD)
     rotated = _elementwise(
         network,
-        _rotate_half(network, patches, 1, num_heads, num_patches, head_dim),
+        _rotate_half(network, patches, batch, num_heads, num_patches, head_dim),
         sin_tensor,
         trt.ElementWiseOperation.PROD,
     )

--- a/python/tensorrt_model_connect/families/dinov3/plugin.py
+++ b/python/tensorrt_model_connect/families/dinov3/plugin.py
@@ -444,20 +444,59 @@ def build_vit_engine(
 
         residual = hidden
         normalized = normalize("norm1", hidden)
-        projections = {}
-        for short, projection in (("q", "q_proj"), ("k", "k_proj"), ("v", "v_proj")):
-            projections[short] = to_heads(project("attention", projection, normalized))
-        for name in ("q", "k"):
-            projections[name] = graph_ops.apply_patch_rope(
+        # A single wide GEMM matches the source checkpoint and avoids three
+        # small projection launches on fixed-shape image tokens.
+        qkv_weight = np.concatenate(
+            [
+                weights[f"{prefix}.attention.{name}_proj.weight"]
+                for name in ("q", "k", "v")
+            ],
+            axis=1,
+        )
+        qkv = graph_ops.linear(network, normalized, qkv_weight, work_dtype)
+        qkv_biases = [
+            weights.get(f"{prefix}.attention.{name}_proj.bias")
+            for name in ("q", "k", "v")
+        ]
+        if any(bias is not None for bias in qkv_biases):
+            zero_bias = np.zeros(hidden_size, dtype=work_dtype)
+            qkv = graph_ops.add_bias(
                 network,
-                projections[name],
-                num_heads=num_heads,
-                num_prefix_tokens=num_prefix,
-                grid_h=grid_h,
-                grid_w=grid_w,
-                head_dim=head_dim,
-                theta=cfg["rope_theta"],
-                dtype=work_dtype,
+                qkv,
+                np.concatenate(
+                    [bias if bias is not None else zero_bias for bias in qkv_biases]
+                ),
+                work_dtype,
+            )
+        projections = {}
+        for index, name in enumerate(("q", "k", "v")):
+            projection = graph_ops.slice_tensor(
+                network,
+                qkv,
+                (0, 0, index * hidden_size),
+                (1, sequence_length, hidden_size),
+            )
+            projections[name] = to_heads(projection)
+        # Q and K use identical RoPE coordinates, so transform them as one batch.
+        qk = network.add_concatenation([projections["q"], projections["k"]])
+        qk.axis = 0
+        qk = graph_ops.apply_patch_rope(
+            network,
+            qk.get_output(0),
+            num_heads=num_heads,
+            num_prefix_tokens=num_prefix,
+            grid_h=grid_h,
+            grid_w=grid_w,
+            head_dim=head_dim,
+            theta=cfg["rope_theta"],
+            dtype=work_dtype,
+        )
+        for index, name in enumerate(("q", "k")):
+            projections[name] = graph_ops.slice_tensor(
+                network,
+                qk,
+                (index, 0, 0, 0),
+                (1, num_heads, sequence_length, head_dim),
             )
         context = graph_ops.attention(
             network,


### PR DESCRIPTION
## Background

The native DINOv3 ViT graph projected Q, K, and V separately and applied the same patch-token RoPE transform to Q and K in two graph branches. On fixed 224x224 ViT-S/16 inference, these redundant paths leave measurable latency on GB300.

## Exit Criteria

- Reduce DINOv3 ViT inference latency against the strongest static FP16 `torch.compile` baseline.
- Preserve the existing full-tensor representation-parity thresholds and output contract.
- Keep the source change entirely within DINOv3 family-owned files; do not touch `IPipeline`, Optimized Runtime, or shared runtime code.

## Implementation

- Concatenate Q/K/V weights and available biases into one projection GEMM, inserting exact zero bias values where a checkpoint omits a projection bias.
- Concatenate Q and K on an internal batch axis, apply their identical 2D patch RoPE transform once, and split them before attention.
- Keep the existing manual attention, exact GELU, FP32 LayerNorm compute, engine outputs, and runtime API unchanged.

## Validation

- `python -m pytest -q tests/e2e/models/dinov3/test_dinov3_vit_builder.py`: 11 passed with real TensorRT, including FP16/FP32 builds and FP32 Transformers parity.
- `python -m pytest -q tests/e2e/models/dinov3/test_dinov3_convnext_builder.py`: 10 passed with real TensorRT.
- DINO static/report plus model encapsulation suites: 181 passed.
- DINO C++ preprocessing and pipeline tests: passed.
- `python3 tools/model_ci.py impact --base github/main --head HEAD --platform-change-policy fallback`: `direct_models=["dinov3"]`, no fallback models.
- Pinned public ViT-S/16 full-tensor gate passed: full cosine 0.99996831, p01 patch cosine 0.99982997, relative Frobenius 0.00797071. Final outputs are byte-identical to the pre-change engine outputs.
- GB300, FP16, batch 1, 224x224, CUDA Graphs enabled:
  - Pure GPU, no transfers, 5000 samples: 0.367188 ms to 0.323486 ms (1.135x).
  - Native model-call wall, median of 3 process p50s with 500 warmups and 1000 samples each: 0.520 ms to 0.477 ms (1.090x).
  - Strongest tested `torch.compile` mode was `reduce-overhead`, `dynamic=False`, one graph with zero graph breaks or recompiles. Optimized native is 1.421x faster for pure GPU, 3.287x faster for the aligned CPU-input/full-CPU-output boundary, and 2.302x faster for the full preprocessed public call.

## Notes For Future Readers

- Performance numbers above require CUDA Graphs; the runtime default and CLI semantics are unchanged.
- TensorRT already lowers the full network to one Myelin layer. Native `GELU_ERF`, `IAttention`, optimization level 5, alternate QKV head reshaping, and CPU preprocessing rewrites were measured and rejected because they were slower or had no reproducible gain.
- Review `plugin.py` first for fused projection and Q/K batching, then `graph_ops.py` for batch-aware RoPE shapes.
- Exact head `bbd747070e49d188b4a97d5b45740bc3cc97af28` passed `trtmc/premerge/required` on 2026-08-18.