### PR TITLE
feat(qualification): add campaign sharding

### DIFF
--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -107,12 +107,40 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
   --resume
 ```
 
+## Shard a campaign
+
+Sharding is an opt-in runner capability; no checked-in CI workflow enables it.
+Run the same selection and run ID on independent hosts or GPUs that share the
+campaign results directory. The index is zero-based:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py run \
+  --platform gb300 --all --run-id gb300-all --shard 0/2
+
+$TRTMC_CHECK_PYTHON tools/model_checks.py run \
+  --platform gb300 --all --run-id gb300-all --shard 1/2
+```
+
+Each worker writes only below `shards/<index>-of-<count>/`. Run exactly one
+consolidator to publish the campaign-level Accuracy and Perf reports while the
+workers are active:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py consolidate \
+  "$TRTMC_CHECK_STORAGE_ROOT/results/gb300-all" --watch
+```
+
+The immutable campaign inventory determines assignment by case order modulo
+the shard count. Resume one failed shard with the same selection, `--shard`,
+run ID, and `--resume`. A shard uses its own writable Perf bundle cache, so
+independent workers never build into the same cache directory.
+
 ## Platforms
 
 Use `--platform gb300`, `--platform auto-thor`, or `--platform l4t-thor`.
 Platform files under `tests/model_checks/platforms/` define task order and
-model exclusions. An excluded model runs no Accuracy suite or Perf entry;
-Accuracy suites remain in the report as `not compared`. Files under
+model exclusions. An excluded model runs no Accuracy suite or Perf entry and
+does not appear in qualification reports. Files under
 `tests/model_checks/environments/` define paths and retention.
 
 Checked-in environments delete Accuracy engines and Perf bundles after each

--- a/tests/tools/test_campaign_shards.py
+++ b/tests/tools/test_campaign_shards.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools import campaign_shards, qualification_report
+from tools.execution_ledger import ExecutionLedger
+
+
+def test_parse_shard_uses_one_zero_based_index_count_value():
+    assert campaign_shards.parse_shard("2/4") == (2, 4)
+    with pytest.raises(campaign_shards.CampaignShardError, match="0 <= INDEX < COUNT"):
+        campaign_shards.parse_shard("4/4")
+
+
+def test_round_robin_assignment_is_deterministic_and_complete():
+    cases = tuple(f"case-{index}" for index in range(7))
+
+    assignments = [
+        campaign_shards.assign_cases(cases, index=index, count=3) for index in range(3)
+    ]
+
+    assert assignments == [
+        ("case-0", "case-3", "case-6"),
+        ("case-1", "case-4"),
+        ("case-2", "case-5"),
+    ]
+    assert set().union(*map(set, assignments)) == set(cases)
+    assert not any(
+        set(left).intersection(right)
+        for left, right in zip(assignments, assignments[1:])
+    )
+    assert campaign_shards.assign_cases(cases, index=0, count=1) == cases
+
+
+def test_only_one_consolidator_can_publish_a_campaign(tmp_path: Path):
+    with campaign_shards.consolidator_lock(tmp_path):
+        with pytest.raises(
+            campaign_shards.CampaignShardError,
+            match="another campaign consolidator",
+        ):
+            with campaign_shards.consolidator_lock(tmp_path):
+                pass
+
+
+def test_campaign_manifest_is_immutable(tmp_path: Path):
+    campaign_shards.open_campaign(tmp_path, {"run_id": "one"})
+
+    with pytest.raises(campaign_shards.CampaignShardError, match="does not match"):
+        campaign_shards.open_campaign(tmp_path, {"run_id": "two"})
+
+
+def _shard_report(root: Path, case_id: str, result: str) -> None:
+    ledger = ExecutionLedger.open(
+        root,
+        campaign_id=root.name,
+        task_kind="accuracy",
+        fingerprint="same-input",
+        cases=[{"id": case_id, "report": {"model": case_id, "workload": "suite"}}],
+    )
+    log = root / "artifacts" / case_id / "logs" / "run.log"
+    log.parent.mkdir(parents=True)
+    log.write_text(f"{case_id}\n", encoding="utf-8")
+    ledger.begin(case_id, stage="compare", evidence={})
+    ledger.finish(case_id, result=result, payload={"status": result})
+    qualification_report.materialize_report(
+        root,
+        report_kind="accuracy",
+        title="Shard",
+        identity={"run_id": root.name, "disposition": "passed"},
+        run={"hostname": root.name},
+        results=[
+            {
+                "id": case_id,
+                "model": case_id,
+                "workload": "suite",
+                "state": "terminal",
+                "result": result,
+                "precision": {"reference": "fp16", "candidate": "fp16"},
+                "debug": {
+                    "logs": [
+                        {
+                            "label": "run.log",
+                            "href": log.relative_to(root).as_posix(),
+                        }
+                    ],
+                    "command_artifacts": [],
+                },
+            }
+        ],
+    )
+
+
+def test_merge_uses_receipts_keeps_missing_cases_pending_and_relocates_artifacts(
+    tmp_path: Path,
+):
+    shard = tmp_path / "shard-0"
+    output = tmp_path / "campaign" / "accuracy"
+    _shard_report(shard, "case-a", "green")
+
+    _, _, report = campaign_shards.merge_receipt_reports(
+        output,
+        report_kind="accuracy",
+        campaign={
+            "run_id": "campaign",
+            "revision": "abc",
+            "platform": "test",
+            "shard_count": 2,
+        },
+        expected_cases=[
+            {
+                "id": "case-a",
+                "shard": 0,
+                "report": {"model": "case-a", "workload": "suite"},
+            },
+            {
+                "id": "case-b",
+                "shard": 1,
+                "report": {"model": "case-b", "workload": "suite"},
+            },
+        ],
+        shard_outputs=[("000-of-002", shard)],
+    )
+
+    assert [(row["id"], row["state"], row["result"]) for row in report["results"]] == [
+        ("case-a", "terminal", "green"),
+        ("case-b", "pending", None),
+    ]
+    href = report["results"][0]["debug"]["logs"][0]["href"]
+    assert href == "artifacts/shards/000-of-002/artifacts/case-a/logs/run.log"
+    assert (output / href).read_text(encoding="utf-8") == "case-a\n"
+    receipt_href = report["receipt_sources"]["case-a"]
+    assert (output / receipt_href).is_file()
+    shard_environment_href = report["run"]["shards"][0]["environment_href"]
+    assert (output / shard_environment_href).is_file()
+    assert report["accounting"]["progress"] == {
+        "pending": 1,
+        "running": 0,
+        "terminal": 1,
+    }
+
+    source_log = shard / "artifacts" / "case-a" / "logs" / "run.log"
+    source_log.write_text("case-a\ncontinued\n", encoding="utf-8")
+    campaign_shards.merge_receipt_reports(
+        output,
+        report_kind="accuracy",
+        campaign={
+            "run_id": "campaign",
+            "revision": "abc",
+            "platform": "test",
+            "shard_count": 2,
+        },
+        expected_cases=[
+            {
+                "id": "case-a",
+                "shard": 0,
+                "report": {"model": "case-a", "workload": "suite"},
+            },
+            {
+                "id": "case-b",
+                "shard": 1,
+                "report": {"model": "case-b", "workload": "suite"},
+            },
+        ],
+        shard_outputs=[("000-of-002", shard)],
+    )
+    assert (output / href).read_text(encoding="utf-8") == "case-a\ncontinued\n"
+
+
+def test_merge_rejects_a_case_from_the_wrong_shard(tmp_path: Path):
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    _shard_report(left, "case-a", "green")
+    _shard_report(right, "case-a", "green")
+
+    with pytest.raises(campaign_shards.CampaignShardError, match="does not match"):
+        campaign_shards.merge_receipt_reports(
+            tmp_path / "output",
+            report_kind="accuracy",
+            campaign={"run_id": "campaign", "shard_count": 2},
+            expected_cases=[{"id": "case-a", "shard": 0, "report": {}}],
+            shard_outputs=[("000-of-002", left), ("001-of-002", right)],
+        )

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -12,7 +12,8 @@ import sys
 import pytest
 import yaml
 
-from tools import model_checks
+from tools import campaign_shards, model_checks, qualification_report
+from tools.execution_ledger import ExecutionLedger
 
 
 def _platform(*, serial: bool = True, excluded_models=()):
@@ -836,6 +837,193 @@ def test_run_dry_run_writes_exact_accuracy_bindings(tmp_path, monkeypatch):
     assert "perf" not in request["commands"]
 
 
+def test_sharded_dry_runs_partition_one_campaign_without_enabling_ci(
+    tmp_path, monkeypatch
+):
+    storage = tmp_path / "storage"
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    selection = [
+        "run",
+        "--platform",
+        "gb300",
+        "--model",
+        "distilgpt2",
+        "--model",
+        "qwen25vl-3b",
+        "--run-id",
+        "sharded-unit",
+        "--dry-run",
+    ]
+
+    assert model_checks.main([*selection, "--shard", "0/2"]) == 0
+    assert model_checks.main([*selection, "--shard", "1/2"]) == 0
+
+    run_root = storage / "results" / "sharded-unit"
+    campaign = json.loads((run_root / "campaign.json").read_text(encoding="utf-8"))
+    assert campaign["shard_count"] == 2
+    assert [case["shard"] for case in campaign["cases"]] == [0, 1, 0, 1]
+    accuracy_bindings = []
+    perf_entries = []
+    for label in ("000-of-002", "001-of-002"):
+        request = json.loads(
+            (run_root / "shards" / label / "request.json").read_text(encoding="utf-8")
+        )
+        command = request["commands"]["accuracy"]
+        accuracy_bindings.append(command[command.index("--binding") + 1])
+        perf_command = request["commands"]["perf"]
+        perf_entries.append(perf_command[perf_command.index("--entry") + 1])
+        assert request["shard"]["name"] == label
+    assert accuracy_bindings == [
+        "distilgpt2=wikitext103_distilgpt2_continuation_parity",
+        "qwen25vl-3b=vlm_mmmu_pro_vision_fixed_mcq",
+    ]
+    assert perf_entries == ["gpt2.generate", "qwen_vl.generate@qwen25vl-3b"]
+
+
+def test_shard_requires_an_explicit_shared_run_id(capsys):
+    with pytest.raises(SystemExit):
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--model",
+                "distilgpt2",
+                "--shard",
+                "0/2",
+            ]
+        )
+    assert "--shard requires an explicit shared --run-id" in capsys.readouterr().err
+
+
+def test_consolidator_preserves_campaign_order_and_receipt_results(
+    tmp_path, monkeypatch
+):
+    run_root = tmp_path / "campaign"
+    cases = [
+        {
+            "binding_id": f"accuracy:model-{suffix}:suite",
+            "task": "accuracy",
+            "id": f"model-{suffix}::suite",
+            "report": {"model": f"model-{suffix}", "workload": "suite"},
+            "shard": index,
+        }
+        for index, suffix in enumerate(("a", "b"))
+    ]
+    selection = {"platform": "gb300", "models": []}
+    campaign = campaign_shards.open_campaign(
+        run_root,
+        {
+            "run_id": "campaign",
+            "platform": "gb300",
+            "revision": "a" * 40,
+            "shard_count": 2,
+            "selection": selection,
+            "cases": cases,
+        },
+    )
+    for index, case in enumerate(cases):
+        label = campaign_shards.shard_name(index, 2)
+        shard_root = run_root / "shards" / label
+        output = shard_root / "accuracy"
+        shard_root.mkdir(parents=True)
+        (shard_root / "request.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "campaign",
+                    "revision": "a" * 40,
+                    "platform": "gb300",
+                    "selection": selection,
+                    "shard": {"index": index, "count": 2, "name": label},
+                }
+            ),
+            encoding="utf-8",
+        )
+        ledger = ExecutionLedger.open(
+            output,
+            campaign_id=label,
+            task_kind="accuracy",
+            fingerprint="fixture",
+            cases=[{"id": case["id"], "report": case["report"]}],
+        )
+        result = "green" if index == 0 else "red"
+        ledger.begin(case["id"], stage="compare")
+        ledger.finish(case["id"], result=result, payload={"fixture": True})
+        qualification_report.materialize_report(
+            output,
+            report_kind="accuracy",
+            title="Shard",
+            identity={"run_id": label, "disposition": "completed"},
+            run={"hostname": label},
+            results=[
+                {
+                    **case["report"],
+                    "id": case["id"],
+                    "state": "terminal",
+                    "result": result,
+                    "precision": {"reference": "fp16", "candidate": "fp16"},
+                    "debug": {"logs": [], "command_artifacts": []},
+                }
+            ],
+        )
+    monkeypatch.setattr(model_checks, "_refresh_shard_report", lambda *_args: None)
+
+    assert model_checks._consolidate_once(run_root) is True
+
+    report = json.loads(
+        (run_root / "accuracy" / "report.json").read_text(encoding="utf-8")
+    )
+    assert [row["id"] for row in report["results"]] == [case["id"] for case in cases]
+    assert report["accounting"]["outcomes"] == {
+        "green": 1,
+        "red": 1,
+        "white": 0,
+        "yellow": 0,
+    }
+    assert set(report["receipt_sources"]) == {case["id"] for case in cases}
+    assert campaign["schema_version"] == campaign_shards.CAMPAIGN_SCHEMA
+
+
+def test_shard_resume_reuses_the_same_member_directory(tmp_path, monkeypatch):
+    storage = tmp_path / "storage"
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    selection = [
+        "run",
+        "--platform",
+        "gb300",
+        "--task",
+        "accuracy",
+        "--model",
+        "distilgpt2",
+        "--run-id",
+        "shard-resume-unit",
+        "--shard",
+        "0/1",
+    ]
+    assert model_checks.main([*selection, "--dry-run"]) == 0
+    commands = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(model_checks.subprocess, "run", run)
+
+    assert model_checks.main([*selection, "--resume"]) == 0
+    assert commands[-1][-1] == "--resume-existing"
+    assert (
+        storage
+        / "results/shard-resume-unit/shards/000-of-001/result.json"
+    ).is_file()
+
+
 def test_l4t_dry_run_passes_managed_hf_cache_seed_to_accuracy(tmp_path, monkeypatch):
     storage = tmp_path / "storage"
     seed = storage / "cache-staging/model"
@@ -1055,6 +1243,28 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
     assert commands[-1][-1] == "--resume-existing"
     result = json.loads((storage / "results/resume-unit/result.json").read_text(encoding="utf-8"))
     assert result["resumed"] is True
+
+
+def test_unsharded_resume_accepts_request_written_before_shard_fields(tmp_path):
+    request = {
+        "schema_version": "trtmc.model-check-run/v1",
+        "run_id": "legacy",
+        "revision": "HEAD",
+        "platform": "gb300",
+        "platform_source": "platform.yaml",
+        "platform_config": {},
+        "environment_source": "environment.yaml",
+        "environment_config": {},
+        "perf_environment_config": None,
+        "selection": {},
+        "commands": {},
+        "shard": None,
+    }
+    previous = {key: value for key, value in request.items() if key not in {"revision", "shard"}}
+    path = tmp_path / "request.json"
+    path.write_text(json.dumps(previous), encoding="utf-8")
+
+    model_checks._verify_resume_request(path, request)
 
 
 def test_perf_resume_command_requires_one_existing_run(tmp_path):

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1747,6 +1747,7 @@ class TestUnitTiers:
     @pytest.mark.parametrize(
         "path",
         [
+            "tools/campaign_shards.py",
             "tools/model_checks.py",
             "tools/model_selection.py",
             "tests/model_checks/environments/gb300.yaml",

--- a/tools/campaign_shards.py
+++ b/tools/campaign_shards.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic campaign sharding and receipt-backed report consolidation."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import deepcopy
+import fcntl
+import json
+import os
+from pathlib import Path
+import shutil
+from typing import Any, Mapping, Sequence
+
+from tools import qualification_report
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError
+
+
+CAMPAIGN_SCHEMA = "trtmc.model-check-sharded-campaign/v1"
+
+
+class CampaignShardError(ValueError):
+    """A shard selection or consolidated campaign is invalid."""
+
+
+def open_campaign(root: Path, manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Create one immutable campaign manifest, or verify the existing one."""
+
+    expected = deepcopy(dict(manifest))
+    expected["schema_version"] = CAMPAIGN_SCHEMA
+    path = Path(root) / "campaign.json"
+    if path.is_file():
+        current = _read_object(path, "sharded campaign")
+        if current != expected:
+            raise CampaignShardError(
+                "sharded campaign request does not match the existing run"
+            )
+        return current
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(expected, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    try:
+        os.link(temporary, path)
+    except FileExistsError:
+        current = _read_object(path, "sharded campaign")
+        if current != expected:
+            raise CampaignShardError(
+                "sharded campaign request does not match the existing run"
+            )
+    finally:
+        temporary.unlink(missing_ok=True)
+    return expected
+
+
+def load_campaign(root: Path) -> dict[str, Any]:
+    campaign = _read_object(Path(root) / "campaign.json", "sharded campaign")
+    if campaign.get("schema_version") != CAMPAIGN_SCHEMA:
+        raise CampaignShardError("invalid sharded campaign schema")
+    return campaign
+
+
+@contextmanager
+def consolidator_lock(root: Path):
+    """Ensure that only one process publishes the global campaign snapshot."""
+
+    path = Path(root) / ".consolidator.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as stream:
+        try:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise CampaignShardError(
+                "another campaign consolidator is already running"
+            ) from error
+        try:
+            yield
+        finally:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def parse_shard(value: str) -> tuple[int, int]:
+    """Parse a zero-based INDEX/COUNT shard selector."""
+
+    index_text, separator, count_text = str(value).partition("/")
+    try:
+        index = int(index_text)
+        count = int(count_text)
+    except ValueError as error:
+        raise CampaignShardError("shard must be a zero-based INDEX/COUNT") from error
+    if not separator or count < 1 or index < 0 or index >= count:
+        raise CampaignShardError("shard must satisfy 0 <= INDEX < COUNT")
+    return index, count
+
+
+def shard_name(index: int, count: int) -> str:
+    if count < 1 or index < 0 or index >= count:
+        raise CampaignShardError("shard must satisfy 0 <= INDEX < COUNT")
+    width = max(3, len(str(count - 1)))
+    return f"{index:0{width}d}-of-{count:0{width}d}"
+
+
+def assign_cases(
+    ordered_case_ids: Sequence[str],
+    *,
+    index: int,
+    count: int,
+) -> tuple[str, ...]:
+    """Return the stable round-robin subset assigned to one shard."""
+
+    shard_name(index, count)
+    normalized = tuple(str(case_id) for case_id in ordered_case_ids)
+    if any(not case_id for case_id in normalized):
+        raise CampaignShardError("campaign case ids must be non-empty")
+    if len(normalized) != len(set(normalized)):
+        raise CampaignShardError("campaign case ids must be unique")
+    return tuple(
+        case_id
+        for position, case_id in enumerate(normalized)
+        if position % count == index
+    )
+
+
+def _read_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CampaignShardError(f"cannot read {label} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise CampaignShardError(f"{label} must contain a JSON object: {path}")
+    return value
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    if not source.is_file() or source.is_symlink():
+        raise CampaignShardError(f"shard artifact is not a regular file: {source}")
+    source_stat = source.stat()
+    if destination.is_file():
+        destination_stat = destination.stat()
+        if (
+            destination_stat.st_size == source_stat.st_size
+            and destination_stat.st_mtime_ns == source_stat.st_mtime_ns
+        ):
+            return
+        if source.suffix == ".log" and source_stat.st_size > destination_stat.st_size:
+            with (
+                source.open("rb") as source_stream,
+                destination.open("ab") as destination_stream,
+            ):
+                source_stream.seek(destination_stat.st_size)
+                shutil.copyfileobj(source_stream, destination_stream)
+            os.utime(
+                destination,
+                ns=(destination_stat.st_atime_ns, source_stat.st_mtime_ns),
+            )
+            return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.copy.tmp")
+    shutil.copy2(source, temporary)
+    temporary.replace(destination)
+
+
+def _relocate_hrefs(
+    value: Any, *, source: Path, destination: Path, prefix: Path
+) -> Any:
+    if isinstance(value, Mapping):
+        relocated: dict[str, Any] = {}
+        for name, item in value.items():
+            if name == "href" and isinstance(item, str):
+                relative = Path(item)
+                if relative.is_absolute() or ".." in relative.parts:
+                    raise CampaignShardError(
+                        f"shard artifact href must be relative: {item!r}"
+                    )
+                target = prefix / relative
+                _copy_file(source / relative, destination / target)
+                relocated[name] = target.as_posix()
+            else:
+                relocated[str(name)] = _relocate_hrefs(
+                    item,
+                    source=source,
+                    destination=destination,
+                    prefix=prefix,
+                )
+        return relocated
+    if isinstance(value, list):
+        return [
+            _relocate_hrefs(item, source=source, destination=destination, prefix=prefix)
+            for item in value
+        ]
+    return deepcopy(value)
+
+
+def _pending_row(case: Mapping[str, Any]) -> dict[str, Any]:
+    row = deepcopy(dict(case.get("report", {})))
+    row.update(
+        {
+            "id": str(case["id"]),
+            "state": "pending",
+            "result": None,
+            "progress": {"stage": None, "attempt": 0},
+            "precision": {
+                "reference": "Not recorded",
+                "candidate": "Not recorded",
+            },
+            "debug": {"logs": [], "command_artifacts": []},
+        }
+    )
+    return row
+
+
+def merge_receipt_reports(
+    output: Path,
+    *,
+    report_kind: str,
+    campaign: Mapping[str, Any],
+    expected_cases: Sequence[Mapping[str, Any]],
+    shard_outputs: Sequence[tuple[str, Path]],
+) -> tuple[Path, Path, dict[str, Any]]:
+    """Merge shard-local receipt projections into one ordered public report."""
+
+    if report_kind not in {"accuracy", "performance"}:
+        raise CampaignShardError(f"unknown qualification report kind: {report_kind}")
+    task_kind = "accuracy" if report_kind == "accuracy" else "performance"
+    expected = [deepcopy(dict(case)) for case in expected_cases]
+    expected_ids = [str(case.get("id", "")) for case in expected]
+    if any(not case_id for case_id in expected_ids) or len(expected_ids) != len(
+        set(expected_ids)
+    ):
+        raise CampaignShardError("consolidated case inventory is invalid")
+    shard_count = campaign.get("shard_count")
+    if not isinstance(shard_count, int) or shard_count < 1:
+        raise CampaignShardError("consolidated shard count is invalid")
+    expected_by_shard = {
+        shard_name(index, shard_count): [
+            str(case["id"]) for case in expected if case.get("shard") == index
+        ]
+        for index in range(shard_count)
+    }
+    if sum(len(case_ids) for case_ids in expected_by_shard.values()) != len(expected):
+        raise CampaignShardError("every consolidated case must belong to one shard")
+
+    rows: dict[str, dict[str, Any]] = {
+        str(case["id"]): _pending_row(case) for case in expected
+    }
+    shard_runs: list[dict[str, Any]] = []
+    receipt_sources: dict[str, str] = {}
+    output = Path(output)
+    for label, source in shard_outputs:
+        source = Path(source)
+        try:
+            ledger = ExecutionLedger.load(source, task_kind=task_kind)
+        except ExecutionLedgerError as error:
+            raise CampaignShardError(str(error)) from error
+        report = _read_object(source / "report.json", "shard report")
+        if report.get("report_kind") != report_kind:
+            raise CampaignShardError(
+                f"shard {label} report kind does not match {report_kind}"
+            )
+        report_rows = report.get("results")
+        if not isinstance(report_rows, list):
+            raise CampaignShardError(f"shard {label} report results must be an array")
+        report_by_id = {
+            str(row.get("id", "")): row
+            for row in report_rows
+            if isinstance(row, Mapping)
+        }
+        ledger_ids = [str(case["id"]) for case in ledger.cases()]
+        assigned_ids = tuple(
+            str(case_id) for case_id in expected_by_shard.get(label, ())
+        )
+        if tuple(ledger_ids) != assigned_ids:
+            raise CampaignShardError(
+                f"shard {label} receipt inventory does not match its assignment"
+            )
+        if set(report_by_id) != set(ledger_ids):
+            raise CampaignShardError(
+                f"shard {label} report does not match its receipts"
+            )
+        ledger_prefix = Path("ledger") / "shards" / label
+        ledger_manifest = _read_object(
+            source / "ledger" / "campaign.json", "shard ledger"
+        )
+        receipt_paths = {
+            str(entry["case"]["id"]): str(entry["receipt"])
+            for entry in ledger_manifest.get("cases", [])
+            if isinstance(entry, Mapping) and isinstance(entry.get("case"), Mapping)
+        }
+        for ledger_file in sorted((source / "ledger").rglob("*.json")):
+            _copy_file(
+                ledger_file,
+                output / ledger_prefix / ledger_file.relative_to(source / "ledger"),
+            )
+        for case_id in ledger_ids:
+            receipt = ledger.receipt(case_id)
+            row = report_by_id[case_id]
+            if row.get("state") != receipt.get("state") or row.get(
+                "result"
+            ) != receipt.get("result"):
+                raise CampaignShardError(
+                    f"shard {label} report is stale for case {case_id!r}"
+                )
+            rows[case_id] = _relocate_hrefs(
+                row,
+                source=source,
+                destination=output,
+                prefix=Path("artifacts") / "shards" / label,
+            )
+            receipt_sources[case_id] = (
+                ledger_prefix / receipt_paths[case_id]
+            ).as_posix()
+        shard_run = report.get("run", {})
+        shard_run = shard_run if isinstance(shard_run, Mapping) else {}
+        shard_runs.append(
+            {
+                "shard": label,
+                **_relocate_hrefs(
+                    shard_run,
+                    source=source,
+                    destination=output,
+                    prefix=Path("artifacts") / "shards" / label,
+                ),
+            }
+        )
+
+    public_run = {
+        "source_revision": campaign.get("revision"),
+        "platform": campaign.get("platform"),
+        "hostname": "multiple shards",
+        "shards": shard_runs,
+    }
+    public_identity = {
+        "run_id": campaign.get("run_id"),
+        "disposition": "completed",
+        "source_revision": campaign.get("revision"),
+    }
+    if any(row["state"] != "terminal" for row in rows.values()):
+        public_identity["disposition"] = "running"
+    return qualification_report.materialize_report(
+        output,
+        report_kind=report_kind,
+        title=(
+            "TRTMC Accuracy & Fidelity Qualification"
+            if report_kind == "accuracy"
+            else "TRTMC Performance Qualification"
+        ),
+        identity=public_identity,
+        run=public_run,
+        results=[rows[case_id] for case_id in expected_ids],
+        metadata={
+            "campaign": {
+                "schema_version": CAMPAIGN_SCHEMA,
+                "shard_count": campaign.get("shard_count"),
+            },
+            "receipt_sources": receipt_sources,
+        },
+    )

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -16,6 +16,7 @@ import shlex
 import stat
 import subprocess
 import sys
+import time
 import tomllib
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -28,6 +29,7 @@ for source_root in (REPOSITORY, PYTHON_SOURCE):
     if str(source_root) not in sys.path:
         sys.path.insert(0, str(source_root))
 
+from tools import campaign_shards  # noqa: E402
 from tools import model_ci  # noqa: E402
 from tools import model_selection  # noqa: E402
 from tools import perf_matrix  # noqa: E402
@@ -39,6 +41,7 @@ from tools.ci.model_reference_cache import (  # noqa: E402
     parse_model_reference_contract,
 )
 from tools.ci.process import CiError  # noqa: E402
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools.validation import catalog as validation_catalog  # noqa: E402
 from tensorrt_model_connect.python_profiles import (  # noqa: E402
     PREBUILT_ONLY_ENV,
@@ -120,6 +123,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--hf-cache-seed-dir",
         type=Path,
         help="existing HF_HOME tree to hard-link into isolated Accuracy caches",
+    )
+    run.add_argument(
+        "--shard",
+        metavar="INDEX/COUNT",
+        help="run one zero-based deterministic shard without enabling CI orchestration",
+    )
+    consolidate = commands.add_parser(
+        "consolidate",
+        help="materialize global reports from a sharded model-check campaign",
+    )
+    consolidate.add_argument("run_root", type=Path)
+    consolidate.add_argument(
+        "--watch",
+        action="store_true",
+        help="continue refreshing until every selected case is terminal",
+    )
+    consolidate.add_argument(
+        "--interval-seconds",
+        type=float,
+        default=15.0,
+        help="refresh interval with --watch (default: 15)",
     )
     return parser
 
@@ -580,6 +604,8 @@ def _perf_projection(
                 "id": f"perf:{model}:{entry_id}",
                 "model": model,
                 "entry": entry_id,
+                "family": case.get("family"),
+                "operation": case.get("operation"),
                 "status": status,
                 **({"reason": reason} if reason else {}),
             }
@@ -908,13 +934,83 @@ def _task_bindings(plan: Mapping[str, Any], task: str) -> list[dict[str, Any]]:
     ]
 
 
+def _campaign_cases(
+    plan: Mapping[str, Any],
+    *,
+    shard_count: int,
+    accuracy_sample_limits: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for task in plan["execution"]["task_order"]:
+        for binding in _task_bindings(plan, task):
+            if task == "accuracy":
+                case_id = f"{binding['model']}::{binding['workload']}"
+                report = {
+                    "model": binding["model"],
+                    "workload": binding["workload"],
+                    "samples": {
+                        "planned": (accuracy_sample_limits or {}).get(
+                            binding["workload"]
+                        ),
+                        "evaluated": None,
+                    },
+                }
+            else:
+                case_id = str(binding["entry"])
+                report = {
+                    "model": binding["model"],
+                    "family": binding.get("family"),
+                    "operation": binding.get("operation"),
+                    "workload": binding["entry"],
+                }
+            cases.append(
+                {
+                    "binding_id": str(binding["id"]),
+                    "task": task,
+                    "id": case_id,
+                    "report": report,
+                }
+            )
+    assignments = {
+        binding_id: index
+        for index in range(shard_count)
+        for binding_id in campaign_shards.assign_cases(
+            [str(case["binding_id"]) for case in cases],
+            index=index,
+            count=shard_count,
+        )
+    }
+    for case in cases:
+        case["shard"] = assignments[str(case["binding_id"])]
+    return cases
+
+
+def _shard_task_bindings(
+    plan: Mapping[str, Any],
+    campaign_cases: Sequence[Mapping[str, Any]],
+    *,
+    task: str,
+    shard_index: int,
+) -> list[dict[str, Any]]:
+    owned = {
+        str(case["binding_id"])
+        for case in campaign_cases
+        if case["task"] == task and case["shard"] == shard_index
+    }
+    return [binding for binding in _task_bindings(plan, task) if binding["id"] in owned]
+
+
 def _selected_perf_reference_contracts(
     plan: Mapping[str, Any],
     models_dir: Path,
+    *,
+    bindings: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[ModelReferenceContract, ...]:
     selected_models = {
         str(binding["model"])
-        for binding in _task_bindings(plan, "perf")
+        for binding in (
+            bindings if bindings is not None else _task_bindings(plan, "perf")
+        )
     }
     if not selected_models:
         return ()
@@ -1006,8 +1102,12 @@ def _accuracy_command(
     environment: Mapping[str, Any],
     arguments: argparse.Namespace,
     output: Path,
+    *,
+    bindings: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[str] | None:
-    bindings = _task_bindings(plan, "accuracy")
+    bindings = (
+        list(bindings) if bindings is not None else _task_bindings(plan, "accuracy")
+    )
     if not bindings:
         return None
     config = environment["tasks"]["accuracy"]
@@ -1049,6 +1149,7 @@ def _resolved_perf_environment(
     storage_root: Path,
     results_root: Path,
     scratch_root: Path,
+    bundle_cache: Path | None = None,
 ) -> Path:
     raw = _read_yaml(source, "performance environment")
     tools = raw.get("tools")
@@ -1065,7 +1166,7 @@ def _resolved_perf_environment(
     storage["storage_root"] = str(storage_root)
     storage["results_root"] = str(results_root)
     storage["scratch_root"] = str(scratch_root)
-    storage["bundle_cache"] = str(storage_root / "engines" / "perf")
+    storage["bundle_cache"] = str(bundle_cache or storage_root / "engines" / "perf")
     storage["bundle_roots"] = []
     storage["runtime_dirs"] = [str(build_dir)]
     raw = _expand_environment(raw, "performance environment")
@@ -1077,8 +1178,10 @@ def _perf_command(
     plan: Mapping[str, Any],
     environment: Mapping[str, Any],
     resolved_environment: Path,
+    *,
+    bindings: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[str] | None:
-    bindings = _task_bindings(plan, "perf")
+    bindings = list(bindings) if bindings is not None else _task_bindings(plan, "perf")
     if not bindings:
         return None
     config = environment["tasks"]["perf"]
@@ -1142,9 +1245,192 @@ def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
     ):
         if previous.get(field) != request.get(field):
             raise ModelCheckError(f"cannot resume because the resolved {field} changed")
+    if request.get("shard") is not None:
+        for field in ("revision", "shard"):
+            if previous.get(field) != request.get(field):
+                raise ModelCheckError(f"cannot resume because the resolved {field} changed")
+
+
+def _perf_shard_output(shard_root: Path) -> Path | None:
+    results_root = shard_root / "perf" / "results"
+    if not results_root.is_dir():
+        return None
+    candidates = sorted(
+        path.parent.parent for path in results_root.glob("*/ledger/campaign.json")
+    )
+    if len(candidates) > 1:
+        raise ModelCheckError(f"shard has multiple Performance runs: {shard_root}")
+    return candidates[0] if candidates else None
+
+
+def _refresh_shard_report(task: str, output: Path) -> None:
+    report = output / "report.json"
+    receipts = list((output / "ledger" / "cases").glob("*/receipt.json"))
+    if report.is_file() and receipts and report.stat().st_mtime_ns >= max(
+        receipt.stat().st_mtime_ns for receipt in receipts
+    ):
+        return
+    if task == "accuracy":
+        trtmc_validate.write_report(output)
+        return
+    try:
+        results = perf_matrix._read_json_object(
+            output / "results.json", "performance results"
+        )
+        ledger = ExecutionLedger.load(output, task_kind="performance")
+        perf_matrix._write_artifacts(output, results, ledger)
+    except ExecutionLedgerError as error:
+        raise ModelCheckError(str(error)) from error
+
+
+def _validate_shard_member(
+    shard_root: Path,
+    *,
+    label: str,
+    index: int,
+    campaign: Mapping[str, Any],
+) -> bool:
+    request_path = shard_root / "request.json"
+    if not request_path.is_file():
+        return False
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ModelCheckError(
+            f"cannot read shard request {request_path}: {error}"
+        ) from error
+    selection = request.get("selection", {}) if isinstance(request, Mapping) else {}
+    stable_selection = (
+        {key: value for key, value in selection.items() if key != "platform_source"}
+        if isinstance(selection, Mapping)
+        else None
+    )
+    expected_shard = {
+        "index": index,
+        "count": campaign["shard_count"],
+        "name": label,
+    }
+    if (
+        not isinstance(request, Mapping)
+        or request.get("run_id") != campaign.get("run_id")
+        or request.get("revision") != campaign.get("revision")
+        or request.get("platform") != campaign.get("platform")
+        or request.get("shard") != expected_shard
+        or stable_selection != campaign.get("selection")
+    ):
+        raise ModelCheckError(f"shard {label} does not belong to this campaign")
+    return True
+
+
+def _consolidate_once(run_root: Path) -> bool:
+    try:
+        campaign = campaign_shards.load_campaign(run_root)
+    except campaign_shards.CampaignShardError as error:
+        raise ModelCheckError(str(error)) from error
+    cases = campaign.get("cases")
+    shard_count = campaign.get("shard_count")
+    if (
+        not isinstance(cases, list)
+        or not isinstance(shard_count, int)
+        or shard_count < 1
+    ):
+        raise ModelCheckError("sharded campaign inventory is invalid")
+    shards = []
+    for index in range(shard_count):
+        label = campaign_shards.shard_name(index, shard_count)
+        shard_root = run_root / "shards" / label
+        ready = False
+        if shard_root.exists():
+            ready = _validate_shard_member(
+                shard_root,
+                label=label,
+                index=index,
+                campaign=campaign,
+            )
+        shards.append((index, label, shard_root, ready))
+
+    all_terminal = True
+    for task, report_kind in (
+        ("accuracy", "accuracy"),
+        ("perf", "performance"),
+    ):
+        expected = [
+            case
+            for case in cases
+            if isinstance(case, Mapping) and case.get("task") == task
+        ]
+        if not expected:
+            continue
+        shard_outputs: list[tuple[str, Path]] = []
+        for _index, label, shard_root, ready in shards:
+            if not ready:
+                output = None
+            elif task == "accuracy":
+                output = shard_root / "accuracy"
+            else:
+                output = _perf_shard_output(shard_root)
+            if output is None or not (output / "ledger" / "campaign.json").is_file():
+                continue
+            _refresh_shard_report(task, output)
+            shard_outputs.append((label, output))
+
+        try:
+            _, _, report = campaign_shards.merge_receipt_reports(
+                run_root / task,
+                report_kind=report_kind,
+                campaign=campaign,
+                expected_cases=expected,
+                shard_outputs=shard_outputs,
+            )
+        except campaign_shards.CampaignShardError as error:
+            raise ModelCheckError(str(error)) from error
+        progress = report["accounting"]["progress"]
+        all_terminal = (
+            all_terminal and not progress["pending"] and not progress["running"]
+        )
+        print(
+            f"{_task_label(task)}: {progress['terminal']}/{report['accounting']['selected']} "
+            f"terminal · {run_root / task / 'report.json'}",
+            flush=True,
+        )
+    return all_terminal
+
+
+def _consolidate(arguments: argparse.Namespace) -> int:
+    if arguments.interval_seconds <= 0:
+        raise ModelCheckError("--interval-seconds must be positive")
+    run_root = arguments.run_root.expanduser().resolve()
+    try:
+        with campaign_shards.consolidator_lock(run_root):
+            while True:
+                complete = _consolidate_once(run_root)
+                if complete or not arguments.watch:
+                    return 0
+                time.sleep(arguments.interval_seconds)
+    except campaign_shards.CampaignShardError as error:
+        raise ModelCheckError(str(error)) from error
+
+
+def _resolved_revision(revision: str) -> str:
+    resolved = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{revision}^{{commit}}"],
+        cwd=REPOSITORY,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    value = resolved.stdout.strip().lower()
+    if resolved.returncode or not EXACT_GIT_REVISION_PATTERN.fullmatch(value):
+        raise ModelCheckError(f"cannot resolve exact source revision: {revision}")
+    return value
 
 
 def _run(arguments: argparse.Namespace) -> int:
+    shard = campaign_shards.parse_shard(arguments.shard) if arguments.shard else None
+    if shard is not None:
+        if not arguments.run_id:
+            raise ModelCheckError("--shard requires an explicit shared --run-id")
+        arguments.revision = _resolved_revision(arguments.revision)
     platform = load_platform(arguments.platform)
     environment = load_execution_environment(
         arguments.environment or str(platform["id"]),
@@ -1180,6 +1466,32 @@ def _run(arguments: argparse.Namespace) -> int:
         "results root",
     )
     run_root = _require_managed_path(results_root / run_id, storage_root, "run root")
+    if shard is None:
+        campaign_cases: list[dict[str, Any]] = []
+        task_bindings = {
+            task: _task_bindings(plan, task) for task in plan["execution"]["task_order"]
+        }
+        execution_root = run_root
+    else:
+        shard_index, shard_count = shard
+        accuracy_sample_limits = trtmc_validate.load_catalog(arguments.catalog).get(
+            "sample_limits", {}
+        )
+        campaign_cases = _campaign_cases(
+            plan,
+            shard_count=shard_count,
+            accuracy_sample_limits=accuracy_sample_limits,
+        )
+        task_bindings = {
+            task: _shard_task_bindings(
+                plan,
+                campaign_cases,
+                task=task,
+                shard_index=shard_index,
+            )
+            for task in plan["execution"]["task_order"]
+        }
+        execution_root = run_root / "shards" / campaign_shards.shard_name(*shard)
     if arguments.hf_cache_seed_dir is not None:
         if not _task_bindings(plan, "accuracy"):
             raise ModelCheckError("--hf-cache-seed-dir requires the Accuracy task")
@@ -1200,17 +1512,35 @@ def _run(arguments: argparse.Namespace) -> int:
                 "Hugging Face cache seed directory does not exist: "
                 f"{arguments.hf_cache_seed_dir}"
             )
+    if shard is not None:
+        stable_selection = {
+            key: value for key, value in plan.items() if key != "platform_source"
+        }
+        try:
+            campaign_shards.open_campaign(
+                run_root,
+                {
+                    "run_id": run_id,
+                    "platform": platform["id"],
+                    "revision": arguments.revision,
+                    "shard_count": shard[1],
+                    "selection": stable_selection,
+                    "cases": campaign_cases,
+                },
+            )
+        except campaign_shards.CampaignShardError as error:
+            raise ModelCheckError(str(error)) from error
     if arguments.resume:
-        if not run_root.is_dir():
-            raise ModelCheckError(f"cannot resume missing run root: {run_root}")
+        if not execution_root.is_dir():
+            raise ModelCheckError(f"cannot resume missing run root: {execution_root}")
     else:
-        if run_root.exists():
-            raise ModelCheckError(f"run root already exists: {run_root}")
-        run_root.mkdir(parents=True)
-    _write_selected_models(plan, run_root)
+        if execution_root.exists():
+            raise ModelCheckError(f"run root already exists: {execution_root}")
+        execution_root.mkdir(parents=True)
+    _write_selected_models(plan, execution_root)
 
     perf_environment = None
-    if _task_bindings(plan, "perf"):
+    if task_bindings.get("perf"):
         build_dir_value = environment["tasks"]["accuracy"]["options"].get("backend-dir")
         if not isinstance(build_dir_value, str) or not build_dir_value:
             raise ModelCheckError(
@@ -1219,11 +1549,12 @@ def _run(arguments: argparse.Namespace) -> int:
             )
         perf_environment = _resolved_perf_environment(
             Path(environment["tasks"]["perf"]["environment"]),
-            destination=run_root / "perf-environment.yaml",
+            destination=execution_root / "perf-environment.yaml",
             build_dir=Path(build_dir_value),
             storage_root=storage_root,
-            results_root=run_root / "perf" / "results",
-            scratch_root=run_root / "work" / "perf",
+            results_root=execution_root / "perf" / "results",
+            scratch_root=execution_root / "work" / "perf",
+            bundle_cache=(execution_root / "cache" / "perf" if shard else None),
         )
     commands: list[tuple[str, list[str] | None]] = []
     for task in plan["execution"]["task_order"]:
@@ -1232,11 +1563,17 @@ def _run(arguments: argparse.Namespace) -> int:
                 plan,
                 environment,
                 arguments,
-                run_root / "accuracy",
+                execution_root / "accuracy",
+                bindings=task_bindings[task],
             )
         else:
             command = (
-                _perf_command(plan, environment, perf_environment)
+                _perf_command(
+                    plan,
+                    environment,
+                    perf_environment,
+                    bindings=task_bindings[task],
+                )
                 if perf_environment is not None
                 else None
             )
@@ -1244,6 +1581,7 @@ def _run(arguments: argparse.Namespace) -> int:
     request = {
         "schema_version": "trtmc.model-check-run/v1",
         "run_id": run_id,
+        "revision": arguments.revision,
         "platform": platform["id"],
         "platform_source": platform["source"],
         "platform_config": platform,
@@ -1257,15 +1595,28 @@ def _run(arguments: argparse.Namespace) -> int:
         "selection": plan,
         "commands": {task: command for task, command in commands if command is not None},
         "dry_run": bool(arguments.dry_run),
+        "shard": (
+            {
+                "index": shard[0],
+                "count": shard[1],
+                "name": campaign_shards.shard_name(*shard),
+            }
+            if shard is not None
+            else None
+        ),
     }
-    request_path = run_root / "request.json"
+    request_path = execution_root / "request.json"
     if arguments.resume:
         _verify_resume_request(request_path, request)
     else:
-        request_path.write_text(
+        temporary_request = request_path.with_name(
+            f".{request_path.name}.{os.getpid()}.tmp"
+        )
+        temporary_request.write_text(
             json.dumps(request, indent=2) + "\n",
             encoding="utf-8",
         )
+        temporary_request.replace(request_path)
 
     execution_commands = list(commands)
     if arguments.resume:
@@ -1278,10 +1629,15 @@ def _run(arguments: argparse.Namespace) -> int:
             else:
                 resume_command = _perf_resume_command(
                     environment,
-                    run_root / "perf" / "results",
+                    execution_root / "perf" / "results",
                 )
                 execution_commands.append((task, resume_command or command))
-    print(_render_run_header(plan, run_id=run_id, run_root=run_root))
+    print(_render_run_header(plan, run_id=run_id, run_root=execution_root))
+    if shard is not None:
+        print(
+            f"Shard: {shard[0]}/{shard[1]} · "
+            f"{sum(len(bindings) for bindings in task_bindings.values())} bindings"
+        )
     print(f"Python profiles: {python_profiles_root} (shared; creates missing profiles)")
     if arguments.verbose or arguments.dry_run:
         print("\nCommands:")
@@ -1296,7 +1652,11 @@ def _run(arguments: argparse.Namespace) -> int:
         return 0
 
     reference_environment: dict[str, str] = {}
-    reference_contracts = _selected_perf_reference_contracts(plan, arguments.models_dir)
+    reference_contracts = _selected_perf_reference_contracts(
+        plan,
+        arguments.models_dir,
+        bindings=task_bindings.get("perf", ()),
+    )
     reference_environment.update(
         _prepare_perf_reference_dependencies(
             reference_contracts,
@@ -1337,7 +1697,7 @@ def _run(arguments: argparse.Namespace) -> int:
         "task_exit_codes": task_results,
         "status": "passed" if all(code == 0 for code in task_results.values()) else "failed",
     }
-    (run_root / "result.json").write_text(
+    (execution_root / "result.json").write_text(
         json.dumps(result, indent=2) + "\n",
         encoding="utf-8",
     )
@@ -1345,7 +1705,7 @@ def _run(arguments: argparse.Namespace) -> int:
     for task, returncode in task_results.items():
         status = "PASSED" if returncode == 0 else "FAILED"
         print(f"  {_task_label(task)}: {status}")
-    print(f"Run root: {run_root}")
+    print(f"Run root: {execution_root}")
     return 0 if result["status"] == "passed" else 1
 
 
@@ -1357,9 +1717,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _check(arguments)
         if arguments.command == "run":
             return _run(arguments)
+        if arguments.command == "consolidate":
+            return _consolidate(arguments)
         raise ModelCheckError(f"unsupported command: {arguments.command}")
     except (
         ModelCheckError,
+        campaign_shards.CampaignShardError,
         model_ci.ModelCIError,
         model_selection.ModelSelectionError,
         perf_matrix.PerfMatrixError,

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1887,7 +1887,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             priority=482,
             name="model_checks_tool",
             matcher=_regex_rule(
-                r"(?:tools/model_(?:checks|selection)\.py|"
+                r"(?:tools/(?:campaign_shards|model_(?:checks|selection))\.py|"
                 r"tests/model_checks/(?:environments|platforms)/[^/]+\.yaml)$"
             ),
             resolver=_match_result(


### PR DESCRIPTION
## Background
P3a made per-case receipts the execution source of truth, but Accuracy and Performance campaigns still ran as one serial host process. P3b needs an opt-in way to distribute one immutable campaign across independent GPUs without allowing workers to race on the global report.

## Exit Criteria
- Partition the frozen Acc/Perf case inventory deterministically with no overlap or omissions.
- Keep shard workers isolated and preserve resume semantics.
- Publish one receipt-backed Accuracy report and one receipt-backed Performance report while shards are running; missing cases remain pending.
- Do not enable sharding in nightly or premerge CI.

## Implementation
- Add a shared campaign-sharding Module for immutable manifests, round-robin assignment, single-consolidator locking, receipt verification, ordered merge, and portable artifact relocation.
- Add `model_checks.py run --shard INDEX/COUNT` and `model_checks.py consolidate RUN_ROOT --watch`, reusing the existing exact `--binding` and `--entry` task Adapters.
- Freeze the exact source revision, require an explicit shared run ID, isolate each shard output and writable Perf bundle cache, and retain backward compatibility for unsharded resume metadata.
- Classify the new orchestration Module in the tools-tier test-impact rule. No workflow files change.

## Validation
- `python -m pytest -q tests/tools/test_trtmc_validate.py tests/tools/test_perf_matrix.py tests/tools/test_model_checks.py tests/tools/test_campaign_shards.py tests/tools/test_execution_ledger.py tests/tools/test_qualification_report.py tests/tools/test_test_impact.py::TestUnitTiers::test_model_checks_tool_triggers_tools_tier tests/tools/test_test_impact.py::TestValidation::test_validate_consistency`: 374 passed on `84057969dc7473315d1e8f933b4e6bf88e45af89`.
- `ruff check tools/campaign_shards.py tools/model_checks.py tools/test_impact.py tests/tools/test_campaign_shards.py tests/tools/test_model_checks.py tests/tools/test_test_impact.py`: passed.
- The broader `tests/tools` run was attempted locally. Its P3b/test-impact failure was fixed and revalidated above; the remaining unrelated model-proof test cannot use `cp --reflink` on this workspace `/tmp` filesystem (`Operation not supported`).
- Target-hardware wall-time proof was not run in this PR; this adds capability only and does not enable CI execution.

## Notes For Future Readers
- Review `tools/campaign_shards.py` first for the shared invariants, then `tools/model_checks.py` for the Accuracy and Performance Adapters.
- Round-robin balances case count, not historical duration. Add weighted scheduling only after hardware measurements show that the extra policy is justified.
- Run exactly one consolidator per campaign. Each worker must use an independent host/GPU and the same campaign run ID, selection, shard count, and source revision.