### PR TITLE
ci(community): harden public CPU checks

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
     env:
       CI_BASE_REF: ${{ github.sha }}^1
+      CI_HEAD_REF: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Check out the exact PR merge
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
@@ -58,6 +59,9 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Check documentation file references
+        run: python3 tools/check_doc_file_references.py --strict website/docs
 
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,16 @@ repos:
         stages: [pre-commit]
       - id: check-yaml
         stages: [pre-commit]
+      - id: check-json
+        stages: [pre-commit]
+      - id: check-toml
+        stages: [pre-commit]
+      - id: check-merge-conflict
+        stages: [pre-commit]
+      - id: check-case-conflict
+        stages: [pre-commit]
+      - id: check-symlinks
+        stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.4
@@ -29,5 +39,5 @@ repos:
         name: TRTMC C++ formatting
         entry: clang-format --dry-run --Werror
         args: [-style=file]
-        files: \.(cpp|h)$
+        files: \.(cc|cpp|cxx|cu|cuh|h|hh|hpp)$
         stages: [pre-commit]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(TRTMC_ENABLE_TRT "Enable TensorRT backend DSO integration" ON)
 option(TRTMC_BUILD_BACKEND_TRT "Build standard TensorRT backend DSO" ON)
 option(TRTMC_BUILD_TESTS "Build C++ unit test executables" ON)
 option(TRTMC_BUILD_BENCHMARKS "Build benchmark executables" ON)
+option(TRTMC_STRICT_CXX "Treat C++ language-conformance warnings as errors" OFF)
 option(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL "Enable optional libtorch-backed multinomial sampler" ON)
 option(TRTMC_DISTRIBUTABLE_BUILD
        "Build distributable artifacts without embedding source/build paths" OFF)
@@ -58,6 +59,11 @@ set(TRTMC_TRT_BACKEND_ABI "" CACHE STRING
   "TensorRT ABI suffix for the standard backend DSO, e.g. 10_15. Empty means auto-detect from headers.")
 set(TRTMC_SOURCE_REVISION "" CACHE STRING
   "Source revision embedded in release benchmark worker provenance.")
+if(TRTMC_STRICT_CXX)
+  add_compile_options(
+    "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Werror=pedantic>"
+  )
+endif()
 if(NOT TRTMC_SOURCE_REVISION)
   execute_process(
     COMMAND git rev-parse HEAD
@@ -719,6 +725,23 @@ if(TRTMC_BUILD_TESTS)
 enable_testing()
 add_custom_target(trtmc_cpp_tests)
 add_custom_target(trtmc_platform_cpp_tests)
+
+if(TARGET trtmc_dataset_benchmark AND TARGET trtmc_benchmark_worker)
+  add_dependencies(trtmc_platform_cpp_tests
+    trtmc
+    trtmc_dataset_benchmark
+    trtmc_benchmark_worker
+  )
+  add_test(NAME test_benchmark_cli_contract
+    COMMAND ${CMAKE_COMMAND}
+      "-DTRTMC_CLI=$<TARGET_FILE:trtmc>"
+      "-DTRTMC_DATASET_BENCHMARK=$<TARGET_FILE:trtmc_dataset_benchmark>"
+      "-DTRTMC_BENCHMARK_WORKER=$<TARGET_FILE:trtmc_benchmark_worker>"
+      "-DTRTMC_TEST_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/benchmark-cli-contract"
+      -P "${PROJECT_SOURCE_DIR}/tests/cpp/test_benchmark_cli_contract.cmake"
+  )
+  set_tests_properties(test_benchmark_cli_contract PROPERTIES LABELS "platform")
+endif()
 
 # Generic capsule test doubles. The good and wrong-identity DSOs intentionally
 # have the same filename in different directories so tests can prove that the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,10 +71,11 @@ pre-commit install --install-hooks
 On Windows, use `py -3 -m pip` in place of `python3 -m pip`.
 
 The hooks trim trailing whitespace, ensure one final newline, validate YAML,
-check Ruff, and verify clang-format. Pre-commit manages the Ruff and
-clang-format environments on Linux, macOS, and Windows. There is no pre-push
-hook: builds and the broader source-only CPU suite run automatically on the
-pull request after the branch is pushed.
+JSON, and TOML, reject merge and filename conflicts or broken symlinks, check
+Ruff, and verify clang-format. Pre-commit manages the Ruff and clang-format
+environments on Linux, macOS, and Windows. There is no pre-push hook: builds
+and the broader source-only CPU suite run automatically on the pull request
+after the branch is pushed.
 
 Start with repository consistency checks:
 
@@ -148,9 +149,11 @@ what the recorded validation proves.
 ### 8. Run contributor-visible public CPU validation
 
 Opening a pull request or pushing a new commit automatically starts Community
-CPU against GitHub's exact pull-request merge revision. Separate jobs run
-source quality, ownership and impact analysis, and the selected source-only C++
-and Python units. No comment or maintainer action is required.
+CPU against GitHub's exact pull-request merge revision. Separate jobs validate
+DCO sign-offs, repository and source quality, documentation, ownership and
+impact analysis, and the selected source-only C++ and Python units. Native CPU
+builds enforce the declared C++17 language mode and exercise the public CLI and
+benchmark executables. No comment or maintainer action is required.
 
 All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
 read-only repository permission and no access to private runners, secrets, or

--- a/requirements/community-ci.txt
+++ b/requirements/community-ci.txt
@@ -10,3 +10,4 @@ lizard==1.24.0
 pytest==8.4.2
 pytest-xdist==3.8.0
 Pillow==12.2.0
+PyYAML>=6.0,<7

--- a/src/cli/jsonl_io.cpp
+++ b/src/cli/jsonl_io.cpp
@@ -6,6 +6,8 @@
 #include "cli/jsonl_io.h"
 
 #include <cmath>
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -44,11 +46,27 @@ DatasetSample parse_dataset_line(const std::string& line, std::size_t line_no) {
 
     auto seed_it = obj.find("seed_index");
     if (seed_it != obj.end()) {
-        if (!seed_it->is_number_integer()) {
+        std::int64_t seed_index = 0;
+        if (seed_it->is_number_unsigned()) {
+            const auto value = seed_it->get<std::uint64_t>();
+            if (value > static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max())) {
+                throw std::runtime_error(
+                    "Field \"seed_index\" is outside the int32 range at line " +
+                    std::to_string(line_no));
+            }
+            seed_index = static_cast<std::int64_t>(value);
+        } else if (seed_it->is_number_integer()) {
+            seed_index = seed_it->get<std::int64_t>();
+        } else {
             throw std::runtime_error("Field \"seed_index\" must be an integer at line " +
                                      std::to_string(line_no));
         }
-        sample.seed_index = seed_it->get<int32_t>();
+        if (seed_index < std::numeric_limits<std::int32_t>::min() ||
+            seed_index > std::numeric_limits<std::int32_t>::max()) {
+            throw std::runtime_error("Field \"seed_index\" is outside the int32 range at line " +
+                                     std::to_string(line_no));
+        }
+        sample.seed_index = static_cast<std::int32_t>(seed_index);
     }
 
     return sample;

--- a/tests/cpp/test_benchmark_cli_contract.cmake
+++ b/tests/cpp/test_benchmark_cli_contract.cmake
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(_required
+    TRTMC_CLI
+    TRTMC_DATASET_BENCHMARK
+    TRTMC_BENCHMARK_WORKER
+    TRTMC_TEST_DIRECTORY)
+  if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
+    message(FATAL_ERROR "${_required} is required")
+  endif()
+endforeach()
+
+function(_trtmc_require_contains LABEL TEXT EXPECTED)
+  string(FIND "${TEXT}" "${EXPECTED}" _position)
+  if(_position EQUAL -1)
+    message(FATAL_ERROR "${LABEL} did not contain '${EXPECTED}':\n${TEXT}")
+  endif()
+endfunction()
+
+execute_process(
+  COMMAND "${TRTMC_CLI}" --help
+  RESULT_VARIABLE _cli_status
+  OUTPUT_VARIABLE _cli_stdout
+  ERROR_VARIABLE _cli_stderr
+)
+if(NOT "${_cli_status}" STREQUAL "0")
+  message(FATAL_ERROR "trtmc --help failed (${_cli_status}):\n${_cli_stdout}\n${_cli_stderr}")
+endif()
+_trtmc_require_contains("trtmc --help" "${_cli_stdout}\n${_cli_stderr}" "Usage:")
+
+execute_process(
+  COMMAND "${TRTMC_BENCHMARK_WORKER}" --help
+  RESULT_VARIABLE _worker_status
+  OUTPUT_VARIABLE _worker_stdout
+  ERROR_VARIABLE _worker_stderr
+)
+if(NOT "${_worker_status}" STREQUAL "0")
+  message(FATAL_ERROR
+    "trtmc_benchmark_worker --help failed (${_worker_status}):\n"
+    "${_worker_stdout}\n${_worker_stderr}")
+endif()
+_trtmc_require_contains(
+  "trtmc_benchmark_worker --help"
+  "${_worker_stdout}\n${_worker_stderr}"
+  "Usage:")
+
+file(MAKE_DIRECTORY "${TRTMC_TEST_DIRECTORY}")
+set(_dataset "${TRTMC_TEST_DIRECTORY}/malformed.jsonl")
+set(_output "${TRTMC_TEST_DIRECTORY}/output.jsonl")
+file(WRITE "${_dataset}" "{\"sample_id\":\"broken\"\n")
+execute_process(
+  COMMAND "${TRTMC_DATASET_BENCHMARK}"
+    "${TRTMC_TEST_DIRECTORY}/missing.bundle"
+    "${_dataset}"
+    "${_output}"
+  RESULT_VARIABLE _dataset_status
+  OUTPUT_VARIABLE _dataset_stdout
+  ERROR_VARIABLE _dataset_stderr
+)
+if("${_dataset_status}" STREQUAL "0")
+  message(FATAL_ERROR "trtmc_dataset_benchmark accepted malformed JSONL")
+endif()
+_trtmc_require_contains(
+  "trtmc_dataset_benchmark malformed JSONL"
+  "${_dataset_stdout}\n${_dataset_stderr}"
+  "Malformed JSON at line 1")

--- a/tests/cpp/test_jsonl_dataset_and_output.cpp
+++ b/tests/cpp/test_jsonl_dataset_and_output.cpp
@@ -26,6 +26,7 @@
 //   - Quotes, backslashes, control characters, and Unicode in string fields
 //   - Missing required fields (sample_id, answer, prompt)
 //   - Wrong field types (e.g. integer sample_id, string seed_index)
+//   - Optional seed_index int32 boundaries and overflow rejection
 //   - Malformed JSONL records (truncated, unbalanced, trailing commas)
 //   - Optional seed_index presence and absence
 //   - Output record round-trip (dump -> parse -> field name/value/type match)
@@ -56,7 +57,8 @@ static void check(bool condition, const char* test_name) {
     }
 }
 
-static void check_throws(const char* test_name, auto&& fn) {
+template <typename Function>
+static void check_throws(const char* test_name, Function&& fn) {
     bool threw = false;
     try {
         fn();
@@ -83,6 +85,50 @@ bool test_parse_with_seed_index() {
     const std::string line = R"({"sample_id":"q2","answer":"7","prompt":"3+4","seed_index":5})";
     auto s = trtmc::cli::parse_dataset_line(line, 1);
     return s.seed_index.has_value() && s.seed_index.value() == 5;
+}
+
+bool test_parse_seed_index_int32_boundaries() {
+    const auto minimum = trtmc::cli::parse_dataset_line(
+        R"({"sample_id":"min","answer":"ok","prompt":"test","seed_index":-2147483648})", 1);
+    const auto maximum = trtmc::cli::parse_dataset_line(
+        R"({"sample_id":"max","answer":"ok","prompt":"test","seed_index":2147483647})", 1);
+    return minimum.seed_index == std::numeric_limits<int32_t>::min() &&
+           maximum.seed_index == std::numeric_limits<int32_t>::max();
+}
+
+bool test_parse_seed_index_overflow() {
+    const std::vector<std::string> lines = {
+        R"({"sample_id":"high","answer":"ok","prompt":"test","seed_index":2147483648})",
+        R"({"sample_id":"low","answer":"ok","prompt":"test","seed_index":-2147483649})",
+        R"({"sample_id":"huge","answer":"ok","prompt":"test","seed_index":18446744073709551615})",
+    };
+    for (const auto& line : lines) {
+        try {
+            trtmc::cli::parse_dataset_line(line, 23);
+            return false;
+        } catch (const std::runtime_error& error) {
+            const std::string message = error.what();
+            if (message.find("seed_index") == std::string::npos ||
+                message.find("int32 range") == std::string::npos ||
+                message.find("23") == std::string::npos) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool test_parse_seed_index_float_is_not_an_integer() {
+    try {
+        trtmc::cli::parse_dataset_line(
+            R"({"sample_id":"float","answer":"ok","prompt":"test","seed_index":1.5})", 9);
+        return false;
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        return message.find("seed_index") != std::string::npos &&
+               message.find("integer") != std::string::npos &&
+               message.find("9") != std::string::npos;
+    }
 }
 
 bool test_parse_with_quotes_and_backslashes() {
@@ -366,6 +412,9 @@ int main() {
     // parse_dataset_line
     check(test_parse_basic(), "parse_basic");
     check(test_parse_with_seed_index(), "parse_with_seed_index");
+    check(test_parse_seed_index_int32_boundaries(), "parse_seed_index_int32_boundaries");
+    check(test_parse_seed_index_overflow(), "parse_seed_index_overflow");
+    check(test_parse_seed_index_float_is_not_an_integer(), "parse_seed_index_float");
     check(test_parse_with_quotes_and_backslashes(), "parse_quotes_backslashes");
     check(test_parse_with_control_characters(), "parse_control_characters");
     check(test_parse_with_unicode(), "parse_unicode");

--- a/tests/tools/test_check_dco.py
+++ b/tests/tools/test_check_dco.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from tools import check_dco
+
+
+def _git(repository: Path, *arguments: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _initialize(repository: Path) -> str:
+    _git(repository, "init", "--quiet")
+    _git(repository, "config", "user.name", "Test Committer")
+    _git(repository, "config", "user.email", "committer@example.com")
+    (repository / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(repository, "add", "tracked.txt")
+    _git(repository, "commit", "--quiet", "-m", "base")
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _commit(repository: Path, message: str) -> str:
+    tracked = repository / "tracked.txt"
+    tracked.write_text(tracked.read_text(encoding="utf-8") + message.splitlines()[0] + "\n")
+    _git(repository, "add", "tracked.txt")
+    environment = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "External Contributor",
+        "GIT_AUTHOR_EMAIL": "contributor@example.com",
+    }
+    _git(repository, "commit", "--quiet", "-m", message, env=environment)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def test_matching_author_signoff_passes(tmp_path: Path) -> None:
+    base = _initialize(tmp_path)
+    head = _commit(
+        tmp_path,
+        "fix: signed contribution\n\nSigned-off-by: External Contributor <contributor@example.com>",
+    )
+
+    commits, failures = check_dco.check_range(tmp_path, base, head)
+
+    assert commits == [head]
+    assert failures == []
+
+
+def test_missing_signoff_reports_the_commit_and_expected_author(tmp_path: Path) -> None:
+    base = _initialize(tmp_path)
+    head = _commit(tmp_path, "fix: unsigned contribution")
+
+    commits, failures = check_dco.check_range(tmp_path, base, head)
+
+    assert commits == [head]
+    assert failures == [
+        f"{head[:12]}: missing Signed-off-by: "
+        "External Contributor <contributor@example.com>"
+    ]
+
+
+def test_different_signoff_does_not_certify_the_author(tmp_path: Path) -> None:
+    base = _initialize(tmp_path)
+    head = _commit(
+        tmp_path,
+        "fix: wrong signoff\n\nSigned-off-by: Someone Else <other@example.com>",
+    )
+
+    _, failures = check_dco.check_range(tmp_path, base, head)
+
+    assert len(failures) == 1
+    assert "does not match author External Contributor <contributor@example.com>" in failures[0]
+    assert "Someone Else <other@example.com>" in failures[0]
+
+
+def test_every_introduced_commit_is_checked(tmp_path: Path) -> None:
+    base = _initialize(tmp_path)
+    _commit(
+        tmp_path,
+        "fix: first\n\nSigned-off-by: External Contributor <contributor@example.com>",
+    )
+    unsigned = _commit(tmp_path, "fix: second")
+    head = _commit(
+        tmp_path,
+        "fix: third\n\nSigned-off-by: External Contributor <contributor@example.com>",
+    )
+
+    commits, failures = check_dco.check_range(tmp_path, base, head)
+
+    assert len(commits) == 3
+    assert len(failures) == 1
+    assert failures[0].startswith(unsigned[:12])

--- a/tests/tools/test_check_structured_files.py
+++ b/tests/tools/test_check_structured_files.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import check_structured_files
+
+
+def test_valid_structured_files_parse(tmp_path: Path) -> None:
+    files = {
+        "value.json": '{"name": "demo", "values": [1, 2]}\n',
+        "value.toml": 'name = "demo"\nvalues = [1, 2]\n',
+        "value.yaml": "name: demo\nvalues:\n  - 1\n  - 2\n",
+        "multi.yml": "name: first\n---\nname: second\n",
+    }
+
+    for name, content in files.items():
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        assert check_structured_files.validate_file(path) is None
+
+
+def test_duplicate_json_key_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"name": "first", "name": "second"}\n', encoding="utf-8")
+
+    failure = check_structured_files.validate_file(path)
+
+    assert failure is not None
+    assert "duplicate JSON key: 'name'" in failure
+
+
+def test_malformed_toml_reports_the_file(tmp_path: Path) -> None:
+    path = tmp_path / "broken.toml"
+    path.write_text('name = "unterminated\n', encoding="utf-8")
+
+    failure = check_structured_files.validate_file(path)
+
+    assert failure is not None
+    assert str(path) in failure
+
+
+def test_malformed_yaml_reports_the_file(tmp_path: Path) -> None:
+    path = tmp_path / "broken.yaml"
+    path.write_text("value: [1, 2\n", encoding="utf-8")
+
+    failure = check_structured_files.validate_file(path)
+
+    assert failure is not None
+    assert str(path) in failure

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -36,7 +36,16 @@ def test_pre_commit_config_installs_only_lightweight_commit_hooks() -> None:
     assert repositories["https://github.com/pre-commit/mirrors-clang-format"]["rev"] == "v22.1.8"
 
     hooks = {hook["id"]: hook for repository in config["repos"] for hook in repository["hooks"]}
-    for hook_id in ("trailing-whitespace", "end-of-file-fixer", "check-yaml"):
+    for hook_id in (
+        "trailing-whitespace",
+        "end-of-file-fixer",
+        "check-yaml",
+        "check-json",
+        "check-toml",
+        "check-merge-conflict",
+        "check-case-conflict",
+        "check-symlinks",
+    ):
         assert hooks[hook_id]["stages"] == ["pre-commit"]
     assert hooks["ruff-check"]["stages"] == ["pre-commit"]
     assert hooks["clang-format"]["stages"] == ["pre-commit"]
@@ -149,6 +158,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert "self-hosted" not in source
     assert "github.event.pull_request.base.sha" not in source
     assert source.count("CI_BASE_REF: ${{ github.sha }}^1") == 2
+    assert source.count("CI_HEAD_REF: ${{ github.event.pull_request.head.sha }}") == 1
     assert "ref: ${{ github.sha }}" in source
     assert "persist-credentials: false" in source
     assert "cancel-in-progress: true" in source
@@ -184,6 +194,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     docs_steps = {step["name"]: step for step in docs["steps"]}
     assert list(docs_steps) == [
         "Check out the exact PR merge",
+        "Check documentation file references",
         "Set up Node",
         "Install website dependencies",
         "Test generated model support inventory",
@@ -199,6 +210,10 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
         "name": "Set up Node",
         "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
         "with": {"node-version": "20"},
+    }
+    assert docs_steps["Check documentation file references"] == {
+        "name": "Check documentation file references",
+        "run": "python3 tools/check_doc_file_references.py --strict website/docs",
     }
     assert docs_steps["Install website dependencies"] == {
         "name": "Install website dependencies",

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1236,7 +1236,9 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert "test_distinct_explicit_hf_cache_paths_reach_both_containers" in stage
     assert 'not model_proof_allocator"' in stage
     assert '"-m"' in stage and '"model_proof_allocator"' in stage
-    assert '["trtmc", "test_cli_args", "test_config_cli_support"]' in script
+    assert '"trtmc_dataset_benchmark"' in script
+    assert '"trtmc_benchmark_worker"' in script
+    assert "test_benchmark_cli_contract" in script
     assert '["trtmc", "trtmc_platform_cpp_tests"]' in script
     assert '"TRTMC_PREMERGE_UNIT_SCOPE", "all"' in stage
     assert "tests/builder/test_cli.py" in script
@@ -1245,6 +1247,8 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert "if native_targets:" in stage
     assert '[build / "trtmc", "version"]' in stage
     assert '[build / "trtmc", "--help"]' in stage
+    assert '"-DTRTMC_BUILD_BENCHMARKS=ON"' in stage
+    assert '"-DTRTMC_STRICT_CXX=ON"' in stage
     assert "--stop-on-failure" in stage
     assert "libtrtmc_model_*.so*" in stage
     assert "-DTRTMC_ENABLE_TRT=OFF" not in stage

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -691,6 +691,8 @@ def test_source_container_runs_units_without_model_fallback(
         ".pre-commit-config.yaml",
         "Dockerfile.community-cpu",
         "requirements/community-ci.txt",
+        "tools/check_dco.py",
+        "tools/check_structured_files.py",
         "tools/community_ci.py",
     ),
 )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1553,6 +1553,8 @@ class TestNoImpact:
             ".pre-commit-config.yaml",
             "Dockerfile.community-cpu",
             "requirements/community-ci.txt",
+            "tools/check_dco.py",
+            "tools/check_structured_files.py",
             "tools/community_ci.py",
         ],
     )

--- a/tools/check_dco.py
+++ b/tools/check_dco.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Require every introduced commit to carry its author's DCO sign-off."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+_SIGN_OFF = re.compile(
+    r"^Signed-off-by:\s*(?P<name>.+?)\s*<(?P<email>[^<>]+)>\s*$",
+    re.IGNORECASE,
+)
+
+
+class DcoError(RuntimeError):
+    """Raised when the requested Git commit range cannot be inspected."""
+
+
+def _git(repository: Path, *arguments: str, binary: bool = False) -> str | bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        capture_output=True,
+        text=not binary,
+        check=False,
+    )
+    if result.returncode:
+        stderr = result.stderr.decode(errors="replace") if binary else result.stderr
+        raise DcoError(stderr.strip() or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def introduced_commits(repository: Path, base: str, head: str) -> list[str]:
+    """Return every commit reachable from head but not from the target base."""
+
+    output = _git(repository, "rev-list", "--reverse", f"{base}..{head}")
+    assert isinstance(output, str)
+    commits = output.splitlines()
+    if not commits:
+        raise DcoError(f"no introduced commits found in {base}..{head}")
+    return commits
+
+
+def _normalize_name(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def _normalize_email(value: str) -> str:
+    return value.strip().casefold()
+
+
+def check_commit(repository: Path, revision: str) -> str | None:
+    """Return a human-readable failure when revision lacks its author's sign-off."""
+
+    payload = _git(repository, "show", "-s", "--format=%an%x00%ae%x00%B", revision, binary=True)
+    assert isinstance(payload, bytes)
+    fields = payload.decode("utf-8", errors="replace").split("\0", maxsplit=2)
+    if len(fields) != 3:
+        raise DcoError(f"could not read author and message for {revision}")
+    author_name, author_email, message = fields
+    expected_name = _normalize_name(author_name)
+    expected_email = _normalize_email(author_email)
+    signoffs: list[tuple[str, str]] = []
+    for line in message.splitlines():
+        match = _SIGN_OFF.fullmatch(line.strip())
+        if match:
+            signoffs.append((match.group("name"), match.group("email")))
+    if any(
+        _normalize_name(name) == expected_name and _normalize_email(email) == expected_email
+        for name, email in signoffs
+    ):
+        return None
+    short = revision[:12]
+    expected = f"{author_name.strip()} <{author_email.strip()}>"
+    if not signoffs:
+        return f"{short}: missing Signed-off-by: {expected}"
+    rendered = ", ".join(f"{name.strip()} <{email.strip()}>" for name, email in signoffs)
+    return f"{short}: Signed-off-by does not match author {expected}; found {rendered}"
+
+
+def check_range(repository: Path, base: str, head: str) -> tuple[list[str], list[str]]:
+    commits = introduced_commits(repository, base, head)
+    failures = [failure for revision in commits if (failure := check_commit(repository, revision))]
+    return commits, failures
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", default="HEAD")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parse_args(argv)
+    repository = arguments.repo_root.resolve()
+    try:
+        commits, failures = check_range(repository, arguments.base, arguments.head)
+    except DcoError as error:
+        print(f"DCO check failed: {error}", file=sys.stderr)
+        return 2
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    if failures:
+        print(
+            "Add the matching sign-off with `git commit --signoff` and update the PR branch.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"DCO sign-offs: {len(commits)} introduced commit(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_structured_files.py
+++ b/tools/check_structured_files.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parse every tracked JSON, TOML, and YAML file without executing repository code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_STRUCTURED_SUFFIXES = frozenset({".json", ".toml", ".yaml", ".yml"})
+
+
+class DuplicateJsonKey(ValueError):
+    """Raised when a JSON object repeats a key."""
+
+
+def _reject_duplicate_json_keys(items: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in items:
+        if key in result:
+            raise DuplicateJsonKey(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def validate_file(path: Path) -> str | None:
+    """Return a concise parse failure for one supported file, otherwise None."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".json":
+            json.loads(text, object_pairs_hook=_reject_duplicate_json_keys)
+        elif path.suffix == ".toml":
+            tomllib.loads(text)
+        elif path.suffix in {".yaml", ".yml"}:
+            list(yaml.safe_load_all(text))
+        else:
+            return None
+    except (OSError, UnicodeError, ValueError, yaml.YAMLError) as error:
+        detail = str(error).splitlines()[0] if str(error) else type(error).__name__
+        return f"{path}: {detail}"
+    return None
+
+
+def tracked_structured_files(repository: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repository,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(detail or "git ls-files failed")
+    names = result.stdout.decode("utf-8", errors="surrogateescape").split("\0")
+    return sorted(
+        repository / name
+        for name in names
+        if name and Path(name).suffix in _STRUCTURED_SUFFIXES
+    )
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    repository = _parse_args(argv).repo_root.resolve()
+    try:
+        files = tracked_structured_files(repository)
+    except RuntimeError as error:
+        print(f"structured-file check failed: {error}", file=sys.stderr)
+        return 2
+    failures = [failure for path in files if (failure := validate_file(path))]
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    if failures:
+        print(f"structured files: {len(files)} checked, {len(failures)} failed", file=sys.stderr)
+        return 1
+    print(f"structured files: {len(files)} checked, 0 failed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -57,9 +57,11 @@ that enters the run-owned container and invokes `pipeline` there.
 ## Community CPU, step by step
 
 Opening a pull request or pushing a new commit automatically starts Community
-CPU against GitHub's exact pull-request merge revision. Source quality,
-ownership and impact, and selected source-only units run as separate jobs on
-GitHub-hosted public CPU runners.
+CPU against GitHub's exact pull-request merge revision. DCO and source quality,
+documentation, ownership and impact, and selected source-only units run as
+separate jobs on GitHub-hosted public CPU runners. Source quality also validates
+tracked structured files and legal headers; the native unit build enforces
+C++17 conformance and exercises the public CLI and benchmark executables.
 
 The jobs check out only the event's immutable merge SHA with read-only
 repository permission, no persisted checkout credentials, and no secrets.

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -99,6 +99,34 @@ class SourceQualityChecks:
     def family_coverage(self) -> None:
         self.context.run(["python", "scripts/check_family_coverage.py"])
 
+    def dco(self) -> None:
+        self.context.run(
+            [
+                "python",
+                "tools/check_dco.py",
+                "--base",
+                self.context.env["CI_BASE_REF"],
+                "--head",
+                self.context.env.get("CI_HEAD_REF", "HEAD"),
+            ]
+        )
+
+    def diff_hygiene(self) -> None:
+        self.context.run(
+            [
+                "git",
+                "diff",
+                "--check",
+                f"{self.context.env['CI_BASE_REF']}...{self.context.env.get('CI_HEAD_REF', 'HEAD')}",
+            ]
+        )
+
+    def structured_files(self) -> None:
+        self.context.run(["python", "tools/check_structured_files.py"])
+
+    def legal_headers(self) -> None:
+        self.context.run(["python", "tools/legal_headers.py", "--check"])
+
     def complexity(self) -> None:
         self.context.run(["lizard", "--version"])
         self.context.run(
@@ -139,7 +167,17 @@ class SourceQualityChecks:
             print("Checking Python lint on changed files:")
             print("\n".join(python_files))
             self.context.run(["ruff", "check", "--config", "ruff.toml", *python_files])
-        cpp_files = self._changed_files(base, "*.cpp", "*.h")
+        cpp_files = self._changed_files(
+            base,
+            "*.cc",
+            "*.cpp",
+            "*.cxx",
+            "*.cu",
+            "*.cuh",
+            "*.h",
+            "*.hh",
+            "*.hpp",
+        )
         if cpp_files:
             print("Checking C++ formatting on changed files:")
             print("\n".join(cpp_files))
@@ -277,7 +315,8 @@ class UnitTestRunner:
                     "Ninja",
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DTRTMC_BUILD_TESTS=ON",
-                    "-DTRTMC_BUILD_BENCHMARKS=OFF",
+                    "-DTRTMC_BUILD_BENCHMARKS=ON",
+                    "-DTRTMC_STRICT_CXX=ON",
                     "-DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF",
                     "-DTRTMC_BUILD_DIFFUSION_KERNELS=OFF",
                     "-DFETCHCONTENT_FULLY_DISCONNECTED=ON",
@@ -295,7 +334,7 @@ class UnitTestRunner:
                 ],
                 limit=self.context.env.get("BUILD_ALL_TIMEOUT", "15m"),
             )
-            if scope == "cli":
+            if scope in {"cli", "all", "community-all"}:
                 self.context.run([build / "trtmc", "version"], limit="1m")
                 self.context.run([build / "trtmc", "--help"], limit="1m")
             leaked = next(build.rglob("libtrtmc_model_*.so*"), None)
@@ -328,8 +367,17 @@ class UnitTestRunner:
                     "tests/builder/test_max_batch_size_cli.py",
                     "tests/builder/test_owned_schedulers.py::test_package_main_module_invokes_build_cli_main",
                 ],
-                ["trtmc", "test_cli_args", "test_config_cli_support"],
-                ["-R", "^(test_cli_args|test_config_cli_support)$"],
+                [
+                    "trtmc",
+                    "trtmc_dataset_benchmark",
+                    "trtmc_benchmark_worker",
+                    "test_cli_args",
+                    "test_config_cli_support",
+                ],
+                [
+                    "-R",
+                    "^(test_benchmark_cli_contract|test_cli_args|test_config_cli_support)$",
+                ],
             )
         if scope in {"all", "community-all"}:
             harness_tests = [

--- a/tools/community_ci.py
+++ b/tools/community_ci.py
@@ -51,6 +51,11 @@ class CommunityCI:
         quality = SourceQualityChecks(context)
         failures = self._collect(
             (
+                ("DCO sign-offs", quality.dco),
+                ("Diff hygiene", quality.diff_hygiene),
+                ("Structured file syntax", quality.structured_files),
+                ("Legal source headers", quality.legal_headers),
+                ("Family coverage", quality.family_coverage),
                 ("Cyclomatic complexity", quality.complexity),
                 ("Changed-file lint and formatting", quality.lint_changed_files),
                 ("Model architecture contracts", quality.architecture_contracts),

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -156,6 +156,8 @@ FULL_UNIT_TEST_INPUT_EXACT = frozenset(
         "Dockerfile.dev.aarch64",
         "Dockerfile.dev.x86",
         "requirements/community-ci.txt",
+        "tools/check_dco.py",
+        "tools/check_structured_files.py",
         "tools/community_ci.py",
         "tools/ci/README.md",
     }

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -2002,6 +2002,8 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
                     ".pre-commit-config.yaml",
                     "Dockerfile.community-cpu",
                     "requirements/community-ci.txt",
+                    "tools/check_dco.py",
+                    "tools/check_structured_files.py",
                     "tools/community_ci.py",
                 }
             ),

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -44,10 +44,11 @@ pre-commit install --install-hooks
 On Windows, use `py -3 -m pip` in place of `python3 -m pip`.
 
 Commit-time hooks trim trailing whitespace, ensure one final newline, validate
-YAML, check Ruff, and verify clang-format. Some commit-time hooks modify files;
-review and stage those fixes before committing again. Pre-commit manages the
-Ruff and clang-format environments on Linux, macOS, and Windows instead of
-depending on host-installed binaries.
+YAML, JSON, and TOML, reject merge and filename conflicts or broken symlinks,
+check Ruff, and verify clang-format. Some commit-time hooks modify files; review
+and stage those fixes before committing again. Pre-commit manages the Ruff and
+clang-format environments on Linux, macOS, and Windows instead of depending on
+host-installed binaries.
 
 The local hook intentionally stays lightweight and does not build the CLI or
 run the complete CPU suite. After pushing, the pull request automatically runs
@@ -139,9 +140,11 @@ performance, and release qualification are different evidence tiers.
 
 Opening the pull request or pushing a new commit automatically starts
 contributor-visible, GitHub-hosted `Community CPU` validation against GitHub's
-exact pull-request merge revision. Separate jobs run source quality, ownership
-and impact, and source-only C++ and Python units. No comment or maintainer action
-is required.
+exact pull-request merge revision. Separate jobs validate DCO sign-offs,
+repository and source quality, documentation, ownership and impact, and
+source-only C++ and Python units. Native CPU builds enforce C++17 and exercise
+the public CLI and benchmark executables. No comment or maintainer action is
+required.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs, and every public job uses a GitHub-hosted


### PR DESCRIPTION
## Background

Community CPU already catches existing lint, formatting, compile, and unit-test failures, but recent contributions exposed deterministic CPU-only gaps: unsigned commits had no public feedback, GCC accepted C++20 syntax as a C++17 extension, benchmark executables were not built, structured and legal repository contracts were not gated, and an out-of-range JSONL seed silently narrowed to `int32_t`.

## Exit Criteria

- Every commit introduced by a pull request has a DCO sign-off matching its author.
- Tracked JSON, TOML, YAML, legal headers, family coverage, diff hygiene, and all supported C++/CUDA formatting extensions fail visibly in Community CPU.
- Source-only native tests compile in strict C++17 mode and build and exercise `trtmc`, `trtmc_dataset_benchmark`, and `trtmc_benchmark_worker`.
- JSONL `seed_index` accepts the complete `int32_t` range and rejects overflow with the source line number.
- GPU/model proof, minimum-Python compatibility, sanitizers, and broader model-owned CPU selection remain follow-up work.

## Implementation

- Extend Source quality with DCO, diff, structured-file, SPDX/legal-header, and family-coverage checks. JSON validation also rejects duplicate object keys.
- Expand the lightweight pre-commit checks to JSON, TOML, conflicts, case collisions, symlinks, and the repository's C++/CUDA source extensions.
- Add an opt-in CMake strict mode that promotes only C++ language-conformance diagnostics to errors, leaving existing TensorRT/CUDA warnings unchanged.
- Build benchmark executables in the public source-only unit lane and add a platform CTest that starts all three public binaries and verifies malformed JSONL fails before model loading.
- Validate `seed_index` before narrowing and add minimum, maximum, overflow, huge unsigned, and non-integer regression cases.
- Keep the contributor guides and CI tutorial synchronized with the expanded public checks.

## Validation

- `env CI_HEAD_REF=HEAD python3 -m tools.community_ci source-quality --base github/main`: passed on `390d587997a7e99def0890368e100e7535b46056` (1 DCO commit, 839 structured files, 5,047 managed legal-header files, 84/84 family coverage, Ruff/clang-format, complexity, and 158 architecture tests).
- `python3 -m tools.community_ci unit --scope all`: passed in the hardened GPU-free container on the exact head (3,570 Python tests passed, 2 skipped; 20 allocator tests passed; strict C++17 completed 148 Ninja build steps; 41/41 platform CTests passed).
- `python3 tools/check_doc_file_references.py --strict website/docs`: passed with 0 errors and 0 warnings.
- `npm --prefix website run test:model-support`: passed.
- `SITE_URL=https://nvidia.github.io BASE_URL=/TensorRT-Model-Connect/ npm --prefix website run build`: passed.
- Real GPU inference and protected model proofs were not run; this change is limited to the public CPU/source contract.

## Notes For Future Readers

- Review `tools/community_ci.py` and `tools/ci/quality.py` first for the public gate, then the CMake strict/binary contract, and finally the focused JSONL behavior change.
- `TRTMC_STRICT_CXX` is opt-in and enabled by Community CPU. Do not replace it with blanket `-Werror`, which would conflate project conformance failures with third-party SDK warnings.
