### PR TITLE
fix(ci): provide TensorRT linker names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,10 @@ FROM ci-common AS ci-runtime
 ARG TENSORRT_VERSION
 ARG TENSORRT_APT_VERSION
 
+ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs
+ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu
+ENV LD_LIBRARY_PATH="$TRT_LIB_DIR:/usr/local/cuda/lib64"
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       "libnvinfer-dev=${TENSORRT_APT_VERSION}" \
@@ -204,17 +208,22 @@ RUN apt-get update && \
       "libnvonnxparsers-dev=${TENSORRT_APT_VERSION}" \
       "libnvonnxparsers11=${TENSORRT_APT_VERSION}" && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir "tensorrt==${TENSORRT_VERSION}"
-
-ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs
-ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu
-ENV LD_LIBRARY_PATH="$TRT_LIB_DIR:/usr/local/cuda/lib64"
+    pip install --no-cache-dir "tensorrt==${TENSORRT_VERSION}" && \
+    TENSORRT_MAJOR="${TENSORRT_VERSION%%.*}" && \
+    test -f "$TRT_LIB_DIR/libnvinfer.so.$TENSORRT_MAJOR" && \
+    test -f "$TRT_LIB_DIR/libnvonnxparser.so.$TENSORRT_MAJOR" && \
+    { test -e "$TRT_LIB_DIR/libnvinfer.so" || \
+      ln -s "libnvinfer.so.$TENSORRT_MAJOR" "$TRT_LIB_DIR/libnvinfer.so"; } && \
+    { test -e "$TRT_LIB_DIR/libnvonnxparser.so" || \
+      ln -s "libnvonnxparser.so.$TENSORRT_MAJOR" "$TRT_LIB_DIR/libnvonnxparser.so"; }
 
 RUN EXPECTED_TENSORRT_VERSION="$TENSORRT_VERSION" python3 -c \
-      'import ctypes, importlib.metadata as m, os; from pathlib import Path; expected = os.environ["EXPECTED_TENSORRT_VERSION"]; versions = tuple(map(int, expected.split("."))); assert all(m.version(name) == expected for name in ("tensorrt", "tensorrt_cu13", "tensorrt_cu13_bindings", "tensorrt_cu13_libs")); import tensorrt; assert tensorrt.__version__ == expected; include = Path("/usr/include/aarch64-linux-gnu"); header = (include / "NvInferVersion.h").read_text().splitlines(); assert (include / "NvOnnxParser.h").is_file(); assert all(f"#define TRT_{name}_ENTERPRISE {value}" in header for name, value in zip(("MAJOR", "MINOR", "PATCH", "BUILD"), versions)); major = versions[0]; libraries = Path(m.distribution("tensorrt_cu13_libs").locate_file("tensorrt_libs")); assert (libraries / f"libnvonnxparser.so.{major}").is_file(); assert next(libraries.glob("libnvinfer_builder_resource_sm110.so.*"), None) is not None; library = ctypes.CDLL(str(libraries / f"libnvinfer.so.{major}")); functions = tuple(getattr(library, f"getInferLib{name}Version") for name in ("Major", "Minor", "Patch", "Build")); [setattr(function, "restype", ctypes.c_int32) for function in functions]; assert tuple(function() for function in functions) == versions' && \
+      'import ctypes, importlib.metadata as m, os; from pathlib import Path; expected = os.environ["EXPECTED_TENSORRT_VERSION"]; versions = tuple(map(int, expected.split("."))); assert all(m.version(name) == expected for name in ("tensorrt", "tensorrt_cu13", "tensorrt_cu13_bindings", "tensorrt_cu13_libs")); import tensorrt; assert tensorrt.__version__ == expected; include = Path("/usr/include/aarch64-linux-gnu"); header = (include / "NvInferVersion.h").read_text().splitlines(); assert (include / "NvOnnxParser.h").is_file(); assert all(f"#define TRT_{name}_ENTERPRISE {value}" in header for name, value in zip(("MAJOR", "MINOR", "PATCH", "BUILD"), versions)); major = versions[0]; libraries = Path(m.distribution("tensorrt_cu13_libs").locate_file("tensorrt_libs")); versioned = tuple(libraries / f"{name}.so.{major}" for name in ("libnvinfer", "libnvonnxparser")); linker = tuple(libraries / f"{name}.so" for name in ("libnvinfer", "libnvonnxparser")); assert all(path.is_file() for path in versioned); assert all(path.is_symlink() and path.resolve() == target.resolve() for path, target in zip(linker, versioned)); assert next(libraries.glob("libnvinfer_builder_resource_sm110.so.*"), None) is not None; library = ctypes.CDLL(str(versioned[0])); functions = tuple(getattr(library, f"getInferLib{name}Version") for name in ("Major", "Minor", "Patch", "Build")); [setattr(function, "restype", ctypes.c_int32) for function in functions]; assert tuple(function() for function in functions) == versions' && \
     printf '#include <NvInferRuntime.h>\n#include <NvOnnxParser.h>\nint main() { return getInferLibVersion() > 0 ? 0 : 1; }\n' | \
-      c++ -x c++ - -I"$TRT_INC_DIR" -I/usr/local/cuda/include -L"$TRT_LIB_DIR" \
+      c++ -x c++ - -I"$TRT_INC_DIR" -I/usr/local/cuda/include \
         -Wl,-rpath,"$TRT_LIB_DIR" -Wl,--no-as-needed \
-        -lnvinfer -lnvonnxparser -o /tmp/trtmc-trt-link-probe && \
+        -x none \
+        "$TRT_LIB_DIR/libnvinfer.so" "$TRT_LIB_DIR/libnvonnxparser.so" \
+        -o /tmp/trtmc-trt-link-probe && \
     /tmp/trtmc-trt-link-probe && \
     rm -f /tmp/trtmc-trt-link-probe

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -530,7 +530,9 @@ def test_source_contract_describes_parameterized_tensorrt_overlay(tmp_path: Path
         "headers": ["NvInferVersion.h", "NvOnnxParser.h"],
         "header_version": "11.2.1.2",
         "native_libraries": [
+            "libnvinfer.so",
             "libnvinfer.so.11",
+            "libnvonnxparser.so",
             "libnvonnxparser.so.11",
             "libnvinfer_builder_resource_sm110.so.*",
         ],

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -621,11 +621,16 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     ):
         assert f'"{distribution}"' in overlay
     assert 'pip install --no-cache-dir "tensorrt==${TENSORRT_VERSION}"' in overlay
+    assert 'ln -s "libnvinfer.so.$TENSORRT_MAJOR"' in overlay
+    assert 'ln -s "libnvonnxparser.so.$TENSORRT_MAJOR"' in overlay
     assert "NvInferVersion.h" in overlay
     assert "NvOnnxParser.h" in overlay
     assert "libnvonnxparser.so" in overlay
     assert "libnvinfer_builder_resource_sm110.so" in overlay
     assert "getInferLibVersion" in overlay
+    assert "-x none" in overlay
+    assert '"$TRT_LIB_DIR/libnvinfer.so" "$TRT_LIB_DIR/libnvonnxparser.so"' in overlay
+    assert "-lnvinfer -lnvonnxparser" not in overlay
     assert "#include <NvInferRuntime.h>" in overlay
     assert "-I/usr/local/cuda/include" in overlay
     assert "c++ -x c++" in overlay

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -113,7 +113,9 @@ class ImageRequirements:
                 "headers": ["NvInferVersion.h", "NvOnnxParser.h"],
                 "header_version": self.tensorrt,
                 "native_libraries": [
+                    "libnvinfer.so",
                     f"libnvinfer.so.{self.tensorrt_major}",
+                    "libnvonnxparser.so",
                     f"libnvonnxparser.so.{self.tensorrt_major}",
                     "libnvinfer_builder_resource_sm110.so.*",
                 ],
@@ -524,11 +526,18 @@ if configured_library_root.resolve() != library_root.resolve() or library_search
     raise SystemExit("TRT_LIB_DIR and LD_LIBRARY_PATH must select tensorrt_cu13_libs")
 required_files = (
     Path(os.environ["TRT_INC_DIR"]) / "NvOnnxParser.h",
+    library_root / "libnvinfer.so",
     library_root / f"libnvinfer.so.{major}",
+    library_root / "libnvonnxparser.so",
     library_root / f"libnvonnxparser.so.{major}",
 )
 if missing := [str(path) for path in required_files if not path.is_file()]:
     raise SystemExit("missing TensorRT overlay files: " + ", ".join(missing))
+for linker_name in ("libnvinfer.so", "libnvonnxparser.so"):
+    linker = library_root / linker_name
+    versioned = library_root / f"{linker_name}.{major}"
+    if not linker.is_symlink() or linker.resolve() != versioned.resolve():
+        raise SystemExit(f"invalid TensorRT linker symlink: {linker}")
 if next(library_root.glob("libnvinfer_builder_resource_sm110.so.*"), None) is None:
     raise SystemExit("missing TensorRT SM110 builder resource")
 print("TENSORRT_OVERLAY_FILES=present")


### PR DESCRIPTION
## Background

The parameterized TensorRT overlays install runtime libraries from the pinned Python distributions. Those distributions expose versioned SONAMEs, while wheel packaging and platform coverage use the compiler-facing `libnvinfer.so` name under `TRT_LIB_DIR`. The missing linker aliases stopped both TensorRT wheel profiles before their smoke tests.

## Exit Criteria

- TensorRT 11.1 and 11.2 overlays provide self-contained compiler-facing library names under `TRT_LIB_DIR`.
- Image validation proves those names resolve to the selected versioned libraries and cannot fall back to system TensorRT.
- Both wheel profiles build and install for Python 3.10 and 3.12, and selected-profile platform coverage passes.

## Implementation

- Add relative `libnvinfer.so` and `libnvonnxparser.so` aliases to each TensorRT overlay after the exact Python distributions are installed.
- Extend the source-owned image contract and runtime probe to require the aliases and verify their resolved targets.
- Link the Docker build probe through the exact `TRT_LIB_DIR` paths instead of `-L`/`-l`, preventing an incomplete overlay from being masked by system libraries.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/tools/test_ensure_ci_docker_image.py tests/tools/test_github_actions_ci.py`: 85 passed.
- `python3 -m ruff check tools/ci/docker_image.py tests/tools/test_ensure_ci_docker_image.py tests/tools/test_github_actions_ci.py`: passed.
- `git diff --check`: passed.
- Built the `ci-runtime` target for TensorRT `11.1.0.106` and `11.2.1.2`: both passed the exact Python, APT, header, native-library, alias, and absolute-link probes.
- `DockerImageManager.validate_image_contract(...)`: passed for both locally built overlays.
- `python3 -m tools.ci pipeline package`: both TensorRT profiles built, audited, and installed Python 3.10 and 3.12 wheels with their matching backend ABI aliases.
- `python3 -m tools.ci pipeline cpp-coverage` with the selected TensorRT 11.2 overlay: 38/38 tests passed; line 59.5%, function 67.5%, branch 38.2%.

## Notes For Future Readers

- This Dockerfile change intentionally changes the source-owned runtime fingerprints. Immutable CI runtime images and their reviewed consumer lock must be refreshed before exact-head premerge can consume this revision.
- Review the Dockerfile alias creation and absolute link probe first, then the matching contract and regression assertions.
