### PR TITLE
fix(ci): allow broker to publish merge checks

### DIFF
--- a/.github/workflows/community-cpu-request.yml
+++ b/.github/workflows/community-cpu-request.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: write
-      checks: read
+      checks: write
       contents: read
       pull-requests: read
 

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -285,7 +285,7 @@ def test_public_cpu_request_is_a_pr_author_comment_dispatcher() -> None:
     assert authorize["runs-on"] == "ubuntu-24.04"
     assert authorize["permissions"] == {
         "actions": "write",
-        "checks": "read",
+        "checks": "write",
         "contents": "read",
         "pull-requests": "read",
     }


### PR DESCRIPTION
## Background
The new `/run-ci` broker accepts an owned-fork request, but the downstream Community CPU run fails before creating any job when it is dispatched with the broker GITHUB_TOKEN. A maintainer dispatch of the same PR #993 snapshot starts normally and creates the exact-merge checks.

## Exit Criteria
- Give the trusted default-branch broker the check permission required by the dispatched Community workflow.
- Keep the broker metadata-only: it must not check out or execute pull-request code.
- Validate the real `/run-ci` path on owned smoke PR #993 after this fix reaches `main`.

## Implementation
- Change the broker job from `checks: read` to `checks: write`.
- Update the workflow permission contract test.

## Validation
- `python3 -m pytest tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py -q`: 77 passed.
- `actionlint .github/workflows/community-cpu-request.yml .github/workflows/community-cpu.yml`: passed.
- `git diff --check`: passed.
- Controlled owned-fork comparison: broker dispatch created zero jobs, while maintainer dispatch of the same PR #993 snapshot initialized exact-merge checks successfully.
- Exact-merge Community CPU on `0a2a2b1bda3d49029e4d90e5445a9780be38c76d`: passed.
- `trtmc/premerge/required` on head `3452d302d6dfbc06d52855971e4e6244e38478fe`: passed.

## Notes For Future Readers
Keep the transitional automatic `pull_request` trigger until PR #993 proves the contributor comment path on `main`. Remove that trigger in a separate cleanup PR after the POC succeeds.
