### PR TITLE
refactor(e2e): render repro commands once with shlex.join

### DIFF
--- a/tests/e2e/models/deepseek_ocr/e2e_plugins/repro.py
+++ b/tests/e2e/models/deepseek_ocr/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class DeepseekOcrReproCommandProvider:
@@ -36,9 +30,9 @@ class DeepseekOcrReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/elf_flow/e2e_plugins/repro.py
+++ b/tests/e2e/models/elf_flow/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class ElfFlowReproCommandProvider:
@@ -35,7 +29,7 @@ class ElfFlowReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(
+            str(
                 case.inputs.get("prompt")
                 or case.inputs.get("source_text")
                 or case.inputs.get("condition_text")

--- a/tests/e2e/models/internvl/e2e_plugins/repro.py
+++ b/tests/e2e/models/internvl/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class InternvlReproCommandProvider:
@@ -36,9 +30,9 @@ class InternvlReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/lance/e2e_plugins/repro.py
+++ b/tests/e2e/models/lance/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class LanceReproCommandProvider:
@@ -36,9 +30,9 @@ class LanceReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/locateanything/e2e_plugins/repro.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class LocateAnythingReproCommandProvider:
@@ -36,9 +30,9 @@ class LocateAnythingReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/ltx_video/e2e_plugins/repro.py
+++ b/tests/e2e/models/ltx_video/e2e_plugins/repro.py
@@ -5,15 +5,10 @@
 
 from __future__ import annotations
 
-import shlex
 from pathlib import Path
 
 from . import _case_artifact_dir
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class LtxVideoReproCommandProvider:
@@ -37,7 +32,7 @@ class LtxVideoReproCommandProvider:
             "generate-video",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
+            str(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
             "--output",
             "/tmp/trtmc_frames",
             "--num-steps",

--- a/tests/e2e/models/phi4_multimodal/e2e_plugins/repro.py
+++ b/tests/e2e/models/phi4_multimodal/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class Phi4MultimodalReproCommandProvider:
@@ -36,9 +30,9 @@ class Phi4MultimodalReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/qwen_image/e2e_plugins/repro.py
+++ b/tests/e2e/models/qwen_image/e2e_plugins/repro.py
@@ -5,15 +5,10 @@
 
 from __future__ import annotations
 
-import shlex
 from pathlib import Path
 
 from . import _case_artifact_dir
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class QwenImageReproCommandProvider:
@@ -37,7 +32,7 @@ class QwenImageReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
+            str(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
             "--output",
             "/tmp/trtmc_qwen_image/output.png",
             "--num-inference-steps",
@@ -46,7 +41,7 @@ class QwenImageReproCommandProvider:
 
         negative_prompt = case.inputs.get("negative_prompt")
         if negative_prompt is not None:
-            infer_parts.extend(["--negative-prompt", _shell_quote(negative_prompt)])
+            infer_parts.extend(["--negative-prompt", str(negative_prompt)])
 
         cfg_scale = case.inputs.get("cfg_scale")
         if cfg_scale is None:
@@ -67,7 +62,7 @@ class QwenImageReproCommandProvider:
 
         image_path = case.inputs.get("image") or case.inputs.get("image_path")
         if image_path:
-            infer_parts.extend(["--image", _shell_quote(image_path)])
+            infer_parts.extend(["--image", str(image_path)])
 
         if ctx.artifacts_dir:
             latent_path = Path(

--- a/tests/e2e/models/qwen_vl/e2e_plugins/repro.py
+++ b/tests/e2e/models/qwen_vl/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class QwenVlReproCommandProvider:
@@ -36,9 +30,9 @@ class QwenVlReproCommandProvider:
             "run",
             bundle_path,
             "--prompt",
-            _shell_quote(case.inputs.get("prompt", "Describe this image.")),
+            str(case.inputs.get("prompt", "Describe this image.")),
             "--image",
-            _shell_quote(image),
+            str(image),
             "--max-new-tokens",
             str(case.inputs.get("max_new_tokens", 30)),
         ]

--- a/tests/e2e/models/sam/e2e_plugins/repro.py
+++ b/tests/e2e/models/sam/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class SamReproCommandProvider:
@@ -41,7 +35,7 @@ class SamReproCommandProvider:
             "segment-prompted",
             bundle_path,
             "--image",
-            _shell_quote(image),
+            str(image),
             "--output",
             "/tmp/trtmc_masks",
             "--point-x",

--- a/tests/e2e/models/sam3/e2e_plugins/repro.py
+++ b/tests/e2e/models/sam3/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class Sam3ReproCommandProvider:
@@ -41,7 +35,7 @@ class Sam3ReproCommandProvider:
             "segment-prompted",
             bundle_path,
             "--image",
-            _shell_quote(image),
+            str(image),
             "--output",
             "/tmp/trtmc_masks",
         ]
@@ -51,7 +45,7 @@ class Sam3ReproCommandProvider:
             or case.metadata.get("text_prompt")
         )
         if prompt is not None:
-            infer_parts.extend(["--prompt", _shell_quote(prompt)])
+            infer_parts.extend(["--prompt", str(prompt)])
         else:
             infer_parts.extend([
                 "--point-x",

--- a/tests/e2e/models/segformer/e2e_plugins/repro.py
+++ b/tests/e2e/models/segformer/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class SegformerReproCommandProvider:
@@ -36,7 +30,7 @@ class SegformerReproCommandProvider:
             "segment",
             bundle_path,
             "--image",
-            _shell_quote(image),
+            str(image),
             "--output",
             "/tmp/trtmc_segformer/seg_output.png",
         ]

--- a/tests/e2e/models/timm_vit/e2e_plugins/repro.py
+++ b/tests/e2e/models/timm_vit/e2e_plugins/repro.py
@@ -5,13 +5,7 @@
 
 from __future__ import annotations
 
-import shlex
-
 from .contracts import E2ECase, ReproCommandProvider, RunContext
-
-
-def _shell_quote(value: object) -> str:
-    return shlex.quote(str(value))
 
 
 class TimmVitReproCommandProvider:
@@ -41,7 +35,7 @@ class TimmVitReproCommandProvider:
             "classify",
             bundle_path,
             "--image",
-            _shell_quote(image),
+            str(image),
         ]
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -814,7 +814,7 @@ def _build_repro_commands(
     _append_declared_build_cli_args(build_parts, case)
     if case.metadata.get("trust_remote_code"):
         build_parts.append("--trust-remote-code")
-    repro["build_bundle"] = " ".join(build_parts)
+    repro["build_bundle"] = shlex.join(build_parts)
 
     # TRT inference command. Model-local repro providers or runner-owned hooks
     # own task-specific CLI recipes; the orchestrator only renders and wraps.
@@ -831,7 +831,7 @@ def _build_repro_commands(
             ]
             if case.inputs.get("prompt_file"):
                 infer_parts.extend(
-                    ["--prompts-file", _shell_quote(str(case.inputs["prompt_file"]))]
+                    ["--prompts-file", str(case.inputs["prompt_file"])]
                 )
             elif case.inputs.get("prompt_repeat") and ctx.artifacts_dir:
                 resolved_prompt = (
@@ -839,11 +839,11 @@ def _build_repro_commands(
                     / "resolved_prompt.txt"
                 )
                 infer_parts.extend(
-                    ["--prompts-file", _shell_quote(str(resolved_prompt))]
+                    ["--prompts-file", str(resolved_prompt)]
                 )
             else:
                 infer_parts.extend(
-                    ["--prompt", _shell_quote(str(case.inputs.get("prompt", "")))]
+                    ["--prompt", str(case.inputs.get("prompt", ""))]
                 )
             infer_parts.extend(
                 ["--max-new-tokens", str(case.inputs.get("max_new_tokens", 20))]
@@ -864,7 +864,7 @@ def _build_repro_commands(
             if runtime_cli_python:
                 infer_parts.extend(["--hf-python", runtime_cli_python])
         infer_parts = _wrap_distributed_repro_command(infer_parts, case)
-        repro["trt_inference"] = " ".join(infer_parts)
+        repro["trt_inference"] = shlex.join(infer_parts)
 
     # Rerun this exact test case
     rerun_parts = [
@@ -882,7 +882,7 @@ def _build_repro_commands(
         rerun_parts.append("--multi-device-only")
     if case.metadata.get("test_category") == "regression":
         rerun_parts.extend(["--e2e-category", "regression"])
-    repro["rerun_test"] = " ".join(rerun_parts)
+    repro["rerun_test"] = shlex.join(rerun_parts)
 
     profile_exports: list[str] = []
     for profile_name, python in (
@@ -901,7 +901,7 @@ def _build_repro_commands(
 
     # Rerun with forced rebuild
     rebuild_parts = list(rerun_parts) + ["--rebuild-engines"]
-    repro["rerun_test_rebuild"] = " ".join(rebuild_parts)
+    repro["rerun_test_rebuild"] = shlex.join(rebuild_parts)
 
     return repro
 
@@ -943,18 +943,6 @@ def _build_plugin_owned_trt_inference_command(
             )
 
     return None
-
-
-def _shell_quote(s: str) -> str:
-    """Simple shell quoting for inclusion in repro commands."""
-    if not s:
-        return '""'
-    # If string contains special chars, wrap in single quotes
-    if any(c in s for c in " \t\n\"'\\$!&|;(){}[]<>?*~`#"):
-        # Escape single quotes inside
-        escaped = s.replace("'", "'\\''")
-        return f"'{escaped}'"
-    return s
 
 
 def _manifest_build_method(build_args: dict[str, Any]) -> str | None:

--- a/tests/e2e_harness/test_repro_commands.py
+++ b/tests/e2e_harness/test_repro_commands.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repro commands must survive a copy into a shell and back out again."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e_harness import orchestrator
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+
+AWKWARD_PROMPTS = (
+    pytest.param("a prompt with spaces", id="spaces"),
+    pytest.param("", id="empty"),
+    pytest.param("it's a prompt", id="single-quote"),
+    pytest.param('say "hello"', id="double-quote"),
+    pytest.param("cost is $PATH and ${HOME}", id="dollar"),
+    pytest.param("back\\slash", id="backslash"),
+    pytest.param("first line\nsecond line", id="newline"),
+    pytest.param("semi; colon && amp | pipe", id="shell-operators"),
+    pytest.param("glob* and ?mark and [bracket]", id="glob"),
+    pytest.param("tab\there", id="tab"),
+    pytest.param("trailing space ", id="trailing-space"),
+    pytest.param("#hash comment", id="hash"),
+)
+
+
+def _make_case(name: str = "repro-unit") -> E2ECase:
+    return E2ECase(
+        name=name,
+        hf_id="hf/unit-model",
+        family="unit",
+        runtime_strategy="unit_runtime",
+        task_strategy="unit_task",
+        reference_backend="unit_ref",
+        bundle=f"{name}.bundle",
+        preflight=[],
+        stages=[StageSpec(name="generate")],
+        determinism={},
+    )
+
+
+def _make_ctx(
+    tmp_path: Path,
+    case: E2ECase,
+    *,
+    engine_dir_name: str = "engines",
+    binary_path: str = "/tmp/trtmc",
+    hf_python: str | None = None,
+) -> RunContext:
+    engine_dir = tmp_path / engine_dir_name
+    engine_dir.mkdir()
+    return RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        binary_path=binary_path,
+        hf_python=hf_python or sys.executable,
+        engine_dir=str(engine_dir),
+    )
+
+
+@pytest.mark.parametrize("prompt", AWKWARD_PROMPTS)
+def test_trt_inference_prompt_survives_a_round_trip(
+    tmp_path: Path,
+    prompt: str,
+) -> None:
+    case = _make_case()
+    case.inputs["prompt"] = prompt
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["trt_inference"])
+
+    assert argv[argv.index("--prompt") + 1] == prompt
+
+
+@pytest.mark.parametrize("prompt", AWKWARD_PROMPTS)
+def test_rendered_commands_are_a_single_shell_word_per_token(
+    tmp_path: Path,
+    prompt: str,
+) -> None:
+    """A prompt must not split into extra argv entries however it is spelled."""
+    case = _make_case()
+    case.inputs["prompt"] = prompt
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["trt_inference"])
+
+    assert argv.count("--prompt") == 1
+    assert argv[0] == ctx.binary_path
+    assert argv[1] == "run"
+    assert argv[2] == "/tmp/unit.bundle"
+
+
+def test_prompts_file_path_with_spaces_round_trips(tmp_path: Path) -> None:
+    case = _make_case()
+    prompt_file = tmp_path / "a dir with spaces" / "prompts.jsonl"
+    case.inputs["prompt_file"] = str(prompt_file)
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["trt_inference"])
+
+    assert argv[argv.index("--prompts-file") + 1] == str(prompt_file)
+
+
+def test_rerun_test_node_id_round_trips(tmp_path: Path) -> None:
+    """The pytest node id carries brackets, which a shell would glob."""
+    case = _make_case("case-with-brackets")
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["rerun_test"])
+
+    assert argv[0] == "pytest"
+    assert argv[1] == f"tests/test_e2e.py::test_e2e[{case.name}]"
+
+
+def test_rerun_rebuild_keeps_the_rerun_argv_and_adds_the_flag(
+    tmp_path: Path,
+) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+
+    rerun = shlex.split(repro["rerun_test"])
+    rebuild = shlex.split(repro["rerun_test_rebuild"])
+
+    assert rebuild == rerun + ["--rebuild-engines"]
+
+
+def test_build_bundle_round_trips(tmp_path: Path) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["build_bundle"])
+
+    assert argv[0] == sys.executable
+    assert "build" in argv
+    assert case.hf_id in argv
+
+
+def test_no_command_carries_pre_quoted_tokens(tmp_path: Path) -> None:
+    """Rendering happens once, so no token should arrive already quoted."""
+    case = _make_case()
+    case.inputs["prompt"] = "plain"
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+
+    for command in repro.values():
+        for token in shlex.split(command):
+            assert not (token.startswith("'") and token.endswith("'"))
+            assert not (token.startswith('"') and token.endswith('"'))
+
+
+# The tokens below were never quoted at all before rendering moved to
+# shlex.join: they were dropped into a " ".join with whatever they contained.
+# A path with a space in it therefore came back as two argv entries.
+
+
+def test_build_bundle_survives_an_engine_dir_with_spaces(tmp_path: Path) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case, engine_dir_name="engine dir")
+
+    # With no bundle path resolved yet, the target falls back to the engine dir.
+    repro = orchestrator._build_repro_commands(case, ctx, None, {})
+    argv = shlex.split(repro["build_bundle"])
+
+    expected = str(Path(ctx.engine_dir) / case.bundle)
+    assert argv[argv.index("-o") + 1] == expected
+
+
+def test_rerun_test_survives_an_engine_dir_with_spaces(tmp_path: Path) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case, engine_dir_name="engine dir")
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["rerun_test"])
+
+    assert argv[argv.index("--engine-dir") + 1] == ctx.engine_dir
+
+
+def test_rerun_test_survives_a_binary_path_with_spaces(tmp_path: Path) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case, binary_path="/opt/my tools/trtmc")
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["rerun_test"])
+
+    assert argv[argv.index("--trtmc-binary") + 1] == "/opt/my tools/trtmc"
+
+
+def test_rerun_test_survives_an_hf_python_with_spaces(tmp_path: Path) -> None:
+    case = _make_case()
+    ctx = _make_ctx(tmp_path, case, hf_python="/opt/py envs/bin/python")
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["rerun_test"])
+
+    assert argv[argv.index("--hf-python") + 1] == "/opt/py envs/bin/python"
+
+
+def test_trt_inference_survives_a_binary_path_with_spaces(tmp_path: Path) -> None:
+    case = _make_case()
+    case.inputs["prompt"] = "hello"
+    ctx = _make_ctx(tmp_path, case, binary_path="/opt/my tools/trtmc")
+
+    repro = orchestrator._build_repro_commands(case, ctx, "/tmp/unit.bundle", {})
+    argv = shlex.split(repro["trt_inference"])
+
+    assert argv[0] == "/opt/my tools/trtmc"
+
+
+def test_bundle_path_with_spaces_round_trips(tmp_path: Path) -> None:
+    case = _make_case()
+    case.inputs["prompt"] = "hello"
+    ctx = _make_ctx(tmp_path, case)
+
+    repro = orchestrator._build_repro_commands(
+        case, ctx, "/tmp/bundle dir/unit.bundle", {}
+    )
+    argv = shlex.split(repro["trt_inference"])
+
+    assert argv[2] == "/tmp/bundle dir/unit.bundle"


### PR DESCRIPTION
## What

Repro command providers now return raw argv tokens, and `shlex.join` renders the shell-ready
string once at the point it is built. Removes the harness's own `_shell_quote` and the
thirteen per-model `_shell_quote` wrappers. Adds round-trip tests.

## Why

Quoting was happening in two different places and disagreeing about who owned it.

`tests/e2e_harness/orchestrator.py` carried a hand-written `_shell_quote`, and each of the
thirteen model repro plugins carried its own one-line wrapper around `shlex.quote`. Providers
pre-quoted some of their tokens, then the orchestrator joined the list with `" ".join`.

Two things fell out of that.

The obvious one: fifteen copies of logic the standard library already provides, and the
harness copy was a hand-rolled reimplementation rather than a call to `shlex.quote`.

The one that actually bites: the tokens nobody thought to pre-quote went into `" ".join`
bare. `ctx.engine_dir`, `ctx.binary_path`, `ctx.hf_python` and the bundle path are all
filesystem paths, none of them were quoted, and any one of them containing a space produced
a command that splits into the wrong argv when pasted into a shell. So
`--trtmc-binary /opt/my tools/trtmc` came out as two arguments.

Mixing the two conventions is what made it easy to miss. When some tokens arrive pre-quoted,
a bare token in the same list looks intentional.

## How

Providers hand back raw tokens. `shlex.join` is the single place a list becomes a string, so
there is one rule instead of a per-call judgement, and `shlex.quote` decides what needs
quoting.

`_shell_quote(str(x))` became `str(x)` at the three orchestrator call sites, and
`_shell_quote(x)` became `str(x)` in the plugins, keeping the coercion the wrapper was doing.
The four `" ".join(...)` calls that build `build_bundle`, `trt_inference`, `rerun_test` and
`rerun_test_rebuild` became `shlex.join(...)`.

`shlex.join` is available on every version this project supports (`requires-python = ">=3.10"`).

Two visible output changes, both intended:

- Paths containing spaces are now quoted, which is the fix.
- The `rerun_test` pytest node id comes out quoted, because
  `tests/test_e2e.py::test_e2e[case-name]` carries brackets that a shell treats as a glob. It
  was previously bare.

Everything that was already pre-quoted renders identically.

## Testing

New file `tests/e2e_harness/test_repro_commands.py`, 35 tests.

Round trip through `shlex.split` for prompt values covering spaces, the empty string, single
quotes, double quotes, dollar signs and `${}`, backslashes, newlines, tabs, `;`, `&&` and
`|`, glob characters, a trailing space, and a leading `#`.

Then the four cases the refactor actually changes: an engine dir with a space in
`build_bundle` and in `rerun_test`, a binary path with a space in `rerun_test` and in
`trt_inference`, an hf-python path with a space, and a bundle path with a space.

```
PYTHONPATH=python python -m pytest tests/e2e_harness/ -q
```

62 passed, which is the existing 27 plus these 35. `ruff check` is clean on every file
touched.

I ran the new tests against the previous implementation as a check on the tests themselves,
and it is worth reporting what that showed. My first pass at this file only exercised the
prompt values, and all of it passed against the old code too, because those tokens were
already being pre-quoted and the hand-rolled `_shell_quote` was, for those inputs, equivalent
to `shlex.quote`. Those tests were describing behaviour, not protecting it.

The six path cases are the ones that fail against the old implementation. The prompt cases
are kept as regression cover for the behaviour that was already correct, but the six are what
demonstrate the bug.

Unit level only. Running the E2E harness itself needs GPUs and built engines, which I do not
have, so this is verified through the argv the orchestrator renders rather than by executing
the commands.

## Notes

The diff spans fourteen files because the wrapper was copied into every model plugin, but each
plugin change is the same three lines: drop the import, drop the wrapper, call `str` instead.
Happy to split the harness change from the plugin cleanup if you would rather review them
separately.

Scope is limited to what #976 describes. #963's other items are untouched.