### PR TITLE
fix(qwen): mask native KV attention for FP16 and BF16

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -9,6 +9,34 @@ import os
 from typing import Any
 
 
+_EXPLICIT_NATIVE_KV_MASK_SMS = frozenset({(8, 6), (12, 1)})
+_EXPLICIT_NATIVE_KV_MASK_TRT_RELEASES = frozenset({(11, 1), (11, 2)})
+
+
+def _trt_major_minor(trt_version: str) -> tuple[int, int] | None:
+    parts = trt_version.split(".", maxsplit=2)
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+def requires_explicit_native_kv_mask(
+    precision: str,
+    trt_version: str,
+    compute_capability: tuple[int, int],
+) -> bool:
+    """Select the validated workaround for broken native active-length masking."""
+    return (
+        precision.lower() == "bf16"
+        and _trt_major_minor(trt_version)
+        in _EXPLICIT_NATIVE_KV_MASK_TRT_RELEASES
+        and tuple(compute_capability) in _EXPLICIT_NATIVE_KV_MASK_SMS
+    )
+
+
 def configure_qwen_builder(
     trt_config: Any,
     quant_ctx: Any | None,

--- a/python/tensorrt_model_connect/families/qwen/builder_policy.py
+++ b/python/tensorrt_model_connect/families/qwen/builder_policy.py
@@ -11,6 +11,7 @@ from typing import Any
 
 _EXPLICIT_NATIVE_KV_MASK_SMS = frozenset({(8, 6), (12, 1)})
 _EXPLICIT_NATIVE_KV_MASK_TRT_RELEASES = frozenset({(11, 1), (11, 2)})
+_EXPLICIT_NATIVE_KV_MASK_MAX_CACHE_LENGTH = 16384
 
 
 def _trt_major_minor(trt_version: str) -> tuple[int, int] | None:
@@ -28,12 +29,28 @@ def requires_explicit_native_kv_mask(
     trt_version: str,
     compute_capability: tuple[int, int],
 ) -> bool:
-    """Select the validated workaround for broken native active-length masking."""
+    """Select the validated workaround for broken native active-length masking.
+
+    On affected targets, BF16 uses the explicit-mask fused kernel directly.
+    FP16 uses the same kernel behind a narrow BF16 attention/KV boundary,
+    because the target's FP16 fused kernel rejects every fourth live input.
+    """
     return (
-        precision.lower() == "bf16"
+        precision.lower() in {"fp16", "bf16"}
         and _trt_major_minor(trt_version)
         in _EXPLICIT_NATIVE_KV_MASK_TRT_RELEASES
         and tuple(compute_capability) in _EXPLICIT_NATIVE_KV_MASK_SMS
+    )
+
+
+def validate_explicit_native_kv_cache_length(max_cache_length: int) -> None:
+    """Fail before TRT for compatibility-path capacities not yet qualified."""
+    if max_cache_length <= _EXPLICIT_NATIVE_KV_MASK_MAX_CACHE_LENGTH:
+        return
+    raise ValueError(
+        "Qwen native-KV attention on this GPU/TensorRT combination currently "
+        "supports max_cache_length <= 16384; got "
+        f"{max_cache_length}. Rebuild with --max-cache-length 16384"
     )
 
 

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -33,13 +33,13 @@ Tensor contract for the Qwen3 TensorRT native KV-cache path:
     position_id     int32   (-1,)
     cache_write_indices int32 (1,)                    # update start slot
     key_value_lengths   int32 (1,)                    # valid length after update
-    cache_k_i       bf16 (1, Hkv, capacity, D)        # static, user-owned
-    cache_v_i       bf16 (1, Hkv, capacity, D)        # static, user-owned
+    cache_k_i       fp16/bf16 (1, Hkv, capacity, D)   # static, user-owned
+    cache_v_i       fp16/bf16 (1, Hkv, capacity, D)   # static, user-owned
   Outputs
     logits          float32 (1, vocab)               # last-row sliced inside the engine
                     or (Sq, vocab) for full-logits diffusion builds
-    present_k_i     bf16 (1, Hkv, capacity, D)        # aliases cache_k_i
-    present_v_i     bf16 (1, Hkv, capacity, D)        # aliases cache_v_i
+    present_k_i     fp16/bf16 (1, Hkv, capacity, D)   # aliases cache_k_i
+    present_v_i     fp16/bf16 (1, Hkv, capacity, D)   # aliases cache_v_i
 
 The legacy dense-mask/row-cache contract remains available for the other model
 types handled by this family.
@@ -59,6 +59,7 @@ from . import graph_blocks
 from .builder_policy import (
     configure_qwen_builder,
     requires_explicit_native_kv_mask,
+    validate_explicit_native_kv_cache_length,
 )
 
 trt = trt_compat.get_trt()
@@ -379,9 +380,12 @@ def build_dual_profile_decoder_engine(
 
     ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` contract.
     Affected TensorRT/GPU combinations replace ``IAttention``'s broken native
-    active-length predicate with an explicit additive mask. It is an internal
-    model-family choice, not a user-facing build flag. The legacy dense-mask
-    graph remains available for non-Qwen3 models handled by this family.
+    active-length predicate with an explicit additive mask. Affected FP16
+    builds keep the surrounding model FP16 but use BF16 for the native cache
+    and attention boundary because that target's FP16 fused kernel rejects a
+    fourth live input. This is an internal model-family choice, not a
+    user-facing build flag. The legacy dense-mask graph remains available for
+    non-Qwen3 models handled by this family.
     """
     _supports_config(config, weights)
     if profile_mode not in ("dual_profile", "prefill", "decode"):
@@ -407,8 +411,10 @@ def build_dual_profile_decoder_engine(
         )
     )
     if explicit_native_attention_mask:
+        validate_explicit_native_kv_cache_length(max_cache_length)
         print(
             "[trtmc build] Using explicit Qwen native-KV attention mask "
+            f"in {'BF16' if precision.lower() == 'fp16' else precision.upper()} "
             f"for SM {compute_capability[0]}.{compute_capability[1]} with "
             f"TensorRT {trt.__version__}",
             file=sys.stderr,
@@ -491,6 +497,25 @@ def build_dual_profile_decoder_engine(
         work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
     else:
         work_np_dtype, work_trt_dtype = np.float32, trt.float32
+    native_attention_trt_dtype = work_trt_dtype
+    if explicit_native_attention_mask and precision.lower() == "fp16":
+        native_attention_trt_dtype = trt.bfloat16
+    native_cache_trt_dtype = (
+        native_attention_trt_dtype if native_kv_cache else work_trt_dtype
+    )
+    if native_kv_cache:
+        metadata = config.raw.setdefault("_native_kv_cache_metadata", {})
+        metadata["native_kv_cache"] = True
+        if native_cache_trt_dtype != work_trt_dtype:
+            metadata["native_kv_contract_version"] = 2
+            metadata["native_kv_cache_dtype"] = (
+                "bf16"
+                if native_cache_trt_dtype == trt.bfloat16
+                else "fp16"
+            )
+        else:
+            metadata["native_kv_contract_version"] = 1
+            metadata.pop("native_kv_cache_dtype", None)
 
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))
@@ -519,10 +544,10 @@ def build_dual_profile_decoder_engine(
     for i in range(num_layers):
         ck = network.add_input(
             graph_ops.layer_tensor_name("cache_k", i),
-            work_trt_dtype, cache_shape)
+            native_cache_trt_dtype, cache_shape)
         cv = network.add_input(
             graph_ops.layer_tensor_name("cache_v", i),
-            work_trt_dtype, cache_shape)
+            native_cache_trt_dtype, cache_shape)
         cache_k_inputs.append(ck)
         cache_v_inputs.append(cv)
 
@@ -752,7 +777,7 @@ def build_dual_profile_decoder_engine(
             cache_write_indices,
             key_value_lengths,
             max_cache_length,
-            work_trt_dtype,
+            native_attention_trt_dtype,
         )
 
     for layer_idx in range(num_layers):
@@ -842,6 +867,7 @@ def build_dual_profile_decoder_engine(
                     else None
                 ),
                 explicit_mask=native_attention_mask,
+                attention_dtype=native_attention_trt_dtype,
             )
             context = native_attention["context"]
             present_k_outs.append(native_attention["present_k"])

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -56,7 +56,10 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
-from .builder_policy import configure_qwen_builder
+from .builder_policy import (
+    configure_qwen_builder,
+    requires_explicit_native_kv_mask,
+)
 
 trt = trt_compat.get_trt()
 
@@ -67,6 +70,76 @@ if TYPE_CHECKING:
 
 
 _NATIVE_PREFILL_CHUNK_TOKENS = 32768
+_EXPLICIT_MASK_PREFILL_CHUNK_TOKENS = 64
+
+
+def _cuda_runtime():
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart
+        except ImportError as exc:
+            raise RuntimeError(
+                "Unable to select Qwen native attention because CUDA Python "
+                "is unavailable"
+            ) from exc
+    return cudart
+
+
+def _current_cuda_compute_capability() -> tuple[int, int]:
+    """Return the active CUDA device's compute capability or fail closed."""
+    cudart = _cuda_runtime()
+    success = getattr(getattr(cudart, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status, device = cudart.cudaGetDevice()
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDevice failed with status {status}")
+        status, properties = cudart.cudaGetDeviceProperties(int(device))
+        if status not in (success, 0):
+            raise RuntimeError(
+                f"cudaGetDeviceProperties({int(device)}) failed with status {status}"
+            )
+        major = int(properties.major)
+        minor = int(properties.minor)
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(
+            f"Unable to query the active CUDA device: {exc}"
+        ) from exc
+    if major <= 0 or minor < 0:
+        raise RuntimeError(
+            "The active CUDA device returned an invalid compute capability"
+        )
+    return major, minor
+
+
+def _resolve_prefill_lengths(
+    max_cache_length: int,
+    opt_prefill_length: int,
+    requested: int | None,
+    *,
+    native_kv_cache: bool,
+    explicit_native_attention_mask: bool,
+    profile_mode: str,
+) -> tuple[int, int]:
+    """Resolve one enqueue's query limit independently of cache capacity."""
+    if requested is None:
+        requested = (
+            min(max_cache_length, _NATIVE_PREFILL_CHUNK_TOKENS)
+            if native_kv_cache
+            else max_cache_length
+        )
+    if (
+        native_kv_cache
+        and explicit_native_attention_mask
+        and profile_mode != "decode"
+    ):
+        requested = min(requested, _EXPLICIT_MASK_PREFILL_CHUNK_TOKENS)
+    resolved_max = max(1, min(requested, max_cache_length))
+    resolved_opt = max(1, min(opt_prefill_length, resolved_max))
+    return resolved_opt, resolved_max
 
 
 def _const_in_work_dtype(
@@ -304,10 +377,11 @@ def build_dual_profile_decoder_engine(
     * ``"decode"``: one fixed-Sq=1 profile only. This is the decode half of a
       split-engine bundle.
 
-    ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` and
-    ``IAttention.key_value_lengths`` contract. It is an internal model-family
-    choice, not a user-facing build flag. The legacy dense-mask graph remains
-    available for non-Qwen3 models handled by this family.
+    ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` contract.
+    Affected TensorRT/GPU combinations replace ``IAttention``'s broken native
+    active-length predicate with an explicit additive mask. It is an internal
+    model-family choice, not a user-facing build flag. The legacy dense-mask
+    graph remains available for non-Qwen3 models handled by this family.
     """
     _supports_config(config, weights)
     if profile_mode not in ("dual_profile", "prefill", "decode"):
@@ -321,18 +395,36 @@ def build_dual_profile_decoder_engine(
     if native_kv_cache and position_type == "alibi":
         raise NotImplementedError(
             "TensorRT native KV cache prototype does not support ALiBi")
-    if max_prefill_length is None:
-        # Physical KV capacity and one TensorRT enqueue's query length are
-        # separate limits. Keep the complete model context in the cache while
-        # bounding activation/workspace pressure for very long prompts; the
-        # family runtime transparently advances through multiple chunks.
-        max_prefill_length = (
-            min(max_cache_length, _NATIVE_PREFILL_CHUNK_TOKENS)
-            if native_kv_cache
-            else max_cache_length
+    compute_capability = (
+        _current_cuda_compute_capability() if native_kv_cache else (0, 0)
+    )
+    explicit_native_attention_mask = (
+        native_kv_cache
+        and requires_explicit_native_kv_mask(
+            precision,
+            trt.__version__,
+            compute_capability,
         )
-    max_prefill_length = max(1, min(max_prefill_length, max_cache_length))
-    opt_prefill_length = max(1, min(opt_prefill_length, max_prefill_length))
+    )
+    if explicit_native_attention_mask:
+        print(
+            "[trtmc build] Using explicit Qwen native-KV attention mask "
+            f"for SM {compute_capability[0]}.{compute_capability[1]} with "
+            f"TensorRT {trt.__version__}",
+            file=sys.stderr,
+        )
+    # Physical KV capacity and one TensorRT enqueue's query length are
+    # separate limits. Keep the complete model context in the cache while
+    # bounding activation/workspace pressure for very long prompts; the
+    # family runtime transparently advances through multiple chunks.
+    opt_prefill_length, max_prefill_length = _resolve_prefill_lengths(
+        max_cache_length,
+        opt_prefill_length,
+        max_prefill_length,
+        native_kv_cache=native_kv_cache,
+        explicit_native_attention_mask=explicit_native_attention_mask,
+        profile_mode=profile_mode,
+    )
 
     multi_bucket_decode = bool(dynamic_kv_profile_rows)
     if multi_bucket_decode:
@@ -650,6 +742,18 @@ def build_dual_profile_decoder_engine(
 
     present_k_outs: list[trt.ITensor] = []
     present_v_outs: list[trt.ITensor] = []
+    native_attention_mask: trt.ITensor | None = None
+    if explicit_native_attention_mask:
+        assert cache_write_indices is not None
+        assert key_value_lengths is not None
+        native_attention_mask = graph_ops.add_native_kv_attention_mask(
+            network,
+            token_id,
+            cache_write_indices,
+            key_value_lengths,
+            max_cache_length,
+            work_trt_dtype,
+        )
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
@@ -734,9 +838,11 @@ def build_dual_profile_decoder_engine(
                 scale=attn_scale, tag=f"{prefix}.attn",
                 recipe_instance=(
                     f"decoder.layers.{layer_idx}.decode_attention"
-                    if profile_mode == "decode"
+                    if profile_mode == "decode" and native_attention_mask is None
                     else None
-                ))
+                ),
+                explicit_mask=native_attention_mask,
+            )
             context = native_attention["context"]
             present_k_outs.append(native_attention["present_k"])
             present_v_outs.append(native_attention["present_v"])

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -1131,6 +1131,91 @@ def add_attention_from_rows(
     )
 
 
+def add_native_kv_attention_mask(
+    network: trt.INetworkDefinition,
+    query_rows: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    cache_capacity: int,
+    target_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Build an additive ``[1, 1, Sq, K]`` active-prefix causal mask.
+
+    The valid region is the intersection of the runtime-active KV prefix and
+    the causal prefix for each query row. This deliberately bypasses
+    ``IAttention.key_value_lengths`` on TensorRT/GPU combinations where that
+    optional input exposes the inactive cache suffix instead of the prefix.
+    """
+    query_shape = network.add_shape(query_rows).get_output(0)
+    query_length = network.add_slice(
+        query_shape, start=(0,), shape=(1,), stride=(1,)
+    ).get_output(0)
+    zero_i32 = add_constant(
+        network, (), np.array(0, dtype=np.int32), dtype=np.int32
+    )
+    one_i32 = add_constant(
+        network, (1,), np.array([1], dtype=np.int32), dtype=np.int32
+    )
+    query_iota = network.add_fill((1,), trt.FillOperation.LINSPACE, trt.int32)
+    query_iota.set_input(0, query_length)
+    query_iota.set_input(1, zero_i32)
+    query_iota.set_input(2, one_i32)
+    query_positions = network.add_elementwise(
+        query_iota.get_output(0),
+        cache_write_indices,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+    query_limits = network.add_elementwise(
+        query_positions, one_i32, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+
+    one_i64 = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64
+    )
+    query_limit_shape = network.add_concatenation([query_length, one_i64])
+    query_limit_shape.axis = 0
+    query_limits_2d = network.add_shuffle(query_limits)
+    query_limits_2d.set_input(1, query_limit_shape.get_output(0))
+
+    key_positions = add_constant(
+        network,
+        (1, cache_capacity),
+        np.arange(cache_capacity, dtype=np.int32).reshape(1, cache_capacity),
+        dtype=np.int32,
+    )
+    key_value_lengths_2d = network.add_shuffle(key_value_lengths)
+    key_value_lengths_2d.reshape_dims = (1, 1)
+    causal = network.add_elementwise(
+        key_positions,
+        query_limits_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    active = network.add_elementwise(
+        key_positions,
+        key_value_lengths_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    valid_positions = network.add_elementwise(
+        causal, active, trt.ElementWiseOperation.AND
+    ).get_output(0)
+
+    zero = add_constant(
+        network, (1, 1), np.array([[0.0]], dtype=np.float32), dtype=np.float32
+    )
+    blocked = add_constant(
+        network,
+        (1, 1),
+        np.array([[-1.0e4]], dtype=np.float32),
+        dtype=np.float32,
+    )
+    zero = _cast_back_to_trt_dtype(network, zero, target_dtype)
+    blocked = _cast_back_to_trt_dtype(network, blocked, target_dtype)
+    additive_mask = network.add_select(
+        valid_positions, zero, blocked
+    ).get_output(0)
+    return add_2d_mask_to_4d(network, additive_mask)
+
+
 def add_native_kv_cache_attention_from_rows(
     network: trt.INetworkDefinition,
     q: trt.ITensor,
@@ -1148,14 +1233,14 @@ def add_native_kv_cache_attention_from_rows(
     scale: float | None = None,
     tag: str | None = None,
     recipe_instance: str | None = None,
+    explicit_mask: trt.ITensor | None = None,
 ) -> dict[str, trt.ITensor]:
     """Update a user-owned KV cache and attend over its active prefix.
 
     ``IKVCacheUpdateLayer`` writes this step's K/V rows into the static,
-    full-capacity cache in place. ``IAttention`` consumes the aliased cache
-    outputs, while ``key_value_lengths`` limits work to the valid prefix.
-    ``LOWER_RIGHT`` causal alignment gives correct autoregressive semantics
-    when the query sequence is shorter than the active KV sequence.
+    full-capacity cache in place. The normal contract passes active lengths to
+    ``IAttention``. The compatibility contract supplies a correct explicit
+    additive mask and omits the broken native length input.
 
     Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The caller
     must bind each output to the same device address as its corresponding
@@ -1250,7 +1335,11 @@ def add_native_kv_cache_attention_from_rows(
             updated_k,
             updated_v,
             trt.AttentionNormalizationOp.SOFTMAX,
-            trt.CausalMaskKind.LOWER_RIGHT,
+            (
+                trt.CausalMaskKind.NONE
+                if explicit_mask is not None
+                else trt.CausalMaskKind.LOWER_RIGHT
+            ),
         )
         if attention is None:
             raise RuntimeError("TensorRT failed to create Qwen native attention")
@@ -1258,7 +1347,10 @@ def add_native_kv_cache_attention_from_rows(
         # Unsupported dtype/head geometries fail at build time instead of silently
         # falling back to a primitive graph with materially lower decode speed.
         attention.decomposable = False
-        attention.key_value_lengths = key_value_lengths
+        if explicit_mask is None:
+            attention.key_value_lengths = key_value_lengths
+        else:
+            attention.mask = explicit_mask
         if tag:
             attention.name = tag
 

--- a/python/tensorrt_model_connect/families/qwen/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen/graph_ops.py
@@ -1234,13 +1234,17 @@ def add_native_kv_cache_attention_from_rows(
     tag: str | None = None,
     recipe_instance: str | None = None,
     explicit_mask: trt.ITensor | None = None,
+    attention_dtype: trt.DataType | None = None,
 ) -> dict[str, trt.ITensor]:
     """Update a user-owned KV cache and attend over its active prefix.
 
     ``IKVCacheUpdateLayer`` writes this step's K/V rows into the static,
     full-capacity cache in place. The normal contract passes active lengths to
     ``IAttention``. The compatibility contract supplies a correct explicit
-    additive mask and omits the broken native length input.
+    additive mask and omits the broken native length input. On targets whose
+    FP16 fused kernel rejects a fourth live input, ``attention_dtype`` allows a
+    narrow BF16 cache/attention boundary while the surrounding model remains
+    FP16.
 
     Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The caller
     must bind each output to the same device address as its corresponding
@@ -1253,6 +1257,24 @@ def add_native_kv_cache_attention_from_rows(
             "Qwen native KV cache requires TensorRT add_kv_cache_update "
             "and add_attention_v2 support"
         )
+
+    output_dtype = q.dtype
+    if attention_dtype is None:
+        attention_dtype = cache_k.dtype
+    if attention_dtype not in {trt.float16, trt.bfloat16}:
+        raise ValueError("Qwen native KV attention requires FP16 or BF16")
+    if cache_k.dtype != attention_dtype or cache_v.dtype != attention_dtype:
+        raise ValueError(
+            "Qwen native KV cache dtype must match the attention dtype"
+        )
+    if explicit_mask is not None and explicit_mask.dtype != attention_dtype:
+        raise ValueError(
+            "Qwen native KV explicit mask dtype must match the attention dtype"
+        )
+    if k_update.dtype != attention_dtype:
+        k_update = network.add_cast(k_update, attention_dtype).get_output(0)
+    if v_update.dtype != attention_dtype:
+        v_update = network.add_cast(v_update, attention_dtype).get_output(0)
 
     k_update_4d = reshape_rows_to_heads_4d(
         network,
@@ -1317,7 +1339,7 @@ def add_native_kv_cache_attention_from_rows(
     q_scaled = network.add_elementwise(
         q_scale_input, scale_t, trt.ElementWiseOperation.PROD
     ).get_output(0)
-    q_scaled = network.add_cast(q_scaled, q_4d.dtype).get_output(0)
+    q_scaled = network.add_cast(q_scaled, attention_dtype).get_output(0)
 
     recipe = nullcontext()
     if recipe_instance is not None:
@@ -1354,9 +1376,12 @@ def add_native_kv_cache_attention_from_rows(
         if tag:
             attention.name = tag
 
+    context_4d = attention.get_output(0)
+    if context_4d.dtype != output_dtype:
+        context_4d = network.add_cast(context_4d, output_dtype).get_output(0)
     context = reshape_heads_4d_to_rows(
         network,
-        attention.get_output(0),
+        context_4d,
         num_heads * head_dim,
         sequence_length=q_seq,
         tag=None if tag is None else tag + ".ctx",

--- a/src/runtime/models/qwen/MODEL.toml
+++ b/src/runtime/models/qwen/MODEL.toml
@@ -9,6 +9,7 @@ runtime_tests = [
   "test_c_abi_runtime_regression|test_c_abi_runtime_regression.cpp|trtmc_model_qwen|_|_",
   "test_qwen_tensor_names|test_qwen_tensor_names.cpp|_|_|_",
   "test_qwen_sampler|test_qwen_sampler.cpp|trtmc_model_qwen|_|_",
+  "test_qwen_native_kv_cache_dtype|test_qwen_native_kv_cache_dtype.cpp|trtmc_model_qwen|_|_",
   "test_qwen_native_kv_cache|test_qwen_native_kv_cache.cpp|trtmc_model_qwen,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
 [validation_profiles]

--- a/src/runtime/models/qwen/kv_cache.cpp
+++ b/src/runtime/models/qwen/kv_cache.cpp
@@ -59,7 +59,7 @@ void validate_native_cache_pair(TrtModule& module, const std::string& cache_name
     }
     if (module.tensor_dtype(cache_name) != cache_dtype ||
         module.tensor_dtype(present_name) != cache_dtype) {
-        throw std::runtime_error("Qwen native KV cache dtype does not match model precision");
+        throw std::runtime_error("Qwen native KV cache dtype does not match declared cache dtype");
     }
 }
 

--- a/src/runtime/models/qwen/plugin.cpp
+++ b/src/runtime/models/qwen/plugin.cpp
@@ -221,14 +221,18 @@ bool engine_uses_native_kv_updates(const TrtModule& module, const QwenKvCacheNam
     return has_write_indices;
 }
 
+int32_t native_kv_contract_version(const std::string& config_json) {
+    return extract_json_int(config_json, "native_kv_contract_version", 0);
+}
+
 void validate_native_kv_marker(const std::string& config_json, bool engine_uses_native_kv) {
     const bool declares_native_kv = extract_json_bool(config_json, "native_kv_cache", false);
     const bool has_version =
         config_json.find("\"native_kv_contract_version\"") != std::string::npos;
     if (!declares_native_kv && !has_version && !engine_uses_native_kv)
         return;
-    if (!declares_native_kv || !engine_uses_native_kv ||
-        extract_json_int(config_json, "native_kv_contract_version", 0) != 1) {
+    const int32_t version = native_kv_contract_version(config_json);
+    if (!declares_native_kv || !engine_uses_native_kv || (version != 1 && version != 2)) {
         throw std::runtime_error("Qwen native KV metadata does not match the engine contract");
     }
 }
@@ -252,6 +256,11 @@ bool validate_native_kv_runtime(const PipelineContext& ctx, const TrtModule& mod
     if (module.tensor_shape(kv_names.cache_k.front()) != expected_shape) {
         throw std::runtime_error(
             "Qwen native KV requires cache shape [1,num_kv_heads,capacity,128]");
+    }
+    if (module.tensor_dtype(kv_names.cache_k.front()) != cache_dtype ||
+        module.tensor_dtype(kv_names.cache_v.front()) != cache_dtype) {
+        throw std::runtime_error(
+            "Qwen native KV cache dtype metadata does not match the engine contract");
     }
     return true;
 }
@@ -376,7 +385,8 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
         QwenKvCacheNames kv_names;
         build_kv_names(ctx, io, kv_names);
 
-        const DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
+        const DType cache_dtype =
+            resolve_qwen_native_kv_cache_dtype(ctx.config_json, ctx.config.precision);
         QwenTriAttentionConfig tri_cfg = qwen_parse_triattention_bundle_config(
             ctx.config_json, ctx.config.max_cache_length, ctx.runtime_config);
 

--- a/src/runtime/models/qwen/plugin_helpers.cpp
+++ b/src/runtime/models/qwen/plugin_helpers.cpp
@@ -313,6 +313,20 @@ DType cache_dtype_from_precision(const std::string& precision) {
     return DType::kFloat32;
 }
 
+DType resolve_qwen_native_kv_cache_dtype(const std::string& config_json,
+                                         const std::string& precision) {
+    const int32_t contract_version = extract_json_int(config_json, "native_kv_contract_version", 0);
+    if (contract_version < 2)
+        return cache_dtype_from_precision(precision);
+
+    const std::string declared = extract_json_string(config_json, "native_kv_cache_dtype", "");
+    if (declared != "fp16" && declared != "bf16") {
+        throw std::runtime_error("Qwen native KV contract v2 requires native_kv_cache_dtype "
+                                 "to be 'fp16' or 'bf16'");
+    }
+    return cache_dtype_from_precision(declared);
+}
+
 // Section data conversion.
 
 std::vector<float> section_to_floats(const std::vector<char>* sec) {

--- a/src/runtime/models/qwen/plugin_helpers.h
+++ b/src/runtime/models/qwen/plugin_helpers.h
@@ -97,6 +97,12 @@ int32_t compute_kv_dim(const BaseConfig& cfg);
 // for use as KV cache element type.
 DType cache_dtype_from_precision(const std::string& precision);
 
+// Resolve the Qwen native-KV cache dtype from its versioned bundle contract.
+// Contract v1 inherits the model precision. Contract v2 requires an explicit
+// native_kv_cache_dtype declaration and fails closed for unsupported values.
+DType resolve_qwen_native_kv_cache_dtype(const std::string& config_json,
+                                         const std::string& precision);
+
 // Reinterpret a raw char section as a vector of floats.
 std::vector<float> section_to_floats(const std::vector<char>* sec);
 

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -122,6 +122,36 @@ def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np
     return host_out
 
 
+@requires_trt
+def test_qwen_native_kv_mask_matches_active_causal_prefix():
+    import tensorrt as trt
+
+    inputs = {
+        "token_id": np.array([11, 12, 13], dtype=np.int32),
+        "cache_write_indices": np.array([2], dtype=np.int32),
+        "key_value_lengths": np.array([5], dtype=np.int32),
+    }
+
+    def build(network, trt_inputs):
+        return {
+            "mask": qwen_graph_ops.add_native_kv_attention_mask(
+                network,
+                trt_inputs["token_id"],
+                trt_inputs["cache_write_indices"],
+                trt_inputs["key_value_lengths"],
+                8,
+                trt.float16,
+            )
+        }
+
+    actual = _run_strongly_typed(build, inputs)["mask"]
+    expected = np.full((1, 1, 3, 8), -1.0e4, dtype=np.float16)
+    expected[0, 0, 0, :3] = 0
+    expected[0, 0, 1, :4] = 0
+    expected[0, 0, 2, :5] = 0
+    np.testing.assert_array_equal(actual, expected)
+
+
 # ---------------------------------------------------------------------------
 # 1. add_layer_norm_native — pure numpy reference comparison
 # ---------------------------------------------------------------------------

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -37,7 +37,12 @@ qwen_vl_graph_ops = load_family_graph_ops("qwen_vl")
 # Helper: run a small TRT graph on a STRONGLY_TYPED network
 # ---------------------------------------------------------------------------
 
-def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+def _run_strongly_typed(
+    build_fn,
+    inputs: dict[str, np.ndarray],
+    *,
+    output_aliases: dict[str, str] | None = None,
+) -> dict[str, np.ndarray]:
     """Build and run a STRONGLY_TYPED TRT engine from build_fn.
 
     IAttention and IRotaryEmbeddingLayer require a STRONGLY_TYPED network;
@@ -50,6 +55,24 @@ def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np
         from cuda.bindings import runtime as cudart
     except ImportError:
         from cuda import cudart  # type: ignore[no-redef]
+
+    try:
+        import ml_dtypes
+    except ImportError:
+        ml_dtypes = None
+
+    def numpy_dtype(dtype):
+        if dtype == trt.float16:
+            return np.dtype(np.float16)
+        if dtype == trt.bfloat16:
+            if ml_dtypes is None:
+                raise RuntimeError("BF16 TensorRT tests require ml_dtypes")
+            return np.dtype(ml_dtypes.bfloat16)
+        if dtype == trt.float32:
+            return np.dtype(np.float32)
+        if dtype == trt.int32:
+            return np.dtype(np.int32)
+        raise TypeError(f"Unsupported TensorRT test dtype: {dtype}")
 
     logger = trt.Logger(trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -64,6 +87,8 @@ def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np
             dt = trt.int32
         elif arr.dtype == np.float16:
             dt = trt.float16
+        elif ml_dtypes is not None and arr.dtype == np.dtype(ml_dtypes.bfloat16):
+            dt = trt.bfloat16
         else:
             dt = trt.float32
         t = network.add_input(name, dt, tuple(arr.shape))
@@ -81,29 +106,47 @@ def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np
     runtime = trt.Runtime(logger)
     engine = runtime.deserialize_cuda_engine(plan)
     ctx = engine.create_execution_context()
+    output_aliases = output_aliases or {}
 
     err, stream = cudart.cudaStreamCreate()
     assert err == 0, f"cudaStreamCreate failed: {err}"
 
-    device_bufs = {}
-    host_out = {}
+    io_tensors = {}
     for i in range(engine.num_io_tensors):
         tname = engine.get_tensor_name(i)
-        shape = tuple(engine.get_tensor_shape(tname))
-        dtype_trt = engine.get_tensor_dtype(tname)
-        np_dtype = np.float16 if dtype_trt == trt.float16 else np.float32
-        nbytes = int(np.prod(shape)) * np.dtype(np_dtype).itemsize
+        io_tensors[tname] = (
+            tuple(engine.get_tensor_shape(tname)),
+            engine.get_tensor_dtype(tname),
+            engine.get_tensor_mode(tname),
+        )
+
+    device_bufs = {}
+    host_out = {}
+    host_inputs = {}
+    for tname, (shape, dtype_trt, mode) in io_tensors.items():
+        if tname in output_aliases:
+            continue
+        np_dtype = numpy_dtype(dtype_trt)
+        nbytes = int(np.prod(shape)) * np_dtype.itemsize
         err, ptr = cudart.cudaMallocAsync(nbytes, stream)
         assert err == 0, f"cudaMalloc failed: {err}"
         device_bufs[tname] = (ptr, nbytes, np_dtype)
-        mode = engine.get_tensor_mode(tname)
         if mode == trt.TensorIOMode.INPUT:
-            arr = inputs[tname].astype(np_dtype if np_dtype != np.float32 else inputs[tname].dtype)
+            arr = np.ascontiguousarray(inputs[tname], dtype=np_dtype)
+            host_inputs[tname] = arr
             cudart.cudaMemcpyAsync(
                 ptr, arr.ctypes.data, arr.nbytes,
                 cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, stream)
         else:
             host_out[tname] = np.zeros(shape, dtype=np_dtype)
+
+    for output_name, input_name in output_aliases.items():
+        assert io_tensors[output_name][2] == trt.TensorIOMode.OUTPUT
+        assert io_tensors[input_name][2] == trt.TensorIOMode.INPUT
+        assert io_tensors[output_name][:2] == io_tensors[input_name][:2]
+        device_bufs[output_name] = device_bufs[input_name]
+
+    for tname, (ptr, _nbytes, _np_dtype) in device_bufs.items():
         ctx.set_tensor_address(tname, ptr)
 
     ctx.execute_async_v3(stream)
@@ -115,7 +158,8 @@ def _run_strongly_typed(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np
             cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost, stream)
 
     cudart.cudaStreamSynchronize(stream)
-    for ptr, nbytes, _ in device_bufs.values():
+    unique_device_bufs = {ptr: (ptr, nbytes) for ptr, nbytes, _ in device_bufs.values()}
+    for ptr, nbytes in unique_device_bufs.values():
         cudart.cudaFreeAsync(ptr, stream)
     cudart.cudaStreamDestroy(stream)
 
@@ -150,6 +194,116 @@ def test_qwen_native_kv_mask_matches_active_causal_prefix():
     expected[0, 0, 1, :4] = 0
     expected[0, 0, 2, :5] = 0
     np.testing.assert_array_equal(actual, expected)
+
+
+@requires_trt
+@pytest.mark.parametrize(
+    ("model_dtype_name", "model_numpy_dtype"),
+    [
+        pytest.param("bfloat16", "bfloat16", id="bf16"),
+        pytest.param("float16", "float16", id="fp16-model-bf16-attention"),
+    ],
+)
+def test_qwen_native_kv_attention_masks_poisoned_inactive_suffix(
+    model_dtype_name,
+    model_numpy_dtype,
+):
+    """The explicit mask exposes only the active, causal cache prefix."""
+    import tensorrt as trt
+
+    ml_dtypes = pytest.importorskip("ml_dtypes")
+    model_dtype = getattr(trt, model_dtype_name)
+    model_numpy_dtype = (
+        ml_dtypes.bfloat16
+        if model_numpy_dtype == "bfloat16"
+        else np.float16
+    )
+    attention_numpy_dtype = ml_dtypes.bfloat16
+
+    query_length = 3
+    cache_capacity = 16
+    cache_write_index = 2
+    active_length = 5
+    num_heads = 4
+    num_kv_heads = 2
+    head_dim = 128
+
+    q = np.ones(
+        (query_length, num_heads * head_dim), dtype=model_numpy_dtype
+    )
+    k_update = np.zeros(
+        (query_length, num_kv_heads * head_dim), dtype=model_numpy_dtype
+    )
+    update_values = np.array([5.0, 7.0, 9.0], dtype=np.float32)
+    v_update = np.broadcast_to(
+        update_values[:, None], (query_length, num_kv_heads * head_dim)
+    ).astype(model_numpy_dtype)
+
+    cache_k = np.zeros(
+        (1, num_kv_heads, cache_capacity, head_dim), dtype=np.float32
+    )
+    cache_v = np.zeros_like(cache_k)
+    cache_v[:, :, 0, :] = 1.0
+    cache_v[:, :, 1, :] = 3.0
+    # If the inactive suffix leaks through attention, these keys dominate the
+    # logits and the large values make the numerical error unmistakable.
+    cache_k[:, :, active_length:, :] = 16.0
+    cache_v[:, :, active_length:, :] = 1000.0
+    cache_k = cache_k.astype(attention_numpy_dtype)
+    cache_v = cache_v.astype(attention_numpy_dtype)
+
+    inputs = {
+        "q": q,
+        "k_update": k_update,
+        "v_update": v_update,
+        "cache_k": cache_k,
+        "cache_v": cache_v,
+        "cache_write_indices": np.array([cache_write_index], dtype=np.int32),
+        "key_value_lengths": np.array([active_length], dtype=np.int32),
+    }
+
+    def build(network, trt_inputs):
+        mask = qwen_graph_ops.add_native_kv_attention_mask(
+            network,
+            trt_inputs["q"],
+            trt_inputs["cache_write_indices"],
+            trt_inputs["key_value_lengths"],
+            cache_capacity,
+            trt.bfloat16,
+        )
+        result = qwen_graph_ops.add_native_kv_cache_attention_from_rows(
+            network,
+            trt_inputs["q"],
+            trt_inputs["k_update"],
+            trt_inputs["v_update"],
+            trt_inputs["cache_k"],
+            trt_inputs["cache_v"],
+            trt_inputs["cache_write_indices"],
+            trt_inputs["key_value_lengths"],
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            q_seq=query_length,
+            explicit_mask=mask,
+            attention_dtype=trt.bfloat16,
+        )
+        assert result["context"].dtype == model_dtype
+        return {
+            "context": result["context"],
+            "present_k": result["present_k"],
+            "present_v": result["present_v"],
+        }
+
+    actual = _run_strongly_typed(
+        build,
+        inputs,
+        output_aliases={"present_k": "cache_k", "present_v": "cache_v"},
+    )["context"].astype(np.float32)
+    expected_rows = np.array([3.0, 4.0, 5.0], dtype=np.float32)
+    expected = np.broadcast_to(
+        expected_rows[:, None], (query_length, num_heads * head_dim)
+    )
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0625)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -6,9 +6,12 @@
 from __future__ import annotations
 
 import importlib
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
+
+from tests.builder.conftest import requires_trt
 
 trt = pytest.importorskip("tensorrt")
 
@@ -61,6 +64,19 @@ class _FakeNetwork:
         return layer
 
 
+class _AttentionRecordingNetwork:
+    def __init__(self, network):
+        self._network = network
+        self.attention = None
+
+    def __getattr__(self, name):
+        return getattr(self._network, name)
+
+    def add_attention_v2(self, *args, **kwargs):
+        self.attention = self._network.add_attention_v2(*args, **kwargs)
+        return self.attention
+
+
 def _add_native_attention(monkeypatch, graph_ops, dtype):
     network = _FakeNetwork()
     heads, kv_heads, head_dim = 4, 2, 128
@@ -98,6 +114,128 @@ def _add_native_attention(monkeypatch, graph_ops, dtype):
         q_seq=1,
     )
     return network, tensors, result
+
+
+def _dual_profile_builder_module():
+    # The Qwen package lazy-loads its plugin; enter through that public module
+    # so its builder imports are initialized in the same order as production.
+    importlib.import_module("tensorrt_model_connect.families.qwen.plugin")
+    return importlib.import_module(
+        "tensorrt_model_connect.families.qwen.dual_profile_decoder_builder"
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "native_kv_cache",
+        "explicit_mask",
+        "profile_mode",
+        "cache_length",
+        "opt_length",
+        "requested",
+        "expected",
+    ),
+    [
+        (True, True, "prefill", 16384, 64, None, (64, 64)),
+        (True, True, "prefill", 16384, 128, 128, (64, 64)),
+        (True, True, "prefill", 16384, 64, 32, (32, 32)),
+        (True, True, "dual_profile", 16384, 128, None, (64, 64)),
+        (True, True, "decode", 16384, 64, None, (64, 16384)),
+        (True, False, "prefill", 40960, 64, None, (64, 32768)),
+        (False, False, "prefill", 40960, 64, None, (64, 40960)),
+    ],
+)
+def test_explicit_mask_prefill_limit(
+    native_kv_cache,
+    explicit_mask,
+    profile_mode,
+    cache_length,
+    opt_length,
+    requested,
+    expected,
+):
+    builder = _dual_profile_builder_module()
+
+    assert builder._resolve_prefill_lengths(
+        cache_length,
+        opt_length,
+        requested,
+        native_kv_cache=native_kv_cache,
+        explicit_native_attention_mask=explicit_mask,
+        profile_mode=profile_mode,
+    ) == expected
+
+
+@pytest.mark.parametrize("compute_capability", [(8, 6), (12, 1)])
+def test_current_cuda_compute_capability(monkeypatch, compute_capability):
+    builder = _dual_profile_builder_module()
+    properties = SimpleNamespace(
+        major=compute_capability[0], minor=compute_capability[1]
+    )
+    runtime = SimpleNamespace(
+        cudaGetDevice=lambda: (0, 0),
+        cudaGetDeviceProperties=lambda _device: (0, properties),
+    )
+    monkeypatch.setattr(builder, "_cuda_runtime", lambda: runtime)
+
+    assert builder._current_cuda_compute_capability() == compute_capability
+
+
+def test_current_cuda_compute_capability_fails_closed(monkeypatch):
+    builder = _dual_profile_builder_module()
+    runtime = SimpleNamespace(cudaGetDevice=lambda: (7, 0))
+    monkeypatch.setattr(builder, "_cuda_runtime", lambda: runtime)
+
+    with pytest.raises(RuntimeError, match="cudaGetDevice failed"):
+        builder._current_cuda_compute_capability()
+
+
+@requires_trt
+def test_qwen_explicit_mask_omits_native_lengths_on_real_trt_network():
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.graph_ops"
+    )
+    builder = trt.Builder(trt.Logger(trt.Logger.ERROR))
+    raw_network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    )
+    network = _AttentionRecordingNetwork(raw_network)
+    q = network.add_input("q", trt.bfloat16, (1, 512))
+    k = network.add_input("k", trt.bfloat16, (1, 256))
+    v = network.add_input("v", trt.bfloat16, (1, 256))
+    cache_k = network.add_input("cache_k", trt.bfloat16, (1, 2, 8, 128))
+    cache_v = network.add_input("cache_v", trt.bfloat16, (1, 2, 8, 128))
+    write_indices = network.add_input(
+        "cache_write_indices", trt.int32, (1,)
+    )
+    lengths = network.add_input("key_value_lengths", trt.int32, (1,))
+    mask = network.add_input("explicit_mask", trt.bfloat16, (1, 1, 1, 8))
+
+    result = graph_ops.add_native_kv_cache_attention_from_rows(
+        network,
+        q,
+        k,
+        v,
+        cache_k,
+        cache_v,
+        write_indices,
+        lengths,
+        num_heads=4,
+        num_kv_heads=2,
+        head_dim=128,
+        q_seq=1,
+        explicit_mask=mask,
+    )
+
+    attention = network.attention
+    assert isinstance(attention, trt.IAttention)
+    assert attention.num_inputs == 4
+    assert attention.mask is mask
+    assert attention.key_value_lengths is None
+    assert attention.causal_kind == trt.CausalMaskKind.NONE
+    assert attention.decomposable is False
+    assert attention.get_input(1) is result["present_k"]
+    assert attention.get_input(2) is result["present_v"]
 
 
 @pytest.mark.parametrize("module_name", _FAMILIES)

--- a/tests/builder/test_qwen_llama_native_kv_attention.py
+++ b/tests/builder/test_qwen_llama_native_kv_attention.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""TensorRT topology checks for the qualified BF16 native-KV path."""
+"""TensorRT topology checks for qualified Qwen native-KV attention paths."""
 
 from __future__ import annotations
 
@@ -236,6 +236,59 @@ def test_qwen_explicit_mask_omits_native_lengths_on_real_trt_network():
     assert attention.decomposable is False
     assert attention.get_input(1) is result["present_k"]
     assert attention.get_input(2) is result["present_v"]
+
+
+@requires_trt
+def test_qwen_fp16_explicit_mask_uses_bf16_native_attention_boundary():
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.graph_ops"
+    )
+    builder = trt.Builder(trt.Logger(trt.Logger.ERROR))
+    raw_network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    )
+    network = _AttentionRecordingNetwork(raw_network)
+    q = network.add_input("q", trt.float16, (1, 512))
+    k = network.add_input("k", trt.float16, (1, 256))
+    v = network.add_input("v", trt.float16, (1, 256))
+    cache_k = network.add_input("cache_k", trt.bfloat16, (1, 2, 8, 128))
+    cache_v = network.add_input("cache_v", trt.bfloat16, (1, 2, 8, 128))
+    write_indices = network.add_input(
+        "cache_write_indices", trt.int32, (1,)
+    )
+    lengths = network.add_input("key_value_lengths", trt.int32, (1,))
+    mask = network.add_input("explicit_mask", trt.bfloat16, (1, 1, 1, 8))
+
+    result = graph_ops.add_native_kv_cache_attention_from_rows(
+        network,
+        q,
+        k,
+        v,
+        cache_k,
+        cache_v,
+        write_indices,
+        lengths,
+        num_heads=4,
+        num_kv_heads=2,
+        head_dim=128,
+        q_seq=1,
+        explicit_mask=mask,
+        attention_dtype=trt.bfloat16,
+    )
+
+    attention = network.attention
+    assert isinstance(attention, trt.IAttention)
+    assert attention.num_inputs == 4
+    assert attention.get_input(0).dtype == trt.bfloat16
+    assert attention.get_input(1).dtype == trt.bfloat16
+    assert attention.get_input(2).dtype == trt.bfloat16
+    assert attention.mask is mask
+    assert attention.key_value_lengths is None
+    assert attention.causal_kind == trt.CausalMaskKind.NONE
+    assert attention.decomposable is False
+    assert result["present_k"].dtype == trt.bfloat16
+    assert result["present_v"].dtype == trt.bfloat16
+    assert result["context"].dtype == trt.float16
 
 
 @pytest.mark.parametrize("module_name", _FAMILIES)

--- a/tests/cpp/models/qwen/test_qwen_native_kv_cache_dtype.cpp
+++ b/tests/cpp/models/qwen/test_qwen_native_kv_cache_dtype.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen/plugin_helpers.h"
+
+#include <cstdio>
+#include <exception>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", name);
+        ++failures;
+    }
+}
+
+void expect_dtype(const std::string& config_json, const std::string& precision,
+                  trtmc::DType expected, const char* name) {
+    try {
+        check(trtmc::resolve_qwen_native_kv_cache_dtype(config_json, precision) == expected, name);
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "FAIL: %s threw unexpectedly: %s\n", name, error.what());
+        ++failures;
+    }
+}
+
+void expect_failure(const std::string& config_json, const char* name) {
+    try {
+        (void)trtmc::resolve_qwen_native_kv_cache_dtype(config_json, "fp16");
+        std::fprintf(stderr, "FAIL: %s did not throw\n", name);
+        ++failures;
+    } catch (const std::runtime_error& error) {
+        check(std::string(error.what()).find("native_kv_cache_dtype") != std::string::npos, name);
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "FAIL: %s threw the wrong exception: %s\n", name, error.what());
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    const std::string contract_v1 = R"({"native_kv_contract_version":1})";
+    expect_dtype(contract_v1, "fp16", trtmc::DType::kFloat16, "v1 inherits FP16");
+    expect_dtype(contract_v1, "bf16", trtmc::DType::kBFloat16, "v1 inherits BF16");
+
+    expect_dtype(R"({"native_kv_contract_version":2,"native_kv_cache_dtype":"fp16"})", "bf16",
+                 trtmc::DType::kFloat16, "v2 selects explicit FP16");
+    expect_dtype(R"({"native_kv_contract_version":2,"native_kv_cache_dtype":"bf16"})", "fp16",
+                 trtmc::DType::kBFloat16, "v2 selects explicit BF16");
+
+    expect_failure(R"({"native_kv_contract_version":2})", "v2 rejects missing dtype");
+    expect_failure(R"({"native_kv_contract_version":2,"native_kv_cache_dtype":"fp32"})",
+                   "v2 rejects invalid dtype");
+
+    if (failures == 0)
+        std::fprintf(stderr, "All Qwen native KV cache dtype tests passed.\n");
+    return failures;
+}

--- a/tests/e2e/models/qwen/test_qwen_builder_engine.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_engine.py
@@ -9,6 +9,8 @@ Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU re
 Postconditions: All standard decoder weight keys are present with correct shapes and the engine builds successfully.
 """
 
+import importlib
+
 import numpy as np
 import pytest
 
@@ -73,8 +75,43 @@ class Qwen3NativePluginTester(FamilyPluginTester):
 )
 @pytest.mark.trt
 @pytest.mark.gpu
-def test_native_qwen3_split_role_engine_contract(tmp_path, role, profile_shapes):
+def test_native_qwen3_split_role_engine_contract(
+    tmp_path,
+    role,
+    profile_shapes,
+    monkeypatch,
+):
     import tensorrt as trt
+
+    importlib.import_module("tensorrt_model_connect.families.qwen.plugin")
+    builder = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.dual_profile_decoder_builder"
+    )
+    graph_ops = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.graph_ops"
+    )
+    policy = importlib.import_module(
+        "tensorrt_model_connect.families.qwen.builder_policy"
+    )
+    expected_explicit_mask = policy.requires_explicit_native_kv_mask(
+        "bf16",
+        trt.__version__,
+        builder._current_cuda_compute_capability(),
+    )
+    native_attention_calls = []
+    original_native_attention = graph_ops.add_native_kv_cache_attention_from_rows
+
+    def _record_native_attention(*args, **kwargs):
+        native_attention_calls.append(
+            (kwargs.get("explicit_mask"), kwargs.get("recipe_instance"))
+        )
+        return original_native_attention(*args, **kwargs)
+
+    monkeypatch.setattr(
+        graph_ops,
+        "add_native_kv_cache_attention_from_rows",
+        _record_native_attention,
+    )
 
     tester = Qwen3NativePluginTester()
     config, weights, _ = tester.prepare_config_and_weights(tmp_path)
@@ -89,6 +126,18 @@ def test_native_qwen3_split_role_engine_contract(tmp_path, role, profile_shapes)
     engine = trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(plan)
 
     assert engine is not None
+    assert len(native_attention_calls) == tester.spec.num_hidden_layers
+    explicit_masks = [call[0] for call in native_attention_calls]
+    recipe_instances = [call[1] for call in native_attention_calls]
+    if expected_explicit_mask:
+        assert all(mask is not None for mask in explicit_masks)
+        assert all(recipe is None for recipe in recipe_instances)
+    else:
+        assert all(mask is None for mask in explicit_masks)
+        expected_recipe = (
+            "decoder.layers.0.decode_attention" if role == "decode" else None
+        )
+        assert recipe_instances == [expected_recipe]
     assert engine.num_optimization_profiles == 1
     assert [
         tuple(shape) for shape in engine.get_tensor_profile_shape("token_id", 0)

--- a/tests/e2e/models/qwen/test_qwen_builder_engine.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_engine.py
@@ -73,12 +73,14 @@ class Qwen3NativePluginTester(FamilyPluginTester):
         ("decode", [(1,), (1,), (1,)]),
     ],
 )
+@pytest.mark.parametrize("precision", ["fp16", "bf16"])
 @pytest.mark.trt
 @pytest.mark.gpu
 def test_native_qwen3_split_role_engine_contract(
     tmp_path,
     role,
     profile_shapes,
+    precision,
     monkeypatch,
 ):
     import tensorrt as trt
@@ -94,7 +96,7 @@ def test_native_qwen3_split_role_engine_contract(
         "tensorrt_model_connect.families.qwen.builder_policy"
     )
     expected_explicit_mask = policy.requires_explicit_native_kv_mask(
-        "bf16",
+        precision,
         trt.__version__,
         builder._current_cuda_compute_capability(),
     )
@@ -103,7 +105,11 @@ def test_native_qwen3_split_role_engine_contract(
 
     def _record_native_attention(*args, **kwargs):
         native_attention_calls.append(
-            (kwargs.get("explicit_mask"), kwargs.get("recipe_instance"))
+            (
+                kwargs.get("explicit_mask"),
+                kwargs.get("recipe_instance"),
+                kwargs.get("attention_dtype"),
+            )
         )
         return original_native_attention(*args, **kwargs)
 
@@ -120,7 +126,7 @@ def test_native_qwen3_split_role_engine_contract(
         config,
         weights,
         tester.spec.max_cache_length,
-        precision="bf16",
+        precision=precision,
         verbose=False,
     )
     engine = trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(plan)
@@ -129,6 +135,13 @@ def test_native_qwen3_split_role_engine_contract(
     assert len(native_attention_calls) == tester.spec.num_hidden_layers
     explicit_masks = [call[0] for call in native_attention_calls]
     recipe_instances = [call[1] for call in native_attention_calls]
+    attention_dtypes = [call[2] for call in native_attention_calls]
+    precision_dtype = trt.float16 if precision == "fp16" else trt.bfloat16
+    expected_cache_dtype = (
+        trt.bfloat16
+        if expected_explicit_mask and precision == "fp16"
+        else precision_dtype
+    )
     if expected_explicit_mask:
         assert all(mask is not None for mask in explicit_masks)
         assert all(recipe is None for recipe in recipe_instances)
@@ -138,6 +151,7 @@ def test_native_qwen3_split_role_engine_contract(
             "decoder.layers.0.decode_attention" if role == "decode" else None
         )
         assert recipe_instances == [expected_recipe]
+    assert attention_dtypes == [expected_cache_dtype]
     assert engine.num_optimization_profiles == 1
     assert [
         tuple(shape) for shape in engine.get_tensor_profile_shape("token_id", 0)
@@ -178,8 +192,20 @@ def test_native_qwen3_split_role_engine_contract(
         present_name = f"present_{stem}_0"
         assert tuple(engine.get_tensor_shape(cache_name)) == expected_cache_shape
         assert tuple(engine.get_tensor_shape(present_name)) == expected_cache_shape
-        assert engine.get_tensor_dtype(cache_name) == trt.bfloat16
+        assert engine.get_tensor_dtype(cache_name) == expected_cache_dtype
         assert engine.get_aliased_input_tensor(present_name) == cache_name
+
+    expected_metadata = {
+        "native_kv_contract_version": (
+            2 if expected_cache_dtype != precision_dtype else 1
+        ),
+        "native_kv_cache": True,
+    }
+    if expected_cache_dtype != precision_dtype:
+        expected_metadata["native_kv_cache_dtype"] = (
+            "bf16" if expected_cache_dtype == trt.bfloat16 else "fp16"
+        )
+    assert tester.get_plugin().get_bundle_config_overrides(config) == expected_metadata
 
 
 def _qwen_tp_builder_module():

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -7,6 +7,7 @@ import pytest
 
 from tensorrt_model_connect.families.qwen.builder_policy import (
     configure_qwen_builder,
+    requires_explicit_native_kv_mask,
 )
 
 
@@ -16,6 +17,31 @@ def _quant_context(format_name: str):
             format=SimpleNamespace(name=format_name),
             exclude_patterns=[],
         ))
+
+
+@pytest.mark.parametrize(
+    ("precision", "trt_version", "compute_capability", "expected"),
+    [
+        ("bf16", "11.1.0.106", (8, 6), True),
+        ("BF16", "11.2.1.2", (12, 1), True),
+        ("fp16", "11.1.0.106", (8, 6), False),
+        ("bf16", "11.2.1.2", (10, 3), False),
+        ("bf16", "11.0.0", (8, 6), False),
+        ("bf16", "11.3.0", (12, 1), False),
+        ("bf16", "unknown", (8, 6), False),
+    ],
+)
+def test_explicit_native_kv_mask_policy_is_narrow(
+    precision,
+    trt_version,
+    compute_capability,
+    expected,
+):
+    assert requires_explicit_native_kv_mask(
+        precision=precision,
+        trt_version=trt_version,
+        compute_capability=compute_capability,
+    ) is expected
 
 
 @pytest.mark.parametrize("override", [None, "", "   "])

--- a/tests/e2e/models/qwen/test_qwen_builder_policy.py
+++ b/tests/e2e/models/qwen/test_qwen_builder_policy.py
@@ -8,6 +8,7 @@ import pytest
 from tensorrt_model_connect.families.qwen.builder_policy import (
     configure_qwen_builder,
     requires_explicit_native_kv_mask,
+    validate_explicit_native_kv_cache_length,
 )
 
 
@@ -24,8 +25,13 @@ def _quant_context(format_name: str):
     [
         ("bf16", "11.1.0.106", (8, 6), True),
         ("BF16", "11.2.1.2", (12, 1), True),
-        ("fp16", "11.1.0.106", (8, 6), False),
+        ("fp16", "11.1.0.106", (8, 6), True),
+        ("FP16", "11.2.1.2", (12, 1), True),
+        ("fp16", "11.2.1.2", (10, 3), False),
         ("bf16", "11.2.1.2", (10, 3), False),
+        ("fp8", "11.2.1.2", (12, 1), False),
+        ("fp32", "11.2.1.2", (12, 1), False),
+        ("fp16", "11.0.0", (8, 6), False),
         ("bf16", "11.0.0", (8, 6), False),
         ("bf16", "11.3.0", (12, 1), False),
         ("bf16", "unknown", (8, 6), False),
@@ -42,6 +48,19 @@ def test_explicit_native_kv_mask_policy_is_narrow(
         trt_version=trt_version,
         compute_capability=compute_capability,
     ) is expected
+
+
+@pytest.mark.parametrize("max_cache_length", [1, 4096, 16384])
+def test_explicit_native_kv_cache_length_accepts_qualified_range(
+    max_cache_length,
+):
+    validate_explicit_native_kv_cache_length(max_cache_length)
+
+
+@pytest.mark.parametrize("max_cache_length", [16385, 40960])
+def test_explicit_native_kv_cache_length_fails_closed(max_cache_length):
+    with pytest.raises(ValueError, match="--max-cache-length 16384"):
+        validate_explicit_native_kv_cache_length(max_cache_length)
 
 
 @pytest.mark.parametrize("override", [None, "", "   "])


### PR DESCRIPTION
## Background

PR #959 fixed Qwen3 native-KV routing and precision plumbing, but it did not change the TensorRT attention input contract. FP16 still reached `IAttention` with Q/K/V plus `key_value_lengths` (four live inputs). On the affected TensorRT 11.1/11.2 kernels, that FP16 wrapper rejects the graph with `Expected 3 live inputs, got 4`.

The same native length input has a separate BF16 failure mode on SM86/SM121: a bounded Qwen3 build can succeed but attend into the inactive fixed-cache suffix and silently generate wrong tokens.

This PR supplies a builder/runtime workaround for both supported native Qwen precisions while retaining fixed-capacity `IKVCacheUpdate`, aliased cache storage, and fused attention.

Refs #955 and #959.

## Exit Criteria

- Qwen3 BF16 with cache capacity 16384 masks the inactive cache suffix and produces correct text on an affected target.
- Qwen3 FP16 with cache capacity 16384 builds and produces correct text on an affected target.
- Both paths retain non-decomposable fused prefill/decode attention and native cache aliasing.
- Mixed FP16 bundles declare their actual cache dtype so the runtime allocates and validates the correct storage.
- Existing same-precision native bundles retain the v1 runtime contract.
- Unqualified affected-target capacities above 16384 fail before TensorRT with an actionable error.
- FP8 stays on its qualified quantized route, and FP32 continues to fail closed for native KV.
- Exact BF16 and FP16 full-model validation on SM86 passes before the draft is marked ready.

## Implementation

- Build one shared additive `[1, 1, Sq, K]` causal active-prefix mask and omit `attention.key_value_lengths` on affected SM86/SM121 + TensorRT 11.1/11.2 builds.
- Keep BF16 entirely BF16 on that path.
- For FP16, keep embeddings, projections, MLPs, logits, and the surrounding residual stream FP16, but:
  - cast RoPE-processed Q and the current K/V updates to BF16;
  - store the native KV cache in BF16;
  - execute explicit-mask fused attention in BF16;
  - cast the attention context back to FP16 before the output projection.
- Emit native-KV contract v2 with `native_kv_cache_dtype=bf16` only when cache precision differs from model precision. The runtime resolves, allocates, and validates that declared dtype. Same-precision FP16/BF16 bundles remain contract v1.
- Cap affected prefill chunks at 64 tokens to retain the validated fused prefill tactic.
- Reject affected-target cache capacities above 16384 with: `Rebuild with --max-cache-length 16384`.
- Leave FP8, FP32, other SMs, and other TensorRT releases on their existing routing policies.

## Validation

Automated validation:

- `PYTHONPATH=python python3 -m pytest -q tests/e2e/models/qwen/test_qwen_builder_policy.py tests/builder/test_qwen_llama_native_kv_attention.py tests/builder/test_graph_ops_native_attn.py`: `76 passed`. This covers policy, routing, real TensorRT topology, explicit-mask numerics, and graph ops. The numeric regression executes both pure BF16 and FP16-model/BF16-attention graphs with a poisoned inactive cache suffix and verifies the causal active-prefix result.
- `PYTHONPATH=python python3 -m pytest -q tests/e2e/models/qwen/test_qwen_builder_engine.py`: `22 passed`, including real FP16/BF16 x prefill/decode split engines.
- `./build-sm86/test_qwen_native_kv_cache && ./build-sm86/test_qwen_native_kv_cache_dtype && ./build-sm86/test_qwen_sampler && ./build-sm86/test_qwen_tensor_names`: passed. The new dtype test covers v1 FP16/BF16 fallback, v2 explicit FP16/BF16 selection, and missing/invalid v2 declarations.
- `git diff --check origin/main...HEAD`: passed.
- Community CPU runs source quality, ownership/impact, docs, and selected C++/Python units against the exact pull-request merge revision; its current-head result is the source-quality evidence for this PR.

SM86 + TensorRT 11.1.0.106 full-model FP16 validation:

- Built `Qwen/Qwen3-0.6B --precision fp16 --max-cache-length 16384` successfully.
- Split bundle: 2593.8 MB total (1441.1 MB prefill, 1152.8 MB decode).
- Bundle metadata: model precision FP16, native-KV contract v2, cache dtype BF16.
- README prompt returned `Paris`; plain prompt continued with ` Paris. The capital of France is also`.
- A prompt spanning three 64-token prefill chunks produced the same correct completion as the BF16 baseline.
- Engine inspection found all 28 decode layers using `_gemv_mha_v1` and all 28 prefill layers using `_gemm_mha_v2`.
- Warm benchmark: 50.50 ms prefill, 15.75 ms decode, 126.97 token/s.
- BF16 baseline from the same setup: 49.93 ms prefill, 15.08 ms decode, 132.59 token/s. Repeated mixed-FP16 runs ranged across both sides of that baseline, so no material steady-state regression was observed.
- The default 40960 build now fails before TRT with the requested `--max-cache-length 16384` guidance.

Targeted SM86 TensorRT 11.1/11.2 attention probes also built and executed correctly with fused tactics. SM120/SM121 was not directly exercised for this PR; its applicability there is guarded by the same release/SM allowlist and covered by the topology and numeric regression tests.

## Notes For Future Readers

- “All precisions” here means both supported unquantized native-KV precisions: FP16 and BF16. FP8 uses a separate qualified quantized graph; FP32 is unsupported for native KV and remains fail-closed.
- The affected FP16 workaround is intentionally mixed precision. The model remains FP16, but native attention and its cache are BF16 because the affected FP16 wrapper cannot accept the required fourth mask input.
- This qualifies cache capacities through 16384, not the model-default 40960 capacity. The latter has no validated dedicated fused tactic on these releases and now fails with an actionable message.
- One cold first-prefill run on SM86 showed roughly 50-60 ms additional setup/tactic cost; warm steady-state timings were comparable.
- CUDA graph capture falls back on this SM86/TRT setup for both the existing BF16 explicit-mask engine and the mixed FP16 engine, so that behavior is not introduced by the FP16 boundary.
- The workaround is release/SM allowlisted and should be requalified or removed when a public TensorRT release fixes the native kernels.
