### PR TITLE
fix(e2e): calibrate nightly model contracts

### DIFF
--- a/python/tensorrt_model_connect/families/fast_foundation_stereo/plugin.py
+++ b/python/tensorrt_model_connect/families/fast_foundation_stereo/plugin.py
@@ -69,7 +69,7 @@ def config_from_dir(model_dir: str | Path) -> dict | None:
         "stereo_accuracy_metric": "cosine_epe_bad2",
         "stereo_min_cosine": 0.999,
         "stereo_max_mean_abs_error": 0.5,
-        "stereo_max_bad_2px_fraction": 0.02,
+        "stereo_max_bad_2px_fraction": 0.03,
         "requires_tokenizer": False,
     }
 

--- a/tests/e2e/models/dinov3/e2e_plugins/comparator.py
+++ b/tests/e2e/models/dinov3/e2e_plugins/comparator.py
@@ -209,7 +209,8 @@ class ImageFeatureExtractionComparator:
             composite_rule=(
                 "exact shapes/counts/pooler invariant and finite tensors; "
                 "full, CLS, register, mean-patch cosine >= 0.999; "
-                "p01 patch cosine >= 0.995; relative Frobenius <= 0.01"
+                "p01 patch cosine >= 0.995; relative Frobenius <= "
+                f"{_threshold(threshold, 'relative_frobenius'):g}"
             ),
             message=(
                 f"DINOv3 semantic parity: full_cos={full_cosine:.8f}, "

--- a/tests/e2e/models/dinov3/test_dinov3_e2e_static.py
+++ b/tests/e2e/models/dinov3/test_dinov3_e2e_static.py
@@ -59,12 +59,17 @@ _THRESHOLDS = {
     "pooler_token_invariant": 1.0,
     "finite_tensors": 1.0,
 }
+_RELATIVE_FROBENIUS_BY_MODEL = {
+    "dinov3-convnext-tiny-pretrain-lvd1689m": 0.015,
+}
 
 
-def _profile() -> ThresholdProfile:
+def _profile(*, relative_frobenius: float = 0.01) -> ThresholdProfile:
+    metrics = dict(_THRESHOLDS)
+    metrics["relative_frobenius"] = relative_frobenius
     return ThresholdProfile(
         task_strategy="image_feature_extraction",
-        metrics=dict(_THRESHOLDS),
+        metrics=metrics,
     )
 
 
@@ -109,7 +114,11 @@ def test_official_gated_manifests_pin_revisions_and_auth_preflight() -> None:
         assert case.reference_family == "image_feature_extraction"
         assert case.user_contract == "representation_parity"
         assert case.metadata["num_register_tokens"] == register_count
-        assert case.threshold_overrides == _THRESHOLDS
+        expected_thresholds = dict(_THRESHOLDS)
+        expected_thresholds["relative_frobenius"] = _RELATIVE_FROBENIUS_BY_MODEL.get(
+            name, _THRESHOLDS["relative_frobenius"]
+        )
+        assert case.threshold_overrides == expected_thresholds
 
         preflight_kinds = [requirement.kind for requirement in case.preflight]
         assert "binary_exists" in preflight_kinds
@@ -244,6 +253,36 @@ def test_semantic_comparator_accepts_exact_full_cls_register_and_patch_features(
     assert np.isclose(result.metrics["mean_patch_cosine"].value, 1.0)
     assert np.isclose(result.metrics["p01_patch_cosine"].value, 1.0)
     assert result.metrics["relative_frobenius"].value == 0.0
+
+
+def test_convnext_relative_frobenius_override_remains_bounded() -> None:
+    hidden = np.ones((1, 5, 8), dtype=np.float32)
+    comparator = ImageFeatureExtractionComparator()
+    stage = StageSpec(name="full_inference", required=True)
+
+    default_result = comparator.compare(
+        _feature_output(hidden * 1.0149, 0),
+        _feature_output(hidden, 0),
+        _profile(),
+        stage,
+    )
+    calibrated_result = comparator.compare(
+        _feature_output(hidden * 1.0149, 0),
+        _feature_output(hidden, 0),
+        _profile(relative_frobenius=0.015),
+        stage,
+    )
+    beyond_result = comparator.compare(
+        _feature_output(hidden * 1.0151, 0),
+        _feature_output(hidden, 0),
+        _profile(relative_frobenius=0.015),
+        stage,
+    )
+
+    assert not default_result.metrics["relative_frobenius"].passed
+    assert calibrated_result.passed
+    assert "relative Frobenius <= 0.015" in calibrated_result.composite_rule
+    assert not beyond_result.metrics["relative_frobenius"].passed
 
 
 def test_semantic_comparator_rejects_bad_patch_tail_without_weakening_thresholds() -> None:

--- a/tests/e2e/models/dinov3/thresholds/dinov3-convnext-tiny-pretrain-lvd1689m.json
+++ b/tests/e2e/models/dinov3/thresholds/dinov3-convnext-tiny-pretrain-lvd1689m.json
@@ -6,7 +6,7 @@
     "register_cosine": 0.999,
     "mean_patch_cosine": 0.999,
     "p01_patch_cosine": 0.995,
-    "relative_frobenius": 0.01,
+    "relative_frobenius": 0.015,
     "shape_match": 1.0,
     "register_count_match": 1.0,
     "pooler_token_invariant": 1.0,

--- a/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparator.py
+++ b/tests/e2e/models/fast_foundation_stereo/e2e_plugins/comparator.py
@@ -70,7 +70,7 @@ class StereoDisparityComparator:
         nonnegative_threshold = threshold.metrics.get("nonnegative_fraction", 1.0)
         cosine_threshold = threshold.metrics.get("global_cosine", 0.999)
         mean_abs_error_threshold = threshold.metrics.get("mean_abs_error", 0.5)
-        bad_2px_threshold = threshold.metrics.get("bad_2px_fraction", 0.02)
+        bad_2px_threshold = threshold.metrics.get("bad_2px_fraction", 0.03)
         metrics = {
             "shape": MetricResult(
                 value=1.0 if shape_passed else 0.0,

--- a/tests/e2e/models/fast_foundation_stereo/manifests/fast-foundation-stereo.json
+++ b/tests/e2e/models/fast_foundation_stereo/manifests/fast-foundation-stereo.json
@@ -20,7 +20,7 @@
       "inputs": {
         "fixture": "generated-office-v1"
       },
-      "notes": "Fixed 700x700 realistic rectified stereo inference through the native C++ runtime. The pinned official PyTorch model receives the identical repo-owned office pair; the gate requires shape, finiteness, non-negative disparity, flattened FP32 cosine similarity >= 0.999, mean endpoint error <= 0.5 px, and bad-2px fraction <= 0.02."
+      "notes": "Fixed 700x700 realistic rectified stereo inference through the native C++ runtime. The pinned official PyTorch model receives the identical repo-owned office pair; the gate requires shape, finiteness, non-negative disparity, flattened FP32 cosine similarity >= 0.999, mean endpoint error <= 0.5 px, and bad-2px fraction <= 0.03."
     }
   ]
 }

--- a/tests/e2e/models/fast_foundation_stereo/test_family.py
+++ b/tests/e2e/models/fast_foundation_stereo/test_family.py
@@ -65,7 +65,7 @@ def test_config_adapter_claims_only_complete_source_package(tmp_path: Path) -> N
     assert config["stereo_accuracy_metric"] == "cosine_epe_bad2"
     assert config["stereo_min_cosine"] == 0.999
     assert config["stereo_max_mean_abs_error"] == 0.5
-    assert config["stereo_max_bad_2px_fraction"] == 0.02
+    assert config["stereo_max_bad_2px_fraction"] == 0.03
 
 
 def test_plugin_owns_unique_strategy_and_skips_tokenizer() -> None:
@@ -1458,7 +1458,7 @@ def test_disparity_comparator_gates_structure_and_pixel_error() -> None:
             "finite_fraction": 1.0,
             "global_cosine": 0.999,
             "mean_abs_error": 0.5,
-            "bad_2px_fraction": 0.02,
+            "bad_2px_fraction": 0.03,
             "nonnegative_fraction": 1.0,
         },
     )
@@ -1498,3 +1498,42 @@ def test_disparity_comparator_gates_structure_and_pixel_error() -> None:
     assert not rescaled.passed
     assert rescaled.metrics["global_cosine"].passed
     assert not rescaled.metrics["mean_abs_error"].passed
+
+
+def test_disparity_comparator_keeps_bad_2px_threshold_bounded() -> None:
+    reference_array = np.full((100, 100), 10.0, dtype=np.float32)
+    reference = StageOutput(
+        stage_name="full_inference",
+        data={"disparity": reference_array, "expected_shape": [100, 100]},
+    )
+    threshold = ThresholdProfile(
+        task_strategy="stereo_disparity",
+        metrics={
+            "finite_fraction": 1.0,
+            "global_cosine": 0.999,
+            "mean_abs_error": 0.5,
+            "bad_2px_fraction": 0.03,
+            "nonnegative_fraction": 1.0,
+        },
+    )
+    comparator = StereoDisparityComparator()
+
+    def compare(bad_pixels: int):
+        actual = reference_array.copy()
+        actual.reshape(-1)[:bad_pixels] += np.float32(2.1)
+        return comparator.compare(
+            StageOutput(stage_name="full_inference", data={"disparity": actual}),
+            reference,
+            threshold,
+            StageSpec(name="full_inference"),
+        )
+
+    within = compare(299)
+    beyond = compare(301)
+
+    assert within.passed
+    assert within.metrics["bad_2px_fraction"].value == pytest.approx(0.0299)
+    assert within.metrics["bad_2px_fraction"].threshold == 0.03
+    assert not beyond.passed
+    assert not beyond.metrics["bad_2px_fraction"].passed
+    assert beyond.metrics["bad_2px_fraction"].value == pytest.approx(0.0301)

--- a/tests/e2e/models/fast_foundation_stereo/test_native_plugin.py
+++ b/tests/e2e/models/fast_foundation_stereo/test_native_plugin.py
@@ -52,7 +52,9 @@ def test_native_plugin_builder_caches_the_standalone_dso(
     assert first == second
     assert first.read_bytes() == b"plugin"
     assert [command[1] for command in calls] == ["-S", "--build"]
-    assert Path(calls[0][2]) == _PLUGIN_DIR
+    plugin_source = Path(calls[0][2])
+    assert plugin_source.name == "native_plugins"
+    assert (plugin_source / "CMakeLists.txt").is_file()
     assert f"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}" in calls[0]
 
 

--- a/tests/e2e/models/fast_foundation_stereo/test_stereo_report.py
+++ b/tests/e2e/models/fast_foundation_stereo/test_stereo_report.py
@@ -91,7 +91,7 @@ def _result(artifact_dir: Path, *, status: str = "pass") -> dict:
                     },
                     "bad_2px_fraction": {
                         "value": 0.0,
-                        "threshold": 0.02,
+                        "threshold": 0.03,
                         "operator": "<=",
                         "passed": True,
                     },
@@ -138,7 +138,7 @@ def test_stereo_report_is_deterministic_and_marks_failed_metrics(tmp_path: Path)
     assert first == second
     assert "FAIL" in first
     assert 'class="fail"' in first
-    assert "bad-2px 0.5 &lt;= 0.02" in first
+    assert "bad-2px 0.5 &lt;= 0.03" in first
 
 
 def test_stereo_report_fails_closed_for_missing_or_malformed_artifacts(

--- a/tests/e2e/models/fast_foundation_stereo/thresholds/fast-foundation-stereo.json
+++ b/tests/e2e/models/fast_foundation_stereo/thresholds/fast-foundation-stereo.json
@@ -3,7 +3,7 @@
     "finite_fraction": 1.0,
     "global_cosine": 0.999,
     "mean_abs_error": 0.5,
-    "bad_2px_fraction": 0.02,
+    "bad_2px_fraction": 0.03,
     "nonnegative_fraction": 1.0
   }
 }


### PR DESCRIPTION
## Background

The first authorized full Nightly run of the official DINOv3 ConvNeXt checkpoint and the new Fast Foundation Stereo family exposed model-owned contract issues. ConvNeXt passed every structural and cosine gate but exceeded the shared ViT relative-Frobenius cap under the TensorRT 11.2 FP16 cohort. Fast Foundation Stereo had both a source-only native-plugin path assertion and a bad-2px ceiling with effectively no fresh-tactic margin.

## Exit Criteria

- Calibrate only the official ConvNeXt relative-Frobenius ceiling from repeated fresh-engine measurements while preserving every ViT, cosine, shape, finite, and invariant gate.
- Keep the calibrated ceiling bounded by focused pass/fail tests rather than changing it to the latest observed value.
- Accept both source and selected-wheel native-plugin layouts while still requiring the real standalone CMake source tree.
- Calibrate the Fast Foundation Stereo bad-2px ceiling from repeated fresh-engine measurements while preserving cosine, MAE, shape, finite, and nonnegative gates.

## Implementation

- Raise only `dinov3-convnext-tiny-pretrain-lvd1689m` relative Frobenius from `0.010` to `0.015`; comparator defaults and both ViT profiles remain `0.010`.
- Make the comparator rule report the effective profile threshold.
- Add boundaries proving default `0.010` rejects `0.0149`, ConvNeXt `0.015` accepts `0.0149`, and `0.0151` still fails.
- Replace the Fast Foundation Stereo source-root equality assertion with a portable contract requiring a `native_plugins` directory containing `CMakeLists.txt`.
- Raise the Fast Foundation Stereo bad-2px ceiling from `0.020` to `0.030` consistently across plugin config, comparator fallback, manifest, threshold sidecar, report, and tests; add `0.0299` pass and `0.0301` fail boundaries.

## Validation

- Official ConvNeXt fresh-engine calibration receipts: `0.01248990`, `0.01248118`, `0.01351969`, and `0.01328089`; all other semantic gates passed. The worst result retains `10.95%` headroom to `0.015`.
- Exact-commit DINOv3 Nightly model proof on a fifth fresh engine: passed; ConvNeXt relative Frobenius `0.01335652`, official ViT passed at its unchanged `0.010` threshold.
- Exact-commit Fast Foundation Stereo Nightly model proof: passed; 126 Python tests and 2 E2E tests passed with fresh main/post engines and native plugin build.
- Fast Foundation Stereo fresh-engine receipts across the supported TensorRT cohorts: `0.019857`, `0.019610`, `0.023414`, `0.018537`, `0.020441`, and `0.024400`; all cosine, MAE, shape, finite, and nonnegative gates passed. The worst result retains `22.95%` headroom to `0.030`.
- Five captured Fast Foundation Stereo outputs, including the exact failed Premerge artifact, replayed successfully at `0.030`.
- Focused DINOv3 comparator/report plus Fast Foundation Stereo tests after rebase: 97 passed.
- Model encapsulation contracts: 158 passed.
- Exact selected-wheel replay of the formerly failing Fast Foundation Stereo test: passed.
- Failed DINOv3 artifact replay with the calibrated profile: ConvNeXt and ViT both passed; ViT retained `0.010`.
- Ruff, `git diff --check`, model ownership validation, test-impact validation, and 82/82 family coverage: passed.

## Notes For Future Readers

- This is not a global threshold relaxation. The comparator default, official ViT, and public timm ViT stay at `0.010`.
- The original `0.010` was introduced before official gated ConvNeXt had a repeatable Nightly cohort. A value of `0.013` is insufficient for the measured fresh-engine spread, while `0.015` remains a strict 1.5% full-representation error ceiling alongside much tighter cosine gates.
- Fast Foundation Stereo keeps cosine `>=0.999`, MAE `<=0.5 px`, and exact structural gates. A `0.025` bad-2px cap leaves only `2.46%` margin over the measured spread; `0.030` retains `22.95%`.
- Full exact-head Premerge and Nightly remain required before merge; no performance result is claimed.
