### PR TITLE
fix(qwen): restore qualified FP8 routing

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -3,24 +3,71 @@
 
 """Qwen family plugin — Qwen, Qwen2, Qwen3, QwQ (text-only, not VL).
 
-Qwen3 uses only the family-owned TensorRT native KV path and fails closed for
-unsupported build modes. Other Qwen variants retain their legacy graph routes.
+Unquantized Qwen3 uses only the family-owned TensorRT native KV path. Qualified
+FP8 builds retain the family-owned quantized graph; all other unsupported
+Qwen3 modes fail closed. Other Qwen variants retain their legacy graph routes.
 """
 
 from __future__ import annotations
 
 from .config import ModelConfig
 from .checkpoint_mapper import WeightDict, load_standard_weights
-from ...parallel_config import normalize_parallel_config
+from ...parallel_config import ParallelConfig, normalize_parallel_config
 from ...quantization.adapters import StandardDecoderCalibrationAdapter
 from .build_routing import (
     native_kv_architecture_capability,
     native_kv_build_capability,
+    native_kv_cache_geometry,
 )
 from .native_kv_contract import validate_native_kv_weights
 from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
 from .standard_decoder_builder import build_standard_decoder_engine
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
+
+
+def _quant_format_name(quant_ctx) -> str | None:
+    quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    return getattr(quant_format, "name", None)
+
+
+def _uses_qualified_qwen3_fp8_path(
+    config: ModelConfig,
+    max_cache_length: int,
+    *,
+    precision: str,
+    quant_ctx,
+    parallel: ParallelConfig,
+    debug_layer_outputs: bool,
+) -> bool:
+    """Recognize the explicit, previously qualified Qwen3 FP8 graph route."""
+
+    raw = config.raw
+    precision_name = str(precision).lower()
+    qualified_route = (
+        not parallel.enabled
+        and precision_name == "fp16"
+        and raw.get("_decoder_engine_layout") == "dual_profile"
+    ) or (
+        parallel.enabled
+        and parallel.tp_size == 4
+        and precision_name == "bf16"
+    )
+    if (
+        not native_kv_architecture_capability(config).eligible
+        or _quant_format_name(quant_ctx) != "fp8"
+        or not qualified_route
+        or debug_layer_outputs
+        or raw.get("_rtx_build_requested")
+        or raw.get("_fp32_layers")
+        or raw.get("dynamic_kv_cache")
+        or raw.get("_runtime_dynamic_kv_requested")
+    ):
+        return False
+    try:
+        native_kv_cache_geometry(config, max_cache_length)
+    except ValueError:
+        return False
+    return True
 
 
 class QwenPlugin:
@@ -86,7 +133,7 @@ class QwenPlugin:
         return int(config.max_position_embeddings) if capability.eligible else 256
 
     def supports_split_decoder_roles(self, config: ModelConfig) -> bool:
-        """Keep quantized legacy Qwen variants on the single-engine path."""
+        """Keep quantized Qwen routes on the family-owned single-engine path."""
         return not bool(config.raw.get("_quantized_build_requested"))
 
     def validate_build_request(self, config: ModelConfig) -> None:
@@ -126,6 +173,14 @@ class QwenPlugin:
             quantized=quant_ctx is not None,
             debug_layer_outputs=debug_layer_outputs,
         )
+        qualified_fp8 = _uses_qualified_qwen3_fp8_path(
+            config,
+            max_cache_length,
+            precision=precision,
+            quant_ctx=quant_ctx,
+            parallel=parallel,
+            debug_layer_outputs=debug_layer_outputs,
+        )
         if capability.eligible:
             validate_native_kv_weights(config, weights)
             config.raw["_decoder_engine_layout_supported"] = True
@@ -152,7 +207,7 @@ class QwenPlugin:
                 native_kv_cache=True,
             )
 
-        if capability.applicable:
+        if capability.applicable and not qualified_fp8:
             raise ValueError(
                 "Qwen3 requires the fixed-capacity native KV path: "
                 f"{capability.reason}"

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -9,6 +9,7 @@ import ast
 from dataclasses import dataclass
 import importlib
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -23,6 +24,7 @@ from tensorrt_model_connect.families.qwen.config import ModelConfig
 from tensorrt_model_connect.families.qwen.native_kv_contract import (
     validate_native_kv_weights,
 )
+from tensorrt_model_connect.parallel_config import ParallelConfig
 
 
 def _config(*, raw_updates: dict | None = None, **overrides) -> ModelConfig:
@@ -258,6 +260,12 @@ def _weights(config: ModelConfig) -> dict[str, object]:
     return weights
 
 
+def _quant_ctx(name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        profile=SimpleNamespace(format=SimpleNamespace(name=name)),
+    )
+
+
 def test_weight_contract_rejects_missing_shape_and_bias():
     config = _small_config()
     weights = _weights(config)
@@ -386,13 +394,155 @@ def test_qwen3_dynamic_kv_fails_before_legacy_builder(monkeypatch):
     assert plugin_module.plugin.get_bundle_config_overrides(config) is None
 
 
-def test_qwen3_explicit_legacy_build_options_fail_closed(monkeypatch):
+def test_qwen3_qualified_fp8_uses_family_quantized_builder(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config(role="dual_profile")
+    config.raw["_decoder_engine_layout"] = "dual_profile"
+    config.raw["_native_kv_cache_metadata"] = {"stale": True}
+    quant_ctx = _quant_ctx("fp8")
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"legacy-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_standard_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="fp16",
+        quant_ctx=quant_ctx,
+    )
+
+    assert result == b"legacy-plan"
+    assert captured["args"][2] == 128
+    assert captured["kwargs"]["precision"] == "fp16"
+    assert captured["kwargs"]["quant_ctx"] is quant_ctx
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+def test_qwen3_qualified_fp8_retains_tensor_parallel_builder(monkeypatch):
     pytest.importorskip("tensorrt")
     plugin_module = importlib.import_module(
         "tensorrt_model_connect.families.qwen.plugin"
     )
     config = _small_config(role="decode")
-    config.raw["_native_kv_cache_metadata"] = {"stale": True}
+    quant_ctx = _quant_ctx("fp8")
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0)
+    captured: dict[str, object] = {}
+
+    def _build(*args, **kwargs):
+        captured.update(args=args, kwargs=kwargs)
+        return b"tp-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_dual_profile_tp_decoder_engine",
+        _build,
+    )
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        _weights(config),
+        128,
+        precision="bf16",
+        quant_ctx=quant_ctx,
+        parallel_config=parallel,
+    )
+
+    assert result == b"tp-plan"
+    assert captured["kwargs"]["quant_ctx"] is quant_ctx
+    assert captured["kwargs"]["parallel_config"] is parallel
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "precision"),
+    [
+        (2, "bf16"),
+        (8, "bf16"),
+        (4, "fp16"),
+    ],
+)
+def test_qwen3_unqualified_fp8_parallel_modes_fail_closed(
+    monkeypatch,
+    tp_size,
+    precision,
+):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config(role="decode")
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=tp_size, rank=0)
+    legacy_called = False
+
+    def _unexpected_legacy(*_args, **_kwargs):
+        nonlocal legacy_called
+        legacy_called = True
+        return b"tp-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "build_dual_profile_tp_decoder_engine",
+        _unexpected_legacy,
+    )
+
+    with pytest.raises(ValueError, match="requires the fixed-capacity native KV path"):
+        plugin_module.plugin.build_engine(
+            config,
+            _weights(config),
+            128,
+            precision=precision,
+            quant_ctx=_quant_ctx("fp8"),
+            parallel_config=parallel,
+        )
+
+    assert not legacy_called
+    assert plugin_module.plugin.get_bundle_config_overrides(config) is None
+
+
+@pytest.mark.parametrize(
+    ("quant_format", "precision", "raw_updates", "debug_layer_outputs"),
+    [
+        ("int8_sq", "fp16", {"_decoder_engine_layout": "dual_profile"}, False),
+        ("fp8", "fp32", {"_decoder_engine_layout": "dual_profile"}, False),
+        ("fp8", "bf16", {"_decoder_engine_layout": "dual_profile"}, False),
+        ("fp8", "fp16", {"_decoder_engine_layout": "split"}, False),
+        (
+            "fp8",
+            "fp16",
+            {
+                "_decoder_engine_layout": "dual_profile",
+                "_rtx_build_requested": True,
+            },
+            False,
+        ),
+        ("fp8", "fp16", {"_decoder_engine_layout": "dual_profile"}, True),
+    ],
+)
+def test_qwen3_unqualified_quantized_modes_still_fail_closed(
+    monkeypatch,
+    quant_format,
+    precision,
+    raw_updates,
+    debug_layer_outputs,
+):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config(role="dual_profile")
+    config.raw.update(raw_updates)
     legacy_called = False
 
     def _unexpected_legacy(*_args, **_kwargs):
@@ -411,8 +561,9 @@ def test_qwen3_explicit_legacy_build_options_fail_closed(monkeypatch):
             config,
             _weights(config),
             128,
-            precision="fp16",
-            quant_ctx=object(),
+            precision=precision,
+            quant_ctx=_quant_ctx(quant_format),
+            debug_layer_outputs=debug_layer_outputs,
         )
 
     assert not legacy_called

--- a/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
+++ b/website/docs/tutorials/advanced/quantization-and-runtime-knobs.md
@@ -76,9 +76,17 @@ native default do not re-enter provider selection when precision changes.
 ```bash
 $TRTMC build Qwen/Qwen3-0.6B \
   -o /tmp/qwen3-fp8.bundle \
+  --decoder-engine-layout dual_profile \
+  --precision fp16 \
   --quantize fp8 \
   --quant-calibration-samples 512
 ```
+
+Dense Qwen3 FP8 uses its qualified family-owned quantized dual-profile graph.
+The single-GPU contract uses FP16. The only qualified tensor-parallel contract
+is TP4 with BF16; other TP sizes and base precisions are unsupported.
+Unquantized FP16 and BF16 builds continue to use the fixed-capacity native-KV
+split path; other Qwen3 quantization formats remain unsupported.
 
 The current quantization surface accepts `fp8`, `int8`, `int8_sq`, `int4`, `int4_awq`, `nvfp4`, and `w4a8`. Family plugins can exclude weight patterns, provide calibration data, and return a family-specific calibration adapter through the `FamilyPlugin` protocol.
 


### PR DESCRIPTION
## Background

Dense Qwen3 FP8 requests are rejected by the unquantized native-KV requirement before the existing family-owned quantized builders can run. This prevents the Qwen3-0.6B FP8 Nightly case from executing.

## Exit Criteria

- Restore only the qualified single-GPU FP16 dual-profile and TP4 BF16 FP8 routes.
- Keep every other unsupported Qwen3 precision, quantization, layout, runtime, and tensor-parallel combination fail-closed.
- Document and test both the accepted and rejected routing boundaries.

## Implementation

- Recognize the two qualified dense-Qwen3 FP8 contracts before applying the native-KV rejection.
- Route them to the existing single-GPU or tensor-parallel quantized builder with the FP8 context unchanged.
- Preserve the fixed-capacity native-KV path for unquantized Qwen3 and reject unsupported formats, layouts, debug and RTX modes, dynamic KV, invalid cache geometry, and unqualified tensor-parallel combinations.

## Validation

- `PYTHONPATH=python python -m pytest -q -p no:cacheprovider tests/e2e/models/qwen/test_qwen_native_kv_routing.py tests/e2e/models/qwen/test_qwen_manifest_contract.py tests/e2e/models/qwen/test_qwen_fp8_quantization_contract.py tests/e2e/models/qwen/test_qwen_builder_policy.py`: `59 passed` on the current head.
- `CI_BASE_REF=bec828242d201fbb89fa10d3e5c41659aa49004e python3 -m tools.ci pipeline source-quality`: passed on the current head, including 158 architecture tests.
- `PYTHONPATH=python:. python tools/test_impact.py --base bec828242d201fbb89fa10d3e5c41659aa49004e --head HEAD --json`: selected the Qwen builder tier and 10 Qwen E2E cases, with no C++ rebuild.
- Patch-identical single-GPU Qwen3-0.6B FP8 validation: two independent fresh rebuild E2Es passed the existing output gates.
- Patch-identical Qwen3-0.6B FP8 TP4 BF16 validation: a fresh four-plan build passed; runtime inference was not validated, so this PR makes no TP4 runtime-qualification claim.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- The allowlist is intentionally exact. Do not widen it without separate build and runtime qualification for the new combination.
- Community CPU passed on synthetic merge `9b58c46515a09666407d6d5448bb0be15b438378`, whose parents are current `main` `bec828242d201fbb89fa10d3e5c41659aa49004e` and PR head `e6b8601e2adf3e9096b2c1a10e9acf92b07c3809`.
- `trtmc/premerge/required` passed on PR head `e6b8601e2adf3e9096b2c1a10e9acf92b07c3809`.
