### PR TITLE
perf(nemotron): batch GPU-sampled prefill

### DIFF
--- a/benchmarks/performance/baselines/hf_transformers.py
+++ b/benchmarks/performance/baselines/hf_transformers.py
@@ -102,6 +102,23 @@ def _ensure_transformers_generic_api(generic_module: Any) -> None:
         setattr(generic_module, "check_model_inputs", check_model_inputs)
 
 
+def _load_model(
+    model_class: Any,
+    arguments: argparse.Namespace,
+    torch_module: Any,
+    common: Mapping[str, Any],
+) -> Any:
+    model_options = {
+        "torch_dtype": _dtype(torch_module, arguments.precision),
+        "low_cpu_mem_usage": True,
+        "device_map": "cuda",
+        **common,
+    }
+    if arguments.experts_implementation:
+        model_options["experts_implementation"] = arguments.experts_implementation
+    return model_class.from_pretrained(arguments.model, **model_options).eval()
+
+
 def _load(arguments: argparse.Namespace) -> tuple[Any, Any, str]:
     import torch
     from transformers import (
@@ -132,15 +149,7 @@ def _load(arguments: argparse.Namespace) -> tuple[Any, Any, str]:
             "causal-lm": AutoModelForCausalLM,
             "seq2seq-lm": AutoModelForSeq2SeqLM,
         }[arguments.task]
-    model_options = {
-        "torch_dtype": _dtype(torch, arguments.precision),
-        "low_cpu_mem_usage": True,
-        **common,
-    }
-    if arguments.experts_implementation:
-        model_options["experts_implementation"] = arguments.experts_implementation
-    model = model_class.from_pretrained(arguments.model, **model_options)
-    model.eval().to("cuda")
+    model = _load_model(model_class, arguments, torch, common)
     resolved_revision = str(
         getattr(model.config, "_commit_hash", None) or arguments.revision or "unresolved"
     )

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -1022,6 +1022,11 @@ additional_profiles:
       precision: fp16
   - model: nemotron-mini-4b
     inherit: nemotron.generate
+    workload:
+      runtime:
+        prefer_gpu_greedy: true
+    baseline:
+      precision: fp16
   - model: nemotron-nano-4b
     inherit: llama.generate
   - model: nemotron-speech-streaming-en-0.6b

--- a/python/tensorrt_model_connect/benchmark/types.py
+++ b/python/tensorrt_model_connect/benchmark/types.py
@@ -14,6 +14,19 @@ from typing import Any, Mapping
 
 COMMAND_DIAGNOSTIC_SCHEMA = "trtmc.command-diagnostic/v1"
 COMMAND_DIAGNOSTIC_PREFIX = "TRTMC_DIAGNOSTIC_JSON="
+_WORKER_RUNTIME_FIELDS = frozenset(
+    {
+        "backend_search_paths",
+        "config",
+        "config_path",
+        "cuda_graphs",
+        "hf_python",
+        "kv_cache_size_bytes",
+        "model_plugin_search_paths",
+        "runtime_cache_path",
+        "set_tokens",
+    }
+)
 
 
 class BenchmarkError(RuntimeError):
@@ -186,6 +199,12 @@ class ResolvedCase:
         model_root = self.model.manifest_path.parent.parent
         request = _absolute_artifact_paths(self.request, model_root)
         runtime = _absolute_artifact_paths(self.runtime, model_root)
+        native_config = dict(runtime.pop("config", {}))
+        for field in tuple(runtime):
+            if field not in _WORKER_RUNTIME_FIELDS:
+                native_config[f"runtime.{field}"] = runtime.pop(field)
+        if native_config:
+            runtime["config"] = native_config
         return {
             "schema_version": 1,
             "case_name": self.name,

--- a/python/tensorrt_model_connect/families/nemotron/default_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron/default_decoder.py
@@ -28,7 +28,7 @@ from . import graph_ops
 from . import graph_blocks
 from .config import ModelConfig
 from .default_dual_profile_decoder import build_dual_profile_decoder_engine
-from .utils import const_in_work_dtype, create_builder_context
+from .utils import builder_workspace_bytes, const_in_work_dtype, create_builder_context
 
 trt = trt_compat.get_trt()
 
@@ -150,7 +150,10 @@ def build_standard_decoder_engine(
         dynamic_kv_profile_rows.sort()
     else:
         dynamic_kv_profile_rows = []
-    builder_context = create_builder_context(verbose=verbose)
+    builder_context = create_builder_context(
+        verbose=verbose,
+        workspace_bytes=builder_workspace_bytes(config),
+    )
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/nemotron/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/nemotron/default_dual_profile_decoder.py
@@ -51,6 +51,7 @@ from tensorrt_model_connect import trt_compat
 from . import graph_ops
 from . import graph_blocks
 from .utils import (
+    builder_workspace_bytes,
     const_in_work_dtype as _const_in_work_dtype,
     create_builder_context,
     norm_multi as _norm_multi,
@@ -187,7 +188,10 @@ def build_dual_profile_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim
     )
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
-    builder_context = create_builder_context(verbose=verbose)
+    builder_context = create_builder_context(
+        verbose=verbose,
+        workspace_bytes=builder_workspace_bytes(config),
+    )
     builder = builder_context.builder
     network = builder_context.network
     trt_config = builder_context.config

--- a/python/tensorrt_model_connect/families/nemotron/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/nemotron/runtime_config_schema.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time configuration for Nemotron decoder engines."""
+
+from __future__ import annotations
+
+from tensorrt_model_connect.runtime_config import ConfigField, Layer, Schema, register_schema
+
+
+_BUILD = frozenset({Layer.BUILD_TIME, Layer.BUNDLE_DEFAULT, Layer.SESSION_REQUEST})
+
+
+register_schema(
+    Schema(
+        namespace="nemotron_decoder",
+        fields=(
+            ConfigField(
+                name="builder_workspace_gib",
+                type_tag="int32",
+                default=0,
+                allowed_layers=_BUILD,
+                validator=lambda value: type(value) is int and value >= 0,
+            ),
+        ),
+    )
+)

--- a/python/tensorrt_model_connect/families/nemotron/tests/test_runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/nemotron/tests/test_runtime_config_schema.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nemotron build-time configuration contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import runpy
+
+import pytest
+
+import tensorrt_model_connect.runtime_config as runtime_config
+from tensorrt_model_connect.runtime_config import SchemaRegistry, resolve_cli_config
+
+
+def _load_schema_without_global_registration():
+    captured = []
+    original = runtime_config.register_schema
+    runtime_config.register_schema = captured.append
+    try:
+        runpy.run_path(str(Path(__file__).parents[1] / "runtime_config_schema.py"))
+    finally:
+        runtime_config.register_schema = original
+    assert len(captured) == 1
+    return captured[0]
+
+
+SCHEMA = _load_schema_without_global_registration()
+
+
+def _registry() -> SchemaRegistry:
+    registry = SchemaRegistry()
+    registry.register_schema(SCHEMA)
+    return registry
+
+
+def test_builder_workspace_is_opt_in_and_typed() -> None:
+    defaults = resolve_cli_config(registry=_registry())
+    qualified = resolve_cli_config(
+        set_tokens=["nemotron_decoder.builder_workspace_gib=2"],
+        registry=_registry(),
+    )
+
+    assert defaults.get("nemotron_decoder", "builder_workspace_gib") == 0
+    assert qualified.get("nemotron_decoder", "builder_workspace_gib") == 2
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "nemotron_decoder.builder_workspace_gib=-1",
+        "nemotron_decoder.builder_workspace_gib=1.5",
+    ],
+)
+def test_invalid_builder_workspace_fails_before_engine_build(token: str) -> None:
+    with pytest.raises(ValueError):
+        resolve_cli_config(set_tokens=[token], registry=_registry())

--- a/python/tensorrt_model_connect/families/nemotron/utils.py
+++ b/python/tensorrt_model_connect/families/nemotron/utils.py
@@ -26,6 +26,21 @@ class BuilderContext:
     config: trt.IBuilderConfig
 
 
+def builder_workspace_bytes(config: object) -> int | None:
+    """Return the model-declared TensorRT tactic workspace limit."""
+    raw = getattr(config, "raw", {})
+    family_options = raw.get("_family_build_options", {}) if isinstance(raw, dict) else {}
+    if not isinstance(family_options, dict):
+        raise ValueError("family build options must be an object")
+    options = family_options.get("nemotron_decoder", {})
+    if not isinstance(options, dict):
+        raise ValueError("nemotron_decoder build options must be an object")
+    workspace_gib = options.get("builder_workspace_gib", 0)
+    if type(workspace_gib) is not int or workspace_gib < 0:
+        raise ValueError("nemotron_decoder.builder_workspace_gib must be a nonnegative integer")
+    return workspace_gib << 30 if workspace_gib else None
+
+
 def create_builder_context(
     *,
     verbose: bool,

--- a/src/runtime/models/nemotron/pipeline.cpp
+++ b/src/runtime/models/nemotron/pipeline.cpp
@@ -420,7 +420,8 @@ bool batched_prefill_supported(const TrtModule* prefill, const NemotronTextGenCo
 } // namespace
 
 bool NemotronTextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
-                                                         std::vector<float>& logits) {
+                                                         std::vector<float>& logits,
+                                                         bool retain_device_logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     if (!batched_prefill_supported(prefill_.get(), config_, sq, state_.get()))
         return false;
@@ -445,12 +446,22 @@ bool NemotronTextGenerationPipeline::run_prefill_batched(const std::vector<int32
         return false;
 
     const auto vocab = static_cast<std::size_t>(config_.vocab_size);
-    const auto& lt = logits_it->second;
-    if (static_cast<std::size_t>(lt.numel()) < vocab)
+    const auto& logits_tensor = logits_it->second;
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab)
         return false;
     logits.resize(vocab);
-    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
-    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+    if (retain_device_logits) {
+        const auto* device_logits =
+            static_cast<const float*>(prefill_->device_ptr(config_.logits_output_name));
+        if (device_logits == nullptr) {
+            throw std::runtime_error(
+                "NemotronTextGenerationPipeline: prefill logits have no device buffer");
+        }
+        d_logits_ptr_ = device_logits + logits_offset;
+    }
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
@@ -468,34 +479,12 @@ bool NemotronTextGenerationPipeline::run_prefill_batched(const std::vector<int32
     return true;
 }
 
-void NemotronTextGenerationPipeline::prime_decoder_after_batched_prefill(
-    const std::vector<int32_t>& input_ids) {
-    if (input_ids.empty())
-        return;
-
-    TrtModule& decoder = bind_decoder_for_step();
-    if (!decoder.cuda_graph_active())
-        return;
-
-    int32_t token_id = input_ids.back();
-    TensorMap inputs;
-    Tensor token_tensor;
-    token_tensor.data = &token_id;
-    token_tensor.shape = {1};
-    token_tensor.dtype = DType::kInt32;
-    inputs[config_.token_id_name] = token_tensor;
-
-    state_->prepare_step(inputs);
-    decoder.forward_async(inputs);
-    decoder.sync();
-}
-
 void NemotronTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
                                                  std::vector<float>& logits, bool gpu_sampling) {
     // Fast path: batched prefill engine writes K/V for the whole prompt in
-    // one forward and returns last-token logits on host.
-    if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
-        prime_decoder_after_batched_prefill(input_ids);
+    // one forward and exposes last-token logits on the sampler's requested
+    // host or device path.
+    if (run_prefill_batched(input_ids, logits, gpu_sampling)) {
         state_->mark_prefill_complete();
         return;
     }
@@ -959,6 +948,8 @@ int32_t NemotronTextGenerationPipeline::run_decode_loop(
                                   result.is_eos))
             break;
         if (result.is_eos)
+            break;
+        if (step + 1 >= max_new_tokens)
             break;
         if (gpu_sampling)
             run_step_device(result.token_id);

--- a/src/runtime/models/nemotron/pipeline.h
+++ b/src/runtime/models/nemotron/pipeline.h
@@ -190,8 +190,8 @@ class NemotronTextGenerationPipeline final : public IPipeline {
                            TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
-    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
-    void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
+    bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
+                             bool retain_device_logits);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,
                                bool is_eos) const;

--- a/tests/builder/test_nemotron_runtime_performance_contract.py
+++ b/tests/builder/test_nemotron_runtime_performance_contract.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static performance contracts for the Nemotron generation runtime."""
+
+from pathlib import Path
+
+
+RUNTIME_SOURCE = (
+    Path(__file__).resolve().parents[2] / "src" / "runtime" / "models" / "nemotron" / "pipeline.cpp"
+)
+
+
+def _function_body(source: str, start: str, end: str) -> str:
+    return source.split(start, maxsplit=1)[1].split(end, maxsplit=1)[0]
+
+
+def test_gpu_greedy_generation_uses_batched_prefill_device_logits() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    prefill = _function_body(
+        source,
+        "bool NemotronTextGenerationPipeline::run_prefill_batched(",
+        "void NemotronTextGenerationPipeline::run_prefill(",
+    )
+    dispatch = _function_body(
+        source,
+        "void NemotronTextGenerationPipeline::run_prefill(",
+        "TrtModule& NemotronTextGenerationPipeline::require_block_prefill(",
+    )
+
+    assert "bool retain_device_logits" in prefill
+    assert "if (retain_device_logits)" in prefill
+    assert "TensorMap outputs = prefill_->forward(inputs)" in prefill
+    assert "logits_tensor.numel()) - vocab" in prefill
+    assert "d_logits_ptr_ = device_logits + logits_offset" in prefill
+    assert "run_prefill_batched(input_ids, logits, gpu_sampling)" in dispatch
+    assert "!gpu_sampling && run_prefill_batched" not in dispatch
+
+
+def test_batched_prefill_does_not_launch_a_discarded_decoder_prime() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+
+    assert "prime_decoder_after_batched_prefill" not in source
+
+
+def test_generation_does_not_run_decoder_after_final_sample() -> None:
+    source = RUNTIME_SOURCE.read_text(encoding="utf-8")
+    decode = _function_body(
+        source,
+        "int32_t NemotronTextGenerationPipeline::run_decode_loop(",
+        "int32_t NemotronTextGenerationPipeline::select_decoder_index(",
+    )
+
+    final_sample_guard = "if (step + 1 >= max_new_tokens)"
+    assert final_sample_guard in decode
+    assert decode.index(final_sample_guard) < decode.index("run_step_device(result.token_id)")

--- a/tests/e2e/models/nemotron/manifests/nemotron-mini-4b.json
+++ b/tests/e2e/models/nemotron/manifests/nemotron-mini-4b.json
@@ -6,6 +6,15 @@
   "runtime_strategy": "nemotron_decoder_kv_cache",
   "task_strategy": "text_generation_causal",
   "precision": "fp16",
+  "build_args": {
+    "decoder_engine_layout": "dual_profile"
+  },
+  "build_cli_args": [
+    {
+      "flag": "--set",
+      "value": "nemotron_decoder.builder_workspace_gib=2"
+    }
+  ],
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
+++ b/tests/e2e/models/nemotron/test_nemotron_manifest_contract.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.e2e_harness.manifest_loader import load_manifest
+from tests.e2e_harness.orchestrator import _append_declared_build_cli_args
+
 
 def test_nemotron_hindi_reference_matches_bundle_precision() -> None:
     manifest_path = Path(__file__).with_name("manifests") / "nemotron-hindi-4b.json"
@@ -15,3 +18,20 @@ def test_nemotron_hindi_reference_matches_bundle_precision() -> None:
 
     assert manifest["precision"] == "bf16"
     assert manifest["testcases"][0]["reference_precision"] == manifest["precision"]
+
+
+def test_nemotron_mini_uses_qualified_compact_build() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "nemotron-mini-4b.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    case = load_manifest(manifest_path)
+    command: list[str] = []
+
+    assert manifest["build_args"] == {"decoder_engine_layout": "dual_profile"}
+    assert manifest["build_cli_args"] == [
+        {
+            "flag": "--set",
+            "value": "nemotron_decoder.builder_workspace_gib=2",
+        }
+    ]
+    _append_declared_build_cli_args(command, case)
+    assert command == ["--set", "nemotron_decoder.builder_workspace_gib=2"]

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -336,6 +336,10 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert by_id["opt.generate"]["workload"]["request"]["max_new_tokens"] == 10
     assert by_id["deepseek_ocr.generate"]["baseline"]["precision"] == "bf16"
     assert by_id["llama.generate@minitron-4b-width"]["baseline"]["precision"] == "fp16"
+    assert by_id["nemotron.generate@nemotron-mini-4b"]["workload"]["runtime"] == {
+        "prefer_gpu_greedy": True
+    }
+    assert by_id["nemotron.generate@nemotron-mini-4b"]["baseline"]["precision"] == "fp16"
     assert by_id["nemotron_h.generate"]["baseline"]["mode"] == "hf-eager"
     assert by_id["nemotron_h.generate"]["workload"]["runtime"] == {"cuda_graphs": True}
     nemotron_baseline = by_id["nemotron_speech_streaming.transcribe"]["baseline"]
@@ -787,9 +791,7 @@ def test_reranking_order_contract_checks_all_document_scores() -> None:
         "baseline": {"output_contract": "reranking-order"},
     }
     candidate = {"output_summary": {"documents": 3, "scores": [0.8, 0.1, 0.4]}}
-    reference = {
-        "output_summary": {"document_count": 3, "scores": [12.0, -4.0, 2.0]}
-    }
+    reference = {"output_summary": {"document_count": 3, "scores": [12.0, -4.0, 2.0]}}
 
     assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
 
@@ -2817,11 +2819,13 @@ def test_candidate_preflight_requires_modelopt_for_auto_fp8(
     monkeypatch.setattr(
         perf_matrix,
         "_run_command",
-        lambda argv, _environment, timeout: calls.append((argv, timeout))
-        or {
-            "exit_code": 1,
-            "stderr_tail": "ModuleNotFoundError: No module named 'modelopt'",
-        },
+        lambda argv, _environment, timeout: (
+            calls.append((argv, timeout))
+            or {
+                "exit_code": 1,
+                "stderr_tail": "ModuleNotFoundError: No module named 'modelopt'",
+            }
+        ),
     )
 
     with pytest.raises(
@@ -2917,6 +2921,54 @@ def test_hf_runner_bridges_removed_input_check_decorator() -> None:
     assert GenericModule.check_model_inputs(forward) is forward
 
 
+def test_hf_runner_loads_model_directly_on_cuda() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/hf_transformers.py"))
+    captured: dict[str, object] = {}
+
+    class FakeTorch:
+        float16 = "float16"
+        float32 = "float32"
+        bfloat16 = "bfloat16"
+
+    class FakeModel:
+        def eval(self):
+            captured["eval"] = True
+            return self
+
+        def to(self, _device):
+            pytest.fail("direct CUDA loading must not copy a complete CPU model")
+
+    class FakeModelClass:
+        @staticmethod
+        def from_pretrained(model, **options):
+            captured.update(model=model, options=options)
+            return FakeModel()
+
+    arguments = Namespace(
+        model="example/model",
+        precision="fp16",
+        experts_implementation=None,
+    )
+    model = runner["_load_model"](
+        FakeModelClass,
+        arguments,
+        FakeTorch,
+        {"local_files_only": True},
+    )
+
+    assert isinstance(model, FakeModel)
+    assert captured == {
+        "model": "example/model",
+        "options": {
+            "torch_dtype": "float16",
+            "low_cpu_mem_usage": True,
+            "device_map": "cuda",
+            "local_files_only": True,
+        },
+        "eval": True,
+    }
+
+
 def test_hf_runner_closes_ignored_disabled_thinking_prompt() -> None:
     runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/hf_transformers.py"))
     captured: dict[str, object] = {}
@@ -2981,9 +3033,7 @@ def test_task_reference_local_only_cli_disables_huggingface_network(monkeypatch)
         captured["transformers"] = os.environ.get("TRANSFORMERS_OFFLINE")
         return 0
 
-    parser = SimpleNamespace(
-        parse_args=lambda _argv: Namespace(local_files_only=True)
-    )
+    parser = SimpleNamespace(parse_args=lambda _argv: Namespace(local_files_only=True))
     monkeypatch.setitem(runner["main"].__globals__, "build_parser", lambda: parser)
     monkeypatch.setitem(runner["main"].__globals__, "run", fake_run)
 

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -882,6 +882,19 @@ def test_sana_runtime_config_resolves_manifest_assets_for_native_worker(tmp_path
     assert Path(worker_config["sana_wm.image_path"]).is_file()
 
 
+def test_gpu_greedy_override_reaches_native_runtime_config(tmp_path: Path) -> None:
+    case = resolve_case(
+        ManifestCatalog().resolve("nemotron-mini-4b"),
+        tmp_path / "pending.bundle",
+        overrides={"runtime.prefer_gpu_greedy": True},
+    )
+
+    assert case.runtime["prefer_gpu_greedy"] is True
+    assert case.worker_request()["runtime"]["config"] == {
+        "runtime.prefer_gpu_greedy": True
+    }
+
+
 def test_multimodal_and_speech_cases_preserve_required_runtime_inputs(tmp_path: Path) -> None:
     vlm = resolve_case(
         ManifestCatalog().resolve("deepseek-ocr-l0"),

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -4544,6 +4544,12 @@ def test_build_bundle_command_uses_manifest_build_settings(tmp_path: Path) -> No
             "decoder_engine_layout": "dual_profile",
             "parallel": {"mode": "tensor_parallel", "tp_size": 2},
         },
+        "build_cli_args": [
+            {
+                "flag": "--set",
+                "value": "nemotron_decoder.builder_workspace_gib=2",
+            }
+        ],
         "quantization": {"format": "fp8", "calibration_samples": 4},
     }
 
@@ -4563,6 +4569,9 @@ def test_build_bundle_command_uses_manifest_build_settings(tmp_path: Path) -> No
         cmd.index("--decoder-engine-layout") : cmd.index("--decoder-engine-layout") + 2
     ]
     assert ["--precision", "bf16"] == cmd[cmd.index("--precision") : cmd.index("--precision") + 2]
+    assert ["--set", "nemotron_decoder.builder_workspace_gib=2"] == cmd[
+        cmd.index("--set") : cmd.index("--set") + 2
+    ]
     assert "--trust-remote-code" in cmd
     assert "--verbose" in cmd
 

--- a/tools/validation/catalog.py
+++ b/tools/validation/catalog.py
@@ -162,6 +162,9 @@ def manifest_record(path: Path) -> dict[str, Any]:
         "fp32_layers": raw.get("fp32_layers", []),
         "quantization": raw.get("quantization", {}),
         "build_args": build_args if isinstance(build_args, dict) else {},
+        "build_cli_args": (
+            raw.get("build_cli_args", []) if isinstance(raw.get("build_cli_args", []), list) else []
+        ),
         "fp8_scales": raw.get("fp8_scales", ""),
         "image_height": raw.get("image_height"),
         "image_width": raw.get("image_width"),

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -9038,6 +9038,28 @@ def _model_asset_path(model: dict[str, Any], value: str) -> Path:
     return REPO_ROOT / "tests" / "e2e" / "data" / asset
 
 
+def _append_manifest_build_cli_args(cmd: list[str], model: dict[str, Any]) -> None:
+    specs = model.get("build_cli_args", [])
+    if not isinstance(specs, list):
+        return
+    for spec in specs:
+        if not isinstance(spec, dict):
+            continue
+        flag = spec.get("flag")
+        if not isinstance(flag, str) or not flag or "value" not in spec:
+            continue
+        value = spec["value"]
+        if value is None or value is False:
+            continue
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                cmd.extend([flag, str(item)])
+            continue
+        cmd.append(flag)
+        if value is not True:
+            cmd.append(str(value))
+
+
 def build_bundle_command(
     model: dict[str, Any],
     *,
@@ -9107,6 +9129,7 @@ def build_bundle_command(
         scales_path = _model_asset_path(model, str(fp8_scales))
         if scales_path.is_file():
             cmd.extend(["--fp8-scales", str(scales_path)])
+    _append_manifest_build_cli_args(cmd, model)
     if extra_build_args:
         cmd.extend(extra_build_args)
     return cmd


### PR DESCRIPTION
## Background

`nemotron-mini-4b` preserved exact FP16 generation output but measured 38.1% slower than the reference on NVIDIA Thor X. The generation path performed avoidable decoder work and moved logits through the host during greedy sampling.

## Exit Criteria

- Preserve the existing exact-token output contract and Accuracy gates.
- Bring warmed TRTMC generation within the registered 5% performance margin on Thor X.
- Validate the exact head revision with Accuracy and Performance on Thor X and GB300.

## Implementation

- Batch prompt prefill, retain the last-token logits on the GPU, and use device-side greedy sampling.
- Remove discarded decoder priming work and skip the final decode launch when its logits cannot be consumed.
- Give Nemotron Mini a dual-profile FP16 engine and route its reviewed runtime override through the benchmark launcher.
- Bound the TensorRT builder workspace through the typed Nemotron configuration.
- Load the FP16 Transformers reference directly on CUDA. Model loading remains outside the timed region, and this avoids retaining a duplicate full CPU model during Thor validation.

## Validation

- `python3 -m pytest -q python/tensorrt_model_connect/families/nemotron/tests/test_runtime_config_schema.py tests/builder/test_nemotron_runtime_performance_contract.py tests/e2e/models/nemotron/test_nemotron_manifest_contract.py tests/tools/test_perf_matrix.py tests/tools/test_trtmc_bench.py tests/tools/test_validation_engine.py`: 493 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: 158 passed; all source-quality checks passed.
- Thor X Accuracy: 20/20 prediction agreement, 0 failed samples, and 35% reference / 35% TRTMC task accuracy.
- Thor X Performance: 225.585 ms TRTMC p50 versus 240.070 ms reference p50; exact token IDs matched and both sides had 10/10 stable samples. Result: green.
- GB300 Accuracy: 20/20 prediction agreement, 0 failed samples, and 35% reference / 35% TRTMC task accuracy.
- GB300 Performance: 22.767 ms TRTMC p50 versus 126.724 ms reference p50; exact token IDs matched and both sides had 10/10 stable samples. Result: green.

All target-hardware results above were produced from exact head `5ee63316a5c2b6571855d323c70254d69792b84a` with FP16 TRTMC and FP16 reference execution.

## Notes For Future Readers

- Review the pipeline execution changes first, then the Nemotron configuration, and finally the benchmark/reference plumbing and contract tests.
- Direct CUDA reference loading changes initialization memory behavior only; initialization is explicitly excluded from the latency measurement contract.

Closes #902
