### PR TITLE
refactor(bert): own bundle builds

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -934,6 +934,10 @@ def build_bundle(
             low-VRAM single-engine/multi-profile layout.
         verbose: Print detailed logs.
     """
+    owner_options = dict(locals())
+    owner_options.pop("model_dir")
+    owner_options.pop("output_path")
+
     if decoder_engine_layout not in ("split", "dual_profile"):
         raise ValueError(
             "decoder_engine_layout must be 'split' or 'dual_profile', "
@@ -1013,6 +1017,26 @@ def build_bundle(
         raise ValueError(
             f"No family plugin for model_type={config.model_type!r}. "
             f"Supported: {supported}")
+
+    if family_has_capability(config, "model_owned_build"):
+        missing = object()
+        declared_build = inspect.getattr_static(plugin, "build", missing)
+        if declared_build is missing:
+            raise TypeError(
+                f"Family {plugin.name} declares model_owned_build without "
+                "a concrete build binding"
+            )
+        if not callable(declared_build):
+            raise TypeError(
+                f"Family {plugin.name} model-owned build binding is not callable"
+            )
+        owner_build = getattr(plugin, "build")
+        if not callable(owner_build):
+            raise TypeError(
+                f"Family {plugin.name} model-owned build binding is not callable"
+            )
+        owner_build(str(model_dir_path), output_path, **owner_options)
+        return
 
     print(f"[trtmc build] Family: {plugin.name}", file=sys.stderr)
     default_precision = getattr(plugin, "default_build_precision", "fp32")

--- a/python/tensorrt_model_connect/families/bert/MODEL.toml
+++ b/python/tensorrt_model_connect/families/bert/MODEL.toml
@@ -4,6 +4,7 @@
 id = "bert"
 plugin = "bert"
 module = "plugin"
+capabilities = ["model_owned_build"]
 aliases = [
   "bert",
 ]

--- a/python/tensorrt_model_connect/families/bert/model.py
+++ b/python/tensorrt_model_connect/families/bert/model.py
@@ -6,18 +6,33 @@
 from __future__ import annotations
 
 
+import json
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 import numpy as np
 from tensorrt_model_connect import trt_compat
-from ....parallel_config import add_all_reduce_sum, normalize_parallel_config
-from ..config import ModelConfig
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    rank_engine_section,
+    require_tensorrt_11_for_tensor_parallel,
+)
+from .config import ModelConfig
+
+try:
+    from cuda.bindings import runtime as _cuda_runtime
+except ImportError:
+    try:
+        from cuda import cudart as _cuda_runtime
+    except ImportError:  # pragma: no cover - environment dependent
+        _cuda_runtime = None
 
 trt = trt_compat.get_trt()
 
 if TYPE_CHECKING:
-    from ....parallel_config import ParallelConfig
-    from ..weights import WeightDict
+    from ...parallel_config import ParallelConfig
+    from .weights import WeightDict
 
 
 def _cast_back_to_trt_dtype(
@@ -147,14 +162,10 @@ def add_activation(
         return network.add_activation(inp, trt.ActivationType.RELU).get_output(0)
     if activation_type in ("relu2", "squared_relu"):
         relu = network.add_activation(inp, trt.ActivationType.RELU).get_output(0)
-        return network.add_elementwise(
-            relu, relu, trt.ElementWiseOperation.PROD
-        ).get_output(0)
+        return network.add_elementwise(relu, relu, trt.ElementWiseOperation.PROD).get_output(0)
     if activation_type == "silu":
         sigmoid = network.add_activation(inp, trt.ActivationType.SIGMOID).get_output(0)
-        return network.add_elementwise(
-            inp, sigmoid, trt.ElementWiseOperation.PROD
-        ).get_output(0)
+        return network.add_elementwise(inp, sigmoid, trt.ElementWiseOperation.PROD).get_output(0)
     raise ValueError(f"Unsupported activation: {activation_type}")
 
 
@@ -438,15 +449,12 @@ def build_encoder_engine(
     intermediate = config.intermediate_size // tp_size
     eps = config.rms_norm_eps
     type_vocab_size = config.raw.get("type_vocab_size", 2)
-    requested_fp32_layers = frozenset(
-        int(layer) for layer in config.raw.get("_fp32_layers", ()))
+    requested_fp32_layers = frozenset(int(layer) for layer in config.raw.get("_fp32_layers", ()))
     invalid_fp32_layers = sorted(
-        layer for layer in requested_fp32_layers
-        if layer < 0 or layer >= num_layers)
+        layer for layer in requested_fp32_layers if layer < 0 or layer >= num_layers
+    )
     if invalid_fp32_layers:
-        raise ValueError(
-            "fp32_layers contains out-of-range indices: "
-            f"{invalid_fp32_layers}")
+        raise ValueError(f"fp32_layers contains out-of-range indices: {invalid_fp32_layers}")
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
     elif precision == "bf16":
@@ -486,15 +494,16 @@ def build_encoder_engine(
     # Shared constants
     # -------------------------------------------------------------------
     embedding_table = add_constant(
-        network, weights["embedding"].shape, weights["embedding"],
-        dtype=work_np_dtype)
+        network, weights["embedding"].shape, weights["embedding"], dtype=work_np_dtype
+    )
     position_embed_table = add_constant(
-        network, weights["position_embedding"].shape,
-        weights["position_embedding"], dtype=work_np_dtype
+        network,
+        weights["position_embedding"].shape,
+        weights["position_embedding"],
+        dtype=work_np_dtype,
     )
     token_type_table = add_constant(
-        network, (type_vocab_size, hidden), weights["token_type_embedding"],
-        dtype=work_np_dtype
+        network, (type_vocab_size, hidden), weights["token_type_embedding"], dtype=work_np_dtype
     )
 
     # Build additive attention mask from attention_mask input:
@@ -502,12 +511,12 @@ def build_encoder_engine(
     # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
     mask_float = network.add_cast(attention_mask_input, work_trt_dtype)
     ones_mask = add_constant(
-        network, (1,), np.array([1.0], dtype=work_np_dtype),
-        dtype=work_np_dtype)
+        network, (1,), np.array([1.0], dtype=work_np_dtype), dtype=work_np_dtype
+    )
     mask_penalty = -1e4 if precision in {"fp16", "bf16"} else -1e10
     neg_large = add_constant(
-        network, (1,), np.array([mask_penalty], dtype=work_np_dtype),
-        dtype=work_np_dtype)
+        network, (1,), np.array([mask_penalty], dtype=work_np_dtype), dtype=work_np_dtype
+    )
     inv_mask = network.add_elementwise(
         ones_mask, mask_float.get_output(0), trt.ElementWiseOperation.SUB
     )  # 0 for real, 1 for pad
@@ -520,15 +529,14 @@ def build_encoder_engine(
 
     # Position indices: [0, 1, 2, ..., max_seq_length-1]
     position_indices = network.add_constant(
-        (max_seq_length,),
-        trt.Weights(np.arange(max_seq_length, dtype=np.int32)))
+        (max_seq_length,), trt.Weights(np.arange(max_seq_length, dtype=np.int32))
+    )
 
     # -------------------------------------------------------------------
     # Embedding: word + position + token_type + LayerNorm
     # -------------------------------------------------------------------
     word_embed = network.add_gather(embedding_table, input_ids, 0)
-    pos_embed = network.add_gather(
-        position_embed_table, position_indices.get_output(0), 0)
+    pos_embed = network.add_gather(position_embed_table, position_indices.get_output(0), 0)
     tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
 
     # Sum all three embedding types
@@ -581,16 +589,14 @@ def build_encoder_engine(
             dtype=layer_np_dtype,
         )
         if hidden_state.dtype != work_trt_dtype:
-            hidden_state = network.add_cast(
-                hidden_state, work_trt_dtype).get_output(0)
+            hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
 
     # -------------------------------------------------------------------
     # Output
     # -------------------------------------------------------------------
     public_output = hidden_state
     if public_output.dtype != trt.float32:
-        public_output = network.add_cast(
-            public_output, trt.float32).get_output(0)
+        public_output = network.add_cast(public_output, trt.float32).get_output(0)
     public_output.name = "hidden_states"
     network.mark_output(public_output)
 
@@ -643,8 +649,7 @@ def _add_seq_layer_norm(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """LayerNorm over the hidden dimension of each sequence row."""
-    return add_layer_norm_native(
-        network, inp, hidden_size, gamma, beta, eps, dtype=dtype)
+    return add_layer_norm_native(network, inp, hidden_size, gamma, beta, eps, dtype=dtype)
 
 
 def _add_encoder_layer(
@@ -677,28 +682,19 @@ def _add_encoder_layer(
     # --- Self-attention (no causal mask, bidirectional) ---
     # QKV projections
     q = add_matmul_rhs_constant(
-        network, hidden, hidden_size, attention_size,
-        weights[f"{prefix}.w_q"], dtype=dtype
+        network, hidden, hidden_size, attention_size, weights[f"{prefix}.w_q"], dtype=dtype
     )
     k = add_matmul_rhs_constant(
-        network, hidden, hidden_size, attention_size,
-        weights[f"{prefix}.w_k"], dtype=dtype
+        network, hidden, hidden_size, attention_size, weights[f"{prefix}.w_k"], dtype=dtype
     )
     v = add_matmul_rhs_constant(
-        network, hidden, hidden_size, attention_size,
-        weights[f"{prefix}.w_v"], dtype=dtype
+        network, hidden, hidden_size, attention_size, weights[f"{prefix}.w_v"], dtype=dtype
     )
 
     # QKV biases
-    q = add_bias_sum(
-        network, q, attention_size, weights[f"{prefix}.q_bias"],
-        dtype=dtype)
-    k = add_bias_sum(
-        network, k, attention_size, weights[f"{prefix}.k_bias"],
-        dtype=dtype)
-    v = add_bias_sum(
-        network, v, attention_size, weights[f"{prefix}.v_bias"],
-        dtype=dtype)
+    q = add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"], dtype=dtype)
+    k = add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"], dtype=dtype)
+    v = add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"], dtype=dtype)
 
     mask_4d = network.add_shuffle(attn_mask)
     mask_4d.reshape_dims = (1, 1, 1, seq_length)
@@ -717,14 +713,13 @@ def _add_encoder_layer(
 
     # Output projection
     attn_out = add_matmul_rhs_constant(
-        network, context_flat, attention_size, hidden_size,
-        weights[f"{prefix}.w_o"], dtype=dtype
+        network, context_flat, attention_size, hidden_size, weights[f"{prefix}.w_o"], dtype=dtype
     )
     if tp_size > 1:
         attn_out = add_all_reduce_sum(network, attn_out, tp_size)
     attn_out = add_bias_sum(
-        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"],
-        dtype=dtype)
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"], dtype=dtype
+    )
 
     # POST-norm: LayerNorm(hidden + attn_out)
     residual1 = network.add_elementwise(hidden, attn_out, trt.ElementWiseOperation.SUM)
@@ -740,22 +735,16 @@ def _add_encoder_layer(
 
     # --- FFN: fc1 -> GELU -> fc2 ---
     fc1 = add_matmul_rhs_constant(
-        network, normed1, hidden_size, intermediate_size,
-        weights[f"{prefix}.w_fc1"], dtype=dtype
+        network, normed1, hidden_size, intermediate_size, weights[f"{prefix}.w_fc1"], dtype=dtype
     )
-    fc1 = add_bias_sum(
-        network, fc1, intermediate_size, weights[f"{prefix}.fc1_bias"],
-        dtype=dtype)
+    fc1 = add_bias_sum(network, fc1, intermediate_size, weights[f"{prefix}.fc1_bias"], dtype=dtype)
     activated = add_activation(network, fc1, hidden_act, dtype=dtype)
     fc2 = add_matmul_rhs_constant(
-        network, activated, intermediate_size, hidden_size,
-        weights[f"{prefix}.w_fc2"], dtype=dtype
+        network, activated, intermediate_size, hidden_size, weights[f"{prefix}.w_fc2"], dtype=dtype
     )
     if tp_size > 1:
         fc2 = add_all_reduce_sum(network, fc2, tp_size)
-    fc2 = add_bias_sum(
-        network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"],
-        dtype=dtype)
+    fc2 = add_bias_sum(network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"], dtype=dtype)
 
     # POST-norm: LayerNorm(normed1 + ffn_out)
     residual2 = network.add_elementwise(normed1, fc2, trt.ElementWiseOperation.SUM)
@@ -770,3 +759,430 @@ def _add_encoder_layer(
     )
 
     return normed2
+
+
+name = "bert"
+runtime_strategy = "bert_encoder_only"
+
+
+def matches(config: object) -> bool:
+    """Return whether this module owns the parsed model config."""
+    return str(getattr(config, "model_type", config)).lower() == name
+
+
+def load_weights(model_dir: str, config: ModelConfig) -> WeightDict:
+    """Load BERT checkpoint weights through the owner-local mapper."""
+    from .weights import load_bert_weights
+
+    return load_bert_weights(model_dir, config)
+
+
+def build_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one single-device or rank-local BERT encoder engine."""
+    if quant_ctx is not None:
+        raise ValueError("BERT builds do not support quantization")
+
+    parallel = normalize_parallel_config(parallel_config)
+    if parallel.enabled:
+        require_tensorrt_11_for_tensor_parallel(
+            parallel,
+            feature="BERT tensor-parallel builds",
+        )
+        if precision != "fp32":
+            raise ValueError("BERT tensor-parallel builds currently support only fp32")
+        return build_tp_encoder_engine(
+            config,
+            weights,
+            max_seq_length=max_cache_length,
+            verbose=verbose,
+            parallel_config=parallel,
+        )
+
+    return build_encoder_engine(
+        config,
+        weights,
+        max_seq_length=max_cache_length,
+        precision=precision,
+        verbose=verbose,
+    )
+
+
+def _detect_tokenizer_frame(
+    source: str,
+    *,
+    revision: str | None = None,
+) -> tuple[list[int], list[int]] | None:
+    """Return the exact BERT special-token prefix and suffix, when detectable."""
+    try:
+        from transformers import AutoTokenizer
+
+        kwargs = {"trust_remote_code": True}
+        if revision:
+            kwargs["revision"] = revision
+        if not Path(source).is_dir():
+            kwargs["local_files_only"] = True
+        tokenizer = AutoTokenizer.from_pretrained(source, **kwargs)
+        default_ids = list(tokenizer.encode("hello"))
+        plain_ids = list(tokenizer.encode("hello", add_special_tokens=False))
+    except Exception:
+        return None
+
+    if default_ids == plain_ids:
+        return [], []
+    if not plain_ids:
+        return default_ids, []
+    for start in range(len(default_ids) - len(plain_ids) + 1):
+        if default_ids[start : start + len(plain_ids)] == plain_ids:
+            return default_ids[:start], default_ids[start + len(plain_ids) :]
+    return None
+
+
+def _wordpiece_tokenizer_needs_rebuild(model_dir: Path) -> bool:
+    """Detect an existing WordPiece tokenizer that omits source vocabulary IDs."""
+    tokenizer_path = model_dir / "tokenizer.json"
+    vocab_path = model_dir / "vocab.txt"
+    config_path = model_dir / "config.json"
+    if not (tokenizer_path.is_file() and vocab_path.is_file() and config_path.is_file()):
+        return False
+    try:
+        tokenizer = json.loads(tokenizer_path.read_text(encoding="utf-8"))
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        tokenizer_model = tokenizer.get("model", {})
+        vocab = tokenizer_model.get("vocab", {})
+        expected_vocab_size = int(config.get("vocab_size", 0))
+        if tokenizer_model.get("type") != "WordPiece":
+            return False
+        if not isinstance(vocab, dict) or not vocab or expected_vocab_size <= 0:
+            return False
+        tokenizer_id_space = max(int(token_id) for token_id in vocab.values()) + 1
+        source_id_space = len(vocab_path.read_text(encoding="utf-8").splitlines())
+        return tokenizer_id_space < expected_vocab_size and source_id_space >= expected_vocab_size
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _ensure_tokenizer_json(model_dir: Path) -> None:
+    """Create or repair BERT tokenizer.json without rewriting sibling metadata."""
+    import tempfile
+
+    tokenizer_path = model_dir / "tokenizer.json"
+    rebuild = _wordpiece_tokenizer_needs_rebuild(model_dir)
+    if tokenizer_path.is_file() and not rebuild:
+        return
+
+    temporary_path: Path | None = None
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(str(model_dir), use_fast=True)
+        with tempfile.TemporaryDirectory(prefix="trtmc-bert-tokenizer-") as temporary:
+            generated = Path(temporary) / "tokenizer.json"
+            backend = getattr(tokenizer, "backend_tokenizer", None)
+            if backend is None:
+                backend = getattr(tokenizer, "_tokenizer", None)
+            if backend is not None and hasattr(backend, "save"):
+                backend.save(str(generated))
+            if not generated.is_file():
+                tokenizer.save_pretrained(temporary)
+            if not generated.is_file():
+                raise RuntimeError("tokenizer conversion did not create tokenizer.json")
+            with tempfile.NamedTemporaryFile(
+                dir=model_dir,
+                prefix=".trtmc-bert-tokenizer-",
+                suffix=".json",
+                delete=False,
+            ) as output:
+                temporary_path = Path(output.name)
+                output.write(generated.read_bytes())
+            temporary_path.replace(tokenizer_path)
+            temporary_path = None
+    except Exception as exc:
+        print(
+            "[trtmc build] Warning: could not generate BERT tokenizer.json "
+            f"(C++ runtime may fail to create tokenizer): {exc}",
+            file=sys.stderr,
+        )
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _tokenizer_adds_special_tokens(model_dir: Path) -> bool:
+    tokenizer_config = model_dir / "tokenizer_config.json"
+    if not tokenizer_config.is_file():
+        return False
+    try:
+        config = json.loads(tokenizer_config.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(config.get("add_bos_token") or config.get("add_eos_token"))
+
+
+def _gpu_name() -> str:
+    """Read the active CUDA device name, returning empty on unavailable runtimes."""
+    if _cuda_runtime is None:
+        return ""
+    try:
+        success = (
+            _cuda_runtime.cudaError_t.cudaSuccess if hasattr(_cuda_runtime, "cudaError_t") else 0
+        )
+        status, device = _cuda_runtime.cudaGetDevice()
+        if status != success:
+            return ""
+        status, properties = _cuda_runtime.cudaGetDeviceProperties(device)
+        if status != success:
+            return ""
+        device_name = properties.name
+        if isinstance(device_name, bytes):
+            return device_name.decode("utf-8", errors="replace").rstrip("\x00")
+        return str(device_name).rstrip("\x00")
+    except Exception:
+        return ""
+
+
+def build(model_dir: str, output_path: str, **options: object) -> None:
+    """Build a complete BERT bundle without shared build orchestration."""
+    import time
+    from datetime import datetime, timezone
+
+    from ...build_timing import (
+        new_build_timing,
+        timed_build_phase,
+        timed_trt_compile,
+        write_build_timing,
+    )
+    from ...bundle_writer import BundleInfo, BundleSection, write_bundle
+
+    model_path = Path(model_dir)
+    parallel = normalize_parallel_config(options.get("parallel_config"))
+    if parallel.cp_enabled:
+        raise NotImplementedError("BERT does not support context-parallel builds")
+
+    precision = str(options.get("precision") or "fp32").lower()
+    if precision not in {"fp16", "bf16", "fp32"}:
+        raise ValueError(f"Unsupported BERT precision: {precision}")
+    if parallel.enabled and precision != "fp32":
+        raise ValueError("BERT tensor-parallel builds currently support only fp32")
+    if (
+        options.get("quantize")
+        or options.get("quant_scales")
+        or (
+            options.get("quant_calibration_samples") is not None
+            and int(options["quant_calibration_samples"]) != 512
+        )
+        or options.get("fp8_scales")
+        or options.get("save_fp8_scales")
+    ):
+        raise ValueError("BERT builds do not support quantization")
+    if options.get("dynamic_kv_cache") or options.get("triattention_stats_path"):
+        raise ValueError("BERT does not use a decoder KV-cache runtime")
+    if options.get("dynamic_kv_profile_rows_override"):
+        raise ValueError("BERT does not support dynamic KV profile rows")
+    if options.get("family_build_options"):
+        raise ValueError("BERT does not support family build options")
+    if options.get("diffusion_overrides"):
+        raise ValueError("BERT does not support diffusion overrides")
+    if options.get("rtx"):
+        raise ValueError("BERT does not support TensorRT-RTX builds")
+    requested_batch_size = options.get("max_batch_size")
+    max_batch_size = 1 if requested_batch_size is None else int(requested_batch_size)
+    if max_batch_size != 1:
+        raise ValueError("BERT supports only max_batch_size=1")
+    decoder_engine_layout = str(options.get("decoder_engine_layout") or "split")
+    if decoder_engine_layout != "split":
+        raise ValueError(
+            "BERT supports only the default decoder_engine_layout='split', "
+            f"got {decoder_engine_layout!r}"
+        )
+    requested_cache_length = options.get("max_cache_length")
+    max_cache_length = 256 if requested_cache_length is None else int(requested_cache_length)
+    if max_cache_length < 1:
+        raise ValueError("max_cache_length must be >= 1")
+
+    config = ModelConfig.from_dir(model_path)
+    if max_cache_length > config.max_position_embeddings:
+        raise ValueError(
+            "max_cache_length exceeds BERT max_position_embeddings "
+            f"({max_cache_length} > {config.max_position_embeddings})"
+        )
+    fp32_layers = sorted(set(options.get("fp32_layers") or ()))
+    config.raw["_model_dir"] = str(model_path)
+    config.raw["_decoder_engine_layout"] = decoder_engine_layout
+    config.raw["_fp32_layers"] = fp32_layers
+    config.raw["_family_build_options"] = {}
+    config.raw["_parallel_build_enabled"] = bool(parallel.enabled)
+    config.raw["_rtx_build_requested"] = False
+    config.raw["_runtime_dynamic_kv_requested"] = False
+    config.raw["_quantized_build_requested"] = False
+    config.raw["_resolved_build_precision"] = precision
+
+    timing = new_build_timing(options.get("build_timing_path"))
+    timing["model_dir"] = str(model_path)
+    timing["output_path"] = str(output_path)
+    started = time.monotonic()
+    write_build_timing(timing)
+
+    with timed_build_phase(timing, "weights_loading_s"):
+        weights = load_weights(str(model_path), config)
+
+    from ...tvm_ffi.graph_build import engine_role, inspection_role, kernel_slots_section
+
+    target_inspection_role = inspection_role()
+    if target_inspection_role is not None and parallel.enabled:
+        raise NotImplementedError("BERT tensor-parallel graph inspection is not supported")
+
+    verbose = bool(options.get("verbose"))
+    with timed_trt_compile(timing, "main_engine"):
+        if parallel.enabled:
+            plans = {
+                rank: build_engine(
+                    config,
+                    weights,
+                    max_cache_length,
+                    precision=precision,
+                    verbose=verbose,
+                    parallel_config=parallel.for_rank(rank),
+                )
+                for rank in range(parallel.tp_size)
+            }
+            sections = [
+                BundleSection(rank_engine_section(rank), plan)
+                for rank, plan in sorted(plans.items())
+            ]
+            decoder_layout = "dual_profile"
+        else:
+
+            def build_role(role: str) -> bytes:
+                with engine_role(role):
+                    return build_engine(
+                        config,
+                        weights,
+                        max_cache_length,
+                        precision=precision,
+                        verbose=verbose,
+                        parallel_config=parallel,
+                    )
+
+            if target_inspection_role is not None:
+                build_role(target_inspection_role)
+                raise RuntimeError("graph inspection did not reach TensorRT serialization")
+            plan = build_role("decode")
+            sections = [BundleSection("engine_plan", plan)]
+            decoder_layout = "single"
+
+    tokenizer_source = str(options.get("tokenizer_source_model_id_or_path") or model_path)
+    tokenizer_revision = (
+        str(options["tokenizer_source_revision"])
+        if options.get("tokenizer_source_revision")
+        else None
+    )
+    with timed_build_phase(timing, "tokenizer_json_ensure_s"):
+        tokenizer_frame = _detect_tokenizer_frame(
+            tokenizer_source,
+            revision=tokenizer_revision,
+        )
+        _ensure_tokenizer_json(model_path)
+        if tokenizer_frame is None:
+            tokenizer_frame = _detect_tokenizer_frame(str(model_path))
+    prefix_ids, suffix_ids = tokenizer_frame or ([], [])
+    add_special_tokens = bool(prefix_ids or suffix_ids)
+    if tokenizer_frame is None:
+        add_special_tokens = _tokenizer_adds_special_tokens(model_path)
+
+    trt_version = trt_compat.tensorrt_version() or "unknown"
+    trt_abi = trt_compat.tensorrt_abi(trt_version)
+    info = BundleInfo(
+        model_id=model_path.name,
+        model_type=config.model_type,
+        family=name,
+        trt_version=trt_version,
+        trt_abi=trt_abi,
+        gpu_name=_gpu_name(),
+        created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        vocab_size=config.vocab_size,
+        hidden_size=config.hidden_size,
+        num_layers=config.num_hidden_layers,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        max_cache_length=max_cache_length,
+        runtime_strategy=runtime_strategy,
+        precision=precision,
+        tokenizer_add_special_tokens=add_special_tokens,
+    )
+
+    source_config = json.loads((model_path / "config.json").read_text(encoding="utf-8"))
+    if not isinstance(source_config, dict):
+        raise ValueError("BERT config.json must contain a JSON object")
+    runtime_config = {
+        key: value for key, value in source_config.items() if not str(key).startswith("_")
+    }
+    runtime_config.update(
+        {
+            "runtime_strategy": runtime_strategy,
+            "engine_backend": "trt",
+            "trt_version": trt_version,
+            "precision": precision,
+            "tokenizer_add_special_tokens": int(add_special_tokens),
+            "decoder_engine_layout": decoder_layout,
+        }
+    )
+    if trt_abi:
+        runtime_config["trt_abi"] = trt_abi
+    if fp32_layers:
+        runtime_config["fp32_layers"] = fp32_layers
+    if tokenizer_frame is not None:
+        runtime_config["tokenizer_special_prefix_ids"] = prefix_ids
+        runtime_config["tokenizer_special_suffix_ids"] = suffix_ids
+    runtime_config.update(parallel.to_bundle_config_fields())
+
+    slot_section = kernel_slots_section()
+    if slot_section is not None:
+        sections.append(BundleSection("kernel_slots.json", slot_section))
+
+    sections.append(
+        BundleSection(
+            "config.json",
+            json.dumps(runtime_config, indent=2).encode("utf-8"),
+        )
+    )
+    for filename in (
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+    ):
+        path = model_path / filename
+        if path.is_file():
+            sections.append(BundleSection(filename, path.read_bytes()))
+
+    kernel_manifest = []
+    for global_name, library in options.get("kernel_artifacts") or ():
+        section_name = f"kernel_{str(global_name).replace('.', '_')}.so"
+        sections.append(BundleSection(section_name, Path(library).read_bytes()))
+        kernel_manifest.append(
+            {
+                "global_name": str(global_name),
+                "func_name": "run",
+                "section": section_name,
+            }
+        )
+    if kernel_manifest:
+        sections.append(
+            BundleSection(
+                "kernel_manifest.json",
+                json.dumps({"kernels": kernel_manifest}).encode("utf-8"),
+            )
+        )
+
+    with timed_build_phase(timing, "bundle_write_s"):
+        write_bundle(output_path, info, sections)
+    timing["total_s"] = time.monotonic() - started
+    write_build_timing(timing)

--- a/python/tensorrt_model_connect/families/bert/model/__init__.py
+++ b/python/tensorrt_model_connect/families/bert/model/__init__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-"""Family-owned TensorRT model construction components."""

--- a/python/tensorrt_model_connect/families/bert/plugin.py
+++ b/python/tensorrt_model_connect/families/bert/plugin.py
@@ -1,62 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""BERT encoder-only family plugin."""
+"""Minimal registry adapter for the model-owned BERT implementation."""
 
 from __future__ import annotations
 
-from ...parallel_config import (
-    normalize_parallel_config,
-    require_tensorrt_11_for_tensor_parallel,
-)
-from .config import ModelConfig
-from .model.model import build_encoder_engine
-from .weights import WeightDict, load_bert_weights
+from . import model
 
 
 class BertPlugin:
     name = "bert"
     runtime_strategy = "bert_encoder_only"
-
-    def matches(self, model_type: str) -> bool:
-        return model_type.lower() == "bert"
-
-    def load_weights(self, model_dir: str, config: ModelConfig) -> WeightDict:
-        return load_bert_weights(model_dir, config)
-
-    def build_engine(
-        self,
-        config: ModelConfig,
-        weights: WeightDict,
-        max_cache_length: int,
-        *,
-        precision: str = "fp32",
-        quant_ctx=None,
-        verbose: bool = False,
-        parallel_config=None,
-    ) -> bytes:
-        parallel = normalize_parallel_config(parallel_config)
-        if parallel.enabled:
-            require_tensorrt_11_for_tensor_parallel(parallel, feature="BERT tensor-parallel builds")
-            if quant_ctx is not None:
-                raise ValueError("BERT tensor-parallel builds do not support quantization")
-            from .model.model import build_tp_encoder_engine
-
-            return build_tp_encoder_engine(
-                config,
-                weights,
-                max_seq_length=max_cache_length,
-                verbose=verbose,
-                parallel_config=parallel,
-            )
-
-        return build_encoder_engine(
-            config,
-            weights,
-            max_seq_length=max_cache_length,
-            precision=precision,
-            verbose=verbose,
-        )
+    matches = staticmethod(model.matches)
+    load_weights = staticmethod(model.load_weights)
+    build_engine = staticmethod(model.build_engine)
 
 
 plugin = BertPlugin()
+plugin.build = model.build

--- a/tests/builder/test_model_owned_build_dispatch.py
+++ b/tests/builder/test_model_owned_build_dispatch.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded contracts for the model-owned build dispatch bridge."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+import tomllib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_model_connect import engine_builder
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FAMILIES_ROOT = REPO_ROOT / "python" / "tensorrt_model_connect" / "families"
+ENGINE_BUILDER = REPO_ROOT / "python" / "tensorrt_model_connect" / "engine_builder.py"
+MODEL_OWNED_BUILD = "model_owned_build"
+
+
+class OwnerFailure(RuntimeError):
+    """Sentinel proving an owner failure is not replaced by legacy dispatch."""
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        model_type="marked_owner",
+        architectures=[],
+        raw={},
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+    )
+
+
+def _select(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: object,
+    *,
+    marked: bool = True,
+) -> None:
+    config = _config()
+    monkeypatch.setattr(engine_builder, "_setup_trt_import", lambda _rtx: None)
+    monkeypatch.setattr(
+        engine_builder.trt_compat,
+        "resolved_summary",
+        lambda: "mock TensorRT",
+    )
+    monkeypatch.setattr(engine_builder, "_resolve_diffusion_entrypoint", lambda _path: None)
+    monkeypatch.setattr(engine_builder.ModelConfig, "from_dir", lambda _path: config)
+    monkeypatch.setattr(engine_builder, "_apply_family_builder_capabilities", lambda _config: None)
+    monkeypatch.setattr(engine_builder, "find_plugin", lambda _config: plugin)
+
+    def has_capability(_config, capability: str) -> bool:
+        assert capability == MODEL_OWNED_BUILD
+        return marked
+
+    monkeypatch.setattr(engine_builder, "family_has_capability", has_capability)
+    monkeypatch.setattr(engine_builder, "_new_build_timing", lambda _path: {"phases": {}})
+    monkeypatch.setattr(engine_builder, "_write_build_timing", lambda _timing: None)
+
+
+def _forbid_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    def legacy(*_args, **_kwargs):
+        raise AssertionError("marked owner must not enter legacy orchestration")
+
+    monkeypatch.setattr(engine_builder, "_load_plugin_weights", legacy)
+    monkeypatch.setattr(engine_builder, "write_bundle", legacy)
+
+
+def test_marked_owner_receives_every_original_option_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def build(model_dir: str, output_path: str, **options: object) -> None:
+        captured.update(
+            model_dir=model_dir,
+            output_path=output_path,
+            options=options,
+        )
+
+    plugin = SimpleNamespace(name="marked_owner")
+    plugin.build = build
+    _select(monkeypatch, plugin)
+    _forbid_legacy(monkeypatch)
+
+    engine_builder.build_bundle(
+        "/models/marked",
+        "/tmp/marked.bundle",
+        max_cache_length=0,
+        precision=None,
+        quant_calibration_samples=0,
+        kernel_artifacts=[],
+        family_build_options={},
+        diffusion_overrides={},
+        build_timing_path="/tmp/marked-timing.json",
+        max_batch_size=0,
+        tokenizer_source_model_id_or_path="source/model",
+        tokenizer_source_revision="revision",
+    )
+
+    assert captured["model_dir"] == "/models/marked"
+    assert captured["output_path"] == "/tmp/marked.bundle"
+    options = captured["options"]
+    assert isinstance(options, dict)
+    expected = set(inspect.signature(engine_builder.build_bundle).parameters) - {
+        "model_dir",
+        "output_path",
+    }
+    assert set(options) == expected
+    assert options["max_cache_length"] == 0
+    assert options["precision"] is None
+    assert options["quant_calibration_samples"] == 0
+    assert options["max_batch_size"] == 0
+    assert options["tokenizer_source_model_id_or_path"] == "source/model"
+    assert options["tokenizer_source_revision"] == "revision"
+
+
+def _missing_plugin() -> object:
+    return SimpleNamespace(name="marked_owner")
+
+
+def _none_plugin() -> object:
+    return SimpleNamespace(name="marked_owner", build=None)
+
+
+def _noncallable_plugin() -> object:
+    return SimpleNamespace(name="marked_owner", build="not callable")
+
+
+def _dynamic_plugin() -> object:
+    plugin = MagicMock()
+    plugin.name = "marked_owner"
+    return plugin
+
+
+@pytest.mark.parametrize(
+    "plugin_factory",
+    (_missing_plugin, _none_plugin, _noncallable_plugin, _dynamic_plugin),
+    ids=("missing", "none", "noncallable", "dynamic-magic-mock"),
+)
+def test_marked_owner_requires_a_concrete_direct_callable(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin_factory,
+) -> None:
+    _select(monkeypatch, plugin_factory())
+    _forbid_legacy(monkeypatch)
+
+    with pytest.raises(TypeError, match="concrete build binding|not callable"):
+        engine_builder.build_bundle("/models/marked", "/tmp/marked.bundle")
+
+
+def test_marked_owner_exception_propagates_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def build(_model_dir: str, _output_path: str, **_options: object) -> None:
+        raise OwnerFailure("owner build failed")
+
+    plugin = SimpleNamespace(name="marked_owner")
+    plugin.build = build
+    _select(monkeypatch, plugin)
+    _forbid_legacy(monkeypatch)
+
+    with pytest.raises(OwnerFailure, match="owner build failed"):
+        engine_builder.build_bundle("/models/marked", "/tmp/marked.bundle")
+
+
+def test_unmarked_plugin_keeps_the_legacy_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def build(*_args, **_kwargs):
+        raise AssertionError("unmarked plugin build binding must be ignored")
+
+    plugin = SimpleNamespace(
+        name="legacy_owner",
+        runtime_strategy="",
+        default_build_precision="fp32",
+    )
+    plugin.build = build
+    _select(monkeypatch, plugin, marked=False)
+
+    def reached_legacy(*_args, **_kwargs):
+        raise OwnerFailure("entered legacy orchestration")
+
+    monkeypatch.setattr(engine_builder, "_load_plugin_weights", reached_legacy)
+
+    with pytest.raises(OwnerFailure, match="entered legacy orchestration"):
+        engine_builder.build_bundle("/models/legacy", "/tmp/legacy.bundle")
+
+
+def _marked_owner_dirs() -> list[Path]:
+    owners = []
+    for descriptor_path in sorted(FAMILIES_ROOT.glob("*/MODEL.toml")):
+        with descriptor_path.open("rb") as stream:
+            descriptor = tomllib.load(stream)
+        capabilities = descriptor.get("capabilities", ())
+        if isinstance(capabilities, str):
+            capabilities = (capabilities,)
+        if MODEL_OWNED_BUILD in capabilities:
+            owners.append(descriptor_path.parent)
+    return owners
+
+
+def _imports_engine_builder(path: Path) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name.endswith("engine_builder") for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.endswith("engine_builder"):
+                return True
+            if any(alias.name == "engine_builder" for alias in node.names):
+                return True
+    return False
+
+
+def _direct_build_bindings(path: Path) -> list[ast.Assign]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    bindings = []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "plugin"
+            and target.attr == "build"
+            for target in node.targets
+        ):
+            bindings.append(node)
+    return bindings
+
+
+def test_marked_owner_builds_are_direct_and_self_contained() -> None:
+    owners = _marked_owner_dirs()
+    assert owners
+
+    violations = []
+    for owner in owners:
+        plugin_path = owner / "plugin.py"
+        bindings = _direct_build_bindings(plugin_path)
+        if len(bindings) != 1 or not isinstance(bindings[0].value, (ast.Name, ast.Attribute)):
+            violations.append(f"{owner.name}: plugin.build must have one direct binding")
+        for source in sorted(owner.rglob("*.py")):
+            if "tests" in source.relative_to(owner).parts:
+                continue
+            if _imports_engine_builder(source):
+                violations.append(
+                    f"{owner.name}: {source.relative_to(REPO_ROOT)} imports engine_builder"
+                )
+
+    engine_tree = ast.parse(
+        ENGINE_BUILDER.read_text(encoding="utf-8"),
+        filename=str(ENGINE_BUILDER),
+    )
+    owner_names = {owner.name for owner in owners}
+    leaked_names = sorted(
+        {
+            node.value
+            for node in ast.walk(engine_tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in owner_names
+        }
+    )
+    if leaked_names:
+        violations.append(f"engine_builder contains marked owner literals: {leaked_names}")
+
+    assert not violations, "\n".join(violations)

--- a/tests/e2e/models/bert/test_bert_builder_tp.py
+++ b/tests/e2e/models/bert/test_bert_builder_tp.py
@@ -18,13 +18,12 @@ pytest.importorskip(
     reason="tensorrt_model_connect requires tensorrt",
 )
 
-from tensorrt_model_connect.checkpoint_mapper import WeightDict
-from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.bert.config import ModelConfig
 from tensorrt_model_connect.families.bert.plugin import BertPlugin
+from tensorrt_model_connect.families.bert.weights import WeightDict
 from tensorrt_model_connect.parallel_config import ParallelConfig
 
-bert_plugin = importlib.import_module(
-    "tensorrt_model_connect.families.bert.plugin")
+bert_model = importlib.import_module("tensorrt_model_connect.families.bert.model")
 
 _LAYERS = 1
 _HIDDEN = 16
@@ -35,7 +34,7 @@ _VOCAB = 24
 
 def _bert_tp_builder_module():
     return pytest.importorskip(
-        "tensorrt_model_connect.families.bert.model.model",
+        "tensorrt_model_connect.families.bert.model",
         reason="TensorRT is required for BERT TP builder tests",
     )
 
@@ -214,7 +213,7 @@ def test_bert_plugin_routes_tp_build(monkeypatch):
         return b"bert-tp-plan"
 
     monkeypatch.setattr(
-        bert_plugin,
+        bert_model,
         "require_tensorrt_11_for_tensor_parallel",
         lambda parallel, *, feature: None,
     )
@@ -236,7 +235,7 @@ def test_bert_plugin_routes_tp_build(monkeypatch):
 
 def test_bert_plugin_rejects_quantized_tp(monkeypatch):
     monkeypatch.setattr(
-        bert_plugin,
+        bert_model,
         "require_tensorrt_11_for_tensor_parallel",
         lambda parallel, *, feature: None,
     )

--- a/tests/e2e/models/bert/test_bert_encoder_builder_mocked.py
+++ b/tests/e2e/models/bert/test_bert_encoder_builder_mocked.py
@@ -73,7 +73,7 @@ def _import_with_fake_trt(module_name: str):
 @pytest.mark.unit
 def test_encoder_seq_layer_norm_uses_native_normalization() -> None:
     """BERT encoder layer norm uses TRT native add_normalization_v2."""
-    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model.model")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model")
 
     class _FakeTensor:
         def __init__(self, name: str, dtype=np.float32, shape: tuple[int, ...] = (3, 4)):

--- a/tests/e2e/models/bert/test_bert_owned_build.py
+++ b/tests/e2e/models/bert/test_bert_owned_build.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Owner-local bundle, option, tokenizer, and TP contracts for BERT."""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("tensorrt", reason="TensorRT is required for BERT owner imports")
+
+from tensorrt_model_connect import bundle_writer
+from tensorrt_model_connect.families.bert import model
+from tensorrt_model_connect.families.bert.plugin import plugin as registry_plugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+from tensorrt_model_connect.tvm_ffi import graph_build
+
+
+def _write_model_dir(root: Path) -> Path:
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "bert",
+                "architectures": ["BertModel"],
+                "vocab_size": 8,
+                "hidden_size": 4,
+                "intermediate_size": 8,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "max_position_embeddings": 512,
+                "_source_private": "remove-me",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "tokenizer_config.json").write_text('{"do_lower_case": true}\n', encoding="utf-8")
+    (root / "tokenizer.json").write_text('{"version":"1.0"}\n', encoding="utf-8")
+    (root / "vocab.txt").write_text("[PAD]\n[UNK]\n[CLS]\n[SEP]\n", encoding="utf-8")
+    return root
+
+
+def _stub_owner_build(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
+    monkeypatch.setattr(model, "load_weights", lambda *_args, **_kwargs: {"weights": True})
+    monkeypatch.setattr(model, "_ensure_tokenizer_json", lambda _path: None)
+    monkeypatch.setattr(model, "_detect_tokenizer_frame", lambda *_args, **_kwargs: ([101], [102]))
+    monkeypatch.setattr(model, "_gpu_name", lambda: "test-gpu")
+    monkeypatch.setattr(model.trt_compat, "tensorrt_version", lambda: "11.1.0")
+    monkeypatch.setattr(model.trt_compat, "tensorrt_abi", lambda _version=None: "11.1")
+
+    def write_bundle(path, info, sections):
+        captured["path"] = path
+        captured["info"] = info
+        captured["sections"] = list(sections)
+
+    monkeypatch.setattr(bundle_writer, "write_bundle", write_bundle)
+
+
+def _section(captured: dict, name: str) -> bytes:
+    return next(section.data for section in captured["sections"] if section.name == name)
+
+
+def test_registry_adapter_binds_direct_owner_functions() -> None:
+    assert registry_plugin.build is model.build
+    assert registry_plugin.matches is model.matches
+    assert registry_plugin.load_weights is model.load_weights
+    assert registry_plugin.build_engine is model.build_engine
+
+
+def test_owner_build_writes_private_free_single_engine_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    output = tmp_path / "bert.bundle"
+    timing_path = tmp_path / "build-timing.json"
+    captured: dict = {}
+    _stub_owner_build(monkeypatch, captured)
+
+    def build_engine(config, _weights, max_cache_length, **kwargs):
+        captured["build_config"] = config
+        captured["max_cache_length"] = max_cache_length
+        captured["build_kwargs"] = kwargs
+        return b"bert-plan"
+
+    monkeypatch.setattr(model, "build_engine", build_engine)
+    model.build(
+        str(model_dir),
+        str(output),
+        max_cache_length=128,
+        precision="fp16",
+        fp32_layers=[1, 1],
+        build_timing_path=str(timing_path),
+    )
+
+    assert captured["path"] == str(output)
+    assert captured["max_cache_length"] == 128
+    assert captured["build_kwargs"]["precision"] == "fp16"
+    assert captured["build_config"].raw["_fp32_layers"] == [1]
+    assert captured["build_config"].raw["_model_dir"] == str(model_dir)
+    assert [section.name for section in captured["sections"]] == [
+        "engine_plan",
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+
+    runtime_config = json.loads(_section(captured, "config.json"))
+    assert not any(key.startswith("_") for key in runtime_config)
+    assert runtime_config["runtime_strategy"] == "bert_encoder_only"
+    assert runtime_config["engine_backend"] == "trt"
+    assert runtime_config["precision"] == "fp16"
+    assert runtime_config["fp32_layers"] == [1]
+    assert runtime_config["tokenizer_special_prefix_ids"] == [101]
+    assert runtime_config["tokenizer_special_suffix_ids"] == [102]
+    assert runtime_config["decoder_engine_layout"] == "single"
+    assert captured["info"].max_cache_length == 128
+    assert captured["info"].gpu_name == "test-gpu"
+    assert captured["info"].tokenizer_add_special_tokens is True
+
+    timing = json.loads(timing_path.read_text(encoding="utf-8"))
+    assert set(timing["phases"]) == {
+        "weights_loading_s",
+        "trt_compile_s",
+        "trt_compile_main_engine_s",
+        "tokenizer_json_ensure_s",
+        "bundle_write_s",
+    }
+    assert timing["total_s"] >= 0.0
+
+
+def test_owner_build_preserves_default_and_rejects_zero_max_length(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    captured: dict = {}
+    _stub_owner_build(monkeypatch, captured)
+    observed: list[int] = []
+
+    def build_engine(_config, _weights, max_cache_length, **_kwargs):
+        observed.append(max_cache_length)
+        return b"plan"
+
+    monkeypatch.setattr(model, "build_engine", build_engine)
+    model.build(str(model_dir), str(tmp_path / "default.bundle"), max_cache_length=None)
+    assert observed == [256]
+
+    with pytest.raises(ValueError, match="max_cache_length must be >= 1"):
+        model.build(str(model_dir), str(tmp_path / "zero.bundle"), max_cache_length=0)
+    with pytest.raises(ValueError, match="max_cache_length must be >= 1"):
+        model.build(str(model_dir), str(tmp_path / "negative.bundle"), max_cache_length=-1)
+    with pytest.raises(ValueError, match="exceeds BERT max_position_embeddings"):
+        model.build(str(model_dir), str(tmp_path / "oversized.bundle"), max_cache_length=513)
+    assert observed == [256]
+
+
+def test_owner_build_emits_concrete_tp_rank_sections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    captured: dict = {}
+    _stub_owner_build(monkeypatch, captured)
+    ranks: list[int] = []
+
+    def build_engine(_config, _weights, _max_cache_length, **kwargs):
+        parallel = kwargs["parallel_config"]
+        ranks.append(parallel.rank)
+        return f"rank-{parallel.rank}".encode()
+
+    monkeypatch.setattr(model, "build_engine", build_engine)
+    model.build(
+        str(model_dir),
+        str(tmp_path / "tp.bundle"),
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4),
+    )
+
+    assert ranks == [0, 1, 2, 3]
+    assert [section.name for section in captured["sections"][:4]] == [
+        "engine_plan_tp_rank0",
+        "engine_plan_tp_rank1",
+        "engine_plan_tp_rank2",
+        "engine_plan_tp_rank3",
+    ]
+    runtime_config = json.loads(_section(captured, "config.json"))
+    assert runtime_config["parallel_mode"] == "tensor_parallel"
+    assert runtime_config["tensor_parallel_size"] == 4
+    assert runtime_config["decoder_engine_layout"] == "dual_profile"
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"quantize": "fp8"}, "do not support quantization"),
+        ({"quant_scales": "scales.json"}, "do not support quantization"),
+        ({"quant_calibration_samples": 0}, "do not support quantization"),
+        ({"rtx": True}, "does not support TensorRT-RTX"),
+        ({"dynamic_kv_cache": True}, "does not use a decoder KV-cache"),
+        ({"triattention_stats_path": "stats.json"}, "does not use a decoder KV-cache"),
+        ({"dynamic_kv_profile_rows_override": [1]}, "dynamic KV profile rows"),
+        ({"family_build_options": {"bert": {"x": 1}}}, "family build options"),
+        ({"diffusion_overrides": {"height": 1}}, "diffusion overrides"),
+        ({"max_batch_size": 0}, "max_batch_size=1"),
+        ({"max_batch_size": 2}, "max_batch_size=1"),
+        ({"decoder_engine_layout": "dual_profile"}, "default decoder_engine_layout"),
+        ({"precision": "int8"}, "Unsupported BERT precision"),
+        (
+            {
+                "parallel_config": ParallelConfig(mode="context_parallel", cp_size=2),
+            },
+            "context-parallel",
+        ),
+        (
+            {
+                "parallel_config": ParallelConfig(mode="tensor_parallel", tp_size=2),
+                "precision": "fp16",
+            },
+            "only fp32",
+        ),
+    ],
+)
+def test_owner_build_rejects_unproven_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    options: dict,
+    message: str,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    monkeypatch.setattr(
+        model,
+        "load_weights",
+        lambda *_args, **_kwargs: pytest.fail("rejected options reached weight loading"),
+    )
+    with pytest.raises((ValueError, NotImplementedError), match=message):
+        model.build(str(model_dir), str(tmp_path / "rejected.bundle"), **options)
+
+
+def test_tokenizer_frame_uses_pinned_offline_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    class Tokenizer:
+        def encode(self, _text, add_special_tokens=True):
+            return [101, 7, 102] if add_special_tokens else [7]
+
+    class AutoTokenizer:
+        @staticmethod
+        def from_pretrained(source, **kwargs):
+            calls.append((source, kwargs))
+            return Tokenizer()
+
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(AutoTokenizer=AutoTokenizer))
+    assert model._detect_tokenizer_frame("org/bert", revision="abc123") == ([101], [102])
+    assert calls == [
+        (
+            "org/bert",
+            {
+                "trust_remote_code": True,
+                "revision": "abc123",
+                "local_files_only": True,
+            },
+        )
+    ]
+
+
+def test_undersized_wordpiece_tokenizer_is_rebuilt_atomically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"vocab_size":4}\n', encoding="utf-8")
+    (model_dir / "vocab.txt").write_text("[PAD]\n[UNK]\nhello\nworld\n", encoding="utf-8")
+    (model_dir / "tokenizer_config.json").write_text('{"do_lower_case":true}\n', encoding="utf-8")
+    (model_dir / "tokenizer.json").write_text(
+        json.dumps({"model": {"type": "WordPiece", "vocab": {"[PAD]": 0, "[UNK]": 1}}}),
+        encoding="utf-8",
+    )
+    metadata = (model_dir / "tokenizer_config.json").read_bytes()
+    assert model._wordpiece_tokenizer_needs_rebuild(model_dir)
+
+    class Backend:
+        @staticmethod
+        def save(path):
+            Path(path).write_text(
+                json.dumps(
+                    {
+                        "model": {
+                            "type": "WordPiece",
+                            "vocab": {"[PAD]": 0, "[UNK]": 1, "hello": 2, "world": 3},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    class AutoTokenizer:
+        @staticmethod
+        def from_pretrained(_source, **_kwargs):
+            return SimpleNamespace(backend_tokenizer=Backend())
+
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(AutoTokenizer=AutoTokenizer))
+    model._ensure_tokenizer_json(model_dir)
+
+    rebuilt = json.loads((model_dir / "tokenizer.json").read_text(encoding="utf-8"))
+    assert rebuilt["model"]["vocab"]["world"] == 3
+    assert (model_dir / "tokenizer_config.json").read_bytes() == metadata
+    assert not list(model_dir.glob(".trtmc-bert-tokenizer-*"))
+
+
+def test_graph_role_slots_and_kernel_artifacts_are_owner_packaged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    kernel = tmp_path / "kernel.so"
+    kernel.write_bytes(b"kernel-bytes")
+    captured: dict = {}
+    _stub_owner_build(monkeypatch, captured)
+    roles: list[str] = []
+
+    @contextmanager
+    def role_scope(role: str):
+        roles.append(role)
+        yield
+
+    monkeypatch.setattr(graph_build, "engine_role", role_scope)
+    monkeypatch.setattr(graph_build, "inspection_role", lambda: None)
+    monkeypatch.setattr(graph_build, "kernel_slots_section", lambda: b'{"slots":[]}')
+    monkeypatch.setattr(model, "build_engine", lambda *_args, **_kwargs: b"plan")
+
+    model.build(
+        str(model_dir),
+        str(tmp_path / "graph.bundle"),
+        kernel_artifacts=[("bert.attention", str(kernel))],
+    )
+
+    assert roles == ["decode"]
+    names = [section.name for section in captured["sections"]]
+    assert names == [
+        "engine_plan",
+        "kernel_slots.json",
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "kernel_bert_attention.so",
+        "kernel_manifest.json",
+    ]
+    assert _section(captured, "kernel_bert_attention.so") == b"kernel-bytes"
+    assert json.loads(_section(captured, "kernel_manifest.json")) == {
+        "kernels": [
+            {
+                "global_name": "bert.attention",
+                "func_name": "run",
+                "section": "kernel_bert_attention.so",
+            }
+        ]
+    }
+
+
+def test_parallel_graph_inspection_fails_before_engine_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = _write_model_dir(tmp_path / "model")
+    captured: dict = {}
+    _stub_owner_build(monkeypatch, captured)
+    monkeypatch.setattr(graph_build, "inspection_role", lambda: "decode")
+    monkeypatch.setattr(
+        model,
+        "build_engine",
+        lambda *_args, **_kwargs: pytest.fail("parallel inspection reached engine build"),
+    )
+
+    with pytest.raises(NotImplementedError, match="tensor-parallel graph inspection"):
+        model.build(
+            str(model_dir),
+            str(tmp_path / "inspection.bundle"),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=2),
+        )
+
+
+def test_gpu_name_probe_matches_legacy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    cuda = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (0, 3),
+        cudaGetDeviceProperties=lambda device: (
+            0,
+            SimpleNamespace(name=b"Test GPU\x00") if device == 3 else None,
+        ),
+    )
+    monkeypatch.setattr(model, "_cuda_runtime", cuda)
+    assert model._gpu_name() == "Test GPU"
+
+    cuda.cudaGetDevice = lambda: (1, 0)
+    assert model._gpu_name() == ""

--- a/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
+++ b/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
@@ -251,7 +251,7 @@ def test_build_encoder_engine_success_passes_activation(monkeypatch: pytest.Monk
     Postconditions: Layer helper receives BERT activation values and engine bytes are returned.
     """
     fake_trt = _make_fake_trt()
-    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model.model", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model", fake_trt)
 
     monkeypatch.setattr(mod, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod, "_add_seq_layer_norm", _fake_tensor_fn("embed_ln"))
@@ -319,7 +319,7 @@ def test_build_encoder_engine_rejects_out_of_range_fp32_layer(
 ) -> None:
     fake_trt = _make_fake_trt()
     mod = _import_with_fake_trt(
-        "tensorrt_model_connect.families.bert.model.model", fake_trt)
+        "tensorrt_model_connect.families.bert.model", fake_trt)
     config = types.SimpleNamespace(
         hidden_size=4,
         num_hidden_layers=2,
@@ -342,7 +342,7 @@ def test_build_encoder_engine_raises_when_builder_returns_none(monkeypatch: pyte
     """
     fake_trt = _make_fake_trt()
     fake_trt.Builder.plan_to_return = None
-    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model.model", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.model", fake_trt)
 
     monkeypatch.setattr(mod, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod, "_add_seq_layer_norm", _fake_tensor_fn("embed_ln"))

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -73,6 +73,92 @@ def _demo_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _root_model_repo(tmp_path: Path) -> Path:
+    family = (
+        tmp_path
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\nplugin = "demo"\nmodule = "plugin"\n'
+        'capabilities = ["model_owned_build"]\n',
+    )
+    _write(
+        family / "__init__.py",
+        'from .plugin import plugin\n\n__all__ = ["plugin"]\n',
+    )
+    _write(
+        family / "plugin.py",
+        "from . import model\n\n"
+        "class DemoPlugin:\n"
+        "    build = staticmethod(model.build)\n\n"
+        "plugin = DemoPlugin()\n",
+    )
+    _write(family / "model.py", "def build():\n    return 'bundle'\n")
+    return tmp_path
+
+
+def test_model_owned_build_uses_root_model_layout_and_metrics(tmp_path: Path) -> None:
+    repo = _root_model_repo(tmp_path)
+
+    family = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert family["noncanonical_model_paths"] == []
+    assert family["metrics"]["model_files"] == 1
+    assert family["metrics"]["model_lines"] == 2
+    assert family["metrics"]["model_bytes"] > 0
+    assert not [
+        item
+        for item in family["violations"]
+        if item["kind"] == "noncanonical_model_path"
+    ]
+
+
+def test_model_owned_build_requires_root_model_file(tmp_path: Path) -> None:
+    repo = _root_model_repo(tmp_path)
+    family_dir = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    (family_dir / "model.py").unlink()
+
+    family = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert family["noncanonical_model_paths"] == ["model.py"]
+    assert family["metrics"]["model_files"] == 0
+    assert {
+        "kind": "noncanonical_model_path",
+        "path": "model.py",
+    } in family["violations"]
+
+
+def test_model_owned_build_rejects_legacy_model_directory(tmp_path: Path) -> None:
+    repo = _root_model_repo(tmp_path)
+    family_dir = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(family_dir / "model/__init__.py", '"""Legacy model package."""\n')
+
+    family = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert family["noncanonical_model_paths"] == ["model/"]
+    assert family["metrics"]["model_files"] == 1
+    assert {
+        "kind": "noncanonical_model_path",
+        "path": "model/",
+    } in family["violations"]
+
+
 def test_audit_classifies_production_tool_and_unreachable_modules(
     tmp_path: Path,
 ) -> None:

--- a/tools/family_specialization.py
+++ b/tools/family_specialization.py
@@ -26,6 +26,7 @@ from typing import Any, Iterable
 SCHEMA_VERSION = 1
 FAMILIES_PACKAGE = "tensorrt_model_connect.families"
 APPROVED_FAMILIES_ROOT_IMPORTS = frozenset({"base"})
+MODEL_OWNED_BUILD_CAPABILITY = "model_owned_build"
 MODEL_ROOT_FILES = frozenset({"__init__.py", "model.py", "parallel.py", "runtime.py"})
 MODEL_ROOT_DIRECTORIES = frozenset({"components"})
 MISPLACED_MODEL_PATHS = frozenset(
@@ -687,8 +688,31 @@ def _sibling_imports(family: str, modules: dict[str, ModuleInfo]) -> list[dict[s
     return sorted(violations, key=lambda item: (item["path"], item["line"]))
 
 
-def _noncanonical_model_paths(family_dir: Path) -> list[str]:
+def _uses_root_model_layout(family_dir: Path) -> bool:
+    manifest = tomllib.loads(
+        (family_dir / "MODEL.toml").read_text(encoding="utf-8")
+    )
+    capabilities = manifest.get("capabilities", ())
+    if isinstance(capabilities, str):
+        capabilities = (capabilities,)
+    if not isinstance(capabilities, (list, tuple)):
+        return False
+    return MODEL_OWNED_BUILD_CAPABILITY in capabilities
+
+
+def _noncanonical_model_paths(
+    family_dir: Path,
+    *,
+    root_model_layout: bool,
+) -> list[str]:
     model_dir = family_dir / "model"
+    if root_model_layout:
+        result = []
+        if not (family_dir / "model.py").is_file():
+            result.append("model.py")
+        if model_dir.exists():
+            result.append("model/")
+        return result
     if not model_dir.is_dir():
         return ["model/"]
     result: list[str] = []
@@ -702,13 +726,20 @@ def _noncanonical_model_paths(family_dir: Path) -> list[str]:
     return result
 
 
-def _source_metrics(family_dir: Path) -> dict[str, int]:
+def _source_metrics(
+    family_dir: Path,
+    *,
+    root_model_layout: bool,
+) -> dict[str, int]:
     files = [
         path
         for path in family_dir.rglob("*")
         if path.is_file() and "__pycache__" not in path.parts
     ]
-    model_files = [path for path in files if (family_dir / "model") in path.parents]
+    if root_model_layout:
+        model_files = [path for path in files if path == family_dir / "model.py"]
+    else:
+        model_files = [path for path in files if (family_dir / "model") in path.parents]
 
     def lines(paths: list[Path]) -> int:
         total = 0
@@ -738,6 +769,7 @@ def audit_family(
     repo_root = repo_root.resolve()
     family_dir = family_dir.resolve()
     family = family_dir.name
+    root_model_layout = _uses_root_model_layout(family_dir)
     modules = _family_modules(repo_root, family_dir)
     package_module = f"{FAMILIES_PACKAGE}.{family}"
     dynamic_entries, dynamic_roots, dynamic_symbols = _dynamic_entrypoints(
@@ -786,7 +818,10 @@ def audit_family(
         symbol_roots,
     )
     sibling_imports = _sibling_imports(family, modules)
-    noncanonical = _noncanonical_model_paths(family_dir)
+    noncanonical = _noncanonical_model_paths(
+        family_dir,
+        root_model_layout=root_model_layout,
+    )
     misplaced = sorted(
         path
         for path in noncanonical
@@ -855,7 +890,10 @@ def audit_family(
 
     return {
         "family": family,
-        "metrics": _source_metrics(family_dir),
+        "metrics": _source_metrics(
+            family_dir,
+            root_model_layout=root_model_layout,
+        ),
         "entrypoints": {
             "production_modules": sorted(production_seeds),
             "dynamic": [


### PR DESCRIPTION
## Background

This is a narrow architecture preview for incremental model ownership. The shared
builder currently owns bundle orchestration for every family, which couples model
changes to one central implementation. This PR migrates BERT only.

## Exit Criteria

- BERT owns its complete build path in `families/bert/model.py`.
- A capability-marked owner is dispatched once and never falls back to legacy orchestration.
- Unmarked families retain their existing behavior.
- No runtime, validation, performance, or repository-wide layout migration is included.

## Implementation

- Added a 24-line capability-driven dispatch bridge with no model-name branch, registry,
  inheritance, request object, or adapter framework.
- Flattened BERT's graph module to the owner root and made it own config parsing, weight
  loading, single-device and TP engine construction, tokenizer repair/framing, graph
  snapshot/patch packaging, build timing, runtime config, and bundle assembly.
- Kept `plugin.py` as a minimal registry adapter with direct owner-function bindings.
- Fail closed on unsupported BERT modes instead of routing back through shared orchestration.
- Taught the specialization audit generically that `model_owned_build` owners use root
  `model.py` and must not retain the legacy `model/` package.

## Validation

- `pytest` focused BERT owner/dispatch/specialization suite: 63 passed.
- Exact model-only projection: 4,759 sibling model files excluded; 42 owner tests passed.
- `model_ci.py validate --revision HEAD`: 83 families.
- `family_specialization.py audit --family bert`: 0 violations.
- Full builder suite: 887 passed, 8 skipped, 1 failed; the remaining SiLU graph-block
  failure reproduces unchanged on pristine `main` and is outside this diff.
- Exact-head BERT premerge model proof: C++ 1 passed, Python 42 passed, BGE E2E passed,
  TRT/HF cosine 0.99999809, one build invocation, no recovery or fallback.
- Same-checkpoint legacy versus owned runtime: identical public headers/sections and
  output shape; cosine 0.99999835, max absolute difference 0.00782.
- Direct real `bert.model.build()` completed without importing `engine_builder`; its
  runtime output versus dispatched owner build had cosine 0.99999786.
- TP4 bundle build produced exactly four rank engines and no single-device fallback.
  TP4 inference was not qualified because an independent NCCL collective reproduced
  the same hardware-fabric failure.
- Required exact-head premerge passed for the current signed-off commit.

## Notes For Future Readers

Suggested review order:

1. The capability dispatch in `engine_builder.py`.
2. BERT's root `model.py` build path and strict option boundary.
3. The generic specialization and no-fallback tests.

This is a temporary incremental migration bridge, not a compatibility promise. A migrated
owner has one production bundle path; failures never fall through to the legacy builder.
