### PR TITLE
perf(eagle-vlm): reduce reranker latency

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -250,6 +250,7 @@ entries:
       precision: fp16
       mode: hf-eager
       reference_backend: hf_transformers
+      local_files_only: true
       timing_scope: task-model-call-wall
       input_preparation_included: false
       output_contract: reranking-order

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -247,10 +247,12 @@ entries:
     baseline:
       runner: task-reference
       adapter: hf-transformers-reranking
+      precision: fp16
       mode: hf-eager
       reference_backend: hf_transformers
       timing_scope: task-model-call-wall
       input_preparation_included: false
+      output_contract: reranking-order
   - id: electra.encode
     family: electra
     operation: encode

--- a/examples/trtmc_benchmark_worker.cpp
+++ b/examples/trtmc_benchmark_worker.cpp
@@ -922,14 +922,7 @@ Json run_rerank(trtmc::IPipeline& pipeline, const Json& request, const TimingCon
         throw std::runtime_error("rerank documents cannot be empty");
     }
     std::vector<float> last;
-    const auto rerank = [&]() {
-        std::vector<float> scores;
-        scores.reserve(documents.size());
-        for (const auto& document : documents) {
-            scores.push_back(pipeline.rerank(query, document));
-        }
-        return scores;
-    };
+    const auto rerank = [&]() { return pipeline.rerank_batch(query, documents); };
     for (int index = 0; index < warmup; ++index) {
         last = rerank();
     }

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -551,6 +551,14 @@ class IPipeline {
         (void)document;
         throw std::runtime_error(std::string(pipeline_type()) + " does not support rerank()");
     }
+    virtual std::vector<float> rerank_batch(const std::string& query,
+                                            const std::vector<std::string>& documents) {
+        std::vector<float> scores;
+        scores.reserve(documents.size());
+        for (const auto& document : documents)
+            scores.push_back(rerank(query, document));
+        return scores;
+    }
 
     // -- Segmentation --
     // Image pixels are RGB HWC float values in [0, 1]. The owning model family

--- a/python/tensorrt_model_connect/families/eagle_vlm/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/graph_blocks.py
@@ -129,6 +129,7 @@ def add_swiglu_mlp(
     hidden_size: int,
     mlp_size: int,
     dtype: np.dtype = np.float32,
+    fp32_down_projection: bool = False,
     quant_ctx: QuantContext | None = None,
     layer_prefix: str = "",
 ) -> trt.ITensor:
@@ -143,7 +144,14 @@ def add_swiglu_mlp(
     swish = network.add_elementwise(gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
     gated = network.add_elementwise(swish.get_output(0), up, trt.ElementWiseOperation.PROD)
 
-    mlp_out = matmul(
-        gated.get_output(0), mlp_size, hidden_size, weights[f"{prefix}.w_down"], f"{_lp}.w_down"
+    down_input = gated.get_output(0)
+    down_matmul = matmul
+    if fp32_down_projection:
+        if down_input.dtype != trt.float32:
+            down_input = network.add_cast(down_input, trt.float32).get_output(0)
+        down_matmul = _make_matmul_fn(network, np.float32, quant_ctx)
+
+    mlp_out = down_matmul(
+        down_input, mlp_size, hidden_size, weights[f"{prefix}.w_down"], f"{_lp}.w_down"
     )
     return mlp_out

--- a/python/tensorrt_model_connect/families/eagle_vlm/graph_ops.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/graph_ops.py
@@ -612,32 +612,39 @@ def _repeat_kv_heads_4d(
         raise ValueError(f"num_heads={num_heads} must be divisible by num_kv_heads={num_kv_heads}")
 
     repeat = num_heads // num_kv_heads
-    if num_kv_heads == 1:
-        concat = network.add_concatenation([x_4d] * repeat)
-        concat.axis = 1
-        return concat.get_output(0)
-
     x_shape = network.add_shape(x_4d).get_output(0)
     batch = network.add_slice(x_shape, start=(0,), shape=(1,), stride=(1,))
     one = add_constant(network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
     seq = network.add_slice(x_shape, start=(2,), shape=(1,), stride=(1,))
+    kv_heads = add_constant(
+        network, (1,), np.array([num_kv_heads], dtype=np.int64), dtype=np.int64)
     dim = add_constant(network, (1,), np.array([head_dim], dtype=np.int64), dtype=np.int64)
-    slice_shape = network.add_concatenation(
-        [batch.get_output(0), one, seq.get_output(0), dim]
+    expanded_shape = network.add_concatenation(
+        [batch.get_output(0), kv_heads, one, seq.get_output(0), dim]
     )
-    slice_shape.axis = 0
+    expanded_shape.axis = 0
+    expanded = network.add_shuffle(x_4d)
+    expanded.set_input(1, expanded_shape.get_output(0))
 
-    repeated = []
-    for head_idx in range(num_kv_heads):
-        head_slice = network.add_slice(
-            x_4d, start=(0, head_idx, 0, 0), shape=(1, 1, 1, head_dim), stride=(1, 1, 1, 1)
-        )
-        head_slice.set_input(2, slice_shape.get_output(0))
-        repeated.extend([head_slice.get_output(0)] * repeat)
+    repeats = add_constant(
+        network,
+        (1, 1, repeat, 1, 1),
+        np.zeros((1, 1, repeat, 1, 1), dtype=np.float32),
+        dtype=np.float32,
+    )
+    repeats = _cast_back_to_trt_dtype(network, repeats, x_4d.dtype)
+    tiled = network.add_elementwise(
+        expanded.get_output(0), repeats, trt.ElementWiseOperation.SUM)
 
-    concat = network.add_concatenation(repeated)
-    concat.axis = 1
-    return concat.get_output(0)
+    heads = add_constant(
+        network, (1,), np.array([num_heads], dtype=np.int64), dtype=np.int64)
+    output_shape = network.add_concatenation(
+        [batch.get_output(0), heads, seq.get_output(0), dim]
+    )
+    output_shape.axis = 0
+    output = network.add_shuffle(tiled.get_output(0))
+    output.set_input(1, output_shape.get_output(0))
+    return output.get_output(0)
 
 
 def _add_decomposed_attention_core(

--- a/python/tensorrt_model_connect/families/eagle_vlm/graph_ops.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/graph_ops.py
@@ -45,6 +45,7 @@ def add_matmul_rhs_constant(
     rhs_width: int,
     rhs_weights: np.ndarray,
     dtype: np.dtype = np.float32,
+    fp32_compute: bool = False,
 ) -> trt.ITensor:
     """Matrix multiply: lhs @ rhs_constant.  rhs is [lhs_width, rhs_width]."""
     rank = len(tuple(lhs.shape))
@@ -55,6 +56,8 @@ def add_matmul_rhs_constant(
         np.asarray(rhs_weights).reshape(rhs_shape),
         dtype=dtype,
     )
+    if fp32_compute and lhs.dtype != trt.float32:
+        lhs = network.add_cast(lhs, trt.float32).get_output(0)
     rhs = _cast_back_to_trt_dtype(network, rhs, lhs.dtype)
     mm = network.add_matrix_multiply(
         lhs,
@@ -102,13 +105,17 @@ def add_rms_norm(
     if need_cast:
         inp = network.add_cast(inp, trt.float32).get_output(0)
         eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+    rank = len(tuple(inp.shape))
+    feature_axis = 1 << (rank - 1)
+    parameter_shape = (1,) * (rank - 1) + (hidden_size,)
     sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
-    mean = network.add_reduce(sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, feature_axis, keep_dims=True)
     denom_in = network.add_elementwise(mean.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
     sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
     recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
     normalized = network.add_elementwise(inp, recip.get_output(0), trt.ElementWiseOperation.PROD)
-    gamma_t = add_constant(network, (1, hidden_size), gamma, dtype=np.float32)
+    gamma_t = add_constant(network, parameter_shape, gamma, dtype=np.float32)
     scaled = network.add_elementwise(
         normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD
     )
@@ -137,15 +144,19 @@ def add_layer_norm(
     if need_cast:
         inp = network.add_cast(inp, trt.float32).get_output(0)
         eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+    rank = len(tuple(inp.shape))
+    feature_axis = 1 << (rank - 1)
+    parameter_shape = (1,) * (rank - 1) + (hidden_size,)
     # mean = reduce_mean(x)
-    mean = network.add_reduce(inp, trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    mean = network.add_reduce(inp, trt.ReduceOperation.AVG, feature_axis, keep_dims=True)
     # x - mean
     centered = network.add_elementwise(inp, mean.get_output(0), trt.ElementWiseOperation.SUB)
     # variance = mean((x - mean)^2)
     sq = network.add_elementwise(
         centered.get_output(0), centered.get_output(0), trt.ElementWiseOperation.PROD
     )
-    var = network.add_reduce(sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    var = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, feature_axis, keep_dims=True)
     # sqrt(var + eps)
     denom_in = network.add_elementwise(var.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
     sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
@@ -155,11 +166,11 @@ def add_layer_norm(
         centered.get_output(0), recip.get_output(0), trt.ElementWiseOperation.PROD
     )
     # gamma * normalized + beta
-    gamma_t = add_constant(network, (1, hidden_size), gamma, dtype=np.float32)
+    gamma_t = add_constant(network, parameter_shape, gamma, dtype=np.float32)
     scaled = network.add_elementwise(
         normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD
     )
-    beta_t = add_constant(network, (1, hidden_size), beta, dtype=np.float32)
+    beta_t = add_constant(network, parameter_shape, beta, dtype=np.float32)
     result = network.add_elementwise(scaled.get_output(0), beta_t, trt.ElementWiseOperation.SUM)
     result = result.get_output(0)
     if need_cast:
@@ -346,11 +357,19 @@ def reshape_rows_to_heads_4d(
     sequence_length: int | None = None,
     tag: str | None = None,
 ) -> trt.ITensor:
-    """Reshape [S, H * D] rows into [1, H, S, D].
+    """Reshape [S, H * D] or [B, S, H * D] rows into attention layout.
 
     The transpose is required for S > 1 because each input row contains all
     heads for one token. ``sequence_length=None`` means runtime-dynamic S.
     """
+    if len(tuple(x.shape)) == 3:
+        batched = network.add_shuffle(x)
+        if tag:
+            batched.name = tag + "_b_s_h_d"
+        batched.reshape_dims = (0, 0, num_heads, head_dim)
+        batched.second_transpose = trt.Permutation([0, 2, 1, 3])
+        return batched.get_output(0)
+
     seq_dim = -1 if sequence_length is None else sequence_length
     r1 = network.add_shuffle(x)
     if tag:
@@ -371,8 +390,17 @@ def reshape_heads_4d_to_rows(
     attention_size: int,
     sequence_length: int | None = None,
     tag: str | None = None,
+    batched: bool = False,
 ) -> trt.ITensor:
-    """Reshape [1, H, S, D] back to [S, H * D]."""
+    """Reshape attention layout back to row-major feature tensors."""
+    if batched:
+        out = network.add_shuffle(x_4d)
+        if tag:
+            out.name = tag + "_b_s_h_d"
+        out.first_transpose = trt.Permutation([0, 2, 1, 3])
+        out.reshape_dims = (0, 0, attention_size)
+        return out.get_output(0)
+
     seq_dim = -1 if sequence_length is None else sequence_length
     out = network.add_shuffle(x_4d)
     if tag:
@@ -438,12 +466,18 @@ def add_apply_rope_native(
     rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
     attention_size = num_heads * head_dim
 
+    batched = len(tuple(inp.shape)) == 3
     inp_4d = reshape_rows_to_heads_4d(network, inp, num_heads, head_dim, sequence_length)
 
-    # Reshape position_id [Sq] -> [1, Sq] (batch=1).
-    seq_dim = -1 if sequence_length is None else sequence_length
-    pos_2d = network.add_shuffle(position_id)
-    pos_2d.reshape_dims = (1, seq_dim)
+    # Single-sequence callers provide [Sq]; batched callers provide [B, Sq]
+    # because TensorRT's rotary layer requires the exact input batch size.
+    if len(tuple(position_id.shape)) == 2:
+        position_ids_2d = position_id
+    else:
+        seq_dim = -1 if sequence_length is None else sequence_length
+        pos_2d = network.add_shuffle(position_id)
+        pos_2d.reshape_dims = (1, seq_dim)
+        position_ids_2d = pos_2d.get_output(0)
 
     rope = network.add_rotary_embedding(
         inp_4d,
@@ -452,9 +486,10 @@ def add_apply_rope_native(
         interleaved,
         rotary_embedding_dim,
     )
-    rope.set_input(3, pos_2d.get_output(0))
+    rope.set_input(3, position_ids_2d)
 
-    return reshape_heads_4d_to_rows(network, rope.get_output(0), attention_size, sequence_length)
+    return reshape_heads_4d_to_rows(
+        network, rope.get_output(0), attention_size, sequence_length, batched=batched)
 
 
 def add_attention_core(
@@ -583,10 +618,13 @@ def _repeat_kv_heads_4d(
         return concat.get_output(0)
 
     x_shape = network.add_shape(x_4d).get_output(0)
+    batch = network.add_slice(x_shape, start=(0,), shape=(1,), stride=(1,))
     one = add_constant(network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
     seq = network.add_slice(x_shape, start=(2,), shape=(1,), stride=(1,))
     dim = add_constant(network, (1,), np.array([head_dim], dtype=np.int64), dtype=np.int64)
-    slice_shape = network.add_concatenation([one, one, seq.get_output(0), dim])
+    slice_shape = network.add_concatenation(
+        [batch.get_output(0), one, seq.get_output(0), dim]
+    )
     slice_shape.axis = 0
 
     repeated = []
@@ -602,7 +640,7 @@ def _repeat_kv_heads_4d(
     return concat.get_output(0)
 
 
-def _add_attention_core_with_logit_softcap(
+def _add_decomposed_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
     k_4d: trt.ITensor,
@@ -613,7 +651,8 @@ def _add_attention_core_with_logit_softcap(
     head_dim: int,
     mask: trt.ITensor | None,
     scale: float,
-    logit_softcap: float,
+    logit_softcap: float | None = None,
+    fp32_accumulation: bool = False,
 ) -> trt.ITensor:
     output_dtype = q_4d.dtype
     k_4d = _repeat_kv_heads_4d(
@@ -626,7 +665,16 @@ def _add_attention_core_with_logit_softcap(
     score_q = q_4d
     score_k = k_4d
     score_mask = mask
-    if output_dtype != trt.float32:
+    if fp32_accumulation:
+        if score_q.dtype != trt.float32:
+            score_q = network.add_cast(score_q, trt.float32).get_output(0)
+        if score_k.dtype != trt.float32:
+            score_k = network.add_cast(score_k, trt.float32).get_output(0)
+        if v_4d.dtype != trt.float32:
+            v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if score_mask is not None and score_mask.dtype != trt.float32:
+            score_mask = network.add_cast(score_mask, trt.float32).get_output(0)
+    elif logit_softcap is not None and output_dtype != trt.float32:
         score_q = network.add_cast(score_q, trt.float32).get_output(0)
         score_k = network.add_cast(score_k, trt.float32).get_output(0)
         if score_mask is not None and score_mask.dtype != trt.float32:
@@ -638,7 +686,9 @@ def _add_attention_core_with_logit_softcap(
     ).get_output(0)
     scores = network.add_elementwise(scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
 
-    scores = add_tanh_softcap(network, scores, logit_softcap, scalar_shape=(1, 1, 1, 1))
+    if logit_softcap is not None:
+        scores = add_tanh_softcap(
+            network, scores, logit_softcap, scalar_shape=(1, 1, 1, 1))
 
     if score_mask is not None:
         scores = network.add_elementwise(
@@ -648,8 +698,8 @@ def _add_attention_core_with_logit_softcap(
     probs = network.add_softmax(scores)
     probs.axes = 1 << 3
     probs_t = probs.get_output(0)
-    if probs_t.dtype != output_dtype:
-        probs_t = network.add_cast(probs_t, output_dtype).get_output(0)
+    if probs_t.dtype != v_4d.dtype:
+        probs_t = network.add_cast(probs_t, v_4d.dtype).get_output(0)
 
     context = network.add_matrix_multiply(
         probs_t, trt.MatrixOperation.NONE, v_4d, trt.MatrixOperation.NONE
@@ -709,10 +759,14 @@ def add_attention_from_rows(
     )
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
-    if logit_softcap is not None and float(logit_softcap) > 0.0:
+    if (
+        fp32_accumulation
+        or (logit_softcap is not None and float(logit_softcap) > 0.0)
+    ):
         if causal:
-            raise NotImplementedError("logit_softcap attention requires an explicit additive mask")
-        ctx_4d = _add_attention_core_with_logit_softcap(
+            raise NotImplementedError(
+                "decomposed attention requires an explicit additive mask")
+        ctx_4d = _add_decomposed_attention_core(
             network,
             q_4d,
             k_4d,
@@ -722,7 +776,12 @@ def add_attention_from_rows(
             head_dim=head_dim,
             mask=mask,
             scale=scale,
-            logit_softcap=float(logit_softcap),
+            logit_softcap=(
+                float(logit_softcap)
+                if logit_softcap is not None and float(logit_softcap) > 0.0
+                else None
+            ),
+            fp32_accumulation=fp32_accumulation,
         )
     else:
         ctx_4d = add_attention_core(
@@ -741,6 +800,7 @@ def add_attention_from_rows(
         attention_size,
         sequence_length=q_seq,
         tag=None if tag is None else tag + ".ctx",
+        batched=len(tuple(q.shape)) == 3,
     )
 
 

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -116,6 +116,11 @@ class EagleVLMPlugin:
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, precision: str = "fp32", verbose: bool = False,
     ) -> bytes | None:
+        # The reranking runtime accepts only query/document tokens and the
+        # text engine exposes no image inputs. Do not build or package an
+        # unreachable vision engine for this mode.
+        if _is_reranker(config):
+            return None
         vision_config = config.raw.get("vision_config")
         if vision_config is None:
             return None
@@ -425,11 +430,11 @@ def _build_eagle_engine(
             trt.ElementWiseOperation.SUM)
         hidden_state = merged.get_output(0)
 
-    # Preserve the reranker's residual stream, norms, attention, and Q/K/V
-    # outputs in FP32. Output and MLP projections remain FP16 because they
-    # dominate latency and are less directly coupled to attention ordering.
-    stable_reranker_residual = is_reranker and work_np_dtype != np.float32
-    if stable_reranker_residual and hidden_state.dtype != trt.float32:
+    # Preserve the reranker's transformer computation in FP32. Ranking can
+    # hinge on score margins below FP16 resolution, so an FP16 projection in
+    # any layer can change the ordering even when task top-1 remains correct.
+    reranker_fp32_compute = is_reranker and work_np_dtype != np.float32
+    if reranker_fp32_compute and hidden_state.dtype != trt.float32:
         hidden_state = network.add_cast(hidden_state, trt.float32).get_output(0)
 
     # --- RoPE tables ---
@@ -464,7 +469,7 @@ def _build_eagle_engine(
         network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
     stable_cos_half_tensor = cos_half_tensor
     stable_sin_half_tensor = sin_half_tensor
-    if stable_reranker_residual:
+    if reranker_fp32_compute:
         stable_cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=np.float32)
         stable_sin_half_tensor = graph_ops.add_constant(
@@ -487,7 +492,7 @@ def _build_eagle_engine(
     else:
         rope_position_ids = all_rope_position_ids
     norm_scalar_shape = (1, 1, 1) if is_reranker else (1, 1)
-    norm_np_dtype = np.float32 if stable_reranker_residual else work_np_dtype
+    norm_np_dtype = np.float32 if reranker_fp32_compute else work_np_dtype
     eps_tensor = graph_ops.add_constant(
         network, norm_scalar_shape, np.array([config.rms_norm_eps], dtype=norm_np_dtype),
         dtype=norm_np_dtype)
@@ -547,21 +552,17 @@ def _build_eagle_engine(
             network, hidden_state, hidden,
             weights[f"{prefix}.input_norm"],
             None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
-        compute_norm1 = norm1
-        if stable_reranker_residual and compute_norm1.dtype != work_trt_dtype:
-            compute_norm1 = network.add_cast(
-                compute_norm1, work_trt_dtype).get_output(0)
 
         # Self-attention: Q, K, V projections
         q = graph_ops.add_matmul_rhs_constant(
-            network, compute_norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
-            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
+            network, norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
+            dtype=norm_np_dtype)
         k = graph_ops.add_matmul_rhs_constant(
-            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
-            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
+            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
+            dtype=norm_np_dtype)
         v = graph_ops.add_matmul_rhs_constant(
-            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
-            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
+            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
+            dtype=norm_np_dtype)
 
         q_rope = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
@@ -579,18 +580,12 @@ def _build_eagle_engine(
             q_seq=runtime_sequence_length, kv_seq=runtime_sequence_length,
             mask=pad_mask_4d,
             scale=attn_scale,
-            fp32_accumulation=stable_reranker_residual)
+            fp32_accumulation=reranker_fp32_compute)
 
         # Output projection
-        compute_attn_concat = attn_concat
-        if stable_reranker_residual and compute_attn_concat.dtype != work_trt_dtype:
-            compute_attn_concat = network.add_cast(
-                compute_attn_concat, work_trt_dtype).get_output(0)
         proj_out = graph_ops.add_matmul_rhs_constant(
-            network, compute_attn_concat, attention_size, hidden,
-            weights[f"{prefix}.w_o"], dtype=work_np_dtype)
-        if stable_reranker_residual and proj_out.dtype != trt.float32:
-            proj_out = network.add_cast(proj_out, trt.float32).get_output(0)
+            network, attn_concat, attention_size, hidden,
+            weights[f"{prefix}.w_o"], dtype=norm_np_dtype)
 
         # Residual
         residual1 = network.add_elementwise(
@@ -602,17 +597,10 @@ def _build_eagle_engine(
             network, residual1.get_output(0), hidden,
             weights[f"{prefix}.post_attn_norm"],
             None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
-        compute_norm2 = norm2
-        if stable_reranker_residual and compute_norm2.dtype != work_trt_dtype:
-            compute_norm2 = network.add_cast(
-                compute_norm2, work_trt_dtype).get_output(0)
-
         mlp_out = graph_blocks.add_swiglu_mlp(
-            network, compute_norm2, weights=weights, prefix=prefix,
+            network, norm2, weights=weights, prefix=prefix,
             hidden_size=hidden, mlp_size=mlp_size,
-            dtype=work_np_dtype)
-        if stable_reranker_residual and mlp_out.dtype != trt.float32:
-            mlp_out = network.add_cast(mlp_out, trt.float32).get_output(0)
+            dtype=norm_np_dtype)
 
         # Final residual
         residual2 = network.add_elementwise(

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -430,11 +430,12 @@ def _build_eagle_engine(
             trt.ElementWiseOperation.SUM)
         hidden_state = merged.get_output(0)
 
-    # Preserve the reranker's transformer computation in FP32. Ranking can
-    # hinge on score margins below FP16 resolution, so an FP16 projection in
-    # any layer can change the ordering even when task top-1 remains correct.
-    reranker_fp32_compute = is_reranker and work_np_dtype != np.float32
-    if reranker_fp32_compute and hidden_state.dtype != trt.float32:
+    # Preserve the reranker's residual stream, norms, attention, and Q/K/V
+    # outputs in FP32. Matrix-heavy projections stay in the requested
+    # precision. The final four MLP down projections return to FP32 to protect
+    # the score ordering closest to the output head.
+    stable_reranker_residual = is_reranker and work_np_dtype != np.float32
+    if stable_reranker_residual and hidden_state.dtype != trt.float32:
         hidden_state = network.add_cast(hidden_state, trt.float32).get_output(0)
 
     # --- RoPE tables ---
@@ -469,7 +470,7 @@ def _build_eagle_engine(
         network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
     stable_cos_half_tensor = cos_half_tensor
     stable_sin_half_tensor = sin_half_tensor
-    if reranker_fp32_compute:
+    if stable_reranker_residual:
         stable_cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=np.float32)
         stable_sin_half_tensor = graph_ops.add_constant(
@@ -492,7 +493,7 @@ def _build_eagle_engine(
     else:
         rope_position_ids = all_rope_position_ids
     norm_scalar_shape = (1, 1, 1) if is_reranker else (1, 1)
-    norm_np_dtype = np.float32 if reranker_fp32_compute else work_np_dtype
+    norm_np_dtype = np.float32 if stable_reranker_residual else work_np_dtype
     eps_tensor = graph_ops.add_constant(
         network, norm_scalar_shape, np.array([config.rms_norm_eps], dtype=norm_np_dtype),
         dtype=norm_np_dtype)
@@ -552,17 +553,21 @@ def _build_eagle_engine(
             network, hidden_state, hidden,
             weights[f"{prefix}.input_norm"],
             None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
+        compute_norm1 = norm1
+        if stable_reranker_residual and compute_norm1.dtype != work_trt_dtype:
+            compute_norm1 = network.add_cast(
+                compute_norm1, work_trt_dtype).get_output(0)
 
         # Self-attention: Q, K, V projections
         q = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
-            dtype=norm_np_dtype)
+            network, compute_norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
         k = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
-            dtype=norm_np_dtype)
+            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
         v = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
-            dtype=norm_np_dtype)
+            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
 
         q_rope = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
@@ -580,12 +585,18 @@ def _build_eagle_engine(
             q_seq=runtime_sequence_length, kv_seq=runtime_sequence_length,
             mask=pad_mask_4d,
             scale=attn_scale,
-            fp32_accumulation=reranker_fp32_compute)
+            fp32_accumulation=stable_reranker_residual)
 
         # Output projection
+        compute_attn_concat = attn_concat
+        if stable_reranker_residual and compute_attn_concat.dtype != work_trt_dtype:
+            compute_attn_concat = network.add_cast(
+                compute_attn_concat, work_trt_dtype).get_output(0)
         proj_out = graph_ops.add_matmul_rhs_constant(
-            network, attn_concat, attention_size, hidden,
-            weights[f"{prefix}.w_o"], dtype=norm_np_dtype)
+            network, compute_attn_concat, attention_size, hidden,
+            weights[f"{prefix}.w_o"], dtype=work_np_dtype)
+        if stable_reranker_residual and proj_out.dtype != trt.float32:
+            proj_out = network.add_cast(proj_out, trt.float32).get_output(0)
 
         # Residual
         residual1 = network.add_elementwise(
@@ -597,10 +608,18 @@ def _build_eagle_engine(
             network, residual1.get_output(0), hidden,
             weights[f"{prefix}.post_attn_norm"],
             None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
+        compute_norm2 = norm2
+        if stable_reranker_residual and compute_norm2.dtype != work_trt_dtype:
+            compute_norm2 = network.add_cast(
+                compute_norm2, work_trt_dtype).get_output(0)
         mlp_out = graph_blocks.add_swiglu_mlp(
-            network, norm2, weights=weights, prefix=prefix,
+            network, compute_norm2, weights=weights, prefix=prefix,
             hidden_size=hidden, mlp_size=mlp_size,
-            dtype=norm_np_dtype)
+            dtype=work_np_dtype,
+            fp32_down_projection=(
+                stable_reranker_residual and layer_idx >= max(0, num_layers - 4)))
+        if stable_reranker_residual and mlp_out.dtype != trt.float32:
+            mlp_out = network.add_cast(mlp_out, trt.float32).get_output(0)
 
         # Final residual
         residual2 = network.add_elementwise(

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     pass
 
 
-_RERANKER_FP32_TAIL_LAYERS = 16
+_RERANKER_MAX_BATCH_SIZE = 2
 
 
 def _is_reranker(config: ModelConfig) -> bool:
@@ -366,14 +366,21 @@ def _build_eagle_engine(
     # dimension so short query/document pairs do not execute the full cache
     # capacity. Embedding keeps the static multimodal input contract.
     if is_reranker:
-        input_ids = network.add_input("input_ids", trt.int32, (-1,))
-        attention_mask_input = network.add_input("attention_mask", trt.int32, (-1,))
+        input_ids = network.add_input("input_ids", trt.int32, (-1, -1))
+        attention_mask_input = network.add_input("attention_mask", trt.int32, (-1, -1))
         profile = builder.create_optimization_profile()
         opt_seq = min(128, seq_length)
-        profile.set_shape("input_ids", (1,), (opt_seq,), (seq_length,))
-        profile.set_shape("attention_mask", (1,), (opt_seq,), (seq_length,))
+        profile.set_shape(
+            "input_ids", (1, 1), (_RERANKER_MAX_BATCH_SIZE, opt_seq),
+            (_RERANKER_MAX_BATCH_SIZE, seq_length))
+        profile.set_shape(
+            "attention_mask", (1, 1), (_RERANKER_MAX_BATCH_SIZE, opt_seq),
+            (_RERANKER_MAX_BATCH_SIZE, seq_length))
         trt_config.add_optimization_profile(profile)
-        sequence_shape = network.add_shape(input_ids).get_output(0)
+        input_shape = network.add_shape(input_ids).get_output(0)
+        sequence_slice = network.add_slice(
+            input_shape, start=(1,), shape=(1,), stride=(1,))
+        sequence_shape = sequence_slice.get_output(0)
         runtime_sequence_length = None
     else:
         input_ids = network.add_input("input_ids", trt.int32, (seq_length,))
@@ -418,6 +425,13 @@ def _build_eagle_engine(
             trt.ElementWiseOperation.SUM)
         hidden_state = merged.get_output(0)
 
+    # Preserve the reranker's residual stream, norms, attention, and Q/K/V
+    # outputs in FP32. Output and MLP projections remain FP16 because they
+    # dominate latency and are less directly coupled to attention ordering.
+    stable_reranker_residual = is_reranker and work_np_dtype != np.float32
+    if stable_reranker_residual and hidden_state.dtype != trt.float32:
+        hidden_state = network.add_cast(hidden_state, trt.float32).get_output(0)
+
     # --- RoPE tables ---
     graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
     # Hugging Face 5.x calls this rope_parameters, while the pinned Nemotron
@@ -448,6 +462,13 @@ def _build_eagle_engine(
         network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
     sin_half_tensor = graph_ops.add_constant(
         network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
+    stable_cos_half_tensor = cos_half_tensor
+    stable_sin_half_tensor = sin_half_tensor
+    if stable_reranker_residual:
+        stable_cos_half_tensor = graph_ops.add_constant(
+            network, cos_half_np.shape, cos_half_np, dtype=np.float32)
+        stable_sin_half_tensor = graph_ops.add_constant(
+            network, sin_half_np.shape, sin_half_np, dtype=np.float32)
     all_rope_position_ids = graph_ops.add_constant(
         network, (seq_length,), np.arange(seq_length, dtype=np.int32),
         dtype=np.int32)
@@ -455,28 +476,21 @@ def _build_eagle_engine(
         position_slice = network.add_slice(
             all_rope_position_ids, start=(0,), shape=(1,), stride=(1,))
         position_slice.set_input(2, sequence_shape)
-        rope_position_ids = position_slice.get_output(0)
+        position_row = network.add_shuffle(position_slice.get_output(0))
+        position_row.reshape_dims = (1, -1)
+        zero_ids = network.add_elementwise(
+            input_ids, input_ids, trt.ElementWiseOperation.SUB)
+        batched_positions = network.add_elementwise(
+            zero_ids.get_output(0), position_row.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        rope_position_ids = batched_positions.get_output(0)
     else:
         rope_position_ids = all_rope_position_ids
+    norm_scalar_shape = (1, 1, 1) if is_reranker else (1, 1)
+    norm_np_dtype = np.float32 if stable_reranker_residual else work_np_dtype
     eps_tensor = graph_ops.add_constant(
-        network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
-        dtype=work_np_dtype)
-    keep_reranker_tail_fp32 = is_reranker and work_np_dtype != np.float32
-    tail_cos_half_tensor = cos_half_tensor
-    tail_sin_half_tensor = sin_half_tensor
-    tail_eps_tensor = eps_tensor
-    if keep_reranker_tail_fp32:
-        # Ranking can hinge on score margins below FP16 resolution. Keep only
-        # a bounded transformer tail and classification head in FP32 rather
-        # than doubling the complete engine with an all-FP32 build.
-        tail_cos_half_tensor = graph_ops.add_constant(
-            network, cos_half_np.shape, cos_half_np, dtype=np.float32)
-        tail_sin_half_tensor = graph_ops.add_constant(
-            network, sin_half_np.shape, sin_half_np, dtype=np.float32)
-        tail_eps_tensor = graph_ops.add_constant(
-            network, (1, 1),
-            np.array([config.rms_norm_eps], dtype=np.float32),
-            dtype=np.float32)
+        network, norm_scalar_shape, np.array([config.rms_norm_eps], dtype=norm_np_dtype),
+        dtype=norm_np_dtype)
     attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
 
     # --- Build padding attention mask from attention_mask input ---
@@ -487,12 +501,13 @@ def _build_eagle_engine(
     mask_float = network.add_cast(
         attention_mask_input, work_trt_dtype)
     # (1 - mask) * -1e10: padding positions get -1e10
+    mask_scalar_shape = (1, 1) if is_reranker else (1,)
     ones_const = graph_ops.add_constant(
-        network, (1,), np.array([1.0], dtype=work_np_dtype),
+        network, mask_scalar_shape, np.array([1.0], dtype=work_np_dtype),
         dtype=work_np_dtype)
     mask_penalty = -1e4 if precision == "fp16" else -1e10
     neg_large = graph_ops.add_constant(
-        network, (1,), np.array([mask_penalty], dtype=work_np_dtype),
+        network, mask_scalar_shape, np.array([mask_penalty], dtype=work_np_dtype),
         dtype=work_np_dtype)
     inv_mask = network.add_elementwise(
         ones_const, mask_float.get_output(0),
@@ -504,7 +519,7 @@ def _build_eagle_engine(
         # [1, 1, 1, S] broadcasts across query positions without materializing
         # an S-by-S mask.
         dynamic_mask = network.add_shuffle(pad_penalty.get_output(0))
-        dynamic_mask.reshape_dims = (1, 1, 1, -1)
+        dynamic_mask.reshape_dims = (0, 1, 1, -1)
         pad_mask_4d = dynamic_mask.get_output(0)
     else:
         pad_mask_row = network.add_shuffle(pad_penalty.get_output(0))
@@ -517,11 +532,6 @@ def _build_eagle_engine(
             query_zeros, pad_mask_row.get_output(0), trt.ElementWiseOperation.SUM)
         pad_mask_4d = graph_ops.add_2d_mask_to_4d(
             network, pad_mask_2d.get_output(0))
-    tail_pad_mask_4d = pad_mask_4d
-    if keep_reranker_tail_fp32 and pad_mask_4d.dtype != trt.float32:
-        tail_pad_mask_4d = network.add_cast(
-            pad_mask_4d, trt.float32).get_output(0)
-
     # --- Encoder layers (no KV cache -- full self-attention over seq_length) ---
     # Single-pass encoder: process all positions at once.
     # Eagle uses LlamaBidirectionalModel with is_causal=False, so we use
@@ -531,45 +541,35 @@ def _build_eagle_engine(
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
-        is_reranker_tail = (
-            keep_reranker_tail_fp32
-            and layer_idx >= max(num_layers - _RERANKER_FP32_TAIL_LAYERS, 0))
-        layer_np_dtype = np.float32 if is_reranker_tail else work_np_dtype
-        layer_eps_tensor = tail_eps_tensor if is_reranker_tail else eps_tensor
-        layer_cos_half_tensor = (
-            tail_cos_half_tensor if is_reranker_tail else cos_half_tensor)
-        layer_sin_half_tensor = (
-            tail_sin_half_tensor if is_reranker_tail else sin_half_tensor)
-        layer_pad_mask_4d = (
-            tail_pad_mask_4d if is_reranker_tail else pad_mask_4d)
-        if is_reranker_tail and hidden_state.dtype != trt.float32:
-            hidden_state = network.add_cast(
-                hidden_state, trt.float32).get_output(0)
 
         # Pre-norm
         norm1 = graph_blocks.apply_norm(
             network, hidden_state, hidden,
             weights[f"{prefix}.input_norm"],
-            None, layer_eps_tensor, "rmsnorm", dtype=layer_np_dtype)
+            None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
+        compute_norm1 = norm1
+        if stable_reranker_residual and compute_norm1.dtype != work_trt_dtype:
+            compute_norm1 = network.add_cast(
+                compute_norm1, work_trt_dtype).get_output(0)
 
         # Self-attention: Q, K, V projections
         q = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
-            dtype=layer_np_dtype)
+            network, compute_norm1, hidden, attention_size, weights[f"{prefix}.w_q"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
         k = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
-            dtype=layer_np_dtype)
+            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_k"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
         v = graph_ops.add_matmul_rhs_constant(
-            network, norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
-            dtype=layer_np_dtype)
+            network, compute_norm1, hidden, kv_attention_size, weights[f"{prefix}.w_v"],
+            dtype=work_np_dtype, fp32_compute=stable_reranker_residual)
 
         q_rope = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
-            layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
+            stable_cos_half_tensor, stable_sin_half_tensor, rope_position_ids,
             head_dim, sequence_length=runtime_sequence_length)
         k_rope = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
-            layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
+            stable_cos_half_tensor, stable_sin_half_tensor, rope_position_ids,
             head_dim, sequence_length=runtime_sequence_length)
 
         attn_concat = graph_ops.add_attention_from_rows(
@@ -577,13 +577,20 @@ def _build_eagle_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=runtime_sequence_length, kv_seq=runtime_sequence_length,
-            mask=layer_pad_mask_4d,
-            scale=attn_scale)
+            mask=pad_mask_4d,
+            scale=attn_scale,
+            fp32_accumulation=stable_reranker_residual)
 
         # Output projection
+        compute_attn_concat = attn_concat
+        if stable_reranker_residual and compute_attn_concat.dtype != work_trt_dtype:
+            compute_attn_concat = network.add_cast(
+                compute_attn_concat, work_trt_dtype).get_output(0)
         proj_out = graph_ops.add_matmul_rhs_constant(
-            network, attn_concat, attention_size, hidden,
-            weights[f"{prefix}.w_o"], dtype=layer_np_dtype)
+            network, compute_attn_concat, attention_size, hidden,
+            weights[f"{prefix}.w_o"], dtype=work_np_dtype)
+        if stable_reranker_residual and proj_out.dtype != trt.float32:
+            proj_out = network.add_cast(proj_out, trt.float32).get_output(0)
 
         # Residual
         residual1 = network.add_elementwise(
@@ -594,12 +601,18 @@ def _build_eagle_engine(
         norm2 = graph_blocks.apply_norm(
             network, residual1.get_output(0), hidden,
             weights[f"{prefix}.post_attn_norm"],
-            None, layer_eps_tensor, "rmsnorm", dtype=layer_np_dtype)
+            None, eps_tensor, "rmsnorm", dtype=norm_np_dtype)
+        compute_norm2 = norm2
+        if stable_reranker_residual and compute_norm2.dtype != work_trt_dtype:
+            compute_norm2 = network.add_cast(
+                compute_norm2, work_trt_dtype).get_output(0)
 
         mlp_out = graph_blocks.add_swiglu_mlp(
-            network, norm2, weights=weights, prefix=prefix,
+            network, compute_norm2, weights=weights, prefix=prefix,
             hidden_size=hidden, mlp_size=mlp_size,
-            dtype=layer_np_dtype)
+            dtype=work_np_dtype)
+        if stable_reranker_residual and mlp_out.dtype != trt.float32:
+            mlp_out = network.add_cast(mlp_out, trt.float32).get_output(0)
 
         # Final residual
         residual2 = network.add_elementwise(
@@ -610,16 +623,9 @@ def _build_eagle_engine(
     # --- Final norm ---
     final_norm = weights.get("final_norm")
     if final_norm is not None and len(final_norm) > 0:
-        final_norm_dtype = (
-            np.float32 if keep_reranker_tail_fp32 else work_np_dtype)
-        final_eps_tensor = (
-            tail_eps_tensor if keep_reranker_tail_fp32 else eps_tensor)
-        if keep_reranker_tail_fp32 and hidden_state.dtype != trt.float32:
-            hidden_state = network.add_cast(
-                hidden_state, trt.float32).get_output(0)
         hidden_state = graph_blocks.apply_norm(
             network, hidden_state, hidden, final_norm, None,
-            final_eps_tensor, "rmsnorm", dtype=final_norm_dtype)
+            eps_tensor, "rmsnorm", dtype=norm_np_dtype)
 
     # --- Output ---
     if is_reranker and "score_weight" in weights:

--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -353,6 +353,8 @@ def _build_eagle_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     seq_length = max_cache_length  # max sequence length for the encoder
+    if seq_length < 1:
+        raise ValueError("Eagle VLM max_cache_length must be positive")
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -360,19 +362,34 @@ def _build_eagle_engine(
     trt_config = builder.create_builder_config()
 
     # --- Inputs ---
-    # input_ids: [seq_length] token IDs (padded to max length)
-    input_ids = network.add_input("input_ids", trt.int32, (seq_length,))
-    # attention_mask: [seq_length] — 1 for real tokens, 0 for padding.
-    # Used to mask out padding positions in bidirectional attention.
-    attention_mask_input = network.add_input("attention_mask", trt.int32, (seq_length,))
-    # input_embed: [seq_length, hidden] — pre-computed features for image tokens
-    input_embed = network.add_input("input_embed", trt.float32, (seq_length, hidden))
-    # use_input_embed: [seq_length] — per-position flag (0.0=use token lookup, 1.0=use input_embed)
-    use_input_embed = network.add_input("use_input_embed", trt.float32, (seq_length,))
-    if work_trt_dtype != trt.float32:
-        input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
-        use_input_embed = network.add_cast(
-            use_input_embed, work_trt_dtype).get_output(0)
+    # Text reranking has no public image-input path. Give it a dynamic token
+    # dimension so short query/document pairs do not execute the full cache
+    # capacity. Embedding keeps the static multimodal input contract.
+    if is_reranker:
+        input_ids = network.add_input("input_ids", trt.int32, (-1,))
+        attention_mask_input = network.add_input("attention_mask", trt.int32, (-1,))
+        profile = builder.create_optimization_profile()
+        opt_seq = min(128, seq_length)
+        profile.set_shape("input_ids", (1,), (opt_seq,), (seq_length,))
+        profile.set_shape("attention_mask", (1,), (opt_seq,), (seq_length,))
+        trt_config.add_optimization_profile(profile)
+        sequence_shape = network.add_shape(input_ids).get_output(0)
+        runtime_sequence_length = None
+    else:
+        input_ids = network.add_input("input_ids", trt.int32, (seq_length,))
+        # attention_mask: 1 for real tokens, 0 for padding.
+        attention_mask_input = network.add_input(
+            "attention_mask", trt.int32, (seq_length,))
+        # Pre-computed features and selector for image-token positions.
+        input_embed = network.add_input(
+            "input_embed", trt.float32, (seq_length, hidden))
+        use_input_embed = network.add_input(
+            "use_input_embed", trt.float32, (seq_length,))
+        if work_trt_dtype != trt.float32:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+            use_input_embed = network.add_cast(
+                use_input_embed, work_trt_dtype).get_output(0)
+        runtime_sequence_length = seq_length
 
     # --- Embedding with input_embed bypass ---
     embedding_table = graph_ops.add_constant(
@@ -381,26 +398,25 @@ def _build_eagle_engine(
     gather = network.add_gather(embedding_table, input_ids, 0)
     token_embed = gather.get_output(0)
 
-    # Select: hidden[i] = input_embed[i] * use[i] + token_embed[i] * (1 - use[i])
-    # Reshape use_input_embed [seq_length] -> [seq_length, 1] for broadcasting
-    use_reshape = network.add_shuffle(use_input_embed)
-    use_reshape.reshape_dims = (seq_length, 1)
-    ones_bcast = graph_ops.add_constant(
-        network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-        dtype=work_np_dtype)
-    inv_use = network.add_elementwise(
-        ones_bcast, use_reshape.get_output(0),
-        trt.ElementWiseOperation.SUB)  # [seq_length, 1]: 1 where token, 0 where embed
-    embed_part = network.add_elementwise(
-        input_embed, use_reshape.get_output(0),
-        trt.ElementWiseOperation.PROD)  # input_embed * use
-    token_part = network.add_elementwise(
-        token_embed, inv_use.get_output(0),
-        trt.ElementWiseOperation.PROD)  # token_embed * (1 - use)
-    merged = network.add_elementwise(
-        embed_part.get_output(0), token_part.get_output(0),
-        trt.ElementWiseOperation.SUM)
-    hidden_state = merged.get_output(0)
+    if is_reranker:
+        hidden_state = token_embed
+    else:
+        # Select image features only at positions marked by use_input_embed.
+        use_reshape = network.add_shuffle(use_input_embed)
+        use_reshape.reshape_dims = (seq_length, 1)
+        ones_bcast = graph_ops.add_constant(
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        inv_use = network.add_elementwise(
+            ones_bcast, use_reshape.get_output(0), trt.ElementWiseOperation.SUB)
+        embed_part = network.add_elementwise(
+            input_embed, use_reshape.get_output(0), trt.ElementWiseOperation.PROD)
+        token_part = network.add_elementwise(
+            token_embed, inv_use.get_output(0), trt.ElementWiseOperation.PROD)
+        merged = network.add_elementwise(
+            embed_part.get_output(0), token_part.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        hidden_state = merged.get_output(0)
 
     # --- RoPE tables ---
     graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
@@ -432,9 +448,16 @@ def _build_eagle_engine(
         network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
     sin_half_tensor = graph_ops.add_constant(
         network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
-    rope_position_ids = graph_ops.add_constant(
+    all_rope_position_ids = graph_ops.add_constant(
         network, (seq_length,), np.arange(seq_length, dtype=np.int32),
         dtype=np.int32)
+    if is_reranker:
+        position_slice = network.add_slice(
+            all_rope_position_ids, start=(0,), shape=(1,), stride=(1,))
+        position_slice.set_input(2, sequence_shape)
+        rope_position_ids = position_slice.get_output(0)
+    else:
+        rope_position_ids = all_rope_position_ids
     eps_tensor = graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
         dtype=work_np_dtype)
@@ -477,15 +500,23 @@ def _build_eagle_engine(
     pad_penalty = network.add_elementwise(
         inv_mask.get_output(0), neg_large,
         trt.ElementWiseOperation.PROD)  # [seq_length]: 0.0 for real, -1e10 for pad
-    pad_mask_row = network.add_shuffle(pad_penalty.get_output(0))
-    pad_mask_row.reshape_dims = (1, seq_length)
-    query_zeros = graph_ops.add_constant(
-        network, (seq_length, 1),
-        np.zeros((seq_length, 1), dtype=work_np_dtype),
-        dtype=work_np_dtype)
-    pad_mask_2d = network.add_elementwise(
-        query_zeros, pad_mask_row.get_output(0), trt.ElementWiseOperation.SUM)
-    pad_mask_4d = graph_ops.add_2d_mask_to_4d(network, pad_mask_2d.get_output(0))
+    if is_reranker:
+        # [1, 1, 1, S] broadcasts across query positions without materializing
+        # an S-by-S mask.
+        dynamic_mask = network.add_shuffle(pad_penalty.get_output(0))
+        dynamic_mask.reshape_dims = (1, 1, 1, -1)
+        pad_mask_4d = dynamic_mask.get_output(0)
+    else:
+        pad_mask_row = network.add_shuffle(pad_penalty.get_output(0))
+        pad_mask_row.reshape_dims = (1, seq_length)
+        query_zeros = graph_ops.add_constant(
+            network, (seq_length, 1),
+            np.zeros((seq_length, 1), dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        pad_mask_2d = network.add_elementwise(
+            query_zeros, pad_mask_row.get_output(0), trt.ElementWiseOperation.SUM)
+        pad_mask_4d = graph_ops.add_2d_mask_to_4d(
+            network, pad_mask_2d.get_output(0))
     tail_pad_mask_4d = pad_mask_4d
     if keep_reranker_tail_fp32 and pad_mask_4d.dtype != trt.float32:
         tail_pad_mask_4d = network.add_cast(
@@ -535,17 +566,17 @@ def _build_eagle_engine(
         q_rope = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
-            head_dim, sequence_length=seq_length)
+            head_dim, sequence_length=runtime_sequence_length)
         k_rope = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             layer_cos_half_tensor, layer_sin_half_tensor, rope_position_ids,
-            head_dim, sequence_length=seq_length)
+            head_dim, sequence_length=runtime_sequence_length)
 
         attn_concat = graph_ops.add_attention_from_rows(
             network, q_rope, k_rope, v,
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=seq_length, kv_seq=seq_length,
+            q_seq=runtime_sequence_length, kv_seq=runtime_sequence_length,
             mask=layer_pad_mask_4d,
             scale=attn_scale)
 

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -5,6 +5,7 @@
 
 #include "runtime/models/eagle_vlm/pipeline.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -185,6 +186,8 @@ EmbeddingResult EncoderPipeline::encode(const std::string& text) {
 float EncoderPipeline::rerank(const std::string& query, const std::string& document) {
     if (!tokenizer_)
         throw std::runtime_error("EncoderPipeline: no tokenizer configured");
+    if (supports_batched_reranking())
+        return rerank_batch(query, {document}).front();
     // Match LlamaNemotronVLRerankProcessor.prompt_template_question_passage()
     // from the pinned checkpoint. The whitespace is part of the trained input
     // contract and changes the token sequence.
@@ -201,31 +204,142 @@ float EncoderPipeline::rerank(const std::string& query, const std::string& docum
     return select_reranking_score(output.result, output.shape, ids.size(), reranking_pooling_);
 }
 
+std::vector<float> EncoderPipeline::rerank_batch(const std::string& query,
+                                                 const std::vector<std::string>& documents) {
+    if (!tokenizer_)
+        throw std::runtime_error("EncoderPipeline: no tokenizer configured");
+    if (documents.empty())
+        return {};
+    if (!supports_batched_reranking()) {
+        std::vector<float> scores;
+        scores.reserve(documents.size());
+        for (const auto& document : documents)
+            scores.push_back(rerank(query, document));
+        return scores;
+    }
+
+    const auto profile_max = reranking_profile_max_shape();
+    const auto max_batch = static_cast<std::size_t>(profile_max[0]);
+    const auto max_sequence = static_cast<std::size_t>(profile_max[1]);
+    std::vector<float> scores;
+    scores.reserve(documents.size());
+
+    for (std::size_t first = 0; first < documents.size(); first += max_batch) {
+        const auto batch_size = std::min(max_batch, documents.size() - first);
+        std::vector<std::vector<int32_t>> token_rows;
+        token_rows.reserve(batch_size);
+        std::size_t sequence_length = 0;
+        for (std::size_t index = 0; index < batch_size; ++index) {
+            std::string combined =
+                "question:" + query + " \n \n passage:" + documents[first + index];
+            auto ids = tokenizer_->encode(combined);
+            canonicalize_reranking_separator_tokens(*tokenizer_, ids);
+            if (ids.empty())
+                throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
+            if (ids.size() > max_sequence)
+                throw std::runtime_error(
+                    "EncoderPipeline: reranking input exceeds the engine sequence profile");
+            sequence_length = std::max(sequence_length, ids.size());
+            token_rows.push_back(std::move(ids));
+        }
+
+        // Masked token ID zero is never attended to and therefore does not
+        // affect valid positions. Right padding matches the reference batch.
+        std::vector<int32_t> padded(batch_size * sequence_length, 0);
+        std::vector<int32_t> attention_mask(batch_size * sequence_length, 0);
+        for (std::size_t row = 0; row < batch_size; ++row) {
+            const auto offset = row * sequence_length;
+            std::copy(token_rows[row].begin(), token_rows[row].end(), padded.begin() + offset);
+            std::fill_n(attention_mask.begin() + offset, token_rows[row].size(), 1);
+        }
+
+        auto output = encode_batch_with_shape(padded, attention_mask, batch_size, sequence_length);
+        const auto element_count = checked_element_count(output.shape);
+        if (output.result.data.size() != element_count || output.shape.size() < 2 ||
+            output.shape.front() != static_cast<int64_t>(batch_size) ||
+            element_count % batch_size != 0)
+            throw std::runtime_error(
+                "EncoderPipeline: batched reranking score shape does not match its inputs");
+        const auto elements_per_row = element_count / batch_size;
+        if (elements_per_row > 1 && output.shape.back() != 1)
+            throw std::runtime_error(
+                "EncoderPipeline: batched reranking output must have one score per position");
+
+        for (std::size_t row = 0; row < batch_size; ++row) {
+            const auto valid_tokens = token_rows[row].size();
+            if (elements_per_row == 1) {
+                scores.push_back(output.result.data[row]);
+            } else {
+                if (valid_tokens > elements_per_row)
+                    throw std::runtime_error(
+                        "EncoderPipeline: batched reranking output is shorter than an input");
+                const auto offset = row * elements_per_row;
+                if (reranking_pooling_ == "last") {
+                    scores.push_back(output.result.data[offset + valid_tokens - 1]);
+                } else if (reranking_pooling_ == "avg") {
+                    double sum = 0.0;
+                    for (std::size_t index = 0; index < valid_tokens; ++index)
+                        sum += output.result.data[offset + index];
+                    scores.push_back(static_cast<float>(sum / static_cast<double>(valid_tokens)));
+                } else {
+                    throw std::runtime_error(
+                        "EncoderPipeline: unsupported reranking pooling mode: " +
+                        reranking_pooling_);
+                }
+            }
+        }
+    }
+    return scores;
+}
+
 EmbeddingResult EncoderPipeline::encode_ids(const std::vector<int32_t>& input_ids) {
     return encode_ids_with_shape(input_ids).result;
 }
 
 EncoderPipeline::EncodedOutput
 EncoderPipeline::encode_ids_with_shape(const std::vector<int32_t>& input_ids) {
-    const auto n = input_ids.size();
-    std::vector<int32_t> mask_i32(n, 1);
-    std::vector<float> mask_f32(n, 1.0f);
+    std::vector<int32_t> attention_mask(input_ids.size(), 1);
+    return forward_ids(input_ids, attention_mask, {static_cast<int64_t>(input_ids.size())});
+}
+
+EncoderPipeline::EncodedOutput
+EncoderPipeline::encode_batch_with_shape(const std::vector<int32_t>& input_ids,
+                                         const std::vector<int32_t>& attention_mask,
+                                         std::size_t batch_size, std::size_t sequence_length) {
+    if (batch_size == 0 || sequence_length == 0 ||
+        input_ids.size() != batch_size * sequence_length ||
+        attention_mask.size() != input_ids.size())
+        throw std::runtime_error("EncoderPipeline: invalid batched reranking input shape");
+    return forward_ids(input_ids, attention_mask,
+                       {static_cast<int64_t>(batch_size), static_cast<int64_t>(sequence_length)});
+}
+
+EncoderPipeline::EncodedOutput
+EncoderPipeline::forward_ids(const std::vector<int32_t>& input_ids,
+                             const std::vector<int32_t>& attention_mask,
+                             const std::vector<int64_t>& shape) {
+    std::vector<float> mask_f32;
+    if (!engine_mask_is_int32(*encoder_)) {
+        mask_f32.reserve(attention_mask.size());
+        for (const auto value : attention_mask)
+            mask_f32.push_back(static_cast<float>(value));
+    }
 
     auto ids_copy = input_ids;
     Tensor ids_t;
     ids_t.data = ids_copy.data();
-    ids_t.shape = {static_cast<int64_t>(n)};
+    ids_t.shape = shape;
     ids_t.dtype = DType::kInt32;
 
     // Match the engine's expected dtype for the attention mask.
     Tensor mask_t;
     if (engine_mask_is_int32(*encoder_)) {
-        mask_t.data = mask_i32.data();
-        mask_t.shape = {static_cast<int64_t>(n)};
+        mask_t.data = const_cast<int32_t*>(attention_mask.data());
+        mask_t.shape = shape;
         mask_t.dtype = DType::kInt32;
     } else {
         mask_t.data = mask_f32.data();
-        mask_t.shape = {static_cast<int64_t>(n)};
+        mask_t.shape = shape;
         mask_t.dtype = DType::kFloat32;
     }
 
@@ -254,6 +368,21 @@ EncoderPipeline::encode_ids_with_shape(const std::vector<int32_t>& input_ids) {
     }
 
     return output;
+}
+
+bool EncoderPipeline::supports_batched_reranking() const {
+    for (const auto& input : encoder_->input_info())
+        if (input.name == "input_ids")
+            return input.shape.size() == 2;
+    return false;
+}
+
+std::vector<int64_t> EncoderPipeline::reranking_profile_max_shape() const {
+    const auto shape = encoder_->input_profile_shape("input_ids", encoder_->profile_idx(),
+                                                     ProfileShapeSelector::kMax);
+    if (shape.size() != 2 || shape[0] <= 0 || shape[1] <= 0)
+        throw std::runtime_error("EncoderPipeline: invalid batched reranking profile");
+    return shape;
 }
 
 } // namespace trtmc

--- a/src/runtime/models/eagle_vlm/pipeline.cpp
+++ b/src/runtime/models/eagle_vlm/pipeline.cpp
@@ -131,6 +131,98 @@ float select_reranking_score(const EmbeddingResult& result, const std::vector<in
     throw std::runtime_error("EncoderPipeline: unsupported reranking pooling mode: " + pooling);
 }
 
+struct RerankingBatchInputs {
+    std::vector<int32_t> input_ids;
+    std::vector<int32_t> attention_mask;
+    std::vector<std::size_t> valid_lengths;
+    std::size_t sequence_length{};
+};
+
+std::vector<int32_t> tokenize_reranking_pair(const ITokenizer& tokenizer, const std::string& query,
+                                             const std::string& document,
+                                             std::size_t max_sequence) {
+    const std::string combined = "question:" + query + " \n \n passage:" + document;
+    auto ids = tokenizer.encode(combined);
+    canonicalize_reranking_separator_tokens(tokenizer, ids);
+    if (ids.empty())
+        throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
+    if (ids.size() > max_sequence)
+        throw std::runtime_error(
+            "EncoderPipeline: reranking input exceeds the engine sequence profile");
+    return ids;
+}
+
+RerankingBatchInputs prepare_reranking_batch(const ITokenizer& tokenizer, const std::string& query,
+                                             const std::vector<std::string>& documents,
+                                             std::size_t first, std::size_t batch_size,
+                                             std::size_t max_sequence) {
+    std::vector<std::vector<int32_t>> token_rows;
+    token_rows.reserve(batch_size);
+    RerankingBatchInputs inputs;
+    inputs.valid_lengths.reserve(batch_size);
+    for (std::size_t index = 0; index < batch_size; ++index) {
+        auto ids =
+            tokenize_reranking_pair(tokenizer, query, documents[first + index], max_sequence);
+        inputs.sequence_length = std::max(inputs.sequence_length, ids.size());
+        inputs.valid_lengths.push_back(ids.size());
+        token_rows.push_back(std::move(ids));
+    }
+
+    // Masked token ID zero is never attended to and therefore does not affect
+    // valid positions. Right padding matches the reference batch.
+    inputs.input_ids.assign(batch_size * inputs.sequence_length, 0);
+    inputs.attention_mask.assign(inputs.input_ids.size(), 0);
+    for (std::size_t row = 0; row < batch_size; ++row) {
+        const auto offset = row * inputs.sequence_length;
+        std::copy(token_rows[row].begin(), token_rows[row].end(),
+                  inputs.input_ids.begin() + offset);
+        std::fill_n(inputs.attention_mask.begin() + offset, token_rows[row].size(), 1);
+    }
+    return inputs;
+}
+
+std::size_t validate_batched_reranking_output(const EmbeddingResult& result,
+                                              const std::vector<int64_t>& shape,
+                                              std::size_t batch_size) {
+    const auto element_count = checked_element_count(shape);
+    if (result.data.size() != element_count || shape.size() < 2 ||
+        shape.front() != static_cast<int64_t>(batch_size) || element_count % batch_size != 0)
+        throw std::runtime_error(
+            "EncoderPipeline: batched reranking score shape does not match its inputs");
+    const auto elements_per_row = element_count / batch_size;
+    if (elements_per_row > 1 && shape.back() != 1)
+        throw std::runtime_error(
+            "EncoderPipeline: batched reranking output must have one score per position");
+    return elements_per_row;
+}
+
+float select_batched_reranking_score(const EmbeddingResult& result, std::size_t row,
+                                     std::size_t elements_per_row, std::size_t valid_tokens,
+                                     const std::string& pooling) {
+    if (elements_per_row == 1)
+        return result.data[row];
+    if (valid_tokens > elements_per_row)
+        throw std::runtime_error(
+            "EncoderPipeline: batched reranking output is shorter than an input");
+
+    const auto offset = row * elements_per_row;
+    if (pooling == "last")
+        return result.data[offset + valid_tokens - 1];
+    if (pooling == "avg") {
+        double sum = 0.0;
+        for (std::size_t index = 0; index < valid_tokens; ++index)
+            sum += result.data[offset + index];
+        return static_cast<float>(sum / static_cast<double>(valid_tokens));
+    }
+    throw std::runtime_error("EncoderPipeline: unsupported reranking pooling mode: " + pooling);
+}
+
+bool is_encoder_output_name(const std::string& name) {
+    return name.find("logits") != std::string::npos || name.find("embed") != std::string::npos ||
+           name.find("output") != std::string::npos || name.find("hidden") != std::string::npos ||
+           name.find("score") != std::string::npos;
+}
+
 } // namespace
 
 // ─── EncoderPipeline ───
@@ -226,68 +318,17 @@ std::vector<float> EncoderPipeline::rerank_batch(const std::string& query,
 
     for (std::size_t first = 0; first < documents.size(); first += max_batch) {
         const auto batch_size = std::min(max_batch, documents.size() - first);
-        std::vector<std::vector<int32_t>> token_rows;
-        token_rows.reserve(batch_size);
-        std::size_t sequence_length = 0;
-        for (std::size_t index = 0; index < batch_size; ++index) {
-            std::string combined =
-                "question:" + query + " \n \n passage:" + documents[first + index];
-            auto ids = tokenizer_->encode(combined);
-            canonicalize_reranking_separator_tokens(*tokenizer_, ids);
-            if (ids.empty())
-                throw std::runtime_error("EncoderPipeline: reranking input produced no tokens");
-            if (ids.size() > max_sequence)
-                throw std::runtime_error(
-                    "EncoderPipeline: reranking input exceeds the engine sequence profile");
-            sequence_length = std::max(sequence_length, ids.size());
-            token_rows.push_back(std::move(ids));
-        }
+        const auto inputs =
+            prepare_reranking_batch(*tokenizer_, query, documents, first, batch_size, max_sequence);
+        auto output = encode_batch_with_shape(inputs.input_ids, inputs.attention_mask, batch_size,
+                                              inputs.sequence_length);
+        const auto elements_per_row =
+            validate_batched_reranking_output(output.result, output.shape, batch_size);
 
-        // Masked token ID zero is never attended to and therefore does not
-        // affect valid positions. Right padding matches the reference batch.
-        std::vector<int32_t> padded(batch_size * sequence_length, 0);
-        std::vector<int32_t> attention_mask(batch_size * sequence_length, 0);
-        for (std::size_t row = 0; row < batch_size; ++row) {
-            const auto offset = row * sequence_length;
-            std::copy(token_rows[row].begin(), token_rows[row].end(), padded.begin() + offset);
-            std::fill_n(attention_mask.begin() + offset, token_rows[row].size(), 1);
-        }
-
-        auto output = encode_batch_with_shape(padded, attention_mask, batch_size, sequence_length);
-        const auto element_count = checked_element_count(output.shape);
-        if (output.result.data.size() != element_count || output.shape.size() < 2 ||
-            output.shape.front() != static_cast<int64_t>(batch_size) ||
-            element_count % batch_size != 0)
-            throw std::runtime_error(
-                "EncoderPipeline: batched reranking score shape does not match its inputs");
-        const auto elements_per_row = element_count / batch_size;
-        if (elements_per_row > 1 && output.shape.back() != 1)
-            throw std::runtime_error(
-                "EncoderPipeline: batched reranking output must have one score per position");
-
-        for (std::size_t row = 0; row < batch_size; ++row) {
-            const auto valid_tokens = token_rows[row].size();
-            if (elements_per_row == 1) {
-                scores.push_back(output.result.data[row]);
-            } else {
-                if (valid_tokens > elements_per_row)
-                    throw std::runtime_error(
-                        "EncoderPipeline: batched reranking output is shorter than an input");
-                const auto offset = row * elements_per_row;
-                if (reranking_pooling_ == "last") {
-                    scores.push_back(output.result.data[offset + valid_tokens - 1]);
-                } else if (reranking_pooling_ == "avg") {
-                    double sum = 0.0;
-                    for (std::size_t index = 0; index < valid_tokens; ++index)
-                        sum += output.result.data[offset + index];
-                    scores.push_back(static_cast<float>(sum / static_cast<double>(valid_tokens)));
-                } else {
-                    throw std::runtime_error(
-                        "EncoderPipeline: unsupported reranking pooling mode: " +
-                        reranking_pooling_);
-                }
-            }
-        }
+        for (std::size_t row = 0; row < batch_size; ++row)
+            scores.push_back(select_batched_reranking_score(output.result, row, elements_per_row,
+                                                            inputs.valid_lengths[row],
+                                                            reranking_pooling_));
     }
     return scores;
 }
@@ -351,9 +392,7 @@ EncoderPipeline::forward_ids(const std::vector<int32_t>& input_ids,
 
     EncodedOutput output;
     for (auto& [name, tensor] : outputs) {
-        if (name.find("logits") != std::string::npos || name.find("embed") != std::string::npos ||
-            name.find("output") != std::string::npos || name.find("hidden") != std::string::npos ||
-            name.find("score") != std::string::npos) {
+        if (is_encoder_output_name(name)) {
             const auto element_count = checked_element_count(tensor.shape);
             if (!tensor.data)
                 throw std::runtime_error("EncoderPipeline: output tensor has no data");

--- a/src/runtime/models/eagle_vlm/pipeline.h
+++ b/src/runtime/models/eagle_vlm/pipeline.h
@@ -27,6 +27,8 @@ class EncoderPipeline final : public IPipeline {
     EmbeddingResult embed(const std::string& text) override;
     EmbeddingResult encode(const std::string& text) override;
     float rerank(const std::string& query, const std::string& document) override;
+    std::vector<float> rerank_batch(const std::string& query,
+                                    const std::vector<std::string>& documents) override;
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "EncoderPipeline"; }
@@ -41,6 +43,14 @@ class EncoderPipeline final : public IPipeline {
     };
 
     EncodedOutput encode_ids_with_shape(const std::vector<int32_t>& input_ids);
+    EncodedOutput encode_batch_with_shape(const std::vector<int32_t>& input_ids,
+                                          const std::vector<int32_t>& attention_mask,
+                                          std::size_t batch_size, std::size_t sequence_length);
+    EncodedOutput forward_ids(const std::vector<int32_t>& input_ids,
+                              const std::vector<int32_t>& attention_mask,
+                              const std::vector<int64_t>& shape);
+    bool supports_batched_reranking() const;
+    std::vector<int64_t> reranking_profile_max_shape() const;
 
     std::unique_ptr<TrtModule> encoder_;
     std::string mode_; // "encoder_only", "embedding", "reranking"

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -521,9 +521,10 @@ class TestAddAttentionCore:
         np.testing.assert_allclose(out.astype(np.float32), ref, atol=1e-3)
 
     @requires_trt
-    def test_batched_gqa_preserves_each_batch_row(self):
+    @pytest.mark.parametrize("num_kv_heads", [1, 2])
+    def test_batched_gqa_preserves_each_batch_row(self, num_kv_heads):
         """Decomposed GQA repeats KV heads without collapsing batch."""
-        batch, sequence, num_heads, num_kv_heads, head_dim = 2, 3, 4, 2, 16
+        batch, sequence, num_heads, head_dim = 2, 3, 4, 16
         rng = np.random.default_rng(31)
         q = rng.standard_normal(
             (batch, sequence, num_heads * head_dim)).astype(np.float32)

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -28,6 +28,7 @@ from tests.builder.owned_graph_modules import load_family_graph_ops, load_graph_
 
 pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
 graph_ops = load_graph_ops()
+eagle_vlm_graph_ops = load_family_graph_ops("eagle_vlm")
 qwen_graph_ops = load_family_graph_ops("qwen")
 qwen_vl_graph_ops = load_family_graph_ops("qwen_vl")
 
@@ -518,6 +519,48 @@ class TestAddAttentionCore:
 
         assert out.dtype == np.float16
         np.testing.assert_allclose(out.astype(np.float32), ref, atol=1e-3)
+
+    @requires_trt
+    def test_batched_gqa_preserves_each_batch_row(self):
+        """Decomposed GQA repeats KV heads without collapsing batch."""
+        batch, sequence, num_heads, num_kv_heads, head_dim = 2, 3, 4, 2, 16
+        rng = np.random.default_rng(31)
+        q = rng.standard_normal(
+            (batch, sequence, num_heads * head_dim)).astype(np.float32)
+        k = rng.standard_normal(
+            (batch, sequence, num_kv_heads * head_dim)).astype(np.float32)
+        v = rng.standard_normal(
+            (batch, sequence, num_kv_heads * head_dim)).astype(np.float32)
+
+        def build(network, trt_inputs):
+            return {
+                "out": eagle_vlm_graph_ops.add_attention_from_rows(
+                    network,
+                    trt_inputs["q"],
+                    trt_inputs["k"],
+                    trt_inputs["v"],
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    q_seq=None,
+                    kv_seq=None,
+                    fp32_accumulation=True,
+                )
+            }
+
+        out = _run_strongly_typed(build, {"q": q, "k": k, "v": v})["out"]
+
+        qh = q.reshape(batch, sequence, num_heads, head_dim).transpose(0, 2, 1, 3)
+        kh = k.reshape(batch, sequence, num_kv_heads, head_dim).transpose(0, 2, 1, 3)
+        vh = v.reshape(batch, sequence, num_kv_heads, head_dim).transpose(0, 2, 1, 3)
+        repeat = num_heads // num_kv_heads
+        ref = _ref_sdpa(
+            qh,
+            np.repeat(kh, repeat, axis=1),
+            np.repeat(vh, repeat, axis=1),
+        )
+        ref = ref.transpose(0, 2, 1, 3).reshape(batch, sequence, -1)
+        np.testing.assert_allclose(out, ref, atol=1e-3)
 
     @requires_trt
     def test_causal_equals_no_mask_for_single_query(self):

--- a/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
+++ b/tests/cpp/models/eagle_vlm/test_eagle_vlm_encoder_pipeline.cpp
@@ -83,18 +83,41 @@ class SeparatorTokenizer : public trtmc::ITokenizer {
     std::string token_for_id(int32_t) const override { return ""; }
 };
 
+class VariableLengthTokenizer : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string& text) const override {
+        return text.find("short") == std::string::npos ? std::vector<int32_t>{1, 2, 3, 4}
+                                                       : std::vector<int32_t>{1, 2};
+    }
+    std::string decode(const std::vector<int32_t>&) const override { return "test"; }
+    int32_t id_for_token(std::string_view) const override { return -1; }
+    std::string token_for_id(int32_t) const override { return ""; }
+};
+
 class FakeScoreModule final : public trtmc::ITrtModule {
   public:
-    FakeScoreModule(std::vector<float> scores, std::vector<int64_t> shape)
-        : scores_(std::move(scores)), shape_(std::move(shape)) {}
+    FakeScoreModule(std::vector<float> scores, std::vector<int64_t> shape,
+                    std::vector<int64_t> input_shape = {4},
+                    std::vector<int64_t> profile_max_shape = {4})
+        : scores_(std::move(scores)), shape_(std::move(shape)),
+          input_shape_(std::move(input_shape)), profile_max_shape_(std::move(profile_max_shape)) {}
 
     trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
         const auto input = inputs.find("input_ids");
-        if (input != inputs.end() && input->second.data && input->second.shape.size() == 1) {
-            const auto size = static_cast<std::size_t>(input->second.shape.front());
+        if (input != inputs.end() && input->second.data) {
+            input_shape_seen_ = input->second.shape;
+            std::size_t size = 1;
+            for (const auto dim : input->second.shape)
+                size *= static_cast<std::size_t>(dim);
             const auto* ids = static_cast<const int32_t*>(input->second.data);
             input_ids_.assign(ids, ids + size);
         }
+        const auto mask = inputs.find("attention_mask");
+        if (mask != inputs.end() && mask->second.data) {
+            const auto* values = static_cast<const int32_t*>(mask->second.data);
+            attention_mask_.assign(values, values + input_ids_.size());
+        }
+        ++forward_calls_;
         return {{"score", trtmc::Tensor{scores_.data(), shape_, trtmc::DType::kFloat32}}};
     }
     trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
@@ -107,8 +130,8 @@ class FakeScoreModule final : public trtmc::ITrtModule {
     int32_t profile_idx() const override { return 0; }
     std::vector<trtmc::TensorInfo> input_info() const override {
         return {
-            {"input_ids", {4}, trtmc::DType::kInt32, true},
-            {"attention_mask", {4}, trtmc::DType::kInt32, true},
+            {"input_ids", input_shape_, trtmc::DType::kInt32, true},
+            {"attention_mask", input_shape_, trtmc::DType::kInt32, true},
         };
     }
     std::vector<trtmc::TensorInfo> output_info() const override {
@@ -122,7 +145,7 @@ class FakeScoreModule final : public trtmc::ITrtModule {
     std::vector<int64_t> tensor_shape(const std::string&) const override { return shape_; }
     std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
                                              trtmc::ProfileShapeSelector) const override {
-        return {4};
+        return profile_max_shape_;
     }
     int32_t optimization_profile_count() const override { return 1; }
     void* device_ptr(const std::string&) const override { return nullptr; }
@@ -130,11 +153,19 @@ class FakeScoreModule final : public trtmc::ITrtModule {
     bool ok() const override { return true; }
     void keep_alive(std::shared_ptr<void>) override {}
     const std::vector<int32_t>& input_ids() const { return input_ids_; }
+    const std::vector<int32_t>& attention_mask() const { return attention_mask_; }
+    const std::vector<int64_t>& input_shape_seen() const { return input_shape_seen_; }
+    int forward_calls() const { return forward_calls_; }
 
   private:
     std::vector<float> scores_;
     std::vector<int64_t> shape_;
+    std::vector<int64_t> input_shape_;
+    std::vector<int64_t> profile_max_shape_;
     std::vector<int32_t> input_ids_;
+    std::vector<int32_t> attention_mask_;
+    std::vector<int64_t> input_shape_seen_;
+    int forward_calls_{0};
 };
 
 // ---------------------------------------------------------------------------
@@ -353,6 +384,28 @@ static void test_encoder_rerank_canonicalizes_checkpoint_separator_tokens() {
           "rerank separator: merges the native separator pieces like HF");
 }
 
+static void test_encoder_rerank_batches_and_masks_documents() {
+    auto tokenizer = std::make_shared<VariableLengthTokenizer>();
+    auto module = std::make_unique<FakeScoreModule>(
+        std::vector<float>{1.0f, 3.0f, 99.0f, 99.0f, 2.0f, 4.0f, 6.0f, 8.0f},
+        std::vector<int64_t>{2, 4, 1}, std::vector<int64_t>{-1, -1}, std::vector<int64_t>{2, 4});
+    auto* module_ptr = module.get();
+    trtmc::EncoderPipeline pipeline(std::move(module), "reranking", tokenizer, "", "avg");
+
+    const auto scores = pipeline.rerank_batch("query", {"short", "long document"});
+    check(scores.size() == 2, "rerank batch: returns one score per document");
+    check(std::abs(scores[0] - 2.0f) < 1e-6f,
+          "rerank batch: excludes right padding from short-document pooling");
+    check(std::abs(scores[1] - 5.0f) < 1e-6f, "rerank batch: pools the complete long document");
+    check(module_ptr->forward_calls() == 1, "rerank batch: executes one engine enqueue");
+    check(module_ptr->input_shape_seen() == std::vector<int64_t>({2, 4}),
+          "rerank batch: binds batch and sequence dimensions");
+    check(module_ptr->input_ids() == std::vector<int32_t>({1, 2, 0, 0, 1, 2, 3, 4}),
+          "rerank batch: right pads shorter token rows");
+    check(module_ptr->attention_mask() == std::vector<int32_t>({1, 1, 0, 0, 1, 1, 1, 1}),
+          "rerank batch: masks padded tokens");
+}
+
 static void test_encoder_rerank_preserves_last_and_scalar_outputs() {
     auto tokenizer = std::make_shared<FixedTokenizer>();
     auto last_module = std::make_unique<FakeScoreModule>(std::vector<float>{0.1f, 0.2f, 0.3f, 0.9f},
@@ -549,6 +602,7 @@ int main() {
     test_encoder_encode_mode();
     test_encoder_rerank();
     test_encoder_rerank_canonicalizes_checkpoint_separator_tokens();
+    test_encoder_rerank_batches_and_masks_documents();
     test_encoder_rerank_preserves_last_and_scalar_outputs();
     test_encoder_rerank_rejects_invalid_score_shape();
     test_encoder_int32_mask();

--- a/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
+++ b/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
@@ -1,6 +1,7 @@
 {
   "name": "nemotron-rerank-vl-1b-v2",
   "hf_id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
+  "hf_revision": "9e95da054312436dfc703319dd2b793a3bee2465",
   "bundle": "nemotron-rerank-vl-1b-v2.bundle",
   "family": "eagle_vlm",
   "runtime_strategy": "eagle_vlm_reranking",

--- a/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
+++ b/tests/e2e/models/eagle_vlm/manifests/nemotron-rerank-vl-1b-v2.json
@@ -6,7 +6,7 @@
   "runtime_strategy": "eagle_vlm_reranking",
   "task_strategy": "reranking",
   "precision": "fp16",
-  "max_cache_length": 256,
+  "max_cache_length": 685,
   "trust_remote_code": true,
   "testcases": [
     {

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -90,7 +90,7 @@ def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
     assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
 
 
-def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
+def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
     monkeypatch,
 ) -> None:
     plugin_module = importlib.import_module(
@@ -105,7 +105,7 @@ def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
     original_add_matmul = graph_ops.add_matmul_rhs_constant
     original_add_attention = graph_ops.add_attention_from_rows
     original_add_mlp = graph_blocks.add_swiglu_mlp
-    num_layers = 3
+    num_layers = 6
 
     class FinalNormCaptured(RuntimeError):
         pass
@@ -116,6 +116,7 @@ def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
     matmul_fp32_compute = []
     attention_fp32 = []
     mlp_dtypes = []
+    mlp_fp32_down_projection = []
 
     def capture_tail_norms(
         network,
@@ -160,6 +161,7 @@ def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
 
     def capture_mlp(*args, **kwargs):
         mlp_dtypes.append(kwargs["dtype"])
+        mlp_fp32_down_projection.append(kwargs["fp32_down_projection"])
         return original_add_mlp(*args, **kwargs)
 
     monkeypatch.setattr(graph_blocks, "apply_norm", capture_tail_norms)
@@ -205,11 +207,20 @@ def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
         "dtype": np.float32,
     }
     assert norm_calls == [fp32_call] * (2 * num_layers + 1)
-    assert matmul_dtypes == [np.float32] * (7 * num_layers)
-    assert matmul_input_dtypes == [trt.float32] * (7 * num_layers)
-    assert matmul_fp32_compute == [False] * (7 * num_layers)
+    expected_fp32_down = [False] * (num_layers - 4) + [True] * 4
+    expected_matmul_dtypes = []
+    expected_matmul_input_dtypes = []
+    for fp32_down in expected_fp32_down:
+        expected_matmul_dtypes.extend(
+            [np.float16] * 6 + [np.float32 if fp32_down else np.float16])
+        expected_matmul_input_dtypes.extend(
+            [trt.float16] * 6 + [trt.float32 if fp32_down else trt.float16])
+    assert matmul_dtypes == expected_matmul_dtypes
+    assert matmul_input_dtypes == expected_matmul_input_dtypes
+    assert matmul_fp32_compute == ([True] * 3 + [False] * 4) * num_layers
     assert attention_fp32 == [True] * num_layers
-    assert mlp_dtypes == [np.float32] * num_layers
+    assert mlp_dtypes == [np.float16] * num_layers
+    assert mlp_fp32_down_projection == expected_fp32_down
 
 
 def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -90,7 +90,7 @@ def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
     assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
 
 
-def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
+def test_eagle_vlm_fp16_reranker_keeps_transformer_compute_in_fp32(
     monkeypatch,
 ) -> None:
     plugin_module = importlib.import_module(
@@ -205,11 +205,11 @@ def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
         "dtype": np.float32,
     }
     assert norm_calls == [fp32_call] * (2 * num_layers + 1)
-    assert matmul_dtypes == [np.float16] * (7 * num_layers)
-    assert matmul_input_dtypes == [trt.float16] * (7 * num_layers)
-    assert matmul_fp32_compute == ([True] * 3 + [False] * 4) * num_layers
+    assert matmul_dtypes == [np.float32] * (7 * num_layers)
+    assert matmul_input_dtypes == [trt.float32] * (7 * num_layers)
+    assert matmul_fp32_compute == [False] * (7 * num_layers)
     assert attention_fp32 == [True] * num_layers
-    assert mlp_dtypes == [np.float16] * num_layers
+    assert mlp_dtypes == [np.float32] * num_layers
 
 
 def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -90,23 +90,32 @@ def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
     assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
 
 
-def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
+def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
     monkeypatch,
 ) -> None:
     plugin_module = importlib.import_module(
         "tensorrt_model_connect.families.eagle_vlm.plugin")
     graph_blocks = importlib.import_module(
         "tensorrt_model_connect.families.eagle_vlm.graph_blocks")
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.graph_ops")
     trt_compat = importlib.import_module("tensorrt_model_connect.trt_compat")
     trt = trt_compat.get_trt()
     original_apply_norm = graph_blocks.apply_norm
-    assert plugin_module._RERANKER_FP32_TAIL_LAYERS == 16
-    num_layers = plugin_module._RERANKER_FP32_TAIL_LAYERS + 2
+    original_add_matmul = graph_ops.add_matmul_rhs_constant
+    original_add_attention = graph_ops.add_attention_from_rows
+    original_add_mlp = graph_blocks.add_swiglu_mlp
+    num_layers = 3
 
     class FinalNormCaptured(RuntimeError):
         pass
 
-    calls = []
+    norm_calls = []
+    matmul_dtypes = []
+    matmul_input_dtypes = []
+    matmul_fp32_compute = []
+    attention_fp32 = []
+    mlp_dtypes = []
 
     def capture_tail_norms(
         network,
@@ -120,12 +129,12 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
         dtype,
         eps=None,
     ):
-        calls.append({
+        norm_calls.append({
             "input_dtype": inp.dtype,
             "eps_dtype": eps_tensor.dtype,
             "dtype": dtype,
         })
-        if len(calls) == 2 * num_layers + 1:
+        if len(norm_calls) == 2 * num_layers + 1:
             raise FinalNormCaptured
         return original_apply_norm(
             network,
@@ -139,7 +148,24 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
             eps=eps,
         )
 
+    def capture_matmul(*args, **kwargs):
+        matmul_dtypes.append(kwargs["dtype"])
+        matmul_input_dtypes.append(args[1].dtype)
+        matmul_fp32_compute.append(kwargs.get("fp32_compute", False))
+        return original_add_matmul(*args, **kwargs)
+
+    def capture_attention(*args, **kwargs):
+        attention_fp32.append(kwargs["fp32_accumulation"])
+        return original_add_attention(*args, **kwargs)
+
+    def capture_mlp(*args, **kwargs):
+        mlp_dtypes.append(kwargs["dtype"])
+        return original_add_mlp(*args, **kwargs)
+
     monkeypatch.setattr(graph_blocks, "apply_norm", capture_tail_norms)
+    monkeypatch.setattr(graph_ops, "add_matmul_rhs_constant", capture_matmul)
+    monkeypatch.setattr(graph_ops, "add_attention_from_rows", capture_attention)
+    monkeypatch.setattr(graph_blocks, "add_swiglu_mlp", capture_mlp)
 
     class RerankerConfig(_Config):
         raw = {"is_reranker": True}
@@ -173,17 +199,17 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
             precision="fp16",
         )
 
-    fp16_call = {
-        "input_dtype": trt.float16,
-        "eps_dtype": trt.float16,
-        "dtype": np.float16,
-    }
     fp32_call = {
         "input_dtype": trt.float32,
         "eps_dtype": trt.float32,
         "dtype": np.float32,
     }
-    assert calls == [fp16_call] * 4 + [fp32_call] * 33
+    assert norm_calls == [fp32_call] * (2 * num_layers + 1)
+    assert matmul_dtypes == [np.float16] * (7 * num_layers)
+    assert matmul_input_dtypes == [trt.float16] * (7 * num_layers)
+    assert matmul_fp32_compute == ([True] * 3 + [False] * 4) * num_layers
+    assert attention_fp32 == [True] * num_layers
+    assert mlp_dtypes == [np.float16] * num_layers
 
 
 def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:
@@ -207,14 +233,14 @@ def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:
     engine = trt.Runtime(trt.Logger(trt.Logger.ERROR)).deserialize_cuda_engine(plan)
 
     assert engine is not None
-    assert tuple(engine.get_tensor_shape("input_ids")) == (-1,)
-    assert tuple(engine.get_tensor_shape("attention_mask")) == (-1,)
+    assert tuple(engine.get_tensor_shape("input_ids")) == (-1, -1)
+    assert tuple(engine.get_tensor_shape("attention_mask")) == (-1, -1)
     assert tuple(
         tuple(shape) for shape in engine.get_tensor_profile_shape("input_ids", 0)
-    ) == ((1,), (32,), (32,))
+    ) == ((1, 1), (2, 32), (2, 32))
     assert tuple(
         tuple(shape) for shape in engine.get_tensor_profile_shape("attention_mask", 0)
-    ) == ((1,), (32,), (32,))
+    ) == ((1, 1), (2, 32), (2, 32))
     io_names = {engine.get_tensor_name(index) for index in range(engine.num_io_tensors)}
     assert "input_embed" not in io_names
     assert "use_input_embed" not in io_names

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -186,6 +186,40 @@ def test_eagle_vlm_fp16_reranker_keeps_bounded_tail_in_fp32(
     assert calls == [fp16_call] * 4 + [fp32_call] * 33
 
 
+def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:
+    import tensorrt as trt
+
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+
+    class RerankerConfig(_Config):
+        raw = {"is_reranker": True}
+        rms_norm_eps = 1e-5
+        rope_theta = 10_000.0
+
+    plan = plugin_module._build_eagle_engine(
+        RerankerConfig(),
+        _weights(),
+        max_cache_length=32,
+        is_reranker=True,
+        precision="fp16",
+    )
+    engine = trt.Runtime(trt.Logger(trt.Logger.ERROR)).deserialize_cuda_engine(plan)
+
+    assert engine is not None
+    assert tuple(engine.get_tensor_shape("input_ids")) == (-1,)
+    assert tuple(engine.get_tensor_shape("attention_mask")) == (-1,)
+    assert tuple(
+        tuple(shape) for shape in engine.get_tensor_profile_shape("input_ids", 0)
+    ) == ((1,), (32,), (32,))
+    assert tuple(
+        tuple(shape) for shape in engine.get_tensor_profile_shape("attention_mask", 0)
+    ) == ((1,), (32,), (32,))
+    io_names = {engine.get_tensor_name(index) for index in range(engine.num_io_tensors)}
+    assert "input_embed" not in io_names
+    assert "use_input_embed" not in io_names
+
+
 def test_eagle_vlm_tp_shards_text_backbone_weights() -> None:
     from tensorrt_model_connect.families.eagle_vlm import tp_builder
 

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_family_plugin_weights.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_family_plugin_weights.py
@@ -9,7 +9,7 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
-
+import importlib
 
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
@@ -142,6 +142,33 @@ class TestEagleVLMPlugin:
         assert vl_cfg["preprocessor_type"] == "simple_chw"
         # After 2x2 pixel_shuffle merge: (384//14//2)^2 = 13^2 = 169
         assert vl_cfg["num_vision_tokens"] == (384 // 14 // 2) ** 2
+
+    def test_reranker_does_not_build_unreachable_vision_engine(
+        self, monkeypatch, tmp_path,
+    ):
+        plugin_module = importlib.import_module(
+            "tensorrt_model_connect.families.eagle_vlm.plugin")
+
+        config = {
+            "model_type": "llama_nemotron_vl_rerank",
+            "is_reranker": True,
+            "vocab_size": self.VOCAB,
+            "hidden_size": self.HIDDEN,
+            "num_hidden_layers": self.LAYERS,
+            "num_attention_heads": self.HEADS,
+            "num_key_value_heads": self.KV_HEADS,
+            "vision_config": {"hidden_size": 64},
+        }
+        _write_config(tmp_path, config)
+        cfg = ModelConfig.from_dir(tmp_path)
+
+        def fail_if_loaded(*_args, **_kwargs):
+            raise AssertionError("reranking must not load vision weights")
+
+        monkeypatch.setattr(
+            plugin_module, "_load_vision_weights", fail_if_loaded)
+
+        assert plugin_module.plugin.build_vision_engine(str(tmp_path), cfg, {}) is None
 
     def test_bundle_config_overrides_embedding(self, tmp_path):
         """Bundle config overrides: embedding mode."""

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -313,6 +313,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     by_id = {case["id"]: case for case in cases}
     assert by_id["deberta.encode"]["baseline"]["precision"] == "fp32"
     assert by_id["eagle_vlm.rerank"]["baseline"]["precision"] == "fp16"
+    assert by_id["eagle_vlm.rerank"]["baseline"]["local_files_only"] is True
     assert by_id["eagle_vlm.rerank"]["baseline"]["output_contract"] == "reranking-order"
     assert by_id["fnet.encode"]["baseline"]["padding"] == "max-length"
     assert by_id["lance.generate"]["baseline"]["python_profile"] == "lance_reference"

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -312,6 +312,8 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     }
     by_id = {case["id"]: case for case in cases}
     assert by_id["deberta.encode"]["baseline"]["precision"] == "fp32"
+    assert by_id["eagle_vlm.rerank"]["baseline"]["precision"] == "fp16"
+    assert by_id["eagle_vlm.rerank"]["baseline"]["output_contract"] == "reranking-order"
     assert by_id["fnet.encode"]["baseline"]["padding"] == "max-length"
     assert by_id["lance.generate"]["baseline"]["python_profile"] == "lance_reference"
     assert by_id["sana_wm.generate_image"]["baseline"]["adapter_options"] == {
@@ -775,6 +777,31 @@ def test_generated_token_count_contract_allows_stochastic_token_content() -> Non
     assert perf_matrix._output_contract(case, candidate, reference) == (
         False,
         "generated token count differs",
+    )
+
+
+def test_reranking_order_contract_checks_all_document_scores() -> None:
+    case = {
+        "operation": "rerank",
+        "baseline": {"output_contract": "reranking-order"},
+    }
+    candidate = {"output_summary": {"documents": 3, "scores": [0.8, 0.1, 0.4]}}
+    reference = {
+        "output_summary": {"document_count": 3, "scores": [12.0, -4.0, 2.0]}
+    }
+
+    assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
+
+    candidate["output_summary"]["scores"] = [0.1, 0.8, 0.4]
+    assert perf_matrix._output_contract(case, candidate, reference) == (
+        False,
+        "reranking order differs",
+    )
+
+    candidate["output_summary"]["scores"] = [0.8, float("nan"), 0.4]
+    assert perf_matrix._output_contract(case, candidate, reference) == (
+        False,
+        "reranking scores are missing or invalid",
     )
 
 

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -1659,6 +1659,30 @@ def _output_contract(
         matched = all(isinstance(value, list) and value for value in left_shape + right_shape)
         matched = matched and left_shape == right_shape
         return matched, "image feature output shape differs" if not matched else ""
+    if contract == "reranking-order":
+        left_scores = left.get("scores")
+        right_scores = right.get("scores")
+        if (
+            not isinstance(left_scores, list)
+            or not isinstance(right_scores, list)
+            or not left_scores
+            or len(left_scores) != len(right_scores)
+            or any(
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                for value in (*left_scores, *right_scores)
+            )
+        ):
+            return False, "reranking scores are missing or invalid"
+        left_order = sorted(
+            range(len(left_scores)), key=lambda index: (-float(left_scores[index]), index)
+        )
+        right_order = sorted(
+            range(len(right_scores)), key=lambda index: (-float(right_scores[index]), index)
+        )
+        matched = left_order == right_order
+        return matched, "reranking order differs" if not matched else ""
     if operation == "generate":
         if contract == "generated-token-count":
             left_tokens = left.get("token_ids")

--- a/tools/performance/catalog.py
+++ b/tools/performance/catalog.py
@@ -353,6 +353,7 @@ def _validate_baseline(case: Mapping[str, Any]) -> None:
         "media-shape",
         "normalized-text",
         "ocr-text",
+        "reranking-order",
         "segmentation-shape",
         "token-agreement",
     }:


### PR DESCRIPTION
## Background

The Nemotron VL reranker executed every document separately at the configured 685-token capacity. That made the FP16 TRTMC path 2.46x slower than the equivalent FP16 Hugging Face reference in #897.

## Exit criteria

- Preserve the reranking workload and output order.
- Measure TRTMC and the reference with the same FP16, 3-warmup, 10-iteration contract.
- Bring TRTMC within the registered 5% equivalence margin.

## Implementation

- Execute the reranker at the request's actual sequence length and batch all documents in one engine call.
- Keep only numerically sensitive residual, normalization, attention, and final projection work in FP32 while retaining FP16 matrix-heavy execution.
- Skip the unused vision engine for the text-only reranker path.
- Pin the Hugging Face reference revision and require the prepared local snapshot for reproducible performance runs.
- Extend runtime and report contracts to carry batched reranking scores without changing other Eagle VLM operations.

## Validation

- ThorX-1, exact source revision `7a99ca7da6ee8d7077aa304248af022af82bff88`:
  - TensorRT bundle build: passed.
  - Eagle VLM C++ pipeline regression: passed.
  - Nemotron reranker end-to-end Accuracy: `1 passed`.
  - Perf run 1: TRTMC 21.352 ms, reference 20.355 ms, +4.90%, yellow/equivalent; both sides stable.
  - Independent Perf repeat: TRTMC 21.388 ms, reference 20.732 ms, +3.17%, yellow/equivalent; both sides stable.
  - Both runs preserved the two-document ranking order.
- Local related suites: `161 passed, 20 skipped, 2 deselected`; the two CUDA-builder cases were covered by the ThorX-1 TensorRT build and hardware validation.
- `git diff --check`: passed.

## Notes

The first offline reference attempt exposed a missing local `main` cache ref used internally by the model's remote code. The formal measurements were run only after mapping that ref to the same pinned and checksum-verified snapshot; no online fallback was used.

Closes #897
