### PR TITLE
feat(reporting): add resumable qualification reports

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -278,23 +278,41 @@ returns nonzero when any selected entry is not ready.
 ## Results and reproduction
 
 Each new run creates a unique directory below `storage.results_root`. The final
-directory contains only:
+directory contains:
 
 ```text
+artifacts/
+assets/
+report.json
 results.json
 report.html
 ```
 
-`results.json` contains resolved configuration, raw samples, timing policies,
-commands, bundle-preparation status and build time, and bounded diagnostic
-output. `report.html` shows the total campaign wall-clock span, each
-model-profile case's wall time, the family matrix, both infer-time p50 values,
-TRTMC bundle preparation, measured scopes, and traffic lights. Its self-contained
-filters search family, operation, model, or entry ID and select traffic-light or
-bundle-preparation status without a server dependency. Per-case wall time
-includes bundle preparation, GPU headroom waits, both commands, and orchestration
-overhead. It and bundle build time are reported for run observability but are
-excluded from the infer-time comparison.
+`results.json` remains the internal resume and execution record. `report.json`
+is the public, queryable qualification snapshot and contains only selected
+entries; catalog and platform exclusions are absent. `report.html` is a static
+frontend that fetches `report.json`; it does not calculate counts, classify a
+case, scan scratch directories, or reconstruct links. The schema and renderer
+are published under `assets/`.
+
+Green, yellow, and red mean the candidate and reference completed a valid
+comparison. White means a selected terminal case did not form a valid
+comparison. Pending and running entries have no light. The header therefore
+shows `Comparable results` (green/yellow/red) separately from equally prominent
+`Operational coverage` (comparable/selected plus white). Platform exclusions
+contribute to neither denominator. A targeted run publishes only the targeted
+entries even though the internal `results.json` retains the complete matrix for
+resume.
+
+Each executed candidate/reference command writes complete stdout and stderr to
+`artifacts/<case>/logs/`; `report.json` exposes only relative links to those real
+files. A preflight failure that launched no subprocess receives a published
+diagnostic log containing the captured failure and replay command. Compute
+precision identifies Reference and TRTMC independently, output validation is
+shown as the prerequisite for latency comparison, and Reference/TRTMC p50
+latencies are separate fields. Metrics, Logs, and Commands remain separate
+report entries. The run environment snapshot is published at
+`artifacts/run/environment.json`.
 
 The preparation receipt uses schema `trtmc.perf-bundle-preparation/v1`, scope
 `test_task`, and the performance run's exact `git_commit`. Each entry under

--- a/python/tensorrt_model_connect/benchmark/builder.py
+++ b/python/tensorrt_model_connect/benchmark/builder.py
@@ -214,11 +214,23 @@ class BundleBuilder:
             _remove_temporary(temporary)
             raise BenchmarkError(
                 f"bundle build for {plan.model.name} timed out after {plan.timeout_s}s; "
-                f"see {stderr_log}"
+                f"see {stderr_log}",
+                stage="build",
+                domain="harness/unknown",
+                code="bundle_build_timeout",
+                artifacts=(
+                    ("Bundle build stdout", stdout_log),
+                    ("Bundle build stderr", stderr_log),
+                ),
             ) from exc
         except OSError as exc:
             _remove_temporary(temporary)
-            raise BenchmarkError(f"cannot start bundle build for {plan.model.name}: {exc}") from exc
+            raise BenchmarkError(
+                f"cannot start bundle build for {plan.model.name}: {exc}",
+                stage="build",
+                domain="harness/unknown",
+                code="bundle_build_start_failed",
+            ) from exc
         elapsed = time.monotonic() - started
         _write_text(stdout_log, completed.stdout)
         _write_text(stderr_log, completed.stderr)
@@ -226,7 +238,14 @@ class BundleBuilder:
             _remove_temporary(temporary)
             raise BenchmarkError(
                 f"bundle build for {plan.model.name} failed with exit code "
-                f"{completed.returncode}; see {stderr_log}"
+                f"{completed.returncode}; see {stderr_log}",
+                stage="build",
+                domain="harness/unknown",
+                code="bundle_build_failed",
+                artifacts=(
+                    ("Bundle build stdout", stdout_log),
+                    ("Bundle build stderr", stderr_log),
+                ),
             )
         os.replace(temporary, plan.bundle)
         record = BundlePreparation(

--- a/python/tensorrt_model_connect/benchmark/cli.py
+++ b/python/tensorrt_model_connect/benchmark/cli.py
@@ -20,7 +20,11 @@ from .builder import BundleBuilder
 from .catalog import ManifestCatalog, expand_sweeps, find_bundle, resolve_case
 from .report import generate_collection_report
 from .service import BenchmarkService, default_output_dir
-from .types import BenchmarkError, ResolvedCase
+from .types import (
+    COMMAND_DIAGNOSTIC_PREFIX,
+    BenchmarkError,
+    ResolvedCase,
+)
 from .worker import find_worker, worker_backend_abi
 
 
@@ -98,6 +102,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         if arguments.command == "report":
             return _report(arguments)
     except BenchmarkError as exc:
+        diagnostic = exc.command_diagnostic()
+        if diagnostic is not None:
+            print(
+                COMMAND_DIAGNOSTIC_PREFIX
+                + json.dumps(diagnostic, separators=(",", ":"), sort_keys=True),
+                file=sys.stderr,
+            )
         parser.error(str(exc))
     return 2
 

--- a/python/tensorrt_model_connect/benchmark/types.py
+++ b/python/tensorrt_model_connect/benchmark/types.py
@@ -12,8 +12,44 @@ from pathlib import Path
 from typing import Any, Mapping
 
 
+COMMAND_DIAGNOSTIC_SCHEMA = "trtmc.command-diagnostic/v1"
+COMMAND_DIAGNOSTIC_PREFIX = "TRTMC_DIAGNOSTIC_JSON="
+
+
 class BenchmarkError(RuntimeError):
     """A benchmark request cannot be resolved or executed safely."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stage: str | None = None,
+        domain: str | None = None,
+        code: str | None = None,
+        artifacts: tuple[tuple[str, Path], ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.domain = domain
+        self.code = code
+        self.artifacts = artifacts
+
+    def command_diagnostic(self) -> dict[str, Any] | None:
+        """Return stable failure evidence for a supervising command runner."""
+
+        if not self.stage or not self.domain or not self.code:
+            return None
+        return {
+            "schema_version": COMMAND_DIAGNOSTIC_SCHEMA,
+            "stage": self.stage,
+            "domain": self.domain,
+            "code": self.code,
+            "artifacts": [
+                {"label": label, "path": str(path)}
+                for label, path in self.artifacts
+                if path.is_file()
+            ],
+        }
 
 
 @dataclass(frozen=True)

--- a/tests/model_checks/environments/auto-thor.yaml
+++ b/tests/model_checks/environments/auto-thor.yaml
@@ -6,6 +6,7 @@ id: auto-thor
 
 environment_variables:
   TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND: torch_sdpa
+  TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF: disable
 
 storage:
   root: ${TRTMC_CHECK_STORAGE_ROOT}

--- a/tests/tools/test_execution_ledger.py
+++ b/tests/tools/test_execution_ledger.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError
+
+
+CASES = [
+    {"id": "model-a::task-a", "model": "model-a", "task": "task-a"},
+    {"id": "model-b::task-b", "model": "model-b", "task": "task-b"},
+]
+
+
+def _ledger(tmp_path) -> ExecutionLedger:
+    return ExecutionLedger.open(
+        tmp_path,
+        campaign_id="run-1",
+        task_kind="accuracy",
+        fingerprint="revision-1",
+        cases=CASES,
+    )
+
+
+def test_open_creates_an_ordered_campaign_and_pending_receipts(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+
+    assert [case["id"] for case in ledger.cases()] == [
+        "model-a::task-a",
+        "model-b::task-b",
+    ]
+    assert [entry["receipt"]["state"] for entry in ledger.snapshot()] == [
+        "pending",
+        "pending",
+    ]
+    manifest = json.loads((tmp_path / "ledger" / "campaign.json").read_text())
+    assert manifest["fingerprint"] == "revision-1"
+    assert not list((tmp_path / "ledger").rglob("*.tmp"))
+
+
+def test_attempt_can_progress_and_publish_one_terminal_receipt(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+
+    assert ledger.begin(
+        "model-a::task-a",
+        stage="candidate",
+        evidence={"command": "run candidate"},
+    ) == 1
+    ledger.update_stage(
+        "model-a::task-a",
+        "compare",
+        evidence={"log": "candidate.log"},
+    )
+    ledger.finish(
+        "model-a::task-a",
+        result="green",
+        payload={"metric": 1.0},
+        evidence={"return_code": 0},
+    )
+
+    receipt = ledger.receipt("model-a::task-a")
+    assert receipt["state"] == "terminal"
+    assert receipt["result"] == "green"
+    assert receipt["payload"] == {"metric": 1.0}
+    assert receipt["attempts"] == [
+        {
+            "attempt": 1,
+            "state": "completed",
+            "stage": "compare",
+            "started_at": receipt["attempts"][0]["started_at"],
+            "finished_at": receipt["attempts"][0]["finished_at"],
+            "evidence": {
+                "command": "run candidate",
+                "log": "candidate.log",
+                "return_code": 0,
+            },
+        }
+    ]
+    with pytest.raises(ExecutionLedgerError, match="terminal"):
+        ledger.begin("model-a::task-a", stage="candidate")
+
+
+@pytest.mark.parametrize(
+    "stage",
+    ["preflight", "build", "reference", "candidate", "compare-or-measure"],
+)
+def test_resume_marks_running_attempt_interrupted_before_retry(tmp_path, stage) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-a::task-a", stage=stage)
+
+    reopened = _ledger(tmp_path)
+    assert reopened.recover_interrupted() == ["model-a::task-a"]
+    receipt = reopened.receipt("model-a::task-a")
+    assert receipt["state"] == "pending"
+    assert receipt["attempts"][0]["state"] == "interrupted"
+    assert receipt["attempts"][0]["stage"] == stage
+    assert reopened.begin("model-a::task-a", stage="candidate") == 2
+
+
+def test_open_rejects_campaign_identity_or_inventory_drift(tmp_path) -> None:
+    _ledger(tmp_path)
+
+    with pytest.raises(ExecutionLedgerError, match="fingerprint"):
+        ExecutionLedger.open(
+            tmp_path,
+            campaign_id="run-1",
+            task_kind="accuracy",
+            fingerprint="revision-2",
+            cases=CASES,
+        )
+    with pytest.raises(ExecutionLedgerError, match="case inventory"):
+        ExecutionLedger.open(
+            tmp_path,
+            campaign_id="run-1",
+            task_kind="accuracy",
+            fingerprint="revision-1",
+            cases=CASES[:1],
+        )
+
+
+def test_invalid_transitions_and_results_are_rejected(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+
+    with pytest.raises(ExecutionLedgerError, match="running"):
+        ledger.finish("model-a::task-a", result="red", payload={})
+    ledger.begin("model-a::task-a", stage="candidate")
+    with pytest.raises(ExecutionLedgerError, match="traffic-light"):
+        ledger.finish("model-a::task-a", result="blue", payload={})
+    with pytest.raises(ExecutionLedgerError, match="unknown case"):
+        ledger.receipt("missing")
+
+
+def test_snapshot_is_deterministic_and_ordered_by_campaign_inventory(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-b::task-b", stage="candidate")
+    ledger.finish("model-b::task-b", result="white", payload={"error": "failed"})
+
+    snapshot = ledger.snapshot()
+
+    assert [row["case"]["id"] for row in snapshot] == [
+        "model-a::task-a",
+        "model-b::task-b",
+    ]
+    assert snapshot[0]["receipt"]["state"] == "pending"
+    assert snapshot[1]["receipt"]["result"] == "white"
+
+
+def test_load_reopens_a_campaign_without_redeclaring_its_inventory(tmp_path) -> None:
+    created = _ledger(tmp_path)
+    created.begin("model-a::task-a", stage="candidate")
+
+    loaded = ExecutionLedger.load(tmp_path, task_kind="accuracy")
+
+    assert loaded.receipt("model-a::task-a")["state"] == "running"
+    with pytest.raises(ExecutionLedgerError, match="task"):
+        ExecutionLedger.load(tmp_path, task_kind="performance")
+
+
+def test_existing_campaign_rejects_a_missing_case_receipt(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    receipt_path = ledger.root / ledger._manifest["cases"][0]["receipt"]
+    receipt_path.unlink()
+
+    with pytest.raises(ExecutionLedgerError, match="missing receipt"):
+        _ledger(tmp_path)
+
+
+def test_load_rejects_corrupt_attempt_history(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-a::task-a", stage="candidate")
+    receipt_path = ledger.root / ledger._manifest["cases"][0]["receipt"]
+    receipt = json.loads(receipt_path.read_text())
+    receipt["attempts"][0]["attempt"] = 7
+    receipt_path.write_text(json.dumps(receipt))
+
+    with pytest.raises(ExecutionLedgerError, match="attempt history"):
+        ExecutionLedger.load(tmp_path)
+
+
+def test_explicit_resume_reopens_only_retryable_white_results(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-a::task-a", stage="candidate")
+    ledger.finish(
+        "model-a::task-a",
+        result="white",
+        payload={"status": "failed"},
+        attempt_outcome="failed",
+        evidence={"retryable": True},
+    )
+    ledger.begin("model-b::task-b", stage="compare")
+    ledger.finish(
+        "model-b::task-b",
+        result="white",
+        payload={"status": "contract-mismatch"},
+        evidence={"retryable": False},
+    )
+
+    assert ledger.reopen_retryable() == ["model-a::task-a"]
+    reopened = ledger.receipt("model-a::task-a")
+    assert reopened["state"] == "pending"
+    assert reopened["result"] is None
+    assert len(reopened["previous_results"]) == 1
+    previous = reopened["previous_results"][0]
+    assert previous["attempt"] == 1
+    assert previous["result"] == "white"
+    assert previous["payload"] == {"status": "failed"}
+    assert previous["finished_at"]
+    assert ledger.begin("model-a::task-a", stage="candidate") == 2
+    assert ledger.receipt("model-b::task-b")["state"] == "terminal"
+
+
+def test_load_rejects_conflicting_case_and_attempt_stage(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-a::task-a", stage="candidate")
+    receipt_path = ledger.root / ledger._manifest["cases"][0]["receipt"]
+    receipt = json.loads(receipt_path.read_text())
+    receipt["stage"] = "reference"
+    receipt_path.write_text(json.dumps(receipt))
+
+    with pytest.raises(ExecutionLedgerError, match="stage differ"):
+        ExecutionLedger.load(tmp_path)

--- a/tests/tools/test_execution_ledger.py
+++ b/tests/tools/test_execution_ledger.py
@@ -99,6 +99,29 @@ def test_resume_marks_running_attempt_interrupted_before_retry(tmp_path, stage) 
     assert reopened.begin("model-a::task-a", stage="candidate") == 2
 
 
+def test_retry_closes_only_the_active_attempt_before_starting_the_next(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.begin("model-a::task-a", stage="reference")
+
+    ledger.retry(
+        "model-a::task-a",
+        attempt_outcome="failed",
+        evidence={"return_code": 1, "retryable": True},
+    )
+
+    pending = ledger.receipt("model-a::task-a")
+    assert pending["state"] == "pending"
+    assert pending["stage"] is None
+    assert pending["active_attempt"] is None
+    assert pending["attempts"][0]["state"] == "failed"
+    assert pending["attempts"][0]["stage"] == "reference"
+    assert pending["attempts"][0]["evidence"] == {
+        "return_code": 1,
+        "retryable": True,
+    }
+    assert ledger.begin("model-a::task-a", stage="reference") == 2
+
+
 def test_open_rejects_campaign_identity_or_inventory_drift(tmp_path) -> None:
     _ledger(tmp_path)
 

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -720,25 +720,35 @@ def test_l4t_environment_selects_qualified_tensorrt_libraries() -> None:
 
 
 @pytest.mark.parametrize(
-    ("platform", "attention_backend"),
+    ("platform", "expected_environment"),
     [
-        ("l4t-thor", "torch_sdpa"),
-        ("gb300", "torch_sdpa"),
-        ("auto-thor", "torch_sdpa"),
+        (
+            "l4t-thor",
+            {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"},
+        ),
+        (
+            "gb300",
+            {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"},
+        ),
+        (
+            "auto-thor",
+            {
+                "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa",
+                "TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF": "disable",
+            },
+        ),
     ],
 )
 def test_checked_in_environment_selects_lance_reference_attention_backend(
     platform,
-    attention_backend,
+    expected_environment,
 ) -> None:
     environment = model_checks._read_yaml(
         model_checks.DEFAULT_ENVIRONMENT_ROOT / f"{platform}.yaml",
         "model-check environment",
     )
 
-    assert environment["environment_variables"] == {
-        "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": attention_backend
-    }
+    assert environment["environment_variables"] == expected_environment
 
 
 def test_l4t_excludes_consolidated_not_compared_models() -> None:

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -637,7 +637,7 @@ def test_selected_models_artifact_records_configured_bindings(tmp_path) -> None:
     assert selection.read_text(encoding="utf-8") == "model-a\nmodel-b\nmodel-c\n"
 
 
-def test_accuracy_platform_exclusions_are_reported_without_execution(tmp_path) -> None:
+def test_accuracy_platform_exclusions_are_removed_before_execution() -> None:
     plan = {
         "models": [
             {
@@ -667,72 +667,10 @@ def test_accuracy_platform_exclusions_are_reported_without_execution(tmp_path) -
             }
         ]
     }
-    output = tmp_path / "accuracy"
-
     assert [
         (binding["model"], binding["workload"])
         for binding in model_checks._task_bindings(plan, "accuracy")
     ] == [("model-a", "suite-a")]
-    written = model_checks._write_accuracy_platform_results(plan, output)
-    _, html_path, report = model_checks.trtmc_validate.write_report(output)
-
-    assert [path.relative_to(output).as_posix() for path in written] == [
-        "model-b/suite-b/comparison.json",
-        "model-c/suite-c/comparison.json",
-    ]
-    assert report["summary"]["platform_excluded"] == 2
-    assert report["summary"]["not_compared"] == 2
-    assert all(result["execution"]["status"] == "not_run" for result in report["results"])
-    assert all("platform_exclusion" in result for result in report["results"])
-    html = html_path.read_text(encoding="utf-8")
-    assert "2 platform excluded" in html
-    assert "Model is excluded from platform test-platform" in html
-    assert "qualification is intentionally deferred" in html
-
-
-def test_accuracy_platform_exclusion_does_not_replace_executed_result(tmp_path) -> None:
-    output = tmp_path / "accuracy"
-    comparison = output / "model-b" / "suite-b" / "comparison.json"
-    comparison.parent.mkdir(parents=True)
-    comparison.write_text(
-        json.dumps(
-            {
-                "model": "model-b",
-                "workload": "suite-b",
-                "execution": {"status": "completed"},
-                "validation": {"status": "passed"},
-            }
-        ),
-        encoding="utf-8",
-    )
-    plan = {
-        "models": [
-            {
-                "tasks": {
-                    "accuracy": {
-                        "bindings": [
-                            {
-                                "model": "model-b",
-                                "workload": "suite-b",
-                                "status": "excluded",
-                                "reason": "Model is excluded from platform test-platform",
-                            }
-                        ]
-                    }
-                }
-            }
-        ]
-    }
-
-    with pytest.raises(
-        model_checks.ModelCheckError,
-        match="refusing to replace a previously executed Accuracy result",
-    ):
-        model_checks._write_accuracy_platform_results(plan, output)
-
-    assert json.loads(comparison.read_text(encoding="utf-8"))["execution"] == {
-        "status": "completed"
-    }
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -1445,6 +1445,54 @@ def test_wall_time_rejects_incomplete_or_invalid_timestamps(
     assert perf_matrix._wall_time_html(record) == "—"
 
 
+def test_public_perf_result_with_unknown_precision_has_no_performance_light() -> None:
+    row = {
+        "id": "model.generate",
+        "status": "green",
+        "resolved_settings": {"model": {"precision": "fp16"}},
+        "candidate": {"precision": "fp16", "samples_ms": [10.0]},
+        "baseline": {"samples_ms": [20.0]},
+        "comparison": {},
+    }
+
+    public = perf_matrix._public_perf_result(row)
+
+    assert public["state"] == "terminal"
+    assert public["result"] == "white"
+    assert public["issue"]["code"] == "comparison_contract"
+    assert public["output_validation"]["status"] == "Pass"
+    assert public["latency"] == {"reference_ms": None, "candidate_ms": None}
+
+
+def test_cleanup_warning_does_not_replace_a_valid_performance_result() -> None:
+    row = {
+        "status": "green",
+        "resolved_settings": {
+            "baseline_precision": "fp16",
+            "model": {"precision": "fp16"},
+        },
+        "candidate": {"precision": "fp16"},
+        "warnings": [
+            {
+                "stage": "cleanup",
+                "code": "resource_cleanup_failed",
+                "message": "scratch directory retained",
+            }
+        ],
+    }
+
+    assert perf_matrix._final_status([row]) == "completed-with-warnings"
+    assert perf_matrix._perf_state_and_result(row) == ("terminal", "green")
+
+
+@pytest.mark.parametrize("status", ["pending", "running"])
+def test_public_perf_progress_has_no_traffic_light(status: str) -> None:
+    public = perf_matrix._public_perf_result({"id": "model.generate", "status": status})
+
+    assert public["state"] == status
+    assert public["result"] is None
+
+
 def test_run_consolidates_results_and_records_replayable_commands(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1483,7 +1531,10 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert len(run_directories) == 1
     output = run_directories[0]
     assert sorted(path.name for path in output.iterdir()) == [
+        "artifacts",
+        "assets",
         "report.html",
+        "report.json",
         "results.json",
     ]
     assert not scratch_root.exists()
@@ -1546,50 +1597,87 @@ def test_run_consolidates_results_and_records_replayable_commands(
     }
     assert rows["gpt2.generate"]["baseline"]["mode"] == "torch-compile"
     assert rows["mamba.generate"]["baseline_contract"]["mode"] == "hf-eager"
+    public_report = json.loads((output / "report.json").read_text(encoding="utf-8"))
+    assert public_report["schema_version"] == "trtmc.qualification-report/v1"
+    assert public_report["report_kind"] == "performance"
+    assert public_report["accounting"] == {
+        "selected": 1,
+        "comparable": 1,
+        "operational_coverage_percent": 100.0,
+        "progress": {"pending": 0, "running": 0, "terminal": 1},
+        "outcomes": {"green": 1, "yellow": 0, "red": 0, "white": 0},
+        "invariants": {
+            "selected": "pending + running + terminal",
+            "terminal": "green + yellow + red + white",
+            "comparable": "green + yellow + red",
+        },
+        "definitions": {
+            "green": {
+                "class": "valid-comparison",
+                "label": "Meets the target",
+                "denominator": "comparable",
+            },
+            "yellow": {
+                "class": "valid-comparison",
+                "label": "Valid comparison in the review band",
+                "denominator": "comparable",
+            },
+            "red": {
+                "class": "valid-comparison",
+                "label": "Valid comparison that misses the target",
+                "denominator": "comparable",
+            },
+            "white": {
+                "class": "coverage-gap",
+                "label": "No valid comparison",
+                "denominator": "selected",
+            },
+        },
+    }
+    assert len(public_report["results"]) == 1
+    public_row = public_report["results"][0]
+    assert public_row["id"] == "gpt2.generate"
+    assert public_row["state"] == "terminal"
+    assert public_row["result"] == "green"
+    assert public_row["precision"] == {
+        "reference": "fp32",
+        "candidate": "fp16",
+    }
+    assert public_row["output_validation"]["status"] == "Pass"
+    assert public_row["latency"] == {
+        "reference_ms": 20.45,
+        "candidate_ms": 10.45,
+    }
+    assert public_row["issue"] is None
+    assert all(
+        "stdout_tail" not in command and "stderr_tail" not in command
+        for command in public_row["commands"].values()
+    )
+    assert "minimax-h3-768p" not in json.dumps(public_report)
+    assert MINIMAX_H3_EXCLUSION_REASON not in json.dumps(public_report)
+    log_records = public_row["debug"]["logs"]
+    assert {record["label"] for record in log_records} == {
+        "TRTMC stdout",
+        "TRTMC stderr",
+        "Reference stdout",
+        "Reference stderr",
+    }
+    for record in log_records:
+        assert not Path(record["href"]).is_absolute()
+        assert (output / record["href"]).is_file()
+
     report = (output / "report.html").read_text(encoding="utf-8")
-    assert ">gpt2<" in report
-    assert "HF eager" in report
-    assert "77 model types" in report
-    assert "107 model comparisons" in report
-    assert "107 single-process profiles" in report
-    assert "1 explicitly excluded profile" in report
-    assert (
-        f"{expected_catalog_coverage['excluded_l0_profiles']} duplicate L0 profiles are excluded"
-    ) in report
-    assert (f"{expected_catalog_coverage['ready_profiles']} ready catalog profiles") in report
-    assert (f"{expected_catalog_coverage['distributed_profiles']} distributed profiles") in report
-    assert (
-        f"{expected_catalog_coverage['other_profiles']} other or unsupported profiles"
-    ) in report
-    assert "<th>Model</th>" in report
-    assert "<th>Task type</th>" in report
-    assert "Total campaign wall time:" in report
-    assert "<th>Model wall time</th>" in report
-    assert "not used for traffic-light classification" in report
-    assert "TRTMC infer p50 (ms)" in report
-    assert "Baseline infer p50 (ms)" in report
-    assert "TRTMC bundle preparation" in report
-    assert "Built · 1m 23.1s" in report
-    assert "83.125 s" in report
-    assert "1 built in this test task (1m 23.1s total)" in report
-    assert "excluded from the infer-time traffic-light comparison" in report
-    assert ">10.450<" in report
-    assert ">20.450<" in report
-    assert "<th>Status</th>" in report
-    assert "<td>green</td>" not in report
-    assert "Needs alignment" not in report
-    assert "Measured scope" in report
-    assert "Timing contracts were validated before execution for 1 comparisons" in report
-    assert "Measured: public pipeline call" in report
-    assert "Measured: public operation call" in report
-    assert "Includes: pipeline-internal preprocessing, model execution, returned output" in report
-    assert "Excludes: model load, compile setup, warmup" in report
-    assert "Show raw commands" in report
-    assert str(fake_trtmc) in report
-    assert str(fake_baseline) in report
-    assert "reproduce.py" not in report
-    assert str(REPOSITORY) in report
-    assert "PYTHONPATH" in report
+    assert 'data-report="report.json"' in report
+    assert "gpt2.generate" not in report
+    assert "minimax-h3-768p" not in report
+    frontend = (output / "assets/qualification-report.js").read_text(
+        encoding="utf-8"
+    )
+    assert "Comparable results" in frontend
+    assert "Operational coverage" in frontend
+    assert "Failures" in frontend
+    assert "Reference latency" in frontend
+    assert "TRTMC latency" in frontend
 
     baseline_argv = rows["gpt2.generate"]["commands"]["baseline"]["argv"]
     request = baseline_argv[baseline_argv.index("--request-json") + 1]
@@ -1612,7 +1700,10 @@ def test_run_consolidates_results_and_records_replayable_commands(
     resumed_rows = {row["id"]: row for row in resumed["cases"]}
     assert resumed_rows["gpt2.generate"]["status"] == "green"
     assert sorted(path.name for path in output.iterdir()) == [
+        "artifacts",
+        "assets",
         "report.html",
+        "report.json",
         "results.json",
     ]
     assert not scratch_root.exists()
@@ -1722,9 +1813,32 @@ def test_run_records_preflight_failure_and_finishes_campaign(
     assert row["reason"] == "profile unavailable"
     assert row["commands"]["resolve"]["rendered"].endswith("run --dry-run")
     assert sorted(path.name for path in output.iterdir()) == [
+        "artifacts",
+        "assets",
         "report.html",
+        "report.json",
         "results.json",
     ]
+    public_report = json.loads((output / "report.json").read_text(encoding="utf-8"))
+    assert public_report["accounting"]["selected"] == 1
+    assert public_report["accounting"]["comparable"] == 0
+    assert public_report["accounting"]["outcomes"]["white"] == 1
+    public_row = public_report["results"][0]
+    assert public_row["state"] == "terminal"
+    assert public_row["result"] == "white"
+    assert public_row["issue"]["stage"] == "reference-preflight"
+    assert public_row["issue"]["code"] == "execution_failure"
+    assert public_row["output_validation"]["status"] == "Not completed"
+    assert public_row["debug"]["logs"] == [
+        {
+            "label": "Reference Preflight diagnostic",
+            "href": "artifacts/gpt2.generate/logs/reference-preflight.log",
+        }
+    ]
+    diagnostic = output / public_row["debug"]["logs"][0]["href"]
+    assert diagnostic.is_file()
+    assert "profile unavailable" in diagnostic.read_text(encoding="utf-8")
+    assert "minimax-h3-768p" not in json.dumps(public_report)
     assert not scratch_root.exists()
 
 

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -1464,6 +1464,95 @@ def test_public_perf_result_with_unknown_precision_has_no_performance_light() ->
     assert public["latency"] == {"reference_ms": None, "candidate_ms": None}
 
 
+def test_public_perf_result_surfaces_quantized_candidate_precision() -> None:
+    row = {
+        "id": "qwen.generate@qwen3-0.6b-fp8",
+        "status": "green",
+        "resolved_settings": {
+            "baseline_precision": "fp16",
+            "model": {
+                "precision": "fp16",
+                "build": {"quantization": {"format": "fp8"}},
+            },
+            "output_contract": "exact-token-ids",
+        },
+        "candidate": {"precision": "fp16", "samples_ms": [5.0]},
+        "baseline": {"precision": "fp16", "samples_ms": [16.0]},
+        "comparison": {},
+    }
+
+    public = perf_matrix._public_perf_result(row)
+
+    assert public["precision"] == {
+        "reference": "fp16",
+        "candidate": "fp8 (fp16 base)",
+    }
+
+
+def test_command_diagnostic_materializes_nested_build_logs(tmp_path: Path) -> None:
+    build_stderr = tmp_path / "bundle-cache" / "build.stderr.log"
+    build_stderr.parent.mkdir()
+    build_stderr.write_text("builder crashed\n", encoding="utf-8")
+    diagnostic = {
+        "schema_version": "trtmc.command-diagnostic/v1",
+        "stage": "build",
+        "domain": "harness/unknown",
+        "code": "bundle_build_failed",
+        "artifacts": [
+            {"label": "Bundle build stderr", "path": str(build_stderr)}
+        ],
+    }
+    command = {
+        "stdout": "",
+        "stderr": (
+            "bundle build failed\n"
+            f"TRTMC_DIAGNOSTIC_JSON={json.dumps(diagnostic, separators=(',', ':'))}\n"
+        ),
+    }
+
+    parsed = perf_matrix._command_diagnostic(command["stderr"])
+    command["diagnostic"] = parsed
+    links = perf_matrix._materialize_command_logs(
+        tmp_path / "report",
+        "gpt2.generate",
+        "trtmc",
+        command,
+    )
+
+    nested = next(item for item in links if item["label"] == "Bundle build stderr")
+    published = tmp_path / "report" / nested["href"]
+    assert published.read_text(encoding="utf-8") == "builder crashed\n"
+    assert not published.is_symlink()
+    assert command["diagnostic"] == {
+        "schema_version": "trtmc.command-diagnostic/v1",
+        "stage": "build",
+        "domain": "harness/unknown",
+        "code": "bundle_build_failed",
+        "artifacts": [nested],
+    }
+
+
+def test_perf_issue_uses_structured_command_failure() -> None:
+    issue = perf_matrix._perf_issue(
+        {
+            "status": "failed",
+            "reason": "trtmc command failed with rc=2",
+            "failure_stage": "build",
+            "failure_domain": "harness/unknown",
+            "failure_code": "bundle_build_failed",
+        },
+        "white",
+    )
+
+    assert issue == {
+        "priority": "P1",
+        "stage": "build",
+        "domain": "harness/unknown",
+        "code": "bundle_build_failed",
+        "message": "trtmc command failed with rc=2",
+    }
+
+
 def test_cleanup_warning_does_not_replace_a_valid_performance_result() -> None:
     row = {
         "status": "green",

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -800,11 +800,16 @@ def test_backend_waits_for_gpu_headroom_before_each_command(
         Namespace(timeout_seconds=30, minimum_gpu_free_fraction=0.25, verbose=False),
         tmp_path,
         row,
+        progress=lambda stage, evidence: events.append(
+            ("progress", stage, tuple(evidence["commands"]))
+        ),
     )
 
     assert events == [
+        ("progress", "candidate", ("trtmc", "baseline")),
         ("wait", 0.25),
         ("run", "candidate"),
+        ("progress", "reference", ("trtmc", "baseline")),
         ("wait", 0.25),
         ("run", "baseline"),
     ]
@@ -832,6 +837,186 @@ def test_backend_waits_for_gpu_headroom_before_each_command(
 )
 def test_resume_keeps_terminal_comparison_results(status: str) -> None:
     assert perf_matrix._should_skip({"status": status})
+
+
+def test_performance_projection_is_rebuilt_from_ordered_live_receipts(tmp_path) -> None:
+    base_rows = [
+        {
+            "id": "model-a.generate",
+            "family": "family-a",
+            "operation": "generate",
+            "model": "model-a",
+            "status": "pending",
+        },
+        {
+            "id": "model-b.generate",
+            "family": "family-b",
+            "operation": "generate",
+            "model": "model-b",
+            "status": "pending",
+        },
+    ]
+    ledger = perf_matrix.ExecutionLedger.open(
+        tmp_path,
+        campaign_id="run-1",
+        task_kind="performance",
+        fingerprint="revision-1",
+        cases=[
+            {"id": row["id"], "report": row}
+            for row in base_rows
+        ],
+    )
+    terminal = {
+        **base_rows[0],
+        "status": "contract-mismatch",
+        "reason": "outputs differ",
+    }
+    ledger.begin("model-a.generate", stage="candidate")
+    ledger.finish("model-a.generate", result="white", payload=terminal)
+    results = {
+        "selected_entry_ids": ["model-a.generate", "model-b.generate"],
+        "cases": [{**base_rows[0], "status": "green"}, {**base_rows[1], "status": "red"}],
+    }
+
+    perf_matrix._sync_perf_results_from_ledger(results, ledger)
+
+    assert results["cases"] == [
+        {**terminal, "progress": {"stage": "candidate", "attempt": 1}},
+        {
+            **base_rows[1],
+            "commands": {},
+            "logs": [],
+            "progress": {"stage": None, "attempt": 0},
+        },
+    ]
+
+
+def test_performance_projection_rejects_receipt_classification_drift(tmp_path) -> None:
+    row = {
+        "id": "model-a.generate",
+        "family": "family-a",
+        "operation": "generate",
+        "model": "model-a",
+        "status": "pending",
+    }
+    ledger = perf_matrix.ExecutionLedger.open(
+        tmp_path,
+        campaign_id="run-1",
+        task_kind="performance",
+        fingerprint="revision-1",
+        cases=[{"id": row["id"], "report": row}],
+    )
+    ledger.begin(row["id"], stage="candidate")
+    ledger.finish(row["id"], result="green", payload={**row, "status": "failed"})
+
+    with pytest.raises(perf_matrix.PerfMatrixError, match="ledger result mismatch"):
+        perf_matrix._sync_perf_results_from_ledger(
+            {"selected_entry_ids": [row["id"]], "cases": [row]},
+            ledger,
+        )
+
+
+def test_performance_adapter_resumes_an_interrupted_case_as_a_new_attempt(
+    tmp_path, monkeypatch
+) -> None:
+    case = next(
+        row
+        for row in perf_matrix._cases(perf_matrix._read_yaml(SUITE))
+        if row["id"] == "gpt2.generate"
+    )
+    results = {
+        "run_id": "run-1",
+        "git_commit": "revision-1",
+        "suite_sha256": "suite-1",
+        "environment_config": {"sha256": "environment-1"},
+        "selected_entry_ids": [case["id"]],
+        "cases": [perf_matrix._pending_perf_row(case)],
+    }
+    options = perf_matrix.RunOptions(
+        output=tmp_path / "output",
+        scratch_root=tmp_path / "scratch",
+        trtmc_bench="trtmc-bench",
+        trtmc_worker=None,
+        hf_transformers_runner=tmp_path / "reference.py",
+        task_reference_runner=tmp_path / "task_reference.py",
+        bundle_cache=None,
+        bundle_roots=(),
+        runtime_dirs=(),
+        local_files_only=True,
+        minimum_free_space_gib=0,
+        minimum_gpu_free_fraction=0,
+        timeout_seconds=1,
+    )
+    contract = perf_matrix.timing_contract(
+        runner=case["baseline"]["runner"], family=case["family"]
+    )
+    preflight = {
+        case["id"]: (
+            {
+                "measurement": {"timing_scope": contract["candidate_timing_scope"]},
+                "_candidate_build_python_profile": "test-build",
+            },
+            [],
+            {},
+        )
+    }
+    arguments = {
+        "selected": [case],
+        "options": options,
+        "results": results,
+        "preflight": preflight,
+        "preflight_failures": {},
+        "reference_preflight": {},
+        "worker": {},
+        "storage_preflight": {},
+    }
+    def interrupt_with_leaf_commands(*_args, **kwargs):
+        kwargs["progress"](
+            "reference",
+            {
+                "commands": {
+                    "resolve": {},
+                    "trtmc": {"argv": ["trtmc-bench"], "cwd": str(REPOSITORY)},
+                    "baseline": {"argv": ["reference"], "cwd": str(REPOSITORY)},
+                }
+            },
+        )
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(perf_matrix, "_run_one", interrupt_with_leaf_commands)
+
+    with pytest.raises(KeyboardInterrupt):
+        perf_matrix._execute_campaign(**arguments)
+    ledger = perf_matrix.ExecutionLedger.load(options.output, task_kind="performance")
+    running = ledger.receipt(case["id"])
+    assert running["state"] == "running"
+    evidence = running["attempts"][0]["evidence"]
+    assert set(evidence["commands"]) == {"resolve", "trtmc", "baseline"}
+    assert evidence["commands"]["trtmc"]["argv"] == ["trtmc-bench"]
+    assert len(evidence["logs"]) == 4
+    assert all((options.output / log["href"]).is_file() for log in evidence["logs"])
+    live = json.loads((options.output / "report.json").read_text(encoding="utf-8"))
+    assert live["results"][0]["progress"] == {"stage": "reference", "attempt": 1}
+    assert len(live["results"][0]["debug"]["logs"]) == 4
+
+    monkeypatch.setattr(
+        perf_matrix,
+        "_run_one",
+        lambda *_args, **_kwargs: {
+            **perf_matrix._pending_perf_row(case),
+            "status": "failed",
+            "reason": "candidate failed",
+            "commands": {},
+        },
+    )
+
+    assert perf_matrix._execute_campaign(**arguments) == 1
+    receipt = ledger.receipt(case["id"])
+    assert receipt["state"] == "terminal"
+    assert [(attempt["attempt"], attempt["state"]) for attempt in receipt["attempts"]] == [
+        (1, "interrupted"),
+        (2, "failed"),
+    ]
 
 
 def test_timing_scope_details_state_measured_included_and_excluded_work() -> None:
@@ -1603,6 +1788,25 @@ def test_run_consolidates_results_and_records_replayable_commands(
         trtmc_worker=fake_worker,
         hf_transformers_runner=fake_baseline,
     )
+    original_preflight = perf_matrix._preflight_selected
+    preflight_calls = 0
+
+    def preflight_after_pending_report(cases, options):
+        nonlocal preflight_calls
+        preflight_calls += 1
+        live = json.loads((options.output / "report.json").read_text(encoding="utf-8"))
+        selected = [row for row in live["results"] if row["id"] == "gpt2.generate"]
+        if preflight_calls == 1:
+            assert [(row["state"], row["result"]) for row in selected] == [
+                ("pending", None)
+            ]
+        return original_preflight(cases, options)
+
+    monkeypatch.setattr(
+        perf_matrix,
+        "_preflight_selected",
+        preflight_after_pending_report,
+    )
 
     exit_code = perf_matrix.main(
         [
@@ -1622,6 +1826,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert sorted(path.name for path in output.iterdir()) == [
         "artifacts",
         "assets",
+        "ledger",
         "report.html",
         "report.json",
         "results.json",
@@ -1783,14 +1988,26 @@ def test_run_consolidates_results_and_records_replayable_commands(
     (output / "results.json").write_text(
         json.dumps(results, indent=2) + "\n", encoding="utf-8"
     )
+    receipt_path = next((output / "ledger" / "cases").glob("*/receipt.json"))
+    receipt_mtime = receipt_path.stat().st_mtime_ns
+
+    assert perf_matrix.main(["report", str(output)]) == 0
+    rebuilt = json.loads((output / "report.json").read_text(encoding="utf-8"))
+    assert rebuilt["results"][0]["result"] == "green"
+    rows["gpt2.generate"]["status"] = "failed"
+    (output / "results.json").write_text(
+        json.dumps(results, indent=2) + "\n", encoding="utf-8"
+    )
 
     assert perf_matrix.main(["resume", str(output)]) == 0
+    assert receipt_path.stat().st_mtime_ns == receipt_mtime
     resumed = json.loads((output / "results.json").read_text(encoding="utf-8"))
     resumed_rows = {row["id"]: row for row in resumed["cases"]}
     assert resumed_rows["gpt2.generate"]["status"] == "green"
     assert sorted(path.name for path in output.iterdir()) == [
         "artifacts",
         "assets",
+        "ledger",
         "report.html",
         "report.json",
         "results.json",
@@ -1904,6 +2121,7 @@ def test_run_records_preflight_failure_and_finishes_campaign(
     assert sorted(path.name for path in output.iterdir()) == [
         "artifacts",
         "assets",
+        "ledger",
         "report.html",
         "report.json",
         "results.json",

--- a/tests/tools/test_qualification_report.py
+++ b/tests/tools/test_qualification_report.py
@@ -112,6 +112,30 @@ def test_materialized_html_is_a_renderer_and_not_a_result_source(tmp_path) -> No
     assert (tmp_path / report["run"]["environment_href"]).is_file()
     assert not list(tmp_path.glob(".report.json.*.tmp"))
 
+    static_paths = [
+        html_path,
+        tmp_path / "assets/qualification-report.css",
+        tmp_path / "assets/qualification-report.js",
+        tmp_path / "assets/qualification-report.schema.json",
+    ]
+    mtimes = {path: path.stat().st_mtime_ns for path in static_paths}
+    qualification_report.materialize_report(
+        tmp_path,
+        report_kind="accuracy",
+        title="Accuracy qualification",
+        identity={"run_id": "run-1"},
+        run={"source_revision": "abc123"},
+        results=[
+            {
+                "id": "model-a::task-a",
+                "model": "model-a",
+                "state": "terminal",
+                "result": "green",
+            }
+        ],
+    )
+    assert {path: path.stat().st_mtime_ns for path in static_paths} == mtimes
+
 
 def test_white_case_without_process_output_gets_a_clickable_diagnostic_log(
     tmp_path,

--- a/tests/tools/test_qualification_report.py
+++ b/tests/tools/test_qualification_report.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from tools import qualification_report
+
+
+def test_outcome_accounting_separates_progress_coverage_and_results() -> None:
+    accounting = qualification_report.outcome_accounting(
+        [
+            {"state": "pending", "result": None},
+            {"state": "running", "result": None},
+            {"state": "terminal", "result": "green"},
+            {"state": "terminal", "result": "yellow"},
+            {"state": "terminal", "result": "red"},
+            {"state": "terminal", "result": "white"},
+        ]
+    )
+
+    assert accounting["selected"] == 6
+    assert accounting["comparable"] == 3
+    assert accounting["operational_coverage_percent"] == 50.0
+    assert accounting["progress"] == {"pending": 1, "running": 1, "terminal": 4}
+    assert accounting["outcomes"] == {
+        "green": 1,
+        "yellow": 1,
+        "red": 1,
+        "white": 1,
+    }
+
+
+def test_outcome_accounting_does_not_allow_a_light_for_running_case() -> None:
+    with pytest.raises(
+        qualification_report.QualificationReportError,
+        match="running case cannot have",
+    ):
+        qualification_report.outcome_accounting(
+            [{"state": "running", "result": "white"}]
+        )
+
+
+@pytest.mark.parametrize(
+    ("green", "yellow", "red", "white", "selected", "comparable"),
+    [
+        (87, 0, 8, 0, 95, 95),
+        (73, 0, 8, 16, 97, 81),
+        (71, 7, 14, 3, 95, 92),
+        (60, 6, 16, 15, 97, 82),
+    ],
+)
+def test_audited_campaign_accounting_after_exclusions_are_removed(
+    green: int,
+    yellow: int,
+    red: int,
+    white: int,
+    selected: int,
+    comparable: int,
+) -> None:
+    rows = [
+        {"state": "terminal", "result": result}
+        for result, count in (
+            ("green", green),
+            ("yellow", yellow),
+            ("red", red),
+            ("white", white),
+        )
+        for _ in range(count)
+    ]
+
+    accounting = qualification_report.outcome_accounting(rows)
+
+    assert accounting["selected"] == selected
+    assert accounting["comparable"] == comparable
+    assert accounting["outcomes"] == {
+        "green": green,
+        "yellow": yellow,
+        "red": red,
+        "white": white,
+    }
+
+
+def test_materialized_html_is_a_renderer_and_not_a_result_source(tmp_path) -> None:
+    json_path, html_path, report = qualification_report.materialize_report(
+        tmp_path,
+        report_kind="accuracy",
+        title="Accuracy qualification",
+        identity={"run_id": "run-1"},
+        run={"source_revision": "abc123"},
+        results=[
+            {
+                "id": "model-a::task-a",
+                "model": "model-a",
+                "state": "terminal",
+                "result": "green",
+            }
+        ],
+    )
+
+    assert json.loads(json_path.read_text(encoding="utf-8")) == report
+    assert report["$schema"] == "assets/qualification-report.schema.json"
+    document = html_path.read_text(encoding="utf-8")
+    assert 'data-report="report.json"' in document
+    assert "model-a" not in document
+    assert "Comparable results" not in document
+    assert (tmp_path / "assets/qualification-report.css").is_file()
+    assert (tmp_path / "assets/qualification-report.js").is_file()
+    assert (tmp_path / "assets/qualification-report.schema.json").is_file()
+    assert report["run"]["environment_href"] == "artifacts/run/environment.json"
+    assert (tmp_path / report["run"]["environment_href"]).is_file()
+    assert not list(tmp_path.glob(".report.json.*.tmp"))
+
+
+def test_white_case_without_process_output_gets_a_clickable_diagnostic_log(
+    tmp_path,
+) -> None:
+    _, _, report = qualification_report.materialize_report(
+        tmp_path,
+        report_kind="performance",
+        title="Performance qualification",
+        identity={"run_id": "run-1"},
+        run={},
+        results=[
+            {
+                "id": "model-a.generate",
+                "state": "terminal",
+                "result": "white",
+                "issue": {
+                    "priority": "P1",
+                    "stage": "reference-preflight",
+                    "domain": "harness/unknown",
+                    "code": "execution_failure",
+                    "message": "profile unavailable",
+                },
+                "commands": {"resolve": {"rendered": "trtmc-bench run --dry-run"}},
+                "debug": {"logs": []},
+            }
+        ],
+    )
+
+    log = report["results"][0]["debug"]["logs"][0]
+    assert log["label"] == "Reference Preflight diagnostic"
+    assert not log["href"].startswith("/")
+    assert "profile unavailable" in (tmp_path / log["href"]).read_text(encoding="utf-8")
+
+
+def test_materializer_rejects_machine_absolute_artifact_links(tmp_path) -> None:
+    absolute_log = tmp_path / "worker.log"
+    absolute_log.write_text("failure\n", encoding="utf-8")
+
+    with pytest.raises(
+        qualification_report.QualificationReportError,
+        match="must be relative",
+    ):
+        qualification_report.materialize_report(
+            tmp_path,
+            report_kind="accuracy",
+            title="Accuracy qualification",
+            identity={"run_id": "run-1"},
+            run={},
+            results=[
+                {
+                    "id": "model-a::task-a",
+                    "state": "terminal",
+                    "result": "white",
+                    "issue": {
+                        "priority": "P1",
+                        "stage": "candidate",
+                        "domain": "harness/unknown",
+                        "code": "execution_error",
+                        "message": "failed",
+                    },
+                    "debug": {"logs": [{"label": "worker", "href": str(absolute_log)}]},
+                }
+            ],
+        )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1729,7 +1729,12 @@ class TestUnitTiers:
     @pytest.mark.parametrize(
         "path",
         [
+            "tools/execution_ledger.py",
             "tools/perf_matrix.py",
+            "tools/qualification_report.py",
+            "tools/qualification_report_assets/qualification-report.css",
+            "tools/qualification_report_assets/qualification-report.js",
+            "tools/qualification_report_assets/qualification-report.schema.json",
             "tools/reporting_html.py",
         ],
     )

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -1390,6 +1390,51 @@ def test_cli_auto_builds_missing_bundle_then_reuses_cache(
     assert cached["builder_tensorrt_version"]
 
 
+def test_cli_emits_structured_bundle_build_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    worker = _worker(tmp_path)
+    cache = tmp_path / "cache"
+
+    def fail_build(
+        command: list[str], _environment: dict[str, str], _timeout_s: int
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, -11, "builder stdout\n", "segfault\n")
+
+    monkeypatch.setenv("TRTMC_BENCH_BUILD_PLATFORM", "test-sm80")
+    monkeypatch.setattr(BundleBuilder, "_execute", staticmethod(fail_build))
+
+    with pytest.raises(SystemExit, match="2"):
+        main(
+            [
+                "run",
+                "--model",
+                "distilgpt2",
+                "--bundle-cache",
+                str(cache),
+                "--worker",
+                str(worker),
+                "-o",
+                str(tmp_path / "result"),
+            ]
+        )
+
+    marker = next(
+        line.split("=", 1)[1]
+        for line in capsys.readouterr().err.splitlines()
+        if line.startswith("TRTMC_DIAGNOSTIC_JSON=")
+    )
+    diagnostic = json.loads(marker)
+    assert diagnostic["stage"] == "build"
+    assert diagnostic["domain"] == "harness/unknown"
+    assert diagnostic["code"] == "bundle_build_failed"
+    artifacts = {item["label"]: Path(item["path"]) for item in diagnostic["artifacts"]}
+    assert artifacts["Bundle build stdout"].read_text(encoding="utf-8") == "builder stdout\n"
+    assert artifacts["Bundle build stderr"].read_text(encoding="utf-8") == "segfault\n"
+
+
 def test_cli_rebuilds_stale_managed_bundle_found_by_bundle_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 from datetime import datetime, timezone
 import json
 import os
@@ -2219,6 +2220,7 @@ def test_print_result_verbose_exposes_raw_commands_and_result_locations(tmp_path
         "  trtmc run --model model-a\n"
         "\n"
         f"Compare result: {comparison}\n"
+        f"Report data:   {report.with_name('report.json')}\n"
         f"Report:         {report}\n"
     )
     assert "package" not in output.lower()
@@ -2296,6 +2298,10 @@ def test_write_report_links_each_comparison(tmp_path):
                 "task_type": "Text → Audio",
                 "user_contract": "tts_audio",
                 "status": "passed",
+                "precision_contract": {
+                    "trtmc_base_precision": "fp16",
+                    "reference_precision": "fp16",
+                },
                 "reference_environment": [
                     {"name": "reference_common", "python": "/profiles/python"}
                 ],
@@ -2325,7 +2331,6 @@ def test_write_report_links_each_comparison(tmp_path):
         "validation_passed": 1,
         "validation_failed": 0,
         "validation_skipped": 0,
-        "platform_excluded": 0,
         "selected_samples": 100,
     }
     assert report["validation_status"] == "passed"
@@ -2333,40 +2338,27 @@ def test_write_report_links_each_comparison(tmp_path):
     assert report["results"][0]["comparison"]["status"] == "agreement"
     assert report["results"][0]["validation"]["status"] == "passed"
     assert "status" not in report["results"][0]
+    assert report["schema_version"] == "trtmc.qualification-report/v1"
+    assert report["accounting"]["selected"] == 1
+    assert report["accounting"]["comparable"] == 1
+    assert report["accounting"]["outcomes"] == {
+        "green": 1,
+        "red": 0,
+        "white": 0,
+        "yellow": 0,
+    }
+    assert report["results"][0]["result"] == "green"
     assert json_path == tmp_path / "report.json"
     assert html_path == tmp_path / "report.html"
     document = html_path.read_text(encoding="utf-8")
-    assert "model-a/workload-a/comparison.json" in document
-    assert "Agreement" in document
-    assert "Completed" in document
-    assert "TRTMC Reference Consistency Report" in document
-    assert "🟢 1 &nbsp; 🟡 0 &nbsp;" in document
-    assert "🔴 0 &nbsp; ⚪ 0" in document
-    assert "Vanilla reproduction" in document
-    assert "<th>Model type</th>" in document
-    assert "<th>Operation</th>" in document
-    assert "<th>Model</th>" in document
-    assert "<th>Task type</th>" in document
-    assert "Text → Audio" in document
-    assert "tts_audio" in document
-    assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
-    assert "Dataset slice (100 samples)" in document
-    assert "<th>Samples</th>" in document
-    assert "<td>100</td>" in document
+    assert 'data-report="report.json"' in document
+    assert "model-a" not in document
+    assert (tmp_path / "assets/qualification-report.js").is_file()
+    assert (tmp_path / "assets/qualification-report.css").is_file()
     assert report["summary"]["selected_samples"] == 100
-    assert "prepared inputs" not in document
-    assert "$ python tools/trtmc_validate.py model-a" in document
-    assert "$ python hf.py" in document
-    assert "$ trtmc run" in document
-    assert 'id="report-filter-search"' in document
-    assert 'id="report-filter-model-type"' in document
-    assert 'id="report-filter-operation"' in document
-    assert 'id="report-filter-task-type"' in document
-    assert 'id="report-filter-status"' in document
-    assert 'data-filter-model-type="example"' in document
-    assert 'data-filter-operation="generate_audio"' in document
-    assert 'data-filter-task-type="Text → Audio"' in document
-    assert 'data-filter-status="green"' in document
+    frontend = (tmp_path / "assets/qualification-report.js").read_text(encoding="utf-8")
+    assert "Complete qualification register" in frontend
+    assert "Vanilla reproduction" in frontend
 
 
 @pytest.mark.parametrize(
@@ -2426,9 +2418,11 @@ def test_write_report_surfaces_quantized_reference_precision_contract(
         "reference_dtype": "bfloat16",
         "comparison": "quantized_vs_unquantized_reference",
     }
-    document = html_path.read_text(encoding="utf-8")
-    assert "TRTMC FP8 (BF16 base) vs HF BF16" in document
-    assert "Quantized candidate vs unquantized reference" in document
+    assert report["results"][0]["precision"] == {
+        "reference": "bf16",
+        "candidate": "fp8 (bf16 base)",
+    }
+    assert "quantized-model" not in html_path.read_text(encoding="utf-8")
 
 
 def test_report_infers_task_type_for_legacy_standard_result(tmp_path):
@@ -2460,31 +2454,139 @@ def test_report_infers_task_type_for_legacy_standard_result(tmp_path):
     assert result["task_strategy"] == "text_to_audio"
     assert result["task_type"] == "Text → Audio"
     assert result["user_contract"] == "tts_audio"
-    document = html_path.read_text(encoding="utf-8")
-    assert "<strong>Text → Audio</strong>" in document
-    assert '<div class="detail">tts_audio</div>' in document
+    assert "bark-large" not in html_path.read_text(encoding="utf-8")
 
 
-def test_traffic_light_counts_are_mutually_exclusive():
+def test_accuracy_traffic_light_statuses_are_mutually_exclusive():
     def result(validation, comparison):
         return {
+            "execution": {"status": "completed"},
             "validation": {"status": validation},
             "comparison": {"status": comparison},
+            "precision_contract": {
+                "trtmc_base_precision": "fp16",
+                "reference_precision": "fp16",
+            },
         }
 
-    assert trtmc_validate._traffic_light_counts(
-        [
+    statuses = [
+        trtmc_validate._traffic_light_status(value)
+        for value in [
             result("passed", "agreement"),
             result("skipped", "not_run"),
             result("failed", "disagreement"),
             result("not_compared", "not_run"),
         ]
-    ) == {
+    ]
+
+    assert Counter(statuses) == {
         "green": 1,
-        "yellow": 1,
         "red": 1,
-        "white": 1,
+        "white": 2,
     }
+
+
+def test_accuracy_result_with_unknown_precision_has_no_result_light() -> None:
+    result = {
+        "execution": {"status": "completed"},
+        "validation": {"status": "passed"},
+        "comparison": {"status": "agreement"},
+    }
+
+    assert trtmc_validate._traffic_light_status(result) == "white"
+    assert trtmc_validate._accuracy_issue(result) == {
+        "priority": "P1",
+        "stage": "preflight",
+        "domain": "policy-config",
+        "code": "comparison_contract",
+        "message": "Reference and TRTMC compute precision were not both recorded",
+    }
+
+
+def test_write_report_removes_legacy_platform_exclusion_rows(tmp_path: Path) -> None:
+    selected = tmp_path / "model-a" / "suite-a"
+    selected.mkdir(parents=True)
+    (selected / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "suite-a",
+                "execution": {"status": "completed", "exit_code": 0},
+                "comparison": {
+                    "status": "agreement",
+                    "mode": "test",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "passed"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    excluded = tmp_path / "excluded-model" / "suite-b"
+    excluded.mkdir(parents=True)
+    (excluded / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "excluded-model",
+                "workload": "suite-b",
+                "execution": {"status": "not_run", "exit_code": None},
+                "comparison": {
+                    "status": "not_run",
+                    "mode": "platform_exclusion",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "not_compared"},
+                "platform_exclusion": {"reason": "not supported"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    json_path, _, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["accounting"]["selected"] == 1
+    assert [row["model"] for row in report["results"]] == ["model-a"]
+    assert "excluded-model" not in json_path.read_text(encoding="utf-8")
+
+
+def test_accuracy_report_publishes_direct_relative_log_links(tmp_path: Path) -> None:
+    case_dir = tmp_path / "model-a" / "suite-a"
+    case_dir.mkdir(parents=True)
+    (case_dir / "worker.log").write_text("raw worker output\n", encoding="utf-8")
+    (case_dir / "execution.log").write_text("raw execution output\n", encoding="utf-8")
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "suite-a",
+                "execution": {"status": "error", "exit_code": 1},
+                "comparison": {
+                    "status": "not_run",
+                    "mode": "",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "failed"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, _, report = trtmc_validate.write_report(tmp_path)
+
+    row = report["results"][0]
+    assert row["result"] == "white"
+    assert row["issue"]["stage"] == "candidate"
+    assert row["debug"]["logs"] == [
+        {"label": "execution.log", "href": "model-a/suite-a/execution.log"},
+        {"label": "worker.log", "href": "model-a/suite-a/worker.log"},
+    ]
+    assert all((tmp_path / item["href"]).is_file() for item in row["debug"]["logs"])
 
 
 def test_diffusion_report_flattens_nested_reference_metrics():
@@ -2621,10 +2723,13 @@ def test_legacy_e2e_result_is_not_reported_as_reference_agreement(tmp_path):
     assert result["comparison"]["status"] == "not_run"
     assert result["validation"]["status"] == "not_compared"
     assert result["not_compared_reason"] == trtmc_validate.LEGACY_E2E_REASON
-    document = html_path.read_text(encoding="utf-8")
-    assert "🟢 0 &nbsp; 🟡 0 &nbsp;" in document
-    assert "🔴 0 &nbsp; ⚪ 1" in document
-    assert "E2E execution does not compare aligned reference" in document
+    assert report["accounting"]["outcomes"] == {
+        "green": 0,
+        "yellow": 0,
+        "red": 0,
+        "white": 1,
+    }
+    assert "model-a" not in html_path.read_text(encoding="utf-8")
 
 
 def test_not_compared_result_replaces_legacy_e2e_row_without_deleting_evidence(
@@ -2678,7 +2783,7 @@ def test_write_report_records_total_duration(tmp_path, monkeypatch):
     _, html_path, report = trtmc_validate.write_report(tmp_path)
 
     assert report["summary"]["duration_seconds"] == 10_923.5
-    assert "3h 02m 04s total duration" in html_path.read_text(encoding="utf-8")
+    assert "10923.5" not in html_path.read_text(encoding="utf-8")
 
 
 def test_write_report_preserves_finalized_duration(tmp_path, monkeypatch):
@@ -2701,7 +2806,7 @@ def test_write_report_preserves_finalized_duration(tmp_path, monkeypatch):
     _, html_path, report = trtmc_validate.write_report(tmp_path)
 
     assert report["summary"]["duration_seconds"] == 10.0
-    assert "0h 00m 10s total duration" in html_path.read_text(encoding="utf-8")
+    assert "10.0" not in html_path.read_text(encoding="utf-8")
 
 
 def test_write_report_does_not_render_validation_wrapper(tmp_path):
@@ -2726,9 +2831,7 @@ def test_write_report_does_not_render_validation_wrapper(tmp_path):
     _, html_path, _ = trtmc_validate.write_report(tmp_path)
 
     document = html_path.read_text(encoding="utf-8")
-    assert "python hf.py --prompt &#x27;&lt;hello&gt;&#x27;" in document
-    assert "Not reached; see comparison.json." in document
-    assert "validation/engine.py" not in document
+    assert "python hf.py" not in document
     migrated = json.loads((case_dir / "comparison.json").read_text(encoding="utf-8"))
     assert "validation" not in migrated["reproduce"]
     assert set(migrated["reproduce"]) == {
@@ -2775,7 +2878,7 @@ def test_write_report_recovers_json_logged_runner_command(tmp_path):
         "trtmc build",
         "trtmc solve model.bundle --field-input 1,2",
     ]
-    assert "$ trtmc solve model.bundle --field-input 1,2" in html_path.read_text(encoding="utf-8")
+    assert "trtmc solve model.bundle --field-input 1,2" in json.dumps(report)
 
 
 def test_report_bounds_large_sample_commands_and_selects_disagreement(tmp_path):
@@ -2836,8 +2939,7 @@ def test_report_bounds_large_sample_commands_and_selects_disagreement(tmp_path):
     assert reproduction["command_logs"]["trtmc"] == ["bundle_run.log"]
     assert "prompt-5000" not in json.dumps(report)
     document = html_path.read_text(encoding="utf-8")
-    assert "Showing 1 of 10000 commands" in document
-    assert "prompt-9999" in document
+    assert "prompt-9999" not in document
     assert "prompt-5000" not in document
     assert (case_dir / "comparison.json").stat().st_size < 20_000
     assert (tmp_path / "report.json").stat().st_size < 20_000
@@ -2939,7 +3041,14 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
                 "model": "model-a",
                 "workload": "workload-a",
                 "status": "failed",
-                "raw_result": {"status": "failed", "work_dir": str(work_dir)},
+                "raw_result": {
+                    "status": "failed",
+                    "work_dir": str(work_dir),
+                    "precision_contract": {
+                        "trtmc_base_precision": "fp16",
+                        "reference_precision": "fp16",
+                    },
+                },
             }
         ),
         encoding="utf-8",
@@ -2965,13 +3074,8 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
         encoding="utf-8"
     ) == json.dumps(prompt, ensure_ascii=False) + "\n"
     rendered = html_path.read_text(encoding="utf-8")
-    assert "1 failed samples · results and vanilla commands" in rendered
-    assert "Reference result" in rendered
-    assert "TRTMC result" in rendered
-    assert "reference answer" in rendered
-    assert "TRTMC answer" in rendered
-    assert "Reference vanilla command" in rendered
-    assert "TRTMC vanilla command" in rendered
+    assert "reference answer" not in rendered
+    assert report["results"][0]["result"] == "red"
     for wrapper in (
         "validation/engine.py",
         "trtmc_compare.py",
@@ -3322,10 +3426,8 @@ def test_report_bounds_inline_failed_samples_but_keeps_full_artifact(tmp_path):
     assert metadata["count"] == sample_count
     assert len(artifact.read_text(encoding="utf-8").splitlines()) == sample_count
     rendered = html_path.read_text(encoding="utf-8")
-    assert "Showing 20 of 25" in rendered
-    assert "sample-19" in rendered
+    assert "sample-19" not in rendered
     assert "sample-20" not in rendered
-    assert "View all in disagreements.jsonl" in rendered
     assert (case_dir / "comparison.json").stat().st_size < 20_000
     assert (tmp_path / "report.json").stat().st_size < 20_000
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -3185,8 +3185,29 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
     assert (case_dir / records[0]["artifacts"]["trtmc_input"]).read_text(
         encoding="utf-8"
     ) == json.dumps(prompt, ensure_ascii=False) + "\n"
+    public_differences = report["results"][0]["sample_differences"]
+    assert public_differences["count"] == 1
+    assert public_differences["classification"] == "failed_samples"
+    assert public_differences["preview"][0]["sample_id"] == "sample-7"
+    assert public_differences["preview"][0]["reason"] == "comparison_threshold"
+    assert public_differences["preview"][0]["reference_result"]["output_text"] == (
+        "reference answer"
+    )
+    assert public_differences["preview"][0]["trtmc_result"]["output_text"] == (
+        "TRTMC answer"
+    )
+    assert public_differences["preview"][0]["reproduce"]["reference"].startswith(
+        "/profiles/reference/bin/python"
+    )
+    assert (tmp_path / public_differences["href"]).is_file()
     rendered = html_path.read_text(encoding="utf-8")
     assert "reference answer" not in rendered
+    frontend = (tmp_path / "assets" / "qualification-report.js").read_text(
+        encoding="utf-8"
+    )
+    assert "sampleDifferences" in frontend
+    assert "results and vanilla commands" in frontend
+    assert "sameMetricValue" in frontend
     assert report["results"][0]["result"] == "red"
     for wrapper in (
         "validation/engine.py",

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -2454,7 +2454,11 @@ def test_report_infers_task_type_for_legacy_standard_result(tmp_path):
     assert result["task_strategy"] == "text_to_audio"
     assert result["task_type"] == "Text → Audio"
     assert result["user_contract"] == "tts_audio"
+    assert result["samples"] == {"planned": 3, "evaluated": 3}
     assert "bark-large" not in html_path.read_text(encoding="utf-8")
+    assert "Samples" in (
+        tmp_path / "assets" / "qualification-report.js"
+    ).read_text(encoding="utf-8")
 
 
 def test_accuracy_traffic_light_statuses_are_mutually_exclusive():
@@ -2583,10 +2587,118 @@ def test_accuracy_report_publishes_direct_relative_log_links(tmp_path: Path) -> 
     assert row["result"] == "white"
     assert row["issue"]["stage"] == "candidate"
     assert row["debug"]["logs"] == [
-        {"label": "execution.log", "href": "model-a/suite-a/execution.log"},
-        {"label": "worker.log", "href": "model-a/suite-a/worker.log"},
+        {
+            "label": "execution.log",
+            "href": "artifacts/cases/model-a/suite-a/logs/execution.log",
+        },
+        {
+            "label": "worker.log",
+            "href": "artifacts/cases/model-a/suite-a/logs/worker.log",
+        },
     ]
     assert all((tmp_path / item["href"]).is_file() for item in row["debug"]["logs"])
+
+
+def test_accuracy_report_materializes_symlinked_logs_inside_report(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "accuracy"
+    case_dir = output / "model-a" / "suite-a"
+    case_dir.mkdir(parents=True)
+    reference_log = tmp_path / "reference-cache" / "hf_native_run.log"
+    reference_log.parent.mkdir()
+    reference_log.write_text("reference output\n", encoding="utf-8")
+    (case_dir / "hf_native_run.log").symlink_to(reference_log)
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "suite-a",
+                "execution": {"status": "completed", "exit_code": 0},
+                "comparison": {
+                    "status": "agreement",
+                    "mode": "test",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "passed"},
+                "precision_contract": {
+                    "trtmc_base_precision": "fp16",
+                    "reference_precision": "fp16",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, _, report = trtmc_validate.write_report(output)
+
+    log = next(
+        item
+        for item in report["results"][0]["debug"]["logs"]
+        if item["label"] == "hf_native_run.log"
+    )
+    published = output / log["href"]
+    assert published.read_text(encoding="utf-8") == "reference output\n"
+    assert not published.is_symlink()
+
+
+def test_run_binding_records_missing_default_dataset_as_preflight_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "model-a",
+            "suite-a",
+            "--output",
+            str(tmp_path / "results"),
+            "--dataset-root",
+            str(tmp_path / "datasets"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            "--limit",
+            "50",
+        ]
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_environments",
+        lambda *_args, **_kwargs: pytest.fail(
+            "missing datasets must fail before reference environment preparation"
+        ),
+    )
+
+    result = trtmc_validate.run_binding(
+        trtmc_validate.Binding("model-a", "suite-a"),
+        arguments=arguments,
+        task_models={
+            "model-a": {
+                "family": "albert",
+                "task_strategy": "encoder_only_nlp",
+                "execution_profiles": {},
+            }
+        },
+        suites={
+            "suite-a": {
+                "id": "suite-a",
+                "dataset": {"default_path": "/mnt/data/missing/data.jsonl"},
+            }
+        },
+    )
+
+    assert result["execution"] == {
+        "status": "error",
+        "exit_code": 1,
+        "retryable": False,
+    }
+    assert result["failure_stage"] == "preflight"
+    assert result["failure_domain"] == "data-artifact"
+    assert result["failure_code"] == "dataset_missing"
+    assert result["reproduce"]["dataset"]["sample_limit"] == 50
+    assert result["reproduce"]["dataset"]["prepared_input_count"] == 0
+    assert "missing/data.jsonl" in result["raw_result"]["error"]
 
 
 def test_diffusion_report_flattens_nested_reference_metrics():

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -513,7 +513,8 @@ def test_binding_scoped_engines_are_isolated_across_suites_and_deleted_on_pass(
     ]
     engine_directories = []
 
-    def run_worker(binding, *, arguments, catalog):
+    def run_worker(binding, *, arguments, catalog, on_retry=None):
+        del on_retry
         engine_directories.append(arguments.engine_dir)
         artifact = arguments.engine_dir / "model-a.bundle"
         assert not artifact.exists()
@@ -1042,7 +1043,7 @@ def test_accuracy_adapter_resumes_an_interrupted_case_as_a_new_attempt(
     assert evidence["commands"]["worker"]["rendered"]
     assert (output / evidence["logs"][0]["href"]).is_file()
     live = json.loads((output / "report.json").read_text(encoding="utf-8"))
-    assert live["results"][0]["progress"] == {"stage": "candidate", "attempt": 1}
+    assert live["results"][0]["progress"] == {"stage": "compare", "attempt": 1}
     assert live["results"][0]["commands"]["worker"]["rendered"]
 
     arguments.resume_existing = True
@@ -1080,6 +1081,103 @@ def test_accuracy_adapter_resumes_an_interrupted_case_as_a_new_attempt(
         (1, "interrupted"),
         (2, "completed"),
     ]
+
+
+def test_accuracy_adapter_records_each_worker_retry_and_reference_stage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "results"
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--binding",
+            "model-a=suite-a",
+            "--output",
+            str(output),
+            "--model-work-dir",
+            str(tmp_path / "work"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            "--engine-retention",
+            "retain",
+            "--hf-cache-retention",
+            "retain",
+            "--model-attempts",
+            "2",
+            "--model-retry-delay-seconds",
+            "0",
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "suite-a")
+    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda *args, **kwargs: None)
+    monkeypatch.setattr(trtmc_validate, "finalize_run_metadata", lambda *args: None)
+    monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
+    monkeypatch.setattr(trtmc_validate, "_check_free_space", lambda *args: 100.0)
+
+    def fail_reference(binding, *, arguments, catalog, attempt):
+        case_dir = trtmc_validate._case_directory(arguments.output, binding)
+        case_dir.mkdir(parents=True, exist_ok=True)
+        worker_log = trtmc_validate._worker_log_path(
+            case_dir,
+            case_attempt=arguments.case_attempt,
+            worker_attempt=attempt,
+        )
+        worker_log.write_text("ReferenceExecutionError: reference crashed\n", encoding="utf-8")
+        result = trtmc_validate._normalize_result(
+            {
+                "model": binding.model,
+                "workload": binding.workload,
+                "executor": "trtmc_compare",
+                "execution": {"status": "error", "exit_code": 1, "retryable": True},
+                "comparison": {
+                    "status": "not_run",
+                    "mode": "",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "failed"},
+                "raw_result": {
+                    "status": "failed",
+                    "error_type": "ReferenceExecutionError",
+                    "error": "HF reference subprocess failed rc=-11",
+                },
+                "worker_log": str(worker_log),
+            }
+        )
+        (case_dir / "comparison.json").write_text(
+            json.dumps(result),
+            encoding="utf-8",
+        )
+        return result
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", fail_reference)
+
+    assert trtmc_validate._run_all_bindings(
+        [binding],
+        arguments=arguments,
+        catalog={"sample_limits": {"suite-a": 1}},
+    ) == 1
+
+    receipt = trtmc_validate.ExecutionLedger.load(
+        output,
+        task_kind="accuracy",
+    ).receipt("model-a::suite-a")
+    assert receipt["result"] == "white"
+    assert receipt["stage"] == "reference"
+    assert [
+        (attempt["attempt"], attempt["state"], attempt["stage"])
+        for attempt in receipt["attempts"]
+    ] == [
+        (1, "failed", "reference"),
+        (2, "failed", "reference"),
+    ]
+    report = json.loads((output / "report.json").read_text(encoding="utf-8"))
+    assert report["results"][0]["progress"] == {
+        "stage": "reference",
+        "attempt": 2,
+    }
+    assert report["results"][0]["issue"]["stage"] == "reference"
 
 
 def test_resume_existing_rejects_different_source_revision(tmp_path, monkeypatch):
@@ -1454,7 +1552,8 @@ def test_all_supervisor_applies_model_failure_policy(
     }
     attempted = []
 
-    def run_worker(binding, *, arguments, catalog):
+    def run_worker(binding, *, arguments, catalog, on_retry=None):
+        del on_retry
         attempted.append(binding.model)
         status = "failed" if binding.model == "model-a" else "passed"
         return {

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -923,6 +923,163 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
     assert returncode == 0
     result = json.loads((case_dir / "comparison.json").read_text(encoding="utf-8"))
     assert result["resource_cleanup"]["engine"]["status"] == "deleted"
+    receipt = trtmc_validate.ExecutionLedger.load(
+        output, task_kind="accuracy"
+    ).receipt("model-a::suite-a")
+    assert receipt["state"] == "terminal"
+    comparison_mtime = (case_dir / "comparison.json").stat().st_mtime_ns
+
+    assert trtmc_validate._run_all_bindings(
+        [binding],
+        arguments=arguments,
+        catalog={"sample_limits": {"suite-a": 1}},
+    ) == 0
+    assert (case_dir / "comparison.json").stat().st_mtime_ns == comparison_mtime
+
+
+def test_accuracy_report_is_rebuilt_from_ordered_live_receipts(tmp_path):
+    cases = [
+        {
+            "id": "model-a::suite-a",
+            "result_path": "model-a/suite-a/comparison.json",
+            "report": {"model": "model-a", "workload": "suite-a", "sample_limit": 20},
+        },
+        {
+            "id": "model-b::suite-b",
+            "result_path": "model-b/suite-b/comparison.json",
+            "report": {"model": "model-b", "workload": "suite-b", "sample_limit": 10},
+        },
+    ]
+    ledger = trtmc_validate.ExecutionLedger.open(
+        tmp_path,
+        campaign_id="run-1",
+        task_kind="accuracy",
+        fingerprint="revision-1",
+        cases=cases,
+    )
+    result = trtmc_validate._normalize_result(
+        {
+            "model": "model-a",
+            "workload": "suite-a",
+            "execution": {"status": "completed", "exit_code": 0},
+            "comparison": {
+                "status": "agreement",
+                "mode": "exact",
+                "primary_metric": None,
+                "metrics": {},
+                "failures": [],
+            },
+            "validation": {"status": "passed"},
+            "precision_contract": {
+                "reference_precision": "fp16",
+                "trtmc_base_precision": "fp16",
+            },
+        }
+    )
+    ledger.begin("model-a::suite-a", stage="candidate")
+    ledger.finish("model-a::suite-a", result="green", payload=result)
+
+    _, _, report = trtmc_validate.write_report(tmp_path)
+
+    assert [(row["id"], row["state"], row["result"]) for row in report["results"]] == [
+        ("model-a::suite-a", "terminal", "green"),
+        ("model-b::suite-b", "pending", None),
+    ]
+    assert [row["progress"] for row in report["results"]] == [
+        {"stage": "candidate", "attempt": 1},
+        {"stage": None, "attempt": 0},
+    ]
+    assert json.loads(
+        (tmp_path / "model-a/suite-a/comparison.json").read_text(encoding="utf-8")
+    ) == result
+    assert report["accounting"]["progress"] == {
+        "pending": 1,
+        "running": 0,
+        "terminal": 1,
+    }
+
+
+def test_accuracy_adapter_resumes_an_interrupted_case_as_a_new_attempt(
+    tmp_path, monkeypatch
+):
+    output = tmp_path / "results"
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--binding",
+            "model-a=suite-a",
+            "--output",
+            str(output),
+            "--model-work-dir",
+            str(tmp_path / "work"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            "--engine-retention",
+            "retain",
+            "--hf-cache-retention",
+            "retain",
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "suite-a")
+    catalog = {"sample_limits": {"suite-a": 1}}
+    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda *args, **kwargs: None)
+    monkeypatch.setattr(trtmc_validate, "finalize_run_metadata", lambda *args: None)
+    monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
+    monkeypatch.setattr(trtmc_validate, "_check_free_space", lambda *args: 100.0)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_run_supervised_binding_with_retries",
+        lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        trtmc_validate._run_all_bindings(
+            [binding], arguments=arguments, catalog=catalog
+        )
+    ledger = trtmc_validate.ExecutionLedger.load(output, task_kind="accuracy")
+    running = ledger.receipt("model-a::suite-a")
+    assert running["state"] == "running"
+    evidence = running["attempts"][0]["evidence"]
+    assert evidence["commands"]["worker"]["rendered"]
+    assert (output / evidence["logs"][0]["href"]).is_file()
+    live = json.loads((output / "report.json").read_text(encoding="utf-8"))
+    assert live["results"][0]["progress"] == {"stage": "candidate", "attempt": 1}
+    assert live["results"][0]["commands"]["worker"]["rendered"]
+
+    arguments.resume_existing = True
+    monkeypatch.setattr(trtmc_validate, "_validate_resume_request", lambda *args: None)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_run_supervised_binding_with_retries",
+        lambda *args, **kwargs: trtmc_validate._normalize_result(
+            {
+                "model": "model-a",
+                "workload": "suite-a",
+                "execution": {"status": "completed", "exit_code": 0},
+                "comparison": {
+                    "status": "agreement",
+                    "mode": "exact",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "passed"},
+                "precision_contract": {
+                    "reference_precision": "fp16",
+                    "trtmc_base_precision": "fp16",
+                },
+            }
+        ),
+    )
+
+    assert trtmc_validate._run_all_bindings(
+        [binding], arguments=arguments, catalog=catalog
+    ) == 0
+    receipt = ledger.receipt("model-a::suite-a")
+    assert receipt["result"] == "green"
+    assert [(attempt["attempt"], attempt["state"]) for attempt in receipt["attempts"]] == [
+        (1, "interrupted"),
+        (2, "completed"),
+    ]
 
 
 def test_resume_existing_rejects_different_source_revision(tmp_path, monkeypatch):

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -5323,6 +5323,97 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
     assert "PYTORCH_CUDA_ALLOC_CONF" not in captured["env"]
 
 
+def test_eval_model_worker_honors_reference_allocator_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    suite = {"id": "suite-a"}
+    model = {
+        "name": "model-a",
+        "hf_id": "org/model-a",
+        "bundle": "model-a.bundle",
+    }
+    args = argparse.Namespace(
+        work_root=str(tmp_path / "work"),
+        engine_dir=str(tmp_path / "engines"),
+        bundle=None,
+    )
+    result_path = tmp_path / "work" / "suite-a" / "model-a" / "eval_worker_result.json"
+    captured: dict[str, str] = {}
+
+    class Result:
+        returncode = 0
+
+    def fake_run(_cmd, **kwargs):
+        captured.update(kwargs["env"])
+        result_path.write_text(
+            json.dumps({"status": "passed"}),
+            encoding="utf-8",
+        )
+        return Result()
+
+    monkeypatch.setenv(
+        validation_engine.REFERENCE_CUDA_ALLOC_CONF_ENV,
+        "disable",
+    )
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+    monkeypatch.setattr(validation_engine, "gpu_memory_used_mib", lambda: [])
+    monkeypatch.setattr(
+        validation_engine,
+        "gpu_memory_back_to_baseline",
+        lambda **_kwargs: (None, []),
+    )
+
+    validation_engine.run_eval_model_worker(suite=suite, model=model, args=args)
+
+    assert "PYTORCH_CUDA_ALLOC_CONF" not in captured
+
+
+def test_hf_reference_failure_has_a_structured_error_type(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    args = argparse.Namespace(
+        hf_python=sys.executable,
+        reference_cache_dir=str(tmp_path / "references"),
+        reference_cache_identity="",
+        hf_dtype="fp16",
+        hf_device="cuda",
+        hf_device_map="",
+        hf_attn_impl="",
+        trust_remote_code=False,
+        local_files_only=True,
+        do_sample=False,
+        apply_chat_template=False,
+        max_new_tokens=None,
+        temperature=None,
+        top_k=None,
+        top_p=None,
+        min_p=None,
+        seed=None,
+    )
+
+    monkeypatch.setattr(
+        validation_engine.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=-11),
+    )
+
+    with pytest.raises(
+        validation_engine.ReferenceExecutionError,
+        match="rc=-11",
+    ):
+        validation_engine.run_hf_reference_subprocess(
+            args,
+            {"hf_id": "org/model", "name": "model-a"},
+            work_dir,
+        )
+
+
 @pytest.mark.parametrize(
     ("precision", "expected"),
     [

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -140,7 +140,11 @@ python tools/trtmc_validate.py gpt2-125m mmlu_continuation_parity \
 
 For configured consistency workloads, the case result is always written to
 `<output>/<model>/<workload>/comparison.json`; `report.json` and `report.html`
-are written at the output root. Exit status `0` means reference consistency
+are written at the output root. `report.json` is the public result contract;
+`report.html` is a static renderer that fetches that JSON and does not own
+counts, verdicts, metrics, or links. The same directory also contains the
+renderer under `assets/` and the run environment snapshot under
+`artifacts/run/environment.json`. Exit status `0` means reference consistency
 passed, `1` means the case ran but validation failed, and `2` means CLI or
 setup validation failed before the case could run. Requesting a model that is
 explicitly marked not compared also writes
@@ -302,11 +306,13 @@ failures.
 `status: not_compared`, and the reason. CI matrix generation can select only
 entries that contain a workload.
 
-The HTML artifact is named **TRTMC Reference Consistency Report** because it
-covers task accuracy as well as token, embedding, and numerical agreement.
-For large datasets it shows one dataset-run command and at most three
+The public artifact is named **TRTMC Accuracy & Fidelity Qualification** because
+it covers task accuracy as well as token, embedding, and numerical agreement.
+For large datasets it records one dataset-run command and at most three
 representative commands per backend. The first disagreement is preferred when
-one exists.
+one exists. The HTML presents Metrics, Logs, Vanilla reproduction, and Commands
+as separate entries. Log entries are relative links to published files, never
+execution-machine paths or captured output tails.
 
 When per-sample differences exist, the model row also shows up to 20 affected
 samples. Each sample contains the exact input, both raw prediction records,
@@ -329,7 +335,7 @@ previews, playable video files up to the artifact size limit, and WAV/audio
 controls are rendered next to the two result records. Passing samples do not
 duplicate media.
 
-The report keeps three statuses separate:
+The report keeps execution evidence and the public outcome separate:
 
 - `execution`: whether the programs completed or errored;
 - `comparison`: whether TRTMC agrees or disagrees with the reference;
@@ -338,8 +344,14 @@ The report keeps three statuses separate:
 An unimplemented consistency contract uses `execution: not_run`,
 `comparison: not_run`, and `validation: not_compared`.
 
-The HTML report renders each status as an independent colored signal and shows
-the primary agreement metric next to it.
+Platform exclusions are removed before `report.json` is materialized and never
+appear in its rows, counts, search data, or denominator. A selected terminal
+case receives green, yellow, or red only after execution completed, both compute
+precisions were recorded, and a valid comparison exists. Otherwise it receives
+white (`No valid comparison`) with structured priority, failed stage, cause
+domain, reason code, and a direct diagnostic-log link. Pending and running cases
+have no traffic light. `Comparable results` counts only green/yellow/red;
+`Operational coverage` reports comparable/selected and the white count.
 
 ## Precision contract
 

--- a/tools/execution_ledger.py
+++ b/tools/execution_ledger.py
@@ -254,6 +254,34 @@ class ExecutionLedger:
         receipt["updated_at"] = finished_at
         self._write_receipt(case_id, receipt)
 
+    def retry(
+        self,
+        case_id: str,
+        *,
+        attempt_outcome: str = "failed",
+        evidence: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Close one failed attempt while leaving its case eligible to run again."""
+
+        if attempt_outcome not in {"failed", "timed_out"}:
+            raise ExecutionLedgerError(
+                f"retry attempt must be failed or timed_out: {attempt_outcome!r}"
+            )
+        receipt = self.receipt(case_id)
+        if receipt["state"] != "running":
+            raise ExecutionLedgerError(f"case {case_id!r} is not running")
+        finished_at = _now()
+        receipt["attempts"][-1]["state"] = attempt_outcome
+        receipt["attempts"][-1]["finished_at"] = finished_at
+        receipt["attempts"][-1]["evidence"].update(
+            deepcopy(dict(evidence or {}))
+        )
+        receipt["state"] = "pending"
+        receipt["stage"] = None
+        receipt["active_attempt"] = None
+        receipt["updated_at"] = finished_at
+        self._write_receipt(case_id, receipt)
+
     def recover_interrupted(self) -> list[str]:
         recovered: list[str] = []
         for case in self.cases():

--- a/tools/execution_ledger.py
+++ b/tools/execution_ledger.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small durable execution ledger shared by qualification runners."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "trtmc.execution-ledger/v1"
+CASE_STATES = ("pending", "running", "terminal")
+TERMINAL_RESULTS = ("green", "yellow", "red", "white")
+ATTEMPT_OUTCOMES = ("completed", "failed", "timed_out")
+ATTEMPT_STATES = ("running", *ATTEMPT_OUTCOMES, "interrupted")
+
+
+class ExecutionLedgerError(ValueError):
+    """The persisted campaign or a requested state transition is invalid."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, ensure_ascii=False, sort_keys=True)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    temporary.replace(path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ExecutionLedgerError(f"cannot read execution ledger file {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ExecutionLedgerError(f"execution ledger file must contain an object: {path}")
+    return value
+
+
+def _case_token(case_id: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", case_id).strip("-") or "case"
+    digest = hashlib.sha256(case_id.encode("utf-8")).hexdigest()[:10]
+    return f"{slug[:80]}-{digest}"
+
+
+class ExecutionLedger:
+    """Persist one immutable campaign inventory and one receipt per selected case."""
+
+    def __init__(self, root: Path, manifest: Mapping[str, Any]) -> None:
+        self.root = root
+        self._manifest = deepcopy(dict(manifest))
+        entries = self._manifest.get("cases")
+        if not isinstance(entries, list):
+            raise ExecutionLedgerError("execution ledger case inventory must be an array")
+        self._cases: dict[str, dict[str, Any]] = {}
+        for entry in entries:
+            if not isinstance(entry, Mapping) or not isinstance(entry.get("case"), Mapping):
+                raise ExecutionLedgerError("execution ledger case entry must be an object")
+            case_id = str(entry["case"].get("id", "")).strip()
+            expected_receipt = f"cases/{_case_token(case_id)}/receipt.json"
+            if not case_id or entry.get("receipt") != expected_receipt:
+                raise ExecutionLedgerError("execution ledger case entry is invalid")
+            if case_id in self._cases:
+                raise ExecutionLedgerError("execution ledger case ids must be unique")
+            self._cases[case_id] = deepcopy(dict(entry))
+
+    @classmethod
+    def load(cls, output: Path, *, task_kind: str | None = None) -> ExecutionLedger:
+        root = Path(output) / "ledger"
+        manifest = _read_json(root / "campaign.json")
+        if manifest.get("schema_version") != SCHEMA_VERSION:
+            raise ExecutionLedgerError("invalid execution ledger campaign schema")
+        if task_kind is not None and manifest.get("task_kind") != task_kind:
+            raise ExecutionLedgerError("execution ledger task does not match the report")
+        ledger = cls(root, manifest)
+        for case in ledger.cases():
+            ledger.receipt(str(case["id"]))
+        return ledger
+
+    @classmethod
+    def open(
+        cls,
+        output: Path,
+        *,
+        campaign_id: str,
+        task_kind: str,
+        fingerprint: str,
+        cases: Sequence[Mapping[str, Any]],
+    ) -> ExecutionLedger:
+        root = Path(output) / "ledger"
+        manifest_path = root / "campaign.json"
+        normalized_cases = [deepcopy(dict(case)) for case in cases]
+        case_ids = [str(case.get("id", "")).strip() for case in normalized_cases]
+        if any(not case_id for case_id in case_ids):
+            raise ExecutionLedgerError("every selected case must have a non-empty id")
+        if len(set(case_ids)) != len(case_ids):
+            raise ExecutionLedgerError("selected case ids must be unique")
+
+        entries = [
+            {
+                "case": case,
+                "receipt": f"cases/{_case_token(case_id)}/receipt.json",
+            }
+            for case_id, case in zip(case_ids, normalized_cases, strict=True)
+        ]
+        expected = {
+            "schema_version": SCHEMA_VERSION,
+            "campaign_id": str(campaign_id),
+            "task_kind": str(task_kind),
+            "fingerprint": str(fingerprint),
+            "cases": entries,
+        }
+        if manifest_path.exists():
+            manifest = _read_json(manifest_path)
+            for field in ("schema_version", "campaign_id", "task_kind", "fingerprint"):
+                if manifest.get(field) != expected[field]:
+                    raise ExecutionLedgerError(
+                        f"execution ledger {field} does not match this campaign"
+                    )
+            if manifest.get("cases") != entries:
+                raise ExecutionLedgerError(
+                    "execution ledger case inventory does not match this campaign"
+                )
+            ledger = cls(root, manifest)
+            for case_id in case_ids:
+                path = ledger._receipt_path(case_id)
+                if not path.exists():
+                    raise ExecutionLedgerError(
+                        f"execution ledger is missing receipt for case {case_id!r}"
+                    )
+                ledger._validate_receipt(case_id, _read_json(path))
+            return ledger
+
+        manifest = expected
+        ledger = cls(root, manifest)
+        for case_id in case_ids:
+            _write_json_atomic(
+                ledger._receipt_path(case_id),
+                ledger._pending_receipt(case_id),
+            )
+        _write_json_atomic(manifest_path, manifest)
+        return ledger
+
+    def cases(self) -> list[dict[str, Any]]:
+        return [deepcopy(entry["case"]) for entry in self._manifest["cases"]]
+
+    def receipt(self, case_id: str) -> dict[str, Any]:
+        path = self._receipt_path(case_id)
+        if not path.is_file() or path.is_symlink():
+            raise ExecutionLedgerError(f"execution ledger has no regular receipt for {case_id!r}")
+        receipt = _read_json(path)
+        self._validate_receipt(case_id, receipt)
+        return deepcopy(receipt)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return [
+            {"case": case, "receipt": self.receipt(str(case["id"]))}
+            for case in self.cases()
+        ]
+
+    def begin(
+        self,
+        case_id: str,
+        *,
+        stage: str,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> int:
+        receipt = self.receipt(case_id)
+        if receipt["state"] == "terminal":
+            raise ExecutionLedgerError(f"case {case_id!r} is already terminal")
+        if receipt["state"] == "running":
+            raise ExecutionLedgerError(f"case {case_id!r} is already running")
+        attempt_number = len(receipt["attempts"]) + 1
+        receipt["state"] = "running"
+        receipt["stage"] = str(stage)
+        receipt["active_attempt"] = attempt_number
+        receipt["attempts"].append(
+            {
+                "attempt": attempt_number,
+                "state": "running",
+                "stage": str(stage),
+                "started_at": _now(),
+                "evidence": deepcopy(dict(evidence or {})),
+            }
+        )
+        receipt["updated_at"] = _now()
+        self._write_receipt(case_id, receipt)
+        return attempt_number
+
+    def update_stage(
+        self,
+        case_id: str,
+        stage: str,
+        *,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> None:
+        receipt = self.receipt(case_id)
+        if receipt["state"] != "running":
+            raise ExecutionLedgerError(f"case {case_id!r} is not running")
+        receipt["stage"] = str(stage)
+        receipt["attempts"][-1]["stage"] = str(stage)
+        receipt["attempts"][-1]["evidence"].update(
+            deepcopy(dict(evidence or {}))
+        )
+        receipt["updated_at"] = _now()
+        self._write_receipt(case_id, receipt)
+
+    def finish(
+        self,
+        case_id: str,
+        *,
+        result: str,
+        payload: Mapping[str, Any],
+        attempt_outcome: str = "completed",
+        evidence: Mapping[str, Any] | None = None,
+    ) -> None:
+        if result not in TERMINAL_RESULTS:
+            raise ExecutionLedgerError(f"unknown traffic-light result: {result!r}")
+        if attempt_outcome not in ATTEMPT_OUTCOMES:
+            raise ExecutionLedgerError(f"unknown attempt outcome: {attempt_outcome!r}")
+        receipt = self.receipt(case_id)
+        if receipt["state"] != "running":
+            raise ExecutionLedgerError(f"case {case_id!r} is not running")
+        finished_at = _now()
+        receipt["state"] = "terminal"
+        receipt["stage"] = receipt["attempts"][-1]["stage"]
+        receipt["active_attempt"] = None
+        receipt["result"] = result
+        receipt["payload"] = deepcopy(dict(payload))
+        receipt["attempts"][-1]["state"] = attempt_outcome
+        receipt["attempts"][-1]["finished_at"] = finished_at
+        receipt["attempts"][-1]["evidence"].update(
+            deepcopy(dict(evidence or {}))
+        )
+        receipt["updated_at"] = finished_at
+        self._write_receipt(case_id, receipt)
+
+    def recover_interrupted(self) -> list[str]:
+        recovered: list[str] = []
+        for case in self.cases():
+            case_id = str(case["id"])
+            receipt = self.receipt(case_id)
+            if receipt["state"] != "running":
+                continue
+            finished_at = _now()
+            receipt["attempts"][-1]["state"] = "interrupted"
+            receipt["attempts"][-1]["finished_at"] = finished_at
+            receipt["state"] = "pending"
+            receipt["stage"] = None
+            receipt["active_attempt"] = None
+            receipt["updated_at"] = finished_at
+            self._write_receipt(case_id, receipt)
+            recovered.append(case_id)
+        return recovered
+
+    def reopen_retryable(self) -> list[str]:
+        reopened: list[str] = []
+        for case in self.cases():
+            case_id = str(case["id"])
+            receipt = self.receipt(case_id)
+            if receipt["state"] != "terminal" or receipt["result"] != "white":
+                continue
+            evidence = receipt["attempts"][-1]["evidence"]
+            if evidence.get("retryable") is not True:
+                continue
+            receipt["previous_results"].append(
+                {
+                    "attempt": receipt["attempts"][-1]["attempt"],
+                    "result": receipt["result"],
+                    "payload": receipt["payload"],
+                    "finished_at": receipt["updated_at"],
+                }
+            )
+            receipt["state"] = "pending"
+            receipt["stage"] = None
+            receipt["result"] = None
+            receipt["payload"] = None
+            receipt["updated_at"] = _now()
+            self._write_receipt(case_id, receipt)
+            reopened.append(case_id)
+        return reopened
+
+    def _pending_receipt(self, case_id: str) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "campaign_id": self._manifest["campaign_id"],
+            "task_kind": self._manifest["task_kind"],
+            "case_id": case_id,
+            "state": "pending",
+            "stage": None,
+            "active_attempt": None,
+            "attempts": [],
+            "previous_results": [],
+            "result": None,
+            "payload": None,
+            "updated_at": _now(),
+        }
+
+    def _receipt_path(self, case_id: str) -> Path:
+        try:
+            relative = self._cases[str(case_id)]["receipt"]
+        except KeyError as error:
+            raise ExecutionLedgerError(f"unknown case: {case_id!r}") from error
+        return self.root / str(relative)
+
+    def _write_receipt(self, case_id: str, receipt: Mapping[str, Any]) -> None:
+        self._validate_receipt(case_id, receipt)
+        _write_json_atomic(self._receipt_path(case_id), receipt)
+
+    def _validate_receipt(self, case_id: str, receipt: Mapping[str, Any]) -> None:
+        if receipt.get("schema_version") != SCHEMA_VERSION:
+            raise ExecutionLedgerError(f"invalid receipt schema for case {case_id!r}")
+        if receipt.get("campaign_id") != self._manifest["campaign_id"]:
+            raise ExecutionLedgerError(f"receipt campaign mismatch for case {case_id!r}")
+        if receipt.get("task_kind") != self._manifest["task_kind"]:
+            raise ExecutionLedgerError(f"receipt task mismatch for case {case_id!r}")
+        if receipt.get("case_id") != case_id:
+            raise ExecutionLedgerError(f"receipt case id mismatch for case {case_id!r}")
+        state = receipt.get("state")
+        if state not in CASE_STATES:
+            raise ExecutionLedgerError(f"invalid receipt state for case {case_id!r}: {state!r}")
+        attempts = receipt.get("attempts")
+        if not isinstance(attempts, list):
+            raise ExecutionLedgerError(f"receipt attempts must be an array for case {case_id!r}")
+        for index, attempt in enumerate(attempts, start=1):
+            if (
+                not isinstance(attempt, Mapping)
+                or attempt.get("attempt") != index
+                or attempt.get("state") not in ATTEMPT_STATES
+                or not str(attempt.get("stage", "")).strip()
+                or not attempt.get("started_at")
+                or not isinstance(attempt.get("evidence"), Mapping)
+            ):
+                raise ExecutionLedgerError(f"invalid attempt history for case {case_id!r}")
+            if attempt.get("state") == "running":
+                if index != len(attempts) or attempt.get("finished_at") is not None:
+                    raise ExecutionLedgerError(f"invalid attempt history for case {case_id!r}")
+            elif not attempt.get("finished_at"):
+                raise ExecutionLedgerError(f"invalid attempt history for case {case_id!r}")
+        previous_results = receipt.get("previous_results")
+        if not isinstance(previous_results, list) or any(
+            not isinstance(previous, Mapping)
+            or previous.get("result") != "white"
+            or not isinstance(previous.get("payload"), Mapping)
+            for previous in previous_results
+        ):
+            raise ExecutionLedgerError(f"invalid previous results for case {case_id!r}")
+        active_attempt = receipt.get("active_attempt")
+        result = receipt.get("result")
+        if state == "running":
+            if not attempts or attempts[-1].get("state") != "running":
+                raise ExecutionLedgerError(f"running case {case_id!r} needs one active attempt")
+            if active_attempt != attempts[-1].get("attempt") or result is not None:
+                raise ExecutionLedgerError(f"running receipt is inconsistent for case {case_id!r}")
+        elif active_attempt is not None:
+            raise ExecutionLedgerError(f"non-running case {case_id!r} has an active attempt")
+        if state == "pending":
+            if receipt.get("stage") is not None:
+                raise ExecutionLedgerError(f"pending case {case_id!r} has a stage")
+            if attempts and attempts[-1].get("state") not in {
+                "interrupted",
+                "failed",
+                "timed_out",
+            }:
+                raise ExecutionLedgerError(f"pending case {case_id!r} has no retryable attempt")
+        if state in {"running", "terminal"} and receipt.get("stage") != attempts[-1].get(
+            "stage"
+        ):
+            raise ExecutionLedgerError(f"case and attempt stage differ for {case_id!r}")
+        if state == "terminal":
+            if result not in TERMINAL_RESULTS or not isinstance(receipt.get("payload"), dict):
+                raise ExecutionLedgerError(f"terminal receipt is incomplete for case {case_id!r}")
+            if not attempts or attempts[-1].get("state") not in ATTEMPT_OUTCOMES:
+                raise ExecutionLedgerError(f"terminal case {case_id!r} has no final attempt")
+        elif result is not None or receipt.get("payload") is not None:
+            raise ExecutionLedgerError(f"non-terminal receipt has a result for case {case_id!r}")

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -908,75 +908,6 @@ def _task_bindings(plan: Mapping[str, Any], task: str) -> list[dict[str, Any]]:
     ]
 
 
-def _platform_task_bindings(
-    plan: Mapping[str, Any],
-    task: str,
-) -> list[dict[str, Any]]:
-    return [
-        binding
-        for model in plan["models"]
-        for binding in model["tasks"].get(task, {}).get("bindings", [])
-        if binding["status"] == "excluded"
-    ]
-
-
-def _accuracy_platform_result(binding: Mapping[str, Any]) -> dict[str, Any]:
-    reason = str(binding["reason"])
-    return {
-        "schema_version": "trtmc.validation-result/v2",
-        "model": str(binding["model"]),
-        "workload": str(binding["workload"]),
-        "executor": "platform_exclusion",
-        "execution": {"status": "not_run", "exit_code": None},
-        "comparison": {
-            "status": "not_run",
-            "mode": "platform_exclusion",
-            "primary_metric": None,
-            "metrics": {},
-            "failures": [],
-        },
-        "validation": {"status": "not_compared"},
-        "not_compared_reason": reason,
-        "platform_exclusion": {"reason": reason},
-        "reference_environment": [],
-        "reproduce": {},
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-
-def _write_accuracy_platform_results(
-    plan: Mapping[str, Any],
-    output: Path,
-) -> list[Path]:
-    written: list[Path] = []
-    for binding in _platform_task_bindings(plan, "accuracy"):
-        workload = str(binding.get("workload", "") or "")
-        if not workload:
-            raise ModelCheckError(
-                f"platform Accuracy binding has no workload: {binding['model']}"
-            )
-        comparison = output / str(binding["model"]) / workload / "comparison.json"
-        if comparison.exists():
-            try:
-                previous = json.loads(comparison.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as exc:
-                raise ModelCheckError(
-                    f"cannot read platform result {comparison}: {exc}"
-                ) from exc
-            if not isinstance(previous.get("platform_exclusion"), Mapping):
-                raise ModelCheckError(
-                    "refusing to replace a previously executed Accuracy result with a "
-                    f"platform exclusion: {binding['model']}={workload}"
-                )
-        comparison.parent.mkdir(parents=True, exist_ok=True)
-        comparison.write_text(
-            json.dumps(_accuracy_platform_result(binding), indent=2) + "\n",
-            encoding="utf-8",
-        )
-        written.append(comparison)
-    return written
-
-
 def _selected_perf_reference_contracts(
     plan: Mapping[str, Any],
     models_dir: Path,
@@ -1364,13 +1295,6 @@ def _run(arguments: argparse.Namespace) -> int:
     if arguments.dry_run:
         return 0
 
-    accuracy_platform_results = _write_accuracy_platform_results(
-        plan,
-        run_root / "accuracy",
-    )
-    if accuracy_platform_results:
-        trtmc_validate.write_report(run_root / "accuracy")
-
     reference_environment: dict[str, str] = {}
     reference_contracts = _selected_perf_reference_contracts(plan, arguments.models_dir)
     reference_environment.update(
@@ -1387,8 +1311,6 @@ def _run(arguments: argparse.Namespace) -> int:
         )
 
     task_results: dict[str, int] = {}
-    if accuracy_platform_results and not _task_bindings(plan, "accuracy"):
-        task_results["accuracy"] = 0
     runnable = [(task, command) for task, command in execution_commands if command is not None]
     for index, (task, command) in enumerate(runnable, start=1):
         label = _task_label(task)

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -26,7 +26,7 @@ import statistics
 import subprocess
 import sys
 import time
-from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
 
 import yaml
 
@@ -66,6 +66,7 @@ from tools.reporting_html import (  # noqa: E402
     task_type_label,
 )
 from tools import model_selection  # noqa: E402
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import qualification_report  # noqa: E402
 
 
@@ -1082,20 +1083,49 @@ def _initial_results(
             ),
         },
         "selected_entry_ids": [str(case["id"]) for case in selected],
-        "cases": [
-            {
-                "id": case["id"],
-                "family": case["family"],
-                "operation": case["operation"],
-                "model": case["model"],
-                "workload_contract": deepcopy(dict(case["workload"])),
-                "measurement_contract": deepcopy(dict(case["measurement"])),
-                "baseline_contract": dict(case["baseline"]),
-                "status": "pending",
-            }
-            for case in cases
-        ],
+        "cases": [_pending_perf_row(case) for case in cases],
     }
+
+
+def _pending_perf_row(case: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "id": case["id"],
+        "family": case["family"],
+        "operation": case["operation"],
+        "model": case["model"],
+        "workload_contract": deepcopy(dict(case["workload"])),
+        "measurement_contract": deepcopy(dict(case["measurement"])),
+        "baseline_contract": dict(case["baseline"]),
+        "status": "pending",
+    }
+
+
+def _open_perf_ledger(
+    output: Path,
+    selected: Sequence[Mapping[str, Any]],
+    results: Mapping[str, Any],
+) -> ExecutionLedger:
+    fingerprint_input = {
+        "git_commit": results.get("git_commit"),
+        "suite_sha256": results.get("suite_sha256"),
+        "environment_sha256": results.get("environment_config", {}).get("sha256"),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_input, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    try:
+        return ExecutionLedger.open(
+            output,
+            campaign_id=str(results.get("run_id") or output.name),
+            task_kind="performance",
+            fingerprint=fingerprint,
+            cases=[
+                {"id": str(case["id"]), "report": _pending_perf_row(case)}
+                for case in selected
+            ],
+        )
+    except ExecutionLedgerError as error:
+        raise PerfMatrixError(str(error)) from error
 
 
 def _load_resume(path: Path) -> dict[str, Any]:
@@ -1747,12 +1777,15 @@ def _materialize_command_logs(
     case_id: str,
     side: str,
     command: MutableMapping[str, Any],
+    *,
+    case_attempt: int = 1,
 ) -> list[dict[str, str]]:
     directory = output / "artifacts" / _slug(case_id) / "logs"
     directory.mkdir(parents=True, exist_ok=True)
     links = []
+    attempt_suffix = "" if case_attempt == 1 else f".case-attempt-{case_attempt}"
     for stream in ("stdout", "stderr"):
-        path = directory / f"{side}.{stream}.log"
+        path = directory / f"{side}{attempt_suffix}.{stream}.log"
         path.write_text(str(command.pop(stream, "")), encoding="utf-8")
         href = path.relative_to(output).as_posix()
         command[f"{stream}_log"] = href
@@ -1771,13 +1804,45 @@ def _materialize_command_logs(
             if not source.is_file():
                 continue
             suffix = "".join(source.suffixes) or ".log"
-            path = directory / f"{side}.{_slug(label)}{suffix}"
+            path = directory / f"{side}{attempt_suffix}.{_slug(label)}{suffix}"
             shutil.copyfile(source, path)
             record = {"label": label, "href": path.relative_to(output).as_posix()}
             materialized.append(record)
             links.append(record)
         diagnostic["artifacts"] = materialized
     return links
+
+
+def _perf_attempt_evidence(
+    output: Path,
+    case_id: str,
+    case_attempt: int,
+    resolve_command: Mapping[str, Any],
+    environment: Mapping[str, str],
+) -> dict[str, Any]:
+    directory = output / "artifacts" / _slug(case_id) / "logs"
+    directory.mkdir(parents=True, exist_ok=True)
+    suffix = "" if case_attempt == 1 else f".case-attempt-{case_attempt}"
+    logs = []
+    for side, label in (("trtmc", "TRTMC"), ("baseline", "Reference")):
+        for stream in ("stdout", "stderr"):
+            path = directory / f"{side}{suffix}.{stream}.log"
+            path.touch(exist_ok=True)
+            logs.append(
+                {
+                    "label": f"{label} {stream} case attempt {case_attempt}",
+                    "href": path.relative_to(output).as_posix(),
+                }
+            )
+    return {
+        "commands": {"resolve": deepcopy(dict(resolve_command))},
+        "logs": logs,
+        "environment": {
+            name: environment[name]
+            for name in REPRODUCTION_ENVIRONMENT_NAMES
+            if environment.get(name)
+        },
+    }
 
 
 def _gpu_memory_usage_mib() -> list[tuple[int, int]]:
@@ -2316,6 +2381,9 @@ def _run_supported_case(
     options: RunOptions,
     case_work: Path,
     row: MutableMapping[str, Any],
+    *,
+    case_attempt: int = 1,
+    progress: Callable[[str, Mapping[str, Any]], None] | None = None,
 ) -> None:
     environment = _case_command_environment(options, case_work)
     digest = _workload_digest(resolved)
@@ -2326,17 +2394,30 @@ def _run_supported_case(
     row["resolved_settings"]["baseline_python_profile"] = profile
     reference_precision = baseline_argv[baseline_argv.index("--precision") + 1]
     row["resolved_settings"]["baseline_precision"] = reference_precision
-    commands = {
-        "trtmc": {"argv": candidate_argv, "rendered": shlex.join(candidate_argv)},
-        "baseline": {"argv": baseline_argv, "rendered": shlex.join(baseline_argv)},
-    }
-    row["commands"] = commands
+    commands = row.setdefault("commands", {})
+    commands.update({
+        "trtmc": {
+            "argv": candidate_argv,
+            "rendered": shlex.join(candidate_argv),
+            "cwd": str(REPOSITORY),
+        },
+        "baseline": {
+            "argv": baseline_argv,
+            "rendered": shlex.join(baseline_argv),
+            "cwd": str(REPOSITORY),
+        },
+    })
     if getattr(options, "verbose", False):
         print(f"[{case['id']}] TRTMC: {commands['trtmc']['rendered']}", flush=True)
         print(f"[{case['id']}] baseline: {commands['baseline']['rendered']}", flush=True)
     order = ("trtmc", "baseline") if _stable_even(str(case["id"])) else ("baseline", "trtmc")
     for side in order:
         argv = candidate_argv if side == "trtmc" else baseline_argv
+        if progress is not None:
+            progress(
+                "candidate" if side == "trtmc" else "reference",
+                {"commands": deepcopy(row["commands"])},
+            )
         _wait_for_gpu_memory_headroom(
             minimum_free_fraction=options.minimum_gpu_free_fraction
         )
@@ -2347,6 +2428,7 @@ def _run_supported_case(
                 str(case["id"]),
                 side,
                 command,
+                case_attempt=case_attempt,
             )
         )
         commands[side] = command
@@ -2391,17 +2473,28 @@ def _run_one(
     options: RunOptions,
     work_root: Path,
     preflight: tuple[dict[str, Any], list[str], dict[str, str]],
+    *,
+    case_attempt: int = 1,
+    progress: Callable[[str, Mapping[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     resolved, _, dry_command = preflight
     digest = _workload_digest(resolved)
     row = _case_row(case, resolved, digest)
     row["commands"]["resolve"] = dry_command
-    case_work = work_root / _slug(str(case["id"]))
+    case_work = work_root / _slug(str(case["id"])) / f"attempt-{case_attempt}"
     if case_work.exists():
         shutil.rmtree(case_work)
     case_work.mkdir(parents=True, exist_ok=True)
     try:
-        _run_supported_case(case, resolved, options, case_work, row)
+        _run_supported_case(
+            case,
+            resolved,
+            options,
+            case_work,
+            row,
+            case_attempt=case_attempt,
+            progress=progress,
+        )
     except (PerfMatrixError, OSError, ValueError, RuntimeError) as exc:
         row["status"] = "failed"
         row["reason"] = str(exc)
@@ -2594,6 +2687,43 @@ def _perf_state_and_result(row: Mapping[str, Any]) -> tuple[str, str | None]:
     ).values():
         return "terminal", "white"
     return "terminal", status if status in qualification_report.RGB_RESULTS else "white"
+
+
+def _sync_perf_results_from_ledger(
+    results: MutableMapping[str, Any],
+    ledger: ExecutionLedger,
+) -> None:
+    rows = _result_rows(results)
+    for entry in ledger.snapshot():
+        case = entry["case"]
+        receipt = entry["receipt"]
+        case_id = str(case["id"])
+        if case_id not in rows:
+            raise PerfMatrixError(f"Performance ledger contains unknown case {case_id!r}")
+        base = case.get("report")
+        if not isinstance(base, Mapping):
+            raise PerfMatrixError(f"invalid Performance ledger descriptor for {case_id!r}")
+        if receipt["state"] == "terminal":
+            row = deepcopy(receipt["payload"])
+            state, derived = _perf_state_and_result(row)
+            if state != "terminal" or receipt["result"] != derived:
+                raise PerfMatrixError(
+                    f"Performance ledger result mismatch for {case_id!r}: "
+                    f"receipt={receipt['result']}, result={derived}"
+                )
+        else:
+            row = {**deepcopy(dict(base)), "status": receipt["state"]}
+            active = receipt["attempts"][-1] if receipt["attempts"] else {}
+            evidence = active.get("evidence", {})
+            evidence = evidence if isinstance(evidence, Mapping) else {}
+            row["commands"] = deepcopy(dict(evidence.get("commands", {})))
+            row["logs"] = deepcopy(list(evidence.get("logs", [])))
+        row["progress"] = {
+            "stage": receipt["stage"],
+            "attempt": receipt["active_attempt"] or len(receipt["attempts"]),
+        }
+        rows[case_id].clear()
+        rows[case_id].update(row)
 
 
 def _perf_issue(row: Mapping[str, Any], result: str | None) -> dict[str, str] | None:
@@ -3323,7 +3453,13 @@ def _report_html(results: Mapping[str, Any]) -> str:
 </body></html>"""
 
 
-def _write_artifacts(output: Path, results: Mapping[str, Any]) -> None:
+def _write_artifacts(
+    output: Path,
+    results: MutableMapping[str, Any],
+    ledger: ExecutionLedger | None = None,
+) -> None:
+    if ledger is not None:
+        _sync_perf_results_from_ledger(results, ledger)
     _write_json(output / "results.json", results)
     _materialize_public_perf_report(output, results)
     legacy_replay = output / "reproduce.py"
@@ -3440,7 +3576,15 @@ def _report_existing(arguments: argparse.Namespace) -> int:
             arguments.preparation_receipt.resolve(), "preparation receipt"
         )
         _apply_bundle_preparation_receipt(results, receipt)
-    _write_artifacts(output, results)
+    try:
+        ledger = (
+            ExecutionLedger.load(output, task_kind="performance")
+            if (output / "ledger" / "campaign.json").is_file()
+            else None
+        )
+    except ExecutionLedgerError as error:
+        raise PerfMatrixError(str(error)) from error
+    _write_artifacts(output, results, ledger)
     print(f"Results: {output / 'results.json'}")
     print(f"Report data: {output / 'report.json'}")
     print(f"Report: {output / 'report.html'}")
@@ -3563,6 +3707,8 @@ def _execute_campaign(
     worker: Mapping[str, Any],
     storage_preflight: Mapping[str, Any],
 ) -> int:
+    ledger = _open_perf_ledger(options.output, selected, results)
+    ledger.recover_interrupted()
     results["candidate_worker_preflight"] = dict(worker)
     results["storage_preflight"] = deepcopy(dict(storage_preflight))
     results["reference_preflight"] = deepcopy(dict(reference_preflight))
@@ -3574,29 +3720,92 @@ def _execute_campaign(
         timing_preflight["status"] = "partial"
     results["timing_preflight"] = timing_preflight
     rows = _result_rows(results)
+    for case in selected:
+        case_id = str(case["id"])
+        receipt = ledger.receipt(case_id)
+        if receipt["state"] == "terminal" or not _should_skip(rows[case_id]):
+            continue
+        ledger.begin(
+            case_id,
+            stage="legacy-import",
+            evidence={
+                "commands": deepcopy(dict(rows[case_id].get("commands", {}))),
+                "logs": deepcopy(list(rows[case_id].get("logs", []))),
+            },
+        )
+        state, result = _perf_state_and_result(rows[case_id])
+        if state != "terminal" or result is None:
+            raise PerfMatrixError(f"cannot import incomplete result for {case_id!r}")
+        ledger.finish(case_id, result=result, payload=rows[case_id])
+    _sync_perf_results_from_ledger(results, ledger)
+    rows = _result_rows(results)
     work_root = options.scratch_root / options.output.name
     work_root.mkdir(parents=True, exist_ok=True)
     for case in selected:
         case_id = str(case["id"])
         failure = preflight_failures.get(case_id)
-        if failure is None or _should_skip(rows[case_id]):
+        receipt = ledger.receipt(case_id)
+        if failure is None or receipt["state"] == "terminal":
             continue
-        rows[case_id].clear()
-        rows[case_id].update(_resolution_failure_row(case, failure))
-    _write_artifacts(options.output, results)
+        failure_row = _resolution_failure_row(case, failure)
+        ledger.begin(
+            case_id,
+            stage="preflight",
+            evidence={"commands": deepcopy(dict(failure_row.get("commands", {})))},
+        )
+        ledger.finish(
+            case_id,
+            result="white",
+            payload=failure_row,
+            attempt_outcome="failed",
+            evidence={"retryable": True},
+        )
+    _write_artifacts(options.output, results, ledger)
     for case in selected:
         case_id = str(case["id"])
-        existing = rows[case_id]
-        if _should_skip(existing):
-            print(f"[{case['id']}] resume: keeping {existing['status']}", flush=True)
+        receipt = ledger.receipt(case_id)
+        if receipt["state"] == "terminal":
+            existing = receipt["payload"]
+            action = "resume: keeping" if case_id in preflight else "preflight: recorded"
+            print(f"[{case['id']}] {action} {existing['status']}", flush=True)
             continue
         if case_id not in preflight:
+            existing = rows[case_id]
             print(
                 f"[{case_id}] skipped: {existing.get('reason', 'preflight failed')}",
                 flush=True,
             )
             continue
-        row = _run_one(case, options, work_root, preflight[case_id])
+        case_attempt = len(receipt["attempts"]) + 1
+        case_work = work_root / _slug(case_id) / f"attempt-{case_attempt}"
+        attempt_evidence = _perf_attempt_evidence(
+            options.output,
+            case_id,
+            case_attempt,
+            preflight[case_id][2],
+            _case_command_environment(options, case_work),
+        )
+        ledger.begin(
+            case_id,
+            stage=("candidate" if _stable_even(case_id) else "reference"),
+            evidence=attempt_evidence,
+        )
+        _write_artifacts(options.output, results, ledger)
+
+        def publish_progress(stage: str, evidence: Mapping[str, Any]) -> None:
+            ledger.update_stage(case_id, stage, evidence=evidence)
+            _write_artifacts(options.output, results, ledger)
+
+        row = _run_one(
+            case,
+            options,
+            work_root,
+            preflight[case_id],
+            case_attempt=case_attempt,
+            progress=publish_progress,
+        )
+        if not row.get("logs"):
+            row["logs"] = deepcopy(attempt_evidence["logs"])
         passed = row.get("status") in {"green", "yellow", "red"}
         bundle_cleanup = _cleanup_managed_bundle(
             preflight[case_id][0],
@@ -3625,13 +3834,38 @@ def _execute_campaign(
                     "message": "; ".join(cleanup_failures),
                 }
             )
-        rows[case_id].clear()
-        rows[case_id].update(row)
-        _write_artifacts(options.output, results)
+        state, result = _perf_state_and_result(row)
+        if state != "terminal" or result is None:
+            raise PerfMatrixError(f"Performance case {case_id!r} did not finish")
+        ledger.finish(
+            case_id,
+            result=result,
+            payload=row,
+            attempt_outcome=(
+                "timed_out"
+                if any(
+                    command.get("exit_code") == 124
+                    for command in row.get("commands", {}).values()
+                    if isinstance(command, Mapping)
+                )
+                else "failed"
+                if row.get("status") == "failed"
+                else "completed"
+            ),
+            evidence={
+                "return_codes": {
+                    name: command.get("exit_code")
+                    for name, command in row.get("commands", {}).items()
+                    if isinstance(command, Mapping) and "exit_code" in command
+                },
+                "retryable": row.get("status") == "failed",
+            },
+        )
+        _write_artifacts(options.output, results, ledger)
     selected_ids = {str(case["id"]) for case in selected}
     results["finished_at"] = _now()
     results["status"] = _final_status(_selected_rows(results, selected_ids))
-    _write_artifacts(options.output, results)
+    _write_artifacts(options.output, results, ledger)
     try:
         work_root.rmdir()
     except OSError:
@@ -3721,11 +3955,13 @@ def _run_new(arguments: argparse.Namespace) -> int:
     )
     storage = _environment_preflight(environment, preliminary_options)
     worker = _preflight_worker(preliminary_options)
-    preflight, references, failures = _preflight_selected(selected, preliminary_options)
     run_id, output = _new_run_directory(results_root, suite)
     options = _run_options(environment, output, verbose=arguments.verbose)
     results = _initial_results(suite_path, suite, cases, selected, environment)
     results["run_id"] = run_id
+    ledger = _open_perf_ledger(output, selected, results)
+    _write_artifacts(output, results, ledger)
+    preflight, references, failures = _preflight_selected(selected, options)
     return _execute_campaign(
         selected=selected,
         options=options,
@@ -3774,6 +4010,10 @@ def _resume(arguments: argparse.Namespace) -> int:
             "cannot resume because the resolved environment values changed"
         )
     options = _run_options(environment, output, verbose=arguments.verbose)
+    ledger = _open_perf_ledger(output, selected, results)
+    ledger.recover_interrupted()
+    ledger.reopen_retryable()
+    _write_artifacts(output, results, ledger)
     storage = _environment_preflight(environment, options)
     worker = _preflight_worker(options)
     preflight, references, failures = _preflight_selected(selected, options)

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -62,6 +62,7 @@ from tools.reporting_html import (  # noqa: E402
     task_type_label,
 )
 from tools import model_selection  # noqa: E402
+from tools import qualification_report  # noqa: E402
 
 
 RESULT_SCHEMA = "trtmc.perf-matrix/v1"
@@ -1040,6 +1041,8 @@ def _initial_results(
         "platform": platform.platform(),
         "python": platform.python_version(),
         "python_executable": sys.executable,
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        "nvidia_visible_devices": os.environ.get("NVIDIA_VISIBLE_DEVICES", ""),
         **_gpu_environment(),
     }
     return {
@@ -1697,9 +1700,29 @@ def _run_command(
         "exit_code": exit_code,
         "elapsed_seconds": elapsed,
         "stdout": stdout,
+        "stderr": stderr,
         "stdout_tail": stdout[-16000:],
         "stderr_tail": stderr[-16000:],
     }
+
+
+def _materialize_command_logs(
+    output: Path,
+    case_id: str,
+    side: str,
+    command: MutableMapping[str, Any],
+) -> list[dict[str, str]]:
+    directory = output / "artifacts" / _slug(case_id) / "logs"
+    directory.mkdir(parents=True, exist_ok=True)
+    links = []
+    for stream in ("stdout", "stderr"):
+        path = directory / f"{side}.{stream}.log"
+        path.write_text(str(command.pop(stream, "")), encoding="utf-8")
+        href = path.relative_to(output).as_posix()
+        command[f"{stream}_log"] = href
+        side_label = "TRTMC" if side == "trtmc" else "Reference"
+        links.append({"label": f"{side_label} {stream}", "href": href})
+    return links
 
 
 def _gpu_memory_usage_mib() -> list[tuple[int, int]]:
@@ -2263,7 +2286,14 @@ def _run_supported_case(
             minimum_free_fraction=options.minimum_gpu_free_fraction
         )
         command = _run_command(argv, environment, options.timeout_seconds)
-        command.pop("stdout", None)
+        row.setdefault("logs", []).extend(
+            _materialize_command_logs(
+                getattr(options, "output", case_work),
+                str(case["id"]),
+                side,
+                command,
+            )
+        )
         commands[side] = command
         if command["exit_code"] != 0:
             row["status"] = "failed"
@@ -2434,9 +2464,14 @@ def _should_skip(row: Mapping[str, Any]) -> bool:
 
 
 def _final_status(rows: Iterable[Mapping[str, Any]]) -> str:
-    statuses = {str(row.get("status")) for row in rows}
+    materialized = list(rows)
+    statuses = {str(row.get("status")) for row in materialized}
     invalid = {"failed", "contract-mismatch", "partial", "pending", "running"}
-    return "completed-with-errors" if statuses & invalid else "completed"
+    if statuses & invalid:
+        return "completed-with-errors"
+    if any(row.get("warnings") for row in materialized):
+        return "completed-with-warnings"
+    return "completed"
 
 
 def _light(status: str) -> str:
@@ -2445,6 +2480,182 @@ def _light(status: str) -> str:
         "yellow": "🟡",
         "red": "🔴",
     }.get(status, "⚪")
+
+
+def _perf_precision(row: Mapping[str, Any]) -> dict[str, str]:
+    resolved = row.get("resolved_settings", {})
+    resolved = resolved if isinstance(resolved, Mapping) else {}
+    model = resolved.get("model", {})
+    model = model if isinstance(model, Mapping) else {}
+    baseline = row.get("baseline", {})
+    baseline = baseline if isinstance(baseline, Mapping) else {}
+    candidate = row.get("candidate", {})
+    candidate = candidate if isinstance(candidate, Mapping) else {}
+    contract = row.get("baseline_contract", {})
+    contract = contract if isinstance(contract, Mapping) else {}
+    reference = (
+        resolved.get("baseline_precision")
+        or baseline.get("precision")
+        or contract.get("precision")
+    )
+    trtmc = candidate.get("precision") or model.get("precision")
+    return {
+        "reference": str(reference).lower() if reference else "Not recorded",
+        "candidate": str(trtmc).lower() if trtmc else "Not recorded",
+    }
+
+
+def _perf_state_and_result(row: Mapping[str, Any]) -> tuple[str, str | None]:
+    status = str(row.get("status", "pending"))
+    if status in {"pending", "running"}:
+        return status, None
+    if status in qualification_report.RGB_RESULTS and "Not recorded" in _perf_precision(
+        row
+    ).values():
+        return "terminal", "white"
+    return "terminal", status if status in qualification_report.RGB_RESULTS else "white"
+
+
+def _perf_issue(row: Mapping[str, Any], result: str | None) -> dict[str, str] | None:
+    if result != "white":
+        return None
+    status = str(row.get("status", "failed"))
+    reason = str(
+        row.get("reason")
+        or (row.get("comparison", {}).get("reason") if isinstance(row.get("comparison"), Mapping) else "")
+        or "performance comparison did not complete"
+    )
+    if status == "contract-mismatch":
+        return {
+            "priority": "P1",
+            "stage": "compare",
+            "domain": "model-workload",
+            "code": "output_not_comparable",
+            "message": reason,
+        }
+    if status in qualification_report.RGB_RESULTS:
+        return {
+            "priority": "P1",
+            "stage": "preflight",
+            "domain": "policy-config",
+            "code": "comparison_contract",
+            "message": "Reference and TRTMC compute precision were not both recorded",
+        }
+    return {
+        "priority": "P1",
+        "stage": str(row.get("failure_stage", "candidate")),
+        "domain": "harness/unknown",
+        "code": "execution_failure",
+        "message": reason,
+    }
+
+
+def _perf_output_validation(
+    row: Mapping[str, Any],
+    result: str | None,
+) -> dict[str, Any]:
+    resolved = row.get("resolved_settings", {})
+    resolved = resolved if isinstance(resolved, Mapping) else {}
+    contract = str(resolved.get("output_contract", "") or "Not recorded")
+    comparison = row.get("comparison", {})
+    comparison = comparison if isinstance(comparison, Mapping) else {}
+    if str(row.get("status")) in qualification_report.RGB_RESULTS:
+        status = "Pass"
+        reason = None
+    elif str(row.get("status")) == "contract-mismatch":
+        status = "Fail"
+        reason = str(comparison.get("reason", "") or row.get("reason", ""))
+    else:
+        status = "Not completed"
+        reason = str(row.get("reason", "") or "") or None
+    return {"status": status, "contract": contract, "reason": reason}
+
+
+def _perf_latency(row: Mapping[str, Any], result: str | None) -> dict[str, float | None]:
+    if result not in qualification_report.RGB_RESULTS:
+        return {"reference_ms": None, "candidate_ms": None}
+    try:
+        return {
+            "reference_ms": _median(row["baseline"]),
+            "candidate_ms": _median(row["candidate"]),
+        }
+    except (KeyError, PerfMatrixError, TypeError, ValueError):
+        return {"reference_ms": None, "candidate_ms": None}
+
+
+def _public_perf_result(row: Mapping[str, Any]) -> dict[str, Any]:
+    state, result = _perf_state_and_result(row)
+    public = deepcopy(dict(row))
+    commands = public.get("commands", {})
+    if isinstance(commands, Mapping):
+        for command in commands.values():
+            if isinstance(command, MutableMapping):
+                command.pop("stdout_tail", None)
+                command.pop("stderr_tail", None)
+    public.update(
+        {
+            "state": state,
+            "result": result,
+            "precision": _perf_precision(row),
+            "output_validation": _perf_output_validation(row, result),
+            "latency": _perf_latency(row, result),
+            "issue": _perf_issue(row, result),
+            "debug": {
+                "logs": [dict(record) for record in row.get("logs", [])],
+            },
+        }
+    )
+    return public
+
+
+def _public_perf_results(results: Mapping[str, Any]) -> list[dict[str, Any]]:
+    selected = {str(value) for value in results.get("selected_entry_ids", [])}
+    return [
+        _public_perf_result(row)
+        for row in results.get("cases", [])
+        if str(row.get("id", "")) in selected
+    ]
+
+
+def _materialize_public_perf_report(
+    output: Path,
+    results: Mapping[str, Any],
+) -> tuple[Path, Path, dict[str, Any]]:
+    environment = results.get("environment", {})
+    environment = environment if isinstance(environment, Mapping) else {}
+    run = {
+        "source_revision": results.get("git_commit"),
+        "hostname": environment.get("hostname"),
+        "gpu": environment.get("gpu"),
+        "gpu_uuid": environment.get("gpu_uuid"),
+        "driver": environment.get("driver"),
+        "platform": environment.get("platform"),
+        "python": environment.get("python"),
+        "python_executable": environment.get("python_executable"),
+        "cuda_visible_devices": environment.get("cuda_visible_devices"),
+        "nvidia_visible_devices": environment.get("nvidia_visible_devices"),
+        "started_at": results.get("started_at"),
+        "finished_at": results.get("finished_at"),
+    }
+    return qualification_report.materialize_report(
+        output,
+        report_kind="performance",
+        title="TRTMC Performance Qualification",
+        identity={
+            "run_id": output.name,
+            "disposition": results.get("status", "running"),
+            "source_revision": results.get("git_commit"),
+        },
+        run=run,
+        results=_public_perf_results(results),
+        metadata={
+            "campaign": {
+                "suite_name": results.get("suite_name"),
+                "suite_sha256": results.get("suite_sha256"),
+                "status": results.get("status", "running"),
+            }
+        },
+    )
 
 
 def _baseline_label(row: Mapping[str, Any]) -> str:
@@ -3034,7 +3245,7 @@ def _report_html(results: Mapping[str, Any]) -> str:
 
 def _write_artifacts(output: Path, results: Mapping[str, Any]) -> None:
     _write_json(output / "results.json", results)
-    (output / "report.html").write_text(_report_html(results), encoding="utf-8")
+    _materialize_public_perf_report(output, results)
     legacy_replay = output / "reproduce.py"
     if legacy_replay.is_file():
         legacy_replay.unlink()
@@ -3151,6 +3362,7 @@ def _report_existing(arguments: argparse.Namespace) -> int:
         _apply_bundle_preparation_receipt(results, receipt)
     _write_artifacts(output, results)
     print(f"Results: {output / 'results.json'}")
+    print(f"Report data: {output / 'report.json'}")
     print(f"Report: {output / 'report.html'}")
     return 0
 
@@ -3326,9 +3538,13 @@ def _execute_campaign(
             if item["status"] == "failed"
         ]
         if cleanup_failures:
-            row["performance_status_before_cleanup_failure"] = row.get("status")
-            row["status"] = "failed"
-            row["reason"] = f"resource cleanup failed: {'; '.join(cleanup_failures)}"
+            row.setdefault("warnings", []).append(
+                {
+                    "stage": "cleanup",
+                    "code": "resource_cleanup_failed",
+                    "message": "; ".join(cleanup_failures),
+                }
+            )
         rows[case_id].clear()
         rows[case_id].update(row)
         _write_artifacts(options.output, results)
@@ -3345,6 +3561,7 @@ def _execute_campaign(
     except OSError:
         pass
     print(f"Results: {options.output / 'results.json'}")
+    print(f"Report data: {options.output / 'report.json'}")
     print(f"Report: {options.output / 'report.html'}")
     return 1 if _campaign_failed(results, selected_ids) else 0
 

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -39,7 +39,11 @@ for source_root in (REPOSITORY, PYTHON_SOURCE):
 
 from benchmarks.performance.baselines.timing_contracts import timing_contract  # noqa: E402
 from tensorrt_model_connect.benchmark.catalog import ManifestCatalog  # noqa: E402
-from tensorrt_model_connect.benchmark.types import BenchmarkError  # noqa: E402
+from tensorrt_model_connect.benchmark.types import (  # noqa: E402
+    COMMAND_DIAGNOSTIC_PREFIX,
+    COMMAND_DIAGNOSTIC_SCHEMA,
+    BenchmarkError,
+)
 from tensorrt_model_connect.benchmark.worker import (  # noqa: E402
     find_worker,
     worker_metadata,
@@ -1685,7 +1689,7 @@ def _run_command(
         stdout = ""
         stderr = str(exc)
     elapsed = time.monotonic() - started
-    return {
+    result = {
         "argv": list(argv),
         "rendered": shlex.join(argv),
         "cwd": str(REPOSITORY),
@@ -1704,6 +1708,38 @@ def _run_command(
         "stdout_tail": stdout[-16000:],
         "stderr_tail": stderr[-16000:],
     }
+    diagnostic = _command_diagnostic(stderr)
+    if diagnostic is not None:
+        result["diagnostic"] = diagnostic
+    return result
+
+
+def _command_diagnostic(stderr: str) -> dict[str, Any] | None:
+    """Read the stable benchmark diagnostic marker without parsing prose."""
+
+    for line in reversed(stderr.splitlines()):
+        if not line.startswith(COMMAND_DIAGNOSTIC_PREFIX):
+            continue
+        try:
+            value = json.loads(line[len(COMMAND_DIAGNOSTIC_PREFIX) :])
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(value, dict) or value.get("schema_version") != COMMAND_DIAGNOSTIC_SCHEMA:
+            return None
+        if not all(str(value.get(name, "")).strip() for name in ("stage", "domain", "code")):
+            return None
+        artifacts = value.get("artifacts", [])
+        if not isinstance(artifacts, list):
+            return None
+        if any(
+            not isinstance(item, Mapping)
+            or not str(item.get("label", "")).strip()
+            or not str(item.get("path", "")).strip()
+            for item in artifacts
+        ):
+            return None
+        return deepcopy(value)
+    return None
 
 
 def _materialize_command_logs(
@@ -1722,6 +1758,25 @@ def _materialize_command_logs(
         command[f"{stream}_log"] = href
         side_label = "TRTMC" if side == "trtmc" else "Reference"
         links.append({"label": f"{side_label} {stream}", "href": href})
+    diagnostic = command.get("diagnostic")
+    if isinstance(diagnostic, MutableMapping):
+        materialized = []
+        artifacts = diagnostic.get("artifacts", [])
+        artifacts = artifacts if isinstance(artifacts, list) else []
+        for index, artifact in enumerate(artifacts, start=1):
+            if not isinstance(artifact, Mapping):
+                continue
+            source = Path(str(artifact.get("path", "")))
+            label = str(artifact.get("label", "") or f"Diagnostic {index}")
+            if not source.is_file():
+                continue
+            suffix = "".join(source.suffixes) or ".log"
+            path = directory / f"{side}.{_slug(label)}{suffix}"
+            shutil.copyfile(source, path)
+            record = {"label": label, "href": path.relative_to(output).as_posix()}
+            materialized.append(record)
+            links.append(record)
+        diagnostic["artifacts"] = materialized
     return links
 
 
@@ -2298,6 +2353,18 @@ def _run_supported_case(
         if command["exit_code"] != 0:
             row["status"] = "failed"
             row["reason"] = f"{side} command failed with rc={command['exit_code']}"
+            diagnostic = command.get("diagnostic", {})
+            diagnostic = diagnostic if isinstance(diagnostic, Mapping) else {}
+            row["failure_stage"] = str(
+                diagnostic.get("stage")
+                or ("candidate" if side == "trtmc" else "reference")
+            )
+            row["failure_domain"] = str(
+                diagnostic.get("domain") or "harness/unknown"
+            )
+            row["failure_code"] = str(
+                diagnostic.get("code") or "execution_failure"
+            )
             return
     candidate = _candidate_result(candidate_dir, digest)
     candidate["precision"] = str(resolved["model"]["precision"])
@@ -2498,7 +2565,20 @@ def _perf_precision(row: Mapping[str, Any]) -> dict[str, str]:
         or baseline.get("precision")
         or contract.get("precision")
     )
-    trtmc = candidate.get("precision") or model.get("precision")
+    base_precision = candidate.get("precision") or model.get("precision")
+    build = model.get("build", {})
+    build = build if isinstance(build, Mapping) else {}
+    quantization = build.get("quantization", {})
+    quantization = quantization if isinstance(quantization, Mapping) else {}
+    quantization_format = str(quantization.get("format", "") or "").lower()
+    if quantization_format and quantization_format not in {"none", "false"}:
+        trtmc = (
+            f"{quantization_format} ({str(base_precision).lower()} base)"
+            if base_precision
+            else quantization_format
+        )
+    else:
+        trtmc = base_precision
     return {
         "reference": str(reference).lower() if reference else "Not recorded",
         "candidate": str(trtmc).lower() if trtmc else "Not recorded",
@@ -2544,8 +2624,8 @@ def _perf_issue(row: Mapping[str, Any], result: str | None) -> dict[str, str] | 
     return {
         "priority": "P1",
         "stage": str(row.get("failure_stage", "candidate")),
-        "domain": "harness/unknown",
-        "code": "execution_failure",
+        "domain": str(row.get("failure_domain", "harness/unknown")),
+        "code": str(row.get("failure_code", "execution_failure")),
         "message": reason,
     }
 

--- a/tools/qualification_report.py
+++ b/tools/qualification_report.py
@@ -198,6 +198,9 @@ def _validate_public_results(output: Path, results: Sequence[dict[str, Any]]) ->
                         f"case debug.{collection} entries must contain href"
                     )
                 _validate_artifact_href(output, record["href"])
+        sample_differences = row.get("sample_differences")
+        if isinstance(sample_differences, Mapping) and sample_differences.get("href"):
+            _validate_artifact_href(output, sample_differences["href"])
 
 
 def _html_shell(title: str) -> str:

--- a/tools/qualification_report.py
+++ b/tools/qualification_report.py
@@ -11,7 +11,6 @@ import json
 import os
 from pathlib import Path
 import re
-import shutil
 from typing import Any, Mapping, Sequence
 
 
@@ -101,6 +100,15 @@ def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
         json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    temporary.replace(path)
+
+
+def _write_bytes_if_changed(path: Path, content: bytes) -> None:
+    if path.is_file() and path.read_bytes() == content:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_bytes(content)
     temporary.replace(path)
 
 
@@ -268,6 +276,6 @@ def materialize_report(
         "qualification-report.js",
         "qualification-report.schema.json",
     ):
-        shutil.copyfile(ASSET_DIRECTORY / name, assets / name)
-    html_path.write_text(_html_shell(title), encoding="utf-8")
+        _write_bytes_if_changed(assets / name, (ASSET_DIRECTORY / name).read_bytes())
+    _write_bytes_if_changed(html_path, _html_shell(title).encode("utf-8"))
     return json_path, html_path, report

--- a/tools/qualification_report.py
+++ b/tools/qualification_report.py
@@ -114,8 +114,13 @@ def _validate_artifact_href(output: Path, href: Any) -> None:
         raise QualificationReportError(
             f"report artifact href must be relative to the report root: {href!r}"
         )
-    if not (output / relative).is_file():
+    artifact = output / relative
+    if not artifact.is_file():
         raise QualificationReportError(f"report artifact does not exist: {href!r}")
+    if artifact.is_symlink():
+        raise QualificationReportError(
+            f"report artifact must be a self-contained regular file: {href!r}"
+        )
 
 
 def _materialize_missing_failure_log(

--- a/tools/qualification_report.py
+++ b/tools/qualification_report.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared public report contract for Accuracy and Performance qualification."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Any, Mapping, Sequence
+
+
+REPORT_SCHEMA = "trtmc.qualification-report/v1"
+RGB_RESULTS = ("green", "yellow", "red")
+TERMINAL_RESULTS = (*RGB_RESULTS, "white")
+CASE_STATES = ("pending", "running", "terminal")
+ASSET_DIRECTORY = Path(__file__).with_name("qualification_report_assets")
+
+
+class QualificationReportError(ValueError):
+    """The public qualification report violates its accounting contract."""
+
+
+def _percentage(numerator: int, denominator: int) -> float:
+    return round(100.0 * numerator / denominator, 2) if denominator else 0.0
+
+
+def outcome_accounting(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return mutually exclusive progress and outcome counts for selected rows."""
+
+    progress = {state: 0 for state in CASE_STATES}
+    outcomes = {result: 0 for result in TERMINAL_RESULTS}
+    for row in results:
+        state = str(row.get("state", "terminal"))
+        if state not in progress:
+            raise QualificationReportError(f"unknown case state: {state}")
+        result = row.get("result")
+        if state == "terminal":
+            if result not in outcomes:
+                raise QualificationReportError(
+                    f"terminal case must have one result in {TERMINAL_RESULTS}: {result!r}"
+                )
+            outcomes[str(result)] += 1
+        elif result is not None:
+            raise QualificationReportError(
+                f"{state} case cannot have a traffic-light result: {result!r}"
+            )
+        progress[state] += 1
+
+    selected = len(results)
+    comparable = sum(outcomes[result] for result in RGB_RESULTS)
+    if progress["terminal"] != comparable + outcomes["white"]:
+        raise QualificationReportError("terminal accounting is not mutually exclusive")
+    if selected != sum(progress.values()):
+        raise QualificationReportError("selected accounting is not mutually exclusive")
+    return {
+        "selected": selected,
+        "comparable": comparable,
+        "operational_coverage_percent": _percentage(comparable, selected),
+        "progress": progress,
+        "outcomes": outcomes,
+        "invariants": {
+            "selected": "pending + running + terminal",
+            "terminal": "green + yellow + red + white",
+            "comparable": "green + yellow + red",
+        },
+        "definitions": {
+            "green": {
+                "class": "valid-comparison",
+                "label": "Meets the target",
+                "denominator": "comparable",
+            },
+            "yellow": {
+                "class": "valid-comparison",
+                "label": "Valid comparison in the review band",
+                "denominator": "comparable",
+            },
+            "red": {
+                "class": "valid-comparison",
+                "label": "Valid comparison that misses the target",
+                "denominator": "comparable",
+            },
+            "white": {
+                "class": "coverage-gap",
+                "label": "No valid comparison",
+                "denominator": "selected",
+            },
+        },
+    }
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _artifact_slug(value: Any) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value)).strip("-") or "case"
+
+
+def _validate_artifact_href(output: Path, href: Any) -> None:
+    relative = Path(str(href))
+    if relative.is_absolute() or ".." in relative.parts:
+        raise QualificationReportError(
+            f"report artifact href must be relative to the report root: {href!r}"
+        )
+    if not (output / relative).is_file():
+        raise QualificationReportError(f"report artifact does not exist: {href!r}")
+
+
+def _materialize_missing_failure_log(
+    output: Path,
+    row: dict[str, Any],
+) -> None:
+    if row.get("state") != "terminal" or row.get("result") != "white":
+        return
+    debug = row.setdefault("debug", {})
+    if not isinstance(debug, dict):
+        raise QualificationReportError("case debug evidence must be a JSON object")
+    logs = debug.setdefault("logs", [])
+    if not isinstance(logs, list):
+        raise QualificationReportError("case debug.logs must be a JSON array")
+    if logs:
+        return
+    issue = row.get("issue")
+    if not isinstance(issue, Mapping):
+        raise QualificationReportError(
+            "white case must provide structured issue evidence"
+        )
+    stage = _artifact_slug(issue.get("stage", "report"))
+    path = (
+        output
+        / "artifacts"
+        / _artifact_slug(row.get("id", "case"))
+        / "logs"
+        / f"{stage}.log"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    evidence = {
+        "case_id": row.get("id"),
+        "issue": dict(issue),
+        "commands": row.get("commands", {}),
+        "reproduce": row.get("reproduce", {}),
+    }
+    path.write_text(
+        json.dumps(evidence, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    logs.append(
+        {
+            "label": f"{str(issue.get('stage', 'report')).replace('-', ' ').title()} diagnostic",
+            "href": path.relative_to(output).as_posix(),
+        }
+    )
+
+
+def _validate_public_results(output: Path, results: Sequence[dict[str, Any]]) -> None:
+    for row in results:
+        if not str(row.get("id", "")).strip():
+            raise QualificationReportError(
+                "every report result must have a non-empty id"
+            )
+        _materialize_missing_failure_log(output, row)
+        if row.get("result") == "white":
+            issue = row.get("issue")
+            required = {"priority", "stage", "domain", "code", "message"}
+            if not isinstance(issue, Mapping) or not required <= issue.keys():
+                raise QualificationReportError(
+                    f"white case {row['id']!r} must provide {sorted(required)}"
+                )
+        debug = row.get("debug", {})
+        if not isinstance(debug, Mapping):
+            raise QualificationReportError("case debug evidence must be a JSON object")
+        for collection in ("logs", "command_artifacts"):
+            records = debug.get(collection, [])
+            if not isinstance(records, list):
+                raise QualificationReportError(
+                    f"case debug.{collection} must be a JSON array"
+                )
+            for record in records:
+                if not isinstance(record, Mapping) or not record.get("href"):
+                    raise QualificationReportError(
+                        f"case debug.{collection} entries must contain href"
+                    )
+                _validate_artifact_href(output, record["href"])
+
+
+def _html_shell(title: str) -> str:
+    safe_title = (
+        title.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{safe_title}</title>
+<link rel="stylesheet" href="assets/qualification-report.css">
+</head><body data-report="report.json">
+<main id="report-root"><p class="meta">Loading report.json…</p></main>
+<script src="assets/qualification-report.js" defer></script>
+</body></html>
+"""
+
+
+def materialize_report(
+    output: Path,
+    *,
+    report_kind: str,
+    title: str,
+    identity: Mapping[str, Any],
+    run: Mapping[str, Any],
+    results: Sequence[Mapping[str, Any]],
+    metadata: Mapping[str, Any] | None = None,
+) -> tuple[Path, Path, dict[str, Any]]:
+    """Atomically publish report.json and a data-only HTML renderer shell."""
+
+    if report_kind not in {"accuracy", "performance"}:
+        raise QualificationReportError(f"unknown report kind: {report_kind}")
+    public_results = [deepcopy(dict(row)) for row in results]
+    _validate_public_results(output, public_results)
+    public_run = deepcopy(dict(run))
+    environment_path = output / "artifacts" / "run" / "environment.json"
+    _write_json_atomic(environment_path, public_run)
+    public_run["environment_href"] = environment_path.relative_to(output).as_posix()
+    report: dict[str, Any] = {
+        "$schema": "assets/qualification-report.schema.json",
+        "schema_version": REPORT_SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "report_kind": report_kind,
+        "identity": {"title": title, **dict(identity)},
+        "run": public_run,
+        "accounting": outcome_accounting(public_results),
+        "results": public_results,
+    }
+    if metadata:
+        for name, value in metadata.items():
+            if name in report:
+                raise QualificationReportError(f"metadata cannot replace {name!r}")
+            report[name] = value
+
+    json_path = output / "report.json"
+    html_path = output / "report.html"
+    _write_json_atomic(json_path, report)
+    assets = output / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    for name in (
+        "qualification-report.css",
+        "qualification-report.js",
+        "qualification-report.schema.json",
+    ):
+        shutil.copyfile(ASSET_DIRECTORY / name, assets / name)
+    html_path.write_text(_html_shell(title), encoding="utf-8")
+    return json_path, html_path, report

--- a/tools/qualification_report_assets/qualification-report.css
+++ b/tools/qualification_report_assets/qualification-report.css
@@ -1,5 +1,7 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 :root {
   --bg: #f3f5f2; --panel: #fff; --raised: #f8faf7; --line: rgba(24,39,26,.12);

--- a/tools/qualification_report_assets/qualification-report.css
+++ b/tools/qualification_report_assets/qualification-report.css
@@ -56,6 +56,10 @@ tr[data-result="white"] { background: #f0f2ef; } tr[data-result="red"] { backgro
 .timing { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
 .log-links { display: grid; gap: 4px; min-width: 110px; }.log-links a { width: fit-content; font-size: 12px; font-weight: 650; white-space: nowrap; }
 .command-artifact { display: block; width: fit-content; margin-top: 5px; font-size: 12px; font-weight: 650; }
+.reproduction { display: grid; gap: 7px; min-width: 180px; }
+.sample-differences .evidence-body { min-width: min(900px,78vw); }
+.sample-differences details.evidence { margin: 8px 0; padding: 8px; border: 1px solid var(--line); border-radius: 8px; }
+.difference-artifact { display: block; width: fit-content; margin-top: 8px; font-size: 12px; font-weight: 650; }
 .unavailable { color: var(--muted); font-size: 12px; }
 details.evidence { min-width: 90px; }.evidence-body { min-width: min(760px,72vw); padding-top: 7px; }
 .evidence-body h4 { margin: 12px 0 4px; }

--- a/tools/qualification_report_assets/qualification-report.css
+++ b/tools/qualification_report_assets/qualification-report.css
@@ -1,0 +1,64 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+:root {
+  --bg: #f3f5f2; --panel: #fff; --raised: #f8faf7; --line: rgba(24,39,26,.12);
+  --line-strong: rgba(24,39,26,.22); --text: #18201a; --muted: #667069;
+  --green: #5c9600; --green-dark: #315500; --amber: #a96f00; --red: #b93434;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+body { min-width: 320px; margin: 0; padding: 28px; color: var(--text); background: var(--bg); font-size: 14px; line-height: 1.45; }
+button, input, select { font: inherit; }
+code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+code { font-size: 12px; }
+a, summary { color: var(--green-dark); }
+summary { cursor: pointer; font-weight: 650; }
+.report-header { margin-bottom: 12px; }
+.report-eyebrow { margin: 0 0 7px; color: var(--green); font-size: 11px; font-weight: 750; letter-spacing: .13em; text-transform: uppercase; }
+h1 { margin: 0 0 5px; font-size: clamp(25px,3vw,34px); line-height: 1.15; }
+h2 { margin: 24px 0 5px; font-size: 18px; }
+.purpose, .meta, .detail { color: var(--muted); }
+.purpose { margin: 0; font-size: 15px; }
+.meta { margin: 6px 0 14px; overflow-wrap: anywhere; }
+.environment-link { font-weight: 650; white-space: nowrap; }
+.disposition { width: fit-content; margin: -4px 0 14px; padding: 6px 9px; border: 1px solid #d4a522; border-radius: 7px; color: #674d14; background: #fff9e8; font-size: 12px; font-weight: 700; }
+.detail { margin-top: 3px; font-size: 11px; }
+.outcome-strip { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 10px; margin: 16px 0; }
+.traffic-summary { display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; min-height: 58px; padding: 11px 14px; border: 1px solid var(--line-strong); border-radius: 12px; background: var(--panel); box-shadow: 0 8px 24px rgba(35,48,37,.07); }
+.traffic-label { width: 100%; color: var(--muted); font-size: 11px; font-weight: 750; letter-spacing: .05em; text-transform: uppercase; }
+.traffic-item { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.traffic-item strong { font-size: 15px; font-variant-numeric: tabular-nums; }
+.progress-summary { width: 100%; margin: 0 0 16px; }
+.signal { display: inline-flex; align-items: center; gap: 7px; font-weight: 650; white-space: nowrap; }
+.signal-light { width: 10px; height: 10px; border-radius: 50%; background: #80868b; box-shadow: 0 0 0 3px #eef0f1; }
+.signal-green { color: #137333; }.signal-green .signal-light { background: #1e8e3e; box-shadow: 0 0 0 3px #e6f4ea; }
+.signal-yellow { color: #8a4f00; }.signal-yellow .signal-light { background: #f9ab00; box-shadow: 0 0 0 3px #fef7e0; }
+.signal-red { color: #b3261e; }.signal-red .signal-light { background: #d93025; box-shadow: 0 0 0 3px #fce8e6; }
+.signal-white { color: #5f6368; }.signal-white .signal-light { background: #fff; border: 2px solid #80868b; box-shadow: 0 0 0 3px #eef0f1; }
+.state { color: var(--muted); font-weight: 650; text-transform: capitalize; }
+.filters { position: sticky; z-index: 10; top: 0; display: flex; flex-wrap: wrap; gap: 10px; align-items: end; margin: 14px 0; padding: 12px; border: 1px solid var(--line-strong); border-radius: 12px; background: rgba(255,255,255,.95); }
+.filters label { display: grid; gap: 4px; color: var(--muted); font-size: 11px; font-weight: 750; text-transform: uppercase; }
+.filters input, .filters select, .filters button { min-height: 36px; padding: 7px 10px; border: 1px solid var(--line-strong); border-radius: 8px; background: #fff; }
+.filters input { min-width: 250px; }.filter-count { margin-left: auto; color: var(--muted); font-size: 12px; }
+.table-wrap { width: 100%; overflow: auto; border: 1px solid var(--line-strong); border-radius: 12px; background: var(--panel); }
+table { width: 100%; border-collapse: separate; border-spacing: 0; }
+.register-table { min-width: 1460px; }.failures table { min-width: 1120px; }
+th, td { padding: 8px 10px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+th:last-child, td:last-child { border-right: 0; } tbody tr:last-child td { border-bottom: 0; }
+th { color: #3f4a42; background: #edf1eb; font-size: 12px; font-weight: 750; white-space: nowrap; }
+tbody tr:nth-child(even) { background: var(--raised); } tbody tr:hover { background: #f2f8ea; }
+tr[data-result="white"] { background: #f0f2ef; } tr[data-result="red"] { background: #fff8f7; }
+.precision-side { display: flex; justify-content: space-between; gap: 10px; white-space: nowrap; }
+.precision-side span { color: var(--muted); font-size: 11px; }.precision-side strong { font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
+.metric { display: flex; justify-content: space-between; gap: 14px; font-size: 12px; font-variant-numeric: tabular-nums; }.metric span { color: var(--muted); }
+.timing { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.log-links { display: grid; gap: 4px; min-width: 110px; }.log-links a { width: fit-content; font-size: 12px; font-weight: 650; white-space: nowrap; }
+.command-artifact { display: block; width: fit-content; margin-top: 5px; font-size: 12px; font-weight: 650; }
+.unavailable { color: var(--muted); font-size: 12px; }
+details.evidence { min-width: 90px; }.evidence-body { min-width: min(760px,72vw); padding-top: 7px; }
+.evidence-body h4 { margin: 12px 0 4px; }
+pre { max-height: 360px; overflow: auto; margin: 4px 0 10px; padding: 10px; border: 1px solid var(--line); border-radius: 8px; background: #f4f6f3; white-space: pre-wrap; overflow-wrap: anywhere; }
+.empty, .fatal { padding: 18px; border: 1px solid var(--line-strong); border-radius: 12px; background: #fff; color: var(--muted); }
+@media (max-width: 760px) { body { padding: 18px 12px; }.outcome-strip { grid-template-columns: 1fr; }.filters { position: static; }.filters label,.filters input,.filters select { width: 100%; min-width: 0; }.filter-count { width: 100%; margin-left: 0; } }

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -100,6 +100,14 @@
     return add(el("div", ""), add(el("div", "precision-side"), el("span", "", "Reference"), el("strong", "", value.reference || "Not recorded")), add(el("div", "precision-side"), el("span", "", "TRTMC"), el("strong", "", value.candidate || "Not recorded")));
   }
 
+  function samples(row) {
+    const planned = Number.isInteger(row.samples?.planned) ? row.samples.planned : null;
+    const evaluated = Number.isInteger(row.samples?.evaluated) ? row.samples.evaluated : null;
+    if (planned === null && evaluated === null) return el("span", "unavailable", "—");
+    if (planned !== null && evaluated !== null && planned !== evaluated) return el("span", "sample-count", `${evaluated} / ${planned}`);
+    return el("span", "sample-count", evaluated ?? planned);
+  }
+
   function metricLine(label, value) {
     return add(el("div", "metric"), el("span", "", label), el("strong", "", value));
   }
@@ -204,7 +212,7 @@
 
   function table(rows, report, compact = false) {
     const kind = report.report_kind;
-    const labels = compact ? ["Result", "Model / task", kind === "accuracy" ? "Accuracy / fidelity" : "Output validation", "Metrics", "Logs", kind === "accuracy" ? "Vanilla reproduction" : "Commands"] : kind === "accuracy" ? ["Model / task", "Compute precision", "Accuracy / fidelity", "Result", "Metrics", "Logs", "Vanilla reproduction", "Commands"] : ["Model / task", "Compute precision", "Output validation", "Reference latency", "TRTMC latency", "Result", "Metrics", "Logs", "Commands"];
+    const labels = compact ? (kind === "accuracy" ? ["Result", "Model / task", "Samples", "Accuracy / fidelity", "Metrics", "Logs", "Vanilla reproduction"] : ["Result", "Model / task", "Output validation", "Metrics", "Logs", "Commands"]) : kind === "accuracy" ? ["Model / task", "Samples", "Compute precision", "Accuracy / fidelity", "Result", "Metrics", "Logs", "Vanilla reproduction", "Commands"] : ["Model / task", "Compute precision", "Output validation", "Reference latency", "TRTMC latency", "Result", "Metrics", "Logs", "Commands"];
     const wrap = el("div", `table-wrap${compact ? " failures" : ""}`);
     const value = el("table", compact ? "" : "register-table");
     const head = el("thead"); const headRow = el("tr"); labels.forEach((label) => headRow.append(el("th", "", label))); head.append(headRow);
@@ -212,8 +220,8 @@
     rows.forEach((row) => {
       const tr = el("tr"); tr.dataset.result = row.result || row.state;
       let cells;
-      if (compact) cells = [resultCell(row), modelTask(row), kind === "accuracy" ? accuracyFacts(row) : outputValidation(row), metrics(row, kind), logs(row), kind === "accuracy" ? vanilla(row) : commands(row)];
-      else if (kind === "accuracy") cells = [modelTask(row), precision(row), accuracyFacts(row), resultCell(row), metrics(row, kind), logs(row), vanilla(row), commands(row)];
+      if (compact) cells = kind === "accuracy" ? [resultCell(row), modelTask(row), samples(row), accuracyFacts(row), metrics(row, kind), logs(row), vanilla(row)] : [resultCell(row), modelTask(row), outputValidation(row), metrics(row, kind), logs(row), commands(row)];
+      else if (kind === "accuracy") cells = [modelTask(row), samples(row), precision(row), accuracyFacts(row), resultCell(row), metrics(row, kind), logs(row), vanilla(row), commands(row)];
       else cells = [modelTask(row), precision(row), outputValidation(row), el("span", "timing", row.latency?.reference_ms == null ? "—" : `${number(row.latency.reference_ms)} ms`), el("span", "timing", row.latency?.candidate_ms == null ? "—" : `${number(row.latency.candidate_ms)} ms`), resultCell(row), metrics(row, kind), logs(row), commands(row)];
       cells.forEach((cell) => add(tr, add(el("td", ""), cell))); body.append(tr);
     });

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -125,16 +125,28 @@
     return percent(value);
   }
 
+  function sameMetricValue(left, right) {
+    if (!Number.isFinite(Number(left)) || !Number.isFinite(Number(right))) return false;
+    return Math.abs(Number(left) - Number(right)) <= 1e-12;
+  }
+
   function accuracyFacts(row) {
     if (row.result === "white") return el("span", "unavailable", "—");
     const comparison = row.comparison || {};
     const metrics = comparison.metrics || {};
     const value = el("div");
     const displayed = new Set();
-    [["prediction_agreement_rate", "Agreement"], ["correctness_agreement_rate", "Correctness agreement"]].forEach(([key, label]) => { if (metrics[key] !== undefined) { value.append(metricLine(label, agreement(metrics[key], metrics))); displayed.add(key); } });
+    const displayedValues = [];
+    [["prediction_agreement_rate", "Agreement"], ["correctness_agreement_rate", "Correctness agreement"]].forEach(([key, label]) => { if (metrics[key] !== undefined) { value.append(metricLine(label, agreement(metrics[key], metrics))); displayed.add(key); displayedValues.push(metrics[key]); } });
     [["hf_accuracy", "Reference accuracy"], ["bundle_accuracy", "TRTMC accuracy"]].forEach(([key, label]) => { if (metrics[key] !== undefined) { value.append(metricLine(label, percent(metrics[key]))); displayed.add(key); } });
     if (metrics.accuracy_delta_bundle_minus_hf !== undefined) { value.append(metricLine("Accuracy delta", percent(metrics.accuracy_delta_bundle_minus_hf, true))); displayed.add("accuracy_delta_bundle_minus_hf"); }
-    if (comparison.primary_metric && !displayed.has(comparison.primary_metric.name)) value.prepend(metricLine(comparison.primary_metric.name, number(comparison.primary_metric.value, 4)));
+    if (comparison.primary_metric && !displayed.has(comparison.primary_metric.name) && !displayedValues.some((item) => sameMetricValue(item, comparison.primary_metric.value))) value.prepend(metricLine(comparison.primary_metric.name, number(comparison.primary_metric.value, 4)));
+    const differenceCount = Number(row.sample_differences?.count || 0);
+    if (differenceCount > 0) {
+      const evaluated = Number.isInteger(row.samples?.evaluated) ? row.samples.evaluated : null;
+      const label = row.sample_differences.classification === "failed_samples" ? "Failed samples" : "Sample differences";
+      value.append(metricLine(label, evaluated === null ? differenceCount : `${differenceCount} / ${evaluated}`));
+    }
     return value.childElementCount ? value : el("span", "unavailable", "See Metrics");
   }
 
@@ -185,11 +197,44 @@
     return [label, `$ ${command}`];
   }
 
+  function sampleDifferences(row) {
+    const differences = row.sample_differences || {};
+    const count = Number(differences.count || 0);
+    if (count <= 0) return null;
+    const noun = differences.classification === "failed_samples" ? "failed samples" : "sample differences";
+    const control = el("details", "evidence sample-differences");
+    control.append(el("summary", "", `${count} ${noun} · results and vanilla commands`));
+    const body = el("div", "evidence-body");
+    (differences.preview || []).forEach((record) => {
+      const reason = String(record.reason || "comparison mismatch").replaceAll("_", " ");
+      const records = [
+        ["Input", record.input || {}],
+        ["Reference result", record.reference_result || {}],
+        ["TRTMC result", record.trtmc_result || {}],
+        ["Comparison", record.comparison || {}],
+        commandBlock("Reference vanilla command", record.reproduce?.reference),
+        commandBlock("TRTMC vanilla command", record.reproduce?.trtmc),
+      ].filter(Boolean);
+      body.append(details(`${record.sample_id || "unknown sample"} · ${reason}`, records));
+    });
+    if (differences.href) {
+      const link = el("a", "difference-artifact", "Open complete disagreements.jsonl");
+      link.href = differences.href; link.target = "_blank"; link.rel = "noopener"; body.append(link);
+    }
+    control.append(body);
+    return control;
+  }
+
   function vanilla(row) {
     const reproduce = row.reproduce || {};
     const dataset = reproduce.dataset || {};
     const records = [commandBlock(dataset.prepared_input_count === undefined ? "Dataset slice" : `Dataset slice (${dataset.prepared_input_count} samples)`, dataset.command), commandBlock("Reference sample", (reproduce.hf || [])[0]), commandBlock("TRTMC sample", (reproduce.trtmc || [])[0])].filter(Boolean);
-    return records.length ? details(`Dataset · Reference ${(reproduce.commands_shown || {}).hf || 0}/${(reproduce.command_count || {}).hf || 0} · TRTMC ${(reproduce.commands_shown || {}).trtmc || 0}/${(reproduce.command_count || {}).trtmc || 0}`, records) : el("span", "unavailable", "Unavailable");
+    const value = el("div", "reproduction");
+    const differences = sampleDifferences(row);
+    if (differences) value.append(differences);
+    if (records.length) value.append(details(`Dataset · Reference ${(reproduce.commands_shown || {}).hf || 0}/${(reproduce.command_count || {}).hf || 0} · TRTMC ${(reproduce.commands_shown || {}).trtmc || 0}/${(reproduce.command_count || {}).trtmc || 0}`, records));
+    if (!value.childElementCount) value.append(el("span", "unavailable", "Unavailable"));
+    return value;
   }
 
   function commands(row) {

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(() => {
+  "use strict";
+
+  const root = document.getElementById("report-root");
+  const reportPath = document.body.dataset.report || "report.json";
+  const resultOrder = ["white", "red", "yellow", "green"];
+  const progressOrder = { running: -2, pending: -1 };
+  const priorityOrder = { P0: 0, P1: 1, P2: 2 };
+  const names = { green: "Green", yellow: "Yellow", red: "Red", white: "No valid comparison" };
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function add(parent, ...children) {
+    children.flat().filter(Boolean).forEach((child) => parent.append(child));
+    return parent;
+  }
+
+  function signal(result) {
+    if (!result) return el("span", "state", "In progress");
+    return add(el("span", `signal signal-${result}`), el("span", "signal-light"), el("span", "", names[result]));
+  }
+
+  function compareRows(left, right) {
+    const leftResult = left.result || left.state;
+    const rightResult = right.result || right.state;
+    const leftRank = progressOrder[leftResult] ?? resultOrder.indexOf(leftResult);
+    const rightRank = progressOrder[rightResult] ?? resultOrder.indexOf(rightResult);
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    const leftPriority = priorityOrder[left.issue?.priority] ?? 99;
+    const rightPriority = priorityOrder[right.issue?.priority] ?? 99;
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+    return String(left.id || "").localeCompare(String(right.id || ""));
+  }
+
+  function number(value, digits = 3) {
+    if (value === null || value === undefined || !Number.isFinite(Number(value))) return "—";
+    return Number(value).toLocaleString(undefined, { maximumFractionDigits: digits });
+  }
+
+  function timestamp(value) {
+    if (!value) return "—";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+  }
+
+  function reportHeader(report) {
+    const fragment = document.createDocumentFragment();
+    const header = el("header", "report-header");
+    add(header, el("p", "report-eyebrow", report.report_kind === "accuracy" ? "Validation report" : "Performance report"), el("h1", "", report.identity.title), el("p", "purpose", report.report_kind === "accuracy" ? "Accuracy and output agreement against the model reference." : "TRTMC and reference latency at aligned public task boundaries."));
+    fragment.append(header);
+    const run = report.run || {};
+    const gpu = (run.gpu_devices || []).map((item) => item.name).filter(Boolean).join(", ") || run.gpu || "—";
+    const runMeta = el("p", "meta", `source=${run.source_revision || report.identity.source_revision || "—"} · host=${run.hostname || "—"} · GPU=${gpu} · ${timestamp(run.started_at)} · ${timestamp(run.finished_at)}`);
+    if (run.environment_href) {
+      const environment = el("a", "environment-link", "Environment snapshot");
+      environment.href = run.environment_href;
+      environment.target = "_blank";
+      environment.rel = "noopener";
+      add(runMeta, document.createTextNode(" · "), environment);
+    }
+    fragment.append(runMeta);
+    const disposition = String(report.identity.disposition || "");
+    if (disposition && !["passed", "completed", "running"].includes(disposition)) fragment.append(el("div", "disposition", `Run disposition: ${disposition}`));
+
+    const accounting = report.accounting;
+    const strip = el("section", "outcome-strip");
+    const comparable = el("div", "traffic-summary");
+    comparable.append(el("span", "traffic-label", "Comparable results"));
+    ["green", "yellow", "red"].forEach((result) => add(comparable, add(el("span", "traffic-item"), signal(result), el("strong", "", accounting.outcomes[result]))));
+    const coverage = el("div", "traffic-summary");
+    coverage.append(el("span", "traffic-label", "Operational coverage"));
+    add(coverage, add(el("span", "traffic-item"), el("span", "", "Valid comparisons"), el("strong", "", `${accounting.comparable} / ${accounting.selected}`)), add(el("span", "traffic-item"), el("span", "", "Coverage"), el("strong", "", `${number(accounting.operational_coverage_percent, 2)}%`)), add(el("span", "traffic-item"), signal("white"), el("strong", "", accounting.outcomes.white)));
+    add(strip, comparable, coverage);
+    fragment.append(strip);
+    if (accounting.progress.pending || accounting.progress.running) {
+      const progress = el("div", "traffic-summary progress-summary");
+      progress.append(el("span", "traffic-label", "Live progress"));
+      add(progress, add(el("span", "traffic-item"), el("span", "", "Pending"), el("strong", "", accounting.progress.pending)), add(el("span", "traffic-item"), el("span", "", "Running"), el("strong", "", accounting.progress.running)), add(el("span", "traffic-item"), el("span", "", "Terminal"), el("strong", "", accounting.progress.terminal)));
+      fragment.append(progress);
+    }
+    return fragment;
+  }
+
+  function modelTask(row) {
+    const box = el("div");
+    add(box, el("code", "", row.model || row.id), el("div", "detail", `${row.task_type || row.operation || "—"} · ${row.workload || row.id || "—"}`));
+    return box;
+  }
+
+  function precision(row) {
+    const value = row.precision || {};
+    return add(el("div", ""), add(el("div", "precision-side"), el("span", "", "Reference"), el("strong", "", value.reference || "Not recorded")), add(el("div", "precision-side"), el("span", "", "TRTMC"), el("strong", "", value.candidate || "Not recorded")));
+  }
+
+  function metricLine(label, value) {
+    return add(el("div", "metric"), el("span", "", label), el("strong", "", value));
+  }
+
+  function percent(value, signed = false) {
+    if (value === null || value === undefined || !Number.isFinite(Number(value))) return "—";
+    const amount = Number(value) * 100;
+    const sign = signed && amount > 0 ? "+" : "";
+    return `${sign}${number(amount, 2)}${signed ? " pp" : "%"}`;
+  }
+
+  function agreement(value, metrics) {
+    const count = Number(metrics.valid_count ?? metrics.sample_count);
+    if (Number.isFinite(Number(value)) && Number.isFinite(count) && count > 0) return `${Math.round(Number(value) * count)} / ${count}`;
+    return percent(value);
+  }
+
+  function accuracyFacts(row) {
+    if (row.result === "white") return el("span", "unavailable", "—");
+    const comparison = row.comparison || {};
+    const metrics = comparison.metrics || {};
+    const value = el("div");
+    const displayed = new Set();
+    [["prediction_agreement_rate", "Agreement"], ["correctness_agreement_rate", "Correctness agreement"]].forEach(([key, label]) => { if (metrics[key] !== undefined) { value.append(metricLine(label, agreement(metrics[key], metrics))); displayed.add(key); } });
+    [["hf_accuracy", "Reference accuracy"], ["bundle_accuracy", "TRTMC accuracy"]].forEach(([key, label]) => { if (metrics[key] !== undefined) { value.append(metricLine(label, percent(metrics[key]))); displayed.add(key); } });
+    if (metrics.accuracy_delta_bundle_minus_hf !== undefined) { value.append(metricLine("Accuracy delta", percent(metrics.accuracy_delta_bundle_minus_hf, true))); displayed.add("accuracy_delta_bundle_minus_hf"); }
+    if (comparison.primary_metric && !displayed.has(comparison.primary_metric.name)) value.prepend(metricLine(comparison.primary_metric.name, number(comparison.primary_metric.value, 4)));
+    return value.childElementCount ? value : el("span", "unavailable", "See Metrics");
+  }
+
+  function outputValidation(row) {
+    const validation = row.output_validation || {};
+    return add(el("div", ""), el("strong", "", validation.status || "Not completed"), el("div", "detail", validation.contract || "—"));
+  }
+
+  function resultCell(row) {
+    if (row.state !== "terminal") return el("span", "state", row.state || "pending");
+    const value = el("div");
+    value.append(signal(row.result));
+    if (row.result === "white" && row.issue) value.append(el("div", "detail", `${row.issue.stage} · ${row.issue.code}`));
+    return value;
+  }
+
+  function details(label, records) {
+    const control = el("details", "evidence");
+    control.append(el("summary", "", label));
+    const body = el("div", "evidence-body");
+    records.forEach(([heading, value]) => add(body, el("h4", "", heading), el("pre", "", typeof value === "string" ? value : JSON.stringify(value, null, 2))));
+    control.append(body);
+    return control;
+  }
+
+  function metrics(row, kind) {
+    const records = [];
+    if (row.issue) records.push(["Failure", row.issue]);
+    if ((row.warnings || []).length) records.push(["Warnings", row.warnings]);
+    if (kind === "accuracy") records.push(["Comparison", row.comparison || {}], ["Validation", row.validation || {}]);
+    else records.push(["Output validation", row.output_validation || {}], ["Reference samples", row.baseline?.samples_ms || []], ["TRTMC samples", row.candidate?.samples_ms || []], ["Comparison", row.comparison || {}]);
+    return details("Metrics", records);
+  }
+
+  function logs(row) {
+    const value = el("div", "log-links");
+    (row.debug?.logs || []).forEach((record) => {
+      if (!record.href) return;
+      const link = el("a", "", record.label || "Open log");
+      link.href = record.href; link.target = "_blank"; link.rel = "noopener"; value.append(link);
+    });
+    if (!value.childElementCount) value.append(el("span", "unavailable", "Unavailable"));
+    return value;
+  }
+
+  function commandBlock(label, command) {
+    if (!command) return null;
+    return [label, `$ ${command}`];
+  }
+
+  function vanilla(row) {
+    const reproduce = row.reproduce || {};
+    const dataset = reproduce.dataset || {};
+    const records = [commandBlock(dataset.prepared_input_count === undefined ? "Dataset slice" : `Dataset slice (${dataset.prepared_input_count} samples)`, dataset.command), commandBlock("Reference sample", (reproduce.hf || [])[0]), commandBlock("TRTMC sample", (reproduce.trtmc || [])[0])].filter(Boolean);
+    return records.length ? details(`Dataset · Reference ${(reproduce.commands_shown || {}).hf || 0}/${(reproduce.command_count || {}).hf || 0} · TRTMC ${(reproduce.commands_shown || {}).trtmc || 0}/${(reproduce.command_count || {}).trtmc || 0}`, records) : el("span", "unavailable", "Unavailable");
+  }
+
+  function commands(row) {
+    const records = [];
+    Object.entries(row.commands || {}).forEach(([name, command]) => {
+      if (command?.rendered) records.push([name === "trtmc" ? "TRTMC" : name === "baseline" ? "Reference" : name, `${command.cwd ? `cwd: ${command.cwd}\n` : ""}$ ${command.rendered}`]);
+    });
+    const value = el("div");
+    if (records.length) value.append(details("Commands", records));
+    (row.debug?.command_artifacts || []).forEach((record) => {
+      if (!record.href) return;
+      const link = el("a", "command-artifact", record.label || "Command artifact");
+      link.href = record.href;
+      link.target = "_blank";
+      link.rel = "noopener";
+      value.append(link);
+    });
+    return value.childElementCount ? value : el("span", "unavailable", "Unavailable");
+  }
+
+  function table(rows, report, compact = false) {
+    const kind = report.report_kind;
+    const labels = compact ? ["Result", "Model / task", kind === "accuracy" ? "Accuracy / fidelity" : "Output validation", "Metrics", "Logs", kind === "accuracy" ? "Vanilla reproduction" : "Commands"] : kind === "accuracy" ? ["Model / task", "Compute precision", "Accuracy / fidelity", "Result", "Metrics", "Logs", "Vanilla reproduction", "Commands"] : ["Model / task", "Compute precision", "Output validation", "Reference latency", "TRTMC latency", "Result", "Metrics", "Logs", "Commands"];
+    const wrap = el("div", `table-wrap${compact ? " failures" : ""}`);
+    const value = el("table", compact ? "" : "register-table");
+    const head = el("thead"); const headRow = el("tr"); labels.forEach((label) => headRow.append(el("th", "", label))); head.append(headRow);
+    const body = el("tbody");
+    rows.forEach((row) => {
+      const tr = el("tr"); tr.dataset.result = row.result || row.state;
+      let cells;
+      if (compact) cells = [resultCell(row), modelTask(row), kind === "accuracy" ? accuracyFacts(row) : outputValidation(row), metrics(row, kind), logs(row), kind === "accuracy" ? vanilla(row) : commands(row)];
+      else if (kind === "accuracy") cells = [modelTask(row), precision(row), accuracyFacts(row), resultCell(row), metrics(row, kind), logs(row), vanilla(row), commands(row)];
+      else cells = [modelTask(row), precision(row), outputValidation(row), el("span", "timing", row.latency?.reference_ms == null ? "—" : `${number(row.latency.reference_ms)} ms`), el("span", "timing", row.latency?.candidate_ms == null ? "—" : `${number(row.latency.candidate_ms)} ms`), resultCell(row), metrics(row, kind), logs(row), commands(row)];
+      cells.forEach((cell) => add(tr, add(el("td", ""), cell))); body.append(tr);
+    });
+    add(value, head, body); wrap.append(value); return wrap;
+  }
+
+  function failures(report) {
+    const rows = report.results.filter((row) => row.state === "terminal" && (row.result === "white" || row.result === "red")).sort(compareRows);
+    const section = el("section", "failures"); section.append(el("h2", "", "Failures"));
+    section.append(rows.length ? table(rows, report, true) : el("div", "empty", "No failures recorded.")); return section;
+  }
+
+  function filters(report, state, render, shown) {
+    const controls = el("div", "filters");
+    const searchLabel = el("label", "", "Search"); const search = el("input"); search.type = "search"; search.value = state.search; search.addEventListener("input", () => { state.search = search.value; render(); }); searchLabel.append(search);
+    const statusLabel = el("label", "", "Status"); const status = el("select"); ["", "pending", "running", "green", "yellow", "red", "white"].forEach((name) => { const option = el("option", "", name || "All"); option.value = name; status.append(option); }); status.value = state.status; status.addEventListener("change", () => { state.status = status.value; render(); }); statusLabel.append(status);
+    const reset = el("button", "", "Reset"); reset.type = "button"; reset.addEventListener("click", () => { state.search = ""; state.status = ""; render(); });
+    add(controls, searchLabel, statusLabel, reset, el("span", "filter-count", `Showing ${shown} of ${report.results.length} selected rows`)); return controls;
+  }
+
+  function register(report) {
+    const section = el("section", ""); const state = { search: "", status: "" };
+    function render() {
+      const query = state.search.trim().toLowerCase();
+      const rows = report.results.filter((row) => (!state.status || (row.result || row.state) === state.status) && (!query || [row.id, row.model, row.family, row.operation, row.task_type, row.workload].some((value) => String(value || "").toLowerCase().includes(query)))).sort(compareRows);
+      section.replaceChildren(el("h2", "", "Complete qualification register"), filters(report, state, render, rows.length), table(rows, report));
+    }
+    render(); return section;
+  }
+
+  function render(report) {
+    if (report.schema_version !== "trtmc.qualification-report/v1") throw new Error(`Unsupported schema: ${report.schema_version}`);
+    root.replaceChildren(reportHeader(report), failures(report), register(report));
+  }
+
+  fetch(reportPath, { cache: "no-store" }).then((response) => { if (!response.ok) throw new Error(`${response.status} ${response.statusText}`); return response.json(); }).then(render).catch((error) => root.replaceChildren(add(el("section", "fatal"), el("h1", "", "Unable to render report.json"), el("pre", "", error.stack || String(error)))));
+})();

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 (() => {
   "use strict";

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -156,7 +156,11 @@
   }
 
   function resultCell(row) {
-    if (row.state !== "terminal") return el("span", "state", row.state || "pending");
+    if (row.state !== "terminal") {
+      const progress = row.progress || {};
+      const details = [progress.stage, progress.attempt ? `attempt ${progress.attempt}` : null].filter(Boolean).join(" · ");
+      return add(el("div", ""), el("span", "state", row.state || "pending"), details ? el("div", "detail", details) : null);
+    }
     const value = el("div");
     value.append(signal(row.result));
     if (row.result === "white" && row.issue) value.append(el("div", "detail", `${row.issue.stage} · ${row.issue.code}`));

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -95,6 +95,16 @@
               "evaluated": {"type": ["integer", "null"], "minimum": 0}
             }
           },
+          "sample_differences": {
+            "type": "object",
+            "required": ["count", "classification", "href", "preview"],
+            "properties": {
+              "count": {"type": "integer", "minimum": 0},
+              "classification": {"enum": ["failed_samples", "sample_differences"]},
+              "href": {"type": ["string", "null"]},
+              "preview": {"type": "array"}
+            }
+          },
           "issue": {"type": ["object", "null"]},
           "debug": {"type": "object"}
         },

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -87,6 +87,14 @@
             "enum": ["green", "yellow", "red", "white", null]
           },
           "precision": {"type": "object"},
+          "samples": {
+            "type": "object",
+            "required": ["planned", "evaluated"],
+            "properties": {
+              "planned": {"type": ["integer", "null"], "minimum": 0},
+              "evaluated": {"type": ["integer", "null"], "minimum": 0}
+            }
+          },
           "issue": {"type": ["object", "null"]},
           "debug": {"type": "object"}
         },

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -86,6 +86,14 @@
             "type": ["string", "null"],
             "enum": ["green", "yellow", "red", "white", null]
           },
+          "progress": {
+            "type": "object",
+            "required": ["stage", "attempt"],
+            "properties": {
+              "stage": {"type": ["string", "null"]},
+              "attempt": {"type": "integer", "minimum": 0}
+            }
+          },
           "precision": {"type": "object"},
           "samples": {
             "type": "object",

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trtmc.qualification-report.schema.json",
+  "title": "TRTMC qualification report",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "report_kind",
+    "identity",
+    "run",
+    "accounting",
+    "results"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "trtmc.qualification-report/v1"
+    },
+    "report_kind": {
+      "enum": ["accuracy", "performance"]
+    },
+    "identity": {
+      "type": "object",
+      "required": ["title", "run_id"]
+    },
+    "run": {
+      "type": "object",
+      "required": ["environment_href"],
+      "properties": {
+        "environment_href": {
+          "type": "string",
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+        }
+      }
+    },
+    "accounting": {
+      "type": "object",
+      "required": [
+        "selected",
+        "comparable",
+        "operational_coverage_percent",
+        "progress",
+        "outcomes",
+        "definitions"
+      ],
+      "properties": {
+        "selected": {"type": "integer", "minimum": 0},
+        "comparable": {"type": "integer", "minimum": 0},
+        "operational_coverage_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "progress": {
+          "type": "object",
+          "required": ["pending", "running", "terminal"],
+          "properties": {
+            "pending": {"type": "integer", "minimum": 0},
+            "running": {"type": "integer", "minimum": 0},
+            "terminal": {"type": "integer", "minimum": 0}
+          }
+        },
+        "outcomes": {
+          "type": "object",
+          "required": ["green", "yellow", "red", "white"],
+          "properties": {
+            "green": {"type": "integer", "minimum": 0},
+            "yellow": {"type": "integer", "minimum": 0},
+            "red": {"type": "integer", "minimum": 0},
+            "white": {"type": "integer", "minimum": 0}
+          }
+        },
+        "definitions": {"type": "object"}
+      }
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "state", "result"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "state": {"enum": ["pending", "running", "terminal"]},
+          "result": {
+            "type": ["string", "null"],
+            "enum": ["green", "yellow", "red", "white", null]
+          },
+          "precision": {"type": "object"},
+          "issue": {"type": ["object", "null"]},
+          "debug": {"type": "object"}
+        },
+        "allOf": [
+          {
+            "if": {"properties": {"state": {"const": "terminal"}}},
+            "then": {
+              "properties": {
+                "result": {"enum": ["green", "yellow", "red", "white"]}
+              }
+            },
+            "else": {"properties": {"result": {"const": null}}}
+          },
+          {
+            "if": {"properties": {"result": {"const": "white"}}},
+            "then": {
+              "required": ["issue", "debug"],
+              "properties": {
+                "issue": {
+                  "type": "object",
+                  "required": ["priority", "stage", "domain", "code", "message"]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1904,7 +1904,12 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             name="report_generation_tool",
             matcher=_path_in(
                 {
+                    "tools/execution_ledger.py",
                     "tools/perf_matrix.py",
+                    "tools/qualification_report.py",
+                    "tools/qualification_report_assets/qualification-report.css",
+                    "tools/qualification_report_assets/qualification-report.js",
+                    "tools/qualification_report_assets/qualification-report.schema.json",
                     "tools/reporting_html.py",
                 }
             ),

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -61,6 +61,7 @@ from tools.reporting_html import (  # noqa: E402
 from tools.validation import catalog as validation_catalog  # noqa: E402
 from tools import trtmc_disagreements  # noqa: E402
 from tools import model_selection  # noqa: E402
+from tools import qualification_report  # noqa: E402
 
 
 DEFAULT_CATALOG = REPO_ROOT / "tests" / "validation" / "model_workloads.yaml"
@@ -2851,29 +2852,163 @@ def _report_counts(
     return validation_counts, comparison_counts, execution_errors
 
 
-def _traffic_light_counts(
-    results: Sequence[Mapping[str, Any]],
-) -> dict[str, int]:
-    counts = {"green": 0, "yellow": 0, "red": 0, "white": 0}
-    for result in results:
-        counts[_traffic_light_status(result)] += 1
-    return counts
-
-
-def _platform_exclusion_count(results: Sequence[Mapping[str, Any]]) -> int:
-    return sum(isinstance(result.get("platform_exclusion"), Mapping) for result in results)
-
-
 def _traffic_light_status(result: Mapping[str, Any]) -> str:
+    execution_status = str(result["execution"]["status"])
     validation_status = str(result["validation"]["status"])
     comparison_status = str(result["comparison"]["status"])
-    if validation_status == "skipped":
-        return "yellow"
-    if comparison_status == "agreement":
+    precision = _accuracy_precision(result)
+    if execution_status != "completed":
+        return "white"
+    if "Not recorded" in precision.values():
+        return "white"
+    if comparison_status not in {"agreement", "disagreement"}:
+        return "white"
+    if validation_status not in {"passed", "failed"}:
+        return "white"
+    if comparison_status == "agreement" and validation_status == "passed":
         return "green"
-    if comparison_status == "disagreement":
+    if comparison_status == "disagreement" or validation_status == "failed":
         return "red"
     return "white"
+
+
+def _accuracy_precision(result: Mapping[str, Any]) -> dict[str, str]:
+    contract = result.get("precision_contract", {})
+    contract = contract if isinstance(contract, Mapping) else {}
+    raw_result = result.get("raw_result", {})
+    raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+    reference = (
+        contract.get("reference_precision")
+        or contract.get("reference_dtype")
+        or raw_result.get("reference_precision")
+        or raw_result.get("reference_dtype")
+    )
+    base = contract.get("trtmc_base_precision") or raw_result.get("precision")
+    quantization = contract.get("trtmc_quantization")
+    if quantization and str(quantization).lower() not in {"none", "false"}:
+        candidate = (
+            f"{str(quantization).lower()} ({str(base).lower()} base)"
+            if base
+            else str(quantization).lower()
+        )
+    else:
+        candidate = str(base).lower() if base else ""
+    return {
+        "reference": str(reference).lower() if reference else "Not recorded",
+        "candidate": candidate or "Not recorded",
+    }
+
+
+def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
+    if _traffic_light_status(result) != "white":
+        return None
+    execution = result.get("execution", {})
+    execution = execution if isinstance(execution, Mapping) else {}
+    if execution.get("status") == "error":
+        raw_result = result.get("raw_result", {})
+        raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+        worker_failure = result.get("executor") == "model_worker"
+        return {
+            "priority": "P1",
+            "stage": "compare" if worker_failure else "candidate",
+            "domain": "harness/unknown",
+            "code": "worker_no_result" if worker_failure else "execution_error",
+            "message": str(
+                execution.get("last_error")
+                or raw_result.get("error")
+                or result.get("not_compared_reason")
+                or "candidate execution did not produce a comparison"
+            ),
+        }
+    precision = _accuracy_precision(result)
+    if "Not recorded" in precision.values():
+        return {
+            "priority": "P1",
+            "stage": "preflight",
+            "domain": "policy-config",
+            "code": "comparison_contract",
+            "message": "Reference and TRTMC compute precision were not both recorded",
+        }
+    comparison = result.get("comparison", {})
+    comparison = comparison if isinstance(comparison, Mapping) else {}
+    return {
+        "priority": "P1",
+        "stage": "compare",
+        "domain": "harness/unknown",
+        "code": "no_valid_comparison",
+        "message": str(
+            result.get("not_compared_reason")
+            or comparison.get("reason")
+            or "comparison evidence is incomplete"
+        ),
+    }
+
+
+def _report_log_links(output: Path, case_dir: Path) -> list[dict[str, str]]:
+    links = []
+    for path in sorted(case_dir.rglob("*.log")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(output).as_posix()
+        links.append({"label": path.relative_to(case_dir).as_posix(), "href": relative})
+    return links
+
+
+def _report_command_artifacts(
+    output: Path,
+    case_dir: Path,
+    result: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    reproduce = result.get("reproduce", {})
+    reproduce = reproduce if isinstance(reproduce, Mapping) else {}
+    command_logs = reproduce.get("command_logs", {})
+    command_logs = command_logs if isinstance(command_logs, Mapping) else {}
+    requested = {
+        str(name)
+        for side in ("hf", "trtmc")
+        for name in command_logs.get(side, [])
+        if str(name).strip()
+    }
+    artifacts = []
+    for name in sorted(requested):
+        matches = sorted(path for path in case_dir.rglob(Path(name).name) if path.is_file())
+        if not matches:
+            continue
+        path = matches[0]
+        artifacts.append(
+            {
+                "label": name,
+                "href": path.relative_to(output).as_posix(),
+            }
+        )
+    return artifacts
+
+
+def _public_accuracy_result(
+    output: Path,
+    path: Path,
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    public = dict(result)
+    public.update(
+        {
+            "id": f"{result.get('model', '')}::{result.get('workload') or 'not-compared'}",
+            "state": "terminal",
+            "result": _traffic_light_status(result),
+            "precision": _accuracy_precision(result),
+            "issue": _accuracy_issue(result),
+            "debug": {
+                "result": path.relative_to(output).as_posix(),
+                "logs": _report_log_links(output, path.parent),
+                "command_artifacts": _report_command_artifacts(
+                    output,
+                    path.parent,
+                    result,
+                ),
+            },
+        }
+    )
+    return public
 
 
 def _report_rows(
@@ -3066,66 +3201,76 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = _normalize_result_files(result_paths)
     result_paths, results = _deduplicate_results(result_paths, results)
+    selected = [
+        (path, result)
+        for path, result in zip(result_paths, results, strict=True)
+        if not isinstance(result.get("platform_exclusion"), Mapping)
+    ]
+    result_paths = [path for path, _result in selected]
+    results = [result for _path, result in selected]
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
-    traffic_light_counts = _traffic_light_counts(results)
-    platform_excluded = _platform_exclusion_count(results)
     sample_counts = [
         count for result in results if (count := _selected_sample_count(result)) is not None
     ]
     generated_at = _utc_now()
-    report = {
-        "schema_version": "trtmc.validation-report/v2",
-        "generated_at": generated_at.isoformat(),
-        "validation_status": (
-            "failed"
-            if not results or validation_counts["failed"]
-            else "incomplete"
-            if validation_counts["not_compared"]
-            else "passed"
+    validation_status = (
+        "failed"
+        if not results or validation_counts["failed"]
+        else "incomplete"
+        if (
+            validation_counts["not_compared"]
+            or validation_counts["skipped"]
+            or execution_errors
+            or any(_traffic_light_status(result) == "white" for result in results)
+        )
+        else "passed"
+    )
+    summary = {
+        "cases": len(results),
+        "execution_completed": sum(
+            result["execution"]["status"] == "completed" for result in results
         ),
-        "summary": {
-            "cases": len(results),
-            "execution_completed": sum(
-                result["execution"]["status"] == "completed" for result in results
-            ),
-            "execution_errors": execution_errors,
-            "agreements": comparison_counts["agreement"],
-            "disagreements": comparison_counts["disagreement"],
-            "not_compared": comparison_counts["not_run"],
-            "validation_passed": validation_counts["passed"],
-            "validation_failed": validation_counts["failed"],
-            "validation_skipped": validation_counts["skipped"],
-            "platform_excluded": platform_excluded,
-            "selected_samples": sum(sample_counts),
-        },
-        "results": results,
+        "execution_errors": execution_errors,
+        "agreements": comparison_counts["agreement"],
+        "disagreements": comparison_counts["disagreement"],
+        "not_compared": comparison_counts["not_run"],
+        "validation_passed": validation_counts["passed"],
+        "validation_failed": validation_counts["failed"],
+        "validation_skipped": validation_counts["skipped"],
+        "selected_samples": sum(sample_counts),
     }
     run_path = output / "run.json"
+    run: dict[str, Any] = {}
     if run_path.is_file():
-        report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
-        duration_seconds = report["run"].get("duration_seconds")
+        run = json.loads(run_path.read_text(encoding="utf-8"))
+        duration_seconds = run.get("duration_seconds")
         if duration_seconds is None:
             duration_seconds = _elapsed_seconds(
-                report["run"].get("started_at"),
+                run.get("started_at"),
                 generated_at,
             )
         if duration_seconds is not None:
-            report["summary"]["duration_seconds"] = duration_seconds
-    json_path = output / "report.json"
-    html_path = output / "report.html"
-    json_path.write_text(
-        json.dumps(report, indent=2, ensure_ascii=False),
-        encoding="utf-8",
+            summary["duration_seconds"] = duration_seconds
+    public_results = [
+        _public_accuracy_result(output, path, result)
+        for path, result in zip(result_paths, results, strict=True)
+    ]
+    return qualification_report.materialize_report(
+        output,
+        report_kind="accuracy",
+        title="TRTMC Accuracy & Fidelity Qualification",
+        identity={
+            "run_id": output.name,
+            "disposition": validation_status,
+            "source_revision": run.get("source_revision"),
+        },
+        run=run,
+        results=public_results,
+        metadata={
+            "validation_status": validation_status,
+            "summary": summary,
+        },
     )
-    document = _report_document(
-        report,
-        rows=_report_rows(output, results, result_paths),
-        comparison_counts=comparison_counts,
-        execution_errors=execution_errors,
-        traffic_light_counts=traffic_light_counts,
-    )
-    html_path.write_text(document, encoding="utf-8")
-    return json_path, html_path, report
 
 
 def _print_result(
@@ -3140,6 +3285,7 @@ def _print_result(
         print("Status: NOT COMPARED")
         print(f"Reason: {not_compared_reason}")
         print(f"Compare result: {comparison}")
+        print(f"Report data:   {report.with_name('report.json')}")
         print(f"Report:         {report}")
         return
     execution = result.get("execution", {})
@@ -3168,6 +3314,7 @@ def _print_result(
             print(f"Worker log: {worker_log}")
     if not verbose:
         print(f"Compare result: {comparison}")
+        print(f"Report data: {report.with_name('report.json')}")
         print(f"Report: {report}")
         return
     reproduce = result.get("reproduce", {})
@@ -3193,6 +3340,7 @@ def _print_result(
         print("  unavailable; see comparison result")
     print()
     print(f"Compare result: {comparison}")
+    print(f"Report data:   {report.with_name('report.json')}")
     print(f"Report:         {report}")
 
 

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1770,6 +1770,82 @@ def run_binding(
     workload = _required_workload(binding)
     case_dir = _case_directory(Path(arguments.output), binding)
     case_dir.mkdir(parents=True, exist_ok=True)
+    dataset_command = shlex.join([sys.executable, *sys.argv])
+    suite = suites[workload]
+    task_type, user_contract = _suite_task_metadata(suite)
+    model = task_models[binding.model]
+    task_strategy = str(model.get("task_strategy", "") or "")
+    dataset = (
+        Path(arguments.dataset)
+        if arguments.dataset
+        else _dataset_path(suite, arguments.dataset_root)
+    )
+    if arguments.dataset is None and not dataset.is_file():
+        message = f"dataset does not exist: {dataset}"
+        execution_log = case_dir / "execution.log"
+        execution_log.write_text(
+            f"Accuracy preflight failed\n{message}\n",
+            encoding="utf-8",
+        )
+        result = _normalize_result(
+            {
+                "model": binding.model,
+                "workload": workload,
+                "family": str(model.get("family", "") or ""),
+                "operation": _operation_for_task_strategy(task_strategy),
+                "task_strategy": task_strategy,
+                "task_type": task_type,
+                "user_contract": user_contract,
+                "executor": "dataset_preflight",
+                "execution": {
+                    "status": "error",
+                    "exit_code": 1,
+                    "retryable": False,
+                },
+                "comparison": {
+                    "status": "not_run",
+                    "mode": "",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "failed"},
+                "failure_stage": "preflight",
+                "failure_domain": "data-artifact",
+                "failure_code": "dataset_missing",
+                "reference_environment": [],
+                "reproduce": {
+                    "dataset": {
+                        "command": dataset_command,
+                        "sample_limit": int(arguments.limit or 0),
+                        "prepared_input_count": 0,
+                    },
+                    "hf": [],
+                    "trtmc": [],
+                },
+                "raw_result": {
+                    "status": "failed",
+                    "error_type": "DatasetNotFoundError",
+                    "error": message,
+                },
+                "raw_result_path": "",
+                "disagreements": {
+                    "count": 0,
+                    "path": "disagreements.jsonl",
+                    "inline_limit": trtmc_disagreements.INLINE_DISAGREEMENT_LIMIT,
+                    "reference_vanilla_available": False,
+                    "trtmc_vanilla_available": False,
+                },
+                "execution_log": str(execution_log),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        (case_dir / "disagreements.jsonl").write_text("", encoding="utf-8")
+        (case_dir / "comparison.json").write_text(
+            json.dumps(result, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return result
     profiles = _binding_profiles(
         binding,
         task_models=task_models,
@@ -1789,17 +1865,6 @@ def run_binding(
     process_env = _source_environment()
     process_env.update(environment.overrides)
     process_env.update(reference_sources.environment)
-    dataset_command = shlex.join([sys.executable, *sys.argv])
-
-    suite = suites[workload]
-    task_type, user_contract = _suite_task_metadata(suite)
-    model = task_models[binding.model]
-    task_strategy = str(model.get("task_strategy", "") or "")
-    dataset = (
-        Path(arguments.dataset)
-        if arguments.dataset
-        else _dataset_path(suite, arguments.dataset_root)
-    )
     command = _comparison_command(
         binding,
         case_dir=case_dir,
@@ -2910,9 +2975,15 @@ def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
         worker_failure = result.get("executor") == "model_worker"
         return {
             "priority": "P1",
-            "stage": "compare" if worker_failure else "candidate",
-            "domain": "harness/unknown",
-            "code": "worker_no_result" if worker_failure else "execution_error",
+            "stage": str(
+                result.get("failure_stage")
+                or ("compare" if worker_failure else "candidate")
+            ),
+            "domain": str(result.get("failure_domain") or "harness/unknown"),
+            "code": str(
+                result.get("failure_code")
+                or ("worker_no_result" if worker_failure else "execution_error")
+            ),
             "message": str(
                 execution.get("last_error")
                 or raw_result.get("error")
@@ -2944,13 +3015,44 @@ def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
     }
 
 
+def _materialize_accuracy_report_artifact(
+    output: Path,
+    case_dir: Path,
+    path: Path,
+    *,
+    category: str,
+) -> str:
+    relative_case = case_dir.relative_to(output)
+    relative_artifact = path.relative_to(case_dir)
+    destination = (
+        output
+        / "artifacts"
+        / "cases"
+        / relative_case
+        / category
+        / relative_artifact
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(path, destination)
+    return destination.relative_to(output).as_posix()
+
+
 def _report_log_links(output: Path, case_dir: Path) -> list[dict[str, str]]:
     links = []
     for path in sorted(case_dir.rglob("*.log")):
         if not path.is_file():
             continue
-        relative = path.relative_to(output).as_posix()
-        links.append({"label": path.relative_to(case_dir).as_posix(), "href": relative})
+        links.append(
+            {
+                "label": path.relative_to(case_dir).as_posix(),
+                "href": _materialize_accuracy_report_artifact(
+                    output,
+                    case_dir,
+                    path,
+                    category="logs",
+                ),
+            }
+        )
     return links
 
 
@@ -2978,10 +3080,43 @@ def _report_command_artifacts(
         artifacts.append(
             {
                 "label": name,
-                "href": path.relative_to(output).as_posix(),
+                "href": _materialize_accuracy_report_artifact(
+                    output,
+                    case_dir,
+                    path,
+                    category="commands",
+                ),
             }
         )
     return artifacts
+
+
+def _accuracy_samples(result: Mapping[str, Any]) -> dict[str, int | None]:
+    reproduce = result.get("reproduce", {})
+    reproduce = reproduce if isinstance(reproduce, Mapping) else {}
+    dataset = reproduce.get("dataset", {})
+    dataset = dataset if isinstance(dataset, Mapping) else {}
+    comparison = result.get("comparison", {})
+    comparison = comparison if isinstance(comparison, Mapping) else {}
+    metrics = comparison.get("metrics", {})
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+
+    def nonnegative(value: Any) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed >= 0 else None
+
+    planned = nonnegative(dataset.get("sample_limit"))
+    if planned == 0:
+        planned = None
+    evaluated = nonnegative(dataset.get("prepared_input_count"))
+    if evaluated is None:
+        evaluated = nonnegative(metrics.get("valid_count"))
+    if evaluated is None:
+        evaluated = nonnegative(metrics.get("sample_count"))
+    return {"planned": planned, "evaluated": evaluated}
 
 
 def _public_accuracy_result(
@@ -2996,6 +3131,7 @@ def _public_accuracy_result(
             "state": "terminal",
             "result": _traffic_light_status(result),
             "precision": _accuracy_precision(result),
+            "samples": _accuracy_samples(result),
             "issue": _accuracy_issue(result),
             "debug": {
                 "result": path.relative_to(output).as_posix(),
@@ -4223,9 +4359,12 @@ def _run_supervised_binding_with_retries(
         revalidation_budget.record_worker_result(result)
         execution = result.get("execution", {})
         execution_error = isinstance(execution, Mapping) and execution.get("status") == "error"
+        retryable = not (
+            isinstance(execution, Mapping) and execution.get("retryable") is False
+        )
         archived = (
             _archive_failed_attempt(case_dir, attempt)
-            if execution_error and attempt < arguments.model_attempts
+            if execution_error and retryable and attempt < arguments.model_attempts
             else {}
         )
         attempt_result = _attempt_record(
@@ -4234,7 +4373,7 @@ def _run_supervised_binding_with_retries(
             archived=archived,
         )
         attempts.append(attempt_result)
-        if not execution_error or attempt == arguments.model_attempts:
+        if not execution_error or not retryable or attempt == arguments.model_attempts:
             break
         print(
             f"  Attempt {attempt}/{arguments.model_attempts}: FAILED",

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -60,6 +60,7 @@ from tools.reporting_html import (  # noqa: E402
 )
 from tools.validation import catalog as validation_catalog  # noqa: E402
 from tools import trtmc_disagreements  # noqa: E402
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import model_selection  # noqa: E402
 from tools import qualification_report  # noqa: E402
 
@@ -745,6 +746,7 @@ def _run_subprocess(command: Sequence[str], log_path: Path, env: Mapping[str, st
             list(command),
             check=False,
             text=True,
+            cwd=REPO_ROOT,
             stdout=output,
             stderr=subprocess.STDOUT,
             env=dict(env),
@@ -771,6 +773,7 @@ def _run_supervised_subprocess(
         process = subprocess.Popen(
             list(command),
             text=True,
+            cwd=REPO_ROOT,
             stdout=output,
             stderr=subprocess.STDOUT,
             env=dict(env),
@@ -3414,17 +3417,91 @@ details {{ min-width: 210px; }}
 """
 
 
+def _accuracy_ledger_report_rows(
+    output: Path,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    ledger = ExecutionLedger.load(output, task_kind="accuracy")
+    terminal_results: list[dict[str, Any]] = []
+    public_results: list[dict[str, Any]] = []
+    for entry in ledger.snapshot():
+        case = entry["case"]
+        receipt = entry["receipt"]
+        report_fields = case.get("report", {})
+        if not isinstance(report_fields, Mapping):
+            raise ValidationError(f"invalid Accuracy ledger descriptor for {case['id']!r}")
+        if receipt["state"] != "terminal":
+            active = receipt["attempts"][-1] if receipt["attempts"] else {}
+            evidence = active.get("evidence", {})
+            evidence = evidence if isinstance(evidence, Mapping) else {}
+            public_results.append(
+                {
+                    **dict(report_fields),
+                    "id": case["id"],
+                    "state": receipt["state"],
+                    "result": None,
+                    "progress": {
+                        "stage": receipt["stage"],
+                        "attempt": receipt["active_attempt"]
+                        or len(receipt["attempts"]),
+                    },
+                    "precision": {
+                        "reference": "Not recorded",
+                        "candidate": "Not recorded",
+                    },
+                    "samples": {
+                        "planned": report_fields.get("sample_limit"),
+                        "evaluated": None,
+                    },
+                    "commands": copy.deepcopy(dict(evidence.get("commands", {}))),
+                    "debug": {
+                        "logs": copy.deepcopy(list(evidence.get("logs", []))),
+                        "command_artifacts": [],
+                    },
+                }
+            )
+            continue
+        result = _normalize_result(receipt["payload"])
+        derived = _traffic_light_status(result)
+        if receipt["result"] != derived:
+            raise ValidationError(
+                f"Accuracy ledger result mismatch for {case['id']!r}: "
+                f"receipt={receipt['result']}, comparison={derived}"
+            )
+        result_path = output / str(case["result_path"])
+        encoded = json.dumps(result, indent=2, ensure_ascii=False)
+        if not result_path.is_file() or result_path.read_text(encoding="utf-8") != encoded:
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = result_path.with_name(f".{result_path.name}.{os.getpid()}.tmp")
+            temporary.write_text(encoded, encoding="utf-8")
+            temporary.replace(result_path)
+        terminal_results.append(result)
+        public = _public_accuracy_result(output, result_path, result)
+        public["progress"] = {
+            "stage": receipt["stage"],
+            "attempt": len(receipt["attempts"]),
+        }
+        public_results.append(public)
+    return terminal_results, public_results
+
+
 def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
-    result_paths = sorted(output.glob("*/*/comparison.json"))
-    results = _normalize_result_files(result_paths)
-    result_paths, results = _deduplicate_results(result_paths, results)
-    selected = [
-        (path, result)
-        for path, result in zip(result_paths, results, strict=True)
-        if not isinstance(result.get("platform_exclusion"), Mapping)
-    ]
-    result_paths = [path for path, _result in selected]
-    results = [result for _path, result in selected]
+    if (output / "ledger" / "campaign.json").is_file():
+        results, public_results = _accuracy_ledger_report_rows(output)
+    else:
+        result_paths = sorted(output.glob("*/*/comparison.json"))
+        results = _normalize_result_files(result_paths)
+        result_paths, results = _deduplicate_results(result_paths, results)
+        selected = [
+            (path, result)
+            for path, result in zip(result_paths, results, strict=True)
+            if not isinstance(result.get("platform_exclusion"), Mapping)
+        ]
+        result_paths = [path for path, _result in selected]
+        results = [result for _path, result in selected]
+        public_results = [
+            _public_accuracy_result(output, path, result)
+            for path, result in zip(result_paths, results, strict=True)
+        ]
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
     sample_counts = [
         count for result in results if (count := _selected_sample_count(result)) is not None
@@ -3443,7 +3520,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
         else "passed"
     )
     summary = {
-        "cases": len(results),
+        "cases": len(public_results),
         "execution_completed": sum(
             result["execution"]["status"] == "completed" for result in results
         ),
@@ -3468,10 +3545,8 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             )
         if duration_seconds is not None:
             summary["duration_seconds"] = duration_seconds
-    public_results = [
-        _public_accuracy_result(output, path, result)
-        for path, result in zip(result_paths, results, strict=True)
-    ]
+    if any(row["state"] != "terminal" for row in public_results):
+        validation_status = "running"
     return qualification_report.materialize_report(
         output,
         report_kind="accuracy",
@@ -4320,7 +4395,11 @@ def _run_supervised_binding(
     case_dir.mkdir(parents=True, exist_ok=True)
     comparison_path = case_dir / "comparison.json"
     comparison_path.unlink(missing_ok=True)
-    worker_log = case_dir / ("worker.log" if attempt == 1 else f"worker.attempt-{attempt}.log")
+    worker_log = _worker_log_path(
+        case_dir,
+        case_attempt=int(getattr(arguments, "case_attempt", 1)),
+        worker_attempt=attempt,
+    )
     command = _worker_command(binding, arguments)
     launch_error = ""
     error_type = "WorkerProcessError"
@@ -4371,6 +4450,20 @@ def _run_supervised_binding(
         encoding="utf-8",
     )
     return result
+
+
+def _worker_log_path(
+    case_dir: Path,
+    *,
+    case_attempt: int,
+    worker_attempt: int,
+) -> Path:
+    if case_attempt == 1:
+        name = "worker.log" if worker_attempt == 1 else f"worker.attempt-{worker_attempt}.log"
+    else:
+        suffix = "" if worker_attempt == 1 else f".worker-attempt-{worker_attempt}"
+        name = f"worker.case-attempt-{case_attempt}{suffix}.log"
+    return case_dir / name
 
 
 def _archive_failed_attempt(case_dir: Path, attempt: int) -> dict[str, str]:
@@ -4551,6 +4644,53 @@ def _validate_resume_request(output: Path) -> None:
         raise ValidationError("cannot resume Accuracy results with a different resolved command")
 
 
+def _accuracy_case_id(binding: Binding) -> str:
+    return f"{binding.model}::{binding.workload or 'not-compared'}"
+
+
+def _open_accuracy_ledger(
+    bindings: Sequence[Binding],
+    arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
+) -> ExecutionLedger:
+    fingerprint_input = {
+        "source_revision": _source_revision(),
+        "command": _resume_command(shlex.join(sys.argv)),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_input, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    cases = []
+    for binding in bindings:
+        result_path = _case_directory(arguments.output, binding) / "comparison.json"
+        sample_limit = (
+            resolve_sample_limit(catalog, binding, arguments.limit)
+            if binding.runnable
+            else None
+        )
+        cases.append(
+            {
+                "id": _accuracy_case_id(binding),
+                "result_path": result_path.relative_to(arguments.output).as_posix(),
+                "report": {
+                    "model": binding.model,
+                    "workload": binding.workload,
+                    "sample_limit": sample_limit,
+                },
+            }
+        )
+    try:
+        return ExecutionLedger.open(
+            arguments.output,
+            campaign_id=arguments.output.name,
+            task_kind="accuracy",
+            fingerprint=fingerprint,
+            cases=cases,
+        )
+    except ExecutionLedgerError as error:
+        raise ValidationError(str(error)) from error
+
+
 def _run_all_bindings(
     bindings: Iterable[Binding],
     *,
@@ -4566,20 +4706,38 @@ def _run_all_bindings(
         arguments.output,
         cuda_visible_devices=arguments.cuda_visible_devices,
     )
+    ledger = _open_accuracy_ledger(bindings, arguments, catalog)
+    if arguments.resume_existing:
+        ledger.recover_interrupted()
+    write_report(arguments.output)
     failed = False
     not_compared = False
     remaining = Counter(binding.model for binding in bindings if binding.runnable)
     model_passed = {model: True for model in remaining}
     for binding in bindings:
+        case_id = _accuracy_case_id(binding)
+        receipt = ledger.receipt(case_id)
         if not binding.runnable:
-            print(
-                f"\nNot compared: {binding.model} / {binding.not_compared_reason}",
-                flush=True,
-            )
-            result, comparison = _write_not_compared_case(
-                binding,
-                arguments.output,
-            )
+            if receipt["state"] == "terminal":
+                result = _normalize_result(receipt["payload"])
+                comparison = _case_directory(arguments.output, binding) / "comparison.json"
+            else:
+                ledger.begin(case_id, stage="preflight")
+                write_report(arguments.output)
+                print(
+                    f"\nNot compared: {binding.model} / {binding.not_compared_reason}",
+                    flush=True,
+                )
+                result, comparison = _write_not_compared_case(
+                    binding,
+                    arguments.output,
+                )
+                normalized = _normalize_result(result)
+                ledger.finish(
+                    case_id,
+                    result=_traffic_light_status(normalized),
+                    payload=normalized,
+                )
             not_compared = True
             _, report_path, _ = write_report(arguments.output)
             _print_result(result, comparison, report_path, arguments.verbose)
@@ -4590,6 +4748,65 @@ def _run_all_bindings(
             arguments,
             binding,
         )
+        if receipt["state"] == "terminal":
+            result = _normalize_result(receipt["payload"])
+            model_failed = result["validation"]["status"] == "failed"
+            model_passed[binding.model] = model_passed[binding.model] and not model_failed
+            remaining[binding.model] -= 1
+            print(
+                f"\nResume: keeping terminal result for {binding.model} / {binding.workload}",
+                flush=True,
+            )
+            _, report_path, _ = write_report(arguments.output)
+            comparison = _case_directory(arguments.output, binding) / "comparison.json"
+            _print_result(result, comparison, report_path, arguments.verbose)
+            failed = failed or model_failed
+            if model_failed and arguments.on_model_failure == "stop":
+                print(f"Stopping after failed model: {binding.model}", flush=True)
+                break
+            continue
+        case_attempt = len(receipt["attempts"]) + 1
+        binding_arguments.case_attempt = case_attempt
+        case_dir = _case_directory(arguments.output, binding)
+        worker_log = _worker_log_path(
+            case_dir,
+            case_attempt=case_attempt,
+            worker_attempt=1,
+        )
+        worker_log.parent.mkdir(parents=True, exist_ok=True)
+        worker_log.touch(exist_ok=True)
+        worker_command = _worker_command(binding, binding_arguments)
+        worker_environment = _worker_environment(binding_arguments)
+        ledger.begin(
+            case_id,
+            stage="preflight",
+            evidence={
+                "commands": {
+                    "worker": {
+                        "argv": worker_command,
+                        "rendered": shlex.join(worker_command),
+                        "cwd": str(REPO_ROOT),
+                    }
+                },
+                "logs": [
+                    {
+                        "label": f"Accuracy worker case attempt {case_attempt}",
+                        "href": worker_log.relative_to(arguments.output).as_posix(),
+                    }
+                ],
+                "environment": {
+                    name: worker_environment[name]
+                    for name in (
+                        "CUDA_VISIBLE_DEVICES",
+                        "HF_HOME",
+                        "LD_LIBRARY_PATH",
+                        "PYTHONPATH",
+                    )
+                    if worker_environment.get(name)
+                },
+            },
+        )
+        write_report(arguments.output)
         result = (
             _resumable_binding_result(arguments.output, binding)
             if arguments.resume_existing
@@ -4597,6 +4814,8 @@ def _run_all_bindings(
         )
         if result is None:
             free_gib = _check_free_space(arguments, binding)
+            ledger.update_stage(case_id, "candidate")
+            write_report(arguments.output)
             print(
                 f"\nStarting worker: {binding.model} / {binding.workload} / "
                 f"{sample_note} / {free_gib:.1f} GiB free",
@@ -4609,7 +4828,7 @@ def _run_all_bindings(
             )
         else:
             print(
-                f"\nResume: keeping terminal result for {binding.model} / {binding.workload}",
+                f"\nResume: importing terminal result for {binding.model} / {binding.workload}",
                 flush=True,
             )
         model_failed = result["validation"]["status"] == "failed"
@@ -4643,6 +4862,30 @@ def _run_all_bindings(
         comparison.write_text(
             json.dumps(result, indent=2, ensure_ascii=False),
             encoding="utf-8",
+        )
+        ledger.update_stage(case_id, "compare")
+        normalized = _normalize_result(result)
+        light = _traffic_light_status(normalized)
+        raw_result = normalized.get("raw_result", {})
+        timed_out = (
+            isinstance(raw_result, Mapping)
+            and raw_result.get("error_type") == "WorkerTimeoutError"
+        )
+        ledger.finish(
+            case_id,
+            result=light,
+            payload=normalized,
+            attempt_outcome=(
+                "timed_out"
+                if timed_out
+                else "failed"
+                if normalized["execution"]["status"] == "error"
+                else "completed"
+            ),
+            evidence={
+                "return_code": normalized["execution"].get("exit_code"),
+                "retryable": normalized["execution"].get("retryable"),
+            },
         )
         _, report_path, _ = write_report(arguments.output)
         comparison = _case_directory(arguments.output, binding) / "comparison.json"

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -3119,6 +3119,82 @@ def _accuracy_samples(result: Mapping[str, Any]) -> dict[str, int | None]:
     return {"planned": planned, "evaluated": evaluated}
 
 
+_SAMPLE_DIFFERENCE_RAW_KEYS = {
+    "generated_token_ids",
+    "generated_token_max_score_ids",
+    "input_token_ids",
+}
+
+
+def _compact_sample_difference(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        compact = {
+            str(name): _compact_sample_difference(item)
+            for name, item in value.items()
+            if name not in _SAMPLE_DIFFERENCE_RAW_KEYS and name != "artifacts"
+        }
+        artifacts = value.get("artifacts")
+        if isinstance(artifacts, Mapping) and artifacts.get("media"):
+            compact["artifacts"] = {
+                "media": _compact_sample_difference(artifacts["media"])
+            }
+        return compact
+    if isinstance(value, list):
+        return [_compact_sample_difference(item) for item in value]
+    return value
+
+
+def _public_sample_differences(
+    output: Path,
+    case_dir: Path,
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    metadata = result.get("disagreements", {})
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    try:
+        count = max(0, int(metadata.get("count", 0) or 0))
+        limit = max(
+            0,
+            int(
+                metadata.get(
+                    "inline_limit",
+                    trtmc_disagreements.INLINE_DISAGREEMENT_LIMIT,
+                )
+            ),
+        )
+    except (TypeError, ValueError):
+        count = 0
+        limit = 0
+    comparison = result.get("comparison", {})
+    failed = isinstance(comparison, Mapping) and comparison.get("status") == "disagreement"
+    public = {
+        "count": count,
+        "classification": "failed_samples" if failed else "sample_differences",
+        "href": None,
+        "preview": [],
+    }
+    if count <= 0:
+        return public
+    artifact_name = str(metadata.get("path", "disagreements.jsonl"))
+    artifact = case_dir / artifact_name
+    if not artifact.is_file():
+        return public
+    public["href"] = _materialize_accuracy_report_artifact(
+        output,
+        case_dir,
+        artifact,
+        category="differences",
+    )
+    public["preview"] = [
+        _compact_sample_difference(record)
+        for record in trtmc_disagreements.load_disagreement_preview(
+            artifact,
+            limit=limit,
+        )
+    ]
+    return public
+
+
 def _public_accuracy_result(
     output: Path,
     path: Path,
@@ -3132,6 +3208,11 @@ def _public_accuracy_result(
             "result": _traffic_light_status(result),
             "precision": _accuracy_precision(result),
             "samples": _accuracy_samples(result),
+            "sample_differences": _public_sample_differences(
+                output,
+                path.parent,
+                result,
+            ),
             "issue": _accuracy_issue(result),
             "debug": {
                 "result": path.relative_to(output).as_posix(),

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 import uuid as uuidlib
 
 import yaml
@@ -2978,10 +2978,7 @@ def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
         worker_failure = result.get("executor") == "model_worker"
         return {
             "priority": "P1",
-            "stage": str(
-                result.get("failure_stage")
-                or ("compare" if worker_failure else "candidate")
-            ),
+            "stage": _accuracy_failure_stage(result),
             "domain": str(result.get("failure_domain") or "harness/unknown"),
             "code": str(
                 result.get("failure_code")
@@ -3016,6 +3013,30 @@ def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
             or "comparison evidence is incomplete"
         ),
     }
+
+
+def _accuracy_failure_stage(result: Mapping[str, Any]) -> str:
+    explicit = str(result.get("failure_stage", "") or "").strip()
+    if explicit:
+        return explicit
+    raw_result = result.get("raw_result", {})
+    raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+    error_type = str(raw_result.get("error_type", "") or "")
+    error = str(raw_result.get("error", "") or "")
+    if error_type == "ReferenceExecutionError" or "HF reference subprocess failed" in error:
+        return "reference"
+    if result.get("executor") == "dataset_preflight":
+        return "preflight"
+    if result.get("executor") == "model_worker":
+        return "compare"
+    return "candidate"
+
+
+def _accuracy_result_stage(result: Mapping[str, Any]) -> str:
+    execution = result.get("execution", {})
+    if isinstance(execution, Mapping) and execution.get("status") == "error":
+        return _accuracy_failure_stage(result)
+    return "compare"
 
 
 def _materialize_accuracy_report_artifact(
@@ -4208,6 +4229,55 @@ def _worker_environment(arguments: argparse.Namespace) -> dict[str, str]:
     return environment
 
 
+def _accuracy_worker_attempt_evidence(
+    binding: Binding,
+    arguments: argparse.Namespace,
+    *,
+    worker_attempt: int,
+) -> dict[str, Any]:
+    case_dir = _case_directory(arguments.output, binding)
+    worker_log = _worker_log_path(
+        case_dir,
+        case_attempt=int(getattr(arguments, "case_attempt", 1)),
+        worker_attempt=worker_attempt,
+    )
+    worker_log.parent.mkdir(parents=True, exist_ok=True)
+    worker_log.touch(exist_ok=True)
+    worker_command = _worker_command(binding, arguments)
+    worker_environment = _worker_environment(arguments)
+    return {
+        "commands": {
+            "worker": {
+                "argv": worker_command,
+                "rendered": shlex.join(worker_command),
+                "cwd": str(REPO_ROOT),
+            }
+        },
+        "logs": [
+            {
+                "label": (
+                    f"Accuracy worker case attempt "
+                    f"{getattr(arguments, 'case_attempt', 1)}, "
+                    f"worker attempt {worker_attempt}"
+                ),
+                "href": worker_log.relative_to(arguments.output).as_posix(),
+            }
+        ],
+        "environment": {
+            name: worker_environment[name]
+            for name in (
+                "CUDA_VISIBLE_DEVICES",
+                "HF_HOME",
+                "LD_LIBRARY_PATH",
+                "PYTHONPATH",
+                "PYTORCH_CUDA_ALLOC_CONF",
+                "TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF",
+            )
+            if worker_environment.get(name)
+        },
+    }
+
+
 def _prepare_hf_on_demand(
     binding: Binding,
     arguments: argparse.Namespace,
@@ -4514,6 +4584,7 @@ def _run_supervised_binding_with_retries(
     *,
     arguments: argparse.Namespace,
     catalog: Mapping[str, Any],
+    on_retry: Callable[[int, Mapping[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     case_dir = _case_directory(arguments.output, binding)
     revalidation_budget = _reused_bundle_revalidation_budget(arguments)
@@ -4547,8 +4618,11 @@ def _run_supervised_binding_with_retries(
             archived=archived,
         )
         attempts.append(attempt_result)
-        if not execution_error or not retryable or attempt == arguments.model_attempts:
+        will_retry = execution_error and retryable and attempt < arguments.model_attempts
+        if not will_retry:
             break
+        if on_retry is not None:
+            on_retry(attempt, result)
         print(
             f"  Attempt {attempt}/{arguments.model_attempts}: FAILED",
             flush=True,
@@ -4767,44 +4841,14 @@ def _run_all_bindings(
             continue
         case_attempt = len(receipt["attempts"]) + 1
         binding_arguments.case_attempt = case_attempt
-        case_dir = _case_directory(arguments.output, binding)
-        worker_log = _worker_log_path(
-            case_dir,
-            case_attempt=case_attempt,
-            worker_attempt=1,
-        )
-        worker_log.parent.mkdir(parents=True, exist_ok=True)
-        worker_log.touch(exist_ok=True)
-        worker_command = _worker_command(binding, binding_arguments)
-        worker_environment = _worker_environment(binding_arguments)
         ledger.begin(
             case_id,
             stage="preflight",
-            evidence={
-                "commands": {
-                    "worker": {
-                        "argv": worker_command,
-                        "rendered": shlex.join(worker_command),
-                        "cwd": str(REPO_ROOT),
-                    }
-                },
-                "logs": [
-                    {
-                        "label": f"Accuracy worker case attempt {case_attempt}",
-                        "href": worker_log.relative_to(arguments.output).as_posix(),
-                    }
-                ],
-                "environment": {
-                    name: worker_environment[name]
-                    for name in (
-                        "CUDA_VISIBLE_DEVICES",
-                        "HF_HOME",
-                        "LD_LIBRARY_PATH",
-                        "PYTHONPATH",
-                    )
-                    if worker_environment.get(name)
-                },
-            },
+            evidence=_accuracy_worker_attempt_evidence(
+                binding,
+                binding_arguments,
+                worker_attempt=1,
+            ),
         )
         write_report(arguments.output)
         result = (
@@ -4814,17 +4858,49 @@ def _run_all_bindings(
         )
         if result is None:
             free_gib = _check_free_space(arguments, binding)
-            ledger.update_stage(case_id, "candidate")
+            ledger.update_stage(case_id, "compare")
             write_report(arguments.output)
             print(
                 f"\nStarting worker: {binding.model} / {binding.workload} / "
                 f"{sample_note} / {free_gib:.1f} GiB free",
                 flush=True,
             )
+
+            def record_retry(
+                worker_attempt: int,
+                attempt_result: Mapping[str, Any],
+            ) -> None:
+                stage = _accuracy_result_stage(attempt_result)
+                execution = attempt_result.get("execution", {})
+                execution = execution if isinstance(execution, Mapping) else {}
+                raw_result = attempt_result.get("raw_result", {})
+                raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+                timed_out = raw_result.get("error_type") == "WorkerTimeoutError"
+                ledger.update_stage(case_id, stage)
+                ledger.retry(
+                    case_id,
+                    attempt_outcome="timed_out" if timed_out else "failed",
+                    evidence={
+                        "return_code": execution.get("exit_code"),
+                        "retryable": True,
+                    },
+                )
+                ledger.begin(
+                    case_id,
+                    stage="compare",
+                    evidence=_accuracy_worker_attempt_evidence(
+                        binding,
+                        binding_arguments,
+                        worker_attempt=worker_attempt + 1,
+                    ),
+                )
+                write_report(arguments.output)
+
             result = _run_supervised_binding_with_retries(
                 binding,
                 arguments=binding_arguments,
                 catalog=catalog,
+                on_retry=record_retry,
             )
         else:
             print(
@@ -4863,7 +4939,7 @@ def _run_all_bindings(
             json.dumps(result, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
-        ledger.update_stage(case_id, "compare")
+        ledger.update_stage(case_id, _accuracy_result_stage(result))
         normalized = _normalize_result(result)
         light = _traffic_light_status(normalized)
         raw_result = normalized.get("raw_result", {})

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -94,6 +94,28 @@ _DIFFUSION_SAMPLE_INPUT_FIELDS = frozenset(
 )
 
 
+class ReferenceExecutionError(RuntimeError):
+    """The reference backend failed before producing comparable output."""
+
+
+def _reference_process_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.setdefault("TOKENIZERS_PARALLELISM", "false")
+    allocator_conf = environment.get(REFERENCE_CUDA_ALLOC_CONF_ENV)
+    if allocator_conf is None:
+        environment.setdefault(
+            "PYTORCH_CUDA_ALLOC_CONF",
+            "expandable_segments:True",
+        )
+    elif allocator_conf.strip().lower() in {"disable", "disabled", "none"}:
+        environment.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+    elif allocator_conf.strip():
+        environment["PYTORCH_CUDA_ALLOC_CONF"] = allocator_conf.strip()
+    else:
+        raise RuntimeError(f"{REFERENCE_CUDA_ALLOC_CONF_ENV} cannot be empty")
+    return environment
+
+
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as source:
@@ -9991,17 +10013,7 @@ def run_hf_reference_subprocess(
         if value is not None:
             cmd.extend([flag, str(value)])
     log_path = work_dir / "hf_run.log"
-    env = os.environ.copy()
-    env.setdefault("TOKENIZERS_PARALLELISM", "false")
-    allocator_conf = os.environ.get(REFERENCE_CUDA_ALLOC_CONF_ENV)
-    if allocator_conf is None:
-        env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
-    elif allocator_conf.strip().lower() in {"disable", "disabled", "none"}:
-        env.pop("PYTORCH_CUDA_ALLOC_CONF", None)
-    elif allocator_conf.strip():
-        env["PYTORCH_CUDA_ALLOC_CONF"] = allocator_conf.strip()
-    else:
-        raise RuntimeError(f"{REFERENCE_CUDA_ALLOC_CONF_ENV} cannot be empty")
+    env = _reference_process_environment()
     with log_path.open("w", encoding="utf-8") as log_f:
         log_f.write(f"$ {shlex.join(cmd)}\n")
         log_f.flush()
@@ -10009,7 +10021,7 @@ def run_hf_reference_subprocess(
             cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env
         )
     if proc.returncode != 0:
-        raise RuntimeError(
+        raise ReferenceExecutionError(
             f"HF reference subprocess failed for {model['name']} rc={proc.returncode}; see {log_path}"
         )
 
@@ -12924,9 +12936,7 @@ def run_eval_model_worker(
         "--request",
         str(request_path),
     ]
-    env = os.environ.copy()
-    env.setdefault("TOKENIZERS_PARALLELISM", "false")
-    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    env = _reference_process_environment()
     with log_path.open("w", encoding="utf-8") as log_f:
         proc = subprocess.run(
             cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env

--- a/website/docs/reference/benchmarking.md
+++ b/website/docs/reference/benchmarking.md
@@ -80,12 +80,18 @@ python3 tools/perf_matrix.py report artifacts/perf/example-run \
   --preparation-receipt artifacts/perf/bundle-preparation.json
 ```
 
-Every new run writes `results.json` and `report.html` below the configured
-results root. The JSON records resolved configuration, provenance, raw
-samples, exact leaf commands, timing policies, and bundle preparation; the
-HTML shows candidate/reference p50 values and the traffic light. The report's
-self-contained controls can filter by text, traffic light, or bundle
-preparation status without a server.
+Every new run writes `results.json`, `report.json`, and `report.html` below the
+configured results root. Before timing preflight starts, it also freezes the
+ordered selected-case inventory in `ledger/campaign.json` and creates one
+atomic receipt per case under `ledger/cases/`. `report.json` is rebuilt from
+those receipts after each state transition, so a caller can poll per-model
+pending, running, and terminal progress. Resume marks a leftover running
+case attempt interrupted, preserves comparable and non-retryable receipts,
+and starts a new attempt for unfinished or explicitly retryable White cases.
+The receipt keeps the earlier failed result and its attempt evidence.
+`results.json` remains the compatibility projection with resolved
+configuration, provenance, raw samples, exact leaf commands, timing policies,
+and bundle preparation. `report.html` is only the renderer for `report.json`.
 
 A separately run bundle-preparation step can be attached with the `report`
 command shown above. The receipt must use schema

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -167,6 +167,15 @@ model ultimately fails.
 Each case writes
 `<output>/<model>/<workload>/comparison.json`; the output root receives
 `report.json` and the **TRTMC Reference Consistency Report** in `report.html`.
+The run also freezes its ordered selected-case inventory in
+`<output>/ledger/campaign.json` and atomically maintains one receipt per case
+under `<output>/ledger/cases/`. `report.json` is rebuilt from those receipts,
+so it includes pending, running, and terminal cases while the command is still
+running. On `--resume-existing`, a leftover running attempt becomes
+interrupted, completed receipts remain unchanged, and only unfinished cases
+can start a new case attempt. Model-worker retries remain nested evidence
+within that case attempt; they are not additional ledger attempts.
+`comparison.json` remains an atomically repaired compatibility projection.
 A not-compared entry writes
 `<output>/<model>/not-compared/comparison.json` without launching a worker.
 Exit status `0` means all attempted comparisons passed, `1` means execution


### PR DESCRIPTION
## Background

Accuracy and Performance qualification reports previously mixed valid comparison outcomes, exclusions, and execution failures in one color summary. Their HTML also reconstructed results from legacy files, while CI consumers had no durable per-case progress source or reliable way to recover interrupted work.

This change establishes `report.json` as the machine-readable qualification snapshot and introduces per-case execution receipts so the same result can drive the HTML report, progress polling, diagnostics, and resume behavior.

## Exit Criteria

- Excluded models do not enter the selected-case set or report denominator.
- Selected cases are represented as pending, running, or terminal; terminal cases resolve to green, yellow, red, or white with white reserved for cases that did not form a valid comparison.
- Accuracy and Performance reports are rendered from their `report.json` data rather than calculating results in HTML.
- Every case attempt retains its command, environment, return code, and published log links.
- Interrupted or retryable work creates a new attempt without overwriting completed evidence.
- Existing qualification thresholds, qualification snapshots, and CI enablement remain unchanged.

## Implementation

- Add a shared qualification report schema, renderer, and static assets for Accuracy and Performance reports.
- Publish operational coverage separately from comparable green/yellow/red outcomes, while preserving white failures and removing platform exclusions before execution.
- Add sample counts, disagreement evidence, compute precision, task metrics, raw logs, commands, and vanilla reproduction details to the report data model.
- Add a durable execution ledger with atomic campaign and per-case receipts. Reports can be rebuilt from receipts, and live progress exposes stage and attempt information.
- Adapt Accuracy and Performance runners to commit evidence at case boundaries, retain completed attempts during resume, and avoid rewriting unchanged report assets.
- Preserve actual Accuracy worker retries as distinct ledger attempts and classify reference, preflight, comparison, candidate, and timeout failures at the stage where they occurred.
- Disable the experimental PyTorch CUDA allocator override for Auto Thor reference workers while leaving other platform environments unchanged.

## Validation

- `git diff --check github/main...HEAD`: passed.
- `PYTHONPATH=.:python python3 -m ruff check tools/execution_ledger.py tools/model_checks.py tools/perf_matrix.py tools/qualification_report.py tools/trtmc_validate.py tools/validation/engine.py tests/tools/test_execution_ledger.py tests/tools/test_model_checks.py tests/tools/test_perf_matrix.py tests/tools/test_qualification_report.py tests/tools/test_trtmc_bench.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py`: passed.
- `PYTHONPATH=.:python pytest -q tests/tools/test_execution_ledger.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py tests/tools/test_model_checks.py tests/tools/test_perf_matrix.py tests/tools/test_qualification_report.py`: 609 passed.
- Exact head `41279632afac3293acf7422b7383716ffd273450`, GB300: `distilgpt2` Accuracy passed with 20/20 samples; Performance produced a valid green comparison with exact-token output validation.
- Exact head `41279632afac3293acf7422b7383716ffd273450`, ThorX-2: `distilgpt2` Accuracy passed with 20/20 samples without the prior reference allocator crash; Performance produced a valid green comparison with exact-token output validation.
- Both target reports recorded the exact source revision, 100% operational coverage, terminal attempt receipts, and valid relative links for every checked environment, command, and log artifact.

## Notes For Future Readers

- Review the shared schema and renderer first, then the execution ledger, followed by the Accuracy and Performance adapters.
- The branch is one unrelated DINOv3 commit behind current `main`; it was intentionally not rebased so the PR head remains the exact four-gate hardware-validated SHA. Rebase and repeat target validation if an up-to-date branch becomes required before merge.
- This PR does not modify a GitHub workflow, trigger private premerge, enable nightly/premerge qualification, change gate values, or modify the qualification snapshot.
- Deterministic sharding and CI publication are follow-up work; the receipt and report contracts in this PR provide the prerequisite capability only.
