### PR TITLE
fix(stablelm): stabilize continuation parity

### DIFF
--- a/python/tensorrt_model_connect/families/stablelm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/stablelm/default_decoder.py
@@ -65,6 +65,7 @@ def build_standard_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    fp32_attention_accumulation: bool = False,
     embed_input: bool = False,
     verbose: bool = False,
     debug_layer_outputs: bool = False,
@@ -89,6 +90,8 @@ def build_standard_decoder_engine(
             rotated-half (LLaMA/Qwen) where (d, d+half) share frequencies.
         scale_attn_weights: Whether to scale attention scores by 1/sqrt(head_dim).
             Most models use this (True, default). GPT-Neo does NOT scale (False).
+        fp32_attention_accumulation: Compute the attention core in FP32 and
+            cast its context back to the model dtype.
         embed_input: If True, add input_embed [1, hidden] and use_input_embed [1]
             engine inputs. When use_input_embed==1, the decoder uses input_embed
             directly instead of the embedding lookup. Used for VL models where
@@ -119,21 +122,38 @@ def build_standard_decoder_engine(
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
+    #   - FP32 precision boundaries    (decode only; the split prefill graph
+    #                                    remains homogeneous FP16)
     #
     # ``TRTMC_NO_DUAL_PROFILE=1`` is an internal escape hatch (perf A/B,
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
+    requested_fp32_layers = (
+        ()
+        if decoder_engine_role == "prefill"
+        else tuple(config.raw.get("_fp32_layers", ()))
+    )
+    has_fp32_boundary = bool(requested_fp32_layers) or fp32_attention_accumulation
     _dual_profile_disabled_for = (
         embed_input
         or debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
+        or has_fp32_boundary
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
     if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
+    if (
+        config.raw.get("_decoder_engine_role") == "dual_profile"
+        and has_fp32_boundary
+    ):
+        raise NotImplementedError(
+            "dual-profile StableLM engines do not support FP32 precision "
+            "boundaries; use the split layout with a homogeneous prefill "
+            "engine and a precision-stabilized decode engine")
     if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
@@ -158,6 +178,16 @@ def build_standard_decoder_engine(
     num_layers = config.num_hidden_layers
     num_heads = config.num_attention_heads
     num_kv_heads = config.num_key_value_heads
+    fp32_layers = frozenset(int(layer) for layer in requested_fp32_layers)
+    invalid_fp32_layers = sorted(
+        layer for layer in fp32_layers if layer < 0 or layer >= num_layers)
+    if invalid_fp32_layers:
+        raise ValueError(
+            f"fp32_layers contains out-of-range indices: {invalid_fp32_layers}")
+    if precision == "fp32":
+        fp32_layers = frozenset()
+    if fp32_layers and quant_ctx is not None:
+        raise ValueError("fp32_layers is not supported with quantized builds")
     head_dim = attention_size // num_heads
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
@@ -410,16 +440,24 @@ def build_standard_decoder_engine(
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        layer_is_fp32 = layer_idx in fp32_layers
+        layer_np_dtype = np.float32 if layer_is_fp32 else work_np_dtype
+        layer_trt_dtype = trt.float32 if layer_is_fp32 else work_trt_dtype
+
+        def _cast_layer_dtype(tensor: trt.ITensor | None) -> trt.ITensor | None:
+            if tensor is None or tensor.dtype == layer_trt_dtype:
+                return tensor
+            return network.add_cast(tensor, layer_trt_dtype).get_output(0)
 
         result = _add_decoder_layer(
             network=network,
-            hidden=hidden_state,
-            cache_k=cache_k_inputs[layer_idx],
-            cache_v=cache_v_inputs[layer_idx],
-            attention_mask=attention_mask,
+            hidden=_cast_layer_dtype(hidden_state),
+            cache_k=_cast_layer_dtype(cache_k_inputs[layer_idx]),
+            cache_v=_cast_layer_dtype(cache_v_inputs[layer_idx]),
+            attention_mask=_cast_layer_dtype(attention_mask),
             position_id=position_id,
             attention_scale=attn_scale,
-            eps_tensor=eps_tensor,
+            eps_tensor=_cast_layer_dtype(eps_tensor),
             eps=config.rms_norm_eps,
             weights=weights,
             prefix=prefix,
@@ -438,19 +476,20 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             alibi_slopes_tensor=alibi_slopes_tensor,
             alibi_indices_tensor=alibi_indices_tensor,
-            dtype=work_np_dtype,
+            dtype=layer_np_dtype,
             quant_ctx=quant_ctx,
-            cos_half_tensor=cos_half_tensor,
-            sin_half_tensor=sin_half_tensor,
+            cos_half_tensor=_cast_layer_dtype(cos_half_tensor),
+            sin_half_tensor=_cast_layer_dtype(sin_half_tensor),
             rotary_embedding_dim=rotary_embedding_dim,
             interleaved_rope=interleaved_rope,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
+            fp32_attention_accumulation=fp32_attention_accumulation,
         )
 
-        hidden_state = result["hidden"]
-        present_k_outputs.append(result["present_k"])
-        present_v_outputs.append(result["present_v"])
+        hidden_state = _cast_work_dtype(result["hidden"])
+        present_k_outputs.append(_cast_work_dtype(result["present_k"]))
+        present_v_outputs.append(_cast_work_dtype(result["present_v"]))
 
         if debug_layer_outputs:
             _mark_debug_output(network, result["post_attn"], f"debug_post_attn_{layer_idx}")
@@ -578,6 +617,7 @@ def _add_decoder_layer(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    fp32_attention_accumulation: bool = False,
     eps: float | None = None,
 ) -> dict[str, trt.ITensor]:
     """Add one standard decoder layer block. Returns hidden, present_k, present_v."""
@@ -604,6 +644,7 @@ def _add_decoder_layer(
         interleaved_rope=interleaved_rope,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
+        fp32_attention_accumulation=fp32_attention_accumulation,
     )
     attn_out = attn["attn_out"]
     present_k = attn["present_k"]

--- a/python/tensorrt_model_connect/families/stablelm/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/stablelm/graph_blocks.py
@@ -148,6 +148,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    fp32_attention_accumulation: bool = False,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -280,6 +281,7 @@ def add_attention_block(
             causal=False,
             mask=mask_4d,
             scale=attention_scale,
+            fp32_accumulation=fp32_attention_accumulation,
         )
     elif ffi_attention_kernel is not None:
         if num_kv_heads != num_heads:

--- a/python/tensorrt_model_connect/families/stablelm/plugin.py
+++ b/python/tensorrt_model_connect/families/stablelm/plugin.py
@@ -43,6 +43,10 @@ class StableLMPlugin:
         mt = model_type.lower()
         return mt == "stablelm" or mt.startswith("stablelm")
 
+    def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
+        del config
+        return True
+
     def load_weights(
         self, model_dir: str, config: ModelConfig,
     ) -> WeightDict:
@@ -191,6 +195,7 @@ class StableLMPlugin:
                 verbose=verbose,
                 parallel_config=parallel)
 
+        decoder_engine_role = config.raw.get("_decoder_engine_role")
         return build_standard_decoder_engine(
             config, weights, max_cache_length,
             precision=precision, quant_ctx=quant_ctx,
@@ -198,6 +203,9 @@ class StableLMPlugin:
             mlp_type="swiglu",
             position_type="rope",
             partial_rotary_factor=partial_rotary,
+            fp32_attention_accumulation=(
+                precision == "fp16" and decoder_engine_role != "prefill"
+            ),
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
+++ b/tests/e2e/models/stablelm/manifests/stablelm2-1.6b.json
@@ -7,6 +7,9 @@
   "runtime_strategy": "stablelm_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
+  "fp32_layers": [
+    23
+  ],
   "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [
@@ -16,9 +19,9 @@
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
       "reference_precision": "fp16",
-      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind all zeros in the indicated finite field of the given polynomial with coefficients in that field. x^5 + 3x^3 + x^2 + 2x in Z_5\nA. 0\nB. 1\nC. 0,1\nD. 0,4\nAnswer:",
-      "max_new_tokens": 20,
-      "notes": "Exact StableLM regression sentinel for QA MMLU sample mmlu_000002. It replaces the former short prompt and reaches the published first divergence at generated-token index 18 without adding another model build or case."
+      "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nLet p = (1, 2, 5, 4)(2, 3) in S_5 . Find the index of <p> in S_5.\nA. 8\nB. 2\nC. 24\nD. 120\nAnswer:",
+      "max_new_tokens": 22,
+      "notes": "Exact StableLM regression sentinel for QA MMLU sample mmlu_000001. It reaches the published first divergence at generated-token index 21 without adding another model build or case."
     }
   ]
 }

--- a/tests/e2e/models/stablelm/test_stablelm_accuracy_regression.py
+++ b/tests/e2e/models/stablelm/test_stablelm_accuracy_regression.py
@@ -22,28 +22,31 @@ _MODEL_DIR = Path(__file__).resolve().parent
 _MANIFEST_PATH = _MODEL_DIR / "manifests" / "stablelm2-1.6b.json"
 _THRESHOLD_PATH = _MODEL_DIR / "thresholds" / "stablelm2-1.6b.json"
 _STABLELM_REVISION = "f499ead74c53749bd93cebc6ce8bc0d7bdf1eaef"
-_MMLU_000002_PROMPT_SHA256 = (
-    "de28bf6b76387fa017c1ffa8e379f87c46439a0b0fc0186798c0f7b4b6a17330"
+_MMLU_000001_PROMPT_SHA256 = (
+    "2885f321f1938150f73629d8cfbbe63944e1aa460d0d37f47683c5c75a41d18f"
 )
 _QA_COMMON_PREFIX = [
-    362,
+    423,
     271,
     10086,
-    682,
-    10105,
-    311,
     279,
-    24524,
-    304,
-    1901,
-    62,
-    18,
-    13,
-    865,
-    61,
-    17,
-    489,
+    2015,
+    315,
+    279,
+    81215,
+    8066,
+    555,
+    320,
+    16,
+    11,
     220,
+    17,
+    11,
+    220,
+    18,
+    11,
+    220,
+    19,
 ]
 
 
@@ -78,17 +81,18 @@ def test_stablelm_premerge_case_replays_the_published_accuracy_signal():
         _THRESHOLD_PATH.read_text(encoding="utf-8"))["threshold_overrides"]
 
     assert manifest["hf_revision"] == _STABLELM_REVISION
-    assert prompt_sha256 == _MMLU_000002_PROMPT_SHA256
-    assert testcase["max_new_tokens"] >= 19
+    assert prompt_sha256 == _MMLU_000001_PROMPT_SHA256
+    assert testcase["max_new_tokens"] >= 22
     assert testcase["reference_precision"] == manifest["precision"] == "fp16"
+    assert manifest["fp32_layers"] == [23]
     assert manifest["max_cache_length"] >= 384
     assert thresholds["contract_token_agreement_rate"] == 1.0
 
 
-def test_stablelm_contract_rejects_the_published_token_18_divergence():
+def test_stablelm_contract_rejects_the_published_token_21_divergence():
     result = plugin.verify(
-        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 17]),
-        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 16]),
+        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 11]),
+        _output("same decoded continuation", [*_QA_COMMON_PREFIX, 2432]),
         _case(),
         _threshold(),
     )
@@ -100,7 +104,7 @@ def test_stablelm_contract_rejects_the_published_token_18_divergence():
 
 
 def test_stablelm_contract_accepts_exact_generated_tokens():
-    exact_tokens = [*_QA_COMMON_PREFIX, 16]
+    exact_tokens = [*_QA_COMMON_PREFIX, 11]
     result = plugin.verify(
         _output("same decoded continuation", exact_tokens),
         _output("same decoded continuation", exact_tokens),
@@ -114,7 +118,7 @@ def test_stablelm_contract_accepts_exact_generated_tokens():
 
 
 def test_stablelm_contract_requires_reference_token_ids_for_strict_gate():
-    trt_output = _output("same decoded continuation", [*_QA_COMMON_PREFIX, 16])
+    trt_output = _output("same decoded continuation", [*_QA_COMMON_PREFIX, 11])
     reference_output = StageOutput(
         stage_name="full_generation",
         data={},

--- a/tests/e2e/models/stablelm/test_stablelm_precision_contract.py
+++ b/tests/e2e/models/stablelm/test_stablelm_precision_contract.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""StableLM precision boundaries required by continuation parity."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+
+
+def _config() -> ModelConfig:
+    return ModelConfig(
+        model_type="stablelm",
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+        rms_norm_eps=1e-5,
+        raw={"partial_rotary_factor": 0.25},
+    )
+
+
+@pytest.mark.parametrize(
+    ("precision", "expected_fp32_accumulation"),
+    (("fp16", True), ("bf16", False), ("fp32", False)),
+)
+def test_stablelm_attention_accumulation_matches_reference_contract(
+    monkeypatch,
+    precision: str,
+    expected_fp32_accumulation: bool,
+) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.plugin"
+    )
+    captured: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        captured.update(kwargs)
+        return b"engine"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        fake_build,
+    )
+
+    plan = plugin_module.StableLMPlugin().build_engine(
+        _config(),
+        WeightDict(),
+        max_cache_length=64,
+        precision=precision,
+    )
+
+    assert plan == b"engine"
+    assert (
+        captured["fp32_attention_accumulation"]
+        is expected_fp32_accumulation
+    )
+
+
+@pytest.mark.parametrize(
+    ("precision", "fp32_layers"),
+    (
+        ("fp16", ()),
+        ("bf16", (1,)),
+        ("bf16", ()),
+    ),
+)
+def test_precision_boundaries_support_asymmetric_split_engines(
+    precision: str,
+    fp32_layers: tuple[int, ...],
+) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.plugin"
+    )
+    config = _config()
+    config.raw["_resolved_build_precision"] = precision
+    config.raw["_fp32_layers"] = list(fp32_layers)
+
+    assert plugin_module.StableLMPlugin().supports_split_decoder_roles(config)
+
+
+def test_fp16_prefill_keeps_the_dynamic_graph_homogeneous(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.plugin"
+    )
+    captured: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        captured.update(kwargs)
+        return b"engine"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        fake_build,
+    )
+    config = _config()
+    config.raw["_decoder_engine_role"] = "prefill"
+
+    plugin_module.StableLMPlugin().build_engine(
+        config,
+        WeightDict(),
+        max_cache_length=64,
+        precision="fp16",
+    )
+
+    assert captured["fp32_attention_accumulation"] is False
+
+
+def test_prefill_ignores_decode_only_fp32_layers(monkeypatch) -> None:
+    builder_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.default_decoder"
+    )
+    called = False
+
+    def fake_dual_build(*args, **kwargs):
+        nonlocal called
+        called = True
+        return b"prefill-engine"
+
+    monkeypatch.setattr(
+        builder_module,
+        "build_dual_profile_decoder_engine",
+        fake_dual_build,
+    )
+    config = _config()
+    config.raw["_decoder_engine_role"] = "prefill"
+    config.raw["_fp32_layers"] = [1]
+
+    plan = builder_module.build_standard_decoder_engine(
+        config,
+        WeightDict(),
+        max_cache_length=64,
+        precision="fp16",
+        fp32_attention_accumulation=False,
+    )
+
+    assert plan == b"prefill-engine"
+    assert called
+
+
+def test_dual_profile_rejects_fp32_precision_boundary() -> None:
+    builder_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.default_decoder"
+    )
+    config = _config()
+    config.raw["_decoder_engine_role"] = "dual_profile"
+
+    with pytest.raises(NotImplementedError, match="FP32 precision boundaries"):
+        builder_module.build_standard_decoder_engine(
+            config,
+            WeightDict(),
+            max_cache_length=64,
+            precision="fp16",
+            fp32_attention_accumulation=True,
+        )


### PR DESCRIPTION
## Background

StableLM2-1.6B could diverge from the FP16 Transformers reference during continuation generation. The first mismatch was caused by a numerically sensitive decode path rather than by sampling, cache length, or a relaxed comparison threshold.

Closes #890.

## Exit criteria

- Preserve the existing 0.90 continuation-parity gate.
- Keep TRTMC and the reference on FP16 base precision.
- Preserve batched prefill performance.
- Validate Accuracy and Perf on both Thor X with TensorRT 11.0 and GB300.

## Implementation

- Keep the prefill engine homogeneous FP16 and batched.
- Apply FP32 attention accumulation and an FP32 final decoder layer only to the decode engine.
- Use split prefill/decode engines when these precision boundaries are requested.
- Reject an explicit dual-profile mixed-precision build with a clear diagnostic because that graph is unsupported.
- Add a deterministic regression case for the previously divergent continuation and unit coverage for the precision/split-engine contract.

## Validation

- Local StableLM tests: 17 passed.
- Ruff and Python bytecode compilation: passed.
- Thor X, TensorRT 11.0 Accuracy: passed; 9/10 exact continuations, 0.90 tie-adjusted exact match, 0.928125 token-prefix agreement.
- Thor X, TensorRT 11.0 Perf: yellow/equivalent; 323.63 ms TRTMC vs 323.15 ms FP16 reference, with exact output token IDs.
- GB300 Accuracy: passed; 0.90 tie-adjusted exact match with FP16 TRTMC and FP16 reference.
- GB300 Perf: green; 41.22 ms TRTMC vs 258.02 ms FP16 reference, with exact output token IDs.

All platform results above were produced from commit `d84e48a0e4c7a926b1f67fc3493ee12ba839e2f5`.

## Notes

The Accuracy acceptance threshold is unchanged. The split design avoids the unsupported dynamic mixed-precision graph on TensorRT 11.0 while retaining batched prefill and limiting the higher-precision work to decode.
