### PR TITLE
fix(gemma): restore MMLU parity and generation efficiency

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -288,6 +288,7 @@ entries:
       mode: torch-compile
       compile_scope: model.forward
       output_contract: exact-text
+      precision: fp16
   - id: glm.generate
     family: glm
     operation: generate

--- a/python/tensorrt_model_connect/families/gemma/graph_ops.py
+++ b/python/tensorrt_model_connect/families/gemma/graph_ops.py
@@ -244,50 +244,19 @@ def add_gelu_new(
 ) -> trt.ITensor:
     """GELU (tanh approximation): 0.5*x*(1+tanh(sqrt(2/pi)*(x+0.044715*x^3))).
 
-    Constants are cast to ``inp.dtype`` so the elementwise ops are valid in
-    a STRONGLY_TYPED network when ``inp`` is bf16 (storage np_dtype is
-    fp16, runtime trt_dtype is bfloat16) or any other non-matching combo.
+    Evaluate TensorRT's fused GELU_TANH implementation in FP32, matching
+    PyTorch's FP16 GELU behavior while avoiding the precision-sensitive FP16
+    cubic intermediates of a manually expanded formula.  Cast the result back
+    to the input dtype for the surrounding MLP.
     """
-    target_dtype = inp.dtype
-    const_shape = (1,) * max(1, len(tuple(inp.shape)))
-
-    def _const(name, value):
-        c = add_constant(
-            network, const_shape, np.array([value], dtype=np.float32), dtype=dtype)
-        return _cast_back_to_trt_dtype(network, c, target_dtype)
-
-    # x^3
-    x_sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
-    x_cu = network.add_elementwise(
-        x_sq.get_output(0), inp, trt.ElementWiseOperation.PROD)
-    # 0.044715 * x^3
-    coeff = _const("coeff", 0.044715)
-    scaled_cube = network.add_elementwise(
-        x_cu.get_output(0), coeff, trt.ElementWiseOperation.PROD)
-    # x + 0.044715 * x^3
-    inner_sum = network.add_elementwise(
-        inp, scaled_cube.get_output(0), trt.ElementWiseOperation.SUM)
-    # sqrt(2/pi) * (x + 0.044715 * x^3)
-    sqrt_2_over_pi = _const("sqrt_2_over_pi", np.sqrt(2.0 / np.pi))
-    tanh_arg = network.add_elementwise(
-        sqrt_2_over_pi, inner_sum.get_output(0),
-        trt.ElementWiseOperation.PROD)
-    # tanh(...)
-    tanh_l = network.add_activation(
-        tanh_arg.get_output(0), trt.ActivationType.TANH)
-    # 1 + tanh(...)
-    one = _const("one", 1.0)
-    one_plus_tanh = network.add_elementwise(
-        one, tanh_l.get_output(0), trt.ElementWiseOperation.SUM)
-    # 0.5 * x
-    half = _const("half", 0.5)
-    half_x = network.add_elementwise(
-        half, inp, trt.ElementWiseOperation.PROD)
-    # 0.5 * x * (1 + tanh(...))
-    result = network.add_elementwise(
-        half_x.get_output(0), one_plus_tanh.get_output(0),
-        trt.ElementWiseOperation.PROD)
-    return result.get_output(0)
+    del dtype
+    output_dtype = inp.dtype
+    work = inp
+    if output_dtype != trt.float32:
+        work = network.add_cast(inp, trt.float32).get_output(0)
+    result = network.add_activation(
+        work, trt.ActivationType.GELU_TANH).get_output(0)
+    return _cast_back_to_trt_dtype(network, result, output_dtype)
 
 
 def add_activation(

--- a/src/runtime/models/gemma/MODEL.toml
+++ b/src/runtime/models/gemma/MODEL.toml
@@ -5,5 +5,9 @@ id = "gemma"
 runtime_library = "libtrtmc_model_gemma.so"
 runtime_plugins = ["plugin.cpp|register_gemma_plugin"]
 runtime_strategies = ["gemma_decoder_kv_cache"]
+runtime_tests = [
+  "test_gemma_sampler|test_gemma_sampler.cpp|trtmc_model_gemma|_|_",
+  "test_gemma_pipeline|test_gemma_pipeline.cpp|trtmc_model_gemma|_|REQUIRES_GPU",
+]
 [validation_profiles]
 decoder_debug = ["gemma_decoder_kv_cache"]

--- a/src/runtime/models/gemma/pipeline.cpp
+++ b/src/runtime/models/gemma/pipeline.cpp
@@ -150,6 +150,14 @@ single_decoder_context(std::unique_ptr<TrtModule> decoder) {
     return decoders;
 }
 
+GemmaTextGenConfig normalize_eos_token_ids(GemmaTextGenConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
 std::string normalize_generation_mode(std::string mode) {
     std::transform(mode.begin(), mode.end(), mode.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -291,8 +299,8 @@ GemmaTextGenerationPipeline::GemmaTextGenerationPipeline(
     std::shared_ptr<void> distributed_owner)
     : distributed_owner_(std::move(distributed_owner)), decoders_(std::move(decoders)),
       prefill_(std::move(prefill)), linear_spec_lora_prefill_(std::move(linear_spec_lora_prefill)),
-      state_(std::move(state)), config_(std::move(config)), stream_(stream),
-      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      state_(std::move(state)), config_(normalize_eos_token_ids(std::move(config))),
+      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       sampler_(std::move(sampler)), logits_output_name_(config_.logits_output_name) {
     if (decoders_.empty()) {
         throw std::runtime_error("GemmaTextGenerationPipeline: no decoder modules");
@@ -350,9 +358,7 @@ TextResult GemmaTextGenerationPipeline::generate(const std::string& prompt,
 
     auto input_ids = encode_prompt(*tokenizer_, config_, prompt, cfg);
     int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-
-    auto sp = gemma_sampling_params_from_config(cfg, eos);
+    auto sp = gemma_sampling_params_from_config(cfg, config_.id_eos_ids);
     last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
@@ -372,8 +378,7 @@ GemmaTextGenerationPipeline::GenerationResult
 GemmaTextGenerationPipeline::generate_ids(const std::vector<int32_t>& input_ids,
                                           const GenerateConfig& cfg) {
     int32_t max_new = cfg.max_new_tokens; // honour exact value (0 = no generation)
-    int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
-    auto sp = gemma_sampling_params_from_config(cfg, eos);
+    auto sp = gemma_sampling_params_from_config(cfg, config_.id_eos_ids);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp, cfg).token_ids};
 }
 
@@ -468,34 +473,11 @@ bool GemmaTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>
     return true;
 }
 
-void GemmaTextGenerationPipeline::prime_decoder_after_batched_prefill(
-    const std::vector<int32_t>& input_ids) {
-    if (input_ids.empty())
-        return;
-
-    TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
-        return;
-
-    int32_t token_id = input_ids.back();
-    TensorMap inputs;
-    Tensor token_tensor;
-    token_tensor.data = &token_id;
-    token_tensor.shape = {1};
-    token_tensor.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = token_tensor;
-
-    state_->prepare_step(inputs);
-    decoder.forward_async(inputs);
-    decoder.sync();
-}
-
 void GemmaTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                               std::vector<float>& logits, bool gpu_sampling) {
     // Fast path: batched prefill engine writes K/V for the whole prompt in
     // one forward and returns last-token logits on host.
     if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
-        prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
     }
@@ -676,7 +658,7 @@ bool GemmaTextGenerationPipeline::append_tokens_until_eos(const std::vector<int3
                                                           const GemmaSamplingParams& params) const {
     for (int32_t token : tokens) {
         output.push_back(token);
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (gemma_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -746,7 +728,7 @@ bool GemmaTextGenerationPipeline::append_linear_spec_tokens(
         const int32_t token = ar_tokens[static_cast<std::size_t>(i)];
         output.push_back(token);
         ++generated;
-        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+        if (gemma_is_eos_token(params, token))
             return true;
     }
     return false;
@@ -876,7 +858,7 @@ GemmaTextGenerationPipeline::generate_linear_spec_from_ids(const std::vector<int
 
     std::vector<int32_t> output = input_ids;
     output.push_back(next_token);
-    if (params.eos_token_id >= 0 && next_token == params.eos_token_id) {
+    if (gemma_is_eos_token(params, next_token)) {
         return TimedGenResult{std::move(output),
                               std::chrono::duration<double, std::milli>(t1 - t0).count(), 0.0};
     }
@@ -956,6 +938,10 @@ int32_t GemmaTextGenerationPipeline::run_decode_loop(
                                   result.is_eos))
             break;
         if (result.is_eos)
+            break;
+        // The sampled token is already the final requested output. Do not
+        // execute a decoder step whose logits cannot be consumed.
+        if (step + 1 >= max_new_tokens)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/gemma/pipeline.h
+++ b/src/runtime/models/gemma/pipeline.h
@@ -30,6 +30,7 @@ struct GemmaTextGenConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
     int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
     bool has_position_input{true};
     std::string chat_template_format{};
     std::string token_id_name{"token_id"};
@@ -190,7 +191,6 @@ class GemmaTextGenerationPipeline final : public IPipeline {
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
     bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
-    void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,
                                bool is_eos) const;

--- a/src/runtime/models/gemma/plugin.cpp
+++ b/src/runtime/models/gemma/plugin.cpp
@@ -524,6 +524,7 @@ class DecoderPlugin final : public IPipelinePlugin {
         tgc.vocab_size = ctx.config.vocab_size;
         tgc.id_bos = ctx.config.id_bos;
         tgc.id_eos = ctx.config.id_eos;
+        tgc.id_eos_ids = ctx.config.id_eos_ids;
         tgc.has_position_input = first_dec.module->has_input(io.position_id);
         tgc.token_id_name = io.token_id;
         tgc.logits_output_name = io.logits;

--- a/src/runtime/models/gemma/sampler.cpp
+++ b/src/runtime/models/gemma/sampler.cpp
@@ -30,9 +30,17 @@
 
 namespace trtmc {
 
+bool gemma_is_eos_token(const GemmaSamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
 // Shared argmax helper — returns {token_id, logprob} for the highest logit.
 static GemmaSampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
-                                            int32_t eos_token_id) {
+                                            const GemmaSamplingParams& params) {
     GemmaSampleResult result;
     const float* best = logits;
     for (int32_t i = 1; i < vocab_size; ++i) {
@@ -41,7 +49,7 @@ static GemmaSampleResult argmax_over_logits(const float* logits, int32_t vocab_s
     }
     result.token_id = static_cast<int32_t>(best - logits);
     result.logprob = *best;
-    result.is_eos = (result.token_id == eos_token_id);
+    result.is_eos = gemma_is_eos_token(params, result.token_id);
     return result;
 }
 
@@ -182,11 +190,11 @@ class GreedySampler final : public GemmaISampler {
         if (vocab_size <= 0 || logits == nullptr) {
             GemmaSampleResult result;
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = gemma_is_eos_token(params, 0);
             return result;
         }
 
-        return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+        return argmax_over_logits(logits, vocab_size, params);
     }
 
     GemmaLogitsLocation logits_location() const override { return GemmaLogitsLocation::HOST; }
@@ -210,12 +218,12 @@ class TopKSampler final : public GemmaISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = gemma_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
 
@@ -233,7 +241,7 @@ class TopKSampler final : public GemmaISampler {
                 result.token_id = dist.indices[static_cast<std::size_t>(i)];
                 result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(i)],
                                                    std::numeric_limits<float>::min()));
-                result.is_eos = (result.token_id == params.eos_token_id);
+                result.is_eos = gemma_is_eos_token(params, result.token_id);
                 return result;
             }
         }
@@ -241,7 +249,7 @@ class TopKSampler final : public GemmaISampler {
         result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
         result.logprob = std::log(std::max(dist.probs[static_cast<std::size_t>(dist.keep - 1)],
                                            std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = gemma_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -278,12 +286,12 @@ class TorchCudaMultinomialSampler final : public GemmaISampler {
 
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = gemma_is_eos_token(params, 0);
             return result;
         }
 
         if (greedy_equivalent(params))
-            return argmax_over_logits(logits, vocab_size, params.eos_token_id);
+            return argmax_over_logits(logits, vocab_size, params);
 
         const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
         ensure_execution_policy(vocab_size);
@@ -312,7 +320,7 @@ class TorchCudaMultinomialSampler final : public GemmaISampler {
             }
         }
         result.logprob = std::log(std::max(picked_prob, std::numeric_limits<float>::min()));
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = gemma_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -381,7 +389,7 @@ class GpuGreedySampler final : public GemmaISampler {
         GemmaSampleResult result;
         if (vocab_size <= 0 || logits == nullptr) {
             result.token_id = 0;
-            result.is_eos = (0 == params.eos_token_id);
+            result.is_eos = gemma_is_eos_token(params, 0);
             return result;
         }
 
@@ -397,7 +405,7 @@ class GpuGreedySampler final : public GemmaISampler {
 
         result.token_id = h_token_id_;
         result.logprob = h_logit_val_;
-        result.is_eos = (result.token_id == params.eos_token_id);
+        result.is_eos = gemma_is_eos_token(params, result.token_id);
         return result;
     }
 
@@ -417,16 +425,26 @@ class GpuGreedySampler final : public GemmaISampler {
 // Factory
 // ─────────────────────────────────────────────────────────────
 
-GemmaSamplingParams gemma_sampling_params_from_config(const GenerateConfig& cfg,
-                                                      int32_t default_eos) {
+GemmaSamplingParams
+gemma_sampling_params_from_config(const GenerateConfig& cfg,
+                                  const std::vector<int32_t>& default_eos_token_ids) {
     GemmaSamplingParams p;
     p.temperature = cfg.temperature;
     p.top_k = cfg.top_k;
     p.top_p = cfg.top_p;
     p.min_p = cfg.min_p;
     p.seed = cfg.seed;
-    p.eos_token_id = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : default_eos;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
     return p;
+}
+
+GemmaSamplingParams gemma_sampling_params_from_config(const GenerateConfig& cfg,
+                                                      int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return gemma_sampling_params_from_config(cfg, defaults);
 }
 
 std::unique_ptr<GemmaISampler>

--- a/src/runtime/models/gemma/sampler.h
+++ b/src/runtime/models/gemma/sampler.h
@@ -30,6 +30,7 @@ struct GemmaSamplingParams {
     float repetition_penalty{1.0f};
     int32_t seed{-1}; // -1 = deterministic (argmax)
     int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
 };
 
 /// Factory options for choosing concrete sampler implementations.
@@ -78,8 +79,14 @@ class GemmaISampler {
 /// Forward-declared here; defined in sampler.cpp alongside the factory.
 struct GenerateConfig; // defined in trtmc/pipeline.h
 
+GemmaSamplingParams
+gemma_sampling_params_from_config(const GenerateConfig& cfg,
+                                  const std::vector<int32_t>& default_eos_token_ids);
 GemmaSamplingParams gemma_sampling_params_from_config(const GenerateConfig& cfg,
                                                       int32_t default_eos = -1);
+
+/// Return true when token_id matches any effective EOS token.
+bool gemma_is_eos_token(const GemmaSamplingParams& params, int32_t token_id);
 
 /// Factory: create sampler from GemmaSamplingParams.
 /// - top_k <= 1 && top_p/min_p disabled && seed == -1 => GreedySampler

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -167,7 +167,12 @@ def run_trt_graph(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarr
 
     trt_inputs = {}
     for name, arr in inputs.items():
-        dt = trt.float32 if arr.dtype == np.float32 else trt.int32
+        if arr.dtype == np.float32:
+            dt = trt.float32
+        elif arr.dtype == np.float16:
+            dt = trt.float16
+        else:
+            dt = trt.int32
         t = network.add_input(name, dt, tuple(arr.shape))
         trt_inputs[name] = t
 
@@ -200,11 +205,15 @@ def run_trt_graph(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarr
     for i in range(engine.num_io_tensors):
         tname = engine.get_tensor_name(i)
         shape = tuple(engine.get_tensor_shape(tname))
-        nbytes = int(np.prod(shape)) * 4
+        mode = engine.get_tensor_mode(tname)
+        nbytes = (
+            inputs[tname].nbytes
+            if mode == trt.TensorIOMode.INPUT
+            else int(np.prod(shape)) * 4
+        )
         err, ptr = cudart.cudaMallocAsync(nbytes, stream)
         _check_cuda(err)
         device_bufs[tname] = ptr
-        mode = engine.get_tensor_mode(tname)
         if mode == trt.TensorIOMode.INPUT:
             arr = inputs[tname]
             cudart.cudaMemcpyAsync(

--- a/tests/cpp/models/gemma/test_gemma_pipeline.cpp
+++ b/tests/cpp/models/gemma/test_gemma_pipeline.cpp
@@ -120,8 +120,7 @@ void test_one_token_batched_prefill_does_not_touch_decoder() {
     auto prefill_stats = std::make_shared<ModuleStats>();
     auto decoder = std::make_unique<CountingModule>(decode_stats, false, stream);
     auto prefill = std::make_unique<CountingModule>(prefill_stats, true, stream);
-    auto cache = std::make_unique<trtmc::GemmaKvCache>(1, 704, 4, stream,
-                                                      trtmc::DType::kFloat32);
+    auto cache = std::make_unique<trtmc::GemmaKvCache>(1, 704, 4, stream, trtmc::DType::kFloat32);
 
     trtmc::GemmaTextGenConfig config;
     config.vocab_size = 4;
@@ -134,8 +133,7 @@ void test_one_token_batched_prefill_does_not_touch_decoder() {
     std::vector<trtmc::GemmaTextGenerationPipeline::DecoderContext> decoders;
     decoders.push_back({704, std::move(decoder)});
     trtmc::GemmaTextGenerationPipeline pipeline(std::move(decoders), std::move(cache), config,
-                                                stream, nullptr, "", nullptr,
-                                                std::move(prefill));
+                                                stream, nullptr, "", nullptr, std::move(prefill));
 
     trtmc::GenerateConfig request;
     request.max_new_tokens = 1;

--- a/tests/cpp/models/gemma/test_gemma_pipeline.cpp
+++ b/tests/cpp/models/gemma/test_gemma_pipeline.cpp
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Batched prefill already supplies the first generated token. A one-token
+// request must therefore finish without launching the decoder for discarded
+// CUDA-graph priming or unused next-token logits.
+
+#include "runtime/models/gemma/kv_cache.h"
+#include "runtime/models/gemma/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+struct ModuleStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+};
+
+class CountingModule final : public trtmc::ITrtModule {
+  public:
+    CountingModule(std::shared_ptr<ModuleStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({704, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({704, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        record(inputs);
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { record(inputs); }
+    void sync() override { cudaStreamSynchronize(stream_); }
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override { cuda_graph_active_ = true; }
+    bool cuda_graph_active() const override { return cuda_graph_active_; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {704, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    void record(const trtmc::TensorMap& inputs) {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        for (const auto& [name, tensor] : inputs)
+            stats_->shapes[name] = tensor.shape;
+    }
+
+    std::shared_ptr<ModuleStats> stats_;
+    bool prefill_{false};
+    bool cuda_graph_active_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+void test_one_token_batched_prefill_does_not_touch_decoder() {
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+        std::cerr << "FAIL: create CUDA stream\n";
+        ++failures;
+        return;
+    }
+
+    auto decode_stats = std::make_shared<ModuleStats>();
+    auto prefill_stats = std::make_shared<ModuleStats>();
+    auto decoder = std::make_unique<CountingModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingModule>(prefill_stats, true, stream);
+    auto cache = std::make_unique<trtmc::GemmaKvCache>(1, 704, 4, stream,
+                                                      trtmc::DType::kFloat32);
+
+    trtmc::GemmaTextGenConfig config;
+    config.vocab_size = 4;
+    config.id_eos = 2;
+    config.num_layers = 1;
+    config.kv_dim = 4;
+    config.prefill_max_length = 704;
+    config.disable_cuda_graph = false;
+
+    std::vector<trtmc::GemmaTextGenerationPipeline::DecoderContext> decoders;
+    decoders.push_back({704, std::move(decoder)});
+    trtmc::GemmaTextGenerationPipeline pipeline(std::move(decoders), std::move(cache), config,
+                                                stream, nullptr, "", nullptr,
+                                                std::move(prefill));
+
+    trtmc::GenerateConfig request;
+    request.max_new_tokens = 1;
+    request.temperature = 0.0F;
+    request.top_k = 1;
+    request.eos_token_id = 3;
+
+    std::vector<int32_t> prompt(700, 1);
+    const auto result = pipeline.generate_ids(prompt, request);
+    check(result.token_ids.size() == 701 && result.token_ids.back() == 2,
+          "one non-EOS token comes from prefill logits");
+    check(prefill_stats->calls == 1, "long batched prefill launches once");
+    check(decode_stats->calls == 0, "one-token request avoids discarded decoder launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>({700}),
+          "prefill receives the complete prompt");
+
+    cudaStreamDestroy(stream);
+}
+
+} // namespace
+
+int main() {
+    test_one_token_batched_prefill_does_not_touch_decoder();
+    return failures;
+}

--- a/tests/cpp/models/gemma/test_gemma_sampler.cpp
+++ b/tests/cpp/models/gemma/test_gemma_sampler.cpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/gemma/sampler.h"
+#include "trtmc/pipeline.h"
+
+#include <iostream>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static trtmc::GemmaSampleResult greedy_sample(const trtmc::GemmaSamplingParams& params,
+                                              int32_t winning_token) {
+    std::vector<float> logits(8, 0.0F);
+    logits[static_cast<std::size_t>(winning_token)] = 1.0F;
+    auto sampler = trtmc::create_gemma_sampler(params);
+    return sampler->sample(logits.data(), static_cast<int32_t>(logits.size()), params);
+}
+
+static void test_any_default_eos_stops_generation() {
+    trtmc::GenerateConfig config;
+    const std::vector<int32_t> defaults{5, 7};
+    const auto params = trtmc::gemma_sampling_params_from_config(config, defaults);
+
+    check(params.eos_token_ids == defaults, "sampler: preserves all default EOS IDs");
+    check(greedy_sample(params, 7).is_eos, "sampler: second default EOS stops generation");
+}
+
+static void test_request_eos_overrides_model_defaults() {
+    trtmc::GenerateConfig config;
+    config.eos_token_id = 3;
+    const auto params =
+        trtmc::gemma_sampling_params_from_config(config, std::vector<int32_t>{5, 7});
+
+    check(params.eos_token_ids == std::vector<int32_t>({3}),
+          "sampler: request EOS replaces model defaults");
+    check(!greedy_sample(params, 7).is_eos,
+          "sampler: overridden model EOS no longer stops generation");
+    check(greedy_sample(params, 3).is_eos, "sampler: explicit request EOS stops generation");
+}
+
+int main() {
+    test_any_default_eos_stops_generation();
+    test_request_eos_overrides_model_defaults();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All Gemma sampler tests passed.\n";
+    return 0;
+}

--- a/tests/e2e/models/gemma/test_gemma_builder_tp.py
+++ b/tests/e2e/models/gemma/test_gemma_builder_tp.py
@@ -112,9 +112,23 @@ class _FakeNetwork:
             return _FakeLayer(lhs + rhs)
         raise AssertionError(f"unexpected elementwise operation: {operation}")
 
+    def add_cast(self, tensor, dtype):
+        assert dtype == self._trt.float32
+        return _FakeLayer(np.asarray(tensor, dtype=np.float32))
+
     def add_activation(self, tensor, activation):
-        assert activation == self._trt.ActivationType.TANH
-        return _FakeLayer(np.tanh(tensor))
+        if activation == self._trt.ActivationType.TANH:
+            return _FakeLayer(np.tanh(tensor))
+        if activation == self._trt.ActivationType.GELU_TANH:
+            result = 0.5 * tensor * (
+                1.0
+                + np.tanh(
+                    math.sqrt(2.0 / math.pi)
+                    * (tensor + 0.044715 * np.power(tensor, 3))
+                )
+            )
+            return _FakeLayer(result)
+        raise AssertionError(f"unexpected activation: {activation}")
 
 
 def test_gemma_dual_profile_mlp_uses_checkpoint_gelu(

--- a/tests/e2e/models/gemma/test_gemma_graph_ops_precision.py
+++ b/tests/e2e/models/gemma/test_gemma_graph_ops_precision.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Precision-contract tests for Gemma graph operations."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+trt = pytest.importorskip("tensorrt")
+
+from tensorrt_model_connect.families.gemma import graph_ops  # noqa: E402
+from tests.builder.conftest import requires_trt, run_trt_graph  # noqa: E402
+
+
+class _Tensor:
+    def __init__(self, dtype, shape=(1, 8)):
+        self.dtype = dtype
+        self.shape = shape
+
+
+class _Layer:
+    def __init__(self, output):
+        self._output = output
+
+    def get_output(self, index):
+        assert index == 0
+        return self._output
+
+
+class _Network:
+    def __init__(self):
+        self.activation_type = None
+        self.activation_dtype = None
+        self.casts = []
+
+    def add_cast(self, tensor, dtype):
+        self.casts.append((tensor.dtype, dtype))
+        return _Layer(_Tensor(dtype, tensor.shape))
+
+    def add_activation(self, tensor, activation_type):
+        self.activation_type = activation_type
+        self.activation_dtype = tensor.dtype
+        return _Layer(_Tensor(tensor.dtype, tensor.shape))
+
+
+def test_gelu_tanh_uses_fused_trt_activation_for_fp16():
+    network = _Network()
+
+    output = graph_ops.add_gelu_new(network, _Tensor(trt.float16))
+
+    assert network.activation_type == trt.ActivationType.GELU_TANH
+    assert network.activation_dtype == trt.float32
+    assert network.casts == [
+        (trt.float16, trt.float32),
+        (trt.float32, trt.float16),
+    ]
+    assert output.dtype == trt.float16
+
+
+def test_gelu_tanh_uses_fused_trt_activation_for_fp32():
+    network = _Network()
+
+    output = graph_ops.add_gelu_new(network, _Tensor(trt.float32))
+
+    assert network.activation_type == trt.ActivationType.GELU_TANH
+    assert network.activation_dtype == trt.float32
+    assert network.casts == []
+    assert output.dtype == trt.float32
+
+
+@requires_trt
+def test_gelu_tanh_fp16_matches_fp32_reference():
+    values = np.array(
+        [-3.1015625, -2.5234375, -2.142578125,
+         2.142578125, 2.521484375, 3.1015625],
+        dtype=np.float16,
+    ).reshape(1, -1)
+
+    def build(network, inputs):
+        activated = graph_ops.add_gelu_new(
+            network, inputs["x"], dtype=np.float16)
+        output = network.add_cast(activated, trt.float32).get_output(0)
+        return {"out": output}
+
+    result = run_trt_graph(build, {"x": values})["out"]
+    x = values.astype(np.float32)
+    reference = (
+        0.5 * x * (
+            1.0 + np.tanh(
+                np.sqrt(2.0 / np.pi) * (x + 0.044715 * x ** 3)
+            )
+        )
+    ).astype(np.float16).astype(np.float32)
+    np.testing.assert_allclose(result, reference, atol=5e-4, rtol=0.0)

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -1787,6 +1787,7 @@ def test_suite_has_explicit_eager_and_task_reference_rows() -> None:
         "output_contract": "normalized-text",
     }
     assert rows["gemma.generate"]["baseline"]["output_contract"] == "exact-text"
+    assert rows["gemma.generate"]["baseline"]["precision"] == "fp16"
     assert rows["phi.generate"]["baseline"]["output_contract"] == "exact-text"
     assert rows["phi_moe.generate"]["baseline"]["output_contract"] == "exact-text"
     assert rows["deepseek_ocr.generate"]["baseline"]["output_contract"] == "ocr-text"


### PR DESCRIPTION
## Background

Gemma 2 2B completed the five-shot MMLU workload but produced no valid multiple-choice predictions at FP16. The expanded FP16 tanh-GELU accumulated enough error to change the answer token, while the generation runtime also performed decoder launches whose logits were discarded and only recognized one of Gemma's configured EOS token IDs.

Fixes #885.

## Exit Criteria

- Restore at least 0.98 MMLU prediction agreement with no more than 0.01 accuracy drop, without changing validation gates.
- Keep the registered Accuracy and Perf precision contracts aligned at FP16.
- Preserve or improve Perf on Thor X and GB300.

## Implementation

- Evaluate Gemma's fused TensorRT `GELU_TANH` activation in FP32 and cast the result back to the surrounding graph precision.
- Carry all configured Gemma EOS token IDs into every sampler and stop on any configured EOS token.
- Remove the discarded decoder launch after batched prefill and avoid computing logits after the final requested token.
- Register focused graph-precision, sampler, and pipeline regression tests.
- Set the Gemma Perf reference explicitly to FP16 so it matches Accuracy and the TRTMC candidate.

## Validation

- `PYTHONPATH=$PWD/python python3 -m pytest tests/e2e/models/gemma/test_gemma_graph_ops_precision.py tests/tools/test_perf_matrix.py -q`: 111 passed, 1 skipped.
- `python -m tools.ci pipeline source-quality`: passed.
- `python -m pytest <Gemma model test files> -q`: 25 passed on GB300.
- `ctest --test-dir <build> --output-on-failure -R 'test_gemma_(pipeline|sampler)'`: passed on both Thor X and GB300 builds at head `579b15b209a16fd89c75d1d91a55733dc7df0833`.
- `python tools/model_checks.py run --platform l4t-thor --model gemma-2-2b --task accuracy --revision 579b15b209a16fd89c75d1d91a55733dc7df0833`: passed on Thor X with TensorRT 11.0; 1.00 prediction agreement, HF/TRTMC accuracy 0.35/0.35, and 0.00 accuracy drop.
- `python tools/perf_matrix.py run benchmarks/performance/release.yaml --entry gemma.generate`: Yellow/pass on Thor X with an FP16 dual-profile bundle; TRTMC p50 92.67 ms versus HF FP16 p50 93.26 ms, with exact output parity.
- `python tools/model_checks.py run --platform gb300 --environment gb300 --model gemma-2-2b --task accuracy --revision 579b15b209a16fd89c75d1d91a55733dc7df0833`: passed on GB300; 1.00 prediction agreement, HF/TRTMC accuracy 0.35/0.35, and 0.00 accuracy drop.
- `python tools/model_checks.py run --platform gb300 --environment gb300 --model gemma-2-2b --task perf --revision 579b15b209a16fd89c75d1d91a55733dc7df0833`: Green/pass on GB300; TRTMC p50 10.64 ms versus HF FP16 p50 59.05 ms, with exact output parity.

## Notes For Future Readers

- Review the FP32 GELU change first, then the EOS and decoder-launch changes. The former restores MMLU parity; the latter prevents the accuracy fix from carrying a generation performance regression.
- Thor X used the memory-efficient dual-profile decoder layout. GB300 used the standard release configuration.
