### PR TITLE
fix(ci): normalize blank tuning controls

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -35,7 +35,7 @@ def configure_qwen_builder(
         major_minor[0] == 11
         and major_minor[1] >= 2
     ):
-        if "TRTMC_BUILDER_OPTIMIZATION_LEVEL" not in os.environ:
+        if not os.environ.get("TRTMC_BUILDER_OPTIMIZATION_LEVEL", "").strip():
             # TRT 11.2+ can otherwise select numerically unstable FP8 tactics.
             trt_config.builder_optimization_level = 0
         fp16_tail_length = 22

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -3,6 +3,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from tensorrt_model_connect.families.qwen.builder_policy import (
     configure_qwen_builder,
 )
@@ -16,7 +18,12 @@ def _quant_context(format_name: str):
         ))
 
 
-def test_qwen_fp8_uses_accuracy_stable_builder_level():
+@pytest.mark.parametrize("override", [None, "", "   "])
+def test_qwen_fp8_uses_accuracy_stable_builder_level(monkeypatch, override):
+    if override is None:
+        monkeypatch.delenv("TRTMC_BUILDER_OPTIMIZATION_LEVEL", raising=False)
+    else:
+        monkeypatch.setenv("TRTMC_BUILDER_OPTIMIZATION_LEVEL", override)
     config = SimpleNamespace(builder_optimization_level=5)
     quant_context = _quant_context("fp8")
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -18,7 +18,9 @@ from pathlib import Path
 import yaml
 
 from tools.ci.container import CiContainer
+from tools.ci.environment import OPTIONAL_TUNING_ENVIRONMENT
 from tools.ci.quality import UnitTestRunner
+from tools.ci.stage import ContainerStageRunner
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -835,6 +837,34 @@ def test_github_container_only_exports_nonempty_hf_transport_controls() -> None:
     assert 'if self.env.get(name, "")' in start_text
     for name in ("HF_HUB_DISABLE_XET", "HF_HUB_DOWNLOAD_TIMEOUT", "HF_HUB_ETAG_TIMEOUT"):
         assert name not in stage_text
+
+
+def test_github_container_only_exports_nonempty_tuning_controls(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    base_env = {
+        "TRTMC_CI_WORKSPACE": str(workspace),
+        "TRTMC_CI_IMAGE": "example.invalid/trtmc:test",
+    }
+
+    for name in OPTIONAL_TUNING_ENVIRONMENT:
+        for value in (None, "", "   ", "3"):
+            env = dict(base_env)
+            if value is not None:
+                env[name] = value
+            arguments = CiContainer(env)._environment_arguments()
+            forwarded = [
+                arguments[index + 1]
+                for index, item in enumerate(arguments[:-1])
+                if item == "-e"
+            ]
+            stage_command = ContainerStageRunner("package", env)._docker_command()
+            if value == "3":
+                assert f"{name}=3" in forwarded
+                assert name in stage_command
+            else:
+                assert not any(item.startswith(f"{name}=") for item in forwarded)
+                assert name not in stage_command
 
 
 def test_github_stage_wrapper_exports_e2e_gpu_controls() -> None:

--- a/tools/ci/container.py
+++ b/tools/ci/container.py
@@ -17,6 +17,7 @@ from .environment import (
     COMMON_ENVIRONMENT,
     OPTIONAL_HUGGING_FACE_ENVIRONMENT,
     TRUSTED_ENVIRONMENT,
+    forwarded_environment,
 )
 from .process import CiError, CommandRunner, GitHubFiles
 
@@ -235,7 +236,10 @@ class CiContainer:
             )
 
     def _environment_arguments(self) -> list[str]:
-        names = COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT
+        names = forwarded_environment(
+            COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT,
+            self.env,
+        )
         arguments = [item for name in names for item in ("-e", f"{name}={self.env.get(name, '')}")]
         if not self.config.hardened:
             arguments.extend(

--- a/tools/ci/environment.py
+++ b/tools/ci/environment.py
@@ -24,6 +24,24 @@ COMMON_ENVIRONMENT = (
     "TRTMC_SELECTED_WHEEL_TENSORRT_VERSION",
 )
 
+OPTIONAL_TUNING_ENVIRONMENT = (
+    "TRTMC_BUILDER_OPTIMIZATION_LEVEL",
+    "TRTMC_MAX_NUM_TACTICS",
+    "TRTMC_AVG_TIMING_ITERATIONS",
+)
+
+
+def forwarded_environment(
+    names: tuple[str, ...], env: dict[str, str]
+) -> tuple[str, ...]:
+    """Omit optional tuning controls that do not carry an effective value."""
+    return tuple(
+        name
+        for name in names
+        if name not in OPTIONAL_TUNING_ENVIRONMENT or env.get(name, "").strip()
+    )
+
+
 TRUSTED_ENVIRONMENT = COMMON_ENVIRONMENT + (
     "ENGINE_DIR",
     "TRTMC_STORAGE_ROOT",
@@ -39,9 +57,7 @@ TRUSTED_ENVIRONMENT = COMMON_ENVIRONMENT + (
     "TRTMC_E2E_DEPRIORITIZE_GPU0",
     "TRTMC_TRT_TIMING_CACHE_PATH",
     "TRTMC_TRT_TIMING_CACHE_DIR",
-    "TRTMC_BUILDER_OPTIMIZATION_LEVEL",
-    "TRTMC_MAX_NUM_TACTICS",
-    "TRTMC_AVG_TIMING_ITERATIONS",
+    *OPTIONAL_TUNING_ENVIRONMENT,
     "TRTMC_ENABLE_LIBTORCH_MULTINOMIAL",
     "PYTHON_COVERAGE_MIN_LINE",
     "PYTHON_COVERAGE_MIN_BRANCH",

--- a/tools/ci/stage.py
+++ b/tools/ci/stage.py
@@ -13,7 +13,7 @@ import signal
 import subprocess
 
 from .container import ContainerConfig
-from .environment import COMMON_ENVIRONMENT, TRUSTED_ENVIRONMENT
+from .environment import COMMON_ENVIRONMENT, TRUSTED_ENVIRONMENT, forwarded_environment
 from .process import CiError, CommandRunner
 
 
@@ -60,7 +60,10 @@ class ContainerStageRunner:
         return result.stdout.strip() == "true"
 
     def _docker_command(self) -> list[str]:
-        names = COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT
+        names = forwarded_environment(
+            COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT,
+            self.env,
+        )
         forwarded = [item for name in names for item in ("-e", name)]
         return [
             "docker",


### PR DESCRIPTION
## Background

Premerge and Nightly executed the same Qwen builder-policy test with different results because trusted CI container setup represented an absent tuning control as an empty environment variable. Qwen treated key presence as an explicit override, so the Nightly validation environment retained the default optimization level instead of selecting the accuracy-stable value.

## Exit Criteria

- Missing, empty, and whitespace-only tuning values behave as no override.
- Explicit nonempty tuning values remain unchanged.
- Trusted container start and stage-exec paths do not propagate blank builder tuning controls.
- Model selection and test passing criteria remain unchanged.

## Implementation

- Normalize the Qwen builder-level check to the existing empty-as-unset convention.
- Define the three optional integer tuning controls together and use one forwarding helper for both `docker run` and `docker exec` paths.
- Cover absent, empty, whitespace-only, and explicit nonempty values in focused regression tests.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python3 -m pytest tests/e2e/models/qwen/test_qwen_builder_policy.py tests/tools/test_github_actions_ci.py -q -p no:cacheprovider`: 70 passed.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 158 passed.
- `python3 -m ruff check --config ruff.toml <changed Python files>`: passed.
- `git diff --check github/main...HEAD`: passed.
- Focused replay in the validation-container environment that exposed the issue: 8 Qwen policy tests passed.

## Notes For Future Readers

- This source change prevents future trusted container start and exec paths from synthesizing blank tuning controls. It does not claim that an already-cached validation image has been rebuilt.
- Validation-image cache invalidation and persisted-image inspection remain a separate private-CI follow-up after this source change is proven.
- The broader Qwen GPU build suite requires a GPU runner; the local CPU-only container reached the expected CUDA initialization boundary, so exact-head CI remains required.
