### PR TITLE
docs(readme): clarify preview project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 <div align="center">
 
-<h1>Public Preview: TensorRT-Model-Connect</h1>
+<h1>TensorRT-Model-Connect</h1>
 
 <p><strong>Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
 
 [Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/overview)
 
 </div>
+
+> **Public Preview** — TensorRT-Model-Connect is evolving rapidly and is
+> intended for evaluation and feedback. APIs, scope, and direction may change.
+> See [Project status](#project-status).
 
 <a id="example-code"></a>
 
@@ -128,6 +132,15 @@ documentation corrections.
 
 Do not disclose suspected security vulnerabilities in a public issue. Follow
 [SECURITY.md](SECURITY.md) to report them privately to NVIDIA PSIRT.
+
+<a id="project-status"></a>
+
+## 🧪 Project status
+
+TensorRT-Model-Connect is an experimental project. Its APIs, scope, and
+direction may evolve as we learn from users. This preview is intended to inform
+future decisions and does not establish a specific product roadmap or release
+timeline.
 
 <a id="contributing"></a>
 


### PR DESCRIPTION
## Background
The README currently identifies the project as Public Preview in its title, but that label alone does not explain what the preview status means. The project needs concise context near the top while keeping the detailed wording measured and approachable.

## Exit Criteria
- A concise Public Preview callout appears before the Example Code section and links to more detail.
- The detailed status language explains that the project is experimental and evolving without implying a specific roadmap or release timeline.

## Implementation
- Restored the plain project title.
- Added a short linked Public Preview callout immediately before Example Code.
- Added a Project status section near the bottom of the README, before Contributing.

## Validation
- `git diff --check github/main...HEAD`: passed.
- `python3 -m pytest tests/tools/test_release_package_legal.py -q`: passed (`5 passed`).

## Notes For Future Readers
- The wording intentionally keeps the top-level callout concise and moves lifecycle context into the linked section.
- Review is primarily requested on the tone and placement of the two status messages.
