### PR TITLE
ci(community): harden external run requests

### DIFF
--- a/.github/WORKFLOW_EXECUTION_POLICY.md
+++ b/.github/WORKFLOW_EXECUTION_POLICY.md
@@ -1,0 +1,72 @@
+# Community CPU execution policy
+
+The repository's contributor-facing `/run-ci` command depends on a narrowly
+scoped GitHub Actions workflow execution protection. The policy is configured
+in GitHub, not in this repository, so changing the workflow alone does not make
+external comments executable.
+
+## Required policy boundary
+
+First identify the enterprise or organization ruleset that currently rejects
+external actors. Applicable rulesets aggregate and the most restrictive rule
+wins, so adding a repository-level allow rule cannot override that denial. At
+the controlling level, retarget the existing restriction to exclude this
+repository, then create a replacement workflow execution protection with all
+of these properties:
+
+- target only `NVIDIA/TensorRT-Model-Connect`;
+- permit the `issue_comment` event for the narrowest actor selector that
+  includes unaffiliated external contributors;
+- retain the existing restrictions for every other repository and event; and
+- start in **Evaluate** mode before changing it to **Active**.
+
+GitHub currently documents actor and event rules, plus repository targeting,
+but not workflow-file targeting. Consequently, `community-cpu.yml` must remain
+the only workflow in this repository that listens to `issue_comment`. The
+repository contract tests enforce that invariant, and CODEOWNERS requires the
+same review boundary for workflow and Community CPU controller changes.
+The central rule cannot determine whether a commenter authored a pull request;
+the workflow's read-only authorization job enforces that relationship before
+any pull-request code is checked out.
+
+See GitHub's public
+[Workflow execution protections documentation](https://docs.github.com/en/organizations/managing-organization-settings/actions-policies/workflow-execution-protections)
+and [ruleset layering documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets#about-rule-layering)
+for the current settings interface and composition semantics. The feature is in
+public preview, so validate the available actor selector in the target
+organization instead of assuming that a similarly named selector has the
+required scope.
+
+## Canary and activation
+
+1. In Evaluate mode, inspect rule insights for a fork pull request whose author
+   has no repository role. Confirm that the proposed repository boundary would
+   permit the author's exact `/run-ci` event after the controlling restriction
+   is retargeted.
+2. Confirm that the workflow itself rejects a non-author with no maintain/admin
+   role, a non-PR issue comment, a closed PR, a PR targeting another branch,
+   and any body other than the exact command.
+3. Confirm that the permitted request runs only on a GitHub-hosted runner, has
+   no secrets, binds checks to the captured merge SHA, and executes the trusted
+   base controller and baseline tests.
+4. Confirm that a fourth failed request for the same merge SHA is rejected.
+5. Confirm that the `main` ruleset requires CODEOWNER approval for the workflow
+   and controller paths and does not grant ordinary writers a bypass.
+6. Activate the replacement repository boundary while the controlling deny
+   still covers this repository, verify it in rule insights, and only then
+   exclude this repository from the controlling deny. For rollback, restore the
+   controlling deny target before disabling the replacement boundary.
+7. Repeat the external-author canary and inspect every event permitted by the
+   replacement policy. Actor and event allowlists may combine across the policy,
+   so verify that an unaffiliated actor cannot reach another existing trigger.
+
+Every issue comment can create a lightweight workflow record after activation;
+only an exact authorized `/run-ci` comment reaches the test jobs. This expected
+Actions UI noise is the tradeoff for keeping the original contributor identity
+and avoiding a bot credential or webhook service.
+
+The workflow's comment-history budget is a soft throttle because authors can
+edit or delete their own comments. Durable per-merge checks cap repeated
+attempts for one revision, and actor-scoped concurrency bounds one account's
+simultaneous work, but organization runner quotas remain the hard
+repository-wide cost ceiling.

--- a/.github/scripts/restore-community-ci-controller.py
+++ b/.github/scripts/restore-community-ci-controller.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restore the trusted Community CPU controller from an authorized base SHA.
+
+The public workflow checks out an untrusted pull-request merge so it can test
+the proposed runtime and package source. Before it installs dependencies or
+selects tests, it loads this script from the authorized base commit and uses it
+to replace the CI controller, build configuration, and baseline tests with
+their versions from that same commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+
+
+COMMON_PATHS = (
+    ".clang-format",
+    "Dockerfile.community-cpu",
+    "requirements/community-ci.txt",
+    "ruff.toml",
+    "tools",
+)
+
+FORBIDDEN_PATHS = ("tools.py",)
+
+PROFILE_PATHS = {
+    "impact": (),
+    "source-quality": (
+        "tests/e2e_harness/__init__.py",
+        "tests/e2e_harness/threshold_policy.py",
+        "tests/tools/test_model_plugin_encapsulation_static.py",
+    ),
+    "unit": (
+        "CMakeLists.txt",
+        "cmake",
+        "conftest.py",
+        "pyproject.toml",
+        "tests",
+    ),
+}
+
+
+class RestoreError(RuntimeError):
+    """Report a fail-closed controller restoration error."""
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RestoreError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def _validate_revision(repository: Path, revision: str) -> str:
+    resolved = _git(repository, "rev-parse", "--verify", f"{revision}^{{commit}}").strip()
+    if len(resolved) != 40 or any(character not in "0123456789abcdef" for character in resolved):
+        raise RestoreError("authorized base did not resolve to a full commit SHA")
+    if revision != resolved:
+        raise RestoreError("authorized base must be supplied as its full commit SHA")
+    return resolved
+
+
+def _safe_path(repository: Path, relative: str) -> Path:
+    candidate = PurePosixPath(relative)
+    if candidate.is_absolute() or ".." in candidate.parts or not candidate.parts:
+        raise RestoreError(f"unsafe controller path: {relative}")
+    destination = repository.joinpath(*candidate.parts)
+    if not destination.is_relative_to(repository):
+        raise RestoreError(f"controller path escapes the repository: {relative}")
+    parent = repository
+    for part in candidate.parts[:-1]:
+        parent /= part
+        if parent.is_symlink():
+            raise RestoreError(f"controller path crosses a symlink: {relative}")
+    return destination
+
+
+def restore(repository: Path, base: str, profile: str) -> None:
+    repository = repository.resolve()
+    if not (repository / ".git").exists():
+        # A GitHub Actions checkout uses a .git directory. Worktrees may use a
+        # .git file, which is also safe for local regression tests.
+        if not (repository / ".git").is_file():
+            raise RestoreError(f"not a Git checkout: {repository}")
+    revision = _validate_revision(repository, base)
+    try:
+        profile_paths = PROFILE_PATHS[profile]
+    except KeyError as error:
+        raise RestoreError(f"unknown restoration profile: {profile}") from error
+
+    paths = tuple(dict.fromkeys((*COMMON_PATHS, *profile_paths)))
+    destinations = tuple(
+        (relative, _safe_path(repository, relative))
+        for relative in (*paths, *FORBIDDEN_PATHS)
+    )
+    for _relative, destination in destinations:
+        if destination.is_dir() and not destination.is_symlink():
+            shutil.rmtree(destination)
+        elif destination.exists() or destination.is_symlink():
+            destination.unlink()
+
+    _git(repository, "restore", f"--source={revision}", "--worktree", "--", *paths)
+    print(f"Restored trusted Community CPU {profile} controller from {revision}.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", type=Path, required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--profile", choices=sorted(PROFILE_PATHS), required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    try:
+        restore(arguments.repository, arguments.base, arguments.profile)
+    except RestoreError as error:
+        print(f"ERROR: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -13,7 +13,13 @@ on:
 permissions: {}
 
 concurrency:
-  group: community-cpu-${{ github.event.issue.number }}
+  # Bound each commenter's public CPU consumption without letting unrelated
+  # comments replace a valid pending request.
+  group: >-
+    ${{ github.event.issue.pull_request != null &&
+        github.event.comment.body == '/run-ci' &&
+        format('community-cpu-actor-{0}', github.actor) ||
+        format('community-cpu-intake-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:
@@ -32,6 +38,7 @@ jobs:
       pull-requests: read
     outputs:
       run_tests: ${{ steps.snapshot.outputs.run_tests }}
+      request_id: ${{ steps.snapshot.outputs.request_id }}
       pr_number: ${{ steps.snapshot.outputs.pr_number }}
       base_sha: ${{ steps.snapshot.outputs.base_sha }}
       head_sha: ${{ steps.snapshot.outputs.head_sha }}
@@ -45,10 +52,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
+          REQUEST_ID: ${{ github.event.comment.id }}
+          REQUEST_CREATED_AT: ${{ github.event.comment.created_at }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REQUEST_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REQUEST_CREATED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
 
           pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           state="$(jq -er '.state' <<<"$pull")"
@@ -81,11 +92,25 @@ jobs:
             esac
           fi
 
-          existing_required="$(
-            gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
-              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))) | sort_by(.started_at) | last // {} | if (.status // "") != "completed" then (.status // "") else (.conclusion // "") end'
+          recent_request_count="$(
+            gh api --method GET --paginate \
+              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100&sort=created&direction=desc" \
+            | jq -ser --arg actor "$ACTOR" --arg request_created_at "$REQUEST_CREATED_AT" \
+              '($request_created_at | fromdateiso8601) as $now | [.. | objects | select(.user.login == $actor and .body == "/run-ci" and ((.created_at | fromdateiso8601) >= ($now - 86400)))] | length'
           )"
+          [[ "$recent_request_count" =~ ^[0-9]+$ ]]
+          if [ "$recent_request_count" -gt 6 ]; then
+            echo "::error::This pull request has reached its daily Community CPU request budget."
+            exit 1
+          fi
+
+          required_state_and_count="$(
+            gh api --method GET --paginate \
+              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=all&per_page=100" \
+            | jq -ser '[.[].check_runs[] | select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))] as $runs | [($runs | sort_by(.started_at) | last // {} | if (.status // "") != "completed" then (.status // "") else (.conclusion // "") end), ($runs | length)] | join("|")'
+          )"
+          IFS='|' read -r existing_required attempt_count <<<"$required_state_and_count"
+          [[ "${attempt_count:-}" =~ ^[0-9]+$ ]]
           case "$existing_required" in
             queued|in_progress|success)
               echo "run_tests=false" >> "$GITHUB_OUTPUT"
@@ -93,9 +118,14 @@ jobs:
               exit 0
               ;;
           esac
+          if [ "$attempt_count" -ge 3 ]; then
+            echo "::error::This exact merge has reached the limit of three Community CPU attempts. Push a new revision or ask a maintainer to investigate."
+            exit 1
+          fi
 
           {
             echo "run_tests=true"
+            echo "request_id=$REQUEST_ID"
             echo "pr_number=$PR_NUMBER"
             echo "base_sha=$base_sha"
             echo "head_sha=$head_sha"
@@ -124,6 +154,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           set -euo pipefail
@@ -144,6 +175,7 @@ jobs:
               "## Community CPU" \
               "" \
               "**Status:** RUNNING" \
+              "- Request: <code>$REQUEST_ID</code>" \
               "- Exact merge: <code>$MERGE_SHA</code>" \
               "" \
               "[View live public logs]($details_url)"
@@ -172,6 +204,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
         run: |
           set -euo pipefail
           details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -182,7 +215,7 @@ jobs:
             local name="$2"
             local external_id
             local check_id
-            external_id="community-cpu:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${key}"
+            external_id="community-cpu:${REQUEST_ID}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${key}"
             jq -n \
               --arg name "$name" \
               --arg head_sha "$MERGE_SHA" \
@@ -240,11 +273,24 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Restore trusted source-quality controller
+        run: |
+          set -euo pipefail
+          controller="$RUNNER_TEMP/restore-community-ci-controller.py"
+          git show "$CI_BASE_REF:.github/scripts/restore-community-ci-controller.py" > "$controller"
+          python3 -I "$controller" \
+            --repository "$GITHUB_WORKSPACE" \
+            --base "$CI_BASE_REF" \
+            --profile source-quality
+
       - name: Install public CPU quality tools
-        run: python3 -m pip install --disable-pip-version-check --requirement requirements/community-ci.txt
+        run: python3 -I -m pip install --disable-pip-version-check --requirement requirements/community-ci.txt
 
       - name: Run source quality
-        run: python3 -m tools.community_ci source-quality --base "$CI_BASE_REF"
+        run: |
+          python3 -I -c \
+            'import importlib.util, runpy, sys; root=sys.argv.pop(1); spec=importlib.util.spec_from_file_location("tools", root+"/tools/__init__.py", submodule_search_locations=[root+"/tools"]); module=importlib.util.module_from_spec(spec); sys.modules["tools"]=module; spec.loader.exec_module(module); runpy.run_module("tools.community_ci", run_name="__main__")' \
+            "$GITHUB_WORKSPACE" source-quality --base "$CI_BASE_REF"
 
   ownership-impact:
     name: Community CPU / Ownership and impact
@@ -274,9 +320,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Restore trusted impact controller
+        run: |
+          set -euo pipefail
+          controller="$RUNNER_TEMP/restore-community-ci-controller.py"
+          git show "$CI_BASE_REF:.github/scripts/restore-community-ci-controller.py" > "$controller"
+          python3 -I "$controller" \
+            --repository "$GITHUB_WORKSPACE" \
+            --base "$CI_BASE_REF" \
+            --profile impact
+
       - name: Resolve source ownership and CPU scope
         id: impact
-        run: python3 -m tools.community_ci impact --base "$CI_BASE_REF"
+        run: |
+          python3 -I -c \
+            'import importlib.util, runpy, sys; root=sys.argv.pop(1); spec=importlib.util.spec_from_file_location("tools", root+"/tools/__init__.py", submodule_search_locations=[root+"/tools"]); module=importlib.util.module_from_spec(spec); sys.modules["tools"]=module; spec.loader.exec_module(module); runpy.run_module("tools.community_ci", run_name="__main__")' \
+            "$GITHUB_WORKSPACE" impact --base "$CI_BASE_REF"
 
   unit:
     name: Community CPU / Unit / C++ and Python
@@ -303,6 +362,21 @@ jobs:
         run: |
           echo "::error::Ownership and impact did not succeed: $IMPACT_RESULT"
           exit 1
+
+      - name: Validate the impact decision
+        if: ${{ needs.initialize.result == 'success' && needs.ownership-impact.result == 'success' }}
+        env:
+          RUN_UNIT_TESTS: ${{ needs.ownership-impact.outputs.run_unit_tests }}
+          UNIT_SCOPE: ${{ needs.ownership-impact.outputs.unit_scope }}
+        run: |
+          set -euo pipefail
+          case "$RUN_UNIT_TESTS:$UNIT_SCOPE" in
+            false:none|true:builder|true:cli|true:all) ;;
+            *)
+              echo "::error::Ownership and impact returned an invalid or incomplete unit decision."
+              exit 1
+              ;;
+          esac
 
       - name: Explain an empty unit scope
         if: >-
@@ -331,6 +405,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Restore trusted unit controller and baseline tests
+        if: >-
+          needs.initialize.result == 'success' &&
+          needs.ownership-impact.result == 'success' &&
+          needs.ownership-impact.outputs.run_unit_tests == 'true'
+        env:
+          CI_BASE_REF: ${{ needs.authorize.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          controller="$RUNNER_TEMP/restore-community-ci-controller.py"
+          git show "$CI_BASE_REF:.github/scripts/restore-community-ci-controller.py" > "$controller"
+          python3 -I "$controller" \
+            --repository "$GITHUB_WORKSPACE" \
+            --base "$CI_BASE_REF" \
+            --profile unit
+
       - name: Run hardened source-only units
         if: >-
           needs.initialize.result == 'success' &&
@@ -338,7 +428,10 @@ jobs:
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         env:
           TRTMC_UNIT_SCOPE: ${{ needs.ownership-impact.outputs.unit_scope }}
-        run: python3 -m tools.community_ci unit --scope "$TRTMC_UNIT_SCOPE"
+        run: |
+          python3 -I -c \
+            'import importlib.util, runpy, sys; root=sys.argv.pop(1); spec=importlib.util.spec_from_file_location("tools", root+"/tools/__init__.py", submodule_search_locations=[root+"/tools"]); module=importlib.util.module_from_spec(spec); sys.modules["tools"]=module; spec.loader.exec_module(module); runpy.run_module("tools.community_ci", run_name="__main__")' \
+            "$GITHUB_WORKSPACE" unit --scope "$TRTMC_UNIT_SCOPE"
 
   required:
     name: Community CPU / Required
@@ -363,6 +456,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
           COMMENT_ID: ${{ needs.initialize.outputs.comment_id }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
@@ -425,6 +519,7 @@ jobs:
                 "## Community CPU" \
                 "" \
                 "**Status:** $status" \
+                "- Request: <code>$REQUEST_ID</code>" \
                 "- Exact merge: <code>$MERGE_SHA</code>" \
                 "- Source quality: <code>$SOURCE_QUALITY_RESULT</code>" \
                 "- Ownership and impact: <code>$OWNERSHIP_IMPACT_RESULT</code>" \

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,16 @@
 # Default owner for the public repository. Replace this entry with project
 # teams once those teams are created in the NVIDIA GitHub organization.
 * @yifeif-nv
+
+# The external-comment policy has repository/event granularity, not workflow
+# path granularity. Keep every trusted entrypoint and controller change inside
+# this explicit review boundary.
+/.github/workflows/ @yifeif-nv
+/.github/scripts/restore-community-ci-controller.py @yifeif-nv
+/requirements/community-ci.txt @yifeif-nv
+/Dockerfile.community-cpu @yifeif-nv
+/tools/community_ci.py @yifeif-nv
+/tools/ci/ @yifeif-nv
+/tools/model_ci.py @yifeif-nv
+/tools/test_impact.py @yifeif-nv
+/tests/ @yifeif-nv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,10 +157,18 @@ comment:
 
 A maintainer or admin may submit the same command on the author's behalf. The
 trusted default-branch `Community CPU` workflow authorizes the actor and
-captures the current base, head, and merge SHAs without checking out
-pull-request code. Separate test jobs then run source quality, ownership and
-impact analysis, and the selected source-only C++ and Python units against that
-exact merge revision.
+captures the current base, head, merge, and request identifiers without
+checking out pull-request code. Separate test jobs then run source quality,
+ownership and impact analysis, and the selected source-only C++ and Python
+units against that exact merge revision. The test jobs restore their CI
+controller, pinned dependencies, build configuration, and baseline tests from
+the captured base SHA before executing the proposed runtime and package source.
+A pull request therefore cannot replace the versioned public controller or
+baseline tests. Changes to the controller, `tools/`, tests, or build
+configuration receive their authoritative validation in the protected suite
+rather than from this public baseline gate. A passing public result is useful
+functional evidence, not proof that arbitrary pull-request code is benign;
+maintainers must still review the diff before authorizing protected CI.
 
 All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
 read-only repository permission and no access to private runners, secrets, or
@@ -173,7 +181,9 @@ than the pull-request head SHA.
 
 Wait for `Community CPU / Required` to pass on the current merge revision.
 Repeating `/run-ci` for an already queued, running, or successful merge is
-safely deduplicated.
+safely deduplicated. A merge revision receives at most three attempts; after
+that, push a corrected revision or ask a maintainer to investigate the repeated
+failure.
 
 If the pull-request head or base changes, the previous merge result is stale.
 Finish the update, rerun local checks, and comment `/run-ci` again for the new

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -37,6 +37,7 @@ def _write_public_ci_fake_gh(fake_bin: Path) -> None:
     fake_jq.write_text(
         """#!/usr/bin/env python3
 import json
+import os
 import sys
 
 arguments = sys.argv[1:]
@@ -88,9 +89,18 @@ if null_input:
         }
     else:
         raise SystemExit(f"unsupported null-input jq expression: {expression}")
+elif "Community CPU / Required" in expression and "check_runs" in expression:
+    sys.stdin.read()
+    result = (
+        os.environ.get("FAKE_EXISTING_REQUIRED", "")
+        + "|"
+        + os.environ.get("FAKE_ATTEMPT_COUNT", "0")
+    )
 else:
     result = json.load(sys.stdin)
-    if isinstance(result, list) and "github-actions[bot]" in expression:
+    if isinstance(result, list) and "request_created_at" in variables:
+        result = int(os.environ.get("FAKE_RECENT_REQUEST_COUNT", "1"))
+    elif isinstance(result, list) and "github-actions[bot]" in expression:
         marker = variables["marker"]
         matches = [
             item
@@ -142,7 +152,9 @@ if "/collaborators/" in endpoint:
 elif "/pulls/" in endpoint:
     print(os.environ["FAKE_PULL_JSON"])
 elif "/commits/" in endpoint and "/check-runs" in endpoint:
-    print(os.environ.get("FAKE_EXISTING_REQUIRED", ""))
+    print('{"check_runs": []}')
+elif endpoint.endswith("comments?per_page=100&sort=created&direction=desc"):
+    print(os.environ.get("FAKE_REQUEST_COMMENTS_JSON", "[]"))
 elif "/issues/" in endpoint and endpoint.endswith("comments?per_page=100"):
     print(os.environ["FAKE_COMMENTS_JSON"])
 elif "/issues/" in endpoint and endpoint.endswith("/comments") and "POST" in arguments:
@@ -210,12 +222,16 @@ def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
             "ACTOR": "pr-author",
             "BASE_SHA": base_sha,
             "COMMENT_ID": "99",
+            "REQUEST_ID": "7654321",
+            "REQUEST_CREATED_AT": "2026-08-23T12:00:00Z",
             "FAKE_ACTOR_ROLE": "maintain",
             "FAKE_CHECK_CAPTURE": str(tmp_path / "checks.jsonl"),
             "FAKE_COMMENT_CAPTURE": str(tmp_path / "comment.md"),
             "FAKE_COMMENTS_JSON": "[]",
             "FAKE_PENDING_CHECK_CAPTURE": str(tmp_path / "pending-checks.jsonl"),
             "FAKE_PULL_JSON": json.dumps(pull),
+            "FAKE_RECENT_REQUEST_COUNT": "1",
+            "FAKE_REQUEST_COMMENTS_JSON": "[]",
             "GH_TOKEN": "test-token",
             "GITHUB_OUTPUT": str(tmp_path / "github-output"),
             "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
@@ -394,6 +410,7 @@ def test_public_cpu_request_captures_the_exact_commented_snapshot(
     assert result.returncode == 0, result.stdout + result.stderr
     assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
         "run_tests=true\n"
+        "request_id=7654321\n"
         "pr_number=980\n"
         f"base_sha={'a' * 40}\n"
         f"head_sha={'b' * 40}\n"
@@ -464,6 +481,7 @@ def test_public_cpu_request_deduplicates_the_current_merge(
 ) -> None:
     environment = _public_ci_environment(tmp_path)
     environment["FAKE_EXISTING_REQUIRED"] = existing
+    environment["FAKE_ATTEMPT_COUNT"] = "1"
     result = subprocess.run(
         [
             "bash",
@@ -486,6 +504,100 @@ def test_public_cpu_request_deduplicates_the_current_merge(
     assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
         "run_tests=false\n"
     )
+
+
+def test_public_cpu_request_limits_failed_attempts_for_one_merge(
+    tmp_path: Path,
+) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment["FAKE_EXISTING_REQUIRED"] = "failure"
+    environment["FAKE_ATTEMPT_COUNT"] = "3"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "authorize",
+                "Authorize the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "limit of three Community CPU attempts" in result.stdout + result.stderr
+    assert not (tmp_path / "github-output").exists()
+
+
+def test_public_cpu_request_limits_daily_pr_requests(tmp_path: Path) -> None:
+    environment = _public_ci_environment(tmp_path)
+    environment["FAKE_RECENT_REQUEST_COUNT"] = "7"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "authorize",
+                "Authorize the current PR merge",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "daily Community CPU request budget" in result.stdout + result.stderr
+    assert not (tmp_path / "github-output").exists()
+
+
+@pytest.mark.parametrize(
+    ("run_unit_tests", "unit_scope", "expected"),
+    [
+        ("false", "none", 0),
+        ("true", "builder", 0),
+        ("true", "cli", 0),
+        ("true", "all", 0),
+        ("", "", 1),
+        ("false", "all", 1),
+        ("true", "none", 1),
+    ],
+)
+def test_public_cpu_unit_decision_fails_closed(
+    run_unit_tests: str,
+    unit_scope: str,
+    expected: int,
+) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "unit",
+                "Validate the impact decision",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "RUN_UNIT_TESTS": run_unit_tests,
+            "UNIT_SCOPE": unit_scope,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == expected
 
 
 def test_public_cpu_initialization_creates_pending_exact_merge_checks(
@@ -520,7 +632,7 @@ def test_public_cpu_initialization_creates_pending_exact_merge_checks(
     assert {check["head_sha"] for check in checks} == {"c" * 40}
     assert {check["status"] for check in checks} == {"in_progress"}
     assert all(
-        check["external_id"].startswith("community-cpu:12345:1:")
+        check["external_id"].startswith("community-cpu:7654321:12345:1:")
         for check in checks
     )
     assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
@@ -559,6 +671,7 @@ def test_public_cpu_initialization_publishes_a_visible_pr_run_link(
     comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
     assert "<!-- trtmc-community-cpu -->" in comment
     assert "**Status:** RUNNING" in comment
+    assert "- Request: <code>7654321</code>" in comment
     assert f"- Exact merge: <code>{'c' * 40}</code>" in comment
     assert "[View live public logs]" in comment
     assert "/actions/runs/12345" in comment
@@ -744,6 +857,37 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert "[View public logs]" in source
     assert '"/repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID"' in source
     assert "The PR changed after public CPU validation was requested" in source
+    assert "filter=all&per_page=100" in source
+    assert "limit of three Community CPU attempts" in source
+    assert "python3 -I -m pip install" in source
+    assert source.count('runpy.run_module("tools.community_ci"') == 3
+    concurrency_group = workflow["concurrency"]["group"]
+    assert "format('community-cpu-actor-{0}', github.actor)" in concurrency_group
+    assert "format('community-cpu-intake-{0}', github.run_id)" in concurrency_group
+    assert workflow["concurrency"]["cancel-in-progress"] is False
+
+    workflow_paths = sorted(
+        {
+            *(REPO_ROOT / ".github" / "workflows").glob("*.yml"),
+            *(REPO_ROOT / ".github" / "workflows").glob("*.yaml"),
+        }
+    )
+    issue_comment_workflows = []
+    for workflow_path in workflow_paths:
+        document = yaml.load(
+            workflow_path.read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        triggers = document.get("on", {})
+        if isinstance(triggers, str):
+            names = {triggers}
+        elif isinstance(triggers, list):
+            names = set(triggers)
+        else:
+            names = set(triggers)
+        if "issue_comment" in names:
+            issue_comment_workflows.append(workflow_path.name)
+    assert issue_comment_workflows == ["community-cpu.yml"]
 
     jobs = workflow["jobs"]
     assert [job["name"] for job in jobs.values()] == [
@@ -767,6 +911,26 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
+        steps = jobs[job_name]["steps"]
+        restore_index = next(
+            index for index, step in enumerate(steps) if step["name"].startswith("Restore trusted")
+        )
+        run_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step["name"]
+            in {
+                "Run source quality",
+                "Resolve source ownership and CPU scope",
+                "Run hardened source-only units",
+            }
+        )
+        assert restore_index < run_index
+        restore = steps[restore_index]["run"]
+        assert (
+            'git show "$CI_BASE_REF:.github/scripts/restore-community-ci-controller.py"' in restore
+        )
+        assert 'python3 -I "$controller"' in restore
     assert jobs["unit"]["needs"] == [
         "authorize",
         "initialize",
@@ -784,6 +948,130 @@ def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
         "contents": "read",
         "pull-requests": "write",
     }
+
+
+def test_trusted_controller_restore_replaces_pr_ci_and_baseline_tests(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q", str(repository)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.email", "ci-test@example.invalid"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repository), "config", "user.name", "CI Test"],
+        check=True,
+    )
+
+    files = {
+        ".clang-format": "trusted\n",
+        "Dockerfile.community-cpu": "trusted\n",
+        "requirements/community-ci.txt": "trusted\n",
+        "ruff.toml": "trusted\n",
+        "tools/__init__.py": "trusted\n",
+        "tools/check_cyclomatic_complexity.py": "trusted\n",
+        "tools/ci/sentinel.py": "trusted\n",
+        "tools/community_ci.py": "trusted controller\n",
+        "tools/model_ci.py": "trusted\n",
+        "tools/model_plugin_isolation.py": "trusted\n",
+        "tools/test_impact.py": "trusted\n",
+        "tools/test_impact_fallback_allowlist.txt": "trusted\n",
+        "CMakeLists.txt": "trusted\n",
+        "cmake/sentinel.cmake": "trusted\n",
+        "conftest.py": "trusted\n",
+        "pyproject.toml": "trusted\n",
+        "tests/base_test.py": "trusted baseline test\n",
+        "src/feature.py": "base source\n",
+    }
+    for relative, contents in files.items():
+        path = repository / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-q", "-m", "base"],
+        check=True,
+    )
+    base = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    (repository / "tools/community_ci.py").write_text("untrusted controller\n", encoding="utf-8")
+    (repository / "tools/added_controller.py").write_text(
+        "untrusted controller extension\n", encoding="utf-8"
+    )
+    (repository / "tests/base_test.py").write_text("disabled\n", encoding="utf-8")
+    (repository / "tests/added_test.py").write_text("untrusted test\n", encoding="utf-8")
+    (repository / "src/feature.py").write_text("proposed source\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-q", "-m", "pull request"],
+        check=True,
+    )
+
+    result = subprocess.run(
+        [
+            "python3",
+            "-I",
+            str(REPO_ROOT / ".github/scripts/restore-community-ci-controller.py"),
+            "--repository",
+            str(repository),
+            "--base",
+            base,
+            "--profile",
+            "unit",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (repository / "tools/community_ci.py").read_text(encoding="utf-8") == (
+        "trusted controller\n"
+    )
+    assert not (repository / "tools/added_controller.py").exists()
+    assert (repository / "tests/base_test.py").read_text(encoding="utf-8") == (
+        "trusted baseline test\n"
+    )
+    assert not (repository / "tests/added_test.py").exists()
+    assert (repository / "src/feature.py").read_text(encoding="utf-8") == (
+        "proposed source\n"
+    )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "community-ci.txt"
+    sentinel.write_text("must survive\n", encoding="utf-8")
+    (repository / "requirements/community-ci.txt").unlink()
+    (repository / "requirements").rmdir()
+    (repository / "requirements").symlink_to(outside, target_is_directory=True)
+
+    unsafe = subprocess.run(
+        [
+            "python3",
+            "-I",
+            str(REPO_ROOT / ".github/scripts/restore-community-ci-controller.py"),
+            "--repository",
+            str(repository),
+            "--base",
+            base,
+            "--profile",
+            "unit",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert unsafe.returncode != 0
+    assert "crosses a symlink" in unsafe.stdout
+    assert sentinel.read_text(encoding="utf-8") == "must survive\n"
 
 
 def test_cpu_image_installs_the_same_pinned_community_requirements() -> None:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -15,11 +15,12 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tools.ci.container import CiContainer
 from tools.ci.environment import OPTIONAL_TUNING_ENVIRONMENT
-from tools.ci.quality import UnitTestRunner
+from tools.ci.quality import ISOLATED_PYTEST, SourceQualityChecks, UnitTestRunner
 from tools.ci.stage import ContainerStageRunner
 
 
@@ -578,13 +579,50 @@ def test_source_quality_pipeline_keeps_the_full_static_gate() -> None:
     architecture_contract = source.split(
         "def architecture_contracts", maxsplit=1
     )[1].split("def _changed_files", maxsplit=1)[0]
-    assert '"pytest"' in architecture_contract
+    assert "ISOLATED_PYTEST" in architecture_contract
+    assert '"-I"' in architecture_contract
     assert (
         "tests/tools/test_model_plugin_encapsulation_static.py"
         in architecture_contract
     )
     assert '"-q"' in architecture_contract
     assert '"no:cacheprovider"' in architecture_contract
+
+
+def test_public_lint_defers_missing_trusted_controller_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "src/kept.py"
+    source.parent.mkdir()
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    class RecordingContext:
+        repository = tmp_path
+        env = {"CI_BASE_REF": "base"}
+
+        def __init__(self) -> None:
+            self.commands: list[list[object]] = []
+
+        def run(self, command: list[object], **_kwargs: object) -> subprocess.CompletedProcess:
+            self.commands.append(command)
+            if command[:3] == ["git", "diff", "--diff-filter=d"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout="tools/added.py\nsrc/kept.py\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    context = RecordingContext()
+    monkeypatch.setattr("tools.ci.quality.shutil.which", lambda _name: "/usr/bin/tool")
+
+    SourceQualityChecks(context).lint_changed_files()
+
+    ruff = next(command for command in context.commands if command[0] == "ruff")
+    assert "src/kept.py" in ruff
+    assert "tools/added.py" not in ruff
 
 
 def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> None:
@@ -956,6 +994,24 @@ def test_github_container_only_exports_nonempty_tuning_controls(tmp_path: Path) 
                 assert name not in stage_command
 
 
+def test_hardened_container_stage_uses_an_isolated_controller(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    command = ContainerStageRunner(
+        "premerge-unit",
+        {
+            "TRTMC_CI_WORKSPACE": str(workspace),
+            "TRTMC_CI_IMAGE": "example.invalid/trtmc:test",
+            "TRTMC_CI_HARDENED": "true",
+        },
+    )._docker_command()
+
+    python_index = command.index("python3")
+    assert command[python_index + 1 : python_index + 3] == ["-I", "-c"]
+    assert "spec_from_file_location('tools'" in command[python_index + 3]
+    assert "runpy.run_module('tools.ci'" in command[python_index + 3]
+
+
 def test_github_stage_wrapper_exports_e2e_gpu_controls() -> None:
     text = _ci_source("environment.py")
     assert "TRTMC_E2E_EXCLUDE_GPU0" in text
@@ -1217,7 +1273,7 @@ def test_builder_unit_scope_runs_python_without_native_build(tmp_path: Path) -> 
     pytest_commands = [
         command
         for command in context.commands
-        if command[:3] == ["python", "-m", "pytest"]
+        if command[:4] == ["python", "-I", "-c", ISOLATED_PYTEST]
     ]
     assert len(pytest_commands) == 1
     assert "tests/builder/" in pytest_commands[0]

--- a/tests/tools/test_selected_wheel_runtime.py
+++ b/tests/tools/test_selected_wheel_runtime.py
@@ -20,7 +20,7 @@ from tools.ci import model_proof_inner as model_proof_inner_module
 from tools.ci.model_proof import ModelProofRequest, ModelProofRunner
 from tools.ci.model_proof_inner import ModelProofInnerPipeline
 from tools.ci.process import CiError
-from tools.ci.quality import UnitTestRunner
+from tools.ci.quality import ISOLATED_PYTEST, UnitTestRunner
 from tools.ci.selected_wheel import SelectedWheelRuntime
 
 
@@ -176,9 +176,12 @@ def test_unit_python_tests_use_selected_wheel_target_without_source_python(
     UnitTestRunner(context).premerge()
 
     command, options = next(
-        call for call in context.calls if call[0][:3] == [str(runtime.python), "-m", "pytest"]
+        call
+        for call in context.calls
+        if call[0][:4] == [str(runtime.python), "-I", "-c", ISOLATED_PYTEST]
     )
     assert command[0] == str(runtime.python)
+    assert command[4] == str(repository)
     updates = options["updates"]
     assert isinstance(updates, dict)
     assert updates["PYTHONPATH"] == f"{runtime.site_packages}:{repository}"

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -62,14 +62,26 @@ head, and merge SHAs. Its authorization and publisher jobs never check out or
 execute PR code.
 
 The test jobs check out only the authorized merge SHA with read-only repository
-permission and no secrets. Separate publisher jobs create
-and complete contributor-visible checks on that merge SHA. They also maintain
-one PR status comment containing the exact merge SHA, per-stage verdicts, and a
-direct link to the public Actions logs so contributors can always find the
-error output even though the checks are not attached to the PR head. If the PR
-head or base changes before publication, every pending public check becomes
-neutral instead of validating the stale snapshot. Comment `/run-ci` again
-only after the new head is ready.
+permission and no secrets. Before installing dependencies or selecting tests,
+they restore the CI controller, build configuration, and baseline tests from
+the captured base SHA; the proposed runtime and package source remains the
+subject under test. Changes to the controller, `tools/`, tests, or build
+configuration receive authoritative coverage from protected CI, not this
+public baseline gate. A green public result is functional evidence, not a
+security proof about arbitrary pull-request code. Separate publisher jobs
+create and complete contributor-visible checks on that merge SHA. They also
+maintain one PR status comment containing the exact merge SHA, per-stage
+verdicts, and a direct link to the public Actions logs so contributors can
+always find the error output even though the checks are not attached to the PR
+head. If the PR head or base changes before publication, every pending public
+check becomes neutral instead of validating the stale snapshot. Comment
+`/run-ci` again only after the new head is ready. Each merge SHA is limited to
+three attempts.
+
+External authors can reach this workflow only when the repository-scoped
+workflow execution policy permits their `issue_comment` event. The versioned
+policy boundary, canary procedure, and rollback expectation are documented in
+`.github/WORKFLOW_EXECUTION_POLICY.md`.
 
 ## Pre-merge, step by step
 

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -9,6 +9,7 @@ Boundary: pre-model CPU validation; isolated model certification is a later stag
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 
@@ -19,6 +20,13 @@ from .context import CiContext
 from .package import WheelPackageManager
 from .process import CiError
 from .selected_wheel import SelectedWheelRuntime
+
+
+ISOLATED_PYTEST = (
+    "import os, runpy, sys; "
+    "sys.path.extend(path for path in sys.argv.pop(1).split(os.pathsep) if path); "
+    "runpy.run_module('pytest', run_name='__main__')"
+)
 
 
 class EnvironmentVerifier:
@@ -104,6 +112,7 @@ class SourceQualityChecks:
         self.context.run(
             [
                 "python",
+                "-I",
                 "tools/check_cyclomatic_complexity.py",
                 "src",
                 "--exclude",
@@ -134,12 +143,14 @@ class SourceQualityChecks:
             base = self.context.env.get(
                 "CI_BASE_REF", f"origin/{self.context.env.get('GITHUB_REF_NAME', 'main')}"
             )
-        python_files = self._changed_files(base, "*.py")
+        python_files = self._lintable_changed_files(self._changed_files(base, "*.py"))
         if python_files:
             print("Checking Python lint on changed files:")
             print("\n".join(python_files))
             self.context.run(["ruff", "check", "--config", "ruff.toml", *python_files])
-        cpp_files = self._changed_files(base, "*.cpp", "*.h")
+        cpp_files = self._lintable_changed_files(
+            self._changed_files(base, "*.cpp", "*.h")
+        )
         if cpp_files:
             print("Checking C++ formatting on changed files:")
             print("\n".join(cpp_files))
@@ -149,12 +160,15 @@ class SourceQualityChecks:
         self.context.run(
             [
                 "python",
-                "-m",
-                "pytest",
+                "-I",
+                "-c",
+                ISOLATED_PYTEST,
+                str(self.context.repository),
                 "tests/tools/test_model_plugin_encapsulation_static.py",
                 "-q",
                 "-p",
                 "no:cacheprovider",
+                "--import-mode=importlib",
             ],
             limit=self.context.env.get("ARCHITECTURE_CONTRACT_TIMEOUT", "3m"),
         )
@@ -166,6 +180,21 @@ class SourceQualityChecks:
             capture_output=True,
         )
         return [line for line in result.stdout.splitlines() if line]
+
+    def _lintable_changed_files(self, paths: list[str]) -> list[str]:
+        lintable = []
+        for relative in paths:
+            if (self.context.repository / relative).is_file():
+                lintable.append(relative)
+            elif relative == "tools.py" or relative.startswith("tools/"):
+                print(
+                    f"Skipping public lint for trusted-controller path {relative}; "
+                    "protected CI validates the proposed file."
+                )
+            else:
+                # Keep unexpected missing paths so the formatter fails closed.
+                lintable.append(relative)
+        return lintable
 
 
 class UnitTestRunner:
@@ -211,10 +240,17 @@ class UnitTestRunner:
             if self.context.env.get("PYTHONPATH"):
                 python_path += f":{self.context.env['PYTHONPATH']}"
             python_environment = {"PYTHONPATH": python_path}
+        isolated_python_path = (
+            str(source)
+            if selected_wheel
+            else os.pathsep.join((str(source / "python"), str(source)))
+        )
         pytest = [
             python,
-            "-m",
-            "pytest",
+            "-I",
+            "-c",
+            ISOLATED_PYTEST,
+            isolated_python_path,
             *python_tests,
             "-q",
             "-x",
@@ -223,6 +259,7 @@ class UnitTestRunner:
             "--dist=worksteal",
             "-p",
             "no:cacheprovider",
+            "--import-mode=importlib",
             "-m",
             "not gpu and not trt and not e2e and not model_proof_allocator",
             "--ignore=tests/builder/test_flashinfer_benchmark.py",
@@ -235,8 +272,6 @@ class UnitTestRunner:
                 "--deselect=tests/tools/test_model_proof_runner.py::"
                 "test_distinct_explicit_hf_cache_paths_reach_both_containers"
             )
-        if selected_wheel:
-            pytest.append("--import-mode=importlib")
         self.context.run(
             pytest,
             limit=self.context.env.get("PYTHON_BUILDER_TIMEOUT", "20m"),
@@ -245,18 +280,19 @@ class UnitTestRunner:
         if scope in {"all", "community-all"}:
             allocator = [
                 python,
-                "-m",
-                "pytest",
+                "-I",
+                "-c",
+                ISOLATED_PYTEST,
+                isolated_python_path,
                 "tests/tools/test_model_proof_runner.py",
                 "-q",
                 "-x",
                 "-p",
                 "no:cacheprovider",
+                "--import-mode=importlib",
                 "-m",
                 "model_proof_allocator",
             ]
-            if selected_wheel:
-                allocator.append("--import-mode=importlib")
             self.context.run(
                 allocator,
                 limit=self.context.env.get("MODEL_PROOF_ALLOCATOR_TIMEOUT", "30m"),

--- a/tools/ci/stage.py
+++ b/tools/ci/stage.py
@@ -65,7 +65,7 @@ class ContainerStageRunner:
             self.env,
         )
         forwarded = [item for name in names for item in ("-e", name)]
-        return [
+        command = [
             "docker",
             "exec",
             "-w",
@@ -73,11 +73,30 @@ class ContainerStageRunner:
             *forwarded,
             self.config.name,
             "python3",
-            "-m",
-            "tools.ci",
-            "pipeline",
-            self.stage,
         ]
+        if self.config.hardened:
+            command.extend(
+                [
+                    "-I",
+                    "-c",
+                    "import importlib.util, runpy, sys; root=sys.argv.pop(1); "
+                    "spec=importlib.util.spec_from_file_location('tools', "
+                    "root+'/tools/__init__.py', submodule_search_locations=[root+'/tools']); "
+                    "module=importlib.util.module_from_spec(spec); sys.modules['tools']=module; "
+                    "spec.loader.exec_module(module); "
+                    "runpy.run_module('tools.ci', run_name='__main__')",
+                    str(self.config.workspace),
+                ]
+            )
+        else:
+            command.extend(["-m", "tools.ci"])
+        command.extend(
+            [
+                "pipeline",
+                self.stage,
+            ]
+        )
+        return command
 
     def _cancel(self, signal_number: int, _frame: object) -> None:
         subprocess.run(

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -145,10 +145,16 @@ CPU` validation by adding this exact comment to the pull request:
 ```
 
 The trusted default-branch `Community CPU` workflow authorizes the actor and
-captures the exact base, head, and merge SHAs without checking out
-pull-request code. Separate jobs in that same workflow run source quality,
-ownership and impact, and source-only C++ and Python units. A maintainer or
-admin may submit the same comment on the author's behalf.
+captures the exact base, head, merge, and request identifiers without checking
+out pull-request code. Separate jobs in that same workflow run source quality,
+ownership and impact, and source-only C++ and Python units. Those jobs restore
+the CI controller, pinned dependencies, build configuration, and baseline tests
+from the captured base SHA before executing the proposed runtime and package
+source. Changes to the controller, `tools/`, tests, or build configuration
+receive their authoritative validation in the protected suite. A passing public
+result is functional evidence, not proof that arbitrary pull-request code is
+benign. A maintainer or admin may submit the same comment on the author's
+behalf.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs, and every public job uses a GitHub-hosted
@@ -161,8 +167,9 @@ merge SHA rather than the pull-request head SHA.
 
 Fix any failures and wait for `Community CPU / Required` to pass. Repeating
 `/run-ci` for the same queued, running, or successful merge is safely
-deduplicated. If the PR head or base changes, comment `/run-ci` again after
-the new revision is ready.
+deduplicated. A merge revision receives at most three attempts; after that,
+push a corrected revision or ask a maintainer to investigate. If the PR head or
+base changes, comment `/run-ci` again after the new revision is ready.
 
 ## 7. Coordinate protected repository CI
 


### PR DESCRIPTION
## Background

Workflow execution protection currently rejects unaffiliated contributors before the repository's exact `/run-ci` authorization job can run. This change prepares the repository side of a narrowly scoped `issue_comment` policy exception while keeping untrusted pull-request execution isolated from write credentials and protected infrastructure.

## Exit Criteria

- An eligible pull-request author can request public CPU validation with the exact `/run-ci` comment after the external policy is activated.
- The request is bound to the original comment and exact base, head, and merge revisions.
- Pull-request code cannot replace the versioned CI controller, dependencies, build configuration, or baseline tests used by the public gate.
- Missing or invalid impact outputs fail closed, and repeated requests are deduplicated and throttled.
- Only one reviewed workflow in the repository can listen to `issue_comment`.

## Implementation

- Restore the Community CPU controller and baseline harness from the authorized base commit before executing the proposed runtime/package source.
- Start Python, pip, pytest, and the hardened unit-container controller in isolated mode to prevent pull-request module shadowing.
- Bind check runs to the request comment, cap attempts per merge revision, add a soft per-PR request throttle, and scope concurrency per actor.
- Add workflow inventory, restoration, symlink, quota, isolated-launcher, and fail-closed impact regression coverage.
- Document the controlling-policy layering, safe activation/rollback order, CODEOWNERS boundary, and canary procedure.

## Validation

- `python3 -m pytest tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py -q` — 95 passed
- Changed-file pre-commit hooks — passed
- Ruff checks for all changed Python files — passed
- Isolated Community CPU launcher smoke test — passed
- Staged diff whitespace and privacy scans — passed

## Notes

- Merging this pull request does not itself relax the active execution protection. Activate the replacement repository boundary first, then exclude this repository from the controlling enterprise/organization deny rule; use the reverse order for rollback.
- The public result is functional evidence, not proof that arbitrary pull-request code is benign. Maintainer review remains required before protected CI is authorized.
- The comment-history budget is a soft throttle because authors can edit or delete comments. Per-merge attempts and per-actor concurrency provide the durable in-repository limits.
- The strict documentation-reference check still reports an unrelated existing stale numerical count; it reports no broken paths from this change.
