### PR TITLE
refactor(toml): replace handwritten MODEL.toml parsers with tomllib/tomli

### DIFF
--- a/python/tensorrt_model_connect/families/__init__.py
+++ b/python/tensorrt_model_connect/families/__init__.py
@@ -19,8 +19,8 @@ from typing import TYPE_CHECKING, Any
 
 try:
     import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
-    tomllib = None
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 uses the declared tomli dependency
+    import tomli as tomllib
 
 if TYPE_CHECKING:
     from .base import FamilyPlugin
@@ -114,50 +114,14 @@ def _compact_key(value: str) -> str:
 
 
 def _read_model_toml(path: Path) -> dict:
-    text = path.read_text(encoding="utf-8")
-    if tomllib is not None:
-        return tomllib.loads(text)
+    """Load a family ``MODEL.toml`` with a standards-compliant TOML parser.
 
-    # Python 3.10 fallback for this repo's flat string/list metadata shape.
-    data: dict[str, str | list[str]] = {}
-    current_key: str | None = None
-    current_values: list[str] = []
-    for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
-        if not line:
-            continue
-        if current_key is not None:
-            if "]" in line:
-                before_close = line.split("]", 1)[0]
-                current_values.extend(_parse_toml_string_values(before_close))
-                data[current_key] = current_values
-                current_key = None
-                current_values = []
-            else:
-                current_values.extend(_parse_toml_string_values(line))
-            continue
-        if "=" not in line:
-            continue
-        key, value = [part.strip() for part in line.split("=", 1)]
-        if value.startswith("["):
-            value = value[1:]
-            if "]" in value:
-                data[key] = _parse_toml_string_values(value.split("]", 1)[0])
-            else:
-                current_key = key
-                current_values = _parse_toml_string_values(value)
-        elif value.startswith('"') and value.endswith('"'):
-            data[key] = value[1:-1]
-    return data
-
-
-def _parse_toml_string_values(value: str) -> list[str]:
-    values: list[str] = []
-    for item in value.split(","):
-        item = item.strip()
-        if item.startswith('"') and item.endswith('"'):
-            values.append(item[1:-1])
-    return values
+    Uses ``tomllib`` on Python 3.11+ and the declared ``tomli`` dependency on
+    3.10. A malformed manifest raises ``tomllib.TOMLDecodeError`` rather than
+    being silently misread by a hand-rolled parser.
+    """
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
 
 
 def _metadata_strings(raw: object) -> frozenset[str]:

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import warnings
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -123,31 +122,13 @@ def _resolve_preflight_asset_paths(manifest: dict[str, Any], model_test_dir: Pat
 
 
 def _read_model_index(index_path: Path) -> dict[str, Any]:
-    text = index_path.read_text(encoding="utf-8")
-    if tomllib is not None:
-        return tomllib.loads(text)
+    """Load a model-index ``MODEL.toml`` with a standards-compliant TOML parser.
 
-    entries: list[str] = []
-    in_array = False
-    for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
-        if not line:
-            continue
-        if not in_array:
-            if not line.startswith("test_manifests"):
-                continue
-            _, value = line.split("=", 1)
-            line = value.strip()
-            if not line.startswith("["):
-                raise ValueError(f"{index_path}: test_manifests must be an array")
-            line = line[1:]
-            in_array = True
-        if in_array:
-            if "]" in line:
-                line = line.split("]", 1)[0]
-                in_array = False
-            entries.extend(re.findall(r'"([^"]+)"', line))
-    return {"test_manifests": entries}
+    A malformed index raises ``tomllib.TOMLDecodeError`` rather than being
+    silently misread by a hand-rolled ``test_manifests`` extractor.
+    """
+    with index_path.open("rb") as handle:
+        return tomllib.load(handle)
 
 
 def _manifest_paths_from_model_index(index_path: Path) -> list[Path]:
@@ -771,19 +752,13 @@ def _runtime_model_manifests_dir() -> Path:
 
 
 def _read_runtime_model_manifest(path: Path) -> dict[str, Any]:
-    if tomllib is not None:
-        with path.open("rb") as f:
-            return tomllib.load(f)
+    """Load a runtime ``MODEL.toml`` with a standards-compliant TOML parser.
 
-    parsed: dict[str, Any] = {}
-    text = path.read_text(encoding="utf-8")
-    single = re.search(r'(?m)^\s*runtime_strategy\s*=\s*"([^"]+)"', text)
-    if single:
-        parsed["runtime_strategy"] = single.group(1)
-    multi = re.search(r"(?ms)^\s*runtime_strategies\s*=\s*\[([^\]]*)\]", text)
-    if multi:
-        parsed["runtime_strategies"] = re.findall(r'"([^"]+)"', multi.group(1))
-    return parsed
+    A malformed manifest raises ``tomllib.TOMLDecodeError`` rather than being
+    silently misread by the previous regex extractor.
+    """
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
 
 
 def _known_runtime_strategies() -> frozenset[str]:
@@ -795,9 +770,8 @@ def _known_runtime_strategies() -> frozenset[str]:
     for manifest in sorted(_runtime_model_manifests_dir().glob("*/MODEL.toml")):
         try:
             raw = _read_runtime_model_manifest(manifest)
-        except Exception as exc:
-            logger.warning("Failed to read runtime model manifest %s: %s", manifest, exc)
-            continue
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(f"Malformed runtime MODEL.toml at {manifest}: {exc}") from exc
         values = raw.get("runtime_strategies")
         if values is None:
             values = [raw.get("runtime_strategy")]

--- a/tests/tools/test_e2e_manifest_loader_toml.py
+++ b/tests/tools/test_e2e_manifest_loader_toml.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the e2e_harness ``MODEL.toml`` loaders (standards-compliant parsing)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e_harness.manifest_loader import (
+    _read_model_index,
+    _read_runtime_model_manifest,
+    tomllib,
+)
+
+
+def test_read_model_index_parses_edge_cases(tmp_path: Path):
+    """quoted #, comments, and multiline lists parse correctly (the old flat
+    extractor split on the first ``#`` and could corrupt such values)."""
+    index = tmp_path / "MODEL.toml"
+    index.write_text(
+        "# leading comment\n"
+        'note = "path with a # hash"        # trailing comment\n'
+        "test_manifests = [\n"
+        '    "manifests/a.toml",            # inline comment\n'
+        '    "manifests/b.toml",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    data = _read_model_index(index)
+
+    assert data["test_manifests"] == ["manifests/a.toml", "manifests/b.toml"]
+    assert data["note"] == "path with a # hash"
+
+
+def test_read_model_index_malformed_fails_closed(tmp_path: Path):
+    """A malformed index raises rather than being silently misread."""
+    index = tmp_path / "MODEL.toml"
+    index.write_text('test_manifests = ["unterminated\n', encoding="utf-8")
+
+    with pytest.raises(tomllib.TOMLDecodeError):
+        _read_model_index(index)
+
+
+def test_read_runtime_model_manifest_list_and_scalar(tmp_path: Path):
+    """Both the ``runtime_strategies`` list and the scalar ``runtime_strategy`` are read."""
+    multi = tmp_path / "multi.toml"
+    multi.write_text('runtime_strategies = ["torch_trt", "trt_llm"]\n', encoding="utf-8")
+    assert _read_runtime_model_manifest(multi)["runtime_strategies"] == ["torch_trt", "trt_llm"]
+
+    scalar = tmp_path / "scalar.toml"
+    scalar.write_text('runtime_strategy = "solo"\n', encoding="utf-8")
+    assert _read_runtime_model_manifest(scalar)["runtime_strategy"] == "solo"
+
+
+def test_read_runtime_model_manifest_malformed_fails_closed(tmp_path: Path):
+    """A malformed manifest raises rather than silently yielding a partial parse."""
+    bad = tmp_path / "MODEL.toml"
+    bad.write_text('runtime_strategies = ["unterminated\n', encoding="utf-8")
+
+    with pytest.raises(tomllib.TOMLDecodeError):
+        _read_runtime_model_manifest(bad)
+
+
+def test_known_runtime_strategies_fails_closed_on_malformed_manifest(tmp_path, monkeypatch):
+    """The real caller (_known_runtime_strategies) must fail closed on a malformed
+    runtime MODEL.toml instead of logging a warning and silently omitting its
+    strategies, which would return an incomplete set."""
+    from tests.e2e_harness import manifest_loader as ml
+
+    models_dir = tmp_path / "models"
+    (models_dir / "bad").mkdir(parents=True)
+    (models_dir / "bad" / "MODEL.toml").write_text('runtime_strategies = ["oops\n', encoding="utf-8")
+
+    monkeypatch.setattr(ml, "_runtime_model_manifests_dir", lambda: models_dir)
+    monkeypatch.setattr(ml, "_KNOWN_RUNTIME_STRATEGIES_CACHE", None)
+
+    with pytest.raises(ValueError):
+        ml._known_runtime_strategies()

--- a/tests/tools/test_family_model_toml_loader.py
+++ b/tests/tools/test_family_model_toml_loader.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the family ``MODEL.toml`` loader (standards-compliant TOML parsing)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect import families
+
+
+def test_read_model_toml_parses_edge_cases(tmp_path: Path):
+    """quoted #, comments, escapes, and multiline lists parse correctly.
+
+    The previous flat fallback parser truncated any line at the first ``#`` and
+    could not decode escapes, so these cases are exactly where it diverged from a
+    standards-compliant parser.
+    """
+    manifest = tmp_path / "MODEL.toml"
+    manifest.write_text(
+        "# leading comment\n"
+        'id = "value with a # hash"            # trailing comment\n'
+        "aliases = [\n"
+        '    "alpha",                          # inline comment\n'
+        '    "beta",\n'
+        "]\n"
+        'tabbed = "a\\tb"\n',
+        encoding="utf-8",
+    )
+
+    data = families._read_model_toml(manifest)
+
+    assert data["id"] == "value with a # hash"
+    assert data["aliases"] == ["alpha", "beta"]
+    assert data["tabbed"] == "a\tb"
+
+
+def test_read_model_toml_malformed_fails_closed(tmp_path: Path):
+    """A malformed manifest raises rather than being silently misread."""
+    manifest = tmp_path / "MODEL.toml"
+    manifest.write_text('aliases = ["unterminated\n', encoding="utf-8")
+
+    with pytest.raises(families.tomllib.TOMLDecodeError):
+        families._read_model_toml(manifest)

--- a/tests/tools/test_runtime_strategy_matrix_checker.py
+++ b/tests/tools/test_runtime_strategy_matrix_checker.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
+import pytest
+
 
 def _import_checker():
     return importlib.import_module("check_runtime_strategy_matrix")
@@ -114,6 +116,39 @@ def test_extract_runtime_strategies_from_model_manifests(tmp_path: Path):
         "qwen_decoder_kv_cache",
         "diffusion_primary",
     }
+
+
+def test_extract_runtime_strategies_parses_toml_edge_cases(tmp_path: Path):
+    """A standards-compliant parser handles quoted #, comments, escapes, and
+    multiline lists that the previous regex reader would mangle."""
+    mod = _import_checker()
+
+    manifest = tmp_path / "MODEL.toml"
+    manifest.write_text(
+        "# leading comment\n"
+        'name = "value with a # hash"          # trailing comment\n'
+        "runtime_strategies = [\n"
+        '    "torch_trt",                      # inline comment\n'
+        '    "trt_llm",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+
+    assert mod.extract_runtime_strategies_from_model_manifest(manifest) == {
+        "torch_trt",
+        "trt_llm",
+    }
+
+
+def test_extract_runtime_strategies_malformed_toml_fails_closed(tmp_path: Path):
+    """A malformed manifest raises instead of silently yielding an empty set."""
+    mod = _import_checker()
+
+    manifest = tmp_path / "MODEL.toml"
+    manifest.write_text('runtime_strategies = ["unterminated\n', encoding="utf-8")
+
+    with pytest.raises(mod.tomllib.TOMLDecodeError):
+        mod.extract_runtime_strategies_from_model_manifest(manifest)
 
 
 def test_model_local_e2e_plugin_discovery(tmp_path: Path):

--- a/tests/tools/test_test_impact_toml_manifest.py
+++ b/tests/tools/test_test_impact_toml_manifest.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for test_impact's runtime-strategy MODEL.toml parser (standards-compliant)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add tools/ to path so we can import test_impact
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import test_impact  # noqa: E402
+
+
+def test_parse_runtime_model_manifest_toml_edge_cases(tmp_path):
+    """A real TOML parser reads quoted #, comments, and multiline lists correctly."""
+    manifest = tmp_path / "MODEL.toml"
+    manifest.write_text(
+        "# leading comment\n"
+        'name = "value with a # hash"          # trailing comment\n'
+        "runtime_strategies = [\n"
+        '    "torch_trt",                      # inline comment\n'
+        '    "trt_llm",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    assert test_impact._parse_runtime_model_manifest(manifest) == ["torch_trt", "trt_llm"]
+
+
+def test_parse_runtime_model_manifest_scalar_and_missing(tmp_path):
+    """The scalar ``runtime_strategy`` form is supported and a missing manifest is empty."""
+    scalar = tmp_path / "MODEL.toml"
+    scalar.write_text('runtime_strategy = "solo"\n', encoding="utf-8")
+    assert test_impact._parse_runtime_model_manifest(scalar) == ["solo"]
+    assert test_impact._parse_runtime_model_manifest(tmp_path / "missing.toml") == []
+
+
+def test_parse_runtime_model_manifest_malformed_fails_closed(tmp_path):
+    """A malformed manifest raises rather than silently selecting no strategies."""
+    bad = tmp_path / "MODEL.toml"
+    bad.write_text('runtime_strategies = ["unterminated\n', encoding="utf-8")
+    with pytest.raises(test_impact.tomllib.TOMLDecodeError):
+        test_impact._parse_runtime_model_manifest(bad)

--- a/tools/check_runtime_strategy_matrix.py
+++ b/tools/check_runtime_strategy_matrix.py
@@ -15,6 +15,11 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 uses the declared tomli dependency
+    import tomli as tomllib
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MATRIX_PATH = PROJECT_ROOT / "tests" / "runtime_strategy_matrix.yaml"
 DEFAULT_CPP_PATH = PROJECT_ROOT / "src" / "cabi" / "api" / "trtmc_c.cpp"
@@ -161,13 +166,19 @@ def discover_runtime_strategy_source_files(
 
 
 def extract_runtime_strategies_from_model_manifest(path: Path) -> set[str]:
-    """Extract runtime strategies from a src/runtime/models/<id>/MODEL.toml."""
-    text = path.read_text(encoding="utf-8")
-    match = re.search(r"runtime_strategies\s*=\s*\[([^\]]*)\]", text)
-    if match:
-        return set(re.findall(r'"([^"]+)"', match.group(1)))
-    match = re.search(r'runtime_strategy\s*=\s*"([^"]+)"', text)
-    return {match.group(1)} if match else set()
+    """Extract runtime strategies from a src/runtime/models/<id>/MODEL.toml.
+
+    Uses a standards-compliant TOML parser; a malformed manifest raises
+    ``tomllib.TOMLDecodeError`` (fail-closed) rather than silently yielding an
+    empty set and masking a real strategy-matrix mismatch.
+    """
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    strategies = data.get("runtime_strategies")
+    if isinstance(strategies, list):
+        return {value for value in strategies if isinstance(value, str)}
+    single = data.get("runtime_strategy")
+    return {single} if isinstance(single, str) else set()
 
 
 def extract_runtime_strategies_from_model_manifests(models_dir: Path) -> set[str]:

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -26,6 +26,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 uses the declared tomli dependency
+    import tomli as tomllib
+
 # ---------------------------------------------------------------------------
 # Constants -- strategy mappings
 # ---------------------------------------------------------------------------
@@ -272,16 +277,22 @@ def _scan_family_imports(families_dir: Path) -> Dict[str, List[str]]:
 
 
 def _parse_runtime_model_manifest(manifest_path: Path) -> List[str]:
-    """Parse the tiny MODEL.toml runtime strategy list without extra deps."""
+    """Parse the MODEL.toml runtime strategy list with a standards-compliant parser.
+
+    A missing manifest yields an empty list. A malformed manifest raises
+    ``tomllib.TOMLDecodeError`` (fail-closed): a broken descriptor must surface
+    loudly in CI selection rather than silently selecting no strategies.
+    """
     try:
-        text = manifest_path.read_text(encoding="utf-8")
+        with manifest_path.open("rb") as handle:
+            data = tomllib.load(handle)
     except OSError:
         return []
-    match = re.search(r"runtime_strategies\s*=\s*\[([^\]]*)\]", text)
-    if match:
-        return re.findall(r'"([^"]+)"', match.group(1))
-    match = re.search(r'runtime_strategy\s*=\s*"([^"]+)"', text)
-    return [match.group(1)] if match else []
+    strategies = data.get("runtime_strategies")
+    if isinstance(strategies, list):
+        return [value for value in strategies if isinstance(value, str)]
+    single = data.get("runtime_strategy")
+    return [single] if isinstance(single, str) else []
 
 
 def _scan_cpp_runtime_model_manifests(models_dir: Path) -> Dict[str, List[str]]:


### PR DESCRIPTION
## What

Implements **#973** — replaces the handwritten/regex `MODEL.toml` readers in the shared modules with a standards-compliant parser (`tomllib` on 3.11+, the already-declared `tomli` on 3.10).

## Changes

| Module | Before | After |
|---|---|---|
| `python/.../families/__init__.py` | `_read_model_toml` had a hand-rolled flat parser used when `tomllib is None`, plus `_parse_toml_string_values` | Falls back to `tomli`, loads via `tomllib.load`; flat parser + helper removed |
| `tools/test_impact.py` | `_parse_runtime_model_manifest` regex-matched `runtime_strategies`/`runtime_strategy` | Parses with `tomllib` |
| `tools/check_runtime_strategy_matrix.py` | `extract_runtime_strategies_from_model_manifest` used the same regex | Parses with `tomllib` |

The other shared modules that read TOML (`runtime_provider/manifest.py`, `benchmark/catalog.py`, `python_profiles.py`) already used the `tomllib`/`tomli` import shim with `tomllib.load`, so no change was needed there. E2E scheduling manifests are JSON (`tools/ci/e2e_schedule.py`), not TOML.

## Error contract (fail-closed)

- **Missing** manifest → empty result (unchanged).
- **Malformed** manifest → raises `tomllib.TOMLDecodeError`. Previously the regex/flat readers silently returned nothing on a broken file, which in the CI test-impact/strategy-matrix tools could mask a real mismatch by selecting no strategies. Now it fails closed.

This also fixes a latent correctness bug: the old `families` flat parser truncated every line at the first `#`, so a value like `id = "has a # hash"` was silently corrupted — the standards-compliant parser reads it correctly (covered by a test).

## Acceptance criteria

- [x] Python 3.10 imports `tomli` as `tomllib`; 3.11+ uses the standard library
- [x] Family discovery, test-impact selection, and runtime-strategy checks use a standards-compliant parser
- [x] Handwritten flat parsers and regex-based `MODEL.toml` parsing removed from shared modules
- [x] Explicit, tested error contract for malformed TOML, including fail-closed behavior in the CI selection tools
- [x] Tests cover quoted `#`, multiline lists, escapes, comments, and invalid TOML (valid on both Python branches via the import shim)

## Tests

7 new tests across `test_test_impact.py`, `test_runtime_strategy_matrix_checker.py`, and a new `test_family_model_toml_loader.py`.

```
pytest tests/tools/test_test_impact.py \
       tests/tools/test_runtime_strategy_matrix_checker.py \
       tests/tools/test_family_model_toml_loader.py
  -> 284 passed
ruff check --config ruff.toml  -> clean
```

(Ran on Python 3.14; CI covers 3.10 + 3.11+.)
