### PR TITLE
fix(qwen): require native KV for Qwen3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 💻 Example Code
 
 ```bash
-trtmc build Qwen/Qwen3-0.6B --max-cache-length 40960 --output qwen3-0.6b.bundle
+trtmc build Qwen/Qwen3-0.6B --max-cache-length 16384 --output qwen3-0.6b.bundle
 trtmc run ./qwen3-0.6b.bundle --prompt "What is the capital of France? Answer in one word." --chat-template --no-thinking
 # Generated text: Paris
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 💻 Example Code
 
 ```bash
-trtmc build Qwen/Qwen3-0.6B --max-cache-length 16384 --output qwen3-0.6b.bundle
+trtmc build Qwen/Qwen3-0.6B --max-cache-length 40960 --output qwen3-0.6b.bundle
 trtmc run ./qwen3-0.6b.bundle --prompt "What is the capital of France? Answer in one word." --chat-template --no-thinking
 # Generated text: Paris
 ```

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -1057,6 +1057,10 @@ def build_bundle(
     if max_cache_length < 1:
         raise ValueError("max_cache_length must be >= 1")
 
+    validate_build_request = getattr(plugin, "validate_build_request", None)
+    if callable(validate_build_request):
+        validate_build_request(config)
+
     # 3. Load weights
     t1 = time.monotonic()
     print("[trtmc build] Loading weights ...", file=sys.stderr)

--- a/python/tensorrt_model_connect/families/qwen/build_routing.py
+++ b/python/tensorrt_model_connect/families/qwen/build_routing.py
@@ -257,8 +257,8 @@ def native_kv_build_capability(
 
     raw = _raw(config)
     reasons: list[str] = []
-    if str(precision).lower() != "bf16":
-        reasons.append("native Qwen3 requires BF16")
+    if str(precision).lower() not in {"fp16", "bf16"}:
+        reasons.append("native Qwen3 requires FP16 or BF16")
     if str(raw.get("_decoder_engine_layout", "split")) != "split":
         reasons.append("native Qwen3 requires split prefill/decode engines")
     if raw.get("_rtx_build_requested"):

--- a/python/tensorrt_model_connect/families/qwen/build_routing.py
+++ b/python/tensorrt_model_connect/families/qwen/build_routing.py
@@ -99,14 +99,14 @@ def native_kv_cache_geometry(
     *,
     element_bytes: int = 2,
 ) -> tuple[int, int]:
-    """Return runtime byte geometry for the required full-context cache."""
+    """Return runtime byte geometry for one fixed native cache capacity."""
 
     capacity = _integer(capacity, "max_cache_length")
     context = _positive(config, "max_position_embeddings")
-    if capacity != context:
+    if capacity <= 0 or capacity > context:
         raise ValueError(
-            "native Qwen KV requires max_cache_length == "
-            f"max_position_embeddings ({context}), got {capacity}"
+            "native Qwen KV requires max_cache_length in "
+            f"[1, max_position_embeddings ({context})], got {capacity}"
         )
     row_bytes = _checked_product(
         "row size",

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -393,8 +393,6 @@ def build_dual_profile_decoder_engine(
     trt_config = builder.create_builder_config()
     configure_qwen_builder(
         trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
-
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
     elif precision == "bf16":

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
@@ -309,8 +309,6 @@ def build_dual_profile_tp_decoder_engine(
     trt_config = builder.create_builder_config()
     configure_qwen_builder(
         trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
-
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
     elif precision == "bf16":

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -1217,11 +1217,11 @@ def add_native_kv_cache_attention_from_rows(
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
 
-    if q_4d.dtype != trt.bfloat16:
-        raise ValueError("Qwen native KV attention requires BF16 queries")
+    if q_4d.dtype not in {trt.float16, trt.bfloat16}:
+        raise ValueError("Qwen native KV attention requires FP16 or BF16 queries")
 
-    # Match the native fused-attention contract exactly: TensorRT consumes a
-    # BF16 query after the FP32 scale has already been applied and rounded.
+    # Match the native fused-attention contract exactly: TensorRT consumes an
+    # FP16/BF16 query after the FP32 scale has already been applied and rounded.
     q_scale_input = network.add_cast(q_4d, trt.float32).get_output(0)
     scale_t = add_constant(
         network,
@@ -1232,7 +1232,7 @@ def add_native_kv_cache_attention_from_rows(
     q_scaled = network.add_elementwise(
         q_scale_input, scale_t, trt.ElementWiseOperation.PROD
     ).get_output(0)
-    q_scaled = network.add_cast(q_scaled, trt.bfloat16).get_output(0)
+    q_scaled = network.add_cast(q_scaled, q_4d.dtype).get_output(0)
 
     recipe = nullcontext()
     if recipe_instance is not None:

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -3,8 +3,8 @@
 
 """Qwen family plugin — Qwen, Qwen2, Qwen3, QwQ (text-only, not VL).
 
-Dense Qwen3 uses the family-owned TensorRT native KV path. Other Qwen
-variants retain their existing legacy graph routes.
+Qwen3 uses only the family-owned TensorRT native KV path and fails closed for
+unsupported build modes. Other Qwen variants retain their legacy graph routes.
 """
 
 from __future__ import annotations
@@ -86,8 +86,22 @@ class QwenPlugin:
         return int(config.max_position_embeddings) if capability.eligible else 256
 
     def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
-        """Keep quantized Qwen on the single-engine correctness path."""
+        """Keep quantized legacy Qwen variants on the single-engine path."""
         return not bool(config.raw.get("_quantized_build_requested"))
+
+    def validate_build_request(self, config: ModelConfig) -> None:
+        """Reject Qwen3 runtime-sized KV before loading checkpoint weights."""
+        if str(config.model_type).lower() != "qwen3":
+            return
+        if (
+            config.raw.get("dynamic_kv_cache")
+            or config.raw.get("_runtime_dynamic_kv_requested")
+        ):
+            raise ValueError(
+                "Qwen3 does not support dynamic KV cache; remove "
+                "--dynamic-kv-cache or set dynamic_kv_cache=False to use "
+                "the fixed-capacity native KV path"
+            )
 
     def load_weights(
         self, model_dir: str, config: ModelConfig,
@@ -102,6 +116,8 @@ class QwenPlugin:
         debug_layer_outputs: bool = False,
     ) -> bytes:
         parallel = normalize_parallel_config(parallel_config)
+        config.raw.pop("_native_kv_cache_metadata", None)
+        self.validate_build_request(config)
         capability = native_kv_build_capability(
             config,
             precision=precision,
@@ -136,7 +152,12 @@ class QwenPlugin:
                 native_kv_cache=True,
             )
 
-        config.raw.pop("_native_kv_cache_metadata", None)
+        if capability.applicable:
+            raise ValueError(
+                "Qwen3 requires the fixed-capacity native KV path: "
+                f"{capability.reason}"
+            )
+
         if parallel.enabled:
             if debug_layer_outputs:
                 raise NotImplementedError(

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -129,7 +129,7 @@ class QwenPlugin:
                 config,
                 weights,
                 max_cache_length,
-                precision="bf16",
+                precision=precision,
                 quant_ctx=None,
                 verbose=verbose,
                 profile_mode=role,

--- a/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -189,8 +189,6 @@ def build_standard_decoder_engine(
     trt_config = builder.create_builder_config()
     configure_qwen_builder(
         trt_config, quant_ctx, trt.__version__, config.num_hidden_layers)
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
-
     # Precision configuration
     if precision == "fp16":
         work_np_dtype = np.float16

--- a/src/runtime/models/qwen/plugin.cpp
+++ b/src/runtime/models/qwen/plugin.cpp
@@ -242,9 +242,10 @@ bool validate_native_kv_runtime(const PipelineContext& ctx, const TrtModule& mod
     if (!native_kv)
         return false;
 
-    if (cache_dtype != DType::kBFloat16 || tri_cfg.enabled || tp_cfg.enabled) {
+    if ((cache_dtype != DType::kFloat16 && cache_dtype != DType::kBFloat16) || tri_cfg.enabled ||
+        tp_cfg.enabled) {
         throw std::runtime_error(
-            "Qwen native KV requires BF16, single-GPU, non-TriAttention runtime");
+            "Qwen native KV requires FP16 or BF16, single-GPU, non-TriAttention runtime");
     }
     const std::vector<int64_t> expected_shape{1, ctx.config.num_kv_heads,
                                               ctx.config.max_cache_length, 128};

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -154,9 +154,45 @@ def test_bf16_uses_exact_fp32_scale_before_fused_attention(
     assert result["context"] is attention[6].get_output(0)
 
 
-@pytest.mark.parametrize("module_name", _FAMILIES)
-def test_unqualified_fp16_graph_fails_closed(monkeypatch, module_name):
-    graph_ops = importlib.import_module(module_name)
+def test_qwen_fp16_uses_exact_fp32_scale_before_fused_attention(monkeypatch):
+    graph_ops = importlib.import_module("tensorrt_model_connect.families.qwen.graph_ops")
+    constants: list[tuple[tuple[int, ...], np.ndarray, np.dtype]] = []
+
+    def _record(network, shape, values, dtype=np.float32):
+        constants.append((shape, np.asarray(values).copy(), np.dtype(dtype)))
+        tensor = _FakeTensor("scale", trt.float32)
+        network.calls.append(("constant", tensor))
+        return tensor
+
+    monkeypatch.setattr(graph_ops, "add_constant", _record)
+    network, tensors, result = _add_native_attention(monkeypatch, graph_ops, trt.float16)
+    relevant = [
+        call
+        for call in network.calls
+        if call[0] in {"cast", "constant", "elementwise", "attention"}
+    ]
+
+    assert len(constants) == 1
+    assert [call[0] for call in relevant] == [
+        "cast",
+        "constant",
+        "elementwise",
+        "cast",
+        "attention",
+    ]
+    upcast, constant, product, downcast, attention = relevant
+    assert upcast[1] is tensors["q"]
+    assert upcast[2] == trt.float32
+    assert constant[1].dtype == trt.float32
+    assert product[3] == trt.ElementWiseOperation.PROD
+    assert downcast[2] == trt.float16
+    assert attention[1] is downcast[3].get_output(0)
+    assert attention[2] is result["present_k"]
+    assert attention[3] is result["present_v"]
+
+
+def test_llama_unqualified_fp16_graph_fails_closed(monkeypatch):
+    graph_ops = importlib.import_module("tensorrt_model_connect.families.llama.graph_ops")
 
     with pytest.raises(ValueError, match="requires BF16"):
         _add_native_attention(monkeypatch, graph_ops, trt.float16)

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 import importlib
+from pathlib import Path
 
 import pytest
 
@@ -102,6 +104,31 @@ def test_route_uses_architecture_not_checkpoint_identity():
 
     assert native_kv_architecture_capability(config).eligible
     assert prefer_native_default(config)
+
+
+@pytest.mark.parametrize(
+    "builder_name",
+    [
+        "standard_decoder_builder.py",
+        "dual_profile_decoder_builder.py",
+        "dual_profile_decoder_tp_builder.py",
+    ],
+)
+def test_qwen_builders_keep_tensorrt_default_workspace_limit(builder_name):
+    family_dir = Path(__file__).parents[4] / "python/tensorrt_model_connect/families/qwen"
+    tree = ast.parse((family_dir / builder_name).read_text(encoding="utf-8"))
+    workspace_limit_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "set_memory_pool_limit"
+        and node.args
+        and isinstance(node.args[0], ast.Attribute)
+        and node.args[0].attr == "WORKSPACE"
+    ]
+
+    assert workspace_limit_calls == []
 
 
 def test_explicit_hf_head_dim_overrides_hidden_divided_by_heads():

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -315,15 +315,114 @@ def test_fp16_native_build_failure_does_not_fall_back(monkeypatch):
     assert not legacy_called
 
 
-def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):
+def test_qwen3_dynamic_kv_fails_before_legacy_builder(monkeypatch):
     pytest.importorskip("tensorrt")
     plugin_module = importlib.import_module(
         "tensorrt_model_connect.families.qwen.plugin"
     )
+    config = _small_config(role="decode")
+    config.raw["dynamic_kv_cache"] = True
+    legacy_called = False
 
+    def _unexpected_legacy(*_args, **_kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _unexpected_legacy,
+    )
+
+    with pytest.raises(ValueError, match="does not support dynamic KV cache"):
+        plugin_module.plugin.build_engine(
+            config,
+            _weights(config),
+            256,
+            precision="fp16",
+        )
+
+    assert not legacy_called
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+def test_qwen3_explicit_legacy_build_options_fail_closed(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
     config = _small_config(role="decode")
     config.raw["_native_kv_cache_metadata"] = {"stale": True}
-    quant_ctx = object()
+    legacy_called = False
+
+    def _unexpected_legacy(*_args, **_kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _unexpected_legacy,
+    )
+
+    with pytest.raises(ValueError, match="requires the fixed-capacity native KV path"):
+        plugin_module.plugin.build_engine(
+            config,
+            _weights(config),
+            128,
+            precision="fp16",
+            quant_ctx=object(),
+        )
+
+    assert not legacy_called
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+def test_qwen3_outside_native_architecture_contract_fails_closed(
+    monkeypatch,
+):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config()
+    config._head_dim = 64
+    legacy_called = False
+
+    def _unexpected_legacy(*_args, **_kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _unexpected_legacy,
+    )
+
+    assert not prefer_native_default(config)
+    assert plugin_module.plugin.default_build_precision(config) == "fp32"
+    assert plugin_module.plugin.default_max_cache_length(config) == 256
+    with pytest.raises(ValueError, match="requires the fixed-capacity native KV path"):
+        plugin_module.plugin.build_engine(
+            config,
+            _weights(config),
+            128,
+            precision="fp16",
+        )
+    assert not legacy_called
+
+
+def test_non_qwen3_variants_retain_the_legacy_builder(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config()
+    config.model_type = "qwen2"
+    config.architectures = ["Qwen2ForCausalLM"]
     captured: dict[str, object] = {}
 
     def _build(*args, **kwargs):
@@ -341,45 +440,8 @@ def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):
         _weights(config),
         128,
         precision="fp16",
-        quant_ctx=quant_ctx,
     )
 
     assert result == b"legacy-plan"
-    assert captured["args"][2] == 128
-    assert captured["kwargs"]["precision"] == "fp16"
-    assert captured["kwargs"]["quant_ctx"] is quant_ctx
-    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
-
-
-def test_plugin_falls_back_outside_the_native_architecture_contract(
-    monkeypatch,
-):
-    pytest.importorskip("tensorrt")
-    plugin_module = importlib.import_module(
-        "tensorrt_model_connect.families.qwen.plugin"
-    )
-    config = _small_config()
-    config._head_dim = 64
-    captured: dict[str, object] = {}
-
-    def _build(*args, **kwargs):
-        captured.update(args=args, kwargs=kwargs)
-        return b"legacy-plan"
-
-    monkeypatch.setattr(
-        plugin_module,
-        "build_standard_decoder_engine",
-        _build,
-    )
-
-    assert not prefer_native_default(config)
-    assert plugin_module.plugin.default_build_precision(config) == "fp32"
-    assert plugin_module.plugin.default_max_cache_length(config) == 256
-    assert plugin_module.plugin.build_engine(
-        config,
-        _weights(config),
-        128,
-        precision="fp16",
-    ) == b"legacy-plan"
     assert captured["args"][2] == 128
     assert captured["kwargs"]["precision"] == "fp16"

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -150,7 +150,7 @@ def test_architecture_variants_fail_closed(overrides, raw_updates, reason):
 @pytest.mark.parametrize(
     ("kwargs", "raw_updates", "reason"),
     [
-        ({"precision": "fp16"}, {}, "BF16"),
+        ({"precision": "fp32"}, {}, "FP16 or BF16"),
         ({"max_cache_length": 40959}, {}, "max_cache_length"),
         ({"parallel_enabled": True}, {}, "tensor parallel"),
         ({"dynamic_kv_cache": True}, {}, "fixed physical"),
@@ -240,7 +240,8 @@ def test_weight_contract_rejects_missing_shape_and_bias():
         validate_native_kv_weights(config, biased)
 
 
-def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
+@pytest.mark.parametrize("precision", ["fp16", "bf16"])
+def test_plugin_builds_the_requested_split_role_directly(monkeypatch, precision):
     pytest.importorskip("tensorrt")
     plugin_module = importlib.import_module(
         "tensorrt_model_connect.families.qwen.plugin"
@@ -263,16 +264,55 @@ def test_plugin_builds_the_requested_split_role_directly(monkeypatch):
         config,
         _weights(config),
         256,
-        precision="bf16",
+        precision=precision,
     )
 
     assert result == b"plan"
     assert captured["kwargs"]["profile_mode"] == "decode"
     assert captured["kwargs"]["native_kv_cache"] is True
+    assert captured["kwargs"]["precision"] == precision
     assert plugin_module.plugin.get_bundle_config_overrides(config) == {
         "native_kv_contract_version": 1,
         "native_kv_cache": True,
     }
+
+
+def test_fp16_native_build_failure_does_not_fall_back(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config(role="decode")
+    legacy_called = False
+
+    def _fail_native(*_args, **_kwargs):
+        raise RuntimeError("native FP16 build failed")
+
+    def _unexpected_legacy(*_args, **_kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_dual_profile_decoder_engine",
+        _fail_native,
+    )
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _unexpected_legacy,
+    )
+
+    with pytest.raises(RuntimeError, match="native FP16 build failed"):
+        plugin_module.plugin.build_engine(
+            config,
+            _weights(config),
+            256,
+            precision="fp16",
+        )
+
+    assert not legacy_called
 
 
 def test_plugin_falls_back_for_explicit_legacy_build_options(monkeypatch):

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -106,6 +106,18 @@ def test_route_uses_architecture_not_checkpoint_identity():
     assert prefer_native_default(config)
 
 
+def test_fixed_native_cache_can_be_smaller_than_model_context():
+    config = _config()
+    capability = native_kv_build_capability(
+        config,
+        max_cache_length=16384,
+    )
+    row_bytes, cache_bytes = native_kv_cache_geometry(config, 16384)
+
+    assert capability.eligible, capability.reason
+    assert cache_bytes == 16384 * row_bytes
+
+
 @pytest.mark.parametrize(
     "builder_name",
     [
@@ -178,7 +190,7 @@ def test_architecture_variants_fail_closed(overrides, raw_updates, reason):
     ("kwargs", "raw_updates", "reason"),
     [
         ({"precision": "fp32"}, {}, "FP16 or BF16"),
-        ({"max_cache_length": 40959}, {}, "max_cache_length"),
+        ({"max_cache_length": 40961}, {}, "max_cache_length"),
         ({"parallel_enabled": True}, {}, "tensor parallel"),
         ({"dynamic_kv_cache": True}, {}, "fixed physical"),
         ({"quantized": True}, {}, "quantized"),

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -69,13 +69,14 @@ The compatibility option `--max-cache-length N` remains accepted but is hidden
 from `build --help`. Omitting it lets the selected family choose the capacity:
 eligible dense Qwen3 and Llama builds use the checkpoint's full
 `max_position_embeddings`; other native or legacy paths normally use 256.
-For those Qwen3/Llama models, an explicit value preserves native KV only when it
-equals the full model context and the other native-KV constraints are also met.
-Qwen3 fails closed instead of falling back when those constraints are not met.
+For dense Qwen3, an explicit positive value up to the model context preserves
+the fixed-capacity native KV path; larger values and other unsupported build
+modes fail closed instead of falling back. Llama applies its own native-KV
+capacity policy.
 
 Eligible dense Qwen3 and Llama checkpoints declare a model-owned native default
 route. A model-only build skips the optimized-provider probe and selects BF16,
-full-context fixed KV, and split prefill/decode engines. Qwen3 has no legacy
+model-context fixed KV, and split prefill/decode engines. Qwen3 has no legacy
 fallback; unsupported Qwen3 build modes fail with the native-KV capability
 reason. Other families probe their exact qualified optimized profiles before
 falling back to their native builder.

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -41,7 +41,7 @@ replaces unsafe filename characters with `-`.
 | `--model-revision REV` | Build a Hugging Face commit, tag, or branch instead of its default revision. |
 | `--trust-remote-code` | Accepted for E2E-command compatibility. The current build dispatcher does not forward this flag as a universal remote-code gate; family/model loaders own their loading behavior. Review the checkpoint and family implementation, and do not assume omitting this flag prevents every remote-code path. |
 | `--decoder-engine-layout split|dual_profile` | Request separate prefill/decode engines or one multi-profile decoder engine. Unsupported split requests log a fallback; inspect `config.json.decoder_engine_layout` and bundle sections for the actual result. |
-| `--dynamic-kv-cache` | Enable runtime-resizable KV cache support. |
+| `--dynamic-kv-cache` | Enable runtime-resizable KV cache support for compatible families. Dense Qwen3 rejects this option and requires fixed-capacity native KV. |
 | `--tensor-parallel-size N`, `--tp-size N` | Build a supported decoder for TP size `1`, `2`, `4`, or `8`. |
 | `--context-parallel-size N`, `--cp-size N` | Build a supported context-parallel bundle for CP size `1`, `2`, `4`, or `8`. TP and CP requests are mutually exclusive. |
 | `--dynamic-kv-profile-rows A,B,C` | Override dynamic-KV optimization profiles. |
@@ -71,12 +71,14 @@ eligible dense Qwen3 and Llama builds use the checkpoint's full
 `max_position_embeddings`; other native or legacy paths normally use 256.
 For those Qwen3/Llama models, an explicit value preserves native KV only when it
 equals the full model context and the other native-KV constraints are also met.
+Qwen3 fails closed instead of falling back when those constraints are not met.
 
 Eligible dense Qwen3 and Llama checkpoints declare a model-owned native default
 route. A model-only build skips the optimized-provider probe and selects BF16,
-full-context fixed KV, and split prefill/decode engines. Other families probe
-their exact qualified optimized profiles before falling back to their native
-builder.
+full-context fixed KV, and split prefill/decode engines. Qwen3 has no legacy
+fallback; unsupported Qwen3 build modes fail with the native-KV capability
+reason. Other families probe their exact qualified optimized profiles before
+falling back to their native builder.
 
 TensorRT is the build backend; there is no public build-method selector. Older
 `--method trt` and `--method auto` spellings remain accepted for compatibility.

--- a/website/docs/api/python-builder.md
+++ b/website/docs/api/python-builder.md
@@ -85,7 +85,7 @@ API or CLI directly for other task-specific operations.
 | --- | --- |
 | `model_id_or_path` | Hugging Face repository ID or resolved local model directory. |
 | `output_path` | Destination `.bundle` bundle path. |
-| `max_cache_length` | Explicit KV cache length. Omitted/`None` lets the family choose: eligible dense Qwen3/Llama use `max_position_embeddings`, while other native or legacy paths normally use 256. Qwen3 rejects a non-full-context value instead of falling back; other families apply their own capability policy. |
+| `max_cache_length` | Explicit KV cache length. Omitted/`None` lets the family choose: eligible dense Qwen3/Llama use `max_position_embeddings`, while other native or legacy paths normally use 256. Dense Qwen3 accepts a positive fixed capacity up to its model context and rejects larger values instead of falling back; other families apply their own capability policy. |
 | `model_revision` | Hugging Face commit, tag, or branch to resolve. |
 | `decoder_engine_layout` | `split` or `dual_profile` for supported decoders. |
 | `dynamic_kv_cache` | Build compatible decoder bundles with runtime-resizable KV cache support. Dense Qwen3 rejects this option and requires fixed-capacity native KV. |

--- a/website/docs/api/python-builder.md
+++ b/website/docs/api/python-builder.md
@@ -85,10 +85,10 @@ API or CLI directly for other task-specific operations.
 | --- | --- |
 | `model_id_or_path` | Hugging Face repository ID or resolved local model directory. |
 | `output_path` | Destination `.bundle` bundle path. |
-| `max_cache_length` | Explicit KV cache length. Omitted/`None` lets the family choose: eligible dense Qwen3/Llama use `max_position_embeddings`, while other native or legacy paths normally use 256. A non-full-context value makes those Qwen3/Llama checkpoints ineligible for native KV. |
+| `max_cache_length` | Explicit KV cache length. Omitted/`None` lets the family choose: eligible dense Qwen3/Llama use `max_position_embeddings`, while other native or legacy paths normally use 256. Qwen3 rejects a non-full-context value instead of falling back; other families apply their own capability policy. |
 | `model_revision` | Hugging Face commit, tag, or branch to resolve. |
 | `decoder_engine_layout` | `split` or `dual_profile` for supported decoders. |
-| `dynamic_kv_cache` | Build decoder bundles with runtime-resizable KV cache support. |
+| `dynamic_kv_cache` | Build compatible decoder bundles with runtime-resizable KV cache support. Dense Qwen3 rejects this option and requires fixed-capacity native KV. |
 | `dynamic_kv_profile_rows_override` | Explicit dynamic-KV profile upper bounds. |
 | `precision` | Engine precision: `fp32`, `fp16`, or `bf16`. |
 | `fp32_layers` | Model-local layer indices that should compute in FP32. |

--- a/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
+++ b/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
@@ -123,8 +123,8 @@ Use `--save-fp8-scales` when you want to reuse calibrated scales across builds.
 ## Dynamic KV cache
 
 ```bash
-$TRTMC build Qwen/Qwen3-0.6B \
-  -o /tmp/qwen3-dynamic.bundle \
+$TRTMC build Qwen/Qwen2.5-0.5B-Instruct \
+  -o /tmp/qwen25-dynamic.bundle \
   --dynamic-kv-cache \
   --dynamic-kv-profile-rows 256,512,1024
 ```
@@ -132,7 +132,7 @@ $TRTMC build Qwen/Qwen3-0.6B \
 At runtime, override the cache memory budget with:
 
 ```bash
-$TRTMC run /tmp/qwen3-dynamic.bundle \
+$TRTMC run /tmp/qwen25-dynamic.bundle \
   --prompt "Summarize dynamic KV cache." \
   --kv-cache-size 512MB
 ```
@@ -143,11 +143,12 @@ budget into admitted decoder contexts and inference-state capacity. During a
 request, the pipeline reads the state's preferred row count and chooses a
 matching decoder context.
 
-For eligible dense Qwen3 and Llama, `--dynamic-kv-cache` deliberately opts out
-of the native full-context fixed-KV route and uses the compatible legacy
-builder. A native full-context bundle rejects runtime `--kv-cache-size`; its
-physical capacity is fixed to the model context and shared by prefill and
-decode.
+Dense Qwen3 supports only its native full-context fixed-KV route and rejects
+`--dynamic-kv-cache`; remove that option to build Qwen3. Eligible dense Llama
+checkpoints still opt out of native KV and use their compatible legacy builder
+when dynamic KV is requested. A native full-context bundle rejects runtime
+`--kv-cache-size`; its physical capacity is fixed to the model context and
+shared by prefill and decode.
 
 <Diagram
   src="/img/diagrams/tutorials/advanced/dynamic-kv-cache.svg"

--- a/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
+++ b/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
@@ -143,7 +143,7 @@ budget into admitted decoder contexts and inference-state capacity. During a
 request, the pipeline reads the state's preferred row count and chooses a
 matching decoder context.
 
-Dense Qwen3 supports only its native full-context fixed-KV route and rejects
+Dense Qwen3 supports only its native fixed-capacity KV route and rejects
 `--dynamic-kv-cache`; remove that option to build Qwen3. Eligible dense Llama
 checkpoints still opt out of native KV and use their compatible legacy builder
 when dynamic KV is requested. A native full-context bundle rejects runtime


### PR DESCRIPTION
## Background
Qwen3 previously fell back to the legacy decoder graph whenever a build request missed the native-KV contract. That made FP16, dynamic KV, and other unsupported modes enter a path that can fail with workspace or TensorRT Myelin errors. The Qwen builders also imposed a fixed 1 GiB workspace cap that excluded valid larger tactics. Related: #955.

## Exit Criteria
- Eligible dense Qwen3 FP16 and BF16 builds use the split fixed-capacity native-KV prefill/decode path.
- Qwen3 accepts any fixed `max_cache_length` in `[1, max_position_embeddings]`; omitting it still selects the model context.
- Every Qwen3 request outside the native contract fails closed; no Qwen3 build reaches the legacy builder.
- Qwen3 dynamic KV is rejected before checkpoint weight loading and produces no bundle.
- Qwen builders retain TensorRT device-sized default WORKSPACE instead of a fixed 1 GiB limit.
- Qwen, Qwen2, Qwen2.5, and other non-Qwen3 variants retain their existing legacy routes.

## Implementation
- Preserve explicit FP16 through Qwen3 native capability routing, fused IAttention scaling, and C++ runtime cache validation.
- Allow bounded fixed native KV capacities up to the model context instead of requiring full context.
- Add a family-owned build-request validation hook so Qwen3 rejects runtime-sized KV before weight loading.
- Remove the Qwen3 plugin fallback to standard or TP legacy builders and surface the exact native capability reason instead.
- Remove the explicit 1 GiB WORKSPACE override from standard, dual-profile, and TP Qwen builders so TensorRT uses its device-derived default.
- Keep the README Quick Start at the validated 16,384-token fixed native capacity.
- Keep shared legacy builders for older Qwen variants and update CLI, Python API, and Dynamic KV documentation boundaries.

## Validation
- `PYTHONPATH=python python -m pytest -q tests/builder/test_cli.py tests/builder/test_qwen_llama_native_kv_attention.py tests/e2e/models/qwen/test_qwen_native_kv_routing.py`: 83 passed on exact head `8fe09badd`.
- README command `trtmc build Qwen/Qwen3-0.6B --max-cache-length 16384 --output ...`: passed on GB300 with BF16 split prefill/decode engines; inspection reported `Max cache length: 16384` and `Runtime strategy: qwen_decoder_kv_cache`; inference produced `Paris`.
- Explicit FP16 Native KV also passed full build-and-run smoke on GB300.
- TensorRT 11.1.0.106 on GB300 reported default WORKSPACE `296889614336` bytes (276.5 GiB), above the issue tactic request `2598728448` bytes.
- Real Qwen3 command with `--precision fp16 --dynamic-kv-cache`: failed before weight loading with the actionable Dynamic KV error and created no bundle.
- `ruff check`, `git diff --check`, focused canonical documentation reference checks, model ownership validation, and test-impact validation: passed.
- Full-site `npm` build was not run because this isolated checkout has no `website/node_modules`.
- The whole-tree doc-reference scan remains blocked by unrelated base issues: missing `website/build/` and a stale manifest-count claim.

## Notes For Future Readers
- Qwen3 fixed capacity and Dynamic KV are separate contracts: bounded fixed capacities remain Native; runtime-resizable KV is rejected.
- This PR removes Qwen3 legacy fallback, not the shared legacy builders used by Qwen2 and Qwen2.5.
- Leaving WORKSPACE unset restores TensorRT default behavior; it does not preallocate the reported maximum, but permits larger tactics during build.
- SM120/SM121 runtime proof and full HF logits/token parity were not run. Current target-hardware evidence is GB300/SM103 build-and-run smoke.

