### PR TITLE
fix(stablelm): use FP32 LM-head accumulation

### DIFF
--- a/python/tensorrt_model_connect/families/stablelm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/stablelm/default_decoder.py
@@ -50,6 +50,63 @@ def _mark_debug_output(
     network.mark_output(out)
 
 
+def _use_fp32_lm_head_accumulation(
+    precision: str, num_layers: int, fp32_layers: frozenset[int]
+) -> bool:
+    """Return whether an FP16 decode tail needs a stable FP32 head reduction."""
+    return (
+        precision == "fp16"
+        and num_layers > 0
+        and num_layers - 1 in fp32_layers
+    )
+
+
+def _add_lm_head(
+    network: trt.INetworkDefinition,
+    hidden_state: trt.ITensor,
+    weights: WeightDict,
+    *,
+    hidden_size: int,
+    out_vocab: int,
+    work_np_dtype: np.dtype,
+    work_trt_dtype,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Build the LM head while preserving the model's output precision.
+
+    A decode-only FP32 boundary can also stabilize the large vocabulary
+    projection's accumulation order. First round the input weights to the
+    requested model dtype, expand those rounded operands for FP32 accumulation,
+    then explicitly round the result back before exposing FP32 logits.
+    """
+    head_np_dtype = np.float32 if fp32_accumulation else work_np_dtype
+    head_trt_dtype = trt.float32 if fp32_accumulation else work_trt_dtype
+    head_input = hidden_state
+    if head_input.dtype != head_trt_dtype:
+        head_input = network.add_cast(head_input, head_trt_dtype).get_output(0)
+
+    head_weights = weights["w_out"]
+    if fp32_accumulation:
+        head_weights = np.asarray(head_weights, dtype=work_np_dtype).astype(
+            np.float32)
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, head_input, hidden_size, out_vocab, head_weights,
+        dtype=head_np_dtype)
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is None:
+        lm_bias = np.zeros(out_vocab, dtype=work_np_dtype)
+    if fp32_accumulation:
+        lm_bias = np.asarray(lm_bias, dtype=work_np_dtype).astype(np.float32)
+    logits = graph_ops.add_bias_sum(
+        network, logits, out_vocab, lm_bias, dtype=head_np_dtype)
+
+    if logits.dtype != work_trt_dtype:
+        logits = network.add_cast(logits, work_trt_dtype).get_output(0)
+    if logits.dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    return logits
+
+
 def build_standard_decoder_engine(
     config: ModelConfig,
     weights: WeightDict,
@@ -517,23 +574,13 @@ def build_standard_decoder_engine(
     # Output vocab may differ from input vocab (e.g. Bark semantic: 129600 in, 10048 out).
     # Derive from w_out shape if available.
     out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
-    logits = graph_ops.add_matmul_rhs_constant(
-        network, hidden_state, hidden, out_vocab, weights["w_out"],
-        dtype=work_np_dtype)
-    # LM head bias (if present, e.g. CodeGen) or zero bias for C++ parity
-    lm_bias = weights.get("lm_head_bias")
-    if lm_bias is not None:
-        logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias,
-                                        dtype=work_np_dtype)
-    else:
-        b_out = np.zeros(out_vocab, dtype=work_np_dtype)
-        logits = graph_ops.add_bias_sum(network, logits, out_vocab, b_out,
-                                        dtype=work_np_dtype)
-
-    # Logits output: always FP32 for accurate argmax/sampling
-    if work_trt_dtype != trt.float32:
-        logits_cast = network.add_cast(logits, trt.float32)
-        logits = logits_cast.get_output(0)
+    logits = _add_lm_head(
+        network, hidden_state, weights,
+        hidden_size=hidden, out_vocab=out_vocab,
+        work_np_dtype=work_np_dtype, work_trt_dtype=work_trt_dtype,
+        fp32_accumulation=_use_fp32_lm_head_accumulation(
+            precision, num_layers, fp32_layers),
+    )
     logits.name = "logits"
     network.mark_output(logits)
 

--- a/tests/e2e/models/stablelm/test_stablelm_precision_contract.py
+++ b/tests/e2e/models/stablelm/test_stablelm_precision_contract.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib
 
+import numpy as np
 import pytest
 
 
@@ -117,6 +118,122 @@ def test_fp16_prefill_keeps_the_dynamic_graph_homogeneous(monkeypatch) -> None:
     )
 
     assert captured["fp32_attention_accumulation"] is False
+
+
+@pytest.mark.parametrize(
+    ("precision", "fp32_layers", "expected"),
+    (
+        ("fp16", frozenset({1}), True),
+        ("fp16", frozenset({0}), False),
+        ("fp16", frozenset(), False),
+        ("bf16", frozenset({1}), False),
+        ("fp32", frozenset({1}), False),
+    ),
+)
+def test_only_fp16_terminal_precision_boundary_stabilizes_the_lm_head(
+    precision: str, fp32_layers: frozenset[int], expected: bool,
+) -> None:
+    builder_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.default_decoder"
+    )
+
+    assert builder_module._use_fp32_lm_head_accumulation(
+        precision, num_layers=2, fp32_layers=fp32_layers
+    ) is expected
+
+
+@pytest.mark.parametrize(
+    ("fp32_accumulation", "expected_matmul_dtype", "expected_casts"),
+    (
+        (False, np.float16, 1),
+        (True, np.float32, 3),
+    ),
+)
+def test_decode_lm_head_stabilizes_accumulation_without_changing_output_precision(
+    monkeypatch,
+    fp32_accumulation: bool,
+    expected_matmul_dtype,
+    expected_casts: int,
+) -> None:
+    builder_module = importlib.import_module(
+        "tensorrt_model_connect.families.stablelm.default_decoder"
+    )
+    trt = builder_module.trt
+
+    class FakeTensor:
+        def __init__(self, dtype) -> None:
+            self.dtype = dtype
+
+    class FakeCast:
+        def __init__(self, tensor: FakeTensor) -> None:
+            self.tensor = tensor
+
+        def get_output(self, index: int) -> FakeTensor:
+            assert index == 0
+            return self.tensor
+
+    class FakeNetwork:
+        def __init__(self) -> None:
+            self.casts: list[tuple[object, object]] = []
+
+        def add_cast(self, tensor: FakeTensor, dtype) -> FakeCast:
+            self.casts.append((tensor.dtype, dtype))
+            return FakeCast(FakeTensor(dtype))
+
+    captured: dict[str, object] = {}
+
+    def fake_matmul(network, lhs, lhs_width, rhs_width, rhs_weights, *, dtype):
+        del network, lhs_width, rhs_width
+        captured["matmul_input_dtype"] = lhs.dtype
+        captured["matmul_dtype"] = dtype
+        captured["matmul_weights"] = rhs_weights.copy()
+        return FakeTensor(lhs.dtype)
+
+    def fake_bias(network, inp, width, bias, *, dtype):
+        del network, width, bias
+        captured["bias_input_dtype"] = inp.dtype
+        captured["bias_dtype"] = dtype
+        return FakeTensor(inp.dtype)
+
+    monkeypatch.setattr(
+        builder_module.graph_ops, "add_matmul_rhs_constant", fake_matmul)
+    monkeypatch.setattr(builder_module.graph_ops, "add_bias_sum", fake_bias)
+
+    network = FakeNetwork()
+    source_weights = np.linspace(0.1, 3.2, 32, dtype=np.float32).reshape(4, 8)
+    output = builder_module._add_lm_head(
+        network,
+        FakeTensor(trt.float16),
+        WeightDict(w_out=source_weights),
+        hidden_size=4,
+        out_vocab=8,
+        work_np_dtype=np.float16,
+        work_trt_dtype=trt.float16,
+        fp32_accumulation=fp32_accumulation,
+    )
+
+    expected_compute_dtype = trt.float32 if fp32_accumulation else trt.float16
+    assert captured["matmul_input_dtype"] == expected_compute_dtype
+    assert captured["matmul_dtype"] == expected_matmul_dtype
+    assert captured["bias_input_dtype"] == expected_compute_dtype
+    assert captured["bias_dtype"] == expected_matmul_dtype
+    expected_weights = (
+        source_weights.astype(np.float16).astype(np.float32)
+        if fp32_accumulation
+        else source_weights
+    )
+    np.testing.assert_array_equal(captured["matmul_weights"], expected_weights)
+    assert network.casts == (
+        [
+            (trt.float16, trt.float32),
+            (trt.float32, trt.float16),
+            (trt.float16, trt.float32),
+        ]
+        if fp32_accumulation
+        else [(trt.float16, trt.float32)]
+    )
+    assert len(network.casts) == expected_casts
+    assert output.dtype == trt.float32
 
 
 def test_prefill_ignores_decode_only_fp32_layers(monkeypatch) -> None:


### PR DESCRIPTION
## Background

The StableLM continuation-parity fix in #938 promotes decode attention and the final decoder block, but the LM-head projection still accumulates in FP16. Different valid TensorRT projection tactics can therefore perturb near-tied FP16 logits even when the source, model revision, and build arguments are unchanged.

This change adds a stronger decode-only accumulation boundary without relaxing StableLM's exact generated-token gate.

## Exit Criteria

- Preserve FP16 operand values and the explicit FP16 logits boundary.
- Keep the existing strict continuation-parity criterion unchanged.
- Leave prefill, BF16, FP32, nonterminal precision boundaries, and tensor-parallel builds unchanged.
- Produce exact generated tokens across repeated fresh engine builds without an unacceptable build, load, or decode regression.

## Implementation

- Round LM-head weights and bias to the requested FP16 model dtype before expanding them for FP32 computation.
- Accumulate the decode LM-head projection in FP32 only when the terminal decoder layer is already an explicit FP32 boundary.
- Round the projection result back to FP16 before exposing the existing FP32 logits output.
- Add focused coverage for routing, operand rounding, and the exact cast sequence.

## Validation

- `PYTHONPATH=python:. python -m pytest tests/e2e/models/stablelm/test_stablelm_precision_contract.py -q`: 16 passed in a TensorRT 11.2 no-GPU environment.
- `ruff check python/tensorrt_model_connect/families/stablelm/default_decoder.py tests/e2e/models/stablelm/test_stablelm_precision_contract.py`: passed.
- `git diff --check`: passed.
- Exact-head `trtmc/premerge/required`: passed on `baa21fe77dc97f79cd26209b5a4a176e6d112ae9` after rebasing onto current `main`.
- Four independent fresh GB300 builds of the same code patch—three before the README-only rebase and one on the current exact head—produced 22/22 exact generated tokens with NED 0. The plans were independently rebuilt rather than reused.
- Decode engine execution across the four builds was 36.84-38.07 ms for 23 launches, compared with 36.82 ms for the FP16-head control.
- Plan-size tradeoff: the decode plan grows by about 411 MB (12.1%), increasing the complete bundle by about 6.1%. This is the explicit cost of stabilizing the large-vocabulary reduction.

## Notes For Future Readers

- Review the LM-head dtype boundary in `default_decoder.py` first, then the focused contract tests.
- Prefill and runtime tensor ABIs are unchanged; tensor-parallel builds retain their existing builder path.
- Thor/TensorRT 11.0 performance was not rerun in this PR. Reviewers should treat the measured plan-size increase as an explicit product tradeoff when deciding whether to merge.
- Related: #890 and #938.
