### PR TITLE
feat(validation): close gate policy gaps

### DIFF
--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -203,6 +203,7 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     assert declared <= configured
     assert configured - declared == {
         "full_duplex_bench_speech_parity",
+        "refcoco_grounding",
         "vlm_mmmu_pro_vision_mcq",
     }
     assert min(catalog["sample_limits"].values()) >= 1
@@ -366,7 +367,7 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
             "strict-model": {"workloads": ["quality"]},
             "observer": {"workloads": ["diagnostic"]},
         },
-        "sample_limits": {"quality": 20, "diagnostic": 5},
+        "sample_limits": {"quality": 20, "diagnostic": 5, "explicit": 5},
     }
     suites = {
         "quality": {
@@ -386,6 +387,12 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
         "unbound": {
             "id": "unbound",
             "description": "Not selected by the current model inventory.",
+            "gates": {"min_sample_pass_rate": 1.0},
+        },
+        "explicit": {
+            "id": "explicit",
+            "description": "Selected only by an explicit command.",
+            "selection": "explicit_only",
             "gates": {"min_sample_pass_rate": 1.0},
         },
     }
@@ -409,10 +416,10 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
 
     assert census["schema_version"] == "trtmc.validation-gate-census/v1"
     assert census["summary"] == {
-        "suites": 3,
+        "suites": 4,
         "bindings": 3,
-        "variants": 4,
-        "blocking_variants": 3,
+        "variants": 5,
+        "blocking_variants": 4,
         "observation_only_variants": 1,
         "invalid_variants": 1,
         "review_required_suites": 1,
@@ -433,6 +440,9 @@ def test_gate_census_groups_resolved_variants_and_exposes_review_gaps() -> None:
         {"code": "no_selected_models"},
         {"code": "sample_limit_unconfigured"},
     ]
+    explicit = next(row for row in census["suites"] if row["id"] == "explicit")
+    assert explicit["selection"] == "explicit_only"
+    assert explicit["review"] == []
 
 
 def test_gate_census_expands_sample_acceptance_at_configured_count() -> None:
@@ -554,9 +564,22 @@ def test_default_gate_census_covers_every_suite_and_binding() -> None:
     invalid = [
         row["id"]
         for row in census["suites"]
-        if any(variant["policy"]["issues"] for variant in row["variants"])
+        if any(
+            variant["policy"]["issues"]
+            or variant.get("sample_acceptance", {}).get("issues")
+            for variant in row["variants"]
+        )
     ]
-    assert invalid == ["refcoco_grounding"]
+    assert invalid == []
+    assert census["summary"]["review_required_suites"] == 0
+    explicit_only = {
+        row["id"] for row in census["suites"] if row["selection"] == "explicit_only"
+    }
+    assert explicit_only == {
+        "full_duplex_bench_speech_parity",
+        "refcoco_grounding",
+        "vlm_mmmu_pro_vision_mcq",
+    }
     mmlu = next(row for row in census["suites"] if row["id"] == "mmlu_five_shot_mcq")
     assert len(mmlu["variants"]) == 2
     assert [

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -861,6 +861,10 @@ def test_default_suites_include_model_aligned_vision_tasks() -> None:
     assert prompted["default_model_names"] == ["sam-vit-base", "sam3"]
     assert prompted["model_overrides"]["by_family"]["sam"]["prompt_mode"] == "point"
     assert prompted["model_overrides"]["by_family"]["sam3"]["prompt_mode"] == "text"
+    assert prompted["sample_acceptance"] == {
+        "min_pass_rate": 0.95,
+        "min_allowed_failures": 1,
+    }
 
     selected = validation_engine.selected_models_for_suite(
         features,
@@ -3447,6 +3451,37 @@ def test_codegen_humaneval_gate_accepts_exact_replay() -> None:
 
     assert result["exact_match_rate"] == 1.0
     assert result["status"] == "passed"
+
+
+def test_prompted_segmentation_rejects_a_bad_tail_hidden_by_the_mean() -> None:
+    suite = validation_engine.suite_by_id(
+        validation_engine.load_suites(), "coco2017_prompted_segmentation"
+    )
+    result = {
+        "status": "passed",
+        "sample_count": 20,
+        "valid_count": 20,
+        "passed_count": 14,
+        "mean_backend_mask_iou": 0.75,
+        "worst_backend_mask_iou": 0.002,
+    }
+
+    validation_engine._apply_sample_acceptance(
+        result,
+        suite["sample_acceptance"],
+    )
+
+    assert result["status"] == "failed"
+    assert result["sample_acceptance"]["allowed_failures"] == 1
+    assert result["sample_acceptance"]["failed_count"] == 6
+    assert result["gate_failures"] == [
+        {
+            "gate": "sample_acceptance",
+            "metric": "failed_samples",
+            "actual": 6,
+            "required": 1,
+        }
+    ]
 
 
 def test_validation_suites_keep_continuation_and_drop_trace_cloze() -> None:

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -62,6 +62,11 @@ default, additional, or diagnostic workload category. A suite that exists in
 from model and all-model runs; it can still be selected explicitly for a
 one-off experiment when its selectors match that model.
 
+Such an intentionally unmapped workload declares `selection: explicit_only`.
+The gate census then treats the missing model binding as deliberate while still
+requiring a configured sample limit and a valid gate policy. This annotation
+does not add the workload to a model or change execution behavior.
+
 The complete selection schema is intentionally just:
 
 ```yaml

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -35,6 +35,7 @@ sample_limits:
   newstest2019_en_ru_marian_translation_parity: 10
   ocrbench_v2_unified: 5
   openwebtext_elf_diffusion_text: 5
+  refcoco_grounding: 20
   seedtts_en_omni_audio_parity: 1
   sana_wm_benchmark_diffusion_video: 2
   seedtts_en_tts_intelligibility: 3

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -463,6 +463,7 @@ suites:
         Run with --limit 10 on GB300. BLEU on ten samples is diagnostic only.
 
   - id: vlm_mmmu_pro_vision_mcq
+    selection: explicit_only
     description: >
       Local VLM multiple-choice accuracy evaluation on MMMU-Pro-Vision. This
       validates image-conditioned question answering for vision-language bundles
@@ -585,6 +586,7 @@ suites:
         runtime. This does not replace the native HF-target suite above.
 
   - id: refcoco_grounding
+    selection: explicit_only
     description: >
       RefCOCO referring-expression grounding accuracy for LocateAnything. HF
       slow/AR and TRTMC consume the same image and official single-instance
@@ -1287,6 +1289,11 @@ suites:
       # numerically close but worse task result from passing.
       min_backend_mask_iou: 0.70
       max_ground_truth_iou_drop_from_hf: 0.05
+    sample_acceptance:
+      # Each prompt first passes or fails at backend mask IoU 0.70. At the
+      # configured 20-sample slice, at most one prompt may miss that threshold.
+      min_pass_rate: 0.95
+      min_allowed_failures: 1
     model_overrides:
       by_family:
         sam:
@@ -1932,6 +1939,7 @@ suites:
       notes: GB300-only aggregate behavioral reference consistency.
 
   - id: full_duplex_bench_speech_parity
+    selection: explicit_only
     description: >
       Speech-response token and waveform consistency on five public
       Full-Duplex-Bench synthetic interruption and pause-handling inputs.

--- a/tools/validation/gate_census.py
+++ b/tools/validation/gate_census.py
@@ -59,10 +59,15 @@ def _review(
     variants: Sequence[Mapping[str, Any]],
     has_models: bool,
     sample_count: int | None,
+    selection: str,
 ) -> list[dict[str, Any]]:
     review: list[dict[str, Any]] = []
-    if not has_models:
+    if selection not in {"model_inventory", "explicit_only"}:
+        review.append({"code": "unsupported_selection", "value": selection})
+    elif selection == "model_inventory" and not has_models:
         review.append({"code": "no_selected_models"})
+    elif selection == "explicit_only" and has_models:
+        review.append({"code": "explicit_only_has_selected_models"})
     if sample_count is None:
         review.append({"code": "sample_limit_unconfigured"})
     if not any(
@@ -107,6 +112,7 @@ def build_gate_census(
     binding_count = 0
     for suite_id, suite in suites.items():
         sample_count, sample_limit_source = _sample_count(catalog, suite_id)
+        selection = str(suite.get("selection", "model_inventory") or "model_inventory")
         grouped: dict[str, dict[str, Any]] = {}
         for model_name, model_spec in catalog.get("models", {}).items():
             if suite_id not in model_spec.get("workloads", []):
@@ -131,6 +137,7 @@ def build_gate_census(
             variants=variants,
             has_models=any(variant["models"] for variant in variants),
             sample_count=sample_count,
+            selection=selection,
         )
         suite_rows.append(
             {
@@ -139,6 +146,7 @@ def build_gate_census(
                 "rationale": str(suite.get("description", "") or "").strip(),
                 "configured_sample_count": sample_count,
                 "sample_limit_source": sample_limit_source,
+                "selection": selection,
                 "variants": variants,
                 "review": review,
             }


### PR DESCRIPTION
## Background
The gate census still reported three review gaps and one invalid variant. Prompted segmentation also judged only mean mask IoU, allowing severe per-sample failures to be hidden by the aggregate.

## Exit Criteria
- The default gate census has no invalid variants or unresolved review entries.
- Intentionally unmapped workloads remain outside model-first runs without being treated as accidental omissions.
- Prompted segmentation applies a sample-count-aware tail budget in addition to mean and task-quality gates.
- This change does not enable any CI or NAS publishing path.

## Implementation
- Add one `selection: explicit_only` annotation for the three intentionally unmapped manual workloads; the census validates it but execution remains driven only by `model_workloads.yaml`.
- Add the reviewed 20-sample RefCOCO limit.
- Apply the existing `sample_acceptance` policy to prompted segmentation: per-sample mask IoU remains 0.70 and at most one of 20 samples may miss it.
- Keep the existing mean mask-IoU and ground-truth regression gates independent.

## Validation
- `python -m pytest -q tests/tools/test_validation_gate_policy.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py`: 457 passed.
- `python -m pytest -q tests/tools/test_model_checks.py tests/tools/test_model_ci.py tests/tools/test_qualification_report.py tests/tools/test_test_impact.py::TestValidation::test_validate_consistency`: 147 passed.
- `ruff check tools/validation/gate_census.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py`: passed.
- `python tools/trtmc_validate.py --gate-census`: 39 suites, 52 variants, 0 invalid variants, and 0 review-required suites.
- Offline replay of preserved 20-sample GB300 masks: SAM3 remains passing with 1/20 misses; SAM changes from aggregate pass to tail failure with 6/20 misses. This replay verifies policy projection, not fresh model inference.

## Notes For Future Readers
- `explicit_only` documents selection intent; it must not be used to add a workload to full model checks.
- The one-failure budget is derived independently of the observed SAM candidate. The existing failing tail is intentionally exposed rather than fitted away.