### PR TITLE
feat(cosmos3): add dual-Spark 720p example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -905,6 +905,7 @@ add_dependencies(test_model_plugin_loader trtmc_model_plugins)
 trtmc_add_test(test_backend_loader)
 trtmc_add_test(test_trt_version)
 trtmc_add_test(test_runtime_measurement)
+trtmc_add_test(test_distributed_runtime)
 
 trtmc_add_test(test_optimized_runtime_host)
 add_dependencies(test_optimized_runtime_host

--- a/examples/models/cosmos3/dual_spark/Dockerfile
+++ b/examples/models/cosmos3/dual_spark/Dockerfile
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This digest is the repository-pinned aarch64 TensorRT 11.1 development image.
+ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt:26.07-py3@sha256:f794a79e8b996d16dbc2e5884e19d8e2269a51c960106c9b49b0061a6926c541
+
+FROM ${TENSORRT_IMAGE} AS builder
+
+ARG PYTORCH_CPU_INDEX=https://download.pytorch.org/whl/cpu
+ARG TORCH_VERSION=2.12.0+cpu
+ARG TRTMC_CUDA_ARCHITECTURES=121-real
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    VIRTUAL_ENV=/opt/venv
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      git \
+      ninja-build \
+      nlohmann-json3-dev \
+      patchelf \
+      pkg-config \
+      python3.12-dev \
+      python3.12-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN target_triplet="$(gcc -dumpmachine)" && \
+    install -d -m 0755 /opt/trtmc/platform && \
+    ln -s "/usr/lib/${target_triplet}" /opt/trtmc/platform/lib && \
+    ln -s "/usr/include/${target_triplet}" /opt/trtmc/platform/include && \
+    test -f /opt/trtmc/platform/lib/libnvinfer.so.11 && \
+    test -f /opt/trtmc/platform/include/NvInferVersion.h
+
+RUN python3.12 -m venv --system-site-packages "${VIRTUAL_ENV}" && \
+    ln -s /usr/bin/cmake "${VIRTUAL_ENV}/bin/cmake"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# Torch remains CPU-only: TensorRT owns GPU execution, while safetensors uses
+# Torch to read checkpoints during the one-time bundle build.
+RUN pip install -U pip && \
+    pip install \
+      "cuda-python>=13.0.3,<14" \
+      "huggingface_hub>=0.23" \
+      "ml_dtypes>=0.4" \
+      "numpy>=1.24,<2.5" \
+      "onnx>=1.16" \
+      "onnxscript>=0.2" \
+      "PyYAML>=6.0" \
+      "safetensors>=0.4" \
+      "sentencepiece>=0.1.99" \
+      "transformers==5.2.0" && \
+    pip install "torch==${TORCH_VERSION}" --index-url "${PYTORCH_CPU_INDEX}" && \
+    pip install "setuptools>=80,<82"
+
+ENV TRT_LIB_DIR=/opt/trtmc/platform/lib \
+    TRT_INC_DIR=/opt/trtmc/platform/include \
+    LD_LIBRARY_PATH=/opt/trtmc/platform/lib:/usr/local/cuda/lib64
+
+WORKDIR /src
+COPY . /src
+
+# Dockerfile.dockerignore excludes every other model family.
+# TRTMC_MODEL_PROOF_MODEL makes that isolation a configure-time invariant.
+RUN pip install --no-deps -e . -C py-only=true && \
+    cmake -S . -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_CUDA_ARCHITECTURES}" \
+      -DTRTMC_BUILD_BACKEND_TRT=ON \
+      -DTRTMC_BUILD_BACKEND_RTX=OFF \
+      -DTRTMC_BUILD_TESTS=OFF \
+      -DTRTMC_BUILD_BENCHMARKS=OFF \
+      -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF \
+      -DTRTMC_ENABLE_TVM_FFI=OFF \
+      -DTRTMC_MODEL_PROOF_MODEL=cosmos3 && \
+    cmake --build build --parallel "$(nproc)" --target \
+      trtmc \
+      trtmc_backend_trt \
+      trtmc_model_cosmos3 && \
+    install -d /opt/trtmc/bin/models/cosmos3 && \
+    install -m 0755 build/trtmc /opt/trtmc/bin/trtmc && \
+    install -m 0755 build/libtrtmc_core.so /opt/trtmc/bin/libtrtmc_core.so && \
+    install -m 0755 build/libtrtmc_backend_trt.so /opt/trtmc/bin/libtrtmc_backend_trt.so && \
+    find build -maxdepth 1 -type f -name 'libtrtmc_backend_trt_*.so' \
+      -exec install -m 0755 '{}' /opt/trtmc/bin/ \; && \
+    install -m 0755 \
+      build/models/cosmos3/libtrtmc_model_cosmos3.so \
+      /opt/trtmc/bin/models/cosmos3/libtrtmc_model_cosmos3.so && \
+    /opt/trtmc/bin/trtmc --version
+
+FROM ${TENSORRT_IMAGE} AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/trtmc/bin:/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    LD_LIBRARY_PATH=/opt/trtmc/bin:/opt/trtmc/platform/lib:/usr/local/cuda/lib64 \
+    TRTMC_BIN=/opt/trtmc/bin/trtmc \
+    TRTMC_MODEL_PLUGIN_DIR=/opt/trtmc/bin/models \
+    TRTMC_TRT_LIBRARY_DIR=/opt/trtmc/platform/lib \
+    HF_HOME=/root/.cache/huggingface \
+    HF_HUB_CACHE=/root/.cache/huggingface/hub \
+    HF_HUB_DISABLE_TELEMETRY=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      ffmpeg \
+      ibverbs-providers \
+      libibverbs1 \
+      rdma-core && \
+    rm -rf /var/lib/apt/lists/* && \
+    install -d -m 0755 \
+      /models \
+      /outputs \
+      /opt/trtmc/licenses \
+      /root/.cache/huggingface/hub
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /opt/trtmc /opt/trtmc
+# Preserve the source target recorded by the Python-only editable install.
+COPY --from=builder /src/python /src/python
+COPY --from=builder /src/LICENSE /src/NOTICE /opt/trtmc/licenses/
+
+RUN test -x /opt/trtmc/bin/trtmc && \
+    test -f /opt/trtmc/bin/models/cosmos3/libtrtmc_model_cosmos3.so && \
+    ffmpeg -version >/dev/null
+
+ARG TRTMC_SOURCE_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/TensorRT-Model-Connect" \
+      org.opencontainers.image.revision="${TRTMC_SOURCE_REVISION}"
+
+WORKDIR /work
+
+ENTRYPOINT ["/opt/trtmc/bin/trtmc"]
+CMD ["--help"]

--- a/examples/models/cosmos3/dual_spark/Dockerfile.dockerignore
+++ b/examples/models/cosmos3/dual_spark/Dockerfile.dockerignore
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Start empty. The image needs shared runtime and builder sources plus Cosmos3;
+# other model families, website sources, repository metadata, generated
+# artifacts, caches, and credentials must not enter the Docker build context.
+*
+
+!CMakeLists.txt
+!pyproject.toml
+!_pyproject_backend.py
+!README.md
+!LICENSE
+!NOTICE
+!ASSET_LICENSES.md
+
+!cmake/
+!cmake/**
+
+!include/
+!include/**
+
+!python/
+!python/**
+python/tensorrt_model_connect/families/**
+!python/tensorrt_model_connect/families/__init__.py
+!python/tensorrt_model_connect/families/cosmos3/
+!python/tensorrt_model_connect/families/cosmos3/**
+
+!src/
+!src/**
+src/runtime/models/**
+!src/runtime/models/cosmos3/
+!src/runtime/models/cosmos3/**
+
+!third_party/
+third_party/**
+!third_party/stb/
+!third_party/stb/**
+
+# Runtime manifests validate their declared C++ test source paths during CMake
+# configuration even when test targets are disabled.
+!tests/
+tests/**
+!tests/cpp/
+tests/cpp/**
+!tests/cpp/models/
+tests/cpp/models/**
+!tests/cpp/models/cosmos3/
+!tests/cpp/models/cosmos3/**
+
+# Guard against basename negations above matching similarly named directories
+# below unrelated source trees.
+examples/**
+website/**
+
+# Defense in depth if a future allowlist entry becomes broader.
+**/__pycache__/
+**/*.py[cod]
+**/*.bundle
+**/*.engine
+**/*.plan
+**/*.trtfb
+**/build/
+**/build-*/
+**/hf-cache/
+/models/
+/outputs/
+/secrets/

--- a/examples/models/cosmos3/dual_spark/README.md
+++ b/examples/models/cosmos3/dual_spark/README.md
@@ -1,0 +1,117 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Cosmos3 dual-Spark video generation example
+
+This example generates one native 1280x720 Cosmos3-Nano video with context
+parallelism across two one-GPU DGX Sparks. A host-side Python launcher prepares
+the hardware-specific TensorRT bundle, synchronizes the exact image and bundle
+to the peer, and starts rank 0 on the primary Spark and rank 1 on the peer.
+It does not start a server, open an application port, or require a browser.
+
+On top of the repository-pinned TensorRT base, the image adds the TRTMC CLI,
+`trtmc_core`, the TensorRT backend, the Cosmos3 model DSO, the Python builder
+environment, FFmpeg, and RDMA runtime packages. It does not contain a model
+checkpoint, TensorRT bundle, generated video, SSH key, or Hugging Face token.
+
+## Requirements
+
+- two networked, one-GPU GB10 DGX Sparks with matching GPU architecture and
+  NVIDIA driver versions;
+- Docker Engine using BuildKit and NVIDIA Container Toolkit on both Sparks;
+- passwordless SSH from the primary to the peer, with the peer host key already
+  present in `known_hosts` and Docker available without an interactive prompt;
+- a direct, active RoCE link between the Sparks; and
+- enough free disk, unified memory, and swap for the checkpoint and TensorRT
+  build.
+
+Run all commands below on the primary Spark from the repository root.
+
+## Build the image once
+
+The default base is the repository-pinned aarch64 TensorRT 26.07 image and the
+default CUDA target is the GB10 GPU's SM 12.1:
+
+```bash
+COSMOS3_SOURCE_REVISION="$(git rev-parse HEAD)"
+
+docker build \
+  --platform linux/arm64 \
+  --file examples/models/cosmos3/dual_spark/Dockerfile \
+  --build-arg TRTMC_SOURCE_REVISION="${COSMOS3_SOURCE_REVISION}" \
+  --tag trtmc-cosmos3-dual-spark:local \
+  .
+```
+
+The Dockerfile uses its adjacent `Dockerfile.dockerignore` to project the
+shared native and Python sources while admitting only the Cosmos3 model family.
+Docker's retired legacy builder does not support Dockerfile-specific ignore
+files; enable BuildKit or use a current Docker release.
+
+Build natively on the primary Spark. TensorRT bundles are specific to the model
+revision, precision, context-parallel topology, TensorRT build, and GPU
+architecture.
+
+## Generate one video
+
+After the one-time image build, select one of the built-in scenes:
+
+```bash
+python3 examples/models/cosmos3/dual_spark/run_dual_spark.py all \
+  --peer-host <SECOND_SPARK> \
+  --image trtmc-cosmos3-dual-spark:local \
+  --scene showcase-high-speed-racing
+```
+
+The first run downloads the public `nvidia/Cosmos3-Nano` checkpoint, builds a
+CP=2 TensorRT bundle on the primary Spark, and copies the exact image and bundle
+to the peer. That preparation can take hours. Later runs reuse the checkpoint
+cache, image, and hardware-specific bundle.
+
+Each showcase preset produces a 189-frame, 7.875-second H.264 MP4 at 24 FPS.
+The available presets correspond to the selected showcase videos:
+
+- `showcase-high-speed-racing`;
+- `showcase-mars-robots`;
+- `showcase-delivery-robot`;
+- `showcase-apple-to-plate`;
+- `showcase-humanoid-sprint`; and
+- `showcase-cake-cutting`.
+
+Use `--scene all` to run the six presets sequentially. To separate the
+expensive preparation from generation, use the `prepare` and `run` actions:
+
+```bash
+python3 examples/models/cosmos3/dual_spark/run_dual_spark.py prepare \
+  --peer-host <SECOND_SPARK> \
+  --image trtmc-cosmos3-dual-spark:local
+
+python3 examples/models/cosmos3/dual_spark/run_dual_spark.py run \
+  --peer-host <SECOND_SPARK> \
+  --image trtmc-cosmos3-dual-spark:local \
+  --scene showcase-delivery-robot
+```
+
+Use `--dry-run` to print the mutation-free JSON execution plan. Run
+`python3 examples/models/cosmos3/dual_spark/run_dual_spark.py --help` for the
+complete CLI surface.
+
+## Network, cache, and output boundaries
+
+- SSH is non-interactive and strict host-key checking remains enabled. Use
+  `--ssh-key` and `--known-hosts` for non-default SSH files.
+- The default RoCE settings are HCA `rocep1s0f0:1`, network interface
+  `enp1s0f0np0`, and GID index `3`. Change them only when both Sparks use the
+  same alternative configuration.
+- The launcher requires NCCL RoCE (`NET/IB`) rather than socket fallback and
+  records cgroup-v2 peak memory for both ranks.
+- Reusable assets and run records live under
+  `~/.cache/trtmc/cosmos3-physics` by default. Each run directory contains its
+  MP4 files, rank logs, container records, and `run.json`. Use `--work-root`
+  to select another primary location; the peer defaults to
+  `/var/tmp/cosmos3-physics-dual-spark`.
+- The public checkpoint is downloaded at preparation time into the mounted
+  Hugging Face cache. No credentials are required. Generated motion can still
+  contain physical or visual errors; review outputs before sharing them.

--- a/examples/models/cosmos3/dual_spark/run_dual_spark.py
+++ b/examples/models/cosmos3/dual_spark/run_dual_spark.py
@@ -1,0 +1,2616 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare and run the native Cosmos3-Nano CP=2 workflow on two DGX Sparks.
+
+This host-side orchestrator uses a locally built example image to build one
+CP=2 TensorRT bundle on the primary Spark, copies the exact image and bundle to
+a peer Spark, and launches one global rank on each host. Each scene has an
+independent file rendezvous and runs only after the previous scene finishes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import getpass
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Mapping, Sequence
+
+
+MODEL_ID = "nvidia/Cosmos3-Nano"
+MODEL_REVISION = "411f42a8fdfb8c5b2583cb8786e0938f49796eaa"
+PRECISION = "bf16"
+WIDTH = 1280
+HEIGHT = 720
+FRAME_COUNT = 189
+FRAME_RATE = 24
+STEPS = 35
+GUIDANCE_SCALE = 6.0
+FLOW_SHIFT = 10.0
+CP_SIZE = 2
+NCCL_ID_BYTES = 128
+PHYSICS_NEGATIVE_PROMPT = (
+    "blur, low detail, jitter, flicker, morphing, floating objects, interpenetrating "
+    "objects, fused objects, teleportation, discontinuous motion, cuts, scene changes, "
+    "text, captions, logos, watermarks"
+)
+
+DEFAULT_IMAGE = "trtmc-cosmos3-dual-spark:local"
+DEFAULT_LOCAL_WORK_ROOT = Path.home() / ".cache" / "trtmc" / "cosmos3-physics"
+DEFAULT_REMOTE_ROOT = "/var/tmp/cosmos3-physics-dual-spark"  # noqa: S108
+DEFAULT_IB_HCA = "rocep1s0f0:1"
+DEFAULT_NET_IFACE = "enp1s0f0np0"
+DEFAULT_GID_INDEX = 3
+
+RUN_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,47}$")
+PEER_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+REMOTE_PATH_PATTERN = re.compile(r"^/[A-Za-z0-9_./-]+$")
+IMAGE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$")
+NETWORK_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+REMOTE_EXEC_HELPER = """\
+import base64
+import json
+import subprocess
+import sys
+
+argv = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
+raise SystemExit(subprocess.run(argv, check=False).returncode)
+"""
+
+REMOTE_ROOT_HELPER = """\
+import os
+import stat
+import sys
+
+root = sys.argv[1]
+os.makedirs(os.path.dirname(root), exist_ok=True)
+try:
+    os.mkdir(root, 0o700)
+except FileExistsError:
+    pass
+
+entry = os.lstat(root)
+if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+    raise SystemExit("remote root must be a real directory")
+if entry.st_uid != os.geteuid():
+    raise SystemExit("remote root must be owned by the SSH user")
+
+flags = os.O_RDONLY | os.O_DIRECTORY
+if hasattr(os, "O_NOFOLLOW"):
+    flags |= os.O_NOFOLLOW
+descriptor = os.open(root, flags)
+try:
+    opened = os.fstat(descriptor)
+    if opened.st_uid != os.geteuid():
+        raise SystemExit("remote root changed ownership during validation")
+    os.fchmod(descriptor, 0o700)
+    if stat.S_IMODE(os.fstat(descriptor).st_mode) != 0o700:
+        raise SystemExit("remote root permissions could not be restricted to 0700")
+finally:
+    os.close(descriptor)
+
+for current_root, directories, filenames in os.walk(root, followlinks=False):
+    for name in (*directories, *filenames):
+        child = os.lstat(os.path.join(current_root, name))
+        if stat.S_ISLNK(child.st_mode):
+            raise SystemExit("remote root must not contain symbolic links")
+        if child.st_uid != os.geteuid():
+            raise SystemExit("remote root contents must be owned by the SSH user")
+"""
+
+
+class DualSparkError(RuntimeError):
+    """A safe, operator-facing dual-Spark workflow error."""
+
+
+@dataclass(frozen=True, slots=True)
+class Scene:
+    slug: str
+    seed: int
+    prompt: Mapping[str, Any]
+    negative_prompt: str | Mapping[str, Any]
+
+
+def _subject(
+    description: str,
+    *,
+    appearance: str,
+    relationship: str,
+    location: str,
+    size: str,
+    orientation: str,
+    pose: str,
+    action: str,
+    state_changes: str,
+    count: int = 1,
+    arms: int = 0,
+    legs: int = 0,
+) -> dict[str, object]:
+    return {
+        "description": description,
+        "appearance_details": appearance,
+        "relationship": relationship,
+        "location": location,
+        "relative_size": size,
+        "orientation": orientation,
+        "pose": pose,
+        "action": action,
+        "state_changes": state_changes,
+        "clothing": "",
+        "expression": "",
+        "gender": "",
+        "age": "",
+        "skin_tone_and_texture": "",
+        "facial_features": "",
+        "number_of_subjects": count,
+        "number_of_arms": arms,
+        "number_of_legs": legs,
+    }
+
+
+def _showcase_prompt(
+    *,
+    subjects: list[dict[str, object]],
+    background: str,
+    light_conditions: str,
+    light_direction: str,
+    shadows: str,
+    illumination: str,
+    composition: str,
+    colors: str,
+    mood: str,
+    camera_motion: str,
+    framing: str,
+    camera_angle: str,
+    focus: str,
+    lens: str,
+    context: str,
+    steps: tuple[str, str, str],
+    temporal_caption: str,
+) -> dict[str, object]:
+    times = ("0:00-0:02", "0:02-0:05", "0:05-0:07.875")
+    actions = [
+        {"time": time_range, "description": description}
+        for time_range, description in zip(times, steps, strict=True)
+    ]
+    segments = [
+        {
+            "segment_index": index,
+            "time_range": time_range,
+            "description": description,
+            "key_changes": description,
+            "camera": camera_motion,
+        }
+        for index, (time_range, description) in enumerate(
+            zip(times, steps, strict=True)
+        )
+    ]
+    return {
+        "subjects": subjects,
+        "background_setting": background,
+        "lighting": {
+            "conditions": light_conditions,
+            "direction": light_direction,
+            "shadows": shadows,
+            "illumination_effect": illumination,
+        },
+        "aesthetics": {
+            "composition": composition,
+            "color_scheme": colors,
+            "mood_atmosphere": mood,
+            "patterns": "Natural, temporally stable surface detail without repetition.",
+        },
+        "cinematography": {
+            "camera_motion": camera_motion,
+            "framing": framing,
+            "camera_angle": camera_angle,
+            "depth_of_field": "Natural cinematic depth of field",
+            "focus": focus,
+            "lens_focal_length": lens,
+        },
+        "style_medium": "Photorealistic live-action video",
+        "artistic_style": (
+            "Physically plausible cinematic realism with stable identity, geometry, "
+            "lighting, and textures in one continuous shot"
+        ),
+        "context": context,
+        "actions": actions,
+        "text_and_signage_elements": [],
+        "segments": segments,
+        "transitions": [],
+        "temporal_caption": temporal_caption,
+        "resolution": {"W": WIDTH, "H": HEIGHT},
+        "aspect_ratio": "16,9",
+        "duration": "7.875s",
+        "fps": FRAME_RATE,
+    }
+
+
+SCENES = (
+    Scene(
+        slug="showcase-high-speed-racing",
+        seed=21001,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "A low, aerodynamic red professional racing car navigating a winding "
+                    "circuit at high speed.",
+                    appearance=(
+                        "Glossy red bodywork, intact aerodynamic surfaces, spinning black "
+                        "tires, realistic suspension."
+                    ),
+                    relationship="Primary vehicle followed continuously through the turns",
+                    location="Center of frame on the racing line",
+                    size="Large within frame",
+                    orientation="Moving away then carving through alternating bends",
+                    pose="Tires firmly contacting the asphalt with body roll under load",
+                    action=(
+                        "Accelerating, braking, and steering through multiple winding turns"
+                    ),
+                    state_changes=(
+                        "Suspension compresses and unloads naturally while the car advances "
+                        "continuously"
+                    ),
+                )
+            ],
+            background=(
+                "A closed professional road-racing circuit with curbs, barriers, distant "
+                "grandstands, and clear safety runoff."
+            ),
+            light_conditions=(
+                "Bright late-afternoon daylight with crisp atmospheric visibility"
+            ),
+            light_direction="Warm sun from camera-left with balanced sky fill",
+            shadows="Stable moving car shadow and strong tire contact shadows",
+            illumination="Specular highlights travel smoothly over the bodywork",
+            composition=(
+                "The car remains the clear focal point while successive bends reveal the "
+                "track geometry."
+            ),
+            colors="Red car against gray asphalt, green verge, and blue sky",
+            mood="Fast, controlled, exhilarating motorsport realism",
+            camera_motion=(
+                "One smooth low chase-camera tracking move with no cuts or teleportation"
+            ),
+            framing="Dynamic wide tracking shot that keeps the whole car visible",
+            camera_angle="Low rear three-quarter angle near track height",
+            focus="Sharp focus on the racing car with natural background motion blur",
+            lens="35mm equivalent",
+            context=(
+                "A high-speed racing event in which a car navigates multiple winding turns."
+            ),
+            steps=(
+                "The car accelerates into the first sweeping turn and loads the outside "
+                "suspension.",
+                "It changes direction through two connected bends while remaining planted "
+                "on the racing line.",
+                "It exits the final turn under acceleration and continues down the circuit.",
+            ),
+            temporal_caption=(
+                "A single red racing car advances continuously through a sequence of winding "
+                "turns, showing credible wheel rotation, steering, inertia, grip, and "
+                "suspension response before accelerating away."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+    Scene(
+        slug="showcase-mars-robots",
+        seed=21003,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "Three rugged humanoid exploration robots operating together on the "
+                    "surface of Mars.",
+                    appearance=(
+                        "White and graphite pressure-sealed shells, dust-coated boots, "
+                        "compact sample canisters, blue status lights."
+                    ),
+                    relationship=(
+                        "A coordinated three-robot survey team moving toward the same base"
+                    ),
+                    location="Across the center foreground and middle distance",
+                    size="Medium to large within frame",
+                    orientation=(
+                        "Initially facing rock samples, then turning toward the base"
+                    ),
+                    pose="Balanced bipedal stances with feet planted in regolith",
+                    action="Collecting geological samples and walking toward a Mars base",
+                    state_changes=(
+                        "Each robot secures a sample, stands, turns, and begins walking"
+                    ),
+                    count=3,
+                    arms=6,
+                    legs=6,
+                )
+            ],
+            background=(
+                "A broad rust-red Martian plain with rocks, shallow ridges, dusty tire "
+                "tracks, and a pressurized Mars habitat in the near distance."
+            ),
+            light_conditions="Clear cold Martian daylight beneath a pale salmon sky",
+            light_direction="Low sun from right with diffuse atmospheric fill",
+            shadows="Long stable shadows attached to all three robots and rocks",
+            illumination="Dusty warm bounce light with crisp metallic highlights",
+            composition=(
+                "All three robots and the destination habitat remain legible throughout "
+                "the continuous shot."
+            ),
+            colors=(
+                "Rust-red terrain, pale sky, white-and-graphite robots, blue status lights"
+            ),
+            mood="Purposeful scientific exploration and teamwork",
+            camera_motion=(
+                "Slow stabilized lateral tracking move that follows the team toward the base"
+            ),
+            framing="Wide shot with all three full robot bodies visible",
+            camera_angle="Human eye-level landscape view",
+            focus="Deep focus across robots, samples, footprints, and base",
+            lens="32mm equivalent",
+            context=(
+                "Three humanoid robots on the surface of Mars collect samples and walk "
+                "toward a Mars base."
+            ),
+            steps=(
+                "The three robots crouch beside separate rocks and grasp geological samples.",
+                "They place the samples into canisters, rise with balanced joint motion, "
+                "and turn toward the habitat.",
+                "The team walks together toward the Mars base, leaving sequential "
+                "footprints in the dust.",
+            ),
+            temporal_caption=(
+                "Three distinct humanoid robots collect one rock sample each, store the "
+                "samples, stand without morphing, then walk in formation toward a visible "
+                "Mars base while their feet remain grounded."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+    Scene(
+        slug="showcase-delivery-robot",
+        seed=21004,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "A compact four-wheeled autonomous delivery robot with a sealed cargo "
+                    "compartment.",
+                    appearance=(
+                        "Matte white shell, black rubber tires, amber marker lights, rain "
+                        "droplets on stable body panels."
+                    ),
+                    relationship="Primary vehicle traversing one shallow puddle",
+                    location="Street level in the center of the alley",
+                    size="Large within frame",
+                    orientation="Rolling left-to-right past the camera",
+                    pose="All four wheels grounded on wet pavement",
+                    action="Rolling steadily through one shallow puddle",
+                    state_changes=(
+                        "Front wheels enter, displace water, and exit; rear wheels repeat "
+                        "the displacement"
+                    ),
+                )
+            ],
+            background=(
+                "A narrow rainy urban alley at night with wet asphalt, restrained cyan and "
+                "magenta neon reflections, closed storefronts, and light rainfall."
+            ),
+            light_conditions="Night rain illuminated by practical neon and street lamps",
+            light_direction=(
+                "Colored side light from storefronts with soft overhead streetlight"
+            ),
+            shadows="Soft wet-ground contact shadow beneath the robot",
+            illumination="Physically plausible reflections and specular rain highlights",
+            composition=(
+                "Low street-level view keeps the robot, its wheels, and the complete puddle "
+                "interaction visible."
+            ),
+            colors=(
+                "Neutral white robot, dark wet street, subtle cyan and magenta reflections"
+            ),
+            mood="Quiet, futuristic, believable last-mile delivery",
+            camera_motion="Gentle street-level tracking pan with one continuous take",
+            framing="Low medium-wide shot showing full robot and puddle",
+            camera_angle="Camera approximately twenty centimeters above pavement",
+            focus="Sharp robot and water-contact zone with soft alley depth",
+            lens="40mm equivalent",
+            context=(
+                "A street-level camera shows a delivery robot rolling over one shallow "
+                "puddle in a rainy neon alley, with realistic water ripples."
+            ),
+            steps=(
+                "The delivery robot approaches one shallow puddle at constant speed as "
+                "rain dimples the surface.",
+                "Its front then rear wheels cross the puddle, pushing small waves and "
+                "outward ripples without a large splash.",
+                "The robot exits onto wet pavement while concentric ripples settle behind it.",
+            ),
+            temporal_caption=(
+                "A four-wheeled delivery robot rolls continuously across exactly one shallow "
+                "rain puddle; wheel contact creates small displaced waves and realistic "
+                "ripples that remain and settle after it passes."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+    Scene(
+        slug="showcase-apple-to-plate",
+        seed=21006,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "A compact collaborative robot arm with a soft parallel gripper.",
+                    appearance=(
+                        "Smooth light-gray links, dark flexible joints, rubber fingertips, "
+                        "small green status light."
+                    ),
+                    relationship="Picking up the apple and placing it on the plate",
+                    location="Center above a tabletop",
+                    size="Large within frame",
+                    orientation="Moving from apple at left to plate at right",
+                    pose="Stable base with gripper aligned around the apple",
+                    action="Grasping, lifting, translating, and releasing one apple",
+                    state_changes=(
+                        "Empty open gripper closes on apple, carries it, opens above plate, "
+                        "then retracts"
+                    ),
+                ),
+                _subject(
+                    "One glossy red apple and one clean white ceramic plate.",
+                    appearance=(
+                        "Single intact red apple with stem; round white plate with raised rim."
+                    ),
+                    relationship=(
+                        "Apple is the transported object; plate is its destination"
+                    ),
+                    location="Apple at left foreground and plate at right foreground",
+                    size="Medium within frame",
+                    orientation="Both upright on the tabletop",
+                    pose="Initially separate and stationary",
+                    action="Apple moves only while held and ends centered on the plate",
+                    state_changes=(
+                        "Apple changes location from tabletop to plate without changing shape"
+                    ),
+                ),
+            ],
+            background=(
+                "A clean demonstration table in a bright robotics laboratory with an "
+                "uncluttered neutral backdrop."
+            ),
+            light_conditions="Soft bright studio daylight",
+            light_direction="Large key from upper-left with frontal fill",
+            shadows="Natural contact shadows under apple, plate, gripper, and robot",
+            illumination="Gentle highlights preserve the apple and ceramic material",
+            composition=(
+                "The full pick-and-place path from apple to plate is visible at all times."
+            ),
+            colors="Red apple, white plate, light-gray robot, neutral background",
+            mood="Clear, calm, reliable robotic dexterity",
+            camera_motion="One fixed camera with a nearly imperceptible push-in",
+            framing="Medium shot of complete robot workspace",
+            camera_angle="Slightly high front view",
+            focus="Sharp focus across gripper, apple, and plate",
+            lens="50mm equivalent",
+            context="The robot arm picks up the apple and places it on the plate.",
+            steps=(
+                "The open gripper approaches and closes gently around the single apple.",
+                "The arm lifts the apple, translates smoothly above the table, and centers "
+                "it over the plate.",
+                "The apple is lowered into contact with the plate; the gripper opens and "
+                "retracts.",
+            ),
+            temporal_caption=(
+                "One unchanged apple is grasped, lifted clear of the table, carried in a "
+                "smooth arc, placed at the center of one plate, released, and left "
+                "stationary as the gripper retracts."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+    Scene(
+        slug="showcase-humanoid-sprint",
+        seed=21011,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "One athletic humanoid robot sprinting on a regulation running track.",
+                    appearance=(
+                        "Lightweight white-and-black shell, exposed precise joints, stable "
+                        "head, red racing bib without text."
+                    ),
+                    relationship="Only runner on the track",
+                    location="Center lane moving left-to-right",
+                    size="Large within frame",
+                    orientation="Leaning slightly forward in the direction of travel",
+                    pose="Dynamic alternating sprint gait with coordinated arm swing",
+                    action="Accelerating into a fast biomechanically plausible sprint",
+                    state_changes=(
+                        "Stride length and cadence increase while body identity and limb "
+                        "count remain constant"
+                    ),
+                    arms=2,
+                    legs=2,
+                )
+            ],
+            background=(
+                "An outdoor athletics stadium with a red synthetic track, white lane lines, "
+                "green infield, and softly blurred empty stands."
+            ),
+            light_conditions="Bright clear morning daylight",
+            light_direction="Sun from rear-left with open-sky fill",
+            shadows="Stable running shadow and distinct foot contact shadows",
+            illumination="Clean highlights define joint motion and track texture",
+            composition=(
+                "Full robot stays visible with lane lines emphasizing forward speed."
+            ),
+            colors="Red track, green infield, white-and-black robot, blue sky",
+            mood="Powerful, focused, technically impressive athletic motion",
+            camera_motion=(
+                "Smooth side-tracking camera matching the robot's speed in one continuous shot"
+            ),
+            framing="Full-body medium-wide profile shot",
+            camera_angle="Waist-height side view",
+            focus="Sharp robot with controlled horizontal background motion blur",
+            lens="45mm equivalent",
+            context="A humanoid robot sprinting on an athletic track.",
+            steps=(
+                "The humanoid robot drives out of acceleration with a grounded right-foot "
+                "push and coordinated opposite arm swing.",
+                "It reaches a fast alternating sprint cycle with clear airborne and "
+                "single-foot support phases.",
+                "The robot sustains speed down its lane with stable posture, rhythmic "
+                "strides, and no foot sliding.",
+            ),
+            temporal_caption=(
+                "One unchanged two-armed, two-legged humanoid robot accelerates and sprints "
+                "down a marked lane using a coherent alternating gait, correct foot "
+                "contacts, natural joint timing, and synchronized arm swing."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+    Scene(
+        slug="showcase-cake-cutting",
+        seed=21012,
+        prompt=_showcase_prompt(
+            subjects=[
+                _subject(
+                    "Two robotic hands viewed from their own head-mounted camera, one "
+                    "stabilizing a cake and one holding a cake knife.",
+                    appearance=(
+                        "Matching white bimanual grippers, black joint covers, clean "
+                        "stainless-steel knife."
+                    ),
+                    relationship="Coordinated bimanual system cutting one cake",
+                    location="Lower left and lower right foreground in ego view",
+                    size="Large foreground elements",
+                    orientation="Both hands directed toward the cake",
+                    pose=(
+                        "One hand gently stabilizes the cake board while the other aligns "
+                        "the knife"
+                    ),
+                    action="Making one smooth precise cut through the cake",
+                    state_changes=(
+                        "Knife descends and advances; cake separates cleanly; knife withdraws"
+                    ),
+                    count=2,
+                    arms=2,
+                ),
+                _subject(
+                    "One small round layered cake on a ceramic serving plate.",
+                    appearance=(
+                        "Stable vanilla frosting, subtle berry decoration, visible layered "
+                        "interior after cutting."
+                    ),
+                    relationship="Object being cut by the two robotic hands",
+                    location="Center of the work surface",
+                    size="Medium to large within frame",
+                    orientation="Upright and centered on the plate",
+                    pose="Stationary on a nonslip mat",
+                    action="Separating along one clean radial cut",
+                    state_changes=(
+                        "Changes from intact cake to one visible clean cut without deformation"
+                    ),
+                ),
+            ],
+            background=(
+                "A quiet modern home kitchen worktop with uncluttered utensils and soft "
+                "neutral cabinetry."
+            ),
+            light_conditions="Soft indoor daylight with warm overhead fill",
+            light_direction="Window light from left and diffused ceiling light",
+            shadows="Gentle stable hand, knife, cake, and plate contact shadows",
+            illumination="Natural frosting texture and restrained metal highlights",
+            composition=(
+                "Ego-view centers the knife path and keeps both robotic hands visible."
+            ),
+            colors=(
+                "Warm neutral kitchen, white frosting, muted berries, white robotic hands"
+            ),
+            mood="Calm, precise, careful domestic assistance",
+            camera_motion=(
+                "Stable first-person head camera with only subtle natural robot-body "
+                "motion and no cuts"
+            ),
+            framing="Ego-view medium close-up of both hands and cake",
+            camera_angle="Slight downward first-person angle",
+            focus="Sharp knife edge, cake contact, and both grippers",
+            lens="35mm equivalent",
+            context=(
+                "Ego-view footage from a bimanual robot's camera as it cuts a cake, with "
+                "smooth, precise motion and soft indoor light."
+            ),
+            steps=(
+                "The stabilizing hand rests beside the cake while the knife hand aligns "
+                "the blade over one radial cut.",
+                "The blade descends and moves smoothly through frosting and layers as the "
+                "other hand prevents the plate from sliding.",
+                "The cut completes cleanly; the knife lifts and both hands pause with the "
+                "cake stable on the plate.",
+            ),
+            temporal_caption=(
+                "From one continuous bimanual robot ego-view, one hand stabilizes the plate "
+                "while the other makes exactly one smooth knife cut through an unchanged "
+                "cake and then withdraws."
+            ),
+        ),
+        negative_prompt=PHYSICS_NEGATIVE_PROMPT,
+    ),
+)
+SCENE_BY_SLUG = {scene.slug: scene for scene in SCENES}
+SCENE_CHOICES = ("all", *SCENE_BY_SLUG)
+
+
+@dataclass(frozen=True, slots=True)
+class Settings:
+    action: str
+    scene: str
+    peer_host: str
+    peer_user: str
+    ssh_key: Path | None
+    known_hosts: Path | None
+    work_root: Path
+    remote_root: str
+    image: str
+    run_id: str
+    ib_hca: str
+    net_iface: str
+    gid_index: int
+    runtime_timeout: int
+    build_timeout: int
+    dry_run: bool
+
+    @property
+    def peer_target(self) -> str:
+        return f"{self.peer_user}@{self.peer_host}"
+
+
+@dataclass(slots=True)
+class MemoryTracker:
+    """Byte-exact cgroup-v2 peak counters for one launched rank."""
+
+    container: str
+    remote: bool
+    cgroup_path: str
+    peak_bytes: int = 0
+    swap_peak_bytes: int = 0
+    samples: int = 0
+    records: list[tuple[int, int, int, int, int]] = field(default_factory=list)
+    initial_events: str = ""
+    latest_events: str = ""
+
+
+def _default_run_id() -> str:
+    return datetime.now(timezone.utc).strftime("physics-%Y%m%d-%H%M%S")
+
+
+def _profile() -> dict[str, int | float]:
+    return {
+        "width": WIDTH,
+        "height": HEIGHT,
+        "frames": FRAME_COUNT,
+        "fps": FRAME_RATE,
+        "steps": STEPS,
+        "guidance_scale": GUIDANCE_SCALE,
+        "flow_shift": FLOW_SHIFT,
+        "context_parallel_size": CP_SIZE,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            f"Prepare and run {len(SCENES)} native 720p Cosmos3-Nano CP=2 physics scenes "
+            "across two one-GPU DGX Sparks."
+        )
+    )
+    parser.add_argument(
+        "action",
+        nargs="?",
+        choices=("all", "prepare", "run"),
+        default="all",
+        help="workflow action (default: all)",
+    )
+    parser.add_argument(
+        "--scene",
+        choices=SCENE_CHOICES,
+        default=os.environ.get("COSMOS3_SCENE", "all"),
+        help="generate all fixed scenes or one scene slug (default: all)",
+    )
+    parser.add_argument("--peer-host", default=os.environ.get("COSMOS3_PEER_HOST", ""))
+    parser.add_argument(
+        "--peer-user",
+        default=os.environ.get("COSMOS3_PEER_USER", getpass.getuser()),
+    )
+    parser.add_argument(
+        "--ssh-key",
+        type=Path,
+        default=(
+            Path(os.environ["COSMOS3_SSH_KEY"])
+            if os.environ.get("COSMOS3_SSH_KEY")
+            else None
+        ),
+    )
+    parser.add_argument(
+        "--known-hosts",
+        type=Path,
+        default=(
+            Path(os.environ["COSMOS3_KNOWN_HOSTS"])
+            if os.environ.get("COSMOS3_KNOWN_HOSTS")
+            else None
+        ),
+    )
+    parser.add_argument(
+        "--work-root",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "COSMOS3_DUAL_SPARK_ROOT",
+                str(DEFAULT_LOCAL_WORK_ROOT),
+            )
+        ),
+    )
+    parser.add_argument(
+        "--remote-root",
+        default=os.environ.get("COSMOS3_REMOTE_ROOT", DEFAULT_REMOTE_ROOT),
+    )
+    parser.add_argument("--image", default=os.environ.get("COSMOS3_IMAGE", DEFAULT_IMAGE))
+    parser.add_argument("--run-id", default=os.environ.get("COSMOS3_RUN_ID", _default_run_id()))
+    parser.add_argument("--ib-hca", default=os.environ.get("COSMOS3_IB_HCA", DEFAULT_IB_HCA))
+    parser.add_argument(
+        "--net-iface",
+        default=os.environ.get("COSMOS3_NET_IFACE", DEFAULT_NET_IFACE),
+    )
+    parser.add_argument(
+        "--gid-index",
+        type=int,
+        default=int(os.environ.get("COSMOS3_GID_INDEX", DEFAULT_GID_INDEX)),
+    )
+    parser.add_argument("--runtime-timeout", type=int, default=2 * 60 * 60)
+    parser.add_argument("--build-timeout", type=int, default=12 * 60 * 60)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print a mutation-free JSON execution plan",
+    )
+    return parser
+
+
+def _settings(arguments: argparse.Namespace) -> Settings:
+    settings = Settings(
+        action=arguments.action,
+        scene=arguments.scene,
+        peer_host=arguments.peer_host,
+        peer_user=arguments.peer_user,
+        ssh_key=arguments.ssh_key.resolve() if arguments.ssh_key else None,
+        known_hosts=arguments.known_hosts.resolve() if arguments.known_hosts else None,
+        work_root=arguments.work_root.resolve(),
+        remote_root=arguments.remote_root.rstrip("/"),
+        image=arguments.image,
+        run_id=arguments.run_id,
+        ib_hca=arguments.ib_hca.removeprefix("="),
+        net_iface=arguments.net_iface.removeprefix("="),
+        gid_index=arguments.gid_index,
+        runtime_timeout=arguments.runtime_timeout,
+        build_timeout=arguments.build_timeout,
+        dry_run=arguments.dry_run,
+    )
+    _validate_settings(settings)
+    return settings
+
+
+def _validate_settings(settings: Settings) -> None:
+    if not RUN_ID_PATTERN.fullmatch(settings.run_id):
+        raise DualSparkError("--run-id must match [a-z0-9][a-z0-9_.-]{0,47}")
+    if not PEER_COMPONENT_PATTERN.fullmatch(settings.peer_host):
+        raise DualSparkError("--peer-host is required and must be a DNS name or IPv4 address")
+    if not PEER_COMPONENT_PATTERN.fullmatch(settings.peer_user):
+        raise DualSparkError("--peer-user contains unsupported characters")
+    if not IMAGE_PATTERN.fullmatch(settings.image):
+        raise DualSparkError("--image contains unsupported characters")
+    if str(settings.work_root) == "/" or "," in str(settings.work_root):
+        raise DualSparkError("--work-root must be scoped and must not contain a comma")
+    if not REMOTE_PATH_PATTERN.fullmatch(settings.remote_root):
+        raise DualSparkError("--remote-root must be an absolute path without spaces")
+    if settings.remote_root == "/" or ".." in Path(settings.remote_root).parts:
+        raise DualSparkError("--remote-root must be a scoped directory")
+    if not NETWORK_NAME_PATTERN.fullmatch(settings.ib_hca):
+        raise DualSparkError("--ib-hca contains unsupported characters")
+    if not NETWORK_NAME_PATTERN.fullmatch(settings.net_iface):
+        raise DualSparkError("--net-iface contains unsupported characters")
+    try:
+        _hca_name, port_text = settings.ib_hca.rsplit(":", 1)
+        port = int(port_text)
+    except (TypeError, ValueError) as exc:
+        raise DualSparkError(
+            "--ib-hca must use HCA:PORT form, for example rocep1s0f0:1"
+        ) from exc
+    if port < 1:
+        raise DualSparkError("--ib-hca port must be positive")
+    if settings.gid_index < 0:
+        raise DualSparkError("--gid-index must be non-negative")
+    if settings.runtime_timeout <= 0 or settings.build_timeout <= 0:
+        raise DualSparkError("timeouts must be positive")
+
+    local_names = {"localhost", "127.0.0.1", socket.gethostname(), socket.getfqdn()}
+    if settings.peer_host in local_names:
+        raise DualSparkError("--peer-host must identify the second DGX Spark")
+
+
+def _selected_scenes(settings: Settings) -> tuple[Scene, ...]:
+    if settings.scene == "all":
+        return SCENES
+    return (SCENE_BY_SLUG[settings.scene],)
+
+
+def _ssh_argv(settings: Settings) -> list[str]:
+    argv = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "ConnectTimeout=15",
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=3",
+    ]
+    if settings.ssh_key is not None:
+        argv.extend(["-i", str(settings.ssh_key), "-o", "IdentitiesOnly=yes"])
+    if settings.known_hosts is not None:
+        argv.extend(["-o", f"UserKnownHostsFile={settings.known_hosts}"])
+    argv.append(settings.peer_target)
+    return argv
+
+
+def _scp_argv(settings: Settings) -> list[str]:
+    argv = [
+        "scp",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "ConnectTimeout=15",
+    ]
+    if settings.ssh_key is not None:
+        argv.extend(["-i", str(settings.ssh_key), "-o", "IdentitiesOnly=yes"])
+    if settings.known_hosts is not None:
+        argv.extend(["-o", f"UserKnownHostsFile={settings.known_hosts}"])
+    return argv
+
+
+def _layout(settings: Settings) -> dict[str, Any]:
+    models = settings.work_root / "models"
+    run_root = settings.work_root / "runs" / settings.run_id
+    return {
+        "hf_cache": settings.work_root / "hf-cache",
+        "models": models,
+        "bundle": models / "cosmos3-nano-cp2-1280x720.trtfb",
+        "remote_bundle": f"{settings.remote_root}/models/cosmos3-nano-cp2-1280x720.trtfb",
+        "preparation": settings.work_root / "preparation.json",
+        "run_root": run_root,
+        "remote_run_root": f"{settings.remote_root}/runs/{settings.run_id}",
+        "run_json": run_root / "run.json",
+    }
+
+
+def _scene_layout(settings: Settings, scene: Scene) -> dict[str, Any]:
+    layout = _layout(settings)
+    scene_root = Path(layout["run_root"]) / scene.slug
+    remote_scene_root = f"{layout['remote_run_root']}/{scene.slug}"
+    rendezvous_name = f"{scene.slug}-seed{scene.seed}.nccl"
+    return {
+        "scene_root": scene_root,
+        "rank0": scene_root / "rank0",
+        "rank1_capture": scene_root / "rank1",
+        "remote_rank1": f"{remote_scene_root}/rank1",
+        "rendezvous": scene_root / "rendezvous" / rendezvous_name,
+        "remote_rendezvous": f"{remote_scene_root}/rendezvous/{rendezvous_name}",
+        "mp4": Path(layout["run_root"]) / f"{scene.slug}-720p.mp4",
+        "rank0_container": f"cosmos3-{settings.run_id}-{scene.slug}-rank0",
+        "rank1_container": f"cosmos3-{settings.run_id}-{scene.slug}-rank1",
+    }
+
+
+def _compact_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _prompt_text(scene: Scene) -> str:
+    return _compact_json(scene.prompt)
+
+
+def _negative_prompt_text(scene: Scene) -> str:
+    if isinstance(scene.negative_prompt, str):
+        return scene.negative_prompt
+    return _compact_json(scene.negative_prompt)
+
+
+def _prompt_record(scene: Scene) -> dict[str, Any]:
+    return {
+        "positive": dict(scene.prompt),
+        "negative": (
+            scene.negative_prompt
+            if isinstance(scene.negative_prompt, str)
+            else dict(scene.negative_prompt)
+        ),
+    }
+
+
+def _generation_argv(scene: Scene) -> list[str]:
+    return [
+        "/opt/trtmc/bin/trtmc",
+        "generate-video",
+        "/models/cosmos3.trtfb",
+        "--prompt",
+        _prompt_text(scene),
+        "--negative-prompt",
+        _negative_prompt_text(scene),
+        "--output",
+        "/outputs/frames",
+        "--seed",
+        str(scene.seed),
+        "--num-steps",
+        str(STEPS),
+        "--guidance-scale",
+        str(GUIDANCE_SCALE),
+        "--height",
+        str(HEIGHT),
+        "--width",
+        str(WIDTH),
+    ]
+
+
+def _rank_environment(settings: Settings, scene: Scene, rank: int) -> dict[str, str]:
+    return {
+        "CUDA_VISIBLE_DEVICES": "0",
+        "WORLD_SIZE": str(CP_SIZE),
+        "RANK": str(rank),
+        "LOCAL_RANK": "0",
+        "TRTMC_NCCL_RENDEZVOUS": f"/rendezvous/{scene.slug}-seed{scene.seed}.nccl",
+        "NCCL_NET": "IB",
+        "NCCL_IB_DISABLE": "0",
+        "NCCL_IB_HCA": f"={settings.ib_hca}",
+        "NCCL_IB_GID_INDEX": str(settings.gid_index),
+        "NCCL_IB_ADDR_FAMILY": "AF_INET",
+        "NCCL_SOCKET_IFNAME": f"={settings.net_iface}",
+        "NCCL_SOCKET_FAMILY": "AF_INET",
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "INIT,NET",
+        "HF_HUB_OFFLINE": "1",
+        "TRANSFORMERS_OFFLINE": "1",
+    }
+
+
+def _rank_docker_argv(
+    settings: Settings,
+    scene: Scene,
+    rank: int,
+    *,
+    uverbs_device: str,
+) -> list[str]:
+    layout = _layout(settings)
+    scene_paths = _scene_layout(settings, scene)
+    if rank == 0:
+        bundle = str(layout["bundle"])
+        output_dir = str(scene_paths["rank0"])
+        rendezvous_dir = str(Path(scene_paths["rendezvous"]).parent)
+        container = str(scene_paths["rank0_container"])
+    elif rank == 1:
+        bundle = str(layout["remote_bundle"])
+        output_dir = str(scene_paths["remote_rank1"])
+        rendezvous_dir = str(Path(scene_paths["remote_rendezvous"]).parent)
+        container = str(scene_paths["rank1_container"])
+    else:
+        raise ValueError("rank must be 0 or 1")
+
+    argv = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        container,
+        "--no-healthcheck",
+        "--label",
+        "trtmc.example=cosmos3-physics-dual-spark",
+        "--label",
+        f"trtmc.run_id={settings.run_id}",
+        "--label",
+        f"trtmc.scene={scene.slug}",
+        "--label",
+        f"trtmc.rank={rank}",
+        "--network",
+        "host",
+        "--ipc",
+        "host",
+        "--gpus",
+        "all",
+        "--ulimit",
+        "memlock=-1:-1",
+        "--ulimit",
+        "stack=67108864",
+        "--cap-add",
+        "IPC_LOCK",
+        "--device",
+        "/dev/infiniband/rdma_cm",
+        "--device",
+        uverbs_device,
+    ]
+    for name, value in _rank_environment(settings, scene, rank).items():
+        argv.extend(["-e", f"{name}={value}"])
+    argv.extend(
+        [
+            "--mount",
+            f"type=bind,src={bundle},dst=/models/cosmos3.trtfb,readonly",
+            "--mount",
+            f"type=bind,src={output_dir},dst=/outputs",
+            "--mount",
+            f"type=bind,src={rendezvous_dir},dst=/rendezvous",
+            "--entrypoint",
+            "/opt/trtmc/bin/trtmc",
+            settings.image,
+            *_generation_argv(scene)[1:],
+        ]
+    )
+    return argv
+
+
+def _bundle_build_argv(settings: Settings) -> list[str]:
+    layout = _layout(settings)
+    pending_name = f"{Path(layout['bundle']).name}.pending"
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "--gpus",
+        "all",
+        "--ipc",
+        "host",
+        "--ulimit",
+        "memlock=-1:-1",
+        "--ulimit",
+        "stack=67108864",
+        "--cap-add",
+        "IPC_LOCK",
+        "--mount",
+        f"type=bind,src={layout['hf_cache']},dst=/root/.cache/huggingface",
+        "--mount",
+        f"type=bind,src={layout['models']},dst=/models",
+        "--entrypoint",
+        "/opt/trtmc/bin/trtmc",
+        settings.image,
+        "build",
+        MODEL_ID,
+        "--model-revision",
+        MODEL_REVISION,
+        "--precision",
+        PRECISION,
+        "--context-parallel-size",
+        str(CP_SIZE),
+        "--video-height",
+        str(HEIGHT),
+        "--video-width",
+        str(WIDTH),
+        "--video-num-frames",
+        str(FRAME_COUNT),
+        "--num-inference-steps",
+        str(STEPS),
+        "-o",
+        f"/models/{pending_name}",
+    ]
+
+
+def execution_plan(settings: Settings) -> dict[str, Any]:
+    layout = _layout(settings)
+    hca_name = settings.ib_hca.rsplit(":", 1)[0]
+    planned_uverbs = {
+        "primary": "/dev/infiniband/<resolved-on-primary>",
+        "peer": "/dev/infiniband/<resolved-on-peer>",
+    }
+    scene_plans = []
+    for scene in _selected_scenes(settings):
+        paths = _scene_layout(settings, scene)
+        scene_plans.append(
+            {
+                "slug": scene.slug,
+                "seed": scene.seed,
+                "prompt": _prompt_record(scene),
+                "rendezvous": {
+                    "bytes": NCCL_ID_BYTES,
+                    "primary": str(paths["rendezvous"]),
+                    "peer": str(paths["remote_rendezvous"]),
+                },
+                "ranks": [
+                    {
+                        "host": "primary",
+                        "rank": 0,
+                        "docker_argv": _rank_docker_argv(
+                            settings, scene, 0, uverbs_device=planned_uverbs["primary"]
+                        ),
+                    },
+                    {
+                        "host": settings.peer_target,
+                        "rank": 1,
+                        "docker_argv": _rank_docker_argv(
+                            settings, scene, 1, uverbs_device=planned_uverbs["peer"]
+                        ),
+                    },
+                ],
+                "mp4": str(paths["mp4"]),
+                "encoding": {
+                    "codec": "libx264",
+                    "crf": 18,
+                    "preset": "slow",
+                    "pixel_format": "yuv420p",
+                    "faststart": True,
+                },
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "action": settings.action,
+        "scene_selection": settings.scene,
+        "selected_scene_slugs": [scene.slug for scene in _selected_scenes(settings)],
+        "dry_run": settings.dry_run,
+        "run_id": settings.run_id,
+        "peer": settings.peer_target,
+        "host_validation": {
+            "authoritative_identity": "NVIDIA GPU UUID",
+            "require_distinct_gpu_uuids": True,
+            "require_matching_gpu_name_compute_capability_driver": True,
+            "machine_id_sources": ["/etc/machine-id", "/var/lib/dbus/machine-id"],
+            "machine_ids_are_advisory_only": True,
+        },
+        "ssh": {
+            "argv": _ssh_argv(settings),
+            "scp_argv": _scp_argv(settings),
+            "batch_mode": True,
+            "strict_host_key_checking": True,
+        },
+        "model": {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION},
+        "profile": _profile(),
+        "roce": {
+            "hca": settings.ib_hca,
+            "gid_index": settings.gid_index,
+            "network_interface": settings.net_iface,
+            "address_family": "AF_INET",
+            "uverbs_resolution": {
+                "sysfs_directory": (
+                    f"/sys/class/infiniband/{hca_name}/device/infiniband_verbs"
+                ),
+                "primary_device": planned_uverbs["primary"],
+                "peer_device": planned_uverbs["peer"],
+                "resolved_at_runtime": True,
+            },
+        },
+        "prepare": {
+            "image": settings.image,
+            "image_source": "prebuilt locally from this example's Dockerfile",
+            "image_sync": "docker image save on primary -> strict SSH -> docker image load",
+            "bundle_build_argv": _bundle_build_argv(settings),
+            "bundle": str(layout["bundle"]),
+            "peer_bundle": str(layout["remote_bundle"]),
+            "require_matching_image_id": True,
+            "require_matching_bundle_sha256": True,
+        },
+        "run": {
+            "order": [scene.slug for scene in _selected_scenes(settings)],
+            "scenes": scene_plans,
+            "run_json": str(layout["run_json"]),
+            "telemetry": {
+                "performance": "parsed from the rank-0 [cosmos3.perf] record",
+                "memory": "sampled from each rank's cgroup-v2 byte counters",
+            },
+        },
+    }
+
+
+def _log(message: str) -> None:
+    print(f"[cosmos3-dual-spark] {message}", file=sys.stderr, flush=True)
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    check: bool = True,
+    timeout: int | float | None = None,
+    input_text: str | None = None,
+    capture: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    _log(f"$ {shlex.join(str(value) for value in argv)}")
+    try:
+        completed = subprocess.run(
+            [str(value) for value in argv],
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.PIPE if capture else None,
+            stdin=None if input_text is not None else subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DualSparkError(f"command timed out after {timeout} seconds") from exc
+    except OSError as exc:
+        raise DualSparkError(f"cannot start required command: {argv[0]}") from exc
+    if check and completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        if len(detail) > 2000:
+            detail = detail[-2000:]
+        suffix = f": {detail}" if detail else ""
+        raise DualSparkError(
+            f"command failed with exit code {completed.returncode}{suffix}"
+        )
+    return completed
+
+
+def _remote_run(
+    settings: Settings,
+    argv: Sequence[str],
+    *,
+    check: bool = True,
+    timeout: int | float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    payload = base64.urlsafe_b64encode(
+        json.dumps([str(value) for value in argv]).encode("utf-8")
+    ).decode("ascii")
+    remote_command = f"python3 - {shlex.quote(payload)}"
+    return _run(
+        [*_ssh_argv(settings), remote_command],
+        check=check,
+        timeout=timeout,
+        input_text=REMOTE_EXEC_HELPER,
+    )
+
+
+def _ensure_private_remote_root(settings: Settings) -> None:
+    _remote_run(
+        settings,
+        ["python3", "-c", REMOTE_ROOT_HELPER, settings.remote_root],
+    )
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _remote_sha256(settings: Settings, path: str) -> str:
+    output = _remote_run(settings, ["sha256sum", "--", path]).stdout.strip()
+    digest = output.split(maxsplit=1)[0] if output else ""
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise DualSparkError(f"peer returned an invalid SHA-256 for {path}")
+    return digest
+
+
+def _image_id(settings: Settings, *, remote: bool) -> str:
+    argv = ["docker", "image", "inspect", "--format", "{{.Id}}", settings.image]
+    completed = (
+        _remote_run(settings, argv, check=False)
+        if remote
+        else _run(argv, check=False)
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _gpu_facts(settings: Settings, *, remote: bool) -> dict[str, str]:
+    argv = [
+        "nvidia-smi",
+        "--query-gpu=uuid,name,compute_cap,driver_version",
+        "--format=csv,noheader,nounits",
+    ]
+    completed = _remote_run(settings, argv) if remote else _run(argv)
+    rows = [row.strip() for row in completed.stdout.splitlines() if row.strip()]
+    location = "peer" if remote else "primary"
+    if len(rows) != 1:
+        raise DualSparkError(
+            f"{location} DGX Spark must expose exactly one GPU; found {len(rows)}"
+        )
+    parts = [part.strip() for part in rows[0].split(",")]
+    if len(parts) != 4:
+        raise DualSparkError(f"could not parse {location} nvidia-smi GPU identity")
+    facts = {
+        "uuid": parts[0],
+        "name": parts[1],
+        "compute_capability": parts[2],
+        "driver": parts[3],
+    }
+    if not re.fullmatch(r"GPU-[0-9A-Fa-f-]+", facts["uuid"]):
+        raise DualSparkError(f"could not parse {location} nvidia-smi GPU UUID")
+    if "GB10" not in facts["name"].upper() or facts["compute_capability"] != "12.1":
+        raise DualSparkError(
+            f"{location} is not the required one-GPU GB10 DGX Spark (reported "
+            f"{facts['name']!r}, compute capability {facts['compute_capability']!r})"
+        )
+    return facts
+
+
+def _read_host_file(settings: Settings, path: str, *, remote: bool) -> str:
+    argv = ["cat", "--", path]
+    completed = _remote_run(settings, argv) if remote else _run(argv)
+    return completed.stdout.strip()
+
+
+def _machine_id(settings: Settings, *, remote: bool) -> str | None:
+    """Return an advisory OS image identifier when one is available.
+
+    DGX Sparks may legitimately share a machine ID after an OS image is cloned,
+    so this value must never be used to decide whether the hosts are distinct.
+    """
+
+    for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+        argv = ["cat", "--", path]
+        completed = (
+            _remote_run(settings, argv, check=False)
+            if remote
+            else _run(argv, check=False)
+        )
+        candidate = completed.stdout.strip().lower()
+        if completed.returncode == 0 and re.fullmatch(r"[0-9a-f]{32}", candidate):
+            return candidate
+    return None
+
+
+def _recorded_gpu_facts(facts: Mapping[str, str]) -> dict[str, str]:
+    """Return provenance-safe GPU facts without publishing the raw UUID."""
+
+    return {
+        "name": facts["name"],
+        "compute_capability": facts["compute_capability"],
+        "driver": facts["driver"],
+        "uuid_sha256": hashlib.sha256(facts["uuid"].encode("ascii")).hexdigest(),
+    }
+
+
+def _validate_host_identity(
+    local_gpu: Mapping[str, str],
+    peer_gpu: Mapping[str, str],
+    local_machine_id: str | None,
+    peer_machine_id: str | None,
+) -> dict[str, Any]:
+    """Validate two matching Spark stacks using GPU UUIDs as host identity."""
+
+    for fact_name in ("name", "compute_capability", "driver"):
+        if local_gpu[fact_name] != peer_gpu[fact_name]:
+            raise DualSparkError(
+                "the two Sparks must use matching GPU/driver stacks "
+                f"({fact_name} differs)"
+            )
+    if local_gpu["uuid"] == peer_gpu["uuid"]:
+        raise DualSparkError(
+            "--peer-host resolves to the primary Spark; two distinct NVIDIA GPU UUIDs "
+            "are required"
+        )
+
+    def optional_hash(value: str | None) -> str | None:
+        return hashlib.sha256(value.encode("ascii")).hexdigest() if value else None
+
+    return {
+        "authoritative_source": "nvidia_gpu_uuid",
+        "primary_gpu_uuid_sha256": hashlib.sha256(
+            local_gpu["uuid"].encode("ascii")
+        ).hexdigest(),
+        "peer_gpu_uuid_sha256": hashlib.sha256(
+            peer_gpu["uuid"].encode("ascii")
+        ).hexdigest(),
+        "machine_ids_authoritative": False,
+        "primary_machine_id_sha256": optional_hash(local_machine_id),
+        "peer_machine_id_sha256": optional_hash(peer_machine_id),
+        "machine_ids_match": (
+            local_machine_id == peer_machine_id
+            if local_machine_id is not None and peer_machine_id is not None
+            else None
+        ),
+    }
+
+
+def _resolve_uverbs_device(
+    settings: Settings,
+    hca_name: str,
+    *,
+    remote: bool,
+) -> str:
+    location = "peer" if remote else "primary"
+    verbs_directory = f"/sys/class/infiniband/{hca_name}/device/infiniband_verbs"
+    argv = ["ls", "-1", "--", verbs_directory]
+    completed = _remote_run(settings, argv) if remote else _run(argv)
+    names = sorted(
+        line.strip()
+        for line in completed.stdout.splitlines()
+        if re.fullmatch(r"uverbs[0-9]+", line.strip())
+    )
+    if len(names) != 1:
+        raise DualSparkError(
+            f"{location} HCA {hca_name!r} must resolve to exactly one uverbs device; "
+            f"found {names}"
+        )
+    device = f"/dev/infiniband/{names[0]}"
+    check_argv = ["test", "-c", device]
+    checked = (
+        _remote_run(settings, check_argv, check=False)
+        if remote
+        else _run(check_argv, check=False)
+    )
+    if checked.returncode != 0:
+        raise DualSparkError(f"{location} resolved uverbs device is unavailable: {device}")
+    return device
+
+
+def _preflight(settings: Settings) -> dict[str, Any]:
+    for executable in ("docker", "ssh", "scp", "nvidia-smi"):
+        if shutil.which(executable) is None:
+            raise DualSparkError(f"required executable is unavailable: {executable}")
+    for label, path in (
+        ("SSH identity", settings.ssh_key),
+        ("known-hosts", settings.known_hosts),
+    ):
+        if path is not None and (not path.is_file() or not os.access(path, os.R_OK)):
+            raise DualSparkError(f"{label} file is not readable: {path}")
+
+    _run(["docker", "info"], timeout=60)
+    _remote_run(settings, ["docker", "info"], timeout=60)
+    _remote_run(settings, ["python3", "--version"], timeout=30)
+
+    local_gpu = _gpu_facts(settings, remote=False)
+    peer_gpu = _gpu_facts(settings, remote=True)
+    local_machine_id = _machine_id(settings, remote=False)
+    peer_machine_id = _machine_id(settings, remote=True)
+    host_identity = _validate_host_identity(
+        local_gpu, peer_gpu, local_machine_id, peer_machine_id
+    )
+
+    hca_name, port_text = settings.ib_hca.rsplit(":", 1)
+    port = int(port_text)
+    resource_checks = (
+        ("-d", f"/sys/class/net/{settings.net_iface}"),
+        ("-d", f"/sys/class/infiniband/{hca_name}"),
+        ("-c", "/dev/infiniband/rdma_cm"),
+        (
+            "-f",
+            f"/sys/class/infiniband/{hca_name}/ports/{port}/gids/{settings.gid_index}",
+        ),
+    )
+    for predicate, path in resource_checks:
+        local = _run(["test", predicate, path], check=False)
+        peer = _remote_run(settings, ["test", predicate, path], check=False)
+        if local.returncode != 0 or peer.returncode != 0:
+            raise DualSparkError(f"required RoCE resource is missing on one or both Sparks: {path}")
+
+    interface_state_path = f"/sys/class/net/{settings.net_iface}/operstate"
+    hca_state_path = f"/sys/class/infiniband/{hca_name}/ports/{port}/state"
+    gid_path = f"/sys/class/infiniband/{hca_name}/ports/{port}/gids/{settings.gid_index}"
+    roce: dict[str, dict[str, str]] = {}
+    for label, remote in (("primary", False), ("peer", True)):
+        uverbs_device = _resolve_uverbs_device(settings, hca_name, remote=remote)
+        interface_state = _read_host_file(
+            settings, interface_state_path, remote=remote
+        ).lower()
+        hca_state = _read_host_file(settings, hca_state_path, remote=remote).upper()
+        gid = _read_host_file(settings, gid_path, remote=remote)
+        if interface_state != "up":
+            raise DualSparkError(f"{label} RoCE network interface is not up")
+        if "ACTIVE" not in hca_state:
+            raise DualSparkError(f"{label} RoCE HCA port is not active")
+        if not gid or gid in {"::", "0:0:0:0:0:0:0:0"}:
+            raise DualSparkError(f"{label} RoCE GID index does not contain a usable address")
+        roce[label] = {
+            "interface_state": interface_state,
+            "hca_state": hca_state,
+            "gid": gid,
+            "uverbs_device": uverbs_device,
+        }
+
+    return {
+        "primary_gpu": _recorded_gpu_facts(local_gpu),
+        "peer_gpu": _recorded_gpu_facts(peer_gpu),
+        "host_identity": host_identity,
+        "roce_hosts": roce,
+    }
+
+
+def _sync_image(settings: Settings, expected_id: str) -> None:
+    if _image_id(settings, remote=True) == expected_id:
+        _log("peer already has the exact image ID")
+        return
+    _log("copying the exact image to the peer Spark")
+    with tempfile.TemporaryFile() as save_stderr_file:
+        try:
+            save = subprocess.Popen(
+                ["docker", "image", "save", settings.image],
+                stdout=subprocess.PIPE,
+                stderr=save_stderr_file,
+                shell=False,
+            )
+        except OSError as exc:
+            raise DualSparkError("cannot start docker image save") from exc
+        assert save.stdout is not None
+        try:
+            load = subprocess.Popen(
+                [*_ssh_argv(settings), "docker image load"],
+                stdin=save.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+            )
+        except OSError as exc:
+            save.kill()
+            save.wait()
+            raise DualSparkError("cannot start peer docker image load") from exc
+        save.stdout.close()
+        try:
+            load_stdout, load_stderr = load.communicate(timeout=settings.build_timeout)
+            save_returncode = save.wait(timeout=30)
+            save_stderr_file.seek(0)
+            save_stderr = save_stderr_file.read()
+        except subprocess.TimeoutExpired as exc:
+            load.kill()
+            save.kill()
+            load.wait()
+            save.wait()
+            raise DualSparkError("timed out while copying the image to the peer") from exc
+    if save_returncode != 0 or load.returncode != 0:
+        detail = (save_stderr + load_stdout + load_stderr).decode("utf-8", "replace")
+        raise DualSparkError(f"image transfer failed: {detail[-2000:]}")
+    if _image_id(settings, remote=True) != expected_id:
+        raise DualSparkError("peer image ID does not match the primary after transfer")
+
+
+def _bundle_spec(image_id: str) -> dict[str, Any]:
+    return {
+        "image_id": image_id,
+        "model": MODEL_ID,
+        "revision": MODEL_REVISION,
+        "precision": PRECISION,
+        **_profile(),
+    }
+
+
+def _prepare_bundle(settings: Settings, image_id: str) -> Path:
+    layout = _layout(settings)
+    bundle = Path(layout["bundle"])
+    marker = bundle.with_suffix(f"{bundle.suffix}.build-spec.json")
+    expected = _bundle_spec(image_id)
+    if bundle.is_file() and bundle.stat().st_size > 0 and marker.is_file():
+        try:
+            if json.loads(marker.read_text(encoding="utf-8")) == expected:
+                _log("reusing the exact native 720p CP=2 TensorRT bundle")
+                return bundle
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    pending = bundle.with_name(f"{bundle.name}.pending")
+    if pending.exists():
+        pending.unlink()
+    _log("building the native 720p CP=2 TensorRT bundle; this can take hours")
+    _run(_bundle_build_argv(settings), timeout=settings.build_timeout, capture=False)
+    if not pending.is_file() or pending.stat().st_size == 0:
+        raise DualSparkError("bundle build completed without a nonempty CP=2 bundle")
+    os.replace(pending, bundle)
+    _write_json(marker, expected)
+    return bundle
+
+
+def _sync_bundle(settings: Settings, bundle: Path) -> str:
+    _ensure_private_remote_root(settings)
+    layout = _layout(settings)
+    remote_bundle = str(layout["remote_bundle"])
+    remote_parent = str(Path(remote_bundle).parent)
+    _remote_run(settings, ["install", "-d", "-m", "0700", remote_parent])
+    digest = _sha256(bundle)
+    existing = _remote_run(settings, ["test", "-f", remote_bundle], check=False)
+    if existing.returncode == 0 and _remote_sha256(settings, remote_bundle) == digest:
+        _log("peer already has the exact CP=2 bundle SHA-256")
+        return digest
+
+    incoming = f"{remote_bundle}.incoming.{settings.run_id}"
+    _remote_run(settings, ["rm", "-f", "--", incoming], check=False)
+    transferred = False
+    try:
+        _run(
+            [*_scp_argv(settings), str(bundle), f"{settings.peer_target}:{incoming}"],
+            timeout=settings.build_timeout,
+            capture=False,
+        )
+        if _remote_sha256(settings, incoming) != digest:
+            raise DualSparkError("peer bundle checksum does not match the primary")
+        _remote_run(settings, ["mv", "-T", "--", incoming, remote_bundle])
+        transferred = True
+    finally:
+        if not transferred:
+            _remote_run(settings, ["rm", "-f", "--", incoming], check=False)
+    return digest
+
+
+def prepare(settings: Settings) -> dict[str, Any]:
+    layout = _layout(settings)
+    Path(layout["hf_cache"]).mkdir(parents=True, exist_ok=True)
+    Path(layout["models"]).mkdir(parents=True, exist_ok=True)
+    facts = _preflight(settings)
+
+    image_id = _image_id(settings, remote=False)
+    if not image_id:
+        raise DualSparkError(
+            f"required image {settings.image!r} is not present locally; "
+            "build it from this example's Dockerfile first"
+        )
+    _log(f"using prebuilt image {settings.image} ({image_id})")
+    _sync_image(settings, image_id)
+
+    bundle = _prepare_bundle(settings, image_id)
+    bundle_digest = _sync_bundle(settings, bundle)
+    preparation = {
+        "schema_version": 1,
+        "prepared_at_utc": datetime.now(timezone.utc).isoformat(),
+        "peer": settings.peer_target,
+        "model": {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION},
+        "profile": _profile(),
+        "image": {"name": settings.image, "id": image_id},
+        "bundle": {
+            "primary_path": str(bundle),
+            "peer_path": str(layout["remote_bundle"]),
+            "sha256": bundle_digest,
+            "bytes": bundle.stat().st_size,
+        },
+        **facts,
+    }
+    _write_json(Path(layout["preparation"]), preparation)
+    _log("preparation complete")
+    return preparation
+
+
+def _require_prepared(settings: Settings) -> dict[str, Any]:
+    layout = _layout(settings)
+    preparation_path = Path(layout["preparation"])
+    if not preparation_path.is_file():
+        raise DualSparkError("prepared assets are missing; run the prepare action first")
+    try:
+        preparation = json.loads(preparation_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DualSparkError("preparation.json is invalid; run prepare again") from exc
+    if (
+        preparation.get("schema_version") != 1
+        or preparation.get("peer") != settings.peer_target
+        or preparation.get("model")
+        != {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION}
+        or preparation.get("profile") != _profile()
+        or preparation.get("image", {}).get("name") != settings.image
+    ):
+        raise DualSparkError("prepared asset provenance does not match this invocation")
+
+    expected_image_id = str(preparation.get("image", {}).get("id", ""))
+    if not expected_image_id or _image_id(settings, remote=False) != expected_image_id:
+        raise DualSparkError("the primary image changed; run prepare again")
+    if _image_id(settings, remote=True) != expected_image_id:
+        raise DualSparkError("the peer image changed; run prepare again")
+
+    bundle = Path(layout["bundle"])
+    if not bundle.is_file() or bundle.stat().st_size == 0:
+        raise DualSparkError(f"required bundle is missing: {bundle}")
+    expected_digest = str(preparation.get("bundle", {}).get("sha256", ""))
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+        raise DualSparkError("preparation.json contains an invalid bundle digest")
+    if _sha256(bundle) != expected_digest:
+        raise DualSparkError("the primary bundle changed; run prepare again")
+    if _remote_sha256(settings, str(layout["remote_bundle"])) != expected_digest:
+        raise DualSparkError("the peer bundle changed; run prepare again")
+    return preparation
+
+
+def _container_exists(settings: Settings, name: str, *, remote: bool) -> bool:
+    argv = ["docker", "inspect", name]
+    completed = (
+        _remote_run(settings, argv, check=False)
+        if remote
+        else _run(argv, check=False)
+    )
+    if completed.returncode == 0:
+        return True
+    if completed.returncode == 1:
+        return False
+    detail = (completed.stderr or completed.stdout or "").strip()
+    suffix = f": {detail[-500:]}" if detail else ""
+    raise DualSparkError(
+        f"could not determine whether container {name!r} exists{suffix}"
+    )
+
+
+def _container_state(settings: Settings, name: str, *, remote: bool) -> dict[str, Any]:
+    argv = ["docker", "inspect", "--format", "{{json .State}}", name]
+    completed = _remote_run(settings, argv) if remote else _run(argv)
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise DualSparkError(f"cannot parse container state for {name}") from exc
+
+
+def _sample_memory_tracker(settings: Settings, tracker: MemoryTracker) -> None:
+    paths = [
+        f"{tracker.cgroup_path}/memory.current",
+        f"{tracker.cgroup_path}/memory.peak",
+        f"{tracker.cgroup_path}/memory.swap.current",
+        f"{tracker.cgroup_path}/memory.swap.peak",
+        f"{tracker.cgroup_path}/memory.events",
+    ]
+    argv = ["cat", "--", *paths]
+    completed = (
+        _remote_run(settings, argv) if tracker.remote else _run(argv)
+    )
+    lines = [line.strip() for line in completed.stdout.splitlines()]
+    values = lines[:4]
+    event_lines = lines[4:]
+    if len(values) != 4 or any(
+        not re.fullmatch(r"[0-9]+", value) for value in values
+    ):
+        raise DualSparkError(
+            f"invalid cgroup-v2 memory counters for {tracker.container}"
+        )
+    if not event_lines or any(
+        not re.fullmatch(r"[a-z_]+ [0-9]+", line) for line in event_lines
+    ):
+        raise DualSparkError(
+            f"invalid cgroup-v2 memory events for {tracker.container}"
+        )
+    current_bytes, peak_bytes, swap_current_bytes, swap_peak_bytes = map(int, values)
+    if peak_bytes < current_bytes or swap_peak_bytes < swap_current_bytes:
+        raise DualSparkError(
+            f"inconsistent cgroup-v2 memory counters for {tracker.container}"
+        )
+    events = "\n".join(event_lines) + "\n"
+    if tracker.samples == 0:
+        tracker.initial_events = events
+    tracker.latest_events = events
+    tracker.peak_bytes = max(tracker.peak_bytes, peak_bytes)
+    tracker.swap_peak_bytes = max(tracker.swap_peak_bytes, swap_peak_bytes)
+    tracker.records.append(
+        (
+            time.time_ns() // 1_000_000,
+            current_bytes,
+            peak_bytes,
+            swap_current_bytes,
+            swap_peak_bytes,
+        )
+    )
+    tracker.samples += 1
+
+
+def _memory_tracker(
+    settings: Settings,
+    container: str,
+    *,
+    remote: bool,
+) -> MemoryTracker:
+    pid_argv = ["docker", "inspect", "--format", "{{.State.Pid}}", container]
+    completed = (
+        _remote_run(settings, pid_argv) if remote else _run(pid_argv)
+    )
+    pid_text = completed.stdout.strip()
+    if not re.fullmatch(r"[1-9][0-9]*", pid_text):
+        raise DualSparkError(f"container is not running for memory monitoring: {container}")
+
+    cgroup_argv = ["cat", "--", f"/proc/{pid_text}/cgroup"]
+    completed = (
+        _remote_run(settings, cgroup_argv) if remote else _run(cgroup_argv)
+    )
+    relative_paths = [
+        line[3:]
+        for line in completed.stdout.splitlines()
+        if line.startswith("0::")
+    ]
+    if len(relative_paths) != 1:
+        raise DualSparkError(f"cannot resolve cgroup-v2 path for {container}")
+    relative = relative_paths[0]
+    if (
+        not relative.startswith("/")
+        or relative == "/"
+        or ".." in Path(relative).parts
+        or "\x00" in relative
+    ):
+        raise DualSparkError(f"unsafe cgroup-v2 path for {container}")
+    cgroup_path = f"/sys/fs/cgroup{relative.rstrip('/')}"
+    counter_paths = (
+        f"{cgroup_path}/memory.current",
+        f"{cgroup_path}/memory.peak",
+        f"{cgroup_path}/memory.swap.current",
+        f"{cgroup_path}/memory.swap.peak",
+        f"{cgroup_path}/memory.events",
+    )
+    for path in counter_paths:
+        check_argv = ["test", "-r", path]
+        checked = (
+            _remote_run(settings, check_argv, check=False)
+            if remote
+            else _run(check_argv, check=False)
+        )
+        if checked.returncode != 0:
+            raise DualSparkError(
+                f"required cgroup-v2 memory counter is unavailable for {container}: {path}"
+            )
+    tracker = MemoryTracker(container=container, remote=remote, cgroup_path=cgroup_path)
+    _sample_memory_tracker(settings, tracker)
+    return tracker
+
+
+def _write_memory_evidence(tracker: MemoryTracker, destination: Path) -> None:
+    if tracker.samples == 0 or not tracker.records:
+        raise DualSparkError(f"no cgroup memory samples for {tracker.container}")
+    destination.mkdir(parents=True, exist_ok=True)
+    rows = [
+        "epoch_ms,container_current_bytes,container_peak_bytes,"
+        "container_swap_current_bytes,container_swap_peak_bytes"
+    ]
+    rows.extend(",".join(str(value) for value in record) for record in tracker.records)
+    evidence = {
+        destination / "memory.csv": "\n".join(rows) + "\n",
+        destination / "memory-events.initial.txt": tracker.initial_events,
+        destination / "memory-events.txt": tracker.latest_events,
+    }
+    for path, text in evidence.items():
+        temporary = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+        temporary.write_text(text, encoding="utf-8")
+        os.replace(temporary, path)
+
+
+def _write_memory_evidence_noexcept(
+    tracker: MemoryTracker,
+    destination: Path,
+) -> None:
+    try:
+        _write_memory_evidence(tracker, destination)
+    except Exception as exc:
+        _log(
+            f"WARNING: could not preserve cgroup memory evidence "
+            f"for {tracker.container}: {exc}"
+        )
+
+
+def _capture_container(
+    settings: Settings,
+    name: str,
+    destination: Path,
+    *,
+    remote: bool,
+) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    logs_argv = ["docker", "logs", name]
+    inspect_argv = ["docker", "inspect", name]
+    logs = (
+        _remote_run(settings, logs_argv, check=False)
+        if remote
+        else _run(logs_argv, check=False)
+    )
+    inspect = (
+        _remote_run(settings, inspect_argv, check=False)
+        if remote
+        else _run(inspect_argv, check=False)
+    )
+    combined = (logs.stdout or "") + (logs.stderr or "")
+    (destination / "container.log").write_text(combined, encoding="utf-8")
+    (destination / "inspect.json").write_text(
+        inspect.stdout or "[]\n",
+        encoding="utf-8",
+    )
+
+
+def _capture_container_noexcept(
+    settings: Settings,
+    name: str,
+    destination: Path,
+    *,
+    remote: bool,
+) -> None:
+    try:
+        _capture_container(settings, name, destination, remote=remote)
+    except Exception as exc:  # Preserve the original run failure during cleanup.
+        _log(f"WARNING: could not capture container {name}: {exc}")
+
+
+def _remove_container_noexcept(settings: Settings, name: str, *, remote: bool) -> bool:
+    argv = ["docker", "rm", "-f", name]
+    try:
+        completed = (
+            _remote_run(settings, argv, check=False, timeout=30)
+            if remote
+            else _run(argv, check=False, timeout=30)
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "").strip()
+            suffix = f": {detail[-500:]}" if detail else ""
+            _log(
+                f"WARNING: docker rm -f returned {completed.returncode} "
+                f"for exact container {name}{suffix}"
+            )
+    except Exception as exc:
+        _log(f"WARNING: could not remove container {name}: {exc}")
+    try:
+        exists = _container_exists(settings, name, remote=remote)
+    except Exception as exc:
+        _log(f"WARNING: could not verify removal of exact container {name}: {exc}")
+        return False
+    if exists:
+        try:
+            state = _container_state(settings, name, remote=remote)
+            running = state.get("Running")
+        except Exception:
+            running = "unknown"
+        _log(
+            f"WARNING: exact container {name} still exists after cleanup "
+            f"(running={running})"
+        )
+        return False
+    return True
+
+
+def _wait_for_rendezvous(settings: Settings, path: Path, container: str) -> None:
+    deadline = time.monotonic() + min(180, settings.runtime_timeout)
+    while time.monotonic() < deadline:
+        if path.is_file() and path.stat().st_size == NCCL_ID_BYTES:
+            return
+        state = _container_state(settings, container, remote=False)
+        if not state.get("Running", False):
+            raise DualSparkError(
+                "rank 0 exited before publishing the NCCL rendezvous"
+            )
+        time.sleep(1)
+    raise DualSparkError("timed out waiting for the NCCL rendezvous")
+
+
+def _transfer_rendezvous(settings: Settings, local_path: Path, remote_path: str) -> None:
+    incoming = f"{remote_path}.incoming"
+    _remote_run(settings, ["rm", "-f", "--", incoming, remote_path], check=False)
+    copied = False
+    try:
+        _run(
+            [*_scp_argv(settings), str(local_path), f"{settings.peer_target}:{incoming}"],
+            timeout=120,
+            capture=False,
+        )
+        size = _remote_run(
+            settings,
+            ["stat", "-c", "%s", "--", incoming],
+        ).stdout.strip()
+        if size != str(NCCL_ID_BYTES):
+            raise DualSparkError("peer received an invalid NCCL rendezvous file")
+        if _remote_sha256(settings, incoming) != _sha256(local_path):
+            raise DualSparkError("peer NCCL rendezvous checksum does not match")
+        _remote_run(settings, ["mv", "-T", "--", incoming, remote_path])
+        copied = True
+    finally:
+        if not copied:
+            _remote_run(settings, ["rm", "-f", "--", incoming], check=False)
+
+
+def _wait_for_containers(
+    settings: Settings,
+    containers: Sequence[tuple[str, bool]],
+    trackers: Mapping[str, MemoryTracker],
+) -> dict[str, dict[str, Any]]:
+    deadline = time.monotonic() + settings.runtime_timeout
+    states: dict[str, dict[str, Any]] = {}
+    finished_trackers: set[str] = set()
+    while time.monotonic() < deadline:
+        states = {
+            name: _container_state(settings, name, remote=remote)
+            for name, remote in containers
+        }
+        for name, tracker in trackers.items():
+            if name in finished_trackers:
+                continue
+            try:
+                _sample_memory_tracker(settings, tracker)
+            except DualSparkError as exc:
+                if tracker.samples == 0:
+                    raise
+                if states[name].get("Running", False):
+                    states[name] = _container_state(
+                        settings,
+                        name,
+                        remote=tracker.remote,
+                    )
+                if states[name].get("Running", False):
+                    raise
+                _log(
+                    f"WARNING: final cgroup memory sample was unavailable "
+                    f"for {name}: {exc}"
+                )
+                finished_trackers.add(name)
+        if all(not state.get("Running", False) for state in states.values()):
+            return states
+        if any(
+            not state.get("Running", False) and int(state.get("ExitCode", 1)) != 0
+            for state in states.values()
+        ):
+            return states
+        time.sleep(1)
+    raise DualSparkError("timed out waiting for Cosmos3 inference")
+
+
+def _verify_frames(frames_dir: Path) -> None:
+    expected = {f"frame_{index:04d}.png" for index in range(FRAME_COUNT)}
+    frame_paths = tuple(frames_dir.glob("frame_*.png"))
+    actual = {path.name for path in frame_paths if path.is_file()}
+    if actual != expected or any(path.stat().st_size == 0 for path in frame_paths):
+        raise DualSparkError(
+            "rank 0 did not produce exactly 189 nonempty sequential frames"
+        )
+
+
+def _verify_rank1_has_no_frames(settings: Settings, remote_output: str) -> None:
+    result = _remote_run(
+        settings,
+        [
+            "find",
+            remote_output,
+            "-maxdepth",
+            "2",
+            "-type",
+            "f",
+            "-name",
+            "frame_*.png",
+            "-print",
+            "-quit",
+        ],
+    )
+    if result.stdout.strip():
+        raise DualSparkError("rank 1 unexpectedly wrote video frames")
+
+
+def _remove_rank1_empty_frames(settings: Settings, remote_output: str) -> None:
+    frames = f"{remote_output}/frames"
+    removed = _remote_run(settings, ["rmdir", "--", frames], check=False)
+    if removed.returncode != 0:
+        detail = (removed.stderr or removed.stdout or "").strip()
+        suffix = f": {detail[-500:]}" if detail else ""
+        raise DualSparkError(
+            "could not remove rank 1's verified-empty frames directory"
+            f"{suffix}"
+        )
+
+
+def _validate_rank_evidence(scene_paths: Mapping[str, Any]) -> None:
+    for rank, directory_key in ((0, "rank0"), (1, "rank1_capture")):
+        directory = Path(scene_paths[directory_key])
+        log_path = directory / "container.log"
+        inspect_path = directory / "inspect.json"
+        if not log_path.is_file() or not inspect_path.is_file():
+            raise DualSparkError(f"rank {rank} diagnostic evidence is incomplete")
+        log_text = log_path.read_text(encoding="utf-8")
+        has_ib_transport = any(
+            re.search(pattern, log_text)
+            for pattern in (
+                r"Using network IB",
+                r"via NET/IB",
+                r"NET/IB[^\n]*Using",
+            )
+        )
+        if not has_ib_transport:
+            raise DualSparkError(f"rank {rank} did not report positive NCCL NET/IB evidence")
+        if any(
+            marker in log_text
+            for marker in (
+                "NET/Socket",
+                "Using network Socket",
+                "Failed to initialize NET plugin IB",
+            )
+        ):
+            raise DualSparkError(f"rank {rank} fell back to NCCL socket transport")
+        try:
+            inspected = json.loads(inspect_path.read_text(encoding="utf-8"))
+            state = inspected[0]["State"]
+        except (IndexError, KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise DualSparkError(f"rank {rank} Docker state evidence is invalid") from exc
+        if state.get("OOMKilled") is not False:
+            raise DualSparkError(f"rank {rank} was OOM-killed or has unknown OOM state")
+        if int(state.get("ExitCode", 1)) != 0:
+            raise DualSparkError(f"rank {rank} did not exit successfully")
+
+
+_COSMOS3_PERF_MS_FIELDS = (
+    "prompt_conditioning_ms",
+    "denoise_prep_ms",
+    "denoiser_engine_load_ms",
+    "denoiser_ms",
+    "scheduler_cfg_ms",
+    "vae_decoder_ms",
+    "generation_excluding_denoiser_load_ms",
+    "total_ms",
+)
+
+
+def _parse_cosmos3_performance(
+    log_path: Path,
+    scene: Scene,
+    rank0_wall_seconds: float,
+) -> dict[str, int | float]:
+    marker = "[cosmos3.perf] "
+    records = [
+        line.split(marker, 1)[1].strip()
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if marker in line
+    ]
+    if len(records) != 1:
+        raise DualSparkError(
+            f"rank 0 must emit exactly one final [cosmos3.perf] record; found {len(records)}"
+        )
+    fields = dict(re.findall(r"([a-z0-9_]+)=([^\s]+)", records[0]))
+    required = {*_COSMOS3_PERF_MS_FIELDS, "cp_size", "seed"}
+    if not required.issubset(fields):
+        missing = sorted(required - fields.keys())
+        raise DualSparkError(f"rank-0 Cosmos3 performance record is missing {missing}")
+
+    performance: dict[str, int | float] = {}
+    for name in _COSMOS3_PERF_MS_FIELDS:
+        try:
+            value = float(fields[name])
+        except ValueError as exc:
+            raise DualSparkError(
+                f"rank-0 Cosmos3 performance field {name} is not numeric"
+            ) from exc
+        if not math.isfinite(value) or value < 0:
+            raise DualSparkError(
+                f"rank-0 Cosmos3 performance field {name} is invalid"
+            )
+        performance[name] = value
+    try:
+        cp_size = int(fields["cp_size"])
+        seed = int(fields["seed"])
+    except ValueError as exc:
+        raise DualSparkError("rank-0 Cosmos3 cp_size or seed is not an integer") from exc
+    if cp_size != CP_SIZE or seed != scene.seed:
+        raise DualSparkError(
+            "rank-0 Cosmos3 performance record does not match the requested CP size and seed"
+        )
+    if not math.isfinite(rank0_wall_seconds) or rank0_wall_seconds < 0:
+        raise DualSparkError("rank-0 wall-clock measurement is invalid")
+    performance.update(
+        {
+            "cp_size": cp_size,
+            "seed": seed,
+            "inference_seconds": performance["total_ms"] / 1000.0,
+            "total_seconds": performance["total_ms"] / 1000.0,
+            "rank0_wall_seconds": rank0_wall_seconds,
+        }
+    )
+    return performance
+
+
+def _package_video(
+    settings: Settings,
+    frames_dir: Path,
+    output: Path,
+) -> dict[str, Any]:
+    layout = _layout(settings)
+    run_root = Path(layout["run_root"])
+    _verify_frames(frames_dir)
+    frames_in_container = "/run/" + str(frames_dir.relative_to(run_root))
+    if output.exists():
+        raise DualSparkError(f"refusing to overwrite an existing MP4: {output}")
+    pending = output.with_name(f"{output.stem}.pending.mp4")
+    if pending.exists():
+        pending.unlink()
+    pending_in_container = "/run/" + str(pending.relative_to(run_root))
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "--mount",
+                f"type=bind,src={run_root},dst=/run",
+                "--entrypoint",
+                "ffmpeg",
+                settings.image,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-framerate",
+                str(FRAME_RATE),
+                "-start_number",
+                "0",
+                "-i",
+                f"{frames_in_container}/frame_%04d.png",
+                "-frames:v",
+                str(FRAME_COUNT),
+                "-r",
+                str(FRAME_RATE),
+                "-an",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "slow",
+                "-crf",
+                "18",
+                "-pix_fmt",
+                "yuv420p",
+                "-movflags",
+                "+faststart",
+                pending_in_container,
+            ],
+            timeout=20 * 60,
+            capture=False,
+        )
+        probe = _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "--mount",
+                f"type=bind,src={run_root},dst=/run,readonly",
+                "--entrypoint",
+                "ffprobe",
+                settings.image,
+                "-v",
+                "error",
+                "-count_frames",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=codec_name,width,height,r_frame_rate,nb_read_frames",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "json",
+                pending_in_container,
+            ],
+            timeout=120,
+        )
+        try:
+            metadata = json.loads(probe.stdout)
+            stream = metadata["streams"][0]
+            duration = float(metadata["format"]["duration"])
+            width = int(stream["width"])
+            height = int(stream["height"])
+            frames = int(stream["nb_read_frames"])
+        except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise DualSparkError("ffprobe returned an invalid video record") from exc
+        if (
+            stream.get("codec_name") != "h264"
+            or width != WIDTH
+            or height != HEIGHT
+            or stream.get("r_frame_rate") != f"{FRAME_RATE}/1"
+            or frames != FRAME_COUNT
+            or not math.isclose(duration, FRAME_COUNT / FRAME_RATE, abs_tol=0.05)
+        ):
+            raise DualSparkError("packaged MP4 does not match the native 720p contract")
+        os.replace(pending, output)
+    except BaseException:
+        if pending.exists():
+            pending.unlink()
+        raise
+    return {
+        "path": str(output),
+        "sha256": _sha256(output),
+        "bytes": output.stat().st_size,
+        "video": {
+            "codec": "h264",
+            "width": width,
+            "height": height,
+            "frames": frames,
+            "fps": FRAME_RATE,
+            "pixel_format": "yuv420p",
+            "encoder": {"crf": 18, "preset": "slow", "faststart": True},
+        },
+    }
+
+
+def _prepare_scene_directories(settings: Settings, scene: Scene) -> None:
+    paths = _scene_layout(settings, scene)
+    Path(paths["rank0"]).mkdir(parents=True, exist_ok=False)
+    Path(paths["rank1_capture"]).mkdir(parents=True, exist_ok=False)
+    Path(paths["rendezvous"]).parent.mkdir(parents=True, exist_ok=False)
+    remote_scene_root = str(Path(paths["remote_rank1"]).parent)
+    _remote_run(
+        settings,
+        [
+            "install",
+            "-d",
+            "-m",
+            "0700",
+            remote_scene_root,
+            str(paths["remote_rank1"]),
+            str(Path(paths["remote_rendezvous"]).parent),
+        ],
+    )
+
+
+def _run_scene(
+    settings: Settings,
+    scene: Scene,
+    roce_hosts: Mapping[str, Mapping[str, str]],
+) -> dict[str, Any]:
+    paths = _scene_layout(settings, scene)
+    rank0_name = str(paths["rank0_container"])
+    rank1_name = str(paths["rank1_container"])
+    try:
+        primary_uverbs = roce_hosts["primary"]["uverbs_device"]
+        peer_uverbs = roce_hosts["peer"]["uverbs_device"]
+    except KeyError as exc:
+        raise DualSparkError("preflight did not resolve both uverbs devices") from exc
+    for device in (primary_uverbs, peer_uverbs):
+        if not re.fullmatch(r"/dev/infiniband/uverbs[0-9]+", device):
+            raise DualSparkError(f"preflight returned an invalid uverbs device: {device}")
+
+    if _container_exists(settings, rank0_name, remote=False):
+        raise DualSparkError(f"primary container already exists: {rank0_name}")
+    if _container_exists(settings, rank1_name, remote=True):
+        raise DualSparkError(f"peer container already exists: {rank1_name}")
+    _prepare_scene_directories(settings, scene)
+
+    rank0_launch_attempted = False
+    rank1_launch_attempted = False
+    rank0_wall_started = 0.0
+    rank0_wall_seconds = 0.0
+    trackers: dict[str, MemoryTracker] = {}
+    cleanup_failures: list[str] = []
+    try:
+        _log(f"starting {scene.slug}: primary rank 0")
+        rank0_launch_attempted = True
+        rank0_wall_started = time.monotonic()
+        _run(
+            _rank_docker_argv(
+                settings, scene, 0, uverbs_device=primary_uverbs
+            )
+        )
+        _wait_for_rendezvous(
+            settings,
+            Path(paths["rendezvous"]),
+            rank0_name,
+        )
+        _transfer_rendezvous(
+            settings,
+            Path(paths["rendezvous"]),
+            str(paths["remote_rendezvous"]),
+        )
+        _log(f"starting {scene.slug}: peer rank 1")
+        rank1_launch_attempted = True
+        _remote_run(
+            settings,
+            _rank_docker_argv(
+                settings, scene, 1, uverbs_device=peer_uverbs
+            ),
+        )
+        trackers = {
+            rank0_name: _memory_tracker(settings, rank0_name, remote=False),
+            rank1_name: _memory_tracker(settings, rank1_name, remote=True),
+        }
+        states = _wait_for_containers(
+            settings,
+            ((rank0_name, False), (rank1_name, True)),
+            trackers,
+        )
+        rank0_wall_seconds = time.monotonic() - rank0_wall_started
+        failures = {
+            name: int(state.get("ExitCode", 1))
+            for name, state in states.items()
+            if int(state.get("ExitCode", 1)) != 0
+        }
+        if failures:
+            raise DualSparkError(f"Cosmos3 ranks failed for {scene.slug}: {failures}")
+    finally:
+        launched = (
+            (rank0_name, False, rank0_launch_attempted, Path(paths["rank0"])),
+            (rank1_name, True, rank1_launch_attempted, Path(paths["rank1_capture"])),
+        )
+        for name, remote, attempted, destination in launched:
+            if not attempted:
+                continue
+            try:
+                exists = _container_exists(settings, name, remote=remote)
+            except Exception as exc:
+                exists = False
+                _log(f"WARNING: could not probe exact container {name}: {exc}")
+            if exists:
+                _capture_container_noexcept(
+                    settings, name, destination, remote=remote
+                )
+            tracker = trackers.get(name)
+            if tracker is not None:
+                _write_memory_evidence_noexcept(tracker, destination)
+        for name, remote, attempted, _destination in launched:
+            if attempted and not _remove_container_noexcept(
+                settings, name, remote=remote
+            ):
+                cleanup_failures.append(name)
+
+    if cleanup_failures:
+        raise DualSparkError(
+            f"could not verify cleanup of exact containers: {cleanup_failures}"
+        )
+    if set(trackers) != {rank0_name, rank1_name}:
+        raise DualSparkError("memory telemetry is incomplete for the two ranks")
+    for destination in (Path(paths["rank0"]), Path(paths["rank1_capture"])):
+        for name in ("memory.csv", "memory-events.initial.txt", "memory-events.txt"):
+            evidence_path = destination / name
+            if not evidence_path.is_file() or evidence_path.stat().st_size == 0:
+                raise DualSparkError(
+                    f"cgroup memory evidence is incomplete: {evidence_path}"
+                )
+
+    _validate_rank_evidence(paths)
+    performance = _parse_cosmos3_performance(
+        Path(paths["rank0"]) / "container.log", scene, rank0_wall_seconds
+    )
+    memory = {
+        "primary": {
+            "rank": 0,
+            "peak_bytes": trackers[rank0_name].peak_bytes,
+            "swap_peak_bytes": trackers[rank0_name].swap_peak_bytes,
+            "samples": trackers[rank0_name].samples,
+            "evidence": {
+                "samples_csv": str(Path(paths["rank0"]) / "memory.csv"),
+                "initial_events": str(Path(paths["rank0"]) / "memory-events.initial.txt"),
+                "final_events": str(Path(paths["rank0"]) / "memory-events.txt"),
+                "container_state": str(Path(paths["rank0"]) / "inspect.json"),
+            },
+            "source": "cgroup-v2 memory.peak",
+        },
+        "peer": {
+            "rank": 1,
+            "peak_bytes": trackers[rank1_name].peak_bytes,
+            "swap_peak_bytes": trackers[rank1_name].swap_peak_bytes,
+            "samples": trackers[rank1_name].samples,
+            "evidence": {
+                "samples_csv": str(Path(paths["rank1_capture"]) / "memory.csv"),
+                "initial_events": str(Path(paths["rank1_capture"]) / "memory-events.initial.txt"),
+                "final_events": str(Path(paths["rank1_capture"]) / "memory-events.txt"),
+                "container_state": str(Path(paths["rank1_capture"]) / "inspect.json"),
+            },
+            "source": "cgroup-v2 memory.peak",
+        },
+    }
+    _verify_rank1_has_no_frames(settings, str(paths["remote_rank1"]))
+    _remove_rank1_empty_frames(settings, str(paths["remote_rank1"]))
+    artifact = _package_video(
+        settings,
+        Path(paths["rank0"]) / "frames",
+        Path(paths["mp4"]),
+    )
+    _log(f"completed {scene.slug}: {paths['mp4']}")
+    return {
+        "slug": scene.slug,
+        "seed": scene.seed,
+        "prompt": _prompt_record(scene),
+        "rank_hosts": {"0": socket.gethostname(), "1": settings.peer_host},
+        "rendezvous_name": Path(paths["rendezvous"]).name,
+        "performance": performance,
+        "memory": memory,
+        "artifact": artifact,
+    }
+
+
+def run_scenes(settings: Settings) -> dict[str, Any]:
+    layout = _layout(settings)
+    facts = _preflight(settings)
+    _ensure_private_remote_root(settings)
+    preparation = _require_prepared(settings)
+    if preparation.get("host_identity") != facts["host_identity"]:
+        raise DualSparkError(
+            "prepared assets belong to a different primary/peer host pair; run prepare again"
+        )
+
+    run_root = Path(layout["run_root"])
+    remote_run_root = str(layout["remote_run_root"])
+    if run_root.exists():
+        raise DualSparkError(f"run directory already exists: {run_root}")
+    if _remote_run(settings, ["test", "-e", remote_run_root], check=False).returncode == 0:
+        raise DualSparkError(f"peer run directory already exists: {remote_run_root}")
+    run_root.mkdir(parents=True, exist_ok=False)
+    _remote_run(settings, ["install", "-d", "-m", "0700", remote_run_root])
+
+    artifacts = []
+    for scene in _selected_scenes(settings):
+        artifacts.append(_run_scene(settings, scene, facts["roce_hosts"]))
+
+    run_record = {
+        "schema_version": 1,
+        "recorded_at_utc": datetime.now(timezone.utc).isoformat(),
+        "run_id": settings.run_id,
+        "scene_selection": settings.scene,
+        "model": {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION},
+        "profile": _profile(),
+        "hosts": {
+            "primary": socket.gethostname(),
+            "peer": settings.peer_host,
+            "primary_gpu": preparation["primary_gpu"],
+            "peer_gpu": preparation["peer_gpu"],
+            "identity": facts["host_identity"],
+        },
+        "artifacts": {
+            "image": preparation["image"],
+            "bundle": preparation["bundle"],
+        },
+        "roce": {
+            "hca": settings.ib_hca,
+            "gid_index": settings.gid_index,
+            "network_interface": settings.net_iface,
+            "address_family": "AF_INET",
+            "hosts": facts["roce_hosts"],
+        },
+        "scenes": artifacts,
+    }
+    _write_json(Path(layout["run_json"]), run_record)
+    _log(f"all scenes complete; provenance: {layout['run_json']}")
+    return run_record
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        settings = _settings(_parser().parse_args(argv))
+        if settings.dry_run:
+            json.dump(execution_plan(settings), sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+            return 0
+
+        if settings.action in {"prepare", "all"}:
+            prepare(settings)
+        if settings.action in {"run", "all"}:
+            run_scenes(settings)
+        return 0
+    except KeyboardInterrupt:
+        print("ERROR: interrupted", file=sys.stderr)
+        return 130
+    except DualSparkError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/include/trtmc/runtime/distributed_runtime.h
+++ b/include/trtmc/runtime/distributed_runtime.h
@@ -12,8 +12,8 @@ namespace trtmc {
 
 struct DistributedRuntimeGroup {
     int world_size{1};
-    // Single-node tensor-parallel rank. Used for communicator position,
-    // engine shard selection, and CUDA device binding in this initial runtime.
+    // Global tensor-parallel rank. Used for communicator position and engine
+    // shard selection. CUDA device binding uses launcher-provided local rank.
     int rank{0};
     int tp_size{1};
     void* communicator{nullptr};
@@ -23,9 +23,11 @@ struct DistributedRuntimeGroup {
 // Initialize an NCCL communicator for TensorRT 11.0+ distributed collective layers.
 //
 // This intentionally avoids compile-time MPI/NCCL dependencies: ranks are
-// discovered from common mpirun environment variables, and NCCL is loaded with
-// dlopen at runtime. Rank 0 writes the NCCL unique ID to a small rendezvous
-// file under /tmp unless TRTMC_NCCL_RENDEZVOUS points elsewhere.
+// discovered from common launcher environment variables, and NCCL is loaded
+// with dlopen at runtime. Rank 0 writes the NCCL unique ID to a small
+// rendezvous file under /tmp unless TRTMC_NCCL_RENDEZVOUS points elsewhere.
+// Multi-node launchers must set that variable to a unique path shared by every
+// rank; node-local /tmp is not a cross-node rendezvous.
 DistributedRuntimeGroup initialize_tensor_parallel_group(int tp_size);
 
 } // namespace trtmc

--- a/python/tensorrt_model_connect/families/cosmos3/MODEL.toml
+++ b/python/tensorrt_model_connect/families/cosmos3/MODEL.toml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "cosmos3"
+plugin = "cosmos3"
+module = "plugin"
+aliases = [
+  "cosmos3",
+  "cosmos3_nano",
+  "cosmos3-nano",
+]
+prefixes = [
+  "cosmos3",
+]
+diffusion_pipeline_classes = [
+  "Cosmos3OmniDiffusersPipeline",
+  "Cosmos3OmniPipeline",
+  "Cosmos3OmniModularPipeline",
+]
+hf_allow_patterns = [
+  "model_index.json",
+  "modular_model_index.json",
+  "config.json",
+  "scheduler/**",
+  "transformer/**",
+  "vae/**",
+  "text_tokenizer/**",
+  "tokenizer/**",
+  "*/config.json",
+  "*/model.safetensors",
+  "*/model-*.safetensors",
+  "*/model.safetensors.index.json",
+  "*/diffusion_pytorch_model.safetensors",
+  "*/diffusion_pytorch_model-*.safetensors",
+  "*/diffusion_pytorch_model.safetensors.index.json",
+]
+hf_required_files = [
+  "nvidia/Cosmos3-Nano|text_tokenizer/tokenizer.json",
+  "nvidia/Cosmos3-Nano|text_tokenizer/tokenizer_config.json",
+]

--- a/python/tensorrt_model_connect/families/cosmos3/__init__.py
+++ b/python/tensorrt_model_connect/families/cosmos3/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-Nano text-to-video family."""
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/python/tensorrt_model_connect/families/cosmos3/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/cosmos3/checkpoint_mapper.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-Nano Diffusers checkpoint discovery and tensor loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    source = Path(path)
+    return json.loads(source.read_text(encoding="utf-8"))
+
+
+def component_safetensor_paths(component_dir: str | Path) -> tuple[Path, ...]:
+    """Resolve one Diffusers component's sharded safetensors deterministically."""
+
+    root = Path(component_dir)
+    index_candidates = (
+        root / "diffusion_pytorch_model.safetensors.index.json",
+        root / "model.safetensors.index.json",
+    )
+    for index_path in index_candidates:
+        if index_path.is_file():
+            weight_map = read_json(index_path).get("weight_map", {})
+            paths = tuple(root / name for name in sorted(set(weight_map.values())))
+            missing = [str(path) for path in paths if not path.is_file()]
+            if missing:
+                raise FileNotFoundError("Missing checkpoint shards: " + ", ".join(missing))
+            return paths
+
+    paths = tuple(
+        sorted(
+            {
+                *root.glob("diffusion_pytorch_model*.safetensors"),
+                *root.glob("model*.safetensors"),
+            }
+        )
+    )
+    if not paths:
+        raise FileNotFoundError(f"No safetensor weights found in {root}")
+    return paths
+
+
+def iter_component_tensors(component_dir: str | Path) -> Iterator[tuple[str, Any]]:
+    """Stream CPU tensors shard-by-shard without duplicating the full checkpoint."""
+
+    from safetensors import safe_open
+
+    seen: set[str] = set()
+    for path in component_safetensor_paths(component_dir):
+        with safe_open(path, framework="pt", device="cpu") as handle:
+            for key in handle.keys():
+                if key in seen:
+                    raise ValueError(f"Duplicate Cosmos3 tensor {key!r}")
+                seen.add(key)
+                yield key, handle.get_tensor(key)
+
+
+def load_component_state_dict(component_dir: str | Path) -> dict[str, Any]:
+    """Materialize a component state dict when a builder needs all weights."""
+
+    return dict(iter_component_tensors(component_dir))
+
+
+def load_vae_decoder_weights(component_dir: str | Path) -> dict[str, Any]:
+    """Load only recurrent decoder tensors and normalization metadata."""
+
+    root = Path(component_dir)
+    config = read_json(root / "config.json")
+    state = load_component_state_dict(root)
+    selected = {
+        name: value
+        for name, value in state.items()
+        if name.startswith("decoder.") or name.startswith("post_quant_conv.")
+    }
+    for field in ("latents_mean", "latents_std"):
+        values = config.get(field)
+        if not isinstance(values, list) or len(values) != 48:
+            raise ValueError(f"Cosmos3 VAE config requires 48-value {field}")
+        selected[f"_{field}"] = values
+    return selected

--- a/python/tensorrt_model_connect/families/cosmos3/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/cosmos3/graph_blocks.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT block used by the Cosmos3 recurrent VAE decoder."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from . import graph_ops
+
+
+trt = trt_compat.get_trt()
+
+
+def add_vae_spatial_attention(
+    network,
+    tensor,
+    *,
+    weights: dict,
+    prefix: str,
+    channels: int,
+    eps: float = 1.0e-6,
+):
+    """Add the single-head spatial attention in the Cosmos3 VAE mid-block."""
+
+    batch, tensor_channels, frames, height, width = tuple(tensor.shape)
+    if tensor_channels != channels:
+        raise ValueError(
+            f"Cosmos3 VAE attention expected {channels} channels, got {tensor_channels}"
+        )
+    batch_frames = batch * frames
+    spatial = height * width
+    identity = tensor
+
+    normalized = graph_ops.add_l2_channel_norm(
+        network,
+        tensor,
+        channels,
+        weights[f"{prefix}.norm.gamma"],
+        eps,
+    )
+    flatten = network.add_shuffle(normalized)
+    flatten.first_transpose = trt.Permutation([0, 2, 3, 4, 1])
+    flatten.reshape_dims = (batch_frames * spatial, channels)
+
+    qkv_weight = weights[f"{prefix}.to_qkv.weight"].reshape(3 * channels, channels).T.copy()
+    qkv = graph_ops.add_matmul_rhs_constant(
+        network,
+        flatten.get_output(0),
+        channels,
+        3 * channels,
+        qkv_weight,
+    )
+    qkv_bias = weights.get(f"{prefix}.to_qkv.bias")
+    if qkv_bias is not None:
+        qkv = graph_ops.add_bias_sum(network, qkv, 3 * channels, qkv_bias)
+
+    qkv_shape = network.add_shuffle(qkv)
+    qkv_shape.reshape_dims = (batch_frames, spatial, 3 * channels)
+    q = network.add_slice(
+        qkv_shape.get_output(0),
+        start=(0, 0, 0),
+        shape=(batch_frames, spatial, channels),
+        stride=(1, 1, 1),
+    ).get_output(0)
+    k = network.add_slice(
+        qkv_shape.get_output(0),
+        start=(0, 0, channels),
+        shape=(batch_frames, spatial, channels),
+        stride=(1, 1, 1),
+    ).get_output(0)
+    v = network.add_slice(
+        qkv_shape.get_output(0),
+        start=(0, 0, 2 * channels),
+        shape=(batch_frames, spatial, channels),
+        stride=(1, 1, 1),
+    ).get_output(0)
+
+    q4 = network.add_shuffle(q)
+    q4.reshape_dims = (batch_frames, 1, spatial, channels)
+    k4 = network.add_shuffle(k)
+    k4.reshape_dims = (batch_frames, 1, spatial, channels)
+    v4 = network.add_shuffle(v)
+    v4.reshape_dims = (batch_frames, 1, spatial, channels)
+    context = graph_ops.add_attention_core(
+        network,
+        q4.get_output(0),
+        k4.get_output(0),
+        v4.get_output(0),
+        scale=1.0 / np.sqrt(max(channels, 1)),
+    )
+
+    context_rows = network.add_shuffle(context)
+    context_rows.reshape_dims = (batch_frames * spatial, channels)
+    projection_weight = weights[f"{prefix}.proj.weight"].reshape(channels, channels).T.copy()
+    projection = graph_ops.add_matmul_rhs_constant(
+        network,
+        context_rows.get_output(0),
+        channels,
+        channels,
+        projection_weight,
+    )
+    projection_bias = weights.get(f"{prefix}.proj.bias")
+    if projection_bias is not None:
+        projection = graph_ops.add_bias_sum(network, projection, channels, projection_bias)
+
+    output_shape = network.add_shuffle(projection)
+    output_shape.reshape_dims = (batch, frames, height, width, channels)
+    output_shape.second_transpose = trt.Permutation([0, 4, 1, 2, 3])
+    return network.add_elementwise(
+        output_shape.get_output(0), identity, trt.ElementWiseOperation.SUM
+    ).get_output(0)

--- a/python/tensorrt_model_connect/families/cosmos3/graph_ops.py
+++ b/python/tensorrt_model_connect/families/cosmos3/graph_ops.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT operations used by the Cosmos3 recurrent VAE decoder."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+
+trt = trt_compat.get_trt()
+
+
+def add_constant(network, shape: tuple[int, ...], values):
+    weights = trt.Weights(np.ascontiguousarray(values, dtype=np.float32))
+    return network.add_constant(shape, weights).get_output(0)
+
+
+def add_matmul_rhs_constant(
+    network,
+    lhs,
+    lhs_width: int,
+    rhs_width: int,
+    rhs_weights,
+):
+    rank = len(tuple(lhs.shape))
+    rhs_shape = (lhs_width, rhs_width) if rank <= 2 else (1,) * (rank - 2) + (lhs_width, rhs_width)
+    rhs = add_constant(
+        network,
+        rhs_shape,
+        np.asarray(rhs_weights).reshape(rhs_shape),
+    )
+    return network.add_matrix_multiply(
+        lhs,
+        trt.MatrixOperation.NONE,
+        rhs,
+        trt.MatrixOperation.NONE,
+    ).get_output(0)
+
+
+def add_bias_sum(network, tensor, width: int, bias):
+    rank = len(tuple(tensor.shape))
+    bias_shape = (width,) if rank <= 1 else (1,) * (rank - 1) + (width,)
+    bias_tensor = add_constant(
+        network,
+        bias_shape,
+        np.asarray(bias).reshape(bias_shape),
+    )
+    return network.add_elementwise(tensor, bias_tensor, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def add_silu(network, tensor):
+    sigmoid = network.add_activation(tensor, trt.ActivationType.SIGMOID).get_output(0)
+    return network.add_elementwise(tensor, sigmoid, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _add_convolution(
+    network,
+    tensor,
+    weight,
+    bias,
+    *,
+    out_channels: int,
+    kernel_shape: tuple[int, ...],
+    convolution_dtype,
+):
+    """Add one FP32 or BF16 convolution."""
+
+    if convolution_dtype == trt.float32:
+        weights = trt.Weights(weight)
+        biases = trt.Weights() if bias is None else trt.Weights(bias)
+        return network.add_convolution_nd(
+            tensor,
+            num_output_maps=out_channels,
+            kernel_shape=kernel_shape,
+            kernel=weights,
+            bias=biases,
+        )
+    if convolution_dtype != trt.bfloat16:
+        raise ValueError(f"Unsupported Cosmos3 VAE convolution dtype: {convolution_dtype}")
+    typed_input = network.add_cast(tensor, trt.bfloat16).get_output(0)
+    weight_tensor = add_constant(network, tuple(weight.shape), weight)
+    typed_weight = network.add_cast(weight_tensor, trt.bfloat16).get_output(0)
+    convolution = network.add_convolution_nd(
+        typed_input,
+        num_output_maps=out_channels,
+        kernel_shape=kernel_shape,
+        kernel=trt.Weights(),
+        bias=trt.Weights(),
+    )
+    convolution.set_input(1, typed_weight)
+    if bias is not None:
+        bias_tensor = add_constant(network, (out_channels,), bias)
+        typed_bias = network.add_cast(bias_tensor, trt.bfloat16).get_output(0)
+        convolution.set_input(2, typed_bias)
+    return convolution
+
+
+def _convolution_output(network, convolution, convolution_dtype):
+    output = convolution.get_output(0)
+    if convolution_dtype == trt.float32:
+        return output
+    return network.add_cast(output, trt.float32).get_output(0)
+
+
+def add_conv3d_as_conv2d(
+    network,
+    tensor,
+    weight,
+    bias,
+    out_channels: int,
+    kernel_size: tuple[int, int, int],
+    stride: tuple[int, int, int] = (1, 1, 1),
+    padding: tuple[int, int, int] = (0, 0, 0),
+    convolution_dtype=None,
+):
+    """Apply a temporal-kernel-one Conv3D as per-frame Conv2D."""
+
+    batch, input_channels, frames, height, width = tuple(tensor.shape)
+    kt, kh, kw = kernel_size
+    st, sh, sw = stride
+    pt, ph, pw = padding
+    if kt != 1 or st != 1 or pt != 0:
+        raise ValueError(
+            "Cosmos3 Conv3D-as-Conv2D requires temporal kernel/stride 1 and no temporal padding"
+        )
+    if convolution_dtype is None:
+        convolution_dtype = trt.float32
+
+    reshape_input = network.add_shuffle(tensor)
+    reshape_input.first_transpose = trt.Permutation([0, 2, 1, 3, 4])
+    reshape_input.reshape_dims = (batch * frames, input_channels, height, width)
+    weights = np.ascontiguousarray(
+        np.asarray(weight).reshape(out_channels, input_channels, kh, kw),
+        dtype=np.float32,
+    )
+    biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+    convolution = _add_convolution(
+        network,
+        reshape_input.get_output(0),
+        weights,
+        biases,
+        out_channels=out_channels,
+        kernel_shape=(kh, kw),
+        convolution_dtype=convolution_dtype,
+    )
+    convolution.stride_nd = (sh, sw)
+    convolution.padding_nd = (ph, pw)
+    convolution_output = _convolution_output(network, convolution, convolution_dtype)
+    output_height = (height + 2 * ph - kh) // sh + 1
+    output_width = (width + 2 * pw - kw) // sw + 1
+    reshape_output = network.add_shuffle(convolution_output)
+    reshape_output.reshape_dims = (
+        batch,
+        frames,
+        out_channels,
+        output_height,
+        output_width,
+    )
+    reshape_output.second_transpose = trt.Permutation([0, 2, 1, 3, 4])
+    return reshape_output.get_output(0)
+
+
+def add_causal_conv3d(
+    network,
+    tensor,
+    cache,
+    weight,
+    bias,
+    out_channels: int,
+    kernel_size: tuple[int, int, int],
+    stride: tuple[int, int, int] = (1, 1, 1),
+    padding_hw: tuple[int, int] = (0, 0),
+    convolution_dtype=None,
+):
+    """Apply a causal Conv3D and return its two-frame updated cache."""
+
+    batch, input_channels, input_frames, height, width = tuple(tensor.shape)
+    kt, kh, kw = kernel_size
+    ph, pw = padding_hw
+    if kt != 3:
+        raise ValueError(f"Cosmos3 causal Conv3D requires temporal kernel 3, got {kt}")
+    if convolution_dtype is None:
+        convolution_dtype = trt.float32
+
+    concatenation = network.add_concatenation([cache, tensor])
+    concatenation.axis = 2
+    temporal = concatenation.get_output(0)
+    if input_frames == 1:
+        reshape_input = network.add_shuffle(temporal)
+        reshape_input.reshape_dims = (batch, input_channels * kt, height, width)
+        weights = np.ascontiguousarray(
+            np.asarray(weight).reshape(out_channels, input_channels * kt, kh, kw),
+            dtype=np.float32,
+        )
+        biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+        convolution = _add_convolution(
+            network,
+            reshape_input.get_output(0),
+            weights,
+            biases,
+            out_channels=out_channels,
+            kernel_shape=(kh, kw),
+            convolution_dtype=convolution_dtype,
+        )
+        convolution.stride_nd = (stride[1], stride[2])
+        convolution.padding_nd = (ph, pw)
+        convolution_output = _convolution_output(network, convolution, convolution_dtype)
+        output_height = (height + 2 * ph - kh) // stride[1] + 1
+        output_width = (width + 2 * pw - kw) // stride[2] + 1
+        reshape_output = network.add_shuffle(convolution_output)
+        reshape_output.reshape_dims = (
+            batch,
+            out_channels,
+            1,
+            output_height,
+            output_width,
+        )
+        output = reshape_output.get_output(0)
+    else:
+        weights = np.ascontiguousarray(
+            np.asarray(weight).reshape(out_channels, input_channels, kt, kh, kw),
+            dtype=np.float32,
+        )
+        biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+        convolution = _add_convolution(
+            network,
+            temporal,
+            weights,
+            biases,
+            out_channels=out_channels,
+            kernel_shape=(kt, kh, kw),
+            convolution_dtype=convolution_dtype,
+        )
+        convolution.stride_nd = stride
+        convolution.padding_nd = (0, ph, pw)
+        output = _convolution_output(network, convolution, convolution_dtype)
+
+    updated_cache = network.add_slice(
+        temporal,
+        start=(0, 0, input_frames, 0, 0),
+        shape=(batch, input_channels, kt - 1, height, width),
+        stride=(1, 1, 1, 1, 1),
+    ).get_output(0)
+    return output, updated_cache
+
+
+def add_spatial_upsample(network, tensor, scale_factor: int = 2):
+    batch, channels, frames, height, width = tuple(tensor.shape)
+    resize = network.add_resize(tensor)
+    resize.resize_mode = trt.InterpolationMode.NEAREST
+    resize.shape = (
+        batch,
+        channels,
+        frames,
+        height * scale_factor,
+        width * scale_factor,
+    )
+    return resize.get_output(0)
+
+
+def add_spatial_upsample_with_conv(
+    network,
+    tensor,
+    weight,
+    bias,
+    scale: int = 2,
+    convolution_dtype=None,
+):
+    upsampled = add_spatial_upsample(network, tensor, scale)
+    return add_conv3d_as_conv2d(
+        network,
+        upsampled,
+        weight=weight,
+        bias=bias,
+        out_channels=int(weight.shape[0]),
+        kernel_size=(1, 3, 3),
+        padding=(0, 1, 1),
+        convolution_dtype=convolution_dtype,
+    )
+
+
+def add_l2_channel_norm(
+    network,
+    tensor,
+    num_channels: int,
+    gamma,
+    eps: float = 1.0e-6,
+):
+    squared = network.add_elementwise(tensor, tensor, trt.ElementWiseOperation.PROD).get_output(0)
+    summed = network.add_reduce(squared, trt.ReduceOperation.SUM, 1 << 1, True).get_output(0)
+    epsilon = add_constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([eps], dtype=np.float32),
+    )
+    denominator = network.add_elementwise(summed, epsilon, trt.ElementWiseOperation.SUM).get_output(
+        0
+    )
+    denominator = network.add_unary(denominator, trt.UnaryOperation.SQRT).get_output(0)
+    inverse = network.add_unary(denominator, trt.UnaryOperation.RECIP).get_output(0)
+    normalized = network.add_elementwise(tensor, inverse, trt.ElementWiseOperation.PROD).get_output(
+        0
+    )
+    scale = np.sqrt(num_channels) * np.asarray(gamma).flatten()[:num_channels]
+    scale_tensor = add_constant(
+        network,
+        (1, num_channels, 1, 1, 1),
+        scale.reshape(1, num_channels, 1, 1, 1),
+    )
+    return network.add_elementwise(
+        normalized, scale_tensor, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+
+
+def add_temporal_pixel_shuffle(network, tensor, factor: int = 2):
+    batch, total_channels, frames, height, width = tuple(tensor.shape)
+    channels = total_channels // factor
+    reshape = network.add_shuffle(tensor)
+    reshape.reshape_dims = (batch, factor, channels, frames, height, width)
+    transpose = network.add_shuffle(reshape.get_output(0))
+    transpose.first_transpose = trt.Permutation([0, 2, 3, 1, 4, 5])
+    output = network.add_shuffle(transpose.get_output(0))
+    output.reshape_dims = (batch, channels, factor * frames, height, width)
+    return output.get_output(0)
+
+
+def add_attention_core(network, q, k, v, *, scale: float):
+    scale_tensor = add_constant(
+        network,
+        (1, 1, 1, 1),
+        np.array([[[[scale]]]], dtype=np.float32),
+    )
+    q_scaled = network.add_elementwise(q, scale_tensor, trt.ElementWiseOperation.PROD).get_output(0)
+    attention = network.add_attention(
+        q_scaled,
+        k,
+        v,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        False,
+    )
+    if attention is None:
+        raise RuntimeError("Could not add native TensorRT VAE attention")
+    attention.decomposable = True
+    return attention.get_output(0)

--- a/python/tensorrt_model_connect/families/cosmos3/model_config.py
+++ b/python/tensorrt_model_connect/families/cosmos3/model_config.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qualified architecture and generation contract for Cosmos3-Nano T2V."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Cosmos3NanoConfig:
+    """Exact public Diffusers architecture of ``nvidia/Cosmos3-Nano``."""
+
+    hidden_size: int = 4096
+    intermediate_size: int = 12288
+    num_hidden_layers: int = 36
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    vocab_size: int = 151936
+    latent_channel: int = 48
+    latent_patch_size: int = 2
+    patch_latent_dim: int = 192
+    timestep_dim: int = 256
+    timestep_scale: float = 0.001
+    rms_norm_eps: float = 1.0e-6
+    rope_theta: float = 5_000_000.0
+    rope_axes_dim: tuple[int, int, int] = (24, 20, 20)
+    temporal_modality_margin: int = 15_000
+    base_fps: int = 24
+    qk_norm_for_text: bool = True
+    use_und_k_norm_for_gen: bool = False
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+
+    vae_spatial_scale: int = 16
+    vae_temporal_scale: int = 4
+    # Preserve the official long-form prompts in every supported CP topology.
+    max_text_seq_len: int = 4096
+
+    video_height: int = 720
+    video_width: int = 1280
+    video_num_frames: int = 189
+    frame_rate: int = 24
+    num_inference_steps: int = 35
+    guidance_scale: float = 6.0
+    flow_shift: float = 10.0
+    seed: int = 42
+
+    @property
+    def latent_frames(self) -> int:
+        return (self.video_num_frames - 1) // self.vae_temporal_scale + 1
+
+    @property
+    def latent_height(self) -> int:
+        return self.video_height // self.vae_spatial_scale
+
+    @property
+    def latent_width(self) -> int:
+        return self.video_width // self.vae_spatial_scale
+
+    @property
+    def patch_height(self) -> int:
+        return _ceil_div(self.latent_height, self.latent_patch_size)
+
+    @property
+    def patch_width(self) -> int:
+        return _ceil_div(self.latent_width, self.latent_patch_size)
+
+    @property
+    def num_vision_tokens(self) -> int:
+        return self.latent_frames * self.patch_height * self.patch_width
+
+
+COSMOS3_NANO = Cosmos3NanoConfig()
+COSMOS3_NANO_NEGATIVE_PROMPT = "blurry, distorted, low quality, jittery, deformed"
+SUPPORTED_CONTEXT_PARALLEL_SIZES = (1, 2, 4, 8)
+
+
+@dataclass(frozen=True)
+class Cosmos3ContextParallelLayout:
+    """Independent padded/sharded lengths for the two transformer pathways."""
+
+    world_size: int
+    text_tokens: int
+    vision_tokens: int
+    padded_text_tokens: int
+    padded_vision_tokens: int
+
+    @property
+    def local_text_tokens(self) -> int:
+        return self.padded_text_tokens // self.world_size
+
+    @property
+    def local_vision_tokens(self) -> int:
+        return self.padded_vision_tokens // self.world_size
+
+    @property
+    def text_padding(self) -> int:
+        return self.padded_text_tokens - self.text_tokens
+
+    @property
+    def vision_padding(self) -> int:
+        return self.padded_vision_tokens - self.vision_tokens
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def context_parallel_layout(
+    text_tokens: int,
+    vision_tokens: int,
+    world_size: int,
+) -> Cosmos3ContextParallelLayout:
+    """Return the official ragged dual-stream Ulysses padding contract."""
+
+    if text_tokens <= 0 or vision_tokens <= 0:
+        raise ValueError("Cosmos3 text and vision token counts must be positive")
+    if world_size not in SUPPORTED_CONTEXT_PARALLEL_SIZES:
+        raise ValueError("Cosmos3 context parallel size must be one of 1, 2, 4, 8")
+    if COSMOS3_NANO.num_attention_heads % world_size:
+        raise ValueError(
+            "Cosmos3 query heads must be divisible by context parallel size "
+            f"({COSMOS3_NANO.num_attention_heads} vs {world_size})"
+        )
+    return Cosmos3ContextParallelLayout(
+        world_size=world_size,
+        text_tokens=text_tokens,
+        vision_tokens=vision_tokens,
+        padded_text_tokens=_ceil_div(text_tokens, world_size) * world_size,
+        padded_vision_tokens=_ceil_div(vision_tokens, world_size) * world_size,
+    )
+
+
+def select_generation_profile(raw: Mapping[str, object]) -> Cosmos3NanoConfig:
+    """Accept only the fixed full-quality T2V recipe for this TensorRT lane."""
+
+    profile = COSMOS3_NANO
+    requested = {
+        "video_height": int(raw.get("video_height", profile.video_height)),
+        "video_width": int(raw.get("video_width", profile.video_width)),
+        "video_num_frames": int(raw.get("video_num_frames", profile.video_num_frames)),
+        "frame_rate": int(raw.get("frame_rate", profile.frame_rate)),
+        "num_inference_steps": int(raw.get("num_inference_steps", profile.num_inference_steps)),
+        "guidance_scale": float(raw.get("guidance_scale", profile.guidance_scale)),
+        "flow_shift": float(raw.get("flow_shift", profile.flow_shift)),
+    }
+    expected = {name: getattr(profile, name) for name in requested}
+    if requested != expected:
+        raise ValueError(
+            "Cosmos3-Nano supports the fixed full-quality T2V profile only: "
+            "1280x720, 189 frames, 35 denoising steps, guidance 6.0, "
+            f"flow shift 10.0 at 24 FPS; requested {requested}"
+        )
+    return profile
+
+
+def validate_transformer_config(raw: Mapping[str, object]) -> None:
+    """Reject a transformer that is not the exact supported Nano backbone."""
+
+    expected = {
+        "hidden_size": COSMOS3_NANO.hidden_size,
+        "intermediate_size": COSMOS3_NANO.intermediate_size,
+        "num_hidden_layers": COSMOS3_NANO.num_hidden_layers,
+        "num_attention_heads": COSMOS3_NANO.num_attention_heads,
+        "num_key_value_heads": COSMOS3_NANO.num_key_value_heads,
+        "head_dim": COSMOS3_NANO.head_dim,
+        "vocab_size": COSMOS3_NANO.vocab_size,
+        "latent_channel": COSMOS3_NANO.latent_channel,
+        "latent_patch_size": COSMOS3_NANO.latent_patch_size,
+        "patch_latent_dim": COSMOS3_NANO.patch_latent_dim,
+        "rms_norm_eps": COSMOS3_NANO.rms_norm_eps,
+        "rope_theta": COSMOS3_NANO.rope_theta,
+        "timestep_scale": COSMOS3_NANO.timestep_scale,
+        "hidden_act": COSMOS3_NANO.hidden_act,
+        "qk_norm_for_text": COSMOS3_NANO.qk_norm_for_text,
+        "use_und_k_norm_for_gen": COSMOS3_NANO.use_und_k_norm_for_gen,
+    }
+    defaults = {
+        # Diffusers omits this field from the public Nano checkpoint because
+        # it equals the transformer constructor default.
+        "use_und_k_norm_for_gen": False,
+    }
+    mismatches = {
+        key: (raw.get(key, defaults.get(key)), value)
+        for key, value in expected.items()
+        if raw.get(key, defaults.get(key)) != value
+    }
+    rope_axes = tuple(
+        raw.get("rope_axes_dim", raw.get("rope_scaling", {}).get("mrope_section", ()))
+    )
+    if rope_axes != COSMOS3_NANO.rope_axes_dim:
+        mismatches["rope_axes_dim"] = (rope_axes, COSMOS3_NANO.rope_axes_dim)
+    if mismatches:
+        details = ", ".join(
+            f"{key}={actual!r} (expected {wanted!r})"
+            for key, (actual, wanted) in sorted(mismatches.items())
+        )
+        raise ValueError(f"Checkpoint is not supported Cosmos3-Nano: {details}")
+
+
+def validate_vae_config(raw: Mapping[str, object]) -> None:
+    """Validate the public Cosmos3 causal 3D autoencoder geometry."""
+
+    expected = {
+        "z_dim": COSMOS3_NANO.latent_channel,
+        "scale_factor_spatial": COSMOS3_NANO.vae_spatial_scale,
+        "scale_factor_temporal": COSMOS3_NANO.vae_temporal_scale,
+        "patch_size": COSMOS3_NANO.latent_patch_size,
+    }
+    mismatches = {
+        key: (raw.get(key), value) for key, value in expected.items() if raw.get(key) != value
+    }
+    if mismatches:
+        details = ", ".join(
+            f"{key}={actual!r} (expected {wanted!r})"
+            for key, (actual, wanted) in sorted(mismatches.items())
+        )
+        raise ValueError(f"Checkpoint has an unsupported Cosmos3 VAE: {details}")

--- a/python/tensorrt_model_connect/families/cosmos3/plugin.py
+++ b/python/tensorrt_model_connect/families/cosmos3/plugin.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-Model-Connect plugin for Cosmos3-Nano text-to-video."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .checkpoint_mapper import read_json
+from .model_config import (
+    COSMOS3_NANO,
+    select_generation_profile,
+    validate_transformer_config,
+    validate_vae_config,
+)
+
+
+COSMOS3_COMMON_BUNDLE_SECTIONS = (
+    "vae_decoder_plan",
+    "vae_decoder_first_frame_plan",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+
+
+class Cosmos3Plugin:
+    name = "cosmos3"
+    default_build_precision = "bf16"
+    runtime_strategy = "diffusion_cosmos3"
+    pipeline_classes = (
+        "Cosmos3OmniDiffusersPipeline",
+        "Cosmos3OmniPipeline",
+        "Cosmos3OmniModularPipeline",
+    )
+
+    def matches(self, model_type: str) -> bool:
+        return model_type.lower() in {
+            "cosmos3",
+            "cosmos3_nano",
+            "cosmos3-nano",
+        }
+
+    def load_weights(self, model_dir: str, config, **_kwargs) -> dict:
+        del config
+        root = Path(model_dir)
+        model_index = root / "model_index.json"
+        transformer_dir = root / "transformer"
+        vae_dir = root / "vae"
+        transformer_config = transformer_dir / "config.json"
+        vae_config = vae_dir / "config.json"
+        required = (model_index, transformer_config, vae_config)
+        missing = [str(path) for path in required if not path.is_file()]
+        if missing:
+            raise FileNotFoundError(
+                "Incomplete Cosmos3-Nano Diffusers checkpoint; missing: " + ", ".join(missing)
+            )
+
+        validate_transformer_config(read_json(transformer_config))
+        validate_vae_config(read_json(vae_config))
+
+        tokenizer_dir = root / "text_tokenizer"
+        if not tokenizer_dir.is_dir():
+            tokenizer_dir = root / "tokenizer"
+        tokenizer_json = tokenizer_dir / "tokenizer.json"
+        tokenizer_config_json = tokenizer_dir / "tokenizer_config.json"
+        tokenizer_assets = (tokenizer_json, tokenizer_config_json)
+        missing_tokenizer_assets = [str(path) for path in tokenizer_assets if not path.is_file()]
+        if missing_tokenizer_assets:
+            raise FileNotFoundError(
+                "Incomplete Cosmos3-Nano Diffusers checkpoint; missing: "
+                + ", ".join(missing_tokenizer_assets)
+            )
+
+        return {
+            "_model_format": "diffusers",
+            "_root_dir": str(root),
+            "_transformer_dir": str(transformer_dir),
+            "_vae_dir": str(vae_dir),
+            "_tokenizer_dir": str(tokenizer_dir),
+            "_transformer_config": read_json(transformer_config),
+            "_vae_config": read_json(vae_config),
+        }
+
+    def build_engine(
+        self,
+        config,
+        weights: dict,
+        _max_cache_length: int,
+        *,
+        precision: str = "bf16",
+        verbose: bool = False,
+        **kwargs,
+    ) -> bytes:
+        del config, weights, _max_cache_length, precision, verbose, kwargs
+        raise NotImplementedError("Cosmos3-Nano uses build_components(), not build_engine()")
+
+    def build_components(
+        self,
+        model_dir: str,
+        config,
+        weights: dict,
+        *,
+        precision: str = "bf16",
+        verbose: bool = False,
+        parallel_config=None,
+        **kwargs,
+    ) -> dict:
+        from .trt_builder import build_cosmos3_components
+
+        return build_cosmos3_components(
+            model_dir,
+            config=config,
+            weights=weights,
+            precision=precision,
+            verbose=verbose,
+            parallel_config=parallel_config,
+            **kwargs,
+        )
+
+    def diffusion_bundle_sections(
+        self, components: dict, *, parallel_config=None
+    ) -> list[tuple[str, bytes]]:
+        from tensorrt_model_connect.parallel_config import (
+            context_denoiser_section,
+            normalize_parallel_config,
+        )
+
+        parallel = normalize_parallel_config(parallel_config)
+        denoiser_section = context_denoiser_section() if parallel.cp_enabled else "denoiser_plan"
+        sections = [(denoiser_section, components["denoiser"])]
+        payloads = {
+            "vae_decoder_plan": components["vae_decoder"],
+            "vae_decoder_first_frame_plan": components["vae_decoder_first_frame"],
+            "tokenizer.json": components["tokenizer_json"],
+            "tokenizer_config.json": components["tokenizer_config_json"],
+        }
+        sections.extend((name, payloads[name]) for name in COSMOS3_COMMON_BUNDLE_SECTIONS)
+        return sections
+
+    def diffusion_bundle_config(self, config, *, components: dict) -> dict:
+        bundle_config = self.get_diffusion_config(config)
+        bundle_config["negative_prompt"] = components["negative_prompt"]
+        return bundle_config
+
+    def diffusion_tokenizer_add_special_tokens(
+        self, model_dir_path, *, detect_tokenizer_add_special_tokens
+    ) -> bool:
+        del model_dir_path, detect_tokenizer_add_special_tokens
+        return False
+
+    def diffusion_tokenizer_bundle_sections(
+        self, model_dir_path, *, ensure_tokenizer_json
+    ) -> list[tuple[str, bytes]]:
+        del model_dir_path, ensure_tokenizer_json
+        return []
+
+    def get_diffusion_config(self, config) -> dict:
+        profile = select_generation_profile(config.raw)
+        seed = int(config.raw.get("seed", profile.seed))
+        if not 0 <= seed <= 2_147_483_647:
+            raise ValueError("Cosmos3-Nano seed must be between 0 and 2147483647")
+        return {
+            "num_inference_steps": profile.num_inference_steps,
+            "guidance_scale": profile.guidance_scale,
+            "flow_shift": profile.flow_shift,
+            "video_height": profile.video_height,
+            "video_width": profile.video_width,
+            "video_num_frames": profile.video_num_frames,
+            "frame_rate": profile.frame_rate,
+            "text_seq_len": COSMOS3_NANO.max_text_seq_len,
+            "seed": seed,
+        }
+
+
+plugin = Cosmos3Plugin()

--- a/python/tensorrt_model_connect/families/cosmos3/transformer_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos3/transformer_builder.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native dual-stream TensorRT denoiser for Cosmos3-Nano T2V."""
+
+from __future__ import annotations
+
+import sys
+from typing import Mapping
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from . import trt_ops as op
+from .checkpoint_mapper import load_component_state_dict
+from .model_config import COSMOS3_NANO, Cosmos3NanoConfig
+
+
+trt = trt_compat.get_trt()
+
+
+def required_transformer_tensor_names(
+    profile: Cosmos3NanoConfig = COSMOS3_NANO,
+) -> tuple[str, ...]:
+    names = [
+        "embed_tokens.weight",
+        "proj_in.weight",
+        "proj_in.bias",
+        "proj_out.weight",
+        "proj_out.bias",
+        "time_embedder.linear_1.weight",
+        "time_embedder.linear_1.bias",
+        "time_embedder.linear_2.weight",
+        "time_embedder.linear_2.bias",
+        "norm.weight",
+        "norm_moe_gen.weight",
+    ]
+    for index in range(profile.num_hidden_layers):
+        prefix = f"layers.{index}"
+        names.extend(
+            (
+                f"{prefix}.input_layernorm.weight",
+                f"{prefix}.input_layernorm_moe_gen.weight",
+                f"{prefix}.post_attention_layernorm.weight",
+                f"{prefix}.post_attention_layernorm_moe_gen.weight",
+                f"{prefix}.self_attn.to_q.weight",
+                f"{prefix}.self_attn.to_k.weight",
+                f"{prefix}.self_attn.to_v.weight",
+                f"{prefix}.self_attn.to_out.weight",
+                f"{prefix}.self_attn.add_q_proj.weight",
+                f"{prefix}.self_attn.add_k_proj.weight",
+                f"{prefix}.self_attn.add_v_proj.weight",
+                f"{prefix}.self_attn.to_add_out.weight",
+                f"{prefix}.self_attn.norm_q.weight",
+                f"{prefix}.self_attn.norm_k.weight",
+                f"{prefix}.self_attn.norm_added_q.weight",
+                f"{prefix}.self_attn.norm_added_k.weight",
+                f"{prefix}.mlp.gate_proj.weight",
+                f"{prefix}.mlp.up_proj.weight",
+                f"{prefix}.mlp.down_proj.weight",
+                f"{prefix}.mlp_moe_gen.gate_proj.weight",
+                f"{prefix}.mlp_moe_gen.up_proj.weight",
+                f"{prefix}.mlp_moe_gen.down_proj.weight",
+            )
+        )
+    return tuple(names)
+
+
+def validate_transformer_state_dict(
+    state: Mapping[str, object],
+    profile: Cosmos3NanoConfig = COSMOS3_NANO,
+) -> None:
+    missing = [name for name in required_transformer_tensor_names(profile) if name not in state]
+    if missing:
+        raise KeyError("Cosmos3-Nano checkpoint is missing tensors: " + ", ".join(missing))
+
+
+def _array(state: Mapping[str, object], name: str) -> np.ndarray:
+    value = state[name]
+    if hasattr(value, "detach"):
+        value = value.detach().float().cpu().numpy()
+    return np.asarray(value, dtype=np.float32)
+
+
+def _parallel_size(parallel_config) -> int:
+    if parallel_config is None:
+        return 1
+    mode = str(getattr(parallel_config, "mode", "single"))
+    if mode == "single":
+        return 1
+    if mode != "context_parallel":
+        raise ValueError("Cosmos3-Nano supports single-device or context-parallel builds")
+    size = int(getattr(parallel_config, "cp_size", 1))
+    if size not in (2, 4, 8):
+        raise ValueError("Cosmos3-Nano context parallel size must be 2, 4, or 8")
+    if COSMOS3_NANO.num_attention_heads % size or COSMOS3_NANO.num_key_value_heads % size:
+        raise ValueError("Cosmos3-Nano CP size must divide both query and KV heads")
+    return size
+
+
+def build_cosmos3_transformer_engine(
+    transformer_dir: str,
+    *,
+    profile: Cosmos3NanoConfig = COSMOS3_NANO,
+    parallel_config=None,
+    verbose: bool = False,
+) -> bytes:
+    """Build one rank-dynamic SD or Ulysses CP denoiser plan."""
+
+    cp_size = _parallel_size(parallel_config)
+    text_length = profile.max_text_seq_len
+    vision_length = profile.num_vision_tokens
+    if text_length % cp_size or vision_length % cp_size:
+        raise ValueError("Cosmos3-Nano fixed engine token counts must divide the CP size")
+    local_text_length = text_length // cp_size
+    local_vision_length = vision_length // cp_size
+
+    state = load_component_state_dict(transformer_dir)
+    validate_transformer_state_dict(state, profile)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    build_config = builder.create_builder_config()
+    build_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    input_ids = network.add_input("input_ids", trt.int32, (text_length,))
+    vision_patches = network.add_input(
+        "vision_patches", trt.float32, (vision_length, profile.patch_latent_dim)
+    )
+    timestep_features = network.add_input(
+        "timestep_features", trt.float32, (1, profile.timestep_dim)
+    )
+    text_cos = network.add_input("text_rotary_cos", trt.float32, (text_length, profile.head_dim))
+    text_sin = network.add_input("text_rotary_sin", trt.float32, (text_length, profile.head_dim))
+    vision_cos = network.add_input(
+        "vision_rotary_cos", trt.float32, (vision_length, profile.head_dim)
+    )
+    vision_sin = network.add_input(
+        "vision_rotary_sin", trt.float32, (vision_length, profile.head_dim)
+    )
+    generation_mask = network.add_input(
+        "generation_attention_mask",
+        trt.float32,
+        (1, 1, 1, text_length + vision_length),
+    )
+    text_causal_mask = None
+    if cp_size > 1:
+        text_causal_mask_array = np.triu(
+            np.full(
+                (text_length, text_length),
+                np.finfo(np.float32).min,
+                dtype=np.float32,
+            ),
+            k=1,
+        ).reshape(1, 1, text_length, text_length)
+        text_causal_mask = op.constant(network, text_causal_mask_array)
+
+    embedding = op.constant(network, _array(state, "embed_tokens.weight"))
+    embedding = op.cast(network, embedding, trt.bfloat16)
+    text = network.add_gather(embedding, input_ids, 0).get_output(0)
+
+    vision = op.linear(
+        network,
+        vision_patches,
+        _array(state, "proj_in.weight"),
+        _array(state, "proj_in.bias"),
+    )
+    timestep = op.linear(
+        network,
+        timestep_features,
+        _array(state, "time_embedder.linear_1.weight"),
+        _array(state, "time_embedder.linear_1.bias"),
+        bf16=False,
+    )
+    timestep = op.silu(network, timestep)
+    timestep = op.linear(
+        network,
+        timestep,
+        _array(state, "time_embedder.linear_2.weight"),
+        _array(state, "time_embedder.linear_2.bias"),
+        bf16=False,
+    )
+    timestep = op.cast(network, timestep, trt.bfloat16)
+    vision = network.add_elementwise(vision, timestep, trt.ElementWiseOperation.SUM).get_output(0)
+
+    if cp_size > 1:
+        text = op.reduce_scatter_replicated(network, text, cp_size)
+        vision = op.reduce_scatter_replicated(network, vision, cp_size)
+        text_cos = op.reduce_scatter_replicated(network, text_cos, cp_size)
+        text_sin = op.reduce_scatter_replicated(network, text_sin, cp_size)
+        vision_cos = op.reduce_scatter_replicated(network, vision_cos, cp_size)
+        vision_sin = op.reduce_scatter_replicated(network, vision_sin, cp_size)
+
+    for index in range(profile.num_hidden_layers):
+        prefix = f"layers.{index}"
+        text_norm = op.rms_norm(
+            network,
+            text,
+            _array(state, f"{prefix}.input_layernorm.weight"),
+            profile.hidden_size,
+            profile.rms_norm_eps,
+        )
+        vision_norm = op.rms_norm(
+            network,
+            vision,
+            _array(state, f"{prefix}.input_layernorm_moe_gen.weight"),
+            profile.hidden_size,
+            profile.rms_norm_eps,
+        )
+
+        def _project(stream, generation: bool, sequence_length: int):
+            projection_names = (
+                ("add_q_proj", "add_k_proj", "add_v_proj")
+                if generation
+                else ("to_q", "to_k", "to_v")
+            )
+            q_name, k_name, v_name = projection_names
+            q = op.linear(network, stream, _array(state, f"{prefix}.self_attn.{q_name}.weight"))
+            k = op.linear(network, stream, _array(state, f"{prefix}.self_attn.{k_name}.weight"))
+            v = op.linear(network, stream, _array(state, f"{prefix}.self_attn.{v_name}.weight"))
+            q_norm_name = "norm_added_q" if generation else "norm_q"
+            k_norm_name = "norm_added_k" if generation else "norm_k"
+            q = op.rms_norm_per_head(
+                network,
+                q,
+                _array(state, f"{prefix}.self_attn.{q_norm_name}.weight"),
+                sequence_length=sequence_length,
+                num_heads=profile.num_attention_heads,
+                head_dim=profile.head_dim,
+                eps=profile.rms_norm_eps,
+            )
+            k = op.rms_norm_per_head(
+                network,
+                k,
+                _array(state, f"{prefix}.self_attn.{k_norm_name}.weight"),
+                sequence_length=sequence_length,
+                num_heads=profile.num_key_value_heads,
+                head_dim=profile.head_dim,
+                eps=profile.rms_norm_eps,
+            )
+            return q, k, v
+
+        text_q, text_k, text_v = _project(text_norm, False, local_text_length)
+        vision_q, vision_k, vision_v = _project(vision_norm, True, local_vision_length)
+        text_q = op.apply_rotate_half_rope(
+            network,
+            text_q,
+            text_cos,
+            text_sin,
+            sequence_length=local_text_length,
+            num_heads=profile.num_attention_heads,
+            head_dim=profile.head_dim,
+        )
+        text_k = op.apply_rotate_half_rope(
+            network,
+            text_k,
+            text_cos,
+            text_sin,
+            sequence_length=local_text_length,
+            num_heads=profile.num_key_value_heads,
+            head_dim=profile.head_dim,
+        )
+        vision_q = op.apply_rotate_half_rope(
+            network,
+            vision_q,
+            vision_cos,
+            vision_sin,
+            sequence_length=local_vision_length,
+            num_heads=profile.num_attention_heads,
+            head_dim=profile.head_dim,
+        )
+        vision_k = op.apply_rotate_half_rope(
+            network,
+            vision_k,
+            vision_cos,
+            vision_sin,
+            sequence_length=local_vision_length,
+            num_heads=profile.num_key_value_heads,
+            head_dim=profile.head_dim,
+        )
+
+        if cp_size == 1:
+            text_context = op.attention(
+                network,
+                text_q,
+                text_k,
+                text_v,
+                q_sequence_length=text_length,
+                kv_sequence_length=text_length,
+                num_heads=profile.num_attention_heads,
+                num_kv_heads=profile.num_key_value_heads,
+                head_dim=profile.head_dim,
+                causal=True,
+            )
+            all_k = network.add_concatenation([text_k, vision_k])
+            all_k.axis = 0
+            all_v = network.add_concatenation([text_v, vision_v])
+            all_v.axis = 0
+            vision_context = op.attention(
+                network,
+                vision_q,
+                all_k.get_output(0),
+                all_v.get_output(0),
+                q_sequence_length=vision_length,
+                kv_sequence_length=text_length + vision_length,
+                num_heads=profile.num_attention_heads,
+                num_kv_heads=profile.num_key_value_heads,
+                head_dim=profile.head_dim,
+                causal=False,
+                mask=generation_mask,
+            )
+        else:
+            text_context, vision_context = op.ulysses_dual_attention(
+                network,
+                text_q,
+                text_k,
+                text_v,
+                vision_q,
+                vision_k,
+                vision_v,
+                local_text_length=local_text_length,
+                local_vision_length=local_vision_length,
+                num_heads=profile.num_attention_heads,
+                num_kv_heads=profile.num_key_value_heads,
+                head_dim=profile.head_dim,
+                world_size=cp_size,
+                generation_mask=generation_mask,
+                text_causal_mask=text_causal_mask,
+            )
+
+        text = op.residual(
+            network,
+            text,
+            op.linear(
+                network,
+                text_context,
+                _array(state, f"{prefix}.self_attn.to_out.weight"),
+            ),
+        )
+        vision = op.residual(
+            network,
+            vision,
+            op.linear(
+                network,
+                vision_context,
+                _array(state, f"{prefix}.self_attn.to_add_out.weight"),
+            ),
+        )
+        text_ffn_input = op.rms_norm(
+            network,
+            text,
+            _array(state, f"{prefix}.post_attention_layernorm.weight"),
+            profile.hidden_size,
+            profile.rms_norm_eps,
+        )
+        vision_ffn_input = op.rms_norm(
+            network,
+            vision,
+            _array(state, f"{prefix}.post_attention_layernorm_moe_gen.weight"),
+            profile.hidden_size,
+            profile.rms_norm_eps,
+        )
+        text = op.residual(
+            network,
+            text,
+            op.swiglu_mlp(
+                network,
+                text_ffn_input,
+                _array(state, f"{prefix}.mlp.gate_proj.weight"),
+                _array(state, f"{prefix}.mlp.up_proj.weight"),
+                _array(state, f"{prefix}.mlp.down_proj.weight"),
+            ),
+        )
+        vision = op.residual(
+            network,
+            vision,
+            op.swiglu_mlp(
+                network,
+                vision_ffn_input,
+                _array(state, f"{prefix}.mlp_moe_gen.gate_proj.weight"),
+                _array(state, f"{prefix}.mlp_moe_gen.up_proj.weight"),
+                _array(state, f"{prefix}.mlp_moe_gen.down_proj.weight"),
+            ),
+        )
+
+    vision = op.rms_norm(
+        network,
+        vision,
+        _array(state, "norm_moe_gen.weight"),
+        profile.hidden_size,
+        profile.rms_norm_eps,
+    )
+    output = op.linear(
+        network,
+        vision,
+        _array(state, "proj_out.weight"),
+        _array(state, "proj_out.bias"),
+    )
+    output = op.cast(network, output, trt.float32)
+    if cp_size > 1:
+        output = op.add_collective(network, output, trt.CollectiveOperation.ALL_GATHER, cp_size)
+    output.name = "noise_prediction_patches"
+    network.mark_output(output)
+
+    print(
+        "[cosmos3] building dual-stream denoiser: "
+        f"layers={profile.num_hidden_layers}, text={text_length}, "
+        f"vision={vision_length}, cp={cp_size}",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, build_config)
+    if plan is None:
+        raise RuntimeError("TensorRT failed to build Cosmos3-Nano denoiser")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/cosmos3/trt_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos3/trt_builder.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Component orchestration for the native Cosmos3-Nano T2V bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .model_config import COSMOS3_NANO_NEGATIVE_PROMPT, select_generation_profile
+
+
+def build_cosmos3_components(
+    model_dir: str,
+    *,
+    config,
+    weights: dict,
+    precision: str = "bf16",
+    verbose: bool = False,
+    parallel_config=None,
+    **_kwargs,
+) -> dict:
+    """Build the dual-stream denoiser and recurrent video decoder plans."""
+
+    del model_dir
+    if precision.lower() not in {"bf16", "bfloat16"}:
+        raise ValueError("Cosmos3-Nano requires BF16 precision")
+    profile = select_generation_profile(config.raw)
+
+    from .transformer_builder import build_cosmos3_transformer_engine
+    from .vae_step_builder import (
+        Cosmos3VaeStepProfile,
+        build_vae_step_engine,
+        load_vae_step_weights,
+    )
+
+    denoiser = build_cosmos3_transformer_engine(
+        weights["_transformer_dir"],
+        profile=profile,
+        parallel_config=parallel_config,
+        verbose=verbose,
+    )
+    vae_weights = load_vae_step_weights(weights["_vae_dir"])
+    vae_profile = Cosmos3VaeStepProfile(profile.latent_height, profile.latent_width)
+    vae_decoder = build_vae_step_engine(
+        vae_weights,
+        profile=vae_profile,
+        first_frame_only=False,
+        verbose=verbose,
+    )
+    vae_decoder_first_frame = build_vae_step_engine(
+        vae_weights,
+        profile=vae_profile,
+        first_frame_only=True,
+        verbose=verbose,
+    )
+    tokenizer_dir = Path(weights["_tokenizer_dir"])
+    tokenizer_json = (tokenizer_dir / "tokenizer.json").read_bytes()
+    tokenizer_config_json = (tokenizer_dir / "tokenizer_config.json").read_bytes()
+    return {
+        "denoiser": bytes(denoiser),
+        "vae_decoder": bytes(vae_decoder),
+        "vae_decoder_first_frame": bytes(vae_decoder_first_frame),
+        "tokenizer_json": tokenizer_json,
+        "tokenizer_config_json": tokenizer_config_json,
+        "negative_prompt": COSMOS3_NANO_NEGATIVE_PROMPT,
+    }

--- a/python/tensorrt_model_connect/families/cosmos3/trt_ops.py
+++ b/python/tensorrt_model_connect/families/cosmos3/trt_ops.py
@@ -1,0 +1,485 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small plugin-free TensorRT graph vocabulary for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+
+trt = trt_compat.get_trt()
+
+
+def cast(network, tensor, dtype):
+    if tensor.dtype == dtype:
+        return tensor
+    return network.add_cast(tensor, dtype).get_output(0)
+
+
+def constant(network, value, *, dtype=np.float32):
+    array = np.ascontiguousarray(value, dtype=dtype)
+    return network.add_constant(tuple(array.shape), array).get_output(0)
+
+
+def linear(network, x, weight, bias=None, *, bf16: bool = True):
+    """Linear projection from a PyTorch-layout ``[out, in]`` weight."""
+
+    rhs = constant(network, np.asarray(weight, dtype=np.float32).T)
+    if bf16:
+        x = cast(network, x, trt.bfloat16)
+        rhs = cast(network, rhs, trt.bfloat16)
+    result = network.add_matrix_multiply(
+        x,
+        trt.MatrixOperation.NONE,
+        rhs,
+        trt.MatrixOperation.NONE,
+    ).get_output(0)
+    if bias is not None:
+        bias_tensor = constant(network, np.asarray(bias, dtype=np.float32).reshape(1, -1))
+        bias_tensor = cast(network, bias_tensor, result.dtype)
+        result = network.add_elementwise(
+            result, bias_tensor, trt.ElementWiseOperation.SUM
+        ).get_output(0)
+    return cast(network, result, trt.bfloat16) if bf16 else result
+
+
+def rms_norm(network, x, weight, hidden_size: int, eps: float):
+    """RMSNorm in FP32 with a BF16 output boundary."""
+
+    x_fp32 = cast(network, x, trt.float32)
+    squared = network.add_elementwise(x_fp32, x_fp32, trt.ElementWiseOperation.PROD).get_output(0)
+    rank = len(tuple(x.shape))
+    mean = network.add_reduce(squared, trt.ReduceOperation.AVG, 1 << (rank - 1), True).get_output(0)
+    epsilon = constant(network, np.array([eps], dtype=np.float32).reshape((1,) * rank))
+    variance = network.add_elementwise(mean, epsilon, trt.ElementWiseOperation.SUM).get_output(0)
+    inverse = network.add_unary(variance, trt.UnaryOperation.SQRT).get_output(0)
+    inverse = network.add_unary(inverse, trt.UnaryOperation.RECIP).get_output(0)
+    normalized = network.add_elementwise(x_fp32, inverse, trt.ElementWiseOperation.PROD).get_output(
+        0
+    )
+    gamma_shape = (1,) * (rank - 1) + (hidden_size,)
+    gamma = constant(network, np.asarray(weight, dtype=np.float32).reshape(gamma_shape))
+    result = network.add_elementwise(normalized, gamma, trt.ElementWiseOperation.PROD).get_output(0)
+    return cast(network, result, trt.bfloat16)
+
+
+def rms_norm_per_head(
+    network,
+    x,
+    weight,
+    *,
+    sequence_length: int,
+    num_heads: int,
+    head_dim: int,
+    eps: float,
+):
+    rows = network.add_shuffle(x)
+    rows.reshape_dims = (sequence_length, num_heads, head_dim)
+    normalized = rms_norm(network, rows.get_output(0), weight, head_dim, eps)
+    result = network.add_shuffle(normalized)
+    result.reshape_dims = (sequence_length, num_heads * head_dim)
+    return result.get_output(0)
+
+
+def silu(network, x):
+    sigmoid = network.add_activation(x, trt.ActivationType.SIGMOID).get_output(0)
+    return network.add_elementwise(x, sigmoid, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def swiglu_mlp(network, x, gate_weight, up_weight, down_weight):
+    gate = silu(network, linear(network, x, gate_weight))
+    up = linear(network, x, up_weight)
+    gated = network.add_elementwise(gate, up, trt.ElementWiseOperation.PROD).get_output(0)
+    return linear(network, gated, down_weight)
+
+
+def residual(network, x, update):
+    x = cast(network, x, trt.float32)
+    update = cast(network, update, trt.float32)
+    return network.add_elementwise(x, update, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def apply_rotate_half_rope(
+    network,
+    rows,
+    cos,
+    sin,
+    *,
+    sequence_length: int,
+    num_heads: int,
+    head_dim: int,
+):
+    """Apply the checkpoint's rotate-half mRoPE values to row-major heads."""
+
+    heads = network.add_shuffle(rows)
+    heads.reshape_dims = (sequence_length, num_heads, head_dim)
+    typed = cast(network, heads.get_output(0), trt.bfloat16)
+
+    cos_view = network.add_shuffle(cast(network, cos, trt.bfloat16))
+    cos_view.reshape_dims = (sequence_length, 1, head_dim)
+    sin_view = network.add_shuffle(cast(network, sin, trt.bfloat16))
+    sin_view.reshape_dims = (sequence_length, 1, head_dim)
+
+    half = head_dim // 2
+    first = network.add_slice(
+        typed, (0, 0, 0), (sequence_length, num_heads, half), (1, 1, 1)
+    ).get_output(0)
+    second = network.add_slice(
+        typed, (0, 0, half), (sequence_length, num_heads, half), (1, 1, 1)
+    ).get_output(0)
+    minus_one = cast(
+        network,
+        constant(network, np.array([[[-1.0]]], dtype=np.float32)),
+        trt.bfloat16,
+    )
+    negative_second = network.add_elementwise(
+        second, minus_one, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    rotated = network.add_concatenation([negative_second, first])
+    rotated.axis = 2
+
+    direct = network.add_elementwise(
+        typed, cos_view.get_output(0), trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    crossed = network.add_elementwise(
+        rotated.get_output(0), sin_view.get_output(0), trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    output = network.add_elementwise(direct, crossed, trt.ElementWiseOperation.SUM)
+    output_rows = network.add_shuffle(output.get_output(0))
+    output_rows.reshape_dims = (sequence_length, num_heads * head_dim)
+    return output_rows.get_output(0)
+
+
+def rows_to_heads(network, x, sequence_length: int, heads: int, head_dim: int):
+    rows = network.add_shuffle(x)
+    rows.reshape_dims = (sequence_length, heads, head_dim)
+    rows.second_transpose = trt.Permutation([1, 0, 2])
+    batched = network.add_shuffle(rows.get_output(0))
+    batched.reshape_dims = (1, heads, sequence_length, head_dim)
+    return batched.get_output(0)
+
+
+def heads_to_rows(network, x, sequence_length: int, hidden_size: int):
+    rows = network.add_shuffle(x)
+    rows.first_transpose = trt.Permutation([0, 2, 1, 3])
+    rows.reshape_dims = (sequence_length, hidden_size)
+    return rows.get_output(0)
+
+
+def attention(
+    network,
+    q,
+    k,
+    v,
+    *,
+    q_sequence_length: int,
+    kv_sequence_length: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    causal: bool,
+    mask=None,
+):
+    """Native TensorRT GQA with fallback for unsupported fused shapes."""
+
+    q4 = rows_to_heads(
+        network, cast(network, q, trt.bfloat16), q_sequence_length, num_heads, head_dim
+    )
+    k4 = rows_to_heads(
+        network, cast(network, k, trt.bfloat16), kv_sequence_length, num_kv_heads, head_dim
+    )
+    v4 = rows_to_heads(
+        network, cast(network, v, trt.bfloat16), kv_sequence_length, num_kv_heads, head_dim
+    )
+    scale = cast(
+        network,
+        constant(network, np.array([[[[1.0 / math.sqrt(head_dim)]]]], dtype=np.float32)),
+        trt.bfloat16,
+    )
+    q4 = network.add_elementwise(q4, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    layer = network.add_attention(
+        q4,
+        k4,
+        v4,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        causal,
+    )
+    if layer is None:
+        raise RuntimeError("TensorRT failed to add Cosmos3 fused attention")
+    layer.decomposable = True
+    if mask is not None:
+        layer.mask = cast(network, mask, trt.bfloat16)
+    return heads_to_rows(
+        network,
+        cast(network, layer.get_output(0), trt.bfloat16),
+        q_sequence_length,
+        num_heads * head_dim,
+    )
+
+
+def add_collective(network, tensor, operation, world_size: int, *, reduce_operation=None):
+    add_layer = getattr(network, "add_dist_collective", None)
+    if add_layer is None:
+        raise RuntimeError("Cosmos3 context parallel requires TensorRT 11 distributed collectives")
+    if reduce_operation is None:
+        reduce_operation = getattr(trt.ReduceOperation, "NONE", trt.ReduceOperation.SUM)
+    layer = add_layer(tensor, operation, reduce_operation, -1, [])
+    if layer is None or not hasattr(layer, "num_ranks"):
+        raise RuntimeError(f"TensorRT failed to add Cosmos3 collective {operation}")
+    layer.name = f"cosmos3_collective_{network.num_layers}_{operation}"
+    layer.num_ranks = int(world_size)
+    return layer.get_output(0)
+
+
+def reduce_scatter_replicated(network, tensor, world_size: int):
+    """Shard identical full rows while cancelling REDUCE_SCATTER's sum."""
+
+    scale = cast(
+        network,
+        constant(network, np.array([[1.0 / world_size]], dtype=np.float32)),
+        tensor.dtype,
+    )
+    scaled = network.add_elementwise(tensor, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    return add_collective(
+        network,
+        scaled,
+        trt.CollectiveOperation.REDUCE_SCATTER,
+        world_size,
+        reduce_operation=trt.ReduceOperation.SUM,
+    )
+
+
+def ulysses_seq_to_heads(
+    network,
+    tensor,
+    *,
+    local_sequence_length: int,
+    total_heads: int,
+    head_dim: int,
+    world_size: int,
+):
+    """Exchange sequence shards for full-sequence head shards."""
+
+    local_heads = total_heads // world_size
+    routed = network.add_shuffle(tensor)
+    routed.reshape_dims = (local_sequence_length, world_size, local_heads, head_dim)
+    routed.second_transpose = trt.Permutation([1, 0, 2, 3])
+    # TensorRT 11.1 has native FP16/FP32 ALL_TO_ALL tactics, but its BF16
+    # collective is routed through Myelin and rejected at engine-build time.
+    # Keep the transformer math in BF16 and use FP16 only on the wire, matching
+    # the precision used by the existing Wan Ulysses implementation.
+    routed_fp16 = cast(network, routed.get_output(0), trt.float16)
+    exchanged = add_collective(
+        network, routed_fp16, trt.CollectiveOperation.ALL_TO_ALL, world_size
+    )
+    full = network.add_shuffle(cast(network, exchanged, trt.bfloat16))
+    full.first_transpose = trt.Permutation([2, 0, 1, 3])
+    full.reshape_dims = (1, local_heads, local_sequence_length * world_size, head_dim)
+    return full.get_output(0)
+
+
+def repeat_kv_heads(network, tensor, *, kv_heads: int, query_heads: int):
+    """Expand each local GQA KV head into its consecutive query-head group."""
+
+    if query_heads % kv_heads:
+        raise ValueError("Cosmos3 local query heads must be a multiple of local KV heads")
+    repeats = query_heads // kv_heads
+    if repeats == 1:
+        return tensor
+    _, _, sequence_length, head_dim = tuple(tensor.shape)
+    parts = []
+    for index in range(kv_heads):
+        head = network.add_slice(
+            tensor,
+            (0, index, 0, 0),
+            (1, 1, sequence_length, head_dim),
+            (1, 1, 1, 1),
+        ).get_output(0)
+        parts.extend([head] * repeats)
+    expanded = network.add_concatenation(parts)
+    expanded.axis = 1
+    return expanded.get_output(0)
+
+
+def ulysses_heads_to_seq(
+    network,
+    tensor,
+    *,
+    local_sequence_length: int,
+    total_heads: int,
+    head_dim: int,
+    world_size: int,
+):
+    """Invert Ulysses head sharding back to local row-major tokens."""
+
+    local_heads = total_heads // world_size
+    routed = network.add_shuffle(tensor)
+    routed.reshape_dims = (local_heads, world_size, local_sequence_length, head_dim)
+    routed.second_transpose = trt.Permutation([1, 0, 2, 3])
+    routed_fp16 = cast(network, routed.get_output(0), trt.float16)
+    exchanged = add_collective(
+        network, routed_fp16, trt.CollectiveOperation.ALL_TO_ALL, world_size
+    )
+    rows = network.add_shuffle(cast(network, exchanged, trt.bfloat16))
+    rows.first_transpose = trt.Permutation([2, 0, 1, 3])
+    rows.reshape_dims = (local_sequence_length, total_heads * head_dim)
+    return rows.get_output(0)
+
+
+def ulysses_dual_attention(
+    network,
+    q_text,
+    k_text,
+    v_text,
+    q_vision,
+    k_vision,
+    v_vision,
+    *,
+    local_text_length: int,
+    local_vision_length: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    world_size: int,
+    generation_mask,
+    text_causal_mask,
+):
+    """Official two-pathway Ulysses exchange with local GQA expansion.
+
+    TensorRT 11.1 cannot compile two collective-adjacent ``IAttention``
+    regions in this graph.  Keep the dominant joint video attention in
+    ``IAttention`` so TensorRT can fuse supported shapes or fall back to its
+    decomposition, and manually decompose the much shorter causal text
+    attention.
+    """
+
+    q_text_full = ulysses_seq_to_heads(
+        network,
+        q_text,
+        local_sequence_length=local_text_length,
+        total_heads=num_heads,
+        head_dim=head_dim,
+        world_size=world_size,
+    )
+    q_vision_full = ulysses_seq_to_heads(
+        network,
+        q_vision,
+        local_sequence_length=local_vision_length,
+        total_heads=num_heads,
+        head_dim=head_dim,
+        world_size=world_size,
+    )
+    kv_inputs = (k_text, v_text, k_vision, v_vision)
+    k_text_full, v_text_full, k_vision_full, v_vision_full = (
+        ulysses_seq_to_heads(
+            network,
+            value,
+            local_sequence_length=(local_text_length if index < 2 else local_vision_length),
+            total_heads=num_kv_heads,
+            head_dim=head_dim,
+            world_size=world_size,
+        )
+        for index, value in enumerate(kv_inputs)
+    )
+    local_query_heads = num_heads // world_size
+    local_kv_heads = num_kv_heads // world_size
+    k_text_full = repeat_kv_heads(
+        network, k_text_full, kv_heads=local_kv_heads, query_heads=local_query_heads
+    )
+    v_text_full = repeat_kv_heads(
+        network, v_text_full, kv_heads=local_kv_heads, query_heads=local_query_heads
+    )
+    k_vision_full = repeat_kv_heads(
+        network, k_vision_full, kv_heads=local_kv_heads, query_heads=local_query_heads
+    )
+    v_vision_full = repeat_kv_heads(
+        network, v_vision_full, kv_heads=local_kv_heads, query_heads=local_query_heads
+    )
+
+    scale = cast(
+        network,
+        constant(network, np.array([[[[1.0 / math.sqrt(head_dim)]]]], dtype=np.float32)),
+        trt.bfloat16,
+    )
+
+    def _fused(q4, k4, v4, *, causal: bool, mask=None):
+        q4 = network.add_elementwise(
+            cast(network, q4, trt.bfloat16), scale, trt.ElementWiseOperation.PROD
+        ).get_output(0)
+        layer = network.add_attention(
+            q4,
+            cast(network, k4, trt.bfloat16),
+            cast(network, v4, trt.bfloat16),
+            trt.AttentionNormalizationOp.SOFTMAX,
+            causal,
+        )
+        if layer is None:
+            raise RuntimeError("TensorRT failed to add Cosmos3 CP fused attention")
+        layer.name = f"cosmos3_cp_attention_{network.num_layers}_joint"
+        layer.decomposable = True
+        if mask is not None:
+            layer.mask = cast(network, mask, trt.bfloat16)
+        return cast(network, layer.get_output(0), trt.bfloat16)
+
+    def _decomposed_causal(q4, k4, v4):
+        k_transpose = network.add_shuffle(k4)
+        k_transpose.second_transpose = trt.Permutation([0, 1, 3, 2])
+        scores = network.add_matrix_multiply(
+            q4,
+            trt.MatrixOperation.NONE,
+            k_transpose.get_output(0),
+            trt.MatrixOperation.NONE,
+        ).get_output(0)
+        scores = cast(network, scores, trt.float32)
+        score_scale = constant(
+            network,
+            np.array([[[[1.0 / math.sqrt(head_dim)]]]], dtype=np.float32),
+        )
+        scores = network.add_elementwise(scores, score_scale, trt.ElementWiseOperation.PROD)
+        scores = network.add_elementwise(
+            scores.get_output(0), text_causal_mask, trt.ElementWiseOperation.SUM
+        ).get_output(0)
+        probabilities = network.add_softmax(scores)
+        probabilities.axes = 1 << 3
+        return network.add_matrix_multiply(
+            cast(network, probabilities.get_output(0), trt.bfloat16),
+            trt.MatrixOperation.NONE,
+            v4,
+            trt.MatrixOperation.NONE,
+        ).get_output(0)
+
+    text_context = _decomposed_causal(q_text_full, k_text_full, v_text_full)
+    all_k = network.add_concatenation([k_text_full, k_vision_full])
+    all_k.axis = 2
+    all_v = network.add_concatenation([v_text_full, v_vision_full])
+    all_v.axis = 2
+    vision_context = _fused(
+        q_vision_full,
+        all_k.get_output(0),
+        all_v.get_output(0),
+        causal=False,
+        mask=generation_mask,
+    )
+    return (
+        ulysses_heads_to_seq(
+            network,
+            text_context,
+            local_sequence_length=local_text_length,
+            total_heads=num_heads,
+            head_dim=head_dim,
+            world_size=world_size,
+        ),
+        ulysses_heads_to_seq(
+            network,
+            vision_context,
+            local_sequence_length=local_vision_length,
+            total_heads=num_heads,
+            head_dim=head_dim,
+            world_size=world_size,
+        ),
+    )

--- a/python/tensorrt_model_connect/families/cosmos3/vae_step_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos3/vae_step_builder.py
@@ -1,0 +1,550 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native recurrent Cosmos3-Nano video autoencoder decoder engines.
+
+The Diffusers decoder consumes one latent frame per call.  Thirty-two causal
+convolutions carry the two preceding feature frames between calls.  Encoding
+that source contract as two fixed TensorRT engines avoids the activation arena
+of the fully unrolled 48-latent graph:
+
+* the initializer consumes one latent and zero caches and emits one video frame;
+* the recurrent step consumes one latent and the 32 caches and emits four frames.
+
+Both engines expose identical fixed-size ``cache_0`` ... ``cache_31`` inputs
+and ``cache_out_0`` ... ``cache_out_31`` outputs.  Initializer cache outputs are
+left-zero-padded to two frames, replacing Diffusers' Python-only ``"Rep"``
+sentinel with an exactly equivalent native tensor contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .checkpoint_mapper import load_vae_decoder_weights
+
+
+OFFICIAL_VAE_WORKSPACE_GIB = 64
+
+
+@dataclass(frozen=True)
+class Cosmos3VaeStepProfile:
+    """Static spatial contract shared by initializer and recurrent engines."""
+
+    latent_height: int
+    latent_width: int
+
+    def __post_init__(self) -> None:
+        if self.latent_height <= 0 or self.latent_width <= 0:
+            raise ValueError(
+                "Cosmos3 VAE step latent dimensions must be positive, got "
+                f"{self.latent_height}x{self.latent_width}"
+            )
+
+    @property
+    def latent_shape(self) -> tuple[int, int, int, int, int]:
+        return (1, 48, 1, self.latent_height, self.latent_width)
+
+    def video_shape(self, *, first_frame_only: bool) -> tuple[int, int, int, int, int]:
+        return (
+            1,
+            3,
+            1 if first_frame_only else 4,
+            self.latent_height * 16,
+            self.latent_width * 16,
+        )
+
+
+def _cuda_runtime():
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart
+        except ImportError as exc:
+            raise RuntimeError(
+                "Cosmos3 VAE build requires CUDA Python to query the active GPU"
+            ) from exc
+    return cudart
+
+
+def _current_cuda_compute_capability() -> tuple[int, int]:
+    cudart = _cuda_runtime()
+    success = getattr(getattr(cudart, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status, device = cudart.cudaGetDevice()
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDevice failed with status {status}")
+        status, properties = cudart.cudaGetDeviceProperties(int(device))
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDeviceProperties failed with status {status}")
+        major = int(properties.major)
+        minor = int(properties.minor)
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"Cosmos3 VAE could not query the active CUDA device: {exc}") from exc
+    if major <= 0 or minor < 0:
+        raise RuntimeError(f"Cosmos3 VAE received invalid CUDA compute capability {major}.{minor}")
+    return major, minor
+
+
+def select_vae_convolution_precision(
+    profile: Cosmos3VaeStepProfile,
+    compute_capability: tuple[int, int],
+) -> str:
+    """Return the qualified convolution precision for one VAE profile and GPU."""
+
+    if (profile.latent_height, profile.latent_width) == (45, 80) and compute_capability >= (
+        8,
+        0,
+    ):
+        return "bf16"
+    return "fp32"
+
+
+@dataclass(frozen=True)
+class Cosmos3VaeCacheSpec:
+    """One source-ordered causal feature-cache tensor."""
+
+    index: int
+    logical_name: str
+    channels: int
+    spatial_scale: int
+
+    def shape(self, profile: Cosmos3VaeStepProfile) -> tuple[int, int, int, int, int]:
+        return (
+            1,
+            self.channels,
+            2,
+            profile.latent_height * self.spatial_scale,
+            profile.latent_width * self.spatial_scale,
+        )
+
+
+# Execution order follows the upstream decoder's mutable feature-cache index.
+# The decoder owns 34 causal convolutions, but the two channel-changing
+# conv_shortcut modules are ordinary residual projections and never use caches.
+VAE_STEP_CACHE_SPECS = (
+    Cosmos3VaeCacheSpec(0, "decoder.conv_in", 48, 1),
+    Cosmos3VaeCacheSpec(1, "decoder.mid_block.resnets.0.conv1", 1024, 1),
+    Cosmos3VaeCacheSpec(2, "decoder.mid_block.resnets.0.conv2", 1024, 1),
+    Cosmos3VaeCacheSpec(3, "decoder.mid_block.resnets.1.conv1", 1024, 1),
+    Cosmos3VaeCacheSpec(4, "decoder.mid_block.resnets.1.conv2", 1024, 1),
+    *(
+        Cosmos3VaeCacheSpec(
+            5 + resnet * 2 + conv - 1, f"decoder.up_blocks.0.resnets.{resnet}.conv{conv}", 1024, 1
+        )
+        for resnet in range(3)
+        for conv in (1, 2)
+    ),
+    Cosmos3VaeCacheSpec(11, "decoder.up_blocks.0.upsampler.time_conv", 1024, 1),
+    *(
+        Cosmos3VaeCacheSpec(
+            12 + resnet * 2 + conv - 1, f"decoder.up_blocks.1.resnets.{resnet}.conv{conv}", 1024, 2
+        )
+        for resnet in range(3)
+        for conv in (1, 2)
+    ),
+    Cosmos3VaeCacheSpec(18, "decoder.up_blocks.1.upsampler.time_conv", 1024, 2),
+    Cosmos3VaeCacheSpec(19, "decoder.up_blocks.2.resnets.0.conv1", 1024, 4),
+    Cosmos3VaeCacheSpec(20, "decoder.up_blocks.2.resnets.0.conv2", 512, 4),
+    Cosmos3VaeCacheSpec(21, "decoder.up_blocks.2.resnets.1.conv1", 512, 4),
+    Cosmos3VaeCacheSpec(22, "decoder.up_blocks.2.resnets.1.conv2", 512, 4),
+    Cosmos3VaeCacheSpec(23, "decoder.up_blocks.2.resnets.2.conv1", 512, 4),
+    Cosmos3VaeCacheSpec(24, "decoder.up_blocks.2.resnets.2.conv2", 512, 4),
+    Cosmos3VaeCacheSpec(25, "decoder.up_blocks.3.resnets.0.conv1", 512, 8),
+    Cosmos3VaeCacheSpec(26, "decoder.up_blocks.3.resnets.0.conv2", 256, 8),
+    Cosmos3VaeCacheSpec(27, "decoder.up_blocks.3.resnets.1.conv1", 256, 8),
+    Cosmos3VaeCacheSpec(28, "decoder.up_blocks.3.resnets.1.conv2", 256, 8),
+    Cosmos3VaeCacheSpec(29, "decoder.up_blocks.3.resnets.2.conv1", 256, 8),
+    Cosmos3VaeCacheSpec(30, "decoder.up_blocks.3.resnets.2.conv2", 256, 8),
+    Cosmos3VaeCacheSpec(31, "decoder.conv_out", 256, 8),
+)
+
+if tuple(spec.index for spec in VAE_STEP_CACHE_SPECS) != tuple(range(32)):
+    raise RuntimeError("Cosmos3 VAE cache specification must contain consecutive indices 0..31")
+
+
+def load_vae_step_weights(checkpoint: str | Path) -> dict[str, np.ndarray | list[float]]:
+    """Load Diffusers decoder tensors plus the checkpoint's latent statistics."""
+
+    selected = load_vae_decoder_weights(checkpoint)
+    result: dict[str, np.ndarray | list[float]] = {}
+    for name, value in selected.items():
+        if name.startswith("_"):
+            result[name] = value
+        else:
+            result[name] = np.ascontiguousarray(
+                value.detach().float().cpu().numpy(), dtype=np.float32
+            )
+    return result
+
+
+def _add_dup_up3d(
+    trt,
+    network,
+    tensor,
+    *,
+    out_channels: int,
+    factor_t: int,
+    factor_s: int,
+    first_frame_only: bool,
+):
+    """TensorRT spelling of Diffusers DupUp3D, including first-chunk trim."""
+
+    batch, in_channels, frames, height, width = tuple(tensor.shape)
+    factor = factor_t * factor_s * factor_s
+    if out_channels * factor % in_channels != 0:
+        raise RuntimeError(
+            f"Invalid Cosmos3 DupUp3D contract {in_channels}->{out_channels}, factor={factor}"
+        )
+    repeats = out_channels * factor // in_channels
+    expanded = network.add_shuffle(tensor)
+    expanded.reshape_dims = (batch, in_channels, 1, frames, height, width)
+    repeated = network.add_concatenation([expanded.get_output(0)] * repeats)
+    repeated.axis = 2
+    factored = network.add_shuffle(repeated.get_output(0))
+    factored.reshape_dims = (
+        batch,
+        out_channels,
+        factor_t,
+        factor_s,
+        factor_s,
+        frames,
+        height,
+        width,
+    )
+    arranged = network.add_shuffle(factored.get_output(0))
+    arranged.first_transpose = trt.Permutation([0, 1, 5, 2, 6, 3, 7, 4])
+    output = network.add_shuffle(arranged.get_output(0))
+    output.reshape_dims = (
+        batch,
+        out_channels,
+        frames * factor_t,
+        height * factor_s,
+        width * factor_s,
+    )
+    result = output.get_output(0)
+    if first_frame_only and factor_t > 1:
+        trim = network.add_slice(
+            result,
+            start=(0, 0, factor_t - 1, 0, 0),
+            shape=(batch, out_channels, frames, height * factor_s, width * factor_s),
+            stride=(1, 1, 1, 1, 1),
+        )
+        result = trim.get_output(0)
+    return result
+
+
+def _add_unpatchify(trt, network, tensor, *, patch_size: int = 2):
+    """TensorRT spelling of Diffusers unpatchify for the Cosmos3 12-channel head."""
+
+    batch, patched_channels, frames, height, width = tuple(tensor.shape)
+    channels = patched_channels // (patch_size * patch_size)
+    factored = network.add_shuffle(tensor)
+    factored.reshape_dims = (
+        batch,
+        channels,
+        patch_size,
+        patch_size,
+        frames,
+        height,
+        width,
+    )
+    arranged = network.add_shuffle(factored.get_output(0))
+    arranged.first_transpose = trt.Permutation([0, 1, 4, 5, 3, 6, 2])
+    output = network.add_shuffle(arranged.get_output(0))
+    output.reshape_dims = (
+        batch,
+        channels,
+        frames,
+        height * patch_size,
+        width * patch_size,
+    )
+    clip = network.add_activation(output.get_output(0), trt.ActivationType.CLIP)
+    clip.alpha = -1.0
+    clip.beta = 1.0
+    return clip.get_output(0)
+
+
+def build_vae_step_engine(
+    weights: dict[str, np.ndarray | list[float]],
+    *,
+    profile: Cosmos3VaeStepProfile,
+    first_frame_only: bool,
+    verbose: bool = False,
+) -> bytes:
+    """Build one fixed initializer or recurrent Cosmos3 VAE engine."""
+
+    from tensorrt_model_connect import trt_compat
+    from . import graph_blocks, graph_ops
+
+    if (profile.latent_height, profile.latent_width) != (45, 80):
+        raise ValueError(
+            "Cosmos3 VAE step engines are qualified only for the 45x80 latent spatial "
+            f"profiles, got {profile.latent_height}x{profile.latent_width}"
+        )
+
+    trt = trt_compat.get_trt()
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.INFO)
+    builder = trt.Builder(logger)
+    flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    network = builder.create_network(flags)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, OFFICIAL_VAE_WORKSPACE_GIB << 30)
+    compute_capability = _current_cuda_compute_capability()
+    convolution_precision = select_vae_convolution_precision(
+        profile,
+        compute_capability,
+    )
+    convolution_dtype = trt.bfloat16 if convolution_precision == "bf16" else trt.float32
+
+    latent = network.add_input("latent_frame", trt.float32, profile.latent_shape)
+    cache_inputs = [
+        network.add_input(f"cache_{spec.index}", trt.float32, spec.shape(profile))
+        for spec in VAE_STEP_CACHE_SPECS
+    ]
+    cache_outputs = [None] * len(VAE_STEP_CACHE_SPECS)
+    cache_index = 0
+
+    def take_cache(logical_name: str, channels: int, scale: int):
+        nonlocal cache_index
+        spec = VAE_STEP_CACHE_SPECS[cache_index]
+        if (spec.logical_name, spec.channels, spec.spatial_scale) != (
+            logical_name,
+            channels,
+            scale,
+        ):
+            raise RuntimeError(
+                f"Cosmos3 VAE cache {cache_index} is {spec}, expected "
+                f"{logical_name}/{channels}/scale{scale}"
+            )
+        index = cache_index
+        cache_index += 1
+        return index, cache_inputs[index]
+
+    mean = graph_ops.add_constant(
+        network,
+        (1, 48, 1, 1, 1),
+        np.asarray(weights["_latents_mean"], dtype=np.float32).reshape(1, 48, 1, 1, 1),
+    )
+    std = graph_ops.add_constant(
+        network,
+        (1, 48, 1, 1, 1),
+        np.asarray(weights["_latents_std"], dtype=np.float32).reshape(1, 48, 1, 1, 1),
+    )
+    scaled = network.add_elementwise(latent, std, trt.ElementWiseOperation.PROD)
+    denormalized = network.add_elementwise(scaled.get_output(0), mean, trt.ElementWiseOperation.SUM)
+    x = graph_ops.add_conv3d_as_conv2d(
+        network,
+        denormalized.get_output(0),
+        weight=weights["post_quant_conv.weight"],
+        bias=weights["post_quant_conv.bias"],
+        out_channels=48,
+        kernel_size=(1, 1, 1),
+        convolution_dtype=convolution_dtype,
+    )
+
+    current_scale = 1
+    index, cache = take_cache("decoder.conv_in", 48, current_scale)
+    x, cache_outputs[index] = graph_ops.add_causal_conv3d(
+        network,
+        x,
+        cache,
+        weight=weights["decoder.conv_in.weight"],
+        bias=weights["decoder.conv_in.bias"],
+        out_channels=1024,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+        convolution_dtype=convolution_dtype,
+    )
+
+    def add_resnet(tensor, *, prefix: str, input_channels: int, output_channels: int):
+        norm1 = graph_ops.add_l2_channel_norm(
+            network,
+            tensor,
+            input_channels,
+            weights[f"{prefix}.norm1.gamma"],
+            1.0e-12,
+        )
+        act1 = graph_ops.add_silu(network, norm1)
+        cache1_index, cache1 = take_cache(f"{prefix}.conv1", input_channels, current_scale)
+        conv1, cache_outputs[cache1_index] = graph_ops.add_causal_conv3d(
+            network,
+            act1,
+            cache1,
+            weight=weights[f"{prefix}.conv1.weight"],
+            bias=weights[f"{prefix}.conv1.bias"],
+            out_channels=output_channels,
+            kernel_size=(3, 3, 3),
+            padding_hw=(1, 1),
+            convolution_dtype=convolution_dtype,
+        )
+        norm2 = graph_ops.add_l2_channel_norm(
+            network,
+            conv1,
+            output_channels,
+            weights[f"{prefix}.norm2.gamma"],
+            1.0e-12,
+        )
+        act2 = graph_ops.add_silu(network, norm2)
+        cache2_index, cache2 = take_cache(f"{prefix}.conv2", output_channels, current_scale)
+        conv2, cache_outputs[cache2_index] = graph_ops.add_causal_conv3d(
+            network,
+            act2,
+            cache2,
+            weight=weights[f"{prefix}.conv2.weight"],
+            bias=weights[f"{prefix}.conv2.bias"],
+            out_channels=output_channels,
+            kernel_size=(3, 3, 3),
+            padding_hw=(1, 1),
+            convolution_dtype=convolution_dtype,
+        )
+        if input_channels == output_channels:
+            shortcut = tensor
+        else:
+            shortcut = graph_ops.add_conv3d_as_conv2d(
+                network,
+                tensor,
+                weight=weights[f"{prefix}.conv_shortcut.weight"],
+                bias=weights[f"{prefix}.conv_shortcut.bias"],
+                out_channels=output_channels,
+                kernel_size=(1, 1, 1),
+                convolution_dtype=convolution_dtype,
+            )
+        return network.add_elementwise(conv2, shortcut, trt.ElementWiseOperation.SUM).get_output(0)
+
+    for middle in range(2):
+        prefix = f"decoder.mid_block.resnets.{middle}"
+        x = add_resnet(x, prefix=prefix, input_channels=1024, output_channels=1024)
+        if middle == 0:
+            x = graph_blocks.add_vae_spatial_attention(
+                network,
+                x,
+                weights=weights,
+                prefix="decoder.mid_block.attentions.0",
+                channels=1024,
+                eps=1.0e-12,
+            )
+
+    decoder_channels = (1024, 1024, 512, 256)
+    previous_channels = 1024
+    for level, output_channels in enumerate(decoder_channels):
+        block_input = x
+        for resnet in range(3):
+            input_channels = previous_channels if resnet == 0 else output_channels
+            prefix = f"decoder.up_blocks.{level}.resnets.{resnet}"
+            x = add_resnet(
+                x,
+                prefix=prefix,
+                input_channels=input_channels,
+                output_channels=output_channels,
+            )
+        previous_channels = output_channels
+
+        has_upsampler = level < 3
+        has_temporal = level in (0, 1)
+        if has_temporal:
+            prefix = f"decoder.up_blocks.{level}.upsampler.time_conv"
+            index, cache = take_cache(prefix, output_channels, current_scale)
+            if first_frame_only:
+                # TensorRT does not allow one ITensor to be both a network
+                # input and output.  Diffusers' first call leaves these two
+                # zero/sentinel caches unchanged, so materialize an explicit
+                # identity output with the same source semantics.
+                cache_outputs[index] = network.add_identity(cache).get_output(0)
+            else:
+                x, cache_outputs[index] = graph_ops.add_causal_conv3d(
+                    network,
+                    x,
+                    cache,
+                    weight=weights[f"{prefix}.weight"],
+                    bias=weights[f"{prefix}.bias"],
+                    out_channels=output_channels * 2,
+                    kernel_size=(3, 1, 1),
+                    convolution_dtype=convolution_dtype,
+                )
+                x = graph_ops.add_temporal_pixel_shuffle(network, x, factor=2)
+
+        if has_upsampler:
+            prefix = f"decoder.up_blocks.{level}.upsampler.resample.1"
+            x = graph_ops.add_spatial_upsample_with_conv(
+                network,
+                x,
+                weight=weights[f"{prefix}.weight"],
+                bias=weights[f"{prefix}.bias"],
+                scale=2,
+                convolution_dtype=convolution_dtype,
+            )
+            current_scale *= 2
+
+            shortcut = _add_dup_up3d(
+                trt,
+                network,
+                block_input,
+                out_channels=output_channels,
+                factor_t=2 if has_temporal else 1,
+                factor_s=2,
+                first_frame_only=first_frame_only,
+            )
+            x = network.add_elementwise(x, shortcut, trt.ElementWiseOperation.SUM).get_output(0)
+
+    x = graph_ops.add_l2_channel_norm(
+        network,
+        x,
+        256,
+        weights["decoder.norm_out.gamma"],
+        1.0e-12,
+    )
+    x = graph_ops.add_silu(network, x)
+    index, cache = take_cache("decoder.conv_out", 256, current_scale)
+    x, cache_outputs[index] = graph_ops.add_causal_conv3d(
+        network,
+        x,
+        cache,
+        weight=weights["decoder.conv_out.weight"],
+        bias=weights["decoder.conv_out.bias"],
+        out_channels=12,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+        convolution_dtype=convolution_dtype,
+    )
+    x = _add_unpatchify(trt, network, x)
+
+    if cache_index != len(VAE_STEP_CACHE_SPECS) or any(value is None for value in cache_outputs):
+        raise RuntimeError(
+            f"Cosmos3 VAE step graph populated {cache_index} caches with "
+            f"{sum(value is not None for value in cache_outputs)} outputs, expected 32"
+        )
+    expected_video_shape = profile.video_shape(first_frame_only=first_frame_only)
+    if tuple(x.shape) != expected_video_shape:
+        raise RuntimeError(
+            f"Cosmos3 VAE step output is {tuple(x.shape)}, expected {expected_video_shape}"
+        )
+    x.name = "video_frame"
+    network.mark_output(x)
+    for spec, cache_output in zip(VAE_STEP_CACHE_SPECS, cache_outputs, strict=True):
+        if tuple(cache_output.shape) != spec.shape(profile):
+            raise RuntimeError(
+                f"Cosmos3 VAE cache_out_{spec.index} is {tuple(cache_output.shape)}, "
+                f"expected {spec.shape(profile)}"
+            )
+        cache_output.name = f"cache_out_{spec.index}"
+        network.mark_output(cache_output)
+
+    kind = "initializer" if first_frame_only else "recurrent"
+    print(
+        f"[cosmos3-vae-step] building {kind}: video={expected_video_shape}, "
+        f"caches={len(VAE_STEP_CACHE_SPECS)}, convolutions={convolution_precision}, "
+        f"sm={compute_capability[0]}{compute_capability[1]}",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError(f"TensorRT returned no serialized Cosmos3 VAE {kind} engine")
+    return bytes(plan)

--- a/src/runtime/core/distributed_runtime.cpp
+++ b/src/runtime/core/distributed_runtime.cpp
@@ -6,6 +6,7 @@
 #include "trtmc/runtime/distributed_runtime.h"
 
 #include "runtime/core/cuda_common.h"
+#include "runtime/core/distributed_runtime_detail.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -52,6 +53,10 @@ std::string env_string(const char* name, const std::string& fallback) {
     return raw;
 }
 
+} // namespace
+
+namespace distributed_runtime_detail {
+
 int detect_world_size() {
     int size = env_int("OMPI_COMM_WORLD_SIZE", -1);
     if (size > 0)
@@ -71,6 +76,23 @@ int detect_rank() {
         return rank;
     return env_int("RANK", 0);
 }
+
+int detect_local_rank(int global_rank) {
+    constexpr const char* names[] = {
+        "OMPI_COMM_WORLD_LOCAL_RANK", "PMI_LOCAL_RANK", "MPI_LOCALRANKID",
+        "MV2_COMM_WORLD_LOCAL_RANK",  "SLURM_LOCALID",  "LOCAL_RANK",
+    };
+    for (const char* name : names) {
+        const int rank = env_int(name, -1);
+        if (rank >= 0)
+            return rank;
+    }
+    return global_rank;
+}
+
+} // namespace distributed_runtime_detail
+
+namespace {
 
 std::filesystem::path rendezvous_path() {
     std::string base = env_string("TRTMC_NCCL_RENDEZVOUS", "");
@@ -188,18 +210,19 @@ NcclUniqueId read_unique_id(const std::filesystem::path& path) {
     return id;
 }
 
-void bind_cuda_device_for_rank(int rank) {
+void bind_cuda_device_for_local_rank(int local_rank) {
     int count = 0;
     if (cudaGetDeviceCount(&count) != cudaSuccess || count <= 0)
         return;
-    if (rank >= count) {
-        throw std::runtime_error("Tensor-parallel rank requires a visible CUDA device with the "
-                                 "same ordinal for this single-node runtime");
+    if (local_rank < 0 || local_rank >= count) {
+        throw std::runtime_error("Tensor-parallel local rank is outside the visible CUDA device "
+                                 "range");
     }
-    auto status = cudaSetDevice(rank);
+    auto status = cudaSetDevice(local_rank);
     if (status != cudaSuccess)
-        throw std::runtime_error(std::string("cudaSetDevice failed for tensor parallel rank: ") +
-                                 cudaGetErrorString(status));
+        throw std::runtime_error(
+            std::string("cudaSetDevice failed for tensor-parallel local rank: ") +
+            cudaGetErrorString(status));
 }
 
 } // namespace
@@ -207,8 +230,8 @@ void bind_cuda_device_for_rank(int rank) {
 DistributedRuntimeGroup initialize_tensor_parallel_group(int tp_size) {
     DistributedRuntimeGroup group;
     group.tp_size = tp_size;
-    group.world_size = detect_world_size();
-    group.rank = detect_rank();
+    group.world_size = distributed_runtime_detail::detect_world_size();
+    group.rank = distributed_runtime_detail::detect_rank();
 
     if (tp_size <= 1)
         return group;
@@ -219,7 +242,8 @@ DistributedRuntimeGroup initialize_tensor_parallel_group(int tp_size) {
     if (group.rank < 0 || group.rank >= tp_size)
         throw std::runtime_error("Tensor-parallel rank is outside [0, tp_size)");
 
-    bind_cuda_device_for_rank(group.rank);
+    const int local_rank = distributed_runtime_detail::detect_local_rank(group.rank);
+    bind_cuda_device_for_local_rank(local_rank);
     auto runtime = std::make_shared<NcclRuntime>();
     const auto path = rendezvous_path();
     NcclUniqueId id{};

--- a/src/runtime/core/distributed_runtime_detail.h
+++ b/src/runtime/core/distributed_runtime_detail.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace trtmc::distributed_runtime_detail {
+
+int detect_world_size();
+int detect_rank();
+int detect_local_rank(int global_rank);
+
+} // namespace trtmc::distributed_runtime_detail

--- a/src/runtime/models/cosmos3/MODEL.toml
+++ b/src/runtime/models/cosmos3/MODEL.toml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "cosmos3"
+runtime_library = "libtrtmc_model_cosmos3.so"
+runtime_plugins = ["plugin.cpp|register_cosmos3_plugin"]
+runtime_strategies = ["diffusion_cosmos3"]
+runtime_tests = [
+  "test_cosmos3_conditioning|test_cosmos3_conditioning.cpp|_|conditioning.cpp|_",
+  "test_cosmos3_options|test_cosmos3_options.cpp|nlohmann_json::nlohmann_json|options.cpp|_",
+]

--- a/src/runtime/models/cosmos3/conditioning.cpp
+++ b/src/runtime/models/cosmos3/conditioning.cpp
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/conditioning.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+namespace {
+
+constexpr int32_t kPadTokenId = 151643;
+constexpr int32_t kEosTokenId = 151645;
+constexpr int32_t kStartOfGenerationTokenId = 151652;
+constexpr int32_t kTemporalModalityMargin = 15000;
+constexpr int32_t kRopeAxisCount = 3;
+constexpr int32_t kRopeAxisDimension = 40;
+constexpr int32_t kMultiAxisFrequencyCount = kRopeAxisCount * kRopeAxisDimension / 2;
+constexpr float kRopeTheta = 5000000.0F;
+constexpr float kMaskedAttentionValue = -3.38953139e38F;
+static_assert(kRopeAxisDimension % 2 == 0);
+static_assert(kRopeAxisCount * kRopeAxisDimension <= kHeadDimension);
+
+std::string strip_trailing_periods(std::string text) {
+    while (!text.empty() &&
+           (text.back() == '.' || std::isspace(static_cast<unsigned char>(text.back())) != 0)) {
+        text.pop_back();
+    }
+    return text;
+}
+
+void fill_rotary_row(std::vector<float>& cos_values, std::vector<float>& sin_values,
+                     std::size_t row, float temporal, float height, float width) {
+    constexpr int32_t kHalfDimension = kHeadDimension / 2;
+    for (int32_t frequency_index = 0; frequency_index < kHalfDimension; ++frequency_index) {
+        float position = temporal;
+        if (frequency_index < kMultiAxisFrequencyCount) {
+            if (frequency_index % 3 == 1)
+                position = height;
+            else if (frequency_index % 3 == 2)
+                position = width;
+        }
+        const float exponent =
+            -2.0F * static_cast<float>(frequency_index) / static_cast<float>(kHeadDimension);
+        const float inverse_frequency = std::pow(kRopeTheta, exponent);
+        const float phase = position * inverse_frequency;
+        const float cosine = std::cos(phase);
+        const float sine = std::sin(phase);
+        const auto base = row * kHeadDimension;
+        cos_values[base + static_cast<std::size_t>(frequency_index)] = cosine;
+        cos_values[base + static_cast<std::size_t>(frequency_index + kHalfDimension)] = cosine;
+        sin_values[base + static_cast<std::size_t>(frequency_index)] = sine;
+        sin_values[base + static_cast<std::size_t>(frequency_index + kHalfDimension)] = sine;
+    }
+}
+
+std::size_t latent_offset(int32_t channel, int32_t frame, int32_t height, int32_t width) {
+    return (((static_cast<std::size_t>(channel) * kLatentFrames + frame) * kLatentHeight + height) *
+            kLatentWidth) +
+           width;
+}
+
+std::size_t patch_offset(int32_t frame, int32_t patch_height, int32_t patch_width,
+                         int32_t inner_height, int32_t inner_width, int32_t channel) {
+    const auto row =
+        (static_cast<std::size_t>(frame) * kPatchHeight + patch_height) * kPatchWidth + patch_width;
+    const auto column = (static_cast<std::size_t>(inner_height) * kLatentPatchSize + inner_width) *
+                            kLatentChannels +
+                        channel;
+    return row * kPatchDimension + column;
+}
+
+} // namespace
+
+std::string format_chat_prompt(const std::string& text, bool negative) {
+    std::string augmented = strip_trailing_periods(text);
+    if (!augmented.empty())
+        augmented += ". ";
+    if (negative) {
+        augmented += "The video is not 7.9 seconds long and is not of 24 FPS. "
+                     "This video is not of 720x1280 resolution.";
+    } else {
+        augmented += "The video is 7.9 seconds long and is of 24 FPS. "
+                     "This video is of 720x1280 resolution.";
+    }
+    return "<|im_start|>system\n"
+           "You are a helpful assistant who will generate videos from a give prompt."
+           "<|im_end|>\n<|im_start|>user\n" +
+           augmented + "<|im_end|>\n<|im_start|>assistant\n";
+}
+
+PromptInputs prepare_prompt_inputs(const ITokenizer& tokenizer, const std::string& text,
+                                   bool negative) {
+    PromptInputs result;
+    auto ids = tokenizer.encode(format_chat_prompt(text, negative));
+    ids.push_back(kEosTokenId);
+    ids.push_back(kStartOfGenerationTokenId);
+    if (ids.empty() || ids.size() > static_cast<std::size_t>(kTextTokens)) {
+        throw std::invalid_argument("Cosmos3 prompt exceeds the fixed 4096-token profile");
+    }
+    result.real_text_tokens = static_cast<int32_t>(ids.size());
+    result.input_ids.assign(kTextTokens, kPadTokenId);
+    std::copy(ids.begin(), ids.end(), result.input_ids.begin());
+
+    result.text_rotary_cos.resize(static_cast<std::size_t>(kTextTokens) * kHeadDimension);
+    result.text_rotary_sin.resize(static_cast<std::size_t>(kTextTokens) * kHeadDimension);
+    for (int32_t token = 0; token < kTextTokens; ++token) {
+        const float position = static_cast<float>(token);
+        fill_rotary_row(result.text_rotary_cos, result.text_rotary_sin,
+                        static_cast<std::size_t>(token), position, position, position);
+    }
+
+    result.vision_rotary_cos.resize(static_cast<std::size_t>(kVisionTokens) * kHeadDimension);
+    result.vision_rotary_sin.resize(static_cast<std::size_t>(kVisionTokens) * kHeadDimension);
+    const float temporal_offset =
+        static_cast<float>(result.real_text_tokens + kTemporalModalityMargin);
+    std::size_t row = 0;
+    for (int32_t frame = 0; frame < kLatentFrames; ++frame) {
+        for (int32_t height = 0; height < kPatchHeight; ++height) {
+            for (int32_t width = 0; width < kPatchWidth; ++width, ++row) {
+                fill_rotary_row(result.vision_rotary_cos, result.vision_rotary_sin, row,
+                                temporal_offset + static_cast<float>(frame),
+                                static_cast<float>(height), static_cast<float>(width));
+            }
+        }
+    }
+
+    result.generation_attention_mask.assign(kTextTokens + kVisionTokens, 0.0F);
+    std::fill(result.generation_attention_mask.begin() + result.real_text_tokens,
+              result.generation_attention_mask.begin() + kTextTokens, kMaskedAttentionValue);
+    return result;
+}
+
+std::vector<float> patchify_latents(const std::vector<float>& latents) {
+    const std::size_t expected =
+        static_cast<std::size_t>(kLatentChannels) * kLatentFrames * kLatentHeight * kLatentWidth;
+    if (latents.size() != expected)
+        throw std::invalid_argument("Cosmos3 latent tensor has an invalid size");
+    std::vector<float> patches(static_cast<std::size_t>(kVisionTokens) * kPatchDimension, 0.0F);
+    for (int32_t frame = 0; frame < kLatentFrames; ++frame) {
+        for (int32_t patch_height = 0; patch_height < kPatchHeight; ++patch_height) {
+            for (int32_t patch_width = 0; patch_width < kPatchWidth; ++patch_width) {
+                for (int32_t inner_height = 0; inner_height < kLatentPatchSize; ++inner_height) {
+                    const int32_t height = patch_height * kLatentPatchSize + inner_height;
+                    if (height >= kLatentHeight)
+                        continue;
+                    for (int32_t inner_width = 0; inner_width < kLatentPatchSize; ++inner_width) {
+                        const int32_t width = patch_width * kLatentPatchSize + inner_width;
+                        if (width >= kLatentWidth)
+                            continue;
+                        for (int32_t channel = 0; channel < kLatentChannels; ++channel) {
+                            patches[patch_offset(frame, patch_height, patch_width, inner_height,
+                                                 inner_width, channel)] =
+                                latents[latent_offset(channel, frame, height, width)];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return patches;
+}
+
+std::vector<float> unpatchify_latents(const std::vector<float>& patches) {
+    if (patches.size() != static_cast<std::size_t>(kVisionTokens) * kPatchDimension)
+        throw std::invalid_argument("Cosmos3 patch tensor has an invalid size");
+    std::vector<float> latents(static_cast<std::size_t>(kLatentChannels) * kLatentFrames *
+                               kLatentHeight * kLatentWidth);
+    for (int32_t frame = 0; frame < kLatentFrames; ++frame) {
+        for (int32_t patch_height = 0; patch_height < kPatchHeight; ++patch_height) {
+            for (int32_t patch_width = 0; patch_width < kPatchWidth; ++patch_width) {
+                for (int32_t inner_height = 0; inner_height < kLatentPatchSize; ++inner_height) {
+                    const int32_t height = patch_height * kLatentPatchSize + inner_height;
+                    if (height >= kLatentHeight)
+                        continue;
+                    for (int32_t inner_width = 0; inner_width < kLatentPatchSize; ++inner_width) {
+                        const int32_t width = patch_width * kLatentPatchSize + inner_width;
+                        if (width >= kLatentWidth)
+                            continue;
+                        for (int32_t channel = 0; channel < kLatentChannels; ++channel) {
+                            latents[latent_offset(channel, frame, height, width)] =
+                                patches[patch_offset(frame, patch_height, patch_width, inner_height,
+                                                     inner_width, channel)];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return latents;
+}
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/conditioning.h
+++ b/src/runtime/models/cosmos3/conditioning.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/tokenizer.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+
+inline constexpr int32_t kLatentChannels = 48;
+inline constexpr int32_t kLatentFrames = 48;
+inline constexpr int32_t kLatentHeight = 45;
+inline constexpr int32_t kLatentWidth = 80;
+inline constexpr int32_t kLatentPatchSize = 2;
+inline constexpr int32_t kPatchHeight = 23;
+inline constexpr int32_t kPatchWidth = 40;
+inline constexpr int32_t kPatchDimension = 192;
+inline constexpr int32_t kVisionTokens = 44160;
+inline constexpr int32_t kTextTokens = 4096;
+inline constexpr int32_t kHeadDimension = 128;
+
+struct PromptInputs {
+    std::vector<int32_t> input_ids;
+    std::vector<float> text_rotary_cos;
+    std::vector<float> text_rotary_sin;
+    std::vector<float> vision_rotary_cos;
+    std::vector<float> vision_rotary_sin;
+    std::vector<float> generation_attention_mask;
+    int32_t real_text_tokens{0};
+};
+
+std::string format_chat_prompt(const std::string& text, bool negative);
+PromptInputs prepare_prompt_inputs(const ITokenizer& tokenizer, const std::string& text,
+                                   bool negative);
+
+std::vector<float> patchify_latents(const std::vector<float>& latents);
+std::vector<float> unpatchify_latents(const std::vector<float>& patches);
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/cosmos3_unipc_coefficients.h
+++ b/src/runtime/models/cosmos3/cosmos3_unipc_coefficients.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// Source-exact scalar coefficients for the qualified Cosmos3-Nano text-to-video
+// profile: 35 inference steps, 1000 training steps, flow shift 10, order-2
+// BH2, flow prediction, predict-x0, lower-order final, and Karras sigmas off.
+// The values were generated on CUDA from the official Diffusers scheduler at
+// revision 904183cd8b6116f79b92268507695f910444daf0.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace trtmc::cosmos3::unipc_coefficients {
+
+inline constexpr std::size_t kStepCount = 35U;
+inline constexpr std::uint32_t kNumTrainTimesteps = 1000U;
+inline constexpr std::uint32_t kFlowShiftBits = 0x41200000U; // 10.0F
+
+struct UpdateCoefficients {
+    std::uint32_t ratio_bits;
+    std::uint32_t coefficient_bits;
+    std::uint32_t rk_bits;
+    std::array<std::uint32_t, 2U> rho_bits;
+};
+
+// clang-format off
+inline constexpr std::array<std::uint32_t, kStepCount> kTimesteps{{
+    999U, 997U, 993U, 990U, 987U, 983U, 979U, 975U, 971U, 966U, 961U, 956U,
+    950U, 944U, 937U, 930U, 922U, 913U, 904U, 894U, 882U, 869U, 855U, 839U,
+    821U, 800U, 776U, 748U, 715U, 675U, 626U, 565U, 486U, 381U, 233U,
+}};
+
+inline constexpr std::array<std::uint32_t, kStepCount> kConversionSigmaBits{{
+    0x3f7fffefU, 0x3f7f4002U, 0x3f7e759fU, 0x3f7d9ff7U, 0x3f7cbe14U,
+    0x3f7bcedfU, 0x3f7ad123U, 0x3f79c383U, 0x3f78a472U, 0x3f777233U,
+    0x3f762ac7U, 0x3f74cbe8U, 0x3f7352fbU, 0x3f71bcfaU, 0x3f700665U,
+    0x3f6e2b29U, 0x3f6c2678U, 0x3f69f2a6U, 0x3f6788f3U, 0x3f64e141U,
+    0x3f61f1bdU, 0x3f5eae63U, 0x3f5b0857U, 0x3f56ed02U, 0x3f5244d1U,
+    0x3f4cf16fU, 0x3f46cb21U, 0x3f3f9cd9U, 0x3f371e21U, 0x3f2ce94eU,
+    0x3f206b29U, 0x3f10c632U, 0x3ef93a11U, 0x3ec34d12U, 0x3e6efa5fU,
+}};
+
+inline constexpr std::array<UpdateCoefficients, kStepCount - 1U> kCorrector{{
+    {0x3f7f4013U, 0xbb3fed0dU, 0x3f800000U, {0x3f000000U, 0x00000000U}},
+    {0x3f7f3505U, 0xbb4afb35U, 0xc1307031U, {0x3c611588U, 0x3f0bc604U}},
+    {0x3f7f290dU, 0xbb56f325U, 0xbfd4250aU, {0x3d800aabU, 0x3ef28ad1U}},
+    {0x3f7f1bffU, 0xbb64008dU, 0xbfaed07bU, {0x3d90093aU, 0x3ee9985dU}},
+    {0x3f7f0db6U, 0xbb724a40U, 0xbf9fc27fU, {0x3d97aa97U, 0x3ee4fd6dU}},
+    {0x3f7efe0bU, 0xbb80fab0U, 0xbf9783c7U, {0x3d9c30b0U, 0x3ee22b54U}},
+    {0x3f7eecceU, 0xbb89992aU, 0xbf9241f5U, {0x3d9f364bU, 0x3ee043c1U}},
+    {0x3f7ed9c4U, 0xbb931df7U, 0xbf8e9383U, {0x3da16570U, 0x3edee506U}},
+    {0x3f7ec4b1U, 0xbb9da77eU, 0xbf8bd714U, {0x3da30f7eU, 0x3edddda9U}},
+    {0x3f7ead42U, 0xbba95ec0U, 0xbf89b185U, {0x3da461feU, 0x3edd1195U}},
+    {0x3f7e931dU, 0xbbb67176U, 0xbf87f388U, {0x3da57b4aU, 0x3edc6f15U}},
+    {0x3f7e75d3U, 0xbbc51694U, 0xbf867de6U, {0x3da665f6U, 0x3edbecabU}},
+    {0x3f7e54d8U, 0xbbd593cdU, 0xbf853a27U, {0x3da735cbU, 0x3edb8145U}},
+    {0x3f7e2f8bU, 0xbbe83a7eU, 0xbf841c81U, {0x3da7ef48U, 0x3edb28acU}},
+    {0x3f7e0523U, 0xbbfd6e78U, 0xbf831aaaU, {0x3da89658U, 0x3edadfbeU}},
+    {0x3f7dd4a0U, 0xbc0ad812U, 0xbf822aa7U, {0x3da934b7U, 0x3edaa2ceU}},
+    {0x3f7d9ccaU, 0xbc18cd97U, 0xbf8148d2U, {0x3da9c7f1U, 0x3eda7166U}},
+    {0x3f7d5c13U, 0xbc28fb0eU, 0xbf806f4dU, {0x3daa5869U, 0x3eda490dU}},
+    {0x3f7d107cU, 0xbc3be110U, 0xbf7f311aU, {0x3daae970U, 0x3eda28ccU}},
+    {0x3f7cb770U, 0xbc5223f4U, 0xbf7d841fU, {0x3dab77a0U, 0x3eda1176U}},
+    {0x3f7c4d87U, 0xbc6c9e49U, 0xbf7bcc57U, {0x3dac090cU, 0x3eda021bU}},
+    {0x3f7bce32U, 0xbc8639c2U, 0xbf7a01dcU, {0x3daca820U, 0x3ed9f936U}},
+    {0x3f7b333aU, 0xbc9998b2U, 0xbf7819d3U, {0x3dad4c7cU, 0x3ed9f9e9U}},
+    {0x3f7a73f8U, 0xbcb180f0U, 0xbf760781U, {0x3dae01ecU, 0x3eda0381U}},
+    {0x3f798419U, 0xbccf7ce4U, 0xbf73bbb0U, {0x3daecf28U, 0x3eda1746U}},
+    {0x3f78517eU, 0xbcf5d03cU, 0xbf711fdaU, {0x3dafb860U, 0x3eda3868U}},
+    {0x3f76c0b8U, 0xbd13f47cU, 0xbf6e1777U, {0x3db0c85cU, 0x3eda6aadU}},
+    {0x3f74a684U, 0xbd3597c5U, 0xbf6a77f4U, {0x3db2145cU, 0x3edab309U}},
+    {0x3f71bb40U, 0xbd644c03U, 0xbf65ffd9U, {0x3db3b1b0U, 0x3edb1c5cU}},
+    {0x3f6d810fU, 0xbd93f784U, 0xbf6046e8U, {0x3db5cd60U, 0x3edbb7f2U}},
+    {0x3f6708c7U, 0xbdc7b9c8U, 0xbf5896dcU, {0x3db8b3f4U, 0x3edca88fU}},
+    {0x3f5c59abU, 0xbe0e9956U, 0xbf4d9421U, {0x3dbcfe70U, 0x3ede3c18U}},
+    {0x3f489bd4U, 0xbe5d90b0U, 0xbf3c3dcbU, {0x3dc4178cU, 0x3ee149a3U}},
+    {0x3f1ca035U, 0xbec6bf95U, 0xbf1c1c50U, {0x3dd24b3cU, 0x3ee94c91U}},
+}};
+// clang-format on
+
+} // namespace trtmc::cosmos3::unipc_coefficients

--- a/src/runtime/models/cosmos3/cosmos3_unipc_cuda.cu
+++ b/src/runtime/models/cosmos3/cosmos3_unipc_cuda.cu
@@ -1,0 +1,417 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/cosmos3_unipc_coefficients.h"
+#include "runtime/models/cosmos3/cosmos3_unipc_cuda.h"
+
+#include <algorithm>
+#include <cstring>
+#include <cuda_bf16.h>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc::cosmos3 {
+namespace {
+
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kMaximumGridSize = 65535;
+
+struct CoefficientView {
+    std::size_t step_count;
+    const std::uint32_t* timesteps;
+    const std::uint32_t* conversion_sigma_bits;
+    const unipc_coefficients::UpdateCoefficients* correctors;
+};
+
+constexpr CoefficientView kOfficialCoefficientView = {
+    unipc_coefficients::kStepCount,
+    unipc_coefficients::kTimesteps.data(),
+    unipc_coefficients::kConversionSigmaBits.data(),
+    unipc_coefficients::kCorrector.data(),
+};
+
+void check_cuda(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Cosmos3 CUDA UniPC ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+    }
+}
+
+float float_from_bits(uint32_t bits) {
+    float value = 0.0F;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+uint32_t float_bits(float value) {
+    uint32_t bits = 0U;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+const CoefficientView& select_coefficient_view(float shift, int32_t num_inference_steps,
+                                               int32_t num_train_timesteps) {
+    if (num_train_timesteps != static_cast<int32_t>(unipc_coefficients::kNumTrainTimesteps) ||
+        float_bits(shift) != unipc_coefficients::kFlowShiftBits) {
+        throw std::invalid_argument(
+            "Cosmos3 CUDA UniPC requires 1000 training steps and flow shift 10");
+    }
+    if (num_inference_steps == static_cast<int32_t>(kOfficialCoefficientView.step_count))
+        return kOfficialCoefficientView;
+    throw std::invalid_argument("Cosmos3 CUDA UniPC requires the qualified 35-step profile");
+}
+
+uint32_t grid_size(std::size_t count) {
+    const std::size_t requested = (count + kBlockSize - 1U) / kBlockSize;
+    return static_cast<uint32_t>(std::min<std::size_t>(requested, kMaximumGridSize));
+}
+
+__device__ __forceinline__ float autocast_bf16_multiply(float left, float right) {
+    // torch.einsum is autocast-eligible.  Cosmos3 wraps the complete denoising
+    // loop in BF16 autocast, so each order-2 K=1 residual product casts both
+    // operands to BF16 and rounds the product back to BF16.
+    const __nv_bfloat16 left_bf16 = __float2bfloat16_rn(left);
+    const __nv_bfloat16 right_bf16 = __float2bfloat16_rn(right);
+    const float product = __fmul_rn(__bfloat162float(left_bf16), __bfloat162float(right_bf16));
+    return __bfloat162float(__float2bfloat16_rn(product));
+}
+
+__device__ __forceinline__ float bf16_output_scalar_multiply(float scalar, float bf16_value) {
+    // TensorIterator keeps a wrapped CPU FP32 scalar in opmath precision when
+    // multiplying a BF16 CUDA tensor, then rounds the BF16 output.
+    return __bfloat162float(__float2bfloat16_rn(__fmul_rn(scalar, bf16_value)));
+}
+
+class DeviceBuffer {
+  public:
+    DeviceBuffer() = default;
+    ~DeviceBuffer() { release(); }
+
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    void allocate(std::size_t bytes) {
+        float* replacement = nullptr;
+        check_cuda(cudaMalloc(&replacement, bytes), "cudaMalloc");
+        release();
+        pointer_ = replacement;
+    }
+
+    void release() noexcept {
+        if (pointer_ != nullptr) {
+            cudaFree(pointer_);
+            pointer_ = nullptr;
+        }
+    }
+
+    float* get() noexcept { return pointer_; }
+    const float* get() const noexcept { return pointer_; }
+
+  private:
+    float* pointer_{nullptr};
+};
+
+struct CorrectCoefficients {
+    float sample_scale;
+    float coefficient;
+    float older_rho;
+    float current_rho;
+    float older_rk;
+    bool has_older;
+};
+
+struct PredictCoefficients {
+    float sample_scale;
+    float coefficient;
+    float previous_rk;
+    float previous_rho;
+    bool has_previous;
+};
+
+__global__ void convert_model_output_kernel(const float* model_output, const float* sample,
+                                            float sigma, float* converted, std::size_t count) {
+    const std::size_t start = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const std::size_t stride = static_cast<std::size_t>(blockDim.x) * gridDim.x;
+    for (std::size_t index = start; index < count; index += stride) {
+        const float scaled = __fmul_rn(sigma, model_output[index]);
+        converted[index] = __fsub_rn(sample[index], scaled);
+    }
+}
+
+__global__ void correct_kernel(const float* model_t, const float* newest_model,
+                               const float* older_model, const float* last_sample, float* sample,
+                               std::size_t count, CorrectCoefficients coefficients) {
+    const std::size_t start = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const std::size_t stride = static_cast<std::size_t>(blockDim.x) * gridDim.x;
+    for (std::size_t index = start; index < count; index += stride) {
+        // Match eager's (model_t - m0), rho * D1_t, and residual-add
+        // boundaries. The older residual is the left operand in the official
+        // corr_res + rho[-1] * D1_t expression.
+        const float current_delta = __fsub_rn(model_t[index], newest_model[index]);
+        const float current_term = __fmul_rn(coefficients.current_rho, current_delta);
+        float correction = __fadd_rn(0.0F, current_term);
+        if (coefficients.has_older) {
+            const float older_delta = __fsub_rn(older_model[index], newest_model[index]);
+            // Eager strength-reduces CUDA-tensor / CPU-scalar division to a
+            // correctly rounded reciprocal followed by a rounded multiply.
+            // __fdividef uses an approximate MUFU.RCP path and is not
+            // bitwise-equivalent for every rk in the qualified trajectory.
+            const float older_reciprocal = __frcp_rn(coefficients.older_rk);
+            const float older_d1 = __fmul_rn(older_delta, older_reciprocal);
+            const float older_term = autocast_bf16_multiply(coefficients.older_rho, older_d1);
+            correction = __fadd_rn(older_term, current_term);
+        }
+
+        const float scaled_sample = __fmul_rn(coefficients.sample_scale, last_sample[index]);
+        const float scaled_model = __fmul_rn(coefficients.coefficient, newest_model[index]);
+        const float base = __fsub_rn(scaled_sample, scaled_model);
+        const float adjustment = __fmul_rn(coefficients.coefficient, correction);
+        sample[index] = __fsub_rn(base, adjustment);
+    }
+}
+
+__global__ void predict_kernel(const float* sample, const float* newest_model,
+                               const float* previous_model, float* output, std::size_t count,
+                               PredictCoefficients coefficients) {
+    const std::size_t start = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const std::size_t stride = static_cast<std::size_t>(blockDim.x) * gridDim.x;
+    for (std::size_t index = start; index < count; index += stride) {
+        float predictor_residual = 0.0F;
+        if (coefficients.has_previous) {
+            const float delta = __fsub_rn(previous_model[index], newest_model[index]);
+            const float reciprocal = __frcp_rn(coefficients.previous_rk);
+            const float d1 = __fmul_rn(delta, reciprocal);
+            predictor_residual = autocast_bf16_multiply(coefficients.previous_rho, d1);
+        }
+
+        const float scaled_sample = __fmul_rn(coefficients.sample_scale, sample[index]);
+        const float scaled_model = __fmul_rn(coefficients.coefficient, newest_model[index]);
+        const float base = __fsub_rn(scaled_sample, scaled_model);
+        // Eager also evaluates the terminal "- coefficient * 0" for the
+        // order-1 path; retaining it preserves signed-zero behavior.
+        const float adjustment =
+            coefficients.has_previous
+                ? bf16_output_scalar_multiply(coefficients.coefficient, predictor_residual)
+                : __fmul_rn(coefficients.coefficient, predictor_residual);
+        output[index] = __fsub_rn(base, adjustment);
+    }
+}
+
+CorrectCoefficients make_correct_coefficients(const CoefficientView& view, int32_t step_index,
+                                              int32_t previous_order) {
+    const auto& source = view.correctors[static_cast<std::size_t>(step_index - 1)];
+    const bool has_older = previous_order == 2;
+    return {
+        float_from_bits(source.ratio_bits),
+        float_from_bits(source.coefficient_bits),
+        has_older ? float_from_bits(source.rho_bits[0]) : 0.0F,
+        float_from_bits(source.rho_bits[has_older ? 1U : 0U]),
+        has_older ? float_from_bits(source.rk_bits) : 1.0F,
+        has_older,
+    };
+}
+
+PredictCoefficients make_predict_coefficients(const CoefficientView& view, int32_t step_index,
+                                              int32_t order) {
+    if (step_index + 1 == static_cast<int32_t>(view.step_count)) {
+        if (order != 1)
+            throw std::logic_error("Cosmos3 CUDA UniPC final predictor must use order one");
+        return {0.0F, -1.0F, 1.0F, 0.0F, false};
+    }
+    const auto& source = view.correctors[static_cast<std::size_t>(step_index)];
+    const bool has_previous = order == 2;
+    return {
+        float_from_bits(source.ratio_bits),
+        float_from_bits(source.coefficient_bits),
+        has_previous ? float_from_bits(source.rk_bits) : 1.0F,
+        has_previous ? 0.5F : 0.0F,
+        has_previous,
+    };
+}
+
+} // namespace
+
+struct FlowUniPCCuda::Impl {
+    explicit Impl(cudaStream_t supplied_stream, const CoefficientView& supplied_coefficients)
+        : stream(supplied_stream), coefficients(supplied_coefficients) {
+        check_cuda(cudaGetDevice(&device), "cudaGetDevice");
+    }
+
+    ~Impl() {
+        int previous_device = device;
+        if (cudaGetDevice(&previous_device) == cudaSuccess && previous_device != device)
+            cudaSetDevice(device);
+        model_output.release();
+        sample.release();
+        converted.release();
+        output.release();
+        history[0].release();
+        history[1].release();
+        last_sample.release();
+        if (previous_device != device)
+            cudaSetDevice(previous_device);
+    }
+
+    void ensure_device() const {
+        int current = -1;
+        check_cuda(cudaGetDevice(&current), "cudaGetDevice");
+        if (current != device)
+            throw std::runtime_error("Cosmos3 CUDA UniPC used on a different CUDA device");
+    }
+
+    void reserve(std::size_t count) {
+        if (count == capacity)
+            return;
+        if (capacity != 0)
+            throw std::invalid_argument("Cosmos3 CUDA UniPC tensor size changed between steps");
+        if (count > std::numeric_limits<std::size_t>::max() / sizeof(float))
+            throw std::overflow_error("Cosmos3 CUDA UniPC tensor byte size overflow");
+        const std::size_t bytes = count * sizeof(float);
+        model_output.allocate(bytes);
+        sample.allocate(bytes);
+        converted.allocate(bytes);
+        output.allocate(bytes);
+        history[0].allocate(bytes);
+        history[1].allocate(bytes);
+        last_sample.allocate(bytes);
+        capacity = count;
+    }
+
+    float* newest() noexcept { return history[newest_history].get(); }
+    const float* older() const noexcept { return history[1U - newest_history].get(); }
+
+    float* append_target() noexcept {
+        if (step_index == 0)
+            return history[0].get();
+        if (step_index == 1)
+            return history[1].get();
+        return history[1U - newest_history].get();
+    }
+
+    void commit_append(float* target) noexcept {
+        newest_history = (target == history[0].get()) ? 0U : 1U;
+    }
+
+    void validate_step_arguments(const float* supplied_model_output, const float* supplied_sample,
+                                 const float* supplied_output, std::size_t count) const {
+        if (supplied_model_output == nullptr || supplied_sample == nullptr ||
+            supplied_output == nullptr) {
+            throw std::invalid_argument("Cosmos3 CUDA UniPC received a null tensor pointer");
+        }
+        if (count == 0)
+            throw std::invalid_argument("Cosmos3 CUDA UniPC received an empty tensor");
+        if (step_index >= static_cast<int32_t>(coefficients.step_count))
+            throw std::out_of_range("Cosmos3 CUDA UniPC has no remaining steps");
+    }
+
+    void upload_inputs(const float* supplied_model_output, const float* supplied_sample,
+                       std::size_t bytes) {
+        check_cuda(cudaMemcpyAsync(model_output.get(), supplied_model_output, bytes,
+                                   cudaMemcpyHostToDevice, stream),
+                   "model-output copy");
+        check_cuda(
+            cudaMemcpyAsync(sample.get(), supplied_sample, bytes, cudaMemcpyHostToDevice, stream),
+            "sample copy");
+    }
+
+    void launch_conversion(std::size_t count, uint32_t grid) {
+        const std::size_t index = static_cast<std::size_t>(step_index);
+        convert_model_output_kernel<<<grid, kBlockSize, 0, stream>>>(
+            model_output.get(), sample.get(),
+            float_from_bits(coefficients.conversion_sigma_bits[index]), converted.get(), count);
+        check_cuda(cudaGetLastError(), "convert kernel launch");
+    }
+
+    void launch_correction_if_needed(std::size_t count, uint32_t grid) {
+        if (step_index == 0)
+            return;
+        const int32_t previous_order = step_index == 1 ? 1 : 2;
+        const CorrectCoefficients coefficients =
+            make_correct_coefficients(this->coefficients, step_index, previous_order);
+        correct_kernel<<<grid, kBlockSize, 0, stream>>>(
+            converted.get(), newest(), coefficients.has_older ? older() : nullptr,
+            last_sample.get(), sample.get(), count, coefficients);
+        check_cuda(cudaGetLastError(), "corrector kernel launch");
+    }
+
+    void append_converted_model(std::size_t bytes) {
+        float* history_target = append_target();
+        check_cuda(cudaMemcpyAsync(history_target, converted.get(), bytes, cudaMemcpyDeviceToDevice,
+                                   stream),
+                   "model-history copy");
+        commit_append(history_target);
+    }
+
+    int32_t prediction_order() const {
+        return step_index == 0 || step_index + 1 == static_cast<int32_t>(coefficients.step_count)
+                   ? 1
+                   : 2;
+    }
+
+    void preserve_corrected_sample(std::size_t bytes) {
+        check_cuda(cudaMemcpyAsync(last_sample.get(), sample.get(), bytes, cudaMemcpyDeviceToDevice,
+                                   stream),
+                   "last-sample copy");
+    }
+
+    void predict_and_download(float* supplied_output, std::size_t count, std::size_t bytes,
+                              uint32_t grid, int32_t order) {
+        const PredictCoefficients coefficients =
+            make_predict_coefficients(this->coefficients, step_index, order);
+        predict_kernel<<<grid, kBlockSize, 0, stream>>>(sample.get(), newest(),
+                                                        order == 2 ? older() : nullptr,
+                                                        output.get(), count, coefficients);
+        check_cuda(cudaGetLastError(), "predictor kernel launch");
+        check_cuda(
+            cudaMemcpyAsync(supplied_output, output.get(), bytes, cudaMemcpyDeviceToHost, stream),
+            "output copy");
+    }
+
+    cudaStream_t stream{nullptr};
+    int device{0};
+    const CoefficientView& coefficients;
+    int32_t step_index{0};
+    uint32_t newest_history{0};
+    std::size_t capacity{0};
+    DeviceBuffer model_output;
+    DeviceBuffer sample;
+    DeviceBuffer converted;
+    DeviceBuffer output;
+    DeviceBuffer history[2];
+    DeviceBuffer last_sample;
+};
+
+FlowUniPCCuda::FlowUniPCCuda(cudaStream_t stream, int32_t num_inference_steps, float shift,
+                             int32_t num_train_timesteps) {
+    const auto& coefficients =
+        select_coefficient_view(shift, num_inference_steps, num_train_timesteps);
+    timesteps_.reserve(coefficients.step_count);
+    for (std::size_t index = 0; index < coefficients.step_count; ++index)
+        timesteps_.push_back(static_cast<int64_t>(coefficients.timesteps[index]));
+    impl_ = std::make_unique<Impl>(stream, coefficients);
+}
+
+FlowUniPCCuda::~FlowUniPCCuda() = default;
+
+void FlowUniPCCuda::step(const float* model_output, const float* sample, float* output,
+                         std::size_t count) {
+    impl_->validate_step_arguments(model_output, sample, output, count);
+    impl_->ensure_device();
+    impl_->reserve(count);
+    const std::size_t bytes = count * sizeof(float);
+    impl_->upload_inputs(model_output, sample, bytes);
+    const uint32_t grid = grid_size(count);
+    impl_->launch_conversion(count, grid);
+    impl_->launch_correction_if_needed(count, grid);
+    impl_->append_converted_model(bytes);
+    const int32_t order = impl_->prediction_order();
+    impl_->preserve_corrected_sample(bytes);
+    impl_->predict_and_download(output, count, bytes, grid, order);
+    check_cuda(cudaStreamSynchronize(impl_->stream), "step stream synchronize");
+    ++impl_->step_index;
+}
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/cosmos3_unipc_cuda.h
+++ b/src/runtime/models/cosmos3/cosmos3_unipc_cuda.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+
+// CUDA implementation of the order-2 BH2 flow UniPC scheduler used by
+// Cosmos3-Nano. Inputs and output are host FP32 arrays. Tensor arithmetic is
+// performed on the caller-supplied CUDA stream; step() synchronizes that stream
+// before returning so output is ready for immediate host use.
+//
+// An instance is stateful and must receive exactly one call per timestep. It is
+// not safe to call an instance concurrently. The stream remains owned by the
+// caller and must outlive this object.
+class FlowUniPCCuda final {
+  public:
+    explicit FlowUniPCCuda(cudaStream_t stream, int32_t num_inference_steps = 35,
+                           float shift = 10.0F, int32_t num_train_timesteps = 1000);
+    ~FlowUniPCCuda();
+
+    FlowUniPCCuda(const FlowUniPCCuda&) = delete;
+    FlowUniPCCuda& operator=(const FlowUniPCCuda&) = delete;
+
+    const std::vector<int64_t>& timesteps() const noexcept { return timesteps_; }
+
+    // model_output, sample, and output point to host FP32 arrays of count
+    // elements. output may alias either input.
+    void step(const float* model_output, const float* sample, float* output, std::size_t count);
+
+  private:
+    struct Impl;
+
+    std::vector<int64_t> timesteps_;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/options.cpp
+++ b/src/runtime/models/cosmos3/options.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/options.h"
+
+#include "trtmc/pipeline.h"
+
+#include <cmath>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+namespace trtmc {
+namespace {
+
+bool matches_qualified_profile(const Cosmos3Options& profile) {
+    return std::tie(profile.video_height, profile.video_width, profile.video_num_frames,
+                    profile.frame_rate, profile.num_inference_steps, profile.guidance_scale,
+                    profile.flow_shift, profile.text_seq_len) ==
+           std::tie(kCosmos3VideoHeight, kCosmos3VideoWidth, kCosmos3VideoFrames, kCosmos3FrameRate,
+                    kCosmos3InferenceSteps, kCosmos3GuidanceScale, kCosmos3FlowShift,
+                    kCosmos3TextSequenceLength);
+}
+
+void validate_profile(const Cosmos3Options& profile, const char* subject) {
+    if (!matches_qualified_profile(profile)) {
+        throw std::invalid_argument(std::string("Cosmos3-Nano ") + subject +
+                                    " requires 1280x720, 189 frames, 24 FPS, 35 steps, CFG 6, "
+                                    "flow shift 10, and a 4096-token profile");
+    }
+    if (profile.seed < 0)
+        throw std::invalid_argument("Cosmos3-Nano seed must be non-negative");
+    if (profile.negative_prompt.empty())
+        throw std::invalid_argument("Cosmos3-Nano requires a non-empty negative prompt");
+}
+
+void validate_overrides(const GenerateConfig& config) {
+    if (!config.initial_latents.empty())
+        throw std::invalid_argument("Cosmos3-Nano does not support --initial-latents-raw");
+    if (config.num_steps != -1 && config.num_steps <= 0)
+        throw std::invalid_argument("Cosmos3-Nano num_steps must be -1 or positive");
+    if (!std::isfinite(config.guidance_scale) ||
+        (config.guidance_scale < 0.0F && config.guidance_scale != -1.0F)) {
+        throw std::invalid_argument(
+            "Cosmos3-Nano guidance_scale must be -1 or finite and non-negative");
+    }
+    if (config.seed < -1)
+        throw std::invalid_argument("Cosmos3-Nano seed must be -1 or non-negative");
+}
+
+} // namespace
+
+Cosmos3Options parse_cosmos3_options(const std::string& config_json) {
+    Cosmos3Options options;
+    const auto parsed = nlohmann::json::parse(config_json);
+    options.negative_prompt = parsed.value("negative_prompt", std::string{});
+    options.num_inference_steps = parsed.value("num_inference_steps", options.num_inference_steps);
+    options.guidance_scale = parsed.value("guidance_scale", options.guidance_scale);
+    options.flow_shift = parsed.value("flow_shift", options.flow_shift);
+    options.seed = parsed.value("seed", options.seed);
+    options.video_height = parsed.value("video_height", options.video_height);
+    options.video_width = parsed.value("video_width", options.video_width);
+    options.video_num_frames = parsed.value("video_num_frames", options.video_num_frames);
+    options.frame_rate = parsed.value("frame_rate", options.frame_rate);
+    options.text_seq_len = parsed.value("text_seq_len", options.text_seq_len);
+    validate_profile(options, "bundle");
+    return options;
+}
+
+Cosmos3Request resolve_cosmos3_request(const Cosmos3Options& options,
+                                       const GenerateConfig& config) {
+    validate_profile(options, "bundle");
+    validate_overrides(config);
+    Cosmos3Request request = options;
+    request.negative_prompt =
+        config.negative_prompt.empty() ? options.negative_prompt : config.negative_prompt;
+    request.num_inference_steps =
+        config.num_steps > 0 ? config.num_steps : options.num_inference_steps;
+    request.guidance_scale =
+        config.guidance_scale >= 0.0F ? config.guidance_scale : options.guidance_scale;
+    request.seed = config.seed >= 0 ? config.seed : options.seed;
+    if (config.height > 0 && config.height != options.video_height)
+        throw std::invalid_argument("Cosmos3-Nano height must match the bundle profile");
+    if (config.width > 0 && config.width != options.video_width)
+        throw std::invalid_argument("Cosmos3-Nano width must match the bundle profile");
+    validate_profile(request, "request");
+    return request;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/cosmos3/options.h
+++ b/src/runtime/models/cosmos3/options.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace trtmc {
+
+struct GenerateConfig;
+
+inline constexpr int32_t kCosmos3VideoHeight = 720;
+inline constexpr int32_t kCosmos3VideoWidth = 1280;
+inline constexpr int32_t kCosmos3VideoFrames = 189;
+inline constexpr int32_t kCosmos3FrameRate = 24;
+inline constexpr int32_t kCosmos3InferenceSteps = 35;
+inline constexpr float kCosmos3GuidanceScale = 6.0F;
+inline constexpr float kCosmos3FlowShift = 10.0F;
+inline constexpr int32_t kCosmos3TextSequenceLength = 4096;
+
+struct Cosmos3Options {
+    std::string negative_prompt;
+    int32_t num_inference_steps{kCosmos3InferenceSteps};
+    float guidance_scale{kCosmos3GuidanceScale};
+    float flow_shift{kCosmos3FlowShift};
+    int32_t seed{42};
+    int32_t video_height{kCosmos3VideoHeight};
+    int32_t video_width{kCosmos3VideoWidth};
+    int32_t video_num_frames{kCosmos3VideoFrames};
+    int32_t frame_rate{kCosmos3FrameRate};
+    int32_t text_seq_len{kCosmos3TextSequenceLength};
+};
+
+using Cosmos3Request = Cosmos3Options;
+
+Cosmos3Options parse_cosmos3_options(const std::string& config_json);
+Cosmos3Request resolve_cosmos3_request(const Cosmos3Options& options, const GenerateConfig& config);
+
+} // namespace trtmc

--- a/src/runtime/models/cosmos3/pipeline.cpp
+++ b/src/runtime/models/cosmos3/pipeline.cpp
@@ -1,0 +1,569 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/pipeline.h"
+
+#include "runtime/models/cosmos3/cosmos3_unipc_cuda.h"
+#include "runtime/models/cosmos3/torch_cuda_normal.h"
+#include "runtime/models/cosmos3/vae_cache_storage.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr int32_t kVideoChannels = 3;
+constexpr int32_t kVaeCacheCount = 32;
+constexpr int32_t kVaeFirstFrameOutputFrames = 1;
+constexpr int32_t kVaeStepOutputFrames = 4;
+constexpr std::size_t kLatentCount = static_cast<std::size_t>(cosmos3::kLatentChannels) *
+                                     cosmos3::kLatentFrames * cosmos3::kLatentHeight *
+                                     cosmos3::kLatentWidth;
+constexpr std::size_t kPatchCount =
+    static_cast<std::size_t>(cosmos3::kVisionTokens) * cosmos3::kPatchDimension;
+
+struct VaeCacheSpec {
+    int32_t channels;
+    int32_t spatial_scale;
+};
+
+constexpr std::array<VaeCacheSpec, kVaeCacheCount> kVaeCacheSpecs = {{
+    {48, 1},   {1024, 1}, {1024, 1}, {1024, 1}, {1024, 1}, {1024, 1}, {1024, 1}, {1024, 1},
+    {1024, 1}, {1024, 1}, {1024, 1}, {1024, 1}, {1024, 2}, {1024, 2}, {1024, 2}, {1024, 2},
+    {1024, 2}, {1024, 2}, {1024, 2}, {1024, 4}, {512, 4},  {512, 4},  {512, 4},  {512, 4},
+    {512, 4},  {512, 8},  {256, 8},  {256, 8},  {256, 8},  {256, 8},  {256, 8},  {256, 8},
+}};
+
+double milliseconds(Clock::time_point begin, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+std::vector<float> copy_as_float(const Tensor& tensor, std::size_t expected, const char* label) {
+    if (tensor.data == nullptr || tensor.numel() != expected || tensor.dtype != DType::kFloat32)
+        throw std::runtime_error(std::string("Cosmos3 ") + label + " has an invalid contract");
+    std::vector<float> output(expected);
+    std::copy_n(static_cast<const float*>(tensor.data), expected, output.begin());
+    return output;
+}
+
+const Tensor& required_output(const TensorMap& outputs, const char* name, const char* component) {
+    const auto found = outputs.find(name);
+    if (found == outputs.end())
+        throw std::runtime_error(std::string("Cosmos3 ") + component +
+                                 " output is missing: " + name);
+    return found->second;
+}
+
+bool has_input_contract(const ITrtModule& module, const std::string& name,
+                        const std::vector<int64_t>& shape, DType dtype) {
+    return module.has_input(name) && module.tensor_shape(name) == shape &&
+           module.tensor_dtype(name) == dtype;
+}
+
+bool has_output_contract(const ITrtModule& module, const std::string& name,
+                         const std::vector<int64_t>& shape, DType dtype) {
+    return module.has_output(name) && module.tensor_shape(name) == shape &&
+           module.tensor_dtype(name) == dtype;
+}
+
+void validate_denoiser_contract(const ITrtModule& module) {
+    const std::vector<int64_t> text_shape = {cosmos3::kTextTokens};
+    const std::vector<int64_t> patch_shape = {cosmos3::kVisionTokens, cosmos3::kPatchDimension};
+    const std::vector<int64_t> time_shape = {1, 256};
+    const std::vector<int64_t> text_rotary_shape = {cosmos3::kTextTokens, cosmos3::kHeadDimension};
+    const std::vector<int64_t> vision_rotary_shape = {cosmos3::kVisionTokens,
+                                                      cosmos3::kHeadDimension};
+    const std::vector<int64_t> mask_shape = {1, 1, 1,
+                                             cosmos3::kTextTokens + cosmos3::kVisionTokens};
+    if (!has_input_contract(module, "input_ids", text_shape, DType::kInt32) ||
+        !has_input_contract(module, "vision_patches", patch_shape, DType::kFloat32) ||
+        !has_input_contract(module, "timestep_features", time_shape, DType::kFloat32) ||
+        !has_input_contract(module, "text_rotary_cos", text_rotary_shape, DType::kFloat32) ||
+        !has_input_contract(module, "text_rotary_sin", text_rotary_shape, DType::kFloat32) ||
+        !has_input_contract(module, "vision_rotary_cos", vision_rotary_shape, DType::kFloat32) ||
+        !has_input_contract(module, "vision_rotary_sin", vision_rotary_shape, DType::kFloat32) ||
+        !has_input_contract(module, "generation_attention_mask", mask_shape, DType::kFloat32) ||
+        !has_output_contract(module, "noise_prediction_patches", patch_shape, DType::kFloat32)) {
+        throw std::invalid_argument("Cosmos3 denoiser has an invalid tensor contract");
+    }
+}
+
+std::vector<int64_t> expected_cache_shape(int32_t index) {
+    const auto& spec = kVaeCacheSpecs.at(static_cast<std::size_t>(index));
+    return {1, spec.channels, 2, cosmos3::kLatentHeight * spec.spatial_scale,
+            cosmos3::kLatentWidth * spec.spatial_scale};
+}
+
+std::size_t expected_cache_nbytes(int32_t index) {
+    std::size_t elements = 1;
+    for (const int64_t dimension : expected_cache_shape(index))
+        elements *= static_cast<std::size_t>(dimension);
+    return elements * sizeof(float);
+}
+
+void validate_vae_contract(const ITrtModule& module, int32_t output_frames, const char* label) {
+    const std::vector<int64_t> latent_shape = {1, cosmos3::kLatentChannels, 1,
+                                               cosmos3::kLatentHeight, cosmos3::kLatentWidth};
+    const std::vector<int64_t> video_shape = {1, kVideoChannels, output_frames, kCosmos3VideoHeight,
+                                              kCosmos3VideoWidth};
+    if (!has_input_contract(module, "latent_frame", latent_shape, DType::kFloat32) ||
+        !has_output_contract(module, "video_frame", video_shape, DType::kFloat32)) {
+        throw std::invalid_argument(std::string("Cosmos3 ") + label +
+                                    " VAE has an invalid frame contract");
+    }
+    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
+        const auto shape = expected_cache_shape(index);
+        if (!has_input_contract(module, "cache_" + std::to_string(index), shape, DType::kFloat32) ||
+            !has_output_contract(module, "cache_out_" + std::to_string(index), shape,
+                                 DType::kFloat32)) {
+            throw std::invalid_argument(std::string("Cosmos3 ") + label +
+                                        " VAE has an invalid cache contract at " +
+                                        std::to_string(index));
+        }
+    }
+}
+
+std::vector<ModuleExternalBinding> make_vae_cache_bindings(const std::vector<void*>& inputs,
+                                                           const std::vector<void*>& outputs) {
+    if (inputs.size() != kVaeCacheCount || outputs.size() != kVaeCacheCount)
+        throw std::invalid_argument("Cosmos3 VAE requires exactly 32 cache pairs");
+    std::vector<ModuleExternalBinding> bindings;
+    bindings.reserve(2 * kVaeCacheCount);
+    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
+        const auto offset = static_cast<std::size_t>(index);
+        if (inputs[offset] == nullptr || outputs[offset] == nullptr)
+            throw std::invalid_argument("Cosmos3 VAE cache binding is null");
+        const auto capacity = expected_cache_nbytes(index);
+        bindings.push_back(
+            ModuleExternalBinding{"cache_" + std::to_string(index), inputs[offset], capacity});
+        bindings.push_back(
+            ModuleExternalBinding{"cache_out_" + std::to_string(index), outputs[offset], capacity});
+    }
+    return bindings;
+}
+
+std::vector<float> run_vae_latent(const std::vector<float>& latents,
+                                  std::vector<float>& latent_frame, int32_t latent_index,
+                                  int32_t chunk_frames, ITrtModule& module) {
+    const std::size_t spatial =
+        static_cast<std::size_t>(cosmos3::kLatentHeight) * cosmos3::kLatentWidth;
+    const std::size_t frame_plane =
+        static_cast<std::size_t>(kCosmos3VideoHeight) * kCosmos3VideoWidth;
+    for (int32_t channel = 0; channel < cosmos3::kLatentChannels; ++channel) {
+        const auto source = static_cast<std::size_t>(channel) * cosmos3::kLatentFrames * spatial +
+                            static_cast<std::size_t>(latent_index) * spatial;
+        std::copy_n(latents.data() + static_cast<std::ptrdiff_t>(source), spatial,
+                    latent_frame.data() + static_cast<std::ptrdiff_t>(channel * spatial));
+    }
+    TensorMap inputs;
+    inputs.emplace("latent_frame", Tensor{latent_frame.data(),
+                                          {1, cosmos3::kLatentChannels, 1, cosmos3::kLatentHeight,
+                                           cosmos3::kLatentWidth},
+                                          DType::kFloat32});
+    const auto outputs = module.forward(inputs);
+    return copy_as_float(required_output(outputs, "video_frame", "VAE"),
+                         static_cast<std::size_t>(kVideoChannels) * chunk_frames * frame_plane,
+                         "VAE output");
+}
+
+void append_video_chunk(ImageResult& result, int32_t& frame_offset, const std::vector<float>& chunk,
+                        int32_t chunk_frames) {
+    const std::size_t frame_plane =
+        static_cast<std::size_t>(kCosmos3VideoHeight) * kCosmos3VideoWidth;
+    for (int32_t frame = 0; frame < chunk_frames; ++frame) {
+        for (std::size_t pixel = 0; pixel < frame_plane; ++pixel) {
+            const auto destination =
+                (static_cast<std::size_t>(frame_offset + frame) * frame_plane + pixel) *
+                kVideoChannels;
+            for (int32_t channel = 0; channel < kVideoChannels; ++channel) {
+                const auto source =
+                    (static_cast<std::size_t>(channel) * chunk_frames + frame) * frame_plane +
+                    pixel;
+                const float clamped = std::clamp(chunk[source], -1.0F, 1.0F);
+                result.pixels[destination + static_cast<std::size_t>(channel)] =
+                    (clamped + 1.0F) * 0.5F;
+            }
+        }
+    }
+    frame_offset += chunk_frames;
+}
+
+void swap_and_rebind_vae_cache_banks(ITrtModule& module, std::vector<void*>& inputs,
+                                     std::vector<void*>& outputs) {
+    std::swap(inputs, outputs);
+    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
+        const auto offset = static_cast<std::size_t>(index);
+        const auto input_name = "cache_" + std::to_string(index);
+        const auto output_name = "cache_out_" + std::to_string(index);
+        module.bind_external(input_name, inputs[offset]);
+        module.bind_external(output_name, outputs[offset]);
+        if (module.device_ptr(input_name) != inputs[offset] ||
+            module.device_ptr(output_name) != outputs[offset]) {
+            throw std::runtime_error("Cosmos3 recurrent VAE cache rebinding failed at " +
+                                     std::to_string(index));
+        }
+    }
+}
+
+float round_to_bfloat16(float value) {
+    uint32_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint32_t exponent = bits & 0x7f800000U;
+    if (exponent != 0x7f800000U) {
+        const uint32_t rounding_bias = 0x7fffU + ((bits >> 16U) & 1U);
+        bits = (bits + rounding_bias) & 0xffff0000U;
+    } else {
+        bits &= 0xffff0000U;
+    }
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+void apply_cfg(const std::vector<float>& conditional, const std::vector<float>& unconditional,
+               float guidance_scale, std::vector<float>& guided) {
+    if (conditional.size() != unconditional.size() || conditional.size() != guided.size())
+        throw std::invalid_argument("Cosmos3 CFG tensors have inconsistent sizes");
+    for (std::size_t index = 0; index < guided.size(); ++index) {
+        const float delta = round_to_bfloat16(conditional[index] - unconditional[index]);
+        const float scaled = round_to_bfloat16(guidance_scale * delta);
+        guided[index] = round_to_bfloat16(unconditional[index] + scaled);
+    }
+}
+
+} // namespace
+
+Cosmos3Pipeline::Cosmos3Pipeline(Cosmos3ModuleLoader module_loader,
+                                 std::unique_ptr<ITokenizer> tokenizer, Cosmos3Options options,
+                                 std::string model_id, std::shared_ptr<void> distributed_owner,
+                                 int32_t distributed_rank, int32_t distributed_world_size)
+    : distributed_owner_(std::move(distributed_owner)), module_loader_(std::move(module_loader)),
+      tokenizer_(std::move(tokenizer)), options_(std::move(options)),
+      model_id_(std::move(model_id)), distributed_rank_(distributed_rank),
+      distributed_world_size_(distributed_world_size) {
+    if (!module_loader_ || !tokenizer_)
+        throw std::invalid_argument("Cosmos3 requires a tokenizer and staged module loader");
+    if (distributed_rank_ < 0 || distributed_rank_ >= distributed_world_size_ ||
+        distributed_world_size_ < 1) {
+        throw std::invalid_argument("Cosmos3 received an invalid distributed rank");
+    }
+    const auto status = cudaStreamCreate(&stream_);
+    if (status != cudaSuccess) {
+        stream_ = nullptr;
+        throw std::runtime_error(std::string("Cosmos3 could not create its CUDA stream: ") +
+                                 cudaGetErrorString(status));
+    }
+}
+
+Cosmos3Pipeline::~Cosmos3Pipeline() {
+    synchronize_stream_noexcept();
+    if (stream_ != nullptr)
+        cudaStreamDestroy(stream_);
+}
+
+std::unique_ptr<ITrtModule>
+Cosmos3Pipeline::load_module(const std::string& section_name,
+                             const std::vector<ModuleExternalBinding>& external_bindings) const {
+    auto module = module_loader_(section_name, stream_, external_bindings);
+    if (!module || !module->ok())
+        throw std::runtime_error("Cosmos3 could not deserialize " + section_name);
+    if (module->stream() != stream_)
+        throw std::runtime_error("Cosmos3 module uses the wrong CUDA stream: " + section_name);
+    module->set_timing_label(section_name);
+    return module;
+}
+
+void Cosmos3Pipeline::synchronize_stream(const char* transition) const {
+    const auto status = cudaStreamSynchronize(stream_);
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Cosmos3 CUDA failure while ") + transition + ": " +
+                                 cudaGetErrorString(status));
+    }
+}
+
+void Cosmos3Pipeline::synchronize_stream_noexcept() const noexcept {
+    if (stream_ != nullptr)
+        (void)cudaStreamSynchronize(stream_);
+}
+
+std::vector<float> Cosmos3Pipeline::run_denoiser(const std::vector<float>& patches,
+                                                 const std::vector<float>& time_features,
+                                                 const cosmos3::PromptInputs& prompt_inputs,
+                                                 ITrtModule& denoiser) const {
+    if (patches.size() != kPatchCount || time_features.size() != 256 ||
+        prompt_inputs.input_ids.size() != cosmos3::kTextTokens ||
+        prompt_inputs.text_rotary_cos.size() !=
+            static_cast<std::size_t>(cosmos3::kTextTokens) * cosmos3::kHeadDimension ||
+        prompt_inputs.text_rotary_sin.size() != prompt_inputs.text_rotary_cos.size() ||
+        prompt_inputs.vision_rotary_cos.size() !=
+            static_cast<std::size_t>(cosmos3::kVisionTokens) * cosmos3::kHeadDimension ||
+        prompt_inputs.vision_rotary_sin.size() != prompt_inputs.vision_rotary_cos.size() ||
+        prompt_inputs.generation_attention_mask.size() !=
+            cosmos3::kTextTokens + cosmos3::kVisionTokens) {
+        throw std::invalid_argument("Cosmos3 denoiser inputs have invalid sizes");
+    }
+
+    TensorMap inputs;
+    inputs.emplace("input_ids", Tensor{const_cast<int32_t*>(prompt_inputs.input_ids.data()),
+                                       {cosmos3::kTextTokens},
+                                       DType::kInt32});
+    inputs.emplace("vision_patches", Tensor{const_cast<float*>(patches.data()),
+                                            {cosmos3::kVisionTokens, cosmos3::kPatchDimension},
+                                            DType::kFloat32});
+    inputs.emplace("timestep_features",
+                   Tensor{const_cast<float*>(time_features.data()), {1, 256}, DType::kFloat32});
+    inputs.emplace("text_rotary_cos",
+                   Tensor{const_cast<float*>(prompt_inputs.text_rotary_cos.data()),
+                          {cosmos3::kTextTokens, cosmos3::kHeadDimension},
+                          DType::kFloat32});
+    inputs.emplace("text_rotary_sin",
+                   Tensor{const_cast<float*>(prompt_inputs.text_rotary_sin.data()),
+                          {cosmos3::kTextTokens, cosmos3::kHeadDimension},
+                          DType::kFloat32});
+    inputs.emplace("vision_rotary_cos",
+                   Tensor{const_cast<float*>(prompt_inputs.vision_rotary_cos.data()),
+                          {cosmos3::kVisionTokens, cosmos3::kHeadDimension},
+                          DType::kFloat32});
+    inputs.emplace("vision_rotary_sin",
+                   Tensor{const_cast<float*>(prompt_inputs.vision_rotary_sin.data()),
+                          {cosmos3::kVisionTokens, cosmos3::kHeadDimension},
+                          DType::kFloat32});
+    inputs.emplace("generation_attention_mask",
+                   Tensor{const_cast<float*>(prompt_inputs.generation_attention_mask.data()),
+                          {1, 1, 1, cosmos3::kTextTokens + cosmos3::kVisionTokens},
+                          DType::kFloat32});
+    const auto outputs = denoiser.forward(inputs);
+    return copy_as_float(required_output(outputs, "noise_prediction_patches", "denoiser"),
+                         kPatchCount, "denoiser output");
+}
+
+void Cosmos3Pipeline::run_denoising(std::vector<float>& latents,
+                                    const cosmos3::PromptInputs& conditional_prompt,
+                                    const cosmos3::PromptInputs& unconditional_prompt,
+                                    const Cosmos3Request& request, double& engine_load_ms,
+                                    double& step_prep_ms, double& denoiser_ms,
+                                    double& scheduler_ms) {
+    if (latents.size() != kLatentCount)
+        throw std::invalid_argument("Cosmos3 denoising latent tensor has an invalid size");
+    const auto load_begin = Clock::now();
+    auto denoiser = load_module("denoiser_plan");
+    const auto load_end = Clock::now();
+    engine_load_ms = milliseconds(load_begin, load_end);
+    step_prep_ms = 0.0;
+    denoiser_ms = 0.0;
+    scheduler_ms = 0.0;
+    validate_denoiser_contract(*denoiser);
+    cosmos3::FlowUniPCCuda scheduler(stream_, request.num_inference_steps, request.flow_shift,
+                                     1000);
+    std::vector<float> guided_patches(kPatchCount);
+    std::vector<float> next(kLatentCount);
+
+    try {
+        for (int32_t step = 0; step < request.num_inference_steps; ++step) {
+            const auto step_begin = Clock::now();
+            const int64_t timestep = scheduler.timesteps().at(static_cast<std::size_t>(step));
+            const auto patches = cosmos3::patchify_latents(latents);
+            const auto time_features = cosmos3::torch_cuda_timestep_features(timestep);
+            const auto prep_end = Clock::now();
+
+            const auto conditional_begin = Clock::now();
+            const auto conditional =
+                run_denoiser(patches, time_features, conditional_prompt, *denoiser);
+            const auto conditional_end = Clock::now();
+            const auto unconditional =
+                run_denoiser(patches, time_features, unconditional_prompt, *denoiser);
+            const auto unconditional_end = Clock::now();
+
+            const auto scheduler_begin = Clock::now();
+            apply_cfg(conditional, unconditional, request.guidance_scale, guided_patches);
+            auto guided = cosmos3::unpatchify_latents(guided_patches);
+            scheduler.step(guided.data(), latents.data(), next.data(), kLatentCount);
+            for (float& value : next)
+                value = round_to_bfloat16(value);
+            latents.swap(next);
+            const auto scheduler_end = Clock::now();
+
+            const double conditional_duration = milliseconds(conditional_begin, conditional_end);
+            const double unconditional_duration = milliseconds(conditional_end, unconditional_end);
+            const double scheduler_duration = milliseconds(scheduler_begin, scheduler_end);
+            step_prep_ms += milliseconds(step_begin, prep_end);
+            denoiser_ms += conditional_duration + unconditional_duration;
+            scheduler_ms += scheduler_duration;
+            if (distributed_rank_ == 0) {
+                std::cerr << std::fixed << std::setprecision(3)
+                          << "[cosmos3.perf.step] step=" << (step + 1) << " timestep=" << timestep
+                          << " prep_ms=" << milliseconds(step_begin, prep_end)
+                          << " conditional_ms=" << conditional_duration
+                          << " unconditional_ms=" << unconditional_duration
+                          << " scheduler_cfg_ms=" << scheduler_duration
+                          << " total_ms=" << milliseconds(step_begin, scheduler_end) << '\n';
+            }
+        }
+        synchronize_stream("finishing denoising");
+    } catch (...) {
+        synchronize_stream_noexcept();
+        throw;
+    }
+}
+
+ImageResult Cosmos3Pipeline::decode_video(const std::vector<float>& latents) {
+    if (latents.size() != kLatentCount)
+        throw std::invalid_argument("Cosmos3 VAE latent tensor has an invalid size");
+    const std::size_t spatial =
+        static_cast<std::size_t>(cosmos3::kLatentHeight) * cosmos3::kLatentWidth;
+    std::vector<float> latent_frame(static_cast<std::size_t>(cosmos3::kLatentChannels) * spatial);
+
+    ImageResult result;
+    result.height = kCosmos3VideoHeight;
+    result.width = kCosmos3VideoWidth;
+    result.channels = kVideoChannels;
+    result.num_frames = kCosmos3VideoFrames;
+    result.pixels.resize(static_cast<std::size_t>(kVideoChannels) * kCosmos3VideoFrames *
+                         kCosmos3VideoHeight * kCosmos3VideoWidth);
+
+    std::vector<std::size_t> cache_capacities;
+    cache_capacities.reserve(kVaeCacheCount);
+    for (int32_t index = 0; index < kVaeCacheCount; ++index)
+        cache_capacities.push_back(expected_cache_nbytes(index));
+    auto input_bank = cosmos3::VaeCacheBank::allocate_for_current_device(cache_capacities);
+    auto output_bank = cosmos3::VaeCacheBank::allocate_for_current_device(cache_capacities);
+    std::cerr << "[cosmos3] recurrent VAE caches="
+              << (input_bank.memory_kind() == cosmos3::VaeCacheMemoryKind::kMappedHost
+                      ? "mapped_host"
+                      : "device")
+              << " bytes=" << (input_bank.total_bytes() + output_bank.total_bytes()) << '\n';
+
+    std::vector<void*> cache_inputs;
+    std::vector<void*> cache_outputs;
+    cache_inputs.reserve(kVaeCacheCount);
+    cache_outputs.reserve(kVaeCacheCount);
+    for (std::size_t index = 0; index < input_bank.size(); ++index) {
+        cache_inputs.push_back(input_bank.device_address(index));
+        cache_outputs.push_back(output_bank.device_address(index));
+    }
+
+    int32_t frame_offset = 0;
+    {
+        auto initializer = load_module("vae_decoder_first_frame_plan",
+                                       make_vae_cache_bindings(cache_inputs, cache_outputs));
+        validate_vae_contract(*initializer, kVaeFirstFrameOutputFrames, "first-frame");
+        try {
+            input_bank.zero_async(stream_);
+            output_bank.zero_async(stream_);
+            synchronize_stream("initializing recurrent VAE caches");
+            append_video_chunk(
+                result, frame_offset,
+                run_vae_latent(latents, latent_frame, 0, kVaeFirstFrameOutputFrames, *initializer),
+                kVaeFirstFrameOutputFrames);
+        } catch (...) {
+            synchronize_stream_noexcept();
+            throw;
+        }
+        std::cerr << "[cosmos3] VAE latent 1/" << cosmos3::kLatentFrames << '\n';
+    }
+
+    std::swap(cache_inputs, cache_outputs);
+    {
+        auto recurrent =
+            load_module("vae_decoder_plan", make_vae_cache_bindings(cache_inputs, cache_outputs));
+        validate_vae_contract(*recurrent, kVaeStepOutputFrames, "recurrent");
+        try {
+            for (int32_t latent_index = 1; latent_index < cosmos3::kLatentFrames; ++latent_index) {
+                append_video_chunk(result, frame_offset,
+                                   run_vae_latent(latents, latent_frame, latent_index,
+                                                  kVaeStepOutputFrames, *recurrent),
+                                   kVaeStepOutputFrames);
+                if (latent_index + 1 < cosmos3::kLatentFrames)
+                    swap_and_rebind_vae_cache_banks(*recurrent, cache_inputs, cache_outputs);
+                std::cerr << "[cosmos3] VAE latent " << (latent_index + 1) << '/'
+                          << cosmos3::kLatentFrames << '\n';
+            }
+            synchronize_stream("finishing recurrent VAE decode");
+        } catch (...) {
+            synchronize_stream_noexcept();
+            throw;
+        }
+    }
+
+    if (frame_offset != kCosmos3VideoFrames)
+        throw std::runtime_error("Cosmos3 recurrent VAE produced the wrong frame count");
+    return result;
+}
+
+ImageResult Cosmos3Pipeline::generate_image(const std::string& prompt,
+                                            const GenerateConfig& config) {
+    std::lock_guard<std::mutex> generation_lock(generation_mutex_);
+    const auto request = resolve_cosmos3_request(options_, config);
+    const auto total_begin = Clock::now();
+
+    const auto prompt_begin = Clock::now();
+    auto conditional_prompt = cosmos3::prepare_prompt_inputs(*tokenizer_, prompt, false);
+    auto unconditional_prompt =
+        cosmos3::prepare_prompt_inputs(*tokenizer_, request.negative_prompt, true);
+    const auto prompt_end = Clock::now();
+    if (distributed_rank_ == 0) {
+        std::cerr << "[cosmos3] prompt_tokens=" << conditional_prompt.real_text_tokens
+                  << " negative_tokens=" << unconditional_prompt.real_text_tokens
+                  << " seed=" << request.seed << " cp=" << distributed_world_size_ << '\n';
+    }
+
+    const auto initial_prep_begin = Clock::now();
+    auto latents = cosmos3::torch_cuda_normal(kLatentCount, static_cast<uint64_t>(request.seed));
+    const auto initial_prep_end = Clock::now();
+
+    double engine_load_ms = 0.0;
+    double step_prep_ms = 0.0;
+    double denoiser_ms = 0.0;
+    double scheduler_ms = 0.0;
+    run_denoising(latents, conditional_prompt, unconditional_prompt, request, engine_load_ms,
+                  step_prep_ms, denoiser_ms, scheduler_ms);
+    const auto denoise_end = Clock::now();
+
+    conditional_prompt = {};
+    unconditional_prompt = {};
+
+    if (distributed_world_size_ > 1 && distributed_rank_ != 0) {
+        // Context-parallel nonzero ranks denoise but intentionally leave media decoding to rank 0.
+        ImageResult empty;
+        empty.num_frames = 0;
+        return empty;
+    }
+
+    const auto vae_begin = Clock::now();
+    auto result = decode_video(latents);
+    const auto vae_end = Clock::now();
+    const auto total_end = Clock::now();
+
+    const double prompt_ms = milliseconds(prompt_begin, prompt_end);
+    const double initial_prep_ms = milliseconds(initial_prep_begin, initial_prep_end);
+    const double denoise_prep_ms = initial_prep_ms + step_prep_ms;
+    const double vae_ms = milliseconds(vae_begin, vae_end);
+    const double total_ms = milliseconds(total_begin, total_end);
+    std::cerr << std::fixed << std::setprecision(3)
+              << "[cosmos3.perf] prompt_conditioning_ms=" << prompt_ms
+              << " denoise_prep_ms=" << denoise_prep_ms
+              << " denoiser_engine_load_ms=" << engine_load_ms << " denoiser_ms=" << denoiser_ms
+              << " scheduler_cfg_ms=" << scheduler_ms << " vae_decoder_ms=" << vae_ms
+              << " generation_excluding_denoiser_load_ms=" << (total_ms - engine_load_ms)
+              << " total_ms=" << total_ms << " cp_size=" << distributed_world_size_
+              << " seed=" << request.seed << '\n';
+    (void)denoise_end;
+    return result;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/cosmos3/pipeline.h
+++ b/src/runtime/models/cosmos3/pipeline.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/backend/prebound_backend.h"
+#include "runtime/models/cosmos3/conditioning.h"
+#include "runtime/models/cosmos3/options.h"
+#include "trtmc/pipeline.h"
+#include "trtmc/tokenizer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+using Cosmos3ModuleLoader = std::function<std::unique_ptr<ITrtModule>(
+    const std::string&, cudaStream_t, const std::vector<ModuleExternalBinding>&)>;
+
+class Cosmos3Pipeline final : public IPipeline {
+  public:
+    Cosmos3Pipeline(Cosmos3ModuleLoader module_loader, std::unique_ptr<ITokenizer> tokenizer,
+                    Cosmos3Options options, std::string model_id,
+                    std::shared_ptr<void> distributed_owner = {}, int32_t distributed_rank = 0,
+                    int32_t distributed_world_size = 1);
+    ~Cosmos3Pipeline() override;
+
+    bool supports_image_generation() const override { return true; }
+    ImageResult generate_image(const std::string& prompt,
+                               const GenerateConfig& config = {}) override;
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "Cosmos3Pipeline"; }
+
+  private:
+    std::unique_ptr<ITrtModule>
+    load_module(const std::string& section_name,
+                const std::vector<ModuleExternalBinding>& external_bindings = {}) const;
+    std::vector<float> run_denoiser(const std::vector<float>& patches,
+                                    const std::vector<float>& time_features,
+                                    const cosmos3::PromptInputs& prompt_inputs,
+                                    ITrtModule& denoiser) const;
+    void run_denoising(std::vector<float>& latents, const cosmos3::PromptInputs& conditional_prompt,
+                       const cosmos3::PromptInputs& unconditional_prompt,
+                       const Cosmos3Request& request, double& engine_load_ms, double& step_prep_ms,
+                       double& denoiser_ms, double& scheduler_ms);
+    ImageResult decode_video(const std::vector<float>& latents);
+    void synchronize_stream(const char* transition) const;
+    void synchronize_stream_noexcept() const noexcept;
+
+    std::shared_ptr<void> distributed_owner_;
+    Cosmos3ModuleLoader module_loader_;
+    std::unique_ptr<ITokenizer> tokenizer_;
+    Cosmos3Options options_;
+    std::string model_id_;
+    int32_t distributed_rank_{0};
+    int32_t distributed_world_size_{1};
+    cudaStream_t stream_{nullptr};
+    std::mutex generation_mutex_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/cosmos3/plugin.cpp
+++ b/src/runtime/models/cosmos3/plugin.cpp
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bundle/bundle_format.h"
+#include "bundle/bundle_view.h"
+#include "runtime/backend/prebound_backend.h"
+#include "runtime/models/cosmos3/pipeline.h"
+#include "trtmc/runtime/distributed_runtime.h"
+#include "trtmc/runtime/pipeline_registry.h"
+#include "trtmc/runtime/trt_backend.h"
+#include "trtmc/tokenizer.h"
+#include "utils/json_helpers.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+namespace {
+
+struct ContextParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t size{1};
+};
+
+ContextParallelRuntimeConfig parse_context_parallel_config(const std::string& config_json) {
+    ContextParallelRuntimeConfig config;
+    auto mode = extract_json_string(config_json, "parallel_mode", "single");
+    if (mode == "single")
+        mode = extract_json_string(config_json, "context_parallel_mode", "single");
+    config.size = extract_json_int(config_json, "context_parallel_size", 1);
+    if (mode != "single" && mode != "context_parallel")
+        throw std::invalid_argument("Cosmos3 supports single-device or context parallel runtime");
+    if (config.size != 1 && config.size != 2 && config.size != 4 && config.size != 8)
+        throw std::invalid_argument("Cosmos3 context_parallel_size must be 1, 2, 4, or 8");
+    config.enabled = mode == "context_parallel" && config.size > 1;
+    return config;
+}
+
+using PlanSectionMap = std::unordered_map<std::string, BundleSectionInfo>;
+
+const BundleSectionInfo& require_section(const BundleInfo& info, const std::string& name) {
+    const auto section = std::find_if(
+        info.sections.begin(), info.sections.end(),
+        [&name](const BundleSectionInfo& candidate) { return candidate.name == name; });
+    if (section == info.sections.end() || section->size == 0)
+        throw std::runtime_error("Cosmos3 bundle is missing or empty: " + name);
+    return *section;
+}
+
+PlanSectionMap index_plan_sections(const BundleInfo& bundle_info, bool context_parallel) {
+    PlanSectionMap sections;
+    const std::string denoiser_name = context_parallel ? "denoiser_plan_cp" : "denoiser_plan";
+    sections.emplace("denoiser_plan", require_section(bundle_info, denoiser_name));
+    for (const char* name : {"vae_decoder_plan", "vae_decoder_first_frame_plan"})
+        sections.emplace(name, require_section(bundle_info, name));
+    return sections;
+}
+
+Cosmos3ModuleLoader make_staged_loader(const PipelineContext& ctx, PlanSectionMap plan_sections,
+                                       DistributedRuntimeGroup distributed_group,
+                                       bool context_parallel) {
+    if (ctx.backend == nullptr)
+        throw std::runtime_error("Cosmos3 requires a TensorRT backend");
+    const std::string bundle_path = ctx.bundle_path;
+    const std::string runtime_cache_path = ctx.runtime_cache_path;
+    IBackend* const backend = ctx.backend;
+    const bool cuda_graphs = ctx.cuda_graphs;
+    return [bundle_path, runtime_cache_path, backend, cuda_graphs,
+            distributed_group = std::move(distributed_group), context_parallel,
+            plan_sections = std::move(plan_sections)](
+               const std::string& logical_name, cudaStream_t stream,
+               const std::vector<ModuleExternalBinding>& external_bindings)
+               -> std::unique_ptr<ITrtModule> {
+        const auto section = plan_sections.find(logical_name);
+        if (section == plan_sections.end())
+            throw std::runtime_error("Cosmos3 has no plan section named " + logical_name);
+        auto plan = ReadBundleSection(bundle_path, section->second);
+        ModuleCreateOptions options;
+        options.stream = stream;
+        options.runtime_cache_path = runtime_cache_path.c_str();
+        options.cuda_graphs = cuda_graphs;
+        if (context_parallel && logical_name == "denoiser_plan") {
+            options.distributed_communicator = distributed_group.communicator;
+            options.distributed_owner = distributed_group.owner;
+        }
+
+        if (external_bindings.empty())
+            return backend->create_module(plan.data(), plan.size(), options);
+        auto* prebound_backend = dynamic_cast<IPreboundBackend*>(backend);
+        if (prebound_backend == nullptr) {
+            throw std::runtime_error(
+                "Cosmos3 requires a TensorRT backend with external I/O prebinding");
+        }
+        return prebound_backend->create_module_prebound(plan.data(), plan.size(), options,
+                                                        external_bindings);
+    };
+}
+
+std::unique_ptr<ITokenizer> load_tokenizer(const BundleFile& bundle) {
+    const auto* tokenizer_json = find_section(bundle, "tokenizer.json");
+    const auto* tokenizer_config = find_section(bundle, "tokenizer_config.json");
+    if (tokenizer_json == nullptr || tokenizer_json->empty() || tokenizer_config == nullptr ||
+        tokenizer_config->empty()) {
+        throw std::runtime_error(
+            "Cosmos3 bundle requires tokenizer.json and tokenizer_config.json");
+    }
+    auto tokenizer = CreateBpeTokenizer(tokenizer_json->data(), tokenizer_json->size(), false);
+    if (!tokenizer)
+        throw std::runtime_error("Cosmos3 could not create its native BPE tokenizer");
+    constexpr std::array<std::pair<const char*, int32_t>, 3> expected = {{
+        {"<|im_start|>", 151644},
+        {"<|im_end|>", 151645},
+        {"<|vision_start|>", 151652},
+    }};
+    for (const auto& [token, id] : expected) {
+        if (tokenizer->id_for_token(token) != id)
+            throw std::runtime_error(std::string("Cosmos3 tokenizer has an invalid ID for ") +
+                                     token);
+    }
+    return tokenizer;
+}
+
+} // namespace
+
+class Cosmos3Plugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        const auto cp_config = parse_context_parallel_config(ctx.config_json);
+        DistributedRuntimeGroup group;
+        if (cp_config.enabled)
+            group = initialize_tensor_parallel_group(cp_config.size);
+        auto tokenizer = load_tokenizer(ctx.bundle);
+        auto plans = index_plan_sections(ctx.bundle.info, cp_config.enabled);
+        auto loader = make_staged_loader(ctx, std::move(plans), group, cp_config.enabled);
+        return std::make_unique<Cosmos3Pipeline>(std::move(loader), std::move(tokenizer),
+                                                 parse_cosmos3_options(ctx.config_json),
+                                                 ctx.bundle.info.model_id, group.owner, group.rank,
+                                                 cp_config.enabled ? group.world_size : 1);
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_cosmos3_plugin, Cosmos3Plugin, "diffusion_cosmos3");
+
+} // namespace trtmc

--- a/src/runtime/models/cosmos3/torch_cuda_normal.cu
+++ b/src/runtime/models/cosmos3/torch_cuda_normal.cu
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/torch_cuda_normal.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+#include <curand_kernel.h>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+namespace {
+
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kUnroll = 4;
+
+void check_cuda(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess)
+        throw std::runtime_error(std::string("Cosmos3 CUDA RNG ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+}
+
+__global__ __launch_bounds__(kBlockSize, 4) void torch_normal_kernel(int64_t count, uint64_t seed,
+                                                                     float* output) {
+    const int64_t thread = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    curandStatePhilox4_32_10_t state;
+    curand_init(seed, static_cast<uint64_t>(thread), 0, &state);
+
+    const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    const int64_t group = stride * kUnroll;
+    const int64_t rounded = ((count - 1) / group + 1) * group;
+    for (int64_t linear = thread; linear < rounded; linear += group) {
+        const float4 values = curand_normal4(&state);
+        const float* source = &values.x;
+#pragma unroll
+        for (uint32_t lane = 0; lane < kUnroll; ++lane) {
+            const int64_t index = linear + stride * lane;
+            if (index < count) {
+                output[index] = __bfloat162float(__float2bfloat16_rn(source[lane]));
+            }
+        }
+    }
+}
+
+__global__ void torch_timestep_features_kernel(int64_t timestep, float* output) {
+    const int32_t index = static_cast<int32_t>(threadIdx.x);
+    const float exponent = -logf(10000.0F) * static_cast<float>(index) / 128.0F;
+    const float frequency = expf(exponent);
+    const float scaled_timestep = static_cast<float>(timestep) * 0.001F;
+    const float phase = scaled_timestep * frequency;
+    output[index] = cosf(phase);
+    output[128 + index] = sinf(phase);
+}
+
+} // namespace
+
+std::vector<float> torch_cuda_normal(std::size_t count, uint64_t seed) {
+    if (count == 0)
+        return {};
+    if (count > static_cast<std::size_t>(std::numeric_limits<int64_t>::max()))
+        throw std::overflow_error("Cosmos3 CUDA RNG tensor is too large");
+
+    int device = 0;
+    check_cuda(cudaGetDevice(&device), "cudaGetDevice");
+    cudaDeviceProp properties{};
+    check_cuda(cudaGetDeviceProperties(&properties, device), "cudaGetDeviceProperties");
+    const auto requested_blocks = (count + kBlockSize - 1U) / kBlockSize;
+    const auto blocks_per_sm =
+        static_cast<std::size_t>(properties.maxThreadsPerMultiProcessor) / kBlockSize;
+    const auto resident_blocks =
+        static_cast<std::size_t>(properties.multiProcessorCount) * blocks_per_sm;
+    const auto grid = static_cast<uint32_t>(std::min(requested_blocks, resident_blocks));
+    if (grid == 0)
+        throw std::runtime_error("Cosmos3 CUDA RNG computed an empty launch grid");
+
+    float* device_output = nullptr;
+    check_cuda(cudaMalloc(&device_output, count * sizeof(float)), "cudaMalloc");
+    try {
+        torch_normal_kernel<<<grid, kBlockSize>>>(static_cast<int64_t>(count), seed, device_output);
+        check_cuda(cudaGetLastError(), "kernel launch");
+        std::vector<float> output(count);
+        check_cuda(
+            cudaMemcpy(output.data(), device_output, count * sizeof(float), cudaMemcpyDeviceToHost),
+            "cudaMemcpy");
+        check_cuda(cudaFree(device_output), "cudaFree");
+        return output;
+    } catch (...) {
+        cudaFree(device_output);
+        throw;
+    }
+}
+
+std::vector<float> torch_cuda_timestep_features(int64_t timestep) {
+    constexpr std::size_t count = 256;
+    float* device_output = nullptr;
+    check_cuda(cudaMalloc(&device_output, count * sizeof(float)), "timestep cudaMalloc");
+    try {
+        torch_timestep_features_kernel<<<1, 128>>>(timestep, device_output);
+        check_cuda(cudaGetLastError(), "timestep kernel launch");
+        std::vector<float> output(count);
+        check_cuda(
+            cudaMemcpy(output.data(), device_output, count * sizeof(float), cudaMemcpyDeviceToHost),
+            "timestep cudaMemcpy");
+        check_cuda(cudaFree(device_output), "timestep cudaFree");
+        return output;
+    } catch (...) {
+        cudaFree(device_output);
+        throw;
+    }
+}
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/torch_cuda_normal.h
+++ b/src/runtime/models/cosmos3/torch_cuda_normal.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+
+// Generate the CUDA Philox normal sequence used by the first BF16
+// torch.randn(..., generator=torch.Generator(device="cuda").manual_seed(seed))
+// call and return each BF16 value losslessly in an FP32 host slot.
+std::vector<float> torch_cuda_normal(std::size_t count, uint64_t seed);
+
+// Match Diffusers Timesteps(256, flip_sin_to_cos=True,
+// downscale_freq_shift=0) after Cosmos3 applies timestep_scale=0.001.
+std::vector<float> torch_cuda_timestep_features(int64_t timestep);
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/vae_cache_storage.cpp
+++ b/src/runtime/models/cosmos3/vae_cache_storage.cpp
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/vae_cache_storage.h"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace trtmc::cosmos3 {
+namespace {
+
+[[noreturn]] void throw_cuda_error(cudaError_t status, const char* operation) {
+    throw std::runtime_error(std::string("Cosmos3 recurrent VAE cache ") + operation +
+                             " failed: " + cudaGetErrorString(status));
+}
+
+void require_cuda_success(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess)
+        throw_cuda_error(status, operation);
+}
+
+std::size_t checked_align_up(std::size_t value) {
+    constexpr std::size_t kMask = kVaeCacheAlignment - 1;
+    static_assert((kVaeCacheAlignment & kMask) == 0, "VAE cache alignment must be a power of two");
+    if (value > std::numeric_limits<std::size_t>::max() - kMask)
+        throw std::overflow_error("Cosmos3 recurrent VAE cache layout overflow");
+    return (value + kMask) & ~kMask;
+}
+
+} // namespace
+
+VaeCacheLayout make_vae_cache_layout(const std::vector<std::size_t>& capacities) {
+    if (capacities.empty())
+        throw std::invalid_argument("Cosmos3 recurrent VAE cache bank must not be empty");
+
+    VaeCacheLayout layout;
+    layout.offsets.reserve(capacities.size());
+    std::size_t cursor = 0;
+    for (const std::size_t capacity : capacities) {
+        if (capacity == 0)
+            throw std::invalid_argument("Cosmos3 recurrent VAE cache capacity must be positive");
+        cursor = checked_align_up(cursor);
+        layout.offsets.push_back(cursor);
+        if (capacity > std::numeric_limits<std::size_t>::max() - cursor)
+            throw std::overflow_error("Cosmos3 recurrent VAE cache layout overflow");
+        cursor += capacity;
+    }
+    layout.total_bytes = checked_align_up(cursor);
+    return layout;
+}
+
+VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory,
+                                                int compute_capability_major,
+                                                int compute_capability_minor) {
+    // GB10 (SM 11.0) is integrated but its qualified recurrent-cache path requires device memory.
+    if (!integrated || (compute_capability_major == 11 && compute_capability_minor == 0))
+        return VaeCacheMemoryKind::kDevice;
+    if (!can_map_host_memory) {
+        throw std::runtime_error(
+            "Cosmos3 integrated GPU cannot map host memory for recurrent VAE caches");
+    }
+    return VaeCacheMemoryKind::kMappedHost;
+}
+
+VaeCacheBank VaeCacheBank::allocate_for_current_device(const std::vector<std::size_t>& capacities) {
+    int device = 0;
+    require_cuda_success(cudaGetDevice(&device), "device query");
+
+    int integrated = 0;
+    require_cuda_success(cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, device),
+                         "integrated-device query");
+    int compute_capability_major = 0;
+    require_cuda_success(cudaDeviceGetAttribute(&compute_capability_major,
+                                                cudaDevAttrComputeCapabilityMajor, device),
+                         "compute-capability-major query");
+    int compute_capability_minor = 0;
+    require_cuda_success(cudaDeviceGetAttribute(&compute_capability_minor,
+                                                cudaDevAttrComputeCapabilityMinor, device),
+                         "compute-capability-minor query");
+    int can_map_host_memory = 0;
+    if (integrated != 0) {
+        require_cuda_success(
+            cudaDeviceGetAttribute(&can_map_host_memory, cudaDevAttrCanMapHostMemory, device),
+            "mapped-host capability query");
+    }
+
+    auto layout = make_vae_cache_layout(capacities);
+    const auto kind =
+        select_vae_cache_memory_kind(integrated != 0, can_map_host_memory != 0,
+                                     compute_capability_major, compute_capability_minor);
+    return VaeCacheBank(std::move(layout), kind);
+}
+
+VaeCacheBank::VaeCacheBank(VaeCacheLayout layout, VaeCacheMemoryKind memory_kind)
+    : layout_(std::move(layout)), memory_kind_(memory_kind) {
+    if (memory_kind_ == VaeCacheMemoryKind::kDevice) {
+        require_cuda_success(cudaMalloc(&allocation_, layout_.total_bytes), "cudaMalloc");
+        device_base_ = allocation_;
+    } else {
+        require_cuda_success(cudaHostAlloc(&allocation_, layout_.total_bytes, cudaHostAllocMapped),
+                             "cudaHostAllocMapped");
+        const cudaError_t alias_status = cudaHostGetDevicePointer(&device_base_, allocation_, 0);
+        if (alias_status != cudaSuccess || device_base_ == nullptr) {
+            (void)cudaFreeHost(allocation_);
+            allocation_ = nullptr;
+            device_base_ = nullptr;
+            if (alias_status != cudaSuccess)
+                throw_cuda_error(alias_status, "cudaHostGetDevicePointer");
+            throw std::runtime_error(
+                "Cosmos3 recurrent VAE cache mapped allocation has no CUDA device alias");
+        }
+    }
+
+    const auto address = reinterpret_cast<std::uintptr_t>(device_base_);
+    if ((address & (kVaeCacheAlignment - 1)) != 0) {
+        release();
+        throw std::runtime_error(
+            "Cosmos3 recurrent VAE cache allocation does not meet CUDA alignment");
+    }
+}
+
+VaeCacheBank::~VaeCacheBank() {
+    release();
+}
+
+void* VaeCacheBank::device_address(std::size_t index) const {
+    if (index >= layout_.offsets.size() || device_base_ == nullptr)
+        throw std::out_of_range("Cosmos3 recurrent VAE cache index is out of range");
+    auto* bytes = static_cast<unsigned char*>(device_base_);
+    return bytes + layout_.offsets[index];
+}
+
+void VaeCacheBank::zero_async(cudaStream_t stream) const {
+    if (device_base_ == nullptr || layout_.total_bytes == 0)
+        throw std::runtime_error("Cosmos3 recurrent VAE cache bank is not allocated");
+    require_cuda_success(cudaMemsetAsync(device_base_, 0, layout_.total_bytes, stream),
+                         "device memset");
+}
+
+void VaeCacheBank::copy_from_async(const VaeCacheBank& source, cudaStream_t stream) const {
+    if (device_base_ == nullptr || source.device_base_ == nullptr ||
+        layout_.offsets != source.layout_.offsets ||
+        layout_.total_bytes != source.layout_.total_bytes) {
+        throw std::invalid_argument("Cosmos3 recurrent VAE cache bank copy is incompatible");
+    }
+    require_cuda_success(cudaMemcpyAsync(device_base_, source.device_base_, layout_.total_bytes,
+                                         cudaMemcpyDeviceToDevice, stream),
+                         "device-to-device copy");
+}
+
+void VaeCacheBank::release() noexcept {
+    if (allocation_ != nullptr) {
+        if (memory_kind_ == VaeCacheMemoryKind::kMappedHost)
+            (void)cudaFreeHost(allocation_);
+        else
+            (void)cudaFree(allocation_);
+    }
+}
+
+} // namespace trtmc::cosmos3

--- a/src/runtime/models/cosmos3/vae_cache_storage.h
+++ b/src/runtime/models/cosmos3/vae_cache_storage.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cuda_runtime_api.h>
+#include <vector>
+
+namespace trtmc::cosmos3 {
+
+// TensorRT device addresses are kept at CUDA's documented minimum allocation
+// alignment even when multiple recurrent-cache tensors share one allocation.
+inline constexpr std::size_t kVaeCacheAlignment = 256;
+
+enum class VaeCacheMemoryKind {
+    kDevice,
+    kMappedHost,
+};
+
+struct VaeCacheLayout {
+    std::vector<std::size_t> offsets;
+    std::size_t total_bytes{0};
+};
+
+// Pure helpers are public inside this model-owned header so policy, overflow,
+// and alignment can be tested without depending on the current CUDA device.
+VaeCacheLayout make_vae_cache_layout(const std::vector<std::size_t>& capacities);
+VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory,
+                                                int compute_capability_major,
+                                                int compute_capability_minor);
+
+// One contiguous recurrent-cache bank. Discrete GPUs and qualified SM 11.0
+// integrated GPUs use cudaMalloc. Other integrated GPUs use a mapped pinned
+// system allocation and expose only its CUDA device alias to TensorRT.
+class VaeCacheBank final {
+  public:
+    static VaeCacheBank allocate_for_current_device(const std::vector<std::size_t>& capacities);
+
+    ~VaeCacheBank();
+
+    VaeCacheBank(const VaeCacheBank&) = delete;
+    VaeCacheBank& operator=(const VaeCacheBank&) = delete;
+
+    void* device_address(std::size_t index) const;
+    std::size_t total_bytes() const { return layout_.total_bytes; }
+    std::size_t size() const { return layout_.offsets.size(); }
+    VaeCacheMemoryKind memory_kind() const { return memory_kind_; }
+
+    void zero_async(cudaStream_t stream) const;
+    void copy_from_async(const VaeCacheBank& source, cudaStream_t stream) const;
+
+  private:
+    VaeCacheBank(VaeCacheLayout layout, VaeCacheMemoryKind memory_kind);
+    void release() noexcept;
+
+    VaeCacheLayout layout_;
+    VaeCacheMemoryKind memory_kind_{VaeCacheMemoryKind::kDevice};
+    void* allocation_{nullptr};
+    void* device_base_{nullptr};
+};
+
+} // namespace trtmc::cosmos3

--- a/tests/cpp/models/cosmos3/test_cosmos3_conditioning.cpp
+++ b/tests/cpp/models/cosmos3/test_cosmos3_conditioning.cpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/conditioning.h"
+
+#include <cstddef>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+static_assert(trtmc::cosmos3::kLatentFrames == 48);
+static_assert(trtmc::cosmos3::kLatentHeight == 45);
+static_assert(trtmc::cosmos3::kLatentWidth == 80);
+static_assert(trtmc::cosmos3::kPatchHeight == 23);
+static_assert(trtmc::cosmos3::kPatchWidth == 40);
+static_assert(trtmc::cosmos3::kVisionTokens == 44160);
+static_assert(trtmc::cosmos3::kTextTokens == 4096);
+void test_chat_template() {
+    const auto positive = trtmc::cosmos3::format_chat_prompt("A robot.", false);
+    if (positive != "<|im_start|>system\n"
+                    "You are a helpful assistant who will generate videos from a give prompt."
+                    "<|im_end|>\n<|im_start|>user\n"
+                    "A robot. The video is 7.9 seconds long and is of 24 FPS. "
+                    "This video is of 720x1280 resolution."
+                    "<|im_end|>\n<|im_start|>assistant\n") {
+        throw std::runtime_error("Cosmos3 positive chat template differs from Diffusers");
+    }
+    if (trtmc::cosmos3::format_chat_prompt("A robot. \t\n", false) != positive) {
+        throw std::runtime_error("Cosmos3 prompt normalization leaves trailing whitespace");
+    }
+    const auto negative = trtmc::cosmos3::format_chat_prompt("artifacts", true);
+    if (negative.find("The video is not 7.9 seconds long") == std::string::npos ||
+        negative.find("This video is not of 720x1280 resolution.") == std::string::npos) {
+        throw std::runtime_error("Cosmos3 negative metadata template is missing");
+    }
+}
+
+void test_patch_round_trip() {
+    constexpr std::size_t count = static_cast<std::size_t>(trtmc::cosmos3::kLatentChannels) *
+                                  trtmc::cosmos3::kLatentFrames * trtmc::cosmos3::kLatentHeight *
+                                  trtmc::cosmos3::kLatentWidth;
+    std::vector<float> latents(count);
+    for (std::size_t index = 0; index < latents.size(); ++index)
+        latents[index] = static_cast<float>(index % 8191U) / 8191.0F;
+    const auto restored =
+        trtmc::cosmos3::unpatchify_latents(trtmc::cosmos3::patchify_latents(latents));
+    if (restored != latents)
+        throw std::runtime_error("Cosmos3 patchify/unpatchify is not lossless");
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_chat_template();
+        test_patch_round_trip();
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: " << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/cosmos3/test_cosmos3_options.cpp
+++ b/tests/cpp/models/cosmos3/test_cosmos3_options.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/cosmos3/options.h"
+#include "trtmc/pipeline.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main() {
+    try {
+        const auto options = trtmc::parse_cosmos3_options(
+            R"({"negative_prompt":"blurry, distorted, low quality, jittery, deformed","num_inference_steps":35,"guidance_scale":6.0,"flow_shift":10.0,"video_height":720,"video_width":1280,"video_num_frames":189,"frame_rate":24,"text_seq_len":4096,"seed":42})");
+        trtmc::GenerateConfig config;
+        config.seed = 7;
+        const auto request = trtmc::resolve_cosmos3_request(options, config);
+        if (request.seed != 7 || request.video_num_frames != 189 || request.video_height != 720 ||
+            request.video_width != 1280 || request.num_inference_steps != 35 ||
+            request.text_seq_len != 4096 ||
+            request.negative_prompt != "blurry, distorted, low quality, jittery, deformed") {
+            throw std::runtime_error("Cosmos3 request resolution changed the fixed profile");
+        }
+        config.num_steps = 34;
+        try {
+            (void)trtmc::resolve_cosmos3_request(options, config);
+            throw std::runtime_error("Cosmos3 accepted a reduced-quality step override");
+        } catch (const std::invalid_argument&) {
+        }
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: " << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/test_distributed_runtime.cpp
+++ b/tests/cpp/test_distributed_runtime.cpp
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/core/distributed_runtime_detail.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr const char* kEnvironmentNames[] = {
+    "OMPI_COMM_WORLD_SIZE",       "PMI_SIZE",       "WORLD_SIZE",
+    "OMPI_COMM_WORLD_RANK",       "PMI_RANK",       "RANK",
+    "OMPI_COMM_WORLD_LOCAL_RANK", "PMI_LOCAL_RANK", "MPI_LOCALRANKID",
+    "MV2_COMM_WORLD_LOCAL_RANK",  "SLURM_LOCALID",  "LOCAL_RANK",
+};
+
+class EnvironmentGuard {
+  public:
+    EnvironmentGuard() {
+        for (const char* name : kEnvironmentNames) {
+            const char* value = std::getenv(name);
+            values_.emplace_back(name, value == nullptr ? std::nullopt
+                                                        : std::optional<std::string>(value));
+            unsetenv(name);
+        }
+    }
+
+    ~EnvironmentGuard() {
+        for (const auto& [name, value] : values_) {
+            if (value.has_value())
+                setenv(name.c_str(), value->c_str(), 1);
+            else
+                unsetenv(name.c_str());
+        }
+    }
+
+    EnvironmentGuard(const EnvironmentGuard&) = delete;
+    EnvironmentGuard& operator=(const EnvironmentGuard&) = delete;
+
+  private:
+    std::vector<std::pair<std::string, std::optional<std::string>>> values_;
+};
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+void test_generic_multinode_rank_uses_local_device_zero() {
+    EnvironmentGuard guard;
+    setenv("WORLD_SIZE", "2", 1);
+    setenv("RANK", "1", 1);
+    setenv("LOCAL_RANK", "0", 1);
+
+    check(trtmc::distributed_runtime_detail::detect_world_size() == 2, "generic world size");
+    check(trtmc::distributed_runtime_detail::detect_rank() == 1, "generic global rank");
+    check(trtmc::distributed_runtime_detail::detect_local_rank(1) == 0, "generic local rank");
+}
+
+void test_mpi_local_rank_precedence() {
+    EnvironmentGuard guard;
+    setenv("LOCAL_RANK", "5", 1);
+    setenv("SLURM_LOCALID", "4", 1);
+    setenv("MV2_COMM_WORLD_LOCAL_RANK", "3", 1);
+    setenv("MPI_LOCALRANKID", "2", 1);
+    setenv("PMI_LOCAL_RANK", "1", 1);
+    setenv("OMPI_COMM_WORLD_LOCAL_RANK", "0", 1);
+
+    check(trtmc::distributed_runtime_detail::detect_local_rank(6) == 0,
+          "Open MPI local rank has precedence");
+}
+
+void test_local_rank_aliases_and_global_fallback() {
+    constexpr const char* aliases[] = {
+        "PMI_LOCAL_RANK", "MPI_LOCALRANKID", "MV2_COMM_WORLD_LOCAL_RANK",
+        "SLURM_LOCALID",  "LOCAL_RANK",
+    };
+    for (const char* alias : aliases) {
+        EnvironmentGuard guard;
+        setenv(alias, "1", 1);
+        check(trtmc::distributed_runtime_detail::detect_local_rank(7) == 1, alias);
+    }
+
+    EnvironmentGuard guard;
+    check(trtmc::distributed_runtime_detail::detect_local_rank(7) == 7,
+          "global rank fallback preserves single-node behavior");
+}
+
+} // namespace
+
+int main() {
+    test_generic_multinode_rank_uses_local_device_zero();
+    test_mpi_local_rank_precedence();
+    test_local_rank_aliases_and_global_fallback();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/e2e/models/cosmos3/MODEL.toml
+++ b/tests/e2e/models/cosmos3/MODEL.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "cosmos3"
+plugin = "cosmos3"
+test_manifests = [
+  "manifests/cosmos3-nano-l0.json",
+  "manifests/cosmos3-nano-l0-cp2.json",
+]
+
+[e2e_defaults.diffusion_media_generation]
+reference_backend = "invariant_only"
+oracle_level = "L4_invariants"
+stages = [
+  { name = "end_to_end", required = true },
+]
+input_fields = [
+  { input = "video_num_frames", manifest = "video_num_frames" },
+  { input = "video_height", manifest = "video_height" },
+  { input = "video_width", manifest = "video_width" },
+  { input = "num_inference_steps", manifest = "num_inference_steps" },
+  { input = "guidance_scale", manifest = "guidance_scale" },
+  { input = "seed", manifest = "seed" },
+]

--- a/tests/e2e/models/cosmos3/e2e_plugins/__init__.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-owned E2E plugin helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def save_full_stderr(
+    stderr: str,
+    artifacts_dir: str,
+    stage_name: str,
+    case_name: str = "",
+) -> tuple[str, str | None]:
+    truncated = stderr[-2000:] if len(stderr) > 2000 else stderr
+    if not artifacts_dir:
+        return truncated, None
+    directory = Path(artifacts_dir) / case_name if case_name else Path(artifacts_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{stage_name}_stderr.log"
+    path.write_text(stderr, encoding="utf-8")
+    return truncated, str(path)

--- a/tests/e2e/models/cosmos3/e2e_plugins/comparator.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/comparator.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3 model-owned E2E comparator plugin."""
+
+from .comparators.diffusion import plugin
+
+comparator = plugin

--- a/tests/e2e/models/cosmos3/e2e_plugins/comparators/__init__.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/comparators/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-owned E2E comparators."""

--- a/tests/e2e/models/cosmos3/e2e_plugins/comparators/diffusion.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/comparators/diffusion.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixed-profile functional comparator for Cosmos3-Nano video output."""
+
+from __future__ import annotations
+
+from ..contracts import CompareResult, MetricResult, StageOutput, StageSpec, ThresholdProfile
+
+_REQUIRED_THRESHOLDS = {
+    "exact_num_frames",
+    "exact_video_width",
+    "exact_video_height",
+    "min_pixel_mean",
+    "max_pixel_mean",
+    "min_pixel_std",
+}
+
+
+def _metric(value: float, threshold: float, operator: str, passed: bool) -> MetricResult:
+    return MetricResult(
+        value=value,
+        threshold=threshold,
+        operator=operator,
+        passed=passed,
+    )
+
+
+class DiffusionComparator:
+    @property
+    def task_strategy(self) -> str:
+        return "diffusion_media_generation"
+
+    def compare(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        missing = sorted(_REQUIRED_THRESHOLDS - set(threshold.metrics))
+        if missing:
+            return CompareResult(
+                stage_name=stage.name,
+                status="failed",
+                composite_rule="all Cosmos3 frame thresholds must be loaded",
+                message=f"Cosmos3 threshold sidecar is incomplete: {missing}",
+            )
+
+        expected_frames = int(threshold.metrics["exact_num_frames"])
+        expected_width = int(threshold.metrics["exact_video_width"])
+        expected_height = int(threshold.metrics["exact_video_height"])
+        min_mean = float(threshold.metrics["min_pixel_mean"])
+        max_mean = float(threshold.metrics["max_pixel_mean"])
+        min_std = float(threshold.metrics["min_pixel_std"])
+        data = trt.data or {}
+        stats = data.get("frame_stats") or {}
+        returncode = int(data.get("returncode", -1))
+        frame_count = int(data.get("num_frames", 0))
+        width = int(stats.get("width", 0))
+        height = int(stats.get("height", 0))
+        consistent = bool(stats.get("dimensions_consistent", False))
+        pixel_mean = float(stats.get("mean", 0.0))
+        pixel_std = float(stats.get("std", 0.0))
+        metrics = {
+            "returncode": _metric(float(returncode), 0.0, "==", returncode == 0),
+            "exact_num_frames": _metric(
+                float(frame_count), float(expected_frames), "==", frame_count == expected_frames
+            ),
+            "exact_video_width": _metric(
+                float(width), float(expected_width), "==", width == expected_width
+            ),
+            "exact_video_height": _metric(
+                float(height), float(expected_height), "==", height == expected_height
+            ),
+            "frame_dimensions_consistent": _metric(
+                float(consistent), 1.0, "==", consistent
+            ),
+            "pixel_mean_min": _metric(pixel_mean, min_mean, ">=", pixel_mean >= min_mean),
+            "pixel_mean_max": _metric(pixel_mean, max_mean, "<=", pixel_mean <= max_mean),
+            "pixel_std_min": _metric(pixel_std, min_std, ">=", pixel_std >= min_std),
+        }
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status="passed" if passed else "failed",
+            metrics=metrics,
+            composite_rule=(
+                f"native command succeeds AND output is exactly {expected_frames} "
+                f"{expected_width}x{expected_height} frames AND pixels are non-degenerate"
+            ),
+            message=f"Cosmos3-Nano fixed-profile invariant check: {'PASS' if passed else 'FAIL'}",
+        )
+
+
+plugin = DiffusionComparator()

--- a/tests/e2e/models/cosmos3/e2e_plugins/contracts.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/contracts.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable E2E contract aliases for Cosmos3-owned plugins."""
+
+from tests.e2e_harness.contracts import *  # noqa: F401,F403

--- a/tests/e2e/models/cosmos3/e2e_plugins/reference.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/reference.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3 model-owned E2E reference plugin."""
+
+from .references.invariant_only import plugin
+
+reference = plugin

--- a/tests/e2e/models/cosmos3/e2e_plugins/references/__init__.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/references/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-owned E2E references."""

--- a/tests/e2e/models/cosmos3/e2e_plugins/references/invariant_only.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/references/invariant_only.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Invariant-only reference backend for Cosmos3 native qualification."""
+
+from __future__ import annotations
+
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+class InvariantOnlyReference:
+    @property
+    def backend_name(self) -> str:
+        return "invariant_only"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        return StageOutput(
+            stage_name=stage.name,
+            data={"_invariant_only": True},
+            timing_s=0.0,
+            metadata={"source": "invariant_only"},
+        )
+
+
+plugin = InvariantOnlyReference()

--- a/tests/e2e/models/cosmos3/e2e_plugins/runner.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/runner.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3 model-owned E2E runner plugin."""
+
+from .runners.diffusion import plugin
+
+runner = plugin

--- a/tests/e2e/models/cosmos3/e2e_plugins/runners/__init__.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/runners/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos3-owned E2E runners."""

--- a/tests/e2e/models/cosmos3/e2e_plugins/runners/diffusion.py
+++ b/tests/e2e/models/cosmos3/e2e_plugins/runners/diffusion.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native distributed ``generate-video`` runner for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from .. import save_full_stderr
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+def _bundle_path(case: E2ECase, ctx: RunContext) -> Path:
+    bundle = Path(case.bundle)
+    return bundle if bundle.is_absolute() else Path(ctx.engine_dir) / bundle
+
+
+def _require_model_plugin_dir(ctx: RunContext) -> str:
+    if not ctx.model_plugin_dir:
+        raise ValueError("Cosmos3 E2E requires an explicit model_plugin_dir")
+    return ctx.model_plugin_dir
+
+
+def _distributed_config(case: E2ECase) -> dict:
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _prepare_distributed_env(case: E2ECase, ctx: RunContext, env: dict[str, str]) -> None:
+    config = _distributed_config(case)
+    if not config or env.get("TRTMC_NCCL_RENDEZVOUS"):
+        return
+    root = Path(ctx.artifacts_dir) / case.name if ctx.artifacts_dir else Path(tempfile.gettempdir())
+    root.mkdir(parents=True, exist_ok=True)
+    rendezvous = root / "cosmos3_cp.nccl_rendezvous.bin"
+    try:
+        rendezvous.unlink()
+    except FileNotFoundError:
+        pass
+    env["TRTMC_NCCL_RENDEZVOUS"] = str(rendezvous)
+
+
+def _wrap_distributed(command: list[str], case: E2ECase, env: dict[str, str]) -> list[str]:
+    config = _distributed_config(case)
+    if not config:
+        return command
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", 1) or 1)
+    wrapped = [launcher, "--tag-output", "-np", str(world_size)]
+    export_env = config.get("export_env", [])
+    if isinstance(export_env, list) and Path(launcher).name == "mpirun":
+        for name in (str(item) for item in export_env):
+            if name in env:
+                wrapped.extend(["-x", f"{name}={env[name]}"])
+    return wrapped + command
+
+
+def _captured_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value or ""
+
+
+def build_generate_video_command(
+    case: E2ECase,
+    ctx: RunContext,
+    output_dir: Path,
+    *,
+    bundle_path: str | Path | None = None,
+) -> list[str]:
+    bundle = Path(bundle_path) if bundle_path is not None else _bundle_path(case, ctx)
+    return [
+        ctx.binary_path,
+        "generate-video",
+        str(bundle),
+        "--prompt",
+        str(case.inputs.get("prompt", "")),
+        "--output",
+        str(output_dir),
+        "--num-steps",
+        str(case.inputs["num_inference_steps"]),
+        "--guidance-scale",
+        str(case.inputs["guidance_scale"]),
+        "--seed",
+        str(case.inputs["seed"]),
+        "--height",
+        str(case.inputs["video_height"]),
+        "--width",
+        str(case.inputs["video_width"]),
+        "--backend-dir",
+        str(Path(ctx.binary_path).parent),
+        "--model-plugin-dir",
+        _require_model_plugin_dir(ctx),
+    ]
+
+
+def _frame_stats(frame_paths: list[Path]) -> dict[str, float | int | bool]:
+    if not frame_paths:
+        return {
+            "mean": 0.0,
+            "std": 0.0,
+            "width": 0,
+            "height": 0,
+            "dimensions_consistent": False,
+        }
+    import numpy as np
+    from PIL import Image
+
+    total = 0.0
+    total_squared = 0.0
+    element_count = 0
+    expected_size: tuple[int, int] | None = None
+    dimensions_consistent = True
+    for frame_path in frame_paths:
+        with Image.open(frame_path) as image:
+            rgb = image.convert("RGB")
+            if expected_size is None:
+                expected_size = rgb.size
+            dimensions_consistent = dimensions_consistent and rgb.size == expected_size
+            pixels = np.asarray(rgb, dtype=np.uint8)
+        total += float(pixels.sum(dtype=np.float64))
+        total_squared += float(np.square(pixels, dtype=np.float64).sum(dtype=np.float64))
+        element_count += int(pixels.size)
+    mean_u8 = total / element_count
+    variance_u8 = max(total_squared / element_count - mean_u8 * mean_u8, 0.0)
+    width, height = expected_size or (0, 0)
+    return {
+        "mean": mean_u8 / 255.0,
+        "std": variance_u8**0.5 / 255.0,
+        "width": width,
+        "height": height,
+        "dimensions_consistent": dimensions_consistent,
+    }
+
+
+class DiffusionMediaRunner:
+    @property
+    def strategy_name(self) -> str:
+        return "diffusion_media_generation"
+
+    def build_trt_inference_command(
+        self,
+        case: E2ECase,
+        ctx: RunContext,
+        bundle_path: str,
+    ) -> list[str] | None:
+        if case.task_strategy != self.strategy_name:
+            return None
+        env = {**os.environ, "LD_LIBRARY_PATH": ctx.ld_library_path}
+        _prepare_distributed_env(case, ctx, env)
+        command = build_generate_video_command(
+            case,
+            ctx,
+            Path(tempfile.mkdtemp(prefix="trtmc_cosmos3_repro_frames_")),
+            bundle_path=bundle_path,
+        )
+        return _wrap_distributed(command, case, env)
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name != "end_to_end":
+            return StageOutput(
+                stage_name=stage.name,
+                data={"error": f"Unsupported Cosmos3 stage: {stage.name}"},
+                metadata={"status": "unsupported_stage"},
+            )
+        artifact_root = Path(ctx.artifacts_dir) / case.name if ctx.artifacts_dir else None
+        if artifact_root is None:
+            output_dir = Path(tempfile.mkdtemp(prefix="cosmos3_frames_"))
+        else:
+            artifact_root.mkdir(parents=True, exist_ok=True)
+            output_dir = artifact_root / "frames"
+            if output_dir.exists():
+                shutil.rmtree(output_dir)
+            output_dir.mkdir(parents=True)
+        command = build_generate_video_command(case, ctx, output_dir)
+        env = {
+            **os.environ,
+            "LD_LIBRARY_PATH": ctx.ld_library_path,
+            "TRTMC_MODEL_PLUGIN_DIR": _require_model_plugin_dir(ctx),
+            "TRTMC_MODEL_PLUGIN_STRICT": "1",
+        }
+        _prepare_distributed_env(case, ctx, env)
+        command = _wrap_distributed(command, case, env)
+        timeout_s = int(case.metadata.get("runtime_timeout_s", 3600))
+        if timeout_s <= 0:
+            raise ValueError("runtime_timeout_s must be positive")
+        started = time.monotonic()
+        timed_out = False
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout_s,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            result = subprocess.CompletedProcess(
+                command,
+                124,
+                stdout=_captured_text(exc.stdout),
+                stderr=_captured_text(exc.stderr),
+            )
+        elapsed = time.monotonic() - started
+        frames = sorted(output_dir.glob("frame_*.png"))
+        stderr, stderr_log = save_full_stderr(
+            result.stderr or "",
+            ctx.artifacts_dir,
+            stage.name,
+            case.name,
+        )
+        data = {
+            "returncode": result.returncode,
+            "num_frames": len(frames),
+            "frames_dir": str(output_dir),
+            "frame_paths": [str(path) for path in frames],
+            "frame_stats": _frame_stats(frames),
+        }
+        metadata = {
+            "command": command,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": stderr,
+            "distributed_runtime": _distributed_config(case),
+        }
+        if timed_out:
+            metadata["error"] = f"timed out after {timeout_s} seconds"
+        if stderr_log:
+            metadata["stderr_log"] = stderr_log
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            text=result.stdout,
+            timing_s=elapsed,
+            metadata=metadata,
+        )
+
+
+plugin = DiffusionMediaRunner()

--- a/tests/e2e/models/cosmos3/manifests/cosmos3-nano-l0-cp2.json
+++ b/tests/e2e/models/cosmos3/manifests/cosmos3-nano-l0-cp2.json
@@ -1,0 +1,70 @@
+{
+  "name": "cosmos3-nano-l0-cp2",
+  "hf_id": "nvidia/Cosmos3-Nano",
+  "hf_revision": "411f42a8fdfb8c5b2583cb8786e0938f49796eaa",
+  "bundle": "cosmos3-nano-l0-cp2.trtfb",
+  "family": "cosmos3",
+  "runtime_strategy": "diffusion_cosmos3",
+  "task_strategy": "diffusion_media_generation",
+  "precision": "bf16",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_timeout_s": 43200,
+  "build_args": {
+    "parallel": {
+      "mode": "context_parallel",
+      "cp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "testcases": [
+    {
+      "name": "cosmos3-nano-l0-cp2",
+      "trace_id": "IT-E2E-COSMOS3-NANO-L0-CP2-01",
+      "model_type": "cosmos3",
+      "ci_tier": "multi_device",
+      "runtime_timeout_s": 7200,
+      "reference_backend": "invariant_only",
+      "oracle_level": "L4_invariants",
+      "user_contract": "diffusion_video",
+      "description": "Cosmos3-Nano fixed 720p CP2 native video generation contract",
+      "test_type": "diffusion",
+      "test_prompt": "{\"description\":\"A modern industrial robotic arm wipes a dirty white plate with a green sponge in a bright residential kitchen. The arm moves smoothly in circular motions while the plate becomes clean.\",\"camera\":\"A stable medium close-up with a subtle push-in.\",\"lighting\":\"Natural daylight with warm overhead fill.\",\"duration\":\"7s\"}",
+      "video_num_frames": 189,
+      "video_height": 720,
+      "video_width": 1280,
+      "num_inference_steps": 35,
+      "guidance_scale": 6.0,
+      "seed": 42,
+      "preflight_requirements": [
+        {
+          "kind": "binary_exists",
+          "args": {},
+          "gating": true
+        },
+        {
+          "kind": "command_available",
+          "args": {
+            "command": "mpirun"
+          },
+          "gating": true
+        },
+        {
+          "kind": "gpu_count_min",
+          "args": {
+            "count": 2
+          },
+          "gating": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/models/cosmos3/manifests/cosmos3-nano-l0.json
+++ b/tests/e2e/models/cosmos3/manifests/cosmos3-nano-l0.json
@@ -1,0 +1,47 @@
+{
+  "name": "cosmos3-nano-l0",
+  "hf_id": "nvidia/Cosmos3-Nano",
+  "hf_revision": "411f42a8fdfb8c5b2583cb8786e0938f49796eaa",
+  "bundle": "cosmos3-nano-l0.trtfb",
+  "family": "cosmos3",
+  "runtime_strategy": "diffusion_cosmos3",
+  "task_strategy": "diffusion_media_generation",
+  "precision": "bf16",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_timeout_s": 43200,
+  "testcases": [
+    {
+      "name": "cosmos3-nano-l0",
+      "trace_id": "IT-E2E-COSMOS3-NANO-L0-01",
+      "model_type": "cosmos3",
+      "ci_tier": "l0_only",
+      "runtime_timeout_s": 7200,
+      "reference_backend": "invariant_only",
+      "oracle_level": "L4_invariants",
+      "user_contract": "diffusion_video",
+      "description": "Cosmos3-Nano fixed 720p single-device native video generation contract",
+      "test_type": "diffusion",
+      "test_prompt": "{\"description\":\"A modern industrial robotic arm wipes a dirty white plate with a green sponge in a bright residential kitchen. The arm moves smoothly in circular motions while the plate becomes clean.\",\"camera\":\"A stable medium close-up with a subtle push-in.\",\"lighting\":\"Natural daylight with warm overhead fill.\",\"duration\":\"7s\"}",
+      "video_num_frames": 189,
+      "video_height": 720,
+      "video_width": 1280,
+      "num_inference_steps": 35,
+      "guidance_scale": 6.0,
+      "seed": 42,
+      "preflight_requirements": [
+        {
+          "kind": "binary_exists",
+          "args": {},
+          "gating": true
+        },
+        {
+          "kind": "gpu_count_min",
+          "args": {
+            "count": 1
+          },
+          "gating": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/models/cosmos3/runner.py
+++ b/tests/e2e/models/cosmos3/runner.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E runner entrypoint for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from tests.e2e_harness.model_runner import (
+    model_names_for_dir,
+    run_model_e2e as run_model_manifest_e2e,
+)
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_PROJECT_DIR = _MODEL_DIR.parents[3]
+LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_binary(config) -> str:
+    cli_value = config.getoption("--trtmc-binary", default=None)
+    if cli_value:
+        return str(Path(cli_value).absolute())
+    default = _PROJECT_DIR / "build" / "trtmc"
+    return str(default) if default.is_file() else ""
+
+
+def _resolve_hf_python(config) -> str:
+    cli_value = config.getoption("--hf-python", default=None)
+    if cli_value:
+        return str(Path(cli_value).absolute())
+    venv = _PROJECT_DIR / ".venv" / "bin" / "python"
+    return str(venv) if venv.is_file() else sys.executable
+
+
+def _resolve_engine_dir(config) -> str:
+    cli_value = config.getoption("--engine-dir", default=None)
+    directory = (
+        Path(cli_value)
+        if cli_value
+        else Path("/mnt/storage/tensorrt-model-connect/engines")
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    return str(directory)
+
+
+def _resolve_model_plugin_dir(config) -> str:
+    cli_value = config.getoption("--model-plugin-dir", default=None)
+    return str(Path(cli_value).absolute()) if cli_value else ""
+
+
+def _resolve_artifacts_dir(config) -> str:
+    cli_value = config.getoption("--e2e-artifacts-dir", default=None)
+    return str(Path(cli_value)) if cli_value else "/tmp/e2e_artifacts/cosmos3"
+
+
+@contextmanager
+def _model_plugin_dir_env(path: str):
+    old_value = os.environ.get("TRTMC_MODEL_PLUGIN_DIR")
+    if path:
+        os.environ["TRTMC_MODEL_PLUGIN_DIR"] = path
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop("TRTMC_MODEL_PLUGIN_DIR", None)
+        else:
+            os.environ["TRTMC_MODEL_PLUGIN_DIR"] = old_value
+
+
+def _resolve_ld_library_path() -> str:
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import importlib.util; s=importlib.util.find_spec('tensorrt_libs'); "
+                "print(s.submodule_search_locations[0])",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            trt_lib_dir = result.stdout.strip()
+        else:
+            LOGGER.warning(
+                "TensorRT library lookup failed with exit code %s: %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            trt_lib_dir = ""
+    except Exception:
+        trt_lib_dir = ""
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    nccl_lib_dir = os.environ.get("TRTMC_NCCL_LIB_DIR", "")
+    return ":".join(
+        path
+        for path in (nccl_lib_dir, trt_lib_dir, "/usr/local/cuda/lib64", existing)
+        if path
+    )
+
+
+def _is_multi_device_case(case) -> bool:
+    return str((case.metadata or {}).get("ci_tier", "")) == "multi_device"
+
+
+def _case_matches_e2e_model(case, filters: set[str]) -> bool:
+    if not filters:
+        return True
+    metadata = case.metadata or {}
+    fields = {
+        case.name,
+        case.family,
+        case.runtime_strategy,
+        case.task_strategy,
+        Path(case.hf_id).name if case.hf_id else "",
+        str(metadata.get("family", "")),
+        str(metadata.get("runtime_strategy", "")),
+    }
+    return bool(filters & {field for field in fields if field})
+
+
+def model_case_names(config=None) -> list[str]:
+    return model_names_for_dir(
+        config=config,
+        model_dir=_MODEL_DIR,
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+    )
+
+
+def run_model_e2e(case_name: str, request) -> None:
+    run_model_manifest_e2e(
+        model_name=case_name,
+        request=request,
+        model_dir=_MODEL_DIR,
+        load_waives=lambda _platform="": {},
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+        resolve_hf_python=_resolve_hf_python,
+        resolve_artifacts_dir=_resolve_artifacts_dir,
+        resolve_binary=_resolve_binary,
+        resolve_ld_library_path=_resolve_ld_library_path,
+        resolve_engine_dir=_resolve_engine_dir,
+        resolve_model_plugin_dir=_resolve_model_plugin_dir,
+        model_plugin_dir_env=_model_plugin_dir_env,
+    )

--- a/tests/e2e/models/cosmos3/test_cosmos3_e2e.py
+++ b/tests/e2e/models/cosmos3/test_cosmos3_e2e.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E entrypoint for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_RUNNER_PATH = Path(__file__).with_name("runner.py")
+_SPEC = importlib.util.spec_from_file_location(
+    f"{Path(__file__).resolve().parent.name}_e2e_runner",
+    _RUNNER_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_runner = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_runner)
+
+
+def pytest_generate_tests(metafunc):
+    if "case_name" in metafunc.fixturenames:
+        metafunc.parametrize("case_name", _runner.model_case_names(metafunc.config))
+
+
+def test_model_e2e(case_name: str, request) -> None:
+    _runner.run_model_e2e(case_name, request)

--- a/tests/e2e/models/cosmos3/test_cosmos3_manifest_contract.py
+++ b/tests/e2e/models/cosmos3/test_cosmos3_manifest_contract.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static contracts for the Cosmos3-Nano 720p proof."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from tests.e2e.models.cosmos3.e2e_plugins.runners import diffusion
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+MODEL_ID = "nvidia/Cosmos3-Nano"
+MODEL_REVISION = "411f42a8fdfb8c5b2583cb8786e0938f49796eaa"
+MANIFEST_FILENAMES = ("cosmos3-nano-l0.json", "cosmos3-nano-l0-cp2.json")
+FIXED_PROFILE = {
+    "video_num_frames": 189,
+    "video_height": 720,
+    "video_width": 1280,
+    "num_inference_steps": 35,
+    "guidance_scale": 6.0,
+}
+FIXED_OUTPUT_THRESHOLDS = {
+    "exact_num_frames": 189,
+    "exact_video_height": 720,
+    "exact_video_width": 1280,
+}
+
+
+@pytest.mark.parametrize(
+    "filename",
+    MANIFEST_FILENAMES,
+)
+def test_cosmos3_manifests_declare_public_pinned_checkpoint(filename: str) -> None:
+    manifest_path = Path(__file__).with_name("manifests") / filename
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    case = load_manifest(manifest_path)
+
+    assert raw["hf_id"] == MODEL_ID
+    assert raw["hf_revision"] == MODEL_REVISION
+    assert "gated" not in raw
+    assert all(item.kind != "hf_auth_token_present" for item in case.preflight)
+
+
+@pytest.mark.parametrize("filename", MANIFEST_FILENAMES)
+def test_cosmos3_manifests_share_fixed_720p_profile(filename: str) -> None:
+    model_dir = Path(__file__).parent
+    case = load_manifest(model_dir / "manifests" / filename)
+    thresholds = json.loads(
+        (model_dir / "thresholds" / filename).read_text(encoding="utf-8")
+    )["threshold_overrides"]
+
+    assert {name: case.inputs[name] for name in FIXED_PROFILE} == FIXED_PROFILE
+    assert {
+        name: thresholds[name] for name in FIXED_OUTPUT_THRESHOLDS
+    } == FIXED_OUTPUT_THRESHOLDS
+
+
+def test_cosmos3_cp1_manifest_remains_single_device() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "cosmos3-nano-l0.json"
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert "build_args" not in raw
+    assert "distributed_runtime" not in raw
+
+
+def test_cosmos3_cp2_manifest_declares_context_parallel_runtime() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "cosmos3-nano-l0-cp2.json"
+    case = load_manifest(manifest_path)
+    parallel = case.metadata["build_args"]["parallel"]
+    distributed = case.metadata["distributed_runtime"]
+
+    assert parallel == {"mode": "context_parallel", "cp_size": 2}
+    assert distributed["enabled"] is True
+    assert distributed["launcher"] == "mpirun"
+    assert distributed["world_size"] == parallel["cp_size"]
+
+
+def test_cosmos3_native_attention_allows_decomposition_fallback() -> None:
+    source_path = (
+        Path(__file__).resolve().parents[4]
+        / "python/tensorrt_model_connect/families/cosmos3/trt_ops.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    values = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute) and target.attr == "decomposable"
+            for target in node.targets
+        )
+    ]
+
+    assert len(values) == 2
+    assert all(isinstance(value, ast.Constant) and value.value is True for value in values)
+
+
+def test_cosmos3_context_parallel_attention_restores_bf16_after_routing() -> None:
+    source_path = (
+        Path(__file__).resolve().parents[4]
+        / "python/tensorrt_model_connect/families/cosmos3/trt_ops.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    functions = {
+        node.name: ast.get_source_segment(source, node) or ""
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+    }
+
+    seq_to_heads = functions["ulysses_seq_to_heads"]
+    dual_attention = functions["ulysses_dual_attention"]
+    assert "trt.float16" in seq_to_heads
+    assert "cast(network, exchanged, trt.bfloat16)" in seq_to_heads
+    assert "trt.float16" not in dual_attention
+    assert "trt.bfloat16" in dual_attention
+
+
+def _runner_case(*, distributed: bool) -> SimpleNamespace:
+    metadata = {"runtime_timeout_s": 1}
+    if distributed:
+        metadata["distributed_runtime"] = {
+            "enabled": True,
+            "launcher": "mpirun",
+            "world_size": 2,
+            "export_env": ["TRTMC_NCCL_RENDEZVOUS"],
+        }
+    return SimpleNamespace(
+        name="cosmos3-contract",
+        task_strategy="diffusion_media_generation",
+        bundle="cosmos3.trtfb",
+        metadata=metadata,
+        inputs={
+            "prompt": "test",
+            "num_inference_steps": 1,
+            "guidance_scale": 1.0,
+            "seed": 7,
+            "video_height": 720,
+            "video_width": 1280,
+        },
+    )
+
+
+def _runner_context(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        artifacts_dir=str(tmp_path),
+        binary_path="/opt/trtmc/bin/trtmc",
+        engine_dir="/models",
+        ld_library_path="/opt/trtmc/lib",
+        model_plugin_dir="/opt/trtmc/lib/models",
+    )
+
+
+def test_cosmos3_distributed_repro_preserves_rendezvous_and_unique_output(
+    tmp_path: Path,
+) -> None:
+    case = _runner_case(distributed=True)
+    ctx = _runner_context(tmp_path)
+
+    first = diffusion.plugin.build_trt_inference_command(case, ctx, "/models/cosmos3.trtfb")
+    second = diffusion.plugin.build_trt_inference_command(case, ctx, "/models/cosmos3.trtfb")
+
+    assert first is not None and second is not None
+    exported = first[first.index("-x") + 1]
+    assert exported.startswith("TRTMC_NCCL_RENDEZVOUS=")
+    assert first[first.index("--output") + 1] != second[second.index("--output") + 1]
+
+
+def test_cosmos3_timeout_returns_failure_and_persists_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = _runner_case(distributed=False)
+    ctx = _runner_context(tmp_path)
+
+    def timeout(command, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            command,
+            1,
+            output="partial output",
+            stderr="timeout diagnostic",
+        )
+
+    monkeypatch.setattr(diffusion.subprocess, "run", timeout)
+    result = diffusion.plugin.run_stage(case, SimpleNamespace(name="end_to_end"), ctx)
+
+    assert result.data["returncode"] == 124
+    assert result.text == "partial output"
+    assert result.metadata["error"] == "timed out after 1 seconds"
+    stderr_log = Path(result.metadata["stderr_log"])
+    assert stderr_log.read_text(encoding="utf-8") == "timeout diagnostic"

--- a/tests/e2e/models/cosmos3/thresholds/cosmos3-nano-l0-cp2.json
+++ b/tests/e2e/models/cosmos3/thresholds/cosmos3-nano-l0-cp2.json
@@ -1,0 +1,10 @@
+{
+  "threshold_overrides": {
+    "exact_num_frames": 189,
+    "exact_video_height": 720,
+    "exact_video_width": 1280,
+    "max_pixel_mean": 0.98,
+    "min_pixel_mean": 0.02,
+    "min_pixel_std": 0.01
+  }
+}

--- a/tests/e2e/models/cosmos3/thresholds/cosmos3-nano-l0.json
+++ b/tests/e2e/models/cosmos3/thresholds/cosmos3-nano-l0.json
@@ -1,0 +1,10 @@
+{
+  "threshold_overrides": {
+    "exact_num_frames": 189,
+    "exact_video_height": 720,
+    "exact_video_width": 1280,
+    "max_pixel_mean": 0.98,
+    "min_pixel_mean": 0.02,
+    "min_pixel_std": 0.01
+  }
+}

--- a/tests/tools/test_cosmos3_dual_spark_example.py
+++ b/tests/tools/test_cosmos3_dual_spark_example.py
@@ -1,0 +1,582 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_ROOT = REPO_ROOT / "examples" / "models" / "cosmos3" / "dual_spark"
+LAUNCHER = EXAMPLE_ROOT / "run_dual_spark.py"
+sys.path.insert(0, str(LAUNCHER.parent))
+
+import run_dual_spark  # noqa: E402
+
+
+EXPECTED_SCENES = (
+    ("showcase-high-speed-racing", 21001, "showcase-high-speed-racing-720p.mp4"),
+    ("showcase-mars-robots", 21003, "showcase-mars-robots-720p.mp4"),
+    ("showcase-delivery-robot", 21004, "showcase-delivery-robot-720p.mp4"),
+    ("showcase-apple-to-plate", 21006, "showcase-apple-to-plate-720p.mp4"),
+    ("showcase-humanoid-sprint", 21011, "showcase-humanoid-sprint-720p.mp4"),
+    ("showcase-cake-cutting", 21012, "showcase-cake-cutting-720p.mp4"),
+)
+
+
+def _clean_environment() -> dict[str, str]:
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith("COSMOS3_")
+    }
+    environment["PATH"] = ""
+    return environment
+
+
+def _dry_run(
+    tmp_path: Path,
+    scene: str,
+    extra_arguments: Sequence[str] = (),
+) -> dict[str, Any]:
+    work_root = tmp_path / "must-not-exist"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(LAUNCHER),
+            "all",
+            "--scene",
+            scene,
+            "--peer-host",
+            "peer.example",
+            "--peer-user",
+            "tester",
+            "--run-id",
+            "contract-run",
+            "--work-root",
+            str(work_root),
+            "--remote-root",
+            "/var/tmp/cosmos3-contract",
+            *extra_arguments,
+            "--dry-run",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_clean_environment(),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stderr == ""
+    assert not work_root.exists()
+    return json.loads(completed.stdout)
+
+
+def _option_value(argv: Sequence[str], option: str) -> str:
+    return argv[argv.index(option) + 1]
+
+
+def _docker_environment(argv: Sequence[str]) -> dict[str, str]:
+    environment: dict[str, str] = {}
+    for index, value in enumerate(argv[:-1]):
+        if value == "-e":
+            name, setting = argv[index + 1].split("=", 1)
+            environment[name] = setting
+    return environment
+
+
+def _generation_command(argv: Sequence[str]) -> list[str]:
+    return list(argv[argv.index("generate-video") :])
+
+
+def test_showcase_prompt_is_built_in_and_compact_in_dry_run(
+    tmp_path: Path,
+) -> None:
+    scene_id = "showcase-high-speed-racing"
+    plan = _dry_run(tmp_path, scene_id)
+    scene_record = plan["run"]["scenes"][0]
+    scene = run_dual_spark.SCENE_BY_SLUG[scene_id]
+    command = _generation_command(scene_record["ranks"][0]["docker_argv"])
+    compact_prompt = run_dual_spark._prompt_text(scene)
+
+    assert scene_record["seed"] == 21001
+    assert scene_record["prompt"] == {
+        "positive": dict(scene.prompt),
+        "negative": scene.negative_prompt,
+    }
+    assert scene_record["prompt"]["positive"]["duration"] == "7.875s"
+    assert json.loads(compact_prompt) == scene.prompt
+    assert "\n" not in compact_prompt
+    assert ": " not in compact_prompt
+    assert _option_value(command, "--prompt") == compact_prompt
+    assert _option_value(
+        command, "--negative-prompt"
+    ) == run_dual_spark._negative_prompt_text(scene)
+
+
+@pytest.mark.parametrize("scene_id,seed,filename", EXPECTED_SCENES)
+def test_launcher_selects_one_native_720p_cp2_scene(
+    tmp_path: Path,
+    scene_id: str,
+    seed: int,
+    filename: str,
+) -> None:
+    plan = _dry_run(tmp_path, scene_id)
+    scene = plan["run"]["scenes"][0]
+
+    assert plan["schema_version"] == 1
+    assert plan["action"] == "all"
+    assert plan["dry_run"] is True
+    assert plan["scene_selection"] == scene_id
+    assert plan["selected_scene_slugs"] == [scene_id]
+    assert plan["run"]["order"] == [scene_id]
+    assert len(plan["run"]["scenes"]) == 1
+    assert (scene["slug"], scene["seed"], Path(scene["mp4"]).name) == (
+        scene_id,
+        seed,
+        filename,
+    )
+    assert plan["profile"] == {
+        "width": 1280,
+        "height": 720,
+        "frames": 189,
+        "fps": 24,
+        "steps": 35,
+        "guidance_scale": 6.0,
+        "flow_shift": 10.0,
+        "context_parallel_size": 2,
+    }
+
+    bundle = plan["prepare"]["bundle_build_argv"]
+    assert plan["prepare"]["image"] == "trtmc-cosmos3-dual-spark:local"
+    assert plan["prepare"]["image_source"] == (
+        "prebuilt locally from this example's Dockerfile"
+    )
+    assert "image_build_argv" not in plan["prepare"]
+    assert _option_value(bundle, "--context-parallel-size") == "2"
+    assert _option_value(bundle, "--video-height") == "720"
+    assert _option_value(bundle, "--video-width") == "1280"
+    assert Path(plan["prepare"]["bundle"]).name == "cosmos3-nano-cp2-1280x720.trtfb"
+
+    assert [(rank["host"], rank["rank"]) for rank in scene["ranks"]] == [
+        ("primary", 0),
+        ("tester@peer.example", 1),
+    ]
+    for rank_number, rank in enumerate(scene["ranks"]):
+        environment = _docker_environment(rank["docker_argv"])
+        assert environment["WORLD_SIZE"] == "2"
+        assert environment["RANK"] == str(rank_number)
+        assert environment["LOCAL_RANK"] == "0"
+        assert environment["CUDA_VISIBLE_DEVICES"] == "0"
+        command = _generation_command(rank["docker_argv"])
+        assert _option_value(command, "--height") == "720"
+        assert _option_value(command, "--width") == "1280"
+        assert _option_value(command, "--seed") == str(seed)
+    assert _generation_command(scene["ranks"][0]["docker_argv"]) == (
+        _generation_command(scene["ranks"][1]["docker_argv"])
+    )
+
+
+def test_launcher_uses_strict_ssh_roce_and_declares_run_telemetry(
+    tmp_path: Path,
+) -> None:
+    identity = tmp_path / "identity"
+    known_hosts = tmp_path / "known_hosts"
+    plan = _dry_run(
+        tmp_path,
+        EXPECTED_SCENES[0][0],
+        ("--ssh-key", str(identity), "--known-hosts", str(known_hosts)),
+    )
+
+    for argv in (plan["ssh"]["argv"], plan["ssh"]["scp_argv"]):
+        joined = " ".join(argv)
+        assert "BatchMode=yes" in joined
+        assert "StrictHostKeyChecking=yes" in joined
+        assert "IdentitiesOnly=yes" in joined
+        assert f"UserKnownHostsFile={known_hosts.resolve()}" in joined
+        assert "StrictHostKeyChecking=no" not in joined
+    assert plan["roce"]["hca"] == "rocep1s0f0:1"
+    assert plan["roce"]["network_interface"] == "enp1s0f0np0"
+    assert plan["roce"]["gid_index"] == 3
+    assert plan["roce"]["uverbs_resolution"]["resolved_at_runtime"] is True
+    assert plan["run"]["telemetry"] == {
+        "performance": "parsed from the rank-0 [cosmos3.perf] record",
+        "memory": "sampled from each rank's cgroup-v2 byte counters",
+    }
+
+
+def test_launcher_parses_one_matching_cosmos3_performance_record(
+    tmp_path: Path,
+) -> None:
+    scene = run_dual_spark.SCENE_BY_SLUG[EXPECTED_SCENES[0][0]]
+    log = tmp_path / "rank0.log"
+    fields = {
+        "prompt_conditioning_ms": 10.0,
+        "denoise_prep_ms": 20.0,
+        "denoiser_engine_load_ms": 30.0,
+        "denoiser_ms": 40.0,
+        "scheduler_cfg_ms": 50.0,
+        "vae_decoder_ms": 60.0,
+        "generation_excluding_denoiser_load_ms": 80_000.0,
+        "total_ms": 82_710.0,
+        "cp_size": 2,
+        "seed": scene.seed,
+    }
+    record = " ".join(f"{name}={value}" for name, value in fields.items())
+    log.write_text(f"noise\n[cosmos3.perf] {record}\n", encoding="utf-8")
+
+    performance = run_dual_spark._parse_cosmos3_performance(log, scene, 85.25)
+
+    assert performance["inference_seconds"] == pytest.approx(82.71)
+    assert performance["total_seconds"] == pytest.approx(82.71)
+    assert performance["rank0_wall_seconds"] == pytest.approx(85.25)
+    assert performance["cp_size"] == 2
+    assert performance["seed"] == scene.seed
+
+
+def test_launcher_tolerates_cgroup_teardown_after_confirmed_container_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = run_dual_spark.Settings(
+        action="run",
+        scene=EXPECTED_SCENES[1][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=Path("/tmp/cosmos3-contract"),
+        remote_root="/var/tmp/cosmos3-contract",
+        image="cosmos3-contract:latest",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    tracker = run_dual_spark.MemoryTracker(
+        container="rank1",
+        remote=True,
+        cgroup_path="/sys/fs/cgroup/disappeared",
+        samples=1,
+    )
+    observed_states = iter(
+        (
+            {"Running": True, "ExitCode": 0},
+            {"Running": False, "ExitCode": 0},
+        )
+    )
+    observed_queries: list[tuple[str, bool]] = []
+
+    def container_state(
+        _settings: run_dual_spark.Settings,
+        name: str,
+        *,
+        remote: bool,
+    ) -> dict[str, Any]:
+        observed_queries.append((name, remote))
+        return next(observed_states)
+
+    monkeypatch.setattr(
+        run_dual_spark,
+        "_container_state",
+        container_state,
+    )
+
+    def missing_cgroup(*_args: Any, **_kwargs: Any) -> None:
+        raise run_dual_spark.DualSparkError("cgroup counters disappeared")
+
+    monkeypatch.setattr(run_dual_spark, "_sample_memory_tracker", missing_cgroup)
+
+    states = run_dual_spark._wait_for_containers(
+        settings,
+        ((tracker.container, tracker.remote),),
+        {tracker.container: tracker},
+    )
+
+    assert states == {"rank1": {"Running": False, "ExitCode": 0}}
+    assert observed_queries == [(tracker.container, True), (tracker.container, True)]
+
+
+def test_launcher_stops_sampling_a_finished_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = run_dual_spark.Settings(
+        action="run",
+        scene=EXPECTED_SCENES[1][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=Path("/tmp/cosmos3-contract"),
+        remote_root="/var/tmp/cosmos3-contract",
+        image="cosmos3-contract:latest",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    rank0 = run_dual_spark.MemoryTracker(
+        container="rank0",
+        remote=False,
+        cgroup_path="/sys/fs/cgroup/rank0",
+        samples=1,
+    )
+    rank1 = run_dual_spark.MemoryTracker(
+        container="rank1",
+        remote=True,
+        cgroup_path="/sys/fs/cgroup/disappeared",
+        samples=1,
+    )
+    observed_states = iter(
+        (
+            {"Running": True, "ExitCode": 0},
+            {"Running": False, "ExitCode": 0},
+            {"Running": False, "ExitCode": 0},
+            {"Running": False, "ExitCode": 0},
+        )
+    )
+    sampled: list[str] = []
+    messages: list[str] = []
+
+    def container_state(
+        _settings: run_dual_spark.Settings,
+        _name: str,
+        *,
+        remote: bool,
+    ) -> dict[str, Any]:
+        del remote
+        return next(observed_states)
+
+    def sample_memory(
+        _settings: run_dual_spark.Settings,
+        tracker: run_dual_spark.MemoryTracker,
+    ) -> None:
+        sampled.append(tracker.container)
+        if tracker.container == rank1.container:
+            raise run_dual_spark.DualSparkError("cgroup counters disappeared")
+
+    monkeypatch.setattr(run_dual_spark, "_container_state", container_state)
+    monkeypatch.setattr(run_dual_spark, "_sample_memory_tracker", sample_memory)
+    monkeypatch.setattr(run_dual_spark, "_log", messages.append)
+    monkeypatch.setattr(run_dual_spark.time, "sleep", lambda _seconds: None)
+
+    states = run_dual_spark._wait_for_containers(
+        settings,
+        ((rank0.container, rank0.remote), (rank1.container, rank1.remote)),
+        {rank0.container: rank0, rank1.container: rank1},
+    )
+
+    assert states == {
+        "rank0": {"Running": False, "ExitCode": 0},
+        "rank1": {"Running": False, "ExitCode": 0},
+    }
+    assert sampled == [rank0.container, rank1.container, rank0.container]
+    assert messages == [
+        "WARNING: final cgroup memory sample was unavailable "
+        "for rank1: cgroup counters disappeared"
+    ]
+
+
+def test_launcher_removes_rank1_verified_empty_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = run_dual_spark.Settings(
+        action="run",
+        scene=EXPECTED_SCENES[1][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=Path("/tmp/cosmos3-contract"),
+        remote_root="/var/tmp/cosmos3-contract",
+        image="cosmos3-contract:latest",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    observed: list[tuple[list[str], bool]] = []
+
+    def remote_run(
+        _settings: run_dual_spark.Settings,
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        **_kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        observed.append((list(argv), check))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(run_dual_spark, "_remote_run", remote_run)
+
+    run_dual_spark._remove_rank1_empty_frames(
+        settings,
+        "/var/tmp/cosmos3-contract/runs/run/scene/rank1",
+    )
+
+    assert observed == [
+        (
+            [
+                "rmdir",
+                "--",
+                "/var/tmp/cosmos3-contract/runs/run/scene/rank1/frames",
+            ],
+            False,
+        )
+    ]
+
+
+def test_prepare_requires_the_readme_image_to_exist_locally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = run_dual_spark.Settings(
+        action="prepare",
+        scene=EXPECTED_SCENES[0][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=tmp_path / "work",
+        remote_root="/var/tmp/cosmos3-contract",
+        image="trtmc-cosmos3-dual-spark:local",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    monkeypatch.setattr(run_dual_spark, "_preflight", lambda _settings: {})
+    monkeypatch.setattr(
+        run_dual_spark,
+        "_image_id",
+        lambda _settings, *, remote: "",
+    )
+
+    with pytest.raises(
+        run_dual_spark.DualSparkError,
+        match="build it from this example's Dockerfile first",
+    ):
+        run_dual_spark.prepare(settings)
+
+
+def test_remote_root_helper_restricts_directory_and_rejects_symlink(tmp_path: Path) -> None:
+    remote_root = tmp_path / "remote-root"
+    remote_root.mkdir(mode=0o755)
+    completed = subprocess.run(
+        [sys.executable, "-c", run_dual_spark.REMOTE_ROOT_HELPER, str(remote_root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert stat.S_IMODE(remote_root.stat().st_mode) == 0o700
+
+    target = tmp_path / "target"
+    target.mkdir()
+    redirected_child = remote_root / "models"
+    redirected_child.symlink_to(target, target_is_directory=True)
+    polluted = subprocess.run(
+        [sys.executable, "-c", run_dual_spark.REMOTE_ROOT_HELPER, str(remote_root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert polluted.returncode != 0
+    assert "must not contain symbolic links" in polluted.stderr
+
+    symlink_root = tmp_path / "symlink-root"
+    symlink_root.symlink_to(target, target_is_directory=True)
+    rejected = subprocess.run(
+        [sys.executable, "-c", run_dual_spark.REMOTE_ROOT_HELPER, str(symlink_root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert rejected.returncode != 0
+    assert "real directory" in rejected.stderr
+
+
+def test_readme_leads_with_the_cli_and_one_time_image_build() -> None:
+    readme = (EXAMPLE_ROOT / "README.md").read_text(encoding="utf-8")
+    normalized = " ".join(readme.split())
+
+    assert "# Cosmos3 dual-Spark video generation example" in readme
+    assert "does not start a server" in normalized
+    assert "## Build the image once" in readme
+    assert "--platform linux/arm64" in readme
+    assert "--build-arg TRTMC_SOURCE_REVISION=" in readme
+    assert "--file examples/models/cosmos3/dual_spark/Dockerfile" in readme
+    assert "python3 examples/models/cosmos3/dual_spark/run_dual_spark.py all" in readme
+    assert "--peer-host <SECOND_SPARK>" in readme
+    assert "--image trtmc-cosmos3-dual-spark:local" in readme
+    assert "one native 1280x720 Cosmos3-Nano video" in normalized
+    assert "1280x720" in readme
+    assert "CP=2" in readme
+    assert "primary" in readme and "peer" in readme
+    assert "can take hours" in readme
+    assert "showcase-delivery-robot" in readme
+    assert "checkpoint, TensorRT bundle, generated video, SSH key" in normalized
+    assert "http://localhost" not in readme
+    assert "browser app" not in readme.lower()
+
+
+def test_dockerfile_ships_a_pinned_isolated_cosmos3_environment() -> None:
+    dockerfile = (EXAMPLE_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    dockerignore = (EXAMPLE_ROOT / "Dockerfile.dockerignore").read_text(
+        encoding="utf-8"
+    )
+
+    assert "nvcr.io/nvidia/tensorrt:26.07-py3@sha256:" in dockerfile
+    assert "ARG TRTMC_CUDA_ARCHITECTURES=121-real" in dockerfile
+    assert "-DTRTMC_MODEL_PROOF_MODEL=cosmos3" in dockerfile
+    assert "-DTRTMC_ENABLE_TVM_FFI=OFF" in dockerfile
+    assert "trtmc_model_cosmos3" in dockerfile
+    assert "ARG TRTMC_SOURCE_REVISION=unknown" in dockerfile
+    assert 'org.opencontainers.image.revision="${TRTMC_SOURCE_REVISION}"' in dockerfile
+    assert 'ENTRYPOINT ["/opt/trtmc/bin/trtmc"]' in dockerfile
+    assert dockerignore.startswith("# SPDX-FileCopyrightText:")
+    assert "\n*\n" in dockerignore
+    assert "!ASSET_LICENSES.md" in dockerignore
+    assert "!python/tensorrt_model_connect/families/__init__.py" in dockerignore
+    assert "!python/tensorrt_model_connect/families/cosmos3/**" in dockerignore
+    assert "!src/runtime/models/cosmos3/**" in dockerignore
+    assert "!tests/cpp/models/cosmos3/**" in dockerignore
+    assert "website/**" in dockerignore
+    assert "nemotron_voicechat" not in dockerignore
+
+
+def test_sample_sources_do_not_contain_private_machine_defaults() -> None:
+    sources = LAUNCHER.read_text(encoding="utf-8")
+    for private_value in (
+        "spark-8363",
+        "spark-7bc1",
+        "169.254.",
+        "/home/rajerao",
+        "/mnt/scratch/.ssh",
+        "id_ed25519_spark_peer",
+    ):
+        assert private_value not in sources
+    for unsafe_pattern in ("shell=True", "eval(", "StrictHostKeyChecking=no"):
+        assert unsafe_pattern not in sources

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -404,7 +404,8 @@ def test_repository_registers_all_current_families() -> None:
 
     families = specialization.family_dirs(repo_root, ())
 
-    assert len(families) == 84
+    assert len(families) == 85
+    assert any(family.name == "cosmos3" for family in families)
     assert any(family.name == "dinov3" for family in families)
     assert any(family.name == "fast_foundation_stereo" for family in families)
     assert any(family.name == "lfm2" for family in families)

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -808,6 +808,8 @@ def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> Non
         ("tests/builder/test_cli.py", "all"),
         ("tests/cpp/test_cli_args.cpp", "all"),
         ("tests/tools/test_cli_contract.py", "all"),
+        ("examples/models/cosmos3/dual_spark/run_dual_spark.py", "all"),
+        ("examples/models/cosmos3/dual_spark/Dockerfile", "all"),
         ("examples/models/nemotron_voicechat/full_duplex/main.cpp", "all"),
         ("examples/models/nemotron_voicechat/full_duplex/Dockerfile", "all"),
         ("examples/models/nemotron_voicechat/full_duplex/CMakeLists.txt", "all"),

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -6783,6 +6783,7 @@ def test_non_diffusion_model_plugins_do_not_carry_diffusion_behavior() -> None:
     Postconditions: unused diffusion sidecars in other model folders are inert placeholders.
     """
     diffusion_families = {
+        "cosmos3",
         "flux",
         "z_image",
         "pixart",
@@ -9085,6 +9086,7 @@ def test_generated_e2e_task_sidecars_are_task_owned() -> None:
         "xlnet",
     }
     diffusion_owners = {
+        "cosmos3",
         "flux",
         "ltx_video",
         "pixart",

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -280,6 +280,13 @@ class TorchReference:
             "hf_id": "example/voicechat-case",
         },
         {
+            "name": "cosmos3-case",
+            "family": "cosmos3",
+            "runtime_strategy": "diffusion_cosmos3",
+            "task_strategy": "diffusion_media_generation",
+            "hf_id": "example/cosmos3-case",
+        },
+        {
             "name": "media-core",
             "family": "media_family",
             "runtime_strategy": "diffusion_media_primary",
@@ -1966,6 +1973,24 @@ class TestUnitTiers:
     @pytest.mark.parametrize(
         "path",
         [
+            "examples/models/cosmos3/dual_spark/run_dual_spark.py",
+            "examples/models/cosmos3/dual_spark/Dockerfile",
+            "examples/models/cosmos3/dual_spark/Dockerfile.dockerignore",
+            "examples/models/cosmos3/dual_spark/README.md",
+        ],
+    )
+    def test_cosmos3_dual_spark_example_is_model_owned(self, imap, path):
+        """The dual-Spark example runs Cosmos3 plus its C++ and tools checks."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "cosmos3_dual_spark_example"
+        assert match.models == ["cosmos3-case"]
+        assert match.unit_tiers == ["cpp", "tools"]
+        assert match.rebuild_cpp is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
             "python/tensorrt_model_connect/benchmark/cli.py",
             "python/tensorrt_model_connect/benchmark/operations.py",
         ],
@@ -2974,6 +2999,7 @@ diff --git a/tests/e2e_harness/manifest_loader.py b/tests/e2e_harness/manifest_l
             "tests/e2e_harness/manifest_loader.py", broad, diff_text, imap
         )
         assert refined.rule == "harness_manifest_diffusion_thresholds"
+        assert "cosmos3-case" in refined.models
         assert "media-core" in refined.models
         assert "decoder-small" not in refined.models
 
@@ -3118,6 +3144,7 @@ diff --git a/python/tensorrt_model_connect/engine_builder.py b/python/tensorrt_m
             imap,
         )
         assert refined.rule == "shared_builder_diffusion_tokenizer"
+        assert "cosmos3-case" in refined.models
         assert "media-core" in refined.models
         assert "decoder-small" not in refined.models
 

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -189,6 +189,7 @@ FULL_UNIT_TEST_ONLY_EXACT = frozenset(
     }
 )
 UNIT_TEST_ONLY_PREFIXES = (
+    "examples/models/cosmos3/dual_spark/",
     "examples/models/nemotron_voicechat/full_duplex/",
     "tests/builder/",
     "tests/cpp/",

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1845,6 +1845,20 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestNoImpact.test_local_qwen3_fixture_scopes_to_qwen3",),
         ),
         ClassificationRule(
+            priority=453,
+            name="cosmos3_dual_spark_example",
+            matcher=_regex_rule(r"examples/models/(cosmos3)/dual_spark/.+$"),
+            resolver=_match_result(
+                "cosmos3_dual_spark_example",
+                _family_models,
+                ["cpp", "tools"],
+                True,
+            ),
+            covered_by=(
+                "TestUnitTiers.test_cosmos3_dual_spark_example_is_model_owned",
+            ),
+        ),
+        ClassificationRule(
             priority=454,
             name="nemotron_voicechat_full_duplex_example",
             matcher=_regex_rule(r"examples/models/(nemotron_voicechat)/full_duplex/.+$"),

--- a/website/data/hf-model-metadata.json
+++ b/website/data/hf-model-metadata.json
@@ -904,6 +904,17 @@
       "architecture_source": "config.architectures"
     },
     {
+      "hf_id": "nvidia/Cosmos3-Nano",
+      "revision": "411f42a8fdfb8c5b2583cb8786e0938f49796eaa",
+      "revision_source": "declared",
+      "metadata_file": "model_index.json",
+      "model_type": null,
+      "architectures": [
+        "Cosmos3OmniDiffusersPipeline"
+      ],
+      "architecture_source": "model_index._class_name"
+    },
+    {
       "hf_id": "nvidia/Llama-3.1-Minitron-4B-Depth-Base",
       "revision": "47f17b2c73bbd07a4b643a0382970704d389f737",
       "revision_source": "resolved",


### PR DESCRIPTION
## Background

This revives the Cosmos3-Nano text-to-video work from closed PR #763 on current
main as a focused command-line example for two one-GPU GB10 DGX Sparks. One
host-side invocation launches native 1280x720 BF16 generation with context
parallelism 2: rank 0 runs on the primary Spark and rank 1 runs on the peer over
the direct RoCE link.

The earlier 256p, single-host Compose flow and the browser application are not
part of this example. The environment is shipped as a pinned, model-isolated
Dockerfile, while the host launcher generates one of three built-in
physics-oriented scenes at a time.

## Exit Criteria

- [x] Rebase the Cosmos3 family/runtime revival onto current upstream main with
  DCO trailers intact.
- [x] Build and run the pinned public Cosmos3-Nano revision at 1280x720,
  189 frames, 24 FPS, 35 steps, guidance 6, and CP=2.
- [x] Launch one TRTMC rank on each of two DGX Sparks from a host-side CLI.
- [x] Require NCCL NET/IB over the direct RoCE link and reject socket fallback.
- [x] Generate one selected scene per invocation and record its MP4, inference
  time, per-node peak memory, rank logs, runtime, media, and transport evidence.
- [x] Validate four successful native-720p CP=2 generations.
- [x] Package the example under `examples/models/cosmos3/dual_spark` with a
  pinned Dockerfile and family-isolated build context.
- [ ] Pass protected `trtmc/premerge/required` on final head `4ce606d6`.

Non-goals are CP=1 comparison, CP=4/8 qualification, input-conditioned
generation, native portrait output, arbitrary prompts, a browser/server
surface, and multi-tenant serving.

## Implementation

- Adds the Cosmos3 family plugin, fixed-profile TensorRT graph/build path,
  checkpoint mapping, native C++ pipeline, conditioning, scheduler/RNG, causal
  VAE, and model-owned E2E assets.
- Adds `examples/models/cosmos3/dual_spark/run_dual_spark.py` to consume a
  prebuilt example image, build/reuse the topology-specific bundle, synchronize
  the exact image and bundle, launch one rank per host, transfer the NCCL
  rendezvous atomically, require RoCE, and preserve run evidence.
- Ships the runtime/builder environment through a pinned TensorRT 11.1
  multi-stage Dockerfile. Its Dockerfile-specific ignore file includes shared
  source plus Cosmos3 while excluding every other model family, repository
  metadata, generated artifacts, caches, credentials, and website sources.
- Separates global rank from local CUDA rank for one-rank-per-Spark execution
  and fixes the sample profile at BF16, 1280x720, 189 frames, 24 FPS, 35 steps,
  guidance 6, flow shift 10, and CP=2.
- Uses standard TensorRT, not TensorRT-RTX. Bundles remain model-, profile-,
  topology-, TensorRT-, image-, and hardware-specific.
- Keeps generated MP4s and the detailed findings report local and outside this
  PR.
- Leaves `website/docs/user-guides/image-video-generation.md` and its
  navigation unchanged from current main.

Current architecture policy assigns GPU lowering and hardware adaptation to
TensorRT or approved TVM-FFI BYOK. This revival still contains family-owned
CUDA helpers for UniPC and PyTorch-compatible RNG/timestep math plus
GPU-dependent causal-VAE behavior. On 2026-08-27, the requester approved
submission as explicit temporary migration debt and authorized protected CI.
Follow-up should migrate these paths to TensorRT/BYOK or platform-neutral
runtime infrastructure; this exception is not precedent for unrelated new
family kernels.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

The following checks passed on `4ce606d6`:

- `python3 -m pytest tests/tools/test_cosmos3_dual_spark_example.py tests/tools/test_test_impact.py tests/tools/test_model_ci.py -q -x -p no:cacheprovider`:
  394 passed.
- `ruff check --config ruff.toml` on all changed Python files: passed.
- Python compilation for the launcher and changed tests/tools: passed.
- Mutation-free dry runs exercised all three scenes and verify CP=2, native
  1280x720, matching rank commands, strict SSH, RoCE, and telemetry contracts.
- `git diff --cached --check`: passed.
- DCO: the exact-head commit contains the configured author's
  `Signed-off-by` trailer.

`docker build --check` could not reach this workspace's Docker daemon socket,
so the new pinned image was not built on this host. That packaging change still
requires exact-head DGX Spark or protected-CI validation.

### Dual-Spark hardware qualification

Four earlier single-run dual-Spark generations completed on the same fixed
model/runtime profile with TensorRT 11.1. These are qualification observations,
not repeated-run medians and not exact-head evidence for the reorganized
Docker packaging:

| Scene | TRTMC inference | Rank-0 wall | Primary / peer peak memory |
| --- | ---: | ---: | ---: |
| LEGO tower collapse | 1494.832 s | 1529.663 s | 54.410 / 54.399 GiB |
| Robots washing dishes | 1502.724 s | 1536.368 s | 54.377 / 54.379 GiB |
| Racing cars | 1501.166 s | 1532.322 s | 54.378 / 54.378 GiB |
| Local NVIDIA-recommended prompt rerun | 1500.647 s | 1534.223 s | 54.377 / 54.378 GiB |

Every retained MP4 independently decoded as H.264 High/yuv420p, 1280x720,
24 FPS, 189 frames, and 7.875 seconds. All eight ranks exited zero with
`OOMKilled=false`, zero swap, and zero cgroup OOM events. Both hosts used
NCCL NET/IB over the direct 200 Gb/s RoCE link with no socket fallback. Neither
prompt material nor generated media from the local recommended-prompt rerun is
included in this PR.

The recommended-prompt rerun materially improved subject/action adherence. The
racing scene was the strongest built-in result. The LEGO and original robot
scenes exposed generation artifacts, so no perfect physics or semantic-fidelity
claim is made.

### Hardware, Environment, and Revisions

- Model: `nvidia/Cosmos3-Nano` revision
  `411f42a8fdfb8c5b2583cb8786e0938f49796eaa`, BF16.
- Profile: native 1280x720, 189 frames, 24 FPS, 35 steps, guidance 6, flow
  shift 10, CP=2.
- Hardware: two one-GPU GB10 DGX Sparks, one rank per host; NVIDIA driver
  580.95.05 on both.
- Qualified runtime: standard TensorRT 11.1.0.106.
- Interconnect: direct 200 Gb/s RoCE with NCCL NET/IB, host staged because
  GPUDirect RDMA is disabled on DGX Spark.

### Not Run / Remaining Gaps

- Protected `trtmc/premerge/required` is pending on the exact final head.
- The reorganized, pinned Docker image has not yet been rebuilt and rerun on the
  two Sparks.
- No native-720p CP=1 comparison was run, so this PR makes no CP=2 speedup
  claim.
- CP=4/8, x86_64 GPUs, non-GB10 accelerators, other TensorRT/driver versions,
  and portability across different DGX software releases were not qualified.
- Conditional and unconditional classifier-free-guidance passes remain
  sequential. The denoiser accounts for about 1374 seconds of the approximately
  1501-second invocation.
- Family-owned CUDA scheduler/RNG helpers and GPU-dependent VAE choices are
  accepted temporary migration debt for this PR, not the architectural end
  state.
- The native path has no integrated safety checker; deployment requires
  external moderation and access controls.

## Notes For Future Readers

Review the fixed model/profile contracts first, then the native pipeline and
distributed-runtime rank handling, followed by the example Dockerfile,
`run_dual_spark.py`, and focused tests. The sample is intentionally
constrained to two matching one-GPU DGX Sparks and fixed built-in prompts.

Build the example image once from the repository root. The first launcher
`prepare` can then take hours because it downloads the checkpoint and
builds/synchronizes the CP=2 TensorRT bundle; later runs reuse the image,
checkpoint cache, and bundle. Inference itself takes about 25 minutes because
each of 35 steps performs sequential conditional and unconditional denoiser
passes at roughly 19.6 seconds each.

This supersedes closed PR #763. Closed PR #819's B200-specific CFG-subgroup and
CP4/8 optimizations remain out of scope. Open PR #211 overlaps part of the
Cosmos family/runtime surface and remains unchanged.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: this adds a large native CUDA/TensorRT family and two-host
execution path with hardware-specific bundles, high memory use, external
SSH/RoCE orchestration, incomplete portability qualification, and explicitly
accepted GPU-lowering migration debt.
