### PR TITLE
feat(contributing): automate PR intake

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,82 @@
+<!--
+Thank you for contributing to TensorRT-Model-Connect.
+
+Complete every section. Use "Not applicable: <reason>" when a field does not
+apply. HTML comments are guidance only and do not count as completed content.
+-->
+
+## Background
+
+<!--
+Explain the problem, motivation, and current behavior. Link the originating
+issue or discussion.
+-->
+
+## Exit Criteria
+
+<!--
+List the observable conditions that must be true for this change to be
+complete. Include important non-goals or boundaries.
+-->
+
+## Implementation
+
+<!--
+Describe the approach and name the affected models/components. State any
+public API, ABI, bundle/artifact, dependency, compatibility, migration, or
+rollout changes.
+-->
+
+### Change categories
+
+<!-- Select at least one. The triage bot converts applicable choices to labels. -->
+
+- [ ] Model or runtime behavior
+- [ ] Public API
+- [ ] ABI
+- [ ] Bundle or artifact format
+- [ ] Dependencies
+- [ ] Documentation only
+- [ ] CI or developer tooling
+
+## Validation
+
+### Commands and Results
+
+<!--
+Paste the exact commands that ran and report their results. Keep compilation,
+unit, inference, parity, performance, and qualification claims separate.
+-->
+
+### Hardware, Environment, and Revisions
+
+<!--
+Record the tested repository head plus model/checkpoint/dataset/dependency
+revisions. Include GPU/CPU, OS/container, CUDA, TensorRT, and precision as
+applicable.
+-->
+
+### Not Run / Remaining Gaps
+
+<!--
+List untested paths, configurations, unavailable hardware, skipped tests, and
+why. Use "None: <reason>" only when the recorded evidence covers every relevant
+path.
+-->
+
+## Notes For Future Readers
+
+<!--
+Record remaining risk, compatibility or rollout notes, artifact rebuild needs,
+third-party provenance, suggested review order, and useful follow-up context.
+-->
+
+### Risk level
+
+<!-- Select exactly one and explain the choice below. -->
+
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+<!-- Risk rationale: -->

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: PR Metadata
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: pr-metadata-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  required:
+    name: PR Metadata / Required
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # This unprivileged check may execute pull-request code. It has read-only
+      # contents permission, no secrets, and no access to protected resources.
+      - name: Check out the exact pull-request merge
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Validate required pull-request evidence
+        run: python3 -m tools.pr_metadata validate --event "$GITHUB_EVENT_PATH"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: PR Triage
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: pr-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: Classify pull request
+    if: ${{ github.repository == 'NVIDIA/TensorRT-Model-Connect' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # This privileged workflow executes only code from the trusted base SHA.
+      # It fetches pull-request Git objects for declarative impact analysis but
+      # never checks out or executes pull-request code.
+      - name: Check out the trusted base revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Fetch the exact pull-request head without checking it out
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          git fetch --no-tags --force \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/trtmc/pr-head"
+          resolved_head="$(git rev-parse 'refs/remotes/trtmc/pr-head^{commit}')"
+          test "$resolved_head" = "$EXPECTED_HEAD_SHA"
+          echo "TRTMC_PR_HEAD_SHA=$resolved_head" >> "$GITHUB_ENV"
+
+      - name: Synchronize model, component, change, and risk labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRTMC_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python3 -m tools.pr_metadata triage
+          --event "$GITHUB_EVENT_PATH"
+          --base "$TRTMC_PR_BASE_SHA"
+          --head "$TRTMC_PR_HEAD_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,13 +133,25 @@ branch that other people are using.
 ### 7. Open a pull request against upstream `main`
 
 Open the pull request from your fork branch to
-`NVIDIA/TensorRT-Model-Connect:main`. Include:
+`NVIDIA/TensorRT-Model-Connect:main`. Complete every section of the pull-request
+template; use `Not applicable: <reason>` instead of deleting a section. Include:
 
-- the problem, scope, and important non-goals;
-- a linked issue or design discussion when applicable;
-- exact validation commands and their results;
-- the model revision, artifacts, environment, and hardware for GPU claims; and
-- tests or paths that were not run, plus any remaining risk.
+- **Background**: the problem, motivation, current behavior, and linked issue;
+- **Exit Criteria**: the conditions that define completion, including important
+  non-goals;
+- **Implementation**: the approach, affected models and components, and any
+  API, ABI, bundle, dependency, compatibility, migration, or rollout changes;
+- **Validation**: exact commands and results, tested head and dependency/model
+  revisions, environment and hardware, plus paths that were not run; and
+- **Notes For Future Readers**: remaining risk, compatibility or rollout notes,
+  third-party provenance, and useful follow-up context.
+
+`PR Metadata / Required` checks that these sections and the structured
+validation evidence are present. The trusted triage workflow derives model and
+component labels from the actual diff and repository ownership metadata; it
+uses the template only for declared risk and compatibility-change labels. DCO
+sign-off is enforced by the repository's DCO check rather than a self-attested
+template checkbox.
 
 Compilation, unit tests, inference, model parity, target-hardware execution,
 performance, and release qualification are separate evidence levels. Claim only

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -230,6 +230,8 @@ def test_source_workflow_inventory_does_not_repeat_premerge_after_merge() -> Non
         "community-cpu.yml",
         "internal-ci-bridge.yml",
         "pages.yml",
+        "pr-metadata.yml",
+        "pr-triage.yml",
     ]
 
     bridge = (workflows / "internal-ci-bridge.yml").read_text(encoding="utf-8")

--- a/tests/tools/test_pr_metadata.py
+++ b/tests/tools/test_pr_metadata.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pull-request evidence validation and automatic classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tools import pr_metadata
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _complete_body() -> str:
+    return """\
+## Background
+
+Fix model selection ambiguity reported in #123.
+
+## Exit Criteria
+
+- Qwen selection is unambiguous.
+- Existing runtime math is unchanged.
+
+## Implementation
+
+Update the Qwen builder and its model-owned tests. There are no public API,
+ABI, bundle, dependency, migration, or rollout changes.
+
+### Change categories
+
+- [x] Model or runtime behavior
+- [ ] Public API
+- [ ] ABI
+- [ ] Bundle or artifact format
+- [ ] Dependencies
+- [ ] Documentation only
+- [ ] CI or developer tooling
+
+## Validation
+
+### Commands and Results
+
+`python3 -m pytest -q tests/builder/test_qwen.py`: 12 passed.
+
+### Hardware, Environment, and Revisions
+
+Repository head `def456`; Qwen revision `abc123`; CPU-only Ubuntu 24.04.
+
+### Not Run / Remaining Gaps
+
+GPU execution was not run because runtime math is unchanged.
+
+## Notes For Future Readers
+
+Backward compatible; no artifact rebuild is required. Review the selection
+logic before the model-owned regression.
+
+### Risk level
+
+- [x] Low
+- [ ] Medium
+- [ ] High
+
+The change is isolated to model selection.
+
+"""
+
+
+def test_complete_pull_request_body_passes() -> None:
+    assert pr_metadata.validate_body(_complete_body()) == []
+
+
+def test_comments_and_headings_do_not_satisfy_required_evidence() -> None:
+    body = _complete_body().replace(
+        "Fix model selection ambiguity reported in #123.",
+        "<!-- contributor left the Background section empty -->",
+    )
+
+    assert "Required section is empty: Background" in pr_metadata.validate_body(body)
+
+
+def test_validation_requires_commands_results_environment_revisions_and_gaps() -> None:
+    body = _complete_body().replace(
+        "Repository head `def456`; Qwen revision `abc123`; CPU-only Ubuntu 24.04.",
+        "<!-- no revisions supplied -->",
+    )
+
+    assert (
+        "Required subsection is empty: Validation / Hardware, Environment, and Revisions"
+        in pr_metadata.validate_body(body)
+    )
+
+
+def test_change_category_and_risk_choices_are_enforced() -> None:
+    body = (
+        _complete_body()
+        .replace("- [x] Model or runtime behavior", "- [ ] Model or runtime behavior")
+        .replace("- [ ] High", "- [x] High")
+    )
+
+    errors = pr_metadata.validate_body(body)
+    assert "Select at least one Change categories option" in errors
+    assert "Select exactly one Risk level option" in errors
+
+
+def test_hidden_comments_cannot_satisfy_checkboxes_or_sections() -> None:
+    body = (
+        _complete_body()
+        .replace(
+            "Fix model selection ambiguity reported in #123.",
+            "<!--\nHidden text.\n## Background\nStill hidden.\n-->",
+        )
+        .replace("- [x] Low", "- [ ] Low\n<!--\n- [x] Low\n-->")
+    )
+
+    errors = pr_metadata.validate_body(body)
+
+    assert "Required section is empty: Background" in errors
+    assert "Select exactly one Risk level option" in errors
+
+
+def test_choices_outside_required_subsections_are_ignored() -> None:
+    body = (
+        _complete_body()
+        .replace("- [x] Model or runtime behavior", "- [ ] Model or runtime behavior")
+        .replace(
+            "### Change categories",
+            "- [x] Public API\n\n### Change categories",
+        )
+        .replace("- [x] Low", "- [ ] Low")
+        .replace(
+            "### Risk level",
+            "- [x] High\n\n### Risk level",
+        )
+    )
+
+    errors = pr_metadata.validate_body(body)
+    labels = pr_metadata.labels_for_impact(
+        {"mode": "models", "affected_models": [], "changes": []}, body
+    )
+
+    assert "Select at least one Change categories option" in errors
+    assert "Select exactly one Risk level option" in errors
+    assert "change:api" not in labels
+    assert "risk:high" not in labels
+
+
+def test_risk_level_requires_a_rationale_beyond_the_checkbox() -> None:
+    body = _complete_body().replace(
+        "The change is isolated to model selection.",
+        "<!-- no risk rationale -->",
+    )
+
+    assert (
+        "Required subsection is empty: Notes For Future Readers / Risk level"
+        in pr_metadata.validate_body(body)
+    )
+
+
+def test_labels_combine_declared_risk_with_repository_impact() -> None:
+    impact = {
+        "mode": "models",
+        "affected_models": ["qwen"],
+        "changes": [
+            {
+                "classifications": [
+                    {"path": "src/runtime/models/qwen/model.cpp", "kind": "model"},
+                    {"path": "website/docs/qwen.md", "kind": "legal_docs"},
+                ]
+            }
+        ],
+    }
+    body = _complete_body().replace("- [ ] Public API", "- [x] Public API")
+
+    assert pr_metadata.labels_for_impact(impact, body) == {
+        "change:api",
+        "component:docs",
+        "component:model",
+        "model:qwen",
+        "risk:low",
+    }
+
+
+def test_broad_change_uses_one_all_models_label() -> None:
+    impact = {
+        "mode": "all",
+        "affected_models": ["albert", "qwen", "whisper"],
+        "changes": [{"classifications": [{"path": "CMakeLists.txt", "kind": "platform"}]}],
+    }
+
+    labels = pr_metadata.labels_for_impact(impact, _complete_body())
+
+    assert "impact:all-models" in labels
+    assert "component:platform" in labels
+    assert not {label for label in labels if label.startswith("model:")}
+
+
+def test_managed_label_sync_preserves_unmanaged_labels() -> None:
+    class RecordingLabels:
+        def __init__(self) -> None:
+            self.ensured: list[str] = []
+            self.added: list[str] = []
+            self.removed: list[str] = []
+
+        def issue_labels(self, _issue_number: int) -> set[str]:
+            return {"bug", "model:old", "risk:high", "component:model"}
+
+        def ensure_label(self, label: str) -> None:
+            self.ensured.append(label)
+
+        def add_labels(self, _issue_number: int, labels: list[str]) -> None:
+            self.added.extend(labels)
+
+        def remove_label(self, _issue_number: int, label: str) -> None:
+            self.removed.append(label)
+
+    client = RecordingLabels()
+    desired = {"component:model", "model:qwen", "risk:low"}
+
+    pr_metadata.sync_managed_labels(client, 123, desired)  # type: ignore[arg-type]
+
+    assert client.ensured == ["component:model", "model:qwen", "risk:low"]
+    assert client.added == ["model:qwen", "risk:low"]
+    assert client.removed == ["model:old", "risk:high"]
+
+
+def test_template_and_validator_share_the_same_contract() -> None:
+    template = (REPO_ROOT / ".github" / "pull_request_template.md").read_text(encoding="utf-8")
+    for title in pr_metadata.REQUIRED_SECTIONS:
+        assert f"## {title}" in template
+    for title in pr_metadata.VALIDATION_SUBSECTIONS:
+        assert f"### {title}" in template
+    for option in (*pr_metadata.CHANGE_CATEGORIES, *pr_metadata.RISK_LEVELS):
+        assert f"- [ ] {option}" in template
+
+
+def test_metadata_workflow_runs_unprivileged_exact_merge_check() -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "pr-metadata.yml"
+    source = path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(source)
+    job = workflow["jobs"]["required"]
+
+    assert "pull_request:" in source
+    assert "types: [opened, edited, synchronize, reopened, ready_for_review]" in source
+    assert "pull_request_target:" not in source
+    assert workflow["permissions"] == {}
+    assert job["name"] == "PR Metadata / Required"
+    assert job["permissions"] == {"contents": "read"}
+    assert "ref: ${{ github.sha }}" in source
+    assert "persist-credentials: false" in source
+    assert "tools.pr_metadata validate" in source
+    assert "pull-requests: write" not in source
+    assert "issues: write" not in source
+    assert "secrets." not in source
+
+
+def test_triage_workflow_never_checks_out_or_executes_pull_request_code() -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "pr-triage.yml"
+    source = path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(source)
+    job = workflow["jobs"]["classify"]
+
+    assert "pull_request_target:" in source
+    assert workflow["permissions"] == {}
+    assert job["permissions"] == {"contents": "read", "issues": "write"}
+    assert "ref: ${{ github.event.pull_request.base.sha }}" in source
+    assert "persist-credentials: false" in source
+    assert "refs/remotes/trtmc/pr-head" in source
+    assert "git checkout" not in source
+    assert "github.event.pull_request.head.ref" not in source
+    assert "tools.pr_metadata triage" in source
+    assert "secrets." not in source

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1554,6 +1554,7 @@ class TestNoImpact:
             "Dockerfile.community-cpu",
             "requirements/community-ci.txt",
             "tools/community_ci.py",
+            "tools/pr_metadata.py",
         ],
     )
     def test_community_cpu_contract_triggers_tools_tier(self, imap, path):

--- a/tools/pr_metadata.py
+++ b/tools/pr_metadata.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate pull-request evidence and synchronize repository-derived labels."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from tools.model_ci import ModelCIError, calculate_impact
+
+
+REQUIRED_SECTIONS = (
+    "Background",
+    "Exit Criteria",
+    "Implementation",
+    "Validation",
+    "Notes For Future Readers",
+)
+VALIDATION_SUBSECTIONS = (
+    "Commands and Results",
+    "Hardware, Environment, and Revisions",
+    "Not Run / Remaining Gaps",
+)
+CHANGE_CATEGORIES = {
+    "Model or runtime behavior": None,
+    "Public API": "change:api",
+    "ABI": "change:abi",
+    "Bundle or artifact format": "change:bundle-format",
+    "Dependencies": "change:dependencies",
+    "Documentation only": "change:documentation-only",
+    "CI or developer tooling": "change:ci-tooling",
+}
+RISK_LEVELS = {"Low": "risk:low", "Medium": "risk:medium", "High": "risk:high"}
+MANAGED_PREFIXES = ("model:", "component:", "risk:", "change:", "impact:")
+COMPONENT_BY_CLASSIFICATION = {
+    "model": "component:model",
+    "unit_builder": "component:builder",
+    "unit_cli": "component:cli",
+    "unit_tests": "component:tests",
+    "legal_docs": "component:docs",
+    "platform": "component:platform",
+    "ci_tooling": "component:ci",
+    "unknown": "component:unknown",
+}
+LABEL_COLORS = {
+    "model": "7057ff",
+    "component": "1d76db",
+    "risk:low": "2da44e",
+    "risk:medium": "bf8700",
+    "risk:high": "cf222e",
+    "change": "d4c5f9",
+    "impact": "8250df",
+}
+_HEADING_RE = re.compile(r"^(?P<level>#{2,3})[ \t]+(?P<title>.+?)[ \t]*$", re.MULTILINE)
+_CHECKBOX_RE = re.compile(r"^- \[(?P<mark>[ xX])\] (?P<label>.+?)[ \t]*$", re.MULTILINE)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+class MetadataError(RuntimeError):
+    """A contributor-actionable pull-request metadata failure."""
+
+
+def _heading_blocks(text: str, level: int) -> dict[str, str]:
+    headings = [match for match in _HEADING_RE.finditer(text) if len(match.group("level")) == level]
+    blocks: dict[str, str] = {}
+    for index, match in enumerate(headings):
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(text)
+        blocks[match.group("title").strip().casefold()] = text[match.end() : end]
+    return blocks
+
+
+def _meaningful(text: str) -> bool:
+    without_comments = _HTML_COMMENT_RE.sub("", text)
+    without_checkboxes = _CHECKBOX_RE.sub("", without_comments)
+    without_headings = _HEADING_RE.sub("", without_checkboxes)
+    return bool(without_headings.strip())
+
+
+def checked_options(body: str, options: Mapping[str, object]) -> list[str]:
+    body = _HTML_COMMENT_RE.sub("", body)
+    checked = {
+        match.group("label").strip()
+        for match in _CHECKBOX_RE.finditer(body)
+        if match.group("mark").strip()
+    }
+    return [option for option in options if option in checked]
+
+
+def validate_body(body: str) -> list[str]:
+    errors: list[str] = []
+    visible_body = _HTML_COMMENT_RE.sub("", body)
+    sections = _heading_blocks(visible_body, 2)
+    for title in REQUIRED_SECTIONS:
+        content = sections.get(title.casefold())
+        if content is None:
+            errors.append(f"Missing required section: {title}")
+        elif title != "Validation" and not _meaningful(content):
+            errors.append(f"Required section is empty: {title}")
+
+    nested_requirements = {
+        "Implementation": ("Change categories",),
+        "Validation": VALIDATION_SUBSECTIONS,
+        "Notes For Future Readers": ("Risk level",),
+    }
+    for section_title, subsection_titles in nested_requirements.items():
+        content = sections.get(section_title.casefold(), "")
+        subsections = _heading_blocks(content, 3)
+        for title in subsection_titles:
+            subsection = subsections.get(title.casefold())
+            if subsection is None:
+                errors.append(f"Missing required subsection: {section_title} / {title}")
+            elif title != "Change categories" and not _meaningful(subsection):
+                errors.append(f"Required subsection is empty: {section_title} / {title}")
+
+    implementation_subsections = _heading_blocks(sections.get("implementation", ""), 3)
+    change_categories = implementation_subsections.get("change categories", "")
+    selected_categories = checked_options(change_categories, CHANGE_CATEGORIES)
+    if not selected_categories:
+        errors.append("Select at least one Change categories option")
+    note_subsections = _heading_blocks(sections.get("notes for future readers", ""), 3)
+    risk_level = note_subsections.get("risk level", "")
+    selected_risks = checked_options(risk_level, RISK_LEVELS)
+    if len(selected_risks) != 1:
+        errors.append("Select exactly one Risk level option")
+    return errors
+
+
+def labels_for_impact(impact: Mapping[str, object], body: str) -> set[str]:
+    labels: set[str] = set()
+    for change in impact.get("changes", []):
+        if not isinstance(change, Mapping):
+            continue
+        for classification in change.get("classifications", []):
+            if not isinstance(classification, Mapping):
+                continue
+            component = COMPONENT_BY_CLASSIFICATION.get(str(classification.get("kind", "")))
+            if component:
+                labels.add(component)
+
+    if impact.get("mode") == "all":
+        labels.add("impact:all-models")
+    else:
+        for model in impact.get("affected_models", []):
+            labels.add(f"model:{model}")
+
+    sections = _heading_blocks(_HTML_COMMENT_RE.sub("", body), 2)
+    implementation_subsections = _heading_blocks(sections.get("implementation", ""), 3)
+    change_categories = implementation_subsections.get("change categories", "")
+    for option in checked_options(change_categories, CHANGE_CATEGORIES):
+        label = CHANGE_CATEGORIES[option]
+        if label:
+            labels.add(label)
+    note_subsections = _heading_blocks(sections.get("notes for future readers", ""), 3)
+    risk_level = note_subsections.get("risk level", "")
+    selected_risks = checked_options(risk_level, RISK_LEVELS)
+    if len(selected_risks) == 1:
+        labels.add(RISK_LEVELS[selected_risks[0]])
+    return labels
+
+
+def _label_spec(name: str) -> tuple[str, str]:
+    if name.startswith("risk:"):
+        color = LABEL_COLORS[name]
+    else:
+        prefix = name.split(":", maxsplit=1)[0]
+        color = LABEL_COLORS[prefix]
+    description = {
+        "model": "Model impact derived from repository ownership metadata",
+        "component": "Component impact derived from changed paths",
+        "risk": "Risk declared in the pull-request template",
+        "change": "Compatibility change declared in the pull-request template",
+        "impact": "Broad impact derived from repository ownership metadata",
+    }[name.split(":", maxsplit=1)[0]]
+    return color, description
+
+
+class GitHubLabels:
+    """Minimal GitHub Issues labels client."""
+
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        opener: Callable[..., Any] = urllib.request.urlopen,
+    ) -> None:
+        self.repository = repository
+        self.token = token
+        self.opener = opener
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, object] | None = None,
+        *,
+        allowed_statuses: Sequence[int] = (),
+    ) -> object:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{self.repository}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": "trtmc-pr-triage",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with self.opener(request, timeout=30) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as error:
+            if error.code in allowed_statuses:
+                return {}
+            detail = error.read().decode("utf-8", errors="replace")
+            raise MetadataError(
+                f"GitHub API {method} {path} failed: {error.code} {detail}"
+            ) from error
+        return json.loads(raw) if raw else {}
+
+    def issue_labels(self, issue_number: int) -> set[str]:
+        payload = self._request("GET", f"/issues/{issue_number}/labels?per_page=100")
+        if not isinstance(payload, list):
+            raise MetadataError("GitHub API returned an invalid issue-label response")
+        return {str(item["name"]) for item in payload if isinstance(item, Mapping)}
+
+    def ensure_label(self, name: str) -> None:
+        color, description = _label_spec(name)
+        self._request(
+            "POST",
+            "/labels",
+            {"name": name, "color": color, "description": description},
+            allowed_statuses=(422,),
+        )
+
+    def add_labels(self, issue_number: int, labels: Sequence[str]) -> None:
+        if labels:
+            self._request("POST", f"/issues/{issue_number}/labels", {"labels": list(labels)})
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        encoded = urllib.parse.quote(label, safe="")
+        self._request(
+            "DELETE",
+            f"/issues/{issue_number}/labels/{encoded}",
+            allowed_statuses=(404,),
+        )
+
+
+def sync_managed_labels(client: GitHubLabels, issue_number: int, desired: set[str]) -> None:
+    current = client.issue_labels(issue_number)
+    managed = {label for label in current if label.startswith(MANAGED_PREFIXES)}
+    for label in sorted(desired):
+        client.ensure_label(label)
+    client.add_labels(issue_number, sorted(desired - current))
+    for label in sorted(managed - desired):
+        client.remove_label(issue_number, label)
+
+
+def _load_event(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("pull_request"), dict):
+        raise MetadataError("GitHub event does not contain pull_request metadata")
+    return payload
+
+
+def _pull_request_body(event: Mapping[str, object]) -> str:
+    pull_request = event["pull_request"]
+    assert isinstance(pull_request, Mapping)
+    body = pull_request.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def _validate(event_path: Path) -> None:
+    errors = validate_body(_pull_request_body(_load_event(event_path)))
+    if errors:
+        for error in errors:
+            print(f"::error title=PR metadata::{error}")
+        raise MetadataError(f"Pull-request metadata has {len(errors)} error(s)")
+    print("Pull-request metadata is complete.")
+
+
+def _triage(event_path: Path, base: str, head: str) -> None:
+    event = _load_event(event_path)
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+    issue_number = event.get("number")
+    if not repository or not token or not isinstance(issue_number, int):
+        raise MetadataError("Triage requires GITHUB_REPOSITORY, GH_TOKEN, and an issue number")
+    impact = calculate_impact(Path.cwd(), base, head, platform_change_policy="all")
+    desired = labels_for_impact(impact, _pull_request_body(event))
+    sync_managed_labels(GitHubLabels(repository, token), issue_number, desired)
+    print(json.dumps({"labels": sorted(desired)}, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("--event", type=Path, required=True)
+    triage = commands.add_parser("triage")
+    triage.add_argument("--event", type=Path, required=True)
+    triage.add_argument("--base", required=True)
+    triage.add_argument("--head", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    try:
+        if arguments.command == "validate":
+            _validate(arguments.event)
+        elif arguments.command == "triage":
+            _triage(arguments.event, arguments.base, arguments.head)
+    except (MetadataError, ModelCIError, OSError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -2015,6 +2015,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
                     "Dockerfile.community-cpu",
                     "requirements/community-ci.txt",
                     "tools/community_ci.py",
+                    "tools/pr_metadata.py",
                 }
             ),
             resolver=_match_result(

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -124,13 +124,24 @@ git rebase upstream/main
 git push --set-upstream origin docs/improve-getting-started
 ```
 
-The pull request should record:
+Complete every pull-request template section. Use
+`Not applicable: <reason>` when a field does not apply instead of deleting it.
+Follow the repository's established PR-description structure:
 
-- exact scope and non-goals;
-- exact base and tested head revisions;
-- commands actually executed;
-- model, artifact, hardware, and environment for GPU claims;
-- remaining risks and paths not executed.
+- **Background** for the problem, motivation, and linked issue;
+- **Exit Criteria** for completion conditions and non-goals;
+- **Implementation** for the approach, affected models/components, and
+  compatibility surface;
+- **Validation** for exact commands and results, tested revisions, hardware and
+  environment, and paths not executed; and
+- **Notes For Future Readers** for remaining risk, provenance, rollout, and
+  follow-up context.
+
+`PR Metadata / Required` verifies this evidence contract, while trusted triage
+automation derives model and component labels from the actual diff and
+repository ownership metadata. Risk and compatibility-change labels come from
+the corresponding template selections. DCO sign-off is enforced separately by
+the repository's DCO check.
 
 Compilation, source tests, model parity, target-hardware execution,
 performance, and release qualification are different evidence tiers.


### PR DESCRIPTION
## Background

The repository has no shared pull-request template or complete automatic
classification, so reviewers often have to ask for test commands, environment,
revisions, compatibility impact, and untested paths before technical review can
start.

A review of the 60 most recent merged PRs found one dominant repository-native
description pattern: `Validation` appeared in 55, `Background` and
`Implementation` in 47 each, `Exit Criteria` in 46, and
`Notes For Future Readers` in 42. This PR turns that established practice into
the contributor-facing default instead of introducing a parallel vocabulary.

## Exit Criteria

- New pull requests start with the repository's established five-section
  structure and require actionable validation evidence.
- Incomplete descriptions fail a contributor-visible, required metadata check.
- Model, component, compatibility-change, and risk labels synchronize within
  the normal pull-request event flow.
- Existing `CODEOWNERS` behavior continues to request the default owner without
  custom mention automation.
- Fork pull-request code never executes in a privileged workflow.

## Implementation

- Add a pull-request template using `Background`, `Exit Criteria`,
  `Implementation`, `Validation`, and `Notes For Future Readers`.
- Keep change-category and risk selections inside those sections for declared
  labels. Derive model and component impact from the exact diff and repository
  ownership metadata.
- Parse declarations only inside the named `Change categories` and `Risk level`
  subsections so incidental checkboxes elsewhere cannot satisfy validation or
  create labels.
- Require exact commands/results, hardware/environment/revisions, and unrun
  paths as structured validation subsections.
- Split automation into an unprivileged exact-merge metadata check and a
  privileged base-code-only label synchronizer that fetches but never checks
  out or executes pull-request code.
- Classify the metadata tool as a precise tools-tier CI contract and document
  the workflow in both contribution guides.
- Leave DCO enforcement to the repository DCO check instead of a self-attested
  template checkbox.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_pr_metadata.py tests/tools/test_test_impact.py -q`: passed, 296 tests.
- `PYTHONPATH=python:. python3 -m tools.community_ci source-quality --base github/main`: passed, including 158 model architecture contract tests.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed for 221 models, 12 core models, and 84 families, with existing allowlist warnings.
- `python3 tools/check_doc_file_references.py --strict website/docs`: passed, 107 documents and 221 path references checked.
- `npm --prefix website run test:model-support`: passed.
- `npm --prefix website run build`: passed, including 34 diagram checks and the production Docusaurus build.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

- Tested head: `ed85ab613334aac7b632337b887466a487447c0e`.
- Base: `github/main@32fdb2190f85ec341230ff0e6ce0d84a57e8e112`.
- CPU/source and documentation validation ran in the repository development
  environment; no model checkpoint, CUDA, TensorRT, or GPU revision applies to
  this contribution-workflow-only change.

### Not Run / Remaining Gaps

- GPU and model inference validation were not run because this change does not
  modify runtime, builder, model, or artifact behavior.
- Live label synchronization cannot execute from the feature branch because
  `pull_request_target` intentionally uses trusted base-branch code; its GitHub
  API behavior and workflow security contract are covered by focused tests.
- `trtmc/premerge/required` returned `FAIL` because the reviewed
  `CONTRIBUTING.md` digest is not yet present in the trusted CI legal-document
  allowlist. This is a trust-boundary configuration synchronization issue, not
  a Source test or reflink failure.
- A narrow trusted-CI allowlist update is pending review. Protected premerge
  must be retriggered after that update lands.

## Notes For Future Readers

- Review the template and validator contract first, the unprivileged metadata
  workflow second, and the privileged triage workflow last.
- Root `CODEOWNERS` remains the owner-request mechanism. This PR does not add a
  bot that mentions individual maintainers.
- DCO is an independent repository check; do not reintroduce a checkbox that
  lets authors self-attest status already determined from commit metadata.
- No public API, ABI, bundle format, dependency, migration, or artifact rebuild
  change is introduced.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The privileged workflow can write labels, but it executes only trusted
base-branch code with read-only contents and issue-write permissions. The
unprivileged workflow is the only path that executes pull-request code.
