### PR TITLE
test(ci): validate contributor /run-ci [do not merge]

### DIFF
--- a/.github/community-ci-smoke.md
+++ b/.github/community-ci-smoke.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Community CI smoke test
+
+This file exists only on a fork pull request used to validate the public
+`/run-ci` path. Do not merge that pull request.


### PR DESCRIPTION
## Background
Validate the contributor-triggered public CPU path on a pull request owned by the maintainer. This avoids running experiments on community contributor pull requests.

## Exit Criteria
- An exact `/run-ci` comment authorizes and dispatches public CPU validation.
- All test jobs run on GitHub-hosted `ubuntu-24.04` runners against the captured merge revision.
- `Community CPU / Required` completes on that exact merge revision.
- Close this pull request without merging it.

## Implementation
- Add one inert smoke-test marker under `.github`.
- Do not change runtime, test, or workflow behavior.

## Validation
- `git diff --check`: passed.
- DCO sign-off: present on commit `ea2d0ba503ca09da1df887a1dc76dababf6117dc`.
- Community CPU: not run yet; this pull request is the test surface.

## Notes For Future Readers
This pull request is temporary and must not be merged. Close it after the `/run-ci` proof of concept finishes.