### PR TITLE
docs(readme): mark project as public preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-<h1>TensorRT-Model-Connect</h1>
+<h1>Public Preview: TensorRT-Model-Connect</h1>
 
-<p><strong>Public Preview — Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
+<p><strong>Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
 
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1>TensorRT-Model-Connect</h1>
 
-<p><strong>Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
+<p><strong>Public Preview — Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
 
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
 


### PR DESCRIPTION
## Background
The README does not currently identify TensorRT-Model-Connect as a public-preview project near its title.

## Exit Criteria
- The top of the README clearly identifies the project as Public Preview.
- No unrelated README content changes.

## Implementation
- Prefixed the existing centered title with `Public Preview:`, preserving the subtitle, navigation links, examples, and anchors.

## Validation
- `git diff --check`: passed.
- `python3 -m pytest tests/tools/test_release_package_legal.py -q`: passed (`5 passed`).

## Notes For Future Readers
- The preview label is intentionally in the title so the status is visible at the top of the repository page.
