### PR TITLE
Parse family import scanning with ast instead of regex

### DIFF
--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1137,6 +1137,75 @@ class TestFamilyOwnedBuilder:
         assert set(match.models) == {"encoder-core"}
 
 
+class TestScanFamilyImports:
+    def test_parent_package_import_is_tracked(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text(
+            "from ..standard_decoder_builder import build\n"
+        )
+        result = test_impact._scan_family_imports(tmp_path)
+        assert result == {"standard_decoder_builder": ["some_family"]}
+
+    def test_single_dot_import_is_family_owned_not_tracked(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text(
+            "from .local_helper_builder import helper\n"
+        )
+        assert test_impact._scan_family_imports(tmp_path) == {}
+
+    def test_aliased_import_tracked_by_real_module_name(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text(
+            "from ..standard_decoder_builder import build as sd\n"
+        )
+        result = test_impact._scan_family_imports(tmp_path)
+        assert result == {"standard_decoder_builder": ["some_family"]}
+
+    def test_multiline_parenthesized_import_resolved(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text(
+            "from .. import (\n    encoder_builder,\n    other_builder as oe,\n)\n"
+        )
+        result = test_impact._scan_family_imports(tmp_path)
+        assert result == {
+            "encoder_builder": ["some_family"],
+            "other_builder": ["some_family"],
+        }
+
+    def test_triple_dot_import_tracked(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text("from ...pkg_builder import helper\n")
+        result = test_impact._scan_family_imports(tmp_path)
+        assert result == {"pkg_builder": ["some_family"]}
+
+    def test_import_like_text_in_comments_and_strings_is_ignored(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text(
+            '"""\nfrom ..fake_builder import y\n"""\n'
+            "# from ..comment_builder import z\n"
+        )
+        assert test_impact._scan_family_imports(tmp_path) == {}
+
+    def test_syntax_error_raises_instead_of_silently_skipping(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text("from ..standard_decoder_builder import (\n")
+        with pytest.raises(SyntaxError):
+            test_impact._scan_family_imports(tmp_path)
+
+    def test_non_builder_import_is_filtered_out(self, tmp_path):
+        family_dir = tmp_path / "some_family"
+        family_dir.mkdir()
+        (family_dir / "model.py").write_text("from ..some_utility import helper\n")
+        assert test_impact._scan_family_imports(tmp_path) == {}
+
+
 # ---------------------------------------------------------------------------
 # C++ scope tests
 # ---------------------------------------------------------------------------

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -251,21 +251,18 @@ def _scan_family_imports(families_dir: Path) -> Dict[str, List[str]]:
             content = py_file.read_text(encoding="utf-8")
         except OSError:
             continue
-        # from ..module_name import ... / from ...module_name import ...
-        for m in re.finditer(r"from\s+(\.+)(\w+)\s+import", content):
-            dots, module = m.group(1), m.group(2)
-            if len(dots) <= 1:
+        tree = ast.parse(content, filename=str(py_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.level <= 1:
                 continue
-            reverse.setdefault(module, set()).add(name)
-        # from .. import module_name / from ... import module_name
-        for m in re.finditer(r"from\s+(\.+)\s+import\s+([\w,\s]+)", content):
-            dots = m.group(1)
-            if len(dots) <= 1:
+            # from ..module_name import ... / from ...module_name import ...
+            if node.module:
+                module = node.module.split(".", 1)[0]
+                reverse.setdefault(module, set()).add(name)
                 continue
-            for mod in m.group(2).split(","):
-                mod = mod.strip()
-                if mod:
-                    reverse.setdefault(mod, set()).add(name)
+            # from .. import module_name / from ... import module_name
+            for alias in node.names:
+                reverse.setdefault(alias.name, set()).add(name)
     # Filter to *_builder modules only (excluding orchestrators)
     filtered: Dict[str, List[str]] = {}
     for module, families in reverse.items():


### PR DESCRIPTION
Fixes #970

## Description

`_scan_family_imports` used two regexes to find relative imports that reach into a parent builder module (as opposed to a family's own single-dot local imports, which don't count). Both regexes had real gaps: neither handled multiline/parenthesized `from` imports correctly, and text inside comments or string literals could be matched as if it were a real import.

Replaced both regexes with `ast.walk` over `ast.ImportFrom` nodes, using `node.level`/`node.module`/`node.names` instead of parsing source text directly, matching the pattern already used elsewhere in this repo (`tools/family_specialization.py`'s `_resolve_from_module`). The existing family-resolution rule is preserved exactly: only imports with 2+ leading dots count as parent-package usage, single-dot imports remain family-owned and are excluded.

- Aliased imports are now tracked by their real module name rather than the local alias.
- A file that fails to parse now raises `SyntaxError` instead of being silently skipped, consistent with the tool's stated zero-false-negative safety invariant.

## Testing

Added `TestScanFamilyImports` (8 new tests) covering: parent-package imports, single-dot exclusion, aliased imports, multiline/parenthesized imports, triple-dot imports, comment/string text being ignored, syntax-error handling, and non-builder filtering. Verified three of the new tests fail against the original regex implementation (multiline imports, comment/string text, syntax-error handling) before this change, confirming they exercise real gaps rather than being vacuous.

`tests/tools/test_test_impact.py` in full: 277 passed. `ruff check` on both changed files: clean.