### PR TITLE
fix(ci): read Community check from PR head

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -87,13 +87,11 @@ jobs:
           base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
           base_ref="$(jq -er '.base.ref' <<<"$pull")"
           head_sha="$(jq -er '.head.sha' <<<"$pull")"
-          merge_sha="$(jq -er '.merge_commit_sha' <<<"$pull")"
 
           test "$state" = "open"
           test "$base_repo" = "$GITHUB_REPOSITORY"
           test "$base_ref" = "main"
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
           if [ "$EVENT_NAME" = "pull_request_target" ] \
             && [ "$head_sha" != "$EVENT_HEAD_SHA" ]; then
             echo "::error::The CI trigger was superseded by a newer PR head."
@@ -103,13 +101,15 @@ jobs:
           # This contributor-visible result is a readiness prerequisite. The
           # maintainer-owned label and this default-branch workflow remain the
           # authorization boundary for protected resources.
+          # GitHub attaches pull_request workflow checks to the PR head even
+          # when their jobs check out the synthetic merge commit.
           community_cpu="$(
             gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
+              "/repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?filter=latest&per_page=100" \
               --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions")) | sort_by(.started_at) | last | .conclusion // empty'
           )"
           if [ "$community_cpu" != "success" ]; then
-            echo "::error::Community CPU / Required must pass on the current PR merge before internal CI can run."
+            echo "::error::Community CPU / Required must pass on the current PR head before internal CI can run."
             exit 1
           fi
           {

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -158,7 +158,6 @@ else:
             "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
         },
         "head": {"sha": pr_head_sha},
-        "merge_commit_sha": "a" * 40,
     }
     environment = os.environ.copy()
     environment.update(
@@ -301,7 +300,9 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "head_repo" not in authorize
     assert "head_ref" not in authorize
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
-    assert '[[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
+    assert "merge_sha" not in authorize
+    assert 'commits/$head_sha/check-runs' in authorize
+    assert 'commits/$merge_sha/check-runs' not in authorize
     assert "Community CPU / Required" in authorize
     assert ".app.slug == \"github-actions\"" in authorize
     assert 'if [ "$community_cpu" != "success" ]; then' in authorize


### PR DESCRIPTION
## Summary

- read the Community CPU required check from the exact pull-request head where GitHub attaches `pull_request` workflow checks
- keep the trusted actor, current-head, repository, base, check-name, and GitHub Actions app validation unchanged
- remove the unused synthetic-merge lookup from the bridge snapshot

## Problem

Community CPU jobs check out the synthetic pull-request merge, but GitHub associates their check runs with the pull-request head SHA. The bridge queried the merge SHA, so it could not find a successful `Community CPU / Required` check and never dispatched premerge CI.

The private premerge remains responsible for resolving and testing the current base-plus-head merge snapshot. This change only aligns the contributor-visible prerequisite lookup with GitHub's check attachment behavior.

## Validation

- `PYTHONPATH=python:. python -m pytest tests/tools/test_github_actions_ci.py -q` — 63 passed
- `python -m ruff check tests/tools/test_github_actions_ci.py` — passed
- workflow YAML parse — passed
- `git diff --check` — passed
- the exact head lookup returns the successful public Community CPU required check for PR #991; the previous merge-SHA lookup returns no matching check

Not run: a live trusted bridge dispatch. `pull_request_target` executes the workflow from the base branch, so the integration proof is available only after this prerequisite lands.
