### PR TITLE
feat(perf): remeasure unsettled timing

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -314,13 +314,16 @@ latencies are separate fields. Metrics, Logs, and Commands remain separate
 report entries. The run environment snapshot is published at
 `artifacts/run/environment.json`.
 
-For valid comparisons, `report.json` also publishes a non-blocking
-`measurement_stability` shadow analysis. It checks the existing ten raw samples
-on each side: the first-five and last-five medians must differ by at most 5%,
-and at least eight samples must lie within 5% of that side's median. The report
-shows `Stable`, `Retry recommended`, or `Not evaluated` in Metrics. This shadow
-evidence does not trigger a retry, change the traffic light, or affect the run
-exit code.
+For valid comparisons, `report.json` publishes `measurement_stability`. It
+checks the ten raw samples on each side: the first-five and last-five medians
+must differ by at most 5%, and at least eight samples must lie within 5% of that
+side's median. A settled first measurement is classified immediately. An
+unsettled measurement starts both Reference and TRTMC once more in fresh
+processes while reusing the prepared bundle. If the second measurement remains
+unsettled, the case is white (`measurement_inconclusive`) and is excluded from
+the comparable-result denominator. Metrics retains both measurements' raw
+samples, and Logs and Commands retain the four leaf executions. Legacy results
+without enforced evidence continue to render their stored shadow analysis.
 
 The preparation receipt uses schema `trtmc.perf-bundle-preparation/v1`, scope
 `test_task`, and the performance run's exact `git_commit`. Each entry under

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -634,8 +634,8 @@ def test_compile_contract_cannot_silently_fall_back_to_eager() -> None:
     assert "mode" in comparison["reason"]
 
 
-def test_timing_stability_shadow_accepts_a_settled_measurement() -> None:
-    stability = perf_matrix._timing_stability_shadow(
+def test_timing_stability_accepts_a_settled_measurement() -> None:
+    stability = perf_matrix._timing_stability(
         [100.0, 101.0, 99.0, 100.0, 100.0, 101.0, 100.0, 99.0, 100.0, 100.0]
     )
 
@@ -644,8 +644,8 @@ def test_timing_stability_shadow_accepts_a_settled_measurement() -> None:
     assert stability["samples_within_band"] == 10
 
 
-def test_timing_stability_shadow_flags_a_measurement_that_is_still_falling() -> None:
-    stability = perf_matrix._timing_stability_shadow(
+def test_timing_stability_flags_a_measurement_that_is_still_falling() -> None:
+    stability = perf_matrix._timing_stability(
         [3.7, 3.4, 3.0, 2.7, 2.3, 1.9, 1.6, 1.4, 1.2, 1.0]
     )
 
@@ -653,8 +653,8 @@ def test_timing_stability_shadow_flags_a_measurement_that_is_still_falling() -> 
     assert stability["half_median_change_percent"] > 5.0
 
 
-def test_timing_stability_shadow_rejects_scattered_samples_even_without_drift() -> None:
-    stability = perf_matrix._timing_stability_shadow(
+def test_timing_stability_rejects_scattered_samples_even_without_drift() -> None:
+    stability = perf_matrix._timing_stability(
         [100.0, 80.0, 120.0, 100.0, 100.0, 100.0, 80.0, 120.0, 100.0, 100.0]
     )
 
@@ -663,8 +663,8 @@ def test_timing_stability_shadow_rejects_scattered_samples_even_without_drift() 
     assert stability["status"] == "unstable"
 
 
-def test_timing_stability_shadow_accepts_exactly_eight_samples_in_band() -> None:
-    stability = perf_matrix._timing_stability_shadow(
+def test_timing_stability_accepts_exactly_eight_samples_in_band() -> None:
+    stability = perf_matrix._timing_stability(
         [100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 120.0, 120.0]
     )
 
@@ -672,8 +672,8 @@ def test_timing_stability_shadow_accepts_exactly_eight_samples_in_band() -> None
     assert stability["status"] == "stable"
 
 
-def test_timing_stability_shadow_does_not_judge_a_nonstandard_sample_count() -> None:
-    stability = perf_matrix._timing_stability_shadow([10.0, 11.0])
+def test_timing_stability_does_not_judge_a_nonstandard_sample_count() -> None:
+    stability = perf_matrix._timing_stability([10.0, 11.0])
 
     assert stability == {
         "status": "not_evaluated",
@@ -846,9 +846,13 @@ def test_backend_waits_for_gpu_headroom_before_each_command(
     monkeypatch.setattr(
         perf_matrix,
         "_candidate_result",
-        lambda _directory, _digest: {},
+        lambda _directory, _digest: {"samples_ms": [10.0] * 10},
     )
-    monkeypatch.setattr(perf_matrix, "_read_baseline", lambda _path: {})
+    monkeypatch.setattr(
+        perf_matrix,
+        "_read_baseline",
+        lambda _path: {"samples_ms": [10.0] * 10},
+    )
     monkeypatch.setattr(
         perf_matrix,
         "_classify",
@@ -892,6 +896,128 @@ def test_backend_waits_for_gpu_headroom_before_each_command(
     output = capsys.readouterr().out
     assert "[example] TRTMC: candidate" in output
     assert "[example] baseline: baseline --precision fp16" in output
+
+
+def test_unsettled_measurement_is_retried_once_in_fresh_processes(
+    tmp_path, monkeypatch
+) -> None:
+    falling = [3.7, 3.4, 3.0, 2.7, 2.3, 1.9, 1.6, 1.4, 1.2, 1.0]
+    settled = [10.0] * 10
+    commands_run = []
+    monkeypatch.setattr(perf_matrix, "_command_environment", lambda: {})
+    monkeypatch.setattr(perf_matrix, "_workload_digest", lambda _resolved: "digest")
+    monkeypatch.setattr(
+        perf_matrix,
+        "_candidate_base_argv",
+        lambda _case, _options: ["candidate"],
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_baseline_argv",
+        lambda _case, _resolved, output, _options: (
+            ["baseline", "--precision", "fp16", "--output", str(output)],
+            "base",
+        ),
+    )
+    monkeypatch.setattr(perf_matrix, "_wait_for_gpu_memory_headroom", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        perf_matrix,
+        "_run_command",
+        lambda argv, _environment, _timeout: commands_run.append(argv[0])
+        or {"exit_code": 0, "stdout": "ok", "stderr": ""},
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_candidate_result",
+        lambda directory, _digest: {
+            "samples_ms": settled if "measurement-2" in str(directory) else falling
+        },
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_read_baseline",
+        lambda _path: {"samples_ms": settled},
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_classify",
+        lambda *_args, **_kwargs: ("green", {}),
+    )
+    monkeypatch.setattr(perf_matrix, "_stable_even", lambda _value: True)
+
+    row = {"resolved_settings": {}}
+    perf_matrix._run_supported_case(
+        {"id": "example"},
+        {"model": {"precision": "fp16"}, "request": {}},
+        Namespace(timeout_seconds=30, minimum_gpu_free_fraction=0, verbose=False),
+        tmp_path / "work",
+        row,
+    )
+
+    assert commands_run == ["candidate", "baseline", "candidate", "baseline"]
+    assert row["status"] == "green"
+    assert row["measurement_stability"]["status"] == "stable_after_retry"
+    assert [attempt["attempt"] for attempt in row["measurement_stability"]["attempts"]] == [1, 2]
+    assert set(row["commands"]) == {
+        "trtmc",
+        "baseline",
+        "trtmc_measurement_2",
+        "baseline_measurement_2",
+    }
+    assert len(row["logs"]) == 8
+    assert any("measurement-2" in record["href"] for record in row["logs"])
+
+
+def test_measurement_that_remains_unsettled_has_no_performance_light(
+    tmp_path, monkeypatch
+) -> None:
+    falling = [3.7, 3.4, 3.0, 2.7, 2.3, 1.9, 1.6, 1.4, 1.2, 1.0]
+    monkeypatch.setattr(perf_matrix, "_command_environment", lambda: {})
+    monkeypatch.setattr(perf_matrix, "_workload_digest", lambda _resolved: "digest")
+    monkeypatch.setattr(perf_matrix, "_candidate_base_argv", lambda *_args: ["candidate"])
+    monkeypatch.setattr(
+        perf_matrix,
+        "_baseline_argv",
+        lambda _case, _resolved, _output, _options: (
+            ["baseline", "--precision", "fp16"],
+            "base",
+        ),
+    )
+    monkeypatch.setattr(perf_matrix, "_wait_for_gpu_memory_headroom", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        perf_matrix,
+        "_run_command",
+        lambda *_args: {"exit_code": 0, "stdout": "", "stderr": ""},
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_candidate_result",
+        lambda *_args: {"samples_ms": falling},
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_read_baseline",
+        lambda _path: {"samples_ms": [10.0] * 10},
+    )
+    monkeypatch.setattr(perf_matrix, "_classify", lambda *_args, **_kwargs: ("yellow", {}))
+    monkeypatch.setattr(perf_matrix, "_stable_even", lambda _value: True)
+
+    row = {"resolved_settings": {}}
+    perf_matrix._run_supported_case(
+        {"id": "example"},
+        {"model": {"precision": "fp16"}, "request": {}},
+        Namespace(timeout_seconds=30, minimum_gpu_free_fraction=0, verbose=False),
+        tmp_path / "work",
+        row,
+    )
+    public = perf_matrix._public_perf_result(row)
+
+    assert row["status"] == "measurement-inconclusive"
+    assert public["result"] == "white"
+    assert public["issue"]["code"] == "measurement_inconclusive"
+    assert public["output_validation"]["status"] == "Pass"
+    assert public["latency"] == {"reference_ms": None, "candidate_ms": None}
+    assert public["measurement_stability"]["status"] == "measurement_inconclusive"
 
 
 @pytest.mark.parametrize(
@@ -2100,7 +2226,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
         "reference_ms": 20.45,
         "candidate_ms": 10.45,
     }
-    assert public_row["measurement_stability"]["mode"] == "shadow"
+    assert public_row["measurement_stability"]["mode"] == "enforced"
     assert public_row["measurement_stability"]["status"] == "stable"
     assert public_row["issue"] is None
     assert all(
@@ -2132,7 +2258,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert "Failures" in frontend
     assert "Reference latency" in frontend
     assert "TRTMC latency" in frontend
-    assert "Timing stability (shadow)" in frontend
+    assert "Timing stability" in frontend
 
     baseline_argv = rows["gpt2.generate"]["commands"]["baseline"]["argv"]
     request = baseline_argv[baseline_argv.index("--request-json") + 1]

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -1779,18 +1779,32 @@ def _materialize_command_logs(
     command: MutableMapping[str, Any],
     *,
     case_attempt: int = 1,
+    measurement_attempt: int = 1,
 ) -> list[dict[str, str]]:
     directory = output / "artifacts" / _slug(case_id) / "logs"
     directory.mkdir(parents=True, exist_ok=True)
     links = []
     attempt_suffix = "" if case_attempt == 1 else f".case-attempt-{case_attempt}"
+    measurement_suffix = (
+        "" if measurement_attempt == 1 else f".measurement-{measurement_attempt}"
+    )
     for stream in ("stdout", "stderr"):
-        path = directory / f"{side}{attempt_suffix}.{stream}.log"
+        path = directory / (
+            f"{side}{attempt_suffix}{measurement_suffix}.{stream}.log"
+        )
         path.write_text(str(command.pop(stream, "")), encoding="utf-8")
         href = path.relative_to(output).as_posix()
         command[f"{stream}_log"] = href
         side_label = "TRTMC" if side == "trtmc" else "Reference"
-        links.append({"label": f"{side_label} {stream}", "href": href})
+        measurement_label = (
+            "" if measurement_attempt == 1 else f" measurement {measurement_attempt}"
+        )
+        links.append(
+            {
+                "label": f"{side_label}{measurement_label} {stream}",
+                "href": href,
+            }
+        )
     diagnostic = command.get("diagnostic")
     if isinstance(diagnostic, MutableMapping):
         materialized = []
@@ -1804,7 +1818,9 @@ def _materialize_command_logs(
             if not source.is_file():
                 continue
             suffix = "".join(source.suffixes) or ".log"
-            path = directory / f"{side}{attempt_suffix}.{_slug(label)}{suffix}"
+            path = directory / (
+                f"{side}{attempt_suffix}{measurement_suffix}.{_slug(label)}{suffix}"
+            )
             shutil.copyfile(source, path)
             record = {"label": label, "href": path.relative_to(output).as_posix()}
             materialized.append(record)
@@ -1985,8 +2001,8 @@ _TIMING_STABILITY_MEDIAN_BAND_PERCENT = 5.0
 _TIMING_STABILITY_MIN_IN_BAND = 8
 
 
-def _timing_stability_shadow(values: Sequence[Any]) -> dict[str, Any]:
-    """Describe timing stability without changing the qualification result."""
+def _timing_stability(values: Sequence[Any]) -> dict[str, Any]:
+    """Decide whether one side's ten timed samples are settled."""
 
     if len(values) != _TIMING_STABILITY_SAMPLE_COUNT:
         return {
@@ -2038,26 +2054,23 @@ def _timing_stability_shadow(values: Sequence[Any]) -> dict[str, Any]:
     }
 
 
-def _measurement_stability_shadow(
-    row: Mapping[str, Any], result: str | None
-) -> dict[str, Any] | None:
-    if result not in qualification_report.RGB_RESULTS:
-        return None
-    baseline = row.get("baseline", {})
-    candidate = row.get("candidate", {})
-    baseline = baseline if isinstance(baseline, Mapping) else {}
-    candidate = candidate if isinstance(candidate, Mapping) else {}
-    reference = _timing_stability_shadow(baseline.get("samples_ms", []))
-    trtmc = _timing_stability_shadow(candidate.get("samples_ms", []))
+def _measurement_stability_evidence(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    reference = _timing_stability(baseline.get("samples_ms", []))
+    trtmc = _timing_stability(candidate.get("samples_ms", []))
     side_statuses = {reference["status"], trtmc["status"]}
     if side_statuses == {"stable"}:
         status = "stable"
     elif "unstable" in side_statuses:
-        status = "retry_recommended"
+        status = "retry_recommended" if mode == "shadow" else "unstable"
     else:
         status = "not_evaluated"
-    return {
-        "mode": "shadow",
+    evidence = {
+        "mode": mode,
         "status": status,
         "policy": {
             "required_samples": _TIMING_STABILITY_SAMPLE_COUNT,
@@ -2070,6 +2083,26 @@ def _measurement_stability_shadow(
         "reference": reference,
         "trtmc": trtmc,
     }
+    return evidence
+
+
+def _measurement_stability(
+    row: Mapping[str, Any], result: str | None
+) -> dict[str, Any] | None:
+    stored = row.get("measurement_stability")
+    if isinstance(stored, Mapping):
+        return deepcopy(dict(stored))
+    if result not in qualification_report.RGB_RESULTS:
+        return None
+    baseline = row.get("baseline", {})
+    candidate = row.get("candidate", {})
+    baseline = baseline if isinstance(baseline, Mapping) else {}
+    candidate = candidate if isinstance(candidate, Mapping) else {}
+    return _measurement_stability_evidence(
+        baseline,
+        candidate,
+        mode="shadow",
+    )
 
 
 def _normalized_text(value: Any) -> str:
@@ -2468,48 +2501,77 @@ def _case_row(
     return row
 
 
-def _run_supported_case(
+def _run_measurement(
     case: Mapping[str, Any],
     resolved: Mapping[str, Any],
     options: RunOptions,
     case_work: Path,
     row: MutableMapping[str, Any],
     *,
+    measurement_attempt: int,
     case_attempt: int = 1,
     progress: Callable[[str, Mapping[str, Any]], None] | None = None,
-) -> None:
+) -> tuple[dict[str, Any], dict[str, Any], str, dict[str, Any]] | None:
     environment = _case_command_environment(options, case_work)
     digest = _workload_digest(resolved)
-    candidate_dir = case_work / "trtmc"
-    baseline_path = case_work / "baseline.json"
-    candidate_argv = [*_candidate_base_argv(case, options), "--output", str(candidate_dir)]
+    commands = row.setdefault("commands", {})
+    order = (
+        ("trtmc", "baseline")
+        if _stable_even(str(case["id"]))
+        else ("baseline", "trtmc")
+    )
+    measurement_work = (
+        case_work
+        if measurement_attempt == 1
+        else case_work / f"measurement-{measurement_attempt}"
+    )
+    measurement_work.mkdir(parents=True, exist_ok=True)
+    candidate_dir = measurement_work / "trtmc"
+    baseline_path = measurement_work / "baseline.json"
+    candidate_argv = [
+        *_candidate_base_argv(case, options),
+        "--output",
+        str(candidate_dir),
+    ]
     baseline_argv, profile = _baseline_argv(case, resolved, baseline_path, options)
     row["resolved_settings"]["baseline_python_profile"] = profile
     reference_precision = baseline_argv[baseline_argv.index("--precision") + 1]
     row["resolved_settings"]["baseline_precision"] = reference_precision
-    commands = row.setdefault("commands", {})
-    commands.update({
-        "trtmc": {
-            "argv": candidate_argv,
-            "rendered": shlex.join(candidate_argv),
+    suffix = "" if measurement_attempt == 1 else f"_measurement_{measurement_attempt}"
+    command_keys = {
+        "trtmc": f"trtmc{suffix}",
+        "baseline": f"baseline{suffix}",
+    }
+    for side, argv in (("trtmc", candidate_argv), ("baseline", baseline_argv)):
+        commands[command_keys[side]] = {
+            "argv": argv,
+            "rendered": shlex.join(argv),
             "cwd": str(REPOSITORY),
-        },
-        "baseline": {
-            "argv": baseline_argv,
-            "rendered": shlex.join(baseline_argv),
-            "cwd": str(REPOSITORY),
-        },
-    })
+        }
     if getattr(options, "verbose", False):
-        print(f"[{case['id']}] TRTMC: {commands['trtmc']['rendered']}", flush=True)
-        print(f"[{case['id']}] baseline: {commands['baseline']['rendered']}", flush=True)
-    order = ("trtmc", "baseline") if _stable_even(str(case["id"])) else ("baseline", "trtmc")
+        label = "" if measurement_attempt == 1 else " remeasurement"
+        print(
+            f"[{case['id']}] TRTMC{label}: "
+            f"{commands[command_keys['trtmc']]['rendered']}",
+            flush=True,
+        )
+        print(
+            f"[{case['id']}] baseline{label}: "
+            f"{commands[command_keys['baseline']]['rendered']}",
+            flush=True,
+        )
     for side in order:
         argv = candidate_argv if side == "trtmc" else baseline_argv
+        stage = "candidate" if side == "trtmc" else "reference"
+        if measurement_attempt > 1:
+            stage = f"remeasure-{stage}"
         if progress is not None:
             progress(
-                "candidate" if side == "trtmc" else "reference",
-                {"commands": deepcopy(row["commands"])},
+                stage,
+                {
+                    "commands": deepcopy(row["commands"]),
+                    "logs": deepcopy(row.get("logs", [])),
+                },
             )
         _wait_for_gpu_memory_headroom(
             minimum_free_fraction=options.minimum_gpu_free_fraction
@@ -2522,25 +2584,27 @@ def _run_supported_case(
                 side,
                 command,
                 case_attempt=case_attempt,
+                measurement_attempt=measurement_attempt,
             )
         )
-        commands[side] = command
+        commands[command_keys[side]] = command
         if command["exit_code"] != 0:
             row["status"] = "failed"
-            row["reason"] = f"{side} command failed with rc={command['exit_code']}"
+            row["reason"] = (
+                f"{side} measurement {measurement_attempt} command failed "
+                f"with rc={command['exit_code']}"
+            )
             diagnostic = command.get("diagnostic", {})
             diagnostic = diagnostic if isinstance(diagnostic, Mapping) else {}
-            row["failure_stage"] = str(
-                diagnostic.get("stage")
-                or ("candidate" if side == "trtmc" else "reference")
-            )
+            row["failure_stage"] = str(diagnostic.get("stage") or stage)
             row["failure_domain"] = str(
                 diagnostic.get("domain") or "harness/unknown"
             )
             row["failure_code"] = str(
                 diagnostic.get("code") or "execution_failure"
             )
-            return
+            row.pop("measurement_stability", None)
+            return None
     candidate = _candidate_result(candidate_dir, digest)
     candidate["precision"] = str(resolved["model"]["precision"])
     baseline = _read_baseline(baseline_path)
@@ -2551,10 +2615,91 @@ def _run_supported_case(
         request=resolved["request"],
         reference_precision=reference_precision,
     )
-    row["candidate"] = candidate
-    row["baseline"] = baseline
-    row["comparison"] = comparison
-    row["status"] = status
+    return candidate, baseline, status, comparison
+
+
+def _run_supported_case(
+    case: Mapping[str, Any],
+    resolved: Mapping[str, Any],
+    options: RunOptions,
+    case_work: Path,
+    row: MutableMapping[str, Any],
+    *,
+    case_attempt: int = 1,
+    progress: Callable[[str, Mapping[str, Any]], None] | None = None,
+) -> None:
+    measurement_attempts: list[dict[str, Any]] = []
+    for measurement_attempt in (1, 2):
+        measured = _run_measurement(
+            case,
+            resolved,
+            options,
+            case_work,
+            row,
+            measurement_attempt=measurement_attempt,
+            case_attempt=case_attempt,
+            progress=progress,
+        )
+        if measured is None:
+            return
+        candidate, baseline, status, comparison = measured
+        row.update(
+            candidate=candidate,
+            baseline=baseline,
+            comparison=comparison,
+            status=status,
+        )
+        if status not in qualification_report.RGB_RESULTS:
+            row.pop("measurement_stability", None)
+            return
+
+        stability = _measurement_stability_evidence(
+            baseline,
+            candidate,
+            mode="enforced",
+        )
+        measurement_attempts.append(
+            {
+                "attempt": measurement_attempt,
+                "result": status,
+                "reference": {
+                    "samples_ms": deepcopy(baseline.get("samples_ms", [])),
+                    "stability": deepcopy(stability["reference"]),
+                },
+                "trtmc": {
+                    "samples_ms": deepcopy(candidate.get("samples_ms", [])),
+                    "stability": deepcopy(stability["trtmc"]),
+                },
+            }
+        )
+        row["measurement_stability"] = {
+            **stability,
+            "attempts": deepcopy(measurement_attempts),
+        }
+        if stability["status"] == "stable":
+            if measurement_attempt == 2:
+                row["measurement_stability"]["status"] = "stable_after_retry"
+            return
+        if stability["status"] == "not_evaluated":
+            row["status"] = "measurement-inconclusive"
+            row["reason"] = "timing stability requires ten valid samples per side"
+            row["failure_stage"] = "measure"
+            row["failure_domain"] = "harness/unknown"
+            row["failure_code"] = "measurement_inconclusive"
+            row["measurement_stability"]["status"] = "measurement_inconclusive"
+            return
+        if measurement_attempt == 1:
+            print(
+                f"[{case['id']}] timing is not settled; measuring once more",
+                flush=True,
+            )
+
+    row["status"] = "measurement-inconclusive"
+    row["reason"] = "timing did not settle after one remeasurement"
+    row["failure_stage"] = "measure"
+    row["failure_domain"] = "harness/unknown"
+    row["failure_code"] = "measurement_inconclusive"
+    row["measurement_stability"]["status"] = "measurement_inconclusive"
 
 
 def _stable_even(value: str) -> bool:
@@ -2862,7 +3007,10 @@ def _perf_output_validation(
     contract = str(resolved.get("output_contract", "") or "Not recorded")
     comparison = row.get("comparison", {})
     comparison = comparison if isinstance(comparison, Mapping) else {}
-    if str(row.get("status")) in qualification_report.RGB_RESULTS:
+    if str(row.get("status")) in {
+        *qualification_report.RGB_RESULTS,
+        "measurement-inconclusive",
+    }:
         status = "Pass"
         reason = None
     elif str(row.get("status")) == "contract-mismatch":
@@ -2902,7 +3050,7 @@ def _public_perf_result(row: Mapping[str, Any]) -> dict[str, Any]:
             "precision": _perf_precision(row),
             "output_validation": _perf_output_validation(row, result),
             "latency": _perf_latency(row, result),
-            "measurement_stability": _measurement_stability_shadow(row, result),
+            "measurement_stability": _measurement_stability(row, result),
             "issue": _perf_issue(row, result),
             "debug": {
                 "logs": [dict(record) for record in row.get("logs", [])],

--- a/tools/qualification_report_assets/qualification-report.js
+++ b/tools/qualification_report_assets/qualification-report.js
@@ -216,21 +216,32 @@
 
   function timingStability(value) {
     if (!value) return null;
-    const labels = { stable: "Stable", retry_recommended: "Retry recommended", not_evaluated: "Not evaluated", unstable: "Unstable" };
+    const labels = { stable: "Stable", stable_after_retry: "Stable after remeasurement", retry_recommended: "Retry recommended", not_evaluated: "Not evaluated", unstable: "Unstable", measurement_inconclusive: "Inconclusive after remeasurement" };
     const control = el("details", "gate-evidence");
-    control.append(el("summary", "", `Timing stability (shadow) · ${labels[value.status] || value.status}`));
+    control.append(el("summary", "", `Timing stability · ${labels[value.status] || value.status}`));
     const body = el("div", "evidence-body");
     const policy = value.policy || {};
     add(body, el("div", "gate-fact", `${policy.required_samples ?? 10} samples · first/last half ≤${number(policy.max_half_median_change_percent ?? 5, 2)}% · at least ${policy.minimum_samples_within_band ?? 8}/${policy.required_samples ?? 10} within median ±${number(policy.median_band_percent ?? 5, 2)}%`));
-    [["Reference", value.reference], ["TRTMC", value.trtmc]].forEach(([name, side]) => {
+    const sideEvidence = (name, side, samples) => {
       if (!side) return;
       if (side.status === "not_evaluated") {
         body.append(el("div", "gate-fact", `${name} · Not evaluated · ${side.sample_count ?? 0} samples`));
         return;
       }
       body.append(el("div", "gate-fact", `${name} · ${labels[side.status] || side.status} · first 5 ${number(side.first_half_median_ms, 3)} ms · last 5 ${number(side.second_half_median_ms, 3)} ms · ${side.samples_within_band}/${side.sample_count} within band`));
-    });
-    body.append(el("div", "detail", "Shadow evidence only; the current result is unchanged."));
+      if (Array.isArray(samples)) body.append(el("div", "detail", `${name} raw latency (ms) · ${samples.map((sample) => number(sample, 3)).join(", ")}`));
+    };
+    if (Array.isArray(value.attempts) && value.attempts.length) {
+      value.attempts.forEach((attempt) => {
+        body.append(el("h4", "", `Measurement ${attempt.attempt}`));
+        sideEvidence("Reference", attempt.reference?.stability, attempt.reference?.samples_ms);
+        sideEvidence("TRTMC", attempt.trtmc?.stability, attempt.trtmc?.samples_ms);
+      });
+    } else {
+      sideEvidence("Reference", value.reference);
+      sideEvidence("TRTMC", value.trtmc);
+    }
+    if (value.mode === "shadow") body.append(el("div", "detail", "Shadow evidence only; the current result is unchanged."));
     control.append(body);
     return control;
   }
@@ -312,7 +323,8 @@
   function commands(row) {
     const records = [];
     Object.entries(row.commands || {}).forEach(([name, command]) => {
-      if (command?.rendered) records.push([name === "trtmc" ? "TRTMC" : name === "baseline" ? "Reference" : name, `${command.cwd ? `cwd: ${command.cwd}\n` : ""}$ ${command.rendered}`]);
+      const labels = { trtmc: "TRTMC", baseline: "Reference", trtmc_measurement_2: "TRTMC measurement 2", baseline_measurement_2: "Reference measurement 2" };
+      if (command?.rendered) records.push([labels[name] || name, `${command.cwd ? `cwd: ${command.cwd}\n` : ""}$ ${command.rendered}`]);
     });
     const value = el("div");
     if (records.length) value.append(details("Commands", records));

--- a/tools/qualification_report_assets/qualification-report.schema.json
+++ b/tools/qualification_report_assets/qualification-report.schema.json
@@ -99,13 +99,20 @@
             "type": ["object", "null"],
             "required": ["mode", "status", "policy", "reference", "trtmc"],
             "properties": {
-              "mode": {"const": "shadow"},
+              "mode": {"enum": ["shadow", "enforced"]},
               "status": {
-                "enum": ["stable", "retry_recommended", "not_evaluated"]
+                "enum": [
+                  "stable",
+                  "stable_after_retry",
+                  "retry_recommended",
+                  "not_evaluated",
+                  "measurement_inconclusive"
+                ]
               },
               "policy": {"type": "object"},
               "reference": {"type": "object"},
-              "trtmc": {"type": "object"}
+              "trtmc": {"type": "object"},
+              "attempts": {"type": "array"}
             }
           },
           "samples": {


### PR DESCRIPTION
## Summary

- make timing stability a prerequisite for Perf traffic-light classification
- remeasure Reference and TRTMC once in fresh processes when the first ten samples are unsettled
- classify persistent instability as white `measurement_inconclusive` and retain both rounds of raw samples, commands, and logs
- keep legacy results readable through the existing shadow projection

## Calibration

Historical result replay found first-round instability in 37/92 comparable L4T cases and 9/82 comparable Thor-X cases. The largest findings were clear settling behavior rather than small boundary noise, so the implementation limits extra work to those cases and caps it at one remeasurement.

## Validation

- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_perf_matrix.py tests/tools/test_qualification_report.py tests/tools/test_model_checks.py tests/tools/test_model_ci.py tests/tools/test_execution_ledger.py` (291 passed)
- `python -m ruff check tools/perf_matrix.py tests/tools/test_perf_matrix.py`
- `git diff --check`

No CI workflow or report publishing configuration is enabled by this change.