### PR TITLE
fix(lfm2): match pinned pretokenizer whitespace splitting

### DIFF
--- a/src/runtime/models/lfm2/pretokenizer.cpp
+++ b/src/runtime/models/lfm2/pretokenizer.cpp
@@ -229,15 +229,25 @@ std::size_t whitespace_piece_end(std::string_view text, std::size_t offset, cons
 
     std::size_t scan = offset;
     std::size_t last_newline_end = offset;
+    std::size_t last_unit_begin = offset;
     while (scan < text.size()) {
         const auto unit = decode_utf8_unit(text, scan);
         if (!is_whitespace(unit.codepoint))
             break;
+        last_unit_begin = scan;
         scan += unit.size;
         if (is_newline(unit.codepoint))
             last_newline_end = scan;
     }
-    return last_newline_end > offset ? last_newline_end : scan;
+    if (last_newline_end > offset)
+        return last_newline_end;
+    // \s+(?!\S): a newline-free run followed by non-whitespace yields its
+    // final whitespace unit to the next piece (it becomes that piece's
+    // prefix). A single-unit run has nothing left to yield and falls through
+    // to the plain \s+ alternative, consuming the unit whole.
+    if (scan < text.size() && last_unit_begin > offset)
+        return last_unit_begin;
+    return scan;
 }
 
 std::size_t next_pretoken_end(std::string_view text, std::size_t offset) {

--- a/tests/cpp/models/lfm2/test_lfm2_pretokenizer.cpp
+++ b/tests/cpp/models/lfm2/test_lfm2_pretokenizer.cpp
@@ -84,6 +84,21 @@ PieceMap pinned_piece_ids() {
         {"'T", {32640}},
         {"SHE", {560, 6347}},
         {"'S", {24406}},
+        {"a", {574}},
+        {" b", {794}},
+        {"5", {530}},
+        {" \t", {46482}},
+        {"trailing", {19310, 8206}},
+        {"  ", {767}},
+        {"def", {3663}},
+        {" f", {792}},
+        {"():\n", {32711}},
+        {"   ", {861}},
+        {" return", {1789}},
+        {" x", {3053}},
+        {"|", {601}},
+        {" a", {768}},
+        {" |", {2171}},
     };
 }
 
@@ -180,6 +195,27 @@ std::vector<Fixture> supported_language_fixtures() {
     };
 }
 
+std::vector<Fixture> whitespace_run_fixtures() {
+    // Pins the \s+(?!\S) alternative of the pinned Split regex: a
+    // newline-free whitespace run followed by non-whitespace yields its final
+    // whitespace unit to the next piece. Every id below is the byte-level BPE
+    // encoding the reference Hugging Face tokenizer assigns the same text.
+    return {
+        {"double-space", "a  b", {"a", " ", " b"}, {574, 730, 794}},
+        {"space-before-digit", "a  5", {"a", " ", " ", "5"}, {574, 730, 730, 530}},
+        {"space-tab", "a \t b", {"a", " \t", " b"}, {574, 46482, 794}},
+        {"trailing-run", "trailing  ", {"trailing", "  "}, {19310, 8206, 767}},
+        {"indented-code",
+         "def f():\n    return  x",
+         {"def", " f", "():\n", "   ", " return", " ", " x"},
+         {3663, 792, 32711, 861, 1789, 730, 3053}},
+        {"markdown-row",
+         "| a |  b |",
+         {"|", " a", " |", " ", " b", " |"},
+         {601, 768, 2171, 730, 794, 2171}},
+    };
+}
+
 void test_pinned_metadata_detection() {
     const std::string pinned = R"({"pre_tokenizer":{"type":"Sequence","pretokenizers":[
       {"type":"Split","pattern":{"Regex":"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"},"behavior":"Isolated","invert":false},
@@ -198,6 +234,19 @@ void test_supported_language_piece_and_id_parity() {
     const std::vector<std::string> added{"<|startoftext|>", "<|im_start|>", "<|im_end|>",
                                          "<|tool_call_start|>"};
     for (const auto& fixture : supported_language_fixtures()) {
+        check(trtmc::lfm2_split_pretokens(fixture.text) == fixture.pieces,
+              std::string(fixture.name) + " pinned Split pieces");
+        auto tokenizer =
+            trtmc::lfm2_wrap_pinned_pretokenizer(std::make_unique<PinnedPieceTokenizer>(), added);
+        check(tokenizer->encode(fixture.text) == fixture.ids,
+              std::string(fixture.name) + " pinned token ids");
+    }
+}
+
+void test_whitespace_run_piece_and_id_parity() {
+    const std::vector<std::string> added{"<|startoftext|>", "<|im_start|>", "<|im_end|>",
+                                         "<|tool_call_start|>"};
+    for (const auto& fixture : whitespace_run_fixtures()) {
         check(trtmc::lfm2_split_pretokens(fixture.text) == fixture.pieces,
               std::string(fixture.name) + " pinned Split pieces");
         auto tokenizer =
@@ -282,6 +331,7 @@ void test_real_pinned_tokenizer_when_provided() {
 int main() {
     test_pinned_metadata_detection();
     test_supported_language_piece_and_id_parity();
+    test_whitespace_run_piece_and_id_parity();
     test_case_insensitive_contractions();
     test_chat_and_tool_added_tokens_are_not_split();
     test_real_pinned_tokenizer_when_provided();


### PR DESCRIPTION
## Background

The native LFM2 pretokenizer reimplements the pinned Split regex from the model's tokenizer.json. Its whitespace branch consumes newline-free whitespace runs whole, which drops the `\s+(?!\S)` alternative: a run followed by non-whitespace must yield its final whitespace unit to the following piece. Any prompt with two or more consecutive spaces before text therefore tokenizes differently than the pinned Hugging Face tokenizer, with indented code as the common case. Reported in #928. Scope is the native C++ tokenization path only, no crash, but token ids silently diverge from what the model was trained on.

| input | pinned HF tokenizer | before this PR |
|---|---|---|
| `a  b` | `a` &#124; ` ` &#124; ` b` | `a` &#124; `  ` &#124; `b` |
| `def f():\n    return  x` | `def` &#124; ` f` &#124; `():\n` &#124; `   ` &#124; ` return` &#124; ` ` &#124; ` x` | `def` &#124; ` f` &#124; `():\n` &#124; `    ` &#124; `return` &#124; `  ` &#124; `x` |

## Change

`whitespace_piece_end` yields the final whitespace unit of a newline-free run when the run is followed by non-whitespace. Single-unit runs and end-of-text runs are consumed whole, matching the plain `\s+` fallback. The newline branch (`\s*[\r\n]+`) is unchanged.

## Validation

- New `test_whitespace_run_piece_and_id_parity` in `test_lfm2_pretokenizer.cpp`: six fixtures (double space, space before digit, space plus tab, trailing run, indented code, markdown row) asserting both Split pieces and token ids. Ids are pinned from the LiquidAI/LFM2-350M tokenizer.json at manifest revision f37d3f5c (byte-identical to main), with piece-wise encoding verified equal to full-text encoding for every fixture. The five affected fixtures fail against the previous splitter (10 failed checks) and pass with the fix; the trailing-run fixture passes before and after, pinning the end-of-text behavior against over-correction.
- Corpus diff of `lfm2_split_pretokens` against Hugging Face tokenizers 0.23.1 running the pinned tokenizer.json: 424 cases covering targeted whitespace patterns, every existing multilingual fixture text, and 400 random whitespace-heavy fuzz strings. Before: 311/424 diverge from the reference pre-tokenization. After: 0/424.
- All existing fixtures pass unchanged.

Evidence environment: splitter and test compiled standalone with clang on a CPU-only macOS arm64 host, since the change touches no CUDA or TensorRT path. The registered `runtime_tests` entry is unchanged, so CI exercises the same test in the TensorRT/CUDA environment.
