### PR TITLE
chore(review): configure CodeRabbit and DCO

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,10 @@ reviews:
       enabled: false
     autofix:
       enabled: false
+    fix_ci:
+      enabled: false
+    resolve_merge_conflict:
+      enabled: false
 
   path_filters:
     - "!third_party/**"
@@ -35,11 +39,12 @@ reviews:
   path_instructions:
     - path: ".github/**"
       instructions: |
-        Treat fork pull requests as untrusted. Preserve the Community CPU to
-        maintainer authorization to internal CI boundary. Never execute or
-        check out an untrusted pull-request head in a privileged workflow.
-        Require least-privilege permissions and full-SHA pinning for
-        third-party actions.
+        Treat fork pull requests as untrusted. Preserve the trust boundary
+        between unprivileged Community CPU validation, maintainer
+        authorization, and protected internal CI. Never execute or check out
+        an untrusted pull-request head in a privileged workflow. Require
+        least-privilege permissions and full-SHA pinning for third-party
+        actions.
 
     - path: "tests/**"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,7 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: en-US
 early_access: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+language: en-US
+early_access: false
+
+reviews:
+  # Start with low-noise, advisory reviews. Human reviewers and repository CI
+  # remain the merge authority.
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  poem: false
+  in_progress_fortune: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Do not let review finishing touches create follow-up code changes. Authors
+  # remain responsible for applying and validating any suggested change.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    autofix:
+      enabled: false
+
+  path_filters:
+    - "!third_party/**"
+
+  path_instructions:
+    - path: ".github/**"
+      instructions: |
+        Treat fork pull requests as untrusted. Preserve the Community CPU to
+        maintainer authorization to internal CI boundary. Never execute or
+        check out an untrusted pull-request head in a privileged workflow.
+        Require least-privilege permissions and full-SHA pinning for
+        third-party actions.
+
+    - path: "tests/**"
+      instructions: |
+        Do not suggest weakening assertions, expected values, validation
+        criteria, comparison oracles, or acceptance thresholds merely to make
+        tests pass.
+
+    - path: "src/**"
+      instructions: |
+        Check ownership boundaries, public API compatibility, runtime safety,
+        TensorRT lifetime rules, error propagation, and cross-platform
+        behavior.
+
+    - path: "include/**"
+      instructions: |
+        Treat public header and ABI changes as high risk. Check lifetime,
+        ownership, compatibility, and documentation implications.
+
+    - path: "python/**"
+      instructions: |
+        Check model-family ownership, configuration isolation, error
+        propagation, deterministic behavior, and parity between Python and
+        native runtime paths.
+
+chat:
+  auto_reply: true
+  art: false
+  allow_non_org_members: true

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Let an author add a missing sign-off without rewriting shared history. Do not
+# permit another contributor to certify a commit on the author's behalf.
+allowRemediationCommits:
+  individual: true
+  thirdParty: false

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ models/hf/*/.cache/
 !.gitignore
 !.dockerignore
 !.pre-commit-config.yaml
+!.coderabbit.yaml
 !website/docs/context/.last_scan_sha
 !.agents/
 !.agents/plugins/

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1567,6 +1567,7 @@ class TestNoImpact:
     @pytest.mark.parametrize(
         "path",
         [
+            ".coderabbit.yaml",
             "CODEOWNERS",
             "ruff.toml",
             "tests/__init__.py",

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -134,6 +134,7 @@ _ORCHESTRATOR_MODULES = {
 _NO_IMPACT_PATTERNS = [
     r"^docs/",
     r"^website/",
+    r"^\.coderabbit\.yaml$",
     r"^\.gitignore$",
     r"^\.clang-format$",
     r"^\.editorconfig$",


### PR DESCRIPTION
## Background

The contribution guide requires DCO sign-offs, and the repository now has the
DCO and CodeRabbit GitHub Apps installed. The repository still needs
version-controlled behavior for both integrations before DCO becomes a merge
gate or automated reviews become part of the normal PR workflow.

## Exit Criteria

- Authors can remediate missing DCO sign-offs without permitting third-party
  certification on their behalf.
- CodeRabbit automatically provides low-noise advisory reviews without
  requesting changes or generating follow-up code edits.
- Review guidance preserves the repository's fork-safety, validation, public
  API, ABI, and model-ownership constraints.

## Implementation

- Add `.github/dco.yml` with individual remediation enabled and third-party
  remediation disabled.
- Add a schema-backed `.coderabbit.yaml` that keeps reviews advisory, skips
  drafts and vendored sources, disables automated finishing-touch changes, and
  supplies path-specific guidance for CI, tests, runtime sources, public
  headers, and Python model infrastructure.
- Allow the root CodeRabbit configuration through the repository's default
  dotfile ignore rule.
- Classify the root CodeRabbit file as review-only repository metadata and
  cover that test-impact decision explicitly, avoiding the conservative
  all-model fallback for future review-configuration edits.

## Validation

- `python3 -c '<parse both YAML files with PyYAML>'`: passed.
- `python3 -c '<validate .coderabbit.yaml against the official v2 JSON schema>'`:
  passed.
- `pre-commit run check-yaml --files .coderabbit.yaml .github/dco.yml`: passed.
- `python3 -m pytest tests/tools/test_test_impact.py -q`: passed, 282 tests.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed for 221
  models, 12 core models, and 84 families.
- `PYTHONPATH=python:. python3 -m tools.community_ci source-quality --base github/main`:
  passed, including 158 model architecture contract tests.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- Review `.github/dco.yml` first, then `.coderabbit.yaml`.
- This PR configures DCO behavior but does not make `DCO` a required status
  check. Existing open PRs should be remediated or closed before activating a
  dedicated `Require DCO on main` ruleset.
- The currently installed legacy `dco` App does not support DCO-2's
  `allowOverrideAction` option, so this configuration does not claim to disable
  the App's maintainer override action.
- CodeRabbit remains advisory. Human reviewers and the existing Community CPU
  and protected premerge checks remain the merge authority.
