### PR TITLE
fix(ci): surface community failures on PRs

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -111,12 +111,62 @@ jobs:
     permissions:
       checks: write
       contents: read
+      issues: write
     outputs:
+      comment_id: ${{ steps.comment.outputs.comment_id }}
       source_quality_check_id: ${{ steps.checks.outputs.source_quality_check_id }}
       ownership_impact_check_id: ${{ steps.checks.outputs.ownership_impact_check_id }}
       unit_check_id: ${{ steps.checks.outputs.unit_check_id }}
       required_check_id: ${{ steps.checks.outputs.required_check_id }}
     steps:
+      - name: Publish public run link
+        id: comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          marker="<!-- trtmc-community-cpu -->"
+          comments="$(
+            gh api --method GET \
+              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100"
+          )"
+          comment_id="$(
+            jq -r --arg marker "$marker" \
+              '[.[] | select(.user.login == "github-actions[bot]" and ((.body // "") | contains($marker)))] | last | .id // empty' \
+              <<<"$comments"
+          )"
+          body="$(
+            printf '%s\n' \
+              "$marker" \
+              "## Community CPU" \
+              "" \
+              "**Status:** RUNNING" \
+              "- Exact merge: <code>$MERGE_SHA</code>" \
+              "" \
+              "[View live public logs]($details_url)"
+          )"
+
+          if [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]; then
+            comment_id="$(
+              gh api --method PATCH \
+                "/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+                -f body="$body" \
+                --jq '.id'
+            )"
+          else
+            comment_id="$(
+              gh api --method POST \
+                "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+                -f body="$body" \
+                --jq '.id'
+            )"
+          fi
+          [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
+          echo "comment_id=$comment_id" >> "$GITHUB_OUTPUT"
+
       - name: Publish pending exact-merge checks
         id: checks
         env:
@@ -307,6 +357,7 @@ jobs:
     permissions:
       checks: write
       contents: read
+      issues: write
       pull-requests: read
     steps:
       - name: Publish exact-merge CPU checks
@@ -314,6 +365,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
           BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+          COMMENT_ID: ${{ needs.initialize.outputs.comment_id }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
@@ -363,6 +415,31 @@ jobs:
               --input "$payload"
           }
 
+          publish_comment() {
+            local status="$1"
+            local message="$2"
+            local body
+            [[ "$COMMENT_ID" =~ ^[1-9][0-9]*$ ]]
+            body="$(
+              printf '%s\n' \
+                "<!-- trtmc-community-cpu -->" \
+                "## Community CPU" \
+                "" \
+                "**Status:** $status" \
+                "- Exact merge: <code>$MERGE_SHA</code>" \
+                "- Source quality: <code>$SOURCE_QUALITY_RESULT</code>" \
+                "- Ownership and impact: <code>$OWNERSHIP_IMPACT_RESULT</code>" \
+                "- Unit / C++ and Python: <code>$UNIT_RESULT</code>" \
+                "" \
+                "$message" \
+                "" \
+                "[View public logs]($details_url)"
+            )"
+            gh api --silent --method PATCH \
+              "/repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" \
+              -f body="$body"
+          }
+
           trap 'rm -f "$payload"' EXIT
           snapshot_current=false
           if pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"; then
@@ -384,6 +461,7 @@ jobs:
             update_check "$OWNERSHIP_IMPACT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
             update_check "$UNIT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
             update_check "$REQUIRED_CHECK_ID" neutral "Stale PR snapshot" "$summary"
+            publish_comment "STALE" "$summary"
             echo "::warning::$summary"
             exit 0
           fi
@@ -405,6 +483,11 @@ jobs:
             && [ "$OWNERSHIP_IMPACT_RESULT" = success ] \
             && [ "$UNIT_RESULT" = success ]; then
             required_conclusion=success
+          fi
+          if [ "$required_conclusion" = success ]; then
+            publish_comment "PASSED" "All required public CPU stages passed."
+          else
+            publish_comment "FAILED" "One or more stages failed. Open the public logs for the exact error output."
           fi
           update_check "$REQUIRED_CHECK_ID" "$required_conclusion" \
             "Community CPU: $required_conclusion" "$summary"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,9 +164,16 @@ exact merge revision.
 
 All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
 read-only repository permission and no access to private runners, secrets, or
-GPUs. Wait for `Community CPU / Required` to pass on the current merge
-revision. Repeating `/run-ci` for an already queued, running, or successful
-merge is safely deduplicated.
+GPUs. Before testing starts, the workflow creates or updates a `Community CPU`
+status comment on the pull request with the exact merge SHA and a direct link
+to live public Actions logs. At completion, the same comment reports each stage
+verdict and links to the complete error output. This comment is the stable log
+entrypoint because the checks themselves are attached to the merge SHA rather
+than the pull-request head SHA.
+
+Wait for `Community CPU / Required` to pass on the current merge revision.
+Repeating `/run-ci` for an already queued, running, or successful merge is
+safely deduplicated.
 
 If the pull-request head or base changes, the previous merge result is stale.
 Finish the update, rerun local checks, and comment `/run-ci` again for the new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,21 @@ Keep each pull request focused on one problem. Add or update focused tests when
 behavior changes, and update documentation when users or developers will observe
 the change.
 
+Install the lightweight commit-time quality hooks once in each clone:
+
+```bash
+python3 -m pip install --requirement requirements/community-ci.txt
+pre-commit install --install-hooks
+```
+
+On Windows, use `py -3 -m pip` in place of `python3 -m pip`.
+
+The hooks trim trailing whitespace, ensure one final newline, validate YAML,
+check Ruff, and verify clang-format. Pre-commit manages the Ruff and
+clang-format environments on Linux, macOS, and Windows. There is no pre-push
+hook: builds and the broader source-only CPU suite run through the public
+`/run-ci` workflow after the branch is pushed.
+
 Start with repository consistency checks:
 
 ```bash
@@ -130,33 +145,63 @@ Compilation, unit tests, inference, model parity, target-hardware execution,
 performance, and release qualification are separate evidence levels. Claim only
 what the recorded validation proves.
 
-### 8. Ask a maintainer to trigger CI
+### 8. Run contributor-visible public CPU validation
+
+Creating a pull request or pushing to a fork does not automatically start
+Community CPU. After local checks pass, the pull-request author adds this exact
+comment:
+
+```text
+/run-ci
+```
+
+A maintainer or admin may submit the same command on the author's behalf. The
+trusted default-branch `Community CPU` workflow authorizes the actor and
+captures the current base, head, and merge SHAs without checking out
+pull-request code. Separate test jobs then run source quality, ownership and
+impact analysis, and the selected source-only C++ and Python units against that
+exact merge revision.
+
+All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
+read-only repository permission and no access to private runners, secrets, or
+GPUs. Wait for `Community CPU / Required` to pass on the current merge
+revision. Repeating `/run-ci` for an already queued, running, or successful
+merge is safely deduplicated.
+
+If the pull-request head or base changes, the previous merge result is stale.
+Finish the update, rerun local checks, and comment `/run-ci` again for the new
+merge revision.
+
+### 9. Ask a maintainer to trigger protected CI
 
 Opening a pull request or pushing to your fork does **not** start the protected
-premerge suite. After your local checks pass and the pull request is ready for
-CI, mention the repository maintainer in a pull-request comment:
+premerge suite. After public CPU validation passes and the pull request is
+ready for protected CI, mention the repository maintainer in a pull-request
+comment:
 
 ```text
 @yifeif-nv This PR is ready for CI. Please trigger CI for the current head.
 ```
 
-The maintainer verifies the pull-request head and applies the one-shot
-`run-internal-ci` label. Only collaborators with repository `maintain` or
-`admin` permission can authorize that trigger.
+The maintainer verifies the pull-request head and the current exact-merge public
+result, then applies the one-shot `run-internal-ci` label. Only collaborators
+with repository `maintain` or `admin` permission can authorize that trigger.
+The trusted bridge consumes the label, rechecks `Community CPU / Required`,
+captures the current PR head SHA, and dispatches protected premerge validation.
 
 Wait for `trtmc/premerge/required` to pass on the exact pull-request head SHA.
 If you push another commit, the previous result no longer validates the current
-head; finish the update, rerun local checks, and mention `@yifeif-nv` once to
-request a new CI run. Private runner details, logs, artifacts, and URLs are not
-part of the public contribution interface.
+head; finish the update, rerun local checks and `/run-ci`, and mention
+`@yifeif-nv` once to request a new protected run. Private runner details,
+logs, artifacts, and URLs are not part of the public contribution interface.
 
-### 9. Respond to review and keep evidence current
+### 10. Respond to review and keep evidence current
 
 Address review feedback on the same topic branch and sign off every new commit.
-Keep the pull request current with upstream when requested. Any head change
-requires fresh validation and a fresh maintainer-triggered CI result before the
-pull request can merge. Maintainers merge accepted changes according to the
-repository ruleset.
+Keep the pull request current with upstream when requested. Any head or base
+change requires a fresh public merge result; any head change also requires a
+fresh maintainer-triggered protected result before the pull request can merge.
+Maintainers merge accepted changes according to the repository ruleset.
 
 ## Established development practices
 

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -90,15 +90,25 @@ if null_input:
         raise SystemExit(f"unsupported null-input jq expression: {expression}")
 else:
     result = json.load(sys.stdin)
-    optional_empty = expression.endswith(" // empty")
-    path = expression.removesuffix(" // empty").removeprefix(".").split(".")
-    for part in path:
-        if not isinstance(result, dict) or part not in result:
-            result = None
-            break
-        result = result[part]
-    if optional_empty and result is None:
-        result = ""
+    if isinstance(result, list) and "github-actions[bot]" in expression:
+        marker = variables["marker"]
+        matches = [
+            item
+            for item in result
+            if item.get("user", {}).get("login") == "github-actions[bot]"
+            and marker in (item.get("body") or "")
+        ]
+        result = matches[-1]["id"] if matches else ""
+    else:
+        optional_empty = expression.endswith(" // empty")
+        path = expression.removesuffix(" // empty").removeprefix(".").split(".")
+        for part in path:
+            if not isinstance(result, dict) or part not in result:
+                result = None
+                break
+            result = result[part]
+        if optional_empty and result is None:
+            result = ""
 
 if exit_status and result is None:
     raise SystemExit(1)
@@ -133,6 +143,15 @@ elif "/pulls/" in endpoint:
     print(os.environ["FAKE_PULL_JSON"])
 elif "/commits/" in endpoint and "/check-runs" in endpoint:
     print(os.environ.get("FAKE_EXISTING_REQUIRED", ""))
+elif "/issues/" in endpoint and endpoint.endswith("comments?per_page=100"):
+    print(os.environ["FAKE_COMMENTS_JSON"])
+elif "/issues/" in endpoint and endpoint.endswith("/comments") and "POST" in arguments:
+    body_argument = arguments[arguments.index("-f") + 1]
+    Path(os.environ["FAKE_COMMENT_CAPTURE"]).write_text(
+        body_argument.removeprefix("body="),
+        encoding="utf-8",
+    )
+    print("99")
 elif endpoint.endswith("/check-runs") and "POST" in arguments:
     input_path = arguments[arguments.index("--input") + 1]
     payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
@@ -150,6 +169,14 @@ elif "/check-runs/" in endpoint and "PATCH" in arguments:
     payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
     with Path(os.environ["FAKE_CHECK_CAPTURE"]).open("a", encoding="utf-8") as stream:
         stream.write(json.dumps(payload) + "\\n")
+elif "/issues/comments/" in endpoint and "PATCH" in arguments:
+    body_argument = arguments[arguments.index("-f") + 1]
+    Path(os.environ["FAKE_COMMENT_CAPTURE"]).write_text(
+        body_argument.removeprefix("body="),
+        encoding="utf-8",
+    )
+    if "--jq" in arguments:
+        print(endpoint.rsplit("/", maxsplit=1)[-1])
 else:
     print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
     raise SystemExit(2)
@@ -182,8 +209,11 @@ def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
         {
             "ACTOR": "pr-author",
             "BASE_SHA": base_sha,
+            "COMMENT_ID": "99",
             "FAKE_ACTOR_ROLE": "maintain",
             "FAKE_CHECK_CAPTURE": str(tmp_path / "checks.jsonl"),
+            "FAKE_COMMENT_CAPTURE": str(tmp_path / "comment.md"),
+            "FAKE_COMMENTS_JSON": "[]",
             "FAKE_PENDING_CHECK_CAPTURE": str(tmp_path / "pending-checks.jsonl"),
             "FAKE_PULL_JSON": json.dumps(pull),
             "GH_TOKEN": "test-token",
@@ -254,6 +284,8 @@ def test_contributor_guides_match_the_live_ci_flow(path: Path) -> None:
             "no access to private",
             "runners, secrets, or",
             "GPUs",
+            "status comment",
+            "public Actions logs",
             "py -3 -m pip",
     ):
         assert marker in source
@@ -499,6 +531,39 @@ def test_public_cpu_initialization_creates_pending_exact_merge_checks(
     )
 
 
+def test_public_cpu_initialization_publishes_a_visible_pr_run_link(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "initialize",
+                "Publish public run link",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
+        "comment_id=99\n"
+    )
+    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
+    assert "<!-- trtmc-community-cpu -->" in comment
+    assert "**Status:** RUNNING" in comment
+    assert f"- Exact merge: <code>{'c' * 40}</code>" in comment
+    assert "[View live public logs]" in comment
+    assert "/actions/runs/12345" in comment
+
+
 def test_public_cpu_verdict_neutralizes_a_stale_snapshot(tmp_path: Path) -> None:
     environment = _public_ci_environment(tmp_path)
     pull = json.loads(environment["FAKE_PULL_JSON"])
@@ -540,6 +605,10 @@ def test_public_cpu_verdict_neutralizes_a_stale_snapshot(tmp_path: Path) -> None
     assert len(checks) == 4
     assert {check["conclusion"] for check in checks} == {"neutral"}
     assert all("PR changed" in check["output"]["summary"] for check in checks)
+    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
+    assert "**Status:** STALE" in comment
+    assert "Comment /run-ci again" in comment
+    assert "[View public logs]" in comment
 
 
 def test_public_cpu_verdict_publishes_success_for_the_exact_snapshot(
@@ -582,6 +651,64 @@ def test_public_cpu_verdict_publishes_success_for_the_exact_snapshot(
     assert len(checks) == 4
     assert {check["conclusion"] for check in checks} == {"success"}
     assert checks[-1]["output"]["title"] == "Community CPU: success"
+    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
+    assert "**Status:** PASSED" in comment
+    assert "- Source quality: <code>success</code>" in comment
+    assert "- Ownership and impact: <code>success</code>" in comment
+    assert "- Unit / C++ and Python: <code>success</code>" in comment
+    assert "[View public logs]" in comment
+
+
+def test_public_cpu_verdict_publishes_failure_comment_before_exiting(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment.update(
+        {
+            "SOURCE_QUALITY_RESULT": "failure",
+            "OWNERSHIP_IMPACT_RESULT": "success",
+            "UNIT_RESULT": "failure",
+            "SOURCE_QUALITY_CHECK_ID": "1",
+            "OWNERSHIP_IMPACT_CHECK_ID": "2",
+            "UNIT_CHECK_ID": "3",
+            "REQUIRED_CHECK_ID": "4",
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "required",
+                "Publish exact-merge CPU checks",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    checks = [
+        json.loads(line)
+        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [check["conclusion"] for check in checks] == [
+        "failure",
+        "success",
+        "failure",
+        "failure",
+    ]
+    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
+    assert "**Status:** FAILED" in comment
+    assert "- Source quality: <code>failure</code>" in comment
+    assert "- Ownership and impact: <code>success</code>" in comment
+    assert "- Unit / C++ and Python: <code>failure</code>" in comment
+    assert "Open the public logs for the exact error output." in comment
+    assert "[View public logs]" in comment
 
 
 def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
@@ -611,6 +738,11 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert 'external_id="community-cpu:' in source
     assert '"/repos/$GITHUB_REPOSITORY/check-runs"' in source
     assert '"/repos/$GITHUB_REPOSITORY/check-runs/$check_id"' in source
+    assert "<!-- trtmc-community-cpu -->" in source
+    assert "Publish public run link" in source
+    assert "[View live public logs]" in source
+    assert "[View public logs]" in source
+    assert '"/repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID"' in source
     assert "The PR changed after public CPU validation was requested" in source
 
     jobs = workflow["jobs"]
@@ -630,6 +762,7 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert jobs["initialize"]["permissions"] == {
         "checks": "write",
         "contents": "read",
+        "issues": "write",
     }
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
@@ -649,6 +782,7 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert jobs["required"]["permissions"] == {
         "checks": "write",
         "contents": "read",
+        "issues": "write",
         "pull-requests": "read",
     }
 

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -226,6 +226,41 @@ def test_pre_commit_config_installs_only_lightweight_commit_hooks() -> None:
     assert "pre-push" not in source
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        REPO_ROOT / "CONTRIBUTING.md",
+        REPO_ROOT / "website" / "docs" / "extend" / "contributing.md",
+    ],
+)
+def test_contributor_guides_match_the_live_ci_flow(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    ordered_markers = [
+        "pre-commit install --install-hooks",
+        "git commit --signoff",
+        "git push --set-upstream origin",
+        "```text\n/run-ci\n```",
+        "Community CPU / Required",
+        "run-internal-ci",
+        "trtmc/premerge/required",
+    ]
+
+    positions = [source.index(marker) for marker in ordered_markers]
+    assert positions == sorted(positions)
+    for marker in (
+            "GitHub-hosted",
+            "ubuntu-24.04",
+            "read-only repository permission",
+            "no access to private",
+            "runners, secrets, or",
+            "GPUs",
+            "py -3 -m pip",
+    ):
+        assert marker in source
+    assert "trusted request workflow" not in source
+    assert "Community CPU Request" not in source
+
+
 def test_impact_publishes_only_the_public_cpu_scope(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -63,10 +63,13 @@ execute PR code.
 
 The test jobs check out only the authorized merge SHA with read-only repository
 permission and no secrets. Separate publisher jobs create
-and complete contributor-visible checks on that merge SHA. If the PR head or
-base changes before publication, every pending public check becomes neutral
-instead of validating the stale snapshot. Comment `/run-ci` again only after
-the new head is ready.
+and complete contributor-visible checks on that merge SHA. They also maintain
+one PR status comment containing the exact merge SHA, per-stage verdicts, and a
+direct link to the public Actions logs so contributors can always find the
+error output even though the checks are not attached to the PR head. If the PR
+head or base changes before publication, every pending public check becomes
+neutral instead of validating the stale snapshot. Comment `/run-ci` again
+only after the new head is ready.
 
 ## Pre-merge, step by step
 

--- a/website/docs/architecture/build-system.md
+++ b/website/docs/architecture/build-system.md
@@ -141,7 +141,7 @@ instead.
 | `dist/tensorrt_model_connect-*.whl` | Built Python/native wheel |
 | Native `.bundle` | Plans/assets dispatched through an installed model/backend DSO |
 | Optimized `.bundle` | Descriptor plus embedded implementation DSO/artifact tree |
-| `website/build/` | Docusaurus production output |
+| Generated build directory under `website/` | Docusaurus production output |
 
 ## Build-time versus run-time availability
 

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -41,6 +41,8 @@ python3 -m pip install --requirement requirements/community-ci.txt
 pre-commit install --install-hooks
 ```
 
+On Windows, use `py -3 -m pip` in place of `python3 -m pip`.
+
 Commit-time hooks trim trailing whitespace, ensure one final newline, validate
 YAML, check Ruff, and verify clang-format. Some commit-time hooks modify files;
 review and stage those fixes before committing again. Pre-commit manages the
@@ -133,7 +135,7 @@ The pull request should record:
 Compilation, source tests, model parity, target-hardware execution,
 performance, and release qualification are different evidence tiers.
 
-## 6. Read public CPU validation
+## 6. Run public CPU validation
 
 The pull-request author starts contributor-visible, GitHub-hosted `Community
 CPU` validation by adding this exact comment to the pull request:
@@ -142,16 +144,19 @@ CPU` validation by adding this exact comment to the pull request:
 /run-ci
 ```
 
-The trusted request workflow runs from `main`, captures the exact PR merge
-revision, and dispatches source quality, ownership and impact, and source-only
-C++ and Python units. A maintainer or admin may submit the same comment on the
-author's behalf.
+The trusted default-branch `Community CPU` workflow authorizes the actor and
+captures the exact base, head, and merge SHAs without checking out
+pull-request code. Separate jobs in that same workflow run source quality,
+ownership and impact, and source-only C++ and Python units. A maintainer or
+admin may submit the same comment on the author's behalf.
 
 The test jobs have read-only repository permission and no access to private
-runners, secrets, or GPUs. Their sanitized checks and detailed public logs are
-published on the exact merge revision. Fix any failures and wait for
-`Community CPU / Required` to pass. If you push another commit, comment
-`/run-ci` again after the new head is ready.
+runners, secrets, or GPUs, and every public job uses a GitHub-hosted
+`ubuntu-24.04` runner. Sanitized checks and detailed public logs are published
+on the exact merge revision. Fix any failures and wait for
+`Community CPU / Required` to pass. Repeating `/run-ci` for the same queued,
+running, or successful merge is safely deduplicated. If the PR head or base
+changes, comment `/run-ci` again after the new revision is ready.
 
 ## 7. Coordinate protected repository CI
 

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -152,11 +152,17 @@ admin may submit the same comment on the author's behalf.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs, and every public job uses a GitHub-hosted
-`ubuntu-24.04` runner. Sanitized checks and detailed public logs are published
-on the exact merge revision. Fix any failures and wait for
-`Community CPU / Required` to pass. Repeating `/run-ci` for the same queued,
-running, or successful merge is safely deduplicated. If the PR head or base
-changes, comment `/run-ci` again after the new revision is ready.
+`ubuntu-24.04` runner. Before testing starts, the workflow creates or updates
+a `Community CPU` status comment on the pull request with the exact merge SHA
+and a direct link to live public Actions logs. At completion, the same comment
+reports each stage verdict and links to the complete error output. This comment
+is the stable log entrypoint because the sanitized checks are attached to the
+merge SHA rather than the pull-request head SHA.
+
+Fix any failures and wait for `Community CPU / Required` to pass. Repeating
+`/run-ci` for the same queued, running, or successful merge is safely
+deduplicated. If the PR head or base changes, comment `/run-ci` again after
+the new revision is ready.
 
 ## 7. Coordinate protected repository CI
 

--- a/website/docs/reference/source-layout.md
+++ b/website/docs/reference/source-layout.md
@@ -15,8 +15,8 @@ Each directory name must agree with the `id` in its own descriptor. The three
 physical names usually match, but their link is the exact
 `runtime_strategy`, not filename equality: current builder/E2E owners
 `magpie_tts` and `wan_t2v` map to runtime owners `magpie` and `wan`,
-respectively. At this revision, all three trees contain 79 descriptors. The E2E
-descriptors declare 209 JSON manifests; runtime descriptors declare 80 unique
+respectively. At this revision, all three trees contain 83 descriptors. The E2E
+descriptors declare 220 JSON manifests; runtime descriptors declare 84 unique
 strategy keys because one runtime owner exposes two strategies. Treat these
 numbers as a checked snapshot, not a constant: the descriptor files are the
 source of truth.

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -77,7 +77,7 @@ Source contains exactly these three workflow files:
 
 | Workflow | Trigger and evidence boundary |
 | --- | --- |
-| `.github/workflows/community-cpu.yml` | Exact `/run-ci` PR comment from the PR author or a maintainer/admin; authorizes the exact public PR snapshot, runs read-only CPU validation, and publishes checks on the merge SHA with separate least-privilege jobs. |
+| `.github/workflows/community-cpu.yml` | Exact `/run-ci` PR comment from the PR author or a maintainer/admin; authorizes the exact public PR snapshot, runs read-only CPU validation, publishes checks on the merge SHA, and maintains a PR comment linking the public logs. |
 | `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, verifies current public CPU success, captures the exact PR head, and dispatches private premerge. |
 | `.github/workflows/pages.yml` | Pushes affecting `website/**` on `main`, or manual runs; builds and deploys only the documentation site to GitHub Pages. |
 


### PR DESCRIPTION
## Background
Community CPU runs are triggered by `issue_comment` and publish their required checks on the exact merge SHA. A real external-fork failure showed that the PR head can therefore display no checks even though public Actions logs exist, leaving contributors without a discoverable error link. The authoritative root guide also omitted the public `/run-ci` stage, while the website guide still described the retired two-workflow architecture.

## Exit Criteria
- Give contributors a stable PR-visible link to live and completed Community CPU logs.
- Report RUNNING, PASSED, FAILED, or STALE plus exact merge and per-stage verdicts.
- Keep all write permission in trusted jobs that never check out PR code.
- Make root and website contribution guides agree with the validated live workflow.
- Prevent the two guides from drifting silently.

## Implementation
- Create or update one sticky `Community CPU` PR comment before tests start.
- Update that comment with source-quality, ownership/impact, and unit verdicts before the required check completes.
- Require successful comment publication before `Community CPU / Required` can conclude success.
- Add only `issues: write` to the trusted initialize and required publisher jobs; test jobs remain `contents: read`.
- Document fork-first development, cross-platform lightweight pre-commit, exact `/run-ci`, GitHub-hosted CPU validation, public log discovery, and maintainer-only protected CI in both contributor guides.
- Repair two stale website reference claims so the documented strict docs command passes.
- Add a contract that enforces the shared contributor flow in both guides.

## Validation
- Isolated documented hook install plus representative Markdown/YAML/Python/C++ run: all five hooks passed.
- `python3 -m pytest tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py -q`: 83 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; CCN max 10 and 158 architecture contracts passed.
- `python3 -m tools.community_ci impact --base github/main`: selected `unit_scope=all`.
- `python3 -m tools.community_ci unit --scope all`: 3516 Python tests passed with 2 skipped, 20 supplemental tests passed, and 38/38 C++ tests passed on the rebased exact head.
- `PYTHONPATH=python:. python3 tools/model_ci.py validate`: passed.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed with existing warnings.
- `actionlint .github/workflows/community-cpu.yml`: passed.
- `python3 tools/check_doc_file_references.py --strict website/docs`: 107 docs, 0 errors, 0 warnings.
- `npm --prefix website ci`: passed.
- `npm --prefix website run build`: passed; 34 diagrams verified and client/server compiled.
- `git diff --check`: passed.
- Community CPU on merge `2f86ab7c5ba9def6acb218ec2ae8b918381cb0a5`: passed ([public run](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/32538051671)).
- `trtmc/premerge/required` on head `8294164da0187f7632c69bbc022e7ed144dbb747`: passed.

## Notes For Future Readers
The canonical CONTRIBUTING.md digest prerequisite must land before protected CI is triggered for this PR. Because `issue_comment` always reads the default-branch workflow, the final live sticky-comment POC must run on an owned smoke PR after merge.

