### PR TITLE
fix(segformer): stabilize validation oracle

### DIFF
--- a/python/tensorrt_model_connect/families/segformer/graph_ops.py
+++ b/python/tensorrt_model_connect/families/segformer/graph_ops.py
@@ -38,6 +38,14 @@ def _cast_back_to_trt_dtype(
     return network.add_cast(tensor, target_dtype).get_output(0)
 
 
+def begin_fp32_decode_head(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+) -> trt.ITensor:
+    """Enter the stable FP32 boundary used by the SegFormer decode head."""
+    return _cast_back_to_trt_dtype(network, tensor, trt.float32)
+
+
 def add_constant(
     network: trt.INetworkDefinition,
     shape: tuple[int, ...],

--- a/python/tensorrt_model_connect/families/segformer/plugin.py
+++ b/python/tensorrt_model_connect/families/segformer/plugin.py
@@ -537,6 +537,12 @@ class SegformerPlugin:
 
         projected = []
         for i, (feat, feat_H, feat_W, feat_hidden) in enumerate(stage_outputs):
+            # Keep the encoder in the requested precision, but perform the
+            # lightweight decode head in FP32.  Small FP16 tactic differences
+            # near class boundaries otherwise flip argmax labels between
+            # otherwise equivalent engine builds.
+            feat = graph_ops.begin_fp32_decode_head(network, feat)
+
             # Reshape to 2D: [1, C, H, W] -> [H*W, C]
             to_2d = network.add_shuffle(feat)
             to_2d.first_transpose = trt.Permutation([0, 2, 3, 1])
@@ -546,11 +552,11 @@ class SegformerPlugin:
             proj = graph_ops.add_matmul_rhs_constant(
                 network, to_2d.get_output(0), feat_hidden, decoder_hidden_size,
                 weights[f"decode_head.linear_c{i}.weight"],
-                dtype=work_np_dtype)
+                dtype=np.float32)
             proj = graph_ops.add_bias_sum(
                 network, proj, decoder_hidden_size,
                 weights[f"decode_head.linear_c{i}.bias"],
-                dtype=work_np_dtype)
+                dtype=np.float32)
 
             # Reshape to 4D: [H*W, D] -> [1, D, H, W]
             to_4d2 = network.add_shuffle(proj)
@@ -583,9 +589,9 @@ class SegformerPlugin:
             num_output_maps=decoder_hidden_size,
             kernel_shape=(1, 1),
             kernel=trt.Weights(np.ascontiguousarray(
-                fuse_w, dtype=work_np_dtype)),
+                fuse_w, dtype=np.float32)),
             bias=trt.Weights(np.ascontiguousarray(
-                fuse_b, dtype=work_np_dtype)))
+                fuse_b, dtype=np.float32)))
 
         # BatchNorm (fused: gamma * (x - mean) / sqrt(var + eps) + beta)
         bn_w = weights["decode_head.bn.weight"]
@@ -597,10 +603,10 @@ class SegformerPlugin:
 
         bn_scale_t = graph_ops.add_constant(
             network, (1, decoder_hidden_size, 1, 1),
-            bn_scale.reshape(1, -1, 1, 1), dtype=work_np_dtype)
+            bn_scale.reshape(1, -1, 1, 1), dtype=np.float32)
         bn_shift_t = graph_ops.add_constant(
             network, (1, decoder_hidden_size, 1, 1),
-            bn_shift.reshape(1, -1, 1, 1), dtype=work_np_dtype)
+            bn_shift.reshape(1, -1, 1, 1), dtype=np.float32)
 
         bn_scaled = network.add_elementwise(
             fuse_conv.get_output(0), bn_scale_t,
@@ -620,9 +626,9 @@ class SegformerPlugin:
             num_output_maps=num_classes,
             kernel_shape=(1, 1),
             kernel=trt.Weights(np.ascontiguousarray(
-                cls_w, dtype=work_np_dtype)),
+                cls_w, dtype=np.float32)),
             bias=trt.Weights(np.ascontiguousarray(
-                cls_b, dtype=work_np_dtype)))
+                cls_b, dtype=np.float32)))
 
         # Output: [1, num_classes, H/4, W/4]
         logits = cls_conv.get_output(0)

--- a/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
@@ -653,7 +653,7 @@ class HfTransformersReference:
             device = torch.device("cuda")
 
             processor = AutoImageProcessor.from_pretrained(
-                hf_id, trust_remote_code=trust_remote_code)
+                hf_id, trust_remote_code=trust_remote_code, use_fast=False)
             model = AutoModelForSemanticSegmentation.from_pretrained(
                 hf_id, trust_remote_code=trust_remote_code,
                 torch_dtype=reference_dtype)

--- a/tests/e2e/models/segformer/test_segformer_hf_reference.py
+++ b/tests/e2e/models/segformer/test_segformer_hf_reference.py
@@ -56,7 +56,55 @@ def test_segmentation_reference_aligns_floating_inputs_with_model_dtype(
     assert isinstance(command, list)
     script = command[command.index("-c") + 1]
     assert "reference_dtype = torch.float16" in script
+    assert "use_fast=False" in script
     assert 'device = torch.device("cuda")' in script
     assert "model.eval().to(device)" in script
     assert "value.to(device=device, dtype=reference_dtype)" in script
     assert "if value.is_floating_point()" in script
+
+
+def test_segmentation_reference_uses_stable_oracle_for_multiple_images(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_reference_subprocess(**kwargs):
+        commands.append(kwargs["command"])
+        return StageOutput(stage_name="full_inference")
+
+    monkeypatch.setattr(
+        hf_transformers,
+        "run_reference_subprocess",
+        fake_run_reference_subprocess,
+    )
+
+    for index in range(2):
+        image = tmp_path / f"input-{index}.png"
+        image.write_bytes(b"image")
+        case = E2ECase(
+            name=f"segformer-multi-image-{index}",
+            hf_id="nvidia/segformer-b0-finetuned-ade-512-512",
+            family="segformer",
+            runtime_strategy="segformer_segmentation",
+            task_strategy="segmentation",
+            bundle="segformer-unit.bundle",
+            inputs={"image": str(image)},
+            metadata={"reference_precision": "fp32"},
+        )
+        hf_transformers.HfTransformersReference()._run_segmentation_ref(
+            case,
+            StageSpec(name="full_inference"),
+            RunContext(
+                case=case,
+                artifacts_dir=str(tmp_path / "artifacts"),
+                reference_python="/opt/venv/bin/python",
+            ),
+        )
+
+    assert len(commands) == 2
+    for index, command in enumerate(commands):
+        script = command[command.index("-c") + 1]
+        assert f"input-{index}.png" in script
+        assert "reference_dtype = torch.float32" in script
+        assert "use_fast=False" in script

--- a/tests/e2e/models/segformer/test_segformer_numerical_contract.py
+++ b/tests/e2e/models/segformer/test_segformer_numerical_contract.py
@@ -52,3 +52,26 @@ def test_gelu_dispatch_keeps_exact_and_tanh_variants_distinct(monkeypatch) -> No
     assert graph_ops.add_activation(None, None, "gelu") is exact
     assert graph_ops.add_activation(None, None, "gelu_new") is approximate
     assert calls == [("erf", np.float32), ("tanh", np.float32)]
+
+
+def test_decode_head_boundary_casts_fp16_features_to_fp32() -> None:
+    fp16_feature = SimpleNamespace(dtype=graph_ops.trt.float16)
+    fp32_feature = SimpleNamespace(dtype=graph_ops.trt.float32)
+    calls = []
+
+    class CastLayer:
+        def get_output(self, index):
+            assert index == 0
+            return fp32_feature
+
+    class Network:
+        def add_cast(self, tensor, dtype):
+            calls.append((tensor, dtype))
+            return CastLayer()
+
+    network = Network()
+
+    assert graph_ops.begin_fp32_decode_head(network, fp16_feature) is fp32_feature
+    assert calls == [(fp16_feature, graph_ops.trt.float32)]
+    assert graph_ops.begin_fp32_decode_head(network, fp32_feature) is fp32_feature
+    assert len(calls) == 1

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -5729,7 +5729,7 @@ def test_fnet_keeps_fp16_candidate_with_declared_fp32_reference(
     assert command[command.index("--precision") + 1] == "fp16"
 
 
-def test_segformer_validation_compares_candidate_and_reference_in_fp16() -> None:
+def test_segformer_validation_keeps_stable_fp32_reference_oracle() -> None:
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(),
         "ade20k_semantic_segmentation",
@@ -5746,7 +5746,7 @@ def test_segformer_validation_compares_candidate_and_reference_in_fp16() -> None
     )
 
     assert model["precision"] == "fp16"
-    assert validation_config["reference_precision"] == "fp16"
+    assert validation_config["reference_precision"] == "fp32"
 
 
 @pytest.mark.parametrize(

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1223,10 +1223,9 @@ suites:
     model_overrides:
       by_model:
         segformer-b0-ade:
-          # The E2E acceptance manifest intentionally keeps a stable FP32
-          # oracle. Validation instead compares the FP16 bundle with an FP16
-          # HF reference so backend consistency is measured at equal precision.
-          reference_precision: fp16
+          # Keep the reference in FP32: on Thor, the HF FP16 path can diverge
+          # materially from both HF FP32 and the FP16 TensorRT engine.
+          reference_precision: fp32
     gates:
       min_backend_pixel_agreement: 0.98
       min_backend_mean_iou: 0.95


### PR DESCRIPTION
## Background

SegFormer ADE20K validation used a fast, half-precision Hugging Face reference path that could disagree with both the canonical FP32 reference and TRTMC. After correcting the reference, repeated TensorRT builds also exposed small tactic-dependent class-boundary flips near the unchanged backend mIoU gate.

Closes #889

## Exit Criteria

- Run the registered 50-image ADE20K Accuracy workload on Thor X and GB300 without lowering the existing parity gates.
- Keep Accuracy and Perf precision contracts aligned: FP32 Hugging Face reference and FP16 TRTMC candidate.
- Keep SegFormer Perf green on both platforms.

## Implementation

- Pin the Hugging Face image processor to its slow path and run the reference in FP32.
- Keep the TensorRT encoder in FP16 while computing the lightweight decode head in FP32, stabilizing class-boundary argmax results across tactic choices.
- Add multi-image reference, precision-contract, and FP32 decode-boundary regressions.

## Validation

- Local focused tests: `278 passed`.
- Thor X, TensorRT 11.0:
  - Accuracy: passed 50/50; backend mIoU `0.951461`, pixel agreement `0.998251`.
  - Perf: green; FP32 reference p50 `9.723 ms`, TRTMC p50 `2.592 ms` (`3.75x`).
- GB300, TensorRT 11.2:
  - Accuracy: passed 50/50; backend mIoU `0.951024`, pixel agreement `0.998286`.
  - Perf: green; FP32 reference p50 `7.582 ms`, TRTMC p50 `0.663 ms` (`11.44x`).

All four hardware runs used commit `42fee01cae1445b31e13bd69cc3ebb80985b5e53`.
