### PR TITLE
feat(validation): add gate policy census

### DIFF
--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -340,6 +340,187 @@ def test_list_shows_mapped_workloads_and_sample_limits(capsys, monkeypatch):
     assert capsys.readouterr().out.strip() == "model-a: workload-a (5 samples)"
 
 
+def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
+    catalog = {
+        "models": {
+            "default-model": {"workloads": ["quality"]},
+            "strict-model": {"workloads": ["quality"]},
+            "observer": {"workloads": ["diagnostic"]},
+        },
+        "sample_limits": {"quality": 20, "diagnostic": 5},
+    }
+    suites = {
+        "quality": {
+            "id": "quality",
+            "description": "Sampled quality parity.",
+            "gates": {"min_prediction_agreement": 0.98},
+            "model_profiles": {
+                "strict-model": {"gates": {"min_prediction_agreement": 1.0}}
+            },
+        },
+        "diagnostic": {
+            "id": "diagnostic",
+            "description": "Diagnostic only.",
+            "gates": {},
+            "gate_policy": "observation_only",
+        },
+        "unbound": {
+            "id": "unbound",
+            "description": "Not selected by the current model inventory.",
+            "gates": {"min_sample_pass_rate": 1.0},
+        },
+    }
+    task_models = {
+        name: {
+            "name": name,
+            "family": "fixture",
+            "task_strategy": "fixture",
+            "runtime_strategy": "fixture",
+            "user_contract": "fixture",
+            "skip": "",
+        }
+        for name in catalog["models"]
+    }
+
+    census = trtmc_validate.build_gate_census(
+        catalog=catalog,
+        suites=suites,
+        task_models=task_models,
+    )
+
+    assert census["schema_version"] == "trtmc.validation-gate-census/v1"
+    assert census["summary"] == {
+        "suites": 3,
+        "bindings": 3,
+        "variants": 4,
+        "blocking_variants": 3,
+        "observation_only_variants": 1,
+        "invalid_variants": 1,
+        "review_required_suites": 2,
+    }
+    quality = next(row for row in census["suites"] if row["id"] == "quality")
+    assert quality["owner"] == {"kind": "workload", "id": "quality"}
+    assert quality["rationale"] == "Sampled quality parity."
+    assert quality["configured_sample_count"] == 20
+    assert [variant["models"] for variant in quality["variants"]] == [
+        ["default-model"],
+        ["strict-model"],
+    ]
+    assert quality["review"] == [
+        {"code": "minimum_sample_count_unapproved"},
+        {
+            "code": "sample_scaling_policy_unapproved",
+            "gates": ["min_prediction_agreement"],
+        },
+    ]
+    diagnostic = next(row for row in census["suites"] if row["id"] == "diagnostic")
+    assert diagnostic["review"] == []
+    unbound = next(row for row in census["suites"] if row["id"] == "unbound")
+    assert unbound["review"] == [
+        {"code": "no_selected_models"},
+        {"code": "sample_limit_unconfigured"},
+        {"code": "minimum_sample_count_unapproved"},
+        {
+            "code": "sample_scaling_policy_unapproved",
+            "gates": ["min_sample_pass_rate"],
+        },
+    ]
+
+
+def test_gate_census_cli_prints_machine_readable_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_load_validation_inputs",
+        lambda arguments: (
+            {"models": {}, "sample_limits": {}},
+            {},
+            (),
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "build_gate_census",
+        lambda **kwargs: {
+            "schema_version": "trtmc.validation-gate-census/v1",
+            "summary": {"suites": 0},
+            "suites": [],
+        },
+    )
+
+    arguments = trtmc_validate.build_parser().parse_args(["--gate-census"])
+
+    assert trtmc_validate._main(arguments) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "schema_version": "trtmc.validation-gate-census/v1",
+        "summary": {"suites": 0},
+        "suites": [],
+    }
+
+
+def test_gate_census_cli_rejects_model_selection(monkeypatch) -> None:
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_load_validation_inputs",
+        lambda arguments: (
+            {"models": {}, "sample_limits": {}},
+            {},
+            (),
+            {},
+        ),
+    )
+    arguments = trtmc_validate.build_parser().parse_args(
+        ["gpt2-125m", "--gate-census"]
+    )
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="global inventory",
+    ):
+        trtmc_validate._main(arguments)
+
+
+def test_default_gate_census_covers_every_suite_and_binding() -> None:
+    catalog = trtmc_validate.load_catalog()
+    suites = {
+        suite["id"]: suite for suite in validation_catalog.load_suites()
+    }
+    task_models = trtmc_validate._validation_models(trtmc_validate.DEFAULT_MODELS)
+
+    census = trtmc_validate.build_gate_census(
+        catalog=catalog,
+        suites=suites,
+        task_models=task_models,
+    )
+
+    assert {row["id"] for row in census["suites"]} == set(suites)
+    assert census["summary"]["bindings"] == sum(
+        len(spec.get("workloads", [])) for spec in catalog["models"].values()
+    )
+    invalid = [
+        row["id"]
+        for row in census["suites"]
+        if any(variant["policy"]["issues"] for variant in row["variants"])
+    ]
+    assert invalid == ["refcoco_grounding"]
+    mmlu = next(row for row in census["suites"] if row["id"] == "mmlu_five_shot_mcq")
+    assert len(mmlu["variants"]) == 2
+    assert [
+        variant["policy"]["gates"][1]["effective"]["allowed_failures"]
+        for variant in mmlu["variants"]
+    ] == [0, 1]
+    asr = next(row for row in census["suites"] if row["id"] == "librispeech_clean_asr")
+    assert asr["variants"][0]["policy"]["gates"][1]["effective"]["kind"] == (
+        "continuous"
+    )
+    marian = next(
+        row
+        for row in census["suites"]
+        if row["id"] == "newstest2019_en_ru_marian_translation_parity"
+    )
+    assert marian["review"] == []
+
+
 def test_resolve_bindings_selects_multiple_explicit_workloads():
     catalog = {
         "sample_limits": {"workload-a": 5, "workload-b": 5},

--- a/tests/tools/test_validation_gate_policy.py
+++ b/tests/tools/test_validation_gate_policy.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from tools.validation.gate_policy import evaluate_shadow_gates
+from tools.validation.gate_policy import (
+    describe_shadow_gate_policy,
+    evaluate_shadow_gates,
+)
 from tools.validation.catalog import load_suites
 
 
@@ -36,6 +39,65 @@ def test_rate_gate_expands_against_actual_sample_count() -> None:
         ],
         "issues": [],
     }
+
+
+def test_policy_description_expands_threshold_without_runtime_metrics() -> None:
+    description = describe_shadow_gate_policy(
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=20,
+    )
+
+    assert description == {
+        "schema_version": "trtmc.validation-gate-policy-description/v1",
+        "policy_mode": "blocking",
+        "sample_count": 20,
+        "gates": [
+            {
+                "gate": "min_prediction_agreement",
+                "metric": "prediction_agreement_rate",
+                "operator": ">=",
+                "required": 0.98,
+                "effective": {
+                    "kind": "proportion",
+                    "required_passes": 20,
+                    "allowed_failures": 0,
+                    "resolution": 0.05,
+                },
+            }
+        ],
+        "issues": [],
+    }
+
+
+def test_policy_description_preserves_continuous_override() -> None:
+    description = describe_shadow_gate_policy(
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=10,
+        metric_kinds={"min_prediction_agreement": "continuous"},
+    )
+
+    assert description["gates"][0]["effective"] == {
+        "kind": "continuous",
+        "sample_count": 10,
+    }
+
+
+def test_policy_description_keeps_gate_visible_without_sample_count() -> None:
+    description = describe_shadow_gate_policy(
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=None,
+    )
+
+    assert description["gates"] == [
+        {
+            "gate": "min_prediction_agreement",
+            "metric": "prediction_agreement_rate",
+            "operator": ">=",
+            "required": 0.9,
+            "effective": {"kind": "proportion", "sample_count": None},
+        }
+    ]
+    assert description["issues"] == [{"code": "sample_count_unavailable"}]
 
 
 def test_accuracy_drop_gate_exposes_discrete_loss_budget() -> None:

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -182,6 +182,20 @@ qualification snapshot, or CI disposition. Unsupported gate names, unavailable
 metrics, non-numeric values, and missing sample counts are explicit `issues` in
 the analysis rather than implicit passes.
 
+Audit the resolved policy inventory without running any model:
+
+```bash
+python tools/trtmc_validate.py --gate-census > gate-census.json
+```
+
+The deterministic JSON groups models that resolve to the same gate variant and
+shows the workload-owned rationale, configured sample count, effective integer
+threshold, and unresolved review items. `minimum_sample_count_unapproved` and
+`sample_scaling_policy_unapproved` are census findings, not runtime failures;
+they keep owner decisions visible without changing current traffic lights or CI
+behavior. A suite that has no selected model or sample limit remains visible in
+the census even though it cannot appear in a model run.
+
 Override the configured limit for one run, or request the complete dataset
 explicitly:
 

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -59,6 +59,7 @@ from tools.reporting_html import (  # noqa: E402
     sorted_filter_values,
 )
 from tools.validation import catalog as validation_catalog  # noqa: E402
+from tools.validation.gate_census import build_gate_census  # noqa: E402
 from tools import trtmc_disagreements  # noqa: E402
 from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import model_selection  # noqa: E402
@@ -3835,6 +3836,11 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--list", action="store_true", help="list model-first workloads")
+    parser.add_argument(
+        "--gate-census",
+        action="store_true",
+        help="print the resolved, non-blocking gate-policy census as JSON",
+    )
     parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
     parser.add_argument("--suites", type=Path, default=DEFAULT_SUITES)
     parser.add_argument("--models-dir", type=Path, default=DEFAULT_MODELS)
@@ -5111,6 +5117,34 @@ def _run_bindings(
 
 def _main(arguments: argparse.Namespace) -> int:
     catalog, suites, ready, task_models = _load_validation_inputs(arguments)
+    if arguments.gate_census:
+        if any(
+            (
+                arguments.list,
+                arguments.all,
+                arguments.model,
+                arguments.workload,
+                arguments.selected_models,
+                arguments.model_selection,
+                arguments.selected_bindings,
+                arguments.selected_workloads,
+            )
+        ):
+            raise ValidationError(
+                "--gate-census is a global inventory and cannot select models or workloads"
+            )
+        print(
+            json.dumps(
+                build_gate_census(
+                    catalog=catalog,
+                    suites=suites,
+                    task_models=task_models,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
     if arguments.list:
         for name, spec in catalog["models"].items():
             not_compared_reason = str(spec.get("not_compared_reason", "") or "")

--- a/tools/validation/gate_census.py
+++ b/tools/validation/gate_census.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a deterministic review inventory from resolved validation gates."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from tools.validation import catalog as validation_catalog
+from tools.validation.gate_policy import describe_shadow_gate_policy
+
+
+def _variant(
+    *,
+    suite: Mapping[str, Any],
+    sample_count: int | None,
+    models: Sequence[str],
+) -> dict[str, Any]:
+    gates = suite.get("gates", {})
+    gates = gates if isinstance(gates, Mapping) else {}
+    metric_kinds = suite.get("gate_metric_kinds", {})
+    metric_kinds = metric_kinds if isinstance(metric_kinds, Mapping) else {}
+    return {
+        "models": list(models),
+        "policy": describe_shadow_gate_policy(
+            configured_gates=gates,
+            sample_count=sample_count,
+            policy_mode=str(suite.get("gate_policy", "blocking") or "blocking"),
+            metric_kinds={str(name): str(kind) for name, kind in metric_kinds.items()},
+        ),
+    }
+
+
+def _review(
+    *,
+    variants: Sequence[Mapping[str, Any]],
+    has_models: bool,
+    sample_count: int | None,
+) -> list[dict[str, Any]]:
+    review: list[dict[str, Any]] = []
+    if not has_models:
+        review.append({"code": "no_selected_models"})
+    if sample_count is None:
+        review.append({"code": "sample_limit_unconfigured"})
+    if not any(variant.get("policy", {}).get("policy_mode") == "blocking" for variant in variants):
+        return review
+    review.append({"code": "minimum_sample_count_unapproved"})
+    scaling_gates = sorted(
+        {
+            str(gate.get("gate"))
+            for variant in variants
+            for gate in variant.get("policy", {}).get("gates", [])
+            if gate.get("effective", {}).get("kind") in {"proportion", "proportion_drop"}
+        }
+    )
+    if scaling_gates:
+        review.append(
+            {
+                "code": "sample_scaling_policy_unapproved",
+                "gates": scaling_gates,
+            }
+        )
+    return review
+
+
+def _sample_count(catalog: Mapping[str, Any], suite_id: str) -> tuple[int | None, str]:
+    configured = catalog.get("sample_limits", {}).get(suite_id)
+    if isinstance(configured, int) and not isinstance(configured, bool) and configured > 0:
+        return configured, "configured"
+    return None, "full_dataset" if configured == -1 else "unconfigured"
+
+
+def _signature(suite: Mapping[str, Any]) -> str:
+    return json.dumps(
+        {
+            "gates": suite.get("gates", {}),
+            "gate_policy": suite.get("gate_policy", "blocking"),
+            "gate_metric_kinds": suite.get("gate_metric_kinds", {}),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def build_gate_census(
+    *,
+    catalog: Mapping[str, Any],
+    suites: Mapping[str, Mapping[str, Any]],
+    task_models: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Group model bindings by resolved gate policy and list approval gaps."""
+
+    suite_rows: list[dict[str, Any]] = []
+    binding_count = 0
+    for suite_id, suite in suites.items():
+        sample_count, sample_limit_source = _sample_count(catalog, suite_id)
+        grouped: dict[str, dict[str, Any]] = {}
+        for model_name, model_spec in catalog.get("models", {}).items():
+            if suite_id not in model_spec.get("workloads", []):
+                continue
+            binding_count += 1
+            resolved = validation_catalog.resolve_suite_for_model(
+                dict(suite),
+                dict(task_models[model_name]),
+            )
+            signature = _signature(resolved)
+            if signature not in grouped:
+                grouped[signature] = _variant(
+                    suite=resolved,
+                    sample_count=sample_count,
+                    models=[],
+                )
+            grouped[signature]["models"].append(str(model_name))
+        variants = list(grouped.values()) or [
+            _variant(suite=suite, sample_count=sample_count, models=[])
+        ]
+        review = _review(
+            variants=variants,
+            has_models=any(variant["models"] for variant in variants),
+            sample_count=sample_count,
+        )
+        suite_rows.append(
+            {
+                "id": str(suite_id),
+                "owner": {"kind": "workload", "id": str(suite_id)},
+                "rationale": str(suite.get("description", "") or "").strip(),
+                "configured_sample_count": sample_count,
+                "sample_limit_source": sample_limit_source,
+                "variants": variants,
+                "review": review,
+            }
+        )
+    variants = [variant for suite in suite_rows for variant in suite["variants"]]
+    return {
+        "schema_version": "trtmc.validation-gate-census/v1",
+        "summary": {
+            "suites": len(suite_rows),
+            "bindings": binding_count,
+            "variants": len(variants),
+            "blocking_variants": sum(
+                variant["policy"]["policy_mode"] == "blocking" for variant in variants
+            ),
+            "observation_only_variants": sum(
+                variant["policy"]["policy_mode"] == "observation_only" for variant in variants
+            ),
+            "invalid_variants": sum(bool(variant["policy"]["issues"]) for variant in variants),
+            "review_required_suites": sum(bool(suite["review"]) for suite in suite_rows),
+        },
+        "suites": suite_rows,
+    }

--- a/tools/validation/gate_policy.py
+++ b/tools/validation/gate_policy.py
@@ -160,12 +160,114 @@ def _effective_gate(
     return {"kind": "continuous", "sample_count": sample_count}
 
 
+def _effective_target(
+    *,
+    kind: str,
+    required: float,
+    sample_count: int,
+) -> dict[str, Any]:
+    effective = _effective_gate(
+        kind=kind,
+        actual=required,
+        required=required,
+        sample_count=sample_count,
+    )
+    effective.pop("observed_drop_count", None)
+    effective.pop("observed_passes", None)
+    effective.pop("observed_failures", None)
+    return effective
+
+
 def _passed(actual: float, operator: str, required: float) -> bool:
     if operator == ">=":
         return actual >= required
     if operator == "<=":
         return actual <= required
     return actual == required
+
+
+def describe_shadow_gate_policy(
+    *,
+    configured_gates: Mapping[str, Any],
+    sample_count: int | None,
+    policy_mode: str = "blocking",
+    metric_kinds: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Describe configured gate targets without requiring runtime metrics."""
+
+    gates: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+    if policy_mode not in {"blocking", "observation_only"}:
+        issues.append({"code": "unsupported_policy_mode", "value": policy_mode})
+    if policy_mode == "blocking" and not configured_gates:
+        issues.append({"code": "empty_gate_policy"})
+    sample_count_available = (
+        isinstance(sample_count, int)
+        and not isinstance(sample_count, bool)
+        and sample_count > 0
+    )
+    if configured_gates and not sample_count_available:
+        issues.append({"code": "sample_count_unavailable"})
+    resolved_metric_kinds = metric_kinds or {}
+    for gate_name in resolved_metric_kinds:
+        if gate_name not in configured_gates:
+            issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
+    for gate, required_value in configured_gates.items():
+        gate_name = str(gate)
+        spec = _gate_spec(gate_name)
+        if spec is None:
+            issues.append({"code": "unsupported_gate", "gate": gate_name})
+            continue
+        metric_name, operator = spec
+        metric_name, _ = _metric_names(gate_name, metric_name, {})
+        try:
+            required = _finite_number(required_value)
+        except (TypeError, ValueError):
+            issues.append(
+                {
+                    "code": "invalid_threshold",
+                    "gate": gate_name,
+                    "value": _issue_value(required_value),
+                }
+            )
+            continue
+        configured_kind = str(resolved_metric_kinds.get(gate_name, "") or "")
+        if configured_kind and configured_kind not in _METRIC_KINDS:
+            issues.append(
+                {
+                    "code": "unsupported_metric_kind",
+                    "gate": gate_name,
+                    "value": configured_kind,
+                }
+            )
+            continue
+        kind = "exact" if operator == "==" else _metric_kind(metric_name, configured_kind)
+        if not sample_count_available:
+            effective = {"kind": kind, "sample_count": None}
+        elif kind == "exact":
+            effective = {"kind": kind, "sample_count": sample_count}
+        else:
+            effective = _effective_target(
+                kind=kind,
+                required=required,
+                sample_count=sample_count,
+            )
+        gates.append(
+            {
+                "gate": gate_name,
+                "metric": metric_name,
+                "operator": operator,
+                "required": required,
+                "effective": effective,
+            }
+        )
+    return {
+        "schema_version": "trtmc.validation-gate-policy-description/v1",
+        "policy_mode": policy_mode,
+        "sample_count": sample_count,
+        "gates": gates,
+        "issues": issues,
+    }
 
 
 def evaluate_shadow_gates(


### PR DESCRIPTION
## Background

Accuracy gates currently expose percentage thresholds without a deterministic inventory of their resolved, sample-aware meaning. This makes it difficult to review model overrides, discrete failure budgets, and suites that still need an explicit governance decision.

## Exit Criteria

- Provide a deterministic, machine-readable census for every configured validation suite and model binding.
- Show resolved gate variants, effective sample thresholds, ownership context, and unresolved review findings.
- Keep runtime traffic lights, qualification snapshots, and CI disposition unchanged.

## Implementation

- Add a validation-owned census module that groups models by their resolved gate policy and keeps unbound suites visible.
- Add a static gate-policy description path that reuses the existing sample-threshold calculations without requiring runtime metrics.
- Expose the inventory through `tools/trtmc_validate.py --gate-census` and document its non-blocking semantics.
- Add fixture and real-catalog coverage for grouping, overrides, continuous metrics, missing sample counts, and CLI behavior.

## Validation

- `PYTHONPATH=.:python python -m pytest -q tests/tools/test_validation_gate_policy.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py`: 448 passed.
- `python -m ruff check tools/validation/gate_policy.py tools/validation/gate_census.py tools/trtmc_validate.py tests/tools/test_validation_gate_policy.py tests/tools/test_trtmc_validate.py`: passed.
- `python tools/legal_headers.py --check --repo-root .`: passed with zero findings.
- `PYTHONPATH=.:python python tools/trtmc_validate.py --gate-census`: resolved 38 suites, 109 bindings, and 51 policy variants; the only structurally invalid suite is the existing unbound `refcoco_grounding` entry.
- Exact-head target-hardware smoke at `0c40f196c8bad184baf5c85ce11dea1fa1f9f813`: one Accuracy case and one Perf case passed on each target platform.

## Notes For Future Readers

- Review `tools/validation/gate_census.py` first, then the static descriptor in `tools/validation/gate_policy.py`, and finally the CLI/tests.
- Census review findings are intentionally advisory. This PR does not approve minimum sample counts, choose scaling policies, change thresholds, enable a CI lane, or alter qualification verdicts.
