### PR TITLE
fix(package): install CPU Torch for wheel smoke

### DIFF
--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1623,6 +1623,55 @@ def test_wheel_model_smoke_checks_py312_wheel_only() -> None:
     assert '"PATH"' not in smoke_block
     assert 'trtmc,\n                "build"' in smoke_block
     assert "InstalledWheelValidator.require_elf(trtmc)" in smoke_block
+    assert smoke_block.index("self._create_venv(venv, wheel)") < smoke_block.index(
+        "self._install_model_smoke_dependencies(python)"
+    ) < smoke_block.index('self.context.run([python, "-m", "pip", "check"])')
+
+
+def test_wheel_model_smoke_installs_pinned_cpu_torch() -> None:
+    from tools.ci.package import (
+        PACKAGE_SMOKE_TORCH_INDEX,
+        PACKAGE_SMOKE_TORCH_VERSION,
+        WheelPackageManager,
+    )
+
+    class RecordingContext:
+        def __init__(self) -> None:
+            self.commands: list[list[object]] = []
+
+        def run(self, command: list[object], **_kwargs: object) -> subprocess.CompletedProcess:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    context = RecordingContext()
+    python = Path("venv/bin/python")
+    WheelPackageManager(context)._install_model_smoke_dependencies(python)
+
+    assert context.commands[0] == [
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--only-binary=:all:",
+        "--index-url",
+        PACKAGE_SMOKE_TORCH_INDEX,
+        f"torch=={PACKAGE_SMOKE_TORCH_VERSION}",
+    ]
+    assert context.commands[1][:3] == [python, "-I", "-c"]
+    assert PACKAGE_SMOKE_TORCH_VERSION in str(context.commands[1][3])
+    assert "torch.version.cuda is None" in str(context.commands[1][3])
+
+    package_text = _ci_source("package.py")
+    clean_smoke_block = package_text.split("def _clean_venv_smoke", maxsplit=1)[1].split(
+        "def _create_venv", maxsplit=1
+    )[0]
+    assert "_install_model_smoke_dependencies" not in clean_smoke_block
+
+    for dockerfile_name in ("Dockerfile.dev.aarch64", "Dockerfile.dev.x86"):
+        dockerfile = (REPO_ROOT / dockerfile_name).read_text()
+        assert f"ARG TORCH_VERSION={PACKAGE_SMOKE_TORCH_VERSION}" in dockerfile
+        assert f"ARG PYTORCH_CPU_INDEX={PACKAGE_SMOKE_TORCH_INDEX}" in dockerfile
 
 
 def test_selective_e2e_zero_model_path_still_generates_report_input_dir() -> None:

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -34,6 +34,8 @@ WHEEL_INSTALL_STATE = "wheel-installed.json"
 RELEASE_LEGAL_FILES = ("LICENSE", "NOTICE", "ASSET_LICENSES.md")
 PACKAGE_TENSORRT_VERSION_ENV = "TRTMC_PACKAGE_TENSORRT_VERSION"
 EXACT_TENSORRT_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
+PACKAGE_SMOKE_TORCH_VERSION = "2.12.0+cpu"
+PACKAGE_SMOKE_TORCH_INDEX = "https://download.pytorch.org/whl/cpu"
 
 
 def _target_tensorrt_version(
@@ -764,6 +766,7 @@ class WheelPackageManager:
         self._create_venv(venv, wheel)
         python = venv / "bin/python"
         trtmc = venv / "bin/trtmc"
+        self._install_model_smoke_dependencies(python)
         self.context.run([python, "-m", "pip", "check"])
         InstalledWheelValidator.require_elf(trtmc)
         clean = ("VIRTUAL_ENV", "CONDA_PREFIX", "TRTMC_TRT_LIBRARY_DIR", "LD_LIBRARY_PATH")
@@ -840,6 +843,34 @@ class WheelPackageManager:
             [python, "-m", "pip", "install", "--disable-pip-version-check", "--upgrade", "pip"]
         )
         self.context.run([python, "-m", "pip", "install", "--disable-pip-version-check", wheel])
+
+    def _install_model_smoke_dependencies(self, python: Path) -> None:
+        self.context.run(
+            [
+                python,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--only-binary=:all:",
+                "--index-url",
+                PACKAGE_SMOKE_TORCH_INDEX,
+                f"torch=={PACKAGE_SMOKE_TORCH_VERSION}",
+            ]
+        )
+        self.context.run(
+            [
+                python,
+                "-I",
+                "-c",
+                (
+                    "import torch; "
+                    f"assert torch.__version__ == {PACKAGE_SMOKE_TORCH_VERSION!r}, "
+                    "torch.__version__; "
+                    "assert torch.version.cuda is None, torch.version.cuda"
+                ),
+            ]
+        )
 
     def _validate_build_platform(self, platform: str) -> None:
         match = re.fullmatch(r"manylinux_2_([0-9]+)_aarch64", platform)


### PR DESCRIPTION
## Summary

- install pinned CPU-only PyTorch in the isolated installed-wheel model smoke environment
- verify the exact Torch version and CPU build before running package checks and the Qwen build
- keep the plain installed-wheel sanity check and base wheel dependency metadata unchanged

## Problem

The Qwen3 FP16 package smoke now follows the native active-position RoPE build path, which uses PyTorch to reproduce the Hugging Face FP32 inverse-frequency calculation. The smoke venv intentionally does not inherit packages from the development container, so it could not see the container's existing Torch installation.

## Implementation

The model smoke installs `torch==2.12.0+cpu` from the public PyTorch CPU index after installing the wheel. It rejects source distributions, then verifies both the exact version and `torch.version.cuda is None` with the isolated venv interpreter. The separate metadata-oriented clean-wheel smoke remains unchanged and Torch-free.

## Validation

- `PYTHONPATH=python:. python -m pytest tests/tools/test_github_actions_ci.py tests/e2e/models/qwen/test_package_smoke_config.py -q` — 65 passed
- `PYTHONPATH=python:. python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q` — 158 passed
- `PYTHONPATH=python:. python tools/test_impact.py --validate` — passed with existing allowlist warnings
- `python -m ruff check tools/ci/package.py tests/tools/test_github_actions_ci.py` — passed
- `git diff --check` — passed
- clean aarch64 Python 3.12 venv installed `torch==2.12.0+cpu`; the CPU-only probe and `pip check` passed

Not run locally: the complete TensorRT wheel build and Qwen GPU smoke. The package CI job is the integration proof for that path.
