### PR TITLE
fix(docs): refresh model support snapshots

### DIFF
--- a/website/data/hf-model-metadata.json
+++ b/website/data/hf-model-metadata.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "snapshot_date": "2026-08-19",
+  "snapshot_date": "2026-08-23",
   "purpose": "Documentation metadata only; checkpoint qualification remains defined by the README release row and E2E manifest.",
   "checkpoints": [
     {
@@ -959,6 +959,15 @@
       "architecture_source": "config.architectures"
     },
     {
+      "hf_id": "nvidia/NVIDIA-NemotronLabs-VoiceChat-11B",
+      "revision": "359ada7b1c60851e40ff08065f9b0340244f27e0",
+      "revision_source": "resolved",
+      "metadata_file": "config.json",
+      "model_type": null,
+      "architectures": [],
+      "architecture_source": null
+    },
+    {
       "hf_id": "nvidia/Nemotron-4-Mini-Hindi-4B-Base",
       "revision": "05c6ef6d2ddaad06bce914990facaf08bc4c581e",
       "revision_source": "resolved",
@@ -1035,7 +1044,7 @@
     },
     {
       "hf_id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
-      "revision": "9c20c4aedf9ec87b6b7346c3bc4754ea030dab35",
+      "revision": "9e95da054312436dfc703319dd2b793a3bee2465",
       "revision_source": "resolved",
       "metadata_file": "config.json",
       "model_type": "llama_nemotron_vl_rerank",

--- a/website/docs/reference/source-layout.md
+++ b/website/docs/reference/source-layout.md
@@ -15,8 +15,8 @@ Each directory name must agree with the `id` in its own descriptor. The three
 physical names usually match, but their link is the exact
 `runtime_strategy`, not filename equality: current builder/E2E owners
 `magpie_tts` and `wan_t2v` map to runtime owners `magpie` and `wan`,
-respectively. At this revision, all three trees contain 83 descriptors. The E2E
-descriptors declare 220 JSON manifests; runtime descriptors declare 84 unique
+respectively. At this revision, all three trees contain 84 descriptors. The E2E
+descriptors declare 221 JSON manifests; runtime descriptors declare 85 unique
 strategy keys because one runtime owner exposes two strategies. Treat these
 numbers as a checked snapshot, not a constant: the descriptor files are the
 source of truth.


### PR DESCRIPTION
## Background

The Docs workflow on current `main` fails during `npm run test:model-support` because the retained Hugging Face metadata still pins the reranker checkpoint to `9c20c4a...`, while the current E2E manifest requires `9e95da0...`. The same snapshot also predates the VoiceChat manifest and the current descriptor/manifest counts.

The failure predates the AI-native blog merge; that merge only retriggered the already-failing Pages workflow.

## Exit Criteria

- Make generated model-support inventory validation pass against the current manifests.
- Restore a successful production Docusaurus build with the GitHub Pages base path.
- Make the source-layout snapshot match the current descriptor and manifest trees.
- Do not change runtime behavior, model qualification, manifests, or test thresholds.

## Implementation

- Refresh `hf-model-metadata.json` to include the current VoiceChat checkpoint and the exact reranker revision declared by E2E.
- Update the snapshot date and source-layout counts to the current repository state: 84 builder/runtime/E2E descriptors, 221 E2E manifests, and 85 runtime strategies.

## Validation

- `jq empty website/data/hf-model-metadata.json`: passed; 118 entries, 118 unique Hugging Face IDs, one VoiceChat entry, and reranker revision `9e95da054312436dfc703319dd2b793a3bee2465`.
- `npm --prefix website run test:model-support`: passed.
- `SITE_URL=https://nvidia.github.io BASE_URL=/TensorRT-Model-Connect/ npm --prefix website run build`: passed; production Docusaurus output generated successfully.
- `python3 tools/test_impact.py --validate`: passed with existing allowlist warnings; 221 models, 12 core groups, and 84 families.
- `git diff --check github/main...HEAD`: passed.
- `Community CPU / Required`: passed on exact head `598210d717b80148a5bd3c8b191dc8af1cc0d19e`.
- `trtmc/premerge/required`: passed on the same exact head.

## Notes For Future Readers

- The failing main run was `TensorRT-Model-Connect Docs` run `32768739931`; the failed blog deployment exposed this existing snapshot drift but did not introduce it.
- These are documentation snapshots only. Checkpoint qualification remains defined by the release row and E2E manifests.
