### PR TITLE
perf(deepseek-ocr): execute only routed experts

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -162,6 +162,8 @@ entries:
     model: deepseek-ocr
     workload:
       testcase: deepseek-ocr
+      runtime:
+        cuda_graphs: true
     baseline:
       runner: task-reference
       adapter: hf-transformers-vlm

--- a/python/tensorrt_model_connect/families/deepseek_ocr/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/graph_blocks.py
@@ -51,7 +51,8 @@ def make_matmul_fn(network, dtype, quant_ctx):
 
         def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
             return graph_ops.add_matmul_rhs_constant(
-                network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype
+                network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype,
+                fp32_accumulation=dtype == np.float32,
             )
 
         return matmul
@@ -388,6 +389,65 @@ def add_swiglu_mlp(
         gated.get_output(0), mlp_size, hidden_size, weights[f"{prefix}.w_down"], f"{_lp}.w_down"
     )
     return mlp_out
+
+
+def add_routed_swiglu_experts(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    top_indices: trt.ITensor,
+    routing_weights: trt.ITensor,
+    *,
+    hidden_size: int,
+    top_k: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Compute only the top-k routed experts selected for each token."""
+    inp_4d = network.add_shuffle(inp)
+    inp_4d.reshape_dims = (-1, 1, 1, hidden_size)
+
+    def packed_weight(values: np.ndarray) -> trt.ITensor:
+        tensor = graph_ops.add_constant(
+            network, values.shape, values, dtype=dtype)
+        if tensor.dtype != inp.dtype:
+            tensor = network.add_cast(tensor, inp.dtype).get_output(0)
+        return tensor
+
+    gate_weights = packed_weight(w_gate)
+    up_weights = packed_weight(w_up)
+    down_weights = packed_weight(w_down)
+    selected_gate = network.add_gather(gate_weights, top_indices, 0)
+    selected_up = network.add_gather(up_weights, top_indices, 0)
+    gate = network.add_matrix_multiply(
+        inp_4d.get_output(0), trt.MatrixOperation.NONE,
+        selected_gate.get_output(0), trt.MatrixOperation.NONE).get_output(0)
+    up = network.add_matrix_multiply(
+        inp_4d.get_output(0), trt.MatrixOperation.NONE,
+        selected_up.get_output(0), trt.MatrixOperation.NONE).get_output(0)
+
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+
+    selected_down = network.add_gather(down_weights, top_indices, 0)
+    down = network.add_matrix_multiply(
+        gated.get_output(0), trt.MatrixOperation.NONE,
+        selected_down.get_output(0), trt.MatrixOperation.NONE).get_output(0)
+    output = network.add_shuffle(down)
+    output.reshape_dims = (-1, top_k, hidden_size)
+
+    route_weights = network.add_shuffle(routing_weights)
+    route_weights.reshape_dims = (-1, top_k, 1)
+    weighted = network.add_elementwise(
+        output.get_output(0), route_weights.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    return network.add_reduce(
+        weighted.get_output(0), trt.ReduceOperation.SUM, 1 << 1,
+        keep_dims=False).get_output(0)
 
 
 def add_gelu_fc_mlp(

--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -73,7 +73,7 @@ class DeepSeekOCRPlugin:
         return model_type.lower() in ("deepseek_vl_v2",)
 
     def load_weights(
-        self, model_dir: str, config: ModelConfig,
+        self, model_dir: str, config: ModelConfig, *, precision: str = "fp32",
     ) -> WeightDict:
         model_dir_path = Path(model_dir)
         readers = _open_safetensors(model_dir_path)
@@ -81,8 +81,29 @@ class DeepSeekOCRPlugin:
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers
+        if precision == "fp16":
+            work_np_dtype = np.float16
+        elif precision == "fp32":
+            work_np_dtype = np.float32
+        else:
+            raise ValueError(
+                f"Unsupported DeepSeek-OCR precision {precision!r}; "
+                "expected fp32 or fp16")
         # MoE config from raw
         raw = config.raw
+        requested_fp32_layers = frozenset(
+            int(layer) for layer in raw.get("_fp32_layers", ()))
+        invalid_fp32_layers = sorted(
+            layer for layer in requested_fp32_layers
+            if layer < 0 or layer > num_layers)
+        if invalid_fp32_layers:
+            raise ValueError(
+                "fp32_layers contains out-of-range indices: "
+                f"{invalid_fp32_layers}")
+        use_fp32_io = (
+            precision == "fp16" and num_layers in requested_fp32_layers)
+        io_precision = "fp32" if use_fp32_io else precision
+        io_np_dtype = np.float32 if use_fp32_io else work_np_dtype
         n_routed_experts = raw.get("n_routed_experts", 64)
         n_shared_experts = raw.get("n_shared_experts", 2)
         num_experts_per_tok = raw.get("num_experts_per_tok", 6)
@@ -102,7 +123,8 @@ class DeepSeekOCRPlugin:
         embedding = _load_tensor(readers, f"{lang_prefix}model.embed_tokens.weight")
         assert embedding.shape == (vocab, hidden), (
             f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
-        weights["embedding"] = embedding.astype(np.float32)
+        embedding = embedding.astype(io_np_dtype)
+        weights["embedding"] = embedding
 
         attention_size = 0
         kv_attention_size = 0
@@ -110,15 +132,19 @@ class DeepSeekOCRPlugin:
         for layer_idx in range(num_layers):
             prefix = f"layer.{layer_idx}"
             hf_prefix = f"{lang_prefix}model.layers.{layer_idx}"
+            layer_precision = (
+                "fp32" if layer_idx in requested_fp32_layers else precision)
+            layer_np_dtype = (
+                np.float32 if layer_precision == "fp32" else np.float16)
 
             # RMSNorm weights
             input_norm = _load_tensor(
                 readers, f"{hf_prefix}.input_layernorm.weight")
-            weights[f"{prefix}.input_norm"] = input_norm.astype(np.float32)
+            weights[f"{prefix}.input_norm"] = input_norm.astype(layer_np_dtype)
 
             post_norm = _load_tensor(
                 readers, f"{hf_prefix}.post_attention_layernorm.weight")
-            weights[f"{prefix}.post_attn_norm"] = post_norm.astype(np.float32)
+            weights[f"{prefix}.post_attn_norm"] = post_norm.astype(layer_np_dtype)
 
             # Standard Q/K/V/O attention projections (no biases)
             q_raw = _load_tensor(
@@ -135,10 +161,10 @@ class DeepSeekOCRPlugin:
             if kv_attention_size == 0:
                 kv_attention_size = k_raw.shape[0]
 
-            q_t = _transpose_2d(q_raw, "q_proj")
-            k_t = _transpose_2d(k_raw, "k_proj")
-            v_t = _transpose_2d(v_raw, "v_proj")
-            o_t = _transpose_2d(o_raw, "o_proj")
+            q_t = _transpose_2d(q_raw, "q_proj", precision=layer_precision)
+            k_t = _transpose_2d(k_raw, "k_proj", precision=layer_precision)
+            v_t = _transpose_2d(v_raw, "v_proj", precision=layer_precision)
+            o_t = _transpose_2d(o_raw, "o_proj", precision=layer_precision)
             del q_raw, k_raw, v_raw, o_raw
 
             weights[f"{prefix}.w_q"] = q_t
@@ -154,10 +180,14 @@ class DeepSeekOCRPlugin:
                 router_raw = _load_tensor(
                     readers, f"{hf_prefix}.mlp.gate.weight")
                 weights[f"{prefix}.router"] = _transpose_2d(
-                    router_raw, "router")
+                    router_raw, "router", precision=layer_precision)
                 del router_raw
 
-                # Per-expert weights
+                # Pack the expert dimension once during checkpoint loading so
+                # routing can gather only the selected experts at runtime.
+                expert_gate_weights = []
+                expert_up_weights = []
+                expert_down_weights = []
                 for e in range(n_routed_experts):
                     exp_hf = f"{hf_prefix}.mlp.experts.{e}"
                     gate_raw = _load_tensor(
@@ -167,13 +197,29 @@ class DeepSeekOCRPlugin:
                     down_raw = _load_tensor(
                         readers, f"{exp_hf}.down_proj.weight")
 
-                    weights[f"{prefix}.expert.{e}.w_gate"] = _transpose_2d(
-                        gate_raw, f"expert_{e}_gate")
-                    weights[f"{prefix}.expert.{e}.w_up"] = _transpose_2d(
-                        up_raw, f"expert_{e}_up")
-                    weights[f"{prefix}.expert.{e}.w_down"] = _transpose_2d(
-                        down_raw, f"expert_{e}_down")
+                    expert_gate_weights.append(
+                        _transpose_2d(
+                            gate_raw, f"expert_{e}_gate",
+                            precision=layer_precision))
+                    expert_up_weights.append(
+                        _transpose_2d(
+                            up_raw, f"expert_{e}_up",
+                            precision=layer_precision))
+                    expert_down_weights.append(
+                        _transpose_2d(
+                            down_raw, f"expert_{e}_down",
+                            precision=layer_precision))
                     del gate_raw, up_raw, down_raw
+
+                weights[f"{prefix}.experts.w_gate"] = np.stack(
+                    expert_gate_weights, axis=0)
+                expert_gate_weights.clear()
+                weights[f"{prefix}.experts.w_up"] = np.stack(
+                    expert_up_weights, axis=0)
+                expert_up_weights.clear()
+                weights[f"{prefix}.experts.w_down"] = np.stack(
+                    expert_down_weights, axis=0)
+                expert_down_weights.clear()
 
                 # Shared expert weights
                 shared_hf = f"{hf_prefix}.mlp.shared_experts"
@@ -185,11 +231,11 @@ class DeepSeekOCRPlugin:
                     readers, f"{shared_hf}.down_proj.weight")
 
                 weights[f"{prefix}.shared.w_gate"] = _transpose_2d(
-                    s_gate_raw, "shared_gate")
+                    s_gate_raw, "shared_gate", precision=layer_precision)
                 weights[f"{prefix}.shared.w_up"] = _transpose_2d(
-                    s_up_raw, "shared_up")
+                    s_up_raw, "shared_up", precision=layer_precision)
                 weights[f"{prefix}.shared.w_down"] = _transpose_2d(
-                    s_down_raw, "shared_down")
+                    s_down_raw, "shared_down", precision=layer_precision)
                 del s_gate_raw, s_up_raw, s_down_raw
             else:
                 # Dense SwiGLU MLP
@@ -201,29 +247,30 @@ class DeepSeekOCRPlugin:
                     readers, f"{hf_prefix}.mlp.down_proj.weight")
 
                 weights[f"{prefix}.w_gate"] = _transpose_2d(
-                    gate_raw, "gate_proj")
+                    gate_raw, "gate_proj", precision=layer_precision)
                 weights[f"{prefix}.w_up"] = _transpose_2d(
-                    up_raw, "up_proj")
+                    up_raw, "up_proj", precision=layer_precision)
                 weights[f"{prefix}.w_down"] = _transpose_2d(
-                    down_raw, "down_proj")
+                    down_raw, "down_proj", precision=layer_precision)
                 del gate_raw, up_raw, down_raw
 
         # Final norm
         final_norm_key = f"{lang_prefix}model.norm.weight"
         if _has_tensor(readers, final_norm_key):
             weights["final_norm"] = _load_tensor(
-                readers, final_norm_key).astype(np.float32)
+                readers, final_norm_key).astype(io_np_dtype)
         else:
-            weights["final_norm"] = np.ones(hidden, dtype=np.float32)
+            weights["final_norm"] = np.ones(hidden, dtype=io_np_dtype)
 
         # LM head
         lm_head_key = f"{lang_prefix}lm_head.weight"
         if _has_tensor(readers, lm_head_key):
             weights["w_out"] = _transpose_2d(
-                _load_tensor(readers, lm_head_key), "lm_head")
+                _load_tensor(readers, lm_head_key), "lm_head",
+                precision=io_precision)
         else:
             weights["w_out"] = _transpose_2d(
-                embedding.copy(), "embedding_tied")
+                embedding.copy(), "embedding_tied", precision=io_precision)
 
         # Store metadata
         weights["_attention_size"] = attention_size  # type: ignore[assignment]
@@ -344,31 +391,61 @@ class DeepSeekOCRPlugin:
         for i in range(num_layers):
             ck = network.add_input(
                 graph_ops.layer_tensor_name("cache_k", i),
-                trt.float32, (max_cache_length, kv_attention_size))
+                trt.float32, (-1, kv_attention_size))
             cv = network.add_input(
                 graph_ops.layer_tensor_name("cache_v", i),
-                trt.float32, (max_cache_length, kv_attention_size))
+                trt.float32, (-1, kv_attention_size))
             cache_k_inputs.append(ck)
             cache_v_inputs.append(cv)
 
-        def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False) -> None:
+        def _add_profile(
+            opt_sq: int,
+            max_sq: int,
+            *,
+            cache_min_rows: int,
+            cache_opt_rows: int,
+            cache_max_rows: int,
+            fixed: bool = False,
+        ) -> None:
             profile = builder.create_optimization_profile()
             min_sq = opt_sq if fixed else 1
             profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
             profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
             profile.set_shape(
                 "attention_mask",
-                (min_sq, max_cache_length + min_sq),
-                (opt_sq, max_cache_length + opt_sq),
-                (max_sq, max_cache_length + max_sq))
+                (min_sq, cache_min_rows + min_sq),
+                (opt_sq, cache_opt_rows + opt_sq),
+                (max_sq, cache_max_rows + max_sq))
             profile.set_shape(
                 "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
             profile.set_shape(
                 "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+            for layer_idx in range(num_layers):
+                profile.set_shape(
+                    graph_ops.layer_tensor_name("cache_k", layer_idx),
+                    (cache_min_rows, kv_attention_size),
+                    (cache_opt_rows, kv_attention_size),
+                    (cache_max_rows, kv_attention_size))
+                profile.set_shape(
+                    graph_ops.layer_tensor_name("cache_v", layer_idx),
+                    (cache_min_rows, kv_attention_size),
+                    (cache_opt_rows, kv_attention_size),
+                    (cache_max_rows, kv_attention_size))
             trt_config.add_optimization_profile(profile)
 
-        _add_profile(opt_prefill_length, max_prefill_length)
-        _add_profile(1, 1, fixed=True)
+        _add_profile(
+            opt_prefill_length,
+            max_prefill_length,
+            cache_min_rows=max_cache_length,
+            cache_opt_rows=max_cache_length,
+            cache_max_rows=max_cache_length)
+        _add_profile(
+            1,
+            1,
+            cache_min_rows=1,
+            cache_opt_rows=min(max_cache_length, MAX_SEQUENCE_PREFILL_LENGTH),
+            cache_max_rows=max_cache_length,
+            fixed=True)
 
         if work_trt_dtype != trt.float32:
             attention_mask = network.add_cast(
@@ -646,9 +723,11 @@ def _add_swiglu_expert(
 ) -> trt.ITensor:
     """Compute a single SwiGLU expert: down(silu(gate(x)) * up(x))."""
     gate = graph_ops.add_matmul_rhs_constant(
-        network, inp, hidden_size, intermediate_size, w_gate, dtype=dtype)
+        network, inp, hidden_size, intermediate_size, w_gate, dtype=dtype,
+        fp32_accumulation=dtype == np.float32)
     up = graph_ops.add_matmul_rhs_constant(
-        network, inp, hidden_size, intermediate_size, w_up, dtype=dtype)
+        network, inp, hidden_size, intermediate_size, w_up, dtype=dtype,
+        fp32_accumulation=dtype == np.float32)
 
     sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
     swish = network.add_elementwise(
@@ -658,7 +737,7 @@ def _add_swiglu_expert(
 
     down = graph_ops.add_matmul_rhs_constant(
         network, gated.get_output(0), intermediate_size, hidden_size, w_down,
-        dtype=dtype)
+        dtype=dtype, fp32_accumulation=dtype == np.float32)
     return down
 
 
@@ -686,7 +765,7 @@ def _add_moe_with_shared_experts(
     1. Router logits -> softmax -> top-k selection
     2. If norm_topk_prob: renormalize selected weights to sum to 1.0
        Else: scale by routed_scaling_factor (default 1.0, i.e. use raw softmax probs)
-    3. Compute all routed expert outputs, select top-k, weighted sum
+    3. Gather and compute only the top-k routed expert outputs, then sum them
     4. Compute shared expert output (always active, applied to original input)
     5. Final = routed_output + shared_output
     """
@@ -725,41 +804,23 @@ def _add_moe_with_shared_experts(
     else:
         final_weights = top_values
 
-    # 5. Compute every routed expert and derive its per-row gate from the
-    # dynamic [Sq, top_k] routing result. This keeps the same dense expert
-    # evaluation strategy as the legacy Sq=1 graph while supporting sequence
-    # prefill without assuming a fixed first dimension.
-    result = None
-    for e in range(n_routed_experts):
-        exp_out = _add_swiglu_expert(
-            network, inp, hidden_size, moe_intermediate,
-            weights[f"{prefix}.expert.{e}.w_gate"],
-            weights[f"{prefix}.expert.{e}.w_up"],
-            weights[f"{prefix}.expert.{e}.w_down"],
-            dtype=dtype,
-        )
-        expert_index = graph_ops.add_constant(
-            network, (1, 1), np.array([[e]], dtype=np.int32), dtype=np.int32)
-        selected = network.add_elementwise(
-            top_indices, expert_index, trt.ElementWiseOperation.EQUAL).get_output(0)
-        selected = network.add_cast(selected, final_weights.dtype).get_output(0)
-        selected_weights = network.add_elementwise(
-            final_weights, selected, trt.ElementWiseOperation.PROD).get_output(0)
-        expert_weight = network.add_reduce(
-            selected_weights, trt.ReduceOperation.SUM, 1 << 1,
-            keep_dims=True).get_output(0)
-        scaled_expert = network.add_elementwise(
-            exp_out, expert_weight, trt.ElementWiseOperation.PROD)
+    # 5. Gather each token's selected expert weights before the three SwiGLU
+    # matmuls. The packed tensors are [experts, in, out], so this remains
+    # dynamic over the prefill sequence dimension without evaluating all 64.
+    result = graph_blocks.add_routed_swiglu_experts(
+        network,
+        inp,
+        top_indices,
+        final_weights,
+        hidden_size=hidden_size,
+        top_k=num_experts_per_tok,
+        w_gate=weights[f"{prefix}.experts.w_gate"],
+        w_up=weights[f"{prefix}.experts.w_up"],
+        w_down=weights[f"{prefix}.experts.w_down"],
+        dtype=dtype,
+    )
 
-        if result is None:
-            result = scaled_expert.get_output(0)
-        else:
-            sum_layer = network.add_elementwise(
-                result, scaled_expert.get_output(0),
-                trt.ElementWiseOperation.SUM)
-            result = sum_layer.get_output(0)
-
-    # 7. Shared expert output (always active, applied to original input)
+    # 6. Shared expert output (always active, applied to original input)
     shared_out = _add_swiglu_expert(
         network, inp, hidden_size, shared_intermediate,
         weights[f"{prefix}.shared.w_gate"],
@@ -768,7 +829,7 @@ def _add_moe_with_shared_experts(
         dtype=dtype,
     )
 
-    # 8. Combine: routed_output + shared_output
+    # 7. Combine: routed_output + shared_output
     combined = network.add_elementwise(
         result, shared_out, trt.ElementWiseOperation.SUM)
 

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
-from . import graph_ops
+from . import graph_blocks, graph_ops
 from .prefill_config import sequence_prefill_profile_lengths
 from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
 from .standard_decoder_builder import _apply_norm
@@ -89,6 +89,9 @@ def shard_deepseek_ocr_weights(
 
         if key.endswith((".w_q", ".w_k", ".w_v", ".w_gate", ".w_up")):
             out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".experts.w_down"):
+            out[key] = np.ascontiguousarray(
+                np.array_split(value, parallel.tp_size, axis=-2)[parallel.rank])
         elif key.endswith((".w_o", ".w_down")):
             out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
         else:
@@ -184,34 +187,17 @@ def _add_moe_tp(
     else:
         scaled_weights = top_values
 
-    routed_local = None
-    for expert_idx in range(n_routed_experts):
-        expert_output = _add_swiglu_local(
-            network, inp, hidden_size, moe_intermediate,
-            weights[f"{prefix}.expert.{expert_idx}.w_gate"],
-            weights[f"{prefix}.expert.{expert_idx}.w_up"],
-            weights[f"{prefix}.expert.{expert_idx}.w_down"],
-        )
-        expert_index = graph_ops.add_constant(
-            network, (1, 1), np.array([[expert_idx]], dtype=np.int32),
-            dtype=np.int32)
-        selected = network.add_elementwise(
-            top_indices, expert_index, trt.ElementWiseOperation.EQUAL).get_output(0)
-        selected = network.add_cast(selected, scaled_weights.dtype).get_output(0)
-        selected_weights = network.add_elementwise(
-            scaled_weights, selected, trt.ElementWiseOperation.PROD).get_output(0)
-        expert_weight = network.add_reduce(
-            selected_weights, trt.ReduceOperation.SUM, 1 << 1,
-            keep_dims=True).get_output(0)
-        scaled = network.add_elementwise(
-            expert_output, expert_weight,
-            trt.ElementWiseOperation.PROD)
-        if routed_local is None:
-            routed_local = scaled.get_output(0)
-        else:
-            summed = network.add_elementwise(
-                routed_local, scaled.get_output(0), trt.ElementWiseOperation.SUM)
-            routed_local = summed.get_output(0)
+    routed_local = graph_blocks.add_routed_swiglu_experts(
+        network,
+        inp,
+        top_indices,
+        scaled_weights,
+        hidden_size=hidden_size,
+        top_k=num_experts_per_tok,
+        w_gate=weights[f"{prefix}.experts.w_gate"],
+        w_up=weights[f"{prefix}.experts.w_up"],
+        w_down=weights[f"{prefix}.experts.w_down"],
+    )
 
     shared_local = _add_swiglu_local(
         network, inp, hidden_size, shared_intermediate,

--- a/src/runtime/models/deepseek_ocr/kv_cache.cpp
+++ b/src/runtime/models/deepseek_ocr/kv_cache.cpp
@@ -243,10 +243,16 @@ void DeepseekOcrKvCache::bind_to(TrtModule& module) {
 
 void DeepseekOcrKvCache::bind_cache_inputs(TrtModule& module) {
     has_position_input_ = module.has_input(names_.position_id);
+    const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
-        module.bind_external(names_.cache_k[li], cache_k_[li].data());
-        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (module.input_is_dynamic(names_.cache_k[li])) {
+            module.bind_external(names_.cache_k[li], cache_k_[li].data(), cache_shape);
+            module.bind_external(names_.cache_v[li], cache_v_[li].data(), cache_shape);
+        } else {
+            module.bind_external(names_.cache_k[li], cache_k_[li].data());
+            module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        }
     }
 }
 

--- a/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
+++ b/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
@@ -60,6 +60,7 @@ static trtmc::TrtLogger g_logger;
 struct CountingTextStats {
     int32_t calls{0};
     std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<int64_t>> bound_shapes;
     std::unordered_map<std::string, std::vector<float>> float_values;
 };
 
@@ -123,6 +124,9 @@ class CountingTextModule final : public trtmc::ITrtModule {
         return nullptr;
     }
     void bind_external(const std::string&, void*) override {}
+    void bind_external(const std::string& name, void*, const std::vector<int64_t>& shape) override {
+        stats_->bound_shapes[name] = shape;
+    }
     int32_t input_rank(const std::string& name) const override {
         return name == "token_id" || name == "position_id" ? 1 : 2;
     }
@@ -756,6 +760,10 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
           "sequence prefill: image embedding selected by position");
     check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
           "sequence prefill: deepstack selected by position");
+    check(prefill_stats->bound_shapes["cache_k_0"] == std::vector<int64_t>({8, 4}),
+          "sequence prefill: dynamic K cache binds at full profile length");
+    check(prefill_stats->bound_shapes["cache_v_0"] == std::vector<int64_t>({8, 4}),
+          "sequence prefill: dynamic V cache binds at full profile length");
 
     cudaStreamDestroy(stream);
 }

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
@@ -86,13 +86,11 @@ def _weights() -> WeightDict:
         inter * hidden, dtype=np.float32).reshape(inter, hidden)
 
     weights["layer.1.router"] = np.zeros((hidden, 2), dtype=np.float32)
-    for expert_idx in range(2):
-        prefix = f"layer.1.expert.{expert_idx}"
-        for key in ("w_gate", "w_up"):
-            weights[f"{prefix}.{key}"] = np.arange(
-                hidden * inter, dtype=np.float32).reshape(hidden, inter)
-        weights[f"{prefix}.w_down"] = np.arange(
-            inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.1.experts.{key}"] = np.arange(
+            2 * hidden * inter, dtype=np.float32).reshape(2, hidden, inter)
+    weights["layer.1.experts.w_down"] = np.arange(
+        2 * inter * hidden, dtype=np.float32).reshape(2, inter, hidden)
     for key in ("w_gate", "w_up"):
         weights[f"layer.1.shared.{key}"] = np.arange(
             hidden * shared, dtype=np.float32).reshape(hidden, shared)
@@ -121,11 +119,11 @@ def test_deepseek_ocr_tp_slices_attention_and_moe_weights() -> None:
     np.testing.assert_array_equal(
         sharded["layer.0.w_down"], weights["layer.0.w_down"][8:16, :])
     np.testing.assert_array_equal(
-        sharded["layer.1.expert.0.w_up"],
-        weights["layer.1.expert.0.w_up"][:, 8:16])
+        sharded["layer.1.experts.w_up"],
+        weights["layer.1.experts.w_up"][:, :, 8:16])
     np.testing.assert_array_equal(
-        sharded["layer.1.expert.0.w_down"],
-        weights["layer.1.expert.0.w_down"][8:16, :])
+        sharded["layer.1.experts.w_down"],
+        weights["layer.1.experts.w_down"][:, 8:16, :])
     np.testing.assert_array_equal(
         sharded["layer.1.shared.w_gate"],
         weights["layer.1.shared.w_gate"][:, 16:32])
@@ -224,6 +222,215 @@ def test_deepseek_ocr_forwards_fp16_to_vision_engine(monkeypatch) -> None:
         "precision": "fp16",
         "verbose": True,
     }
+
+
+def test_deepseek_ocr_loads_weights_at_their_build_precision(monkeypatch) -> None:
+    config = _config()
+    config.num_hidden_layers = 3
+    config.raw.update({
+        "n_routed_experts": 2,
+        "n_shared_experts": 2,
+        "num_experts_per_tok": 2,
+        "first_k_dense_replace": 1,
+        "moe_intermediate_size": 4,
+        "_fp32_layers": [1, 3],
+    })
+
+    tensors: dict[str, np.ndarray] = {
+        "model.embed_tokens.weight": np.zeros((32, 8), dtype=np.float32),
+        "model.norm.weight": np.ones(8, dtype=np.float32),
+        "lm_head.weight": np.zeros((32, 8), dtype=np.float32),
+    }
+    for layer_idx in range(3):
+        prefix = f"model.layers.{layer_idx}"
+        tensors[f"{prefix}.input_layernorm.weight"] = np.ones(8, dtype=np.float32)
+        tensors[f"{prefix}.post_attention_layernorm.weight"] = np.ones(
+            8, dtype=np.float32)
+        for projection in ("q_proj", "k_proj", "v_proj"):
+            tensors[f"{prefix}.self_attn.{projection}.weight"] = np.zeros(
+                (16, 8), dtype=np.float32)
+        tensors[f"{prefix}.self_attn.o_proj.weight"] = np.zeros(
+            (8, 16), dtype=np.float32)
+
+    dense_prefix = "model.layers.0.mlp"
+    for projection in ("gate_proj", "up_proj"):
+        tensors[f"{dense_prefix}.{projection}.weight"] = np.zeros(
+            (16, 8), dtype=np.float32)
+    tensors[f"{dense_prefix}.down_proj.weight"] = np.zeros(
+        (8, 16), dtype=np.float32)
+
+    for layer_idx in (1, 2):
+        moe_prefix = f"model.layers.{layer_idx}.mlp"
+        tensors[f"{moe_prefix}.gate.weight"] = np.zeros(
+            (2, 8), dtype=np.float32)
+        for expert_idx in range(2):
+            expert_prefix = f"{moe_prefix}.experts.{expert_idx}"
+            for projection in ("gate_proj", "up_proj"):
+                tensors[f"{expert_prefix}.{projection}.weight"] = np.zeros(
+                    (4, 8), dtype=np.float32)
+            tensors[f"{expert_prefix}.down_proj.weight"] = np.zeros(
+                (8, 4), dtype=np.float32)
+        shared_prefix = f"{moe_prefix}.shared_experts"
+        for projection in ("gate_proj", "up_proj"):
+            tensors[f"{shared_prefix}.{projection}.weight"] = np.zeros(
+                (8, 8), dtype=np.float32)
+        tensors[f"{shared_prefix}.down_proj.weight"] = np.zeros(
+            (8, 8), dtype=np.float32)
+
+    monkeypatch.setattr(deepseek_ocr_module, "_open_safetensors", lambda _path: object())
+    monkeypatch.setattr(
+        deepseek_ocr_module,
+        "_has_tensor",
+        lambda _readers, name: name in tensors,
+    )
+    monkeypatch.setattr(
+        deepseek_ocr_module,
+        "_load_tensor",
+        lambda _readers, name: tensors[name].copy(),
+    )
+
+    weights = deepseek_ocr_module.DeepSeekOCRPlugin().load_weights(
+        "/model", config, precision="fp16")
+
+    assert weights["layer.0.w_q"].dtype == np.float16
+    assert weights["layer.0.w_gate"].dtype == np.float16
+    assert weights["layer.1.w_q"].dtype == np.float32
+    assert weights["layer.1.experts.w_gate"].dtype == np.float32
+    assert weights["layer.1.experts.w_gate"].shape == (2, 8, 4)
+    assert weights["layer.2.experts.w_gate"].dtype == np.float16
+    assert weights["layer.2.experts.w_gate"].shape == (2, 8, 4)
+    assert weights["embedding"].dtype == np.float32
+    assert weights["final_norm"].dtype == np.float32
+    assert weights["w_out"].dtype == np.float32
+
+
+def test_deepseek_ocr_moe_multiplies_only_routed_experts(monkeypatch) -> None:
+    rhs_constant_matmuls: list[tuple[str, tuple[int, ...], bool]] = []
+    routed_matmuls: list[tuple[str, str, str, str]] = []
+    weight_gathers: list[tuple[str, str, int]] = []
+
+    class Tensor:
+        def __init__(self, name: str, shape=(), dtype="fp16") -> None:
+            self.name = name
+            self.shape = tuple(shape)
+            self.dtype = dtype
+
+    class Layer:
+        def __init__(self, *outputs: Tensor) -> None:
+            self.outputs = outputs
+
+        def get_output(self, index: int) -> Tensor:
+            return self.outputs[index]
+
+        @property
+        def reshape_dims(self):
+            return self.outputs[0].shape
+
+        @reshape_dims.setter
+        def reshape_dims(self, shape) -> None:
+            self.outputs[0].shape = tuple(shape)
+
+    class Network:
+        def add_softmax(self, tensor):
+            return Layer(Tensor(f"softmax({tensor.name})", dtype=tensor.dtype))
+
+        def add_topk(self, tensor, _operation, top_k, _axes):
+            return Layer(
+                Tensor("top_values", (-1, top_k), tensor.dtype),
+                Tensor("top_indices", (-1, top_k), "int32"),
+            )
+
+        def add_reduce(self, tensor, _operation, _axes, keep_dims):
+            del keep_dims
+            return Layer(Tensor(f"reduce({tensor.name})", dtype=tensor.dtype))
+
+        def add_elementwise(self, lhs, rhs, _operation):
+            return Layer(Tensor(f"elementwise({lhs.name},{rhs.name})", dtype=lhs.dtype))
+
+        def add_activation(self, tensor, _operation):
+            return Layer(Tensor(f"activation({tensor.name})", dtype=tensor.dtype))
+
+        def add_cast(self, tensor, dtype):
+            return Layer(Tensor(f"cast({tensor.name})", dtype=dtype))
+
+        def add_shuffle(self, tensor):
+            return Layer(Tensor(f"shuffle({tensor.name})", tensor.shape, tensor.dtype))
+
+        def add_gather(self, data, indices, axis):
+            weight_gathers.append((data.name, indices.name, axis))
+            return Layer(Tensor(f"gather({data.name})", dtype=data.dtype))
+
+        def add_matrix_multiply(self, lhs, _lhs_op, rhs, _rhs_op):
+            routed_matmuls.append((lhs.name, rhs.name, lhs.dtype, rhs.dtype))
+            return Layer(Tensor(f"mm({lhs.name},{rhs.name})", dtype=lhs.dtype))
+
+    def add_matmul_rhs_constant(
+        _network, inp, _lhs_width, _rhs_width, values, dtype=np.float32,
+        fp32_accumulation=True,
+    ):
+        del dtype
+        rhs_constant_matmuls.append(
+            (inp.name, values.shape, fp32_accumulation))
+        return Tensor(f"rhs_mm_{len(rhs_constant_matmuls)}", dtype=inp.dtype)
+
+    constants = 0
+
+    def add_constant(_network, shape, _values, dtype=np.float32):
+        nonlocal constants
+        constants += 1
+        tensor_dtype = "int32" if dtype == np.int32 else "fp16"
+        return Tensor(f"weight{constants}", shape, tensor_dtype)
+
+    monkeypatch.setattr(
+        deepseek_ocr_module.graph_ops,
+        "add_matmul_rhs_constant",
+        add_matmul_rhs_constant,
+    )
+    monkeypatch.setattr(deepseek_ocr_module.graph_ops, "add_constant", add_constant)
+    monkeypatch.setattr(
+        deepseek_ocr_module.graph_ops,
+        "trt",
+        SimpleNamespace(float16="fp16", float32="fp32"),
+    )
+
+    hidden_size = 16
+    intermediate_size = 32
+    num_experts = 8
+    weights = WeightDict({"layer.1.router": np.ones((hidden_size, num_experts))})
+    weights["layer.1.experts.w_gate"] = np.ones(
+        (num_experts, hidden_size, intermediate_size))
+    weights["layer.1.experts.w_up"] = np.ones(
+        (num_experts, hidden_size, intermediate_size))
+    weights["layer.1.experts.w_down"] = np.ones(
+        (num_experts, intermediate_size, hidden_size))
+    weights["layer.1.shared.w_gate"] = np.ones((hidden_size, intermediate_size))
+    weights["layer.1.shared.w_up"] = np.ones((hidden_size, intermediate_size))
+    weights["layer.1.shared.w_down"] = np.ones((intermediate_size, hidden_size))
+
+    output = deepseek_ocr_module._add_moe_with_shared_experts(
+        Network(),
+        Tensor("input", (-1, hidden_size)),
+        weights,
+        "layer.1",
+        hidden_size,
+        num_experts,
+        intermediate_size,
+        num_experts_per_tok=2,
+        shared_intermediate=intermediate_size,
+        dtype=np.float16,
+    )
+
+    assert output.dtype == "fp16"
+    assert len(routed_matmuls) == 3
+    assert all(
+        lhs_dtype == rhs_dtype == "fp16"
+        for _, _, lhs_dtype, rhs_dtype in routed_matmuls
+    )
+    assert len(rhs_constant_matmuls) == 4  # router + shared SwiGLU
+    assert [fp32 for _, _, fp32 in rhs_constant_matmuls] == [
+        True, False, False, False
+    ]
+    assert len(weight_gathers) == 3
 
 
 def test_deepseek_ocr_vision_mask_keeps_image_attention_bidirectional() -> None:


### PR DESCRIPTION
## Summary

- Execute only the selected top-k routed experts from packed expert weights.
- Bind decoder KV-cache inputs to live bucketed lengths while preserving the 4096-token maximum context.
- Honor the configured mixed precision and enable CUDA graphs for the release performance case.
- Add regression coverage for sparse routing, dynamic cache binding, tensor-parallel sharding, and weight precision.

## Validation

- Thor X, TensorRT 11.0: Accuracy green (5/5 samples, 100% prediction agreement); Perf green (TRTMC p50 4651.74 ms, reference p50 5112.99 ms).
- GB300, TensorRT 11.2: Accuracy green (5/5 samples, 100% prediction agreement); Perf green (TRTMC p50 509.30 ms, reference p50 6764.63 ms).
- OCR output contract passed on both platforms.
- Native DeepSeek-OCR pipeline test passed on both platforms.
- 14 targeted builder/TP tests and 143 OCR contract/task/performance-matrix tests passed.

Fixes #892
