### PR TITLE
fix(mixtral): stabilize continuation parity

### DIFF
--- a/python/tensorrt_model_connect/families/mixtral/plugin.py
+++ b/python/tensorrt_model_connect/families/mixtral/plugin.py
@@ -445,13 +445,24 @@ def _add_mixtral_moe_block(
       5. Compute ALL expert SwiGLU outputs -> [num_experts, hidden]
       6. Gather selected experts, scale, and sum -> [1, hidden]
     """
-    # 1. Router logits
+    # 1. Router logits. HF's linear projection returns the model dtype; the
+    # FP32 routing boundary starts after that output has been quantized.
     router_logits = graph_ops.add_matmul_rhs_constant(
         network, inp, hidden_size, num_experts,
         weights[f"{prefix}.router"], dtype=dtype)
 
+    # HF Mixtral deliberately performs the numerically sensitive routing
+    # operations in FP32, even when the model weights and hidden states are
+    # FP16/BF16.  Keeping softmax/top-k in the model dtype can change the
+    # selected expert for close router scores, making generation depend on the
+    # tactic selected for an otherwise equivalent engine build.
+    routing_logits = router_logits
+    if routing_logits.dtype != trt.float32:
+        routing_logits = network.add_cast(
+            routing_logits, trt.float32).get_output(0)
+
     # 2. Softmax over router logits
-    sm = network.add_softmax(router_logits)
+    sm = network.add_softmax(routing_logits)
     sm.axes = 1 << 1
 
     # 3. TopK selection
@@ -502,16 +513,28 @@ def _add_mixtral_moe_block(
         expert_out = network.add_gather(
             stacked_out, idx_flat.get_output(0), 0)
 
+        # HF multiplies the model-dtype expert output by the FP32 routing
+        # weight, then converts that contribution back to the hidden-state
+        # dtype before accumulating it into the output tensor.
+        expert_value = expert_out.get_output(0)
+        if expert_value.dtype != trt.float32:
+            expert_value = network.add_cast(
+                expert_value, trt.float32).get_output(0)
+
         # Scale
         scaled_expert = network.add_elementwise(
-            expert_out.get_output(0), w_slice.get_output(0),
+            expert_value, w_slice.get_output(0),
             trt.ElementWiseOperation.PROD)
+        scaled_value = scaled_expert.get_output(0)
+        if scaled_value.dtype != inp.dtype:
+            scaled_value = network.add_cast(
+                scaled_value, inp.dtype).get_output(0)
 
         if result is None:
-            result = scaled_expert.get_output(0)
+            result = scaled_value
         else:
             sum_layer = network.add_elementwise(
-                result, scaled_expert.get_output(0),
+                result, scaled_value,
                 trt.ElementWiseOperation.SUM)
             result = sum_layer.get_output(0)
 

--- a/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
+++ b/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
@@ -8,7 +8,9 @@
   "e2e_parallel_resource": "exclusive_gpu",
   "precision": "fp16",
   "fp32_layers": [
-    4
+    3,
+    4,
+    5
   ],
   "max_cache_length": 256,
   "trust_remote_code": false,

--- a/tests/e2e/models/mixtral/test_mixtral_build_contract.py
+++ b/tests/e2e/models/mixtral/test_mixtral_build_contract.py
@@ -16,9 +16,10 @@ def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
 
 
-def test_acceptance_build_keeps_penultimate_decoder_layer_in_fp32() -> None:
+def test_mmlu_continuation_build_stabilizes_first_divergence() -> None:
+    """Keep the layers required for exact mmlu_000003 token-33 parity."""
     manifest_path = Path(__file__).parent / "manifests" / "mixtral-stories-15m.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["precision"] == "fp16"
-    assert manifest["fp32_layers"] == [4]
+    assert manifest["fp32_layers"] == [3, 4, 5]

--- a/tests/e2e/models/mixtral/test_mixtral_router_precision.py
+++ b/tests/e2e/models/mixtral/test_mixtral_router_precision.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Precision-contract tests for Mixtral expert routing."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+
+
+plugin = importlib.import_module("tensorrt_model_connect.families.mixtral.plugin")
+
+
+class _Tensor:
+    def __init__(self, name: str, dtype: str) -> None:
+        self.name = name
+        self.dtype = dtype
+
+
+class _Layer:
+    def __init__(self, *outputs: _Tensor) -> None:
+        self._outputs = outputs
+        self.axes = 0
+        self.axis = 0
+        self.reshape_dims = ()
+
+    def get_output(self, index: int) -> _Tensor:
+        return self._outputs[index]
+
+
+class _Network:
+    def __init__(self) -> None:
+        self.events: list[tuple] = []
+
+    def add_cast(self, tensor: _Tensor, dtype: str) -> _Layer:
+        output = _Tensor(f"cast({tensor.name})", dtype)
+        self.events.append(("cast", tensor, dtype, output))
+        return _Layer(output)
+
+    def add_softmax(self, tensor: _Tensor) -> _Layer:
+        self.events.append(("softmax", tensor))
+        return _Layer(_Tensor("router_probabilities", tensor.dtype))
+
+    def add_topk(self, tensor: _Tensor, operation, top_k: int, axes: int) -> _Layer:
+        self.events.append(("topk", tensor, operation, top_k, axes))
+        return _Layer(
+            _Tensor("top_values", tensor.dtype),
+            _Tensor("top_indices", "int32"),
+        )
+
+    def add_reduce(self, tensor: _Tensor, operation, axes: int, keep_dims: bool) -> _Layer:
+        self.events.append(("reduce", tensor, operation, axes, keep_dims))
+        return _Layer(_Tensor("top_values_sum", tensor.dtype))
+
+    def add_elementwise(self, lhs: _Tensor, rhs: _Tensor, operation) -> _Layer:
+        assert lhs.dtype == rhs.dtype
+        output = _Tensor(f"{operation}({lhs.name},{rhs.name})", lhs.dtype)
+        self.events.append(("elementwise", lhs, rhs, operation, output))
+        return _Layer(output)
+
+    def add_concatenation(self, tensors: list[_Tensor]) -> _Layer:
+        self.events.append(("concatenation", tensors))
+        return _Layer(_Tensor("experts", tensors[0].dtype))
+
+    def add_slice(self, tensor: _Tensor, *, start, shape, stride) -> _Layer:
+        self.events.append(("slice", tensor, start, shape, stride))
+        return _Layer(_Tensor(f"slice({tensor.name})", tensor.dtype))
+
+    def add_shuffle(self, tensor: _Tensor) -> _Layer:
+        self.events.append(("shuffle", tensor))
+        return _Layer(_Tensor(f"shuffle({tensor.name})", tensor.dtype))
+
+    def add_gather(self, tensor: _Tensor, indices: _Tensor, axis: int) -> _Layer:
+        self.events.append(("gather", tensor, indices, axis))
+        return _Layer(_Tensor("expert_output", tensor.dtype))
+
+
+def test_fp16_mixtral_quantizes_router_logits_before_fp32_routing(monkeypatch) -> None:
+    """Match HF's FP16 router projection and FP32 routing boundaries."""
+    fake_trt = SimpleNamespace(
+        float32="fp32",
+        TopKOperation=SimpleNamespace(MAX="max"),
+        ReduceOperation=SimpleNamespace(SUM="sum"),
+        ElementWiseOperation=SimpleNamespace(DIV="div", PROD="prod", SUM="sum"),
+    )
+    monkeypatch.setattr(plugin, "trt", fake_trt)
+
+    def fake_matmul(network, inp, _in_features, _out_features, weight, *, dtype):
+        assert inp.dtype == "fp16"
+        assert dtype == np.float16
+        assert weight.dtype == np.float32
+        return _Tensor("router_logits", "fp16")
+
+    monkeypatch.setattr(plugin.graph_ops, "add_matmul_rhs_constant", fake_matmul)
+    monkeypatch.setattr(
+        plugin,
+        "_add_swiglu_expert",
+        lambda *args, **kwargs: _Tensor("expert", "fp16"),
+    )
+
+    network = _Network()
+    result = plugin._add_mixtral_moe_block(
+        network=network,
+        inp=_Tensor("hidden_states", "fp16"),
+        weights={
+            "layer.0.router": np.array(
+                [[0.1, -0.2], [0.3, -0.4]], dtype=np.float32),
+            **{
+                f"layer.0.expert.{expert}.{name}": np.zeros((2, 2), dtype=np.float16)
+                for expert in range(2)
+                for name in ("w_gate", "w_up", "w_down")
+            },
+        },
+        prefix="layer.0",
+        hidden_size=2,
+        num_experts=2,
+        moe_intermediate=2,
+        top_k=2,
+        dtype=np.float16,
+    )
+
+    softmax_input = next(
+        event[1] for event in network.events if event[0] == "softmax"
+    )
+    topk_input = next(event[1] for event in network.events if event[0] == "topk")
+    router_cast = next(
+        event for event in network.events
+        if event[0] == "cast" and event[1].name == "router_logits"
+    )
+    assert router_cast[1].dtype == "fp16"
+    assert router_cast[2] == "fp32"
+    assert softmax_input.dtype == "fp32"
+    assert topk_input.dtype == "fp32"
+
+    products = [
+        event
+        for event in network.events
+        if event[0] == "elementwise" and event[3] == "prod"
+    ]
+    assert products
+    assert all(lhs.dtype == rhs.dtype == "fp32" for _, lhs, rhs, _, _ in products)
+    assert result.dtype == "fp16"


### PR DESCRIPTION
## Background

`mixtral-stories-15m` could select a different continuation at the near-tie in `mmlu_000003` token 33. The failure depended on TensorRT tactic and GPU architecture because the TRTMC graph did not preserve the Hugging Face Mixtral routing precision boundaries, and later FP16 decoder layers could amplify the remaining numeric difference.

Closes #887.

## Exit Criteria

- Preserve the Hugging Face FP16 routing dtype transitions.
- Produce exact continuation parity for all 10 configured MMLU samples on ThorX and GB300.
- Keep the release Perf entry executable and Green on both platforms.

## Implementation

- Keep the router projection in model precision, then run router softmax, top-k, and renormalization in FP32.
- Apply expert routing weights in FP32 and cast each contribution back to the hidden-state dtype before accumulation.
- Keep decoder layers 3 through 5 in FP32 for the affected model profile.
- Add unit and manifest-contract coverage for the dtype transitions and required stabilization layers.

## Validation

- Local targeted tests: `3 passed`.
- ThorX, TensorRT 11.0, Accuracy FP16/FP16: 10/10 exact; exact-match and token-prefix agreement both `1.0`.
- ThorX, TensorRT 11.0, Perf: Green; baseline/TRTMC p50 ratio `2.61x`.
- GB300, TensorRT 11.2, Accuracy FP16/FP16: 10/10 exact; exact-match and token-prefix agreement both `1.0`.
- GB300, TensorRT 11.2, Perf: Green; baseline/TRTMC p50 ratio `8.83x`.
- Three independent GB300 engine builds with the final precision profile each produced 10/10 exact continuation parity.

## Notes

- Validation used commit `998bb387f0066195d6d1d1edb0919f4492a3cccb` on both platforms.
- The release Perf contract retains its existing FP32 reference and FP16 TRTMC candidate precisions.
