### PR TITLE
refactor: centralize TensorRT ABI parsing

### DIFF
--- a/python/tensorrt_model_connect/benchmark/builder.py
+++ b/python/tensorrt_model_connect/benchmark/builder.py
@@ -20,6 +20,7 @@ import tempfile
 import time
 from typing import Any, Iterable, Mapping, Sequence
 
+from .. import trt_compat
 from .types import BenchmarkError, ModelDescriptor, ResolvedCase
 
 
@@ -292,13 +293,13 @@ def _resolve_builder_runtime(backend_abi: str | None) -> _BuilderRuntime:
         current_version = metadata.version("tensorrt")
     except metadata.PackageNotFoundError:
         current_version = "unavailable"
-    current_abi = _version_abi(current_version)
+    current_abi = trt_compat.tensorrt_abi(current_version)
     if backend_abi is None or current_abi == backend_abi:
         return _BuilderRuntime(current_version, current_abi, backend_abi)
 
     for root in _candidate_tensorrt_roots():
         version = _direct_tensorrt_version(root)
-        if _version_abi(version) != backend_abi:
+        if trt_compat.tensorrt_abi(version) != backend_abi:
             continue
         return _BuilderRuntime(
             version=version,
@@ -344,11 +345,6 @@ def _direct_tensorrt_version(root: Path) -> str:
         return ""
     match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
     return match.group(1) if match else ""
-
-
-def _version_abi(version: str) -> str:
-    match = re.search(r"(\d+)\.(\d+)", version)
-    return f"{match.group(1)}.{match.group(2)}" if match else ""
 
 
 def _group_cases(

--- a/python/tensorrt_model_connect/trt_compat.py
+++ b/python/tensorrt_model_connect/trt_compat.py
@@ -109,6 +109,7 @@ def tensorrt_version() -> str:
 
 
 def tensorrt_abi(version: str | None = None) -> str:
+    """Return the TensorRT major.minor ABI, or an empty string if unavailable."""
     match = re.search(r"(\d+)\.(\d+)", version or tensorrt_version() or "")
     if not match:
         return ""

--- a/tests/builder/test_trt_compat_boundary.py
+++ b/tests/builder/test_trt_compat_boundary.py
@@ -44,6 +44,14 @@ def _is_sys_modules_subscript(node: ast.AST) -> bool:
     )
 
 
+def test_tensorrt_abi_contract() -> None:
+    assert trt_compat.tensorrt_abi("11.1.0.106") == "11.1"
+    assert trt_compat.tensorrt_abi("11.123.0.999") == "11.123"
+    assert trt_compat.tensorrt_abi("11") == ""
+    assert trt_compat.tensorrt_abi("unknown") == ""
+    assert trt_compat.tensorrt_abi("TensorRT 11.2.0") == "11.2"
+
+
 def test_tensor_rt_python_api_is_imported_only_through_compat_layer():
     """Builder code must route TensorRT Python API access through trt_compat."""
     violations: list[str] = []

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4924,7 +4924,10 @@ def test_ensure_bundle_replaces_incompatible_tensorrt_abi(
         return Result()
 
     monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
-    monkeypatch.setattr(validation_engine, "runtime_tensorrt_abi", lambda: "11.1")
+    monkeypatch.setattr(
+        "tensorrt_model_connect.trt_compat.tensorrt_abi",
+        lambda _version=None: "11.1",
+)
 
     _, built = validation_engine.ensure_bundle(
         {
@@ -4969,7 +4972,10 @@ def test_ensure_bundle_replaces_mismatched_precision(
         return Result()
 
     monkeypatch.setattr(validation_engine.subprocess, "run", fake_run)
-    monkeypatch.setattr(validation_engine, "runtime_tensorrt_abi", lambda: "11.1")
+    monkeypatch.setattr(
+        "tensorrt_model_connect.trt_compat.tensorrt_abi",
+        lambda _version=None: "11.1",
+    )
 
     _, built = validation_engine.ensure_bundle(
         {
@@ -4989,7 +4995,10 @@ def test_ensure_bundle_replaces_mismatched_precision(
 
 
 def test_bundle_reuse_rejects_unrecognized_precision(monkeypatch) -> None:
-    monkeypatch.setattr(validation_engine, "runtime_tensorrt_abi", lambda: "11.1")
+    monkeypatch.setattr(
+        "tensorrt_model_connect.trt_compat.tensorrt_abi",
+        lambda _version=None: "11.1",
+    )
 
     assert not validation_engine._bundle_can_be_reused(
         {

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -54,14 +54,16 @@ def _target_tensorrt_version(
 
 
 def _package_variant_version(repository: Path, tensorrt_version: str) -> str:
+    from tensorrt_model_connect import trt_compat
+
     with (repository / "pyproject.toml").open("rb") as stream:
         pyproject = tomllib.load(stream)
     package = pyproject["tool"]["tensorrt-model-connect"]["package"]
     base_version = str(package["base-version"])
     if "+" in base_version:
         raise CiError("base package version must not contain a local version segment")
-    major, minor, *_ = tensorrt_version.split(".")
-    return f"{base_version}+trt{major}{minor}"
+    abi = trt_compat.tensorrt_abi(tensorrt_version)
+    return f"{base_version}+trt{abi.replace('.', '')}"
 
 
 def _required_tensorrt_version(metadata_text: str) -> str:
@@ -120,17 +122,14 @@ def _validate_package_variant(
     return tensorrt_version, package_version
 
 
-def _tensorrt_abi(version: str) -> str:
-    major, minor, *_ = version.split(".")
-    return f"{major}_{minor}"
-
-
 def _validate_backend_files(
     location: str,
     tensorrt_version: str,
     backends: dict[str, bytes],
 ) -> None:
-    abi = _tensorrt_abi(tensorrt_version)
+    from tensorrt_model_connect import trt_compat
+
+    abi = trt_compat.tensorrt_abi(tensorrt_version).replace(".", "_")
     generic = "libtrtmc_backend_trt.so"
     versioned = f"libtrtmc_backend_trt_{abi}.so"
     expected = {generic, versioned}
@@ -149,7 +148,9 @@ def _validate_backend_identity(
     backend_abi: str,
     runtime_version: str,
 ) -> None:
-    expected_abi = _tensorrt_abi(tensorrt_version)
+    from tensorrt_model_connect import trt_compat
+
+    expected_abi = trt_compat.tensorrt_abi(tensorrt_version).replace(".", "_")
     if backend_abi.replace(".", "_") != expected_abi:
         raise CiError(
             f"{location}: TensorRT backend reports ABI {backend_abi}; expected "

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -9220,14 +9220,6 @@ def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
         return None
 
 
-def runtime_tensorrt_abi() -> str:
-    try:
-        import tensorrt
-    except Exception:
-        return ""
-    parts = str(tensorrt.__version__).split(".")
-    return ".".join(parts[:2]) if len(parts) >= 2 else ""
-
 
 def _bundle_can_be_reused(
     inspection: Mapping[str, str],
@@ -9236,6 +9228,8 @@ def _bundle_can_be_reused(
     expected_precision: str,
     allow_unknown: bool,
 ) -> bool:
+    from tensorrt_model_connect import trt_compat
+
     if not inspection:
         return allow_unknown
     raw_cache = inspection.get("Max cache length")
@@ -9261,7 +9255,7 @@ def _bundle_can_be_reused(
             if bundle_precision != expected_precision:
                 return False
     bundle_abi = inspection.get("TRT ABI", "")
-    runtime_abi = runtime_tensorrt_abi()
+    runtime_abi = trt_compat.tensorrt_abi()
     return not bundle_abi or not runtime_abi or bundle_abi == runtime_abi
 
 


### PR DESCRIPTION
## Summary

Centralize TensorRT ABI parsing through `trt_compat.tensorrt_abi` for the remaining Python consumers covered by #969.

This removes local TensorRT major/minor parsing from benchmark building, validation, and packaging while keeping caller-specific output formatting separate from the shared ABI parsing contract.

## Scope

- use `trt_compat.tensorrt_abi` in benchmark runtime resolution
- use the shared helper for validation-time TensorRT ABI checks
- use the shared helper for package version and backend ABI validation
- remove local `_version_abi`, `runtime_tensorrt_abi`, and `_tensorrt_abi` helpers
- document the shared ABI result
- add shared contract coverage for normal, unknown, incomplete, prefixed, and future multi-digit version strings
- migrate validation tests away from the removed private helper

## Non-goals

- no change to the existing `trt_compat.tensorrt_abi` parsing semantics
- no changes to unrelated TensorRT version gates or non-ABI version parsing
- no GPU, model-parity, or performance claims

## Validation

Tested base:

`c1beb5d3f4dd4871788213759ee08158ef402e54`

Tested head:

`6b341b43c6280035efd694dfa4aedd2a210aebd5`

Commands executed:

```bash
PYTHONPATH=python:. python3 -m pytest \
  tests/builder/test_trt_compat_boundary.py \
  tests/tools/test_release_backend_abi.py \
  tests/tools/test_validation_engine.py \
  -q -rs
```

Result: `304 passed, 1 skipped`

The skipped test requires optional `pyarrow`, which was not installed locally.

```bash
PYTHONPATH=python:. python3 -m pytest tests/tools/test_trtmc_bench.py -q
```

Result: `72 passed`

```bash
pre-commit run --files \
  python/tensorrt_model_connect/benchmark/builder.py \
  python/tensorrt_model_connect/trt_compat.py \
  tools/validation/engine.py \
  tools/ci/package.py \
  tests/builder/test_trt_compat_boundary.py \
  tests/tools/test_validation_engine.py
```

Result: passed

```bash
PYTHONPATH=python:. python3 tools/model_ci.py validate
```

Result: passed

```bash
PYTHONPATH=python:. python3 tools/test_impact.py --validate
```

Result: passed with repository warnings

```bash
git diff --check
```

Result: passed

## Remaining risk / not run

- GPU validation was not run
- protected premerge CI has not yet been run
- one validation test was skipped locally because optional `pyarrow` was unavailable

Closes #969