### PR TITLE
ci(community): add contributor-triggered CPU validation

### DIFF
--- a/.github/workflows/community-cpu-request.yml
+++ b/.github/workflows/community-cpu-request.yml
@@ -4,18 +4,16 @@
 name: Community CPU Request
 
 run-name: >-
-  PR #${{ github.event.pull_request.number }} · public CPU request
+  PR #${{ github.event.issue.number }} · public CPU request
 
 on:
-  pull_request_target:
-    branches:
-      - main
-    types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 
 concurrency:
-  group: community-cpu-request-${{ github.event.pull_request.number }}
+  group: community-cpu-request-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -24,13 +22,15 @@ jobs:
     if: >-
       github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
       github.ref == 'refs/heads/main' &&
-      github.event.label.name == 'run-ci'
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/run-ci'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write
+      checks: read
       contents: read
-      pull-requests: write
+      pull-requests: read
 
     steps:
       # This default-branch workflow reads public PR metadata only. It never
@@ -39,28 +39,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
-          [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-
-          actor_role="$(
-            gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
-              --jq '.role_name'
-          )"
-          case "$actor_role" in
-            maintain|admin) ;;
-            *)
-              echo "::error::Only actors with maintain or admin access may request public CPU CI."
-              exit 1
-              ;;
-          esac
 
           pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           state="$(jq -er '.state' <<<"$pull")"
+          pr_author="$(jq -er '.user.login' <<<"$pull")"
           base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
           base_ref="$(jq -er '.base.ref' <<<"$pull")"
           base_sha="$(jq -er '.base.sha' <<<"$pull")"
@@ -73,10 +59,33 @@ jobs:
           [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
           [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
-          if [ "$head_sha" != "$EVENT_HEAD_SHA" ]; then
-            echo "::error::The run-ci label was superseded by a newer PR head."
-            exit 1
+
+          if [ "$ACTOR" != "$pr_author" ]; then
+            actor_role="$(
+              gh api --method GET \
+                "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
+                --jq '.role_name' 2>/dev/null || true
+            )"
+            case "$actor_role" in
+              maintain|admin) ;;
+              *)
+                echo "::error::Only the PR author or a maintainer/admin may request public CPU CI."
+                exit 1
+                ;;
+            esac
           fi
+
+          existing_required="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
+              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))) | sort_by(.started_at) | last // {} | if (.status // "") != "completed" then (.status // "") else (.conclusion // "") end'
+          )"
+          case "$existing_required" in
+            queued|in_progress|success)
+              echo "Community CPU is already $existing_required for merge $merge_sha."
+              exit 0
+              ;;
+          esac
 
           umask 077
           payload="$RUNNER_TEMP/community-cpu-dispatch.json"
@@ -98,13 +107,3 @@ jobs:
           gh api --silent --method POST \
             "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/dispatches" \
             --input "$payload"
-
-      - name: Consume the public CPU trigger label
-        if: ${{ always() }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          gh api --silent --method DELETE \
-            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-ci"

--- a/.github/workflows/community-cpu-request.yml
+++ b/.github/workflows/community-cpu-request.yml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Community CPU Request
+
+run-name: >-
+  PR #${{ github.event.pull_request.number }} · public CPU request
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: community-cpu-request-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize public CPU request
+    if: >-
+      github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.label.name == 'run-ci'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+
+    steps:
+      # This default-branch workflow reads public PR metadata only. It never
+      # checks out or executes the pull-request head.
+      - name: Authorize and dispatch the current PR merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          actor_role="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
+              --jq '.role_name'
+          )"
+          case "$actor_role" in
+            maintain|admin) ;;
+            *)
+              echo "::error::Only actors with maintain or admin access may request public CPU CI."
+              exit 1
+              ;;
+          esac
+
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          state="$(jq -er '.state' <<<"$pull")"
+          base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
+          base_ref="$(jq -er '.base.ref' <<<"$pull")"
+          base_sha="$(jq -er '.base.sha' <<<"$pull")"
+          head_sha="$(jq -er '.head.sha' <<<"$pull")"
+          merge_sha="$(jq -er '.merge_commit_sha' <<<"$pull")"
+
+          test "$state" = "open"
+          test "$base_repo" = "$GITHUB_REPOSITORY"
+          test "$base_ref" = "main"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$head_sha" != "$EVENT_HEAD_SHA" ]; then
+            echo "::error::The run-ci label was superseded by a newer PR head."
+            exit 1
+          fi
+
+          umask 077
+          payload="$RUNNER_TEMP/community-cpu-dispatch.json"
+          trap 'rm -f "$payload"' EXIT
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg base_sha "$base_sha" \
+            --arg head_sha "$head_sha" \
+            --arg merge_sha "$merge_sha" \
+            '{
+              ref: "main",
+              inputs: {
+                pr_number: $pr_number,
+                base_sha: $base_sha,
+                head_sha: $head_sha,
+                merge_sha: $merge_sha
+              }
+            }' > "$payload"
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/dispatches" \
+            --input "$payload"
+
+      - name: Consume the public CPU trigger label
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method DELETE \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-ci"

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -3,33 +3,134 @@
 
 name: Community CPU
 
-run-name: "PR #${{ github.event.pull_request.number }} · public CPU validation"
+run-name: "PR #${{ inputs.pr_number }} · public CPU validation"
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to test
+        required: true
+        type: string
+      base_sha:
+        description: Exact main revision in the requested merge
+        required: true
+        type: string
+      head_sha:
+        description: Exact pull-request head revision
+        required: true
+        type: string
+      merge_sha:
+        description: Exact pull-request merge revision to test
+        required: true
+        type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: community-cpu-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: community-cpu-${{ inputs.pr_number }}-${{ inputs.merge_sha }}
+  cancel-in-progress: false
 
 env:
-  CI_BASE_REF: ${{ github.event.pull_request.base.sha }}
+  CI_BASE_REF: ${{ inputs.base_sha }}
 
 jobs:
+  initialize:
+    name: Initialize exact-merge public checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
+    outputs:
+      source_quality_check_id: ${{ steps.checks.outputs.source_quality_check_id }}
+      ownership_impact_check_id: ${{ steps.checks.outputs.ownership_impact_check_id }}
+      unit_check_id: ${{ steps.checks.outputs.unit_check_id }}
+      required_check_id: ${{ steps.checks.outputs.required_check_id }}
+    steps:
+      - name: Validate the dispatched PR snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          MERGE_SHA: ${{ inputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          for revision in "$BASE_SHA" "$HEAD_SHA" "$MERGE_SHA"; do
+            [[ "$revision" =~ ^[0-9a-f]{40}$ ]]
+          done
+
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -er '.state' <<<"$pull")" = "open"
+          test "$(jq -er '.base.repo.full_name' <<<"$pull")" = "$GITHUB_REPOSITORY"
+          test "$(jq -er '.base.ref' <<<"$pull")" = "main"
+          test "$(jq -er '.base.sha' <<<"$pull")" = "$BASE_SHA"
+          test "$(jq -er '.head.sha' <<<"$pull")" = "$HEAD_SHA"
+          test "$(jq -er '.merge_commit_sha' <<<"$pull")" = "$MERGE_SHA"
+
+      - name: Publish pending exact-merge checks
+        id: checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ inputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          payload="$RUNNER_TEMP/community-cpu-check.json"
+
+          create_check() {
+            local key="$1"
+            local name="$2"
+            local external_id
+            local check_id
+            external_id="community-cpu:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${key}"
+            jq -n \
+              --arg name "$name" \
+              --arg head_sha "$MERGE_SHA" \
+              --arg details_url "$details_url" \
+              --arg external_id "$external_id" \
+              '{
+                name: $name,
+                head_sha: $head_sha,
+                status: "in_progress",
+                details_url: $details_url,
+                external_id: $external_id,
+                output: {
+                  title: "Maintainer-authorized public CPU validation",
+                  summary: "Public CPU validation is running for this exact PR merge revision."
+                }
+              }' > "$payload"
+            check_id="$(
+              gh api --method POST \
+                "/repos/$GITHUB_REPOSITORY/check-runs" \
+                --input "$payload" \
+                --jq '.id'
+            )"
+            [[ "$check_id" =~ ^[1-9][0-9]*$ ]]
+            echo "${key}_check_id=$check_id" >> "$GITHUB_OUTPUT"
+          }
+
+          trap 'rm -f "$payload"' EXIT
+          create_check source_quality "Community CPU / Source quality"
+          create_check ownership_impact "Community CPU / Ownership and impact"
+          create_check unit "Community CPU / Unit / C++ and Python"
+          create_check required "Community CPU / Required"
+
   source-quality:
     name: Community CPU / Source quality
+    needs: initialize
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - name: Check out the current PR merge
+      - name: Check out the authorized PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ inputs.merge_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -46,16 +147,19 @@ jobs:
 
   ownership-impact:
     name: Community CPU / Ownership and impact
+    needs: initialize
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     outputs:
       run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
       unit_scope: ${{ steps.impact.outputs.unit_scope }}
     steps:
-      - name: Check out the current PR merge
+      - name: Check out the authorized PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ inputs.merge_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -71,12 +175,22 @@ jobs:
   unit:
     name: Community CPU / Unit / C++ and Python
     if: ${{ always() }}
-    needs: ownership-impact
+    needs:
+      - initialize
+      - ownership-impact
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    permissions:
+      contents: read
     steps:
+      - name: Require successful request initialization
+        if: ${{ needs.initialize.result != 'success' }}
+        run: |
+          echo "::error::The exact PR snapshot could not be initialized."
+          exit 1
+
       - name: Require successful impact analysis
-        if: ${{ needs.ownership-impact.result != 'success' }}
+        if: ${{ needs.initialize.result == 'success' && needs.ownership-impact.result != 'success' }}
         env:
           IMPACT_RESULT: ${{ needs.ownership-impact.result }}
         run: |
@@ -85,22 +199,25 @@ jobs:
 
       - name: Explain an empty unit scope
         if: >-
+          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests != 'true'
         run: echo "No source-only C++ or Python unit tests are required for this change."
 
-      - name: Check out the current PR merge
+      - name: Check out the authorized PR merge
         if: >-
+          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ inputs.merge_sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
         if: >-
+          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
@@ -109,6 +226,7 @@ jobs:
 
       - name: Run hardened source-only units
         if: >-
+          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         env:
@@ -116,23 +234,117 @@ jobs:
         run: python3 -m tools.community_ci unit --scope "$TRTMC_UNIT_SCOPE"
 
   required:
-    name: Community CPU / Required
-    if: ${{ always() }}
+    name: Publish exact-merge public checks
+    if: ${{ always() && needs.initialize.result == 'success' }}
     needs:
+      - initialize
       - source-quality
       - ownership-impact
       - unit
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
     steps:
-      - name: Publish the public CPU verdict
+      - name: Publish exact-merge CPU checks
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          MERGE_SHA: ${{ inputs.merge_sha }}
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
-          IMPACT_RESULT: ${{ needs.ownership-impact.result }}
+          OWNERSHIP_IMPACT_RESULT: ${{ needs.ownership-impact.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
+          SOURCE_QUALITY_CHECK_ID: ${{ needs.initialize.outputs.source_quality_check_id }}
+          OWNERSHIP_IMPACT_CHECK_ID: ${{ needs.initialize.outputs.ownership_impact_check_id }}
+          UNIT_CHECK_ID: ${{ needs.initialize.outputs.unit_check_id }}
+          REQUIRED_CHECK_ID: ${{ needs.initialize.outputs.required_check_id }}
         run: |
-          printf 'Source quality: %s\nOwnership and impact: %s\nUnit: %s\n' \
-            "$SOURCE_QUALITY_RESULT" "$IMPACT_RESULT" "$UNIT_RESULT"
-          test "$SOURCE_QUALITY_RESULT" = success
-          test "$IMPACT_RESULT" = success
-          test "$UNIT_RESULT" = success
+          set -euo pipefail
+          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          payload="$RUNNER_TEMP/community-cpu-check-result.json"
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          result_conclusion() {
+            case "$1" in
+              success) echo success ;;
+              failure) echo failure ;;
+              cancelled) echo cancelled ;;
+              skipped) echo skipped ;;
+              *) echo neutral ;;
+            esac
+          }
+
+          update_check() {
+            local check_id="$1"
+            local conclusion="$2"
+            local title="$3"
+            local summary="$4"
+            [[ "$check_id" =~ ^[1-9][0-9]*$ ]]
+            jq -n \
+              --arg conclusion "$conclusion" \
+              --arg completed_at "$completed_at" \
+              --arg details_url "$details_url" \
+              --arg title "$title" \
+              --arg summary "$summary" \
+              '{
+                status: "completed",
+                conclusion: $conclusion,
+                completed_at: $completed_at,
+                details_url: $details_url,
+                output: {title: $title, summary: $summary}
+              }' > "$payload"
+            gh api --silent --method PATCH \
+              "/repos/$GITHUB_REPOSITORY/check-runs/$check_id" \
+              --input "$payload"
+          }
+
+          trap 'rm -f "$payload"' EXIT
+          snapshot_current=false
+          if pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"; then
+            state="$(jq -r '.state // empty' <<<"$pull")"
+            base_sha="$(jq -r '.base.sha // empty' <<<"$pull")"
+            head_sha="$(jq -r '.head.sha // empty' <<<"$pull")"
+            merge_sha="$(jq -r '.merge_commit_sha // empty' <<<"$pull")"
+            if [ "$state" = "open" ] \
+              && [ "$base_sha" = "$BASE_SHA" ] \
+              && [ "$head_sha" = "$HEAD_SHA" ] \
+              && [ "$merge_sha" = "$MERGE_SHA" ]; then
+              snapshot_current=true
+            fi
+          fi
+
+          if [ "$snapshot_current" != true ]; then
+            summary="The PR changed after public CPU validation was requested. Ask a maintainer to apply run-ci again."
+            update_check "$SOURCE_QUALITY_CHECK_ID" neutral "Stale PR snapshot" "$summary"
+            update_check "$OWNERSHIP_IMPACT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
+            update_check "$UNIT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
+            update_check "$REQUIRED_CHECK_ID" neutral "Stale PR snapshot" "$summary"
+            echo "::warning::$summary"
+            exit 0
+          fi
+
+          source_conclusion="$(result_conclusion "$SOURCE_QUALITY_RESULT")"
+          impact_conclusion="$(result_conclusion "$OWNERSHIP_IMPACT_RESULT")"
+          unit_conclusion="$(result_conclusion "$UNIT_RESULT")"
+          summary="Source quality: $SOURCE_QUALITY_RESULT; Ownership and impact: $OWNERSHIP_IMPACT_RESULT; Unit: $UNIT_RESULT."
+
+          update_check "$SOURCE_QUALITY_CHECK_ID" "$source_conclusion" \
+            "Source quality: $SOURCE_QUALITY_RESULT" "$summary"
+          update_check "$OWNERSHIP_IMPACT_CHECK_ID" "$impact_conclusion" \
+            "Ownership and impact: $OWNERSHIP_IMPACT_RESULT" "$summary"
+          update_check "$UNIT_CHECK_ID" "$unit_conclusion" \
+            "Unit: $UNIT_RESULT" "$summary"
+
+          required_conclusion=failure
+          if [ "$SOURCE_QUALITY_RESULT" = success ] \
+            && [ "$OWNERSHIP_IMPACT_RESULT" = success ] \
+            && [ "$UNIT_RESULT" = success ]; then
+            required_conclusion=success
+          fi
+          update_check "$REQUIRED_CHECK_ID" "$required_conclusion" \
+            "Community CPU: $required_conclusion" "$summary"
+          test "$required_conclusion" = success

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -7,8 +7,8 @@ run-name: >-
   PR #${{ github.event.pull_request.number || inputs.pr_number }} · public CPU validation
 
 on:
-  # Transitional trigger: keep this until the run-ci broker is available on
-  # main. Remove pull_request after the run-ci broker is available on main.
+  # Transitional trigger: keep this until the /run-ci broker is available on
+  # main. Remove pull_request after the /run-ci broker is available on main.
   pull_request:
     branches:
       - main
@@ -108,7 +108,7 @@ jobs:
                 details_url: $details_url,
                 external_id: $external_id,
                 output: {
-                  title: "Maintainer-authorized public CPU validation",
+                  title: "Contributor-requested public CPU validation",
                   summary: "Public CPU validation is running for this exact PR merge revision."
                 }
               }' > "$payload"
@@ -341,7 +341,7 @@ jobs:
           fi
 
           if [ "$snapshot_current" != true ]; then
-            summary="The PR changed after public CPU validation was requested. Ask a maintainer to apply run-ci again."
+            summary="The PR changed after public CPU validation was requested. Comment /run-ci again."
             update_check "$SOURCE_QUALITY_CHECK_ID" neutral "Stale PR snapshot" "$summary"
             update_check "$OWNERSHIP_IMPACT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
             update_check "$UNIT_CHECK_ID" neutral "Stale PR snapshot" "$summary"

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -3,9 +3,15 @@
 
 name: Community CPU
 
-run-name: "PR #${{ inputs.pr_number }} · public CPU validation"
+run-name: >-
+  PR #${{ github.event.pull_request.number || inputs.pr_number }} · public CPU validation
 
 on:
+  # Transitional trigger: keep this until the run-ci broker is available on
+  # main. Remove pull_request after the run-ci broker is available on main.
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,11 +34,12 @@ on:
 permissions: {}
 
 concurrency:
-  group: community-cpu-${{ inputs.pr_number }}-${{ inputs.merge_sha }}
+  group: >-
+    community-cpu-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.merge_commit_sha || inputs.merge_sha }}
   cancel-in-progress: false
 
 env:
-  CI_BASE_REF: ${{ inputs.base_sha }}
+  CI_BASE_REF: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
 
 jobs:
   initialize:
@@ -50,6 +57,7 @@ jobs:
       required_check_id: ${{ steps.checks.outputs.required_check_id }}
     steps:
       - name: Validate the dispatched PR snapshot
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -72,6 +80,7 @@ jobs:
           test "$(jq -er '.merge_commit_sha' <<<"$pull")" = "$MERGE_SHA"
 
       - name: Publish pending exact-merge checks
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         id: checks
         env:
           GH_TOKEN: ${{ github.token }}
@@ -130,7 +139,7 @@ jobs:
       - name: Check out the authorized PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ inputs.merge_sha }}
+          ref: ${{ inputs.merge_sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -159,7 +168,7 @@ jobs:
       - name: Check out the authorized PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ inputs.merge_sha }}
+          ref: ${{ inputs.merge_sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -211,7 +220,7 @@ jobs:
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ inputs.merge_sha }}
+          ref: ${{ inputs.merge_sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -234,7 +243,7 @@ jobs:
         run: python3 -m tools.community_ci unit --scope "$TRTMC_UNIT_SCOPE"
 
   required:
-    name: Publish exact-merge public checks
+    name: Community CPU / Required
     if: ${{ always() && needs.initialize.result == 'success' }}
     needs:
       - initialize
@@ -248,7 +257,21 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      - name: Publish the transitional automatic CPU verdict
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
+          OWNERSHIP_IMPACT_RESULT: ${{ needs.ownership-impact.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+        run: |
+          printf 'Source quality: %s\nOwnership and impact: %s\nUnit: %s\n' \
+            "$SOURCE_QUALITY_RESULT" "$OWNERSHIP_IMPACT_RESULT" "$UNIT_RESULT"
+          test "$SOURCE_QUALITY_RESULT" = success
+          test "$OWNERSHIP_IMPACT_RESULT" = success
+          test "$UNIT_RESULT" = success
+
       - name: Publish exact-merge CPU checks
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -106,7 +106,7 @@ jobs:
           community_cpu="$(
             gh api --method GET \
               "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
-              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions")) | sort_by(.started_at) | last | .conclusion // empty'
+              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))) | sort_by(.started_at) | last | .conclusion // empty'
           )"
           if [ "$community_cpu" != "success" ]; then
             echo "::error::Community CPU / Required must pass on the current PR merge before internal CI can run."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 minimum_pre_commit_version: "3.2.0"
-default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -32,13 +31,3 @@ repos:
         args: [-style=file]
         files: \.(cpp|h)$
         stages: [pre-commit]
-
-  - repo: local
-    hooks:
-      - id: trtmc-community-pre-push
-        name: TRTMC Community CPU pre-push gate
-        entry: python -m tools.community_ci pre-push
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,25 +15,29 @@ repos:
       - id: check-yaml
         stages: [pre-commit]
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
     hooks:
-      - id: trtmc-python-quality
+      - id: ruff-check
         name: TRTMC Python quality
-        entry: python3 -m tools.community_ci format-python
-        language: system
-        files: \.py$
+        args: [--config, ruff.toml]
         stages: [pre-commit]
 
-      - id: trtmc-cpp-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.8
+    hooks:
+      - id: clang-format
         name: TRTMC C++ formatting
-        entry: python3 -m tools.community_ci format-cpp
-        language: system
+        entry: clang-format --dry-run --Werror
+        args: [-style=file]
         files: \.(cpp|h)$
         stages: [pre-commit]
 
+  - repo: local
+    hooks:
       - id: trtmc-community-pre-push
         name: TRTMC Community CPU pre-push gate
-        entry: python3 -m tools.community_ci pre-push
+        entry: python -m tools.community_ci pre-push
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,16 @@ minimum_pre_commit_version: "3.2.0"
 default_install_hook_types: [pre-commit, pre-push]
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        stages: [pre-commit]
+      - id: end-of-file-fixer
+        stages: [pre-commit]
+      - id: check-yaml
+        stages: [pre-commit]
+
   - repo: local
     hooks:
       - id: trtmc-python-quality

--- a/Dockerfile.community-cpu
+++ b/Dockerfile.community-cpu
@@ -67,8 +67,14 @@ COPY community-ci.txt /tmp/trtmc-community-ci.txt
 RUN pip install --requirement /tmp/trtmc-community-ci.txt && \
     rm -f /tmp/trtmc-community-ci.txt
 
-ENV TRT_LIB_DIR=/usr/lib/x86_64-linux-gnu
-ENV TRT_INC_DIR=/usr/include/x86_64-linux-gnu
+RUN multiarch="$(gcc -dumpmachine)" && \
+    test -d "/usr/lib/${multiarch}" && \
+    test -d "/usr/include/${multiarch}" && \
+    ln -s "/usr/lib/${multiarch}" /opt/trtmc-tensorrt-lib && \
+    ln -s "/usr/include/${multiarch}" /opt/trtmc-tensorrt-include
+
+ENV TRT_LIB_DIR=/opt/trtmc-tensorrt-lib
+ENV TRT_INC_DIR=/opt/trtmc-tensorrt-include
 ENV LD_LIBRARY_PATH="${TRT_LIB_DIR}:/usr/local/cuda/lib64"
 
 RUN python3.12 -c \

--- a/Dockerfile.dev.aarch64
+++ b/Dockerfile.dev.aarch64
@@ -30,6 +30,8 @@ RUN python3.12 -m venv --system-site-packages ${VIRTUAL_ENV} && \
     ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
+COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt
+
 RUN pip install -U pip && \
     pip install \
       "apache-tvm-ffi==0.1.12" \
@@ -44,7 +46,9 @@ RUN pip install -U pip && \
       "sentencepiece>=0.1.99" \
       "transformers==5.2.0" && \
     pip install "torch==${TORCH_VERSION}" --index-url "${PYTORCH_CPU_INDEX}" && \
-    pip install "setuptools>=80,<82"
+    pip install "setuptools>=80,<82" && \
+    pip install --requirement /tmp/trtmc-community-ci.txt && \
+    rm -f /tmp/trtmc-community-ci.txt
 
 ENV TRT_LIB_DIR=/usr/lib/aarch64-linux-gnu
 ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu

--- a/Dockerfile.dev.x86
+++ b/Dockerfile.dev.x86
@@ -30,6 +30,8 @@ RUN python3.12 -m venv --system-site-packages ${VIRTUAL_ENV} && \
     ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
+COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt
+
 RUN pip install -U pip && \
     pip install \
       "apache-tvm-ffi==0.1.12" \
@@ -44,7 +46,9 @@ RUN pip install -U pip && \
       "sentencepiece>=0.1.99" \
       "transformers==5.2.0" && \
     pip install "torch==${TORCH_VERSION}" --index-url "${PYTORCH_CPU_INDEX}" && \
-    pip install "setuptools>=80,<82"
+    pip install "setuptools>=80,<82" && \
+    pip install --requirement /tmp/trtmc-community-ci.txt && \
+    rm -f /tmp/trtmc-community-ci.txt
 
 ENV TRT_LIB_DIR=/usr/lib/x86_64-linux-gnu
 ENV TRT_INC_DIR=/usr/include/x86_64-linux-gnu

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -195,6 +195,8 @@ def test_pre_commit_config_installs_fast_commit_and_complete_push_hooks() -> Non
     assert config["default_install_hook_types"] == ["pre-commit", "pre-push"]
 
     hooks = {hook["id"]: hook for repository in config["repos"] for hook in repository["hooks"]}
+    for hook_id in ("trailing-whitespace", "end-of-file-fixer", "check-yaml"):
+        assert hooks[hook_id]["stages"] == ["pre-commit"]
     assert hooks["trtmc-python-quality"]["stages"] == ["pre-commit"]
     assert hooks["trtmc-cpp-format"]["stages"] == ["pre-commit"]
     assert hooks["trtmc-community-pre-push"]["stages"] == ["pre-push"]

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -194,14 +194,28 @@ def test_pre_commit_config_installs_fast_commit_and_complete_push_hooks() -> Non
     config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
     assert config["default_install_hook_types"] == ["pre-commit", "pre-push"]
 
+    repositories = {repository["repo"]: repository for repository in config["repos"]}
+    assert repositories["https://github.com/astral-sh/ruff-pre-commit"]["rev"] == "v0.16.4"
+    assert (
+        repositories["https://github.com/pre-commit/mirrors-clang-format"]["rev"]
+        == "v22.1.8"
+    )
+
     hooks = {hook["id"]: hook for repository in config["repos"] for hook in repository["hooks"]}
     for hook_id in ("trailing-whitespace", "end-of-file-fixer", "check-yaml"):
         assert hooks[hook_id]["stages"] == ["pre-commit"]
-    assert hooks["trtmc-python-quality"]["stages"] == ["pre-commit"]
-    assert hooks["trtmc-cpp-format"]["stages"] == ["pre-commit"]
+    assert hooks["ruff-check"]["stages"] == ["pre-commit"]
+    assert hooks["clang-format"]["stages"] == ["pre-commit"]
+    assert hooks["clang-format"]["entry"] == "clang-format --dry-run --Werror"
     assert hooks["trtmc-community-pre-push"]["stages"] == ["pre-push"]
+    assert hooks["trtmc-community-pre-push"]["entry"] == (
+        "python -m tools.community_ci pre-push"
+    )
     assert hooks["trtmc-community-pre-push"]["always_run"] is True
     assert hooks["trtmc-community-pre-push"]["pass_filenames"] is False
+
+    source = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    assert "python3 -m tools.community_ci format-" not in source
 
 
 def test_impact_publishes_only_the_public_cpu_scope(
@@ -579,6 +593,11 @@ def test_cpu_image_installs_the_same_pinned_community_requirements() -> None:
     assert "pip install --no-deps" in dockerfile
     assert '"tensorrt_cu13_bindings==${TENSORRT_VERSION}"' in dockerfile
     assert '"tensorrt==${TENSORRT_VERSION}"' not in dockerfile
+    assert 'multiarch="$(gcc -dumpmachine)"' in dockerfile
+    assert "ENV TRT_LIB_DIR=/opt/trtmc-tensorrt-lib" in dockerfile
+    assert "ENV TRT_INC_DIR=/opt/trtmc-tensorrt-include" in dockerfile
+    assert "/usr/lib/x86_64-linux-gnu" not in dockerfile
+    assert "/usr/include/x86_64-linux-gnu" not in dockerfile
     assert "NVIDIA_VISIBLE_DEVICES" not in dockerfile
     assert "!requirements/" not in dockerignore
     assert "!requirements/community-ci.txt" not in dockerignore

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import json
 import subprocess
 from pathlib import Path
 
@@ -17,6 +18,174 @@ from tools.ci.process import CiError
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow_step_script(workflow_name: str, job_name: str, step_name: str) -> str:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(
+            encoding="utf-8"
+        )
+    )
+    return next(
+        step["run"]
+        for step in workflow["jobs"][job_name]["steps"]
+        if step["name"] == step_name
+    )
+
+
+def _write_public_ci_fake_gh(fake_bin: Path) -> None:
+    fake_jq = fake_bin / "jq"
+    fake_jq.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+arguments = sys.argv[1:]
+variables = {}
+expression = ""
+null_input = False
+raw_output = False
+exit_status = False
+index = 0
+while index < len(arguments):
+    argument = arguments[index]
+    if argument == "--arg":
+        variables[arguments[index + 1]] = arguments[index + 2]
+        index += 3
+        continue
+    if argument.startswith("-"):
+        null_input = null_input or "n" in argument[1:]
+        raw_output = raw_output or "r" in argument[1:]
+        exit_status = exit_status or "e" in argument[1:]
+    else:
+        expression = argument
+    index += 1
+
+if null_input:
+    if 'ref: "main"' in expression:
+        result = {
+            "ref": "main",
+            "inputs": {
+                key: variables[key]
+                for key in ("pr_number", "base_sha", "head_sha", "merge_sha")
+            },
+        }
+    elif 'status: "completed"' in expression:
+        result = {
+            "status": "completed",
+            "conclusion": variables["conclusion"],
+            "completed_at": variables["completed_at"],
+            "details_url": variables["details_url"],
+            "output": {
+                "title": variables["title"],
+                "summary": variables["summary"],
+            },
+        }
+    else:
+        raise SystemExit(f"unsupported null-input jq expression: {expression}")
+else:
+    result = json.load(sys.stdin)
+    optional_empty = expression.endswith(" // empty")
+    path = expression.removesuffix(" // empty").removeprefix(".").split(".")
+    for part in path:
+        if not isinstance(result, dict) or part not in result:
+            result = None
+            break
+        result = result[part]
+    if optional_empty and result is None:
+        result = ""
+
+if exit_status and result is None:
+    raise SystemExit(1)
+if raw_output:
+    if isinstance(result, bool):
+        print(str(result).lower())
+    elif result is not None:
+        print(result)
+else:
+    print(json.dumps(result))
+""",
+        encoding="utf-8",
+    )
+    fake_jq.chmod(0o755)
+
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+arguments = sys.argv[1:]
+endpoint = next(
+    (argument for argument in arguments if argument.startswith("/repos/")),
+    "",
+)
+if "/collaborators/" in endpoint:
+    print(os.environ["FAKE_ACTOR_ROLE"])
+elif "/pulls/" in endpoint:
+    print(os.environ["FAKE_PULL_JSON"])
+elif "/actions/workflows/community-cpu.yml/dispatches" in endpoint:
+    input_path = arguments[arguments.index("--input") + 1]
+    Path(os.environ["FAKE_DISPATCH_CAPTURE"]).write_text(
+        Path(input_path).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+elif "/check-runs/" in endpoint and "PATCH" in arguments:
+    input_path = arguments[arguments.index("--input") + 1]
+    payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    with Path(os.environ["FAKE_CHECK_CAPTURE"]).open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload) + "\\n")
+else:
+    print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+
+def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_public_ci_fake_gh(fake_bin)
+    base_sha = "a" * 40
+    head_sha = "b" * 40
+    merge_sha = "c" * 40
+    pull = {
+        "state": "open",
+        "base": {
+            "ref": "main",
+            "sha": base_sha,
+            "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
+        },
+        "head": {"sha": head_sha},
+        "merge_commit_sha": merge_sha,
+    }
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "ACTOR": "trusted-maintainer",
+            "BASE_SHA": base_sha,
+            "EVENT_HEAD_SHA": head_sha,
+            "FAKE_ACTOR_ROLE": "maintain",
+            "FAKE_CHECK_CAPTURE": str(tmp_path / "checks.jsonl"),
+            "FAKE_DISPATCH_CAPTURE": str(tmp_path / "dispatch.json"),
+            "FAKE_PULL_JSON": json.dumps(pull),
+            "GH_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "12345",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "HEAD_SHA": head_sha,
+            "MERGE_SHA": merge_sha,
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "PR_NUMBER": "980",
+            "RUNNER_TEMP": str(tmp_path),
+        }
+    )
+    return environment
 
 
 def test_pre_commit_config_installs_fast_commit_and_complete_push_hooks() -> None:
@@ -105,31 +274,233 @@ def test_pre_push_collects_source_and_unit_failures(
     assert "test_config_cli_support failed" in str(error.value)
 
 
-def test_public_workflow_is_read_only_cpu_only_and_has_one_required_verdict() -> None:
+def test_public_cpu_request_is_a_trusted_label_only_dispatcher() -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "community-cpu-request.yml"
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    source = path.read_text(encoding="utf-8")
+
+    assert workflow["permissions"] == {}
+    assert "pull_request_target:" in source
+    assert "types: [labeled]" in source
+    assert "github.event.label.name == 'run-ci'" in source
+    assert "github.ref == 'refs/heads/main'" in source
+    assert "maintain|admin)" in source
+    assert "Only actors with maintain or admin access" in source
+    assert "actions/workflows/community-cpu.yml/dispatches" in source
+    assert 'ref: "main"' in source
+    for input_name in ("pr_number", "base_sha", "head_sha", "merge_sha"):
+        assert f"{input_name}: ${input_name}" in source
+    assert "/labels/run-ci" in source
+    assert "always()" in source
+    assert "actions/checkout@" not in source
+    assert "secrets." not in source
+    assert "self-hosted" not in source
+
+    authorize = workflow["jobs"]["authorize"]
+    assert authorize["permissions"] == {
+        "actions": "write",
+        "contents": "read",
+        "pull-requests": "write",
+    }
+
+
+def test_public_cpu_request_dispatches_the_exact_labeled_snapshot(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu-request.yml",
+                "authorize",
+                "Authorize and dispatch the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    dispatch = json.loads((tmp_path / "dispatch.json").read_text(encoding="utf-8"))
+    assert dispatch == {
+        "ref": "main",
+        "inputs": {
+            "pr_number": "980",
+            "base_sha": "a" * 40,
+            "head_sha": "b" * 40,
+            "merge_sha": "c" * 40,
+        },
+    }
+
+
+def test_public_cpu_request_rejects_a_new_push_after_the_label(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment["EVENT_HEAD_SHA"] = "d" * 40
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu-request.yml",
+                "authorize",
+                "Authorize and dispatch the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "superseded by a newer PR head" in result.stdout + result.stderr
+    assert not (tmp_path / "dispatch.json").exists()
+
+
+def test_public_cpu_verdict_neutralizes_a_stale_snapshot(tmp_path: Path) -> None:
+    environment = _public_ci_environment(tmp_path)
+    pull = json.loads(environment["FAKE_PULL_JSON"])
+    pull["head"]["sha"] = "d" * 40
+    environment.update(
+        {
+            "FAKE_PULL_JSON": json.dumps(pull),
+            "SOURCE_QUALITY_RESULT": "success",
+            "OWNERSHIP_IMPACT_RESULT": "success",
+            "UNIT_RESULT": "success",
+            "SOURCE_QUALITY_CHECK_ID": "1",
+            "OWNERSHIP_IMPACT_CHECK_ID": "2",
+            "UNIT_CHECK_ID": "3",
+            "REQUIRED_CHECK_ID": "4",
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "required",
+                "Publish exact-merge CPU checks",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    checks = [
+        json.loads(line)
+        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(checks) == 4
+    assert {check["conclusion"] for check in checks} == {"neutral"}
+    assert all("PR changed" in check["output"]["summary"] for check in checks)
+
+
+def test_public_cpu_verdict_publishes_success_for_the_exact_snapshot(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment.update(
+        {
+            "SOURCE_QUALITY_RESULT": "success",
+            "OWNERSHIP_IMPACT_RESULT": "success",
+            "UNIT_RESULT": "success",
+            "SOURCE_QUALITY_CHECK_ID": "1",
+            "OWNERSHIP_IMPACT_CHECK_ID": "2",
+            "UNIT_CHECK_ID": "3",
+            "REQUIRED_CHECK_ID": "4",
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "required",
+                "Publish exact-merge CPU checks",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    checks = [
+        json.loads(line)
+        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(checks) == 4
+    assert {check["conclusion"] for check in checks} == {"success"}
+    assert checks[-1]["output"]["title"] == "Community CPU: success"
+
+
+def test_public_workflow_is_dispatched_read_only_cpu_and_publishes_exact_merge_checks() -> None:
     path = REPO_ROOT / ".github" / "workflows" / "community-cpu.yml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     source = path.read_text(encoding="utf-8")
 
     assert workflow["run-name"] == (
-        "PR #${{ github.event.pull_request.number }} · public CPU validation"
+        "PR #${{ inputs.pr_number }} · public CPU validation"
     )
-    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["permissions"] == {}
+    assert "workflow_dispatch:" in source
+    assert "\n  pull_request:" not in source
     assert "pull_request_target" not in source
+    assert "github.event.pull_request" not in source
     assert "self-hosted" not in source
     assert "secrets." not in source
     assert "persist-credentials: false" in source
     assert "--gpus" not in source
     assert "upload-pages" not in source
+    assert "ref: ${{ inputs.merge_sha }}" in source
+    assert 'external_id="community-cpu:' in source
+    assert '"/repos/$GITHUB_REPOSITORY/check-runs"' in source
+    assert '"/repos/$GITHUB_REPOSITORY/check-runs/$check_id"' in source
+    assert "The PR changed after public CPU validation was requested" in source
 
     jobs = workflow["jobs"]
     assert [job["name"] for job in jobs.values()] == [
+        "Initialize exact-merge public checks",
         "Community CPU / Source quality",
         "Community CPU / Ownership and impact",
         "Community CPU / Unit / C++ and Python",
-        "Community CPU / Required",
+        "Publish exact-merge public checks",
     ]
-    assert jobs["unit"]["needs"] == "ownership-impact"
-    assert jobs["required"]["needs"] == ["source-quality", "ownership-impact", "unit"]
+    assert jobs["initialize"]["permissions"] == {
+        "checks": "write",
+        "contents": "read",
+        "pull-requests": "read",
+    }
+    for job_name in ("source-quality", "ownership-impact", "unit"):
+        assert jobs[job_name]["permissions"] == {"contents": "read"}
+    assert jobs["unit"]["needs"] == ["initialize", "ownership-impact"]
+    assert jobs["required"]["needs"] == [
+        "initialize",
+        "source-quality",
+        "ownership-impact",
+        "unit",
+    ]
+    assert jobs["required"]["permissions"] == {
+        "checks": "write",
+        "contents": "read",
+        "pull-requests": "read",
+    }
 
 
 def test_cpu_image_installs_the_same_pinned_community_requirements() -> None:

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-import os
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -126,6 +126,8 @@ if "/collaborators/" in endpoint:
     print(os.environ["FAKE_ACTOR_ROLE"])
 elif "/pulls/" in endpoint:
     print(os.environ["FAKE_PULL_JSON"])
+elif "/commits/" in endpoint and "/check-runs" in endpoint:
+    print(os.environ.get("FAKE_EXISTING_REQUIRED", ""))
 elif "/actions/workflows/community-cpu.yml/dispatches" in endpoint:
     input_path = arguments[arguments.index("--input") + 1]
     Path(os.environ["FAKE_DISPATCH_CAPTURE"]).write_text(
@@ -161,14 +163,14 @@ def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
             "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
         },
         "head": {"sha": head_sha},
+        "user": {"login": "pr-author"},
         "merge_commit_sha": merge_sha,
     }
     environment = os.environ.copy()
     environment.update(
         {
-            "ACTOR": "trusted-maintainer",
+            "ACTOR": "pr-author",
             "BASE_SHA": base_sha,
-            "EVENT_HEAD_SHA": head_sha,
             "FAKE_ACTOR_ROLE": "maintain",
             "FAKE_CHECK_CAPTURE": str(tmp_path / "checks.jsonl"),
             "FAKE_DISPATCH_CAPTURE": str(tmp_path / "dispatch.json"),
@@ -274,37 +276,41 @@ def test_pre_push_collects_source_and_unit_failures(
     assert "test_config_cli_support failed" in str(error.value)
 
 
-def test_public_cpu_request_is_a_trusted_label_only_dispatcher() -> None:
+def test_public_cpu_request_is_a_pr_author_comment_dispatcher() -> None:
     path = REPO_ROOT / ".github" / "workflows" / "community-cpu-request.yml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     source = path.read_text(encoding="utf-8")
 
     assert workflow["permissions"] == {}
-    assert "pull_request_target:" in source
-    assert "types: [labeled]" in source
-    assert "github.event.label.name == 'run-ci'" in source
+    assert "issue_comment:" in source
+    assert "types: [created]" in source
+    assert "github.event.issue.pull_request != null" in source
+    assert "github.event.comment.body == '/run-ci'" in source
     assert "github.ref == 'refs/heads/main'" in source
+    assert 'if [ "$ACTOR" != "$pr_author" ]; then' in source
     assert "maintain|admin)" in source
-    assert "Only actors with maintain or admin access" in source
+    assert "Only the PR author or a maintainer/admin" in source
     assert "actions/workflows/community-cpu.yml/dispatches" in source
     assert 'ref: "main"' in source
     for input_name in ("pr_number", "base_sha", "head_sha", "merge_sha"):
         assert f"{input_name}: ${input_name}" in source
-    assert "/labels/run-ci" in source
-    assert "always()" in source
+    assert "/labels/run-ci" not in source
+    assert "pull_request_target" not in source
     assert "actions/checkout@" not in source
     assert "secrets." not in source
     assert "self-hosted" not in source
 
     authorize = workflow["jobs"]["authorize"]
+    assert authorize["runs-on"] == "ubuntu-24.04"
     assert authorize["permissions"] == {
         "actions": "write",
+        "checks": "read",
         "contents": "read",
-        "pull-requests": "write",
+        "pull-requests": "read",
     }
 
 
-def test_public_cpu_request_dispatches_the_exact_labeled_snapshot(
+def test_public_cpu_request_dispatches_the_exact_commented_snapshot(
     tmp_path: Path,
 ) -> None:
     environment = _public_ci_environment(tmp_path)
@@ -338,11 +344,12 @@ def test_public_cpu_request_dispatches_the_exact_labeled_snapshot(
     }
 
 
-def test_public_cpu_request_rejects_a_new_push_after_the_label(
+def test_public_cpu_request_rejects_an_unrelated_commenter(
     tmp_path: Path,
 ) -> None:
     environment = _public_ci_environment(tmp_path)
-    environment["EVENT_HEAD_SHA"] = "d" * 40
+    environment["ACTOR"] = "unrelated-user"
+    environment["FAKE_ACTOR_ROLE"] = "read"
     result = subprocess.run(
         [
             "bash",
@@ -361,7 +368,62 @@ def test_public_cpu_request_rejects_a_new_push_after_the_label(
     )
 
     assert result.returncode != 0
-    assert "superseded by a newer PR head" in result.stdout + result.stderr
+    assert "Only the PR author or a maintainer/admin" in result.stdout + result.stderr
+    assert not (tmp_path / "dispatch.json").exists()
+
+
+def test_public_cpu_request_allows_a_maintainer_to_help(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment["ACTOR"] = "trusted-maintainer"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu-request.yml",
+                "authorize",
+                "Authorize and dispatch the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / "dispatch.json").is_file()
+
+
+@pytest.mark.parametrize("existing", ["queued", "in_progress", "success"])
+def test_public_cpu_request_deduplicates_the_current_merge(
+    tmp_path: Path,
+    existing: str,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment["FAKE_EXISTING_REQUIRED"] = existing
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu-request.yml",
+                "authorize",
+                "Authorize and dispatch the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"already {existing}" in result.stdout
     assert not (tmp_path / "dispatch.json").exists()
 
 
@@ -461,7 +523,7 @@ def test_public_workflow_supports_safe_transition_and_exact_merge_checks() -> No
     assert workflow["permissions"] == {}
     assert "workflow_dispatch:" in source
     assert "\n  pull_request:" in source
-    assert "Remove pull_request after the run-ci broker is available on main" in source
+    assert "Remove pull_request after the /run-ci broker is available on main" in source
     assert "pull_request_target" not in source
     assert "self-hosted" not in source
     assert "secrets." not in source
@@ -487,6 +549,7 @@ def test_public_workflow_supports_safe_transition_and_exact_merge_checks() -> No
         "contents": "read",
         "pull-requests": "read",
     }
+    assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
     assert jobs["unit"]["needs"] == ["initialize", "ownership-impact"]

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -14,7 +14,6 @@ import pytest
 import yaml
 
 from tools import community_ci
-from tools.ci.process import CiError
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -190,9 +189,9 @@ def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
     return environment
 
 
-def test_pre_commit_config_installs_fast_commit_and_complete_push_hooks() -> None:
+def test_pre_commit_config_installs_only_lightweight_commit_hooks() -> None:
     config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
-    assert config["default_install_hook_types"] == ["pre-commit", "pre-push"]
+    assert "default_install_hook_types" not in config
 
     repositories = {repository["repo"]: repository for repository in config["repos"]}
     assert repositories["https://github.com/astral-sh/ruff-pre-commit"]["rev"] == "v0.16.4"
@@ -207,15 +206,11 @@ def test_pre_commit_config_installs_fast_commit_and_complete_push_hooks() -> Non
     assert hooks["ruff-check"]["stages"] == ["pre-commit"]
     assert hooks["clang-format"]["stages"] == ["pre-commit"]
     assert hooks["clang-format"]["entry"] == "clang-format --dry-run --Werror"
-    assert hooks["trtmc-community-pre-push"]["stages"] == ["pre-push"]
-    assert hooks["trtmc-community-pre-push"]["entry"] == (
-        "python -m tools.community_ci pre-push"
-    )
-    assert hooks["trtmc-community-pre-push"]["always_run"] is True
-    assert hooks["trtmc-community-pre-push"]["pass_filenames"] is False
+    assert all(hook["stages"] == ["pre-commit"] for hook in hooks.values())
 
     source = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     assert "python3 -m tools.community_ci format-" not in source
+    assert "pre-push" not in source
 
 
 def test_impact_publishes_only_the_public_cpu_scope(
@@ -260,36 +255,6 @@ def test_impact_publishes_only_the_public_cpu_scope(
     summary = github_summary.read_text(encoding="utf-8")
     assert "Unit scope: `cli`" in summary
     assert "src/runtime/config/cli_support.cpp" in summary
-
-
-def test_pre_push_collects_source_and_unit_failures(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runner = community_ci.CommunityCI(REPO_ROOT, dict(os.environ))
-    calls = []
-    monkeypatch.setattr(runner, "resolve_base", lambda _base: "base-sha")
-
-    def fail_source(_base: str) -> None:
-        calls.append("source")
-        raise CiError("format failed")
-
-    def run_impact(_base: str) -> dict[str, object]:
-        calls.append("impact")
-        return {"unit_scope": "cli"}
-
-    def fail_unit(scope: str) -> None:
-        calls.append(f"unit:{scope}")
-        raise CiError("test_config_cli_support failed")
-
-    monkeypatch.setattr(runner, "source_quality", fail_source)
-    monkeypatch.setattr(runner, "impact", run_impact)
-    monkeypatch.setattr(runner, "unit", fail_unit)
-
-    with pytest.raises(CiError, match="format failed") as error:
-        runner.pre_push(None)
-
-    assert calls == ["source", "impact", "unit:cli"]
-    assert "test_config_cli_support failed" in str(error.value)
 
 
 def test_public_cpu_request_is_a_pr_author_comment_dispatcher() -> None:

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -450,25 +450,25 @@ def test_public_cpu_verdict_publishes_success_for_the_exact_snapshot(
     assert checks[-1]["output"]["title"] == "Community CPU: success"
 
 
-def test_public_workflow_is_dispatched_read_only_cpu_and_publishes_exact_merge_checks() -> None:
+def test_public_workflow_supports_safe_transition_and_exact_merge_checks() -> None:
     path = REPO_ROOT / ".github" / "workflows" / "community-cpu.yml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     source = path.read_text(encoding="utf-8")
 
     assert workflow["run-name"] == (
-        "PR #${{ inputs.pr_number }} · public CPU validation"
+        "PR #${{ github.event.pull_request.number || inputs.pr_number }} · public CPU validation"
     )
     assert workflow["permissions"] == {}
     assert "workflow_dispatch:" in source
-    assert "\n  pull_request:" not in source
+    assert "\n  pull_request:" in source
+    assert "Remove pull_request after the run-ci broker is available on main" in source
     assert "pull_request_target" not in source
-    assert "github.event.pull_request" not in source
     assert "self-hosted" not in source
     assert "secrets." not in source
     assert "persist-credentials: false" in source
     assert "--gpus" not in source
     assert "upload-pages" not in source
-    assert "ref: ${{ inputs.merge_sha }}" in source
+    assert "ref: ${{ inputs.merge_sha || github.event.pull_request.merge_commit_sha }}" in source
     assert 'external_id="community-cpu:' in source
     assert '"/repos/$GITHUB_REPOSITORY/check-runs"' in source
     assert '"/repos/$GITHUB_REPOSITORY/check-runs/$check_id"' in source
@@ -480,7 +480,7 @@ def test_public_workflow_is_dispatched_read_only_cpu_and_publishes_exact_merge_c
         "Community CPU / Source quality",
         "Community CPU / Ownership and impact",
         "Community CPU / Unit / C++ and Python",
-        "Publish exact-merge public checks",
+        "Community CPU / Required",
     ]
     assert jobs["initialize"]["permissions"] == {
         "checks": "write",

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -212,6 +212,7 @@ def test_source_workflow_inventory_does_not_repeat_premerge_after_merge() -> Non
         *workflows.glob("*.yaml"),
     }
     assert sorted(path.name for path in workflow_files) == [
+        "community-cpu-request.yml",
         "community-cpu.yml",
         "internal-ci-bridge.yml",
         "pages.yml",
@@ -304,6 +305,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert '[[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert "Community CPU / Required" in authorize
     assert ".app.slug == \"github-actions\"" in authorize
+    assert '(.external_id // "") | startswith("community-cpu:")' in authorize
     assert 'if [ "$community_cpu" != "success" ]; then' in authorize
     assert 'echo "head_sha=$head_sha"' in authorize
     assert "pr_number=$PR_NUMBER" in authorize

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -682,6 +682,15 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     )
     for architecture, source_dockerfile in source_dockerfiles.items():
         assert "FROM ${TENSORRT_IMAGE}" in source_dockerfile
+        assert (
+            "COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt"
+            in source_dockerfile
+        )
+        assert (
+            "pip install --requirement /tmp/trtmc-community-ci.txt"
+            in source_dockerfile
+        )
+        assert "pre-commit>=" not in source_dockerfile
         assert "https://download.pytorch.org/whl/cpu" in source_dockerfile
         assert "torch.version.cuda is None" in source_dockerfile
         assert "TRTMC_TORCH_CUDA_ARCH_LIST" not in source_dockerfile

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -7,7 +7,7 @@ graph, and these classes define **what** each test stage does.
 
 The shortest useful reading order is:
 
-1. `.github/workflows/community-cpu-request.yml` — the trusted `run-ci` label broker.
+1. `.github/workflows/community-cpu-request.yml` — the trusted `/run-ci` comment broker.
 2. `.github/workflows/community-cpu.yml` — exact-merge public CPU validation.
 3. `.github/workflows/internal-ci-bridge.yml` — the exact-head protected dispatch boundary.
 4. `tools/ci/__main__.py` — the public command-line interface.
@@ -18,7 +18,7 @@ The shortest useful reading order is:
 
 ```mermaid
 flowchart LR
-    A[Trusted actor adds run-ci] --> B[Public CPU checks exact PR merge]
+    A[PR author comments /run-ci] --> B[Public CPU checks exact PR merge]
     B --> C[Public exact-merge verdict]
     C --> D[Trusted actor adds run-internal-ci]
     D --> E[Private Internal premerge exact PR head]
@@ -55,19 +55,18 @@ that enters the run-owned container and invokes `pipeline` there.
 
 ## Community CPU, step by step
 
-An actor with `maintain` or `admin` permission applies the one-shot `run-ci`
-label after reviewing the public pull request. The default-branch request
-workflow verifies the actor, open PR, `main` base, and label-event head SHA. It
-never checks out or executes PR code. It then dispatches the default-branch
-Community CPU workflow with the exact base, head, and merge SHAs and consumes
-the label.
+The pull-request author comments `/run-ci`; a maintainer or admin may submit the
+same command on the author's behalf. The default-branch request workflow
+verifies the actor, open PR, and `main` base. It never checks out or executes PR
+code. It dispatches the default-branch Community CPU workflow with the exact
+base, head, and merge SHAs.
 
 The dispatched test jobs check out only the authorized merge SHA with
 read-only repository permission and no secrets. Separate publisher jobs create
 and complete contributor-visible checks on that merge SHA. If the PR head or
 base changes before publication, every pending public check becomes neutral
-instead of validating the stale snapshot. Apply `run-ci` again only after the
-new head is ready.
+instead of validating the stale snapshot. Comment `/run-ci` again only after
+the new head is ready.
 
 ## Pre-merge, step by step
 
@@ -135,7 +134,7 @@ gh api --method PATCH \
 
 This is an explicit operator recovery, not an automatic trusted-workflow
 mutation. Wait for the PR API and source branch SHA to match, confirm the PR is
-still open and targets `main`, then add `run-internal-ci` again. Use `run-ci`
+still open and targets `main`, then add `run-internal-ci` again. Use `/run-ci`
 only to refresh public CPU validation for the current merge revision, and never
 dispatch protected CI while the two heads differ or the current public required
 check is absent.

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -7,26 +7,29 @@ graph, and these classes define **what** each test stage does.
 
 The shortest useful reading order is:
 
-1. `.github/workflows/internal-ci-bridge.yml` — the exact-head dispatch boundary.
-2. `tools/ci/__main__.py` — the public command-line interface.
-3. `tools/ci/pipeline.py` — the named non-model stages and their ordered steps.
-4. `tools/ci/model_proof.py` and `model_proof_inner.py` — one isolated model proof.
+1. `.github/workflows/community-cpu-request.yml` — the trusted `run-ci` label broker.
+2. `.github/workflows/community-cpu.yml` — exact-merge public CPU validation.
+3. `.github/workflows/internal-ci-bridge.yml` — the exact-head protected dispatch boundary.
+4. `tools/ci/__main__.py` — the public command-line interface.
+5. `tools/ci/pipeline.py` — the named non-model stages and their ordered steps.
+6. `tools/ci/model_proof.py` and `model_proof_inner.py` — one isolated model proof.
 
 ## The system at a glance
 
 ```mermaid
 flowchart LR
-    A[Trusted actor adds run-internal-ci] --> B[Source bridge captures exact PR head]
-    B --> C[Private Internal premerge]
-    C --> D[Legal, ownership, and impact]
-    D --> E[Source quality and units]
-    E --> F1[Model A proof]
-    E --> F2[Model B proof]
-    E --> FN[Model N proof]
-    F1 --> G[Private report and artifacts]
-    F2 --> G
-    FN --> G
-    G --> H[Sanitized exact-head status]
+    A[Trusted actor adds run-ci] --> B[Public CPU checks exact PR merge]
+    B --> C[Public exact-merge verdict]
+    C --> D[Trusted actor adds run-internal-ci]
+    D --> E[Private Internal premerge exact PR head]
+    E --> F[Legal, ownership, source quality, and units]
+    F --> G1[Model A proof]
+    F --> G2[Model B proof]
+    F --> GN[Model N proof]
+    G1 --> H[Private report and artifacts]
+    G2 --> H
+    GN --> H
+    H --> I[Sanitized exact-head status]
 ```
 
 Each model box is a separate isolated job. Source contains the test
@@ -49,6 +52,22 @@ python3 -m tools.ci model-proof --model patchtsmixer --suite premerge
 
 `pipeline` runs in the current environment. `stage` is the host-side bridge
 that enters the run-owned container and invokes `pipeline` there.
+
+## Community CPU, step by step
+
+An actor with `maintain` or `admin` permission applies the one-shot `run-ci`
+label after reviewing the public pull request. The default-branch request
+workflow verifies the actor, open PR, `main` base, and label-event head SHA. It
+never checks out or executes PR code. It then dispatches the default-branch
+Community CPU workflow with the exact base, head, and merge SHAs and consumes
+the label.
+
+The dispatched test jobs check out only the authorized merge SHA with
+read-only repository permission and no secrets. Separate publisher jobs create
+and complete contributor-visible checks on that merge SHA. If the PR head or
+base changes before publication, every pending public check becomes neutral
+instead of validating the stale snapshot. Apply `run-ci` again only after the
+new head is ready.
 
 ## Pre-merge, step by step
 
@@ -116,8 +135,10 @@ gh api --method PATCH \
 
 This is an explicit operator recovery, not an automatic trusted-workflow
 mutation. Wait for the PR API and source branch SHA to match, confirm the PR is
-still open and targets `main`, then add `run-internal-ci` again. Never use
-`run-ci`, and never dispatch while the two heads differ.
+still open and targets `main`, then add `run-internal-ci` again. Use `run-ci`
+only to refresh public CPU validation for the current merge revision, and never
+dispatch protected CI while the two heads differ or the current public required
+check is absent.
 
 ### 2. Select the work
 

--- a/tools/community_ci.py
+++ b/tools/community_ci.py
@@ -27,7 +27,6 @@ from tools.model_ci import ModelCIError, calculate_impact, discover_catalog
 
 
 UNIT_SCOPES = ("none", "builder", "cli", "all")
-ZERO_REVISION = "0" * 40
 
 
 class CommunityCI:
@@ -42,20 +41,6 @@ class CommunityCI:
         self.env = dict(env or os.environ)
         self.commands = CommandRunner(cwd=self.repository, env=self.env)
         self.github = GitHubFiles(self.env)
-
-    def format_python(self, files: Sequence[str]) -> None:
-        selected = self._existing_files(files, {".py"})
-        if not selected:
-            print("No Python files require quality checks.")
-            return
-        self.commands.run(["ruff", "check", "--config", "ruff.toml", *selected])
-
-    def format_cpp(self, files: Sequence[str]) -> None:
-        selected = self._existing_files(files, {".cpp", ".h"})
-        if not selected:
-            print("No C++ files require formatting checks.")
-            return
-        self.commands.run(["clang-format", "--dry-run", "--Werror", *selected])
 
     def source_quality(self, base: str | None) -> None:
         resolved_base = self.resolve_base(base)
@@ -157,35 +142,10 @@ class CommunityCI:
                     capture_output=True,
                 )
 
-    def pre_push(self, base: str | None) -> None:
-        resolved_base = self.resolve_base(base)
-        failures: list[str] = []
-        try:
-            self.source_quality(resolved_base)
-        except (CiError, ModelCIError) as error:
-            failures.append(str(error))
-
-        impact: dict[str, object] | None = None
-        try:
-            impact = self.impact(resolved_base)
-        except (CiError, ModelCIError) as error:
-            failures.append(f"Ownership and impact: {error}")
-
-        if impact is not None:
-            try:
-                self.unit(str(impact["unit_scope"]))
-            except CiError as error:
-                failures.append(f"C++ and Python unit tests: {error}")
-
-        self._raise_failures("Community CPU pre-push gate", failures)
-
     def resolve_base(self, explicit: str | None) -> str:
         configured = explicit or self.env.get("TRTMC_COMMUNITY_BASE_REF", "")
         candidates = [configured] if configured else []
         candidates.extend(("upstream/main", "github/main", "origin/main"))
-        pre_push_from = self.env.get("PRE_COMMIT_FROM_REF", "")
-        if pre_push_from and pre_push_from != ZERO_REVISION:
-            candidates.append(pre_push_from)
 
         seen: set[str] = set()
         for candidate in candidates:
@@ -241,14 +201,6 @@ class CommunityCI:
             print(f"Reusing Community CPU image: {image}")
         return image
 
-    def _existing_files(self, files: Sequence[str], suffixes: set[str]) -> list[str]:
-        selected = []
-        for value in files:
-            path = self.repository / value
-            if path.is_file() and path.suffix in suffixes:
-                selected.append(value)
-        return selected
-
     @staticmethod
     def _collect(checks: Sequence[tuple[str, Callable[[], None]]]) -> list[str]:
         failures = []
@@ -274,12 +226,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
 
-    python_format = commands.add_parser("format-python", help="Check changed Python files")
-    python_format.add_argument("files", nargs="*")
-    cpp_format = commands.add_parser("format-cpp", help="Check changed C++ files")
-    cpp_format.add_argument("files", nargs="*")
-
-    for name in ("source-quality", "impact", "pre-push"):
+    for name in ("source-quality", "impact"):
         command = commands.add_parser(name)
         command.add_argument("--base")
 
@@ -292,18 +239,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     arguments = build_parser().parse_args(argv)
     runner = CommunityCI()
     try:
-        if arguments.command == "format-python":
-            runner.format_python(arguments.files)
-        elif arguments.command == "format-cpp":
-            runner.format_cpp(arguments.files)
-        elif arguments.command == "source-quality":
+        if arguments.command == "source-quality":
             runner.source_quality(arguments.base)
         elif arguments.command == "impact":
             runner.impact(arguments.base)
         elif arguments.command == "unit":
             runner.unit(arguments.scope)
-        else:
-            runner.pre_push(arguments.base)
     except (CiError, ModelCIError) as error:
         print(f"ERROR: {error}")
         return 1

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -38,7 +38,7 @@ Install the local quality hooks once in the clone:
 
 ```bash
 python3 -m pip install --requirement requirements/community-ci.txt
-pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
+pre-commit install --install-hooks
 ```
 
 Commit-time hooks trim trailing whitespace, ensure one final newline, validate
@@ -47,12 +47,10 @@ review and stage those fixes before committing again. Pre-commit manages the
 Ruff and clang-format environments on Linux, macOS, and Windows instead of
 depending on host-installed binaries.
 
-Push-time hooks are check-only: they run the complete source-quality and
-ownership analysis, followed by the selected source-only C++ and Python unit
-scope in a hardened, GPU-free Linux container. This requires Docker with Linux
-containers; use WSL2 on Windows. The public image supports Linux x86_64 and
-ARM64, including Docker Desktop on macOS. Native Windows without WSL2/Linux
-containers cannot run the TensorRT CLI build gate. The protected suite retains
+The local hook intentionally stays lightweight and does not build the CLI or
+run the complete CPU suite. After pushing, comment `/run-ci` on the pull request
+to run source quality, ownership analysis, and the selected source-only C++ and
+Python units on GitHub-hosted public CPU runners. The protected suite retains
 the filesystem-specific cache-reflink contract that public runners cannot
 portably execute.
 

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -128,17 +128,23 @@ performance, and release qualification are different evidence tiers.
 
 ## 6. Read public CPU validation
 
-A maintainer starts contributor-visible, GitHub-hosted `Community CPU`
-validation by applying the one-shot `run-ci` label after reviewing the proposed
-workflow and tooling changes. The trusted request workflow consumes the label,
-captures the exact PR merge revision, and dispatches source quality, ownership
-and impact, and source-only C++ and Python units from the workflow on `main`.
+The pull-request author starts contributor-visible, GitHub-hosted `Community
+CPU` validation by adding this exact comment to the pull request:
+
+```text
+/run-ci
+```
+
+The trusted request workflow runs from `main`, captures the exact PR merge
+revision, and dispatches source quality, ownership and impact, and source-only
+C++ and Python units. A maintainer or admin may submit the same comment on the
+author's behalf.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs. Their sanitized checks and detailed public logs are
 published on the exact merge revision. Fix any failures and wait for
-`Community CPU / Required` to pass. If you push another commit, ask the
-maintainer to apply `run-ci` again.
+`Community CPU / Required` to pass. If you push another commit, comment
+`/run-ci` again after the new head is ready.
 
 ## 7. Coordinate protected repository CI
 
@@ -155,7 +161,7 @@ After public CPU validation passes, the maintainer verifies the PR's
 label, verifies the current exact-merge public CPU result, captures the
 immutable PR head SHA, and dispatches private premerge validation for that exact
 revision. The public result is contributor feedback, not an authorization
-token; each maintainer-owned label remains a separate security boundary.
+token; `run-internal-ci` remains the protected-resource security boundary.
 
 Wait for the `trtmc/premerge/required` status on the same head SHA to complete
 successfully. If the head changes intentionally, finish the update and local

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -128,11 +128,17 @@ performance, and release qualification are different evidence tiers.
 
 ## 6. Read public CPU validation
 
-Every pull request automatically receives contributor-visible, GitHub-hosted
-`Community CPU` checks for source quality, ownership and impact, and source-only
-C++ and Python units. These checks have read-only repository permission and no
-access to private runners, secrets, or GPUs. Fix their detailed failures and
-wait for `Community CPU / Required` on the current PR merge revision.
+A maintainer starts contributor-visible, GitHub-hosted `Community CPU`
+validation by applying the one-shot `run-ci` label after reviewing the proposed
+workflow and tooling changes. The trusted request workflow consumes the label,
+captures the exact PR merge revision, and dispatches source quality, ownership
+and impact, and source-only C++ and Python units from the workflow on `main`.
+
+The test jobs have read-only repository permission and no access to private
+runners, secrets, or GPUs. Their sanitized checks and detailed public logs are
+published on the exact merge revision. Fix any failures and wait for
+`Community CPU / Required` to pass. If you push another commit, ask the
+maintainer to apply `run-ci` again.
 
 ## 7. Coordinate protected repository CI
 
@@ -144,11 +150,12 @@ pass and the pull request is ready, add this comment:
 @yifeif-nv This PR is ready for CI. Please trigger CI for the current head.
 ```
 
-The maintainer verifies the PR's `headRefOid` and applies `run-internal-ci`.
-The trusted bridge consumes that label, verifies the current public CPU result,
-captures the immutable PR head SHA, and dispatches private premerge validation
-for that exact revision. The public result is contributor feedback, not an
-authorization token; the maintainer-owned label remains the security boundary.
+After public CPU validation passes, the maintainer verifies the PR's
+`headRefOid` and applies `run-internal-ci`. The trusted bridge consumes that
+label, verifies the current exact-merge public CPU result, captures the
+immutable PR head SHA, and dispatches private premerge validation for that exact
+revision. The public result is contributor feedback, not an authorization
+token; each maintainer-owned label remains a separate security boundary.
 
 Wait for the `trtmc/premerge/required` status on the same head SHA to complete
 successfully. If the head changes intentionally, finish the update and local

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -43,11 +43,18 @@ pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
 
 Commit-time hooks trim trailing whitespace, ensure one final newline, validate
 YAML, check Ruff, and verify clang-format. Some commit-time hooks modify files;
-review and stage those fixes before committing again. Push-time hooks are
-check-only: they run the complete source-quality and ownership analysis,
-followed by the selected source-only C++ and Python unit scope in a hardened,
-GPU-free container. The protected suite retains the filesystem-specific
-cache-reflink contract that public runners cannot portably execute.
+review and stage those fixes before committing again. Pre-commit manages the
+Ruff and clang-format environments on Linux, macOS, and Windows instead of
+depending on host-installed binaries.
+
+Push-time hooks are check-only: they run the complete source-quality and
+ownership analysis, followed by the selected source-only C++ and Python unit
+scope in a hardened, GPU-free Linux container. This requires Docker with Linux
+containers; use WSL2 on Windows. The public image supports Linux x86_64 and
+ARM64, including Docker Desktop on macOS. Native Windows without WSL2/Linux
+containers cannot run the TensorRT CLI build gate. The protected suite retains
+the filesystem-specific cache-reflink contract that public runners cannot
+portably execute.
 
 ## 2. Find the owner before editing
 

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -41,11 +41,13 @@ python3 -m pip install --requirement requirements/community-ci.txt
 pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
 ```
 
-Commit-time hooks check Ruff and clang-format. Push-time hooks run the complete
-source-quality and ownership analysis, followed by the selected source-only C++
-and Python unit scope in a hardened, GPU-free container. The protected suite
-retains the filesystem-specific cache-reflink contract that public runners
-cannot portably execute.
+Commit-time hooks trim trailing whitespace, ensure one final newline, validate
+YAML, check Ruff, and verify clang-format. Some commit-time hooks modify files;
+review and stage those fixes before committing again. Push-time hooks are
+check-only: they run the complete source-quality and ownership analysis,
+followed by the selected source-only C++ and Python unit scope in a hardened,
+GPU-free container. The protected suite retains the filesystem-specific
+cache-reflink contract that public runners cannot portably execute.
 
 ## 2. Find the owner before editing
 

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -9,14 +9,15 @@ CPU request broker and executor, the Internal CI Bridge, and the path-scoped
 Pages deployment. Protected premerge, including legal compliance, and nightly
 orchestration run in private Internal CI.
 
-An authorized collaborator with maintain or admin access first applies
-`run-ci` to run public CPU validation on the exact current PR merge, then
-applies `run-internal-ci` to dispatch the exact current PR head after the public
-required check passes. Source receives contributor-visible public CPU checks
-and only the sanitized `trtmc/premerge/required` status from protected CI. Raw
-protected logs, artifacts, runner details, internal packages, and the complete
-report remain private. Neither label path triggers on a push to `main`, so
-merging a passing PR does not rerun the same premerge suite.
+The pull-request author first comments `/run-ci` to run public CPU validation
+on the exact current PR merge. After the public required check passes, an
+authorized collaborator with maintain or admin access applies
+`run-internal-ci` to dispatch the exact current PR head. Source receives
+contributor-visible public CPU checks and only the sanitized
+`trtmc/premerge/required` status from protected CI. Raw protected logs,
+artifacts, runner details, internal packages, and the complete report remain
+private. Neither path triggers on a push to `main`, so merging a passing PR
+does not rerun the same premerge suite.
 
 Source has no separate pull-request documentation-validation workflow. The
 Pages workflow builds the site before deployment from `main`, but it is not a
@@ -76,7 +77,7 @@ Source contains exactly these four workflow files:
 
 | Workflow | Trigger and evidence boundary |
 | --- | --- |
-| `.github/workflows/community-cpu-request.yml` | One-shot `run-ci` label; authorizes the actor and dispatches only an exact public PR snapshot without executing PR code. |
+| `.github/workflows/community-cpu-request.yml` | Exact `/run-ci` PR comment from the PR author or a maintainer/admin; dispatches only an exact public PR snapshot without executing PR code. |
 | `.github/workflows/community-cpu.yml` | Manual dispatch from the trusted request broker; runs read-only public CPU validation and publishes checks on the exact PR merge SHA. |
 | `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, verifies current public CPU success, captures the exact PR head, and dispatches private premerge. |
 | `.github/workflows/pages.yml` | Pushes affecting `website/**` on `main`, or manual runs; builds and deploys only the documentation site to GitHub Pages. |

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -4,17 +4,19 @@ title: Testing Reference
 
 ## CI and evidence boundary
 
-Source contains the test implementation and two GitHub workflows: the Internal
-CI Bridge and the path-scoped Pages deployment. Premerge, including legal
-compliance, and nightly orchestration run in private Internal CI.
+Source contains the test implementation and four GitHub workflows: the public
+CPU request broker and executor, the Internal CI Bridge, and the path-scoped
+Pages deployment. Protected premerge, including legal compliance, and nightly
+orchestration run in private Internal CI.
 
-An authorized collaborator with maintain or admin access applies
-`run-internal-ci` to dispatch the exact current PR head. Source receives only
-the sanitized
-`trtmc/premerge/required` status for that head. Raw logs, artifacts, runner
-details, internal packages, and the complete report remain private. Neither the
-Source bridge nor Internal premerge triggers on a push to `main`, so merging a
-passing PR does not rerun the same premerge suite.
+An authorized collaborator with maintain or admin access first applies
+`run-ci` to run public CPU validation on the exact current PR merge, then
+applies `run-internal-ci` to dispatch the exact current PR head after the public
+required check passes. Source receives contributor-visible public CPU checks
+and only the sanitized `trtmc/premerge/required` status from protected CI. Raw
+protected logs, artifacts, runner details, internal packages, and the complete
+report remain private. Neither label path triggers on a push to `main`, so
+merging a passing PR does not rerun the same premerge suite.
 
 Source has no separate pull-request documentation-validation workflow. The
 Pages workflow builds the site before deployment from `main`, but it is not a
@@ -70,11 +72,13 @@ change must not claim that this checker passes.
 
 ## Active workflow inventory
 
-Source contains exactly these two workflow files:
+Source contains exactly these four workflow files:
 
 | Workflow | Trigger and evidence boundary |
 | --- | --- |
-| `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, captures the exact PR head, posts a pending sanitized status, and dispatches private premerge. |
+| `.github/workflows/community-cpu-request.yml` | One-shot `run-ci` label; authorizes the actor and dispatches only an exact public PR snapshot without executing PR code. |
+| `.github/workflows/community-cpu.yml` | Manual dispatch from the trusted request broker; runs read-only public CPU validation and publishes checks on the exact PR merge SHA. |
+| `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, verifies current public CPU success, captures the exact PR head, and dispatches private premerge. |
 | `.github/workflows/pages.yml` | Pushes affecting `website/**` on `main`, or manual runs; builds and deploys only the documentation site to GitHub Pages. |
 
 Internal scheduled nightly and model proof are not Source workflows. Their raw


### PR DESCRIPTION
## Background

First-time fork contributors can be held at GitHub's workflow-approval boundary before the automatic `pull_request` Community CPU workflow creates a run or check. Contributors need a self-service public CPU path that targets an exact PR snapshot without giving pull-request code protected permissions.

## Exit Criteria

- The PR author can request Community CPU by posting the exact `/run-ci` comment; a maintainer/admin can help on the author's behalf.
- The trusted comment broker never checks out or executes pull-request code.
- Every broker and test job runs on GitHub-hosted `ubuntu-24.04`; no public test receives secrets, private resources, self-hosted runners, or GPUs.
- Contributors receive Source quality, Ownership and impact, Unit, and Required checks on the exact requested merge revision.
- Local hooks stay lightweight and commit-time only: whitespace/final-newline/YAML hygiene, Ruff, and clang-format.
- The x86_64 and ARM64 development images install the same centrally pinned contributor tools as Community CPU.
- Commit-time Ruff and clang-format hooks use pre-commit-managed environments on Linux, macOS, and Windows; heavyweight source-quality, impact, and CPU units run only through contributor-triggered GitHub-hosted Community CI.
- Protected Internal CI remains separately authorized by `run-internal-ci` after the current public Required check passes.

## Implementation

- Add a default-branch `issue_comment` broker that accepts only an exact `/run-ci` comment from the PR author or a maintainer/admin, validates the open `main` PR, suppresses duplicate current-merge requests, and dispatches exact base/head/merge SHAs.
- Keep the broker metadata-only: it never checks out PR code and has only Actions write plus Checks/Contents/Pull Requests read permissions.
- Run Community CPU test jobs on GitHub-hosted `ubuntu-24.04` with only `contents: read`, then publish exact-merge checks from trusted initialization/publication jobs.
- Retain the existing `pull_request` trigger only as the bootstrap path for this migration PR; remove it after the comment broker is present on `main` and proven on a real external fork.
- Preserve trusted check identifiers, stale-snapshot neutralization, and the separate maintainer-only Internal CI bridge.
- Add standard hygiene hooks explicitly limited to `pre-commit`.
- Install `requirements/community-ci.txt` in both development images instead of duplicating loose tool version ranges or adding an incomplete package extra.
- Provision Ruff and clang-format through their pinned pre-commit repositories instead of requiring host-installed binaries, and make the public CPU image discover architecture-specific TensorRT paths through `gcc -dumpmachine`.
- Remove the local pre-push hook and combined pre-push command; `/run-ci` is the single heavyweight CPU validation entrypoint.

## Validation

- `actionlint .github/workflows/*.yml`: passed for all Source workflows with actionlint 1.7.12.
- `pre-commit run --hook-stage pre-commit --files ...`: passed for the changed hook, Docker, test, and contributor-documentation files.
- Cross-platform managed-hook probe on ARM64: pre-commit provisioned and passed Ruff `0.16.4` and clang-format `22.1.8` environments without using host-installed tool entrypoints.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; maximum CCN 10 and 158 architecture-contract tests passed.
- `python3 -m tools.community_ci impact --base github/main`: passed; selected `unit_scope=all` for the complete PR.
- `python3 -m pytest -q -p no:cacheprovider tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py tests/tools/test_model_ci.py tests/tools/test_test_impact.py`: 432 passed.
- `PYTHONPATH=python:. python3 tools/model_ci.py validate`: passed for 83 model families.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed with the existing allowlist warnings.
- `python3 -m tools.legal_headers --check`: passed with no findings.
- `npm --prefix website run build`: passed, including 34 diagram checks and the production Docusaurus build.
- `python3 tools/check_doc_file_references.py --strict website/docs`: still reports the pre-existing `website/build/` reference and stale manifest count in untouched documents; neither finding is introduced here.
- Exact-head Community CPU passed Source quality, Ownership/impact, the complete source-only Unit scope, and Required on final head `6ecaa1db86a0f8de9d4adff78dcf61dfcc77bf05` after removing pre-push.
- `docker build --file Dockerfile.community-cpu --tag trtmc-community-cpu:arm64-portability-test requirements`: passed on ARM64 using public SBSA CUDA/TensorRT packages.
- `docker run --rm --network none trtmc-community-cpu:arm64-portability-test ...`: passed; reported `aarch64`, pre-commit `4.6.2`, Ruff `0.16.4`, clang-format `22.1.8`, Lizard `1.24.0`, and valid neutral TensorRT include/library paths. The temporary image tag was removed afterward.

## Notes For Future Readers

- The comment broker and manually dispatched executor must be present on `main` before GitHub will use them. This PR keeps the automatic trigger for bootstrap only.
- After merge, validate `/run-ci` on a real first-time external fork PR, then remove `pull_request` from Community CPU in a small follow-up.
- A new PR head or base requires a new `/run-ci` comment. Current queued, in-progress, or successful Required checks suppress duplicate work for the same merge SHA.
- Do not automatically chain public CPU success into protected CI; maintainers apply `run-internal-ci` only after reviewing the current exact-head PR and public verdict.
