### PR TITLE
perf(olmo2): fit split generation on Thor

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import gc
 import importlib
 import inspect
 import json
@@ -37,7 +38,12 @@ from .families import (
     resolve_nemo_archive_model_dir,
 )
 from .hf_snapshot import GENERIC_HF_ALLOW_PATTERNS, hf_snapshot_allow_patterns
-from .bundle_writer import BundleInfo, BundleSection, write_bundle
+from .bundle_writer import (
+    BundleInfo,
+    BundleSection,
+    _bundle_section_from_file,
+    write_bundle,
+)
 from . import trt_compat
 from .triattention_export import (
     TriAttentionBundleConfig,
@@ -65,6 +71,59 @@ class _OmittedMaxCacheLength(int):
 
 
 _OMITTED_MAX_CACHE_LENGTH = _OmittedMaxCacheLength(256)
+
+
+def _spool_split_plan(
+    plan: bytes,
+    output_path: str | Path,
+) -> tuple[tempfile.TemporaryDirectory, Path]:
+    spool = tempfile.TemporaryDirectory(
+        prefix=".trtmc-split-plan-",
+        dir=Path(output_path).parent,
+    )
+    plan_path = Path(spool.name) / "prefill.engine"
+    plan_path.write_bytes(plan)
+    return spool, plan_path
+
+
+def _apply_staged_bundle_loading(
+    plugin: object,
+    sections: list[BundleSection],
+) -> None:
+    """Keep plugin-declared model plans out of eager bundle materialization."""
+
+    staged_names = set(getattr(plugin, "staged_bundle_sections", ()))
+    if not staged_names:
+        return
+
+    section_names = [section.name for section in sections]
+    lazy_sections = [name for name in section_names if name in staged_names]
+    if not lazy_sections:
+        raise ValueError(
+            f"Plugin {getattr(plugin, 'name', '<unknown>')} declared staged bundle "
+            "sections, but none are present"
+        )
+
+    config_index = next(
+        (index for index, section in enumerate(sections) if section.name == "config.json"),
+        None,
+    )
+    if config_index is None:
+        raise ValueError("Staged bundle loading requires a config.json section")
+
+    config_section = sections[config_index]
+    config = json.loads(config_section.data)
+    config["bundle_loading"] = {
+        "mode": "staged",
+        "eager_sections": [
+            name for name in section_names if name not in staged_names
+        ],
+        "lazy_sections": lazy_sections,
+    }
+    sections[config_index] = BundleSection(
+        "config.json",
+        json.dumps(config, indent=2).encode("utf-8"),
+    )
 
 
 def _setup_trt_import(rtx: bool) -> None:
@@ -1284,6 +1343,8 @@ def build_bundle(
 
     engine_plan: bytes
     prefill_engine_plan: bytes | None = None
+    prefill_engine_plan_path: Path | None = None
+    prefill_engine_spool: tempfile.TemporaryDirectory | None = None
     tp_engine_plans: dict[int, bytes] = {}
     actual_decoder_engine_layout = "single"
     engine_t0 = time.monotonic()
@@ -1316,8 +1377,22 @@ def build_bundle(
                 file=sys.stderr,
             )
 
+            # A serialized prefill plan can be several GiB. Spool it beside the
+            # destination so the decode build does not retain both plans plus
+            # the model weights in ordinary memory.
+            prefill_engine_spool, prefill_engine_plan_path = _spool_split_plan(
+                prefill_engine_plan,
+                output_path,
+            )
+            prefill_engine_plan = None
+            gc.collect()
+
             decode_t0 = time.monotonic()
-            engine_plan = _build_split_plugin_engine_with_role("decode")
+            try:
+                engine_plan = _build_split_plugin_engine_with_role("decode")
+            except Exception:
+                prefill_engine_spool.cleanup()
+                raise
             decode_elapsed = time.monotonic() - decode_t0
             _add_build_timing(
                 build_timing, "trt_compile_decode_engine_s", decode_elapsed)
@@ -1483,7 +1558,13 @@ def build_bundle(
         # engine for compatibility with existing tools and add the prefill engine
         # under a role-specific section.
         sections = [BundleSection("engine_plan", engine_plan)]
-        if prefill_engine_plan is not None:
+        if prefill_engine_plan_path is not None:
+            sections.append(
+                _bundle_section_from_file(
+                    "prefill_engine_plan", prefill_engine_plan_path
+                )
+            )
+        elif prefill_engine_plan is not None:
             sections.append(BundleSection("prefill_engine_plan", prefill_engine_plan))
 
     # Add vision engine section if present
@@ -1642,8 +1723,14 @@ def build_bundle(
         manifest_json = json.dumps({"kernels": manifest_entries}).encode("utf-8")
         sections.append(BundleSection("kernel_manifest.json", manifest_json))
 
+    _apply_staged_bundle_loading(plugin, sections)
+
     write_t0 = time.monotonic()
-    write_bundle(output_path, info, sections)
+    try:
+        write_bundle(output_path, info, sections)
+    finally:
+        if prefill_engine_spool is not None:
+            prefill_engine_spool.cleanup()
     _add_build_timing(build_timing, "bundle_write_s", time.monotonic() - write_t0)
     t4 = time.monotonic()
     build_timing["total_s"] = t4 - t0

--- a/python/tensorrt_model_connect/families/olmo2/plugin.py
+++ b/python/tensorrt_model_connect/families/olmo2/plugin.py
@@ -41,8 +41,12 @@ from ...parallel_config import (
 )
 
 
+_BUILDER_WORKSPACE_BYTES = 256 << 20
+
+
 class Olmo2Plugin:
     name = "olmo2"
+    staged_bundle_sections = ("engine_plan", "prefill_engine_plan")
 
     def matches(self, model_type: str) -> bool:
         return model_type.lower() == "olmo2"
@@ -172,6 +176,7 @@ class Olmo2Plugin:
                 max_cache_length,
                 precision=precision,
                 verbose=verbose,
+                workspace_bytes=_BUILDER_WORKSPACE_BYTES,
             )
 
         import sys
@@ -204,6 +209,8 @@ class Olmo2Plugin:
         network = builder.create_network(
             1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
         trt_config = builder.create_builder_config()
+        trt_config.set_memory_pool_limit(
+            trt.MemoryPoolType.WORKSPACE, _BUILDER_WORKSPACE_BYTES)
         trt_config.clear_flag(trt.BuilderFlag.TF32)
 
         # Inputs

--- a/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
+++ b/python/tensorrt_model_connect/families/olmo2/prefill_builder.py
@@ -40,6 +40,7 @@ def build_olmo2_prefill_engine(
     *,
     precision: str = "fp32",
     verbose: bool = False,
+    workspace_bytes: int,
 ) -> bytes:
     """Build one dynamic-Sq profile that consumes a prompt in one enqueue."""
     trt = trt_compat.get_trt()
@@ -61,13 +62,15 @@ def build_olmo2_prefill_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     max_prefill_length = max(1, int(max_cache_length))
-    opt_prefill_length = min(128, max_prefill_length)
+    opt_prefill_length = min(352, max_prefill_length)
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(
+        trt.MemoryPoolType.WORKSPACE, workspace_bytes)
     trt_config.clear_flag(trt.BuilderFlag.TF32)
 
     token_id = network.add_input("token_id", trt.int32, (-1,))

--- a/src/runtime/models/olmo2/pipeline.cpp
+++ b/src/runtime/models/olmo2/pipeline.cpp
@@ -474,7 +474,7 @@ void Olmo2TextGenerationPipeline::prime_decoder_after_batched_prefill(
         return;
 
     TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
+    if (!decoder.cuda_graph_active() || decoder.cuda_graph_captured())
         return;
 
     int32_t token_id = input_ids.back();

--- a/src/runtime/models/olmo2/plugin.cpp
+++ b/src/runtime/models/olmo2/plugin.cpp
@@ -59,6 +59,21 @@ struct DecoderProfileRoles {
     std::vector<DecoderProfileInfo> decode_profiles;
 };
 
+const BundleSectionInfo* find_bundle_section_info(const BundleInfo& info, const std::string& name) {
+    const auto section =
+        std::find_if(info.sections.begin(), info.sections.end(),
+                     [&](const BundleSectionInfo& candidate) { return candidate.name == name; });
+    return section == info.sections.end() ? nullptr : &*section;
+}
+
+bool has_bundle_section(const BundleFile& bundle, const std::string& name) {
+    const auto* eager = find_section(bundle, name);
+    if (eager != nullptr && !eager->empty())
+        return true;
+    const auto* section = find_bundle_section_info(bundle.info, name);
+    return section != nullptr && section->size > 0;
+}
+
 int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
     if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
         return -1;
@@ -331,7 +346,7 @@ class Olmo2DecoderPlugin final : public IPipelinePlugin {
     load_split_prefill_module(const PipelineContext& ctx, cudaStream_t stream, const IoMap& io,
                               const Olmo2KvCacheNames& kv_names, int32_t& prefill_profile_idx,
                               int32_t& prefill_max_length, std::string& prefill_log_label) {
-        if (find_section(ctx.bundle, "prefill_engine_plan") == nullptr)
+        if (!has_bundle_section(ctx.bundle, "prefill_engine_plan"))
             return nullptr;
 
         auto split_prefill_modules =
@@ -368,9 +383,15 @@ class Olmo2DecoderPlugin final : public IPipelinePlugin {
     static BackendProfileModules
     load_decoder_profile_modules(const PipelineContext& ctx, const std::string& section_name,
                                  cudaStream_t stream, const TensorParallelRuntime* tp_runtime) {
-        auto* plan = find_section(ctx.bundle, section_name);
-        if (plan == nullptr || plan->empty())
-            throw std::runtime_error(section_name + " section is missing");
+        std::vector<char> staged_plan;
+        const auto* plan = find_section(ctx.bundle, section_name);
+        if (plan == nullptr || plan->empty()) {
+            const auto* section = find_bundle_section_info(ctx.bundle.info, section_name);
+            if (section == nullptr || section->size == 0)
+                throw std::runtime_error(section_name + " section is missing");
+            staged_plan = ReadBundleSection(ctx.bundle_path, *section);
+            plan = &staged_plan;
+        }
         if (ctx.backend == nullptr)
             throw std::runtime_error("No backend loaded");
 

--- a/src/runtime/models/olmo2/plugin.cpp
+++ b/src/runtime/models/olmo2/plugin.cpp
@@ -74,6 +74,19 @@ bool has_bundle_section(const BundleFile& bundle, const std::string& name) {
     return section != nullptr && section->size > 0;
 }
 
+const std::vector<char>& load_bundle_section(const PipelineContext& ctx, const std::string& name,
+                                             std::vector<char>& staged) {
+    const auto* eager = find_section(ctx.bundle, name);
+    if (eager != nullptr && !eager->empty())
+        return *eager;
+
+    const auto* section = find_bundle_section_info(ctx.bundle.info, name);
+    if (section == nullptr || section->size == 0)
+        throw std::runtime_error(name + " section is missing");
+    staged = ReadBundleSection(ctx.bundle_path, *section);
+    return staged;
+}
+
 int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
     if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
         return -1;
@@ -384,14 +397,7 @@ class Olmo2DecoderPlugin final : public IPipelinePlugin {
     load_decoder_profile_modules(const PipelineContext& ctx, const std::string& section_name,
                                  cudaStream_t stream, const TensorParallelRuntime* tp_runtime) {
         std::vector<char> staged_plan;
-        const auto* plan = find_section(ctx.bundle, section_name);
-        if (plan == nullptr || plan->empty()) {
-            const auto* section = find_bundle_section_info(ctx.bundle.info, section_name);
-            if (section == nullptr || section->size == 0)
-                throw std::runtime_error(section_name + " section is missing");
-            staged_plan = ReadBundleSection(ctx.bundle_path, *section);
-            plan = &staged_plan;
-        }
+        const auto& plan = load_bundle_section(ctx, section_name, staged_plan);
         if (ctx.backend == nullptr)
             throw std::runtime_error("No backend loaded");
 
@@ -414,10 +420,10 @@ class Olmo2DecoderPlugin final : public IPipelinePlugin {
 
         const auto t0 = std::chrono::steady_clock::now();
         auto modules =
-            ctx.backend->create_profile_modules(plan->data(), plan->size(), opts, profile_indices);
+            ctx.backend->create_profile_modules(plan.data(), plan.size(), opts, profile_indices);
         const auto t1 = std::chrono::steady_clock::now();
         const double load_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-        log_trt_load_timing(section_name.c_str(), load_ms, plan->size());
+        log_trt_load_timing(section_name.c_str(), load_ms, plan.size());
         for (auto& entry : modules.modules) {
             entry.module->set_timing_label(entry.profile_idx == 0 ? section_name + ":profile0"
                                                                   : section_name + ":decode");

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -823,20 +823,30 @@ class TestBuildBundleOrchestration:
                 with patch("tensorrt_model_connect.engine_builder._get_gpu_name",
                            return_value=""):
                     with patch("tensorrt_model_connect.engine_builder._ensure_tokenizer_json"):
-                        with patch("tensorrt_model_connect.engine_builder.write_bundle") as mock_write:
+                        captured = {}
+
+                        def capture_bundle(_output, _info, sections):
+                            captured["sections"] = sections
+                            captured["prefill_path"] = sections[1].source_path
+                            assert sections[1].source_path.read_bytes() == b"prefill:prefill"
+
+                        with patch(
+                            "tensorrt_model_connect.engine_builder.write_bundle",
+                            side_effect=capture_bundle,
+                        ):
                             build_bundle(
                                 str(model_dir),
                                 output_path,
                                 precision="bf16",
                             )
 
-        sections = mock_write.call_args[0][2]
+        sections = captured["sections"]
         assert [section.name for section in sections[:2]] == [
             "engine_plan",
             "prefill_engine_plan",
         ]
         assert sections[0].data == b"decode:dual_profile"
-        assert sections[1].data == b"prefill:prefill"
+        assert not captured["prefill_path"].exists()
         assert scopes == [
             "split-example_decoder-h64-l2-bf16-noquant-prefill",
             "split-example_decoder-h64-l2-bf16-noquant-decode",

--- a/tests/e2e/models/olmo2/test_olmo2_builder_tp.py
+++ b/tests/e2e/models/olmo2/test_olmo2_builder_tp.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ pytest.importorskip("tensorrt", reason="TensorRT is required for family builder 
 
 
 from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.bundle_writer import BundleSection
 from tensorrt_model_connect.parallel_config import ParallelConfig
 
 
@@ -170,4 +172,40 @@ def test_olmo2_plugin_routes_split_prefill_builds(monkeypatch) -> None:
     assert calls["build"]["kwargs"] == {
         "precision": "fp32",
         "verbose": False,
+        "workspace_bytes": 256 << 20,
     }
+
+
+def test_split_plan_spool_releases_temporary_artifact(tmp_path: Path) -> None:
+    from tensorrt_model_connect.engine_builder import _spool_split_plan
+
+    spool, plan_path = _spool_split_plan(
+        b"prefill-plan",
+        tmp_path / "olmo2.bundle",
+    )
+    assert plan_path.read_bytes() == b"prefill-plan"
+
+    spool.cleanup()
+    assert not plan_path.exists()
+
+
+def test_olmo2_stages_engine_plans_in_bundle_config() -> None:
+    from tensorrt_model_connect.engine_builder import _apply_staged_bundle_loading
+    from tensorrt_model_connect.families.olmo2.plugin import plugin
+
+    sections = [
+        BundleSection("engine_plan", b"decode"),
+        BundleSection("prefill_engine_plan", b"prefill"),
+        BundleSection("tokenizer.json", b"{}"),
+        BundleSection("config.json", b"{}"),
+    ]
+
+    _apply_staged_bundle_loading(plugin, sections)
+
+    config = next(section for section in sections if section.name == "config.json")
+    assert config.data == (
+        b'{\n  "bundle_loading": {\n    "mode": "staged",\n'
+        b'    "eager_sections": [\n      "tokenizer.json",\n'
+        b'      "config.json"\n    ],\n    "lazy_sections": [\n'
+        b'      "engine_plan",\n      "prefill_engine_plan"\n    ]\n  }\n}'
+    )

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -232,6 +232,19 @@ def _fake_gpu_lease_context(
     return CiContext(REPO_ROOT, env)
 
 
+def _use_deterministic_gpu_lease_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = SimpleNamespace(now=0.0)
+
+    def advance_clock(seconds: float) -> None:
+        clock.now += seconds
+
+    monkeypatch.setattr(
+        gpu_lease_module,
+        "time",
+        SimpleNamespace(monotonic=lambda: clock.now, sleep=advance_clock),
+    )
+
+
 def _fake_proof_environment(
     tmp_path: Path,
     fake_bin: Path,
@@ -2403,12 +2416,15 @@ def test_explicit_runner_gpu_id_still_acquires_a_slot_lease(tmp_path: Path) -> N
 @pytest.mark.model_proof_allocator
 def test_capacity_gated_exclusive_lease_skips_a_memory_busy_gpu(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Keep subprocess scheduling from consuming the deliberately short lease
+    # deadline while preserving the queue and capacity transitions under test.
+    _use_deterministic_gpu_lease_clock(monkeypatch)
     context = _fake_gpu_lease_context(
         tmp_path,
         "2, 284208, 184208, 100000\n3, 284208, 34208, 250000",
     )
-    context.env["FAKE_NVIDIA_SMI_DELAY_SECONDS"] = "0.25"
     artifacts = tmp_path / "artifacts"
     lease = GpuLease(
         context,
@@ -2778,16 +2794,7 @@ def test_capacity_gated_lease_waits_for_memory_reclaim_without_requeueing(
 ) -> None:
     # Drive the short capacity settle window explicitly so host scheduling
     # cannot turn the second memory sample into an unrelated GPU requeue.
-    clock = SimpleNamespace(now=0.0)
-
-    def advance_clock(seconds: float) -> None:
-        clock.now += seconds
-
-    monkeypatch.setattr(
-        gpu_lease_module,
-        "time",
-        SimpleNamespace(monotonic=lambda: clock.now, sleep=advance_clock),
-    )
+    _use_deterministic_gpu_lease_clock(monkeypatch)
     context = _fake_gpu_lease_context(
         tmp_path,
         "2, 284208, 184208, 100000\n3, 284208, 174208, 110000",


### PR DESCRIPTION
## Background

Issue #898 reports that aligned FP32 OLMo2 generation on Thor preserved exact token IDs but took 609.55 ms versus a 336.89 ms reference. The split-engine path also had to fit the target's constrained host memory during build and bundle loading.

## Exit Criteria

- Preserve exact-token output for the registered OLMo2 generation workload.
- Bring Thor latency inside the existing 5% performance margin without relaxing the gate.
- Keep split-engine build and load within the target memory constraints.
- Avoid a performance regression on GB300.

## Implementation

- Spool serialized split-engine plans to temporary files so the prefill plan can be released before TensorRT builds the decode plan, then package both plans from file-backed sections.
- Mark the OLMo2 engine sections for staged loading so only one multi-gigabyte plan payload is resident while the runtime deserializes the bundle.
- Cap TensorRT builder workspace for both OLMo2 engines and tune the prefill profile's optimum sequence length to the registered workload.
- Skip decoder graph priming after its CUDA graph has already been captured, removing repeated context work from every generation call.
- Add focused coverage for temporary-plan cleanup, staged bundle configuration, and the OLMo2 builder settings.

## Validation

- `pytest -q tests/builder/test_engine_builder_extended.py tests/e2e/models/olmo2/test_olmo2_builder_tp.py tests/e2e/models/olmo2/test_olmo2_accuracy_regression.py`: 10 passed, 1 skipped.
- ThorX-1 Accuracy at `8fdecc77473dd021f8dba2fe15ed6c56baa139c5`: Green; 10/10 samples passed with 100% token-prefix, prediction, and exact-match agreement.
- ThorX-1 Perf at the same SHA: Yellow/equivalent; TRTMC p50 340.760 ms versus reference p50 336.046 ms (+1.40%), with stable 10-sample measurements and identical token IDs.
- GB300 Accuracy at the same SHA: Green; 10/10 samples passed with 100% token-prefix, prediction, and exact-match agreement.
- GB300 Perf at the same SHA: Green; TRTMC p50 35.528 ms versus reference p50 148.349 ms (4.176x faster), with stable 10-sample measurements and identical token IDs.
- OLMo2 C++ targets and fresh split-engine bundles built successfully on both target architectures.

## Notes For Future Readers

- Review the generic file-backed plan lifecycle first, followed by OLMo2 staged loading, profile settings, and the one-time graph priming condition.
- The performance policy and registered workload are unchanged.

Closes #898
