### PR TITLE
ci(community): run public CPU checks on pull requests

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -75,7 +75,7 @@ jobs:
 
   unit:
     name: Community CPU / Unit / C++ and Python
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs: ownership-impact
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -124,7 +124,7 @@ jobs:
 
   required:
     name: Community CPU / Required
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs:
       - source-quality
       - ownership-impact

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     env:
-      CI_BASE_REF: ${{ github.event.pull_request.base.sha }}
+      CI_BASE_REF: ${{ github.sha }}^1
     steps:
       - name: Check out the exact PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     env:
-      CI_BASE_REF: ${{ github.event.pull_request.base.sha }}
+      CI_BASE_REF: ${{ github.sha }}^1
     outputs:
       run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
       unit_scope: ${{ steps.impact.outputs.unit_scope }}

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -9,7 +9,7 @@ run-name: >-
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -4,234 +4,33 @@
 name: Community CPU
 
 run-name: >-
-  PR #${{ github.event.issue.number }} · public CPU validation
+  PR #${{ github.event.pull_request.number }} · public CPU · merge ${{ github.event.pull_request.merge_commit_sha }}
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 
 concurrency:
-  group: community-cpu-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  group: community-cpu-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  authorize:
-    name: Authorize public CPU request
-    if: >-
-      github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
-      github.ref == 'refs/heads/main' &&
-      github.event.issue.pull_request != null &&
-      github.event.comment.body == '/run-ci'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      checks: read
-      contents: read
-      pull-requests: read
-    outputs:
-      run_tests: ${{ steps.snapshot.outputs.run_tests }}
-      pr_number: ${{ steps.snapshot.outputs.pr_number }}
-      base_sha: ${{ steps.snapshot.outputs.base_sha }}
-      head_sha: ${{ steps.snapshot.outputs.head_sha }}
-      merge_sha: ${{ steps.snapshot.outputs.merge_sha }}
-
-    steps:
-      # This trusted job reads PR metadata only. It never checks out or
-      # executes pull-request code.
-      - name: Authorize the current PR merge
-        id: snapshot
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ACTOR: ${{ github.actor }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euo pipefail
-          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
-
-          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
-          state="$(jq -er '.state' <<<"$pull")"
-          pr_author="$(jq -er '.user.login' <<<"$pull")"
-          base_repo="$(jq -er '.base.repo.full_name' <<<"$pull")"
-          base_ref="$(jq -er '.base.ref' <<<"$pull")"
-          base_sha="$(jq -er '.base.sha' <<<"$pull")"
-          head_sha="$(jq -er '.head.sha' <<<"$pull")"
-          merge_sha="$(jq -er '.merge_commit_sha' <<<"$pull")"
-
-          test "$state" = "open"
-          test "$base_repo" = "$GITHUB_REPOSITORY"
-          test "$base_ref" = "main"
-          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
-
-          if [ "$ACTOR" != "$pr_author" ]; then
-            actor_role="$(
-              gh api --method GET \
-                "/repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" \
-                --jq '.role_name' 2>/dev/null || true
-            )"
-            case "$actor_role" in
-              maintain|admin) ;;
-              *)
-                echo "::error::Only the PR author or a maintainer/admin may request public CPU CI."
-                exit 1
-                ;;
-            esac
-          fi
-
-          existing_required="$(
-            gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
-              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))) | sort_by(.started_at) | last // {} | if (.status // "") != "completed" then (.status // "") else (.conclusion // "") end'
-          )"
-          case "$existing_required" in
-            queued|in_progress|success)
-              echo "run_tests=false" >> "$GITHUB_OUTPUT"
-              echo "Community CPU is already $existing_required for merge $merge_sha."
-              exit 0
-              ;;
-          esac
-
-          {
-            echo "run_tests=true"
-            echo "pr_number=$PR_NUMBER"
-            echo "base_sha=$base_sha"
-            echo "head_sha=$head_sha"
-            echo "merge_sha=$merge_sha"
-          } >> "$GITHUB_OUTPUT"
-
-  initialize:
-    name: Initialize exact-merge public checks
-    needs: authorize
-    if: ${{ needs.authorize.outputs.run_tests == 'true' }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-    outputs:
-      comment_id: ${{ steps.comment.outputs.comment_id }}
-      source_quality_check_id: ${{ steps.checks.outputs.source_quality_check_id }}
-      ownership_impact_check_id: ${{ steps.checks.outputs.ownership_impact_check_id }}
-      unit_check_id: ${{ steps.checks.outputs.unit_check_id }}
-      required_check_id: ${{ steps.checks.outputs.required_check_id }}
-    steps:
-      - name: Publish public run link
-        id: comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
-          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          marker="<!-- trtmc-community-cpu -->"
-          comments="$(
-            gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100"
-          )"
-          comment_id="$(
-            jq -r --arg marker "$marker" \
-              '[.[] | select(.user.login == "github-actions[bot]" and ((.body // "") | contains($marker)))] | last | .id // empty' \
-              <<<"$comments"
-          )"
-          body="$(
-            printf '%s\n' \
-              "$marker" \
-              "## Community CPU" \
-              "" \
-              "**Status:** RUNNING" \
-              "- Exact merge: <code>$MERGE_SHA</code>" \
-              "" \
-              "[View live public logs]($details_url)"
-          )"
-
-          if [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]; then
-            comment_id="$(
-              gh api --method PATCH \
-                "/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
-                -f body="$body" \
-                --jq '.id'
-            )"
-          else
-            comment_id="$(
-              gh api --method POST \
-                "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-                -f body="$body" \
-                --jq '.id'
-            )"
-          fi
-          [[ "$comment_id" =~ ^[1-9][0-9]*$ ]]
-          echo "comment_id=$comment_id" >> "$GITHUB_OUTPUT"
-
-      - name: Publish pending exact-merge checks
-        id: checks
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          payload="$RUNNER_TEMP/community-cpu-check.json"
-
-          create_check() {
-            local key="$1"
-            local name="$2"
-            local external_id
-            local check_id
-            external_id="community-cpu:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${key}"
-            jq -n \
-              --arg name "$name" \
-              --arg head_sha "$MERGE_SHA" \
-              --arg details_url "$details_url" \
-              --arg external_id "$external_id" \
-              '{
-                name: $name,
-                head_sha: $head_sha,
-                status: "in_progress",
-                details_url: $details_url,
-                external_id: $external_id,
-                output: {
-                  title: "Contributor-requested public CPU validation",
-                  summary: "Public CPU validation is running for this exact PR merge revision."
-                }
-              }' > "$payload"
-            check_id="$(
-              gh api --method POST \
-                "/repos/$GITHUB_REPOSITORY/check-runs" \
-                --input "$payload" \
-                --jq '.id'
-            )"
-            [[ "$check_id" =~ ^[1-9][0-9]*$ ]]
-            echo "${key}_check_id=$check_id" >> "$GITHUB_OUTPUT"
-          }
-
-          trap 'rm -f "$payload"' EXIT
-          create_check source_quality "Community CPU / Source quality"
-          create_check ownership_impact "Community CPU / Ownership and impact"
-          create_check unit "Community CPU / Unit / C++ and Python"
-          create_check required "Community CPU / Required"
-
   source-quality:
     name: Community CPU / Source quality
-    needs:
-      - authorize
-      - initialize
-    if: ${{ needs.authorize.outputs.run_tests == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
     env:
-      CI_BASE_REF: ${{ needs.authorize.outputs.base_sha }}
+      CI_BASE_REF: ${{ github.event.pull_request.base.sha }}
     steps:
-      - name: Check out the authorized PR merge
+      - name: Check out the exact PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ needs.authorize.outputs.merge_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -248,24 +47,20 @@ jobs:
 
   ownership-impact:
     name: Community CPU / Ownership and impact
-    needs:
-      - authorize
-      - initialize
-    if: ${{ needs.authorize.outputs.run_tests == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
     env:
-      CI_BASE_REF: ${{ needs.authorize.outputs.base_sha }}
+      CI_BASE_REF: ${{ github.event.pull_request.base.sha }}
     outputs:
       run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
       unit_scope: ${{ steps.impact.outputs.unit_scope }}
     steps:
-      - name: Check out the authorized PR merge
+      - name: Check out the exact PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ needs.authorize.outputs.merge_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -280,24 +75,15 @@ jobs:
 
   unit:
     name: Community CPU / Unit / C++ and Python
-    if: ${{ always() && needs.authorize.outputs.run_tests == 'true' }}
-    needs:
-      - authorize
-      - initialize
-      - ownership-impact
+    if: ${{ always() }}
+    needs: ownership-impact
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read
     steps:
-      - name: Require successful request initialization
-        if: ${{ needs.initialize.result != 'success' }}
-        run: |
-          echo "::error::The exact PR snapshot could not be initialized."
-          exit 1
-
       - name: Require successful impact analysis
-        if: ${{ needs.initialize.result == 'success' && needs.ownership-impact.result != 'success' }}
+        if: ${{ needs.ownership-impact.result != 'success' }}
         env:
           IMPACT_RESULT: ${{ needs.ownership-impact.result }}
         run: |
@@ -306,25 +92,22 @@ jobs:
 
       - name: Explain an empty unit scope
         if: >-
-          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests != 'true'
         run: echo "No source-only C++ or Python unit tests are required for this change."
 
-      - name: Check out the authorized PR merge
+      - name: Check out the exact PR merge
         if: >-
-          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: ${{ needs.authorize.outputs.merge_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
         if: >-
-          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
@@ -333,7 +116,6 @@ jobs:
 
       - name: Run hardened source-only units
         if: >-
-          needs.initialize.result == 'success' &&
           needs.ownership-impact.result == 'success' &&
           needs.ownership-impact.outputs.run_unit_tests == 'true'
         env:
@@ -342,152 +124,26 @@ jobs:
 
   required:
     name: Community CPU / Required
-    if: >-
-      always() &&
-      needs.authorize.outputs.run_tests == 'true' &&
-      needs.initialize.result == 'success'
+    if: ${{ always() }}
     needs:
-      - authorize
-      - initialize
       - source-quality
       - ownership-impact
       - unit
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
+    permissions: {}
     steps:
-      - name: Publish exact-merge CPU checks
+      - name: Require every public CPU stage
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
-          BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
-          COMMENT_ID: ${{ needs.initialize.outputs.comment_id }}
-          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-          MERGE_SHA: ${{ needs.authorize.outputs.merge_sha }}
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
           OWNERSHIP_IMPACT_RESULT: ${{ needs.ownership-impact.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
-          SOURCE_QUALITY_CHECK_ID: ${{ needs.initialize.outputs.source_quality_check_id }}
-          OWNERSHIP_IMPACT_CHECK_ID: ${{ needs.initialize.outputs.ownership_impact_check_id }}
-          UNIT_CHECK_ID: ${{ needs.initialize.outputs.unit_check_id }}
-          REQUIRED_CHECK_ID: ${{ needs.initialize.outputs.required_check_id }}
         run: |
           set -euo pipefail
-          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          payload="$RUNNER_TEMP/community-cpu-check-result.json"
-          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-          result_conclusion() {
-            case "$1" in
-              success) echo success ;;
-              failure) echo failure ;;
-              cancelled) echo cancelled ;;
-              skipped) echo skipped ;;
-              *) echo neutral ;;
-            esac
-          }
-
-          update_check() {
-            local check_id="$1"
-            local conclusion="$2"
-            local title="$3"
-            local summary="$4"
-            [[ "$check_id" =~ ^[1-9][0-9]*$ ]]
-            jq -n \
-              --arg conclusion "$conclusion" \
-              --arg completed_at "$completed_at" \
-              --arg details_url "$details_url" \
-              --arg title "$title" \
-              --arg summary "$summary" \
-              '{
-                status: "completed",
-                conclusion: $conclusion,
-                completed_at: $completed_at,
-                details_url: $details_url,
-                output: {title: $title, summary: $summary}
-              }' > "$payload"
-            gh api --silent --method PATCH \
-              "/repos/$GITHUB_REPOSITORY/check-runs/$check_id" \
-              --input "$payload"
-          }
-
-          publish_comment() {
-            local status="$1"
-            local message="$2"
-            local body
-            [[ "$COMMENT_ID" =~ ^[1-9][0-9]*$ ]]
-            body="$(
-              printf '%s\n' \
-                "<!-- trtmc-community-cpu -->" \
-                "## Community CPU" \
-                "" \
-                "**Status:** $status" \
-                "- Exact merge: <code>$MERGE_SHA</code>" \
-                "- Source quality: <code>$SOURCE_QUALITY_RESULT</code>" \
-                "- Ownership and impact: <code>$OWNERSHIP_IMPACT_RESULT</code>" \
-                "- Unit / C++ and Python: <code>$UNIT_RESULT</code>" \
-                "" \
-                "$message" \
-                "" \
-                "[View public logs]($details_url)"
-            )"
-            gh api --silent --method PATCH \
-              "/repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" \
-              -f body="$body"
-          }
-
-          trap 'rm -f "$payload"' EXIT
-          snapshot_current=false
-          if pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"; then
-            state="$(jq -r '.state // empty' <<<"$pull")"
-            base_sha="$(jq -r '.base.sha // empty' <<<"$pull")"
-            head_sha="$(jq -r '.head.sha // empty' <<<"$pull")"
-            merge_sha="$(jq -r '.merge_commit_sha // empty' <<<"$pull")"
-            if [ "$state" = "open" ] \
-              && [ "$base_sha" = "$BASE_SHA" ] \
-              && [ "$head_sha" = "$HEAD_SHA" ] \
-              && [ "$merge_sha" = "$MERGE_SHA" ]; then
-              snapshot_current=true
-            fi
-          fi
-
-          if [ "$snapshot_current" != true ]; then
-            summary="The PR changed after public CPU validation was requested. Comment /run-ci again."
-            update_check "$SOURCE_QUALITY_CHECK_ID" neutral "Stale PR snapshot" "$summary"
-            update_check "$OWNERSHIP_IMPACT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
-            update_check "$UNIT_CHECK_ID" neutral "Stale PR snapshot" "$summary"
-            update_check "$REQUIRED_CHECK_ID" neutral "Stale PR snapshot" "$summary"
-            publish_comment "STALE" "$summary"
-            echo "::warning::$summary"
-            exit 0
-          fi
-
-          source_conclusion="$(result_conclusion "$SOURCE_QUALITY_RESULT")"
-          impact_conclusion="$(result_conclusion "$OWNERSHIP_IMPACT_RESULT")"
-          unit_conclusion="$(result_conclusion "$UNIT_RESULT")"
-          summary="Source quality: $SOURCE_QUALITY_RESULT; Ownership and impact: $OWNERSHIP_IMPACT_RESULT; Unit: $UNIT_RESULT."
-
-          update_check "$SOURCE_QUALITY_CHECK_ID" "$source_conclusion" \
-            "Source quality: $SOURCE_QUALITY_RESULT" "$summary"
-          update_check "$OWNERSHIP_IMPACT_CHECK_ID" "$impact_conclusion" \
-            "Ownership and impact: $OWNERSHIP_IMPACT_RESULT" "$summary"
-          update_check "$UNIT_CHECK_ID" "$unit_conclusion" \
-            "Unit: $UNIT_RESULT" "$summary"
-
-          required_conclusion=failure
-          if [ "$SOURCE_QUALITY_RESULT" = success ] \
-            && [ "$OWNERSHIP_IMPACT_RESULT" = success ] \
-            && [ "$UNIT_RESULT" = success ]; then
-            required_conclusion=success
-          fi
-          if [ "$required_conclusion" = success ]; then
-            publish_comment "PASSED" "All required public CPU stages passed."
-          else
-            publish_comment "FAILED" "One or more stages failed. Open the public logs for the exact error output."
-          fi
-          update_check "$REQUIRED_CHECK_ID" "$required_conclusion" \
-            "Community CPU: $required_conclusion" "$summary"
-          test "$required_conclusion" = success
+          printf '%s\n' \
+            "Source quality: $SOURCE_QUALITY_RESULT" \
+            "Ownership and impact: $OWNERSHIP_IMPACT_RESULT" \
+            "Unit / C++ and Python: $UNIT_RESULT"
+          test "$SOURCE_QUALITY_RESULT" = success
+          test "$OWNERSHIP_IMPACT_RESULT" = success
+          test "$UNIT_RESULT" = success

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -4,7 +4,7 @@
 name: Community CPU
 
 run-name: >-
-  PR #${{ github.event.pull_request.number }} · public CPU · merge ${{ github.event.pull_request.merge_commit_sha }}
+  PR #${{ github.event.pull_request.number }} · public CPU · merge ${{ github.sha }}
 
 on:
   pull_request:

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      checks: read
+      actions: read
       contents: read
       pull-requests: write
     outputs:
@@ -103,12 +103,12 @@ jobs:
           # This contributor-visible result is a readiness prerequisite. The
           # maintainer-owned label and this default-branch workflow remain the
           # authorization boundary for protected resources.
-          community_cpu="$(
+          community_cpu_run="$(
             gh api --method GET \
-              "/repos/$GITHUB_REPOSITORY/commits/$merge_sha/check-runs?filter=latest&per_page=100" \
-              --jq '.check_runs | map(select(.name == "Community CPU / Required" and .app.slug == "github-actions" and ((.external_id // "") | startswith("community-cpu:")))) | sort_by(.started_at) | last | .conclusion // empty'
+              "/repos/$GITHUB_REPOSITORY/actions/workflows/community-cpu.yml/runs?event=pull_request&per_page=100" \
+              --jq ".workflow_runs | map(select(.head_sha == \"$head_sha\" and .conclusion == \"success\" and .display_title == \"PR #$PR_NUMBER · public CPU · merge $merge_sha\")) | sort_by(.updated_at) | last | .id // empty"
           )"
-          if [ "$community_cpu" != "success" ]; then
+          if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::Community CPU / Required must pass on the current PR merge before internal CI can run."
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,8 @@ On Windows, use `py -3 -m pip` in place of `python3 -m pip`.
 The hooks trim trailing whitespace, ensure one final newline, validate YAML,
 check Ruff, and verify clang-format. Pre-commit manages the Ruff and
 clang-format environments on Linux, macOS, and Windows. There is no pre-push
-hook: builds and the broader source-only CPU suite run through the public
-`/run-ci` workflow after the branch is pushed.
+hook: builds and the broader source-only CPU suite run automatically on the
+pull request after the branch is pushed.
 
 Start with repository consistency checks:
 
@@ -147,37 +147,20 @@ what the recorded validation proves.
 
 ### 8. Run contributor-visible public CPU validation
 
-Creating a pull request or pushing to a fork does not automatically start
-Community CPU. After local checks pass, the pull-request author adds this exact
-comment:
-
-```text
-/run-ci
-```
-
-A maintainer or admin may submit the same command on the author's behalf. The
-trusted default-branch `Community CPU` workflow authorizes the actor and
-captures the current base, head, and merge SHAs without checking out
-pull-request code. Separate test jobs then run source quality, ownership and
-impact analysis, and the selected source-only C++ and Python units against that
-exact merge revision.
+Opening a pull request or pushing a new commit automatically starts Community
+CPU against GitHub's exact pull-request merge revision. Separate jobs run
+source quality, ownership and impact analysis, and the selected source-only C++
+and Python units. No comment or maintainer action is required.
 
 All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
 read-only repository permission and no access to private runners, secrets, or
-GPUs. Before testing starts, the workflow creates or updates a `Community CPU`
-status comment on the pull request with the exact merge SHA and a direct link
-to live public Actions logs. At completion, the same comment reports each stage
-verdict and links to the complete error output. This comment is the stable log
-entrypoint because the checks themselves are attached to the merge SHA rather
-than the pull-request head SHA.
+GPUs. GitHub publishes native pull-request checks and public Actions logs,
+including the complete output for every failed command.
 
-Wait for `Community CPU / Required` to pass on the current merge revision.
-Repeating `/run-ci` for an already queued, running, or successful merge is
-safely deduplicated.
-
-If the pull-request head or base changes, the previous merge result is stale.
-Finish the update, rerun local checks, and comment `/run-ci` again for the new
-merge revision.
+Wait for `Community CPU / Required` to pass on the current merge revision. A
+new commit automatically validates the new merge revision and cancels an older
+in-progress run for the same pull request. If `main` advances and GitHub asks
+for an update, rebase or update the branch so the new exact merge is validated.
 
 ### 9. Ask a maintainer to trigger protected CI
 
@@ -198,8 +181,8 @@ captures the current PR head SHA, and dispatches protected premerge validation.
 
 Wait for `trtmc/premerge/required` to pass on the exact pull-request head SHA.
 If you push another commit, the previous result no longer validates the current
-head; finish the update, rerun local checks and `/run-ci`, and mention
-`@yifeif-nv` once to request a new protected run. Private runner details,
+head; finish the update, wait for automatic Community CPU validation, and
+mention `@yifeif-nv` once to request a new protected run. Private runner details,
 logs, artifacts, and URLs are not part of the public contribution interface.
 
 ### 10. Respond to review and keep evidence current

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -138,7 +138,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert workflow["permissions"] == {}
     assert "pull_request:" in source
     assert "branches: [main]" in source
-    assert "types: [opened, synchronize, reopened, ready_for_review]" in source
+    assert "types: [opened, synchronize, reopened]" in source
     assert "issue_comment:" not in source
     assert "pull_request_target" not in source
     assert "workflow_dispatch:" not in source

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 from pathlib import Path
@@ -21,215 +20,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def _workflow_step_script(workflow_name: str, job_name: str, step_name: str) -> str:
     workflow = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(
-            encoding="utf-8"
-        )
+        (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
     )
     return next(
-        step["run"]
-        for step in workflow["jobs"][job_name]["steps"]
-        if step["name"] == step_name
+        step["run"] for step in workflow["jobs"][job_name]["steps"] if step["name"] == step_name
     )
-
-
-def _write_public_ci_fake_gh(fake_bin: Path) -> None:
-    fake_jq = fake_bin / "jq"
-    fake_jq.write_text(
-        """#!/usr/bin/env python3
-import json
-import sys
-
-arguments = sys.argv[1:]
-variables = {}
-expression = ""
-null_input = False
-raw_output = False
-exit_status = False
-index = 0
-while index < len(arguments):
-    argument = arguments[index]
-    if argument == "--arg":
-        variables[arguments[index + 1]] = arguments[index + 2]
-        index += 3
-        continue
-    if argument.startswith("-"):
-        null_input = null_input or "n" in argument[1:]
-        raw_output = raw_output or "r" in argument[1:]
-        exit_status = exit_status or "e" in argument[1:]
-    else:
-        expression = argument
-    index += 1
-
-if null_input:
-    if 'status: "in_progress"' in expression:
-        result = {
-            "name": variables["name"],
-            "head_sha": variables["head_sha"],
-            "status": "in_progress",
-            "details_url": variables["details_url"],
-            "external_id": variables["external_id"],
-            "output": {
-                "title": "Contributor-requested public CPU validation",
-                "summary": (
-                    "Public CPU validation is running for this exact PR merge revision."
-                ),
-            },
-        }
-    elif 'status: "completed"' in expression:
-        result = {
-            "status": "completed",
-            "conclusion": variables["conclusion"],
-            "completed_at": variables["completed_at"],
-            "details_url": variables["details_url"],
-            "output": {
-                "title": variables["title"],
-                "summary": variables["summary"],
-            },
-        }
-    else:
-        raise SystemExit(f"unsupported null-input jq expression: {expression}")
-else:
-    result = json.load(sys.stdin)
-    if isinstance(result, list) and "github-actions[bot]" in expression:
-        marker = variables["marker"]
-        matches = [
-            item
-            for item in result
-            if item.get("user", {}).get("login") == "github-actions[bot]"
-            and marker in (item.get("body") or "")
-        ]
-        result = matches[-1]["id"] if matches else ""
-    else:
-        optional_empty = expression.endswith(" // empty")
-        path = expression.removesuffix(" // empty").removeprefix(".").split(".")
-        for part in path:
-            if not isinstance(result, dict) or part not in result:
-                result = None
-                break
-            result = result[part]
-        if optional_empty and result is None:
-            result = ""
-
-if exit_status and result is None:
-    raise SystemExit(1)
-if raw_output:
-    if isinstance(result, bool):
-        print(str(result).lower())
-    elif result is not None:
-        print(result)
-else:
-    print(json.dumps(result))
-""",
-        encoding="utf-8",
-    )
-    fake_jq.chmod(0o755)
-
-    fake_gh = fake_bin / "gh"
-    fake_gh.write_text(
-        """#!/usr/bin/env python3
-import json
-import os
-from pathlib import Path
-import sys
-
-arguments = sys.argv[1:]
-endpoint = next(
-    (argument for argument in arguments if argument.startswith("/repos/")),
-    "",
-)
-if "/collaborators/" in endpoint:
-    print(os.environ["FAKE_ACTOR_ROLE"])
-elif "/pulls/" in endpoint:
-    print(os.environ["FAKE_PULL_JSON"])
-elif "/commits/" in endpoint and "/check-runs" in endpoint:
-    print(os.environ.get("FAKE_EXISTING_REQUIRED", ""))
-elif "/issues/" in endpoint and endpoint.endswith("comments?per_page=100"):
-    print(os.environ["FAKE_COMMENTS_JSON"])
-elif "/issues/" in endpoint and endpoint.endswith("/comments") and "POST" in arguments:
-    body_argument = arguments[arguments.index("-f") + 1]
-    Path(os.environ["FAKE_COMMENT_CAPTURE"]).write_text(
-        body_argument.removeprefix("body="),
-        encoding="utf-8",
-    )
-    print("99")
-elif endpoint.endswith("/check-runs") and "POST" in arguments:
-    input_path = arguments[arguments.index("--input") + 1]
-    payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
-    capture = Path(os.environ["FAKE_PENDING_CHECK_CAPTURE"])
-    existing = (
-        capture.read_text(encoding="utf-8").splitlines()
-        if capture.exists()
-        else []
-    )
-    with capture.open("a", encoding="utf-8") as stream:
-        stream.write(json.dumps(payload) + "\\n")
-    print(len(existing) + 1)
-elif "/check-runs/" in endpoint and "PATCH" in arguments:
-    input_path = arguments[arguments.index("--input") + 1]
-    payload = json.loads(Path(input_path).read_text(encoding="utf-8"))
-    with Path(os.environ["FAKE_CHECK_CAPTURE"]).open("a", encoding="utf-8") as stream:
-        stream.write(json.dumps(payload) + "\\n")
-elif "/issues/comments/" in endpoint and "PATCH" in arguments:
-    body_argument = arguments[arguments.index("-f") + 1]
-    Path(os.environ["FAKE_COMMENT_CAPTURE"]).write_text(
-        body_argument.removeprefix("body="),
-        encoding="utf-8",
-    )
-    if "--jq" in arguments:
-        print(endpoint.rsplit("/", maxsplit=1)[-1])
-else:
-    print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
-    raise SystemExit(2)
-""",
-        encoding="utf-8",
-    )
-    fake_gh.chmod(0o755)
-
-
-def _public_ci_environment(tmp_path: Path) -> dict[str, str]:
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    _write_public_ci_fake_gh(fake_bin)
-    base_sha = "a" * 40
-    head_sha = "b" * 40
-    merge_sha = "c" * 40
-    pull = {
-        "state": "open",
-        "base": {
-            "ref": "main",
-            "sha": base_sha,
-            "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
-        },
-        "head": {"sha": head_sha},
-        "user": {"login": "pr-author"},
-        "merge_commit_sha": merge_sha,
-    }
-    environment = os.environ.copy()
-    environment.update(
-        {
-            "ACTOR": "pr-author",
-            "BASE_SHA": base_sha,
-            "COMMENT_ID": "99",
-            "FAKE_ACTOR_ROLE": "maintain",
-            "FAKE_CHECK_CAPTURE": str(tmp_path / "checks.jsonl"),
-            "FAKE_COMMENT_CAPTURE": str(tmp_path / "comment.md"),
-            "FAKE_COMMENTS_JSON": "[]",
-            "FAKE_PENDING_CHECK_CAPTURE": str(tmp_path / "pending-checks.jsonl"),
-            "FAKE_PULL_JSON": json.dumps(pull),
-            "GH_TOKEN": "test-token",
-            "GITHUB_OUTPUT": str(tmp_path / "github-output"),
-            "GITHUB_REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
-            "GITHUB_RUN_ATTEMPT": "1",
-            "GITHUB_RUN_ID": "12345",
-            "GITHUB_SERVER_URL": "https://github.com",
-            "HEAD_SHA": head_sha,
-            "MERGE_SHA": merge_sha,
-            "PATH": f"{fake_bin}:{environment['PATH']}",
-            "PR_NUMBER": "980",
-            "RUNNER_TEMP": str(tmp_path),
-        }
-    )
-    return environment
 
 
 def test_pre_commit_config_installs_only_lightweight_commit_hooks() -> None:
@@ -238,10 +33,7 @@ def test_pre_commit_config_installs_only_lightweight_commit_hooks() -> None:
 
     repositories = {repository["repo"]: repository for repository in config["repos"]}
     assert repositories["https://github.com/astral-sh/ruff-pre-commit"]["rev"] == "v0.16.4"
-    assert (
-        repositories["https://github.com/pre-commit/mirrors-clang-format"]["rev"]
-        == "v22.1.8"
-    )
+    assert repositories["https://github.com/pre-commit/mirrors-clang-format"]["rev"] == "v22.1.8"
 
     hooks = {hook["id"]: hook for repository in config["repos"] for hook in repository["hooks"]}
     for hook_id in ("trailing-whitespace", "end-of-file-fixer", "check-yaml"):
@@ -269,7 +61,6 @@ def test_contributor_guides_match_the_live_ci_flow(path: Path) -> None:
         "pre-commit install --install-hooks",
         "git commit --signoff",
         "git push --set-upstream origin",
-        "```text\n/run-ci\n```",
         "Community CPU / Required",
         "run-internal-ci",
         "trtmc/premerge/required",
@@ -278,19 +69,20 @@ def test_contributor_guides_match_the_live_ci_flow(path: Path) -> None:
     positions = [source.index(marker) for marker in ordered_markers]
     assert positions == sorted(positions)
     for marker in (
-            "GitHub-hosted",
-            "ubuntu-24.04",
-            "read-only repository permission",
-            "no access to private",
-            "runners, secrets, or",
-            "GPUs",
-            "status comment",
-            "public Actions logs",
-            "py -3 -m pip",
+        "automatically",
+        "GitHub-hosted",
+        "ubuntu-24.04",
+        "read-only repository permission",
+        "no access to private",
+        "runners, secrets, or",
+        "GPUs",
+        "pull-request checks",
+        "public Actions logs",
+        "py -3 -m pip",
     ):
         assert marker in source
-    assert "trusted request workflow" not in source
-    assert "Community CPU Request" not in source
+    assert "/run-ci" not in source
+    assert "status comment" not in source
 
 
 def test_impact_publishes_only_the_public_cpu_scope(
@@ -329,461 +121,101 @@ def test_impact_publishes_only_the_public_cpu_scope(
     result = runner.impact(None)
 
     assert result["unit_scope"] == "cli"
-    assert github_output.read_text(encoding="utf-8") == (
-        "run_unit_tests=true\nunit_scope=cli\n"
-    )
+    assert github_output.read_text(encoding="utf-8") == ("run_unit_tests=true\nunit_scope=cli\n")
     summary = github_summary.read_text(encoding="utf-8")
     assert "Unit scope: `cli`" in summary
     assert "src/runtime/config/cli_support.cpp" in summary
 
 
-def test_public_cpu_workflow_authorizes_pr_author_comments() -> None:
-    path = REPO_ROOT / ".github" / "workflows" / "community-cpu.yml"
-    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
-    source = path.read_text(encoding="utf-8")
-    authorize_source = source.split("\n  authorize:", maxsplit=1)[1].split(
-        "\n  initialize:", maxsplit=1
-    )[0]
-
-    assert workflow["permissions"] == {}
-    assert "issue_comment:" in source
-    assert "types: [created]" in source
-    assert "github.event.issue.pull_request != null" in source
-    assert "github.event.comment.body == '/run-ci'" in source
-    assert "github.ref == 'refs/heads/main'" in source
-    assert 'if [ "$ACTOR" != "$pr_author" ]; then' in source
-    assert "maintain|admin)" in source
-    assert "Only the PR author or a maintainer/admin" in source
-    assert "actions/workflows/community-cpu.yml/dispatches" not in source
-    assert "/labels/run-ci" not in source
-    assert "pull_request_target" not in source
-    assert "actions/checkout@" not in authorize_source
-    assert "secrets." not in source
-    assert "self-hosted" not in source
-
-    authorize = workflow["jobs"]["authorize"]
-    assert authorize["runs-on"] == "ubuntu-24.04"
-    assert authorize["permissions"] == {
-        "checks": "read",
-        "contents": "read",
-        "pull-requests": "read",
-    }
-
-
-def test_public_cpu_request_captures_the_exact_commented_snapshot(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "authorize",
-                "Authorize the current PR merge",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
-        "run_tests=true\n"
-        "pr_number=980\n"
-        f"base_sha={'a' * 40}\n"
-        f"head_sha={'b' * 40}\n"
-        f"merge_sha={'c' * 40}\n"
-    )
-
-
-def test_public_cpu_request_rejects_an_unrelated_commenter(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    environment["ACTOR"] = "unrelated-user"
-    environment["FAKE_ACTOR_ROLE"] = "read"
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "authorize",
-                "Authorize the current PR merge",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert "Only the PR author or a maintainer/admin" in result.stdout + result.stderr
-    assert not (tmp_path / "github-output").exists()
-
-
-def test_public_cpu_request_allows_a_maintainer_to_help(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    environment["ACTOR"] = "trusted-maintainer"
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "authorize",
-                "Authorize the current PR merge",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert (tmp_path / "github-output").read_text(encoding="utf-8").startswith(
-        "run_tests=true\n"
-    )
-
-
-@pytest.mark.parametrize("existing", ["queued", "in_progress", "success"])
-def test_public_cpu_request_deduplicates_the_current_merge(
-    tmp_path: Path,
-    existing: str,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    environment["FAKE_EXISTING_REQUIRED"] = existing
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "authorize",
-                "Authorize the current PR merge",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert f"already {existing}" in result.stdout
-    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
-        "run_tests=false\n"
-    )
-
-
-def test_public_cpu_initialization_creates_pending_exact_merge_checks(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "initialize",
-                "Publish pending exact-merge checks",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    checks = [
-        json.loads(line)
-        for line in (tmp_path / "pending-checks.jsonl")
-        .read_text(encoding="utf-8")
-        .splitlines()
-    ]
-    assert len(checks) == 4
-    assert {check["head_sha"] for check in checks} == {"c" * 40}
-    assert {check["status"] for check in checks} == {"in_progress"}
-    assert all(
-        check["external_id"].startswith("community-cpu:12345:1:")
-        for check in checks
-    )
-    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
-        "source_quality_check_id=1\n"
-        "ownership_impact_check_id=2\n"
-        "unit_check_id=3\n"
-        "required_check_id=4\n"
-    )
-
-
-def test_public_cpu_initialization_publishes_a_visible_pr_run_link(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "initialize",
-                "Publish public run link",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
-        "comment_id=99\n"
-    )
-    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
-    assert "<!-- trtmc-community-cpu -->" in comment
-    assert "**Status:** RUNNING" in comment
-    assert f"- Exact merge: <code>{'c' * 40}</code>" in comment
-    assert "[View live public logs]" in comment
-    assert "/actions/runs/12345" in comment
-
-
-def test_public_cpu_verdict_neutralizes_a_stale_snapshot(tmp_path: Path) -> None:
-    environment = _public_ci_environment(tmp_path)
-    pull = json.loads(environment["FAKE_PULL_JSON"])
-    pull["head"]["sha"] = "d" * 40
-    environment.update(
-        {
-            "FAKE_PULL_JSON": json.dumps(pull),
-            "SOURCE_QUALITY_RESULT": "success",
-            "OWNERSHIP_IMPACT_RESULT": "success",
-            "UNIT_RESULT": "success",
-            "SOURCE_QUALITY_CHECK_ID": "1",
-            "OWNERSHIP_IMPACT_CHECK_ID": "2",
-            "UNIT_CHECK_ID": "3",
-            "REQUIRED_CHECK_ID": "4",
-        }
-    )
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "required",
-                "Publish exact-merge CPU checks",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    checks = [
-        json.loads(line)
-        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
-    ]
-    assert len(checks) == 4
-    assert {check["conclusion"] for check in checks} == {"neutral"}
-    assert all("PR changed" in check["output"]["summary"] for check in checks)
-    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
-    assert "**Status:** STALE" in comment
-    assert "Comment /run-ci again" in comment
-    assert "[View public logs]" in comment
-
-
-def test_public_cpu_verdict_publishes_success_for_the_exact_snapshot(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    environment.update(
-        {
-            "SOURCE_QUALITY_RESULT": "success",
-            "OWNERSHIP_IMPACT_RESULT": "success",
-            "UNIT_RESULT": "success",
-            "SOURCE_QUALITY_CHECK_ID": "1",
-            "OWNERSHIP_IMPACT_CHECK_ID": "2",
-            "UNIT_CHECK_ID": "3",
-            "REQUIRED_CHECK_ID": "4",
-        }
-    )
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "required",
-                "Publish exact-merge CPU checks",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    checks = [
-        json.loads(line)
-        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
-    ]
-    assert len(checks) == 4
-    assert {check["conclusion"] for check in checks} == {"success"}
-    assert checks[-1]["output"]["title"] == "Community CPU: success"
-    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
-    assert "**Status:** PASSED" in comment
-    assert "- Source quality: <code>success</code>" in comment
-    assert "- Ownership and impact: <code>success</code>" in comment
-    assert "- Unit / C++ and Python: <code>success</code>" in comment
-    assert "[View public logs]" in comment
-
-
-def test_public_cpu_verdict_publishes_failure_comment_before_exiting(
-    tmp_path: Path,
-) -> None:
-    environment = _public_ci_environment(tmp_path)
-    environment.update(
-        {
-            "SOURCE_QUALITY_RESULT": "failure",
-            "OWNERSHIP_IMPACT_RESULT": "success",
-            "UNIT_RESULT": "failure",
-            "SOURCE_QUALITY_CHECK_ID": "1",
-            "OWNERSHIP_IMPACT_CHECK_ID": "2",
-            "UNIT_CHECK_ID": "3",
-            "REQUIRED_CHECK_ID": "4",
-        }
-    )
-    result = subprocess.run(
-        [
-            "bash",
-            "-c",
-            _workflow_step_script(
-                "community-cpu.yml",
-                "required",
-                "Publish exact-merge CPU checks",
-            ),
-        ],
-        cwd=REPO_ROOT,
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    checks = [
-        json.loads(line)
-        for line in (tmp_path / "checks.jsonl").read_text(encoding="utf-8").splitlines()
-    ]
-    assert [check["conclusion"] for check in checks] == [
-        "failure",
-        "success",
-        "failure",
-        "failure",
-    ]
-    comment = (tmp_path / "comment.md").read_text(encoding="utf-8")
-    assert "**Status:** FAILED" in comment
-    assert "- Source quality: <code>failure</code>" in comment
-    assert "- Ownership and impact: <code>success</code>" in comment
-    assert "- Unit / C++ and Python: <code>failure</code>" in comment
-    assert "Open the public logs for the exact error output." in comment
-    assert "[View public logs]" in comment
-
-
-def test_public_workflow_is_a_single_comment_driven_exact_merge_gate() -> None:
+def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     path = REPO_ROOT / ".github" / "workflows" / "community-cpu.yml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     source = path.read_text(encoding="utf-8")
 
     assert workflow["run-name"] == (
-        "PR #${{ github.event.issue.number }} · public CPU validation"
+        "PR #${{ github.event.pull_request.number }} · public CPU · merge "
+        "${{ github.event.pull_request.merge_commit_sha }}"
     )
     assert workflow["permissions"] == {}
-    assert "issue_comment:" in source
-    assert "workflow_dispatch:" not in source
-    assert "\n  pull_request:" not in source
-    assert not (
-        REPO_ROOT / ".github" / "workflows" / "community-cpu-request.yml"
-    ).exists()
+    assert "pull_request:" in source
+    assert "branches: [main]" in source
+    assert "types: [opened, synchronize, reopened, ready_for_review]" in source
+    assert "issue_comment:" not in source
     assert "pull_request_target" not in source
-    assert "self-hosted" not in source
+    assert "workflow_dispatch:" not in source
+    assert "/run-ci" not in source
+    assert "checks: write" not in source
+    assert "pull-requests: write" not in source
     assert "secrets." not in source
+    assert "self-hosted" not in source
+    assert "github.event.pull_request.base.sha" in source
+    assert "ref: ${{ github.sha }}" in source
     assert "persist-credentials: false" in source
+    assert "cancel-in-progress: true" in source
     assert "--gpus" not in source
-    assert "upload-pages" not in source
-    assert "ref: ${{ needs.authorize.outputs.merge_sha }}" in source
-    assert "github.event.pull_request" not in source
-    assert "inputs." not in source
-    assert 'external_id="community-cpu:' in source
-    assert '"/repos/$GITHUB_REPOSITORY/check-runs"' in source
-    assert '"/repos/$GITHUB_REPOSITORY/check-runs/$check_id"' in source
-    assert "<!-- trtmc-community-cpu -->" in source
-    assert "Publish public run link" in source
-    assert "[View live public logs]" in source
-    assert "[View public logs]" in source
-    assert '"/repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID"' in source
-    assert "The PR changed after public CPU validation was requested" in source
+    assert "check-runs" not in source
+    assert "issues/comments" not in source
 
     jobs = workflow["jobs"]
     assert [job["name"] for job in jobs.values()] == [
-        "Authorize public CPU request",
-        "Initialize exact-merge public checks",
         "Community CPU / Source quality",
         "Community CPU / Ownership and impact",
         "Community CPU / Unit / C++ and Python",
         "Community CPU / Required",
     ]
-    assert jobs["authorize"]["permissions"] == {
-        "checks": "read",
-        "contents": "read",
-        "pull-requests": "read",
-    }
-    assert jobs["initialize"]["permissions"] == {
-        "checks": "write",
-        "contents": "read",
-        "pull-requests": "write",
-    }
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
-    assert jobs["unit"]["needs"] == [
-        "authorize",
-        "initialize",
-        "ownership-impact",
-    ]
+    assert jobs["unit"]["needs"] == "ownership-impact"
     assert jobs["required"]["needs"] == [
-        "authorize",
-        "initialize",
         "source-quality",
         "ownership-impact",
         "unit",
     ]
-    assert jobs["required"]["permissions"] == {
-        "checks": "write",
-        "contents": "read",
-        "pull-requests": "write",
+    assert jobs["required"]["permissions"] == {}
+
+
+@pytest.mark.parametrize(
+    ("source_quality", "ownership_impact", "unit", "expected_returncode"),
+    [
+        ("success", "success", "success", 0),
+        ("failure", "success", "success", 1),
+        ("success", "failure", "failure", 1),
+    ],
+)
+def test_public_required_job_fails_closed(
+    source_quality: str,
+    ownership_impact: str,
+    unit: str,
+    expected_returncode: int,
+) -> None:
+    environment = {
+        **os.environ,
+        "SOURCE_QUALITY_RESULT": source_quality,
+        "OWNERSHIP_IMPACT_RESULT": ownership_impact,
+        "UNIT_RESULT": unit,
     }
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-cpu.yml",
+                "required",
+                "Require every public CPU stage",
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == expected_returncode, result.stdout + result.stderr
+    assert f"Source quality: {source_quality}" in result.stdout
+    assert f"Ownership and impact: {ownership_impact}" in result.stdout
+    assert f"Unit / C++ and Python: {unit}" in result.stdout
 
 
 def test_cpu_image_installs_the_same_pinned_community_requirements() -> None:

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -147,7 +147,8 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert "pull-requests: write" not in source
     assert "secrets." not in source
     assert "self-hosted" not in source
-    assert "github.event.pull_request.base.sha" in source
+    assert "github.event.pull_request.base.sha" not in source
+    assert source.count("CI_BASE_REF: ${{ github.sha }}^1") == 2
     assert "ref: ${{ github.sha }}" in source
     assert "persist-credentials: false" in source
     assert "cancel-in-progress: true" in source

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -133,8 +133,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     source = path.read_text(encoding="utf-8")
 
     assert workflow["run-name"] == (
-        "PR #${{ github.event.pull_request.number }} · public CPU · merge "
-        "${{ github.event.pull_request.merge_commit_sha }}"
+        "PR #${{ github.event.pull_request.number }} · public CPU · merge ${{ github.sha }}"
     )
     assert workflow["permissions"] == {}
     assert "pull_request:" in source

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -165,6 +165,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
+    assert jobs["unit"]["if"] == "${{ !cancelled() }}"
     assert jobs["unit"]["needs"] == "ownership-impact"
     assert jobs["required"]["needs"] == [
         "source-quality",
@@ -172,6 +173,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
         "unit",
     ]
     assert jobs["required"]["permissions"] == {}
+    assert jobs["required"]["if"] == "${{ !cancelled() }}"
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -141,8 +141,11 @@ if "/collaborators/" in endpoint:
     print(os.environ["FAKE_ACTOR_ROLE"])
 elif "/pulls/" in endpoint:
     print(os.environ["FAKE_PULL_JSON"])
-elif "/check-runs" in endpoint:
-    print(os.environ["FAKE_COMMUNITY_CONCLUSION"])
+elif "/actions/workflows/community-cpu.yml/runs" in endpoint:
+    if os.environ["FAKE_COMMUNITY_CONCLUSION"] == "success":
+        print("12345")
+    else:
+        print("")
 else:
     print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
     raise SystemExit(2)
@@ -279,7 +282,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "github.ref == 'refs/heads/main'" in workflow
     assert "permissions: {}" in workflow
     assert authorize_permissions.strip() == (
-        "checks: read\n      contents: read\n      pull-requests: write"
+        "actions: read\n      contents: read\n      pull-requests: write"
     )
     assert dispatch_permissions.strip() == "{}"
 
@@ -303,9 +306,11 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert '[[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
     assert "Community CPU / Required" in authorize
-    assert ".app.slug == \"github-actions\"" in authorize
-    assert '(.external_id // "") | startswith("community-cpu:")' in authorize
-    assert 'if [ "$community_cpu" != "success" ]; then' in authorize
+    assert "/actions/workflows/community-cpu.yml/runs?event=pull_request" in authorize
+    assert '.head_sha == \\"$head_sha\\"' in authorize
+    assert '.conclusion == \\"success\\"' in authorize
+    assert "PR #$PR_NUMBER · public CPU · merge $merge_sha" in authorize
+    assert 'if ! [[ "$community_cpu_run" =~ ^[1-9][0-9]*$ ]]; then' in authorize
     assert 'echo "head_sha=$head_sha"' in authorize
     assert "pr_number=$PR_NUMBER" in authorize
     for legacy in (

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -7,8 +7,8 @@ graph, and these classes define **what** each test stage does.
 
 The shortest useful reading order is:
 
-1. `.github/workflows/community-cpu.yml` — trusted `/run-ci` authorization and
-   exact-merge public CPU validation.
+1. `.github/workflows/community-cpu.yml` — automatic, exact-merge public CPU
+   validation for pull requests.
 2. `.github/workflows/internal-ci-bridge.yml` — the exact-head protected dispatch boundary.
 3. `tools/ci/__main__.py` — the public command-line interface.
 4. `tools/ci/pipeline.py` — the named non-model stages and their ordered steps.
@@ -18,7 +18,7 @@ The shortest useful reading order is:
 
 ```mermaid
 flowchart LR
-    A[PR author comments /run-ci] --> B[Public CPU checks exact PR merge]
+    A[PR opened or updated] --> B[Public CPU checks exact PR merge]
     B --> C[Public exact-merge verdict]
     C --> D[Trusted actor adds run-internal-ci]
     D --> E[Private Internal premerge exact PR head]
@@ -55,21 +55,16 @@ that enters the run-owned container and invokes `pipeline` there.
 
 ## Community CPU, step by step
 
-The pull-request author comments `/run-ci`; a maintainer or admin may submit the
-same command on the author's behalf. The default-branch Community CPU workflow
-verifies the actor, open PR, and `main` base, then captures the exact base,
-head, and merge SHAs. Its authorization and publisher jobs never check out or
-execute PR code.
+Opening a pull request or pushing a new commit automatically starts Community
+CPU against GitHub's exact pull-request merge revision. Source quality,
+ownership and impact, and selected source-only units run as separate jobs on
+GitHub-hosted public CPU runners.
 
-The test jobs check out only the authorized merge SHA with read-only repository
-permission and no secrets. Separate publisher jobs create
-and complete contributor-visible checks on that merge SHA. They also maintain
-one PR status comment containing the exact merge SHA, per-stage verdicts, and a
-direct link to the public Actions logs so contributors can always find the
-error output even though the checks are not attached to the PR head. If the PR
-head or base changes before publication, every pending public check becomes
-neutral instead of validating the stale snapshot. Comment `/run-ci` again
-only after the new head is ready.
+The jobs check out only the event's immutable merge SHA with read-only
+repository permission, no persisted checkout credentials, and no secrets.
+GitHub publishes the native pull-request checks and public Actions logs. A new
+commit creates a new merge revision and cancels any older in-progress run for
+that pull request.
 
 ## Pre-merge, step by step
 
@@ -137,10 +132,10 @@ gh api --method PATCH \
 
 This is an explicit operator recovery, not an automatic trusted-workflow
 mutation. Wait for the PR API and source branch SHA to match, confirm the PR is
-still open and targets `main`, then add `run-internal-ci` again. Use `/run-ci`
-only to refresh public CPU validation for the current merge revision, and never
-dispatch protected CI while the two heads differ or the current public required
-check is absent.
+still open and targets `main`, and wait for automatic Community CPU validation
+on the current merge revision. Then add `run-internal-ci` again. Never dispatch
+protected CI while the two heads differ or the current public required check is
+absent.
 
 ### 2. Select the work
 

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -50,9 +50,9 @@ Ruff and clang-format environments on Linux, macOS, and Windows instead of
 depending on host-installed binaries.
 
 The local hook intentionally stays lightweight and does not build the CLI or
-run the complete CPU suite. After pushing, comment `/run-ci` on the pull request
-to run source quality, ownership analysis, and the selected source-only C++ and
-Python units on GitHub-hosted public CPU runners. The protected suite retains
+run the complete CPU suite. After pushing, the pull request automatically runs
+source quality, ownership analysis, and the selected source-only C++ and Python
+units on GitHub-hosted public CPU runners. The protected suite retains
 the filesystem-specific cache-reflink contract that public runners cannot
 portably execute.
 
@@ -137,32 +137,21 @@ performance, and release qualification are different evidence tiers.
 
 ## 6. Run public CPU validation
 
-The pull-request author starts contributor-visible, GitHub-hosted `Community
-CPU` validation by adding this exact comment to the pull request:
-
-```text
-/run-ci
-```
-
-The trusted default-branch `Community CPU` workflow authorizes the actor and
-captures the exact base, head, and merge SHAs without checking out
-pull-request code. Separate jobs in that same workflow run source quality,
-ownership and impact, and source-only C++ and Python units. A maintainer or
-admin may submit the same comment on the author's behalf.
+Opening the pull request or pushing a new commit automatically starts
+contributor-visible, GitHub-hosted `Community CPU` validation against GitHub's
+exact pull-request merge revision. Separate jobs run source quality, ownership
+and impact, and source-only C++ and Python units. No comment or maintainer action
+is required.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs, and every public job uses a GitHub-hosted
-`ubuntu-24.04` runner. Before testing starts, the workflow creates or updates
-a `Community CPU` status comment on the pull request with the exact merge SHA
-and a direct link to live public Actions logs. At completion, the same comment
-reports each stage verdict and links to the complete error output. This comment
-is the stable log entrypoint because the sanitized checks are attached to the
-merge SHA rather than the pull-request head SHA.
+`ubuntu-24.04` runner. GitHub publishes public Actions logs with the complete
+output for every failed command, together with native pull-request checks.
 
-Fix any failures and wait for `Community CPU / Required` to pass. Repeating
-`/run-ci` for the same queued, running, or successful merge is safely
-deduplicated. If the PR head or base changes, comment `/run-ci` again after
-the new revision is ready.
+Fix any failures and wait for `Community CPU / Required` to pass. A new commit
+automatically validates the new merge revision and cancels an older in-progress
+Community CPU run for the same pull request. If `main` advances and GitHub asks
+for an update, rebase or update the branch to validate the new exact merge.
 
 ## 7. Coordinate protected repository CI
 

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -77,7 +77,7 @@ Source contains exactly these three workflow files:
 
 | Workflow | Trigger and evidence boundary |
 | --- | --- |
-| `.github/workflows/community-cpu.yml` | Pull-request open, update, reopen, or ready-for-review event; automatically runs read-only CPU validation against the exact GitHub merge revision and publishes native checks with public logs. |
+| `.github/workflows/community-cpu.yml` | Pull-request open, update, or reopen event; automatically runs read-only CPU validation against the exact GitHub merge revision and publishes native checks with public logs. |
 | `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, verifies current public CPU success, captures the exact PR head, and dispatches private premerge. |
 | `.github/workflows/pages.yml` | Pushes affecting `website/**` on `main`, or manual runs; builds and deploys only the documentation site to GitHub Pages. |
 

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -4,16 +4,16 @@ title: Testing Reference
 
 ## CI and evidence boundary
 
-Source contains the test implementation and four GitHub workflows: the public
-CPU request broker and executor, the Internal CI Bridge, and the path-scoped
-Pages deployment. Protected premerge, including legal compliance, and nightly
+Source contains the test implementation and three GitHub workflows: automatic
+public CPU validation, the Internal CI Bridge, and the path-scoped Pages
+deployment. Protected premerge, including legal compliance, and nightly
 orchestration run in private Internal CI.
 
-The pull-request author first comments `/run-ci` to run public CPU validation
-on the exact current PR merge. After the public required check passes, an
-authorized collaborator with maintain or admin access applies
-`run-internal-ci` to dispatch the exact current PR head. Source receives
-contributor-visible public CPU checks and only the sanitized
+Opening or updating a pull request automatically runs public CPU validation on
+the exact current PR merge. After the public required check passes, an
+authorized collaborator with maintain or admin access applies `run-internal-ci`
+to dispatch the exact current PR head. Source receives contributor-visible
+native pull-request checks and public Actions logs, plus only the sanitized
 `trtmc/premerge/required` status from protected CI. Raw protected logs,
 artifacts, runner details, internal packages, and the complete report remain
 private. Neither path triggers on a push to `main`, so merging a passing PR
@@ -77,7 +77,7 @@ Source contains exactly these three workflow files:
 
 | Workflow | Trigger and evidence boundary |
 | --- | --- |
-| `.github/workflows/community-cpu.yml` | Exact `/run-ci` PR comment from the PR author or a maintainer/admin; authorizes the exact public PR snapshot, runs read-only CPU validation, publishes checks on the merge SHA, and maintains a PR comment linking the public logs. |
+| `.github/workflows/community-cpu.yml` | Pull-request open, update, reopen, or ready-for-review event; automatically runs read-only CPU validation against the exact GitHub merge revision and publishes native checks with public logs. |
 | `.github/workflows/internal-ci-bridge.yml` | One-shot `run-internal-ci` label or manual request; authorizes the actor, verifies current public CPU success, captures the exact PR head, and dispatches private premerge. |
 | `.github/workflows/pages.yml` | Pushes affecting `website/**` on `main`, or manual runs; builds and deploys only the documentation site to GitHub Pages. |
 


### PR DESCRIPTION
## Background

External contributors cannot self-service the current `/run-ci` workflow: fork-triggered runs fail before creating jobs while the same comment from a maintainer succeeds. Public CPU validation should use the standard read-only pull-request model used by mature open-source projects, while protected GPU and private CI remain maintainer-triggered.

## Exit Criteria

- Opening or updating a pull request automatically runs contributor-visible CPU validation on GitHub-hosted runners.
- Jobs that execute pull-request code have read-only repository access, no secrets, and no GPU or private-runner access.
- GitHub-native checks and public logs replace the comment broker and custom check publisher.
- Internal CI remains limited to maintain/admin actors and requires a successful Community CPU run for the current head and exact merge.
- Contributor and testing documentation describes the automatic flow without `/run-ci`.

## Implementation

- Replace the `issue_comment` controller with a `pull_request` workflow for open, synchronize, and reopen events. Every job uses `ubuntu-24.04`; checkout jobs use `contents: read`, an immutable event merge SHA, and `persist-credentials: false`. Source quality and impact resolve their base from that tested merge's first parent instead of the potentially stale pull-request payload base.
- Keep source quality, ownership/impact, selective units, and a fail-closed required job as native GitHub checks. Per-PR concurrency cancels stale in-progress runs after a new commit.
- Bind the protected bridge to a successful `community-cpu.yml` workflow receipt whose head and run title match the current PR head and merge SHA. The bridge still requires `maintain|admin` and owns the protected dispatch secret.
- Remove obsolete comment/publisher simulations and replace them with automatic-trigger, permission, exact-merge, and required-verdict contracts.
- Update the root contribution guide, website contributor guide, testing reference, and CI tutorial.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_community_ci.py tests/tools/test_github_actions_ci.py -q`: 74 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; CCN max 10, Ruff passed, and 158 architecture contracts passed.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed for 221 manifests, 12 core models, and 84 families.
- `PYTHONPATH=python:. python3 tools/test_impact.py --base github/main --head HEAD --json`: selected the `tools` unit tier with no C++ rebuild.
- Changed-file pre-commit hooks: passed.
- `actionlint .github/workflows/community-cpu.yml .github/workflows/internal-ci-bridge.yml`: passed.
- [Automatic Community CPU run 32667027095](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/32667027095) on head `e482f259bedd3f538b6d4c5aab7c01321ccfcebb` and merge `30ee6bdcddc60c6e9ff734a535a68c6b78bd615c`: source quality, ownership/impact, selected CPU units, and required all passed without a comment.
- Public run logs identify GitHub Hosted Compute Agents, `Secret source: None`, `Contents: read` plus metadata for checkout jobs, metadata-only permission for the required job, `persist-credentials: false`, and checkout of the exact merge SHA.
- The bridge's live receipt query resolves the current successful run as `32667027095`. Superseding pushes cancelled older revisions without starting new unit work, and marking an already-tested draft ready no longer causes a duplicate run.
- The public log resolved `30ee6bdcddc60c6e9ff734a535a68c6b78bd615c^1` to current `main@678906f15d7706185bce5af4d7f3d9f9c748d6c6`, while the pull-request payload still exposed stale base `e9132e79fba1bd22e5b121a4f339268e64a6faaf`.
- `trtmc/premerge/required` on exact head `e482f259bedd3f538b6d4c5aab7c01321ccfcebb`: passed after the canonical guide digest landed through private CI PR #43. Protected legal, source quality, units, and all five selected fallback model proofs passed.
- `npm --prefix website ci`: passed.
- `python3 tools/check_doc_file_references.py --strict website/docs`: no broken paths; failed on an unrelated existing `220` versus `221` manifest count in `website/docs/reference/source-layout.md`.
- `npm --prefix website run build`: diagram validation passed; the build stopped on unrelated missing Hugging Face metadata for `nvidia/NVIDIA-NemotronLabs-VoiceChat-11B`.

## Notes For Future Readers

- Review the new Community CPU workflow first, the bridge receipt check second, and the deleted simulations/documentation last.
- This intentionally chooses automatic pull-request CI instead of the comment-controller direction in #1007; the two approaches should not be merged together.
- Bootstrap used a maintainer-only exact-head private dispatch because live source `main` still recognizes the old custom-check contract. After this PR merges, the source bridge consumes the automatic workflow receipt; its exact query was exercised against run `32667027095` before the final protected verdict.
- This PR proves the cross-fork merge path and effective read-only/no-secret permissions, but its author is also a repository maintainer. A true unaffiliated-contributor event can only be observed after this workflow reaches `main`; do not claim that actor-policy POC before then.
