### PR TITLE
perf(qwen): reduce generation overhead

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -1042,6 +1042,11 @@ additional_profiles:
     inherit: qwen.generate
   - model: qwen3-4b-instruct-2507
     inherit: qwen.generate
+    workload:
+      runtime:
+        cuda_graphs: true
+    baseline:
+      precision: fp16
   - model: qwen3-moe-tiny-random
     inherit: qwen_moe.generate
   - model: riva-translate-4b

--- a/src/runtime/models/qwen/pipeline.cpp
+++ b/src/runtime/models/qwen/pipeline.cpp
@@ -437,9 +437,11 @@ void validate_generation_capacity(const std::vector<int32_t>& input_ids, int32_t
         return;
 
     const auto capacity = static_cast<std::size_t>(kv->max_length());
-    if (input_ids.size() > capacity ||
-        (max_new_tokens > 0 &&
-         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size())) {
+    // Prefill logits produce the first generated token. Only later generated
+    // tokens are fed back through the decoder and consume additional KV rows.
+    const auto decoder_tokens =
+        static_cast<std::size_t>(max_new_tokens > 0 ? max_new_tokens - 1 : 0);
+    if (input_ids.size() > capacity || decoder_tokens > capacity - input_ids.size()) {
         throw std::runtime_error(
             "Qwen requested prompt and generation exceed the model's fixed KV cache capacity");
     }
@@ -560,7 +562,7 @@ void QwenTextGenerationPipeline::prime_decoder_after_batched_prefill(
         return;
 
     TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
+    if (!decoder.cuda_graph_active() || decoder.cuda_graph_captured())
         return;
 
     int32_t token_id = input_ids.back();

--- a/tests/builder/test_qwen_runtime_performance_contract.py
+++ b/tests/builder/test_qwen_runtime_performance_contract.py
@@ -36,3 +36,16 @@ def test_one_token_generation_does_not_prime_an_unused_decoder_graph() -> None:
     )[0]
 
     assert "run_prefill(input_ids, logits, gpu_sampling, max_new_tokens > 1)" in generate
+
+
+def test_decoder_graph_is_only_primed_before_its_first_capture() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    prime = source.split(
+        "void QwenTextGenerationPipeline::prime_decoder_after_batched_prefill(", maxsplit=1
+    )[1].split("void QwenTextGenerationPipeline::run_prefill(", maxsplit=1)[0]
+
+    assert "decoder.cuda_graph_active()" in prime
+    assert "decoder.cuda_graph_captured()" in prime
+    assert prime.index("decoder.cuda_graph_captured()") < prime.index(
+        "decoder.forward_async(inputs)"
+    )

--- a/tests/cpp/models/qwen/test_qwen_native_kv_cache.cpp
+++ b/tests/cpp/models/qwen/test_qwen_native_kv_cache.cpp
@@ -79,8 +79,10 @@ int test_trt_external_alias() {
 #endif
 
 int main() {
-    int failures = trtmc::test::run_native_kv_contract_tests<
-        trtmc::QwenTextGenerationPipeline, trtmc::QwenKvCache, trtmc::QwenTextGenConfig>("Qwen");
+    int failures =
+        trtmc::test::run_native_kv_contract_tests<trtmc::QwenTextGenerationPipeline,
+                                                  trtmc::QwenKvCache, trtmc::QwenTextGenConfig,
+                                                  /*LastRequestedTokenConsumesKv=*/false>("Qwen");
 #if NV_TENSORRT_MAJOR >= 11
     failures += test_trt_external_alias();
 #endif

--- a/tests/cpp/native_kv_cache_contract_test.h
+++ b/tests/cpp/native_kv_cache_contract_test.h
@@ -238,15 +238,11 @@ int run_native_kv_contract_tests(const char* model) {
           "rejects a non-int32 cache_write_indices input");
     check(rejects_native_contract<Cache>(
               stream,
-              [](auto& module) {
-                  module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16);
-              }),
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16); }),
           "rejects a cache with the wrong capacity");
     check(rejects_native_contract<Cache>(
               stream,
-              [](auto& module) {
-                  module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32);
-              }),
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32); }),
           "rejects a cache with the wrong dtype");
 
     {

--- a/tests/cpp/native_kv_cache_contract_test.h
+++ b/tests/cpp/native_kv_cache_contract_test.h
@@ -214,7 +214,8 @@ bool rejects_native_contract(cudaStream_t stream, Mutate mutate) {
     return false;
 }
 
-template <typename Pipeline, typename Cache, typename Config>
+template <typename Pipeline, typename Cache, typename Config,
+          bool LastRequestedTokenConsumesKv = true>
 int run_native_kv_contract_tests(const char* model) {
     int failures = 0;
     const auto check = [&](bool condition, const std::string& message) {
@@ -237,11 +238,15 @@ int run_native_kv_contract_tests(const char* model) {
           "rejects a non-int32 cache_write_indices input");
     check(rejects_native_contract<Cache>(
               stream,
-              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16); }),
+              [](auto& module) {
+                  module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16);
+              }),
           "rejects a cache with the wrong capacity");
     check(rejects_native_contract<Cache>(
               stream,
-              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32); }),
+              [](auto& module) {
+                  module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32);
+              }),
           "rejects a cache with the wrong dtype");
 
     {
@@ -294,10 +299,10 @@ int run_native_kv_contract_tests(const char* model) {
               "legacy attention-mask cache path still advances normally");
     }
 
-    const auto make_config = [] {
+    const auto make_config = [](int32_t eos_id = 9) {
         Config config;
         config.vocab_size = 16;
-        config.id_eos = 9;
+        config.id_eos = eos_id;
         config.disable_cuda_graph = true;
         config.prefill_max_length = 4;
         config.num_layers = 1;
@@ -315,16 +320,17 @@ int run_native_kv_contract_tests(const char* model) {
     const std::vector<int32_t> prompt{10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
 
     {
+        const int32_t capacity = LastRequestedTokenConsumesKv ? 11 : 10;
         auto prefill_trace = std::make_shared<NativeKvTrace>();
         auto decode_trace = std::make_shared<NativeKvTrace>();
-        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
-                                                            true, prefill_trace);
-        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
-                                                            true, decode_trace);
-        auto cache = std::make_unique<Cache>(1, 11, 2, stream, DType::kFloat16);
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, capacity, 1, 2,
+                                                            DType::kFloat16, true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, capacity, 1, 2,
+                                                            DType::kFloat16, true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, capacity, 2, stream, DType::kFloat16);
         Cache* cache_ptr = cache.get();
         std::vector<typename Pipeline::DecoderContext> decoders;
-        decoders.push_back(typename Pipeline::DecoderContext{11, std::move(decoder)});
+        decoders.push_back(typename Pipeline::DecoderContext{capacity, std::move(decoder)});
         Pipeline pipeline(std::move(decoders), std::move(cache), make_config(), stream, nullptr, "",
                           nullptr, std::move(prefill));
         const auto result = pipeline.generate_ids(prompt, make_request(1));
@@ -360,8 +366,40 @@ int run_native_kv_contract_tests(const char* model) {
         Cache* cache_ptr = cache.get();
         std::vector<typename Pipeline::DecoderContext> decoders;
         decoders.push_back(typename Pipeline::DecoderContext{11, std::move(decoder)});
-        Pipeline pipeline(std::move(decoders), std::move(cache), make_config(), stream, nullptr, "",
+        Pipeline pipeline(std::move(decoders), std::move(cache),
+                          make_config(LastRequestedTokenConsumesKv ? 9 : 15), stream, nullptr, "",
                           nullptr, std::move(prefill));
+        bool overflow = false;
+        std::size_t output_tokens = 0;
+        try {
+            output_tokens = pipeline.generate_ids(prompt, make_request(2)).token_ids.size();
+        } catch (const std::runtime_error&) {
+            overflow = true;
+        }
+        if constexpr (LastRequestedTokenConsumesKv) {
+            check(overflow && prefill_trace->calls.empty() && decode_trace->calls.empty() &&
+                      cache_ptr->position() == 0,
+                  "request over capacity is rejected before any runtime progression");
+        } else {
+            check(!overflow && output_tokens == 12 && prefill_trace->calls.size() == 3 &&
+                      decode_trace->calls.size() == 1 && cache_ptr->position() == 11,
+                  "the final requested token does not consume an extra KV row");
+        }
+    }
+
+    if constexpr (!LastRequestedTokenConsumesKv) {
+        auto prefill_trace = std::make_shared<NativeKvTrace>();
+        auto decode_trace = std::make_shared<NativeKvTrace>();
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 10, 1, 2, DType::kFloat16,
+                                                            true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 10, 1, 2, DType::kFloat16,
+                                                            true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, 10, 2, stream, DType::kFloat16);
+        Cache* cache_ptr = cache.get();
+        std::vector<typename Pipeline::DecoderContext> decoders;
+        decoders.push_back(typename Pipeline::DecoderContext{10, std::move(decoder)});
+        Pipeline pipeline(std::move(decoders), std::move(cache), make_config(15), stream, nullptr,
+                          "", nullptr, std::move(prefill));
         bool overflow = false;
         try {
             (void)pipeline.generate_ids(prompt, make_request(2));
@@ -370,7 +408,7 @@ int run_native_kv_contract_tests(const char* model) {
         }
         check(overflow && prefill_trace->calls.empty() && decode_trace->calls.empty() &&
                   cache_ptr->position() == 0,
-              "request over capacity is rejected before any runtime progression");
+              "a request needing a decoder row beyond capacity is rejected before execution");
     }
 
     cudaStreamDestroy(stream);

--- a/tests/e2e/models/qwen/test_qwen_performance_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_performance_contract.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Release-performance contract for Qwen3-4B generation."""
+
+from pathlib import Path
+
+import yaml
+
+
+RELEASE_CONFIG = Path(__file__).resolve().parents[4] / "benchmarks/performance/release.yaml"
+
+
+def test_qwen3_4b_uses_cuda_graphs_with_an_fp16_reference() -> None:
+    release = yaml.safe_load(RELEASE_CONFIG.read_text(encoding="utf-8"))
+    profile = next(
+        item
+        for item in release["additional_profiles"]
+        if item["model"] == "qwen3-4b-instruct-2507"
+    )
+
+    assert profile["inherit"] == "qwen.generate"
+    assert profile["workload"]["runtime"]["cuda_graphs"] is True
+    assert profile["baseline"]["precision"] == "fp16"


### PR DESCRIPTION
## Background

`qwen3-4b-instruct-2507` preserved exact FP16 output but measured 39.7% slower than its reference on Thor X. This change removes repeated CUDA-graph setup from the generation path and keeps the release comparison precision aligned.

## Exit Criteria

- Preserve exact-token Accuracy behavior on Thor X and GB300.
- Bring the Thor X release workload back within the existing 5% performance policy without weakening the gate.
- Keep the fixed native KV-cache boundary valid for full-capacity prompts.

## Implementation

- Enable CUDA graphs for the Qwen3-4B release workload and compare against an FP16 reference.
- Skip decoder graph priming once the graph is already captured.
- Account for the first generated token coming from prefill so fixed KV capacity only reserves rows consumed by later decoder steps.
- Add source and native-contract regressions for graph priming, release policy, and KV-cache capacity boundaries.

## Validation

- `python3 -m pytest -q tests/builder/test_qwen_runtime_performance_contract.py tests/e2e/models/qwen/test_qwen_performance_contract.py`: 4 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: passed all complexity, lint, architecture, and source-quality checks; 158 tests passed.
- `test_qwen_native_kv_cache` native executable: passed on GB300 at exact head `500ca807556eaa5a5b8d59717af559dfe41889dc`.
- GB300 model checks at the exact head: Accuracy passed 20/20 with exact agreement and 0 failed samples; Perf passed green with 9.34 ms TRTMC p50 versus 71.31 ms reference p50.
- Thor X model checks at the exact head: Accuracy passed 20/20 with exact agreement and 0 failed samples; Perf passed green with 102.80 ms TRTMC p50 versus 109.88 ms reference p50. Both 10-sample timing series were stable and output tokens matched exactly.
- A broader local Qwen collection reached 298 passed and 4 skipped; 11 GPU/E2E cases were not runnable in the local no-CUDA/read-only-storage environment and were covered by the target-hardware checks above.

## Notes For Future Readers

- Review the runtime changes first, then the Qwen-specific release profile, followed by the shared native KV-cache contract tests.
- The existing 5% performance policy is unchanged.

Closes #901
