### PR TITLE
fix(benchmark): restore Minitron runtime contract

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -1015,6 +1015,8 @@ additional_profiles:
     inherit: llama.generate
   - model: minitron-4b-width
     inherit: llama.generate
+    baseline:
+      precision: fp16
   - model: nemotron-mini-4b
     inherit: nemotron.generate
   - model: nemotron-nano-4b

--- a/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
@@ -5,6 +5,11 @@
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
+  "precision": "fp16",
+  "max_cache_length": 256,
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "trust_remote_code": false,
   "testcases": [
     {
@@ -13,10 +18,10 @@
       "ci_tier": "l0_only",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "reference_precision": "fp32",
+      "reference_precision": "fp16",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
       "max_new_tokens": 8,
-      "notes": "PR L0 repro for Minitron width-pruned 4B. Uses the same checkpoint, llama_decoder_kv_cache runtime, runner, comparator, continuation artifact contract, and full cache budget with shorter decode budget."
+      "notes": "PR L0 repro for Minitron width-pruned 4B. Uses the same checkpoint, llama_decoder_kv_cache runtime, runner, comparator, continuation artifact contract, and a bounded cache budget with shorter decode budget."
     }
   ]
 }

--- a/tests/e2e/models/llama/manifests/minitron-4b-width.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width.json
@@ -5,6 +5,10 @@
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
+  "precision": "fp16",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "trust_remote_code": false,
   "testcases": [
     {
@@ -12,7 +16,7 @@
       "trace_id": "IT-E2E-MNTRW-01",
       "reference_family": "causal_base_continuation",
       "user_contract": "continuation_parity",
-      "reference_precision": "fp32",
+      "reference_precision": "fp16",
       "ci_tier": "nightly_only",
       "l0_replacement": "minitron-4b-width-l0",
       "l0_replacement_reason": "Minitron width-pruned 4B scale stays nightly; minitron-4b-width-l0 keeps the same decoder path with shorter decode for PR L0.",

--- a/tests/e2e/models/llama/test_llama_build_contract.py
+++ b/tests/e2e/models/llama/test_llama_build_contract.py
@@ -18,10 +18,8 @@ def test_falcon3_split_decoder_build_reserves_an_exclusive_gpu() -> None:
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
 
 
-def test_native_minitron_manifests_use_family_build_defaults() -> None:
+def test_native_minitron_regression_uses_family_build_defaults() -> None:
     for manifest_name in (
-        "minitron-4b-width.json",
-        "minitron-4b-width-l0.json",
         "minitron-4b-width-regression-native-kv-chunked-prefill.json",
     ):
         manifest_path = Path(__file__).parent / "manifests" / manifest_name
@@ -32,6 +30,30 @@ def test_native_minitron_manifests_use_family_build_defaults() -> None:
         assert "max_cache_length" not in manifest, manifest_name
         assert "precision" not in case.metadata, manifest_name
         assert "max_cache_length" not in case.inputs, manifest_name
+
+
+def test_minitron_width_release_profiles_use_qualified_runtime_contract() -> None:
+    expected_cache_lengths = {
+        "minitron-4b-width.json": None,
+        "minitron-4b-width-l0.json": 256,
+    }
+    for manifest_name, expected_cache_length in expected_cache_lengths.items():
+        manifest_path = Path(__file__).parent / "manifests" / manifest_name
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        case = load_manifest(manifest_path)
+
+        assert manifest["precision"] == "fp16", manifest_name
+        assert manifest["build_args"] == {
+            "decoder_engine_layout": "dual_profile"
+        }, manifest_name
+        if expected_cache_length is None:
+            assert "max_cache_length" not in manifest, manifest_name
+            assert "max_cache_length" not in case.inputs, manifest_name
+        else:
+            assert manifest["max_cache_length"] == expected_cache_length, manifest_name
+            assert case.inputs["max_cache_length"] == expected_cache_length, manifest_name
+        assert case.metadata["precision"] == "fp16", manifest_name
+        assert case.metadata["reference_precision"] == "fp16", manifest_name
 
 
 def test_native_minitron_regression_exceeds_one_prefill_profile() -> None:

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -332,6 +332,10 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert by_id["phi_moe.generate"]["baseline"]["output_contract"] == "exact-text"
     assert by_id["opt.generate"]["workload"]["request"]["max_new_tokens"] == 10
     assert by_id["deepseek_ocr.generate"]["baseline"]["precision"] == "bf16"
+    assert (
+        by_id["llama.generate@minitron-4b-width"]["baseline"]["precision"]
+        == "fp16"
+    )
     assert by_id["nemotron_h.generate"]["baseline"]["mode"] == "hf-eager"
     assert by_id["nemotron_h.generate"]["workload"]["runtime"] == {
         "cuda_graphs": True

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -171,6 +171,19 @@ def test_catalog_reuses_existing_model_manifests_for_different_tasks(tmp_path: P
         assert (case.operation, case.measurement.warmup, case.measurement.iterations) == expected
 
 
+def test_benchmark_uses_qualified_minitron_width_precision(tmp_path: Path) -> None:
+    model = ManifestCatalog().resolve("minitron-4b-width")
+    case = resolve_case(model, _bundle(tmp_path, model.bundle_name))
+
+    options = benchmark_builder._build_options(model, (case,))
+
+    assert model.precision == "fp16"
+    assert model.identity()["precision"] == "fp16"
+    assert options["precision"] == "fp16"
+    assert options["max_cache_length"] == 256
+    assert options["decoder_engine_layout"] == "dual_profile"
+
+
 def test_operation_registry_declares_supported_task_semantics() -> None:
     operations = {operation.name: operation for operation in registered_operations()}
     adapters = {adapter.task_strategy: adapter for adapter in registered_task_adapters()}


### PR DESCRIPTION
## Summary

- restore the Minitron width release and L0 profiles to their qualified FP16 precision
- use one dual-profile decoder engine for the bounded release workloads
- align the performance reference with the FP16 candidate contract
- keep the dedicated native-KV regression profile on the family-default BF16 path

The release manifests lost their explicit precision and decoder layout while the native-KV regression coverage was introduced. That made the generic release benchmark inherit FP32 and the split-engine layout, producing the multi-fold Thor X regression reported in #893. This change restores the release contract without changing the performance gate. It also bounds the PR L0 cache to 256 rows so the short L0 workload does not expand its dual-profile engine to the model's 131K context limit.

## Validation

- Local: 536 targeted tests passed
- GB300 L0 E2E: passed with the bounded FP16 dual-profile cache
- Thor X, aarch64, TensorRT 11.0:
  - Accuracy: green, aligned FP16/FP16
  - Perf: yellow, 735.16 ms vs 722.73 ms reference (1.72% difference, inside the existing 5% review band), exact-token validation passed
- GB300:
  - Accuracy: green, aligned FP16/FP16
  - Perf: green, 64.74 ms vs 347.21 ms reference, exact-token validation passed

Fixes #893
