### PR TITLE
refactor(builder): pilot model-owned builds

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -931,11 +931,39 @@ def build_bundle(
             low-VRAM single-engine/multi-profile layout.
         verbose: Print detailed logs.
     """
+    model_options = dict(locals())
+    model_options.pop("model_dir")
+    model_options.pop("output_path")
+
     if decoder_engine_layout not in ("split", "dual_profile"):
         raise ValueError(
             "decoder_engine_layout must be 'split' or 'dual_profile', "
             f"got {decoder_engine_layout!r}")
     _setup_trt_import(rtx)
+    model_dir_path = Path(model_dir)
+    diffusion_entrypoint = _resolve_diffusion_entrypoint(model_dir_path)
+    if diffusion_entrypoint is not None:
+        _, selected_plugin = diffusion_entrypoint
+    else:
+        selected_plugin = find_plugin(ModelConfig.from_dir(model_dir_path))
+    declared_build = (
+        inspect.getattr_static(selected_plugin, "build", None)
+        if selected_plugin is not None
+        else None
+    )
+    if declared_build is not None:
+        family_build = getattr(selected_plugin, "build")
+        if not callable(family_build):
+            raise TypeError(
+                f"Family {selected_plugin.name} build attribute is not callable"
+            )
+        family_build(
+            str(model_dir_path),
+            output_path,
+            options=model_options,
+        )
+        return
+
     parallel = normalize_parallel_config(parallel_config)
     try:
         print(
@@ -947,7 +975,6 @@ def build_bundle(
             "TensorRT Python bindings are required for raw TRT builds. "
             "Install a matching tensorrt package in the active Python environment."
         ) from exc
-    model_dir_path = Path(model_dir)
     t0 = time.monotonic()
     build_timing = _new_build_timing(build_timing_path)
     build_timing["model_dir"] = str(model_dir_path)

--- a/python/tensorrt_model_connect/families/bert/model/model.py
+++ b/python/tensorrt_model_connect/families/bert/model/model.py
@@ -770,3 +770,338 @@ def _add_encoder_layer(
     )
 
     return normed2
+
+
+def _build_call_supports(function, name: str) -> bool:
+    import inspect
+
+    return name in inspect.signature(function).parameters
+
+
+def _detect_build_tokenizer_frame(
+    source: str,
+    *,
+    revision: str | None = None,
+) -> tuple[list[int], list[int]] | None:
+    from pathlib import Path
+
+    try:
+        from transformers import AutoTokenizer
+
+        kwargs = {"trust_remote_code": True}
+        if revision:
+            kwargs["revision"] = revision
+        if not Path(source).is_dir():
+            kwargs["local_files_only"] = True
+        tokenizer = AutoTokenizer.from_pretrained(source, **kwargs)
+        default_ids = list(tokenizer.encode("hello"))
+        plain_ids = list(tokenizer.encode("hello", add_special_tokens=False))
+    except Exception:
+        return None
+    if default_ids == plain_ids:
+        return [], []
+    if not plain_ids:
+        return default_ids, []
+    for start in range(len(default_ids) - len(plain_ids) + 1):
+        if default_ids[start : start + len(plain_ids)] == plain_ids:
+            return default_ids[:start], default_ids[start + len(plain_ids) :]
+    return None
+
+
+def _ensure_build_tokenizer(model_dir) -> None:
+    import tempfile
+    from pathlib import Path
+
+    tokenizer_path = model_dir / "tokenizer.json"
+    if tokenizer_path.is_file():
+        return
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(str(model_dir), use_fast=True)
+        with tempfile.TemporaryDirectory(prefix="trtmc-tokenizer-") as temporary:
+            generated = Path(temporary) / "tokenizer.json"
+            backend = getattr(tokenizer, "backend_tokenizer", None)
+            if backend is None:
+                backend = getattr(tokenizer, "_tokenizer", None)
+            if backend is not None and hasattr(backend, "save"):
+                backend.save(str(generated))
+            if not generated.is_file():
+                tokenizer.save_pretrained(temporary)
+            if not generated.is_file():
+                raise RuntimeError("tokenizer conversion did not create tokenizer.json")
+            with tempfile.NamedTemporaryFile(
+                dir=model_dir,
+                prefix=".trtmc-tokenizer-",
+                suffix=".json",
+                delete=False,
+            ) as output:
+                temporary_path = Path(output.name)
+                output.write(generated.read_bytes())
+            temporary_path.replace(tokenizer_path)
+    except Exception as exc:
+        print(
+            "[trtmc build] Warning: could not generate tokenizer.json "
+            f"(C++ runtime may fail to create tokenizer): {exc}",
+            file=sys.stderr,
+        )
+
+
+def build(model_dir: str, output_path: str, *, options: dict[str, object]) -> None:
+    """Build one complete BERT bundle without shared model orchestration."""
+
+    import json
+    import re
+    import time
+    from dataclasses import replace
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from tensorrt_model_connect import trt_compat as build_trt_compat
+    from tensorrt_model_connect.build_timing import (
+        add_build_timing,
+        new_build_timing,
+        write_build_timing,
+    )
+    from tensorrt_model_connect.bundle_writer import BundleInfo, BundleSection, write_bundle
+    from tensorrt_model_connect.parallel_config import (
+        normalize_parallel_config,
+        rank_engine_section,
+        require_tensorrt_11_for_tensor_parallel,
+    )
+    from tensorrt_model_connect.families.bert.plugin import plugin
+
+    model_path = Path(model_dir)
+    parallel = normalize_parallel_config(options.get("parallel_config"))
+    if parallel.cp_enabled:
+        raise NotImplementedError("BERT does not support context-parallel builds")
+    if options.get("dynamic_kv_cache") or options.get("triattention_stats_path"):
+        raise ValueError("BERT does not use a decoder KV-cache runtime")
+
+    config = ModelConfig.from_dir(model_path)
+    config.raw["_model_dir"] = str(model_path)
+    config.raw["_fp32_layers"] = sorted(set(options.get("fp32_layers") or ()))
+    config.raw["_family_build_options"] = dict(options.get("family_build_options") or {})
+    config.raw["_parallel_build_enabled"] = bool(parallel.enabled)
+    config.raw["_rtx_build_requested"] = bool(options.get("rtx"))
+    precision = str(options.get("precision") or "fp32").lower()
+    config.raw["_resolved_build_precision"] = precision
+    max_cache_length = int(options.get("max_cache_length") or 256)
+    if max_cache_length < 1:
+        raise ValueError("max_cache_length must be >= 1")
+
+    timing = new_build_timing(options.get("build_timing_path"))
+    timing["model_dir"] = str(model_path)
+    timing["output_path"] = str(output_path)
+    started = time.monotonic()
+    write_build_timing(timing)
+
+    weights_started = time.monotonic()
+    weight_kwargs = {"precision": precision} if _build_call_supports(
+        plugin.load_weights, "precision"
+    ) else {}
+    weights = plugin.load_weights(str(model_path), config, **weight_kwargs)
+    add_build_timing(timing, "weights_loading_s", time.monotonic() - weights_started)
+    write_build_timing(timing)
+
+    quantize = options.get("quantize")
+    quant_ctx = None
+    quant_plan = None
+    if quantize:
+        from tensorrt_model_connect.quantization import QuantPlan, build_quant_context
+
+        quant_plan = QuantPlan.from_build_args(
+            precision=precision,
+            quantize=str(quantize),
+            quant_scales=options.get("quant_scales"),
+            quant_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+        )
+        quant_method = str(config.raw.get("quantization_config", {}).get("quant_method", "")).lower()
+        if quant_plan.scale_source == "modelopt" and quant_method in {
+            "awq",
+            "gptq",
+            "compressed-tensors",
+            "compressed_tensors",
+        }:
+            quant_plan = replace(quant_plan, scale_source="prequantized")
+        quant_ctx = build_quant_context(
+            format_name=quant_plan.quant_format,
+            model_dir=str(model_path),
+            config=config,
+            scales_json=options.get("quant_scales"),
+            num_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+            plugin=plugin,
+            quant_plan=quant_plan,
+            graph_ops=sys.modules[__name__],
+        )
+
+    if parallel.enabled:
+        require_tensorrt_11_for_tensor_parallel(parallel, feature="BERT tensor-parallel builds")
+        if quant_ctx is not None:
+            raise ValueError("BERT tensor-parallel builds do not support quantization")
+
+    verbose = bool(options.get("verbose"))
+    compile_started = time.monotonic()
+    if parallel.enabled:
+        plans = {
+            rank: plugin.build_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel.for_rank(rank),
+            )
+            for rank in range(parallel.tp_size)
+        }
+        sections = [
+            BundleSection(rank_engine_section(rank), plan)
+            for rank, plan in sorted(plans.items())
+        ]
+        decoder_layout = "dual_profile"
+    else:
+        from tensorrt_model_connect.tvm_ffi.graph_build import (
+            engine_role,
+            inspection_role,
+        )
+
+        role = (
+            "dual_profile"
+            if str(options.get("decoder_engine_layout") or "split") == "dual_profile"
+            else "decode"
+        )
+
+        def build_role(selected_role: str) -> bytes:
+            with engine_role(selected_role):
+                return plugin.build_engine(
+                    config,
+                    weights,
+                    max_cache_length,
+                    precision=precision,
+                    quant_ctx=quant_ctx,
+                    verbose=verbose,
+                    parallel_config=parallel,
+                )
+
+        target_role = inspection_role()
+        if target_role is not None:
+            build_role(target_role)
+            raise RuntimeError("graph inspection did not reach TensorRT serialization")
+        plan = build_role(role)
+        sections = [BundleSection("engine_plan", plan)]
+        decoder_layout = "dual_profile" if role == "dual_profile" else "single"
+    compile_elapsed = time.monotonic() - compile_started
+    add_build_timing(timing, "trt_compile_s", compile_elapsed)
+    add_build_timing(timing, "trt_compile_main_engine_s", compile_elapsed)
+    write_build_timing(timing)
+
+    tokenizer_source = str(options.get("tokenizer_source_model_id_or_path") or model_path)
+    tokenizer_frame = _detect_build_tokenizer_frame(
+        tokenizer_source,
+        revision=(
+            str(options["tokenizer_source_revision"])
+            if options.get("tokenizer_source_revision")
+            else None
+        ),
+    )
+    _ensure_build_tokenizer(model_path)
+    if tokenizer_frame is None:
+        tokenizer_frame = _detect_build_tokenizer_frame(str(model_path))
+    prefix_ids, suffix_ids = tokenizer_frame or ([], [])
+    add_special_tokens = bool(prefix_ids or suffix_ids)
+
+    trt_version = build_trt_compat.tensorrt_version() or "unknown"
+    version_match = re.search(r"(\d+)\.(\d+)", trt_version)
+    trt_abi = f"{version_match.group(1)}.{version_match.group(2)}" if version_match else ""
+    try:
+        from tensorrt_model_connect.runtime_provider.target import (
+            _probe_current_target_with_device,
+        )
+
+        gpu_name = str(_probe_current_target_with_device()[0]["gpu_name"])
+    except Exception:
+        gpu_name = ""
+    info = BundleInfo(
+        model_id=model_path.name,
+        model_type=config.model_type,
+        family=plugin.name,
+        trt_version=trt_version,
+        trt_abi=trt_abi,
+        gpu_name=gpu_name,
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        vocab_size=config.vocab_size,
+        hidden_size=config.hidden_size,
+        num_layers=config.num_hidden_layers,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        max_cache_length=max_cache_length,
+        runtime_strategy=plugin.runtime_strategy,
+        precision=precision,
+        quantization=(quant_plan.quant_format if quant_plan else "none"),
+        tokenizer_add_special_tokens=add_special_tokens,
+    )
+
+    source_config = model_path / "config.json"
+    runtime_config = (
+        json.loads(source_config.read_text(encoding="utf-8"))
+        if source_config.is_file()
+        else dict(config.raw)
+    )
+    runtime_config.update(
+        {
+            "runtime_strategy": plugin.runtime_strategy,
+            "engine_backend": "trt_rtx" if options.get("rtx") else "trt",
+            "trt_version": trt_version,
+            "precision": precision,
+            "tokenizer_add_special_tokens": int(add_special_tokens),
+            "decoder_engine_layout": decoder_layout,
+        }
+    )
+    if trt_abi:
+        runtime_config["trt_abi"] = trt_abi
+    if tokenizer_frame is not None:
+        runtime_config["tokenizer_special_prefix_ids"] = prefix_ids
+        runtime_config["tokenizer_special_suffix_ids"] = suffix_ids
+    if quant_plan is not None:
+        runtime_config["quantization"] = quant_plan.as_config_dict()
+    runtime_config.update(parallel.to_bundle_config_fields())
+
+    for filename in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.txt",
+        "special_tokens_map.json",
+    ):
+        path = model_path / filename
+        if path.is_file():
+            sections.append(BundleSection(filename, path.read_bytes()))
+    sections.append(
+        BundleSection("config.json", json.dumps(runtime_config, indent=2).encode("utf-8"))
+    )
+
+    from tensorrt_model_connect.tvm_ffi.graph_build import kernel_slots_section
+
+    slot_section = kernel_slots_section()
+    if slot_section is not None:
+        sections.append(BundleSection("kernel_slots.json", slot_section))
+    kernel_manifest = []
+    for global_name, library in options.get("kernel_artifacts") or ():
+        section_name = f"kernel_{global_name.replace('.', '_')}.so"
+        sections.append(BundleSection(section_name, Path(library).read_bytes()))
+        kernel_manifest.append(
+            {"global_name": global_name, "func_name": "run", "section": section_name}
+        )
+    if kernel_manifest:
+        sections.append(
+            BundleSection(
+                "kernel_manifest.json",
+                json.dumps({"kernels": kernel_manifest}).encode("utf-8"),
+            )
+        )
+
+    write_started = time.monotonic()
+    write_bundle(output_path, info, sections)
+    add_build_timing(timing, "bundle_write_s", time.monotonic() - write_started)
+    timing["total_s"] = time.monotonic() - started
+    write_build_timing(timing)

--- a/python/tensorrt_model_connect/families/bert/plugin.py
+++ b/python/tensorrt_model_connect/families/bert/plugin.py
@@ -10,6 +10,7 @@ from ...parallel_config import (
     require_tensorrt_11_for_tensor_parallel,
 )
 from .config import ModelConfig
+from .model.model import build as build_model_bundle
 from .model.model import build_encoder_engine
 from .weights import WeightDict, load_bert_weights
 
@@ -60,3 +61,4 @@ class BertPlugin:
 
 
 plugin = BertPlugin()
+plugin.build = build_model_bundle

--- a/python/tensorrt_model_connect/families/gpt2/model.py
+++ b/python/tensorrt_model_connect/families/gpt2/model.py
@@ -1,0 +1,529 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Complete model-owned GPT-2 bundle build orchestration."""
+
+from __future__ import annotations
+
+import sys
+
+
+def _dynamic_kv_profile_rows(
+    max_cache_length: int,
+    kv_budget: int,
+    *,
+    bucket_rows: int = 32,
+    preferred_rows: list[int] | None = None,
+) -> list[int]:
+    if max_cache_length < 1:
+        return [1]
+    start = ((max(kv_budget, 1) + bucket_rows - 1) // bucket_rows) * bucket_rows
+    start = max(bucket_rows, min(start, max_cache_length))
+    rows: list[int] = []
+
+    def add_row(value: int) -> None:
+        rounded = (
+            (min(max(value, 1), max_cache_length) + bucket_rows - 1) // bucket_rows
+        ) * bucket_rows
+        rounded = max(bucket_rows, min(rounded, max_cache_length))
+        if rounded not in rows:
+            rows.append(rounded)
+
+    for value in preferred_rows or ():
+        add_row(value)
+    row = start
+    while row < max_cache_length:
+        add_row(row)
+        next_row = max(row + bucket_rows, row * 2)
+        row = (
+            (min(next_row, max_cache_length) + bucket_rows - 1) // bucket_rows
+        ) * bucket_rows
+    add_row(max_cache_length)
+    rows.sort()
+    return rows
+
+
+def _sanitize_dynamic_kv_profile_rows(
+    rows: list[int] | None,
+    max_cache_length: int,
+) -> list[int] | None:
+    if rows is None:
+        return None
+    sanitized = sorted(
+        {max(1, min(int(value), max_cache_length)) for value in rows}
+    )
+    if not sanitized:
+        raise ValueError("dynamic_kv_profile_rows_override must contain at least one row")
+    return sanitized
+
+
+def _build_call_supports(function, name: str) -> bool:
+    import inspect
+
+    return name in inspect.signature(function).parameters
+
+
+def _detect_build_tokenizer_frame(
+    source: str,
+    *,
+    revision: str | None = None,
+) -> tuple[list[int], list[int]] | None:
+    from pathlib import Path
+
+    try:
+        from transformers import AutoTokenizer
+
+        kwargs = {"trust_remote_code": True}
+        if revision:
+            kwargs["revision"] = revision
+        if not Path(source).is_dir():
+            kwargs["local_files_only"] = True
+        tokenizer = AutoTokenizer.from_pretrained(source, **kwargs)
+        default_ids = list(tokenizer.encode("hello"))
+        plain_ids = list(tokenizer.encode("hello", add_special_tokens=False))
+    except Exception:
+        return None
+    if default_ids == plain_ids:
+        return [], []
+    if not plain_ids:
+        return default_ids, []
+    for start in range(len(default_ids) - len(plain_ids) + 1):
+        if default_ids[start : start + len(plain_ids)] == plain_ids:
+            return default_ids[:start], default_ids[start + len(plain_ids) :]
+    return None
+
+
+def _ensure_build_tokenizer(model_dir) -> None:
+    import tempfile
+    from pathlib import Path
+
+    tokenizer_path = model_dir / "tokenizer.json"
+    if tokenizer_path.is_file():
+        return
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(str(model_dir), use_fast=True)
+        with tempfile.TemporaryDirectory(prefix="trtmc-tokenizer-") as temporary:
+            generated = Path(temporary) / "tokenizer.json"
+            backend = getattr(tokenizer, "backend_tokenizer", None)
+            if backend is None:
+                backend = getattr(tokenizer, "_tokenizer", None)
+            if backend is not None and hasattr(backend, "save"):
+                backend.save(str(generated))
+            if not generated.is_file():
+                tokenizer.save_pretrained(temporary)
+            if not generated.is_file():
+                raise RuntimeError("tokenizer conversion did not create tokenizer.json")
+            with tempfile.NamedTemporaryFile(
+                dir=model_dir,
+                prefix=".trtmc-tokenizer-",
+                suffix=".json",
+                delete=False,
+            ) as output:
+                temporary_path = Path(output.name)
+                output.write(generated.read_bytes())
+            temporary_path.replace(tokenizer_path)
+    except Exception as exc:
+        print(
+            "[trtmc build] Warning: could not generate tokenizer.json "
+            f"(C++ runtime may fail to create tokenizer): {exc}",
+            file=sys.stderr,
+        )
+
+
+def build(model_dir: str, output_path: str, *, options: dict[str, object]) -> None:
+    """Build one complete GPT-2 bundle without shared model orchestration."""
+
+    import json
+    import re
+    import time
+    from dataclasses import replace
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from tensorrt_model_connect import trt_compat as build_trt_compat
+    from tensorrt_model_connect.build_timing import (
+        add_build_timing,
+        new_build_timing,
+        write_build_timing,
+    )
+    from tensorrt_model_connect.bundle_writer import BundleInfo, BundleSection, write_bundle
+    from .config import ModelConfig
+    from tensorrt_model_connect.parallel_config import (
+        normalize_parallel_config,
+        rank_engine_section,
+        require_tensorrt_11_for_tensor_parallel,
+    )
+    from tensorrt_model_connect.families.gpt2.plugin import plugin
+
+    model_path = Path(model_dir)
+    parallel = normalize_parallel_config(options.get("parallel_config"))
+    if parallel.cp_enabled:
+        raise NotImplementedError("GPT-2 does not support context-parallel builds")
+
+    config = ModelConfig.from_dir(model_path)
+    config.raw["_model_dir"] = str(model_path)
+    config.raw["_fp32_layers"] = sorted(set(options.get("fp32_layers") or ()))
+    config.raw["_family_build_options"] = dict(options.get("family_build_options") or {})
+    config.raw["_parallel_build_enabled"] = bool(parallel.enabled)
+    config.raw["_rtx_build_requested"] = bool(options.get("rtx"))
+    precision = str(options.get("precision") or "fp32").lower()
+    config.raw["_resolved_build_precision"] = precision
+    max_cache_length = int(options.get("max_cache_length") or 256)
+    if max_cache_length < 1:
+        raise ValueError("max_cache_length must be >= 1")
+
+    dynamic_kv_cache = bool(options.get("dynamic_kv_cache"))
+    dynamic_kv_budget = 1
+    triattention_config = None
+    triattention_section = None
+    if options.get("triattention_stats_path"):
+        from tensorrt_model_connect.triattention_export import (
+            TriAttentionBundleConfig,
+            export_triattention_stats_section,
+        )
+
+        recent_window = int(options.get("triattention_recent_window") or 0)
+        divide_length = int(options.get("triattention_divide_length") or 0)
+        score_aggregation = str(
+            options.get("triattention_score_aggregation") or "mean"
+        )
+        if recent_window < 0:
+            raise ValueError("TriAttention recent_window must be >= 0")
+        if divide_length < 1:
+            raise ValueError("TriAttention divide_length must be >= 1")
+        if score_aggregation not in {"mean", "max"}:
+            raise ValueError("TriAttention score_aggregation must be 'mean' or 'max'")
+        dynamic_kv_budget = int(
+            options.get("triattention_kv_budget") or max_cache_length
+        )
+        if dynamic_kv_budget < 1 or dynamic_kv_budget > max_cache_length:
+            raise ValueError("TriAttention kv_budget must fit max_cache_length")
+        triattention_config = TriAttentionBundleConfig(
+            kv_budget=dynamic_kv_budget,
+            divide_length=divide_length,
+            recent_window=recent_window,
+            score_aggregation=score_aggregation,
+            count_prompt_tokens=bool(options.get("triattention_count_prompt_tokens", True)),
+            protect_prefill=bool(options.get("triattention_protect_prefill", True)),
+            disable_mlr=bool(options.get("triattention_disable_mlr", False)),
+            disable_trig=bool(options.get("triattention_disable_trig", False)),
+        )
+        triattention_section = export_triattention_stats_section(
+            str(options["triattention_stats_path"]),
+            config=config,
+        )
+        dynamic_kv_cache = True
+
+    timing = new_build_timing(options.get("build_timing_path"))
+    timing["model_dir"] = str(model_path)
+    timing["output_path"] = str(output_path)
+    started = time.monotonic()
+    write_build_timing(timing)
+
+    weights_started = time.monotonic()
+    weight_kwargs = {"precision": precision} if _build_call_supports(
+        plugin.load_weights, "precision"
+    ) else {}
+    weights = plugin.load_weights(str(model_path), config, **weight_kwargs)
+    add_build_timing(timing, "weights_loading_s", time.monotonic() - weights_started)
+    write_build_timing(timing)
+
+    quantize = options.get("quantize")
+    quant_ctx = None
+    quant_plan = None
+    if quantize:
+        from tensorrt_model_connect.quantization import QuantPlan, build_quant_context
+
+        quant_plan = QuantPlan.from_build_args(
+            precision=precision,
+            quantize=str(quantize),
+            quant_scales=options.get("quant_scales"),
+            quant_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+        )
+        quant_method = str(config.raw.get("quantization_config", {}).get("quant_method", "")).lower()
+        if quant_plan.scale_source == "modelopt" and quant_method in {
+            "awq",
+            "gptq",
+            "compressed-tensors",
+            "compressed_tensors",
+        }:
+            quant_plan = replace(quant_plan, scale_source="prequantized")
+        quant_ctx = build_quant_context(
+            format_name=quant_plan.quant_format,
+            model_dir=str(model_path),
+            config=config,
+            scales_json=options.get("quant_scales"),
+            num_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+            plugin=plugin,
+            quant_plan=quant_plan,
+            graph_ops=__import__(
+                "tensorrt_model_connect.families.gpt2.graph_ops",
+                fromlist=["*"],
+            ),
+        )
+
+    if parallel.enabled:
+        require_tensorrt_11_for_tensor_parallel(parallel, feature="GPT-2 tensor-parallel builds")
+        if quant_ctx is not None:
+            raise ValueError("GPT-2 tensor-parallel builds do not support quantization")
+
+    if dynamic_kv_cache:
+        rows = _sanitize_dynamic_kv_profile_rows(
+            options.get("dynamic_kv_profile_rows_override"),
+            max_cache_length,
+        )
+        if rows is None:
+            preferred_rows = (
+                [max(32, dynamic_kv_budget // 2)]
+                if triattention_config is not None and dynamic_kv_budget >= 4096
+                else None
+            )
+            rows = _dynamic_kv_profile_rows(
+                max_cache_length,
+                dynamic_kv_budget,
+                preferred_rows=preferred_rows,
+            )
+        config.raw["dynamic_kv_cache"] = True
+        config.raw["_dynamic_kv_opt_length"] = max_cache_length
+        config.raw["_dynamic_kv_profile_rows"] = rows
+    if parallel.enabled and dynamic_kv_cache:
+        raise NotImplementedError(
+            "Tensor-parallel GPT-2 builds do not support dynamic_kv_cache"
+        )
+
+    verbose = bool(options.get("verbose"))
+    compile_started = time.monotonic()
+    if parallel.enabled:
+        plans = {
+            rank: plugin.build_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel.for_rank(rank),
+            )
+            for rank in range(parallel.tp_size)
+        }
+        sections = [
+            BundleSection(rank_engine_section(rank), plan)
+            for rank, plan in sorted(plans.items())
+        ]
+        decoder_layout = "dual_profile"
+    else:
+        from tensorrt_model_connect.tvm_ffi.graph_build import (
+            engine_role,
+            inspection_role,
+        )
+
+        def build_role(role: str) -> bytes:
+            previous = config.raw.get("_decoder_engine_role")
+            config.raw["_decoder_engine_role"] = role
+            try:
+                with engine_role(role):
+                    return plugin.build_engine(
+                        config,
+                        weights,
+                        max_cache_length,
+                        precision=precision,
+                        quant_ctx=quant_ctx,
+                        verbose=verbose,
+                        parallel_config=parallel,
+                    )
+            finally:
+                if previous is None:
+                    config.raw.pop("_decoder_engine_role", None)
+                else:
+                    config.raw["_decoder_engine_role"] = previous
+
+        target_role = inspection_role()
+        if target_role is not None:
+            build_role(target_role)
+            raise RuntimeError("graph inspection did not reach TensorRT serialization")
+
+        split = (
+            str(options.get("decoder_engine_layout") or "split") == "split"
+            and not dynamic_kv_cache
+        )
+        if split:
+            config.raw["_active_split_decoder_build"] = True
+            try:
+                quant_label = str(quantize or "noquant")
+
+                def build_split_role(selected_role: str) -> bytes:
+                    scope = (
+                        f"split-{config.model_type}-h{config.hidden_size}"
+                        f"-l{config.num_hidden_layers}-{precision}-{quant_label}"
+                        f"-{selected_role}"
+                    )
+                    with build_trt_compat.scoped_timing_cache(scope):
+                        return build_role(selected_role)
+
+                prefill_started = time.monotonic()
+                prefill_plan = build_split_role("prefill")
+                add_build_timing(
+                    timing,
+                    "trt_compile_prefill_engine_s",
+                    time.monotonic() - prefill_started,
+                )
+                decode_started = time.monotonic()
+                plan = build_split_role("decode")
+                add_build_timing(
+                    timing,
+                    "trt_compile_decode_engine_s",
+                    time.monotonic() - decode_started,
+                )
+            finally:
+                config.raw.pop("_active_split_decoder_build", None)
+            sections = [
+                BundleSection("engine_plan", plan),
+                BundleSection("prefill_engine_plan", prefill_plan),
+            ]
+            decoder_layout = "split"
+        else:
+            role = (
+                "dual_profile"
+                if str(options.get("decoder_engine_layout") or "split") == "dual_profile"
+                else "decode"
+            )
+            plan = build_role(role)
+            sections = [BundleSection("engine_plan", plan)]
+            decoder_layout = "dual_profile" if role == "dual_profile" else "single"
+    compile_elapsed = time.monotonic() - compile_started
+    add_build_timing(timing, "trt_compile_s", compile_elapsed)
+    add_build_timing(timing, "trt_compile_main_engine_s", compile_elapsed)
+    write_build_timing(timing)
+    if triattention_config is not None and triattention_section is not None:
+        sections.append(
+            BundleSection(triattention_config.stats_section, triattention_section)
+        )
+
+    tokenizer_source = str(options.get("tokenizer_source_model_id_or_path") or model_path)
+    tokenizer_frame = _detect_build_tokenizer_frame(
+        tokenizer_source,
+        revision=(
+            str(options["tokenizer_source_revision"])
+            if options.get("tokenizer_source_revision")
+            else None
+        ),
+    )
+    _ensure_build_tokenizer(model_path)
+    if tokenizer_frame is None:
+        tokenizer_frame = _detect_build_tokenizer_frame(str(model_path))
+    prefix_ids, suffix_ids = tokenizer_frame or ([], [])
+    add_special_tokens = bool(prefix_ids or suffix_ids)
+
+    trt_version = build_trt_compat.tensorrt_version() or "unknown"
+    version_match = re.search(r"(\d+)\.(\d+)", trt_version)
+    trt_abi = f"{version_match.group(1)}.{version_match.group(2)}" if version_match else ""
+    try:
+        from tensorrt_model_connect.runtime_provider.target import (
+            _probe_current_target_with_device,
+        )
+
+        gpu_name = str(_probe_current_target_with_device()[0]["gpu_name"])
+    except Exception:
+        gpu_name = ""
+    info = BundleInfo(
+        model_id=model_path.name,
+        model_type=config.model_type,
+        family=plugin.name,
+        trt_version=trt_version,
+        trt_abi=trt_abi,
+        gpu_name=gpu_name,
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        vocab_size=config.vocab_size,
+        hidden_size=config.hidden_size,
+        num_layers=config.num_hidden_layers,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        max_cache_length=max_cache_length,
+        runtime_strategy=plugin.runtime_strategy,
+        precision=precision,
+        quantization=(quant_plan.quant_format if quant_plan else "none"),
+        tokenizer_add_special_tokens=add_special_tokens,
+    )
+
+    source_config = model_path / "config.json"
+    runtime_config = (
+        json.loads(source_config.read_text(encoding="utf-8"))
+        if source_config.is_file()
+        else dict(config.raw)
+    )
+    runtime_config.update(
+        {
+            "runtime_strategy": plugin.runtime_strategy,
+            "engine_backend": "trt_rtx" if options.get("rtx") else "trt",
+            "trt_version": trt_version,
+            "precision": precision,
+            "tokenizer_add_special_tokens": int(add_special_tokens),
+            "decoder_engine_layout": decoder_layout,
+        }
+    )
+    if trt_abi:
+        runtime_config["trt_abi"] = trt_abi
+    if tokenizer_frame is not None:
+        runtime_config["tokenizer_special_prefix_ids"] = prefix_ids
+        runtime_config["tokenizer_special_suffix_ids"] = suffix_ids
+    if quant_plan is not None:
+        runtime_config["quantization"] = quant_plan.as_config_dict()
+    if dynamic_kv_cache:
+        runtime_config["dynamic_kv_cache"] = True
+        runtime_config["dynamic_kv_profile_rows"] = config.raw[
+            "_dynamic_kv_profile_rows"
+        ]
+    if triattention_config is not None:
+        runtime_config["triattention"] = triattention_config.to_dict()
+    runtime_config.update(parallel.to_bundle_config_fields())
+
+    generation_config = model_path / "generation_config.json"
+    if generation_config.is_file():
+        generation = json.loads(generation_config.read_text(encoding="utf-8"))
+        if "eos_token_id" in generation:
+            runtime_config["eos_token_id"] = generation["eos_token_id"]
+
+    for filename in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "vocab.json",
+        "merges.txt",
+        "vocab.txt",
+        "special_tokens_map.json",
+        "tokenizer.model",
+    ):
+        path = model_path / filename
+        if path.is_file():
+            sections.append(BundleSection(filename, path.read_bytes()))
+    sections.append(
+        BundleSection("config.json", json.dumps(runtime_config, indent=2).encode("utf-8"))
+    )
+
+    from tensorrt_model_connect.tvm_ffi.graph_build import kernel_slots_section
+
+    slot_section = kernel_slots_section()
+    if slot_section is not None:
+        sections.append(BundleSection("kernel_slots.json", slot_section))
+    kernel_manifest = []
+    for global_name, library in options.get("kernel_artifacts") or ():
+        section_name = f"kernel_{global_name.replace('.', '_')}.so"
+        sections.append(BundleSection(section_name, Path(library).read_bytes()))
+        kernel_manifest.append(
+            {"global_name": global_name, "func_name": "run", "section": section_name}
+        )
+    if kernel_manifest:
+        sections.append(
+            BundleSection(
+                "kernel_manifest.json",
+                json.dumps({"kernels": kernel_manifest}).encode("utf-8"),
+            )
+        )
+
+    write_started = time.monotonic()
+    write_bundle(output_path, info, sections)
+    add_build_timing(timing, "bundle_write_s", time.monotonic() - write_started)
+    timing["total_s"] = time.monotonic() - started
+    write_build_timing(timing)

--- a/python/tensorrt_model_connect/families/gpt2/plugin.py
+++ b/python/tensorrt_model_connect/families/gpt2/plugin.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import numpy as np
 
+from . import graph_ops as _graph_ops
 from .config import ModelConfig
 from .checkpoint_mapper import (
     WeightDict,
@@ -30,6 +31,7 @@ from .checkpoint_mapper import (
 from ...parallel_config import normalize_parallel_config
 from .standard_decoder_builder import build_standard_decoder_engine
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
+from .model import build as _build_model_bundle
 
 
 class GPT2Plugin:
@@ -205,3 +207,5 @@ class GPT2Plugin:
 
 
 plugin = GPT2Plugin()
+plugin.build = _build_model_bundle
+plugin.graph_ops = _graph_ops

--- a/python/tensorrt_model_connect/families/timm_vit/model/model.py
+++ b/python/tensorrt_model_connect/families/timm_vit/model/model.py
@@ -301,3 +301,252 @@ def add_attention_core(
 
 # Backward-compatible name used by existing tests and call sites.
 _add_attention_core = add_attention_core
+
+
+def _build_call_supports(function, name: str) -> bool:
+    import inspect
+
+    return name in inspect.signature(function).parameters
+
+
+def build(model_dir: str, output_path: str, *, options: dict[str, object]) -> None:
+    """Build one complete timm ViT bundle without shared model orchestration."""
+
+    import json
+    import re
+    import sys
+    import time
+    from dataclasses import replace
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from tensorrt_model_connect import trt_compat as build_trt_compat
+    from tensorrt_model_connect.build_timing import (
+        add_build_timing,
+        new_build_timing,
+        write_build_timing,
+    )
+    from tensorrt_model_connect.bundle_writer import BundleInfo, BundleSection, write_bundle
+    from ..config import ModelConfig
+    from tensorrt_model_connect.parallel_config import (
+        normalize_parallel_config,
+        rank_engine_section,
+        require_tensorrt_11_for_tensor_parallel,
+    )
+    from tensorrt_model_connect.families.timm_vit.plugin import plugin
+
+    model_path = Path(model_dir)
+    parallel = normalize_parallel_config(options.get("parallel_config"))
+    if parallel.cp_enabled:
+        raise NotImplementedError("timm_vit does not support context-parallel builds")
+    if options.get("dynamic_kv_cache") or options.get("triattention_stats_path"):
+        raise ValueError("timm_vit does not use a decoder KV-cache runtime")
+
+    config = ModelConfig.from_dir(model_path)
+    config.raw["_model_dir"] = str(model_path)
+    config.raw["_fp32_layers"] = sorted(set(options.get("fp32_layers") or ()))
+    config.raw["_family_build_options"] = dict(options.get("family_build_options") or {})
+    config.raw["_parallel_build_enabled"] = bool(parallel.enabled)
+    config.raw["_rtx_build_requested"] = bool(options.get("rtx"))
+    precision = str(options.get("precision") or "fp32").lower()
+    config.raw["_resolved_build_precision"] = precision
+    max_cache_length = int(options.get("max_cache_length") or 256)
+    if max_cache_length < 1:
+        raise ValueError("max_cache_length must be >= 1")
+
+    timing = new_build_timing(options.get("build_timing_path"))
+    timing["model_dir"] = str(model_path)
+    timing["output_path"] = str(output_path)
+    started = time.monotonic()
+    write_build_timing(timing)
+
+    weights_started = time.monotonic()
+    weight_kwargs = {"precision": precision} if _build_call_supports(
+        plugin.load_weights, "precision"
+    ) else {}
+    weights = plugin.load_weights(str(model_path), config, **weight_kwargs)
+    add_build_timing(timing, "weights_loading_s", time.monotonic() - weights_started)
+    write_build_timing(timing)
+
+    quantize = options.get("quantize")
+    quant_ctx = None
+    quant_plan = None
+    if quantize:
+        from tensorrt_model_connect.quantization import QuantPlan, build_quant_context
+
+        quant_plan = QuantPlan.from_build_args(
+            precision=precision,
+            quantize=str(quantize),
+            quant_scales=options.get("quant_scales"),
+            quant_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+        )
+        quant_method = str(config.raw.get("quantization_config", {}).get("quant_method", "")).lower()
+        if quant_plan.scale_source == "modelopt" and quant_method in {
+            "awq",
+            "gptq",
+            "compressed-tensors",
+            "compressed_tensors",
+        }:
+            quant_plan = replace(quant_plan, scale_source="prequantized")
+        quant_ctx = build_quant_context(
+            format_name=quant_plan.quant_format,
+            model_dir=str(model_path),
+            config=config,
+            scales_json=options.get("quant_scales"),
+            num_calibration_samples=int(options.get("quant_calibration_samples") or 512),
+            plugin=plugin,
+            quant_plan=quant_plan,
+            graph_ops=sys.modules[__name__],
+        )
+
+    if parallel.enabled:
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="timm_vit tensor-parallel MLP builds"
+        )
+        if quant_ctx is not None:
+            raise ValueError("timm_vit tensor-parallel builds do not support quantization")
+
+    verbose = bool(options.get("verbose"))
+    compile_started = time.monotonic()
+    if parallel.enabled:
+        plans = {
+            rank: plugin.build_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel.for_rank(rank),
+            )
+            for rank in range(parallel.tp_size)
+        }
+        sections = [
+            BundleSection(rank_engine_section(rank), plan)
+            for rank, plan in sorted(plans.items())
+        ]
+        decoder_layout = "dual_profile"
+    else:
+        from tensorrt_model_connect.tvm_ffi.graph_build import (
+            engine_role,
+            inspection_role,
+        )
+
+        role = (
+            "dual_profile"
+            if str(options.get("decoder_engine_layout") or "split") == "dual_profile"
+            else "decode"
+        )
+
+        def build_role(selected_role: str) -> bytes:
+            with engine_role(selected_role):
+                return plugin.build_engine(
+                    config,
+                    weights,
+                    max_cache_length,
+                    precision=precision,
+                    quant_ctx=quant_ctx,
+                    verbose=verbose,
+                    parallel_config=parallel,
+                )
+
+        target_role = inspection_role()
+        if target_role is not None:
+            build_role(target_role)
+            raise RuntimeError("graph inspection did not reach TensorRT serialization")
+        plan = build_role(role)
+        sections = [BundleSection("engine_plan", plan)]
+        decoder_layout = "dual_profile" if role == "dual_profile" else "single"
+    compile_elapsed = time.monotonic() - compile_started
+    add_build_timing(timing, "trt_compile_s", compile_elapsed)
+    add_build_timing(timing, "trt_compile_main_engine_s", compile_elapsed)
+    write_build_timing(timing)
+
+    trt_version = build_trt_compat.tensorrt_version() or "unknown"
+    version_match = re.search(r"(\d+)\.(\d+)", trt_version)
+    trt_abi = f"{version_match.group(1)}.{version_match.group(2)}" if version_match else ""
+    try:
+        from tensorrt_model_connect.runtime_provider.target import (
+            _probe_current_target_with_device,
+        )
+
+        gpu_name = str(_probe_current_target_with_device()[0]["gpu_name"])
+    except Exception:
+        gpu_name = ""
+    info = BundleInfo(
+        model_id=model_path.name,
+        model_type=config.model_type,
+        family=plugin.name,
+        trt_version=trt_version,
+        trt_abi=trt_abi,
+        gpu_name=gpu_name,
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        vocab_size=config.vocab_size,
+        hidden_size=config.hidden_size,
+        num_layers=config.num_hidden_layers,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        max_cache_length=max_cache_length,
+        runtime_strategy=plugin.runtime_strategy,
+        precision=precision,
+        quantization=(quant_plan.quant_format if quant_plan else "none"),
+        tokenizer_add_special_tokens=False,
+    )
+
+    source_config = model_path / "config.json"
+    runtime_config = (
+        json.loads(source_config.read_text(encoding="utf-8"))
+        if source_config.is_file()
+        else dict(config.raw)
+    )
+    overrides = plugin.get_bundle_config_overrides(config)
+    runtime_config.update(
+        {
+            "runtime_strategy": plugin.runtime_strategy,
+            "engine_backend": "trt_rtx" if options.get("rtx") else "trt",
+            "trt_version": trt_version,
+            "precision": precision,
+            "tokenizer_add_special_tokens": 0,
+            "decoder_engine_layout": decoder_layout,
+            **overrides,
+        }
+    )
+    if trt_abi:
+        runtime_config["trt_abi"] = trt_abi
+    if quant_plan is not None:
+        runtime_config["quantization"] = quant_plan.as_config_dict()
+    runtime_config.update(parallel.to_bundle_config_fields())
+
+    for filename in ("preprocessor_config.json", "processor_config.json"):
+        path = model_path / filename
+        if path.is_file():
+            sections.append(BundleSection(filename, path.read_bytes()))
+    sections.append(
+        BundleSection("config.json", json.dumps(runtime_config, indent=2).encode("utf-8"))
+    )
+
+    from tensorrt_model_connect.tvm_ffi.graph_build import kernel_slots_section
+
+    slot_section = kernel_slots_section()
+    if slot_section is not None:
+        sections.append(BundleSection("kernel_slots.json", slot_section))
+    kernel_manifest = []
+    for global_name, library in options.get("kernel_artifacts") or ():
+        section_name = f"kernel_{global_name.replace('.', '_')}.so"
+        sections.append(BundleSection(section_name, Path(library).read_bytes()))
+        kernel_manifest.append(
+            {"global_name": global_name, "func_name": "run", "section": section_name}
+        )
+    if kernel_manifest:
+        sections.append(
+            BundleSection(
+                "kernel_manifest.json",
+                json.dumps({"kernels": kernel_manifest}).encode("utf-8"),
+            )
+        )
+
+    write_started = time.monotonic()
+    write_bundle(output_path, info, sections)
+    add_build_timing(timing, "bundle_write_s", time.monotonic() - write_started)
+    timing["total_s"] = time.monotonic() - started
+    write_build_timing(timing)

--- a/python/tensorrt_model_connect/families/timm_vit/plugin.py
+++ b/python/tensorrt_model_connect/families/timm_vit/plugin.py
@@ -479,3 +479,5 @@ class TimmVitPlugin:
 
 
 plugin = TimmVitPlugin()
+plugin.build = graph_ops.build
+plugin.graph_ops = graph_ops

--- a/tests/builder/test_model_owned_build_dispatch.py
+++ b/tests/builder/test_model_owned_build_dispatch.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_model_connect import engine_builder
+
+
+def _select(monkeypatch: pytest.MonkeyPatch, plugin: object) -> None:
+    monkeypatch.setattr(engine_builder, "_setup_trt_import", lambda _rtx: None)
+    monkeypatch.setattr(engine_builder, "_resolve_diffusion_entrypoint", lambda _path: None)
+    monkeypatch.setattr(engine_builder.ModelConfig, "from_dir", lambda _path: object())
+    monkeypatch.setattr(engine_builder, "find_plugin", lambda _config: plugin)
+
+
+def test_declared_model_owned_build_receives_complete_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class Plugin:
+        name = "pilot"
+
+        def build(self, model_dir: str, output_path: str, *, options: dict[str, object]) -> None:
+            captured.update(
+                model_dir=model_dir,
+                output_path=output_path,
+                options=options,
+            )
+
+    _select(monkeypatch, Plugin())
+    monkeypatch.setattr(
+        engine_builder,
+        "normalize_parallel_config",
+        lambda _value: pytest.fail("legacy orchestration must not run"),
+    )
+
+    engine_builder.build_bundle(
+        "/models/pilot",
+        "/tmp/pilot.bundle",
+        max_cache_length=64,
+        precision="fp16",
+        family_build_options={"pilot.option": True},
+    )
+
+    assert captured["model_dir"] == "/models/pilot"
+    assert captured["output_path"] == "/tmp/pilot.bundle"
+    options = captured["options"]
+    assert isinstance(options, dict)
+    assert options["max_cache_length"] == 64
+    assert options["precision"] == "fp16"
+    assert options["family_build_options"] == {"pilot.option": True}
+    assert "model_dir" not in options
+    assert "output_path" not in options
+
+
+def test_magic_mock_does_not_invent_model_owned_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _select(monkeypatch, MagicMock(name="legacy_plugin"))
+
+    def legacy_marker(_value: object) -> object:
+        raise RuntimeError("entered legacy orchestration")
+
+    monkeypatch.setattr(engine_builder, "normalize_parallel_config", legacy_marker)
+
+    with pytest.raises(RuntimeError, match="entered legacy orchestration"):
+        engine_builder.build_bundle("/models/legacy", "/tmp/legacy.bundle")
+
+
+def test_declared_noncallable_build_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Plugin:
+        name = "broken"
+        build = "not-callable"
+
+    _select(monkeypatch, Plugin())
+
+    with pytest.raises(TypeError, match="build attribute is not callable"):
+        engine_builder.build_bundle("/models/broken", "/tmp/broken.bundle")
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "python/tensorrt_model_connect/families/bert/model/model.py",
+        "python/tensorrt_model_connect/families/gpt2/model.py",
+        "python/tensorrt_model_connect/families/timm_vit/model/model.py",
+    ),
+)
+def test_migrated_model_builds_do_not_import_engine_builder(relative: str) -> None:
+    root = Path(__file__).resolve().parents[2]
+    tree = ast.parse((root / relative).read_text(encoding="utf-8"))
+    imported = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    assert not [name for name in imported if name.endswith("engine_builder")]

--- a/tests/builder/test_model_owned_family_builds.py
+++ b/tests/builder/test_model_owned_family_builds.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+
+import pytest
+
+from tensorrt_model_connect import build_timing, bundle_writer, config, trt_compat
+
+
+def _fake_trt() -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        __version__="11.1.0",
+        ElementWiseOperation=types.SimpleNamespace(SUM="sum", SUB="sub", PROD="prod"),
+        MatrixOperation=types.SimpleNamespace(NONE="none", TRANSPOSE="transpose"),
+        AttentionNormalizationOp=types.SimpleNamespace(SOFTMAX="softmax"),
+        ActivationType=types.SimpleNamespace(SIGMOID="sigmoid", TANH="tanh"),
+        ReduceOperation=types.SimpleNamespace(AVG="avg"),
+        UnaryOperation=types.SimpleNamespace(SQRT="sqrt", RECIP="recip"),
+        NetworkDefinitionCreationFlag=types.SimpleNamespace(EXPLICIT_BATCH=0, STRONGLY_TYPED=1),
+        BuilderFlag=types.SimpleNamespace(TF32="tf32", DISABLE_TIMING_CACHE="disable"),
+        MemoryPoolType=types.SimpleNamespace(WORKSPACE="workspace"),
+        Permutation=lambda value: tuple(value),
+        float32="float32",
+        float16="float16",
+        bfloat16="bfloat16",
+        int32="int32",
+    )
+
+
+def _import_family(monkeypatch: pytest.MonkeyPatch, module_name: str):
+    fake = _fake_trt()
+    monkeypatch.setitem(sys.modules, "tensorrt", fake)
+    monkeypatch.setattr(trt_compat, "_module", fake)
+    for name in tuple(sys.modules):
+        if name == module_name or name.startswith(module_name.rpartition(".")[0] + "."):
+            sys.modules.pop(name, None)
+    return importlib.import_module(module_name)
+
+
+def _config(model_type: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        model_type=model_type,
+        raw={"model_type": model_type},
+        vocab_size=32,
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+    )
+
+
+def _patch_common(
+    monkeypatch: pytest.MonkeyPatch,
+    model_config: object,
+) -> list[tuple[object, list[object]]]:
+    written: list[tuple[object, list[object]]] = []
+    monkeypatch.setattr(config.ModelConfig, "from_dir", lambda _path: model_config)
+    monkeypatch.setattr(build_timing, "new_build_timing", lambda _path: {})
+    monkeypatch.setattr(build_timing, "add_build_timing", lambda *_args: None)
+    monkeypatch.setattr(build_timing, "write_build_timing", lambda _timing: None)
+    monkeypatch.setattr(
+        bundle_writer,
+        "write_bundle",
+        lambda _path, info, sections: written.append((info, list(sections))),
+    )
+    return written
+
+
+def test_bert_model_owned_build_writes_complete_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    model = _import_family(
+        monkeypatch,
+        "tensorrt_model_connect.families.bert.model.model",
+    )
+    plugin_module = importlib.import_module("tensorrt_model_connect.families.bert.plugin")
+    plugin = plugin_module.plugin
+    cfg = _config("bert")
+    written = _patch_common(monkeypatch, cfg)
+    monkeypatch.setattr(model.ModelConfig, "from_dir", lambda _path: cfg)
+    monkeypatch.setattr(plugin, "load_weights", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(plugin, "build_engine", lambda *_args, **_kwargs: b"bert-plan")
+    monkeypatch.setattr(model, "_detect_build_tokenizer_frame", lambda *_args, **_kwargs: ([], []))
+    monkeypatch.setattr(model, "_ensure_build_tokenizer", lambda _path: None)
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "bert"}))
+
+    model.build(str(tmp_path), str(tmp_path / "bert.bundle"), options={"precision": "fp16"})
+
+    info, sections = written[0]
+    by_name = {section.name: section.data for section in sections}
+    assert info.family == "bert"
+    assert info.precision == "fp16"
+    assert by_name["engine_plan"] == b"bert-plan"
+    runtime = json.loads(by_name["config.json"])
+    assert runtime["runtime_strategy"] == "bert_encoder_only"
+    assert runtime["precision"] == "fp16"
+    assert not any(key.startswith("_") for key in runtime)
+
+
+def test_timm_vit_model_owned_build_writes_preprocess_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    model = _import_family(
+        monkeypatch,
+        "tensorrt_model_connect.families.timm_vit.model.model",
+    )
+    plugin_module = importlib.import_module("tensorrt_model_connect.families.timm_vit.plugin")
+    plugin = plugin_module.plugin
+    cfg = _config("vit_base_patch16_224")
+    cfg.raw.update(
+        {
+            "input_size": [3, 224, 224],
+            "patch_size": 16,
+            "num_features": 8,
+            "depth": 1,
+            "num_heads": 2,
+            "num_classes": 5,
+        }
+    )
+    written = _patch_common(monkeypatch, cfg)
+    timm_config = importlib.import_module(
+        "tensorrt_model_connect.families.timm_vit.config"
+    )
+    monkeypatch.setattr(timm_config.ModelConfig, "from_dir", lambda _path: cfg)
+    monkeypatch.setattr(plugin, "load_weights", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(plugin, "build_engine", lambda *_args, **_kwargs: b"vit-plan")
+    (tmp_path / "config.json").write_text(json.dumps(cfg.raw))
+
+    model.build(str(tmp_path), str(tmp_path / "vit.bundle"), options={"precision": "fp16"})
+
+    info, sections = written[0]
+    by_name = {section.name: section.data for section in sections}
+    assert info.family == "timm_vit"
+    assert by_name["engine_plan"] == b"vit-plan"
+    runtime = json.loads(by_name["config.json"])
+    assert runtime["runtime_strategy"] == "timm_vit_image_classification"
+    assert runtime["input_image_h"] == 224
+    assert runtime["num_classes"] == 5
+    assert not any(key.startswith("_") for key in runtime)
+
+
+def test_gpt2_model_owned_build_preserves_split_decoder_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    model = _import_family(
+        monkeypatch,
+        "tensorrt_model_connect.families.gpt2.model",
+    )
+    plugin_module = importlib.import_module("tensorrt_model_connect.families.gpt2.plugin")
+    plugin = plugin_module.plugin
+    cfg = _config("gpt2")
+    written = _patch_common(monkeypatch, cfg)
+    gpt2_config = importlib.import_module("tensorrt_model_connect.families.gpt2.config")
+    monkeypatch.setattr(gpt2_config.ModelConfig, "from_dir", lambda _path: cfg)
+    monkeypatch.setattr(plugin, "load_weights", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        plugin,
+        "build_engine",
+        lambda config_value, *_args, **_kwargs: str(
+            config_value.raw["_decoder_engine_role"]
+        ).encode("utf-8"),
+    )
+    monkeypatch.setattr(model, "_detect_build_tokenizer_frame", lambda *_args, **_kwargs: ([], []))
+    monkeypatch.setattr(model, "_ensure_build_tokenizer", lambda _path: None)
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "gpt2"}))
+
+    model.build(
+        str(tmp_path),
+        str(tmp_path / "gpt2.bundle"),
+        options={"precision": "fp16", "decoder_engine_layout": "split"},
+    )
+
+    info, sections = written[0]
+    by_name = {section.name: section.data for section in sections}
+    assert info.family == "gpt2"
+    assert by_name["engine_plan"] == b"decode"
+    assert by_name["prefill_engine_plan"] == b"prefill"
+    runtime = json.loads(by_name["config.json"])
+    assert runtime["runtime_strategy"] == "gpt2_decoder_kv_cache"
+    assert runtime["decoder_engine_layout"] == "split"
+    assert not any(key.startswith("_") for key in runtime)
+
+
+@pytest.mark.parametrize(
+    ("maximum", "budget"),
+    ((16, 1), (256, 1), (4096, 512), (8192, 4096)),
+)
+def test_gpt2_model_owned_dynamic_kv_profiles_match_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+    maximum: int,
+    budget: int,
+) -> None:
+    model = _import_family(
+        monkeypatch,
+        "tensorrt_model_connect.families.gpt2.model",
+    )
+    from tensorrt_model_connect.engine_builder import _compute_dynamic_kv_profile_rows
+
+    assert model._dynamic_kv_profile_rows(maximum, budget) == (
+        _compute_dynamic_kv_profile_rows(maximum, budget)
+    )


### PR DESCRIPTION
## Background

This draft previews the smallest model-owned build shape: the shared builder
resolves a family and dispatches, while the family owns its complete bundle
construction.

It pilots three deliberately different families:

- BERT: encoder
- GPT-2: decoder, split engines, and KV cache
- timm ViT: vision classifier

## Exit Criteria

- Migrated families use explicit model-owned `build()` entrypoints.
- Unmigrated families continue through the existing legacy path unchanged.
- Bundle sections, runtime config, header contracts, and runtime outputs remain
  equivalent.
- No new BuilderDriver, BundleSpec, base class, registry, or CLI surface is
  introduced.

This draft does not attempt the all-family rollout, diffusion/FP8 migration,
TP4 qualification, or removal of the temporary fallback.

## Implementation

- Add a small static-declaration dispatch at the start of
  `engine_builder.build_bundle()`.
- Put complete build orchestration in the three family-owned model modules.
- Keep temporary `plugin.py` attachments so existing discovery and tooling
  remain unchanged during the pilot.
- Add focused tests for dispatch, legacy fallback, option forwarding,
  recursion avoidance, and family bundle contracts.

The intended end state removes both the central legacy body and the
compatibility attachments after every family owns its build.

## Validation

Validated after a conflict-free rebase onto `github/main` at `3595a3e56`:

- Builder/CLI focused tests: `159 passed`
- BERT/GPT-2/timm focused tests: `18 passed, 9 skipped`
- Source isolation and specialization tests: `34 passed`
- Ruff: passed
- Test-impact validation: passed (`212 models`, `80 families`)
- Model catalog validation: passed (`80 models`)

Local TensorRT 11.1 / GB300 smoke proof was also run on the same patch before
the conflict-free rebase:

- Tiny BERT, GPT-2, and timm ViT bundles built and executed through the
  current-source C++ runtime.
- Owned and legacy builds had identical section sets, runtime config, and key
  header contracts.
- BERT output cosine: `0.999999833`
- GPT-2 generated output and token IDs: exact match
- timm ViT top class: exact match

Not run: TP4 multi-GPU proofs, diffusion/FP8 families, or full
production-checkpoint builds for GPT-2 and timm ViT.

## Notes For Future Readers

Suggested review order:

1. The dispatch seam in `engine_builder.py`
2. The two focused test files
3. The three model-owned build implementations

This is intentionally a draft architecture preview. It should not be merged
as the rollout plan without first deciding whether this level of explicit
duplication is the desired family contract.
