### PR TITLE
fix(cli): unify kv-cache-size byte parser between CLI and benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,7 +691,10 @@ set_target_properties(trtmc PROPERTIES
 )
 
 if(TRTMC_BUILD_BENCHMARKS)
-  add_executable(trtmc_dataset_benchmark examples/trtmc_dataset_benchmark.cpp)
+  add_executable(trtmc_dataset_benchmark
+    examples/trtmc_dataset_benchmark.cpp
+    src/cli/args.cpp
+  )
   target_link_libraries(trtmc_dataset_benchmark PRIVATE trtmc_core)
   target_include_directories(trtmc_dataset_benchmark PRIVATE ${PROJECT_SOURCE_DIR}/src)
   target_include_directories(trtmc_dataset_benchmark SYSTEM PRIVATE

--- a/examples/trtmc_dataset_benchmark.cpp
+++ b/examples/trtmc_dataset_benchmark.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "cli/jsonl_io.h"
+#include "cli/args.h"
 #include "trtmc/config/cli_support.h"
 #include "trtmc/config/schema_registry.h"
 #include "trtmc/pipeline.h"
@@ -108,28 +109,10 @@ void usage() {
 }
 
 std::uint64_t parse_size_bytes(const std::string& text) {
-    if (text.empty())
-        throw std::runtime_error("Empty kv-cache-size");
-    std::size_t idx = 0;
-    const double value = std::stod(text, &idx);
-    std::string suffix = text.substr(idx);
-    for (char& ch : suffix)
-        ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
-    double multiplier = 1.0;
-    if (suffix.empty() || suffix == "B") {
-        multiplier = 1.0;
-    } else if (suffix == "K" || suffix == "KB" || suffix == "KIB") {
-        multiplier = 1024.0;
-    } else if (suffix == "M" || suffix == "MB" || suffix == "MIB") {
-        multiplier = 1024.0 * 1024.0;
-    } else if (suffix == "G" || suffix == "GB" || suffix == "GIB") {
-        multiplier = 1024.0 * 1024.0 * 1024.0;
-    } else if (suffix == "T" || suffix == "TB" || suffix == "TIB") {
-        multiplier = 1024.0 * 1024.0 * 1024.0 * 1024.0;
-    } else {
-        throw std::runtime_error("Unsupported kv-cache-size suffix: " + suffix);
-    }
-    return static_cast<std::uint64_t>(value * multiplier);
+    auto parsed = trtmc::cli::parse_byte_size(text);
+    if (!parsed.has_value())
+        throw std::runtime_error("Invalid kv-cache-size: " + text);
+    return *parsed;
 }
 
 } // namespace

--- a/examples/trtmc_dataset_benchmark.cpp
+++ b/examples/trtmc_dataset_benchmark.cpp
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "cli/jsonl_io.h"
 #include "cli/args.h"
+#include "cli/jsonl_io.h"
 #include "trtmc/config/cli_support.h"
 #include "trtmc/config/schema_registry.h"
 #include "trtmc/pipeline.h"

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -345,6 +345,40 @@ void test_bad_kv_cache_size_fails() {
     check(args.error_message.find("--kv-cache-size expects") == 0, "bad kv cache message");
 }
 
+void test_parse_byte_size_si_vs_iec() {
+    using trtmc::cli::parse_byte_size;
+    check(parse_byte_size("1GB") == 1000ull * 1000 * 1000, "1GB is decimal");
+    check(parse_byte_size("1GiB") == 1024ull * 1024 * 1024, "1GiB is binary");
+    check(parse_byte_size("1GB") != parse_byte_size("1GiB"), "GB and GiB differ");
+    check(parse_byte_size("1KB") == 1000ull, "1KB is decimal");
+    check(parse_byte_size("1KiB") == 1024ull, "1KiB is binary");
+    check(parse_byte_size("1MB") == 1000ull * 1000, "1MB is decimal");
+    check(parse_byte_size("1MiB") == 1024ull * 1024, "1MiB is binary");
+    check(parse_byte_size("1TB") == 1000ull * 1000 * 1000 * 1000, "1TB is decimal");
+    check(parse_byte_size("1TiB") == 1024ull * 1024 * 1024 * 1024, "1TiB is binary");
+}
+
+void test_parse_byte_size_case_and_fractional() {
+    using trtmc::cli::parse_byte_size;
+    check(parse_byte_size("1gb") == parse_byte_size("1GB"), "lowercase suffix matches uppercase");
+    check(parse_byte_size("1Gb") == parse_byte_size("1GB"), "mixed-case suffix matches");
+    check(parse_byte_size("1gib") == parse_byte_size("1GiB"), "lowercase iec suffix matches");
+    check(parse_byte_size("1.5GB") == 1500000000ull, "fractional value scales correctly");
+    check(parse_byte_size("100") == 100ull, "no suffix means bytes");
+    check(parse_byte_size("100B") == 100ull, "explicit B suffix means bytes");
+}
+
+void test_parse_byte_size_rejects_invalid() {
+    using trtmc::cli::parse_byte_size;
+    check(!parse_byte_size("").has_value(), "empty string rejected");
+    check(!parse_byte_size("0GB").has_value(), "zero rejected");
+    check(!parse_byte_size("-1GB").has_value(), "negative rejected");
+    check(!parse_byte_size("10GBx").has_value(), "trailing garbage rejected");
+    check(!parse_byte_size("10XB").has_value(), "unsupported suffix rejected");
+    check(!parse_byte_size("abc").has_value(), "non-numeric rejected");
+    check(!parse_byte_size("99999999999999999999999TB").has_value(), "overflow rejected");
+}
+
 void test_invalid_generation_sampling_values_fail() {
     auto negative_tokens =
         parse({"trtmc", "run", "bundle.bundle", "--prompt", "hello", "--max-new-tokens", "-5"});
@@ -512,6 +546,9 @@ int main() {
     test_missing_value_fails();
     test_missing_prompt_is_distinct_from_empty_prompt();
     test_bad_kv_cache_size_fails();
+    test_parse_byte_size_si_vs_iec();
+    test_parse_byte_size_case_and_fractional();
+    test_parse_byte_size_rejects_invalid();
     test_invalid_generation_sampling_values_fail();
     test_generation_sampling_boundaries_parse();
     test_unexpected_positional_fails();


### PR DESCRIPTION
Closes #971.

The dataset benchmark had its own `parse_size_bytes()`, which treated `KB`/`MB`/`GB` as 1024-based (binary) and threw `std::runtime_error` on error. The main CLI's `parse_byte_size()` treats `KB`/`MB`/`GB` as 1000-based (decimal, SI) and `KiB`/`MiB`/`GiB` as 1024-based (binary, IEC), returning `std::optional`. Same option (`--kv-cache-size`), same-looking input, different byte count depending on which executable parsed it.

## Fix

`trtmc_dataset_benchmark` now compiles and links `src/cli/args.cpp`, and calls the same `trtmc::cli::parse_byte_size()` the main CLI uses — matching the existing pattern `test_cli_args` already uses for the same source file. The benchmark's own `parse_size_bytes()` is now a thin adapter that preserves its existing throw-on-invalid contract at the one call site, rather than a second implementation of the parsing logic itself.

Kept the existing main-CLI contract (`1GB != 1GiB`) rather than changing it, per the issue's acceptance criteria.

## Tests

Added `test_parse_byte_size_si_vs_iec`, `test_parse_byte_size_case_and_fractional`, and `test_parse_byte_size_rejects_invalid` to `tests/cpp/test_cli_args.cpp` — there was no direct test coverage of `parse_byte_size()` before this, only indirect coverage via `test_bad_kv_cache_size_fails`. Covers SI vs IEC suffixes, case-insensitivity, fractional values, zero/negative rejection, trailing-garbage rejection, unsupported-suffix rejection, and overflow rejection.

Verified by compiling `tests/cpp/test_cli_args.cpp` + `src/cli/args.cpp` standalone (`g++ -std=c++17 -I src`) — all tests pass, including the new ones. Also verified the edited `examples/trtmc_dataset_benchmark.cpp` with a syntax-only compile (`-fsyntax-only`) against the project's real headers. I don't have a CUDA/TensorRT toolchain available to do a full linked build of `trtmc_dataset_benchmark` itself, so that specific executable's link step is unverified beyond the syntax check — flagging that directly rather than claiming a full build I didn't run.