### PR TITLE
feat(validation): add shadow gate analysis

### DIFF
--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1000,6 +1000,158 @@ def test_accuracy_report_is_rebuilt_from_ordered_live_receipts(tmp_path):
     }
 
 
+def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_path):
+    cases = [
+        {
+            "id": "model-a::suite-a",
+            "result_path": "model-a/suite-a/comparison.json",
+            "report": {"model": "model-a", "workload": "suite-a", "sample_limit": 20},
+        }
+    ]
+    ledger = trtmc_validate.ExecutionLedger.open(
+        tmp_path,
+        campaign_id="run-1",
+        task_kind="accuracy",
+        fingerprint="revision-1",
+        cases=cases,
+    )
+    result = trtmc_validate._normalize_result(
+        {
+            "model": "model-a",
+            "workload": "suite-a",
+            "execution": {"status": "completed", "exit_code": 0},
+            "comparison": {
+                "status": "agreement",
+                "mode": "mcq",
+                "primary_metric": None,
+                "metrics": {"prediction_agreement_rate": 0.95},
+                "failures": [],
+            },
+            "validation": {"status": "passed"},
+            "precision_contract": {
+                "reference_precision": "fp16",
+                "trtmc_base_precision": "fp16",
+            },
+            "raw_result": {
+                "configured_gates": {"min_prediction_agreement": 0.98},
+                "gate_policy": "blocking",
+            },
+            "reproduce": {
+                "dataset": {
+                    "sample_limit": 20,
+                    "prepared_input_count": 20,
+                }
+            },
+        }
+    )
+    ledger.begin("model-a::suite-a", stage="compare")
+    ledger.finish("model-a::suite-a", result="green", payload=result)
+
+    _, _, report = trtmc_validate.write_report(tmp_path)
+
+    row = report["results"][0]
+    assert row["result"] == "green"
+    assert row["comparison"]["gate_evaluation"] == {
+        "schema_version": "trtmc.validation-gate-evaluation/v1",
+        "status": "fail",
+        "sample_count": 20,
+        "checks": [
+            {
+                "gate": "min_prediction_agreement",
+                "metric": "prediction_agreement_rate",
+                "operator": ">=",
+                "actual": 0.95,
+                "required": 0.98,
+                "verdict": "fail",
+                "effective": {
+                    "kind": "proportion",
+                    "required_passes": 20,
+                    "allowed_failures": 0,
+                    "observed_passes": 19,
+                    "observed_failures": 1,
+                    "resolution": 0.05,
+                },
+            }
+        ],
+        "issues": [],
+    }
+
+
+def test_accuracy_shadow_gate_uses_valid_pairs_not_prepared_inputs(tmp_path):
+    case_dir = tmp_path / "model-a" / "suite-a"
+    case_dir.mkdir(parents=True)
+    result_path = case_dir / "comparison.json"
+    result_path.write_text("{}", encoding="utf-8")
+    result = trtmc_validate._normalize_result(
+        {
+            "model": "model-a",
+            "workload": "suite-a",
+            "execution": {"status": "completed", "exit_code": 0},
+            "comparison": {
+                "status": "disagreement",
+                "mode": "mcq",
+                "primary_metric": None,
+                "metrics": {
+                    "prediction_agreement_rate": 18 / 19,
+                    "valid_count": 19,
+                },
+                "failures": [],
+            },
+            "validation": {"status": "failed"},
+            "raw_result": {
+                "configured_gates": {"min_prediction_agreement": 0.95},
+                "gate_policy": "blocking",
+            },
+            "reproduce": {
+                "dataset": {
+                    "sample_limit": 20,
+                    "prepared_input_count": 20,
+                }
+            },
+        }
+    )
+
+    public = trtmc_validate._public_accuracy_result(tmp_path, result_path, result)
+
+    assert public["samples"] == {"planned": 20, "evaluated": 20}
+    evaluation = public["comparison"]["gate_evaluation"]
+    assert evaluation["sample_count"] == 19
+    assert evaluation["checks"][0]["effective"]["observed_failures"] == 1
+
+
+def test_accuracy_shadow_gate_preserves_worst_nested_metric(tmp_path):
+    case_dir = tmp_path / "model-a" / "suite-a"
+    case_dir.mkdir(parents=True)
+    result_path = case_dir / "comparison.json"
+    result_path.write_text("{}", encoding="utf-8")
+    result = trtmc_validate._normalize_result(
+        {
+            "model": "model-a",
+            "workload": "suite-a",
+            "execution": {"status": "completed", "exit_code": 0},
+            "raw_result": {
+                "status": "failed",
+                "valid_count": 5,
+                "metrics": {
+                    "pixel_mean": {"mean": 0.5, "min": 0.1, "max": 0.9}
+                },
+                "configured_gates": {"max_pixel_mean": 0.85},
+                "gate_policy": "blocking",
+            },
+            "reproduce": {
+                "dataset": {"sample_limit": 5, "prepared_input_count": 5}
+            },
+        }
+    )
+
+    public = trtmc_validate._public_accuracy_result(tmp_path, result_path, result)
+
+    evaluation = public["comparison"]["gate_evaluation"]
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["metric"] == "max_pixel_mean"
+    assert evaluation["checks"][0]["actual"] == 0.9
+
+
 def test_accuracy_adapter_resumes_an_interrupted_case_as_a_new_attempt(
     tmp_path, monkeypatch
 ):

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -138,6 +138,25 @@ def test_full_duplex_bench_scorer_rejects_stale_summary_after_crash(
         )
 
 
+def test_full_duplex_gate_actuals_use_worst_aggregate_delta() -> None:
+    actuals = validation_engine._full_duplex_gate_actuals(
+        {
+            "metrics": {
+                "synthetic_pause_handling.tor": {"abs_delta": 0.02},
+                "candor_pause_handling.tor": {"abs_delta": 0.08},
+                "icc_backchannel.frequency": {"abs_delta": 0.004},
+                "icc_backchannel.jsd": {"abs_delta": 0.01},
+            }
+        }
+    )
+
+    assert actuals == {
+        "tor_abs_delta": 0.08,
+        "backchannel_frequency_abs_delta": 0.004,
+        "backchannel_jsd_abs_delta": 0.01,
+    }
+
+
 def test_full_duplex_bench_rejects_short_slice_before_inference(tmp_path: Path) -> None:
     answers = {
         "schema_version": "trtmc.full-duplex-bench-validation/v1",
@@ -666,6 +685,7 @@ def test_default_suites_include_text_generation_gap_models() -> None:
         humaneval, codegen
     )
     assert resolved_codegen["gates"] == {"min_exact_match_rate": 1.0}
+    assert resolved_codegen["gate_policy"] == "blocking"
 
     for suite_id in (
         "newstest2019_en_ru_marian_translation_parity",
@@ -675,6 +695,29 @@ def test_default_suites_include_text_generation_gap_models() -> None:
         assert validation_engine.suite_by_id(suites, suite_id)["scoring"]["task_metric"] == (
             "sacrebleu"
         )
+
+
+def test_default_suites_classify_every_empty_gate_policy() -> None:
+    suites = validation_engine.load_suites()
+
+    unclassified = [
+        suite["id"]
+        for suite in suites
+        if not suite.get("gates")
+        and suite.get("gate_policy") != "observation_only"
+    ]
+
+    assert unclassified == []
+
+
+def test_asr_similarity_gate_is_not_classified_as_a_sample_pass_rate() -> None:
+    suites = validation_engine.load_suites()
+
+    for suite_id in ("librispeech_clean_asr", "librispeech_clean_asr_streaming"):
+        suite = validation_engine.suite_by_id(suites, suite_id)
+        assert suite["gate_metric_kinds"] == {
+            "min_prediction_agreement": "continuous"
+        }
 
 
 def test_phi_moe_mmlu_uses_model_specific_agreement_gate() -> None:
@@ -1163,6 +1206,7 @@ def test_prompted_segmentation_uses_family_prompt_semantics(tmp_path: Path) -> N
     assert point["status"] == "passed"
     assert text["status"] == "passed"
     assert point["mean_backend_mask_iou"] == 1.0
+    assert point["worst_backend_mask_iou"] == 1.0
     assert text["mean_backend_mask_iou"] == 1.0
 
 
@@ -7612,6 +7656,12 @@ def test_eval_one_model_reuses_cached_hf_builds_bundle_and_reruns_bundle(
     assert result["prediction_agreement_rate"] == 0.5
     assert result["status"] == "failed"
     assert result["error_type"] == "BenchmarkGateError"
+    assert result["configured_gates"] == {
+        "max_accuracy_drop_from_hf": 0.01,
+        "min_prediction_agreement": 0.98,
+    }
+    assert result["gate_metric_kinds"] == {}
+    assert result["gate_policy"] == "blocking"
     assert result["gate_failures"] == [
         {
             "gate": "max_accuracy_drop_from_hf",

--- a/tests/tools/test_validation_gate_policy.py
+++ b/tests/tools/test_validation_gate_policy.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from tools.validation.gate_policy import evaluate_shadow_gates
+from tools.validation.catalog import load_suites
+
+
+def test_rate_gate_expands_against_actual_sample_count() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 0.95},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+    )
+
+    assert evaluation == {
+        "schema_version": "trtmc.validation-gate-evaluation/v1",
+        "status": "fail",
+        "sample_count": 20,
+        "checks": [
+            {
+                "gate": "min_prediction_agreement",
+                "metric": "prediction_agreement_rate",
+                "operator": ">=",
+                "actual": 0.95,
+                "required": 0.98,
+                "verdict": "fail",
+                "effective": {
+                    "kind": "proportion",
+                    "required_passes": 20,
+                    "allowed_failures": 0,
+                    "observed_passes": 19,
+                    "observed_failures": 1,
+                    "resolution": 0.05,
+                },
+            }
+        ],
+        "issues": [],
+    }
+
+
+def test_accuracy_drop_gate_exposes_discrete_loss_budget() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"accuracy_drop_from_hf": 0.05},
+        configured_gates={"max_accuracy_drop_from_hf": 0.01},
+        sample_count=20,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"] == [
+        {
+            "gate": "max_accuracy_drop_from_hf",
+            "metric": "accuracy_drop_from_hf",
+            "operator": "<=",
+            "actual": 0.05,
+            "required": 0.01,
+            "verdict": "fail",
+            "effective": {
+                "kind": "proportion_drop",
+                "allowed_drop_count": 0,
+                "observed_drop_count": 1,
+                "resolution": 0.05,
+            },
+        }
+    ]
+
+
+def test_unknown_gate_is_an_invalid_shadow_policy() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"prediction_agreement": 0.98},
+        sample_count=20,
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["checks"] == []
+    assert evaluation["issues"] == [
+        {
+            "code": "unsupported_gate",
+            "gate": "prediction_agreement",
+        }
+    ]
+
+
+def test_missing_metric_is_an_invalid_shadow_policy() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["checks"] == []
+    assert evaluation["issues"] == [
+        {
+            "code": "metric_unavailable",
+            "gate": "min_prediction_agreement",
+            "metric": "prediction_agreement_rate",
+        }
+    ]
+
+
+def test_continuous_gate_does_not_claim_an_integer_failure_budget() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"backend_mask_iou": 0.754},
+        configured_gates={"min_backend_mask_iou": 0.70},
+        sample_count=5,
+    )
+
+    assert evaluation["status"] == "pass"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "continuous",
+        "sample_count": 5,
+    }
+
+
+def test_tts_rate_gate_exposes_three_sample_zero_failure_smoke() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"correctness_agreement_rate": 2 / 3},
+        configured_gates={"min_correctness_agreement": 0.95},
+        sample_count=3,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "proportion",
+        "required_passes": 3,
+        "allowed_failures": 0,
+        "observed_passes": 2,
+        "observed_failures": 1,
+        "resolution": 1 / 3,
+    }
+
+
+def test_blocking_policy_with_no_gates_is_invalid() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={},
+        configured_gates={},
+        sample_count=20,
+        policy_mode="blocking",
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["issues"] == [{"code": "empty_gate_policy"}]
+
+
+def test_observation_only_policy_can_explicitly_have_no_gates() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={},
+        configured_gates={},
+        sample_count=3,
+        policy_mode="observation_only",
+    )
+
+    assert evaluation["status"] == "observation_only"
+    assert evaluation["checks"] == []
+    assert evaluation["issues"] == []
+
+
+def test_blocking_policy_requires_an_actual_sample_count() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=None,
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["checks"] == []
+    assert evaluation["issues"] == [{"code": "sample_count_unavailable"}]
+
+
+def test_rate_gate_recalculates_for_each_actual_sample_count() -> None:
+    expected = {
+        3: (3, 0),
+        5: (5, 0),
+        10: (10, 0),
+        20: (20, 0),
+        50: (49, 1),
+        100: (98, 2),
+    }
+
+    for sample_count, (required_passes, allowed_failures) in expected.items():
+        evaluation = evaluate_shadow_gates(
+            metrics={"prediction_agreement_rate": 1.0},
+            configured_gates={"min_prediction_agreement": 0.98},
+            sample_count=sample_count,
+        )
+
+        effective = evaluation["checks"][0]["effective"]
+        assert effective["required_passes"] == required_passes
+        assert effective["allowed_failures"] == allowed_failures
+
+
+def test_direct_minimum_gate_uses_its_declared_metric() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"temporal_consistency": 0.72},
+        configured_gates={"temporal_consistency": 0.6},
+        sample_count=5,
+    )
+
+    assert evaluation["status"] == "pass"
+    assert evaluation["checks"][0] == {
+        "gate": "temporal_consistency",
+        "metric": "temporal_consistency",
+        "operator": ">=",
+        "actual": 0.72,
+        "required": 0.6,
+        "verdict": "pass",
+        "effective": {"kind": "continuous", "sample_count": 5},
+    }
+
+
+def test_direct_reranking_gate_uses_worst_sample_not_mean() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={
+            "pairwise_ordering_agreement": 1.0,
+            "min_pairwise_ordering_agreement": 0.5,
+        },
+        configured_gates={"pairwise_ordering_agreement": 1.0},
+        sample_count=2,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["metric"] == "min_pairwise_ordering_agreement"
+    assert evaluation["checks"][0]["actual"] == 0.5
+
+
+def test_exact_gate_uses_equality_instead_of_a_range() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"num_frames": 120},
+        configured_gates={"exact_num_frames": 121},
+        sample_count=1,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["operator"] == "=="
+
+
+def test_non_numeric_threshold_is_an_invalid_shadow_policy() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"min_prediction_agreement": "strict"},
+        sample_count=20,
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["issues"] == [
+        {
+            "code": "invalid_threshold",
+            "gate": "min_prediction_agreement",
+            "value": "strict",
+        }
+    ]
+
+
+def test_every_configured_suite_gate_is_understood_by_shadow_analysis() -> None:
+    class AvailableMetrics(dict):
+        def get(self, key, default=None):  # noqa: ANN001, ANN201
+            return 1.0
+
+        def __getitem__(self, key):  # noqa: ANN001, ANN201
+            return 1.0
+
+    unsupported: list[tuple[str, str]] = []
+    for suite in load_suites():
+        gates = suite.get("gates", {})
+        if not gates:
+            continue
+        evaluation = evaluate_shadow_gates(
+            metrics=AvailableMetrics(),
+            configured_gates=gates,
+            sample_count=20,
+        )
+        unsupported.extend(
+            (str(suite["id"]), str(issue.get("gate", "")))
+            for issue in evaluation["issues"]
+            if issue["code"] == "unsupported_gate"
+        )
+
+    assert unsupported == []
+
+
+def test_unknown_policy_mode_is_invalid() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+        policy_mode="optional",
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["issues"] == [
+        {"code": "unsupported_policy_mode", "value": "optional"}
+    ]
+
+
+def test_non_finite_metric_is_invalid() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": float("nan")},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["issues"] == [
+        {
+            "code": "invalid_metric",
+            "gate": "min_prediction_agreement",
+            "metric": "prediction_agreement_rate",
+            "value": "nan",
+        }
+    ]
+
+
+def test_workload_can_mark_rate_named_metric_as_continuous() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 0.8953},
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=20,
+        metric_kinds={"min_prediction_agreement": "continuous"},
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "continuous",
+        "sample_count": 20,
+    }
+
+
+def test_metric_kind_cannot_target_an_unconfigured_gate() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+        metric_kinds={"min_typo": "continuous"},
+    )
+
+    assert evaluation["status"] == "invalid"
+    assert evaluation["issues"] == [
+        {"code": "metric_kind_without_gate", "gate": "min_typo"}
+    ]
+
+
+def test_continuous_gate_keeps_its_configured_aggregate_semantics() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"pixel_mean": 0.5},
+        configured_gates={"min_pixel_mean": 0.15, "max_pixel_mean": 0.85},
+        sample_count=5,
+    )
+
+    assert evaluation["status"] == "pass"
+    assert [check["actual"] for check in evaluation["checks"]] == [0.5, 0.5]
+    assert [check["verdict"] for check in evaluation["checks"]] == ["pass", "pass"]
+
+
+def test_exact_gate_fails_when_any_observed_value_differs() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"min_num_frames": 120, "max_num_frames": 121},
+        configured_gates={"exact_num_frames": 121},
+        sample_count=5,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["actual"] == {"min": 120.0, "max": 121.0}
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "exact",
+        "sample_count": 5,
+    }
+
+
+def test_continuation_smoke_exposes_one_failure_budget_at_ten_samples() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"tie_adjusted_exact_match_rate": 0.9},
+        configured_gates={"min_tie_adjusted_exact_match_rate": 0.9},
+        sample_count=10,
+    )
+
+    assert evaluation["status"] == "pass"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "proportion",
+        "required_passes": 9,
+        "allowed_failures": 1,
+        "observed_passes": 9,
+        "observed_failures": 1,
+        "resolution": 0.1,
+    }
+
+
+def test_codegen_zero_failure_gate_rejects_one_divergence() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"exact_match_rate": 0.9},
+        configured_gates={"min_exact_match_rate": 1.0},
+        sample_count=10,
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["effective"]["allowed_failures"] == 0
+    assert evaluation["checks"][0]["effective"]["observed_failures"] == 1
+
+
+def test_sam_shadow_does_not_invent_an_uncalibrated_tail_gate() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"mean_backend_mask_iou": 0.754, "min_mean_backend_mask_iou": 0.2},
+        configured_gates={"min_backend_mask_iou": 0.7},
+        sample_count=5,
+    )
+
+    assert evaluation["status"] == "pass"
+    assert evaluation["checks"][0]["metric"] == "mean_backend_mask_iou"
+    assert evaluation["checks"][0]["actual"] == 0.754

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -164,6 +164,24 @@ or repeats samples: when the configured limit exceeds the available count, it
 runs the available samples. `report.json` and the `Samples` column of
 `report.html` record the actual prepared sample count.
 
+Suites with configured gates resolve to `gate_policy: blocking`. A suite with
+no gates must declare `gate_policy: observation_only`; shadow analysis marks an
+empty blocking policy invalid instead of silently describing it as valid.
+Completed Accuracy results preserve the
+resolved gate configuration and publish a non-blocking analysis under
+`comparison.gate_evaluation` in `report.json`. The analysis uses the valid
+paired-sample count when available and expands rate gates into required passes,
+allowed failures, observed passes, and observed failures. For example,
+`min_prediction_agreement: 0.98` requires 20/20 at 20 valid samples and 49/50 at
+50 valid samples. Continuous metrics retain their numeric threshold and do not
+claim an integer failure budget.
+
+This analysis is shadow evidence: it is shown separately in the HTML Metrics
+details and does not change the existing comparison status, traffic light,
+qualification snapshot, or CI disposition. Unsupported gate names, unavailable
+metrics, non-numeric values, and missing sample counts are explicit `issues` in
+the analysis rather than implicit passes.
+
 Override the configured limit for one run, or request the complete dataset
 explicitly:
 

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -249,6 +249,7 @@ suites:
         starcoder2-3b:
           build_generation_headroom: true
     gates: {}
+    gate_policy: observation_only
     ci:
       eligible: false
       lane: local_only
@@ -347,6 +348,7 @@ suites:
       scorer: continuation
       task_metric: sacrebleu
     gates: {}
+    gate_policy: observation_only
     ci:
       eligible: false
       lane: local_only
@@ -392,6 +394,7 @@ suites:
       scorer: continuation
       task_metric: sacrebleu
     gates: {}
+    gate_policy: observation_only
     ci:
       eligible: false
       lane: local_only
@@ -446,6 +449,7 @@ suites:
         riva-translate-4b:
           build_generation_headroom: true
     gates: {}
+    gate_policy: observation_only
     ci:
       eligible: false
       lane: local_only
@@ -738,6 +742,9 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.05
       min_prediction_agreement: 0.90
+    gate_metric_kinds:
+      # This is mean normalized transcript similarity, not an exact-match rate.
+      min_prediction_agreement: continuous
     ci:
       eligible: false
       lane: local_only
@@ -787,6 +794,9 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.05
       min_prediction_agreement: 0.90
+    gate_metric_kinds:
+      # This is mean normalized transcript similarity, not an exact-match rate.
+      min_prediction_agreement: continuous
     model_profiles:
       nemotron-3.5-asr-streaming-0.6b:
         generation:

--- a/tools/qualification_report_assets/qualification-report.css
+++ b/tools/qualification_report_assets/qualification-report.css
@@ -55,6 +55,14 @@ tr[data-result="white"] { background: #f0f2ef; } tr[data-result="red"] { backgro
 .precision-side { display: flex; justify-content: space-between; gap: 10px; white-space: nowrap; }
 .precision-side span { color: var(--muted); font-size: 11px; }.precision-side strong { font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
 .metric { display: flex; justify-content: space-between; gap: 14px; font-size: 12px; font-variant-numeric: tabular-nums; }.metric span { color: var(--muted); }
+.metric-evidence { display: grid; gap: 6px; min-width: 130px; }
+.gate-check { position: relative; margin: 8px 0; padding: 9px 74px 9px 10px; border: 1px solid var(--line); border-left-width: 4px; border-radius: 8px; background: var(--raised); }
+.gate-check h4 { margin: 0 0 4px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
+.gate-pass { border-left-color: var(--green); }.gate-fail { border-left-color: var(--red); }
+.gate-fact { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; }
+.gate-verdict { position: absolute; top: 9px; right: 10px; font-size: 11px; }
+.gate-pass .gate-verdict { color: var(--green-dark); }.gate-fail .gate-verdict { color: var(--red); }
+.gate-issue { margin: 8px 0; padding: 9px 10px; border-left: 4px solid var(--amber); border-radius: 8px; background: #fff9e8; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
 .timing { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
 .log-links { display: grid; gap: 4px; min-width: 110px; }.log-links a { width: fit-content; font-size: 12px; font-weight: 650; white-space: nowrap; }
 .command-artifact { display: block; width: fit-content; margin-top: 5px; font-size: 12px; font-weight: 650; }

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -178,13 +178,42 @@
     return control;
   }
 
+  function gateEvaluation(value) {
+    if (!value || !value.schema_version) return null;
+    const control = el("details", "evidence gate-evaluation");
+    const sampleText = value.sample_count === null || value.sample_count === undefined ? "sample count unavailable" : `${value.sample_count} valid samples`;
+    control.append(el("summary", "", `Gate analysis (shadow) · ${String(value.status || "unknown").toUpperCase()} · ${sampleText}`));
+    const body = el("div", "evidence-body");
+    (value.checks || []).forEach((check) => {
+      const effective = check.effective || {};
+      const card = el("section", `gate-check gate-${check.verdict || "unknown"}`);
+      const actual = check.actual && typeof check.actual === "object" ? `${number(check.actual.min, 6)}..${number(check.actual.max, 6)}` : number(check.actual, 6);
+      add(card, el("h4", "", check.gate || "Unnamed gate"), el("div", "gate-fact", `${check.metric || "—"} · actual ${actual} ${check.operator || ""} required ${number(check.required, 6)}`));
+      if (effective.kind === "proportion") add(card, el("div", "gate-fact", `${effective.observed_passes}/${value.sample_count} passed · ${effective.observed_failures} failed · requires ${effective.required_passes}/${value.sample_count} · allows ${effective.allowed_failures} failed`));
+      else if (effective.kind === "proportion_drop") add(card, el("div", "gate-fact", `${effective.observed_drop_count} net samples lost · allows ${effective.allowed_drop_count}`));
+      else if (effective.kind === "exact") add(card, el("div", "gate-fact", `Observed range ${actual} · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
+      else add(card, el("div", "gate-fact", `Continuous metric · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
+      card.append(el("strong", "gate-verdict", String(check.verdict || "unknown").toUpperCase()));
+      body.append(card);
+    });
+    (value.issues || []).forEach((issue) => body.append(el("div", "gate-issue", [issue.code, issue.gate, issue.metric].filter(Boolean).join(" · "))));
+    control.append(body);
+    return control;
+  }
+
   function metrics(row, kind) {
     const records = [];
     if (row.issue) records.push(["Failure", row.issue]);
     if ((row.warnings || []).length) records.push(["Warnings", row.warnings]);
-    if (kind === "accuracy") records.push(["Comparison", row.comparison || {}], ["Validation", row.validation || {}]);
+    let gate = null;
+    if (kind === "accuracy") {
+      const comparison = { ...(row.comparison || {}) };
+      gate = gateEvaluation(comparison.gate_evaluation);
+      delete comparison.gate_evaluation;
+      records.push(["Comparison", comparison], ["Validation", row.validation || {}]);
+    }
     else records.push(["Output validation", row.output_validation || {}], ["Reference samples", row.baseline?.samples_ms || []], ["TRTMC samples", row.candidate?.samples_ms || []], ["Comparison", row.comparison || {}]);
-    return details("Metrics", records);
+    return add(el("div", "metric-evidence"), gate, details("Metrics", records));
   }
 
   function logs(row) {

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -63,6 +63,7 @@ from tools import trtmc_disagreements  # noqa: E402
 from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import model_selection  # noqa: E402
 from tools import qualification_report  # noqa: E402
+from tools.validation.gate_policy import evaluate_shadow_gates  # noqa: E402
 
 
 DEFAULT_CATALOG = REPO_ROOT / "tests" / "validation" / "model_workloads.yaml"
@@ -1219,7 +1220,11 @@ _COMPARISON_METRICS = (
     "hf_mean_iou",
     "bundle_mean_iou",
     "backend_mean_iou",
+    "worst_backend_mask_iou",
     "mean_iou_drop_from_hf",
+    "tor_abs_delta",
+    "backchannel_frequency_abs_delta",
+    "backchannel_jsd_abs_delta",
     "mean_vector_cosine",
     "min_vector_cosine",
     "mean_pair_cosine_abs_delta",
@@ -3115,6 +3120,14 @@ def _report_command_artifacts(
     return artifacts
 
 
+def _nonnegative_sample_count(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
 def _accuracy_samples(result: Mapping[str, Any]) -> dict[str, int | None]:
     reproduce = result.get("reproduce", {})
     reproduce = reproduce if isinstance(reproduce, Mapping) else {}
@@ -3125,22 +3138,51 @@ def _accuracy_samples(result: Mapping[str, Any]) -> dict[str, int | None]:
     metrics = comparison.get("metrics", {})
     metrics = metrics if isinstance(metrics, Mapping) else {}
 
-    def nonnegative(value: Any) -> int | None:
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return None
-        return parsed if parsed >= 0 else None
-
-    planned = nonnegative(dataset.get("sample_limit"))
+    planned = _nonnegative_sample_count(dataset.get("sample_limit"))
     if planned == 0:
         planned = None
-    evaluated = nonnegative(dataset.get("prepared_input_count"))
+    evaluated = _nonnegative_sample_count(dataset.get("prepared_input_count"))
     if evaluated is None:
-        evaluated = nonnegative(metrics.get("valid_count"))
+        evaluated = _nonnegative_sample_count(metrics.get("valid_count"))
     if evaluated is None:
-        evaluated = nonnegative(metrics.get("sample_count"))
+        evaluated = _nonnegative_sample_count(metrics.get("sample_count"))
     return {"planned": planned, "evaluated": evaluated}
+
+
+def _accuracy_gate_sample_count(
+    comparison: Mapping[str, Any],
+    samples: Mapping[str, int | None],
+) -> int | None:
+    metrics = comparison.get("metrics", {})
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+    valid_count = _nonnegative_sample_count(metrics.get("valid_count"))
+    return valid_count if valid_count is not None else samples.get("evaluated")
+
+
+def _shadow_gate_metrics(
+    comparison: Mapping[str, Any],
+    raw_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    value = comparison.get("metrics", {})
+    metrics = dict(value) if isinstance(value, Mapping) else {}
+    metrics.update(
+        {
+            str(name): metric
+            for name, metric in raw_result.items()
+            if isinstance(metric, (int, float)) and not isinstance(metric, bool)
+        }
+    )
+    nested = raw_result.get("metrics", {})
+    if isinstance(nested, Mapping):
+        for name, summary in nested.items():
+            if not isinstance(summary, Mapping):
+                continue
+            for statistic in ("mean", "min", "max"):
+                metric = summary.get(statistic)
+                if isinstance(metric, (int, float)) and not isinstance(metric, bool):
+                    key = str(name) if statistic == "mean" else f"{statistic}_{name}"
+                    metrics[key] = metric
+    return metrics
 
 
 _SAMPLE_DIFFERENCE_RAW_KEYS = {
@@ -3225,13 +3267,35 @@ def _public_accuracy_result(
     result: Mapping[str, Any],
 ) -> dict[str, Any]:
     public = dict(result)
+    samples = _accuracy_samples(result)
+    comparison = result.get("comparison", {})
+    comparison = dict(comparison) if isinstance(comparison, Mapping) else {}
+    raw_result = result.get("raw_result", {})
+    raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+    configured_gates = raw_result.get("configured_gates")
+    policy_mode = str(raw_result.get("gate_policy", "") or "")
+    if isinstance(configured_gates, Mapping) or policy_mode:
+        comparison["gate_evaluation"] = evaluate_shadow_gates(
+            metrics=_shadow_gate_metrics(comparison, raw_result),
+            configured_gates=(
+                configured_gates if isinstance(configured_gates, Mapping) else {}
+            ),
+            sample_count=_accuracy_gate_sample_count(comparison, samples),
+            policy_mode=policy_mode or "blocking",
+            metric_kinds=(
+                raw_result.get("gate_metric_kinds")
+                if isinstance(raw_result.get("gate_metric_kinds"), Mapping)
+                else {}
+            ),
+        )
     public.update(
         {
             "id": f"{result.get('model', '')}::{result.get('workload') or 'not-compared'}",
             "state": "terminal",
             "result": _traffic_light_status(result),
             "precision": _accuracy_precision(result),
-            "samples": _accuracy_samples(result),
+            "samples": samples,
+            "comparison": comparison,
             "sample_differences": _public_sample_differences(
                 output,
                 path.parent,

--- a/tools/validation/catalog.py
+++ b/tools/validation/catalog.py
@@ -280,4 +280,6 @@ def resolve_suite_for_model(suite: dict[str, Any], model: dict[str, Any]) -> dic
             raise ValueError(f"Suite {suite['id']} gate profile for {owner} must be a mapping")
         gates.update(profile_gates)
     resolved["gates"] = gates
+    if gates:
+        resolved["gate_policy"] = "blocking"
     return resolved

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -10674,7 +10674,9 @@ def compare_prompted_segmentation_prediction_sets(
             }
         )
     valid = [case for case in cases if "error" not in case]
-    mean_backend_iou = _mean([float(case["backend_mask_iou"]) for case in valid])
+    backend_ious = [float(case["backend_mask_iou"]) for case in valid]
+    mean_backend_iou = _mean(backend_ious)
+    worst_backend_iou = min(backend_ious, default=0.0)
     hf_gt_iou = _mean([float(case["hf_ground_truth_iou"]) for case in valid])
     bundle_gt_iou = _mean([float(case["bundle_ground_truth_iou"]) for case in valid])
     min_backend_iou = float(gates.get("min_backend_mask_iou", 0.90))
@@ -10694,6 +10696,7 @@ def compare_prompted_segmentation_prediction_sets(
         "valid_count": len(valid),
         "prompt_mode": prompt_mode,
         "mean_backend_mask_iou": mean_backend_iou,
+        "worst_backend_mask_iou": worst_backend_iou,
         "hf_mean_ground_truth_iou": hf_gt_iou,
         "bundle_mean_ground_truth_iou": bundle_gt_iou,
         "ground_truth_iou_drop_from_hf": gt_drop,
@@ -11156,6 +11159,24 @@ def run_full_duplex_bench_comparison(
     return summary
 
 
+def _full_duplex_gate_actuals(summary: Mapping[str, Any]) -> dict[str, float]:
+    metrics = summary.get("metrics", {})
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+    fields = {
+        "tor_abs_delta": ".tor",
+        "backchannel_frequency_abs_delta": ".frequency",
+        "backchannel_jsd_abs_delta": ".jsd",
+    }
+    return {
+        result_name: max(
+            float(metric["abs_delta"])
+            for name, metric in metrics.items()
+            if str(name).endswith(suffix) and isinstance(metric, Mapping)
+        )
+        for result_name, suffix in fields.items()
+    }
+
+
 def validate_full_duplex_bench_answers(answers: Path) -> None:
     """Reject non-formal slices before starting either inference backend."""
     from tools.full_duplex_bench_score import validate_requests_manifest
@@ -11421,6 +11442,7 @@ def eval_one_model(
             "passed_count": summary["passed_count"],
             "metric_gate_count": summary["metric_gate_count"],
             "metric_gate_pass_rate": summary["metric_gate_pass_rate"],
+            **_full_duplex_gate_actuals(summary),
             "metrics": report_metrics,
             "gates": summary["gates"],
             "gate_failures": summary["gate_failures"],
@@ -11597,6 +11619,7 @@ def eval_one_model(
             "valid_count": summary["valid_count"],
             "prompt_mode": summary["prompt_mode"],
             "mean_backend_mask_iou": summary["mean_backend_mask_iou"],
+            "worst_backend_mask_iou": summary["worst_backend_mask_iou"],
             "hf_mean_ground_truth_iou": summary["hf_mean_ground_truth_iou"],
             "bundle_mean_ground_truth_iou": summary["bundle_mean_ground_truth_iou"],
             "ground_truth_iou_drop_from_hf": summary[
@@ -11632,6 +11655,7 @@ def eval_one_model(
             "sample_pass_rate": summary["sample_pass_rate"],
             "hf_top1_accuracy": summary["hf_top1_accuracy"],
             "bundle_top1_accuracy": summary["bundle_top1_accuracy"],
+            "metrics": summary["metrics"],
             "mean_pairwise_ordering_agreement": summary["metrics"][
                 "pairwise_ordering_agreement"
             ]["mean"],
@@ -11867,6 +11891,10 @@ def eval_one_model(
                 else "failed"
             ),
         }
+        if "require_matching_initial_latents" in suite.get("gates", {}):
+            # The comparator raises before producing a result when any pair is
+            # missing or has different initial-latent evidence.
+            result["matching_initial_latents"] = 1.0
     else:
         hf_data = json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8"))
         bundle_data = json.loads((work_dir / "bundle_predictions.json").read_text(encoding="utf-8"))
@@ -11926,6 +11954,13 @@ def eval_one_model(
                     suite.get("gates", {}),
                 )
             )
+    configured_gates = dict(suite.get("gates", {}))
+    result["configured_gates"] = configured_gates
+    result["gate_metric_kinds"] = dict(suite.get("gate_metric_kinds", {}))
+    result["gate_policy"] = str(
+        suite.get("gate_policy")
+        or ("blocking" if configured_gates else "")
+    )
     (work_dir / "eval_result.json").write_text(
         json.dumps(result, indent=2, ensure_ascii=False),
         encoding="utf-8",

--- a/tools/validation/gate_policy.py
+++ b/tools/validation/gate_policy.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample-aware, non-blocking analysis of configured validation gates."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+
+_METRIC_ALIASES = {
+    "backend_mask_iou": "mean_backend_mask_iou",
+    "correctness_agreement": "correctness_agreement_rate",
+    "prediction_agreement": "prediction_agreement_rate",
+}
+_PROPORTION_METRICS = {
+    "correctness_agreement_rate",
+    "exact_match_rate",
+    "normalized_transcript_exact_agreement_rate",
+    "prediction_agreement_rate",
+    "sample_agreement_rate",
+    "sample_pass_rate",
+    "shared_sampling_inputs_match_rate",
+    "tie_adjusted_exact_match_rate",
+    "top1_agreement",
+    "vector_pass_rate",
+}
+_PROPORTION_DROP_METRICS = {
+    "accuracy_drop_from_hf",
+    "pass_rate_drop_from_hf",
+    "top1_accuracy_drop_from_hf",
+}
+_DIRECT_GATE_SPECS = {
+    "exact_num_frames": ("num_frames", "=="),
+    "exact_video_height": ("video_height", "=="),
+    "exact_video_width": ("video_width", "=="),
+    "kendall_tau": ("min_kendall_tau", ">="),
+    "pairwise_ordering_agreement": ("min_pairwise_ordering_agreement", ">="),
+    "psnr": ("min_psnr", ">="),
+    "require_matching_initial_latents": ("matching_initial_latents", ">="),
+    "score_correlation": ("min_score_correlation", ">="),
+    "spearman_rho": ("min_spearman_rho", ">="),
+    "ssim": ("min_ssim", ">="),
+    "temporal_consistency": ("min_temporal_consistency", ">="),
+}
+
+_METRIC_KINDS = {"continuous", "proportion", "proportion_drop"}
+
+
+def _gate_spec(gate: str) -> tuple[str, str] | None:
+    if gate.startswith("min_"):
+        return gate.removeprefix("min_"), ">="
+    if gate.startswith("max_"):
+        return gate.removeprefix("max_"), "<="
+    return _DIRECT_GATE_SPECS.get(gate)
+
+
+def _finite_number(value: Any) -> float:
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("non-finite number")
+    return number
+
+
+def _issue_value(value: Any) -> Any:
+    try:
+        return str(value) if not math.isfinite(float(value)) else value
+    except (TypeError, ValueError):
+        return value
+
+
+def _metric_names(
+    gate: str,
+    metric: str,
+    metrics: Mapping[str, Any],
+) -> tuple[str, str]:
+    alias = _METRIC_ALIASES.get(metric)
+    if alias and (metrics.get(alias) is not None or metrics.get(metric) is None):
+        metric = alias
+    actual = (
+        gate
+        if gate not in _DIRECT_GATE_SPECS and metrics.get(gate) is not None
+        else gate
+        if metrics.get(metric) is None and metrics.get(gate) is not None
+        else metric
+    )
+    return metric, actual
+
+
+def _exact_range_check(
+    *,
+    gate: str,
+    metric: str,
+    required: float,
+    metrics: Mapping[str, Any],
+    sample_count: int,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    minimum = metrics.get(f"min_{metric}")
+    maximum = metrics.get(f"max_{metric}")
+    if minimum is None or maximum is None:
+        return None, None
+    try:
+        observed = {"min": _finite_number(minimum), "max": _finite_number(maximum)}
+    except (TypeError, ValueError):
+        return None, {
+            "code": "invalid_metric",
+            "gate": gate,
+            "metric": metric,
+            "value": {"min": _issue_value(minimum), "max": _issue_value(maximum)},
+        }
+    passed = observed["min"] == required and observed["max"] == required
+    return {
+        "gate": gate,
+        "metric": metric,
+        "operator": "==",
+        "actual": observed,
+        "required": required,
+        "verdict": "pass" if passed else "fail",
+        "effective": {"kind": "exact", "sample_count": sample_count},
+    }, None
+
+
+def _metric_kind(metric: str, configured: str) -> str:
+    if configured:
+        return configured
+    if metric in _PROPORTION_DROP_METRICS:
+        return "proportion_drop"
+    if metric in _PROPORTION_METRICS:
+        return "proportion"
+    return "continuous"
+
+
+def _effective_gate(
+    *,
+    kind: str,
+    actual: float,
+    required: float,
+    sample_count: int,
+) -> dict[str, Any]:
+    if kind == "proportion_drop":
+        return {
+            "kind": kind,
+            "allowed_drop_count": math.floor(required * sample_count + 1e-12),
+            "observed_drop_count": round(actual * sample_count),
+            "resolution": 1 / sample_count,
+        }
+    if kind == "proportion":
+        required_passes = math.ceil(required * sample_count - 1e-12)
+        observed_passes = min(sample_count, max(0, round(actual * sample_count)))
+        return {
+            "kind": kind,
+            "required_passes": required_passes,
+            "allowed_failures": sample_count - required_passes,
+            "observed_passes": observed_passes,
+            "observed_failures": sample_count - observed_passes,
+            "resolution": 1 / sample_count,
+        }
+    return {"kind": "continuous", "sample_count": sample_count}
+
+
+def _passed(actual: float, operator: str, required: float) -> bool:
+    if operator == ">=":
+        return actual >= required
+    if operator == "<=":
+        return actual <= required
+    return actual == required
+
+
+def evaluate_shadow_gates(
+    *,
+    metrics: Mapping[str, Any],
+    configured_gates: Mapping[str, Any],
+    sample_count: int | None,
+    policy_mode: str = "blocking",
+    metric_kinds: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Explain the effective sample-level meaning of existing gate values."""
+    checks: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+    if policy_mode not in {"blocking", "observation_only"}:
+        issues.append({"code": "unsupported_policy_mode", "value": policy_mode})
+    if policy_mode == "blocking" and not configured_gates:
+        issues.append({"code": "empty_gate_policy"})
+    sample_count_available = (
+        isinstance(sample_count, int)
+        and not isinstance(sample_count, bool)
+        and sample_count > 0
+    )
+    if configured_gates and not sample_count_available:
+        issues.append({"code": "sample_count_unavailable"})
+    gates_to_evaluate = configured_gates if sample_count_available else {}
+    resolved_metric_kinds = metric_kinds or {}
+    for gate_name in resolved_metric_kinds:
+        if gate_name not in configured_gates:
+            issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
+    for gate, required_value in gates_to_evaluate.items():
+        gate_name = str(gate)
+        spec = _gate_spec(gate_name)
+        if spec is None:
+            issues.append({"code": "unsupported_gate", "gate": gate_name})
+            continue
+        metric_name, operator = spec
+        metric_name, actual_metric = _metric_names(gate_name, metric_name, metrics)
+        try:
+            required = _finite_number(required_value)
+        except (TypeError, ValueError):
+            issues.append(
+                {
+                    "code": "invalid_threshold",
+                    "gate": gate_name,
+                    "value": _issue_value(required_value),
+                }
+            )
+            continue
+        if operator == "==":
+            exact_check, exact_issue = _exact_range_check(
+                gate=gate_name,
+                metric=metric_name,
+                required=required,
+                metrics=metrics,
+                sample_count=sample_count,
+            )
+            if exact_issue:
+                issues.append(exact_issue)
+                continue
+            if exact_check:
+                checks.append(exact_check)
+                continue
+        if metrics.get(actual_metric) is None:
+            issues.append(
+                {
+                    "code": "metric_unavailable",
+                    "gate": gate_name,
+                    "metric": metric_name,
+                }
+            )
+            continue
+        try:
+            actual = _finite_number(metrics[actual_metric])
+        except (TypeError, ValueError):
+            issues.append(
+                {
+                    "code": "invalid_metric",
+                    "gate": gate_name,
+                    "metric": actual_metric,
+                    "value": _issue_value(metrics[actual_metric]),
+                }
+            )
+            continue
+        configured_kind = str(resolved_metric_kinds.get(gate_name, "") or "")
+        if configured_kind and configured_kind not in _METRIC_KINDS:
+            issues.append(
+                {
+                    "code": "unsupported_metric_kind",
+                    "gate": gate_name,
+                    "value": configured_kind,
+                }
+            )
+            continue
+        checks.append(
+            {
+                "gate": gate_name,
+                "metric": actual_metric,
+                "operator": operator,
+                "actual": actual,
+                "required": required,
+                "verdict": "pass" if _passed(actual, operator, required) else "fail",
+                "effective": _effective_gate(
+                    kind=_metric_kind(metric_name, configured_kind),
+                    actual=actual,
+                    required=required,
+                    sample_count=sample_count,
+                ),
+            }
+        )
+    return {
+        "schema_version": "trtmc.validation-gate-evaluation/v1",
+        "status": (
+            "invalid"
+            if issues
+            else "observation_only"
+            if policy_mode == "observation_only"
+            else "fail"
+            if any(check["verdict"] == "fail" for check in checks)
+            else "pass"
+        ),
+        "sample_count": sample_count,
+        "checks": checks,
+        "issues": issues,
+    }


### PR DESCRIPTION
## Background

Accuracy gates are configured as rates, but small validation slices make their effective meaning discrete. For example, a 0.90 gate over 10 samples means 9 required passes and one allowed failure. The current report does not expose that effective sample-level meaning, and an empty or unrecognized gate can be difficult to distinguish from a meaningful policy.

## Exit Criteria

- Publish sample-aware gate analysis in `report.json`, including required passes, allowed failures, and observed failures when a metric is a proportion.
- Surface invalid, unsupported, or incomplete gate configuration as explicit shadow-analysis issues.
- Render the analysis from `report.json` without changing existing Accuracy traffic lights, qualification snapshots, exit behavior, or CI policy.
- Require suites with no blocking gates to declare `observation_only` explicitly.

## Implementation

- Adds one validation gate-policy module that evaluates existing configured gates against recorded metrics and the actual paired sample count.
- Distinguishes proportion, proportion-drop, and continuous metrics so continuous similarity values are not presented as integer sample budgets.
- Preserves the resolved gate configuration and metric-kind metadata in case results, then projects a non-blocking `comparison.gate_evaluation` into the public report contract.
- Adds a compact `Gate analysis (shadow)` section to the existing Metrics details renderer. The renderer only consumes JSON; it does not calculate thresholds or verdicts.
- Marks intentionally ungated diagnostic suites as `observation_only` and documents the shadow-only contract.

## Validation

- `node --check tools/qualification_report_assets/qualification-report.js`: passed.
- `git diff --check github/main...HEAD`: passed.
- `python tools/legal_headers.py --check --repo-root .`: passed with 0 findings.
- `python -m ruff check tools/validation/gate_policy.py tools/trtmc_validate.py tools/validation/catalog.py tools/validation/engine.py tests/tools/test_validation_gate_policy.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py`: passed.
- `PYTHONPATH=.:python python -m pytest -q tests/tools/test_validation_gate_policy.py tests/tools/test_qualification_report.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py tests/tools/test_test_impact.py`: 719 passed.
- Exact head `eda539baef3936604d26333238b790a443f05697`, GB300, `gpt2-125m` Accuracy with `mmlu_continuation_parity`: passed 10/10; shadow analysis required 9, allowed 1 failure, observed 0; formal result remained green.
- Exact head `eda539baef3936604d26333238b790a443f05697`, ThorX, same Accuracy case: passed with the same gate expansion and formal result.
- Exact head `eda539baef3936604d26333238b790a443f05697`, GB300 and ThorX, `gpt2-125m` Perf: both passed output validation and remained green; report log links were verified to resolve.

## Notes For Future Readers

- Review `tools/validation/gate_policy.py` first, then the report projection in `tools/trtmc_validate.py`, and finally the renderer changes.
- This is shadow evidence only. It deliberately does not enable a CI lane or replace the current blocking gate implementation.
- Internal premerge CI has not been requested for this head.
