### PR TITLE
docs(readme): show Qwen cache length

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 💻 Example Code
 
 ```bash
-trtmc build Qwen/Qwen3-0.6B -o qwen3-0.6b.bundle
+trtmc build Qwen/Qwen3-0.6B --max-cache-length 16384 --output qwen3-0.6b.bundle
 trtmc run ./qwen3-0.6b.bundle --prompt "What is the capital of France? Answer in one word." --chat-template --no-thinking
 # Generated text: Paris
 ```


### PR DESCRIPTION
## Background
The README example hides the cache profile used by the documented Qwen3-0.6B flow.

## Exit Criteria
- Show the 16,384-token cache length in the one-line example build command.
- Keep precision implicit because dense Qwen3 already selects BF16 by default.

## Implementation
- Keep the build command on one line.
- Add `--max-cache-length 16384` and use the long-form `--output` option.

## Validation
- `git diff --check github/main...HEAD`: passed.
- Full engine build: not run because this is a documentation-only command-format change.

## Notes For Future Readers
- Keep the precision flag omitted unless the Qwen family default changes.