### PR TITLE
fix(ci): grant PR triage label permission

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     steps:
       # This privileged workflow executes only code from the trusted base SHA.
       # It fetches pull-request Git objects for declarative impact analysis but

--- a/tests/tools/test_pr_metadata.py
+++ b/tests/tools/test_pr_metadata.py
@@ -267,7 +267,10 @@ def test_triage_workflow_never_checks_out_or_executes_pull_request_code() -> Non
 
     assert "pull_request_target:" in source
     assert workflow["permissions"] == {}
-    assert job["permissions"] == {"contents": "read", "issues": "write"}
+    assert job["permissions"] == {
+        "contents": "read",
+        "pull-requests": "write",
+    }
     assert "ref: ${{ github.event.pull_request.base.sha }}" in source
     assert "persist-credentials: false" in source
     assert "refs/remotes/trtmc/pr-head" in source


### PR DESCRIPTION
## Background

PR Triage failed on fork-based PR #1032 while adding derived labels. The job received `Issues: write`, but GitHub returned `403 Resource not accessible by integration`; the existing Internal CI bridge successfully updates labels on the same PR with `Pull requests: write`.

## Exit Criteria

- PR Triage requests the label permission proven to work for pull requests from forks.
- The workflow security contract remains locked down by a regression test.
- No pull-request head code is checked out or executed by the privileged workflow.

## Implementation

- Replace the classify job's `issues: write` permission with `pull-requests: write`.
- Update the workflow contract test to require the corrected least-privilege permission.
- Keep the trusted-base checkout and declarative pull-request diff analysis unchanged.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_pr_metadata.py::test_triage_workflow_never_checks_out_or_executes_pull_request_code -q`: failed before the workflow fix and passed after it.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_pr_metadata.py tests/tools/test_github_actions_ci.py -q`: 80 passed.
- `python3 -m ruff check tests/tools/test_pr_metadata.py`: passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Head: `b6167c84eb67112b79fae8a7c44e8f5c11f522cd`
- Base: `github/main` at `411b6b95461f9e1544bbb2ee648c0abcb95732e3`
- Local CPU-only validation with Python 3.12.3; no CUDA, TensorRT, model, or checkpoint dependency applies.

### Not Run / Remaining Gaps

- The live fork-PR label mutation cannot be exercised from the feature branch because `pull_request_target` executes the workflow from the base branch. After merge, retriggering PR Triage on #1032 provides the end-to-end check.

## Notes For Future Readers

- Review `.github/workflows/pr-triage.yml` first, then the exact permission assertion in `tests/tools/test_pr_metadata.py`.
- Keep this workflow on trusted base-branch code; it fetches PR Git objects for analysis but must never execute pull-request code with the write-capable token.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this is a one-line permission correction with focused regression coverage, but it affects a privileged `pull_request_target` workflow. The workflow retains least privilege and its existing trusted-code boundary.
