### PR TITLE
fix(ci): restore nightly model proofs

### DIFF
--- a/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_accuracy_contract.py
@@ -21,43 +21,52 @@ def test_qwen25_validation_uses_aligned_fp32_precision() -> None:
     } == {"fp32"}
 
 
-def test_qwen_vl_rejects_observed_point_eight_prediction_agreement() -> None:
+def test_qwen_vl_rejects_observed_point_eight_sample_acceptance() -> None:
     suite = validation_engine.suite_by_id(
         validation_engine.load_suites(),
         "vlm_mmmu_pro_vision_fixed_mcq",
     )
     gates = suite["gates"]
-    assert gates["min_prediction_agreement"] == 0.95
-
-    observed_summary = {
-        "hf": {"overall_accuracy": 0.0},
-        "bundle": {"overall_accuracy": 0.0},
-        "prediction_agreement_rate": 0.8,
-        "correctness_agreement_rate": 1.0,
+    sample_acceptance = suite["sample_acceptance"]
+    assert gates == {"max_accuracy_drop_from_hf": 0.02}
+    assert sample_acceptance == {
+        "min_pass_rate": 0.95,
+        "min_allowed_failures": 0,
     }
-    observed_result = validation_engine.prediction_agreement_gate_result(
-        observed_summary,
-        gates,
+
+    observed_result = {
+        "status": "passed",
+        "sample_count": 20,
+        "valid_count": 20,
+        "passed_count": 16,
+        "prediction_agreement_rate": 0.8,
+    }
+    validation_engine._apply_sample_acceptance(
+        observed_result,
+        sample_acceptance,
     )
 
     assert observed_result["status"] == "failed"
     assert observed_result["error_type"] == "BenchmarkGateError"
     assert observed_result["gate_failures"] == [
         {
-            "gate": "min_prediction_agreement",
-            "metric": "prediction_agreement_rate",
-            "actual": 0.8,
-            "required": 0.95,
+            "gate": "sample_acceptance",
+            "metric": "failed_samples",
+            "actual": 4,
+            "required": 1,
         }
     ]
 
-    boundary_summary = {
-        **observed_summary,
+    boundary_result = {
+        "status": "passed",
+        "sample_count": 20,
+        "valid_count": 20,
+        "passed_count": 19,
         "prediction_agreement_rate": 0.95,
     }
-    boundary_result = validation_engine.prediction_agreement_gate_result(
-        boundary_summary,
-        gates,
+    validation_engine._apply_sample_acceptance(
+        boundary_result,
+        sample_acceptance,
     )
     assert boundary_result["status"] == "passed"
-    assert boundary_result["gate_failures"] == []
+    assert boundary_result.get("gate_failures", []) == []

--- a/tests/e2e/models/sam2/manifests/sam2-l4-local.json
+++ b/tests/e2e/models/sam2/manifests/sam2-l4-local.json
@@ -8,6 +8,7 @@
   "benchmark_exclusion_reason": "Requires the model-owned five-frame public C ABI",
   "e2e_parallel_resource": "exclusive_gpu",
   "ci_tier": "nightly_only",
+  "model_proof_exclusion_reason": "Requires the externally provisioned local L4 bundle, five RGB8 frames, and golden evidence",
   "preflight_requirements": [],
   "inputs": {
     "fixture_dir": "sam2-l4-fixtures"

--- a/tests/e2e/models/sam2/test_sam2_l0_contract.py
+++ b/tests/e2e/models/sam2/test_sam2_l0_contract.py
@@ -73,6 +73,9 @@ def test_l0_manifest_is_threshold_free_and_keeps_nightly_separate() -> None:
     assert testcase["oracle_level"] == "L4_invariants"
     assert not requires_threshold_sidecar({**l0, **testcase})
     assert nightly["ci_tier"] == "nightly_only"
+    assert "externally provisioned local L4 bundle" in nightly[
+        "model_proof_exclusion_reason"
+    ]
     assert nightly["testcases"][0]["test_category"] == "regression"
 
 

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -613,6 +613,31 @@ def test_dinov3_premerge_uses_public_mirror_and_nightly_keeps_officials(
     assert all(case["ci_tier"] == "nightly_only" for case in nightly["e2e_cases"])
 
 
+def test_sam2_nightly_model_proof_uses_the_public_core_case(tmp_path: Path) -> None:
+    selection = _run_test_selection(tmp_path, "sam2", "nightly")
+
+    assert [case["name"] for case in selection["e2e_cases"]] == [
+        "sam2-public-core-l0"
+    ]
+    assert selection["e2e_cases"][0]["ci_tier"] == "l0_only"
+
+
+def test_model_proof_rejects_an_empty_exclusion_reason(tmp_path: Path) -> None:
+    def invalidate_reason(source: Path, _projection: dict[str, object]) -> None:
+        manifest = source / "tests/e2e/models/sam2/manifests/sam2-l4-local.json"
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+        payload["model_proof_exclusion_reason"] = " "
+        manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CiError, match="must be a nonempty string"):
+        _run_test_selection(
+            tmp_path,
+            "sam2",
+            "nightly",
+            projection_setup=invalidate_reason,
+        )
+
+
 @pytest.mark.parametrize(
     ("family", "smoke_case", "regression_case"),
     (

--- a/tools/ci/model_proof_selection.py
+++ b/tools/ci/model_proof_selection.py
@@ -187,6 +187,17 @@ class ModelProofSelector:
             tests.append(fields[0])
         return tests
 
+    @staticmethod
+    def _model_proof_excluded(data: dict[str, object], path: Path) -> bool:
+        if "model_proof_exclusion_reason" not in data:
+            return False
+        reason = data["model_proof_exclusion_reason"]
+        if not isinstance(reason, str) or not reason.strip():
+            raise CiError(
+                f"model_proof_exclusion_reason must be a nonempty string: {path}"
+            )
+        return True
+
     def _reference_cache(
         self, owner: dict[str, object], family: str, owner_manifest: Path
     ) -> dict[str, str] | None:
@@ -208,6 +219,7 @@ class ModelProofSelector:
             data = json.loads(path.read_text(encoding="utf-8"))
             if data.get("skip_reason") or data.get("skip"):
                 continue
+            manifest_excluded = self._model_proof_excluded(data, path)
             resource = str(data.get("e2e_parallel_resource") or "shared")
             if resource not in {"shared", "exclusive_gpu"}:
                 raise CiError(f"E2E manifest has invalid e2e_parallel_resource: {path}")
@@ -242,6 +254,9 @@ class ModelProofSelector:
                         f"{path}"
                     )
                 if testcase.get("skip_reason") or testcase.get("skip"):
+                    continue
+                testcase_excluded = self._model_proof_excluded(testcase, path)
+                if manifest_excluded or testcase_excluded:
                     continue
                 name = str(testcase.get("name") or "")
                 if not name:

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -816,6 +816,17 @@ def _result(
     }
 
 
+def _model_proof_excluded(payload: dict[str, object], path: str) -> bool:
+    if "model_proof_exclusion_reason" not in payload:
+        return False
+    reason = payload["model_proof_exclusion_reason"]
+    if not isinstance(reason, str) or not reason.strip():
+        raise ModelCIError(
+            f"model_proof_exclusion_reason must be a nonempty string: {path}"
+        )
+    return True
+
+
 def _scheduled_models(
     repo_root: Path,
     catalog: OwnershipCatalog,
@@ -870,6 +881,7 @@ def _scheduled_models(
                     raise ModelCIError(f"invalid E2E manifest JSON: {entry.path}") from exc
                 if manifest.get("skip_reason") or manifest.get("skip"):
                     continue
+                manifest_excluded = _model_proof_excluded(manifest, entry.path)
                 testcases = manifest.get("testcases", [])
                 if not isinstance(testcases, list):
                     continue
@@ -877,6 +889,9 @@ def _scheduled_models(
                     if not isinstance(testcase, dict):
                         continue
                     if testcase.get("skip_reason") or testcase.get("skip"):
+                        continue
+                    testcase_excluded = _model_proof_excluded(testcase, entry.path)
+                    if manifest_excluded or testcase_excluded:
                         continue
                     name = str(testcase.get("name") or "")
                     if not name:


### PR DESCRIPTION
## Background

The first complete model fanout after the runtime-overlay repair exposed two independent source-contract gaps. Generic SAM2 Nightly proof selection chose an externally provisioned L4 case that cannot run in the hermetic model-proof environment. Qwen-VL still tested a retired aggregate agreement gate after that suite migrated to batch sample acceptance.

## Exit Criteria

- Generic SAM2 Nightly proof uses a reproducible, hermetic case while the external L4 accuracy contract remains available in the full E2E catalog.
- Qwen-VL continues to reject 80% agreement and accept the 95% boundary under the current sample-acceptance schema.
- Nightly inventory and model-proof selection resolve exactly the same cases.
- No runtime implementation or numeric acceptance threshold changes.

## Implementation

- Add an auditable `model_proof_exclusion_reason` to the externally provisioned `sam2-l4-local` manifest. Both the inventory and proof selector validate this field and exclude that case only from generic hermetic proofs; existing fallback logic then selects `sam2-public-core-l0`.
- Keep the local L4 manifest, runner, golden comparison, and full E2E catalog unchanged.
- Update the stale Qwen-VL regression to exercise `sample_acceptance` at the existing 95% boundary while retaining the independent 2% maximum accuracy-drop gate.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/tools/test_model_ci.py tests/tools/test_model_proof_runner.py`: 238 passed.
- Qwen-VL model-owned tests in the TensorRT 11.2 runtime: 75 passed, 8 skipped.
- Qwen-VL before/after regression: the current-main test reproduces the missing retired gate; this branch passes both accuracy-contract tests.
- SAM2 before/after selector probe: current main selects `sam2-l4-local`; this branch selects only `sam2-public-core-l0` for generic Nightly proof.
- Network-disabled SAM2 public-core cache check: one pinned repository resolved from the local cache with zero network calls.
- Focused SAM2 and Qwen-VL contracts, Ruff, JSON parsing, and `git diff --check`: passed.

## Notes For Future Readers

- The SAM2 change is an explicit generic-proof scope decision, not a numeric relaxation: the unavailable external L4 case is retained for its provisioned lane, while generic CI certifies the existing public-core L0 case.
- Full target-hardware SAM2 proof and complete all-model/VLM/release certification remain required after merge; local selector and cache checks do not substitute for that evidence.
