### PR TITLE
fix(package): avoid prebuild package import

### DIFF
--- a/tests/tools/test_release_backend_abi.py
+++ b/tests/tools/test_release_backend_abi.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
 import zipfile
 from pathlib import Path
 
@@ -66,6 +69,51 @@ def test_package_profile_resolves_unique_metadata(
         f'tensorrt=={tensorrt_version}; platform_machine == "x86_64"',
     ]
     assert _package_variant_version(REPO_ROOT, tensorrt_version) == package_version
+
+
+def test_package_ci_abi_validation_does_not_require_source_package_import() -> None:
+    script = textwrap.dedent(
+        """
+        from pathlib import Path
+        import sys
+
+        sys.path.insert(0, str(Path.cwd()))
+        from tools.ci.package import (
+            _package_variant_version,
+            _validate_backend_files,
+            _validate_backend_identity,
+        )
+
+        version = "11.1.0.106"
+        package_version = _package_variant_version(Path.cwd(), version)
+        _validate_backend_files(
+            "wheel",
+            version,
+            {
+                "libtrtmc_backend_trt.so": b"backend",
+                "libtrtmc_backend_trt_11_1.so": b"backend",
+            },
+        )
+        _validate_backend_identity("wheel", version, "11_1", version)
+        print(package_version)
+        """
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            script,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("+trt111")
 
 
 def test_package_profile_default_preserves_development_metadata(
@@ -259,17 +307,20 @@ def test_backend_identity_matches_wheel_tensorrt_version() -> None:
     _validate_backend_identity("wheel", TENSORRT_VERSION, "11_1", TENSORRT_VERSION)
 
 
-def test_backend_contract_derives_future_tensorrt_abi() -> None:
-    version = "11.2.0.113"
+@pytest.mark.parametrize(
+    ("version", "abi"),
+    (("11.2.0.113", "11_2"), ("100.42.0.113", "100_42")),
+)
+def test_backend_contract_derives_future_tensorrt_abi(version: str, abi: str) -> None:
     metadata = TENSORRT_METADATA.replace(TENSORRT_VERSION, version)
 
     assert _required_tensorrt_version(metadata) == version
     _validate_backend_files(
         "wheel",
         version,
-        _backend_files("libtrtmc_backend_trt.so", "libtrtmc_backend_trt_11_2.so"),
+        _backend_files("libtrtmc_backend_trt.so", f"libtrtmc_backend_trt_{abi}.so"),
     )
-    _validate_backend_identity("wheel", version, "11_2", version)
+    _validate_backend_identity("wheel", version, abi, version)
 
 
 def test_backend_identity_rejects_wrong_abi() -> None:

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -53,16 +53,22 @@ def _target_tensorrt_version(
     return version
 
 
-def _package_variant_version(repository: Path, tensorrt_version: str) -> str:
-    from tensorrt_model_connect import trt_compat
+def _tensorrt_abi(version: str) -> str:
+    """Return an exact package target's major.minor ABI without importing the package."""
+    if not EXACT_TENSORRT_VERSION.fullmatch(version):
+        raise CiError(f"TensorRT ABI requires an exact four-part version, got {version!r}")
+    major, minor, *_ = version.split(".")
+    return f"{major}.{minor}"
 
+
+def _package_variant_version(repository: Path, tensorrt_version: str) -> str:
     with (repository / "pyproject.toml").open("rb") as stream:
         pyproject = tomllib.load(stream)
     package = pyproject["tool"]["tensorrt-model-connect"]["package"]
     base_version = str(package["base-version"])
     if "+" in base_version:
         raise CiError("base package version must not contain a local version segment")
-    abi = trt_compat.tensorrt_abi(tensorrt_version)
+    abi = _tensorrt_abi(tensorrt_version)
     return f"{base_version}+trt{abi.replace('.', '')}"
 
 
@@ -127,9 +133,7 @@ def _validate_backend_files(
     tensorrt_version: str,
     backends: dict[str, bytes],
 ) -> None:
-    from tensorrt_model_connect import trt_compat
-
-    abi = trt_compat.tensorrt_abi(tensorrt_version).replace(".", "_")
+    abi = _tensorrt_abi(tensorrt_version).replace(".", "_")
     generic = "libtrtmc_backend_trt.so"
     versioned = f"libtrtmc_backend_trt_{abi}.so"
     expected = {generic, versioned}
@@ -148,9 +152,7 @@ def _validate_backend_identity(
     backend_abi: str,
     runtime_version: str,
 ) -> None:
-    from tensorrt_model_connect import trt_compat
-
-    expected_abi = trt_compat.tensorrt_abi(tensorrt_version).replace(".", "_")
+    expected_abi = _tensorrt_abi(tensorrt_version).replace(".", "_")
     if backend_abi.replace(".", "_") != expected_abi:
         raise CiError(
             f"{location}: TensorRT backend reports ABI {backend_abi}; expected "


### PR DESCRIPTION
## Background

PR #1017 changed the packaging bootstrap to import `tensorrt_model_connect.trt_compat` while deriving wheel and backend ABI metadata. The package stage runs before the product package is installed and does not place `python/` on `sys.path`, so both TensorRT wheel profiles fail before the build starts.

## Exit Criteria

- Packaging ABI derivation works before `tensorrt_model_connect` is importable.
- Wheel version, backend filename, and backend identity checks retain the same major/minor ABI behavior, including multi-digit future versions.
- Installed-wheel validation remains responsible for proving imports resolve to the built wheel.

## Implementation

- Parse the already validated four-part TensorRT target inside the packaging bootstrap boundary.
- Remove the three pre-install imports of the product package.
- Add an isolated subprocess regression test with both environment isolation and site-packages disabled, covering all three ABI consumers.

## Validation

- `python3 -m pytest tests/tools/test_release_backend_abi.py::test_package_ci_abi_validation_does_not_require_source_package_import -q`: failed before the fix with `ModuleNotFoundError`, then passed.
- `python3 -m pytest tests/tools/test_release_backend_abi.py tests/tools/test_github_actions_ci.py tests/builder/test_trt_compat_boundary.py -q`: 100 tests passed.
- `pre-commit run --files tools/ci/package.py tests/tools/test_release_backend_abi.py`: passed.
- `git diff --check`: passed.

Full aarch64 wheel construction was not run locally; exact-head GitHub and protected premerge checks are pending.

## Notes For Future Readers

- The local parser intentionally accepts only the exact four-part version contract already required by package metadata. Broader runtime-version discovery remains centralized in `trt_compat`.
- Keep both `-I` and `-S` on the subprocess regression test: `-I` alone still exposes system site-packages and can hide this bootstrap failure.
