### PR TITLE
fix(builders): remove fixed 1 GiB workspace caps

### DIFF
--- a/python/tensorrt_model_connect/families/albert/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/albert/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/albert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/albert/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/bark/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bark/decoder_tp_builder.py
@@ -316,7 +316,6 @@ def build_bark_tp_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/bark/default_decoder.py
+++ b/python/tensorrt_model_connect/families/bark/default_decoder.py
@@ -142,7 +142,7 @@ def build_standard_decoder_engine(
         dynamic_kv_profile_rows.sort()
     else:
         dynamic_kv_profile_rows = []
-    builder_context = create_builder_context(verbose=verbose, workspace_bytes=1 << 30)
+    builder_context = create_builder_context(verbose=verbose)
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/bark/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/bark/default_dual_profile_decoder.py
@@ -188,7 +188,7 @@ def build_dual_profile_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim
     )
     int(head_dim * partial_rotary_factor)
-    builder_context = create_builder_context(verbose=verbose, workspace_bytes=1 << 30)
+    builder_context = create_builder_context(verbose=verbose)
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/bark/plugin.py
+++ b/python/tensorrt_model_connect/families/bark/plugin.py
@@ -782,7 +782,6 @@ def _build_bark_fine_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Input: pre-computed summed embeddings [seq_length, hidden_size]
     # C++ runtime sums the 8 codebook embeddings + position embedding and

--- a/python/tensorrt_model_connect/families/bark/utils.py
+++ b/python/tensorrt_model_connect/families/bark/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bart/decoder_tp_builder.py
@@ -311,7 +311,6 @@ def build_bart_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     token_id = network.add_input("token_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/bart/plugin.py
+++ b/python/tensorrt_model_connect/families/bart/plugin.py
@@ -210,7 +210,6 @@ class BartPlugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         token_id = network.add_input("token_id", trt.int32, (1,))
@@ -387,7 +386,6 @@ def _build_bart_encoder(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     tc.clear_flag(trt.BuilderFlag.TF32)
 
     input_ids = network.add_input("input_ids", trt.int32, (max_enc_seq,))

--- a/python/tensorrt_model_connect/families/bert/model.py
+++ b/python/tensorrt_model_connect/families/bert/model.py
@@ -469,7 +469,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
@@ -338,7 +338,6 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/dual_profile_decoder_tp_builder.py
@@ -303,7 +303,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
@@ -185,7 +185,6 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/canary/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/canary/decoder_tp_builder.py
@@ -374,7 +374,6 @@ def build_canary_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -1233,7 +1233,6 @@ class CanaryPlugin:
         b = trt.Builder(log)
         net = b.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         tc = b.create_builder_config()
-        tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         tid = net.add_input("token_id", trt.int32, (-1,))
         pid = net.add_input("position_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/codegen/default_decoder.py
+++ b/python/tensorrt_model_connect/families/codegen/default_decoder.py
@@ -188,7 +188,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/codegen/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/codegen/default_dual_profile_decoder.py
@@ -232,7 +232,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/codegen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/codegen/dual_profile_decoder_tp_builder.py
@@ -303,7 +303,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/codegen/utils.py
+++ b/python/tensorrt_model_connect/families/codegen/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/convbert/builder.py
+++ b/python/tensorrt_model_connect/families/convbert/builder.py
@@ -68,7 +68,6 @@ def build_convbert_encoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     S = max_seq_length  # alias for brevity

--- a/python/tensorrt_model_connect/families/convbert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/convbert/tp_builder.py
@@ -193,7 +193,6 @@ def build_tp_convbert_encoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     S = max_seq_length  # alias for brevity

--- a/python/tensorrt_model_connect/families/deberta/model/parallel.py
+++ b/python/tensorrt_model_connect/families/deberta/model/parallel.py
@@ -313,7 +313,6 @@ def build_tp_deberta_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))

--- a/python/tensorrt_model_connect/families/deberta/plugin.py
+++ b/python/tensorrt_model_connect/families/deberta/plugin.py
@@ -252,7 +252,6 @@ def _build_deberta_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))

--- a/python/tensorrt_model_connect/families/deepseek_ocr/default_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/default_decoder.py
@@ -184,7 +184,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/deepseek_ocr/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/default_dual_profile_decoder.py
@@ -230,7 +230,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -370,7 +370,6 @@ class DeepSeekOCRPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # -----------------------------------------------------------
         # Inputs

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -383,7 +383,6 @@ def build_deepseek_ocr_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     multi_device_preview = getattr(
         trt.PreviewFeature, "MULTIDEVICE_RUNTIME_10_16", None)
     if multi_device_preview is not None:

--- a/python/tensorrt_model_connect/families/deepseek_ocr/utils.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/deepseek_v2/default_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/deepseek_v2/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
@@ -405,7 +405,6 @@ class DeepSeekV2Plugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         if precision == "fp16":
             work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/deepseek_v2/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/tp_builder.py
@@ -566,7 +566,6 @@ def build_deepseek_v2_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/deepseek_v2/utils.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/distilbert/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/distilbert/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/distilbert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/distilbert/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/dpr/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/dpr/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/dpr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/dpr/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -358,7 +358,6 @@ def _build_eagle_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     # input_ids: [seq_length] token IDs (padded to max length)
@@ -677,7 +676,6 @@ def _build_siglip_vision_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Input: pixel_values [3, image_size, image_size]
     pixel_values = network.add_input(

--- a/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
@@ -83,7 +83,6 @@ def build_eagle_vlm_tp_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     input_ids = network.add_input("input_ids", trt.int32, (seq_length,))
     attention_mask_input = network.add_input("attention_mask", trt.int32, (seq_length,))

--- a/python/tensorrt_model_connect/families/electra/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/electra/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/electra/tp_builder.py
+++ b/python/tensorrt_model_connect/families/electra/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/elf_flow/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/elf_flow/t5_encoder_builder.py
@@ -75,7 +75,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     config.clear_flag(trt.BuilderFlag.TF32)
 
     # --- Inputs ---

--- a/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
@@ -296,7 +296,6 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     import os as _os_pv
     if _os_pv.environ.get("TRTMC_TRT_DETAILED_VERBOSITY") == "1":
         trt_config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED

--- a/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/falcon/dual_profile_decoder_tp_builder.py
@@ -304,7 +304,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/falcon/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/falcon/standard_decoder_builder.py
@@ -184,7 +184,6 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     import os as _os_pv
     if _os_pv.environ.get("TRTMC_TRT_DETAILED_VERBOSITY") == "1":
         trt_config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED

--- a/python/tensorrt_model_connect/families/flux/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/flux/t5_encoder_builder.py
@@ -103,7 +103,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     input_ids = network.add_input(
@@ -311,7 +310,6 @@ def _build_t5_encoder_engine_batched(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs (dynamic leading batch dim) ---
     input_ids = network.add_input("input_ids", trt.int32, (-1, max_seq_len))

--- a/python/tensorrt_model_connect/families/fnet/fnet_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/fnet/fnet_encoder_builder.py
@@ -79,7 +79,6 @@ def build_fnet_encoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     S = max_seq_length

--- a/python/tensorrt_model_connect/families/fnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/fnet/tp_builder.py
@@ -151,7 +151,6 @@ def build_tp_fnet_encoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     S = max_seq_length

--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
@@ -294,7 +294,6 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
@@ -307,7 +307,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
@@ -179,7 +179,6 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/glm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/glm/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/glm/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/glm/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/glm/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/glm/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/glm/utils.py
+++ b/python/tensorrt_model_connect/families/glm/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/gpt2/default_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt2/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt2/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt2/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt2/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/gpt2/default_dual_profile_decoder_tp.py
@@ -239,7 +239,6 @@ def build_dual_profile_tp_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt2/utils.py
+++ b/python/tensorrt_model_connect/families/gpt2/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/gpt_neo/default_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_decoder.py
@@ -183,7 +183,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder.py
@@ -232,7 +232,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/default_dual_profile_decoder_tp.py
@@ -242,7 +242,6 @@ def build_dual_profile_tp_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neo/utils.py
+++ b/python/tensorrt_model_connect/families/gpt_neo/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/gpt_neox/default_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neox/default_decoder.py
@@ -190,7 +190,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neox/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_neox/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neox/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/gpt_neox/default_dual_profile_decoder_tp.py
@@ -239,7 +239,6 @@ def build_dual_profile_tp_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_neox/utils.py
+++ b/python/tensorrt_model_connect/families/gpt_neox/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/gpt_oss/default_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_oss/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/gpt_oss/plugin.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/plugin.py
@@ -263,8 +263,6 @@ class GptOssPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(
-            trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         if precision == "fp16":
             work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/gpt_oss/tp_builder.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/tp_builder.py
@@ -533,7 +533,6 @@ def build_gpt_oss_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/gpt_oss/utils.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/utils.py
@@ -82,7 +82,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -94,7 +94,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/granite/default_decoder.py
+++ b/python/tensorrt_model_connect/families/granite/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/granite/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/granite/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/granite/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/granite/dual_profile_decoder_tp_builder.py
@@ -306,7 +306,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/granite/utils.py
+++ b/python/tensorrt_model_connect/families/granite/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/internlm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/internlm/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/internlm/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/internlm/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/internlm/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/internlm/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/internlm/utils.py
+++ b/python/tensorrt_model_connect/families/internlm/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/internvl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/internvl/default_decoder.py
@@ -184,7 +184,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/internvl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/internvl/default_dual_profile_decoder.py
@@ -230,7 +230,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/internvl/tp_builder.py
+++ b/python/tensorrt_model_connect/families/internvl/tp_builder.py
@@ -307,7 +307,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     multi_device_preview = getattr(
         trt.PreviewFeature, "MULTIDEVICE_RUNTIME_10_16", None)
     if multi_device_preview is not None:

--- a/python/tensorrt_model_connect/families/internvl/utils.py
+++ b/python/tensorrt_model_connect/families/internvl/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/lance/default_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_decoder.py
@@ -193,7 +193,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
@@ -248,7 +248,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/lance/utils.py
+++ b/python/tensorrt_model_connect/families/lance/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -337,13 +337,14 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    # Full-context Llama prefill can require a large fused-attention tactic
-    # workspace while TensorRT is building the plan. This is build-time
+    # Native full-context Llama prefill can require a large fused-attention
+    # tactic workspace while TensorRT is building the plan. This is build-time
     # scratch only (it is not serialized as runtime KV memory), and the limit
-    # does not allocate the bytes eagerly.
-    workspace_bytes = 16 << 30 if native_kv_cache else 1 << 30
-    trt_config.set_memory_pool_limit(
-        trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    # does not allocate the bytes eagerly. Other paths keep TensorRT's device
+    # default instead of imposing the former 1 GiB cap.
+    if native_kv_cache:
+        trt_config.set_memory_pool_limit(
+            trt.MemoryPoolType.WORKSPACE, 16 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
@@ -203,7 +203,6 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/locateanything/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/locateanything/decoder_tp_builder.py
@@ -113,7 +113,6 @@ def build_qwen_vl_tp_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/locateanything/default_decoder.py
+++ b/python/tensorrt_model_connect/families/locateanything/default_decoder.py
@@ -184,7 +184,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/locateanything/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/locateanything/default_dual_profile_decoder.py
@@ -230,7 +230,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/locateanything/onnx_vision_builder.py
+++ b/python/tensorrt_model_connect/families/locateanything/onnx_vision_builder.py
@@ -55,7 +55,6 @@ def build_engine_from_onnx(
             "ONNX parsing failed:\n" + "\n".join(errors))
 
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if verbose:
         print(f"[trtmc build] Building vision TRT engine from ONNX "

--- a/python/tensorrt_model_connect/families/locateanything/utils.py
+++ b/python/tensorrt_model_connect/families/locateanything/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/ltx_video/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/ltx_video/t5_encoder_builder.py
@@ -92,7 +92,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     input_ids = network.add_input(

--- a/python/tensorrt_model_connect/families/m2m_100/plugin.py
+++ b/python/tensorrt_model_connect/families/m2m_100/plugin.py
@@ -289,7 +289,6 @@ class M2M100Plugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         token_id = network.add_input("token_id", trt.int32, (1,))
@@ -520,7 +519,6 @@ def _build_m2m100_encoder(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     tc.clear_flag(trt.BuilderFlag.TF32)
 
     # Input: token IDs [max_source_length]

--- a/python/tensorrt_model_connect/families/magpie_tts/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/magpie_tts/decoder_tp_builder.py
@@ -159,7 +159,6 @@ def build_magpie_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     input_embed = network.add_input("input_embed", trt.float32, (-1, hidden))

--- a/python/tensorrt_model_connect/families/magpie_tts/plugin.py
+++ b/python/tensorrt_model_connect/families/magpie_tts/plugin.py
@@ -768,7 +768,6 @@ class MagpieTTSPlugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         # Dynamic inputs: seq_len varies from 1 (decode) to ctx_len (prefill)
@@ -1180,7 +1179,6 @@ def _build_magpie_encoder(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     tc.clear_flag(trt.BuilderFlag.TF32)
 
     eps_tensor = graph_ops.add_constant(

--- a/python/tensorrt_model_connect/families/mamba/plugin.py
+++ b/python/tensorrt_model_connect/families/mamba/plugin.py
@@ -236,7 +236,6 @@ class MambaPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # -----------------------------------------------------------
         # Inputs

--- a/python/tensorrt_model_connect/families/mamba/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mamba/tp_builder.py
@@ -266,7 +266,6 @@ def build_mamba_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     conv_state_inputs = []

--- a/python/tensorrt_model_connect/families/marian/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/marian/decoder_tp_builder.py
@@ -309,7 +309,6 @@ def build_marian_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     token_id = network.add_input("token_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/marian/plugin.py
+++ b/python/tensorrt_model_connect/families/marian/plugin.py
@@ -183,7 +183,6 @@ class MarianPlugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         token_id = network.add_input("token_id", trt.int32, (1,))
@@ -350,7 +349,6 @@ def _build_marian_encoder(config, weights, *, verbose=False, precision="fp32"):
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     tc.clear_flag(trt.BuilderFlag.TF32)
 
     input_ids = network.add_input("input_ids", trt.int32, (max_pos,))

--- a/python/tensorrt_model_connect/families/mistral/default_decoder.py
+++ b/python/tensorrt_model_connect/families/mistral/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/mistral/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/mistral/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/mistral/utils.py
+++ b/python/tensorrt_model_connect/families/mistral/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/mixtral/default_decoder.py
+++ b/python/tensorrt_model_connect/families/mixtral/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/mixtral/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/mixtral/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/mixtral/plugin.py
+++ b/python/tensorrt_model_connect/families/mixtral/plugin.py
@@ -203,7 +203,6 @@ class MixtralPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         if precision == "fp16":
             work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/mixtral/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mixtral/tp_builder.py
@@ -300,7 +300,6 @@ def build_mixtral_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/mixtral/utils.py
+++ b/python/tensorrt_model_connect/families/mixtral/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/modernbert/model/parallel.py
+++ b/python/tensorrt_model_connect/families/modernbert/model/parallel.py
@@ -138,7 +138,6 @@ def build_tp_modernbert_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     input_ids = network.add_input("input_ids", trt.int32, (max_seq,))

--- a/python/tensorrt_model_connect/families/modernbert/plugin.py
+++ b/python/tensorrt_model_connect/families/modernbert/plugin.py
@@ -188,7 +188,6 @@ class ModernbertPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         # Inputs

--- a/python/tensorrt_model_connect/families/mpnet/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/mpnet/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/mpnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mpnet/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/nemotron/default_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron/default_decoder.py
@@ -150,7 +150,7 @@ def build_standard_decoder_engine(
         dynamic_kv_profile_rows.sort()
     else:
         dynamic_kv_profile_rows = []
-    builder_context = create_builder_context(verbose=verbose, workspace_bytes=1 << 30)
+    builder_context = create_builder_context(verbose=verbose)
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/nemotron/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron/default_dual_profile_decoder.py
@@ -187,7 +187,7 @@ def build_dual_profile_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim
     )
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
-    builder_context = create_builder_context(verbose=verbose, workspace_bytes=1 << 30)
+    builder_context = create_builder_context(verbose=verbose)
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/nemotron/utils.py
+++ b/python/tensorrt_model_connect/families/nemotron/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/nemotron_h/plugin.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/plugin.py
@@ -317,7 +317,6 @@ class NemotronHPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # --- Inputs ---
         token_id = network.add_input("token_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
@@ -488,7 +488,6 @@ def build_nemotron_h_tp_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/nemotron_labs_diffusion/default_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron_labs_diffusion/default_decoder.py
@@ -184,7 +184,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/nemotron_labs_diffusion/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron_labs_diffusion/default_dual_profile_decoder.py
@@ -230,7 +230,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/nemotron_labs_diffusion/utils.py
+++ b/python/tensorrt_model_connect/families/nemotron_labs_diffusion/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/olmo/default_decoder.py
+++ b/python/tensorrt_model_connect/families/olmo/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/olmo/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/olmo/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/olmo/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/olmo/dual_profile_decoder_tp_builder.py
@@ -306,7 +306,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/olmo/utils.py
+++ b/python/tensorrt_model_connect/families/olmo/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/olmo2/plugin.py
+++ b/python/tensorrt_model_connect/families/olmo2/plugin.py
@@ -204,7 +204,6 @@ class Olmo2Plugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         # Inputs

--- a/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
+++ b/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
@@ -68,7 +68,6 @@ def build_olmo2_prefill_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     token_id = network.add_input("token_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/olmo2/tp_builder.py
+++ b/python/tensorrt_model_connect/families/olmo2/tp_builder.py
@@ -124,7 +124,6 @@ def build_olmo2_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     # Inputs

--- a/python/tensorrt_model_connect/families/opt/default_decoder.py
+++ b/python/tensorrt_model_connect/families/opt/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/opt/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/opt/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/opt/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/opt/default_dual_profile_decoder_tp.py
@@ -239,7 +239,6 @@ def build_dual_profile_tp_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/opt/utils.py
+++ b/python/tensorrt_model_connect/families/opt/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/personaplex/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/personaplex/decoder_tp_builder.py
@@ -64,7 +64,7 @@ def _apply_norm(
         dtype=dtype, eps=eps)
 
 
-@with_builder_context(workspace_bytes=1 << 30)
+@with_builder_context()
 def build_personaplex_tp_decoder_engine(
     config: "ModelConfig",
     weights: "WeightDict",

--- a/python/tensorrt_model_connect/families/personaplex/default_decoder.py
+++ b/python/tensorrt_model_connect/families/personaplex/default_decoder.py
@@ -55,7 +55,6 @@ def _mark_debug_output(
 
 
 @with_builder_context(
-    workspace_bytes=1 << 30,
     disable_tf32=True,
     builder_optimization_level=1,
     max_num_tactics=1,

--- a/python/tensorrt_model_connect/families/personaplex/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/personaplex/default_dual_profile_decoder.py
@@ -145,7 +145,7 @@ def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
 # ---------------------------------------------------------------------------
 
 
-@with_builder_context(workspace_bytes=1 << 30)
+@with_builder_context()
 def build_dual_profile_decoder_engine(
     config: "ModelConfig",
     weights: "WeightDict",

--- a/python/tensorrt_model_connect/families/personaplex/default_dual_profile_decoder_tp.py
+++ b/python/tensorrt_model_connect/families/personaplex/default_dual_profile_decoder_tp.py
@@ -156,7 +156,7 @@ def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
 # ---------------------------------------------------------------------------
 
 
-@with_builder_context(workspace_bytes=1 << 30)
+@with_builder_context()
 def build_dual_profile_tp_decoder_engine(
     config: "ModelConfig",
     weights: "WeightDict",

--- a/python/tensorrt_model_connect/families/personaplex/mimi_streaming_encoder.py
+++ b/python/tensorrt_model_connect/families/personaplex/mimi_streaming_encoder.py
@@ -313,7 +313,6 @@ def _add_mimi_streaming_transformer_layer(
 
 
 @with_builder_context(
-    workspace_bytes=1 << 30,
     explicit_batch=True,
     disable_tf32=True,
     builder_optimization_level=0,

--- a/python/tensorrt_model_connect/families/personaplex/utils.py
+++ b/python/tensorrt_model_connect/families/personaplex/utils.py
@@ -63,7 +63,7 @@ BuilderContextFactory = Callable[[], BuilderContext]
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     explicit_batch: bool = False,
     disable_tf32: bool = False,
@@ -85,8 +85,9 @@ def create_builder_context(
         )
         context.network = context.builder.create_network(flags)
         context.config = context.builder.create_builder_config()
-        context.config.set_memory_pool_limit(
-            trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+        if workspace_bytes is not None:
+            context.config.set_memory_pool_limit(
+                trt.MemoryPoolType.WORKSPACE, workspace_bytes)
         if disable_tf32:
             context.config.clear_flag(trt.BuilderFlag.TF32)
         if builder_optimization_level is not None:
@@ -101,7 +102,7 @@ def create_builder_context(
 
 def with_builder_context(
     *,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     explicit_batch: bool = False,
     disable_tf32: bool = False,

--- a/python/tensorrt_model_connect/families/phi/default_decoder.py
+++ b/python/tensorrt_model_connect/families/phi/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/phi/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/phi/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/phi/utils.py
+++ b/python/tensorrt_model_connect/families/phi/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/phi4_multimodal/default_decoder.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/default_decoder.py
@@ -195,7 +195,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi4_multimodal/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/default_dual_profile_decoder.py
@@ -230,7 +230,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi4_multimodal/utils.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/phi_moe/default_decoder.py
+++ b/python/tensorrt_model_connect/families/phi_moe/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi_moe/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/phi_moe/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/phi_moe/plugin.py
+++ b/python/tensorrt_model_connect/families/phi_moe/plugin.py
@@ -250,7 +250,6 @@ class PhiMoEPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # -----------------------------------------------------------
         # Inputs

--- a/python/tensorrt_model_connect/families/phi_moe/tp_builder.py
+++ b/python/tensorrt_model_connect/families/phi_moe/tp_builder.py
@@ -389,7 +389,6 @@ def build_phi_moe_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/phi_moe/utils.py
+++ b/python/tensorrt_model_connect/families/phi_moe/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/pixart/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/pixart/t5_encoder_builder.py
@@ -83,7 +83,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     input_ids = network.add_input(

--- a/python/tensorrt_model_connect/families/qwen3_5/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_5/plugin.py
@@ -463,7 +463,6 @@ class Qwen35Plugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # --- Inputs ---
         token_id = network.add_input("token_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/qwen3_omni/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen3_omni/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -569,7 +569,6 @@ class Qwen3OmniPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         if precision == "fp16":
             work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/qwen3_omni/utils.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/qwen_moe/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen_moe/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/qwen_moe/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/plugin.py
@@ -328,7 +328,6 @@ class Qwen3MoePlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         if precision == "fp16":
             work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/qwen_moe/tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/tp_builder.py
@@ -495,7 +495,6 @@ def build_qwen_moe_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/qwen_moe/utils.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
@@ -113,7 +113,6 @@ def build_qwen_vl_tp_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype = np.float16

--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -58,21 +58,23 @@ def _decode_attention_backend(config: ModelConfig) -> str:
     return backend
 
 
-def _decoder_profile_options(config: ModelConfig) -> tuple[int, int | None, int]:
+def _decoder_profile_options(
+    config: ModelConfig,
+) -> tuple[int, int | None, int | None]:
     decoder_options = _decoder_build_options(config)
     max_prefill_length = int(decoder_options.get("max_prefill_length", 0))
     opt_prefill_length = int(decoder_options.get("opt_prefill_length", 64))
-    builder_workspace_gib = int(decoder_options.get("builder_workspace_gib", 1))
+    builder_workspace_gib = int(decoder_options.get("builder_workspace_gib", 0))
     if max_prefill_length < 0:
         raise ValueError("qwen_vl_decoder.max_prefill_length must be >= 0")
     if opt_prefill_length <= 0:
         raise ValueError("qwen_vl_decoder.opt_prefill_length must be > 0")
-    if builder_workspace_gib <= 0:
-        raise ValueError("qwen_vl_decoder.builder_workspace_gib must be > 0")
+    if builder_workspace_gib < 0:
+        raise ValueError("qwen_vl_decoder.builder_workspace_gib must be >= 0")
     return (
         opt_prefill_length,
         max_prefill_length or None,
-        builder_workspace_gib << 30,
+        builder_workspace_gib << 30 if builder_workspace_gib else None,
     )
 
 

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -154,7 +154,7 @@ def build_dual_profile_decoder_engine(
     precision: str = "fp16",
     opt_prefill_length: int = 64,
     max_prefill_length: int | None = None,
-    builder_workspace_bytes: int = 1 << 30,
+    builder_workspace_bytes: int | None = None,
     quant_ctx: "QuantContext | None" = None,
     norm_type: str = "rmsnorm",
     mlp_type: str = "swiglu",
@@ -186,7 +186,8 @@ def build_dual_profile_decoder_engine(
 
     ``opt_prefill_length`` and ``max_prefill_length`` bound the prefill
     optimization profile independently from the KV cache capacity.
-    ``builder_workspace_bytes`` controls TensorRT tactic workspace.
+    ``builder_workspace_bytes`` optionally caps TensorRT tactic workspace;
+    ``None`` preserves TensorRT's device default.
 
     ``profile_mode`` controls which optimization profiles are emitted:
 

--- a/python/tensorrt_model_connect/families/qwen_vl/onnx_vision_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/onnx_vision_builder.py
@@ -56,7 +56,6 @@ def build_engine_from_onnx(
             "ONNX parsing failed:\n" + "\n".join(errors))
 
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if verbose:
         print(f"[trtmc build] Building vision TRT engine from ONNX "

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -616,7 +616,6 @@ def _build_qwen3_vl_decoder(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     token_id = network.add_input("token_id", trt.int32, (-1,))

--- a/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
@@ -40,9 +40,9 @@ DECODER_SCHEMA = Schema(
         ConfigField(
             name="builder_workspace_gib",
             type_tag="int32",
-            default=1,
+            default=0,
             allowed_layers=_BUILD,
-            validator=lambda value: isinstance(value, int) and value > 0,
+            validator=lambda value: isinstance(value, int) and value >= 0,
         ),
     ),
 )

--- a/python/tensorrt_model_connect/families/qwen_vl/utils.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/roberta/encoder_builder.py
+++ b/python/tensorrt_model_connect/families/roberta/encoder_builder.py
@@ -85,7 +85,6 @@ def build_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/roberta/tp_builder.py
+++ b/python/tensorrt_model_connect/families/roberta/tp_builder.py
@@ -161,7 +161,6 @@ def build_tp_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
     # which causes significant accuracy loss across 12+ encoder layers.
     trt_config.clear_flag(trt.BuilderFlag.TF32)

--- a/python/tensorrt_model_connect/families/rwkv/plugin.py
+++ b/python/tensorrt_model_connect/families/rwkv/plugin.py
@@ -273,7 +273,6 @@ class RwkvPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # -----------------------------------------------------------
         # Inputs

--- a/python/tensorrt_model_connect/families/rwkv/tp_builder.py
+++ b/python/tensorrt_model_connect/families/rwkv/tp_builder.py
@@ -298,7 +298,6 @@ def build_rwkv_tp_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     attn_state_inputs = []

--- a/python/tensorrt_model_connect/families/sam/plugin.py
+++ b/python/tensorrt_model_connect/families/sam/plugin.py
@@ -687,7 +687,6 @@ class SamPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         eps_t = graph_ops.add_constant(
             network, (1, 1), np.array([1e-6], dtype=np.float32))

--- a/python/tensorrt_model_connect/families/sana_wm/components/gemma/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/components/gemma/dual_profile_decoder_builder.py
@@ -357,7 +357,6 @@ def build_dual_profile_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/sana_wm/components/gemma/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/components/gemma/dual_profile_decoder_tp_builder.py
@@ -321,7 +321,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/sana_wm/components/gemma/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/components/gemma/standard_decoder_builder.py
@@ -206,7 +206,6 @@ def build_standard_decoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # Precision configuration
     if precision == "fp16":

--- a/python/tensorrt_model_connect/families/sana_wm/components/ltx_video/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/components/ltx_video/t5_encoder_builder.py
@@ -75,7 +75,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     input_ids = network.add_input(

--- a/python/tensorrt_model_connect/families/segformer/plugin.py
+++ b/python/tensorrt_model_connect/families/segformer/plugin.py
@@ -268,7 +268,6 @@ class SegformerPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         def _mark_debug(tensor, name):
             """Mark a tensor as debug output (identity to avoid aliasing)."""

--- a/python/tensorrt_model_connect/families/segformer/segformer_tp_builder.py
+++ b/python/tensorrt_model_connect/families/segformer/segformer_tp_builder.py
@@ -109,7 +109,6 @@ def build_segformer_tp_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     pixel_values = network.add_input("pixel_values", trt.float32, (1, 3, H_in, W_in))
 

--- a/python/tensorrt_model_connect/families/stablelm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/stablelm/default_decoder.py
@@ -265,7 +265,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/stablelm/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/stablelm/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/stablelm/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/stablelm/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/stablelm/utils.py
+++ b/python/tensorrt_model_connect/families/stablelm/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/starcoder2/default_decoder.py
+++ b/python/tensorrt_model_connect/families/starcoder2/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/starcoder2/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/starcoder2/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/starcoder2/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/starcoder2/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/starcoder2/utils.py
+++ b/python/tensorrt_model_connect/families/starcoder2/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/t5/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/t5/decoder_tp_builder.py
@@ -289,7 +289,6 @@ def build_t5_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     token_id = network.add_input("token_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/t5/plugin.py
+++ b/python/tensorrt_model_connect/families/t5/plugin.py
@@ -148,7 +148,6 @@ class T5Plugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         tc = builder.create_builder_config()
-        tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
         tc.clear_flag(trt.BuilderFlag.TF32)
         token_id = network.add_input("token_id", trt.int32, (1,))
         position_id = network.add_input("position_id", trt.int32, (1,))
@@ -277,7 +276,6 @@ def _build_t5_encoder(config, weights, *, verbose=False, precision="fp32"):
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     tc.clear_flag(trt.BuilderFlag.TF32)
     et = graph_ops.add_constant(
         network, (1, 1), np.array([eps], dtype=work_np_dtype),

--- a/python/tensorrt_model_connect/families/wan_t2v/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/wan_t2v/t5_encoder_builder.py
@@ -83,7 +83,6 @@ def build_t5_encoder_engine(
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
     input_ids = network.add_input(

--- a/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
@@ -362,7 +362,6 @@ def build_whisper_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))

--- a/python/tensorrt_model_connect/families/whisper/plugin.py
+++ b/python/tensorrt_model_connect/families/whisper/plugin.py
@@ -313,7 +313,6 @@ class WhisperPlugin:
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
-        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         token_id = network.add_input("token_id", trt.int32, (1,))
         position_id = network.add_input("position_id", trt.int32, (1,))
@@ -568,7 +567,6 @@ def _build_whisper_encoder(config, weights, *, precision="fp32", verbose=False):
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     tc = builder.create_builder_config()
-    tc.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     eps_tensor = graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype), dtype=work_np_dtype

--- a/python/tensorrt_model_connect/families/xglm/default_decoder.py
+++ b/python/tensorrt_model_connect/families/xglm/default_decoder.py
@@ -178,7 +178,6 @@ def build_standard_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/xglm/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/xglm/default_dual_profile_decoder.py
@@ -229,7 +229,6 @@ def build_dual_profile_decoder_engine(
 
     builder_context = create_builder_context(
         verbose=verbose,
-        workspace_bytes=1 << 30,
     )
     builder = builder_context.builder
     network = builder_context.network

--- a/python/tensorrt_model_connect/families/xglm/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/xglm/dual_profile_decoder_tp_builder.py
@@ -300,7 +300,6 @@ def build_dual_profile_tp_decoder_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16

--- a/python/tensorrt_model_connect/families/xglm/utils.py
+++ b/python/tensorrt_model_connect/families/xglm/utils.py
@@ -29,7 +29,7 @@ class BuilderContext:
 def create_builder_context(
     *,
     verbose: bool,
-    workspace_bytes: int,
+    workspace_bytes: int | None = None,
     strongly_typed: bool = True,
     disable_tf32: bool = False,
 ) -> BuilderContext:
@@ -41,7 +41,8 @@ def create_builder_context(
         flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(flags)
     config = builder.create_builder_config()
-    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    if workspace_bytes is not None:
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     if disable_tf32:
         config.clear_flag(trt.BuilderFlag.TF32)
     return BuilderContext(

--- a/python/tensorrt_model_connect/families/xlnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/xlnet/tp_builder.py
@@ -231,7 +231,6 @@ def build_tp_xlnet_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     # -------------------------------------------------------------------

--- a/python/tensorrt_model_connect/families/xlnet/xlnet_builder.py
+++ b/python/tensorrt_model_connect/families/xlnet/xlnet_builder.py
@@ -147,7 +147,6 @@ def build_xlnet_engine(
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     # -------------------------------------------------------------------

--- a/tests/builder/test_repository_contracts.py
+++ b/tests/builder/test_repository_contracts.py
@@ -15,6 +15,9 @@ from tests.tools.test_perf_matrix import (
 from tests.tools.test_trtmc_validate import (
     test_model_workload_catalog_covers_every_ready_model as _check_validation_coverage,
 )
+from tests.tools.test_workspace_policy import (
+    test_model_builders_do_not_impose_one_gib_workspace_limits as _check_workspace_policy,
+)
 
 
 def test_ready_models_have_validation_workloads() -> None:
@@ -31,3 +34,7 @@ def test_family_sources_remain_isolated() -> None:
 
 def test_repository_family_inventory_is_current() -> None:
     _check_family_inventory()
+
+
+def test_model_builders_use_tensorrt_default_workspace() -> None:
+    _check_workspace_policy()

--- a/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
+++ b/tests/e2e/models/bert/test_bert_owned_encoder_builders_coverage.py
@@ -295,7 +295,7 @@ def test_build_encoder_engine_success_passes_activation(monkeypatch: pytest.Monk
     assert all(isinstance(call, dict) for call in layer_calls)
 
     builder = fake_trt.Builder.last_instance
-    assert builder.config.pool_limits == [("workspace", 1 << 30)]
+    assert builder.config.pool_limits == []
     assert builder.config.cleared_flags == ["tf32"]
     assert [t.name for t in builder.network.outputs] == ["hidden_states"]
     assert builder.network.outputs[0].dtype == "float32"

--- a/tests/e2e/models/flux/test_flux_owned_encoder_builders_coverage.py
+++ b/tests/e2e/models/flux/test_flux_owned_encoder_builders_coverage.py
@@ -466,7 +466,7 @@ def test_build_t5_encoder_engine_success_exercises_relative_bias_fallback(monkey
 
     assert plan == b"engine-plan"
     builder = fake_trt.Builder.last_instance
-    assert builder.config.pool_limits == [("workspace", 1 << 30)]
+    assert builder.config.pool_limits == []
     assert [t.name for t in builder.network.outputs] == ["text_embeddings"]
     assert [t.dtype for t in builder.network.outputs] == ["float32"]
 

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_onnx_vision_builder.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_onnx_vision_builder.py
@@ -212,7 +212,7 @@ def test_onnx_builder_success_and_plan_none_branches() -> None:
         plan = mod.build_vision_engine_from_onnx(b"good-onnx", verbose=True)
         assert plan == b"engine-plan"
         assert _FakeBuilder.last_instance.flags == 3
-        assert _FakeBuilder.last_instance.config.calls == [("workspace", 1 << 30)]
+        assert _FakeBuilder.last_instance.config.calls == []
 
         _FakeBuilder.plan_to_return = None
         with pytest.raises(RuntimeError, match="TensorRT vision engine build failed"):

--- a/tests/tools/test_workspace_policy.py
+++ b/tests/tools/test_workspace_policy.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FAMILIES_ROOT = REPO_ROOT / "python/tensorrt_model_connect/families"
+ONE_GIB = 1 << 30
+
+
+def _integer_literal(node: ast.expr | None) -> int | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.LShift)
+        and isinstance(node.left, ast.Constant)
+        and isinstance(node.left.value, int)
+        and isinstance(node.right, ast.Constant)
+        and isinstance(node.right.value, int)
+    ):
+        return node.left.value << node.right.value
+    return None
+
+
+def _target_mentions_workspace(node: ast.expr) -> bool:
+    return isinstance(node, ast.Name) and "workspace" in node.id.lower()
+
+
+def _function_defaults(node: ast.FunctionDef | ast.AsyncFunctionDef):
+    positional = [*node.args.posonlyargs, *node.args.args]
+    positional_defaults = zip(positional[-len(node.args.defaults) :], node.args.defaults)
+    yield from positional_defaults
+    yield from (
+        (argument, default)
+        for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults)
+        if default is not None
+    )
+
+
+def _one_gib_workspace_lines(path: Path) -> list[int]:
+    source = path.read_text(encoding="utf-8")
+    if "workspace" not in source.lower():
+        return []
+    tree = ast.parse(source, filename=str(path))
+    violations: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "set_memory_pool_limit"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Attribute)
+                and node.args[0].attr == "WORKSPACE"
+                and _integer_literal(node.args[1]) == ONE_GIB
+            ):
+                violations.add(node.lineno)
+            for keyword in node.keywords:
+                if (
+                    keyword.arg is not None
+                    and "workspace" in keyword.arg.lower()
+                    and _integer_literal(keyword.value) == ONE_GIB
+                ):
+                    violations.add(keyword.value.lineno)
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and "workspace" in node.args[0].value.lower()
+                and node.args[0].value.lower().endswith("_gib")
+                and _integer_literal(node.args[1]) == 1
+            ):
+                violations.add(node.lineno)
+            field_name = next(
+                (
+                    keyword.value.value
+                    for keyword in node.keywords
+                    if keyword.arg == "name"
+                    and isinstance(keyword.value, ast.Constant)
+                    and isinstance(keyword.value.value, str)
+                ),
+                None,
+            )
+            field_default = next(
+                (keyword.value for keyword in node.keywords if keyword.arg == "default"),
+                None,
+            )
+            if (
+                isinstance(field_name, str)
+                and "workspace" in field_name.lower()
+                and field_name.lower().endswith("_gib")
+                and _integer_literal(field_default) == 1
+            ):
+                violations.add(node.lineno)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(_target_mentions_workspace(target) for target in targets):
+                if _integer_literal(node.value) == ONE_GIB:
+                    violations.add(node.lineno)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for argument, default in _function_defaults(node):
+                if "workspace" in argument.arg.lower() and _integer_literal(default) == ONE_GIB:
+                    violations.add(default.lineno)
+    return sorted(violations)
+
+
+def test_model_builders_do_not_impose_one_gib_workspace_limits() -> None:
+    violations = {
+        path.relative_to(REPO_ROOT): lines
+        for path in FAMILIES_ROOT.rglob("*.py")
+        if "tests" not in path.parts
+        if (lines := _one_gib_workspace_lines(path))
+    }
+
+    assert not violations, f"fixed 1 GiB TensorRT workspace limits found: {violations}"

--- a/website/docs/features/config-and-backends.md
+++ b/website/docs/features/config-and-backends.md
@@ -63,7 +63,7 @@ The Qwen-VL build schemas have these exact defaults and validation rules:
 | `qwen_vl_decoder.decode_attention` | `string`, `native` | Accepts `native` or `decomposed`; decomposed decode is valid only for an active split-decoder build. |
 | `qwen_vl_decoder.max_prefill_length` | `int32`, `0` | Nonnegative; zero lets the builder use the cache-length bound for the prefill maximum. |
 | `qwen_vl_decoder.opt_prefill_length` | `int32`, `64` | Must be positive and is clamped to the effective prefill maximum. |
-| `qwen_vl_decoder.builder_workspace_gib` | `int32`, `1` | Must be positive and controls the decoder builder workspace independently of the cache bound. |
+| `qwen_vl_decoder.builder_workspace_gib` | `int32`, `0` | Nonnegative; zero preserves TensorRT's device default, while a positive value caps decoder builder workspace independently of the cache bound. |
 | `qwen_vl_lora.enabled` | `bool`, `false` | Dynamic binding currently supports Qwen2.5-VL only and rejects tensor-parallel builds. |
 | `qwen_vl_lora.max_rank` | `int32`, `0` | Schema range is 0 through 256; enabling LoRA requires 1 through 256. |
 | `qwen_vl_lora.target_modules` | `string`, `q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj` | Comma-separated non-empty subset of exactly those seven projection names. |


### PR DESCRIPTION
## Summary

- remove every remaining fixed 1 GiB TensorRT tactic-workspace cap from production model-family builders
- let uncapped builders retain TensorRT's device-adaptive WORKSPACE default, while preserving explicit non-1 GiB policies and user-provided overrides
- make family-local builder helpers accept `None` without calling `set_memory_pool_limit`
- change Qwen-VL's `builder_workspace_gib` default to `0`, meaning TensorRT default, while positive values remain supported as explicit caps
- add a repository-wide AST contract that rejects reintroduced 1 GiB workspace setters, helper arguments, defaults, and indirect assignments

This is the repository-wide follow-up to #959. It covers 67 additional model families and removes 175 literal 1 GiB limits from production sources.

## Why

A 1 GiB WORKSPACE limit constrains TensorRT's tactic search and can exclude otherwise valid kernels. Leaving the pool unset uses TensorRT's device default; it is an upper bound for build-time tactic workspace, not an eager allocation.

On GB300 with TensorRT 11.1.0.106, the device default is `296889614336` bytes (about 276.5 GiB).

## Validation

- `git diff --check github/main...HEAD`
- `ruff check` on all changed Python files
- `python3 -m compileall -q python/tensorrt_model_connect/families tests/tools/test_workspace_policy.py tests/builder/test_repository_contracts.py`
- `python3 tools/model_ci.py validate`
- `python3 tools/test_impact.py --validate`
- local targeted tests: 14 passed
- GB300 targeted builder/lifetime tests: 35 passed
- GB300 repository-wide builder contracts: 5 passed
- production-source residual scan: no fixed 1 GiB workspace limits found

Test-impact analysis selects the `builder` and `tools` unit tiers plus 154 L0 model cases, so this PR is opened as draft for the full GitHub CI surface.
