### PR TITLE
fix(ci): preserve multiline file command values

### DIFF
--- a/tests/tools/test_ci_process.py
+++ b/tests/tools/test_ci_process.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared CI process and GitHub file-command primitives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.ci.process import GitHubFiles
+
+
+@pytest.mark.parametrize(
+    ("variable", "operation"),
+    [
+        ("GITHUB_ENV", "environment"),
+        ("GITHUB_OUTPUT", "output"),
+    ],
+)
+def test_github_assignment_uses_delimiter_for_multiline_values(
+    tmp_path: Path,
+    variable: str,
+    operation: str,
+) -> None:
+    destination = tmp_path / variable.lower()
+    github = GitHubFiles({variable: str(destination)})
+
+    getattr(github, operation)("result", "first line\ninjected=value")
+
+    assert destination.read_text(encoding="utf-8") == (
+        "result<<TRTMC_EOF\nfirst line\ninjected=value\nTRTMC_EOF\n"
+    )
+
+
+def test_github_assignment_avoids_delimiter_collision(tmp_path: Path) -> None:
+    destination = tmp_path / "github-output"
+    github = GitHubFiles({"GITHUB_OUTPUT": str(destination)})
+
+    github.output("result", "first line\nTRTMC_EOF\nlast line")
+
+    assert destination.read_text(encoding="utf-8") == (
+        "result<<TRTMC_EOF_\nfirst line\nTRTMC_EOF\nlast line\nTRTMC_EOF_\n"
+    )

--- a/tools/ci/process.py
+++ b/tools/ci/process.py
@@ -57,10 +57,10 @@ class GitHubFiles:
         self.env = dict(env or os.environ)
 
     def environment(self, name: str, value: str) -> None:
-        self._append("GITHUB_ENV", f"{name}={value}\n")
+        self._append("GITHUB_ENV", self._assignment(name, value))
 
     def output(self, name: str, value: str) -> None:
-        self._append("GITHUB_OUTPUT", f"{name}={value}\n", create_parent=True)
+        self._append("GITHUB_OUTPUT", self._assignment(name, value), create_parent=True)
 
     def summary(self, text: str = "") -> None:
         self._append("GITHUB_STEP_SUMMARY", f"{text}\n")
@@ -74,3 +74,14 @@ class GitHubFiles:
             path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
             handle.write(text)
+
+    @staticmethod
+    def _assignment(name: str, value: str) -> str:
+        if "\n" not in value and "\r" not in value:
+            return f"{name}={value}\n"
+
+        delimiter = "TRTMC_EOF"
+        value_lines = set(value.splitlines())
+        while delimiter in value_lines:
+            delimiter += "_"
+        return f"{name}<<{delimiter}\n{value}\n{delimiter}\n"


### PR DESCRIPTION
## Background

The shared GitHub file-command writer serialized every environment variable and step output as `name=value`. Embedded newlines were therefore parsed as additional file commands instead of remaining part of the original value.

## Exit Criteria

- Preserve existing serialization for single-line values.
- Use GitHub's multiline delimiter syntax for `GITHUB_ENV` and `GITHUB_OUTPUT`.
- Ensure the chosen delimiter cannot occur on a line by itself inside the value.

## Implementation

- Route environment and output assignments through one serializer.
- Emit a collision-free `name<<delimiter` block only for multiline values.
- Add regression coverage for both GitHub files and a delimiter collision.

## Validation

- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_ci_process.py tests/tools/test_community_ci.py -k "not public_required_job"`: 10 passed, 5 Bash-dependent cases deselected on Windows.
- `python -m ruff check --config ruff.toml tools/ci/process.py tests/tools/test_ci_process.py`: passed.
- `python -m ruff format --check --config ruff.toml tools/ci/process.py tests/tools/test_ci_process.py`: passed.
- `PYTHONPATH=python:. python tools/model_ci.py validate`: passed (84 families, 221 models).
- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_model_plugin_encapsulation_static.py -p no:cacheprovider`: 158 passed.
- `PYTHONPATH=python:. python -m tools.community_ci impact --base github/main`: selected `mode=all`, `unit_scope=all`.

## Notes For Future Readers

GitHub requires the delimiter form for multiline environment and output values. The serializer keeps the compact `name=value` form for one-line callers so current outputs remain unchanged.