### PR TITLE
feat(perf): add timing stability shadow

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -314,6 +314,14 @@ latencies are separate fields. Metrics, Logs, and Commands remain separate
 report entries. The run environment snapshot is published at
 `artifacts/run/environment.json`.
 
+For valid comparisons, `report.json` also publishes a non-blocking
+`measurement_stability` shadow analysis. It checks the existing ten raw samples
+on each side: the first-five and last-five medians must differ by at most 5%,
+and at least eight samples must lie within 5% of that side's median. The report
+shows `Stable`, `Retry recommended`, or `Not evaluated` in Metrics. This shadow
+evidence does not trigger a retry, change the traffic light, or affect the run
+exit code.
+
 The preparation receipt uses schema `trtmc.perf-bundle-preparation/v1`, scope
 `test_task`, and the performance run's exact `git_commit`. Each entry under
 `bundles` records `model`, the final `bundle` path used by the campaign,

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -634,6 +634,54 @@ def test_compile_contract_cannot_silently_fall_back_to_eager() -> None:
     assert "mode" in comparison["reason"]
 
 
+def test_timing_stability_shadow_accepts_a_settled_measurement() -> None:
+    stability = perf_matrix._timing_stability_shadow(
+        [100.0, 101.0, 99.0, 100.0, 100.0, 101.0, 100.0, 99.0, 100.0, 100.0]
+    )
+
+    assert stability["status"] == "stable"
+    assert stability["sample_count"] == 10
+    assert stability["samples_within_band"] == 10
+
+
+def test_timing_stability_shadow_flags_a_measurement_that_is_still_falling() -> None:
+    stability = perf_matrix._timing_stability_shadow(
+        [3.7, 3.4, 3.0, 2.7, 2.3, 1.9, 1.6, 1.4, 1.2, 1.0]
+    )
+
+    assert stability["status"] == "unstable"
+    assert stability["half_median_change_percent"] > 5.0
+
+
+def test_timing_stability_shadow_rejects_scattered_samples_even_without_drift() -> None:
+    stability = perf_matrix._timing_stability_shadow(
+        [100.0, 80.0, 120.0, 100.0, 100.0, 100.0, 80.0, 120.0, 100.0, 100.0]
+    )
+
+    assert stability["half_median_change_percent"] == 0.0
+    assert stability["samples_within_band"] == 6
+    assert stability["status"] == "unstable"
+
+
+def test_timing_stability_shadow_accepts_exactly_eight_samples_in_band() -> None:
+    stability = perf_matrix._timing_stability_shadow(
+        [100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 120.0, 120.0]
+    )
+
+    assert stability["samples_within_band"] == 8
+    assert stability["status"] == "stable"
+
+
+def test_timing_stability_shadow_does_not_judge_a_nonstandard_sample_count() -> None:
+    stability = perf_matrix._timing_stability_shadow([10.0, 11.0])
+
+    assert stability == {
+        "status": "not_evaluated",
+        "sample_count": 2,
+        "reason": "requires_10_samples",
+    }
+
+
 def test_suite_timing_contract_drift_is_rejected_before_execution() -> None:
     case = next(
         value
@@ -1689,6 +1737,77 @@ def test_public_perf_result_surfaces_quantized_candidate_precision() -> None:
     }
 
 
+def test_public_perf_result_publishes_timing_stability_as_shadow_evidence() -> None:
+    row = {
+        "id": "model.generate",
+        "status": "yellow",
+        "resolved_settings": {
+            "baseline_precision": "fp16",
+            "model": {"precision": "fp16"},
+            "output_contract": "exact-token-ids",
+        },
+        "candidate": {
+            "precision": "fp16",
+            "samples_ms": [
+                3.7,
+                3.4,
+                3.0,
+                2.7,
+                2.3,
+                1.9,
+                1.6,
+                1.4,
+                1.2,
+                1.0,
+            ],
+        },
+        "baseline": {
+            "precision": "fp16",
+            "samples_ms": [
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+                2.0,
+            ],
+        },
+        "comparison": {},
+    }
+
+    public = perf_matrix._public_perf_result(row)
+
+    assert public["result"] == "yellow"
+    assert public["measurement_stability"]["mode"] == "shadow"
+    assert public["measurement_stability"]["status"] == "retry_recommended"
+    assert public["measurement_stability"]["reference"]["status"] == "stable"
+    assert public["measurement_stability"]["trtmc"]["status"] == "unstable"
+
+
+def test_public_perf_result_does_not_evaluate_stability_without_valid_comparison() -> None:
+    row = {
+        "id": "model.generate",
+        "status": "contract-mismatch",
+        "resolved_settings": {
+            "baseline_precision": "fp16",
+            "model": {"precision": "fp16"},
+            "output_contract": "exact-token-ids",
+        },
+        "candidate": {"precision": "fp16", "samples_ms": [10.0] * 10},
+        "baseline": {"precision": "fp16", "samples_ms": [10.0] * 10},
+        "comparison": {"reason": "outputs differ"},
+    }
+
+    public = perf_matrix._public_perf_result(row)
+
+    assert public["result"] == "white"
+    assert public["measurement_stability"] is None
+
+
 def test_command_diagnostic_materializes_nested_build_logs(tmp_path: Path) -> None:
     build_stderr = tmp_path / "bundle-cache" / "build.stderr.log"
     build_stderr.parent.mkdir()
@@ -1981,6 +2100,8 @@ def test_run_consolidates_results_and_records_replayable_commands(
         "reference_ms": 20.45,
         "candidate_ms": 10.45,
     }
+    assert public_row["measurement_stability"]["mode"] == "shadow"
+    assert public_row["measurement_stability"]["status"] == "stable"
     assert public_row["issue"] is None
     assert all(
         "stdout_tail" not in command and "stderr_tail" not in command
@@ -2011,6 +2132,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "Failures" in frontend
     assert "Reference latency" in frontend
     assert "TRTMC latency" in frontend
+    assert "Timing stability (shadow)" in frontend
 
     baseline_argv = rows["gpt2.generate"]["commands"]["baseline"]["argv"]
     request = baseline_argv[baseline_argv.index("--request-json") + 1]

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -1979,6 +1979,99 @@ def _median(result: Mapping[str, Any]) -> float:
     return float(statistics.median(float(value) for value in values))
 
 
+_TIMING_STABILITY_SAMPLE_COUNT = 10
+_TIMING_STABILITY_MAX_HALF_CHANGE_PERCENT = 5.0
+_TIMING_STABILITY_MEDIAN_BAND_PERCENT = 5.0
+_TIMING_STABILITY_MIN_IN_BAND = 8
+
+
+def _timing_stability_shadow(values: Sequence[Any]) -> dict[str, Any]:
+    """Describe timing stability without changing the qualification result."""
+
+    if len(values) != _TIMING_STABILITY_SAMPLE_COUNT:
+        return {
+            "status": "not_evaluated",
+            "sample_count": len(values),
+            "reason": "requires_10_samples",
+        }
+    try:
+        samples = [float(value) for value in values]
+    except (TypeError, ValueError):
+        return {
+            "status": "not_evaluated",
+            "sample_count": len(values),
+            "reason": "invalid_samples",
+        }
+    if not all(math.isfinite(value) and value > 0.0 for value in samples):
+        return {
+            "status": "not_evaluated",
+            "sample_count": len(samples),
+            "reason": "invalid_samples",
+        }
+
+    middle = len(samples) // 2
+    median_ms = float(statistics.median(samples))
+    first_half_median_ms = float(statistics.median(samples[:middle]))
+    second_half_median_ms = float(statistics.median(samples[middle:]))
+    half_change_percent = (
+        abs(second_half_median_ms - first_half_median_ms)
+        / first_half_median_ms
+        * 100.0
+    )
+    samples_within_band = sum(
+        abs(sample - median_ms) / median_ms * 100.0
+        <= _TIMING_STABILITY_MEDIAN_BAND_PERCENT
+        for sample in samples
+    )
+    stable = (
+        half_change_percent <= _TIMING_STABILITY_MAX_HALF_CHANGE_PERCENT
+        and samples_within_band >= _TIMING_STABILITY_MIN_IN_BAND
+    )
+    return {
+        "status": "stable" if stable else "unstable",
+        "sample_count": len(samples),
+        "median_ms": median_ms,
+        "first_half_median_ms": first_half_median_ms,
+        "second_half_median_ms": second_half_median_ms,
+        "half_median_change_percent": half_change_percent,
+        "samples_within_band": samples_within_band,
+    }
+
+
+def _measurement_stability_shadow(
+    row: Mapping[str, Any], result: str | None
+) -> dict[str, Any] | None:
+    if result not in qualification_report.RGB_RESULTS:
+        return None
+    baseline = row.get("baseline", {})
+    candidate = row.get("candidate", {})
+    baseline = baseline if isinstance(baseline, Mapping) else {}
+    candidate = candidate if isinstance(candidate, Mapping) else {}
+    reference = _timing_stability_shadow(baseline.get("samples_ms", []))
+    trtmc = _timing_stability_shadow(candidate.get("samples_ms", []))
+    side_statuses = {reference["status"], trtmc["status"]}
+    if side_statuses == {"stable"}:
+        status = "stable"
+    elif "unstable" in side_statuses:
+        status = "retry_recommended"
+    else:
+        status = "not_evaluated"
+    return {
+        "mode": "shadow",
+        "status": status,
+        "policy": {
+            "required_samples": _TIMING_STABILITY_SAMPLE_COUNT,
+            "max_half_median_change_percent": (
+                _TIMING_STABILITY_MAX_HALF_CHANGE_PERCENT
+            ),
+            "median_band_percent": _TIMING_STABILITY_MEDIAN_BAND_PERCENT,
+            "minimum_samples_within_band": _TIMING_STABILITY_MIN_IN_BAND,
+        },
+        "reference": reference,
+        "trtmc": trtmc,
+    }
+
+
 def _normalized_text(value: Any) -> str:
     return " ".join(str(value or "").split()).strip().casefold()
 
@@ -2809,6 +2902,7 @@ def _public_perf_result(row: Mapping[str, Any]) -> dict[str, Any]:
             "precision": _perf_precision(row),
             "output_validation": _perf_output_validation(row, result),
             "latency": _perf_latency(row, result),
+            "measurement_stability": _measurement_stability_shadow(row, result),
             "issue": _perf_issue(row, result),
             "debug": {
                 "logs": [dict(record) for record in row.get("logs", [])],

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -214,6 +214,27 @@
     return control;
   }
 
+  function timingStability(value) {
+    if (!value) return null;
+    const labels = { stable: "Stable", retry_recommended: "Retry recommended", not_evaluated: "Not evaluated", unstable: "Unstable" };
+    const control = el("details", "gate-evidence");
+    control.append(el("summary", "", `Timing stability (shadow) · ${labels[value.status] || value.status}`));
+    const body = el("div", "evidence-body");
+    const policy = value.policy || {};
+    add(body, el("div", "gate-fact", `${policy.required_samples ?? 10} samples · first/last half ≤${number(policy.max_half_median_change_percent ?? 5, 2)}% · at least ${policy.minimum_samples_within_band ?? 8}/${policy.required_samples ?? 10} within median ±${number(policy.median_band_percent ?? 5, 2)}%`));
+    [["Reference", value.reference], ["TRTMC", value.trtmc]].forEach(([name, side]) => {
+      if (!side) return;
+      if (side.status === "not_evaluated") {
+        body.append(el("div", "gate-fact", `${name} · Not evaluated · ${side.sample_count ?? 0} samples`));
+        return;
+      }
+      body.append(el("div", "gate-fact", `${name} · ${labels[side.status] || side.status} · first 5 ${number(side.first_half_median_ms, 3)} ms · last 5 ${number(side.second_half_median_ms, 3)} ms · ${side.samples_within_band}/${side.sample_count} within band`));
+    });
+    body.append(el("div", "detail", "Shadow evidence only; the current result is unchanged."));
+    control.append(body);
+    return control;
+  }
+
   function metrics(row, kind) {
     const records = [];
     if (row.issue) records.push(["Failure", row.issue]);
@@ -229,7 +250,7 @@
       records.push(["Comparison", comparison], ["Validation", row.validation || {}]);
     }
     else records.push(["Output validation", row.output_validation || {}], ["Reference samples", row.baseline?.samples_ms || []], ["TRTMC samples", row.candidate?.samples_ms || []], ["Comparison", row.comparison || {}]);
-    return add(el("div", "metric-evidence"), acceptance, gate, details("Metrics", records));
+    return add(el("div", "metric-evidence"), timingStability(row.measurement_stability), acceptance, gate, details("Metrics", records));
   }
 
   function logs(row) {

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -95,6 +95,19 @@
             }
           },
           "precision": {"type": "object"},
+          "measurement_stability": {
+            "type": ["object", "null"],
+            "required": ["mode", "status", "policy", "reference", "trtmc"],
+            "properties": {
+              "mode": {"const": "shadow"},
+              "status": {
+                "enum": ["stable", "retry_recommended", "not_evaluated"]
+              },
+              "policy": {"type": "object"},
+              "reference": {"type": "object"},
+              "trtmc": {"type": "object"}
+            }
+          },
           "samples": {
             "type": "object",
             "required": ["planned", "evaluated"],


### PR DESCRIPTION
## Background
The release performance report currently applies its existing latency policy as soon as candidate and reference outputs form a valid comparison. Ten recorded latency samples can still be settling or scattered, so the report needs measurement-quality evidence before any stability policy is enforced.

## Exit Criteria
- Publish a deterministic stability assessment for both Reference and TRTMC from the existing ten raw latency samples.
- Keep the assessment in shadow mode: no traffic-light, retry, exit-code, suite-threshold, or CI behavior changes.
- Expose the evidence through report.json and the existing Metrics entry.

## Implementation
- Check that the first-five and last-five medians differ by no more than 5%, and that at least 8 of 10 samples are within 5% of the side median.
- Publish Stable, Retry recommended, or Not evaluated for valid comparisons; invalid comparisons do not receive timing-stability evidence.
- Extend the qualification report schema and renderer, and document the report-only contract.

## Validation
- `env PYTHONPATH=python python3 -m pytest -q tests/tools/test_execution_ledger.py tests/tools/test_qualification_report.py tests/tools/test_validation_gate_policy.py tests/tools/test_perf_matrix.py tests/tools/test_trtmc_validate.py`: 335 passed.
- `python3 -m ruff check --config ruff.toml tools/perf_matrix.py tests/tools/test_perf_matrix.py`: passed.
- `node --check tools/qualification_report_assets/qualification-report.js`: passed.
- `python3 -m json.tool tools/qualification_report_assets/qualification-report.schema.json`: passed.
- Historical results were replayed locally to exercise the shadow projection; no new target-hardware run was performed.

## Notes For Future Readers
- Review the stability helper and public projection first, then the schema/renderer, and finally the boundary tests.
- Shadow recommendations intentionally do not trigger a second process or turn a result white. The observed recommendation rate should be calibrated before a separate change enables enforcement.