### PR TITLE
test(ci): validate failure comments [do not merge]

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Owned PR #1000 smoke marker; this comment-only change must not be merged.
 name: Community CPU
 
 run-name: >-

--- a/scripts/community_ci_failure_smoke.py
+++ b/scripts/community_ci_failure_smoke.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Intentional Ruff failure for the owned Community CI visibility smoke test."""
+
+import os

--- a/scripts/community_ci_failure_smoke.py
+++ b/scripts/community_ci_failure_smoke.py
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-"""Intentional Ruff failure for the owned Community CI visibility smoke test."""
-
-import os


### PR DESCRIPTION
## Background
Validate the live PR-visible Community CPU failure UX on an owned fork without touching any contributor pull request.

## Exit Criteria
- `/run-ci` creates a sticky PR comment before tests start.
- The intentional Ruff failure updates the same comment to FAILED.
- The comment shows the exact merge, stage verdicts, and a working public Actions log link.
- A follow-up fix updates that same comment to PASSED.
- Close this pull request and delete the branch without merging.

## Implementation
- Add one intentionally unused import in a temporary smoke script.
- Bypass pre-commit only for this explicit failure fixture.

## Validation
- Not run yet: this pull request is the live failure test surface.

## Notes For Future Readers
This pull request is owned infrastructure test data. Do not merge it.