### PR TITLE
fix(qwen): block unsafe SM121 native KV builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ trtmc run ./qwen3-0.6b.bundle --prompt "What is the capital of France? Answer in
 # Generated text: Paris
 ```
 
+Qwen3 native-KV builds are blocked on SM121 with TensorRT ABI 11.1 or 11.2
+because that combination can produce incorrect output. See
+[Known Issues](https://nvidia.github.io/TensorRT-Model-Connect/release-support/known-issues)
+for the exact boundary and alternatives.
+
 The same bundle works from
 [C++](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api):
 

--- a/python/tensorrt_model_connect/families/qwen/build_routing.py
+++ b/python/tensorrt_model_connect/families/qwen/build_routing.py
@@ -10,6 +10,7 @@ import operator
 
 _INT32_MAX = (1 << 31) - 1
 _UINT64_MAX = (1 << 64) - 1
+_UNSAFE_NATIVE_KV_TRT_ABIS = {(12, 1): frozenset({"11.1", "11.2"})}
 
 
 class NativeKvCapability:
@@ -38,6 +39,91 @@ def _result(
         applicable and not reasons,
         "; ".join(reasons) or "supported",
     )
+
+
+def native_kv_platform_capability(
+    *,
+    compute_capability: tuple[int, int],
+    tensorrt_abi: str,
+) -> NativeKvCapability:
+    """Reject target/runtime pairs known to produce incorrect native-KV output."""
+
+    unsupported_abis = _UNSAFE_NATIVE_KV_TRT_ABIS.get(compute_capability, ())
+    if unsupported_abis and not tensorrt_abi:
+        return _result(
+            reasons=[
+                "Qwen3 native KV cannot determine the TensorRT ABI on SM121; "
+                "TensorRT ABI 11.1 and 11.2 can produce incorrect output. Use "
+                "a different supported GPU or backend; see GitHub issue #955"
+            ]
+        )
+    if tensorrt_abi not in unsupported_abis:
+        return _result()
+    sm = f"SM{compute_capability[0]}{compute_capability[1]}"
+    return _result(
+        reasons=[
+            f"Qwen3 native KV on {sm} with TensorRT ABI {tensorrt_abi} "
+            "can produce incorrect output. Use a different supported GPU or "
+            "backend for Qwen3 on SM121; see GitHub issue #955"
+        ]
+    )
+
+
+def active_cuda_compute_capability(runtime: object | None = None) -> tuple[int, int]:
+    """Return the active CUDA device's validated compute capability."""
+
+    if runtime is None:
+        try:
+            from cuda.bindings import runtime as binding_runtime
+
+            runtime = binding_runtime
+        except ImportError:
+            try:
+                from cuda import cudart
+
+                runtime = cudart
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Qwen3 native KV target validation requires CUDA Python"
+                ) from exc
+
+    success = getattr(getattr(runtime, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status, device = runtime.cudaGetDevice()
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDevice failed with status {status}")
+        status, properties = runtime.cudaGetDeviceProperties(int(device))
+        if status not in (success, 0):
+            raise RuntimeError(
+                f"cudaGetDeviceProperties({device}) failed with status {status}"
+            )
+        major = getattr(properties, "major", None)
+        minor = getattr(properties, "minor", None)
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(
+            f"Unable to inspect the active CUDA device for Qwen3 native KV: {exc}"
+        ) from exc
+
+    if type(major) is not int or type(minor) is not int or major <= 0 or minor < 0:
+        raise RuntimeError("CUDA returned an invalid compute capability")
+    return major, minor
+
+
+def validate_native_kv_platform(
+    *,
+    tensorrt_abi: str,
+    runtime: object | None = None,
+) -> None:
+    """Fail before build when the active target has a known correctness defect."""
+
+    decision = native_kv_platform_capability(
+        compute_capability=active_cuda_compute_capability(runtime),
+        tensorrt_abi=tensorrt_abi,
+    )
+    if not decision.eligible:
+        raise ValueError(decision.reason)
 
 
 def _raw(config: object) -> dict:

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -10,6 +10,8 @@ Qwen3 modes fail closed. Other Qwen variants retain their legacy graph routes.
 
 from __future__ import annotations
 
+from tensorrt_model_connect import trt_compat
+
 from .config import ModelConfig
 from .checkpoint_mapper import WeightDict, load_standard_weights
 from ...parallel_config import ParallelConfig, normalize_parallel_config
@@ -18,6 +20,7 @@ from .build_routing import (
     native_kv_architecture_capability,
     native_kv_build_capability,
     native_kv_cache_geometry,
+    validate_native_kv_platform,
 )
 from .native_kv_contract import validate_native_kv_weights
 from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
@@ -136,8 +139,13 @@ class QwenPlugin:
         """Keep quantized Qwen routes on the family-owned single-engine path."""
         return not bool(config.raw.get("_quantized_build_requested"))
 
-    def validate_build_request(self, config: ModelConfig) -> None:
-        """Reject Qwen3 runtime-sized KV before loading checkpoint weights."""
+    def validate_build_request(
+        self,
+        config: ModelConfig,
+        *,
+        native_kv_requested: bool | None = None,
+    ) -> None:
+        """Reject unsafe Qwen3 native-KV requests before loading weights."""
         if str(config.model_type).lower() != "qwen3":
             return
         if (
@@ -149,6 +157,20 @@ class QwenPlugin:
                 "--dynamic-kv-cache or set dynamic_kv_cache=False to use "
                 "the fixed-capacity native KV path"
             )
+        if native_kv_requested is None:
+            precision = str(
+                config.raw.get("_resolved_build_precision", "")
+            ).lower()
+            native_kv_requested = (
+                not config.raw.get("_quantized_build_requested")
+                and not config.raw.get("_parallel_build_enabled")
+                and not config.raw.get("_rtx_build_requested")
+                and (not precision or precision in {"fp16", "bf16"})
+                and native_kv_architecture_capability(config).eligible
+            )
+        if not native_kv_requested:
+            return
+        validate_native_kv_platform(tensorrt_abi=trt_compat.tensorrt_abi())
 
     def load_weights(
         self, model_dir: str, config: ModelConfig,
@@ -164,7 +186,6 @@ class QwenPlugin:
     ) -> bytes:
         parallel = normalize_parallel_config(parallel_config)
         config.raw.pop("_native_kv_cache_metadata", None)
-        self.validate_build_request(config)
         capability = native_kv_build_capability(
             config,
             precision=precision,
@@ -172,6 +193,10 @@ class QwenPlugin:
             parallel_enabled=parallel.enabled,
             quantized=quant_ctx is not None,
             debug_layer_outputs=debug_layer_outputs,
+        )
+        self.validate_build_request(
+            config,
+            native_kv_requested=capability.eligible,
         )
         qualified_fp8 = _uses_qualified_qwen3_fp8_path(
             config,

--- a/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_routing.py
@@ -14,11 +14,14 @@ from types import SimpleNamespace
 import pytest
 
 from tensorrt_model_connect.families.qwen.build_routing import (
+    active_cuda_compute_capability,
     native_kv_architecture_capability,
     native_kv_build_capability,
     native_kv_cache_geometry,
+    native_kv_platform_capability,
     prefer_native_default,
     resolved_head_dim,
+    validate_native_kv_platform,
 )
 from tensorrt_model_connect.families.qwen.config import ModelConfig
 from tensorrt_model_connect.families.qwen.native_kv_contract import (
@@ -212,6 +215,80 @@ def test_unqualified_build_modes_fail_closed(kwargs, raw_updates, reason):
     assert reason in decision.reason
 
 
+@pytest.mark.parametrize(
+    ("compute_capability", "tensorrt_abi", "eligible"),
+    [
+        ((12, 1), "11.1", False),
+        ((12, 1), "11.2", False),
+        ((12, 0), "11.2", True),
+        ((10, 3), "11.2", True),
+        ((12, 1), "11.0", True),
+        ((12, 1), "12.0", True),
+        ((12, 1), "", False),
+    ],
+    ids=(
+        "sm121-trt-11.1",
+        "sm121-trt-11.2",
+        "sm120-trt-11.2",
+        "sm103-trt-11.2",
+        "sm121-trt-11.0",
+        "sm121-trt-12.0",
+        "sm121-trt-unknown",
+    ),
+)
+def test_native_kv_platform_rejects_only_confirmed_unsafe_combinations(
+    compute_capability,
+    tensorrt_abi,
+    eligible,
+):
+    decision = native_kv_platform_capability(
+        compute_capability=compute_capability,
+        tensorrt_abi=tensorrt_abi,
+    )
+
+    assert decision.eligible is eligible
+    if not eligible:
+        assert "incorrect output" in decision.reason
+        assert "#955" in decision.reason
+
+
+def test_active_cuda_compute_capability_reads_process_device():
+    runtime = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (0, 3),
+        cudaGetDeviceProperties=lambda device: (
+            0,
+            SimpleNamespace(major=12, minor=1) if device == 3 else None,
+        ),
+    )
+
+    assert active_cuda_compute_capability(runtime) == (12, 1)
+
+
+def test_active_cuda_compute_capability_fails_closed_on_probe_error():
+    runtime = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (17, None),
+    )
+
+    with pytest.raises(RuntimeError, match="cudaGetDevice failed with status 17"):
+        active_cuda_compute_capability(runtime)
+
+
+def test_native_kv_platform_validation_rejects_unsafe_active_device():
+    runtime = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (0, 0),
+        cudaGetDeviceProperties=lambda _device: (
+            0,
+            SimpleNamespace(major=12, minor=1),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="SM121.*TensorRT ABI 11.2.*incorrect output"):
+        validate_native_kv_platform(runtime=runtime, tensorrt_abi="11.2")
+
+
 @dataclass
 class _Tensor:
     shape: tuple[int, ...]
@@ -394,6 +471,69 @@ def test_qwen3_dynamic_kv_fails_before_legacy_builder(monkeypatch):
     assert plugin_module.plugin.get_bundle_config_overrides(config) is None
 
 
+def test_qwen3_sm121_guard_runs_in_plugin_validation(monkeypatch):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    routing_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.build_routing"
+    )
+    config = _small_config()
+    config.raw["_resolved_build_precision"] = "bf16"
+
+    monkeypatch.setattr(
+        routing_module,
+        "active_cuda_compute_capability",
+        lambda: (12, 1),
+    )
+    monkeypatch.setattr(plugin_module.trt_compat, "tensorrt_abi", lambda: "11.2")
+
+    with pytest.raises(ValueError, match="SM121.*incorrect output"):
+        plugin_module.plugin.validate_build_request(config)
+
+
+def _simulate_unsafe_sm121(monkeypatch, plugin_module):
+    routing_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.build_routing"
+    )
+    monkeypatch.setattr(
+        routing_module,
+        "active_cuda_compute_capability",
+        lambda: (12, 1),
+    )
+    monkeypatch.setattr(plugin_module.trt_compat, "tensorrt_abi", lambda: "11.2")
+
+
+@pytest.mark.parametrize(
+    "raw_updates",
+    [
+        {"_quantized_build_requested": True},
+        {"_parallel_build_enabled": True},
+        {"_resolved_build_precision": "fp32"},
+    ],
+    ids=("quantized", "tensor-parallel", "fp32"),
+)
+def test_non_native_qwen3_requests_skip_platform_guard(monkeypatch, raw_updates):
+    pytest.importorskip("tensorrt")
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.plugin"
+    )
+    config = _small_config()
+    config.raw.update(raw_updates)
+
+    def _unexpected_validation(**_kwargs):
+        raise AssertionError("non-native Qwen3 request must not use the platform guard")
+
+    monkeypatch.setattr(
+        plugin_module,
+        "validate_native_kv_platform",
+        _unexpected_validation,
+    )
+
+    plugin_module.plugin.validate_build_request(config)
+
+
 def test_qwen3_qualified_fp8_uses_family_quantized_builder(monkeypatch):
     pytest.importorskip("tensorrt")
     plugin_module = importlib.import_module(
@@ -404,6 +544,7 @@ def test_qwen3_qualified_fp8_uses_family_quantized_builder(monkeypatch):
     config.raw["_native_kv_cache_metadata"] = {"stale": True}
     quant_ctx = _quant_ctx("fp8")
     captured: dict[str, object] = {}
+    _simulate_unsafe_sm121(monkeypatch, plugin_module)
 
     def _build(*args, **kwargs):
         captured.update(args=args, kwargs=kwargs)
@@ -439,6 +580,7 @@ def test_qwen3_qualified_fp8_retains_tensor_parallel_builder(monkeypatch):
     quant_ctx = _quant_ctx("fp8")
     parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0)
     captured: dict[str, object] = {}
+    _simulate_unsafe_sm121(monkeypatch, plugin_module)
 
     def _build(*args, **kwargs):
         captured.update(args=args, kwargs=kwargs)

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -31,6 +31,11 @@ The bounded cache profile is intended for the first portable native-attention
 build. The first build may download model files and compile TensorRT engines.
 `qwen3-0.6b.bundle` is the runnable output.
 
+This native-KV path is blocked on SM121 with TensorRT ABI 11.1 or 11.2 because
+the affected combination can build an engine that produces incorrect output.
+See [Limitations / Known Issues](../release-support/known-issues.md) for the
+exact boundary and alternatives.
+
 ## 3. Inspect the bundle
 
 ```bash

--- a/website/docs/release-support/known-issues.md
+++ b/website/docs/release-support/known-issues.md
@@ -21,6 +21,12 @@ description: Current boundaries that users must account for when interpreting fe
   TP/CP flags do not establish blanket support.
 - The public detection API does not establish a supported detector without a
   model-owned runtime strategy and E2E manifest.
+- Qwen3 native-KV builds are blocked on SM121 with TensorRT ABI 11.1 or 11.2.
+  Engines for this combination can build successfully but produce incorrect
+  output ([issue #955](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/955)).
+  Use a different supported GPU or backend for Qwen3 on SM121. Qwen2 and
+  Qwen2.5 routes, SM120 and SM103, and qualified FP8 routes are not
+  covered by this restriction.
 
 Use the current source, exact manifest, and test evidence when this page and a
 newer implementation differ.


### PR DESCRIPTION
## Background

Qwen3 native-KV engines on SM121 can build successfully with TensorRT ABI 11.1 or 11.2 and then return deterministic incorrect tokens, as reported in #955. A successful engine build is therefore not sufficient correctness evidence for this target/runtime tuple.

## Exit Criteria

- Reject affected dense Qwen3 native-KV builds before checkpoint weights are loaded.
- Keep Qwen2/Qwen2.5, SM120, SM103, qualified FP8 and other non-native routes, and explicitly identified future TensorRT ABIs outside the restriction.
- Fail closed on SM121 when the active CUDA device or TensorRT ABI cannot be identified.
- Document the exact user-visible boundary and provide an actionable diagnostic.

## Implementation

- Add a loader-safe, family-owned CUDA compute-capability probe and a narrow SM121/TensorRT ABI denylist to the Qwen native-KV routing contract.
- Invoke the platform validation from the existing pre-weight family hook. Direct plugin builds pass their resolved native-KV capability back into validation so qualified FP8 and tensor-parallel routes are not misclassified.
- Cover the unsafe/safe platform matrix, CUDA probe failures, plugin wiring, and non-native route preservation.
- Document the restriction in the README, Qwen quick start, and known issues.

## Validation

- `$env:PYTHONPATH = 'python;.'; py -3 -m pytest tests/e2e/models/qwen/test_qwen_native_kv_routing.py --confcutdir=tests/e2e/models/qwen --basetemp=.tmp/pytest-final -q`: 37 passed, 21 skipped because TensorRT is unavailable in the local Windows environment.
- `py -3 -m ruff check python/tensorrt_model_connect/families/qwen/build_routing.py python/tensorrt_model_connect/families/qwen/plugin.py tests/e2e/models/qwen/test_qwen_native_kv_routing.py`: passed.
- `$env:PYTHONPATH = 'python;.'; py -3 tools/model_ci.py validate`: passed for 84 families.
- `$env:PYTHONPATH = 'python;.'; py -3 tools/test_impact.py --validate`: passed with existing stale fallback-allowlist warnings.
- `py -3 tools/check_doc_file_references.py --strict website/docs`: passed with 0 errors and 0 warnings.
- `npm.cmd --prefix website exec -- docusaurus build website`: production site build passed.
- `git diff --check upstream/main...HEAD`: passed.
- `npm.cmd --prefix website run build`: the wrapper did not reach Docusaurus because its diagram check reports the unmodified `static/img/diagrams/architecture/build-ownership.svg` as stale on Windows.
- Community CPU / Required and all public child jobs passed for exact head `a2cb00fc6e1c58624284819a7e4b061aef12cc52`.

No SM121 GPU inference or parity run was available locally. Protected target-hardware validation remains required.

## Notes For Future Readers

Review the platform matrix and probe first, then the Qwen plugin hook, followed by the focused tests and documentation. The restriction is intentionally tied to confirmed ABI families rather than all SM12x devices or future TensorRT releases; an unknown ABI fails closed only on SM121.

This mitigates #955 by preventing silent wrong output; it does not claim that the underlying TensorRT kernel defect is fixed.