### PR TITLE
perf(mistral): reduce generation latency

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -496,10 +496,14 @@ entries:
     model: mistral-7b
     workload:
       testcase: mistral-7b
+      runtime:
+        config:
+          runtime.prefer_gpu_greedy: true
     baseline:
       runner: hf-transformers
       mode: torch-compile
       compile_scope: model.forward
+      precision: fp16
   - id: mixtral.generate
     family: mixtral
     operation: generate

--- a/src/runtime/models/mistral/pipeline.cpp
+++ b/src/runtime/models/mistral/pipeline.cpp
@@ -420,7 +420,8 @@ bool batched_prefill_supported(const TrtModule* prefill, const MistralTextGenCon
 } // namespace
 
 bool MistralTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
-                                                        std::vector<float>& logits) {
+                                                        std::vector<float>& logits,
+                                                        bool retain_device_logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     if (!batched_prefill_supported(prefill_.get(), config_, sq, state_.get()))
         return false;
@@ -445,12 +446,22 @@ bool MistralTextGenerationPipeline::run_prefill_batched(const std::vector<int32_
         return false;
 
     const auto vocab = static_cast<std::size_t>(config_.vocab_size);
-    const auto& lt = logits_it->second;
-    if (static_cast<std::size_t>(lt.numel()) < vocab)
+    const auto& logits_tensor = logits_it->second;
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab)
         return false;
     logits.resize(vocab);
-    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
-    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+    if (retain_device_logits) {
+        const auto* device_logits =
+            static_cast<const float*>(prefill_->device_ptr(config_.logits_output_name));
+        if (device_logits == nullptr) {
+            throw std::runtime_error(
+                "MistralTextGenerationPipeline: prefill logits have no device buffer");
+        }
+        d_logits_ptr_ = device_logits + logits_offset;
+    }
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
@@ -474,7 +485,7 @@ void MistralTextGenerationPipeline::prime_decoder_after_batched_prefill(
         return;
 
     TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
+    if (!decoder.cuda_graph_active() || decoder.cuda_graph_captured())
         return;
 
     int32_t token_id = input_ids.back();
@@ -493,8 +504,9 @@ void MistralTextGenerationPipeline::prime_decoder_after_batched_prefill(
 void MistralTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                                 std::vector<float>& logits, bool gpu_sampling) {
     // Fast path: batched prefill engine writes K/V for the whole prompt in
-    // one forward and returns last-token logits on host.
-    if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
+    // one forward and exposes last-token logits on the sampler's requested
+    // host or device path.
+    if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
         prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;

--- a/src/runtime/models/mistral/pipeline.h
+++ b/src/runtime/models/mistral/pipeline.h
@@ -190,7 +190,8 @@ class MistralTextGenerationPipeline final : public IPipeline {
                            TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
-    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
+                             bool retain_device_logits);
     void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,

--- a/tests/builder/test_mistral_runtime_performance_contract.py
+++ b/tests/builder/test_mistral_runtime_performance_contract.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static performance contracts for the Mistral generation runtime."""
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_SOURCE = REPOSITORY_ROOT / "src" / "runtime" / "models" / "mistral" / "pipeline.cpp"
+
+
+def _function_body(source: str, start: str, end: str) -> str:
+    return source.split(start, maxsplit=1)[1].split(end, maxsplit=1)[0]
+
+
+def test_gpu_greedy_generation_uses_batched_prefill_device_logits() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    prefill = _function_body(
+        source,
+        "bool MistralTextGenerationPipeline::run_prefill_batched(",
+        "void MistralTextGenerationPipeline::prime_decoder_after_batched_prefill(",
+    )
+    dispatch = _function_body(
+        source,
+        "void MistralTextGenerationPipeline::run_prefill(",
+        "TrtModule& MistralTextGenerationPipeline::require_block_prefill(",
+    )
+
+    assert "bool retain_device_logits" in prefill
+    assert "const auto logits_offset" in prefill
+    assert "d_logits_ptr_ = device_logits + logits_offset" in prefill
+    assert "run_prefill_batched(input_ids, logits, gpu_sampling)" in dispatch
+    assert "!gpu_sampling && run_prefill_batched" not in dispatch
+
+
+def test_decoder_graph_is_only_primed_before_its_first_capture() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    prime = _function_body(
+        source,
+        "void MistralTextGenerationPipeline::prime_decoder_after_batched_prefill(",
+        "void MistralTextGenerationPipeline::run_prefill(",
+    )
+
+    assert "decoder.cuda_graph_active()" in prime
+    assert "decoder.cuda_graph_captured()" in prime
+    assert prime.index("decoder.cuda_graph_captured()") < prime.index(
+        "decoder.forward_async(inputs)"
+    )

--- a/tests/builder/test_mistral_runtime_performance_contract.py
+++ b/tests/builder/test_mistral_runtime_performance_contract.py
@@ -5,9 +5,12 @@
 
 from pathlib import Path
 
+import yaml
+
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RUNTIME_SOURCE = REPOSITORY_ROOT / "src" / "runtime" / "models" / "mistral" / "pipeline.cpp"
+RELEASE_CONFIG = REPOSITORY_ROOT / "benchmarks" / "performance" / "release.yaml"
 
 
 def _function_body(source: str, start: str, end: str) -> str:
@@ -47,3 +50,11 @@ def test_decoder_graph_is_only_primed_before_its_first_capture() -> None:
     assert prime.index("decoder.cuda_graph_captured()") < prime.index(
         "decoder.forward_async(inputs)"
     )
+
+
+def test_release_case_enables_gpu_greedy_with_aligned_fp16_reference() -> None:
+    release = yaml.safe_load(RELEASE_CONFIG.read_text(encoding="utf-8"))
+    entry = next(item for item in release["entries"] if item["id"] == "mistral.generate")
+
+    assert entry["workload"]["runtime"]["config"] == {"runtime.prefer_gpu_greedy": True}
+    assert entry["baseline"]["precision"] == "fp16"

--- a/tests/e2e/models/mistral/manifests/mistral-7b-l0.json
+++ b/tests/e2e/models/mistral/manifests/mistral-7b-l0.json
@@ -7,6 +7,9 @@
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
   "max_cache_length": 256,
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "trust_remote_code": false,
   "testcases": [
     {

--- a/tests/e2e/models/mistral/manifests/mistral-7b.json
+++ b/tests/e2e/models/mistral/manifests/mistral-7b.json
@@ -7,6 +7,9 @@
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
   "max_cache_length": 256,
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
   "trust_remote_code": false,
   "testcases": [
     {

--- a/tests/e2e/models/mistral/test_mistral_performance_contract.py
+++ b/tests/e2e/models/mistral/test_mistral_performance_contract.py
@@ -6,10 +6,6 @@
 import json
 from pathlib import Path
 
-import yaml
-
-
-REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 MANIFESTS = Path(__file__).with_name("manifests")
 
 
@@ -17,15 +13,3 @@ def test_mistral_7b_manifests_use_one_dual_profile_engine() -> None:
     for name in ("mistral-7b.json", "mistral-7b-l0.json"):
         manifest = json.loads((MANIFESTS / name).read_text(encoding="utf-8"))
         assert manifest["build_args"]["decoder_engine_layout"] == "dual_profile"
-
-
-def test_release_case_enables_gpu_greedy_with_aligned_fp16_reference() -> None:
-    release = yaml.safe_load(
-        (REPOSITORY_ROOT / "benchmarks" / "performance" / "release.yaml").read_text(
-            encoding="utf-8"
-        )
-    )
-    entry = next(item for item in release["entries"] if item["id"] == "mistral.generate")
-
-    assert entry["workload"]["runtime"]["config"] == {"runtime.prefer_gpu_greedy": True}
-    assert entry["baseline"]["precision"] == "fp16"

--- a/tests/e2e/models/mistral/test_mistral_performance_contract.py
+++ b/tests/e2e/models/mistral/test_mistral_performance_contract.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qualification configuration contracts for Mistral generation."""
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+MANIFESTS = Path(__file__).with_name("manifests")
+
+
+def test_mistral_7b_manifests_use_one_dual_profile_engine() -> None:
+    for name in ("mistral-7b.json", "mistral-7b-l0.json"):
+        manifest = json.loads((MANIFESTS / name).read_text(encoding="utf-8"))
+        assert manifest["build_args"]["decoder_engine_layout"] == "dual_profile"
+
+
+def test_release_case_enables_gpu_greedy_with_aligned_fp16_reference() -> None:
+    release = yaml.safe_load(
+        (REPOSITORY_ROOT / "benchmarks" / "performance" / "release.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    entry = next(item for item in release["entries"] if item["id"] == "mistral.generate")
+
+    assert entry["workload"]["runtime"]["config"] == {"runtime.prefer_gpu_greedy": True}
+    assert entry["baseline"]["precision"] == "fp16"


### PR DESCRIPTION
## Background

Mistral-7B generation latency was 200.32 ms on Thor X versus a 121.01 ms FP16 reference, despite exact output-token agreement. This change addresses the dominant runtime overhead while preserving the existing accuracy contract.

Closes #900.

## Exit criteria

- Preserve FP16 reference/TRTMC output agreement and MMLU accuracy gates.
- Reduce Mistral generation latency to within the configured 5% equivalence band or better on Thor X.
- Validate Accuracy and Performance on both ThorX-1 and GB300 at the exact submitted revision.

## Implementation

- Batch Mistral prefill instead of issuing one runtime call per prompt token.
- Preserve the final device logits needed by GPU greedy sampling.
- Avoid repeating graph priming after graph capture is complete.
- Use the established dual-profile decoder layout and GPU-greedy runtime path for the performance workload.
- Add focused runtime and manifest contract coverage.

## Validation

Validated revision: `25f74164d3363b801fab399e256165cdeb0a873f`

### GB300

- Accuracy: pass; MMLU 20/20 prediction agreement, 0 failed samples; FP16 reference and FP16 TRTMC.
- Performance: green; TRTMC p50 9.109 ms, reference p50 42.686 ms, reference/TRTMC ratio 4.686x; exact generated tokens.

### ThorX-1

- Accuracy: pass; MMLU 20/20 prediction agreement, 0 failed samples; reference accuracy 30%, TRTMC accuracy 30%; FP16 reference and FP16 TRTMC.
- Performance: yellow/equivalent; TRTMC p50 116.728 ms, reference p50 121.285 ms, TRTMC 3.90% faster; stable samples and exact generated tokens.
- The original 200.32 ms TRTMC latency was reduced to 116.728 ms.

ThorX-1 validation used a 30 GiB hugepage carveout with swap disabled. At the issue's 48 GiB carveout, only about 8 GiB ordinary host memory remained and the FP16 reference process was terminated while loading weights. Both compared backends completed under the same 30 GiB environment; this is an environment-capacity constraint, not a relaxed performance gate.

### Local

- Focused Mistral contract tests: 4 passed.
- Nearby non-GPU regression suite: 215 passed.
- Broader selected suite: 225 passed; four GPU/TensorRT tests were unavailable without a device.
- Formatting and source-quality checks passed.
