### PR TITLE
build(ci): define TensorRT runtime overlays

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Repository-wide ARM64 development container. It provides the TensorRT,
-# CUDA, Python, and all declared execution-profile dependencies used to develop
-# and build any TRTMC model supported by the selected target. Project source is
-# mounted at runtime; this image does not contain a model or choose a runtime.
+# Repository-wide ARM64 development container. Common CUDA, Python, tooling,
+# and model execution profiles are built once; the final stage adds one exact
+# TensorRT version as an immutable overlay. Project source is mounted at
+# runtime, so the image does not contain a model or choose an application.
 
-ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt:26.07-py3@sha256:f794a79e8b996d16dbc2e5884e19d8e2269a51c960106c9b49b0061a6926c541
-FROM ${TENSORRT_IMAGE} AS ci-base
-
+ARG CUDA_IMAGE=nvidia/cuda:13.3.0-devel-ubuntu24.04@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52
 ARG TENSORRT_VERSION=11.1.0.106
+ARG TENSORRT_APT_VERSION=11.1.0.106-1+cuda13.3
+FROM ${CUDA_IMAGE} AS ci-common-base
+
 ARG PYTORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu130
 ARG TORCH_VERSION=2.12.0+cu130
 ARG TORCHVISION_VERSION=0.27.0+cu130
@@ -36,34 +37,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12-venv \
     python3-pip \
     lcov \
+    nlohmann-json3-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# The pinned NVIDIA NGC image is the official TensorRT 11.1 ARM64 development
-# release. Validate the Python binding, C++ headers, runtime library, and Thor
-# (SM110) builder resource before adding any project dependencies.
-RUN python3.12 -c \
-      "import tensorrt; assert tensorrt.__version__ == '${TENSORRT_VERSION}', tensorrt.__version__" && \
-    grep -q "#define TRT_MAJOR_ENTERPRISE 11" \
-      /usr/include/aarch64-linux-gnu/NvInferVersion.h && \
-    grep -q "#define TRT_MINOR_ENTERPRISE 1" \
-      /usr/include/aarch64-linux-gnu/NvInferVersion.h && \
-    grep -q "#define TRT_PATCH_ENTERPRISE 0" \
-      /usr/include/aarch64-linux-gnu/NvInferVersion.h && \
-    grep -q "#define TRT_BUILD_ENTERPRISE 106" \
-      /usr/include/aarch64-linux-gnu/NvInferVersion.h && \
-    test -f /usr/lib/aarch64-linux-gnu/libnvinfer.so.11 && \
-    test -f /usr/lib/aarch64-linux-gnu/libnvinfer_builder_resource_sm110.so.11.1.0
 
 # ── Python venv with all deps ───────────────────────────────────────────────
 ENV VIRTUAL_ENV=/opt/venv
-RUN python3.12 -m venv --system-site-packages $VIRTUAL_ENV
+RUN python3.12 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# The venv inherits the official TensorRT binding from the NGC image. CMake
-# derives the backend ABI alias from the matching NvInferVersion.h.
-RUN pip install -U pip && \
-    python3.12 -c \
-      "import tensorrt; assert tensorrt.__version__ == '${TENSORRT_VERSION}', tensorrt.__version__"
+RUN pip install -U pip
 
 # CUDA Python bindings (needed by debug_runner.py / diff tools). Match the
 # CUDA 13.0 Python stack pulled by PyTorch.
@@ -144,17 +126,10 @@ RUN pip install --force-reinstall \
       "torchaudio==${TORCHAUDIO_VERSION}" \
       --index-url "${PYTORCH_CUDA_INDEX}" && \
     pip install "setuptools>=80,<82" && \
-    LD_LIBRARY_PATH="/opt/venv/lib/python3.12/site-packages/tensorrt_libs:/usr/local/cuda/lib64" \
-      python3 -c "import tensorrt; assert tensorrt.__version__ == '${TENSORRT_VERSION}', tensorrt.__version__" && \
     python3 -c "import torch; assert torch.__version__ == '${TORCH_VERSION}', torch.__version__" && \
     python3 -c "import importlib.metadata as m; assert m.version('nvidia-modelopt') == '${MODELOPT_VERSION}', m.version('nvidia-modelopt')"
 
 # ── Environment ─────────────────────────────────────────────────────────────
-# Pre-compute paths so cmake / runtime find TRT without manual exports
-ENV TRT_LIB_DIR=/usr/lib/aarch64-linux-gnu
-ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu
-ENV LD_LIBRARY_PATH="$TRT_LIB_DIR:/usr/local/cuda/lib64"
-
 # ARM64 Blackwell targets use the system CUDA 13 cuBLAS kernels. Keep PyTorch/HF
 # reference inference on the system cuBLAS instead of pip-installed CUDA libs.
 ENV LD_PRELOAD=/usr/local/cuda/lib64/libcublas.so.13
@@ -164,18 +139,11 @@ ENV LD_PRELOAD=/usr/local/cuda/lib64/libcublas.so.13
 #   python3 -m pytest --help | grep -- '--cov' && \
 #   gcovr --version && lcov --version && genhtml --version
 
-# Keep the final layer small and cache-friendly. Isolated validation runs have
-# networking disabled, so CMake must find nlohmann/json in the image instead of
-# falling back to FetchContent during each isolated scratch build.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nlohmann-json3-dev && \
-    rm -rf /var/lib/apt/lists/*
-
 # Build every family-declared Python execution profile while network access is
 # available. The family-owned lock and verification files are the only package
 # source of truth; python_profiles.py additionally rejects non-exact pins and
 # verifies every installed distribution before marking a profile ready.
-FROM ci-base AS python-profile-builder
+FROM ci-common-base AS python-profile-builder
 
 ENV PYTHONPATH=/opt/trtmc-profile-source
 ENV TRTMC_PYTHON_PROFILE_ROOT=/opt/trtmc-python-profiles
@@ -187,8 +155,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     pip install "maturin==1.14.1"
 # Avoid compiling profile-local CUDA extensions for every architecture known
-# to a GPU-less Docker build. Keep 10.0 as the existing default; Jetson AGX
-# Thor callers pass 11.0 for SM110.
+# to a GPU-less Docker build. Keep 10.0 as the GB300 target.
 COPY python/tensorrt_model_connect /opt/trtmc-profile-source/tensorrt_model_connect
 COPY .github/scripts/build-python-profiles.py /opt/trtmc-build-python-profiles.py
 RUN python3 /opt/trtmc-build-python-profiles.py \
@@ -197,7 +164,7 @@ RUN python3 /opt/trtmc-build-python-profiles.py \
 # Do not retain the full builder source tree in the development image. Only the
 # verified virtual environments cross the stage boundary, so sibling model
 # implementations cannot satisfy imports in an isolated source projection.
-FROM ci-base AS ci-runtime
+FROM ci-common-base AS ci-common
 
 COPY --from=python-profile-builder \
     /opt/trtmc-python-profiles /opt/trtmc-python-profiles
@@ -206,6 +173,48 @@ ENV TRTMC_PYTHON_PROFILE_ROOT=/opt/trtmc-python-profiles
 # the image after changing their lock or verification files.
 ENV TRTMC_PYTHON_PROFILE_PREBUILT_ONLY=1
 
-WORKDIR /workspace/tensorrt-model-connect
+# Keep the reusable common layer independent of every TensorRT release. The
+# version overlay below is the only stage allowed to add bindings, headers, or
+# native runtime libraries.
+RUN python3 -c \
+      'import importlib.metadata as m, importlib.util; assert importlib.util.find_spec("tensorrt") is None; missing = ("tensorrt", "tensorrt_cu13", "tensorrt_cu13_bindings", "tensorrt_cu13_libs"); assert all(not tuple(m.distributions(name=name)) for name in missing)' && \
+    test ! -e /usr/include/aarch64-linux-gnu/NvInferVersion.h && \
+    test ! -e /usr/include/aarch64-linux-gnu/NvOnnxParser.h && \
+    test -z "$(find /opt/venv -name 'libnvinfer.so*' -print -quit)" && \
+    test -z "$(find /opt/venv -name 'libnvonnxparser.so*' -print -quit)"
 
+WORKDIR /workspace/tensorrt-model-connect
 CMD ["bash"]
+
+# Add one exact TensorRT toolchain without rebuilding common dependencies or
+# execution profiles. The same target is built with different version arguments
+# to produce immutable TRT 11.1 and TRT 11.2 overlays.
+FROM ci-common AS ci-runtime
+
+ARG TENSORRT_VERSION
+ARG TENSORRT_APT_VERSION
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      "libnvinfer-dev=${TENSORRT_APT_VERSION}" \
+      "libnvinfer-headers-dev=${TENSORRT_APT_VERSION}" \
+      "libnvinfer-headers-plugin-dev=${TENSORRT_APT_VERSION}" \
+      "libnvinfer-safe-headers-dev=${TENSORRT_APT_VERSION}" \
+      "libnvinfer11=${TENSORRT_APT_VERSION}" \
+      "libnvonnxparsers-dev=${TENSORRT_APT_VERSION}" \
+      "libnvonnxparsers11=${TENSORRT_APT_VERSION}" && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir "tensorrt==${TENSORRT_VERSION}"
+
+ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs
+ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu
+ENV LD_LIBRARY_PATH="$TRT_LIB_DIR:/usr/local/cuda/lib64"
+
+RUN EXPECTED_TENSORRT_VERSION="$TENSORRT_VERSION" python3 -c \
+      'import ctypes, importlib.metadata as m, os; from pathlib import Path; expected = os.environ["EXPECTED_TENSORRT_VERSION"]; versions = tuple(map(int, expected.split("."))); assert all(m.version(name) == expected for name in ("tensorrt", "tensorrt_cu13", "tensorrt_cu13_bindings", "tensorrt_cu13_libs")); import tensorrt; assert tensorrt.__version__ == expected; include = Path("/usr/include/aarch64-linux-gnu"); header = (include / "NvInferVersion.h").read_text().splitlines(); assert (include / "NvOnnxParser.h").is_file(); assert all(f"#define TRT_{name}_ENTERPRISE {value}" in header for name, value in zip(("MAJOR", "MINOR", "PATCH", "BUILD"), versions)); major = versions[0]; libraries = Path(m.distribution("tensorrt_cu13_libs").locate_file("tensorrt_libs")); assert (libraries / f"libnvonnxparser.so.{major}").is_file(); assert next(libraries.glob("libnvinfer_builder_resource_sm110.so.*"), None) is not None; library = ctypes.CDLL(str(libraries / f"libnvinfer.so.{major}")); functions = tuple(getattr(library, f"getInferLib{name}Version") for name in ("Major", "Minor", "Patch", "Build")); [setattr(function, "restype", ctypes.c_int32) for function in functions]; assert tuple(function() for function in functions) == versions' && \
+    printf '#include <NvInferRuntime.h>\n#include <NvOnnxParser.h>\nint main() { return getInferLibVersion() > 0 ? 0 : 1; }\n' | \
+      c++ -x c++ - -I"$TRT_INC_DIR" -I/usr/local/cuda/include -L"$TRT_LIB_DIR" \
+        -Wl,-rpath,"$TRT_LIB_DIR" -Wl,--no-as-needed \
+        -lnvinfer -lnvonnxparser -o /tmp/trtmc-trt-link-probe && \
+    /tmp/trtmc-trt-link-probe && \
+    rm -f /tmp/trtmc-trt-link-probe

--- a/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/lance/python_profile_requirements/lance_reference.lock.txt
@@ -1,4 +1,3 @@
-flash-attn==2.8.3
 huggingface-hub==0.29.1
 imageio==2.34.0
 numpy==1.26.4

--- a/python/tensorrt_model_connect/families/lance/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/lance/python_profile_verify.py
@@ -8,10 +8,8 @@ import imageio
 import numpy
 import scipy
 import sklearn
-from flash_attn import flash_attn_varlen_func
 from transformers.cache_utils import SlidingWindowCache
 
-assert metadata.version("flash-attn") == "2.8.3"
 assert metadata.version("huggingface-hub") == "0.29.1"
 assert metadata.version("imageio") == "2.34.0"
 assert metadata.version("numpy") == "1.26.4"
@@ -25,9 +23,7 @@ assert callable(imageio.imread)
 assert numpy.__version__ == "1.26.4"
 assert scipy.__version__ == "1.12.0"
 assert sklearn.__version__ == "1.4.2"
-assert callable(flash_attn_varlen_func)
 assert SlidingWindowCache is not None
 print(
-    f"flash-attn={metadata.version('flash-attn')} "
-    f"transformers={metadata.version('transformers')}"
+    f"attention=torch-sdpa transformers={metadata.version('transformers')}"
 )

--- a/tests/e2e/models/lance/e2e_plugins/references/lance_image_attention_compat/flash_attn/__init__.py
+++ b/tests/e2e/models/lance/e2e_plugins/references/lance_image_attention_compat/flash_attn/__init__.py
@@ -4,9 +4,8 @@
 """Packed-attention compatibility for Lance reference environments.
 
 Lance imports FlashAttention's packed, dense, rotary, and padding helpers while
-loading its official image-reference modules. Platforms without a qualified
-FlashAttention package can explicitly select this PyTorch implementation. It is
-never selected by CPU architecture inference.
+loading its official image-reference modules. The reference runner always maps
+those imports to this PyTorch SDPA implementation.
 """
 
 from __future__ import annotations

--- a/tests/e2e/models/lance/e2e_plugins/references/lance_official.py
+++ b/tests/e2e/models/lance/e2e_plugins/references/lance_official.py
@@ -31,18 +31,6 @@ _IMAGE_REFERENCE_COMPAT = Path(__file__).with_name("lance_image_compat")
 _IMAGE_REFERENCE_ATTENTION_COMPAT = Path(__file__).with_name(
     "lance_image_attention_compat"
 )
-_ATTENTION_BACKEND_ENV = "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND"
-_ATTENTION_BACKENDS = frozenset({"flash_attn", "torch_sdpa"})
-
-
-def _attention_backend(environment: dict[str, str]) -> str:
-    attention_backend = environment.get(_ATTENTION_BACKEND_ENV, "flash_attn").strip()
-    if attention_backend not in _ATTENTION_BACKENDS:
-        raise RuntimeError(
-            "unsupported Lance reference attention backend "
-            f"{attention_backend!r}; expected one of {sorted(_ATTENTION_BACKENDS)}"
-        )
-    return attention_backend
 
 
 def _image_reference_environment(
@@ -51,15 +39,13 @@ def _image_reference_environment(
     """Expose only the optional imports needed by upstream's image path."""
     environment = dict(os.environ if base is None else base)
     existing = environment.get("PYTHONPATH", "").strip()
-    attention_backend = _attention_backend(environment)
-    attention_compat = (
-        str(_IMAGE_REFERENCE_ATTENTION_COMPAT)
-        if attention_backend == "torch_sdpa"
-        else ""
-    )
     environment["PYTHONPATH"] = os.pathsep.join(
         value
-        for value in (attention_compat, str(_IMAGE_REFERENCE_COMPAT), existing)
+        for value in (
+            str(_IMAGE_REFERENCE_ATTENTION_COMPAT),
+            str(_IMAGE_REFERENCE_COMPAT),
+            existing,
+        )
         if value
     )
     return environment
@@ -68,18 +54,8 @@ def _image_reference_environment(
 def _image_reference_vit_path(
     artifact_dir: Path,
     vit_path: Path,
-    *,
-    attention_backend: str,
 ) -> Path:
     """Create a run-owned VIT view that selects SDPA without editing HF cache."""
-    if attention_backend == "flash_attn":
-        return vit_path
-    if attention_backend != "torch_sdpa":
-        raise RuntimeError(
-            "unsupported Lance reference attention backend "
-            f"{attention_backend!r}; expected one of {sorted(_ATTENTION_BACKENDS)}"
-        )
-
     source_config = vit_path / "config.json"
     try:
         config = json.loads(source_config.read_text(encoding="utf-8"))
@@ -268,7 +244,6 @@ class LanceOfficialReference:
         reference_vit_path = _image_reference_vit_path(
             artifact_dir,
             vit_path,
-            attention_backend=_attention_backend(environment),
         )
         request_path.write_text(
             json.dumps(

--- a/tests/e2e/models/lance/test_lance_official_reference.py
+++ b/tests/e2e/models/lance/test_lance_official_reference.py
@@ -12,8 +12,6 @@ import subprocess
 import sys
 from types import SimpleNamespace
 
-import pytest
-
 from tests.e2e.models.lance.e2e_plugins.references import lance_official
 
 
@@ -78,10 +76,8 @@ def test_lance_image_reference_provides_decord_import_without_video_support() ->
     assert environment["PYTHONPATH"].endswith(":/existing/python/path")
 
 
-def test_lance_image_reference_adds_explicit_sdpa_fallback() -> None:
-    environment = lance_official._image_reference_environment(
-        {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"}
-    )
+def test_lance_image_reference_uses_sdpa_fallback() -> None:
+    environment = lance_official._image_reference_environment({})
 
     assert environment["PYTHONPATH"].split(os.pathsep)[:2] == [
         str(lance_official._IMAGE_REFERENCE_ATTENTION_COMPAT),
@@ -103,12 +99,7 @@ def test_lance_sdpa_fallback_is_importable_without_distribution_metadata() -> No
                 "else:\n raise AssertionError('fallback must not publish metadata')"
             ),
         ],
-        env=lance_official._image_reference_environment(
-            {
-                **os.environ,
-                "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa",
-            }
-        ),
+        env=lance_official._image_reference_environment(dict(os.environ)),
         capture_output=True,
         text=True,
     )
@@ -137,7 +128,6 @@ def test_lance_sdpa_vit_overlay_preserves_checkpoint_and_changes_only_config(
     overlay = lance_official._image_reference_vit_path(
         tmp_path / "artifacts",
         vit_path,
-        attention_backend="torch_sdpa",
     )
 
     assert overlay != vit_path
@@ -150,39 +140,6 @@ def test_lance_sdpa_vit_overlay_preserves_checkpoint_and_changes_only_config(
     assert json.loads(config_path.read_text(encoding="utf-8"))[
         "_attn_implementation"
     ] == "flash_attention_2"
-
-
-def test_lance_native_flash_attention_uses_original_vit_checkpoint(
-    tmp_path: Path,
-) -> None:
-    vit_path = tmp_path / "Qwen2.5-VL-ViT"
-    vit_path.mkdir()
-
-    assert (
-        lance_official._image_reference_vit_path(
-            tmp_path / "artifacts",
-            vit_path,
-            attention_backend="flash_attn",
-        )
-        == vit_path
-    )
-
-
-def test_lance_image_reference_keeps_explicit_native_flash_attention() -> None:
-    environment = lance_official._image_reference_environment(
-        {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "flash_attn"}
-    )
-
-    assert str(lance_official._IMAGE_REFERENCE_ATTENTION_COMPAT) not in environment[
-        "PYTHONPATH"
-    ].split(os.pathsep)
-
-
-def test_lance_image_reference_rejects_unknown_attention_backend() -> None:
-    with pytest.raises(RuntimeError, match="unsupported Lance reference attention backend"):
-        lance_official._image_reference_environment(
-            {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "automatic"}
-        )
 
 
 def test_lance_image_reference_keeps_upstream_visual_generation_contract(
@@ -235,10 +192,6 @@ def test_lance_image_reference_keeps_upstream_visual_generation_contract(
         lambda *_args: str(artifact_dir),
     )
     monkeypatch.setattr(lance_official.subprocess, "run", run)
-    monkeypatch.setenv(
-        "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND",
-        "torch_sdpa",
-    )
     monkeypatch.setattr(
         lance_official,
         "save_full_stderr",

--- a/tests/e2e/models/lance/test_lance_python_profiles.py
+++ b/tests/e2e/models/lance/test_lance_python_profiles.py
@@ -13,7 +13,7 @@ def test_lance_reference_profile_pins_upstream_transformers_stack() -> None:
         / "lance_reference.lock.txt"
     ).read_text(encoding="utf-8")
 
-    assert "flash-attn==2.8.3" in requirements
+    assert "flash-attn" not in requirements
     assert "huggingface-hub==0.29.1" in requirements
     assert "imageio==2.34.0" in requirements
     assert "numpy==1.26.4" in requirements

--- a/tests/model_checks/environments/auto-thor.yaml
+++ b/tests/model_checks/environments/auto-thor.yaml
@@ -5,7 +5,6 @@ schema_version: trtmc.model-check-environment/v1
 id: auto-thor
 
 environment_variables:
-  TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND: torch_sdpa
   TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF: disable
 
 storage:

--- a/tests/model_checks/environments/gb300.yaml
+++ b/tests/model_checks/environments/gb300.yaml
@@ -4,9 +4,6 @@
 schema_version: trtmc.model-check-environment/v1
 id: gb300
 
-environment_variables:
-  TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND: torch_sdpa
-
 storage:
   root: ${TRTMC_CHECK_STORAGE_ROOT}
   results_root: ${TRTMC_CHECK_STORAGE_ROOT}/results

--- a/tests/model_checks/environments/l4t-thor.yaml
+++ b/tests/model_checks/environments/l4t-thor.yaml
@@ -8,9 +8,6 @@ library_dirs:
   - ${TRTMC_CHECK_STORAGE_ROOT}/runtime/TensorRT-11.0.2.2/lib
 executable_dirs:
   - /usr/local/cuda/bin
-environment_variables:
-  TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND: torch_sdpa
-
 storage:
   root: ${TRTMC_CHECK_STORAGE_ROOT}
   results_root: ${TRTMC_CHECK_STORAGE_ROOT}/results

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -12,7 +13,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-from tools.ci.docker_image import WorkflowImageLock
+import pytest
+
+from tools.ci.docker_image import CiError, DockerImageManager, WorkflowImageLock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -21,6 +24,29 @@ DEFAULT_PROFILES = (
     "chronos,deepseek_ocr,elf_flow,elf_flow_reference,internlm,lance_reference,magpie_tts_reference,"
     "nemotron_h_reference,phi4_multimodal,reference_common,sana_wm_reference"
 )
+TENSORRT_VERSION = "11.1.0.106"
+TENSORRT_APT_VERSION = "11.1.0.106-1+cuda13.3"
+TENSORRT_DISTRIBUTIONS = {
+    name: TENSORRT_VERSION
+    for name in (
+        "tensorrt",
+        "tensorrt_cu13",
+        "tensorrt_cu13_bindings",
+        "tensorrt_cu13_libs",
+    )
+}
+TENSORRT_APT_PACKAGES = {
+    name: TENSORRT_APT_VERSION
+    for name in (
+        "libnvinfer-dev",
+        "libnvinfer-headers-dev",
+        "libnvinfer-headers-plugin-dev",
+        "libnvinfer-safe-headers-dev",
+        "libnvinfer11",
+        "libnvonnxparsers-dev",
+        "libnvonnxparsers11",
+    )
+}
 
 
 def _record_lock_open_modes(monkeypatch, lock_path: Path, *, lose_create_race=False) -> list[str]:
@@ -112,6 +138,11 @@ if [ "${1:-}" = "run" ]; then
   fi
   cat <<'EOF'
 TENSORRT_VERSION=11.1.0.106
+TENSORRT_PYTHON_DISTRIBUTIONS={"tensorrt":"11.1.0.106","tensorrt_cu13":"11.1.0.106","tensorrt_cu13_bindings":"11.1.0.106","tensorrt_cu13_libs":"11.1.0.106"}
+TENSORRT_APT_PACKAGES={"libnvinfer-dev":"11.1.0.106-1+cuda13.3","libnvinfer-headers-dev":"11.1.0.106-1+cuda13.3","libnvinfer-headers-plugin-dev":"11.1.0.106-1+cuda13.3","libnvinfer-safe-headers-dev":"11.1.0.106-1+cuda13.3","libnvinfer11":"11.1.0.106-1+cuda13.3","libnvonnxparsers-dev":"11.1.0.106-1+cuda13.3","libnvonnxparsers11":"11.1.0.106-1+cuda13.3"}
+TENSORRT_HEADER_VERSION=11.1.0.106
+TENSORRT_OVERLAY_FILES=present
+TENSORRT_NATIVE_VERSION=11.1.0.106
 MODELOPT_VERSION=0.44.0
 NLOHMANN_JSON_HEADER=present
 EOF
@@ -265,7 +296,9 @@ default_execution_profiles = ["reference|demo"]
     (demo_root / "verify.py").write_text("import demo_package\n", encoding="utf-8")
 
     (repo_root / "Dockerfile").write_text(
-        "ARG TENSORRT_VERSION=11.1.0.106\nARG MODELOPT_VERSION=0.44.0\n",
+        "ARG TENSORRT_VERSION=11.1.0.106\n"
+        "ARG TENSORRT_APT_VERSION=11.1.0.106-1+cuda13.3\n"
+        "ARG MODELOPT_VERSION=0.44.0\n",
         encoding="utf-8",
     )
     return repo_root, manifest, requirements
@@ -432,6 +465,185 @@ def test_missing_prebuilt_profiles_rebuilds_the_image(tmp_path: Path) -> None:
     assert "prebuilt Python profiles differ" in result.stdout
 
 
+def test_tensorrt_overlay_contract_reports_each_mismatch(tmp_path: Path) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    manager = DockerImageManager(repo_root)
+    requirements = manager._read_requirements()
+    actual = {
+        "TENSORRT_VERSION": TENSORRT_VERSION,
+        "TENSORRT_PYTHON_DISTRIBUTIONS": json.dumps(
+            TENSORRT_DISTRIBUTIONS, separators=(",", ":"), sort_keys=True
+        ),
+        "TENSORRT_APT_PACKAGES": json.dumps(
+            TENSORRT_APT_PACKAGES, separators=(",", ":"), sort_keys=True
+        ),
+        "TENSORRT_HEADER_VERSION": TENSORRT_VERSION,
+        "TENSORRT_OVERLAY_FILES": "present",
+        "TENSORRT_NATIVE_VERSION": TENSORRT_VERSION,
+        "MODELOPT_VERSION": "0.44.0",
+        "NLOHMANN_JSON_HEADER": "present",
+        "NEMO_PROMPT_RNNT": "available",
+        "PYTHON_PROFILES": "demo,reference_common",
+    }
+    mismatches = (
+        ("TENSORRT_PYTHON_DISTRIBUTIONS", "{}", "Python distribution versions"),
+        ("TENSORRT_APT_PACKAGES", "{}", "APT package versions"),
+        ("TENSORRT_HEADER_VERSION", "11.1.0.105", "C++ header version"),
+        ("TENSORRT_OVERLAY_FILES", "missing", "header or native library is missing"),
+        ("TENSORRT_NATIVE_VERSION", "11.1.0.105", "native runtime version"),
+    )
+
+    for key, wrong_value, reason in mismatches:
+        observed = {**actual, key: wrong_value}
+        assert any(reason in item for item in manager._version_mismatches(observed, requirements))
+
+
+def test_source_contract_describes_parameterized_tensorrt_overlay(tmp_path: Path) -> None:
+    __import__("tensorrt_model_connect.python_profiles")
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    manager = DockerImageManager(repo_root)
+
+    default_contract = manager.source_contract()
+    selected_json = manager.source_contract_json(
+        tensorrt_version="11.2.1.2",
+        tensorrt_apt_version="11.2.1.2-1+cuda13.3",
+    )
+    selected_contract = json.loads(selected_json)
+
+    assert selected_contract == manager.source_contract(
+        tensorrt_version="11.2.1.2",
+        tensorrt_apt_version="11.2.1.2-1+cuda13.3",
+    )
+    assert selected_contract["schema_version"] == 1
+    assert selected_contract["environment_contract_version"] == 1
+    assert (
+        selected_contract["common_input_fingerprint"]
+        == default_contract["common_input_fingerprint"]
+    )
+    assert selected_contract["input_fingerprint"] != default_contract["input_fingerprint"]
+    assert selected_contract["python_profiles"] == ["demo", "reference_common"]
+    assert selected_contract["tensorrt"] == {
+        "version": "11.2.1.2",
+        "apt_version": "11.2.1.2-1+cuda13.3",
+        "python_distributions": {name: "11.2.1.2" for name in TENSORRT_DISTRIBUTIONS},
+        "apt_packages": {name: "11.2.1.2-1+cuda13.3" for name in TENSORRT_APT_PACKAGES},
+        "headers": ["NvInferVersion.h", "NvOnnxParser.h"],
+        "header_version": "11.2.1.2",
+        "native_libraries": [
+            "libnvinfer.so.11",
+            "libnvonnxparser.so.11",
+            "libnvinfer_builder_resource_sm110.so.*",
+        ],
+        "native_library_distribution": "tensorrt_cu13_libs",
+        "native_runtime_version": "11.2.1.2",
+    }
+
+
+def test_source_contract_loads_profiles_without_ambient_pythonpath(tmp_path: Path) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; "
+            "from tools.ci.docker_image import DockerImageManager; "
+            "print(','.join(DockerImageManager(Path.cwd(), {}).source_contract()"
+            "['python_profiles']))",
+        ],
+        cwd=repo_root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "demo,reference_common"
+
+
+def test_validate_image_contract_returns_the_verified_source_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    manager = DockerImageManager(repo_root)
+    expected = manager._read_requirements()
+    actual = {
+        "TENSORRT_VERSION": expected.tensorrt,
+        "TENSORRT_PYTHON_DISTRIBUTIONS": json.dumps(
+            expected.python_distributions, separators=(",", ":"), sort_keys=True
+        ),
+        "TENSORRT_APT_PACKAGES": json.dumps(
+            expected.apt_packages, separators=(",", ":"), sort_keys=True
+        ),
+        "TENSORRT_OVERLAY_FILES": "present",
+        "TENSORRT_HEADER_VERSION": expected.tensorrt,
+        "TENSORRT_NATIVE_VERSION": expected.tensorrt,
+        "MODELOPT_VERSION": expected.modelopt,
+        "NLOHMANN_JSON_HEADER": "present",
+        "NEMO_PROMPT_RNNT": "available",
+        "PYTHON_PROFILES": expected.python_profiles,
+    }
+    monkeypatch.setattr(manager, "_query_fingerprint", lambda _: expected.fingerprint)
+    monkeypatch.setattr(manager, "_query_versions", lambda _: actual)
+
+    assert manager.validate_image_contract("example.invalid/runtime@sha256:test") == (
+        expected.contract()
+    )
+
+
+def test_validate_image_contract_fails_closed_on_a_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    manager = DockerImageManager(repo_root)
+    expected = manager._read_requirements()
+    monkeypatch.setattr(manager, "_query_fingerprint", lambda _: expected.fingerprint)
+    monkeypatch.setattr(manager, "_query_versions", lambda _: {})
+
+    with pytest.raises(CiError, match="TensorRT version mismatch"):
+        manager.validate_image_contract("example.invalid/runtime@sha256:test")
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value", "message"),
+    (
+        ("tensorrt_version", "11.2", "TENSORRT_VERSION must be an exact four-part version"),
+        ("tensorrt_version", "", "TENSORRT_VERSION must be an exact four-part version"),
+        (
+            "tensorrt_apt_version",
+            "11.2.*",
+            "TENSORRT_APT_VERSION must be an exact package version",
+        ),
+        (
+            "tensorrt_apt_version",
+            "",
+            "TENSORRT_APT_VERSION must be an exact package version",
+        ),
+    ),
+)
+def test_source_contract_rejects_non_exact_overlay_versions(
+    tmp_path: Path,
+    keyword: str,
+    value: str,
+    message: str,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    with pytest.raises(CiError, match=message):
+        DockerImageManager(repo_root).source_contract(**{keyword: value})
+
+
+def test_source_contract_rejects_mixed_tensorrt_overlay_versions(tmp_path: Path) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    with pytest.raises(CiError, match="must select the same TensorRT version"):
+        DockerImageManager(repo_root).source_contract(
+            tensorrt_version="11.2.1.2",
+            tensorrt_apt_version=TENSORRT_APT_VERSION,
+        )
+
+
 def test_profile_sources_are_fingerprinted_and_repo_is_the_build_context() -> None:
     script = SCRIPT.read_text(encoding="utf-8")
 
@@ -447,6 +659,10 @@ def test_profile_sources_are_fingerprinted_and_repo_is_the_build_context() -> No
     assert '"--user"' in script
     assert '"65534:65534"' in script
     assert '"--read-only"' in script
+    assert '"tensorrt_cu13_bindings"' in script
+    assert '"libnvonnxparsers-dev"' in script
+    assert "getInferLibBuildVersion" in script
+    assert "source_contract_json" in script
 
 
 def test_profile_fingerprint_ignores_manifest_comments_and_ownership_fields(

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -559,22 +559,25 @@ def test_source_quality_pipeline_keeps_the_full_static_gate() -> None:
     assert '"no:cacheprovider"' in architecture_contract
 
 
-def test_source_tensorrt_install_contract_uses_the_official_public_release() -> None:
+def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
     assert (
-        "ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt:26.07-py3"
-        "@sha256:f794a79e8b996d16dbc2e5884e19d8e2269a51c960106c9b49b0061a6926c541"
+        "ARG CUDA_IMAGE=nvidia/cuda:13.3.0-devel-ubuntu24.04"
+        "@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52"
         in dockerfile
     )
-    assert "FROM ${TENSORRT_IMAGE} AS ci-base" in dockerfile
-    assert "ARG TENSORRT_VERSION=11.1.0.106" in dockerfile
-    assert "#define TRT_MAJOR_ENTERPRISE 11" in dockerfile
-    assert "#define TRT_MINOR_ENTERPRISE 1" in dockerfile
-    assert "#define TRT_PATCH_ENTERPRISE 0" in dockerfile
-    assert "#define TRT_BUILD_ENTERPRISE 106" in dockerfile
+    assert dockerfile.count("ARG TENSORRT_VERSION=11.1.0.106") == 1
+    assert dockerfile.count("ARG TENSORRT_APT_VERSION=11.1.0.106-1+cuda13.3") == 1
+    assert "ARG TENSORRT_VERSION\n" in dockerfile
+    assert "ARG TENSORRT_APT_VERSION\n" in dockerfile
+    assert "RUN python3.12 -m venv $VIRTUAL_ENV" in dockerfile
+    assert "--system-site-packages" not in dockerfile
     assert "ENV TRT_ROOT=" not in dockerfile
     assert "ENV PIP_FIND_LINKS=" not in dockerfile
-    assert "ENV TRT_LIB_DIR=/usr/lib/aarch64-linux-gnu" in dockerfile
+    assert (
+        "ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs"
+        in dockerfile
+    )
     assert "ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu" in dockerfile
     assert "ghcr.io" not in dockerfile
     assert "TENSORRT_SDK_IMAGE" not in dockerfile
@@ -583,7 +586,49 @@ def test_source_tensorrt_install_contract_uses_the_official_public_release() -> 
     from_lines = [
         line for line in dockerfile.splitlines() if line.startswith("FROM ")
     ]
-    assert from_lines[-1] == "FROM ci-base AS ci-runtime"
+    assert from_lines == [
+        "FROM ${CUDA_IMAGE} AS ci-common-base",
+        "FROM ci-common-base AS python-profile-builder",
+        "FROM ci-common-base AS ci-common",
+        "FROM ci-common AS ci-runtime",
+    ]
+
+    common = dockerfile.split("FROM ci-common-base AS ci-common", maxsplit=1)[1].split(
+        "FROM ci-common AS ci-runtime", maxsplit=1
+    )[0]
+    assert "COPY --from=python-profile-builder" in common
+    assert "TRTMC_PYTHON_PROFILE_PREBUILT_ONLY=1" in common
+    assert 'find_spec("tensorrt") is None' in common
+    assert "NvInferVersion.h" in common
+    assert "NvOnnxParser.h" in common
+
+    overlay = dockerfile.split("FROM ci-common AS ci-runtime", maxsplit=1)[1]
+    for package in (
+        "libnvinfer-dev",
+        "libnvinfer-headers-dev",
+        "libnvinfer-headers-plugin-dev",
+        "libnvinfer-safe-headers-dev",
+        "libnvinfer11",
+        "libnvonnxparsers-dev",
+        "libnvonnxparsers11",
+    ):
+        assert f'"{package}=${{TENSORRT_APT_VERSION}}"' in overlay
+    for distribution in (
+        "tensorrt",
+        "tensorrt_cu13",
+        "tensorrt_cu13_bindings",
+        "tensorrt_cu13_libs",
+    ):
+        assert f'"{distribution}"' in overlay
+    assert 'pip install --no-cache-dir "tensorrt==${TENSORRT_VERSION}"' in overlay
+    assert "NvInferVersion.h" in overlay
+    assert "NvOnnxParser.h" in overlay
+    assert "libnvonnxparser.so" in overlay
+    assert "libnvinfer_builder_resource_sm110.so" in overlay
+    assert "getInferLibVersion" in overlay
+    assert "#include <NvInferRuntime.h>" in overlay
+    assert "-I/usr/local/cuda/include" in overlay
+    assert "c++ -x c++" in overlay
 
     source_dockerfiles = {
         "aarch64": (REPO_ROOT / "Dockerfile.dev.aarch64").read_text(
@@ -636,6 +681,7 @@ def test_source_tensorrt_install_contract_uses_the_official_public_release() -> 
     assert '"$REPO_ROOT/Dockerfile"' in ci_docker_build
     assert "Dockerfile.dev.aarch64" not in ci_docker_build
     assert "Dockerfile.dev.x86" not in ci_docker_build
+    assert "--target" not in ci_docker_build
 
     pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     assert 'dynamic = ["version", "dependencies"]' in pyproject

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -480,19 +480,19 @@ def test_task_environment_exports_checked_in_environment_variables(
     tmp_path,
     monkeypatch,
 ):
-    monkeypatch.setenv("TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND", "ambient")
+    monkeypatch.setenv("TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF", "ambient")
 
     environment = model_checks._task_environment(
         {
             "storage": {"python_profiles_root": str(tmp_path / "profiles")},
             "environment_variables": {
-                "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"
+                "TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF": "disable"
             },
         }
     )
 
-    assert environment["TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND"] == "torch_sdpa"
-    assert os.environ["TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND"] == "ambient"
+    assert environment["TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF"] == "disable"
+    assert os.environ["TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF"] == "ambient"
 
 
 def test_task_environment_rejects_missing_executable_directory(tmp_path):
@@ -724,22 +724,21 @@ def test_l4t_environment_selects_qualified_tensorrt_libraries() -> None:
     [
         (
             "l4t-thor",
-            {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"},
+            {},
         ),
         (
             "gb300",
-            {"TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa"},
+            {},
         ),
         (
             "auto-thor",
             {
-                "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND": "torch_sdpa",
                 "TRTMC_REFERENCE_PYTORCH_CUDA_ALLOC_CONF": "disable",
             },
         ),
     ],
 )
-def test_checked_in_environment_selects_lance_reference_attention_backend(
+def test_checked_in_environment_contains_only_platform_controls(
     platform,
     expected_environment,
 ) -> None:
@@ -748,7 +747,7 @@ def test_checked_in_environment_selects_lance_reference_attention_backend(
         "model-check environment",
     )
 
-    assert environment["environment_variables"] == expected_environment
+    assert environment.get("environment_variables", {}) == expected_environment
 
 
 def test_l4t_excludes_consolidated_not_compared_models() -> None:

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -3790,7 +3790,7 @@ def test_lance_image_only_decord_stub_rejects_video_use() -> None:
         modules["decord"].VideoReader("video.mp4")
 
 
-def test_lance_reference_loads_explicit_sdpa_attention_compat(
+def test_lance_reference_loads_sdpa_attention_compat(
     tmp_path: Path, monkeypatch
 ) -> None:
     runner = runpy.run_path(str(REPOSITORY / "tools/lance_reference.py"))
@@ -3800,13 +3800,28 @@ def test_lance_reference_loads_explicit_sdpa_attention_compat(
         "import flash_attn\nATTENTION = flash_attn.flash_attn_varlen_func.__module__\n",
         encoding="utf-8",
     )
-    monkeypatch.setenv("TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND", "torch_sdpa")
     monkeypatch.delitem(sys.modules, "flash_attn", raising=False)
 
     upstream = runner["_load_upstream"](reference_repo)
 
     assert upstream.ATTENTION.endswith("flash_attn")
     assert "lance_image_attention_compat" in sys.modules["flash_attn"].__file__
+
+
+def test_lance_reference_selects_sdpa_in_a_run_owned_vit_view(tmp_path: Path) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "tools/lance_reference.py"))
+    vit_path = tmp_path / "Qwen2.5-VL-ViT"
+    vit_path.mkdir()
+    config = vit_path / "config.json"
+    config.write_text('{"_attn_implementation": "flash_attention_2"}\n')
+    weights = vit_path / "vit.safetensors"
+    weights.write_bytes(b"weights")
+
+    overlay = runner["_sdpa_vit_path"](tmp_path / "run", vit_path)
+
+    assert json.loads((overlay / "config.json").read_text())["_attn_implementation"] == "sdpa"
+    assert (overlay / "vit.safetensors").resolve() == weights.resolve()
+    assert json.loads(config.read_text())["_attn_implementation"] == "flash_attention_2"
 
 
 def test_lance_git_revision_scopes_safe_directory(tmp_path: Path, monkeypatch) -> None:

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -23,7 +23,25 @@ from .process import CiError, CommandRunner, GitHubFiles
 
 
 FINGERPRINT_LABEL = "org.nvidia.trtmc.ci-input-fingerprint"
+ENVIRONMENT_CONTRACT_VERSION = 1
 IMMUTABLE_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
+EXACT_TENSORRT_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
+EXACT_APT_VERSION = re.compile(r"[0-9][0-9A-Za-z.+:~_-]*")
+TENSORRT_DISTRIBUTIONS = (
+    "tensorrt",
+    "tensorrt_cu13",
+    "tensorrt_cu13_bindings",
+    "tensorrt_cu13_libs",
+)
+TENSORRT_APT_PACKAGES = (
+    "libnvinfer-dev",
+    "libnvinfer-headers-dev",
+    "libnvinfer-headers-plugin-dev",
+    "libnvinfer-safe-headers-dev",
+    "libnvinfer11",
+    "libnvonnxparsers-dev",
+    "libnvonnxparsers11",
+)
 
 
 @dataclass(frozen=True)
@@ -59,10 +77,50 @@ class ImageRequirements:
     """Source-derived contract that the Docker image must satisfy."""
 
     inputs: tuple[Path, ...]
+    common_fingerprint: str
     fingerprint: str
     tensorrt: str
+    tensorrt_apt: str
     modelopt: str
     python_profiles: str
+
+    @property
+    def python_distributions(self) -> dict[str, str]:
+        return {name: self.tensorrt for name in TENSORRT_DISTRIBUTIONS}
+
+    @property
+    def apt_packages(self) -> dict[str, str]:
+        return {name: self.tensorrt_apt for name in TENSORRT_APT_PACKAGES}
+
+    @property
+    def tensorrt_major(self) -> str:
+        return self.tensorrt.split(".", 1)[0]
+
+    def contract(self) -> dict[str, object]:
+        """Return the source-owned runtime contract for an overlay image."""
+        return {
+            "schema_version": 1,
+            "environment_contract_version": ENVIRONMENT_CONTRACT_VERSION,
+            "common_input_fingerprint": self.common_fingerprint,
+            "input_fingerprint": self.fingerprint,
+            "modelopt_version": self.modelopt,
+            "python_profiles": self.python_profiles.split(","),
+            "tensorrt": {
+                "version": self.tensorrt,
+                "apt_version": self.tensorrt_apt,
+                "python_distributions": self.python_distributions,
+                "apt_packages": self.apt_packages,
+                "headers": ["NvInferVersion.h", "NvOnnxParser.h"],
+                "header_version": self.tensorrt,
+                "native_libraries": [
+                    f"libnvinfer.so.{self.tensorrt_major}",
+                    f"libnvonnxparser.so.{self.tensorrt_major}",
+                    "libnvinfer_builder_resource_sm110.so.*",
+                ],
+                "native_library_distribution": "tensorrt_cu13_libs",
+                "native_runtime_version": self.tensorrt,
+            },
+        }
 
 
 class WorkflowImageLock:
@@ -141,21 +199,66 @@ class DockerImageManager:
             self._write_stamp(stamp, image_id)
             print(
                 f"CI Docker image '{image}' verified: TensorRT {versions['TENSORRT_VERSION']}, "
-                f"modelopt {versions['MODELOPT_VERSION']}, nlohmann/json headers, NeMo prompt "
-                f"RNN-T and prebuilt Python profiles ({versions['PYTHON_PROFILES']}) present, "
+                f"exact Python, APT header, C++ header, and native runtime contracts, modelopt "
+                f"{versions['MODELOPT_VERSION']}, nlohmann/json headers, NeMo prompt RNN-T and "
+                f"prebuilt Python profiles ({versions['PYTHON_PROFILES']}) present, "
                 f"image {image_id}"
             )
             return image_id
 
-    def _read_requirements(self) -> ImageRequirements:
-        registry = self._load_profile_registry()
+    def source_contract(
+        self,
+        *,
+        tensorrt_version: str | None = None,
+        tensorrt_apt_version: str | None = None,
+    ) -> dict[str, object]:
+        """Return a JSON-compatible contract for one parameterized TRT overlay."""
+        return self._read_requirements(
+            tensorrt_version=tensorrt_version,
+            tensorrt_apt_version=tensorrt_apt_version,
+        ).contract()
+
+    def source_contract_json(
+        self,
+        *,
+        tensorrt_version: str | None = None,
+        tensorrt_apt_version: str | None = None,
+    ) -> str:
+        """Serialize ``source_contract`` deterministically for external validation."""
+        return json.dumps(
+            self.source_contract(
+                tensorrt_version=tensorrt_version,
+                tensorrt_apt_version=tensorrt_apt_version,
+            ),
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def validate_image_contract(
+        self,
+        image: str,
+        *,
+        tensorrt_version: str | None = None,
+        tensorrt_apt_version: str | None = None,
+    ) -> dict[str, object]:
+        """Validate one immutable overlay image against its Source contract."""
+        expected = self._read_requirements(
+            tensorrt_version=tensorrt_version,
+            tensorrt_apt_version=tensorrt_apt_version,
+        )
+        self._validate(image, expected, self._query_versions(image))
+        return expected.contract()
+
+    def _read_requirements(
+        self,
+        *,
+        tensorrt_version: str | None = None,
+        tensorrt_apt_version: str | None = None,
+    ) -> ImageRequirements:
+        registry, profile_names = self._load_profile_registry()
         profiles = registry["profiles"]
-        profile_module = importlib.import_module(
-            "tensorrt_model_connect.python_profiles"
-        )
-        expected_profiles = ",".join(
-            profile_module.prebuilt_python_profile_names(registry)
-        )
+        expected_profiles = ",".join(profile_names)
         if not expected_profiles:
             raise CiError("No family-owned Python execution profiles were declared")
 
@@ -178,30 +281,83 @@ class DockerImageManager:
             package_root / "families/__init__.py",
             *assets,
         }
-        semantic_contract = {"version": registry.get("version"), "profiles": profiles}
-        semantic_payload = json.dumps(
-            semantic_contract, ensure_ascii=True, separators=(",", ":"), sort_keys=True
-        ).encode("utf-8")
-        semantic_fingerprint = hashlib.sha256(semantic_payload).hexdigest()
-        fingerprint = self._fingerprint_inputs(tuple(sorted(inputs)), semantic_fingerprint)
-
         dockerfile_text = (self.config.repository / self.config.dockerfile).read_text(
             encoding="utf-8"
         )
-        tensorrt = self._docker_argument(dockerfile_text, "TENSORRT_VERSION")
+        tensorrt = self._exact_tensorrt_version(
+            self._docker_argument(dockerfile_text, "TENSORRT_VERSION")
+            if tensorrt_version is None
+            else tensorrt_version
+        )
+        tensorrt_apt = self._exact_apt_version(
+            self._docker_argument(dockerfile_text, "TENSORRT_APT_VERSION")
+            if tensorrt_apt_version is None
+            else tensorrt_apt_version
+        )
+        if not tensorrt_apt.startswith(f"{tensorrt}-"):
+            raise CiError(
+                "TENSORRT_APT_VERSION must select the same TensorRT version as TENSORRT_VERSION"
+            )
+        common_semantic_contract = {
+            "environment_contract_version": ENVIRONMENT_CONTRACT_VERSION,
+            "version": registry.get("version"),
+            "profiles": profiles,
+        }
+        common_semantic_payload = json.dumps(
+            common_semantic_contract,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        common_semantic_fingerprint = hashlib.sha256(common_semantic_payload).hexdigest()
+        common_fingerprint = self._fingerprint_inputs(
+            tuple(sorted(inputs)), common_semantic_fingerprint
+        )
+        overlay_payload = json.dumps(
+            {"apt_version": tensorrt_apt, "version": tensorrt},
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        fingerprint = hashlib.sha256(
+            b"tensorrt-overlay\0"
+            + common_fingerprint.encode("ascii")
+            + b"\0"
+            + overlay_payload
+        ).hexdigest()
+
         modelopt = self._docker_argument(dockerfile_text, "MODELOPT_VERSION")
         return ImageRequirements(
-            tuple(sorted(inputs)), fingerprint, tensorrt, modelopt, expected_profiles
+            tuple(sorted(inputs)),
+            common_fingerprint,
+            fingerprint,
+            tensorrt,
+            tensorrt_apt,
+            modelopt,
+            expected_profiles,
         )
 
-    def _load_profile_registry(self) -> dict[str, object]:
+    def _load_profile_registry(self) -> tuple[dict[str, object], tuple[str, ...]]:
         package_path = str(self.config.repository / "python")
+        package_name = "tensorrt_model_connect"
+        previous_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == package_name or name.startswith(f"{package_name}.")
+        }
+        for name in previous_modules:
+            sys.modules.pop(name, None)
         sys.path.insert(0, package_path)
         try:
             module = importlib.import_module("tensorrt_model_connect.python_profiles")
-            return module.load_python_profile_registry()
+            registry = module.load_python_profile_registry()
+            return registry, module.prebuilt_python_profile_names(registry)
         finally:
             sys.path.remove(package_path)
+            for name in tuple(sys.modules):
+                if name == package_name or name.startswith(f"{package_name}."):
+                    sys.modules.pop(name, None)
+            sys.modules.update(previous_modules)
 
     def _fingerprint_inputs(self, inputs: tuple[Path, ...], semantic: str) -> str:
         digest = hashlib.sha256()
@@ -224,6 +380,18 @@ class DockerImageManager:
         if not match:
             raise CiError(f"Could not find ARG {name} in Dockerfile")
         return match.group(1).strip()
+
+    @staticmethod
+    def _exact_tensorrt_version(value: str) -> str:
+        if not EXACT_TENSORRT_VERSION.fullmatch(value):
+            raise CiError("TENSORRT_VERSION must be an exact four-part version")
+        return value
+
+    @staticmethod
+    def _exact_apt_version(value: str) -> str:
+        if not EXACT_APT_VERSION.fullmatch(value):
+            raise CiError("TENSORRT_APT_VERSION must be an exact package version")
+        return value
 
     def _verification_stamp(self, fingerprint: str) -> Path | None:
         run_id = self.env.get("GITHUB_RUN_ID", "")
@@ -293,14 +461,90 @@ class DockerImageManager:
 
     def _query_versions(self, image: str) -> dict[str, str]:
         probe = r"""
+import ctypes
 import importlib.metadata as metadata
 import json
+import os
+import re
+import subprocess
 from pathlib import Path
 
 import tensorrt
 from nemo.collections.asr.models.rnnt_bpe_models_prompt import EncDecRNNTBPEModelWithPrompt
 
 print(f"TENSORRT_VERSION={tensorrt.__version__}")
+distributions = {
+    name: metadata.version(name)
+    for name in (
+        "tensorrt",
+        "tensorrt_cu13",
+        "tensorrt_cu13_bindings",
+        "tensorrt_cu13_libs",
+    )
+}
+print("TENSORRT_PYTHON_DISTRIBUTIONS=" + json.dumps(distributions, separators=(",", ":"), sort_keys=True))
+apt_packages = {}
+for package in (
+    "libnvinfer-dev",
+    "libnvinfer-headers-dev",
+    "libnvinfer-headers-plugin-dev",
+    "libnvinfer-safe-headers-dev",
+    "libnvinfer11",
+    "libnvonnxparsers-dev",
+    "libnvonnxparsers11",
+):
+    result = subprocess.run(
+        ["dpkg-query", "-W", "-f=${Version}", package],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    apt_packages[package] = result.stdout.strip()
+print("TENSORRT_APT_PACKAGES=" + json.dumps(apt_packages, separators=(",", ":"), sort_keys=True))
+
+header = Path(os.environ["TRT_INC_DIR"]) / "NvInferVersion.h"
+header_text = header.read_text(encoding="utf-8")
+header_parts = []
+for name in ("MAJOR", "MINOR", "PATCH", "BUILD"):
+    values = []
+    for macro in (f"TRT_{name}_ENTERPRISE", f"NV_TENSORRT_{name}"):
+        match = re.search(rf"^#define\s+{macro}\s+([0-9]+)\b", header_text, re.MULTILINE)
+        if match:
+            values.append(match.group(1))
+    if not values or len(set(values)) != 1:
+        raise SystemExit(f"could not resolve one TensorRT {name.lower()} value from {header}")
+    header_parts.append(values[0])
+print("TENSORRT_HEADER_VERSION=" + ".".join(header_parts))
+
+library_root = Path(metadata.distribution("tensorrt_cu13_libs").locate_file("tensorrt_libs"))
+major = header_parts[0]
+configured_library_root = Path(os.environ["TRT_LIB_DIR"])
+library_search = os.environ.get("LD_LIBRARY_PATH", "").split(":", 1)[0]
+if configured_library_root.resolve() != library_root.resolve() or library_search != str(configured_library_root):
+    raise SystemExit("TRT_LIB_DIR and LD_LIBRARY_PATH must select tensorrt_cu13_libs")
+required_files = (
+    Path(os.environ["TRT_INC_DIR"]) / "NvOnnxParser.h",
+    library_root / f"libnvinfer.so.{major}",
+    library_root / f"libnvonnxparser.so.{major}",
+)
+if missing := [str(path) for path in required_files if not path.is_file()]:
+    raise SystemExit("missing TensorRT overlay files: " + ", ".join(missing))
+if next(library_root.glob("libnvinfer_builder_resource_sm110.so.*"), None) is None:
+    raise SystemExit("missing TensorRT SM110 builder resource")
+print("TENSORRT_OVERLAY_FILES=present")
+
+library = ctypes.CDLL(str(library_root / f"libnvinfer.so.{major}"))
+native_parts = []
+for symbol in (
+    "getInferLibMajorVersion",
+    "getInferLibMinorVersion",
+    "getInferLibPatchVersion",
+    "getInferLibBuildVersion",
+):
+    function = getattr(library, symbol)
+    function.restype = ctypes.c_int32
+    native_parts.append(str(function()))
+print("TENSORRT_NATIVE_VERSION=" + ".".join(native_parts))
 print("MODELOPT_VERSION=" + metadata.version("nvidia-modelopt"))
 print("NLOHMANN_JSON_HEADER=" + ("present" if Path("/usr/include/nlohmann/json.hpp").is_file() else "missing"))
 print("NEMO_PROMPT_RNNT=available")
@@ -351,6 +595,31 @@ print("PYTHON_PROFILES=" + ",".join(sorted(profiles)))
     def _version_mismatches(actual: dict[str, str], expected: ImageRequirements) -> list[str]:
         checks = (
             ("TENSORRT_VERSION", expected.tensorrt, "TensorRT version mismatch"),
+            (
+                "TENSORRT_PYTHON_DISTRIBUTIONS",
+                json.dumps(expected.python_distributions, separators=(",", ":"), sort_keys=True),
+                "TensorRT Python distribution versions mismatch",
+            ),
+            (
+                "TENSORRT_APT_PACKAGES",
+                json.dumps(expected.apt_packages, separators=(",", ":"), sort_keys=True),
+                "TensorRT APT package versions mismatch",
+            ),
+            (
+                "TENSORRT_OVERLAY_FILES",
+                "present",
+                "TensorRT header or native library is missing",
+            ),
+            (
+                "TENSORRT_HEADER_VERSION",
+                expected.tensorrt,
+                "TensorRT C++ header version mismatch",
+            ),
+            (
+                "TENSORRT_NATIVE_VERSION",
+                expected.tensorrt,
+                "TensorRT native runtime version mismatch",
+            ),
             ("MODELOPT_VERSION", expected.modelopt, "modelopt version mismatch"),
         )
         reasons = [

--- a/tools/lance_reference.py
+++ b/tools/lance_reference.py
@@ -21,8 +21,6 @@ import types
 from typing import Any, Iterator, Sequence
 
 
-_ATTENTION_BACKEND_ENV = "TRTMC_LANCE_REFERENCE_ATTENTION_BACKEND"
-_ATTENTION_BACKENDS = frozenset({"flash_attn", "torch_sdpa"})
 _ATTENTION_COMPAT = (
     Path(__file__).resolve().parents[1]
     / "tests/e2e/models/lance/e2e_plugins/references/lance_image_attention_compat"
@@ -148,6 +146,32 @@ def _model_paths(arguments: argparse.Namespace) -> tuple[Path, Path, Path, str]:
     return model_path, vit_path, vae_path, _snapshot_revision(root)
 
 
+def _sdpa_vit_path(root: Path, vit_path: Path) -> Path:
+    """Create a run-owned VIT view that selects PyTorch SDPA."""
+    source_config = vit_path / "config.json"
+    try:
+        config = json.loads(source_config.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Lance VIT has no valid config: {source_config}") from exc
+    if not isinstance(config, dict):
+        raise RuntimeError(f"Lance VIT config must contain an object: {source_config}")
+
+    overlay = root / "vit_torch_sdpa"
+    overlay.mkdir(parents=True)
+    for source in vit_path.iterdir():
+        if source.name != "config.json":
+            (overlay / source.name).symlink_to(
+                source.resolve(),
+                target_is_directory=source.is_dir(),
+            )
+    config["_attn_implementation"] = "sdpa"
+    (overlay / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return overlay
+
+
 def _dataset_payload(*, image: Path, prompt: str, instruction: str, count: int) -> dict[str, Any]:
     sample = {
         "interleave_array": [str(image.resolve()), [instruction, prompt, ""]],
@@ -184,21 +208,15 @@ def _decord_image_only_stub() -> dict[str, types.ModuleType]:
     return {"decord": decord, "decord.video_reader": video_reader}
 
 
-def _configure_attention_backend() -> None:
-    backend = os.environ.get(_ATTENTION_BACKEND_ENV, "flash_attn").strip()
-    if backend not in _ATTENTION_BACKENDS:
-        raise RuntimeError(
-            "unsupported Lance reference attention backend "
-            f"{backend!r}; expected one of {sorted(_ATTENTION_BACKENDS)}"
-        )
-    if backend == "torch_sdpa":
-        compat = str(_ATTENTION_COMPAT)
-        if compat not in sys.path:
-            sys.path.insert(0, compat)
+def _configure_attention_compatibility() -> None:
+    """Expose the repository-owned SDPA implementation as ``flash_attn``."""
+    compat = str(_ATTENTION_COMPAT)
+    if compat not in sys.path:
+        sys.path.insert(0, compat)
 
 
 def _load_upstream(reference_repo: Path) -> Any:
-    _configure_attention_backend()
+    _configure_attention_compatibility()
     try:
         import decord  # noqa: F401
     except ImportError:
@@ -392,10 +410,11 @@ def run(arguments: argparse.Namespace) -> int:
             ),
             encoding="utf-8",
         )
+        reference_vit_path = _sdpa_vit_path(root, vit_path)
         samples, answers = _run_upstream(
             arguments,
             model_path,
-            vit_path,
+            reference_vit_path,
             vae_path,
             dataset,
             root / "results",


### PR DESCRIPTION
## Summary

- build CUDA, Python dependencies, and model execution profiles once in a TensorRT-free `ci-common` target
- add a single parameterized `ci-runtime` overlay for exact TensorRT 11.1 and 11.2 toolchains
- expose a Source-owned runtime contract that verifies Python distributions, APT packages, headers, native libraries, and profile fingerprints
- use PyTorch SDPA for Lance references and remove the external `flash-attn` profile dependency

## Validation

- built the TensorRT-free common image and resolved all 11 prebuilt Python profiles with networking disabled
- built and validated exact TensorRT 11.1.0.106 and 11.2.1.2 overlays
- created a TensorRT Builder on NVIDIA GB300 from both overlays
- verified plain `docker build .` still produces the default TensorRT 11.1 runtime
- `85 passed` for the Docker image/runtime contract tests
- `20 passed` for the focused Lance SDPA and model-check tests
- Ruff and `git diff --check` pass