### PR TITLE
ci(community): gate documentation builds

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -45,6 +45,40 @@ jobs:
       - name: Run source quality
         run: python3 -m tools.community_ci source-quality --base "$CI_BASE_REF"
 
+  docs:
+    name: Community CPU / Docs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact PR merge
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+
+      - name: Install website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Test generated model support inventory
+        working-directory: website
+        run: npm run test:model-support
+
+      - name: Build production documentation
+        working-directory: website
+        env:
+          SITE_URL: https://nvidia.github.io
+          BASE_URL: /TensorRT-Model-Connect/
+        run: npm run build
+
   ownership-impact:
     name: Community CPU / Ownership and impact
     runs-on: ubuntu-24.04
@@ -127,6 +161,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - source-quality
+      - docs
       - ownership-impact
       - unit
     runs-on: ubuntu-24.04
@@ -136,14 +171,17 @@ jobs:
       - name: Require every public CPU stage
         env:
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
           OWNERSHIP_IMPACT_RESULT: ${{ needs.ownership-impact.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
         run: |
           set -euo pipefail
           printf '%s\n' \
             "Source quality: $SOURCE_QUALITY_RESULT" \
+            "Docs: $DOCS_RESULT" \
             "Ownership and impact: $OWNERSHIP_IMPACT_RESULT" \
             "Unit / C++ and Python: $UNIT_RESULT"
           test "$SOURCE_QUALITY_RESULT" = success
+          test "$DOCS_RESULT" = success
           test "$OWNERSHIP_IMPACT_RESULT" = success
           test "$UNIT_RESULT" = success

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -159,34 +159,81 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     jobs = workflow["jobs"]
     assert [job["name"] for job in jobs.values()] == [
         "Community CPU / Source quality",
+        "Community CPU / Docs",
         "Community CPU / Ownership and impact",
         "Community CPU / Unit / C++ and Python",
         "Community CPU / Required",
     ]
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
-    for job_name in ("source-quality", "ownership-impact", "unit"):
+    for job_name in ("source-quality", "docs", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
     assert jobs["unit"]["if"] == "${{ !cancelled() }}"
     assert jobs["unit"]["needs"] == "ownership-impact"
     assert jobs["required"]["needs"] == [
         "source-quality",
+        "docs",
         "ownership-impact",
         "unit",
     ]
     assert jobs["required"]["permissions"] == {}
     assert jobs["required"]["if"] == "${{ !cancelled() }}"
 
+    docs = jobs["docs"]
+    assert "if" not in docs
+    assert "needs" not in docs
+    docs_steps = {step["name"]: step for step in docs["steps"]}
+    assert list(docs_steps) == [
+        "Check out the exact PR merge",
+        "Set up Node",
+        "Install website dependencies",
+        "Test generated model support inventory",
+        "Build production documentation",
+    ]
+    assert all("if" not in step for step in docs_steps.values())
+    assert docs_steps["Check out the exact PR merge"]["with"] == {
+        "ref": "${{ github.sha }}",
+        "fetch-depth": 0,
+        "persist-credentials": False,
+    }
+    assert docs_steps["Set up Node"] == {
+        "name": "Set up Node",
+        "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+        "with": {"node-version": "20"},
+    }
+    assert docs_steps["Install website dependencies"] == {
+        "name": "Install website dependencies",
+        "working-directory": "website",
+        "run": "npm ci",
+    }
+    assert docs_steps["Test generated model support inventory"] == {
+        "name": "Test generated model support inventory",
+        "working-directory": "website",
+        "run": "npm run test:model-support",
+    }
+    assert docs_steps["Build production documentation"] == {
+        "name": "Build production documentation",
+        "working-directory": "website",
+        "env": {
+            "SITE_URL": "https://nvidia.github.io",
+            "BASE_URL": "/TensorRT-Model-Connect/",
+        },
+        "run": "npm run build",
+    }
+
 
 @pytest.mark.parametrize(
-    ("source_quality", "ownership_impact", "unit", "expected_returncode"),
+    ("source_quality", "docs", "ownership_impact", "unit", "expected_returncode"),
     [
-        ("success", "success", "success", 0),
-        ("failure", "success", "success", 1),
-        ("success", "failure", "failure", 1),
+        ("success", "success", "success", "success", 0),
+        ("failure", "success", "success", "success", 1),
+        ("success", "failure", "success", "success", 1),
+        ("success", "skipped", "success", "success", 1),
+        ("success", "success", "failure", "failure", 1),
     ],
 )
 def test_public_required_job_fails_closed(
     source_quality: str,
+    docs: str,
     ownership_impact: str,
     unit: str,
     expected_returncode: int,
@@ -194,6 +241,7 @@ def test_public_required_job_fails_closed(
     environment = {
         **os.environ,
         "SOURCE_QUALITY_RESULT": source_quality,
+        "DOCS_RESULT": docs,
         "OWNERSHIP_IMPACT_RESULT": ownership_impact,
         "UNIT_RESULT": unit,
     }
@@ -216,6 +264,7 @@ def test_public_required_job_fails_closed(
 
     assert result.returncode == expected_returncode, result.stdout + result.stderr
     assert f"Source quality: {source_quality}" in result.stdout
+    assert f"Docs: {docs}" in result.stdout
     assert f"Ownership and impact: {ownership_impact}" in result.stdout
     assert f"Unit / C++ and Python: {unit}" in result.stdout
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -266,6 +266,38 @@ def test_only_pages_workflow_creates_deployment_objects() -> None:
     assert deployments == [("pages.yml", "deploy", "github-pages")]
 
 
+def test_community_docs_gate_matches_pages_predeploy_contract() -> None:
+    workflows = REPO_ROOT / ".github" / "workflows"
+    pages = yaml.safe_load((workflows / "pages.yml").read_text(encoding="utf-8"))
+    community = yaml.safe_load(
+        (workflows / "community-cpu.yml").read_text(encoding="utf-8")
+    )
+
+    pages_build = pages["jobs"]["build"]
+    pages_steps = {step["name"]: step for step in pages_build["steps"]}
+    docs = community["jobs"]["docs"]
+    docs_steps = {step["name"]: step for step in docs["steps"]}
+
+    assert str(pages_steps["Set up Node"]["with"]["node-version"]) == "20"
+    assert docs_steps["Set up Node"] == {
+        "name": "Set up Node",
+        "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+        "with": {"node-version": "20"},
+    }
+    assert pages_build["defaults"]["run"]["working-directory"] == "website"
+    assert docs_steps["Test generated model support inventory"] == {
+        "name": "Test generated model support inventory",
+        "working-directory": "website",
+        "run": pages_steps["Test generated model support inventory"]["run"],
+    }
+    assert pages_steps["Test generated model support inventory"]["run"] == (
+        "npm run test:model-support"
+    )
+    assert docs_steps["Install website dependencies"]["run"] == "npm ci"
+    assert docs_steps["Build production documentation"]["run"] == "npm run build"
+    assert pages_steps["Build site"]["run"].strip().endswith("npm run build")
+
+
 def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     workflow = (
         REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"


### PR DESCRIPTION
## Background

PR #1019 passed Community CPU and protected premerge, then the main-only Docs workflow failed after merge. The tested PR merge and final squash had identical trees; this was not a stale-head or squash-timing problem.

The coverage gap was structural: Community source quality and source-only units never executed Node or the website contract, protected premerge relied on that incomplete public prerequisite, and `npm run test:model-support` first ran in the post-merge Pages workflow. The stale metadata therefore surfaced only after landing.

## Exit Criteria

- Run the Pages inventory and production-build contracts against every exact pull-request merge revision.
- Make `Community CPU / Required` fail closed when documentation validation fails or is skipped.
- Keep the contributor-visible docs job read-only, secret-free, and independent of protected/GPU resources.
- Preserve the main-only Pages deployment workflow.

## Implementation

- Add a parallel `Community CPU / Docs` job that checks out `${{ github.sha }}`, pins Node 20, runs `npm ci`, executes `npm run test:model-support`, and builds production docs with the real GitHub Pages site/base URLs.
- Add the Docs job to the required aggregator and require its result to be literal `success`.
- Extend Community workflow tests to lock the unconditional exact-merge job shape and fail-closed aggregation.
- Add a cross-workflow regression proving Community and Pages use the same Node version, inventory command, dependency install, and production build contract.

## Validation

- `python3 -m pytest tests/tools/test_community_ci.py -q -p no:cacheprovider`: passed, 12 tests.
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q -p no:cacheprovider`: passed, 67 tests.
- `npm --prefix website ci`: passed.
- `npm --prefix website run test:model-support`: passed.
- `SITE_URL=https://nvidia.github.io BASE_URL=/TensorRT-Model-Connect/ npm --prefix website run build`: passed.
- Negative control: restoring the stale pre-#1020 metadata made `npm --prefix website run test:model-support` fail with exit code 1; restoring current main made it pass again.
- `python3 tools/test_impact.py --validate`: passed with existing allowlist warnings; 221 models, 12 core groups, and 84 families.
- `git diff --check github/main...HEAD`: passed.
- `Community CPU / Docs`: passed on exact head `712a7b2bfc26178e483c4ba5f2a37d4da542753a` in 1m10s.
- `Community CPU / Required`: passed only after Docs, source quality, ownership/impact, and units all succeeded on the same exact merge.
- `trtmc/premerge/required`: passed on the exact PR head.

## Notes For Future Readers

- The inventory consumes metadata, manifests, model descriptors, runtime source, and website data, so the Docs job intentionally runs for every PR instead of maintaining another incomplete path filter.
- The job has only `contents: read`; it has no Pages write permission, OIDC permission, secrets, deployment environment, or protected runner access.
- #1020 repaired the incident. Main Docs run `32770953344` subsequently built and deployed successfully; this PR prevents the same class of post-merge surprise.
