### PR TITLE
perf(dinov3): streamline feature output copies

### DIFF
--- a/src/runtime/models/dinov3/pipeline.cpp
+++ b/src/runtime/models/dinov3/pipeline.cpp
@@ -31,6 +31,8 @@ std::size_t validated_numel(const Tensor& tensor, const char* name) {
         }
         count *= static_cast<std::size_t>(dim);
     }
+    if (count > std::numeric_limits<std::size_t>::max() / sizeof(float))
+        throw std::runtime_error(std::string("DINOv3 output '") + name + "' is too large");
     return count;
 }
 
@@ -41,6 +43,18 @@ std::vector<float> tensor_to_floats(const Tensor& tensor, const char* name) {
 
     std::vector<float> result(count);
     std::copy_n(static_cast<const float*>(tensor.data), count, result.data());
+    return result;
+}
+
+std::vector<float> copy_device_tensor_to_floats(const void* data, std::size_t count,
+                                                cudaStream_t stream, const char* name) {
+    std::vector<float> result(count);
+    const auto status =
+        cudaMemcpyAsync(result.data(), data, count * sizeof(float), cudaMemcpyDeviceToHost, stream);
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("DINOv3 output '") + name +
+                                 "' D2H copy failed: " + cudaGetErrorString(status));
+    }
     return result;
 }
 
@@ -61,6 +75,32 @@ Dinov3ImageFeaturePipeline::Dinov3ImageFeaturePipeline(std::unique_ptr<TrtModule
       model_id_(std::move(model_id)) {
     if (!model_ || !model_->ok())
         throw std::runtime_error("Dinov3ImageFeaturePipeline: invalid model");
+
+    if (!model_->has_input("pixel_values") || model_->input_is_dynamic("pixel_values") ||
+        !model_->has_output("last_hidden_state") || !model_->has_output("pooler_output"))
+        return;
+
+    auto hidden_shape = model_->tensor_shape("last_hidden_state");
+    auto pooler_shape = model_->tensor_shape("pooler_output");
+    const auto hidden = model_->device_ptr("last_hidden_state");
+    const auto pooler = model_->device_ptr("pooler_output");
+    if (hidden == nullptr || pooler == nullptr ||
+        model_->tensor_dtype("last_hidden_state") != DType::kFloat32 ||
+        model_->tensor_dtype("pooler_output") != DType::kFloat32 || hidden_shape.size() != 3 ||
+        pooler_shape.size() != 2 || hidden_shape[0] != 1 || pooler_shape[0] != 1 ||
+        hidden_shape[2] != pooler_shape[1])
+        return;
+
+    const auto hidden_count =
+        validated_numel({hidden, hidden_shape, DType::kFloat32}, "last_hidden_state");
+    const auto pooler_count =
+        validated_numel({pooler, pooler_shape, DType::kFloat32}, "pooler_output");
+    if (pooler_count > hidden_count)
+        return;
+    hidden_count_ = hidden_count;
+    pooler_count_ = pooler_count;
+    hidden_shape_ = std::move(hidden_shape);
+    pooler_shape_ = std::move(pooler_shape);
 }
 
 ImageFeaturesResult Dinov3ImageFeaturePipeline::extract_image_features(const float* pixels,
@@ -70,6 +110,25 @@ ImageFeaturesResult Dinov3ImageFeaturePipeline::extract_image_features(const flo
     const std::vector<int64_t> input_shape{1, 3, preprocess_config_.input_image_h,
                                            preprocess_config_.input_image_w};
     Tensor input{pixel_values.data(), input_shape, DType::kFloat32};
+    if (hidden_count_ != 0) {
+        model_->forward_async({{"pixel_values", input}});
+        ImageFeaturesResult result;
+        try {
+            result.last_hidden_state =
+                copy_device_tensor_to_floats(model_->device_ptr("last_hidden_state"), hidden_count_,
+                                             model_->stream(), "last_hidden_state");
+        } catch (...) {
+            model_->sync();
+            throw;
+        }
+        model_->sync();
+        result.last_hidden_state_shape = hidden_shape_;
+        result.pooler_output.assign(result.last_hidden_state.begin(),
+                                    result.last_hidden_state.begin() + pooler_count_);
+        result.pooler_output_shape = pooler_shape_;
+        return result;
+    }
+
     const auto outputs = model_->forward({{"pixel_values", input}});
 
     const auto& hidden = require_output(outputs, "last_hidden_state");

--- a/src/runtime/models/dinov3/pipeline.cpp
+++ b/src/runtime/models/dinov3/pipeline.cpp
@@ -58,6 +58,21 @@ std::vector<float> copy_device_tensor_to_floats(const void* data, std::size_t co
     return result;
 }
 
+bool supports_direct_output(const TrtModule& model) {
+    return model.has_input("pixel_values") && !model.input_is_dynamic("pixel_values") &&
+           model.has_output("last_hidden_state") && model.has_output("pooler_output");
+}
+
+bool has_float32_outputs(const TrtModule& model) {
+    return model.tensor_dtype("last_hidden_state") == DType::kFloat32 &&
+           model.tensor_dtype("pooler_output") == DType::kFloat32;
+}
+
+bool has_supported_shapes(const std::vector<int64_t>& hidden, const std::vector<int64_t>& pooler) {
+    return hidden.size() == 3 && pooler.size() == 2 && hidden[0] == 1 && pooler[0] == 1 &&
+           hidden[2] == pooler[1];
+}
+
 const Tensor& require_output(const TensorMap& outputs, const char* name) {
     const auto output = outputs.find(name);
     if (output == outputs.end())
@@ -76,19 +91,16 @@ Dinov3ImageFeaturePipeline::Dinov3ImageFeaturePipeline(std::unique_ptr<TrtModule
     if (!model_ || !model_->ok())
         throw std::runtime_error("Dinov3ImageFeaturePipeline: invalid model");
 
-    if (!model_->has_input("pixel_values") || model_->input_is_dynamic("pixel_values") ||
-        !model_->has_output("last_hidden_state") || !model_->has_output("pooler_output"))
+    if (!supports_direct_output(*model_))
         return;
 
     auto hidden_shape = model_->tensor_shape("last_hidden_state");
     auto pooler_shape = model_->tensor_shape("pooler_output");
     const auto hidden = model_->device_ptr("last_hidden_state");
     const auto pooler = model_->device_ptr("pooler_output");
-    if (hidden == nullptr || pooler == nullptr ||
-        model_->tensor_dtype("last_hidden_state") != DType::kFloat32 ||
-        model_->tensor_dtype("pooler_output") != DType::kFloat32 || hidden_shape.size() != 3 ||
-        pooler_shape.size() != 2 || hidden_shape[0] != 1 || pooler_shape[0] != 1 ||
-        hidden_shape[2] != pooler_shape[1])
+    if (hidden == nullptr || pooler == nullptr)
+        return;
+    if (!has_float32_outputs(*model_) || !has_supported_shapes(hidden_shape, pooler_shape))
         return;
 
     const auto hidden_count =

--- a/src/runtime/models/dinov3/pipeline.h
+++ b/src/runtime/models/dinov3/pipeline.h
@@ -10,9 +10,11 @@
 #include "trtmc/pipeline.h"
 #include "trtmc/runtime/trt_module.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace trtmc {
 
@@ -32,6 +34,10 @@ class Dinov3ImageFeaturePipeline final : public IPipeline, public IImageFeatureE
     std::unique_ptr<TrtModule> model_;
     Dinov3PreprocessConfig preprocess_config_;
     std::string model_id_;
+    std::size_t hidden_count_{0};
+    std::size_t pooler_count_{0};
+    std::vector<int64_t> hidden_shape_;
+    std::vector<int64_t> pooler_shape_;
 };
 
 } // namespace trtmc

--- a/tests/cpp/models/dinov3/test_dinov3_pipeline.cpp
+++ b/tests/cpp/models/dinov3/test_dinov3_pipeline.cpp
@@ -26,9 +26,13 @@ void check(bool condition, const char* name) {
 
 class FakeDinov3Module final : public trtmc::ITrtModule {
   public:
-    explicit FakeDinov3Module(bool include_pooler = true) : include_pooler_(include_pooler) {}
+    explicit FakeDinov3Module(bool include_pooler = true, bool expose_device_outputs = false,
+                              bool dynamic_input = false)
+        : include_pooler_(include_pooler), expose_device_outputs_(expose_device_outputs),
+          dynamic_input_(dynamic_input) {}
 
     trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++forward_calls;
         const auto input = inputs.find("pixel_values");
         if (input != inputs.end() && input->second.data != nullptr) {
             input_shape = input->second.shape;
@@ -45,7 +49,7 @@ class FakeDinov3Module final : public trtmc::ITrtModule {
     }
     trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
     void forward_device_async(const trtmc::DeviceTensorMap&) override {}
-    void forward_async(const trtmc::TensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override { ++forward_async_calls; }
     void sync() override {}
     cudaStream_t stream() const override { return nullptr; }
     void enable_cuda_graph() override {}
@@ -64,8 +68,12 @@ class FakeDinov3Module final : public trtmc::ITrtModule {
     bool has_output(const std::string& name) const override {
         return name == "last_hidden_state" || (include_pooler_ && name == "pooler_output");
     }
-    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        require_known_name(name);
+        return trtmc::DType::kFloat32;
+    }
     std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        require_known_name(name);
         return name == "pooler_output" ? std::vector<int64_t>{1, 2} : std::vector<int64_t>{1, 3, 2};
     }
     std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
@@ -73,17 +81,38 @@ class FakeDinov3Module final : public trtmc::ITrtModule {
         return {1, 3, 1, 1};
     }
     int32_t optimization_profile_count() const override { return 1; }
-    void* device_ptr(const std::string&) const override { return nullptr; }
+    void* device_ptr(const std::string& name) const override {
+        require_known_name(name);
+        if (!expose_device_outputs_)
+            return nullptr;
+        if (name == "last_hidden_state")
+            return const_cast<float*>(hidden_.data());
+        if (name == "pooler_output" && include_pooler_)
+            return const_cast<float*>(pooler_.data());
+        return nullptr;
+    }
     void bind_external(const std::string&, void*) override {}
+    bool input_is_dynamic(const std::string& name) const override {
+        return name == "pixel_values" && dynamic_input_;
+    }
     bool ok() const override { return true; }
     void keep_alive(std::shared_ptr<void>) override {}
 
     std::vector<int64_t> input_shape;
     std::vector<float> input_values;
     trtmc::DType input_dtype{trtmc::DType::kInt8};
+    int forward_calls{0};
+    int forward_async_calls{0};
 
   private:
+    void require_known_name(const std::string& name) const {
+        if (!has_input(name) && !has_output(name))
+            throw std::runtime_error("unexpected tensor introspection: " + name);
+    }
+
     bool include_pooler_{true};
+    bool expose_device_outputs_{false};
+    bool dynamic_input_{false};
     std::vector<float> hidden_{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F};
     std::vector<float> pooler_{7.0F, 8.0F};
 };
@@ -143,6 +172,19 @@ void test_pipeline_requires_pooler_output() {
     check(threw, "DINOv3 missing pooler_output rejected");
 }
 
+void test_dynamic_engine_uses_runtime_shape_fallback() {
+    auto module = std::make_unique<FakeDinov3Module>(true, true, true);
+    auto* module_ptr = module.get();
+    trtmc::Dinov3ImageFeaturePipeline pipeline(std::move(module), identity_config());
+    const std::vector<float> image{0.25F, 0.5F, 0.75F};
+    const auto result = pipeline.extract_image_features(image.data(), 1, 1);
+
+    check(module_ptr->forward_calls == 1, "DINOv3 dynamic engine uses synchronous fallback");
+    check(module_ptr->forward_async_calls == 0, "DINOv3 dynamic engine skips direct output path");
+    check(result.pooler_output == std::vector<float>({7, 8}),
+          "DINOv3 dynamic fallback preserves explicit pooler output");
+}
+
 void test_image_feature_capability_is_opt_in() {
     PlainPipeline pipeline;
     trtmc::IPipeline* base = &pipeline;
@@ -165,6 +207,7 @@ void test_pipeline_rejects_invalid_module() {
 int main() {
     test_pipeline_returns_both_named_outputs_with_shapes();
     test_pipeline_requires_pooler_output();
+    test_dynamic_engine_uses_runtime_shape_fallback();
     test_image_feature_capability_is_opt_in();
     test_pipeline_rejects_invalid_module();
 


### PR DESCRIPTION
## Background

DINOv3 feature extraction returned two FP32 tensors through the generic module path. That path synchronized the engine, copied both outputs into generic host staging, and then copied them again into the public result. The DINOv3 contract already requires `pooler_output` to be exactly token zero of `last_hidden_state`.

## Exit Criteria

- Preserve the public `last_hidden_state` and `pooler_output` values and shapes exactly.
- Improve batch-1 feature-extraction latency without changing the DINOv3 engine graph or parity thresholds.
- Keep the implementation entirely model-owned; do not change `IPipeline`, the generic TensorRT backend, Optimized Runtime, or EdgeLLM/Qwen paths.

## Implementation

- Validate and cache the fixed DINOv3 output metadata once when the pipeline is created.
- Enqueue the engine asynchronously, copy `last_hidden_state` directly from its device binding into the final result, and derive `pooler_output` from the copied CLS token.
- Retain the original generic path for dynamic-shape engines, alternate modules, or unexpected tensor contracts.
- Add a model-owned regression test proving dynamic engines use the fallback and preserve their explicit pooler output.

## Validation

- Focused Release C++ tests: `test_dinov3_image_preprocess` and `test_dinov3_pipeline` both passed.
- Boundary regression tests: `test_pipeline_api`, `test_optimized_runtime_host`, and `test_optimized_runtime_bundle_contract` all passed.
- `PYTHONPATH=python:. python3 -m pytest -q tests/e2e/models/dinov3/test_dinov3_e2e_static.py tests/e2e/models/dinov3/test_dinov3_report.py tests/e2e/models/dinov3/test_dinov3_vit_builder.py tests/e2e/models/dinov3/test_dinov3_convnext_builder.py`: 29 passed, 5 skipped.
- Exact-head `trtmc/premerge/required`: PASS at `388bd71b87ac0a625554e47fc0addc5af91dd051`, including Source quality, Unit, DINOv3 model proof, and Combined HTML certification.
- Full public DINOv3 ViT-S/16 TRT-vs-timm proof: passed with full cosine `0.99996831`, p01 patch cosine `0.99982997`, and relative Frobenius error `0.00797071`; all existing thresholds and exact invariants passed.
- Complete TRT feature JSON remained byte-identical to the merged implementation.
- Local GB300 / TensorRT 11.1 / FP16 / batch 1 / 224x224 / CUDA Graph benchmark at exact head `388bd71b8`: six fresh processes with 500 warmups and 1000 timed model calls each; median of per-process p50 improved from `0.410230 ms` to `0.374741 ms` (`-8.65%`, `1.095x`). Candidate and baseline used the same bundle, worker, backend, image, and timing boundary; only the DINOv3 model plugin changed.

## Notes For Future Readers

- Review `src/runtime/models/dinov3/pipeline.cpp` first; the header only stores validated static metadata, and the test covers fallback routing.
- The retained engine is batch-1 latency/granularity bound rather than compute- or HBM-saturated: profiling shows about 100 dependency-ordered kernels per query, and representative LayerNorm, FC, and attention kernels launch too few blocks to fill the GPU. Further material engine gains require deeper kernel fusion/persistent execution or more parallel work, not generic runtime changes in this PR.
- FP16 LayerNorm accumulation and removing the internal pooler binding were measured but intentionally rejected: they produced only small gains while changing numerical or engine-I/O compatibility. This PR keeps engine outputs byte-stable.
