### PR TITLE
feat(validation): add batch sample acceptance

### DIFF
--- a/tests/tools/test_deepseek_ocr_task_eval.py
+++ b/tests/tools/test_deepseek_ocr_task_eval.py
@@ -120,9 +120,10 @@ def test_deepseek_ocr_declares_model_owned_bf16_reference(
         "reference_dtype": "bfloat16",
         "comparison": "reference_defined",
     }
-    assert suite["gates"] == {
-        "max_accuracy_drop_from_hf": 0.02,
-        "min_prediction_agreement": 0.95,
+    assert suite["gates"] == {"max_accuracy_drop_from_hf": 0.02}
+    assert suite["sample_acceptance"] == {
+        "min_pass_rate": 0.95,
+        "min_allowed_failures": 0,
     }
     assert (
         validation_engine.resolve_hf_reference_dtype(
@@ -149,10 +150,16 @@ def test_c829_deepseek_ocr_receipt_passes_declared_parity_gates() -> None:
         },
         suite["gates"],
     )
+    result.update({"sample_count": 5, "valid_count": 5, "passed_count": 5})
+    validation_engine._apply_sample_acceptance(
+        result,
+        suite["sample_acceptance"],
+    )
 
     assert result["status"] == "passed"
     assert result["accuracy_drop_from_hf"] == 0.0
     assert result["gate_failures"] == []
+    assert result["sample_acceptance"]["verdict"] == "pass"
 
 
 def test_deepseek_ocr_bad_receipt_fails_both_parity_gates() -> None:
@@ -168,13 +175,18 @@ def test_deepseek_ocr_bad_receipt_fails_both_parity_gates() -> None:
         },
         suite["gates"],
     )
+    result.update({"sample_count": 5, "valid_count": 5, "passed_count": 4})
+    validation_engine._apply_sample_acceptance(
+        result,
+        suite["sample_acceptance"],
+    )
 
     assert result["status"] == "failed"
     assert result["error_type"] == "BenchmarkGateError"
     assert result["accuracy_drop_from_hf"] == pytest.approx(0.2)
     assert [failure["gate"] for failure in result["gate_failures"]] == [
         "max_accuracy_drop_from_hf",
-        "min_prediction_agreement",
+        "sample_acceptance",
     ]
 
 

--- a/tests/tools/test_gpt2_task_eval.py
+++ b/tests/tools/test_gpt2_task_eval.py
@@ -45,6 +45,14 @@ def _suite() -> dict[str, Any]:
 def _apply_suite_gates(receipt: dict[str, Any]) -> dict[str, Any]:
     result = dict(receipt)
     validation_engine.apply_metric_gates(result, _suite()["gates"])
+    result["valid_count"] = int(result["sample_count"])
+    result["passed_count"] = int(result["sample_count"]) - int(
+        result["divergent_count"]
+    )
+    validation_engine._apply_sample_acceptance(
+        result,
+        _suite()["sample_acceptance"],
+    )
     return result
 
 
@@ -53,7 +61,11 @@ def test_distilgpt2_suite_owns_sample_level_continuation_gate() -> None:
 
     assert suite["selectors"]["model_names"] == ["distilgpt2"]
     assert suite["scoring"]["scorer"] == "continuation"
-    assert suite["gates"] == {"min_tie_adjusted_exact_match_rate": 0.9}
+    assert suite["gates"] == {}
+    assert suite["sample_acceptance"] == {
+        "min_pass_rate": 0.9,
+        "min_allowed_failures": 0,
+    }
     assert suite["ci"]["eligible"] is False
     assert suite["ci"]["lane"] == "local_only"
 
@@ -91,9 +103,9 @@ def test_distilgpt2_regressed_receipt_fails_closed() -> None:
     assert result["error_type"] == "BenchmarkGateError"
     assert result["gate_failures"] == [
         {
-            "gate": "min_tie_adjusted_exact_match_rate",
-            "metric": "tie_adjusted_exact_match_rate",
-            "actual": 0.85,
-            "required": 0.9,
+            "gate": "sample_acceptance",
+            "metric": "failed_samples",
+            "actual": 3,
+            "required": 2,
         }
     ]

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -173,6 +173,7 @@ def _make_repo(
         "tools/validation/artifacts.py",
         "tools/validation/catalog.py",
         "tools/validation/engine.py",
+        "tools/validation/gate_policy.py",
         "tools/validation/model_plugin_contract.py",
     ):
         _write(repo, validation_module, "# validation module\n")
@@ -1226,6 +1227,7 @@ def test_projection_contains_only_selected_model_and_stable_git_blobs(
         "tools/validation/artifacts.py",
         "tools/validation/catalog.py",
         "tools/validation/engine.py",
+        "tools/validation/gate_policy.py",
         "tools/validation/model_plugin_contract.py",
         "tools/ci/__init__.py",
         "tools/ci/__main__.py",

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -428,6 +428,50 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
     ]
 
 
+def test_gate_census_accepts_an_explicit_sample_policy() -> None:
+    catalog = {
+        "models": {"model-a": {"workloads": ["quality"]}},
+        "sample_limits": {"quality": 20},
+    }
+    suites = {
+        "quality": {
+            "id": "quality",
+            "description": "Sampled quality parity.",
+            "gates": {"min_prediction_agreement": 0.98},
+            "gate_sample_policy": {
+                "minimum_sample_count": 20,
+                "calibration_sample_count": 20,
+                "scaling": {"min_prediction_agreement": "fixed_count"},
+            },
+        }
+    }
+    task_models = {
+        "model-a": {
+            "name": "model-a",
+            "family": "fixture",
+            "task_strategy": "fixture",
+            "runtime_strategy": "fixture",
+            "user_contract": "fixture",
+            "skip": "",
+        }
+    }
+
+    census = trtmc_validate.build_gate_census(
+        catalog=catalog,
+        suites=suites,
+        task_models=task_models,
+    )
+
+    assert census["summary"]["review_required_suites"] == 0
+    quality = census["suites"][0]
+    assert quality["review"] == []
+    assert quality["variants"][0]["policy"]["sample_policy"] == {
+        "minimum_sample_count": 20,
+        "calibration_sample_count": 20,
+        "scaling": {"min_prediction_agreement": "fixed_count"},
+    }
+
+
 def test_gate_census_cli_prints_machine_readable_json(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         trtmc_validate,
@@ -1218,6 +1262,11 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
             "raw_result": {
                 "configured_gates": {"min_prediction_agreement": 0.98},
                 "gate_policy": "blocking",
+                "gate_sample_policy": {
+                    "minimum_sample_count": 20,
+                    "calibration_sample_count": 20,
+                    "scaling": {"min_prediction_agreement": "rate"},
+                },
             },
             "reproduce": {
                 "dataset": {
@@ -1248,6 +1297,7 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
                 "verdict": "fail",
                 "effective": {
                     "kind": "proportion",
+                    "scaling": "rate",
                     "required_passes": 20,
                     "allowed_failures": 0,
                     "observed_passes": 19,
@@ -1257,6 +1307,11 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
             }
         ],
         "issues": [],
+        "sample_policy": {
+            "minimum_sample_count": 20,
+            "calibration_sample_count": 20,
+            "scaling": {"min_prediction_agreement": "rate"},
+        },
     }
 
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -397,7 +397,7 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
         "blocking_variants": 3,
         "observation_only_variants": 1,
         "invalid_variants": 1,
-        "review_required_suites": 2,
+        "review_required_suites": 1,
     }
     quality = next(row for row in census["suites"] if row["id"] == "quality")
     assert quality["owner"] == {"kind": "workload", "id": "quality"}
@@ -407,28 +407,17 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
         ["default-model"],
         ["strict-model"],
     ]
-    assert quality["review"] == [
-        {"code": "minimum_sample_count_unapproved"},
-        {
-            "code": "sample_scaling_policy_unapproved",
-            "gates": ["min_prediction_agreement"],
-        },
-    ]
+    assert quality["review"] == []
     diagnostic = next(row for row in census["suites"] if row["id"] == "diagnostic")
     assert diagnostic["review"] == []
     unbound = next(row for row in census["suites"] if row["id"] == "unbound")
     assert unbound["review"] == [
         {"code": "no_selected_models"},
         {"code": "sample_limit_unconfigured"},
-        {"code": "minimum_sample_count_unapproved"},
-        {
-            "code": "sample_scaling_policy_unapproved",
-            "gates": ["min_sample_pass_rate"],
-        },
     ]
 
 
-def test_gate_census_accepts_an_explicit_sample_policy() -> None:
+def test_gate_census_expands_sample_acceptance_at_configured_count() -> None:
     catalog = {
         "models": {"model-a": {"workloads": ["quality"]}},
         "sample_limits": {"quality": 20},
@@ -437,11 +426,10 @@ def test_gate_census_accepts_an_explicit_sample_policy() -> None:
         "quality": {
             "id": "quality",
             "description": "Sampled quality parity.",
-            "gates": {"min_prediction_agreement": 0.98},
-            "gate_sample_policy": {
-                "minimum_sample_count": 20,
-                "calibration_sample_count": 20,
-                "scaling": {"min_prediction_agreement": "fixed_count"},
+            "gates": {},
+            "sample_acceptance": {
+                "min_pass_rate": 0.98,
+                "min_allowed_failures": 1,
             },
         }
     }
@@ -465,10 +453,13 @@ def test_gate_census_accepts_an_explicit_sample_policy() -> None:
     assert census["summary"]["review_required_suites"] == 0
     quality = census["suites"][0]
     assert quality["review"] == []
-    assert quality["variants"][0]["policy"]["sample_policy"] == {
-        "minimum_sample_count": 20,
-        "calibration_sample_count": 20,
-        "scaling": {"min_prediction_agreement": "fixed_count"},
+    assert quality["variants"][0]["policy"]["policy_mode"] == "blocking"
+    assert quality["variants"][0]["sample_acceptance"] == {
+        "sample_count": 20,
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
+        "allowed_failures": 1,
+        "issues": [],
     }
 
 
@@ -551,9 +542,13 @@ def test_default_gate_census_covers_every_suite_and_binding() -> None:
     mmlu = next(row for row in census["suites"] if row["id"] == "mmlu_five_shot_mcq")
     assert len(mmlu["variants"]) == 2
     assert [
-        variant["policy"]["gates"][1]["effective"]["allowed_failures"]
+        variant["sample_acceptance"]["min_pass_rate"]
         for variant in mmlu["variants"]
-    ] == [0, 1]
+    ] == [0.98, 0.95]
+    assert [
+        variant["sample_acceptance"]["allowed_failures"]
+        for variant in mmlu["variants"]
+    ] == [1, 1]
     asr = next(row for row in census["suites"] if row["id"] == "librispeech_clean_asr")
     assert asr["variants"][0]["policy"]["gates"][1]["effective"]["kind"] == (
         "continuous"
@@ -1227,7 +1222,7 @@ def test_accuracy_report_is_rebuilt_from_ordered_live_receipts(tmp_path):
     }
 
 
-def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_path):
+def test_accuracy_report_exposes_backend_sample_acceptance(tmp_path):
     cases = [
         {
             "id": "model-a::suite-a",
@@ -1251,7 +1246,10 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
                 "status": "agreement",
                 "mode": "mcq",
                 "primary_metric": None,
-                "metrics": {"prediction_agreement_rate": 0.95},
+                "metrics": {
+                    "prediction_agreement_rate": 0.95,
+                    "accuracy_drop_from_hf": 0.0,
+                },
                 "failures": [],
             },
             "validation": {"status": "passed"},
@@ -1260,12 +1258,17 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
                 "trtmc_base_precision": "fp16",
             },
             "raw_result": {
-                "configured_gates": {"min_prediction_agreement": 0.98},
+                "configured_gates": {"max_accuracy_drop_from_hf": 0.01},
                 "gate_policy": "blocking",
-                "gate_sample_policy": {
-                    "minimum_sample_count": 20,
-                    "calibration_sample_count": 20,
-                    "scaling": {"min_prediction_agreement": "rate"},
+                "sample_acceptance": {
+                    "sample_count": 20,
+                    "passed_count": 19,
+                    "failed_count": 1,
+                    "min_pass_rate": 0.98,
+                    "min_allowed_failures": 1,
+                    "allowed_failures": 1,
+                    "verdict": "pass",
+                    "issues": [],
                 },
             },
             "reproduce": {
@@ -1283,36 +1286,17 @@ def test_accuracy_report_exposes_shadow_gate_evaluation_without_recoloring(tmp_p
 
     row = report["results"][0]
     assert row["result"] == "green"
-    assert row["comparison"]["gate_evaluation"] == {
-        "schema_version": "trtmc.validation-gate-evaluation/v1",
-        "status": "fail",
+    assert row["comparison"]["sample_acceptance"] == {
         "sample_count": 20,
-        "checks": [
-            {
-                "gate": "min_prediction_agreement",
-                "metric": "prediction_agreement_rate",
-                "operator": ">=",
-                "actual": 0.95,
-                "required": 0.98,
-                "verdict": "fail",
-                "effective": {
-                    "kind": "proportion",
-                    "scaling": "rate",
-                    "required_passes": 20,
-                    "allowed_failures": 0,
-                    "observed_passes": 19,
-                    "observed_failures": 1,
-                    "resolution": 0.05,
-                },
-            }
-        ],
+        "passed_count": 19,
+        "failed_count": 1,
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
+        "allowed_failures": 1,
+        "verdict": "pass",
         "issues": [],
-        "sample_policy": {
-            "minimum_sample_count": 20,
-            "calibration_sample_count": 20,
-            "scaling": {"min_prediction_agreement": "rate"},
-        },
     }
+    assert row["comparison"]["gate_evaluation"]["status"] == "pass"
 
 
 def test_accuracy_shadow_gate_uses_valid_pairs_not_prepared_inputs(tmp_path):
@@ -3150,6 +3134,43 @@ def test_accuracy_result_with_unknown_precision_has_no_result_light() -> None:
         "domain": "policy-config",
         "code": "comparison_contract",
         "message": "Reference and TRTMC compute precision were not both recorded",
+    }
+
+
+def test_accuracy_result_with_incomplete_samples_is_white() -> None:
+    result = trtmc_validate._normalize_result(
+        {
+            "raw_result": {
+                "status": "invalid",
+                "error_type": "SampleEvidenceError",
+                "error": "incomplete_samples",
+                "sample_acceptance": {
+                    "sample_count": 19,
+                    "passed_count": 19,
+                    "failed_count": 0,
+                    "min_pass_rate": 0.98,
+                    "min_allowed_failures": 1,
+                    "allowed_failures": 1,
+                    "verdict": "invalid",
+                    "issues": [
+                        {"code": "incomplete_samples", "expected": 20, "actual": 19}
+                    ],
+                },
+                "precision_contract": {
+                    "reference_precision": "fp16",
+                    "trtmc_base_precision": "fp16",
+                },
+            }
+        }
+    )
+
+    assert trtmc_validate._traffic_light_status(result) == "white"
+    assert trtmc_validate._accuracy_issue(result) == {
+        "priority": "P1",
+        "stage": "compare",
+        "domain": "data-artifact",
+        "code": "incomplete_samples",
+        "message": "incomplete_samples",
     }
 
 

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -659,7 +659,7 @@ def test_default_suites_include_text_generation_gap_models() -> None:
         ),
         "wikitext103_distilgpt2_continuation_parity": (
             ["distilgpt2"],
-            {"min_tie_adjusted_exact_match_rate": 0.9},
+            {},
         ),
         "newstest2019_en_ru_marian_translation_parity": (["marian-en-ru"], {}),
         "wmt14_en_de_t5_translation_parity": (["t5-small"], {}),
@@ -684,7 +684,11 @@ def test_default_suites_include_text_generation_gap_models() -> None:
     resolved_codegen = validation_engine.resolve_suite_for_model(
         humaneval, codegen
     )
-    assert resolved_codegen["gates"] == {"min_exact_match_rate": 1.0}
+    assert resolved_codegen["gates"] == {}
+    assert resolved_codegen["sample_acceptance"] == {
+        "min_pass_rate": 1.0,
+        "min_allowed_failures": 0,
+    }
     assert resolved_codegen["gate_policy"] == "blocking"
 
     for suite_id in (
@@ -704,6 +708,7 @@ def test_default_suites_classify_every_empty_gate_policy() -> None:
         suite["id"]
         for suite in suites
         if not suite.get("gates")
+        and not suite.get("sample_acceptance")
         and suite.get("gate_policy") != "observation_only"
     ]
 
@@ -720,7 +725,7 @@ def test_asr_similarity_gate_is_not_classified_as_a_sample_pass_rate() -> None:
         }
 
 
-def test_phi_moe_mmlu_uses_model_specific_agreement_gate() -> None:
+def test_phi_moe_mmlu_uses_model_specific_sample_acceptance() -> None:
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(), "mmlu_five_shot_mcq"
     )
@@ -733,8 +738,14 @@ def test_phi_moe_mmlu_uses_model_specific_agreement_gate() -> None:
         suite, models["internlm2-1.8b"]
     )
 
-    assert phi["gates"]["min_prediction_agreement"] == 0.95
-    assert internlm["gates"]["min_prediction_agreement"] == 0.98
+    assert phi["sample_acceptance"] == {
+        "min_pass_rate": 0.95,
+        "min_allowed_failures": 1,
+    }
+    assert internlm["sample_acceptance"] == {
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
+    }
 
 
 def test_default_suites_include_one_dpg_bench_diffusion_image_suite() -> None:
@@ -1101,6 +1112,9 @@ def test_semantic_segmentation_parity_reports_dataset_miou(tmp_path: Path) -> No
     assert summary["hf_mean_iou"] == 1.0
     assert summary["bundle_mean_iou"] == 1.0
     assert summary["backend_pixel_agreement"] == 1.0
+    assert summary["passed_count"] == 1
+    assert summary["sample_pass_rate"] == 1.0
+    assert summary["cases"][0]["passed"] is True
 
 
 def test_semantic_segmentation_uses_postprocessed_hf_map_for_backend_parity(
@@ -1207,6 +1221,9 @@ def test_prompted_segmentation_uses_family_prompt_semantics(tmp_path: Path) -> N
     assert text["status"] == "passed"
     assert point["mean_backend_mask_iou"] == 1.0
     assert point["worst_backend_mask_iou"] == 1.0
+    assert point["passed_count"] == 1
+    assert point["sample_pass_rate"] == 1.0
+    assert point["cases"][0]["passed"] is True
     assert text["mean_backend_mask_iou"] == 1.0
 
 
@@ -1260,6 +1277,9 @@ def test_prompted_segmentation_empty_prediction_is_a_comparison_failure(
 
     assert summary["status"] == "failed"
     assert summary["valid_count"] == 1
+    assert summary["passed_count"] == 0
+    assert summary["sample_pass_rate"] == 0.0
+    assert summary["cases"][0]["passed"] is False
     assert summary["mean_backend_mask_iou"] == 0.0
     assert summary["cases"][0]["bundle_empty_prediction"] is True
 
@@ -3358,6 +3378,9 @@ def test_codegen_humaneval_gate_rejects_qa_accuracy_replays(
     result = {
         "exact_match_rate": summary["exact_match_rate"],
         "token_prefix_agreement": summary["token_prefix_agreement"],
+        "sample_count": summary["count"],
+        "valid_count": summary["count"],
+        "passed_count": summary["tie_adjusted_exact_count"],
     }
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(), "humaneval_code_continuation_parity"
@@ -3369,17 +3392,20 @@ def test_codegen_humaneval_gate_rejects_qa_accuracy_replays(
     )
     suite = validation_engine.resolve_suite_for_model(suite, codegen)
 
-    validation_engine.apply_metric_gates(result, suite["gates"])
+    validation_engine._apply_sample_acceptance(
+        result,
+        suite["sample_acceptance"],
+    )
 
     assert result["exact_match_rate"] == exact_match_rate
     assert result["token_prefix_agreement"] == token_prefix_agreement
     assert result["status"] == "failed"
     assert result["gate_failures"] == [
         {
-            "gate": "min_exact_match_rate",
-            "metric": "exact_match_rate",
-            "actual": exact_match_rate,
-            "required": 1.0,
+            "gate": "sample_acceptance",
+            "metric": "failed_samples",
+            "actual": len(divergences),
+            "required": 0,
         }
     ]
 
@@ -3398,7 +3424,12 @@ def test_codegen_humaneval_gate_accepts_exact_replay() -> None:
     summary = validation_engine.compare_continuation_sets(
         predictions, predictions, require_token_ids=True
     )
-    result = {"exact_match_rate": summary["exact_match_rate"]}
+    result = {
+        "exact_match_rate": summary["exact_match_rate"],
+        "sample_count": summary["count"],
+        "valid_count": summary["count"],
+        "passed_count": summary["tie_adjusted_exact_count"],
+    }
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(), "humaneval_code_continuation_parity"
     )
@@ -3409,7 +3440,10 @@ def test_codegen_humaneval_gate_accepts_exact_replay() -> None:
     )
     suite = validation_engine.resolve_suite_for_model(suite, codegen)
 
-    validation_engine.apply_metric_gates(result, suite["gates"])
+    validation_engine._apply_sample_acceptance(
+        result,
+        suite["sample_acceptance"],
+    )
 
     assert result["exact_match_rate"] == 1.0
     assert result["status"] == "passed"
@@ -3425,8 +3459,10 @@ def test_validation_suites_keep_continuation_and_drop_trace_cloze() -> None:
     assert continuation["dataset"]["kind"] == "mmlu_five_shot_json"
     assert continuation["scoring"]["scorer"] == "continuation"
     assert continuation["user_contract"] == "continuation_parity"
-    assert continuation["gates"] == {
-        "min_tie_adjusted_exact_match_rate": 0.9
+    assert continuation["gates"] == {}
+    assert continuation["sample_acceptance"] == {
+        "min_pass_rate": 0.9,
+        "min_allowed_failures": 1,
     }
 
 
@@ -7656,9 +7692,20 @@ def test_eval_one_model_reuses_cached_hf_builds_bundle_and_reruns_bundle(
     assert result["prediction_agreement_rate"] == 0.5
     assert result["status"] == "failed"
     assert result["error_type"] == "BenchmarkGateError"
-    assert result["configured_gates"] == {
-        "max_accuracy_drop_from_hf": 0.01,
-        "min_prediction_agreement": 0.98,
+    assert result["configured_gates"] == {"max_accuracy_drop_from_hf": 0.01}
+    assert result["configured_sample_acceptance"] == {
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
+    }
+    assert result["sample_acceptance"] == {
+        "sample_count": 2,
+        "passed_count": 1,
+        "failed_count": 1,
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
+        "allowed_failures": 1,
+        "verdict": "pass",
+        "issues": [],
     }
     assert result["gate_metric_kinds"] == {}
     assert result["gate_policy"] == "blocking"
@@ -7669,12 +7716,6 @@ def test_eval_one_model_reuses_cached_hf_builds_bundle_and_reruns_bundle(
             "actual": 0.5,
             "required": 0.01,
         },
-        {
-            "gate": "min_prediction_agreement",
-            "metric": "prediction_agreement_rate",
-            "actual": 0.5,
-            "required": 0.98,
-        }
     ]
     assert (work_dir / "summary.json").is_file()
 

--- a/tests/tools/test_validation_gate_policy.py
+++ b/tests/tools/test_validation_gate_policy.py
@@ -252,6 +252,124 @@ def test_rate_gate_recalculates_for_each_actual_sample_count() -> None:
         assert effective["allowed_failures"] == allowed_failures
 
 
+def test_fixed_count_policy_does_not_expand_failure_budget_with_more_samples() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 0.9},
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=20,
+        sample_policy={
+            "minimum_sample_count": 10,
+            "calibration_sample_count": 10,
+            "scaling": {"min_prediction_agreement": "fixed_count"},
+        },
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["sample_policy"] == {
+        "minimum_sample_count": 10,
+        "calibration_sample_count": 10,
+        "scaling": {"min_prediction_agreement": "fixed_count"},
+    }
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "proportion",
+        "scaling": "fixed_count",
+        "calibration_sample_count": 10,
+        "required_passes": 19,
+        "allowed_failures": 1,
+        "observed_passes": 18,
+        "observed_failures": 2,
+        "resolution": 0.05,
+    }
+
+
+def test_rate_policy_recalculates_integer_budget_for_larger_sample() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 0.98},
+        configured_gates={"min_prediction_agreement": 0.98},
+        sample_count=50,
+        sample_policy={
+            "minimum_sample_count": 20,
+            "calibration_sample_count": 20,
+            "scaling": {"min_prediction_agreement": "rate"},
+        },
+    )
+
+    assert evaluation["status"] == "pass"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "proportion",
+        "scaling": "rate",
+        "required_passes": 49,
+        "allowed_failures": 1,
+        "observed_passes": 49,
+        "observed_failures": 1,
+        "resolution": 0.02,
+    }
+
+
+def test_fixed_count_policy_preserves_zero_task_quality_drop_budget() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"pass_rate_drop_from_hf": 0.05},
+        configured_gates={"max_pass_rate_drop_from_hf": 0.05},
+        sample_count=20,
+        sample_policy={
+            "minimum_sample_count": 3,
+            "calibration_sample_count": 3,
+            "scaling": {"max_pass_rate_drop_from_hf": "fixed_count"},
+        },
+    )
+
+    assert evaluation["status"] == "fail"
+    assert evaluation["checks"][0]["effective"] == {
+        "kind": "proportion_drop",
+        "scaling": "fixed_count",
+        "calibration_sample_count": 3,
+        "allowed_drop_count": 0,
+        "observed_drop_count": 1,
+        "resolution": 0.05,
+    }
+
+
+def test_sample_policy_marks_too_small_run_as_insufficient_evidence() -> None:
+    evaluation = evaluate_shadow_gates(
+        metrics={"prediction_agreement_rate": 1.0},
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=9,
+        sample_policy={
+            "minimum_sample_count": 10,
+            "calibration_sample_count": 10,
+            "scaling": {"min_prediction_agreement": "fixed_count"},
+        },
+    )
+
+    assert evaluation["status"] == "insufficient_evidence"
+    assert evaluation["issues"] == [
+        {
+            "code": "minimum_sample_count_not_met",
+            "actual": 9,
+            "required": 10,
+        }
+    ]
+
+
+def test_declared_sample_policy_requires_scaling_for_every_rate_gate() -> None:
+    description = describe_shadow_gate_policy(
+        configured_gates={"min_prediction_agreement": 0.9},
+        sample_count=10,
+        sample_policy={
+            "minimum_sample_count": 10,
+            "calibration_sample_count": 10,
+            "scaling": {},
+        },
+    )
+
+    assert description["issues"] == [
+        {
+            "code": "sample_scaling_policy_missing",
+            "gate": "min_prediction_agreement",
+        }
+    ]
+
+
 def test_direct_minimum_gate_uses_its_declared_metric() -> None:
     evaluation = evaluate_shadow_gates(
         metrics={"temporal_consistency": 0.72},

--- a/tests/tools/test_validation_gate_policy.py
+++ b/tests/tools/test_validation_gate_policy.py
@@ -3,6 +3,7 @@
 
 from tools.validation.gate_policy import (
     describe_shadow_gate_policy,
+    evaluate_sample_acceptance,
     evaluate_shadow_gates,
 )
 from tools.validation.catalog import load_suites
@@ -252,121 +253,97 @@ def test_rate_gate_recalculates_for_each_actual_sample_count() -> None:
         assert effective["allowed_failures"] == allowed_failures
 
 
-def test_fixed_count_policy_does_not_expand_failure_budget_with_more_samples() -> None:
-    evaluation = evaluate_shadow_gates(
-        metrics={"prediction_agreement_rate": 0.9},
-        configured_gates={"min_prediction_agreement": 0.9},
-        sample_count=20,
-        sample_policy={
-            "minimum_sample_count": 10,
-            "calibration_sample_count": 10,
-            "scaling": {"min_prediction_agreement": "fixed_count"},
-        },
+def test_sample_acceptance_allows_one_failure_for_small_sample_set() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.98, "min_allowed_failures": 1},
+        sample_count=10,
+        passed_count=9,
+        expected_count=10,
     )
 
-    assert evaluation["status"] == "fail"
-    assert evaluation["sample_policy"] == {
-        "minimum_sample_count": 10,
-        "calibration_sample_count": 10,
-        "scaling": {"min_prediction_agreement": "fixed_count"},
-    }
-    assert evaluation["checks"][0]["effective"] == {
-        "kind": "proportion",
-        "scaling": "fixed_count",
-        "calibration_sample_count": 10,
-        "required_passes": 19,
+    assert evaluation == {
+        "sample_count": 10,
+        "passed_count": 9,
+        "failed_count": 1,
+        "min_pass_rate": 0.98,
+        "min_allowed_failures": 1,
         "allowed_failures": 1,
-        "observed_passes": 18,
-        "observed_failures": 2,
-        "resolution": 0.05,
+        "verdict": "pass",
+        "issues": [],
     }
 
 
-def test_rate_policy_recalculates_integer_budget_for_larger_sample() -> None:
-    evaluation = evaluate_shadow_gates(
-        metrics={"prediction_agreement_rate": 0.98},
-        configured_gates={"min_prediction_agreement": 0.98},
-        sample_count=50,
-        sample_policy={
-            "minimum_sample_count": 20,
-            "calibration_sample_count": 20,
-            "scaling": {"min_prediction_agreement": "rate"},
-        },
+def test_sample_acceptance_keeps_rate_budget_for_larger_sample_set() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.98, "min_allowed_failures": 1},
+        sample_count=100,
+        passed_count=98,
+        expected_count=100,
     )
 
-    assert evaluation["status"] == "pass"
-    assert evaluation["checks"][0]["effective"] == {
-        "kind": "proportion",
-        "scaling": "rate",
-        "required_passes": 49,
-        "allowed_failures": 1,
-        "observed_passes": 49,
-        "observed_failures": 1,
-        "resolution": 0.02,
-    }
+    assert evaluation["allowed_failures"] == 2
+    assert evaluation["passed_count"] == 98
+    assert evaluation["failed_count"] == 2
+    assert evaluation["verdict"] == "pass"
 
 
-def test_fixed_count_policy_preserves_zero_task_quality_drop_budget() -> None:
-    evaluation = evaluate_shadow_gates(
-        metrics={"pass_rate_drop_from_hf": 0.05},
-        configured_gates={"max_pass_rate_drop_from_hf": 0.05},
+def test_sample_acceptance_fails_above_effective_failure_budget() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.98, "min_allowed_failures": 1},
         sample_count=20,
-        sample_policy={
-            "minimum_sample_count": 3,
-            "calibration_sample_count": 3,
-            "scaling": {"max_pass_rate_drop_from_hf": "fixed_count"},
-        },
+        passed_count=18,
+        expected_count=20,
     )
 
-    assert evaluation["status"] == "fail"
-    assert evaluation["checks"][0]["effective"] == {
-        "kind": "proportion_drop",
-        "scaling": "fixed_count",
-        "calibration_sample_count": 3,
-        "allowed_drop_count": 0,
-        "observed_drop_count": 1,
-        "resolution": 0.05,
-    }
+    assert evaluation["allowed_failures"] == 1
+    assert evaluation["passed_count"] == 18
+    assert evaluation["failed_count"] == 2
+    assert evaluation["verdict"] == "fail"
 
 
-def test_sample_policy_marks_too_small_run_as_insufficient_evidence() -> None:
-    evaluation = evaluate_shadow_gates(
-        metrics={"prediction_agreement_rate": 1.0},
-        configured_gates={"min_prediction_agreement": 0.9},
-        sample_count=9,
-        sample_policy={
-            "minimum_sample_count": 10,
-            "calibration_sample_count": 10,
-            "scaling": {"min_prediction_agreement": "fixed_count"},
-        },
+def test_sample_acceptance_rejects_incomplete_evidence() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.98, "min_allowed_failures": 1},
+        sample_count=19,
+        passed_count=19,
+        expected_count=20,
     )
 
-    assert evaluation["status"] == "insufficient_evidence"
+    assert evaluation["verdict"] == "invalid"
+    assert evaluation["issues"] == [
+        {"code": "incomplete_samples", "expected": 20, "actual": 19}
+    ]
+
+
+def test_sample_acceptance_rejects_a_failure_allowance_covering_every_sample() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.98, "min_allowed_failures": 3},
+        sample_count=3,
+        passed_count=2,
+        expected_count=3,
+    )
+
+    assert evaluation["verdict"] == "invalid"
     assert evaluation["issues"] == [
         {
-            "code": "minimum_sample_count_not_met",
-            "actual": 9,
-            "required": 10,
+            "code": "min_allowed_failures_out_of_range",
+            "value": 3,
+            "sample_count": 3,
         }
     ]
 
 
-def test_declared_sample_policy_requires_scaling_for_every_rate_gate() -> None:
-    description = describe_shadow_gate_policy(
-        configured_gates={"min_prediction_agreement": 0.9},
+def test_sample_acceptance_rejects_a_zero_pass_rate() -> None:
+    evaluation = evaluate_sample_acceptance(
+        policy={"min_pass_rate": 0.0, "min_allowed_failures": 0},
         sample_count=10,
-        sample_policy={
-            "minimum_sample_count": 10,
-            "calibration_sample_count": 10,
-            "scaling": {},
-        },
+        passed_count=0,
+        expected_count=10,
     )
 
-    assert description["issues"] == [
-        {
-            "code": "sample_scaling_policy_missing",
-            "gate": "min_prediction_agreement",
-        }
+    assert evaluation["verdict"] == "invalid"
+    assert evaluation["issues"] == [
+        {"code": "min_pass_rate_out_of_range", "value": 0.0}
     ]
 
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -196,6 +196,27 @@ they keep owner decisions visible without changing current traffic lights or CI
 behavior. A suite that has no selected model or sample limit remains visible in
 the census even though it cannot appear in a model run.
 
+Suites may approve their sample behavior explicitly with
+`gate_sample_policy`. `minimum_sample_count` is the smallest run that can form
+qualification evidence, while `calibration_sample_count` records the slice on
+which the configured threshold was reviewed. Every proportion or proportion-
+drop gate then chooses one scaling rule:
+
+```yaml
+gate_sample_policy:
+  minimum_sample_count: 20
+  calibration_sample_count: 20
+  scaling:
+    min_prediction_agreement: fixed_count
+```
+
+`fixed_count` preserves the calibrated number of allowed failures or task-
+quality drops when the sample count changes. `rate` preserves the configured
+percentage and recomputes the integer budget for the actual sample count. Runs
+below the declared minimum are reported as `insufficient_evidence` by the
+shadow analysis. These declarations remain non-blocking: they do not recolor
+the current result or enable a CI lane.
+
 Override the configured limit for one run, or request the complete dataset
 explicitly:
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -190,32 +190,25 @@ python tools/trtmc_validate.py --gate-census > gate-census.json
 
 The deterministic JSON groups models that resolve to the same gate variant and
 shows the workload-owned rationale, configured sample count, effective integer
-threshold, and unresolved review items. `minimum_sample_count_unapproved` and
-`sample_scaling_policy_unapproved` are census findings, not runtime failures;
-they keep owner decisions visible without changing current traffic lights or CI
-behavior. A suite that has no selected model or sample limit remains visible in
-the census even though it cannot appear in a model run.
+threshold, and unresolved configuration items. A suite that has no selected
+model or sample limit remains visible in the census even though it cannot
+appear in a model run.
 
-Suites may approve their sample behavior explicitly with
-`gate_sample_policy`. `minimum_sample_count` is the smallest run that can form
-qualification evidence, while `calibration_sample_count` records the slice on
-which the configured threshold was reviewed. Every proportion or proportion-
-drop gate then chooses one scaling rule:
+When a scorer produces one pass/fail outcome per sample, configure the batch
+decision once:
 
 ```yaml
-gate_sample_policy:
-  minimum_sample_count: 20
-  calibration_sample_count: 20
-  scaling:
-    min_prediction_agreement: fixed_count
+sample_acceptance:
+  min_pass_rate: 0.98
+  min_allowed_failures: 1
 ```
 
-`fixed_count` preserves the calibrated number of allowed failures or task-
-quality drops when the sample count changes. `rate` preserves the configured
-percentage and recomputes the integer budget for the actual sample count. Runs
-below the declared minimum are reported as `insufficient_evidence` by the
-shadow analysis. These declarations remain non-blocking: they do not recolor
-the current result or enable a CI lane.
+The batch allows
+`max(floor((1 - min_pass_rate) * sample_count), min_allowed_failures)` failed
+samples. Each scorer still owns the per-sample pass/fail rule (for example, an
+IoU threshold). Missing sample outcomes invalidate the comparison; aggregate
+gates such as task-accuracy drop remain independent. The resolved counts and
+verdict are written to `report.json`; HTML only renders them.
 
 Override the configured limit for one run, or request the complete dataset
 explicitly:

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -84,6 +84,14 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.01
       min_prediction_agreement: 0.98
+    gate_sample_policy:
+      # This sampled quality suite keeps its reviewed rates as the slice grows;
+      # the census always expands them into the resulting integer budgets.
+      minimum_sample_count: 20
+      calibration_sample_count: 20
+      scaling:
+        max_accuracy_drop_from_hf: rate
+        min_prediction_agreement: rate
     ci:
       eligible: false
       lane: local_only
@@ -190,6 +198,13 @@ suites:
       # divergence in the default 10-sample smoke. Exact HF argmax ties remain
       # visible in raw divergence diagnostics but are gate-equivalent.
       min_tie_adjusted_exact_match_rate: 0.9
+    gate_sample_policy:
+      # The suite contract is exactly one non-tied divergence, including when
+      # a developer runs more than the default ten samples.
+      minimum_sample_count: 10
+      calibration_sample_count: 10
+      scaling:
+        min_tie_adjusted_exact_match_rate: fixed_count
     ci:
       eligible: false
       lane: local_only
@@ -250,6 +265,13 @@ suites:
           build_generation_headroom: true
     gates: {}
     gate_policy: observation_only
+    gate_sample_policy:
+      # CodeGen activates this deterministic gate through its model profile;
+      # StarCoder2 remains observation-only.
+      minimum_sample_count: 10
+      calibration_sample_count: 10
+      scaling:
+        min_exact_match_rate: fixed_count
     ci:
       eligible: false
       lane: local_only
@@ -301,6 +323,12 @@ suites:
       # Samples are the pass/fail unit. Exact HF argmax ties remain visible in
       # raw diagnostics but are gate-equivalent.
       min_tie_adjusted_exact_match_rate: 0.9
+    gate_sample_policy:
+      # Keep the reviewed two-divergence budget fixed as the slice grows.
+      minimum_sample_count: 20
+      calibration_sample_count: 20
+      scaling:
+        min_tie_adjusted_exact_match_rate: fixed_count
     ci:
       eligible: false
       lane: local_only
@@ -506,6 +534,14 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.02
       min_prediction_agreement: 0.95
+    gate_sample_policy:
+      # Five samples can only express a zero-failure result. Larger sampled
+      # quality runs retain the declared rates and expose the new integer budget.
+      minimum_sample_count: 5
+      calibration_sample_count: 5
+      scaling:
+        max_accuracy_drop_from_hf: rate
+        min_prediction_agreement: rate
     ci:
       eligible: false
       lane: local_only
@@ -567,6 +603,12 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.02
       min_prediction_agreement: 0.95
+    gate_sample_policy:
+      minimum_sample_count: 5
+      calibration_sample_count: 5
+      scaling:
+        max_accuracy_drop_from_hf: rate
+        min_prediction_agreement: rate
     ci:
       eligible: false
       lane: local_only
@@ -685,6 +727,14 @@ suites:
     gates:
       max_accuracy_drop_from_hf: 0.02
       min_prediction_agreement: 0.95
+    gate_sample_policy:
+      # OCRBench is sampled task quality: retain the declared rates when a
+      # larger representative slice is selected and show its integer budget.
+      minimum_sample_count: 5
+      calibration_sample_count: 5
+      scaling:
+        max_accuracy_drop_from_hf: rate
+        min_prediction_agreement: rate
     ci:
       eligible: false
       lane: local_only
@@ -859,6 +909,14 @@ suites:
     gates:
       max_pass_rate_drop_from_hf: 0.05
       min_correctness_agreement: 0.95
+    gate_sample_policy:
+      # At three samples both nominal 5% margins mean zero failures. Keep that
+      # explicit; this does not claim statistical validation of a 95% rate.
+      minimum_sample_count: 3
+      calibration_sample_count: 3
+      scaling:
+        max_pass_rate_drop_from_hf: fixed_count
+        min_correctness_agreement: fixed_count
     ci:
       eligible: false
       lane: local_only

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -75,23 +75,17 @@ suites:
           hf_use_cache: false
     model_profiles:
       phi-moe:
-        gates:
+        sample_acceptance:
           # Permit one backend disagreement in the 20-sample smoke slice when
           # task accuracy is preserved; the accuracy-drop gate remains strict.
-          min_prediction_agreement: 0.95
+          min_pass_rate: 0.95
     build:
       min_max_cache_length: 0
     gates:
       max_accuracy_drop_from_hf: 0.01
-      min_prediction_agreement: 0.98
-    gate_sample_policy:
-      # This sampled quality suite keeps its reviewed rates as the slice grows;
-      # the census always expands them into the resulting integer budgets.
-      minimum_sample_count: 20
-      calibration_sample_count: 20
-      scaling:
-        max_accuracy_drop_from_hf: rate
-        min_prediction_agreement: rate
+    sample_acceptance:
+      min_pass_rate: 0.98
+      min_allowed_failures: 1
     ci:
       eligible: false
       lane: local_only
@@ -193,18 +187,12 @@ suites:
           prompt_truncation_side: left
     build:
       min_max_cache_length: 0
-    gates:
-      # Validation samples are the pass/fail unit. Allow one non-tied
-      # divergence in the default 10-sample smoke. Exact HF argmax ties remain
-      # visible in raw divergence diagnostics but are gate-equivalent.
-      min_tie_adjusted_exact_match_rate: 0.9
-    gate_sample_policy:
-      # The suite contract is exactly one non-tied divergence, including when
-      # a developer runs more than the default ten samples.
-      minimum_sample_count: 10
-      calibration_sample_count: 10
-      scaling:
-        min_tie_adjusted_exact_match_rate: fixed_count
+    gates: {}
+    sample_acceptance:
+      # Exact HF argmax ties remain visible in raw divergence diagnostics but
+      # are sample-pass equivalent.
+      min_pass_rate: 0.9
+      min_allowed_failures: 1
     ci:
       eligible: false
       lane: local_only
@@ -252,11 +240,12 @@ suites:
       scorer: continuation
     model_profiles:
       codegen-350m:
-        gates:
+        sample_acceptance:
           # CodeGen greedy continuations are deterministic. Any token
           # divergence is an accuracy regression, including the 1/10 failure
           # that the original diagnostic-only suite silently accepted.
-          min_exact_match_rate: 1.0
+          min_pass_rate: 1.0
+          min_allowed_failures: 0
     model_overrides:
       by_model:
         codegen-350m:
@@ -265,13 +254,6 @@ suites:
           build_generation_headroom: true
     gates: {}
     gate_policy: observation_only
-    gate_sample_policy:
-      # CodeGen activates this deterministic gate through its model profile;
-      # StarCoder2 remains observation-only.
-      minimum_sample_count: 10
-      calibration_sample_count: 10
-      scaling:
-        min_exact_match_rate: fixed_count
     ci:
       eligible: false
       lane: local_only
@@ -319,16 +301,12 @@ suites:
       by_model:
         distilgpt2:
           build_generation_headroom: true
-    gates:
-      # Samples are the pass/fail unit. Exact HF argmax ties remain visible in
-      # raw diagnostics but are gate-equivalent.
-      min_tie_adjusted_exact_match_rate: 0.9
-    gate_sample_policy:
-      # Keep the reviewed two-divergence budget fixed as the slice grows.
-      minimum_sample_count: 20
-      calibration_sample_count: 20
-      scaling:
-        min_tie_adjusted_exact_match_rate: fixed_count
+    gates: {}
+    sample_acceptance:
+      # Exact HF argmax ties remain visible in raw diagnostics but are
+      # sample-pass equivalent.
+      min_pass_rate: 0.9
+      min_allowed_failures: 0
     ci:
       eligible: false
       lane: local_only
@@ -533,15 +511,9 @@ suites:
       min_max_cache_length: 512
     gates:
       max_accuracy_drop_from_hf: 0.02
-      min_prediction_agreement: 0.95
-    gate_sample_policy:
-      # Five samples can only express a zero-failure result. Larger sampled
-      # quality runs retain the declared rates and expose the new integer budget.
-      minimum_sample_count: 5
-      calibration_sample_count: 5
-      scaling:
-        max_accuracy_drop_from_hf: rate
-        min_prediction_agreement: rate
+    sample_acceptance:
+      min_pass_rate: 0.95
+      min_allowed_failures: 0
     ci:
       eligible: false
       lane: local_only
@@ -602,13 +574,9 @@ suites:
       min_max_cache_length: 1024
     gates:
       max_accuracy_drop_from_hf: 0.02
-      min_prediction_agreement: 0.95
-    gate_sample_policy:
-      minimum_sample_count: 5
-      calibration_sample_count: 5
-      scaling:
-        max_accuracy_drop_from_hf: rate
-        min_prediction_agreement: rate
+    sample_acceptance:
+      min_pass_rate: 0.95
+      min_allowed_failures: 0
     ci:
       eligible: false
       lane: local_only
@@ -726,15 +694,9 @@ suites:
       min_max_cache_length: 1024
     gates:
       max_accuracy_drop_from_hf: 0.02
-      min_prediction_agreement: 0.95
-    gate_sample_policy:
-      # OCRBench is sampled task quality: retain the declared rates when a
-      # larger representative slice is selected and show its integer budget.
-      minimum_sample_count: 5
-      calibration_sample_count: 5
-      scaling:
-        max_accuracy_drop_from_hf: rate
-        min_prediction_agreement: rate
+    sample_acceptance:
+      min_pass_rate: 0.95
+      min_allowed_failures: 0
     ci:
       eligible: false
       lane: local_only
@@ -908,15 +870,9 @@ suites:
       min_max_cache_length: 1024
     gates:
       max_pass_rate_drop_from_hf: 0.05
-      min_correctness_agreement: 0.95
-    gate_sample_policy:
-      # At three samples both nominal 5% margins mean zero failures. Keep that
-      # explicit; this does not claim statistical validation of a 95% rate.
-      minimum_sample_count: 3
-      calibration_sample_count: 3
-      scaling:
-        max_pass_rate_drop_from_hf: fixed_count
-        min_correctness_agreement: fixed_count
+    sample_acceptance:
+      min_pass_rate: 0.95
+      min_allowed_failures: 0
     ci:
       eligible: false
       lane: local_only

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -102,6 +102,7 @@ PLATFORM_PROJECTION_EXACT = frozenset(
         "tools/validation/artifacts.py",
         "tools/validation/catalog.py",
         "tools/validation/engine.py",
+        "tools/validation/gate_policy.py",
         "tools/validation/model_plugin_contract.py",
         *MODEL_ROOT_PLATFORM_FILES,
     }

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -184,6 +184,8 @@
     const sampleText = value.sample_count === null || value.sample_count === undefined ? "sample count unavailable" : `${value.sample_count} valid samples`;
     control.append(el("summary", "", `Gate analysis (shadow) · ${String(value.status || "unknown").toUpperCase()} · ${sampleText}`));
     const body = el("div", "evidence-body");
+    const samplePolicy = value.sample_policy || null;
+    if (samplePolicy) add(body, el("div", "gate-fact", `Minimum ${samplePolicy.minimum_sample_count ?? "—"} samples · calibrated at ${samplePolicy.calibration_sample_count ?? "—"}`));
     (value.checks || []).forEach((check) => {
       const effective = check.effective || {};
       const card = el("section", `gate-check gate-${check.verdict || "unknown"}`);
@@ -193,6 +195,7 @@
       else if (effective.kind === "proportion_drop") add(card, el("div", "gate-fact", `${effective.observed_drop_count} net samples lost · allows ${effective.allowed_drop_count}`));
       else if (effective.kind === "exact") add(card, el("div", "gate-fact", `Observed range ${actual} · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
       else add(card, el("div", "gate-fact", `Continuous metric · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
+      if (effective.scaling) add(card, el("div", "gate-fact", `Sample scaling: ${effective.scaling}${effective.calibration_sample_count ? ` · calibration ${effective.calibration_sample_count}` : ""}`));
       card.append(el("strong", "gate-verdict", String(check.verdict || "unknown").toUpperCase()));
       body.append(card);
     });

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -184,8 +184,6 @@
     const sampleText = value.sample_count === null || value.sample_count === undefined ? "sample count unavailable" : `${value.sample_count} valid samples`;
     control.append(el("summary", "", `Gate analysis (shadow) · ${String(value.status || "unknown").toUpperCase()} · ${sampleText}`));
     const body = el("div", "evidence-body");
-    const samplePolicy = value.sample_policy || null;
-    if (samplePolicy) add(body, el("div", "gate-fact", `Minimum ${samplePolicy.minimum_sample_count ?? "—"} samples · calibrated at ${samplePolicy.calibration_sample_count ?? "—"}`));
     (value.checks || []).forEach((check) => {
       const effective = check.effective || {};
       const card = el("section", `gate-check gate-${check.verdict || "unknown"}`);
@@ -195,11 +193,23 @@
       else if (effective.kind === "proportion_drop") add(card, el("div", "gate-fact", `${effective.observed_drop_count} net samples lost · allows ${effective.allowed_drop_count}`));
       else if (effective.kind === "exact") add(card, el("div", "gate-fact", `Observed range ${actual} · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
       else add(card, el("div", "gate-fact", `Continuous metric · ${effective.sample_count ?? value.sample_count ?? "—"} valid samples`));
-      if (effective.scaling) add(card, el("div", "gate-fact", `Sample scaling: ${effective.scaling}${effective.calibration_sample_count ? ` · calibration ${effective.calibration_sample_count}` : ""}`));
       card.append(el("strong", "gate-verdict", String(check.verdict || "unknown").toUpperCase()));
       body.append(card);
     });
     (value.issues || []).forEach((issue) => body.append(el("div", "gate-issue", [issue.code, issue.gate, issue.metric].filter(Boolean).join(" · "))));
+    control.append(body);
+    return control;
+  }
+
+  function sampleAcceptance(value) {
+    if (!value) return null;
+    const failed = Number(value.failed_count || 0);
+    const total = Number(value.sample_count || 0);
+    const control = el("details", "evidence sample-acceptance");
+    control.append(el("summary", "", `Sample acceptance · ${String(value.verdict || "unknown").toUpperCase()} · ${failed}/${total} failed`));
+    const body = el("div", "evidence-body");
+    add(body, el("div", "gate-fact", `Pass rate ≥${number(Number(value.min_pass_rate) * 100, 2)}% · minimum allowed failures ${value.min_allowed_failures ?? "—"} · allows ${value.allowed_failures ?? "—"}`));
+    (value.issues || []).forEach((issue) => body.append(el("div", "gate-issue", issue.code || "invalid sample acceptance")));
     control.append(body);
     return control;
   }
@@ -209,14 +219,17 @@
     if (row.issue) records.push(["Failure", row.issue]);
     if ((row.warnings || []).length) records.push(["Warnings", row.warnings]);
     let gate = null;
+    let acceptance = null;
     if (kind === "accuracy") {
       const comparison = { ...(row.comparison || {}) };
       gate = gateEvaluation(comparison.gate_evaluation);
+      acceptance = sampleAcceptance(comparison.sample_acceptance);
       delete comparison.gate_evaluation;
+      delete comparison.sample_acceptance;
       records.push(["Comparison", comparison], ["Validation", row.validation || {}]);
     }
     else records.push(["Output validation", row.output_validation || {}], ["Reference samples", row.baseline?.samples_ms || []], ["TRTMC samples", row.candidate?.samples_ms || []], ["Comparison", row.comparison || {}]);
-    return add(el("div", "metric-evidence"), gate, details("Metrics", records));
+    return add(el("div", "metric-evidence"), acceptance, gate, details("Metrics", records));
   }
 
   function logs(row) {

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -2981,6 +2981,27 @@ def _accuracy_issue(result: Mapping[str, Any]) -> dict[str, str] | None:
     if execution.get("status") == "error":
         raw_result = result.get("raw_result", {})
         raw_result = raw_result if isinstance(raw_result, Mapping) else {}
+        if raw_result.get("error_type") == "SampleEvidenceError":
+            acceptance = raw_result.get("sample_acceptance", {})
+            issues = (
+                acceptance.get("issues", [])
+                if isinstance(acceptance, Mapping)
+                else []
+            )
+            code = str(issues[0].get("code", "invalid_sample_evidence")) if issues else (
+                "invalid_sample_evidence"
+            )
+            return {
+                "priority": "P1",
+                "stage": "compare",
+                "domain": (
+                    "data-artifact"
+                    if code in {"incomplete_samples", "invalid_sample_counts"}
+                    else "policy-config"
+                ),
+                "code": code,
+                "message": str(raw_result.get("error") or code),
+            }
         worker_failure = result.get("executor") == "model_worker"
         return {
             "priority": "P1",
@@ -3274,8 +3295,9 @@ def _public_accuracy_result(
     raw_result = result.get("raw_result", {})
     raw_result = raw_result if isinstance(raw_result, Mapping) else {}
     configured_gates = raw_result.get("configured_gates")
+    sample_acceptance = raw_result.get("sample_acceptance")
     policy_mode = str(raw_result.get("gate_policy", "") or "")
-    if isinstance(configured_gates, Mapping) or policy_mode:
+    if configured_gates or (policy_mode == "observation_only" and not sample_acceptance):
         comparison["gate_evaluation"] = evaluate_shadow_gates(
             metrics=_shadow_gate_metrics(comparison, raw_result),
             configured_gates=(
@@ -3288,13 +3310,9 @@ def _public_accuracy_result(
                 if isinstance(raw_result.get("gate_metric_kinds"), Mapping)
                 else {}
             ),
-            sample_policy=(
-                raw_result.get("gate_sample_policy")
-                if isinstance(raw_result.get("gate_sample_policy"), Mapping)
-                and raw_result.get("gate_sample_policy")
-                else None
-            ),
         )
+    if isinstance(sample_acceptance, Mapping):
+        comparison["sample_acceptance"] = dict(sample_acceptance)
     public.update(
         {
             "id": f"{result.get('model', '')}::{result.get('workload') or 'not-compared'}",

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -3288,6 +3288,12 @@ def _public_accuracy_result(
                 if isinstance(raw_result.get("gate_metric_kinds"), Mapping)
                 else {}
             ),
+            sample_policy=(
+                raw_result.get("gate_sample_policy")
+                if isinstance(raw_result.get("gate_sample_policy"), Mapping)
+                and raw_result.get("gate_sample_policy")
+                else None
+            ),
         )
     public.update(
         {

--- a/tools/validation/catalog.py
+++ b/tools/validation/catalog.py
@@ -280,6 +280,22 @@ def resolve_suite_for_model(suite: dict[str, Any], model: dict[str, Any]) -> dic
             raise ValueError(f"Suite {suite['id']} gate profile for {owner} must be a mapping")
         gates.update(profile_gates)
     resolved["gates"] = gates
-    if gates:
+    sample_acceptance = dict(resolved.get("sample_acceptance", {}))
+    for owner, source in (
+        (model.get("family"), family_profile),
+        (model.get("name"), profile),
+    ):
+        profile_acceptance = source.get("sample_acceptance", {})
+        if not isinstance(profile_acceptance, dict):
+            raise ValueError(
+                f"Suite {suite['id']} sample_acceptance profile for {owner} "
+                "must be a mapping"
+            )
+        sample_acceptance.update(profile_acceptance)
+    if sample_acceptance:
+        resolved["sample_acceptance"] = sample_acceptance
+    else:
+        resolved.pop("sample_acceptance", None)
+    if gates or sample_acceptance:
         resolved["gate_policy"] = "blocking"
     return resolved

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -48,6 +48,7 @@ from tests.e2e_harness.registry import (  # noqa: E402
 )
 from tools.validation import artifacts as validation_artifacts  # noqa: E402
 from tools.validation import catalog as validation_catalog  # noqa: E402
+from tools.validation.gate_policy import evaluate_sample_acceptance  # noqa: E402
 from tools.validation.model_plugin_contract import (  # noqa: E402
     deserialize_stage_output,
     manifest_path_from_work_manifest,
@@ -5574,11 +5575,15 @@ def prediction_agreement_gate_result(
     gates: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Evaluate task-accuracy and direct prediction-agreement gates."""
-    max_accuracy_drop = float(
-        gates.get("max_accuracy_drop_from_hf", 0.05)
+    max_accuracy_drop = (
+        float(gates["max_accuracy_drop_from_hf"])
+        if "max_accuracy_drop_from_hf" in gates
+        else None
     )
-    min_agreement = float(
-        gates.get("min_prediction_agreement", 0.90)
+    min_agreement = (
+        float(gates["min_prediction_agreement"])
+        if "min_prediction_agreement" in gates
+        else None
     )
     raw_accuracy_drop = (
         float(summary["hf"]["overall_accuracy"])
@@ -5594,7 +5599,7 @@ def prediction_agreement_gate_result(
         accuracy_drop = 0.0
     prediction_agreement = float(summary["prediction_agreement_rate"])
     failures: list[dict[str, Any]] = []
-    if accuracy_drop > max_accuracy_drop:
+    if max_accuracy_drop is not None and accuracy_drop > max_accuracy_drop:
         failures.append(
             {
                 "gate": "max_accuracy_drop_from_hf",
@@ -5603,7 +5608,7 @@ def prediction_agreement_gate_result(
                 "required": max_accuracy_drop,
             }
         )
-    if prediction_agreement < min_agreement:
+    if min_agreement is not None and prediction_agreement < min_agreement:
         failures.append(
             {
                 "gate": "min_prediction_agreement",
@@ -5617,8 +5622,12 @@ def prediction_agreement_gate_result(
         "accuracy_drop_from_hf": accuracy_drop,
         "raw_accuracy_drop_from_hf": raw_accuracy_drop,
         "gates": {
-            "max_accuracy_drop_from_hf": max_accuracy_drop,
-            "min_prediction_agreement": min_agreement,
+            name: value
+            for name, value in (
+                ("max_accuracy_drop_from_hf", max_accuracy_drop),
+                ("min_prediction_agreement", min_agreement),
+            )
+            if value is not None
         },
         "gate_failures": failures,
     }
@@ -5636,11 +5645,15 @@ def tts_intelligibility_gate_result(
     summary: Mapping[str, Any],
     gates: Mapping[str, Any],
 ) -> dict[str, Any]:
-    max_pass_rate_drop = float(
-        gates.get("max_pass_rate_drop_from_hf", 0.05)
+    max_pass_rate_drop = (
+        float(gates["max_pass_rate_drop_from_hf"])
+        if "max_pass_rate_drop_from_hf" in gates
+        else None
     )
-    min_correctness_agreement = float(
-        gates.get("min_correctness_agreement", 0.95)
+    min_correctness_agreement = (
+        float(gates["min_correctness_agreement"])
+        if "min_correctness_agreement" in gates
+        else None
     )
     pass_rate_drop = (
         float(summary["hf"]["overall_accuracy"])
@@ -5650,17 +5663,68 @@ def tts_intelligibility_gate_result(
     return {
         "status": (
             "passed"
-            if pass_rate_drop <= max_pass_rate_drop
-            and correctness_agreement >= min_correctness_agreement
+            if (max_pass_rate_drop is None or pass_rate_drop <= max_pass_rate_drop)
+            and (
+                min_correctness_agreement is None
+                or correctness_agreement >= min_correctness_agreement
+            )
             else "failed"
         ),
         "pass_rate_drop_from_hf": pass_rate_drop,
         "correctness_agreement_rate": correctness_agreement,
         "gates": {
-            "max_pass_rate_drop_from_hf": max_pass_rate_drop,
-            "min_correctness_agreement": min_correctness_agreement,
+            name: value
+            for name, value in (
+                ("max_pass_rate_drop_from_hf", max_pass_rate_drop),
+                ("min_correctness_agreement", min_correctness_agreement),
+            )
+            if value is not None
         },
     }
+
+
+def _apply_sample_acceptance(
+    result: dict[str, Any],
+    policy: Mapping[str, Any] | None,
+) -> None:
+    if not policy:
+        return
+    expected_count = int(result.get("sample_count", 0) or 0)
+    valid_count = int(result.get("valid_count", expected_count) or 0)
+    passed_count = int(result.get("passed_count", 0) or 0)
+    evaluation = evaluate_sample_acceptance(
+        policy=policy,
+        sample_count=valid_count,
+        passed_count=passed_count,
+        expected_count=expected_count,
+    )
+    result["sample_acceptance"] = evaluation
+    if evaluation["verdict"] == "pass":
+        result.setdefault("status", "passed")
+        return
+    if evaluation["verdict"] == "invalid":
+        result["status"] = "invalid"
+        result["error_type"] = "SampleEvidenceError"
+        result["error"] = "; ".join(
+            str(issue.get("code", "invalid_sample_acceptance"))
+            for issue in evaluation["issues"]
+        )
+        return
+    result["status"] = "failed"
+    failure = {
+        "gate": "sample_acceptance",
+        "metric": "failed_samples",
+        "actual": evaluation["failed_count"],
+        "required": evaluation["allowed_failures"],
+    }
+    failures = result.setdefault("gate_failures", [])
+    if failure not in failures:
+        failures.append(failure)
+    result["error_type"] = "BenchmarkGateError"
+    result["error"] = (
+        f"sample_acceptance actual={evaluation['failed_count']} "
+        f"allowed={evaluation['allowed_failures']}"
+    )
 
 
 def _load_diffusion_validation_comparator(work_dir: Path) -> Any:
@@ -10540,8 +10604,16 @@ def compare_semantic_segmentation_prediction_sets(
     min_pixel = float(gates.get("min_backend_pixel_agreement", 0.98))
     min_backend_iou = float(gates.get("min_backend_mean_iou", 0.95))
     max_drop = float(gates.get("max_mean_iou_drop_from_hf", 0.01))
+    for case in cases:
+        if "error" in case:
+            continue
+        case["passed"] = (
+            float(case["backend_pixel_agreement"]) >= min_pixel
+            and float(case["backend_mean_iou"]) >= min_backend_iou
+        )
     mean_iou_drop = hf_metrics["mean_iou"] - bundle_metrics["mean_iou"]
     valid_count = sum("error" not in case for case in cases)
+    passed_count = sum(bool(case.get("passed")) for case in cases)
     status = (
         "passed"
         if valid_count > 0
@@ -10555,6 +10627,8 @@ def compare_semantic_segmentation_prediction_sets(
         "status": status,
         "sample_count": len(cases),
         "valid_count": valid_count,
+        "passed_count": passed_count,
+        "sample_pass_rate": passed_count / valid_count if valid_count else 0.0,
         "hf_mean_iou": hf_metrics["mean_iou"],
         "bundle_mean_iou": bundle_metrics["mean_iou"],
         "mean_iou_drop_from_hf": mean_iou_drop,
@@ -10681,6 +10755,9 @@ def compare_prompted_segmentation_prediction_sets(
     bundle_gt_iou = _mean([float(case["bundle_ground_truth_iou"]) for case in valid])
     min_backend_iou = float(gates.get("min_backend_mask_iou", 0.90))
     max_gt_drop = float(gates.get("max_ground_truth_iou_drop_from_hf", 0.05))
+    for case in valid:
+        case["passed"] = float(case["backend_mask_iou"]) >= min_backend_iou
+    passed_count = sum(bool(case.get("passed")) for case in cases)
     gt_drop = hf_gt_iou - bundle_gt_iou
     status = (
         "passed"
@@ -10694,6 +10771,8 @@ def compare_prompted_segmentation_prediction_sets(
         "status": status,
         "sample_count": len(cases),
         "valid_count": len(valid),
+        "passed_count": passed_count,
+        "sample_pass_rate": passed_count / len(valid) if valid else 0.0,
         "prompt_mode": prompt_mode,
         "mean_backend_mask_iou": mean_backend_iou,
         "worst_backend_mask_iou": worst_backend_iou,
@@ -11499,10 +11578,11 @@ def eval_one_model(
             **base_result,
             "mode": scorer,
             "status": summary["status"],
+            "sample_count": summary["sample_count"],
             "valid_count": summary["valid_count"],
             "passed_count": summary["passed_count"],
-            "skipped_count": summary["skipped_count"],
             "sample_pass_rate": summary["sample_pass_rate"],
+            "skipped_count": summary["skipped_count"],
             "metrics": summary["metrics"],
         }
         if summary["execution_errors"]:
@@ -11528,6 +11608,7 @@ def eval_one_model(
             **base_result,
             "mode": scorer,
             "status": summary["status"],
+            "sample_count": summary["sample_count"],
             "valid_count": summary["valid_count"],
             "passed_count": summary["passed_count"],
             "sample_agreement_rate": summary["sample_agreement_rate"],
@@ -11585,7 +11666,10 @@ def eval_one_model(
             **base_result,
             "mode": scorer,
             "status": summary["status"],
+            "sample_count": summary["sample_count"],
             "valid_count": summary["valid_count"],
+            "passed_count": summary["passed_count"],
+            "sample_pass_rate": summary["sample_pass_rate"],
             "hf_mean_iou": summary["hf_mean_iou"],
             "bundle_mean_iou": summary["bundle_mean_iou"],
             "mean_iou_drop_from_hf": summary["mean_iou_drop_from_hf"],
@@ -11616,7 +11700,10 @@ def eval_one_model(
             **base_result,
             "mode": scorer,
             "status": summary["status"],
+            "sample_count": summary["sample_count"],
             "valid_count": summary["valid_count"],
+            "passed_count": summary["passed_count"],
+            "sample_pass_rate": summary["sample_pass_rate"],
             "prompt_mode": summary["prompt_mode"],
             "mean_backend_mask_iou": summary["mean_backend_mask_iou"],
             "worst_backend_mask_iou": summary["worst_backend_mask_iou"],
@@ -11812,8 +11899,13 @@ def eval_one_model(
         result = {
             **base_result,
             "mode": "continuation",
+            "sample_count": summary["count"],
+            "valid_count": summary["count"],
+            "passed_count": summary["tie_adjusted_exact_count"],
             "evaluation_policy": (
-                "threshold_gated" if suite.get("gates", {}) else "diagnostic_only"
+                "threshold_gated"
+                if suite.get("gates", {}) or suite.get("sample_acceptance")
+                else "diagnostic_only"
             ),
             "comparison_granularity": summary.get("comparison_granularity", ""),
             "exact_match_rate": summary["exact_match_rate"],
@@ -11916,6 +12008,8 @@ def eval_one_model(
         result = {
             **base_result,
             "mode": scorer,
+            "sample_count": summary["total_count"],
+            "valid_count": summary["total_count"],
             "hf_accuracy": summary["hf"]["overall_accuracy"],
             "bundle_accuracy": summary["bundle"]["overall_accuracy"],
             "accuracy_delta_bundle_minus_hf": summary["accuracy_delta_bundle_minus_hf"],
@@ -11930,6 +12024,10 @@ def eval_one_model(
             "bundle_valid_prediction_rate": summary["bundle"].get("valid_prediction_rate"),
         }
         if scorer in {"grounding_iou", "mcq", "ocrbench_v2", "asr_transcript"}:
+            if scorer != "asr_transcript":
+                result["passed_count"] = summary["total_count"] - len(
+                    summary["disagreements"]
+                )
             result.update(
                 prediction_agreement_gate_result(
                     summary,
@@ -11948,6 +12046,7 @@ def eval_one_model(
                     }
                 )
         elif scorer == "tts_intelligibility":
+            result["passed_count"] = summary["agreement_count"]
             result.update(
                 tts_intelligibility_gate_result(
                     summary,
@@ -11955,13 +12054,18 @@ def eval_one_model(
                 )
             )
     configured_gates = dict(suite.get("gates", {}))
+    sample_acceptance = suite.get("sample_acceptance")
+    _apply_sample_acceptance(
+        result,
+        sample_acceptance if isinstance(sample_acceptance, Mapping) else None,
+    )
     result["configured_gates"] = configured_gates
     result["gate_metric_kinds"] = dict(suite.get("gate_metric_kinds", {}))
-    if suite.get("gate_sample_policy"):
-        result["gate_sample_policy"] = dict(suite["gate_sample_policy"])
+    if isinstance(sample_acceptance, Mapping):
+        result["configured_sample_acceptance"] = dict(sample_acceptance)
     result["gate_policy"] = str(
         suite.get("gate_policy")
-        or ("blocking" if configured_gates else "")
+        or ("blocking" if configured_gates or sample_acceptance else "")
     )
     (work_dir / "eval_result.json").write_text(
         json.dumps(result, indent=2, ensure_ascii=False),

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -11957,6 +11957,8 @@ def eval_one_model(
     configured_gates = dict(suite.get("gates", {}))
     result["configured_gates"] = configured_gates
     result["gate_metric_kinds"] = dict(suite.get("gate_metric_kinds", {}))
+    if suite.get("gate_sample_policy"):
+        result["gate_sample_policy"] = dict(suite["gate_sample_policy"])
     result["gate_policy"] = str(
         suite.get("gate_policy")
         or ("blocking" if configured_gates else "")

--- a/tools/validation/gate_census.py
+++ b/tools/validation/gate_census.py
@@ -30,6 +30,11 @@ def _variant(
             sample_count=sample_count,
             policy_mode=str(suite.get("gate_policy", "blocking") or "blocking"),
             metric_kinds={str(name): str(kind) for name, kind in metric_kinds.items()},
+            sample_policy=(
+                suite.get("gate_sample_policy")
+                if isinstance(suite.get("gate_sample_policy"), Mapping)
+                else None
+            ),
         ),
     }
 
@@ -47,7 +52,16 @@ def _review(
         review.append({"code": "sample_limit_unconfigured"})
     if not any(variant.get("policy", {}).get("policy_mode") == "blocking" for variant in variants):
         return review
-    review.append({"code": "minimum_sample_count_unapproved"})
+    blocking_policies = [
+        variant.get("policy", {})
+        for variant in variants
+        if variant.get("policy", {}).get("policy_mode") == "blocking"
+    ]
+    if any(
+        policy.get("sample_policy", {}).get("minimum_sample_count") is None
+        for policy in blocking_policies
+    ):
+        review.append({"code": "minimum_sample_count_unapproved"})
     scaling_gates = sorted(
         {
             str(gate.get("gate"))
@@ -56,11 +70,23 @@ def _review(
             if gate.get("effective", {}).get("kind") in {"proportion", "proportion_drop"}
         }
     )
-    if scaling_gates:
+    unapproved_scaling_gates = [
+        gate
+        for gate in scaling_gates
+        if any(
+            gate not in policy.get("sample_policy", {}).get("scaling", {})
+            for policy in blocking_policies
+            if any(
+                check.get("gate") == gate
+                for check in policy.get("gates", [])
+            )
+        )
+    ]
+    if unapproved_scaling_gates:
         review.append(
             {
                 "code": "sample_scaling_policy_unapproved",
-                "gates": scaling_gates,
+                "gates": unapproved_scaling_gates,
             }
         )
     return review
@@ -79,6 +105,7 @@ def _signature(suite: Mapping[str, Any]) -> str:
             "gates": suite.get("gates", {}),
             "gate_policy": suite.get("gate_policy", "blocking"),
             "gate_metric_kinds": suite.get("gate_metric_kinds", {}),
+            "gate_sample_policy": suite.get("gate_sample_policy", {}),
         },
         sort_keys=True,
         separators=(",", ":"),

--- a/tools/validation/gate_census.py
+++ b/tools/validation/gate_census.py
@@ -10,7 +10,10 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from tools.validation import catalog as validation_catalog
-from tools.validation.gate_policy import describe_shadow_gate_policy
+from tools.validation.gate_policy import (
+    describe_sample_acceptance,
+    describe_shadow_gate_policy,
+)
 
 
 def _variant(
@@ -21,22 +24,34 @@ def _variant(
 ) -> dict[str, Any]:
     gates = suite.get("gates", {})
     gates = gates if isinstance(gates, Mapping) else {}
+    acceptance = suite.get("sample_acceptance")
+    acceptance = acceptance if isinstance(acceptance, Mapping) else None
     metric_kinds = suite.get("gate_metric_kinds", {})
     metric_kinds = metric_kinds if isinstance(metric_kinds, Mapping) else {}
-    return {
-        "models": list(models),
-        "policy": describe_shadow_gate_policy(
-            configured_gates=gates,
-            sample_count=sample_count,
-            policy_mode=str(suite.get("gate_policy", "blocking") or "blocking"),
-            metric_kinds={str(name): str(kind) for name, kind in metric_kinds.items()},
-            sample_policy=(
-                suite.get("gate_sample_policy")
-                if isinstance(suite.get("gate_sample_policy"), Mapping)
-                else None
-            ),
+    policy = describe_shadow_gate_policy(
+        configured_gates=gates,
+        sample_count=sample_count,
+        # An empty aggregate-gate list is valid when sample acceptance is the
+        # blocking rule.
+        policy_mode=(
+            "observation_only"
+            if acceptance and not gates
+            else str(suite.get("gate_policy", "blocking") or "blocking")
         ),
+        metric_kinds={str(name): str(kind) for name, kind in metric_kinds.items()},
+    )
+    if acceptance:
+        policy["policy_mode"] = "blocking"
+    variant = {
+        "models": list(models),
+        "policy": policy,
     }
+    if acceptance:
+        variant["sample_acceptance"] = describe_sample_acceptance(
+            policy=acceptance,
+            sample_count=sample_count,
+        )
+    return variant
 
 
 def _review(
@@ -50,45 +65,13 @@ def _review(
         review.append({"code": "no_selected_models"})
     if sample_count is None:
         review.append({"code": "sample_limit_unconfigured"})
-    if not any(variant.get("policy", {}).get("policy_mode") == "blocking" for variant in variants):
-        return review
-    blocking_policies = [
-        variant.get("policy", {})
+    if not any(
+        variant.get("policy", {}).get("policy_mode") == "blocking"
         for variant in variants
-        if variant.get("policy", {}).get("policy_mode") == "blocking"
-    ]
-    if any(
-        policy.get("sample_policy", {}).get("minimum_sample_count") is None
-        for policy in blocking_policies
     ):
-        review.append({"code": "minimum_sample_count_unapproved"})
-    scaling_gates = sorted(
-        {
-            str(gate.get("gate"))
-            for variant in variants
-            for gate in variant.get("policy", {}).get("gates", [])
-            if gate.get("effective", {}).get("kind") in {"proportion", "proportion_drop"}
-        }
-    )
-    unapproved_scaling_gates = [
-        gate
-        for gate in scaling_gates
-        if any(
-            gate not in policy.get("sample_policy", {}).get("scaling", {})
-            for policy in blocking_policies
-            if any(
-                check.get("gate") == gate
-                for check in policy.get("gates", [])
-            )
-        )
-    ]
-    if unapproved_scaling_gates:
-        review.append(
-            {
-                "code": "sample_scaling_policy_unapproved",
-                "gates": unapproved_scaling_gates,
-            }
-        )
+        return review
+    if any(variant.get("sample_acceptance", {}).get("issues") for variant in variants):
+        review.append({"code": "invalid_sample_acceptance"})
     return review
 
 
@@ -105,7 +88,7 @@ def _signature(suite: Mapping[str, Any]) -> str:
             "gates": suite.get("gates", {}),
             "gate_policy": suite.get("gate_policy", "blocking"),
             "gate_metric_kinds": suite.get("gate_metric_kinds", {}),
-            "gate_sample_policy": suite.get("gate_sample_policy", {}),
+            "sample_acceptance": suite.get("sample_acceptance", {}),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -168,12 +151,18 @@ def build_gate_census(
             "bindings": binding_count,
             "variants": len(variants),
             "blocking_variants": sum(
-                variant["policy"]["policy_mode"] == "blocking" for variant in variants
+                variant["policy"]["policy_mode"] == "blocking"
+                for variant in variants
             ),
             "observation_only_variants": sum(
-                variant["policy"]["policy_mode"] == "observation_only" for variant in variants
+                variant["policy"]["policy_mode"] == "observation_only"
+                for variant in variants
             ),
-            "invalid_variants": sum(bool(variant["policy"]["issues"]) for variant in variants),
+            "invalid_variants": sum(
+                bool(variant["policy"]["issues"])
+                or bool(variant.get("sample_acceptance", {}).get("issues"))
+                for variant in variants
+            ),
             "review_required_suites": sum(bool(suite["review"]) for suite in suite_rows),
         },
         "suites": suite_rows,

--- a/tools/validation/gate_policy.py
+++ b/tools/validation/gate_policy.py
@@ -47,7 +47,6 @@ _DIRECT_GATE_SPECS = {
 }
 
 _METRIC_KINDS = {"continuous", "proportion", "proportion_drop"}
-_SAMPLE_SCALING_MODES = {"fixed_count", "rate"}
 
 
 def _gate_spec(gate: str) -> tuple[str, str] | None:
@@ -133,119 +132,27 @@ def _metric_kind(metric: str, configured: str) -> str:
     return "continuous"
 
 
-def _positive_sample_count(value: Any) -> int | None:
-    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-        return value
-    return None
-
-
-def _normalized_sample_policy(
-    *,
-    sample_policy: Mapping[str, Any] | None,
-    configured_gates: Mapping[str, Any],
-    metric_kinds: Mapping[str, str],
-) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
-    if sample_policy is None:
-        return None, []
-    if not isinstance(sample_policy, Mapping):
-        return None, [{"code": "invalid_sample_policy"}]
-
-    issues: list[dict[str, Any]] = []
-    supported_fields = {
-        "minimum_sample_count",
-        "calibration_sample_count",
-        "scaling",
-    }
-    unsupported_fields = sorted(str(key) for key in sample_policy if key not in supported_fields)
-    if unsupported_fields:
-        issues.append(
-            {
-                "code": "unsupported_sample_policy_fields",
-                "fields": unsupported_fields,
-            }
-        )
-
-    minimum = _positive_sample_count(sample_policy.get("minimum_sample_count"))
-    if minimum is None:
-        issues.append({"code": "invalid_minimum_sample_count"})
-    calibration = _positive_sample_count(sample_policy.get("calibration_sample_count"))
-    if calibration is None:
-        issues.append({"code": "invalid_calibration_sample_count"})
-
-    raw_scaling = sample_policy.get("scaling", {})
-    if not isinstance(raw_scaling, Mapping):
-        issues.append({"code": "invalid_sample_scaling_policy"})
-        raw_scaling = {}
-    scaling = {str(gate): str(mode) for gate, mode in raw_scaling.items()}
-
-    for gate in configured_gates:
-        gate_name = str(gate)
-        spec = _gate_spec(gate_name)
-        if spec is None:
-            continue
-        metric_name, operator = spec
-        metric_name, _ = _metric_names(gate_name, metric_name, {})
-        configured_kind = str(metric_kinds.get(gate_name, "") or "")
-        kind = "exact" if operator == "==" else _metric_kind(metric_name, configured_kind)
-        if kind not in {"proportion", "proportion_drop"}:
-            continue
-        mode = scaling.get(gate_name)
-        if mode is None:
-            issues.append({"code": "sample_scaling_policy_missing", "gate": gate_name})
-        elif mode not in _SAMPLE_SCALING_MODES:
-            issues.append(
-                {
-                    "code": "unsupported_sample_scaling_policy",
-                    "gate": gate_name,
-                    "value": mode,
-                }
-            )
-
-    return {
-        "minimum_sample_count": minimum,
-        "calibration_sample_count": calibration,
-        "scaling": scaling,
-    }, issues
-
-
 def _effective_gate(
     *,
     kind: str,
     actual: float,
     required: float,
     sample_count: int,
-    scaling: str | None = None,
-    calibration_sample_count: int | None = None,
 ) -> dict[str, Any]:
-    policy_fields: dict[str, Any] = {}
-    if scaling:
-        policy_fields["scaling"] = scaling
-    if scaling == "fixed_count" and calibration_sample_count is not None:
-        policy_fields["calibration_sample_count"] = calibration_sample_count
     if kind == "proportion_drop":
         allowed_drop_count = math.floor(required * sample_count + 1e-12)
-        if scaling == "fixed_count" and calibration_sample_count is not None:
-            allowed_drop_count = math.floor(
-                required * calibration_sample_count + 1e-12
-            )
         return {
             "kind": kind,
-            **policy_fields,
             "allowed_drop_count": allowed_drop_count,
             "observed_drop_count": round(actual * sample_count),
             "resolution": 1 / sample_count,
         }
     if kind == "proportion":
         allowed_failures = sample_count - math.ceil(required * sample_count - 1e-12)
-        if scaling == "fixed_count" and calibration_sample_count is not None:
-            allowed_failures = calibration_sample_count - math.ceil(
-                required * calibration_sample_count - 1e-12
-            )
         required_passes = max(0, sample_count - allowed_failures)
         observed_passes = min(sample_count, max(0, round(actual * sample_count)))
         return {
             "kind": kind,
-            **policy_fields,
             "required_passes": required_passes,
             "allowed_failures": allowed_failures,
             "observed_passes": observed_passes,
@@ -260,16 +167,12 @@ def _effective_target(
     kind: str,
     required: float,
     sample_count: int,
-    scaling: str | None = None,
-    calibration_sample_count: int | None = None,
 ) -> dict[str, Any]:
     effective = _effective_gate(
         kind=kind,
         actual=required,
         required=required,
         sample_count=sample_count,
-        scaling=scaling,
-        calibration_sample_count=calibration_sample_count,
     )
     effective.pop("observed_drop_count", None)
     effective.pop("observed_passes", None)
@@ -285,21 +188,106 @@ def _passed(actual: float, operator: str, required: float) -> bool:
     return actual == required
 
 
-def _effective_passed(
+def evaluate_sample_acceptance(
     *,
-    actual: float,
-    operator: str,
-    required: float,
-    effective: Mapping[str, Any],
-) -> bool:
-    if effective.get("scaling") == "fixed_count":
-        if effective.get("kind") == "proportion":
-            return int(effective["observed_failures"]) <= int(effective["allowed_failures"])
-        if effective.get("kind") == "proportion_drop":
-            return int(effective["observed_drop_count"]) <= int(
-                effective["allowed_drop_count"]
-            )
-    return _passed(actual, operator, required)
+    policy: Mapping[str, Any],
+    sample_count: int,
+    passed_count: int,
+    expected_count: int,
+) -> dict[str, Any]:
+    """Apply one batch-level pass-rate rule to sample-level outcomes."""
+
+    issues: list[dict[str, Any]] = []
+    supported = {"min_pass_rate", "min_allowed_failures"}
+    unknown = sorted(str(name) for name in policy if name not in supported)
+    if unknown:
+        issues.append({"code": "unsupported_sample_acceptance_fields", "fields": unknown})
+    try:
+        min_pass_rate = _finite_number(policy["min_pass_rate"])
+    except (KeyError, TypeError, ValueError):
+        min_pass_rate = 0.0
+        issues.append({"code": "invalid_min_pass_rate"})
+    if not 0.0 < min_pass_rate <= 1.0:
+        issues.append({"code": "min_pass_rate_out_of_range", "value": min_pass_rate})
+    value = policy.get("min_allowed_failures")
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        min_allowed_failures = 0
+        issues.append({"code": "invalid_min_allowed_failures", "value": value})
+    else:
+        min_allowed_failures = value
+    if sample_count != expected_count:
+        issues.append(
+            {"code": "incomplete_samples", "expected": expected_count, "actual": sample_count}
+        )
+    if sample_count <= 0 or passed_count < 0 or passed_count > sample_count:
+        issues.append(
+            {
+                "code": "invalid_sample_counts",
+                "sample_count": sample_count,
+                "passed_count": passed_count,
+            }
+        )
+    if sample_count > 0 and min_allowed_failures >= sample_count:
+        issues.append(
+            {
+                "code": "min_allowed_failures_out_of_range",
+                "value": min_allowed_failures,
+                "sample_count": sample_count,
+            }
+        )
+    rate_allowed_failures = max(
+        0,
+        sample_count - math.ceil(min_pass_rate * sample_count - 1e-12),
+    )
+    allowed_failures = max(rate_allowed_failures, min_allowed_failures)
+    failed_count = max(0, sample_count - passed_count)
+    return {
+        "sample_count": sample_count,
+        "passed_count": passed_count,
+        "failed_count": failed_count,
+        "min_pass_rate": min_pass_rate,
+        "min_allowed_failures": min_allowed_failures,
+        "allowed_failures": allowed_failures,
+        "verdict": (
+            "invalid"
+            if issues
+            else "pass"
+            if failed_count <= allowed_failures
+            else "fail"
+        ),
+        "issues": issues,
+    }
+
+
+def describe_sample_acceptance(
+    *,
+    policy: Mapping[str, Any],
+    sample_count: int | None,
+) -> dict[str, Any]:
+    if sample_count is None:
+        return {
+            "sample_count": None,
+            "min_pass_rate": policy.get("min_pass_rate"),
+            "min_allowed_failures": policy.get("min_allowed_failures"),
+            "allowed_failures": None,
+            "issues": [{"code": "sample_count_unavailable"}],
+        }
+    evaluation = evaluate_sample_acceptance(
+        policy=policy,
+        sample_count=sample_count,
+        passed_count=sample_count,
+        expected_count=sample_count,
+    )
+    return {
+        name: evaluation[name]
+        for name in (
+            "sample_count",
+            "min_pass_rate",
+            "min_allowed_failures",
+            "allowed_failures",
+            "issues",
+        )
+    }
 
 
 def describe_shadow_gate_policy(
@@ -308,7 +296,6 @@ def describe_shadow_gate_policy(
     sample_count: int | None,
     policy_mode: str = "blocking",
     metric_kinds: Mapping[str, str] | None = None,
-    sample_policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Describe configured gate targets without requiring runtime metrics."""
 
@@ -326,12 +313,6 @@ def describe_shadow_gate_policy(
     if configured_gates and not sample_count_available:
         issues.append({"code": "sample_count_unavailable"})
     resolved_metric_kinds = metric_kinds or {}
-    normalized_sample_policy, sample_policy_issues = _normalized_sample_policy(
-        sample_policy=sample_policy,
-        configured_gates=configured_gates,
-        metric_kinds=resolved_metric_kinds,
-    )
-    issues.extend(sample_policy_issues)
     for gate_name in resolved_metric_kinds:
         if gate_name not in configured_gates:
             issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
@@ -370,21 +351,10 @@ def describe_shadow_gate_policy(
         elif kind == "exact":
             effective = {"kind": kind, "sample_count": sample_count}
         else:
-            scaling = (
-                normalized_sample_policy["scaling"].get(gate_name)
-                if normalized_sample_policy
-                else None
-            )
             effective = _effective_target(
                 kind=kind,
                 required=required,
                 sample_count=sample_count,
-                scaling=scaling,
-                calibration_sample_count=(
-                    normalized_sample_policy["calibration_sample_count"]
-                    if normalized_sample_policy
-                    else None
-                ),
             )
         gates.append(
             {
@@ -395,16 +365,13 @@ def describe_shadow_gate_policy(
                 "effective": effective,
             }
         )
-    result = {
+    return {
         "schema_version": "trtmc.validation-gate-policy-description/v1",
         "policy_mode": policy_mode,
         "sample_count": sample_count,
         "gates": gates,
         "issues": issues,
     }
-    if normalized_sample_policy is not None:
-        result["sample_policy"] = normalized_sample_policy
-    return result
 
 
 def evaluate_shadow_gates(
@@ -414,7 +381,6 @@ def evaluate_shadow_gates(
     sample_count: int | None,
     policy_mode: str = "blocking",
     metric_kinds: Mapping[str, str] | None = None,
-    sample_policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Explain the effective sample-level meaning of existing gate values."""
     checks: list[dict[str, Any]] = []
@@ -432,27 +398,6 @@ def evaluate_shadow_gates(
         issues.append({"code": "sample_count_unavailable"})
     gates_to_evaluate = configured_gates if sample_count_available else {}
     resolved_metric_kinds = metric_kinds or {}
-    normalized_sample_policy, sample_policy_issues = _normalized_sample_policy(
-        sample_policy=sample_policy,
-        configured_gates=configured_gates,
-        metric_kinds=resolved_metric_kinds,
-    )
-    issues.extend(sample_policy_issues)
-    sample_count_insufficient = False
-    if (
-        normalized_sample_policy is not None
-        and sample_count_available
-        and normalized_sample_policy["minimum_sample_count"] is not None
-        and sample_count < normalized_sample_policy["minimum_sample_count"]
-    ):
-        sample_count_insufficient = True
-        issues.append(
-            {
-                "code": "minimum_sample_count_not_met",
-                "actual": sample_count,
-                "required": normalized_sample_policy["minimum_sample_count"],
-            }
-        )
     for gate_name in resolved_metric_kinds:
         if gate_name not in configured_gates:
             issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
@@ -520,22 +465,11 @@ def evaluate_shadow_gates(
                 }
             )
             continue
-        scaling = (
-            normalized_sample_policy["scaling"].get(gate_name)
-            if normalized_sample_policy
-            else None
-        )
         effective = _effective_gate(
             kind=_metric_kind(metric_name, configured_kind),
             actual=actual,
             required=required,
             sample_count=sample_count,
-            scaling=scaling,
-            calibration_sample_count=(
-                normalized_sample_policy["calibration_sample_count"]
-                if normalized_sample_policy
-                else None
-            ),
         )
         checks.append(
             {
@@ -544,29 +478,15 @@ def evaluate_shadow_gates(
                 "operator": operator,
                 "actual": actual,
                 "required": required,
-                "verdict": (
-                    "pass"
-                    if _effective_passed(
-                        actual=actual,
-                        operator=operator,
-                        required=required,
-                        effective=effective,
-                    )
-                    else "fail"
-                ),
+                "verdict": "pass" if _passed(actual, operator, required) else "fail",
                 "effective": effective,
             }
         )
-    configuration_issues = [
-        issue for issue in issues if issue.get("code") != "minimum_sample_count_not_met"
-    ]
-    result = {
+    return {
         "schema_version": "trtmc.validation-gate-evaluation/v1",
         "status": (
             "invalid"
-            if configuration_issues
-            else "insufficient_evidence"
-            if sample_count_insufficient
+            if issues
             else "observation_only"
             if policy_mode == "observation_only"
             else "fail"
@@ -577,6 +497,3 @@ def evaluate_shadow_gates(
         "checks": checks,
         "issues": issues,
     }
-    if normalized_sample_policy is not None:
-        result["sample_policy"] = normalized_sample_policy
-    return result

--- a/tools/validation/gate_policy.py
+++ b/tools/validation/gate_policy.py
@@ -47,6 +47,7 @@ _DIRECT_GATE_SPECS = {
 }
 
 _METRIC_KINDS = {"continuous", "proportion", "proportion_drop"}
+_SAMPLE_SCALING_MODES = {"fixed_count", "rate"}
 
 
 def _gate_spec(gate: str) -> tuple[str, str] | None:
@@ -132,27 +133,121 @@ def _metric_kind(metric: str, configured: str) -> str:
     return "continuous"
 
 
+def _positive_sample_count(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def _normalized_sample_policy(
+    *,
+    sample_policy: Mapping[str, Any] | None,
+    configured_gates: Mapping[str, Any],
+    metric_kinds: Mapping[str, str],
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    if sample_policy is None:
+        return None, []
+    if not isinstance(sample_policy, Mapping):
+        return None, [{"code": "invalid_sample_policy"}]
+
+    issues: list[dict[str, Any]] = []
+    supported_fields = {
+        "minimum_sample_count",
+        "calibration_sample_count",
+        "scaling",
+    }
+    unsupported_fields = sorted(str(key) for key in sample_policy if key not in supported_fields)
+    if unsupported_fields:
+        issues.append(
+            {
+                "code": "unsupported_sample_policy_fields",
+                "fields": unsupported_fields,
+            }
+        )
+
+    minimum = _positive_sample_count(sample_policy.get("minimum_sample_count"))
+    if minimum is None:
+        issues.append({"code": "invalid_minimum_sample_count"})
+    calibration = _positive_sample_count(sample_policy.get("calibration_sample_count"))
+    if calibration is None:
+        issues.append({"code": "invalid_calibration_sample_count"})
+
+    raw_scaling = sample_policy.get("scaling", {})
+    if not isinstance(raw_scaling, Mapping):
+        issues.append({"code": "invalid_sample_scaling_policy"})
+        raw_scaling = {}
+    scaling = {str(gate): str(mode) for gate, mode in raw_scaling.items()}
+
+    for gate in configured_gates:
+        gate_name = str(gate)
+        spec = _gate_spec(gate_name)
+        if spec is None:
+            continue
+        metric_name, operator = spec
+        metric_name, _ = _metric_names(gate_name, metric_name, {})
+        configured_kind = str(metric_kinds.get(gate_name, "") or "")
+        kind = "exact" if operator == "==" else _metric_kind(metric_name, configured_kind)
+        if kind not in {"proportion", "proportion_drop"}:
+            continue
+        mode = scaling.get(gate_name)
+        if mode is None:
+            issues.append({"code": "sample_scaling_policy_missing", "gate": gate_name})
+        elif mode not in _SAMPLE_SCALING_MODES:
+            issues.append(
+                {
+                    "code": "unsupported_sample_scaling_policy",
+                    "gate": gate_name,
+                    "value": mode,
+                }
+            )
+
+    return {
+        "minimum_sample_count": minimum,
+        "calibration_sample_count": calibration,
+        "scaling": scaling,
+    }, issues
+
+
 def _effective_gate(
     *,
     kind: str,
     actual: float,
     required: float,
     sample_count: int,
+    scaling: str | None = None,
+    calibration_sample_count: int | None = None,
 ) -> dict[str, Any]:
+    policy_fields: dict[str, Any] = {}
+    if scaling:
+        policy_fields["scaling"] = scaling
+    if scaling == "fixed_count" and calibration_sample_count is not None:
+        policy_fields["calibration_sample_count"] = calibration_sample_count
     if kind == "proportion_drop":
+        allowed_drop_count = math.floor(required * sample_count + 1e-12)
+        if scaling == "fixed_count" and calibration_sample_count is not None:
+            allowed_drop_count = math.floor(
+                required * calibration_sample_count + 1e-12
+            )
         return {
             "kind": kind,
-            "allowed_drop_count": math.floor(required * sample_count + 1e-12),
+            **policy_fields,
+            "allowed_drop_count": allowed_drop_count,
             "observed_drop_count": round(actual * sample_count),
             "resolution": 1 / sample_count,
         }
     if kind == "proportion":
-        required_passes = math.ceil(required * sample_count - 1e-12)
+        allowed_failures = sample_count - math.ceil(required * sample_count - 1e-12)
+        if scaling == "fixed_count" and calibration_sample_count is not None:
+            allowed_failures = calibration_sample_count - math.ceil(
+                required * calibration_sample_count - 1e-12
+            )
+        required_passes = max(0, sample_count - allowed_failures)
         observed_passes = min(sample_count, max(0, round(actual * sample_count)))
         return {
             "kind": kind,
+            **policy_fields,
             "required_passes": required_passes,
-            "allowed_failures": sample_count - required_passes,
+            "allowed_failures": allowed_failures,
             "observed_passes": observed_passes,
             "observed_failures": sample_count - observed_passes,
             "resolution": 1 / sample_count,
@@ -165,12 +260,16 @@ def _effective_target(
     kind: str,
     required: float,
     sample_count: int,
+    scaling: str | None = None,
+    calibration_sample_count: int | None = None,
 ) -> dict[str, Any]:
     effective = _effective_gate(
         kind=kind,
         actual=required,
         required=required,
         sample_count=sample_count,
+        scaling=scaling,
+        calibration_sample_count=calibration_sample_count,
     )
     effective.pop("observed_drop_count", None)
     effective.pop("observed_passes", None)
@@ -186,12 +285,30 @@ def _passed(actual: float, operator: str, required: float) -> bool:
     return actual == required
 
 
+def _effective_passed(
+    *,
+    actual: float,
+    operator: str,
+    required: float,
+    effective: Mapping[str, Any],
+) -> bool:
+    if effective.get("scaling") == "fixed_count":
+        if effective.get("kind") == "proportion":
+            return int(effective["observed_failures"]) <= int(effective["allowed_failures"])
+        if effective.get("kind") == "proportion_drop":
+            return int(effective["observed_drop_count"]) <= int(
+                effective["allowed_drop_count"]
+            )
+    return _passed(actual, operator, required)
+
+
 def describe_shadow_gate_policy(
     *,
     configured_gates: Mapping[str, Any],
     sample_count: int | None,
     policy_mode: str = "blocking",
     metric_kinds: Mapping[str, str] | None = None,
+    sample_policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Describe configured gate targets without requiring runtime metrics."""
 
@@ -209,6 +326,12 @@ def describe_shadow_gate_policy(
     if configured_gates and not sample_count_available:
         issues.append({"code": "sample_count_unavailable"})
     resolved_metric_kinds = metric_kinds or {}
+    normalized_sample_policy, sample_policy_issues = _normalized_sample_policy(
+        sample_policy=sample_policy,
+        configured_gates=configured_gates,
+        metric_kinds=resolved_metric_kinds,
+    )
+    issues.extend(sample_policy_issues)
     for gate_name in resolved_metric_kinds:
         if gate_name not in configured_gates:
             issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
@@ -247,10 +370,21 @@ def describe_shadow_gate_policy(
         elif kind == "exact":
             effective = {"kind": kind, "sample_count": sample_count}
         else:
+            scaling = (
+                normalized_sample_policy["scaling"].get(gate_name)
+                if normalized_sample_policy
+                else None
+            )
             effective = _effective_target(
                 kind=kind,
                 required=required,
                 sample_count=sample_count,
+                scaling=scaling,
+                calibration_sample_count=(
+                    normalized_sample_policy["calibration_sample_count"]
+                    if normalized_sample_policy
+                    else None
+                ),
             )
         gates.append(
             {
@@ -261,13 +395,16 @@ def describe_shadow_gate_policy(
                 "effective": effective,
             }
         )
-    return {
+    result = {
         "schema_version": "trtmc.validation-gate-policy-description/v1",
         "policy_mode": policy_mode,
         "sample_count": sample_count,
         "gates": gates,
         "issues": issues,
     }
+    if normalized_sample_policy is not None:
+        result["sample_policy"] = normalized_sample_policy
+    return result
 
 
 def evaluate_shadow_gates(
@@ -277,6 +414,7 @@ def evaluate_shadow_gates(
     sample_count: int | None,
     policy_mode: str = "blocking",
     metric_kinds: Mapping[str, str] | None = None,
+    sample_policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Explain the effective sample-level meaning of existing gate values."""
     checks: list[dict[str, Any]] = []
@@ -294,6 +432,27 @@ def evaluate_shadow_gates(
         issues.append({"code": "sample_count_unavailable"})
     gates_to_evaluate = configured_gates if sample_count_available else {}
     resolved_metric_kinds = metric_kinds or {}
+    normalized_sample_policy, sample_policy_issues = _normalized_sample_policy(
+        sample_policy=sample_policy,
+        configured_gates=configured_gates,
+        metric_kinds=resolved_metric_kinds,
+    )
+    issues.extend(sample_policy_issues)
+    sample_count_insufficient = False
+    if (
+        normalized_sample_policy is not None
+        and sample_count_available
+        and normalized_sample_policy["minimum_sample_count"] is not None
+        and sample_count < normalized_sample_policy["minimum_sample_count"]
+    ):
+        sample_count_insufficient = True
+        issues.append(
+            {
+                "code": "minimum_sample_count_not_met",
+                "actual": sample_count,
+                "required": normalized_sample_policy["minimum_sample_count"],
+            }
+        )
     for gate_name in resolved_metric_kinds:
         if gate_name not in configured_gates:
             issues.append({"code": "metric_kind_without_gate", "gate": str(gate_name)})
@@ -361,6 +520,23 @@ def evaluate_shadow_gates(
                 }
             )
             continue
+        scaling = (
+            normalized_sample_policy["scaling"].get(gate_name)
+            if normalized_sample_policy
+            else None
+        )
+        effective = _effective_gate(
+            kind=_metric_kind(metric_name, configured_kind),
+            actual=actual,
+            required=required,
+            sample_count=sample_count,
+            scaling=scaling,
+            calibration_sample_count=(
+                normalized_sample_policy["calibration_sample_count"]
+                if normalized_sample_policy
+                else None
+            ),
+        )
         checks.append(
             {
                 "gate": gate_name,
@@ -368,20 +544,29 @@ def evaluate_shadow_gates(
                 "operator": operator,
                 "actual": actual,
                 "required": required,
-                "verdict": "pass" if _passed(actual, operator, required) else "fail",
-                "effective": _effective_gate(
-                    kind=_metric_kind(metric_name, configured_kind),
-                    actual=actual,
-                    required=required,
-                    sample_count=sample_count,
+                "verdict": (
+                    "pass"
+                    if _effective_passed(
+                        actual=actual,
+                        operator=operator,
+                        required=required,
+                        effective=effective,
+                    )
+                    else "fail"
                 ),
+                "effective": effective,
             }
         )
-    return {
+    configuration_issues = [
+        issue for issue in issues if issue.get("code") != "minimum_sample_count_not_met"
+    ]
+    result = {
         "schema_version": "trtmc.validation-gate-evaluation/v1",
         "status": (
             "invalid"
-            if issues
+            if configuration_issues
+            else "insufficient_evidence"
+            if sample_count_insufficient
             else "observation_only"
             if policy_mode == "observation_only"
             else "fail"
@@ -392,3 +577,6 @@ def evaluate_shadow_gates(
         "checks": checks,
         "issues": issues,
     }
+    if normalized_sample_policy is not None:
+        result["sample_policy"] = normalized_sample_policy
+    return result


### PR DESCRIPTION
## Background

Accuracy workloads currently mix a per-sample quality threshold with a percentage applied to the whole selected slice. At small sample counts, rates such as `0.98` collapse to an implicit zero-failure rule, and changing the slice size changes the tolerated failure count without making that decision explicit.

## Exit Criteria

- Keep each scorer responsible for deciding whether one sample passes (for example, by IoU or output agreement).
- Apply one batch-level rule from the actual sample count: `max(floor((1 - min_pass_rate) * sample_count), min_allowed_failures)`.
- Treat incomplete or invalid sample evidence as white rather than a model regression.
- Publish the resolved counts and verdict in `report.json`; keep HTML as a renderer.
- Do not change qualification snapshots or enable an Accuracy/Perf CI lane.

## Implementation

- Add `sample_acceptance` with only `min_pass_rate` and `min_allowed_failures`, replacing calibration counts and per-gate scaling metadata.
- Centralize policy validation and the batch decision in the existing gate-policy module. Workload scorers only publish `sample_count`, `passed_count`, and `failed_count`.
- Keep aggregate task-quality gates, such as accuracy or mean-IoU drop, independent from sample acceptance.
- Record incomplete evidence as `SampleEvidenceError`; the report exposes it as a white `data-artifact` failure.
- Store the resolved policy, allowed failures, observed counts, and verdict in `report.json`. The report JavaScript only renders those fields.
- Update the census and the first governed Accuracy cohort: MMLU, continuation, HumanEval, WikiText, VLM, OCR, and SeedTTS. CI eligibility remains unchanged.

## Validation

- `PYTHONPATH=python:. ../../.venv-trtmc/bin/python tools/model_ci.py validate`: passed for exact head `0cffcfe2788a63238663deac5bd5984114fb520d`.
- `PYTHONPATH=python:. ../../.venv-trtmc/bin/python tools/test_impact.py --validate`: passed with existing repository warnings.
- Focused gate, model-contract, report, and SegFormer tests: 481 passed.
- Premerge Python test scope: 3393 passed and 1 skipped; two environment-dependent cases were not runnable in the local TensorRT/filesystem setup and remain covered by exact CI.
- `../../.venv-trtmc/bin/ruff check ...`: passed for the changed Python files.
- `node --check tools/qualification_report_assets/qualification-report.js`: passed.
- `git diff --check github/main...HEAD`: passed.
- Exact head `0cffcfe2788a63238663deac5bd5984114fb520d` passed one GPT-2 Accuracy and Perf case on both GB300 and ThorX-2. Both Accuracy reports were green with 10/10 samples passing, zero failed samples, and one allowed failure; both Perf reports were green with exact-token output validation passing.

## Notes For Future Readers

- Suggested review order: `tools/validation/gate_policy.py`, scorer count production in `tools/validation/engine.py`, workload configuration, then report/census projection.
- `report.json` is the source of truth. Do not duplicate the acceptance formula in the HTML renderer or CI consumer.
- This PR provides the policy and reporting capability only; it does not enable a new CI lane.
