### PR TITLE
perf(modernbert): execute actual sequence length

### DIFF
--- a/python/tensorrt_model_connect/families/modernbert/plugin.py
+++ b/python/tensorrt_model_connect/families/modernbert/plugin.py
@@ -172,6 +172,8 @@ class ModernbertPlugin:
         intermediate = config.intermediate_size
         eps = config.raw.get("norm_eps", config.rms_norm_eps)
         max_seq = max_cache_length
+        if max_seq < 1:
+            raise ValueError("ModernBERT max_cache_length must be positive")
         if precision == "fp16":
             work_np_dtype, work_trt_dtype = np.float16, trt.float16
         elif precision == "fp32":
@@ -191,8 +193,14 @@ class ModernbertPlugin:
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         # Inputs
-        input_ids = network.add_input("input_ids", trt.int32, (max_seq,))
-        attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq,))
+        input_ids = network.add_input("input_ids", trt.int32, (-1,))
+        attention_mask_input = network.add_input("attention_mask", trt.int32, (-1,))
+        profile = builder.create_optimization_profile()
+        opt_seq = min(16, max_seq)
+        profile.set_shape("input_ids", (1,), (opt_seq,), (max_seq,))
+        profile.set_shape("attention_mask", (1,), (opt_seq,), (max_seq,))
+        trt_config.add_optimization_profile(profile)
+        sequence_shape = network.add_shape(input_ids).get_output(0)
 
         # Attention mask: [seq] int -> [1, 1, 1, seq] additive float mask.
         mask_float = network.add_cast(attention_mask_input, work_trt_dtype)
@@ -210,7 +218,7 @@ class ModernbertPlugin:
             inv_mask.get_output(0), neg_large, trt.ElementWiseOperation.PROD
         )
         pad_mask_4d = network.add_shuffle(pad_penalty.get_output(0))
-        pad_mask_4d.reshape_dims = (1, 1, 1, max_seq)
+        pad_mask_4d.reshape_dims = (1, 1, 1, -1)
 
         # Pre-compute RoPE tables for both theta values
         rope_tables = {}
@@ -227,9 +235,14 @@ class ModernbertPlugin:
                 dtype=work_np_dtype)
             rope_tables[theta] = (cos, sin)
 
-        pos_indices = graph_ops.add_constant(
+        all_pos_indices = graph_ops.add_constant(
             network, (max_seq,), np.arange(max_seq, dtype=np.int32), dtype=np.int32
         )
+        pos_slice = network.add_slice(
+            all_pos_indices, start=(0,), shape=(1,), stride=(1,)
+        )
+        pos_slice.set_input(2, sequence_shape)
+        pos_indices = pos_slice.get_output(0)
 
         # Embedding
         embed_table = graph_ops.add_constant(
@@ -283,7 +296,7 @@ class ModernbertPlugin:
                 sin_table,
                 pos_indices,
                 head_dim,
-                sequence_length=max_seq,
+                sequence_length=None,
             )
             k = graph_ops.add_apply_rope_native(
                 network,
@@ -294,7 +307,7 @@ class ModernbertPlugin:
                 sin_table,
                 pos_indices,
                 head_dim,
-                sequence_length=max_seq,
+                sequence_length=None,
             )
 
             context_flat = graph_ops.add_attention_from_rows(
@@ -304,8 +317,8 @@ class ModernbertPlugin:
                 v,
                 num_heads=num_heads,
                 head_dim=head_dim,
-                q_seq=max_seq,
-                kv_seq=max_seq,
+                q_seq=None,
+                kv_seq=None,
                 mask=pad_mask_4d.get_output(0),
             )
 

--- a/tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py
+++ b/tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py
@@ -77,6 +77,8 @@ class TestModernbertBuildEngine:
         return t
 
     def test_build_engine_returns_bytes(self, tmp_path):
+        import tensorrt as trt
+
         from tensorrt_model_connect.families.modernbert import plugin
 
         config = {
@@ -98,3 +100,17 @@ class TestModernbertBuildEngine:
 
         assert isinstance(engine, bytes)
         assert len(engine) > 0
+
+        runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
+        deserialized = runtime.deserialize_cuda_engine(engine)
+        assert deserialized is not None
+        assert tuple(deserialized.get_tensor_shape("input_ids")) == (-1,)
+        assert tuple(deserialized.get_tensor_shape("attention_mask")) == (-1,)
+        assert tuple(
+            tuple(shape)
+            for shape in deserialized.get_tensor_profile_shape("input_ids", 0)
+        ) == ((1,), (16,), (32,))
+        assert tuple(
+            tuple(shape)
+            for shape in deserialized.get_tensor_profile_shape("attention_mask", 0)
+        ) == ((1,), (16,), (32,))


### PR DESCRIPTION
## Background

ModernBERT encoded every request at `max_cache_length`, so short inputs still executed all 256 positions. This fixed-shape work dominated the measured call and produced the Thor regression reported in #896.

## Exit Criteria

- Execute the actual runtime sequence length while retaining the configured maximum length.
- Preserve the FP32 Accuracy and exact-output contracts.
- Pass fresh Accuracy and Perf runs from the exact PR head on GB300 and ThorX-2.

## Implementation

- Make token and attention-mask inputs dynamic under one bounded TensorRT optimization profile.
- Slice positional indices from the runtime input shape and propagate dynamic sequence dimensions through RoPE and attention.
- Reject non-positive maximum lengths and verify serialized engine input/profile shapes in the TensorRT integration test.

## Validation

Exact head: `acce4dffa78931846e7ea863638f2686f3a4e38f`

- `PYTHONPATH=python:. python3 -m pytest -q tests/e2e/models/modernbert/test_modernbert_attention_contract.py tests/e2e/models/modernbert/test_modernbert_build_contract.py tests/e2e/models/modernbert/test_modernbert_builder_tp.py tests/e2e/models/modernbert/test_modernbert_family_plugin_weights.py`: 16 passed.
- `python3 -m ruff check python/tensorrt_model_connect/families/modernbert/plugin.py tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py`: passed.
- `test_modernbert_encoder_pipeline` and `pytest -q tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py`: passed on GB300 and ThorX-2 with the exact head build.
- GB300 Accuracy: green; FP32 reference and TRTMC, 50 dataset samples and 100 vector comparisons, vector pass rate 100%.
- GB300 Perf: green and stable; TRTMC p50 2.165 ms versus reference p50 6.171 ms, 2.85x faster; output contract passed.
- ThorX-2 Accuracy: green; FP32 reference and TRTMC, 50 dataset samples and 100 vector comparisons, vector pass rate 100%.
- ThorX-2 Perf: green and stable; TRTMC p50 3.552 ms versus reference p50 4.407 ms, 1.24x faster; output contract passed.

## Notes For Future Readers

- The optimization profile remains bounded by `max_cache_length`; this reduces executed work for short requests rather than lowering model capacity or relaxing a qualification gate.
- The previous private run stopped in legal snapshot validation before source or model jobs ran. This rebased head uses the current canonical source snapshot and requires a fresh exact-head CI result.

Fixes #896