### PR TITLE
fix(ci): grant PR comment permission

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -111,7 +111,7 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write
+      pull-requests: write
     outputs:
       comment_id: ${{ steps.comment.outputs.comment_id }}
       source_quality_check_id: ${{ steps.checks.outputs.source_quality_check_id }}
@@ -357,8 +357,7 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Publish exact-merge CPU checks
         env:

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -762,7 +762,7 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert jobs["initialize"]["permissions"] == {
         "checks": "write",
         "contents": "read",
-        "issues": "write",
+        "pull-requests": "write",
     }
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
@@ -782,8 +782,7 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert jobs["required"]["permissions"] == {
         "checks": "write",
         "contents": "read",
-        "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
     }
 
 


### PR DESCRIPTION
## Background
Owned smoke PR #1000 proved that the new sticky Community comment fails at initialization with `Resource not accessible by integration (HTTP 403)`. The job received `Issues: write`, but the PR timeline comment endpoint requires the GitHub App token to use the Pull requests write permission in this repository.

## Exit Criteria
- Allow trusted publisher jobs to create and update the PR-visible Community status comment.
- Keep every job that checks out pull-request code read-only.
- Remove the ineffective Issues write scope.
- Re-run the owned failure and recovery POC after this fix reaches main.

## Implementation
- Replace `issues: write` with `pull-requests: write` in the initialize publisher.
- Upgrade the required publisher from pull-request read to write and remove Issues write.
- Update the least-privilege workflow contract.

## Validation
- `python3 -m pytest tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py -q`: 83 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; CCN max 10 and 158 architecture contracts passed.
- `python3 -m tools.community_ci impact --base github/main`: selected `unit_scope=all`.
- `actionlint .github/workflows/community-cpu.yml`: passed.
- Configured pre-commit hooks: passed.
- `git diff --check`: passed.

## Notes For Future Readers
The live POC must run after merge because `issue_comment` always executes the default-branch workflow. Owned do-not-merge PR #1000 remains the test surface.