### PR TITLE
ci: make runtime fingerprints contract-driven

### DIFF
--- a/.github/scripts/build-python-profiles.py
+++ b/.github/scripts/build-python-profiles.py
@@ -5,27 +5,52 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
+import sys
+import types
 from pathlib import Path
 
-from tensorrt_model_connect.python_profiles import (
-    load_python_profile_registry,
-    prebuilt_python_profile_names,
-    profile_root,
-    resolve_profile_python,
-)
+
+def _load_profile_api():
+    """Load the builder API without executing package application metadata."""
+    package_name = "tensorrt_model_connect"
+    package_root = Path(
+        os.environ.get(
+            "TRTMC_PYTHON_PROFILE_SOURCE",
+            "/opt/trtmc-profile-source/tensorrt_model_connect",
+        )
+    ).resolve()
+    module_name = f"{package_name}.python_profiles"
+    package = types.ModuleType(package_name)
+    package.__package__ = package_name
+    package.__path__ = [str(package_root)]
+    sys.modules[package_name] = package
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        package_root / "python_profiles.py",
+    )
+    if spec is None or spec.loader is None:
+        raise SystemExit("unable to load the Python profile builder API")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def main() -> None:
-    names = prebuilt_python_profile_names(load_python_profile_registry())
+    profile_api = _load_profile_api()
+    names = profile_api.prebuilt_python_profile_names(
+        profile_api.load_python_profile_registry()
+    )
     if not names:
         raise SystemExit("no prebuilt Python profiles were declared")
 
     base_python = os.environ.get("TRTMC_BASE_PYTHON", "/opt/venv/bin/python")
     resolved: dict[str, dict[str, str]] = {}
     for name in names:
-        python = resolve_profile_python(name, base_python)
+        python = profile_api.resolve_profile_python(name, base_python)
         ready = Path(python).parent.parent / ".ready"
         if not ready.is_file():
             raise SystemExit(f"profile {name!r} was not marked ready: {ready}")
@@ -35,7 +60,7 @@ def main() -> None:
         "schema_version": 1,
         "profiles": resolved,
     }
-    root = profile_root()
+    root = profile_api.profile_root()
     (root / ".image-ready.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",

--- a/.github/scripts/build-python-profiles.py
+++ b/.github/scripts/build-python-profiles.py
@@ -20,7 +20,7 @@ from tensorrt_model_connect.python_profiles import (
 def main() -> None:
     names = prebuilt_python_profile_names(load_python_profile_registry())
     if not names:
-        raise SystemExit("no family-owned Python profiles were declared")
+        raise SystemExit("no prebuilt Python profiles were declared")
 
     base_python = os.environ.get("TRTMC_BASE_PYTHON", "/opt/venv/bin/python")
     resolved: dict[str, dict[str, str]] = {}

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -103,8 +103,8 @@ jobs:
           # authorization boundary for protected resources.
           community_cpu_run="$(
             gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/runs?event=pull_request&per_page=100" \
-              --jq ".workflow_runs | map(select(.head_sha == \"$head_sha\" and .conclusion == \"success\")) | sort_by(.updated_at) | last | .id // empty"
+              "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/runs?event=pull_request&head_sha=$head_sha&per_page=100" \
+              --jq '.workflow_runs | map(select(.conclusion == "success")) | sort_by(.updated_at) | last | .id // empty'
           )"
           if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::Community CPU / Required must pass on the current PR head before internal CI can run."

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -87,13 +87,11 @@ jobs:
           base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
           base_ref="$(jq -er '.base.ref' <<<"$pull")"
           head_sha="$(jq -er '.head.sha' <<<"$pull")"
-          merge_sha="$(jq -er '.merge_commit_sha' <<<"$pull")"
 
           test "$state" = "open"
           test "$base_repo" = "$GITHUB_REPOSITORY"
           test "$base_ref" = "main"
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
           if [ "$EVENT_NAME" = "pull_request_target" ] \
             && [ "$head_sha" != "$EVENT_HEAD_SHA" ]; then
             echo "::error::The CI trigger was superseded by a newer PR head."
@@ -106,10 +104,10 @@ jobs:
           community_cpu_run="$(
             gh api --method GET \
               "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/runs?event=pull_request&per_page=100" \
-              --jq ".workflow_runs | map(select(.head_sha == \"$head_sha\" and .conclusion == \"success\" and .display_title == \"PR #$PR_NUMBER · public CPU · merge $merge_sha\")) | sort_by(.updated_at) | last | .id // empty"
+              --jq ".workflow_runs | map(select(.head_sha == \"$head_sha\" and .conclusion == \"success\")) | sort_by(.updated_at) | last | .id // empty"
           )"
           if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Community CPU / Required must pass on the current PR merge before internal CI can run."
+            echo "::error::Community CPU / Required must pass on the current PR head before internal CI can run."
             exit 1
           fi
           {
@@ -118,7 +116,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Consume the trusted trigger label
-        if: ${{ always() && github.event_name == 'pull_request_target' }}
+        if: ${{ success() && github.event_name == 'pull_request_target' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,9 +173,10 @@ comment:
 @yifeif-nv This PR is ready for CI. Please trigger CI for the current head.
 ```
 
-The maintainer verifies the pull-request head and the current exact-merge public
-result, then applies the one-shot `run-internal-ci` label. Only collaborators
-with repository `maintain` or `admin` permission can authorize that trigger.
+The maintainer verifies the pull-request head and a successful Community CPU
+run for that head, then applies the one-shot `run-internal-ci` label. Only
+collaborators with repository `maintain` or `admin` permission can authorize
+that trigger.
 The trusted bridge consumes the label, rechecks `Community CPU / Required`,
 captures the current PR head SHA, and dispatches protected premerge validation.
 
@@ -188,10 +189,10 @@ logs, artifacts, and URLs are not part of the public contribution interface.
 ### 10. Respond to review and keep evidence current
 
 Address review feedback on the same topic branch and sign off every new commit.
-Keep the pull request current with upstream when requested. Any head or base
-change requires a fresh public merge result; any head change also requires a
-fresh maintainer-triggered protected result before the pull request can merge.
-Maintainers merge accepted changes according to the repository ruleset.
+Keep the pull request current with upstream when requested. A new head requires
+a fresh public merge result and a fresh maintainer-triggered protected result
+before the pull request can merge. Maintainers merge accepted changes according
+to the repository ruleset.
 
 ## Established development practices
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,9 @@ collaborators with repository `maintain` or `admin` permission can authorize
 that trigger.
 The trusted bridge consumes the label, rechecks `Community CPU / Required`,
 captures the current PR head SHA, and dispatches protected premerge validation.
+If authorization rejects the request, ask the maintainer to remove and re-add
+the retained label after satisfying the reported prerequisite. Adding an
+already-present label does not create a new trigger event.
 
 Wait for `trtmc/premerge/required` to pass on the exact pull-request head SHA.
 If you push another commit, the previous result no longer validates the current

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,6 @@ ENV LD_PRELOAD=/usr/local/cuda/lib64/libcublas.so.13
 # verifies every installed distribution before marking a profile ready.
 FROM ci-common-base AS python-profile-builder
 
-ENV PYTHONPATH=/opt/trtmc-profile-source
 ENV TRTMC_PYTHON_PROFILE_ROOT=/opt/trtmc-python-profiles
 # sphn publishes no aarch64 wheel. Keep its Rust build toolchain in this
 # throwaway builder stage; the final development stage receives only the

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,9 +139,9 @@ ENV LD_PRELOAD=/usr/local/cuda/lib64/libcublas.so.13
 #   python3 -m pytest --help | grep -- '--cov' && \
 #   gcovr --version && lcov --version && genhtml --version
 
-# Build every family-declared Python execution profile while network access is
-# available. The family-owned lock and verification files are the only package
-# source of truth; python_profiles.py additionally rejects non-exact pins and
+# Build every declarative Python execution profile while network access is
+# available. Family-owned declarations, lock files, and verification scripts
+# are the package source of truth; python_profiles.py rejects non-exact pins and
 # verifies every installed distribution before marking a profile ready.
 FROM ci-common-base AS python-profile-builder
 

--- a/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
@@ -106,8 +106,8 @@ Source contains only the Internal CI Bridge and Pages workflows. Premerge,
 including legal compliance, and nightly orchestration are private Internal CI.
 
 - `run-internal-ci` is the one-shot trusted trigger; `run-ci` is retired.
-- The bridge verifies event, PR metadata, and source branch heads before
-  dispatching the exact PR head.
+- The bridge verifies the label event, current PR metadata head, and successful
+  Community CPU result for that head before dispatching it.
 - Source receives only `trtmc/premerge/required` as `PENDING`, `PASS`, or
   `FAIL` on that exact head.
 - A successful bridge dispatch is not a successful premerge result.

--- a/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
@@ -71,9 +71,9 @@ verifies the open PR targets `main`, and rechecks the event SHA, PR metadata
 SHA, and successful Community CPU run for that head before dispatching only
 `pr_number` and `head_sha`.
 
-Internal CI runs legal compliance and premerge tests against that exact head.
-It may use the merge base only to select impacted tests; do not describe the
-merge base or a synthetic merge commit as the tested revision.
+Internal CI resolves and tests the exact pull-request merge whose first parent
+is the current `main` revision and whose second parent is the authorized PR
+head. It publishes the sanitized result on that exact head SHA.
 
 The Source-visible premerge result is only the sanitized
 `trtmc/premerge/required` status on that exact head: `PENDING`, then `PASS` or

--- a/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
@@ -40,25 +40,14 @@ Read `.github/workflows/internal-ci-bridge.yml` from current `github/main`.
 Source keeps only Internal CI Bridge and Pages workflows. Premerge, including
 legal compliance, and nightly execution stay in private Internal CI.
 
-Before triggering premerge, compare the PR metadata head with the independently
-resolved source branch head. This catches a GitHub PR tracking ref that stopped
-advancing after a push:
+Before triggering premerge, capture the current PR metadata head and inspect its
+existing protected status:
 
 ```bash
 REPOSITORY=NVIDIA/TensorRT-Model-Connect
 PR_NUMBER=<number>
 pull=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
 PR_HEAD_SHA=$(jq -er '.head.sha' <<<"$pull")
-HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<<"$pull")
-HEAD_REF=$(jq -r '.head.ref // empty' <<<"$pull")
-test -n "$HEAD_REPOSITORY"
-test -n "$HEAD_REF"
-HEAD_REF_URI=$(jq -rn --arg value "$HEAD_REF" '$value | @uri')
-BRANCH_HEAD_SHA=$(gh api \
-  "repos/$HEAD_REPOSITORY/branches/$HEAD_REF_URI" \
-  --jq .commit.sha)
-test "$PR_HEAD_SHA" = "$BRANCH_HEAD_SHA"
-
 gh api \
   "repos/$REPOSITORY/commits/$PR_HEAD_SHA/status" \
   --jq '[.statuses[] |
@@ -69,26 +58,18 @@ gh pr edit "$PR_NUMBER" \
   --add-label run-internal-ci
 ```
 
-Apply this check to both same-repository and accessible fork PRs. If the source
-repository is absent, the source branch cannot be read, or the two SHAs still
-differ after six 10-second retries, do not add the label:
-
-- If the source branch SHA changes during the retries, an author is still
-  pushing. Wait for it to settle and retry.
-- If the source branch remains stable while the PR metadata SHA remains behind,
-  treat the PR tracking ref as stale. Follow the recovery procedure in
-  `tools/ci/README.md`, verify equality, and only then add the label.
-- If a label event was already created for an older SHA, allow the bridge to
-  consume it and report `TRIGGER_SUPERSEDED`; add a new label only after the
-  current PR and branch SHAs agree.
+If a label event was created for an older SHA, let the bridge report the
+superseded trigger, wait for Community CPU on the current PR head, and retry.
+When authorization fails and leaves `run-internal-ci` attached, remove it before
+adding it again; adding an existing label does not emit another label event.
 
 Only an actor whose repository permission is `maintain` or `admin`
 may add the one-shot trigger.
 
 Never use the legacy `run-ci` label. The bridge consumes `run-internal-ci`,
 verifies the open PR targets `main`, and rechecks the event SHA, PR metadata
-SHA, and actual source branch SHA before dispatching only `pr_number` and
-`head_sha`.
+SHA, and successful Community CPU run for that head before dispatching only
+`pr_number` and `head_sha`.
 
 Internal CI runs legal compliance and premerge tests against that exact head.
 It may use the merge base only to select impacted tests; do not describe the
@@ -96,7 +77,7 @@ merge base or a synthetic merge commit as the tested revision.
 
 The Source-visible premerge result is only the sanitized
 `trtmc/premerge/required` status on that exact head: `PENDING`, then `PASS` or
-`FAIL`, with a target URL under the Source commit's `/tests` tree. A successful
+`FAIL`, with a target URL on the pull request's checks page. A successful
 bridge dispatch is not a successful premerge result.
 
 Raw logs, artifacts, internal packages, runner details, and nightly execution

--- a/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
@@ -144,36 +144,20 @@ Queued, missing, skipped, or failed checks are not green.
 ## 7. Start Exact-Head Premerge When Authorized
 
 Creating or pushing the PR does not start premerge. When CI execution is
-authorized, resolve the PR API head and actual source branch head independently
-before adding the one-shot trigger:
+authorized, resolve the current PR API head before adding the one-shot trigger:
 
 ```bash
 REPOSITORY=NVIDIA/TensorRT-Model-Connect
 PR_NUMBER=<number>
 pull=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
 PR_HEAD_SHA=$(jq -er '.head.sha' <<<"$pull")
-HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<<"$pull")
-HEAD_REF=$(jq -r '.head.ref // empty' <<<"$pull")
-test -n "$HEAD_REPOSITORY"
-test -n "$HEAD_REF"
-HEAD_REF_URI=$(jq -rn --arg value "$HEAD_REF" '$value | @uri')
-BRANCH_HEAD_SHA=$(gh api \
-  "repos/$HEAD_REPOSITORY/branches/$HEAD_REF_URI" \
-  --jq .commit.sha)
 test "$PR_HEAD_SHA" = "$PUSHED_SHA"
-test "$PR_HEAD_SHA" = "$BRANCH_HEAD_SHA"
 
 gh api \
   "repos/$REPOSITORY/commits/$PR_HEAD_SHA/status" \
   --jq '[.statuses[] |
     select(.context == "trtmc/premerge/required")][0]'
 ```
-
-Apply the equality check to same-repository and accessible fork PRs. Retry for
-up to six 10-second intervals while GitHub metadata settles. If the source
-repository or branch cannot be read, the source branch is still moving, or the
-SHAs do not converge, do not trigger CI; follow `tools/ci/README.md` and hand
-the stale-head recovery to `$pr-babysitter`.
 
 If the exact head already has `PENDING` or `PASS` for
 `trtmc/premerge/required`, do not trigger it again. Otherwise an actor with
@@ -184,6 +168,10 @@ gh pr edit "$PR_NUMBER" \
   --repo "$REPOSITORY" \
   --add-label run-internal-ci
 ```
+
+If authorization fails and retains the label, remove `run-internal-ci` before
+adding it again after the reported prerequisite is satisfied. Re-adding an
+already-present label is a no-op and does not trigger the bridge.
 
 Never use the legacy `run-ci` label. The bridge consumes the trigger, verifies
 the exact head, and dispatches private Internal CI. A successful Source bridge

--- a/python/tensorrt_model_connect/families/__init__.py
+++ b/python/tensorrt_model_connect/families/__init__.py
@@ -55,7 +55,6 @@ class _FamilyMetadata:
     default_build_route: str = ""
     debug_runner: str = ""
     debug_runtime_strategies: frozenset[str] = frozenset()
-    python_profile_specs: tuple[str, ...] = ()
     default_execution_profiles: tuple[str, ...] = ()
 
 
@@ -228,9 +227,6 @@ def _load_family_metadata() -> list[_FamilyMetadata]:
             if isinstance(raw.get("debug_runner"), str) else "",
             debug_runtime_strategies=_metadata_strings(
                 raw.get("debug_runtime_strategies")
-            ),
-            python_profile_specs=tuple(
-                _metadata_strings(raw.get("python_profile_specs"))
             ),
             default_execution_profiles=tuple(
                 _metadata_strings(raw.get("default_execution_profiles"))

--- a/python/tensorrt_model_connect/families/__init__.py
+++ b/python/tensorrt_model_connect/families/__init__.py
@@ -464,17 +464,6 @@ def _metadata_warm_file_spec(
     return parts[0], parts[1], parts[2], parts[3]
 
 
-def _metadata_bool(value: str, field_name: str) -> bool:
-    normalized = value.strip().lower()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-    raise ValueError(
-        f"Invalid {field_name} bool {value!r}; expected true or false"
-    )
-
-
 def family_default_execution_profiles(family: object) -> dict[str, str]:
     """Return phase -> Python profile defaults from family-owned metadata."""
     metadata = _matching_family_metadata(family)
@@ -495,40 +484,9 @@ def family_python_profile_specs() -> dict[str, dict[str, object]]:
     ``name|requirements|verification_script|system_site_packages|prebuild``.
     Paths are package-relative so profile assets stay under the owning family.
     """
-    profiles: dict[str, dict[str, object]] = {}
-    for meta in _load_family_metadata():
-        for spec in meta.python_profile_specs:
-            parts = [part.strip() for part in spec.split("|")]
-            if len(parts) not in {3, 4, 5} or any(
-                not part for part in parts[:3]
-            ):
-                raise ValueError(
-                    f"Invalid python_profile_specs entry {spec!r} for family "
-                    f"{meta.id}; expected "
-                    "'name|requirements|verification_script|"
-                    "system_site_packages|prebuild'"
-                )
-            name, requirements, verification_script_file = parts[:3]
-            system_site_packages = (
-                _metadata_bool(parts[3], "python_profile_specs")
-                if len(parts) >= 4 else True
-            )
-            prebuild = (
-                _metadata_bool(parts[4], "python_profile_specs")
-                if len(parts) == 5 else True
-            )
-            if name in profiles:
-                raise ValueError(
-                    f"Python profile {name!r} is declared by multiple families"
-                )
-            profiles[name] = {
-                "kind": "venv",
-                "requirements": requirements,
-                "verification_script_file": verification_script_file,
-                "system_site_packages": system_site_packages,
-                "prebuild": prebuild,
-            }
-    return profiles
+    from ..python_profiles import family_python_profile_specs as load_specs
+
+    return load_specs()
 
 
 def family_hf_required_files_by_id() -> dict[str, list[str]]:

--- a/python/tensorrt_model_connect/python_profiles.py
+++ b/python/tensorrt_model_connect/python_profiles.py
@@ -594,6 +594,7 @@ def _run_profile_command(
 
 def _profile_install_environment() -> dict[str, str]:
     environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
     if not environment.get("MAX_JOBS", "").strip():
         environment["MAX_JOBS"] = _DEFAULT_PROFILE_BUILD_JOBS
     return environment
@@ -754,6 +755,7 @@ def _materialize_venv_profile(
                     [str(tmp_python), "-c", verification_script],
                     description=f"verify Python profile {profile_name!r}",
                     timeout=300,
+                    env=_profile_install_environment(),
                 )
 
             ready_path_tmp = tmp_dir / ".ready"

--- a/python/tensorrt_model_connect/python_profiles.py
+++ b/python/tensorrt_model_connect/python_profiles.py
@@ -123,8 +123,6 @@ def load_python_profile_registry() -> dict[str, Any]:
         raise ValueError("python_profiles.toml is missing a [profiles] table")
     profiles = dict(raw_profiles)
 
-    from .families import family_python_profile_specs
-
     for name, spec in family_python_profile_specs().items():
         if name in profiles:
             raise ValueError(
@@ -135,6 +133,66 @@ def load_python_profile_registry() -> dict[str, Any]:
     registry["profiles"] = profiles
     _validate_python_profile_registry(registry)
     return registry
+
+
+def _profile_metadata_bool(value: str, field_name: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"Invalid {field_name} bool {value!r}; expected true or false"
+    )
+
+
+def family_python_profile_specs() -> dict[str, dict[str, object]]:
+    """Read family-owned profile declarations without importing family code."""
+    profiles: dict[str, dict[str, object]] = {}
+    for manifest in sorted((_PACKAGE_DIR / "families").glob("*/MODEL.toml")):
+        with manifest.open("rb") as stream:
+            raw = tomllib.load(stream)
+        family_id = raw.get("id") or raw.get("plugin") or manifest.parent.name
+        raw_specs = raw.get("python_profile_specs", [])
+        if not isinstance(raw_specs, list):
+            raise ValueError(
+                f"python_profile_specs for family {family_id} must be a list"
+            )
+        for spec in raw_specs:
+            if not isinstance(spec, str):
+                raise ValueError(
+                    f"python_profile_specs for family {family_id} must contain strings"
+                )
+            parts = [part.strip() for part in spec.split("|")]
+            if len(parts) not in {3, 4, 5} or any(not part for part in parts[:3]):
+                raise ValueError(
+                    f"Invalid python_profile_specs entry {spec!r} for family "
+                    f"{family_id}; expected 'name|requirements|verification_script|"
+                    "system_site_packages|prebuild'"
+                )
+            name, requirements, verification_script_file = parts[:3]
+            system_site_packages = (
+                _profile_metadata_bool(parts[3], "python_profile_specs")
+                if len(parts) >= 4
+                else True
+            )
+            prebuild = (
+                _profile_metadata_bool(parts[4], "python_profile_specs")
+                if len(parts) == 5
+                else True
+            )
+            if name in profiles:
+                raise ValueError(
+                    f"Python profile {name!r} is declared by multiple families"
+                )
+            profiles[name] = {
+                "kind": "venv",
+                "requirements": requirements,
+                "verification_script_file": verification_script_file,
+                "system_site_packages": system_site_packages,
+                "prebuild": prebuild,
+            }
+    return profiles
 
 
 def _profile_asset_path(path_spec: str, *, field: str, profile_name: str) -> Path:
@@ -387,6 +445,7 @@ def _apply_declared_defaults(
     profiles: dict[str, str],
     defaults: Mapping[str, Any] | None,
     *,
+    declared_profiles: set[str] | None = None,
     source: str,
 ) -> None:
     if not defaults:
@@ -400,6 +459,10 @@ def _apply_declared_defaults(
         name = str(profile).strip()
         if not name:
             raise ValueError(f"{source}[{phase!r}] must be a non-empty string")
+        if declared_profiles is not None and name not in declared_profiles:
+            raise ValueError(
+                f"{source}[{phase!r}] selects undeclared profile {name!r}"
+            )
         profiles[phase] = name
 
 
@@ -412,6 +475,7 @@ def default_execution_profiles(
     """Return declarative default profile selections for a model case."""
     profiles = {phase: DEFAULT_PROFILE for phase in PROFILE_PHASES}
     registry = load_python_profile_registry()
+    declared_profiles = set(registry["profiles"])
 
     if family:
         from .families import family_default_execution_profiles
@@ -419,6 +483,7 @@ def default_execution_profiles(
         _apply_declared_defaults(
             profiles,
             family_default_execution_profiles(family),
+            declared_profiles=declared_profiles,
             source=f"family metadata {family}",
         )
 
@@ -436,6 +501,7 @@ def default_execution_profiles(
         _apply_declared_defaults(
             profiles,
             defaults,
+            declared_profiles=declared_profiles,
             source=f"{section_name}.{key}",
         )
 

--- a/python/tensorrt_model_connect/python_profiles.py
+++ b/python/tensorrt_model_connect/python_profiles.py
@@ -36,6 +36,30 @@ _PROFILE_INSTALL_TIMEOUT_SECONDS = 7200
 _EXACT_REQUIREMENT_RE = re.compile(
     r"^([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[A-Za-z0-9,._-]+\])?==([^\s;]+)$"
 )
+_EXACT_VERSION_RE = re.compile(
+    r"(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*"
+    r"(?:(?:a|b|rc)[0-9]+)?"
+    r"(?:\.post[0-9]+)?"
+    r"(?:\.dev[0-9]+)?"
+    r"(?:\+[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*)?",
+    re.IGNORECASE,
+)
+_PROFILE_NAME_RE = re.compile(r"[a-z][a-z0-9_]*")
+_REGISTRY_KEYS = {
+    "version",
+    "profiles",
+    "reference_backend_defaults",
+    "runtime_strategy_defaults",
+}
+_PASSTHROUGH_PROFILE_KEYS = {"kind"}
+_VENV_PROFILE_KEYS = {
+    "kind",
+    "prebuild",
+    "requirements",
+    "system_site_packages",
+    "verification_script",
+    "verification_script_file",
+}
 
 
 def _absolute_python(path: str) -> str:
@@ -87,16 +111,17 @@ def profile_root() -> Path:
 
 @lru_cache(maxsize=1)
 def load_python_profile_registry() -> dict[str, Any]:
-    """Load the declarative profile registry bundled with the Python builder."""
+    """Load generic and family-owned profiles into one validated registry."""
     registry_file = _PACKAGE_DIR / "python_profiles.toml"
     with registry_file.open("rb") as f:
         registry = tomllib.load(f)
     if not isinstance(registry, dict):
         raise ValueError("python_profiles.toml must decode to an object")
     registry = dict(registry)
-    profiles = dict(registry.get("profiles", {}))
-    if not isinstance(profiles, dict):
+    raw_profiles = registry.get("profiles", {})
+    if not isinstance(raw_profiles, dict):
         raise ValueError("python_profiles.toml is missing a [profiles] table")
+    profiles = dict(raw_profiles)
 
     from .families import family_python_profile_specs
 
@@ -108,7 +133,144 @@ def load_python_profile_registry() -> dict[str, Any]:
             )
         profiles[name] = spec
     registry["profiles"] = profiles
+    _validate_python_profile_registry(registry)
     return registry
+
+
+def _profile_asset_path(path_spec: str, *, field: str, profile_name: str) -> Path:
+    path = Path(path_spec)
+    if not path_spec or path.is_absolute() or ".." in path.parts:
+        raise ValueError(
+            f"Execution profile {profile_name!r} has an unsafe {field} path"
+        )
+    resolved = (_PACKAGE_DIR / path).resolve()
+    try:
+        resolved.relative_to(_PACKAGE_DIR.resolve())
+    except ValueError as error:
+        raise ValueError(
+            f"Execution profile {profile_name!r} has an unsafe {field} path"
+        ) from error
+    if not resolved.is_file():
+        raise ValueError(
+            f"Execution profile {profile_name!r} references missing {field} "
+            f"asset {path_spec!r}"
+        )
+    return resolved
+
+
+def _validate_python_profile_registry(registry: Mapping[str, Any]) -> None:
+    """Reject ambiguous or non-hermetic profile declarations before building."""
+    unknown_registry_keys = set(registry) - _REGISTRY_KEYS
+    if unknown_registry_keys:
+        raise ValueError(
+            "Python profile registry has unknown top-level keys: "
+            + ", ".join(sorted(unknown_registry_keys))
+        )
+    if type(registry.get("version")) is not int or registry["version"] != 1:
+        raise ValueError("python_profiles.toml version must be integer 1")
+
+    profiles = registry.get("profiles")
+    if not isinstance(profiles, Mapping) or DEFAULT_PROFILE not in profiles:
+        raise ValueError("python_profiles.toml must declare profiles.base")
+    for name, raw_spec in profiles.items():
+        if type(name) is not str or _PROFILE_NAME_RE.fullmatch(name) is None:
+            raise ValueError(f"Invalid execution profile name: {name!r}")
+        if not isinstance(raw_spec, Mapping):
+            raise ValueError(f"Execution profile {name!r} must be a table")
+        kind = raw_spec.get("kind")
+        allowed_keys = (
+            _PASSTHROUGH_PROFILE_KEYS
+            if kind == "passthrough"
+            else _VENV_PROFILE_KEYS
+            if kind == "venv"
+            else set()
+        )
+        if not allowed_keys:
+            raise ValueError(
+                f"Execution profile {name!r} has unsupported kind {kind!r}"
+            )
+        unknown_keys = set(raw_spec) - allowed_keys
+        if unknown_keys:
+            raise ValueError(
+                f"Execution profile {name!r} has unknown keys: "
+                + ", ".join(sorted(unknown_keys))
+            )
+        if kind == "passthrough":
+            continue
+        for field in ("system_site_packages", "prebuild"):
+            if field in raw_spec and type(raw_spec[field]) is not bool:
+                raise ValueError(
+                    f"Execution profile {name!r} field {field} must be a bool"
+                )
+        requirements = raw_spec.get("requirements")
+        if type(requirements) is not str:
+            raise ValueError(
+                f"Execution profile {name!r} must declare a requirements path"
+            )
+        requirements_path = _profile_asset_path(
+            requirements, field="requirements", profile_name=name
+        )
+        _exact_pinned_requirements(requirements_path.read_text(encoding="utf-8"))
+
+        inline_verification = raw_spec.get("verification_script")
+        file_verification = raw_spec.get("verification_script_file")
+        if bool(inline_verification) == bool(file_verification):
+            raise ValueError(
+                f"Execution profile {name!r} must declare exactly one of "
+                "verification_script and verification_script_file"
+            )
+        if inline_verification is not None and type(inline_verification) is not str:
+            raise ValueError(
+                f"Execution profile {name!r} verification_script must be a string"
+            )
+        if file_verification is not None:
+            if type(file_verification) is not str:
+                raise ValueError(
+                    f"Execution profile {name!r} verification_script_file "
+                    "must be a string"
+                )
+            _profile_asset_path(
+                file_verification,
+                field="verification_script_file",
+                profile_name=name,
+            )
+
+    declared_profiles = set(profiles)
+    for section_name in (
+        "runtime_strategy_defaults",
+        "reference_backend_defaults",
+    ):
+        section = registry.get(section_name, {})
+        if not isinstance(section, Mapping):
+            raise ValueError(
+                f"python_profiles.toml [{section_name}] must be an object"
+            )
+        for selector, defaults in section.items():
+            if type(selector) is not str or not selector.strip():
+                raise ValueError(
+                    f"python_profiles.toml [{section_name}] keys must be strings"
+                )
+            if not isinstance(defaults, Mapping):
+                raise ValueError(
+                    f"python_profiles.toml [{section_name}.{selector}] "
+                    "must be an object"
+                )
+            for phase, profile in defaults.items():
+                if phase not in PROFILE_PHASES:
+                    raise ValueError(
+                        f"python_profiles.toml [{section_name}.{selector}] "
+                        f"contains unsupported phase {phase!r}"
+                    )
+                if type(profile) is not str or not profile.strip():
+                    raise ValueError(
+                        f"python_profiles.toml [{section_name}.{selector}] "
+                        f"phase {phase!r} must select a profile"
+                    )
+                if profile not in declared_profiles:
+                    raise ValueError(
+                        f"python_profiles.toml [{section_name}.{selector}] "
+                        f"selects undeclared profile {profile!r}"
+                    )
 
 
 def prebuilt_python_profile_names(
@@ -157,6 +319,11 @@ def _exact_pinned_requirements(requirements_text: str) -> dict[str, str]:
                 f"line {line_number} is {raw_line!r}"
             )
         name, version = match.groups()
+        if _EXACT_VERSION_RE.fullmatch(version) is None:
+            raise ValueError(
+                "Python profile requirements must be exact name==version pins; "
+                f"line {line_number} is {raw_line!r}"
+            )
         normalized_name = re.sub(r"[-_.]+", "-", name).lower()
         if normalized_name in pinned:
             raise ValueError(
@@ -256,7 +423,6 @@ def default_execution_profiles(
         )
 
     sections = (
-        ("family_defaults", str(family or "").strip()),
         ("runtime_strategy_defaults", str(runtime_strategy or "").strip()),
         ("reference_backend_defaults", str(reference_backend or "").strip()),
     )
@@ -463,7 +629,7 @@ def _materialize_venv_profile(
         raise RuntimeError(
             f"Execution profile {profile_name!r} is not prebuilt for this source "
             f"at {env_dir}. The CI image is stale or incomplete; rebuild it from "
-            "the current Dockerfile and family-owned profile locks."
+            "the current Dockerfile and declarative profile locks."
         )
 
     root.mkdir(parents=True, exist_ok=True)

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -265,6 +265,22 @@ def test_family_profile_registry_is_fully_exact_pinned():
         assert pins, name
 
 
+def test_profile_contract_has_one_family_owned_source_of_truth() -> None:
+    package_root = Path(shared_profiles.__file__).resolve().parent
+    with (package_root / "python_profiles.toml").open("rb") as stream:
+        shared_registry = shared_profiles.tomllib.load(stream)
+    from tensorrt_model_connect.families import family_python_profile_specs
+
+    shared_names = set(shared_registry["profiles"])
+    family_names = set(family_python_profile_specs())
+    merged_names = set(shared_profiles.load_python_profile_registry()["profiles"])
+
+    assert shared_names == {"base", "reference_common"}
+    assert family_names
+    assert shared_names.isdisjoint(family_names)
+    assert merged_names == shared_names | family_names
+
+
 def test_lazy_profiles_are_excluded_from_the_shared_ci_image() -> None:
     registry = shared_profiles.load_python_profile_registry()
     prebuilt = shared_profiles.prebuilt_python_profile_names(registry)
@@ -280,6 +296,32 @@ def test_profile_lock_rejects_non_exact_or_duplicate_requirements():
         shared_profiles._exact_pinned_requirements(
             "huggingface-hub==0.28.1\nhuggingface_hub==0.28.1\n"
         )
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    (
+        "demo==1.*",
+        "demo===latest",
+        "demo==https://example.invalid/demo.whl",
+    ),
+)
+def test_profile_lock_rejects_non_deterministic_exact_pin_lookalikes(requirement):
+    with pytest.raises(ValueError, match="exact name==version pins"):
+        shared_profiles._exact_pinned_requirements(requirement + "\n")
+
+
+def test_profile_registry_validates_supported_global_defaults():
+    registry = shared_profiles.load_python_profile_registry()
+    registry["runtime_strategy_defaults"] = {
+        "demo": {"runtime": "reference_common"}
+    }
+
+    shared_profiles._validate_python_profile_registry(registry)
+
+    registry["runtime_strategy_defaults"]["demo"]["runtime"] = "missing"
+    with pytest.raises(ValueError, match="undeclared profile"):
+        shared_profiles._validate_python_profile_registry(registry)
 
 
 def test_exact_profile_pin_accepts_only_local_builds_of_same_public_version():

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -157,6 +157,7 @@ def test_profile_source_builds_use_a_safe_default_job_limit(monkeypatch, tmp_pat
     requirements = tmp_path / "requirements.lock.txt"
     requirements.write_text("demo-package==1.0\n", encoding="utf-8")
     monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.setenv("PYTHONPATH", "/untrusted/profile/source")
     monkeypatch.delenv(shared_profiles.PREBUILT_ONLY_ENV, raising=False)
     monkeypatch.setenv(shared_profiles.PROFILE_ROOT_ENV, str(tmp_path / "profiles"))
     monkeypatch.setattr(
@@ -181,13 +182,17 @@ def test_profile_source_builds_use_a_safe_default_job_limit(monkeypatch, tmp_pat
         {
             "requirements": str(requirements),
             "system_site_packages": False,
+            "verification_script": "print('verified')",
         },
         sys.executable,
     )
 
     install = next(call for call in commands if call[1].startswith("install "))
     assert install[3]["env"]["MAX_JOBS"] == "4"
+    assert "PYTHONPATH" not in install[3]["env"]
     assert install[2] == 7200
+    verify = next(call for call in commands if call[1].startswith("verify "))
+    assert "PYTHONPATH" not in verify[3]["env"]
 
 
 def test_profile_source_builds_respect_an_explicit_job_limit(monkeypatch):

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 import sys
 import time
 from pathlib import Path
@@ -312,7 +313,7 @@ def test_profile_lock_rejects_non_deterministic_exact_pin_lookalikes(requirement
 
 
 def test_profile_registry_validates_supported_global_defaults():
-    registry = shared_profiles.load_python_profile_registry()
+    registry = copy.deepcopy(shared_profiles.load_python_profile_registry())
     registry["runtime_strategy_defaults"] = {
         "demo": {"runtime": "reference_common"}
     }
@@ -322,6 +323,91 @@ def test_profile_registry_validates_supported_global_defaults():
     registry["runtime_strategy_defaults"]["demo"]["runtime"] = "missing"
     with pytest.raises(ValueError, match="undeclared profile"):
         shared_profiles._validate_python_profile_registry(registry)
+
+
+def test_family_default_profile_must_be_declared(monkeypatch):
+    import tensorrt_model_connect.families as family_profiles
+
+    monkeypatch.setattr(
+        family_profiles,
+        "family_default_execution_profiles",
+        lambda _family: {"runtime": "missing"},
+    )
+
+    with pytest.raises(ValueError, match="selects undeclared profile 'missing'"):
+        shared_profiles.default_execution_profiles(family="demo")
+
+
+@pytest.mark.parametrize(
+    ("path_spec", "message"),
+    (
+        ("/tmp/absolute.lock.txt", "unsafe requirements path"),
+        ("../outside.lock.txt", "unsafe requirements path"),
+        ("missing.lock.txt", "missing requirements asset"),
+    ),
+)
+def test_profile_registry_rejects_unsafe_or_missing_assets(
+    monkeypatch, tmp_path, path_spec, message
+):
+    package_root = tmp_path / "package"
+    package_root.mkdir()
+    monkeypatch.setattr(shared_profiles, "_PACKAGE_DIR", package_root)
+
+    with pytest.raises(ValueError, match=message):
+        shared_profiles._profile_asset_path(
+            path_spec,
+            field="requirements",
+            profile_name="demo",
+        )
+
+
+def test_profile_registry_rejects_symlink_escape(monkeypatch, tmp_path):
+    package_root = tmp_path / "package"
+    package_root.mkdir()
+    outside = tmp_path / "outside.lock.txt"
+    outside.write_text("demo==1.0\n", encoding="utf-8")
+    (package_root / "escaped.lock.txt").symlink_to(outside)
+    monkeypatch.setattr(shared_profiles, "_PACKAGE_DIR", package_root)
+
+    with pytest.raises(ValueError, match="unsafe requirements path"):
+        shared_profiles._profile_asset_path(
+            "escaped.lock.txt",
+            field="requirements",
+            profile_name="demo",
+        )
+
+
+def test_profile_registry_rejects_ambiguous_schema_fields():
+    def add_unknown_top_level(registry):
+        registry["unknown"] = True
+
+    def add_unknown_profile_field(registry):
+        registry["profiles"]["base"]["unknown"] = True
+
+    def use_unknown_kind(registry):
+        registry["profiles"]["base"]["kind"] = "dynamic"
+
+    def use_non_boolean_flag(registry):
+        registry["profiles"]["reference_common"]["prebuild"] = 1
+
+    def declare_two_verification_sources(registry):
+        registry["profiles"]["reference_common"]["verification_script_file"] = (
+            registry["profiles"]["reference_common"]["requirements"]
+        )
+
+    cases = (
+        (add_unknown_top_level, "unknown top-level keys"),
+        (add_unknown_profile_field, "unknown keys"),
+        (use_unknown_kind, "unsupported kind"),
+        (use_non_boolean_flag, "must be a bool"),
+        (declare_two_verification_sources, "exactly one"),
+    )
+    baseline = shared_profiles.load_python_profile_registry()
+    for mutate, message in cases:
+        registry = copy.deepcopy(baseline)
+        mutate(registry)
+        with pytest.raises(ValueError, match=message):
+            shared_profiles._validate_python_profile_registry(registry)
 
 
 def test_exact_profile_pin_accepts_only_local_builds_of_same_public_version():

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -732,7 +732,7 @@ def test_profile_sources_are_fingerprinted_and_repo_is_the_build_context() -> No
     assert "semantic_fingerprint" in script
     assert 'b"python-profile-registry\\0"' in script
     assert "assets: set[Path]" in script
-    assert 'Path("tools/ci/process.py")' in script
+    assert 'Path("tools/ci/process.py")' not in script
     assert 'package_root / "python_profiles.py"' in script
     assert '"-f"' in script
     assert "str(self.config.dockerfile)" in script
@@ -808,6 +808,37 @@ def test_source_contract_does_not_execute_or_fingerprint_package_init(
 
     assert changed["common_input_fingerprint"] == baseline["common_input_fingerprint"]
     assert changed["input_fingerprint"] == baseline["input_fingerprint"]
+
+
+def test_profile_builder_does_not_execute_package_init(tmp_path: Path) -> None:
+    package_root = tmp_path / "tensorrt_model_connect"
+    package_root.mkdir()
+    (package_root / "__init__.py").write_text(
+        "raise RuntimeError('package init must not execute')\n",
+        encoding="utf-8",
+    )
+    (package_root / "python_profiles.py").write_text(
+        "def load_python_profile_registry(): return {}\n"
+        "def prebuilt_python_profile_names(registry): return ()\n"
+        "def profile_root(): raise AssertionError('not reached')\n"
+        "def resolve_profile_python(name, base_python): raise AssertionError('not reached')\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["TRTMC_PYTHON_PROFILE_SOURCE"] = str(package_root)
+    env["PYTHONPATH"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / ".github/scripts/build-python-profiles.py")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "no prebuilt Python profiles were declared" in result.stderr
+    assert "package init must not execute" not in result.stderr
 
 
 def test_source_contract_does_not_execute_or_fingerprint_family_loader(
@@ -895,7 +926,7 @@ def test_profile_fingerprint_changes_for_referenced_profile_asset_content(
     (
         Path("Dockerfile"),
         Path(".github/scripts/build-python-profiles.py"),
-        Path("tools/ci/process.py"),
+        Path("python/tensorrt_model_connect/python_profiles.py"),
         Path("python/tensorrt_model_connect/families/demo/verify.py"),
     ),
 )
@@ -914,3 +945,30 @@ def test_profile_fingerprint_changes_for_every_baked_recipe_input(
     changed = _resolved_image_for_repo(tmp_path / "recipe-change", repo_root)
 
     assert changed != baseline
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        Path("tools/__init__.py"),
+        Path("tools/ci/__init__.py"),
+        Path("tools/ci/__main__.py"),
+        Path("tools/ci/docker_image.py"),
+        Path("tools/ci/process.py"),
+    ),
+)
+def test_profile_fingerprint_ignores_contract_producer_code(
+    tmp_path: Path,
+    relative_path: Path,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
+    target = repo_root / relative_path
+    target.write_text(
+        target.read_text(encoding="utf-8") + "\n# Control-plane-only change.\n",
+        encoding="utf-8",
+    )
+
+    changed = _resolved_image_for_repo(tmp_path / "producer-change", repo_root)
+
+    assert changed == baseline

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -268,7 +268,6 @@ def _write_profile_fingerprint_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
     for source in (
         REPO_ROOT / "python" / "tensorrt_model_connect" / "__init__.py",
         REPO_ROOT / "python" / "tensorrt_model_connect" / "python_profiles.py",
-        REPO_ROOT / "python" / "tensorrt_model_connect" / "python_profiles.toml",
     ):
         shutil.copy2(source, package_root / source.name)
     shutil.copy2(
@@ -284,10 +283,27 @@ plugin = "demo"
 module = "plugin"
 aliases = ["demo"]
 prefixes = ["demo"]
+default_execution_profiles = ["reference|demo"]
 python_profile_specs = [
   "demo|families/demo/requirements.lock.txt|families/demo/verify.py|true",
+  "lazy_demo|families/demo/requirements.lock.txt|families/demo/verify.py|true|false",
 ]
-default_execution_profiles = ["reference|demo"]
+""",
+        encoding="utf-8",
+    )
+    profile_registry = package_root / "python_profiles.toml"
+    profile_registry.write_text(
+        """version = 1
+
+[profiles.base]
+kind = "passthrough"
+
+[profiles.reference_common]
+kind = "venv"
+requirements = "families/demo/requirements.lock.txt"
+system_site_packages = true
+verification_script = "import demo_package"
+
 """,
         encoding="utf-8",
     )
@@ -515,7 +531,7 @@ def test_source_contract_describes_parameterized_tensorrt_overlay(tmp_path: Path
         tensorrt_apt_version="11.2.1.2-1+cuda13.3",
     )
     assert selected_contract["schema_version"] == 1
-    assert selected_contract["environment_contract_version"] == 1
+    assert selected_contract["environment_contract_version"] == 2
     assert (
         selected_contract["common_input_fingerprint"]
         == default_contract["common_input_fingerprint"]
@@ -694,6 +710,55 @@ def test_profile_fingerprint_ignores_manifest_comments_and_ownership_fields(
     assert ownership_changed == baseline
 
 
+def test_profile_fingerprint_ignores_unrelated_family_loader_changes(
+    tmp_path: Path,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
+
+    family_loader = (
+        repo_root / "python" / "tensorrt_model_connect" / "families" / "__init__.py"
+    )
+    family_loader.write_text(
+        family_loader.read_text(encoding="utf-8")
+        + "\n# Unrelated application-only family parsing change.\n",
+        encoding="utf-8",
+    )
+
+    changed = _resolved_image_for_repo(tmp_path / "family-loader-change", repo_root)
+    assert changed == baseline
+
+
+def test_profile_fingerprint_ignores_registry_comments(tmp_path: Path) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
+
+    registry = repo_root / "python" / "tensorrt_model_connect" / "python_profiles.toml"
+    registry.write_text(
+        "# Review-only comment.\n" + registry.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    changed = _resolved_image_for_repo(tmp_path / "registry-comment", repo_root)
+    assert changed == baseline
+
+
+def test_profile_fingerprint_ignores_lazy_profile_declarations(tmp_path: Path) -> None:
+    repo_root, manifest, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
+
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace(
+            "lazy_demo|families/demo/requirements.lock.txt",
+            "renamed_lazy_demo|families/demo/requirements.lock.txt",
+        ),
+        encoding="utf-8",
+    )
+
+    changed = _resolved_image_for_repo(tmp_path / "lazy-profile-change", repo_root)
+    assert changed == baseline
+
+
 def test_profile_fingerprint_changes_for_semantic_profile_declaration(
     tmp_path: Path,
 ) -> None:
@@ -702,8 +767,9 @@ def test_profile_fingerprint_changes_for_semantic_profile_declaration(
 
     manifest.write_text(
         manifest.read_text(encoding="utf-8").replace(
-            "families/demo/verify.py|true",
-            "families/demo/verify.py|false",
+            "demo|families/demo/requirements.lock.txt|families/demo/verify.py|true",
+            "demo|families/demo/requirements.lock.txt|families/demo/verify.py|false",
+            1,
         ),
         encoding="utf-8",
     )

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -100,6 +100,12 @@ def test_workflow_image_lock_retries_when_another_runner_creates_file(
     assert modes == ["r+", "x+", "r+"]
 
 
+def test_default_image_lock_wait_covers_one_profile_install_budget() -> None:
+    manager = DockerImageManager(REPO_ROOT, {})
+
+    assert manager.config.lock_timeout >= 7200
+
+
 def _write_fake_docker(tmp_path: Path, existing_images: dict[str, str]) -> tuple[Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
@@ -582,6 +588,34 @@ def test_source_contract_loads_profiles_without_ambient_pythonpath(tmp_path: Pat
     assert result.stdout.strip() == "demo,reference_common"
 
 
+def test_image_contract_cli_emits_canonical_contract_json(tmp_path: Path) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.ci",
+            "image",
+            "contract",
+            "--tensorrt-version",
+            "11.2.1.2",
+            "--tensorrt-apt-version",
+            "11.2.1.2-1+cuda13.3",
+        ],
+        cwd=repo_root,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    contract = json.loads(result.stdout)
+    assert contract["environment_contract_version"] == 2
+    assert contract["tensorrt"]["version"] == "11.2.1.2"
+    assert contract["tensorrt"]["apt_version"] == "11.2.1.2-1+cuda13.3"
+
+
 def test_validate_image_contract_returns_the_verified_source_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -662,6 +696,35 @@ def test_source_contract_rejects_mixed_tensorrt_overlay_versions(tmp_path: Path)
         )
 
 
+def test_source_contract_rechecks_profile_asset_containment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    outside = tmp_path / "outside.lock.txt"
+    outside.write_text("demo==1.0\n", encoding="utf-8")
+    manager = DockerImageManager(repo_root)
+    monkeypatch.setattr(
+        manager,
+        "_load_profile_registry",
+        lambda: (
+            {
+                "version": 1,
+                "profiles": {
+                    "demo": {
+                        "kind": "venv",
+                        "prebuild": True,
+                        "requirements": str(outside),
+                    }
+                },
+            },
+            ("demo",),
+        ),
+    )
+
+    with pytest.raises(CiError, match="unsafe requirements path"):
+        manager.source_contract()
+
+
 def test_profile_sources_are_fingerprinted_and_repo_is_the_build_context() -> None:
     script = SCRIPT.read_text(encoding="utf-8")
 
@@ -669,6 +732,7 @@ def test_profile_sources_are_fingerprinted_and_repo_is_the_build_context() -> No
     assert "semantic_fingerprint" in script
     assert 'b"python-profile-registry\\0"' in script
     assert "assets: set[Path]" in script
+    assert 'Path("tools/ci/process.py")' in script
     assert 'package_root / "python_profiles.py"' in script
     assert '"-f"' in script
     assert "str(self.config.dockerfile)" in script
@@ -729,6 +793,42 @@ def test_profile_fingerprint_ignores_unrelated_family_loader_changes(
     assert changed == baseline
 
 
+def test_source_contract_does_not_execute_or_fingerprint_package_init(
+    tmp_path: Path,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = DockerImageManager(repo_root).source_contract()
+    package_init = repo_root / "python" / "tensorrt_model_connect" / "__init__.py"
+    package_init.write_text(
+        "raise RuntimeError('package metadata must not execute')\n",
+        encoding="utf-8",
+    )
+
+    changed = DockerImageManager(repo_root).source_contract()
+
+    assert changed["common_input_fingerprint"] == baseline["common_input_fingerprint"]
+    assert changed["input_fingerprint"] == baseline["input_fingerprint"]
+
+
+def test_source_contract_does_not_execute_or_fingerprint_family_loader(
+    tmp_path: Path,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = DockerImageManager(repo_root).source_contract()
+    family_loader = (
+        repo_root / "python" / "tensorrt_model_connect" / "families" / "__init__.py"
+    )
+    family_loader.write_text(
+        "raise RuntimeError('family loader must not execute')\n",
+        encoding="utf-8",
+    )
+
+    changed = DockerImageManager(repo_root).source_contract()
+
+    assert changed["common_input_fingerprint"] == baseline["common_input_fingerprint"]
+    assert changed["input_fingerprint"] == baseline["input_fingerprint"]
+
+
 def test_profile_fingerprint_ignores_registry_comments(tmp_path: Path) -> None:
     repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
     baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
@@ -787,4 +887,30 @@ def test_profile_fingerprint_changes_for_referenced_profile_asset_content(
     requirements.write_text("demo-package==1.0.1\n", encoding="utf-8")
 
     changed = _resolved_image_for_repo(tmp_path / "asset-change", repo_root)
+    assert changed != baseline
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        Path("Dockerfile"),
+        Path(".github/scripts/build-python-profiles.py"),
+        Path("tools/ci/process.py"),
+        Path("python/tensorrt_model_connect/families/demo/verify.py"),
+    ),
+)
+def test_profile_fingerprint_changes_for_every_baked_recipe_input(
+    tmp_path: Path,
+    relative_path: Path,
+) -> None:
+    repo_root, _, _ = _write_profile_fingerprint_repo(tmp_path)
+    baseline = _resolved_image_for_repo(tmp_path / "baseline", repo_root)
+    target = repo_root / relative_path
+    target.write_text(
+        target.read_text(encoding="utf-8") + "\n# Environment-affecting recipe change.\n",
+        encoding="utf-8",
+    )
+
+    changed = _resolved_image_for_repo(tmp_path / "recipe-change", repo_root)
+
     assert changed != baseline

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -120,6 +120,7 @@ def _run_internal_ci_snapshot(
     event_name: str = "pull_request_target",
     actor_role: str = "maintain",
     community_conclusion: str = "success",
+    community_merge_sha: str | None = None,
     system_path: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     fake_bin = tmp_path / "bin"
@@ -142,7 +143,12 @@ if "/collaborators/" in endpoint:
 elif "/pulls/" in endpoint:
     print(os.environ["FAKE_PULL_JSON"])
 elif "/actions/workflows/community-cpu.yml/runs" in endpoint:
-    if os.environ["FAKE_COMMUNITY_CONCLUSION"] == "success":
+    query = arguments[arguments.index("--jq") + 1]
+    old_merge = os.environ["FAKE_COMMUNITY_MERGE_SHA"]
+    if (
+        os.environ["FAKE_COMMUNITY_CONCLUSION"] == "success"
+        and (not old_merge or "display_title" not in query or old_merge in query)
+    ):
         print("12345")
     else:
         print("")
@@ -171,6 +177,7 @@ else:
             "EVENT_NAME": event_name,
             "FAKE_ACTOR_ROLE": actor_role,
             "FAKE_COMMUNITY_CONCLUSION": community_conclusion,
+            "FAKE_COMMUNITY_MERGE_SHA": community_merge_sha or "",
             "FAKE_PULL_JSON": json.dumps(pull),
             "GH_TOKEN": "test-token",
             "GITHUB_OUTPUT": str(output),
@@ -304,18 +311,18 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "head_repo" not in authorize
     assert "head_ref" not in authorize
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
-    assert '[[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert "Community CPU / Required" in authorize
     assert "/actions/workflows/community-cpu.yml/runs?event=pull_request" in authorize
     assert '.head_sha == \\"$head_sha\\"' in authorize
     assert '.conclusion == \\"success\\"' in authorize
-    assert "PR #$PR_NUMBER · public CPU · merge $merge_sha" in authorize
+    assert "display_title" not in authorize
     assert 'if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then' in authorize
     assert 'echo "head_sha=$head_sha"' in authorize
     assert "pr_number=$PR_NUMBER" in authorize
     for legacy in (
         "base_sha",
         "BASE_SHA",
+        "merge_sha",
         "MERGE_SHA",
         "EVENT_BASE_SHA",
     ):
@@ -324,7 +331,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
         "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
     ) in authorize
     assert "gh api --silent --method DELETE" in authorize
-    assert "always() && github.event_name == 'pull_request_target'" in authorize
+    assert "success() && github.event_name == 'pull_request_target'" in authorize
 
     assert "needs: authorize" in dispatch
     assert workflow_config["jobs"]["dispatch"]["environment"] == {
@@ -396,6 +403,21 @@ def test_internal_ci_bridge_uses_upstream_pr_metadata_without_fork_access(
         tmp_path,
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_internal_ci_bridge_accepts_a_green_head_after_the_base_moves(
+    tmp_path: Path,
+) -> None:
+    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
+
+    result = _run_internal_ci_snapshot(
+        tmp_path,
+        event_head_sha=head_sha,
+        pr_head_sha=head_sha,
+        community_merge_sha="b" * 40,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -478,7 +500,7 @@ def test_internal_ci_bridge_tests_do_not_depend_on_host_jq(tmp_path: Path) -> No
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_internal_ci_trigger_label_is_always_consumed() -> None:
+def test_internal_ci_trigger_label_is_consumed_only_after_authorization() -> None:
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
             encoding="utf-8"
@@ -491,7 +513,7 @@ def test_internal_ci_trigger_label_is_always_consumed() -> None:
     )
 
     assert step["if"] == (
-        "${{ always() && github.event_name == 'pull_request_target' }}"
+        "${{ success() && github.event_name == 'pull_request_target' }}"
     )
     assert step["env"]["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -312,9 +312,12 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "head_ref" not in authorize
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert "Community CPU / Required" in authorize
-    assert "/actions/workflows/community-cpu.yml/runs?event=pull_request" in authorize
-    assert '.head_sha == \\"$head_sha\\"' in authorize
-    assert '.conclusion == \\"success\\"' in authorize
+    assert (
+        "/actions/workflows/community-cpu.yml/runs?event=pull_request&head_sha=$head_sha"
+        in authorize
+    )
+    assert '.head_sha == \\"$head_sha\\"' not in authorize
+    assert '.conclusion == "success"' in authorize
     assert "display_title" not in authorize
     assert 'if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then' in authorize
     assert 'echo "head_sha=$head_sha"' in authorize
@@ -656,6 +659,7 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     assert 'find_spec("tensorrt") is None' in common
     assert "NvInferVersion.h" in common
     assert "NvOnnxParser.h" in common
+    assert "ENV PYTHONPATH=/opt/trtmc-profile-source" not in dockerfile
 
     overlay = dockerfile.split("FROM ci-common AS ci-runtime", maxsplit=1)[1]
     for package in (

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -120,6 +120,7 @@ def _run_internal_ci_snapshot(
     event_name: str = "pull_request_target",
     actor_role: str = "maintain",
     community_conclusion: str = "success",
+    community_head_sha: str | None = None,
     community_merge_sha: str | None = None,
     system_path: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
@@ -132,6 +133,7 @@ def _run_internal_ci_snapshot(
 import json
 import os
 import sys
+from urllib.parse import parse_qs, urlsplit
 
 arguments = sys.argv[1:]
 endpoint = next(
@@ -145,8 +147,10 @@ elif "/pulls/" in endpoint:
 elif "/actions/workflows/community-cpu.yml/runs" in endpoint:
     query = arguments[arguments.index("--jq") + 1]
     old_merge = os.environ["FAKE_COMMUNITY_MERGE_SHA"]
+    requested_head = parse_qs(urlsplit(endpoint).query).get("head_sha", [""])[0]
     if (
         os.environ["FAKE_COMMUNITY_CONCLUSION"] == "success"
+        and requested_head == os.environ["FAKE_COMMUNITY_HEAD_SHA"]
         and (not old_merge or "display_title" not in query or old_merge in query)
     ):
         print("12345")
@@ -177,6 +181,7 @@ else:
             "EVENT_NAME": event_name,
             "FAKE_ACTOR_ROLE": actor_role,
             "FAKE_COMMUNITY_CONCLUSION": community_conclusion,
+            "FAKE_COMMUNITY_HEAD_SHA": community_head_sha or pr_head_sha,
             "FAKE_COMMUNITY_MERGE_SHA": community_merge_sha or "",
             "FAKE_PULL_JSON": json.dumps(pull),
             "GH_TOKEN": "test-token",
@@ -436,6 +441,22 @@ def test_internal_ci_bridge_requires_current_community_cpu_success(
         event_head_sha=head_sha,
         pr_head_sha=head_sha,
         community_conclusion="failure",
+    )
+
+    assert result.returncode != 0
+    assert "Community CPU / Required must pass" in result.stdout + result.stderr
+
+
+def test_internal_ci_bridge_rejects_community_cpu_from_another_head(
+    tmp_path: Path,
+) -> None:
+    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
+
+    result = _run_internal_ci_snapshot(
+        tmp_path,
+        event_head_sha=head_sha,
+        pr_head_sha=head_sha,
+        community_head_sha="f7b48712c82318ded4e41c0dd7003379e1790198",
     )
 
     assert result.returncode != 0

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -72,71 +72,22 @@ that pull request.
 ### 1. Pin and authorize the PR
 
 An actor with `maintain` or `admin` permission adds the one-shot
-`run-internal-ci` label. The Source bridge removes the label even when
-authorization fails, verifies that the open pull request targets `main`, and
-compares three independent views of the requested revision:
+`run-internal-ci` label. The Source bridge verifies that the open pull request
+targets `main` and compares the label event's head SHA with the pull request
+API's current head SHA. It consumes the label only after authorization succeeds,
+so a rejected or stale request does not silently erase the retry signal.
 
-- the head SHA captured by the label event;
-- the pull request API's current head SHA;
-- the source repository's actual branch head SHA.
+The bridge also requires a successful Community CPU run for that exact head.
+It intentionally does not bind readiness to the synthetic merge SHA: when
+`main` advances without a PR push, GitHub changes the merge SHA but does not
+start a new `pull_request` run. The protected workflow still fetches and tests
+the current exact merge independently.
 
-The bridge rereads the PR and branch for up to one minute before classifying a
-mismatch. Accessible forks receive the same check. A missing, deleted, or
-otherwise inaccessible source repository or branch fails closed.
-
-If all three agree, the bridge dispatches only the PR number and exact head SHA.
-If the PR changed after the label was added, it reports a superseded trigger
-instead of dispatching the older revision. If the PR API remains behind a
-stable source branch, it reports a stale PR tracking ref. Guard failures publish
-a failing `trtmc/premerge/required` status on the PR metadata head when
-possible and update one public PR diagnostic comment. The comment contains
-only public SHAs, recovery guidance, and the Source bridge run; it never links
-to or names private CI resources.
-
-Internal CI checks out that exact head. It does not create a synthetic merge or
-overlay newer `main` commits. A merge base may select impacted tests, but it
-does not change the tested tree. If the PR head changes, trigger the new head
-once.
-
-#### Recover a stale pull-request tracking ref
-
-First verify the mismatch independently. Repeat the check for about one minute
-to distinguish normal post-push propagation from a stuck ref:
-
-```bash
-REPOSITORY=NVIDIA/TensorRT-Model-Connect
-PR_NUMBER=<number>
-pull=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
-BASE_REF=$(jq -er '.base.ref' <<<"$pull")
-PR_HEAD_SHA=$(jq -er '.head.sha' <<<"$pull")
-HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<<"$pull")
-HEAD_REF=$(jq -r '.head.ref // empty' <<<"$pull")
-test -n "$HEAD_REPOSITORY"
-test -n "$HEAD_REF"
-HEAD_REF_URI=$(jq -rn --arg value "$HEAD_REF" '$value | @uri')
-BRANCH_HEAD_SHA=$(gh api \
-  "repos/$HEAD_REPOSITORY/branches/$HEAD_REF_URI" \
-  --jq .commit.sha)
-printf 'PR metadata: %s\nSource branch: %s\n' \
-  "$PR_HEAD_SHA" "$BRANCH_HEAD_SHA"
-```
-
-If `BRANCH_HEAD_SHA` is still changing, wait; the author is pushing. If it is
-stable and `PR_HEAD_SHA` remains behind, refresh GitHub's PR index by setting
-the existing base to the same value:
-
-```bash
-gh api --method PATCH \
-  "repos/$REPOSITORY/pulls/$PR_NUMBER" \
-  -f base="$BASE_REF"
-```
-
-This is an explicit operator recovery, not an automatic trusted-workflow
-mutation. Wait for the PR API and source branch SHA to match, confirm the PR is
-still open and targets `main`, and wait for automatic Community CPU validation
-on the current merge revision. Then add `run-internal-ci` again. Never dispatch
-protected CI while the two heads differ or the current public required check is
-absent.
+If the two head views agree, the bridge dispatches only the PR number and exact
+head SHA. If the PR changed after the label was added, it reports a superseded
+trigger instead of dispatching the older revision. Internal CI then resolves
+and tests the current exact PR merge. If the PR head changes, wait for Community
+CPU and trigger the new head once.
 
 ### 2. Select the work
 

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -372,17 +372,26 @@ the producing class remains the source of truth for optional evidence fields.
 
 - **Functionality / units:** `DockerImageManager` fingerprints image inputs,
   serializes concurrent builds with `WorkflowImageLock`, verifies dependency
-  versions, and reuses only a matching local image.
-- **Inputs:** Repository files such as the Dockerfile, `.dockerignore`, Python
-  profile registry and requirements, plus `DockerImageConfig` values resolved
-  from the environment.
+  versions, exposes Runtime Contract v2, and reuses only a matching local image.
+- **Inputs:** The common fingerprint includes the Dockerfile, `.dockerignore`,
+  profile builder and registry implementations, the normalized declarations of
+  every prebuilt Python profile, and their referenced lock and verification
+  files. The overlay fingerprint adds the exact TensorRT Python and APT
+  versions. Family metadata remains family-owned; comments, ownership fields,
+  lazy profiles, the general family loader, and package `__init__.py` metadata
+  are deliberately excluded because they do not change the baked environment.
 - **Outputs:** Returns an immutable Docker ID shaped as
   `sha256:<64 lowercase hex characters>`. It exports a fingerprinted
   `TRTMC_CI_IMAGE` tag through `GITHUB_ENV`, may write
   `image_ref=sha256:...` through `GITHUB_OUTPUT`, and maintains a local
-  verification stamp.
+  verification stamp. `python3 -m tools.ci image contract` prints the complete
+  canonical contract JSON, including the full common and overlay fingerprints
+  and `environment_contract_version=2`; callers may select an exact overlay
+  with `--tensorrt-version` and `--tensorrt-apt-version`.
 - **Boundary:** It proves image identity and contents. It neither starts a
-  container nor chooses a CI stage.
+  container nor chooses a CI stage. Local image verification is serialized by
+  a six-hour default lock budget, overridable with
+  `TRTMC_CI_IMAGE_LOCK_TIMEOUT`.
 
 ### `container.py`
 

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -95,7 +95,7 @@ CPU and trigger the new head once.
 ### 2. Select the work
 
 The Internal Ownership and Impact job runs `tools/model_ci.py impact` against
-the merge base and exact tested head. It emits:
+the tested merge revision's first parent and the exact tested merge. It emits:
 
 - directly affected models;
 - representative fallback models for shared-platform changes;

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -45,6 +45,7 @@ All public commands use one entry point:
 python3 -m tools.ci --help
 python3 -m tools.ci pipeline source-quality
 python3 -m tools.ci image ensure
+python3 -m tools.ci image contract
 python3 -m tools.ci container start
 python3 -m tools.ci stage premerge-unit
 python3 -m tools.ci model-proof --model patchtsmixer --suite premerge
@@ -380,6 +381,10 @@ the producing class remains the source of truth for optional evidence fields.
   versions. Family metadata remains family-owned; comments, ownership fields,
   lazy profiles, the general family loader, and package `__init__.py` metadata
   are deliberately excluded because they do not change the baked environment.
+  The profile builder loads its narrow API through a synthetic package, so
+  package initialization is also absent from the actual image-build path.
+  Contract-producer and CLI control-plane files are reviewed separately and do
+  not perturb the semantic runtime fingerprint when their output is unchanged.
 - **Outputs:** Returns an immutable Docker ID shaped as
   `sha256:<64 lowercase hex characters>`. It exports a fingerprinted
   `TRTMC_CI_IMAGE` tag through `GITHUB_ENV`, may write

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -76,6 +76,9 @@ An actor with `maintain` or `admin` permission adds the one-shot
 targets `main` and compares the label event's head SHA with the pull request
 API's current head SHA. It consumes the label only after authorization succeeds,
 so a rejected or stale request does not silently erase the retry signal.
+Because adding an existing label does not create another label event, retry a
+rejected request by removing `run-internal-ci` and adding it again after the
+reported prerequisite is satisfied.
 
 The bridge also requires a successful Community CPU run for that exact head.
 It intentionally does not bind readiness to the synthetic merge SHA: when

--- a/tools/ci/__main__.py
+++ b/tools/ci/__main__.py
@@ -25,6 +25,12 @@ class CiCommand:
         image = commands.add_parser("image", help="Manage the immutable CI Docker image")
         image_commands = image.add_subparsers(dest="image_command", required=True)
         image_commands.add_parser("ensure", help="Build or verify the CI Docker image")
+        image_contract = image_commands.add_parser(
+            "contract",
+            help="Print the canonical Source runtime contract",
+        )
+        image_contract.add_argument("--tensorrt-version")
+        image_contract.add_argument("--tensorrt-apt-version")
         container = commands.add_parser("container", help="Manage the run-owned CI container")
         container_commands = container.add_subparsers(dest="container_command", required=True)
         container_commands.add_parser("start", help="Start a clean CI container")
@@ -66,6 +72,23 @@ class CiCommand:
             from .docker_image import DockerImageManager
 
             DockerImageManager(Path.cwd(), dict(os.environ)).ensure()
+            return 0
+        if (arguments.command, getattr(arguments, "image_command", None)) == (
+            "image",
+            "contract",
+        ):
+            if remaining:
+                self.parser.error(
+                    f"unrecognized image contract arguments: {' '.join(remaining)}"
+                )
+            from .docker_image import DockerImageManager
+
+            print(
+                DockerImageManager(Path.cwd(), dict(os.environ)).source_contract_json(
+                    tensorrt_version=arguments.tensorrt_version,
+                    tensorrt_apt_version=arguments.tensorrt_apt_version,
+                )
+            )
             return 0
         if arguments.command == "container" and arguments.container_command == "start":
             from .container import CiContainer

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -284,11 +284,6 @@ class DockerImageManager:
             self.config.dockerfile,
             Path(".dockerignore"),
             Path(".github/scripts/build-python-profiles.py"),
-            Path("tools/__init__.py"),
-            Path("tools/ci/__init__.py"),
-            Path("tools/ci/__main__.py"),
-            Path("tools/ci/docker_image.py"),
-            Path("tools/ci/process.py"),
             package_root / "python_profiles.py",
             *assets,
         }

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -23,7 +23,7 @@ from .process import CiError, CommandRunner, GitHubFiles
 
 
 FINGERPRINT_LABEL = "org.nvidia.trtmc.ci-input-fingerprint"
-ENVIRONMENT_CONTRACT_VERSION = 1
+ENVIRONMENT_CONTRACT_VERSION = 2
 IMMUTABLE_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
 EXACT_TENSORRT_VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
 EXACT_APT_VERSION = re.compile(r"[0-9][0-9A-Za-z.+:~_-]*")
@@ -262,11 +262,12 @@ class DockerImageManager:
         profiles = registry["profiles"]
         expected_profiles = ",".join(profile_names)
         if not expected_profiles:
-            raise CiError("No family-owned Python execution profiles were declared")
+            raise CiError("No prebuilt Python execution profiles were declared")
 
         package_root = Path("python/tensorrt_model_connect")
         assets: set[Path] = set()
-        for spec in profiles.values():
+        prebuilt_profiles = {name: profiles[name] for name in profile_names}
+        for spec in prebuilt_profiles.values():
             if not isinstance(spec, dict):
                 continue
             for field in ("requirements", "verification_script_file"):
@@ -280,7 +281,6 @@ class DockerImageManager:
             Path(".github/scripts/build-python-profiles.py"),
             package_root / "__init__.py",
             package_root / "python_profiles.py",
-            package_root / "families/__init__.py",
             *assets,
         }
         dockerfile_text = (self.config.repository / self.config.dockerfile).read_text(
@@ -303,7 +303,7 @@ class DockerImageManager:
         common_semantic_contract = {
             "environment_contract_version": ENVIRONMENT_CONTRACT_VERSION,
             "version": registry.get("version"),
-            "profiles": profiles,
+            "profiles": prebuilt_profiles,
         }
         common_semantic_payload = json.dumps(
             common_semantic_contract,

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
-import importlib
+import importlib.util
 import json
 import os
 import re
 import sys
 import time
+import types
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,6 +43,7 @@ TENSORRT_APT_PACKAGES = (
     "libnvonnxparsers-dev",
     "libnvonnxparsers11",
 )
+DEFAULT_IMAGE_LOCK_TIMEOUT_SECONDS = 6 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -57,7 +59,10 @@ class DockerImageConfig:
 
     @classmethod
     def from_environment(cls, repository: Path, env: dict[str, str]) -> "DockerImageConfig":
-        timeout_text = env.get("TRTMC_CI_IMAGE_LOCK_TIMEOUT", "5400")
+        timeout_text = env.get(
+            "TRTMC_CI_IMAGE_LOCK_TIMEOUT",
+            str(DEFAULT_IMAGE_LOCK_TIMEOUT_SECONDS),
+        )
         if not timeout_text.isdigit() or int(timeout_text) < 1:
             raise CiError("TRTMC_CI_IMAGE_LOCK_TIMEOUT must be a positive integer")
         return cls(
@@ -273,13 +278,17 @@ class DockerImageManager:
             for field in ("requirements", "verification_script_file"):
                 value = str(spec.get(field, "") or "").strip()
                 if value:
-                    assets.add(package_root / value)
+                    assets.add(self._profile_asset_input(package_root, value, field))
 
         inputs = {
             self.config.dockerfile,
             Path(".dockerignore"),
             Path(".github/scripts/build-python-profiles.py"),
-            package_root / "__init__.py",
+            Path("tools/__init__.py"),
+            Path("tools/ci/__init__.py"),
+            Path("tools/ci/__main__.py"),
+            Path("tools/ci/docker_image.py"),
+            Path("tools/ci/process.py"),
             package_root / "python_profiles.py",
             *assets,
         }
@@ -339,9 +348,33 @@ class DockerImageManager:
             expected_profiles,
         )
 
+    def _profile_asset_input(
+        self,
+        package_root: Path,
+        path_spec: str,
+        field: str,
+    ) -> Path:
+        relative = Path(path_spec)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise CiError(f"Python profile has an unsafe {field} path: {path_spec!r}")
+        absolute_root = (self.config.repository / package_root).resolve()
+        resolved = (absolute_root / relative).resolve()
+        try:
+            resolved.relative_to(absolute_root)
+        except ValueError as error:
+            raise CiError(
+                f"Python profile has an unsafe {field} path: {path_spec!r}"
+            ) from error
+        if not resolved.is_file():
+            raise CiError(
+                f"Python profile references a missing {field} asset: {path_spec!r}"
+            )
+        return package_root / relative
+
     def _load_profile_registry(self) -> tuple[dict[str, object], tuple[str, ...]]:
-        package_path = str(self.config.repository / "python")
         package_name = "tensorrt_model_connect"
+        package_root = self.config.repository / "python" / package_name
+        module_name = f"{package_name}.python_profiles"
         previous_modules = {
             name: module
             for name, module in sys.modules.items()
@@ -349,13 +382,23 @@ class DockerImageManager:
         }
         for name in previous_modules:
             sys.modules.pop(name, None)
-        sys.path.insert(0, package_path)
+        package = types.ModuleType(package_name)
+        package.__package__ = package_name
+        package.__path__ = [str(package_root)]
+        sys.modules[package_name] = package
         try:
-            module = importlib.import_module("tensorrt_model_connect.python_profiles")
+            spec = importlib.util.spec_from_file_location(
+                module_name,
+                package_root / "python_profiles.py",
+            )
+            if spec is None or spec.loader is None:
+                raise CiError("Could not load the Source Python profile registry")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
             registry = module.load_python_profile_registry()
             return registry, module.prebuilt_python_profile_names(registry)
         finally:
-            sys.path.remove(package_path)
             for name in tuple(sys.modules):
                 if name == package_name or name.startswith(f"{package_name}."):
                     sys.modules.pop(name, None)

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -165,10 +165,11 @@ pass and the pull request is ready, add this comment:
 
 After public CPU validation passes, the maintainer verifies the PR's
 `headRefOid` and applies `run-internal-ci`. The trusted bridge consumes that
-label, verifies the current exact-merge public CPU result, captures the
-immutable PR head SHA, and dispatches private premerge validation for that exact
-revision. The public result is contributor feedback, not an authorization
-token; `run-internal-ci` remains the protected-resource security boundary.
+label after authorization succeeds, verifies a successful public CPU run for
+the current head, captures the immutable PR head SHA, and dispatches private
+premerge validation for that exact revision. The public result is contributor
+feedback, not an authorization token; `run-internal-ci` remains the
+protected-resource security boundary.
 
 Wait for the `trtmc/premerge/required` status on the same head SHA to complete
 successfully. If the head changes intentionally, finish the update and local


### PR DESCRIPTION
## Background

Runtime image fingerprints currently include general loader behavior even when a change cannot affect the baked CI environment. That over-invalidates compatible pull requests, while real environment changes still need an exact and reviewable runtime contract. The protected-CI bridge also tied public readiness to a synthetic merge SHA that GitHub can replace without starting another public run.

## Exit Criteria

- Runtime fingerprints change for every family-owned prebuilt profile declaration, lock, verification script, Docker recipe, or builder implementation change.
- Unrelated family-loader changes, package metadata, registry or manifest comments, ownership metadata, lazy profiles, and CI control-plane refactors do not change the runtime fingerprint.
- Model-specific declarations remain family-owned while CI consumes one validated canonical projection through a stable command interface.
- A green Community CPU result for the exact PR head remains usable when `main` advances, while any new PR head requires fresh authorization.

## Implementation

- Read family-owned profile declarations directly from `MODEL.toml` without importing package or family loader code.
- Reject ambiguous registry fields, undeclared family defaults, unsafe or escaping asset paths, duplicate profiles, and non-deterministic requirement pins.
- Fingerprint normalized prebuilt semantics, referenced assets, and the exact image-builder inputs; add the exact TensorRT overlay as a second fingerprint layer.
- Load the profile builder through a synthetic package so application `__init__.py` code is absent from both the build path and fingerprint.
- Expose Runtime Contract v2 through `python3 -m tools.ci image contract` and extend the default image-lock budget for cold profile builds.
- Authorize protected CI from the exact PR head plus its successful Community CPU run, without depending on a regenerated merge title; retain failed authorization labels for recovery.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_ensure_ci_docker_image.py tests/tools/test_e2e_python_profiles.py tests/tools/test_family_specialization.py tests/tools/test_specialize_family.py tests/tools/test_test_impact.py tests/tools/test_model_plugin_encapsulation_static.py tests/tools/test_github_actions_ci.py tests/tools/test_check_doc_file_references.py`: 600 passed.
- `ruff check .github/scripts/build-python-profiles.py tools/ci/docker_image.py python/tensorrt_model_connect/families/__init__.py tests/tools/test_ensure_ci_docker_image.py`: passed.
- Parsed all public workflow YAML and ran `git diff --check`: passed.

## Notes For Future Readers

- Review `python_profiles.py` first for the data-only family projection, `docker_image.py` for semantic fingerprinting, `build-python-profiles.py` for the synthetic package boundary, and `internal-ci-bridge.yml` for the head-bound trigger.
- Runtime Contract producer code remains security-sensitive even though it is not a baked image input; the coordinated catalog workflow reviews producer changes separately.
- The coordinated Runtime Catalog foundation and qualified v2 entries must land before this pull request is eligible for required premerge and merge. Keep this pull request draft until those entries are ready.
