### PR TITLE
fix(ci): restore Llama and SAM2 nightly proofs

### DIFF
--- a/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -402,18 +402,21 @@ def build_dual_profile_decoder_engine(
                      cache_rows_max: int | None = None):
         prof = builder.create_optimization_profile()
         min_sq = opt_sq if fixed else 1
+        if multi_bucket_decode:
+            cmn = cache_rows_min if cache_rows_min is not None else max_cache_length
+            cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
+            cmx = cache_rows_max if cache_rows_max is not None else max_cache_length
+        else:
+            cmn = cop = cmx = max_cache_length
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
         if not native_kv_cache:
             prof.set_shape(
                 "attention_mask",
-                (min_sq, max_cache_length + min_sq),
-                (opt_sq, max_cache_length + opt_sq),
-                (max_sq, max_cache_length + max_sq))
+                (min_sq, cmn + min_sq),
+                (opt_sq, cop + opt_sq),
+                (max_sq, cmx + max_sq))
         if multi_bucket_decode:
-            cmn = cache_rows_min if cache_rows_min is not None else 1
-            cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
-            cmx = cache_rows_max if cache_rows_max is not None else max_cache_length
             for i in range(num_layers):
                 for name in (graph_ops.layer_tensor_name("cache_k", i),
                              graph_ops.layer_tensor_name("cache_v", i)):

--- a/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
@@ -122,18 +122,24 @@ def build_standard_decoder_engine(
     #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
-    #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
     #
     # ``TRTMC_NO_DUAL_PROFILE=1`` is an internal escape hatch (perf A/B,
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     requested_fp32_layers = tuple(config.raw.get("_fp32_layers", ()))
+    dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
+    if dynamic_kv_cache and position_type == "alibi":
+        raise ValueError("dynamic_kv_cache is not supported for ALiBi decoder builds")
+    dynamic_kv_profile_rows = (
+        config.raw.get("_dynamic_kv_profile_rows") if dynamic_kv_cache else None
+    )
+    if dynamic_kv_cache and not dynamic_kv_profile_rows:
+        dynamic_kv_profile_rows = [max_cache_length]
     _dual_profile_disabled_for = (
         embed_input
         or debug_layer_outputs
         or hidden_state_output
         or bool(requested_fp32_layers)
-        or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
     if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
@@ -155,6 +161,7 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             alibi_bias_scale=alibi_bias_scale,
             verbose=verbose,
+            dynamic_kv_profile_rows=dynamic_kv_profile_rows,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
@@ -179,7 +186,6 @@ def build_standard_decoder_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
-    dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
     dynamic_kv_opt_rows = int(config.raw.get("_dynamic_kv_opt_length", max_cache_length))
     dynamic_kv_opt_rows = max(1, min(dynamic_kv_opt_rows, max_cache_length))
     raw_profile_rows = config.raw.get("_dynamic_kv_profile_rows")

--- a/src/runtime/models/llama/kv_cache.cpp
+++ b/src/runtime/models/llama/kv_cache.cpp
@@ -402,10 +402,24 @@ void LlamaKvCache::bind_cache_inputs(TrtModule& module) {
         bind_native_cache(module);
         return;
     }
+    // A dual-profile prefill engine exposes dynamic cache rows even though it
+    // consumes the complete runtime allocation. Bind the runtime-sized view,
+    // which can be smaller than the engine profile's opt/max shape after a
+    // --kv-cache-size override.
+    dynamic_binding_enabled_ =
+        !names_.cache_k.empty() && module.input_is_dynamic(names_.cache_k.front());
+    bound_cache_rows_ = 0;
+    const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
-        module.bind_external(names_.cache_k[li], cache_k_[li].data());
-        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (dynamic_binding_enabled_) {
+            module.bind_external(names_.cache_k[li], cache_k_[li].data(), cache_shape);
+            module.bind_external(names_.cache_v[li], cache_v_[li].data(), cache_shape);
+            bound_cache_rows_ = max_length_;
+        } else {
+            module.bind_external(names_.cache_k[li], cache_k_[li].data());
+            module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        }
     }
 }
 

--- a/src/runtime/models/llama/plugin.cpp
+++ b/src/runtime/models/llama/plugin.cpp
@@ -49,17 +49,6 @@ struct TensorParallelRuntime {
     DistributedRuntimeGroup group;
 };
 
-struct DecoderProfileInfo {
-    int32_t profile_idx{0};
-    int32_t kv_rows{0};
-};
-
-struct DecoderProfileRoles {
-    int32_t prefill_profile_idx{-1};
-    int32_t prefill_max_length{0};
-    std::vector<DecoderProfileInfo> decode_profiles;
-};
-
 int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
     if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
         return -1;
@@ -98,28 +87,6 @@ int32_t cache_row_dim_from_module(const TrtModule& module, const std::string& te
                              "'");
 }
 
-bool cache_input_is_dynamic(const TrtModule& module, const std::string& tensor_name) {
-    const auto shape = module.tensor_shape(tensor_name);
-    return !shape.empty() && shape[0] == -1;
-}
-
-bool cache_input_supports_runtime_rows(const TrtModule& module, const std::string& tensor_name) {
-    if (!cache_input_is_dynamic(module, tensor_name))
-        return false;
-    const int32_t num_profiles = module.optimization_profile_count();
-    if (num_profiles <= 0)
-        return false;
-    for (int32_t profile_idx = 0; profile_idx < num_profiles; ++profile_idx) {
-        const int32_t min_rows = dim_at(
-            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMin), 0);
-        const int32_t max_rows = dim_at(
-            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax), 0);
-        if (min_rows > 0 && max_rows > min_rows)
-            return true;
-    }
-    return false;
-}
-
 TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
     TensorParallelRuntimeConfig cfg;
     cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
@@ -130,66 +97,6 @@ TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::stri
 
 std::string tp_engine_section_name(int32_t rank) {
     return "engine_plan_tp_rank" + std::to_string(rank);
-}
-
-int32_t profile_token_max_length(const TrtModule& module, const std::string& token_id_name,
-                                 int32_t profile_idx) {
-    return dim_at(
-        module.input_profile_shape(token_id_name, profile_idx, ProfileShapeSelector::kMax), 0);
-}
-
-int32_t profile_cache_rows(const TrtModule& module, const std::string& cache_name,
-                           int32_t profile_idx, int32_t fallback_rows) {
-    const auto cache_rows = [](const std::vector<int64_t>& shape) {
-        return dim_at(shape, shape.size() == 4 ? 2 : 0);
-    };
-    const int32_t static_rows = cache_rows(module.tensor_shape(cache_name));
-    if (static_rows > 0)
-        return static_rows;
-
-    if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
-        const int32_t max_rows = cache_rows(
-            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax));
-        if (max_rows > 0)
-            return max_rows;
-    }
-    return fallback_rows;
-}
-
-DecoderProfileRoles detect_decoder_profile_roles(const TrtModule& module,
-                                                 const std::string& token_id_name,
-                                                 const std::string& cache_k_name,
-                                                 int32_t fallback_rows) {
-    DecoderProfileRoles roles;
-    const int32_t num_profiles = module.optimization_profile_count();
-    if (num_profiles <= 0) {
-        roles.decode_profiles.push_back(DecoderProfileInfo{0, fallback_rows});
-        return roles;
-    }
-
-    for (int32_t profile_idx = 0; profile_idx < num_profiles; ++profile_idx) {
-        const int32_t token_max = profile_token_max_length(module, token_id_name, profile_idx);
-        if (token_max > 1) {
-            if (token_max > roles.prefill_max_length) {
-                roles.prefill_profile_idx = profile_idx;
-                roles.prefill_max_length = token_max;
-            }
-            continue;
-        }
-
-        roles.decode_profiles.push_back(DecoderProfileInfo{
-            profile_idx, profile_cache_rows(module, cache_k_name, profile_idx, fallback_rows)});
-    }
-
-    if (roles.decode_profiles.empty()) {
-        const int32_t fallback_profile =
-            roles.prefill_profile_idx >= 0 ? roles.prefill_profile_idx : 0;
-        roles.decode_profiles.push_back(DecoderProfileInfo{
-            fallback_profile,
-            profile_cache_rows(module, cache_k_name, fallback_profile, fallback_rows)});
-    }
-
-    return roles;
 }
 
 std::string format_bytes(std::uint64_t bytes) {
@@ -577,9 +484,13 @@ class DecoderPlugin final : public IPipelinePlugin {
                            std::unique_ptr<TrtModule>& prefill_module) {
         std::vector<LlamaTextGenerationPipeline::DecoderContext> decoders;
         decoders.reserve(profile_modules.modules.size());
-        for (const auto& profile : profile_roles.decode_profiles) {
-            if (profile.kv_rows > runtime_rows && !decoders.empty())
-                break;
+        std::vector<int32_t> available_rows;
+        available_rows.reserve(profile_roles.decode_profiles.size());
+        for (const auto& profile : profile_roles.decode_profiles)
+            available_rows.push_back(profile.kv_rows);
+        const auto selected_rows = select_decoder_profile_rows(available_rows, runtime_rows);
+        for (std::size_t index = 0; index < selected_rows.size(); ++index) {
+            const auto& profile = profile_roles.decode_profiles[index];
             auto* found = find_profile_module(profile_modules, profile.profile_idx);
             if (found == nullptr || !found->module)
                 continue;
@@ -592,6 +503,10 @@ class DecoderPlugin final : public IPipelinePlugin {
 
         if (decoders.empty())
             throw std::runtime_error("No decoder profile available for engine_plan");
+        if (decoders.back().kv_rows < runtime_rows) {
+            throw std::runtime_error(
+                "Loaded decoder profiles do not cover the selected runtime KV capacity");
+        }
         return decoders;
     }
 

--- a/src/runtime/models/llama/plugin_helpers.cpp
+++ b/src/runtime/models/llama/plugin_helpers.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -72,6 +73,16 @@ struct TokenizerSpecialFrame {
 
 using TokenizerFactory = std::unique_ptr<ITokenizer> (*)(const char*, std::size_t, bool);
 
+int32_t cache_rows_from_shape(const std::vector<int64_t>& shape) {
+    const std::size_t row_index = shape.size() == 4 ? 2 : 0;
+    if (shape.empty() || row_index >= shape.size())
+        return -1;
+    const int64_t rows = shape[row_index];
+    if (rows <= 0 || rows > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(rows);
+}
+
 } // namespace
 
 void log_trt_load_timing(const char* label, double load_deserialize_ms, std::size_t plan_bytes) {
@@ -80,6 +91,111 @@ void log_trt_load_timing(const char* label, double load_deserialize_ms, std::siz
          << (label ? label : "engine") << "\" load_deserialize_ms=" << load_deserialize_ms
          << " plan_bytes=" << plan_bytes;
     std::cerr << line.str() << '\n';
+}
+
+std::vector<int32_t> select_decoder_profile_rows(const std::vector<int32_t>& ordered_profile_rows,
+                                                 int32_t runtime_rows) {
+    if (runtime_rows <= 0 || ordered_profile_rows.empty()) {
+        throw std::invalid_argument(
+            "Decoder profile selection requires positive runtime rows and profiles");
+    }
+    int32_t previous_rows = 0;
+    for (const int32_t profile_rows : ordered_profile_rows) {
+        if (profile_rows <= 0 || profile_rows < previous_rows) {
+            throw std::invalid_argument("Decoder KV profile rows must be positive and ordered");
+        }
+        previous_rows = profile_rows;
+    }
+
+    std::vector<int32_t> selected;
+    selected.reserve(ordered_profile_rows.size());
+    for (const int32_t profile_rows : ordered_profile_rows) {
+        selected.push_back(profile_rows);
+        if (profile_rows >= runtime_rows)
+            break;
+    }
+    if (selected.back() < runtime_rows) {
+        throw std::runtime_error("No decoder KV profile can cover the selected runtime capacity");
+    }
+    return selected;
+}
+
+bool cache_input_supports_runtime_rows(const TrtModule& module, const std::string& tensor_name) {
+    if (!module.input_is_dynamic(tensor_name))
+        return false;
+    const int32_t num_profiles = module.optimization_profile_count();
+    for (int32_t profile_idx = 0; profile_idx < num_profiles; ++profile_idx) {
+        const auto min_shape =
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMin);
+        const auto max_shape =
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax);
+        if (!min_shape.empty() && !max_shape.empty() && min_shape.front() > 0 &&
+            max_shape.front() > min_shape.front()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int32_t decoder_profile_cache_rows(const TrtModule& module, const std::string& tensor_name,
+                                   int32_t profile_idx, int32_t fallback_rows) {
+    if (!module.input_is_dynamic(tensor_name)) {
+        const int32_t static_rows = cache_rows_from_shape(module.tensor_shape(tensor_name));
+        if (static_rows > 0)
+            return static_rows;
+    }
+    if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
+        const int32_t max_rows = cache_rows_from_shape(
+            module.input_profile_shape(tensor_name, profile_idx, ProfileShapeSelector::kMax));
+        if (max_rows > 0)
+            return max_rows;
+    }
+    return fallback_rows;
+}
+
+DecoderProfileRoles detect_decoder_profile_roles(const TrtModule& module,
+                                                 const std::string& token_id_name,
+                                                 const std::string& cache_k_name,
+                                                 int32_t fallback_rows) {
+    const auto token_max_length = [&](int32_t profile_idx) -> int32_t {
+        const auto shape =
+            module.input_profile_shape(token_id_name, profile_idx, ProfileShapeSelector::kMax);
+        if (shape.empty() || shape.front() <= 0 ||
+            shape.front() > std::numeric_limits<int32_t>::max()) {
+            return -1;
+        }
+        return static_cast<int32_t>(shape.front());
+    };
+
+    DecoderProfileRoles roles;
+    const int32_t num_profiles = module.optimization_profile_count();
+    if (num_profiles <= 0) {
+        roles.decode_profiles.push_back(DecoderProfileInfo{0, fallback_rows});
+        return roles;
+    }
+
+    for (int32_t profile_idx = 0; profile_idx < num_profiles; ++profile_idx) {
+        const int32_t token_max = token_max_length(profile_idx);
+        if (token_max > 1) {
+            if (token_max > roles.prefill_max_length) {
+                roles.prefill_profile_idx = profile_idx;
+                roles.prefill_max_length = token_max;
+            }
+            continue;
+        }
+        roles.decode_profiles.push_back(DecoderProfileInfo{
+            profile_idx,
+            decoder_profile_cache_rows(module, cache_k_name, profile_idx, fallback_rows)});
+    }
+
+    if (roles.decode_profiles.empty()) {
+        const int32_t fallback_profile =
+            roles.prefill_profile_idx >= 0 ? roles.prefill_profile_idx : 0;
+        roles.decode_profiles.push_back(DecoderProfileInfo{
+            fallback_profile,
+            decoder_profile_cache_rows(module, cache_k_name, fallback_profile, fallback_rows)});
+    }
+    return roles;
 }
 
 // Tokenizer helpers.

--- a/src/runtime/models/llama/plugin_helpers.h
+++ b/src/runtime/models/llama/plugin_helpers.h
@@ -61,6 +61,17 @@ struct DualProfileModules {
     std::unique_ptr<ITrtModule> decode;  // Sq=1 profile, or the only profile if single-profile
 };
 
+struct DecoderProfileInfo {
+    int32_t profile_idx{0};
+    int32_t kv_rows{0};
+};
+
+struct DecoderProfileRoles {
+    int32_t prefill_profile_idx{-1};
+    int32_t prefill_max_length{0};
+    std::vector<DecoderProfileInfo> decode_profiles;
+};
+
 // Load an engine from a serialized plan via the backend and create two
 // execution contexts — one per optimization profile — sharing the engine.
 // When the engine has fewer than 2 profiles, `prefill` is left null and
@@ -96,6 +107,27 @@ int32_t compute_kv_dim(const BaseConfig& cfg);
 // Convert the BaseConfig precision string ("fp16", "bf16", "fp32") to a DType
 // for use as KV cache element type.
 DType cache_dtype_from_precision(const std::string& precision);
+
+// Return whether the engine input can be rebound to a runtime-selected row
+// count. Tensor shape reports may already contain the active/opt shape, so
+// dynamicity must come from the module's declared input metadata.
+bool cache_input_supports_runtime_rows(const TrtModule& module, const std::string& tensor_name);
+
+// Read a decode profile's KV row ceiling. Dynamic inputs must use that
+// profile's kMAX metadata rather than tensor_shape(), which may report the
+// currently active positive shape.
+int32_t decoder_profile_cache_rows(const TrtModule& module, const std::string& tensor_name,
+                                   int32_t profile_idx, int32_t fallback_rows);
+
+DecoderProfileRoles detect_decoder_profile_roles(const TrtModule& module,
+                                                 const std::string& token_id_name,
+                                                 const std::string& cache_k_name,
+                                                 int32_t fallback_rows);
+
+// Keep every decode bucket below the requested runtime capacity plus the
+// first ceiling bucket that can execute that capacity.
+std::vector<int32_t> select_decoder_profile_rows(const std::vector<int32_t>& ordered_profile_rows,
+                                                 int32_t runtime_rows);
 
 // Reinterpret a raw char section as a vector of floats.
 std::vector<float> section_to_floats(const std::vector<char>* sec);

--- a/tests/cpp/models/llama/test_llama_native_kv_cache.cpp
+++ b/tests/cpp/models/llama/test_llama_native_kv_cache.cpp
@@ -6,9 +6,49 @@
 #include "../../native_kv_cache_contract_test.h"
 #include "runtime/models/llama/kv_cache.h"
 #include "runtime/models/llama/pipeline.h"
+#include "runtime/models/llama/plugin_helpers.h"
+
+namespace {
+
+int test_dynamic_prefill_uses_runtime_cache_rows() {
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess)
+        return 1;
+
+    int failures = 0;
+    {
+        trtmc::LlamaKvCache cache(1, 1000, 2, stream, trtmc::DType::kFloat16);
+        trtmc::test::NativeKvModuleStub prefill(stream, 1, 131072, 1, 2, trtmc::DType::kFloat16,
+                                                /*native=*/false, nullptr, 4, 16,
+                                                /*dynamic_legacy_cache=*/true);
+
+        cache.bind_cache_inputs(prefill);
+        if (!trtmc::cache_input_supports_runtime_rows(prefill, "cache_k_0")) {
+            std::cerr << "FAIL [Llama]: dynamic metadata survives positive active tensor shape\n";
+            ++failures;
+        }
+        if (prefill.bound_shape("cache_k_0") != std::vector<int64_t>{1000, 2} ||
+            prefill.bound_shape("cache_v_0") != std::vector<int64_t>{1000, 2}) {
+            std::cerr << "FAIL [Llama]: dynamic prefill binds runtime-sized cache rows\n";
+            ++failures;
+        }
+
+        trtmc::TensorMap inputs;
+        cache.prepare_step(inputs, 4);
+        if (inputs.at("attention_mask").shape != std::vector<int64_t>{4, 1004}) {
+            std::cerr << "FAIL [Llama]: dynamic prefill mask uses runtime cache rows\n";
+            ++failures;
+        }
+    }
+    cudaStreamDestroy(stream);
+    return failures;
+}
+
+} // namespace
 
 int main() {
     return trtmc::test::run_native_kv_contract_tests<
-        trtmc::LlamaTextGenerationPipeline, trtmc::LlamaKvCache, trtmc::LlamaTextGenConfig>(
-        "Llama");
+               trtmc::LlamaTextGenerationPipeline, trtmc::LlamaKvCache, trtmc::LlamaTextGenConfig>(
+               "Llama") +
+           test_dynamic_prefill_uses_runtime_cache_rows();
 }

--- a/tests/cpp/models/llama/test_llama_plugin_helpers.cpp
+++ b/tests/cpp/models/llama/test_llama_plugin_helpers.cpp
@@ -6,6 +6,7 @@
 // Unit tests for runtime plugin helper parsing.
 // Focus: tokenizer_add_special_tokens detection from bundle config.
 
+#include "../../native_kv_cache_contract_test.h"
 #include "runtime/models/llama/plugin_helpers.h"
 
 #include <iostream>
@@ -76,6 +77,45 @@ static void test_bool_true_parsed() {
     auto bundle = make_bundle_with_config(R"({"tokenizer_add_special_tokens":true})");
     check(trtmc::detect_add_special_tokens(bundle) == true,
           "detect_add_special_tokens: bool true parsed as true");
+}
+
+static void test_decoder_profile_selection_keeps_runtime_ceiling() {
+    check_ids(trtmc::select_decoder_profile_rows({256, 131072}, 1000), {256, 131072},
+              "decoder profile selection keeps first runtime ceiling");
+    check_ids(trtmc::select_decoder_profile_rows({256, 131072}, 256), {256},
+              "decoder profile selection stops at exact runtime capacity");
+    bool rejected = false;
+    try {
+        (void)trtmc::select_decoder_profile_rows({256}, 131072);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    check(rejected, "decoder profile selection rejects an undersized largest bucket");
+}
+
+static void test_dynamic_profile_rows_use_profile_metadata() {
+    trtmc::test::NativeKvModuleStub module(nullptr, 1, 131072, 1, 2, trtmc::DType::kFloat16,
+                                           /*native=*/false, nullptr, 4, 16,
+                                           /*dynamic_legacy_cache=*/true, {131072, 256, 131072},
+                                           {131072, 1, 1});
+
+    check(module.tensor_shape("cache_k_0") == std::vector<int64_t>{131072, 2},
+          "dynamic module reports a positive active cache shape");
+    check(trtmc::cache_input_supports_runtime_rows(module, "cache_k_0"),
+          "dynamic input metadata enables runtime rows despite positive active shape");
+    check(trtmc::decoder_profile_cache_rows(module, "cache_k_0", 1, 131072) == 256,
+          "first dynamic decode profile uses its own row ceiling");
+    check(trtmc::decoder_profile_cache_rows(module, "cache_k_0", 2, 131072) == 131072,
+          "second dynamic decode profile uses its own row ceiling");
+
+    const auto roles = trtmc::detect_decoder_profile_roles(module, "token_id", "cache_k_0", 131072);
+    check(roles.prefill_profile_idx == 0 && roles.prefill_max_length == 131072,
+          "role detection keeps the dynamic prefill profile");
+    check(roles.decode_profiles.size() == 2 && roles.decode_profiles[0].profile_idx == 1 &&
+              roles.decode_profiles[0].kv_rows == 256 &&
+              roles.decode_profiles[1].profile_idx == 2 &&
+              roles.decode_profiles[1].kv_rows == 131072,
+          "role detection preserves per-profile dynamic KV ceilings");
 }
 
 static void test_exact_special_frame_overrides_native_unigram_fallback() {
@@ -152,6 +192,8 @@ int main() {
     test_integer_true_parsed();
     test_bool_false_parsed();
     test_bool_true_parsed();
+    test_decoder_profile_selection_keeps_runtime_ceiling();
+    test_dynamic_profile_rows_use_profile_metadata();
     test_exact_special_frame_overrides_native_unigram_fallback();
     test_exact_special_frame_respects_add_special_false();
 

--- a/tests/cpp/native_kv_cache_contract_test.h
+++ b/tests/cpp/native_kv_cache_contract_test.h
@@ -36,14 +36,21 @@ class NativeKvModuleStub final : public ITrtModule {
     NativeKvModuleStub(cudaStream_t stream, int32_t layers, int32_t capacity, int32_t kv_heads,
                        int32_t head_dim, DType dtype, bool native = true,
                        std::shared_ptr<NativeKvTrace> trace = nullptr, int32_t profile_limit = 4,
-                       int32_t vocab_size = 16)
-        : stream_(stream), native_(native), trace_(std::move(trace)), vocab_size_(vocab_size) {
+                       int32_t vocab_size = 16, bool dynamic_legacy_cache = false,
+                       std::vector<int32_t> dynamic_profile_rows = {},
+                       std::vector<int32_t> token_profile_max_lengths = {})
+        : stream_(stream), native_(native), trace_(std::move(trace)), vocab_size_(vocab_size),
+          dynamic_legacy_cache_(dynamic_legacy_cache), dynamic_cache_width_(kv_heads * head_dim),
+          dynamic_profile_rows_(std::move(dynamic_profile_rows)),
+          token_profile_max_lengths_(std::move(token_profile_max_lengths)) {
+        if (dynamic_legacy_cache_ && dynamic_profile_rows_.empty())
+            dynamic_profile_rows_.push_back(capacity);
         if (native_) {
             add("cache_write_indices", {1}, DType::kInt32, true);
             add("key_value_lengths", {1}, DType::kInt32, true);
         }
         add("position_id", {1}, DType::kInt32, true);
-        if (trace_) {
+        if (trace_ || !token_profile_max_lengths_.empty()) {
             add("token_id", {profile_limit}, DType::kInt32, true);
             add("logits", {profile_limit, vocab_size}, DType::kFloat32, false);
         }
@@ -99,11 +106,29 @@ class NativeKvModuleStub final : public ITrtModule {
         const auto it = tensors_.find(name);
         return it == tensors_.end() ? std::vector<int64_t>{} : it->second.shape;
     }
-    std::vector<int64_t> input_profile_shape(const std::string& name, int32_t,
-                                             ProfileShapeSelector) const override {
+    std::vector<int64_t> input_profile_shape(const std::string& name, int32_t profile_idx,
+                                             ProfileShapeSelector selector) const override {
+        if (name == "token_id" && !token_profile_max_lengths_.empty()) {
+            const int32_t tokens =
+                selector == ProfileShapeSelector::kMin
+                    ? 1
+                    : token_profile_max_lengths_.at(static_cast<std::size_t>(profile_idx));
+            return {tokens};
+        }
+        if (dynamic_legacy_cache_ && name.rfind("cache_", 0) == 0) {
+            const int32_t rows =
+                selector == ProfileShapeSelector::kMin
+                    ? 1
+                    : dynamic_profile_rows_.at(static_cast<std::size_t>(profile_idx));
+            return {rows, dynamic_cache_width_};
+        }
         return tensor_shape(name);
     }
-    int32_t optimization_profile_count() const override { return 1; }
+    int32_t optimization_profile_count() const override {
+        if (!token_profile_max_lengths_.empty())
+            return static_cast<int32_t>(token_profile_max_lengths_.size());
+        return dynamic_legacy_cache_ ? static_cast<int32_t>(dynamic_profile_rows_.size()) : 1;
+    }
     void* device_ptr(const std::string& name) const override {
         const auto it = bindings_.find(name);
         return it == bindings_.end() ? nullptr : it->second;
@@ -115,10 +140,21 @@ class NativeKvModuleStub final : public ITrtModule {
         if (native_ && name.rfind("cache_", 0) == 0)
             bindings_["present_" + name.substr(6)] = ptr;
     }
+    void bind_external(const std::string& name, void* ptr,
+                       const std::vector<int64_t>& shape) override {
+        bind_external(name, ptr);
+        binding_shapes_[name] = shape;
+    }
+    std::vector<int64_t> bound_shape(const std::string& name) const {
+        const auto it = binding_shapes_.find(name);
+        return it == binding_shapes_.end() ? std::vector<int64_t>{} : it->second;
+    }
     int32_t input_rank(const std::string& name) const override {
         return has_input(name) ? static_cast<int32_t>(tensor_shape(name).size()) : 0;
     }
-    bool input_is_dynamic(const std::string&) const override { return false; }
+    bool input_is_dynamic(const std::string& name) const override {
+        return dynamic_legacy_cache_ && name.rfind("cache_", 0) == 0;
+    }
     bool ok() const override { return stream_ != nullptr; }
     void keep_alive(std::shared_ptr<void> value) override {
         keep_alive_.push_back(std::move(value));
@@ -150,9 +186,14 @@ class NativeKvModuleStub final : public ITrtModule {
     bool native_;
     std::shared_ptr<NativeKvTrace> trace_;
     int32_t vocab_size_;
+    bool dynamic_legacy_cache_;
+    int32_t dynamic_cache_width_;
+    std::vector<int32_t> dynamic_profile_rows_;
+    std::vector<int32_t> token_profile_max_lengths_;
     std::vector<float> logits_;
     std::unordered_map<std::string, Entry> tensors_;
     std::unordered_map<std::string, void*> bindings_;
+    std::unordered_map<std::string, std::vector<int64_t>> binding_shapes_;
     std::vector<std::shared_ptr<void>> keep_alive_;
 };
 

--- a/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width-l0.json
@@ -1,12 +1,23 @@
 {
   "name": "minitron-4b-width-l0",
   "hf_id": "nvidia/Llama-3.1-Minitron-4B-Width-Base",
+  "hf_revision": "5205ef7d36204947e3b973cb8b147a816ccd7e6a",
   "bundle": "minitron-4b-width-l0.bundle",
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
   "max_cache_length": 256,
+  "build_cli_args": [
+    {
+      "flag": "--dynamic-kv-cache",
+      "value": true
+    },
+    {
+      "flag": "--dynamic-kv-profile-rows",
+      "value": "256,131072"
+    }
+  ],
   "build_args": {
     "decoder_engine_layout": "dual_profile"
   },

--- a/tests/e2e/models/llama/manifests/minitron-4b-width.json
+++ b/tests/e2e/models/llama/manifests/minitron-4b-width.json
@@ -1,11 +1,22 @@
 {
   "name": "minitron-4b-width",
   "hf_id": "nvidia/Llama-3.1-Minitron-4B-Width-Base",
+  "hf_revision": "5205ef7d36204947e3b973cb8b147a816ccd7e6a",
   "bundle": "minitron-4b-width.bundle",
   "family": "llama",
   "runtime_strategy": "llama_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
+  "build_cli_args": [
+    {
+      "flag": "--dynamic-kv-cache",
+      "value": true
+    },
+    {
+      "flag": "--dynamic-kv-profile-rows",
+      "value": "256,131072"
+    }
+  ],
   "build_args": {
     "decoder_engine_layout": "dual_profile"
   },

--- a/tests/e2e/models/llama/test_llama_build_contract.py
+++ b/tests/e2e/models/llama/test_llama_build_contract.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 
 from tests.e2e_harness.manifest_loader import load_manifest
+from tests.e2e_harness.orchestrator import _append_declared_build_cli_args
 
 
 def test_falcon3_split_decoder_build_reserves_an_exclusive_gpu() -> None:
@@ -43,9 +44,26 @@ def test_minitron_width_release_profiles_use_qualified_runtime_contract() -> Non
         case = load_manifest(manifest_path)
 
         assert manifest["precision"] == "fp16", manifest_name
+        assert (
+            case.hf_revision == "5205ef7d36204947e3b973cb8b147a816ccd7e6a"
+        ), manifest_name
         assert manifest["build_args"] == {
             "decoder_engine_layout": "dual_profile"
         }, manifest_name
+        assert case.metadata["build_cli_args"] == [
+            {"flag": "--dynamic-kv-cache", "value": True},
+            {
+                "flag": "--dynamic-kv-profile-rows",
+                "value": "256,131072",
+            },
+        ], manifest_name
+        build_cli_args: list[str] = []
+        _append_declared_build_cli_args(build_cli_args, case)
+        assert build_cli_args == [
+            "--dynamic-kv-cache",
+            "--dynamic-kv-profile-rows",
+            "256,131072",
+        ], manifest_name
         if expected_cache_length is None:
             assert "max_cache_length" not in manifest, manifest_name
             assert "max_cache_length" not in case.inputs, manifest_name

--- a/tests/e2e/models/llama/test_llama_native_kv_routing.py
+++ b/tests/e2e/models/llama/test_llama_native_kv_routing.py
@@ -324,6 +324,52 @@ def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):
     assert plugin_module.plugin.get_bundle_config_overrides(config) is None
 
 
+def test_dynamic_kv_dual_profile_dispatches_bucket_rows(monkeypatch):
+    pytest.importorskip("tensorrt")
+    builder_module = importlib.import_module(
+        "tensorrt_model_connect.families.llama.standard_decoder_builder"
+    )
+    config = _small_config(role="dual_profile")
+    config.raw["dynamic_kv_cache"] = True
+    config.raw["_dynamic_kv_profile_rows"] = [256, 131072]
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"dynamic-dual-profile-plan"
+
+    monkeypatch.setattr(
+        builder_module,
+        "build_dual_profile_decoder_engine",
+        _build,
+    )
+
+    plan = builder_module.build_standard_decoder_engine(
+        config,
+        _weights(config),
+        131072,
+        precision="fp16",
+    )
+
+    assert plan == b"dynamic-dual-profile-plan"
+    assert captured["args"][2] == 131072
+    assert captured["kwargs"]["precision"] == "fp16"
+    assert captured["kwargs"]["dynamic_kv_profile_rows"] == [256, 131072]
+    assert captured["kwargs"]["profile_mode"] == "dual_profile"
+
+    config.raw.pop("_dynamic_kv_profile_rows")
+    captured.clear()
+    plan = builder_module.build_standard_decoder_engine(
+        config,
+        _weights(config),
+        131072,
+        precision="fp16",
+    )
+
+    assert plan == b"dynamic-dual-profile-plan"
+    assert captured["kwargs"]["dynamic_kv_profile_rows"] == [131072]
+
+
 def test_plugin_falls_back_outside_the_native_architecture_contract(
     monkeypatch,
 ):

--- a/tests/e2e/models/llama/test_llama_standard_decoder.py
+++ b/tests/e2e/models/llama/test_llama_standard_decoder.py
@@ -136,6 +136,18 @@ class TestTensorNamingContract:
         assert "present_v_0" in outputs
         assert "present_v_1" in outputs
 
+        engine = _deserialize_engine(plan)
+        assert engine.get_tensor_profile_shape("attention_mask", 0) == [
+            (1, 5),
+            (4, 8),
+            (4, 8),
+        ]
+        assert engine.get_tensor_profile_shape("attention_mask", 1) == [
+            (1, 5),
+            (1, 5),
+            (1, 5),
+        ]
+
     def test_layernorm_gelu_fc(self):
         """LayerNorm + gelu_fc MLP, same I/O names."""
         plan = self._build_engine(
@@ -247,17 +259,26 @@ class TestTensorNamingContract:
             rope_theta=10000.0,
         )
         config.raw["dynamic_kv_cache"] = True
-        config.raw["_dynamic_kv_opt_length"] = 2
         weights = _make_weights(hidden, vocab, num_layers, attention_size, mlp_size)
 
         plan = build_standard_decoder_engine(config, weights, max_cache)
         engine = _deserialize_engine(plan)
 
         assert engine is not None
-        assert engine.num_optimization_profiles == 1
-        assert tuple(engine.get_tensor_shape("attention_mask")) == (1, -1)
+        assert engine.num_optimization_profiles == 2
+        assert tuple(engine.get_tensor_shape("attention_mask")) == (-1, -1)
         assert tuple(engine.get_tensor_shape("cache_k_0")) == (-1, attention_size)
         assert tuple(engine.get_tensor_shape("cache_v_0")) == (-1, attention_size)
+        assert engine.get_tensor_profile_shape("attention_mask", 0) == [
+            (1, 2),
+            (4, 8),
+            (4, 8),
+        ]
+        assert engine.get_tensor_profile_shape("attention_mask", 1) == [
+            (1, 2),
+            (1, 5),
+            (1, 5),
+        ]
 
     def test_dynamic_kv_cache_multiple_profiles(self):
         from tensorrt_model_connect.config import ModelConfig
@@ -286,19 +307,30 @@ class TestTensorNamingContract:
         engine = _deserialize_engine(plan)
 
         assert engine is not None
-        assert engine.num_optimization_profiles == 3
-        assert engine.get_tensor_profile_shape("attention_mask", 0) == [(1, 2), (1, 3), (1, 3)]
-        assert engine.get_tensor_profile_shape("attention_mask", 1) == [(1, 2), (1, 4), (1, 4)]
-        assert engine.get_tensor_profile_shape("attention_mask", 2) == [(1, 2), (1, 5), (1, 5)]
-        assert engine.get_tensor_profile_shape("cache_k_0", 0) == [(1, attention_size),
-                                                                    (2, attention_size),
-                                                                    (2, attention_size)]
-        assert engine.get_tensor_profile_shape("cache_k_0", 1) == [(1, attention_size),
-                                                                    (3, attention_size),
-                                                                    (3, attention_size)]
-        assert engine.get_tensor_profile_shape("cache_k_0", 2) == [(1, attention_size),
-                                                                    (4, attention_size),
-                                                                    (4, attention_size)]
+        assert engine.num_optimization_profiles == 4
+        assert engine.get_tensor_profile_shape("attention_mask", 0) == [
+            (1, 2),
+            (4, 8),
+            (4, 8),
+        ]
+        assert engine.get_tensor_profile_shape("cache_k_0", 0) == [
+            (1, attention_size),
+            (4, attention_size),
+            (4, attention_size),
+        ]
+        for profile, cache_rows in enumerate((2, 3, 4), start=1):
+            assert engine.get_tensor_profile_shape(
+                "attention_mask", profile
+            ) == [
+                (1, 2),
+                (1, cache_rows + 1),
+                (1, cache_rows + 1),
+            ]
+            assert engine.get_tensor_profile_shape("cache_k_0", profile) == [
+                (1, attention_size),
+                (cache_rows, attention_size),
+                (cache_rows, attention_size),
+            ]
 
     def test_dynamic_kv_cache_rejects_alibi(self):
         from tensorrt_model_connect.config import ModelConfig

--- a/tests/tools/test_selected_wheel_runtime.py
+++ b/tests/tools/test_selected_wheel_runtime.py
@@ -13,10 +13,13 @@ import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from tools.ci.context import CiContext
 from tools.ci import model_proof_inner as model_proof_inner_module
 from tools.ci.model_proof import ModelProofRequest, ModelProofRunner
 from tools.ci.model_proof_inner import ModelProofInnerPipeline
+from tools.ci.process import CiError
 from tools.ci.quality import UnitTestRunner
 from tools.ci.selected_wheel import SelectedWheelRuntime
 
@@ -366,6 +369,8 @@ def test_model_proof_stages_wheel_model_dso_but_keeps_source_cpp_tests(
     packaged = target / "tensorrt_model_connect/bin" / runtime_library
     packaged.parent.mkdir(parents=True)
     packaged.write_bytes(b"\x7fELFwheel")
+    packaged_core = packaged.parent / "libtrtmc_core.so"
+    packaged_core.write_bytes(b"\x7fELFwheel-core")
     runtime = SelectedWheelRuntime(
         wheel=tmp_path / "wheel.whl",
         site_packages=target,
@@ -404,6 +409,22 @@ def test_model_proof_stages_wheel_model_dso_but_keeps_source_cpp_tests(
     assert facts["runtime_library_sha256"] == hashlib.sha256(
         packaged.read_bytes()
     ).hexdigest()
+    staged_core = staged.parent / packaged_core.name
+    core_digest = hashlib.sha256(packaged_core.read_bytes()).hexdigest()
+    assert staged_core.is_file() and not staged_core.is_symlink()
+    assert staged_core.read_bytes() == packaged_core.read_bytes()
+    assert staged_core.resolve().is_relative_to(staged.parent.resolve())
+    assert facts["runtime_core_library"] == packaged_core.name
+    assert facts["runtime_core_library_source"] == "selected-wheel"
+    assert facts["runtime_core_library_sha256"] == core_digest
+    assert facts["staged_runtime_core_library_sha256"] == core_digest
+
+    outside_core = tmp_path / "outside-libtrtmc_core.so"
+    outside_core.write_bytes(b"\x7fELFoutside")
+    packaged_core.unlink()
+    packaged_core.symlink_to(outside_core)
+    with pytest.raises(CiError, match="selected wheel core DSO is missing or unsafe"):
+        pipeline._validate_dso("fixture", runtime_library)
 
     calls: list[tuple[list[object], dict[str, str]]] = []
     monkeypatch.setattr(

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -178,10 +178,29 @@ def test_benchmark_uses_qualified_minitron_width_precision(tmp_path: Path) -> No
     options = benchmark_builder._build_options(model, (case,))
 
     assert model.precision == "fp16"
+    assert model.hf_revision == "5205ef7d36204947e3b973cb8b147a816ccd7e6a"
     assert model.identity()["precision"] == "fp16"
     assert options["precision"] == "fp16"
     assert options["max_cache_length"] == 256
     assert options["decoder_engine_layout"] == "dual_profile"
+    assert options["extra_cli_args"] == [
+        "--dynamic-kv-cache",
+        "--dynamic-kv-profile-rows",
+        "256,131072",
+    ]
+    command = benchmark_builder._build_command(
+        model,
+        case.bundle_path,
+        options,
+        benchmark_builder._BuilderRuntime("11.2", "11.2", "11.2"),
+    )
+    assert command[-3:] == (
+        "--dynamic-kv-cache",
+        "--dynamic-kv-profile-rows",
+        "256,131072",
+    )
+    revision_index = command.index("--model-revision")
+    assert command[revision_index + 1] == model.hf_revision
 
 
 def test_operation_registry_declares_supported_task_semantics() -> None:

--- a/tools/ci/model_proof_inner.py
+++ b/tools/ci/model_proof_inner.py
@@ -619,6 +619,7 @@ class ModelProofInnerPipeline:
             raise CiError(f"model DSO links a sibling model DSO: {sorted(dependencies)}")
         scratch = dsos[0]
         runtime_dso = scratch
+        runtime_core: Path | None = None
         runtime_library_source = "scratch-build"
         if self.selected_wheel:
             native_dir = (
@@ -634,6 +635,13 @@ class ModelProofInnerPipeline:
                 raise CiError(
                     f"selected wheel model DSO is missing or unsafe: {runtime_library}"
                 )
+            runtime_core = native_dir / "libtrtmc_core.so"
+            if (
+                runtime_core.is_symlink()
+                or not runtime_core.is_file()
+                or not runtime_core.resolve().is_relative_to(native_dir)
+            ):
+                raise CiError("selected wheel core DSO is missing or unsafe: libtrtmc_core.so")
             runtime_library_source = "selected-wheel"
 
         plugin_dir = self.work / "model-plugins" / runtime_model
@@ -642,6 +650,24 @@ class ModelProofInnerPipeline:
         shutil.copy2(runtime_dso, staged)
         if staged.read_bytes() != runtime_dso.read_bytes():
             raise CiError("staged plugin DSO does not byte-match its runtime source")
+        core_facts: dict[str, str] = {}
+        if runtime_core is not None:
+            staged_core = plugin_dir / runtime_core.name
+            shutil.copy2(runtime_core, staged_core)
+            if (
+                staged_core.is_symlink()
+                or not staged_core.is_file()
+                or not staged_core.resolve().is_relative_to(plugin_dir.resolve())
+                or staged_core.read_bytes() != runtime_core.read_bytes()
+            ):
+                raise CiError("staged core DSO does not byte-match its selected wheel source")
+            core_digest = hashlib.sha256(staged_core.read_bytes()).hexdigest()
+            core_facts = {
+                "runtime_core_library": runtime_core.name,
+                "runtime_core_library_sha256": core_digest,
+                "staged_runtime_core_library_sha256": core_digest,
+                "runtime_core_library_source": "selected-wheel",
+            }
         scratch_digest = hashlib.sha256(scratch.read_bytes()).hexdigest()
         digest = hashlib.sha256(staged.read_bytes()).hexdigest()
         for key, value in {
@@ -655,9 +681,12 @@ class ModelProofInnerPipeline:
             "model_dso_count": "1",
             "network": "disabled",
             "plugin_search": "strict",
+            **core_facts,
         }.items():
             self.status.fact(key, value)
-        self.status.step("dso_isolation", "passed", "exactly one DSO; no sibling model DT_NEEDED")
+        self.status.step(
+            "dso_isolation", "passed", "exactly one model DSO; no sibling model DT_NEEDED"
+        )
         return staged, scratch_digest, runtime_library_source
 
     def _run_cpp_tests(self, tests: list[str]) -> None:


### PR DESCRIPTION
## Background

Full selected-wheel certification exposed two independent failures in model-owned proof paths:

- The FP16 Minitron dual-profile decoder read a fixed 131072-row cache view during short decode. Its first generated token was correct, but subsequent tokens collapsed to token ID 0.
- The isolated selected-wheel model DSO was staged without its matching `libtrtmc_core.so`, so direct C ABI loading could not resolve the DSO's `$ORIGIN` dependency.

## Exit Criteria

- Preserve Minitron's full 131072-token maximum capacity without relaxing continuation parity.
- Keep runtime-sized cache overrides and decode-profile transitions correct and fail closed when no profile covers the requested capacity.
- Keep selected-wheel model loading hermetic while preserving the wheel's native dependency closure.
- Do not change any comparison threshold or acceptance boundary.

## Implementation

- Enable dynamic KV profiles for the qualified Minitron full and L0 manifests, using decode ceilings at 256 and 131072 rows and pinning the public model revision.
- Make dual-profile attention-mask shapes follow each cache-row profile. Runtime role detection now reads dynamic profile maxima, retains the first ceiling profile, binds prefill to the selected runtime cache size, and rejects undersized profile sets.
- Stage the selected wheel's regular, non-symlink `libtrtmc_core.so` beside the isolated model DSO, with containment, byte-identity, and SHA-256 evidence checks.
- Add builder-shape, runtime-binding, profile-selection, benchmark-forwarding, selected-wheel staging, and shared Llama/Qwen cache regressions.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q -p no:cacheprovider tests/tools/test_selected_wheel_runtime.py tests/tools/test_model_proof_runner.py tests/tools/test_trtmc_bench.py tests/e2e/models/llama/test_llama_build_contract.py tests/e2e/models/llama/test_llama_native_kv_routing.py tests/e2e/models/llama/test_llama_standard_decoder.py`: **268 passed, 16 skipped**.
- `python3 tools/test_impact.py --validate`: passed with the repository's existing stale-allowlist warnings.
- Final py312 aarch64 wheel archive, RPATH, metadata, and clean-venv installation validation: passed.
- Target-hardware Minitron proof with the final wheel:
  - default 131072-row capacity produced the exact 20-token HF continuation;
  - a 953-row runtime override produced the same exact continuation;
  - a 301-token prompt crossed the 256-row bucket, selected decoder index 1 at 320 active rows, and matched HF token IDs exactly.
- Final-wheel SAM2 loader control: the isolated model DSO alone reproduced the missing-core error; staging its matching wheel core beside it loaded successfully.
- Ruff, clang-format dry-run, JSON parsing, and `git diff --check`: passed.

## Notes For Future Readers

- The full manifest still has no `max_cache_length` override; its model-owned maximum remains 131072. L0 remains bounded to 256.
- This validates full-capacity storage and a real decode-profile transition, not a 131k-token prompt. Legacy dense prefill remains a separate long-context limitation.
- Review the Llama builder/runtime profile contract first, then the selected-wheel DSO staging closure.
- Repository premerge and the complete Nightly have not yet run on this PR head.
