### PR TITLE
perf(bark): batch semantic and coarse prefill

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -2727,7 +2727,11 @@ def run(arguments: argparse.Namespace) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     try:
-        return run(build_parser().parse_args(argv))
+        arguments = build_parser().parse_args(argv)
+        if arguments.local_files_only:
+            os.environ["HF_HUB_OFFLINE"] = "1"
+            os.environ["TRANSFORMERS_OFFLINE"] = "1"
+        return run(arguments)
     except (KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/python/tensorrt_model_connect/families/bark/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/bark/default_dual_profile_decoder.py
@@ -130,6 +130,7 @@ def build_dual_profile_decoder_engine(
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
+    embed_input: bool = False,
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
@@ -155,6 +156,8 @@ def build_dual_profile_decoder_engine(
     Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
     mode. In either mode, cache_k/cache_v inputs are declared dynamic when
     bucket profiles are requested so each profile can constrain their row count.
+    ``embed_input`` replaces token IDs with caller-provided embeddings; Bark
+    uses this for its host-composed semantic and coarse prefill sequences.
     """
     _supports_config(config, weights)
     if profile_mode not in ("dual_profile", "prefill"):
@@ -198,7 +201,12 @@ def build_dual_profile_decoder_engine(
         work_np_dtype, work_trt_dtype = (np.float16, trt.bfloat16)
     else:
         work_np_dtype, work_trt_dtype = (np.float32, trt.float32)
-    token_id = network.add_input("token_id", trt.int32, (-1,))
+    token_id = None
+    input_embed = None
+    if embed_input:
+        input_embed = network.add_input("input_embed", trt.float32, (-1, hidden))
+    else:
+        token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
     cache_shape: tuple[int, int]
@@ -233,7 +241,15 @@ def build_dual_profile_decoder_engine(
     ):
         prof = builder.create_optimization_profile()
         min_sq = opt_sq if fixed else 1
-        prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+        if embed_input:
+            prof.set_shape(
+                "input_embed",
+                (min_sq, hidden),
+                (opt_sq, hidden),
+                (max_sq, hidden),
+            )
+        else:
+            prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape(
             "attention_mask",
@@ -315,9 +331,6 @@ def build_dual_profile_decoder_engine(
                     )
             else:
                 _add_profile(1, 1, fixed=True)
-    embedding_table = _const_in_work_dtype(
-        network, (vocab, hidden), weights["embedding"], work_np_dtype, work_trt_dtype
-    )
     position_embed_table: trt.ITensor | None = None
     pos_embed_np = weights["position_embedding"]
     position_embed_table = _const_in_work_dtype(
@@ -331,8 +344,16 @@ def build_dual_profile_decoder_engine(
     )
     attn_scale = 1.0 / np.sqrt(max(head_dim, 1)) if scale_attn_weights else 1.0
     matmul = _make_matmul_fn(network, work_np_dtype, quant_ctx)
-    emb = network.add_gather(embedding_table, token_id, 0)
-    hidden_state = emb.get_output(0)
+    if embed_input:
+        hidden_state = input_embed
+        if hidden_state.dtype != work_trt_dtype:
+            hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+    else:
+        embedding_table = _const_in_work_dtype(
+            network, (vocab, hidden), weights["embedding"], work_np_dtype, work_trt_dtype
+        )
+        emb = network.add_gather(embedding_table, token_id, 0)
+        hidden_state = emb.get_output(0)
     if position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)
         pos_add = network.add_elementwise(

--- a/python/tensorrt_model_connect/families/bark/plugin.py
+++ b/python/tensorrt_model_connect/families/bark/plugin.py
@@ -494,8 +494,20 @@ class BarkPlugin:
                 verbose=verbose,
                 parallel_config=parallel,
             )
+        engine_role = str(config.raw.get("_decoder_engine_role", "decode"))
+        if engine_role not in {"decode", "dual_profile"}:
+            raise ValueError(
+                "Bark supports decoder_engine_layout='dual_profile' for batched prefill; "
+                f"got engine role {engine_role!r}"
+            )
         return _build_bark_standard_engine(
-            weights, "semantic", sem_cfg, max_cache_length, precision=precision, verbose=verbose
+            weights,
+            "semantic",
+            sem_cfg,
+            max_cache_length,
+            precision=precision,
+            verbose=verbose,
+            engine_role=engine_role,
         )
 
     def build_extra_engines(
@@ -540,6 +552,11 @@ class BarkPlugin:
                         parallel_config=rank_parallel,
                     )
         else:
+            engine_role = (
+                "dual_profile"
+                if config.raw.get("_decoder_engine_layout") == "dual_profile"
+                else "decode"
+            )
             with timed_trt_compile(build_timing, "extra_bark_coarse_decoder"):
                 coarse_plan = _build_bark_standard_engine(
                     weights,
@@ -548,6 +565,7 @@ class BarkPlugin:
                     max_cache_length,
                     precision=precision,
                     verbose=verbose,
+                    engine_role=engine_role,
                 )
             result["coarse_engine_plan"] = coarse_plan
 
@@ -698,6 +716,8 @@ def _build_bark_standard_engine(
     max_cache_length: int,
     precision: str = "fp32",
     verbose: bool = False,
+    *,
+    engine_role: str = "decode",
 ) -> bytes:
     """Build a standard decoder engine for semantic or coarse using build_standard_decoder_engine."""
     from .standard_decoder_builder import build_standard_decoder_engine
@@ -719,12 +739,24 @@ def _build_bark_standard_engine(
         max_position_embeddings=sub_cfg.get("max_position", 1024),
         rms_norm_eps=1e-05,
         rope_theta=10000.0,
-        raw={},
+        raw={"_decoder_engine_role": engine_role},
     )
     if verbose:
         print(
             f"[trtmc build]   Building {sub_model} engine: layers={sub_cfg['num_layers']}, hidden={hidden}, vocab={sub_cfg['vocab_size']}, output_vocab={sub_cfg.get('output_vocab', sub_cfg['vocab_size'])}",
             file=sys.stderr,
+        )
+    if engine_role == "dual_profile":
+        from .default_dual_profile_decoder import build_dual_profile_decoder_engine
+
+        return build_dual_profile_decoder_engine(
+            sub_mc,
+            sub_weights,
+            max_cache_length,
+            precision=precision,
+            verbose=verbose,
+            profile_mode="dual_profile",
+            embed_input=True,
         )
     return build_standard_decoder_engine(
         sub_mc, sub_weights, max_cache_length, precision=precision, verbose=verbose

--- a/python/tensorrt_model_connect/families/bark/plugin.py
+++ b/python/tensorrt_model_connect/families/bark/plugin.py
@@ -62,7 +62,18 @@ def _load_bark_state_dict(model_dir: str) -> dict:
             for key in reader.keys():
                 state_dict[key] = reader.get_tensor(key).numpy()
         return state_dict
-    return torch.load(str(model_path), map_location="cpu", weights_only=True)
+    return torch.load(
+        str(model_path),
+        map_location="cpu",
+        weights_only=True,
+        mmap=True,
+    )
+
+
+def _discard_checkpoint_prefix(state_dict: dict, prefix: str) -> None:
+    for key in tuple(state_dict):
+        if key.startswith(prefix):
+            del state_dict[key]
 
 
 def _detect_sub_model_config(state_dict: dict, prefix: str) -> dict:
@@ -194,14 +205,14 @@ def _map_bark_decoder_weights(
 
     def _to_np(t):
         if hasattr(t, "numpy"):
-            return t.numpy().astype(np.float32)
+            t = t.numpy()
         return np.asarray(t, dtype=np.float32)
 
     def _t2d(w):
         """Transpose [out, in] -> [in, out] for matmul."""
         a = _to_np(w)
         if a.ndim == 2:
-            return np.ascontiguousarray(a.T)
+            return a.T
         return a
 
     # Embedding
@@ -312,14 +323,14 @@ def _map_bark_fine_weights(
 
     def _to_np(t):
         if hasattr(t, "numpy"):
-            return t.numpy().astype(np.float32)
+            t = t.numpy()
         return np.asarray(t, dtype=np.float32)
 
     def _t2d(w):
         """Transpose [out, in] -> [in, out] for matmul."""
         a = _to_np(w)
         if a.ndim == 2:
-            return np.ascontiguousarray(a.T)
+            return a.T
         return a
 
     # 8 embedding tables
@@ -437,15 +448,22 @@ class BarkPlugin:
         sem_w = _map_bark_decoder_weights(state_dict, "semantic", semantic_cfg)
         for k, v in sem_w.items():
             weights[f"semantic.{k}"] = v
+        _discard_checkpoint_prefix(state_dict, "semantic.")
 
         coarse_w = _map_bark_decoder_weights(state_dict, "coarse_acoustics", coarse_cfg)
         for k, v in coarse_w.items():
             weights[f"coarse.{k}"] = v
+        _discard_checkpoint_prefix(state_dict, "coarse_acoustics.")
 
         # Map fine model weights
         fine_w = _map_bark_fine_weights(state_dict, fine_cfg)
         for k, v in fine_w.items():
             weights[k] = v
+        _discard_checkpoint_prefix(state_dict, "fine_acoustics.")
+
+        for key in tuple(state_dict):
+            if not key.startswith("codec_model."):
+                del state_dict[key]
 
         # Store raw state_dict for codec engine builds
         weights["_state_dict"] = state_dict
@@ -572,20 +590,12 @@ class BarkPlugin:
         # Add embedding tables as raw bundle sections.
         # The C++ runtime does host-side embedding lookup for embed_input mode.
         state_dict = weights.get("_state_dict")
-        if state_dict is not None:
-            sem_key = "semantic.input_embeds_layer.weight"
-            if sem_key in state_dict:
-                w = state_dict[sem_key]
-                if hasattr(w, "numpy"):
-                    w = w.numpy()
-                result["semantic_embed"] = np.asarray(w, dtype=np.float32).tobytes()
-
-            coarse_key = "coarse_acoustics.input_embeds_layer.weight"
-            if coarse_key in state_dict:
-                w = state_dict[coarse_key]
-                if hasattr(w, "numpy"):
-                    w = w.numpy()
-                result["coarse_embed"] = np.asarray(w, dtype=np.float32).tobytes()
+        for section, key in (
+            ("semantic_embed", "semantic.embedding"),
+            ("coarse_embed", "coarse.embedding"),
+        ):
+            if key in weights:
+                result[section] = np.asarray(weights[key], dtype=np.float32).tobytes()
 
         # Calculate max codec frames from max_cache_length.
         # Semantic generates at most ~(max_cache_length - 257) tokens.

--- a/src/runtime/models/bark/pipeline.cpp
+++ b/src/runtime/models/bark/pipeline.cpp
@@ -79,6 +79,39 @@ void mask_coarse_logits_for_codebook(std::vector<float>& logits, int32_t codeboo
     }
 }
 
+int32_t bark_batched_prefill_length(TrtModule* module, BarkKvCache* cache,
+                                    const std::vector<float>& embeddings, int32_t hidden_size,
+                                    int32_t max_length) {
+    if (module == nullptr || cache == nullptr || hidden_size <= 0 || embeddings.empty() ||
+        embeddings.size() % static_cast<std::size_t>(hidden_size) != 0 ||
+        !module->has_input("input_embed")) {
+        return 0;
+    }
+
+    const int32_t seq_len =
+        static_cast<int32_t>(embeddings.size() / static_cast<std::size_t>(hidden_size));
+    return seq_len > 1 && seq_len <= max_length ? seq_len : 0;
+}
+
+void collect_bark_prefill_kv(TrtModule& module, int32_t num_layers,
+                             std::vector<const void*>& present_k,
+                             std::vector<const void*>& present_v) {
+    present_k.reserve(static_cast<std::size_t>(num_layers));
+    present_v.reserve(static_cast<std::size_t>(num_layers));
+    for (int32_t layer = 0; layer < num_layers; ++layer) {
+        const std::string suffix = "_" + std::to_string(layer);
+        const void* key = module.device_ptr("present_k" + suffix);
+        const void* value = module.device_ptr("present_v" + suffix);
+        if (key == nullptr || value == nullptr) {
+            throw std::runtime_error(
+                "BarkPipeline: batched prefill is missing KV output for layer " +
+                std::to_string(layer));
+        }
+        present_k.push_back(key);
+        present_v.push_back(value);
+    }
+}
+
 // Dump tokens to ``<dump_path><suffix>`` when dump_path is non-empty.
 // Replaces the TRTMC_BARK_DUMP env var. Value flows in through the
 // ``audio_bark.dump_path`` schema field.
@@ -316,15 +349,9 @@ bool BarkPipeline::run_batched_prefill(TrtModule* module, BarkInferenceState& st
                                        const std::vector<float>& embeddings, int32_t hidden_size,
                                        std::vector<float>& logits, const char* stage) {
     auto* cache = dynamic_cast<BarkKvCache*>(&state);
-    if (module == nullptr || cache == nullptr || hidden_size <= 0 || embeddings.empty() ||
-        embeddings.size() % static_cast<std::size_t>(hidden_size) != 0 ||
-        !module->has_input("input_embed")) {
-        return false;
-    }
-
     const int32_t seq_len =
-        static_cast<int32_t>(embeddings.size() / static_cast<std::size_t>(hidden_size));
-    if (seq_len <= 1 || seq_len > state.max_length())
+        bark_batched_prefill_length(module, cache, embeddings, hidden_size, state.max_length());
+    if (seq_len == 0)
         return false;
 
     TensorMap inputs;
@@ -343,22 +370,7 @@ bool BarkPipeline::run_batched_prefill(TrtModule* module, BarkInferenceState& st
 
     std::vector<const void*> present_k;
     std::vector<const void*> present_v;
-    present_k.reserve(static_cast<std::size_t>(state.num_layers()));
-    present_v.reserve(static_cast<std::size_t>(state.num_layers()));
-    for (int32_t layer = 0; layer < state.num_layers(); ++layer) {
-        const std::string suffix = "_" + std::to_string(layer);
-        const std::string key_name = "present_k" + suffix;
-        const std::string value_name = "present_v" + suffix;
-        const void* key = module->device_ptr(key_name);
-        const void* value = module->device_ptr(value_name);
-        if (key == nullptr || value == nullptr) {
-            throw std::runtime_error(
-                "BarkPipeline: batched prefill is missing KV output for layer " +
-                std::to_string(layer));
-        }
-        present_k.push_back(key);
-        present_v.push_back(value);
-    }
+    collect_bark_prefill_kv(*module, state.num_layers(), present_k, present_v);
     cache->write_prefill_kv(present_k, present_v, seq_len);
     std::cerr << "[trtmc] Bark " << stage << " prefill: " << seq_len << " tokens in one call"
               << std::endl;

--- a/src/runtime/models/bark/pipeline.cpp
+++ b/src/runtime/models/bark/pipeline.cpp
@@ -168,6 +168,12 @@ void BarkPipeline::set_fine_embeddings(std::vector<float> embed, std::vector<flo
     fine_position_embed_ = std::move(pos_embed);
 }
 
+void BarkPipeline::set_prefill_modules(std::unique_ptr<TrtModule> semantic_prefill,
+                                       std::unique_ptr<TrtModule> coarse_prefill) {
+    semantic_prefill_ = std::move(semantic_prefill);
+    coarse_prefill_ = std::move(coarse_prefill);
+}
+
 AudioResult BarkPipeline::generate_audio(const std::string& prompt, const GenerateConfig& cfg) {
     // Tokenize the prompt
     std::vector<int32_t> input_ids;
@@ -237,7 +243,7 @@ void BarkPipeline::run_step_with_embed(TrtModule& module, BarkInferenceState& st
                                        std::vector<float>& logits) {
     Tensor embed_tensor;
     embed_tensor.data = const_cast<float*>(embed);
-    embed_tensor.shape = {embed_dim};
+    embed_tensor.shape = {1, embed_dim};
     embed_tensor.dtype = DType::kFloat32;
 
     float use_embed = 1.0F;
@@ -306,6 +312,59 @@ void BarkPipeline::run_step_with_token(TrtModule& module, BarkInferenceState& st
     state.advance();
 }
 
+bool BarkPipeline::run_batched_prefill(TrtModule* module, BarkInferenceState& state,
+                                       const std::vector<float>& embeddings, int32_t hidden_size,
+                                       std::vector<float>& logits, const char* stage) {
+    auto* cache = dynamic_cast<BarkKvCache*>(&state);
+    if (module == nullptr || cache == nullptr || hidden_size <= 0 || embeddings.empty() ||
+        embeddings.size() % static_cast<std::size_t>(hidden_size) != 0 ||
+        !module->has_input("input_embed")) {
+        return false;
+    }
+
+    const int32_t seq_len =
+        static_cast<int32_t>(embeddings.size() / static_cast<std::size_t>(hidden_size));
+    if (seq_len <= 1 || seq_len > state.max_length())
+        return false;
+
+    TensorMap inputs;
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(embeddings.data()), {seq_len, hidden_size}, DType::kFloat32};
+    cache->bind_cache_inputs(*module);
+    state.prepare_step(inputs, seq_len);
+
+    const TensorMap outputs = module->forward(inputs);
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        throw std::runtime_error("BarkPipeline: batched prefill has no 'logits' output");
+    const auto& logits_tensor = logits_it->second;
+    logits.resize(static_cast<std::size_t>(logits_tensor.numel()));
+    std::memcpy(logits.data(), logits_tensor.data, logits_tensor.numel() * sizeof(float));
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    present_k.reserve(static_cast<std::size_t>(state.num_layers()));
+    present_v.reserve(static_cast<std::size_t>(state.num_layers()));
+    for (int32_t layer = 0; layer < state.num_layers(); ++layer) {
+        const std::string suffix = "_" + std::to_string(layer);
+        const std::string key_name = "present_k" + suffix;
+        const std::string value_name = "present_v" + suffix;
+        const void* key = module->device_ptr(key_name);
+        const void* value = module->device_ptr(value_name);
+        if (key == nullptr || value == nullptr) {
+            throw std::runtime_error(
+                "BarkPipeline: batched prefill is missing KV output for layer " +
+                std::to_string(layer));
+        }
+        present_k.push_back(key);
+        present_v.push_back(value);
+    }
+    cache->write_prefill_kv(present_k, present_v, seq_len);
+    std::cerr << "[trtmc] Bark " << stage << " prefill: " << seq_len << " tokens in one call"
+              << std::endl;
+    return true;
+}
+
 int32_t BarkPipeline::sample_top_k(const float* logits, int32_t vocab_size, float temperature,
                                    int32_t top_k) {
     if (config_.greedy) {
@@ -334,7 +393,8 @@ std::vector<int32_t> BarkPipeline::run_semantic(const std::vector<int32_t>& text
     std::vector<float> logits;
     std::vector<float> embed_a(static_cast<std::size_t>(cfg.hidden_size));
     std::vector<float> embed_b(static_cast<std::size_t>(cfg.hidden_size));
-    std::vector<float> embed_buf(static_cast<std::size_t>(cfg.hidden_size));
+    std::vector<float> prefill_embeddings(static_cast<std::size_t>(kBarkMaxTextLen + 1) *
+                                          cfg.hidden_size);
 
     // Prefill text tokens
     const auto copy_len = std::min(static_cast<int32_t>(text_ids.size()), kBarkMaxTextLen);
@@ -343,15 +403,23 @@ std::vector<int32_t> BarkPipeline::run_semantic(const std::vector<int32_t>& text
         copy_embed_row(semantic_embed_.data(), text_tok, cfg.hidden_size, embed_a.data());
         copy_embed_row(semantic_embed_.data(), cfg.semantic_pad_token, cfg.hidden_size,
                        embed_b.data());
-        sum_embed_rows(embed_a.data(), embed_b.data(), cfg.hidden_size, embed_buf.data());
-        run_step_with_embed(*semantic_, *semantic_state_, embed_buf.data(), cfg.hidden_size,
-                            logits);
+        float* row = prefill_embeddings.data() + static_cast<std::size_t>(pos) * cfg.hidden_size;
+        sum_embed_rows(embed_a.data(), embed_b.data(), cfg.hidden_size, row);
     }
 
     // Prefill infer token
     copy_embed_row(semantic_embed_.data(), cfg.semantic_infer_token, cfg.hidden_size,
-                   embed_buf.data());
-    run_step_with_embed(*semantic_, *semantic_state_, embed_buf.data(), cfg.hidden_size, logits);
+                   prefill_embeddings.data() +
+                       static_cast<std::size_t>(kBarkMaxTextLen) * cfg.hidden_size);
+    if (!run_batched_prefill(semantic_prefill_.get(), *semantic_state_, prefill_embeddings,
+                             cfg.hidden_size, logits, "semantic")) {
+        for (int32_t pos = 0; pos <= kBarkMaxTextLen; ++pos) {
+            run_step_with_embed(*semantic_, *semantic_state_,
+                                prefill_embeddings.data() +
+                                    static_cast<std::size_t>(pos) * cfg.hidden_size,
+                                cfg.hidden_size, logits);
+        }
+    }
 
     // Autoregressive generation
     std::vector<int32_t> semantic_tokens;
@@ -369,8 +437,13 @@ std::vector<int32_t> BarkPipeline::run_semantic(const std::vector<int32_t>& text
 
         semantic_tokens.push_back(token);
 
-        // During decode, use token_id path (no embedding injection)
-        run_step_with_token(*semantic_, *semantic_state_, token, logits);
+        if (semantic_->has_input("token_id")) {
+            run_step_with_token(*semantic_, *semantic_state_, token, logits);
+        } else {
+            copy_embed_row(semantic_embed_.data(), token, cfg.hidden_size, embed_a.data());
+            run_step_with_embed(*semantic_, *semantic_state_, embed_a.data(), cfg.hidden_size,
+                                logits);
+        }
     }
 
     std::cerr << "[trtmc] Bark semantic: generated " << semantic_tokens.size() << " tokens"
@@ -409,18 +482,20 @@ std::vector<int32_t> BarkPipeline::run_coarse(const std::vector<int32_t>& semant
         coarse_state_->reset();
         coarse_state_->bind_to(*coarse_);
 
-        // Prefill coarse window
-        for (std::size_t i = 0; i + 1 < window_plan.input_tokens.size(); ++i) {
+        std::vector<float> prefill_embeddings(window_plan.input_tokens.size() *
+                                              static_cast<std::size_t>(cfg.hidden_size));
+        for (std::size_t i = 0; i < window_plan.input_tokens.size(); ++i) {
             copy_embed_row(coarse_embed_.data(), window_plan.input_tokens[i], cfg.hidden_size,
-                           embed_buf.data());
-            run_step_with_embed(*coarse_, *coarse_state_, embed_buf.data(), cfg.hidden_size,
-                                logits);
+                           prefill_embeddings.data() + i * cfg.hidden_size);
         }
-
-        // Last prefill token
-        copy_embed_row(coarse_embed_.data(), window_plan.input_tokens.back(), cfg.hidden_size,
-                       embed_buf.data());
-        run_step_with_embed(*coarse_, *coarse_state_, embed_buf.data(), cfg.hidden_size, logits);
+        if (!run_batched_prefill(coarse_prefill_.get(), *coarse_state_, prefill_embeddings,
+                                 cfg.hidden_size, logits, "coarse")) {
+            for (std::size_t i = 0; i < window_plan.input_tokens.size(); ++i) {
+                run_step_with_embed(*coarse_, *coarse_state_,
+                                    prefill_embeddings.data() + i * cfg.hidden_size,
+                                    cfg.hidden_size, logits);
+            }
+        }
 
         // Generate
         for (int32_t step = 0; step < window_plan.generated_this_window; ++step) {
@@ -434,8 +509,12 @@ std::vector<int32_t> BarkPipeline::run_coarse(const std::vector<int32_t>& semant
 
             if (step + 1 < window_plan.generated_this_window) {
                 copy_embed_row(coarse_embed_.data(), token, cfg.hidden_size, embed_buf.data());
-                run_step_with_embed(*coarse_, *coarse_state_, embed_buf.data(), cfg.hidden_size,
-                                    logits);
+                if (coarse_->has_input("token_id")) {
+                    run_step_with_token(*coarse_, *coarse_state_, token, logits);
+                } else {
+                    run_step_with_embed(*coarse_, *coarse_state_, embed_buf.data(), cfg.hidden_size,
+                                        logits);
+                }
             }
         }
     }

--- a/src/runtime/models/bark/pipeline.h
+++ b/src/runtime/models/bark/pipeline.h
@@ -45,6 +45,8 @@ class BarkPipeline final : public IPipeline {
     void set_codec_module(std::unique_ptr<TrtModule> codec);
     void set_fine_module(std::unique_ptr<TrtModule> fine);
     void set_fine_embeddings(std::vector<float> embed, std::vector<float> pos_embed);
+    void set_prefill_modules(std::unique_ptr<TrtModule> semantic_prefill,
+                             std::unique_ptr<TrtModule> coarse_prefill);
 
   private:
     std::vector<int32_t> run_semantic(const std::vector<int32_t>& text_ids, int32_t max_tokens);
@@ -57,12 +59,17 @@ class BarkPipeline final : public IPipeline {
                              int32_t embed_dim, std::vector<float>& logits);
     void run_step_with_token(TrtModule& module, BarkInferenceState& state, int32_t token_id,
                              std::vector<float>& logits);
+    bool run_batched_prefill(TrtModule* module, BarkInferenceState& state,
+                             const std::vector<float>& embeddings, int32_t hidden_size,
+                             std::vector<float>& logits, const char* stage);
     int32_t sample_top_k(const float* logits, int32_t vocab_size, float temperature, int32_t top_k);
 
     std::unique_ptr<TrtModule> semantic_;
     std::unique_ptr<TrtModule> coarse_;
     std::unique_ptr<TrtModule> codec_;
     std::unique_ptr<TrtModule> fine_;
+    std::unique_ptr<TrtModule> semantic_prefill_;
+    std::unique_ptr<TrtModule> coarse_prefill_;
     std::unique_ptr<BarkInferenceState> semantic_state_;
     std::unique_ptr<BarkInferenceState> coarse_state_;
     std::vector<float> semantic_embed_;

--- a/src/runtime/models/bark/plugin.cpp
+++ b/src/runtime/models/bark/plugin.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <exception>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -154,29 +155,59 @@ class BarkPlugin final : public IPipelinePlugin {
         // Load semantic engine (main plan or rank-local TP section)
         const std::string semantic_section =
             tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
-        auto sem_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, semantic_section), "bark semantic", decoder_opts);
-
-        // Load coarse engine (single plan or rank-local TP section)
         const std::string coarse_section = tp_config.enabled
                                                ? coarse_tp_engine_section_name(tp_group.rank)
                                                : std::string("coarse_engine_plan");
-        auto coarse_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, coarse_section), "bark coarse", decoder_opts);
+        const bool dual_profile =
+            !tp_config.enabled &&
+            extract_json_string(json, "decoder_engine_layout", "single") == "dual_profile";
 
-        cudaStream_t stream = sem_loaded.module->stream();
+        std::unique_ptr<TrtModule> semantic;
+        std::unique_ptr<TrtModule> coarse;
+        std::unique_ptr<TrtModule> semantic_prefill;
+        std::unique_ptr<TrtModule> coarse_prefill;
+        cudaStream_t stream = nullptr;
+        if (dual_profile) {
+            auto semantic_profiles =
+                load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, semantic_section),
+                                          "bark semantic", decoder_opts);
+            semantic = std::move(semantic_profiles.decode);
+            semantic_prefill = std::move(semantic_profiles.prefill);
+            stream = semantic->stream();
+
+            ModuleCreateOptions coarse_opts = decoder_opts;
+            coarse_opts.stream = stream;
+            auto coarse_profiles = load_dual_profile_modules(
+                ctx.backend, find_section(ctx.bundle, coarse_section), "bark coarse", coarse_opts);
+            coarse = std::move(coarse_profiles.decode);
+            coarse_prefill = std::move(coarse_profiles.prefill);
+            if (!semantic_prefill || !coarse_prefill)
+                throw std::runtime_error("Bark dual-profile bundle is missing a prefill profile");
+        } else {
+            auto sem_loaded =
+                load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, semantic_section),
+                                          "bark semantic", decoder_opts);
+            semantic = std::move(sem_loaded.module);
+            stream = semantic->stream();
+
+            ModuleCreateOptions coarse_opts = decoder_opts;
+            coarse_opts.stream = stream;
+            auto coarse_loaded = load_trt_module_from_plan(
+                ctx.backend, find_section(ctx.bundle, coarse_section), "bark coarse", coarse_opts);
+            coarse = std::move(coarse_loaded.module);
+        }
+
         BarkConfig bark_cfg = make_bark_config(ctx);
 
         // Create KvCaches for semantic and coarse stages
-        int32_t sem_kv_dim =
-            decoder_cache_row_width(*sem_loaded.module, compute_kv_dim(ctx.config));
+        int32_t sem_kv_dim = decoder_cache_row_width(*semantic, compute_kv_dim(ctx.config));
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<BarkInferenceState> sem_state = std::make_unique<BarkKvCache>(
             ctx.config.num_layers, ctx.config.max_cache_length, sem_kv_dim, stream, cache_dtype);
 
         // Coarse engine may have different dimensions -- resolve with semantic fallbacks
-        std::unique_ptr<BarkInferenceState> coarse_state(make_bark_coarse_kv_cache(
-            json, ctx.config, *coarse_loaded.module, stream, cache_dtype));
+        std::unique_ptr<BarkInferenceState> coarse_state(
+            make_bark_coarse_kv_cache(json, ctx.config, *coarse, stream, cache_dtype));
 
         // Load embeddings
         auto sem_embed = section_to_floats(find_section(ctx.bundle, "semantic_embed"));
@@ -188,10 +219,14 @@ class BarkPlugin final : public IPipelinePlugin {
         auto bark_tokenizer = try_create_native_tokenizer(ctx.bundle, /*add_special_tokens=*/false);
 
         auto pipeline = std::make_unique<BarkPipeline>(
-            std::move(sem_loaded.module), std::move(coarse_loaded.module), std::move(sem_state),
-            std::move(coarse_state), std::move(sem_embed), std::move(coarse_embed),
-            std::move(bark_cfg), stream, std::move(bark_tokenizer), ctx.bundle.info.model_id);
+            std::move(semantic), std::move(coarse), std::move(sem_state), std::move(coarse_state),
+            std::move(sem_embed), std::move(coarse_embed), std::move(bark_cfg), stream,
+            std::move(bark_tokenizer), ctx.bundle.info.model_id);
 
+        if (semantic_prefill && coarse_prefill)
+            pipeline->set_prefill_modules(std::move(semantic_prefill), std::move(coarse_prefill));
+
+        opts.stream = stream;
         attach_optional_bark_modules(*pipeline, ctx, opts);
 
         return pipeline;

--- a/tests/cpp/models/bark/test_bark_pipeline.cpp
+++ b/tests/cpp/models/bark/test_bark_pipeline.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime_api.h>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace {
@@ -24,6 +25,62 @@ void check(bool condition, const char* name) {
         ++failures;
     }
 }
+
+struct PrefillStats {
+    int32_t calls{0};
+    std::vector<int64_t> input_embed_shape;
+};
+
+class CountingPrefillModule final : public trtmc::ITrtModule {
+  public:
+    CountingPrefillModule(std::shared_ptr<PrefillStats> stats, std::vector<float> logits,
+                          cudaStream_t stream)
+        : stats_(std::move(stats)), logits_(std::move(logits)), stream_(stream) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        const auto found = inputs.find("input_embed");
+        stats_->input_embed_shape =
+            found == inputs.end() ? std::vector<int64_t>{} : found->second.shape;
+        return {{"logits", trtmc::Tensor{logits_.data(),
+                                         {1, static_cast<int64_t>(logits_.size())},
+                                         trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "input_embed" || name == "position_id" || name == "attention_mask";
+    }
+    bool has_output(const std::string& name) const override { return name == "logits"; }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "input_embed" || name == "attention_mask" ? 2 : 1;
+    }
+    bool input_is_dynamic(const std::string&) const override { return true; }
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<PrefillStats> stats_;
+    std::vector<float> logits_;
+    cudaStream_t stream_{nullptr};
+};
 
 void test_bark_generate_audio() {
     trtmc::BarkConfig bcfg;
@@ -89,6 +146,123 @@ void test_bark_generate_audio() {
     check(out.sample_rate == 24000, "bark generate_audio sample_rate");
 
     cudaStreamDestroy(stream);
+}
+
+void test_bark_batches_semantic_and_coarse_prefill() {
+    trtmc::BarkConfig bcfg;
+    bcfg.hidden_size = 4;
+    bcfg.text_pad_token = 5;
+    bcfg.semantic_pad_token = 3;
+    bcfg.semantic_infer_token = 4;
+    bcfg.semantic_input_vocab = 6;
+    bcfg.semantic_output_vocab = 10048;
+    bcfg.semantic_vocab_size = 4;
+    bcfg.n_coarse_codebooks = 2;
+    bcfg.codebook_size = 4;
+    bcfg.coarse_semantic_pad_token = 10;
+    bcfg.coarse_infer_token = 9;
+    bcfg.max_coarse_input_length = 4;
+    bcfg.max_coarse_history = 4;
+    bcfg.sliding_window_len = 10;
+    bcfg.greedy = true;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto sem_cache = std::make_unique<trtmc::BarkKvCache>(0, 512, 0, stream);
+    auto coarse_cache = std::make_unique<trtmc::BarkKvCache>(0, 16, 0, stream);
+    const std::vector<float> sem_logits = {0.9F, 0.8F, 0.7F, 0.1F, 0.0F};
+    const std::vector<float> coarse_logits(12, 0.1F);
+    auto sem_engine = trtmc::test::build_mock_mask_only_engine(513, 5, sem_logits);
+    auto coarse_engine = trtmc::test::build_mock_mask_only_engine(17, 12, coarse_logits);
+    if (!sem_engine || !coarse_engine) {
+        cudaStreamDestroy(stream);
+        return;
+    }
+
+    auto semantic = std::make_unique<trtmc::TrtModuleImpl>(
+        sem_engine.get(), sem_engine->createExecutionContext(), stream);
+    auto coarse = std::make_unique<trtmc::TrtModuleImpl>(
+        coarse_engine.get(), coarse_engine->createExecutionContext(), stream);
+    std::vector<float> sem_embed(6 * 4, 0.1F);
+    std::vector<float> coarse_embed(11 * 4, 0.1F);
+    trtmc::BarkPipeline pipeline(std::move(semantic), std::move(coarse), std::move(sem_cache),
+                                 std::move(coarse_cache), sem_embed, coarse_embed, bcfg, stream);
+
+    auto semantic_stats = std::make_shared<PrefillStats>();
+    auto coarse_stats = std::make_shared<PrefillStats>();
+    pipeline.set_prefill_modules(
+        std::make_unique<CountingPrefillModule>(semantic_stats, sem_logits, stream),
+        std::make_unique<CountingPrefillModule>(coarse_stats, coarse_logits, stream));
+
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    (void)pipeline.generate_audio("", gen_cfg);
+
+    check(semantic_stats->calls == 1, "bark semantic prefill uses one batched call");
+    check(semantic_stats->input_embed_shape == std::vector<int64_t>({257, 4}),
+          "bark semantic prefill batches 256 text slots plus infer token");
+    check(coarse_stats->calls == 1, "bark coarse prefill uses one batched call per window");
+    check(coarse_stats->input_embed_shape.size() == 2 && coarse_stats->input_embed_shape[0] > 1 &&
+              coarse_stats->input_embed_shape[1] == 4,
+          "bark coarse prefill batches the complete window context");
+
+    cudaStreamDestroy(stream);
+}
+
+void test_bark_dual_profile_decode_uses_one_embedding_row() {
+    trtmc::BarkConfig bcfg;
+    bcfg.hidden_size = 4;
+    bcfg.text_pad_token = 5;
+    bcfg.semantic_pad_token = 3;
+    bcfg.semantic_infer_token = 4;
+    bcfg.semantic_input_vocab = 6;
+    bcfg.semantic_output_vocab = 5;
+    bcfg.semantic_vocab_size = 4;
+    bcfg.n_coarse_codebooks = 2;
+    bcfg.codebook_size = 4;
+    bcfg.coarse_semantic_pad_token = 10;
+    bcfg.coarse_infer_token = 9;
+    bcfg.max_coarse_input_length = 4;
+    bcfg.max_coarse_history = 4;
+    bcfg.sliding_window_len = 10;
+    bcfg.greedy = true;
+
+    cudaStream_t stream = nullptr;
+    auto sem_cache = std::make_unique<trtmc::BarkKvCache>(0, 512, 0, stream);
+    auto coarse_cache = std::make_unique<trtmc::BarkKvCache>(0, 16, 0, stream);
+    const std::vector<float> sem_logits = {0.9F, 0.8F, 0.7F, 0.1F, 0.0F};
+    const std::vector<float> coarse_logits(12, 0.1F);
+
+    auto semantic_decode_stats = std::make_shared<PrefillStats>();
+    auto coarse_decode_stats = std::make_shared<PrefillStats>();
+    auto semantic_prefill_stats = std::make_shared<PrefillStats>();
+    auto coarse_prefill_stats = std::make_shared<PrefillStats>();
+    auto semantic =
+        std::make_unique<CountingPrefillModule>(semantic_decode_stats, sem_logits, stream);
+    auto coarse =
+        std::make_unique<CountingPrefillModule>(coarse_decode_stats, coarse_logits, stream);
+
+    std::vector<float> sem_embed(6 * 4, 0.1F);
+    std::vector<float> coarse_embed(11 * 4, 0.1F);
+    trtmc::BarkPipeline pipeline(std::move(semantic), std::move(coarse), std::move(sem_cache),
+                                 std::move(coarse_cache), sem_embed, coarse_embed, bcfg, stream);
+    pipeline.set_prefill_modules(
+        std::make_unique<CountingPrefillModule>(semantic_prefill_stats, sem_logits, stream),
+        std::make_unique<CountingPrefillModule>(coarse_prefill_stats, coarse_logits, stream));
+
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 2;
+    (void)pipeline.generate_audio("", gen_cfg);
+
+    check(semantic_decode_stats->calls == 2,
+          "bark embed-only semantic engine decodes each generated token");
+    check(semantic_decode_stats->input_embed_shape == std::vector<int64_t>({1, 4}),
+          "bark semantic decode uses one rank-2 embedding row");
+    check(coarse_decode_stats->calls > 0,
+          "bark embed-only coarse engine decodes after batched prefill");
+    check(coarse_decode_stats->input_embed_shape == std::vector<int64_t>({1, 4}),
+          "bark coarse decode uses one rank-2 embedding row");
 }
 
 void test_bark_constructor_validates_semantic() {
@@ -163,6 +337,8 @@ void test_bark_constructor_validates_embed() {
 
 int main() {
     test_bark_generate_audio();
+    test_bark_batches_semantic_and_coarse_prefill();
+    test_bark_dual_profile_decode_uses_one_embedding_row();
     test_bark_constructor_validates_semantic();
     test_bark_constructor_validates_embed();
     if (failures > 0) {

--- a/tests/e2e/models/bark/manifests/bark-large.json
+++ b/tests/e2e/models/bark/manifests/bark-large.json
@@ -7,6 +7,9 @@
   "task_strategy": "text_to_audio",
   "precision": "fp32",
   "e2e_size": "large",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "max_cache_length": 1024,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/bark/manifests/bark-small-fp32-l0.json
+++ b/tests/e2e/models/bark/manifests/bark-small-fp32-l0.json
@@ -7,6 +7,9 @@
   "task_strategy": "text_to_audio",
   "precision": "fp32",
   "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "max_cache_length": 1024,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/bark/manifests/bark-small.json
+++ b/tests/e2e/models/bark/manifests/bark-small.json
@@ -8,6 +8,9 @@
   "precision": "fp16",
   "reference_precision": "fp32",
   "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "build_env": {
     "TRTMC_TRT_TIMING_CACHE_PATH": "",
     "TRTMC_TRT_TIMING_CACHE_DIR": "",

--- a/tests/e2e/models/bark/test_bark_build_contract.py
+++ b/tests/e2e/models/bark/test_bark_build_contract.py
@@ -23,6 +23,14 @@ def test_large_acceptance_build_preserves_audited_full_precision() -> None:
     assert manifest["precision"] == "fp32"
 
 
+def test_single_device_builds_share_weights_between_prefill_and_decode() -> None:
+    manifests = Path(__file__).parent / "manifests"
+
+    for name in ("bark-large.json", "bark-small.json", "bark-small-fp32-l0.json"):
+        manifest = json.loads((manifests / name).read_text(encoding="utf-8"))
+        assert manifest["build_args"]["decoder_engine_layout"] == "dual_profile"
+
+
 def test_large_acceptance_build_has_a_precision_matched_l0() -> None:
     model_dir = Path(__file__).parent
     large = json.loads((model_dir / "manifests" / "bark-large.json").read_text(encoding="utf-8"))

--- a/tests/e2e/models/bark/test_bark_builder_engine.py
+++ b/tests/e2e/models/bark/test_bark_builder_engine.py
@@ -371,6 +371,29 @@ class TestBarkEngine(FamilyPluginTestMixin):
 
     # --- Bark-specific Tier 1 tests ---
 
+    def test_pytorch_checkpoint_is_memory_mapped(self, tmp_path, monkeypatch):
+        torch = pytest.importorskip("torch")
+        checkpoint = tmp_path / "pytorch_model.bin"
+        checkpoint.touch()
+        expected = {"weight": object()}
+        load_kwargs = {}
+
+        def fake_load(path, **kwargs):
+            assert path == str(checkpoint)
+            load_kwargs.update(kwargs)
+            return expected
+
+        monkeypatch.setattr(torch, "load", fake_load)
+
+        actual = bark_plugin_module._load_bark_state_dict(str(tmp_path))
+
+        assert actual is expected
+        assert load_kwargs == {
+            "map_location": "cpu",
+            "weights_only": True,
+            "mmap": True,
+        }
+
     def test_dual_profile_builds_one_semantic_and_one_coarse_plan(
         self, tester, tmp_path, monkeypatch
     ):
@@ -421,6 +444,15 @@ class TestBarkEngine(FamilyPluginTestMixin):
         plugin = bark_plugin_module.BarkPlugin()
 
         assert not getattr(plugin, "supports_split_decoder_roles", False)
+
+    def test_load_weights_retains_only_codec_checkpoint_tensors(
+        self, tester, tmp_path
+    ):
+        _, weights, _ = tester.prepare_config_and_weights(tmp_path)
+
+        assert all(
+            key.startswith("codec_model.") for key in weights["_state_dict"]
+        )
 
     def test_fused_qkv_correctly_split(self, tester, tmp_path):
         """Validate that Bark's fused att_proj [3H, H] is correctly split into Q/K/V.

--- a/tests/e2e/models/bark/test_bark_builder_engine.py
+++ b/tests/e2e/models/bark/test_bark_builder_engine.py
@@ -34,6 +34,8 @@ Postconditions: All weight keys are present with correct shapes, fused QKV is sp
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pytest
 
@@ -74,6 +76,10 @@ _FINE_MAX_POS = 32
 _FINE_N_EMBED_TABLES = 8
 _FINE_N_LM_HEADS = 7
 _FINE_CODEBOOK_SIZE = 16
+
+bark_plugin_module = importlib.import_module(
+    "tensorrt_model_connect.families.bark.plugin"
+)
 
 
 def _make_bark_tp_weights(
@@ -364,6 +370,57 @@ class TestBarkEngine(FamilyPluginTestMixin):
         pass
 
     # --- Bark-specific Tier 1 tests ---
+
+    def test_dual_profile_builds_one_semantic_and_one_coarse_plan(
+        self, tester, tmp_path, monkeypatch
+    ):
+        config, weights, _ = tester.prepare_config_and_weights(tmp_path)
+        config.raw["_decoder_engine_layout"] = "dual_profile"
+        weights["_state_dict"] = None
+        plugin = bark_plugin_module.BarkPlugin()
+
+        calls: list[tuple[str, str]] = []
+
+        def fake_decoder_builder(
+            weights,
+            sub_model,
+            sub_cfg,
+            max_cache_length,
+            precision="fp32",
+            verbose=False,
+            *,
+            engine_role="decode",
+        ):
+            del weights, sub_cfg, max_cache_length, precision, verbose
+            calls.append((sub_model, engine_role))
+            return f"{sub_model}-{engine_role}".encode()
+
+        monkeypatch.setattr(
+            bark_plugin_module, "_build_bark_standard_engine", fake_decoder_builder
+        )
+        monkeypatch.setattr(
+            bark_plugin_module,
+            "_build_bark_fine_engine",
+            lambda *args, **kwargs: b"fine",
+        )
+
+        config.raw["_decoder_engine_role"] = "dual_profile"
+        assert plugin.build_engine(config, weights, 32) == b"semantic-dual_profile"
+        config.raw.pop("_decoder_engine_role")
+
+        extras = plugin.build_extra_engines(config, weights, 32)
+
+        assert extras["coarse_engine_plan"] == b"coarse-dual_profile"
+        assert "coarse_prefill_engine_plan" not in extras
+        assert calls == [
+            ("semantic", "dual_profile"),
+            ("coarse", "dual_profile"),
+        ]
+
+    def test_bark_does_not_duplicate_weights_for_split_decoder_roles(self):
+        plugin = bark_plugin_module.BarkPlugin()
+
+        assert not getattr(plugin, "supports_split_decoder_roles", False)
 
     def test_fused_qkv_correctly_split(self, tester, tmp_path):
         """Validate that Bark's fused att_proj [3H, H] is correctly split into Q/K/V.

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections import Counter
 from contextlib import nullcontext
 import json
+import os
 from argparse import Namespace
 from pathlib import Path
 import runpy
@@ -2939,6 +2940,27 @@ def test_bark_reference_maps_public_token_cap_to_semantic_stage() -> None:
         "semantic_max_new_tokens": 128
     }
     assert runner["_bark_generation_options"]({"max_new_tokens": 0}) == {}
+
+
+def test_task_reference_local_only_cli_disables_huggingface_network(monkeypatch) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    captured: dict[str, str | None] = {}
+
+    def fake_run(_arguments):
+        captured["hub"] = os.environ.get("HF_HUB_OFFLINE")
+        captured["transformers"] = os.environ.get("TRANSFORMERS_OFFLINE")
+        return 0
+
+    parser = SimpleNamespace(
+        parse_args=lambda _argv: Namespace(local_files_only=True)
+    )
+    monkeypatch.setitem(runner["main"].__globals__, "build_parser", lambda: parser)
+    monkeypatch.setitem(runner["main"].__globals__, "run", fake_run)
+
+    assert runner["main"]([]) == 0
+    assert captured == {"hub": "1", "transformers": "1"}
 
 
 def test_magpie_reference_maps_public_token_cap_to_decoder_steps() -> None:

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4073,6 +4073,7 @@ def test_run_tts_bundle_generates_audio_and_batches_asr(tmp_path: Path, monkeypa
         },
     )
     commands: list[list[str]] = []
+    transcribe_options: list[dict[str, object]] = []
 
     class Result:
         returncode = 0
@@ -4086,11 +4087,12 @@ def test_run_tts_bundle_generates_audio_and_batches_asr(tmp_path: Path, monkeypa
         return Result()
 
     monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
-    monkeypatch.setattr(
-        validation_engine,
-        "_transcribe_audio_files",
-        lambda paths, **_kwargs: ["The test sentence." for _path in paths],
-    )
+
+    def fake_transcribe(paths, **kwargs):
+        transcribe_options.append(kwargs)
+        return ["The test sentence." for _path in paths]
+
+    monkeypatch.setattr(validation_engine, "_transcribe_audio_files", fake_transcribe)
     args = argparse.Namespace(
         work_dir=str(work_dir),
         raw_output="",
@@ -4104,6 +4106,7 @@ def test_run_tts_bundle_generates_audio_and_batches_asr(tmp_path: Path, monkeypa
         config="",
         set=[],
         cuda_visible_devices="",
+        local_files_only=True,
     )
 
     validation_engine.run_tts_bundle(args)
@@ -4112,9 +4115,46 @@ def test_run_tts_bundle_generates_audio_and_batches_asr(tmp_path: Path, monkeypa
     assert commands[0][commands[0].index("--max-new-tokens") + 1] == "12"
     assert "audio_magpie.seed=42" in commands[0]
     assert "audio_bark.seed=42" in commands[0]
+    assert transcribe_options == [
+        {
+            "python": sys.executable,
+            "model_id": "openai/whisper-large-v3-turbo",
+            "local_files_only": True,
+        }
+    ]
     predictions = json.loads((work_dir / "bundle_predictions.json").read_text(encoding="utf-8"))
     assert predictions["responses"][0]["output_text"] == "The test sentence."
     assert Path(predictions["responses"][0]["wav_path"]).is_file()
+
+
+def test_tts_asr_passes_local_files_only_to_the_pipeline(
+    tmp_path: Path, monkeypatch
+) -> None:
+    wav_path = tmp_path / "sample.wav"
+    _write_pcm_wav(wav_path)
+    scripts: list[str] = []
+    environments: list[dict[str, str]] = []
+
+    def fake_run(command, **kwargs):
+        scripts.append(command[2])
+        environments.append(kwargs["env"])
+        return SimpleNamespace(returncode=0, stdout='["hello"]\n', stderr="")
+
+    monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
+
+    assert validation_engine._transcribe_audio_files(
+        [wav_path],
+        python="python",
+        model_id="openai/whisper-large-v3-turbo",
+        local_files_only=True,
+    ) == ["hello"]
+    assert scripts[0].count("local_files_only=local_files_only") == 2
+    assert "model_kwargs" not in scripts[0]
+    assert "model=model" in scripts[0]
+    assert "tokenizer=processor.tokenizer" in scripts[0]
+    assert "feature_extractor=processor.feature_extractor" in scripts[0]
+    assert environments[0]["HF_HUB_OFFLINE"] == "1"
+    assert environments[0]["TRANSFORMERS_OFFLINE"] == "1"
 
 
 def test_ocrbench_v2_scores_short_vqa_with_contains() -> None:

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -6293,18 +6293,26 @@ import numpy as np
 import torch
 from scipy.io import wavfile
 from scipy.signal import resample
-from transformers import pipeline
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 
 paths = %(paths)r
 model_id = %(model_id)r
 local_files_only = %(local_files_only)r
 device = 0 if torch.cuda.is_available() else -1
-model_kwargs = {"local_files_only": True} if local_files_only else {}
+model = AutoModelForSpeechSeq2Seq.from_pretrained(
+    model_id,
+    local_files_only=local_files_only,
+)
+processor = AutoProcessor.from_pretrained(
+    model_id,
+    local_files_only=local_files_only,
+)
 transcriber = pipeline(
     "automatic-speech-recognition",
-    model=model_id,
+    model=model,
+    tokenizer=processor.tokenizer,
+    feature_extractor=processor.feature_extractor,
     device=device,
-    model_kwargs=model_kwargs,
 )
 target_sample_rate = int(transcriber.feature_extractor.sampling_rate)
 waveforms = []
@@ -6330,12 +6338,17 @@ print(json.dumps([str(item.get("text", "")).strip() for item in outputs]))
         "model_id": model_id,
         "local_files_only": local_files_only,
     }
+    environment = _reference_process_environment()
+    if local_files_only:
+        environment["HF_HUB_OFFLINE"] = "1"
+        environment["TRANSFORMERS_OFFLINE"] = "1"
     proc = subprocess.run(
         [python, "-c", script],
         check=False,
         text=True,
         capture_output=True,
         timeout=max(600, 120 * len(wav_paths)),
+        env=environment,
     )
     if proc.returncode != 0:
         raise RuntimeError(
@@ -8682,6 +8695,7 @@ def run_tts_bundle(args: argparse.Namespace) -> None:
         [Path(row["wav_path"]) for row in responses],
         python=str(args.hf_python or sys.executable),
         model_id=str(scoring.get("asr_model", "openai/whisper-large-v3-turbo")),
+        local_files_only=bool(getattr(args, "local_files_only", False)),
     )
     for row, transcript in zip(responses, transcripts, strict=True):
         row["output_text"] = transcript
@@ -9686,6 +9700,7 @@ def _namespace_for_run_bundle(
         top_p=args.top_p,
         min_p=args.min_p,
         seed=args.seed,
+        local_files_only=bool(getattr(args, "local_files_only", False)),
     )
 
 


### PR DESCRIPTION
## Background

`bark-large` previously took 28,815.85 ms on Thor X versus 6,768.28 ms for the aligned FP32 reference. Profiling showed that semantic and coarse prefill issued one TensorRT call per input token, repeatedly synchronizing and transferring host-composed embeddings.

Fixes #894.

## Exit Criteria

- Batch semantic and coarse prefill without changing Bark sampling or audio output.
- Preserve single-profile and tensor-parallel compatibility.
- Keep checkpoint loading and local-only qualification reliable on constrained targets.
- Pass Accuracy and Performance qualification on GB300 and Thor X from the same final commit.

## Implementation

- Add embedding-input prefill profiles for Bark's semantic and coarse decoders while retaining token-input decode profiles on the same TensorRT engine weights.
- Run each host-composed prefill sequence in one TensorRT call and commit the resulting KV cache before autoregressive decode.
- Retain only checkpoint tensors needed after engine construction and memory-map PyTorch checkpoints to reduce peak build memory.
- Make local-only task references enter Hugging Face and Transformers offline mode before loading model assets.
- Keep the existing single-profile path as the fallback and extend unit/build-contract coverage for profile selection, cache transfer, manifest configuration, and offline execution.

## Validation

All target qualification results below are from `ab8a31f7e78378357b462c9f32dd06a2cb1384a0`.

- `pytest -q tests/tools/test_perf_matrix.py`: 136 passed.
- Bark and validation non-hardware tests with the current worktree on `PYTHONPATH`: 372 passed, 3 skipped.
- Accuracy qualification: GB300 and Thor X each passed 3/3 FP32 samples with 100% reference/TRTMC prediction agreement and 100% task accuracy.
- Performance qualification on GB300: TRTMC p50 1,128.32 ms versus reference p50 9,784.03 ms (8.67x); both sides had 10/10 measured samples in the stability band and the audio-shape contract passed.
- Performance qualification on Thor X: TRTMC p50 4,749.95 ms versus reference p50 6,862.87 ms (1.44x); both sides had 10/10 measured samples in the stability band and the audio-shape contract passed.

## Notes For Future Readers

- Review the dual-profile builder first, then the Bark runtime cache handoff, and finally the compatibility tests.
- Coarse decode remains the largest stage, but the complete pipeline now meets the registered target without changing the FP32 audio contract.
- CI results for the rebased final head are pending and must be evaluated from the exact-head required status.
