### PR TITLE
feat(ci): add local protected failure report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN pip install "nvidia-modelopt==${MODELOPT_VERSION}"
 RUN pip install \
     "pytest<9" \
     pytest-cov \
+    "jsonschema==4.26.0" \
     coverage \
     gcovr \
     pytest-xdist \

--- a/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/doc-sync/SKILL.md
@@ -102,8 +102,9 @@ root graph helpers, or paths copied from another branch.
 
 ## CI Documentation Contract
 
-Source contains only the Internal CI Bridge and Pages workflows. Premerge,
-including legal compliance, and nightly orchestration are private Internal CI.
+Source contains Community CPU, the Internal CI Bridge, and Pages workflows.
+Premerge, including legal compliance, and nightly orchestration are private
+Internal CI.
 
 - `run-internal-ci` is the one-shot trusted trigger; `run-ci` is retired.
 - The bridge verifies the label event, current PR metadata head, and successful
@@ -111,6 +112,9 @@ including legal compliance, and nightly orchestration are private Internal CI.
 - Source receives only `trtmc/premerge/required` as `PENDING`, `PASS`, or
   `FAIL` on that exact head.
 - A successful bridge dispatch is not a successful premerge result.
+- `tools/public_failure/` is a local-only P0 renderer until a separately
+  reviewed private finalizer is integrated; its presence does not mean failure
+  reports or comments are published.
 - Never copy private logs, artifacts, package coordinates, runner details, or
   internal URLs into Source docs, Actions, Pages, or PR comments.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0", "torch>=2.0"]
+test = ["pytest>=7.0", "torch>=2.0", "jsonschema>=4.23,<5"]
 # Build-only dependency for official Wan checkpoints containing T5/VAE .pth
 # files. Kept out of the base install and never required by the C++ runtime.
 wan = ["torch>=2.0"]

--- a/requirements/community-ci.txt
+++ b/requirements/community-ci.txt
@@ -9,4 +9,5 @@ clang-format==22.1.8
 lizard==1.24.0
 pytest==8.4.2
 pytest-xdist==3.8.0
+jsonschema==4.26.0
 Pillow==12.2.0

--- a/tests/tools/fixtures/public_failure/context.json
+++ b/tests/tools/fixtures/public_failure/context.json
@@ -1,0 +1,11 @@
+{
+  "repository": "NVIDIA/TensorRT-Model-Connect",
+  "pr_number": 123,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "tested_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "tested_revision_kind": "head",
+  "run_attempt": 1,
+  "result": "failure",
+  "generated_at": "2026-08-26T00:00:00Z"
+}

--- a/tests/tools/fixtures/public_failure/internal-failure.json
+++ b/tests/tools/fixtures/public_failure/internal-failure.json
@@ -1,0 +1,35 @@
+{
+  "failures": [
+    {
+      "failure_type": "compare_fail",
+      "stage": "model-proof",
+      "model": "patchtsmixer",
+      "backend": "native",
+      "gpu_type": "H100",
+      "test_id": "tests/e2e/models/patchtsmixer/test_patchtsmixer_e2e.py::test_model_e2e",
+      "reason_code": "metric_threshold_exceeded",
+      "metric": {
+        "name": "max_relative_l2",
+        "observed": 0.021,
+        "operator": "<=",
+        "threshold": 0.01,
+        "internal_debug": "this field must not appear"
+      },
+      "raw_log": "Authorization: Bearer FAKE_INTERNAL_TOKEN",
+      "command": "private-runner --internal-only"
+    },
+    {
+      "failure_type": "build_fail",
+      "stage": "build",
+      "model": "llama",
+      "backend": "native",
+      "gpu_type": "H100",
+      "test_id": "tests/e2e/models/llama/test_llama_e2e.py::test_model_e2e",
+      "reason_code": "build_failed",
+      "stack_trace": "internal stack trace must not appear"
+    }
+  ],
+  "jenkins_url": "http://jenkins.internal/job/123",
+  "employee_email": "fake-user@nvidia.com",
+  "access_token": "ghp_FAKE_INTERNAL_TOKEN_123456"
+}

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from tools.public_failure.contract import (
+    PublicFailureValidationError,
+    serialize_public_failure,
+    validate_public_failure,
+)
+from tools.public_failure.export import ExportContext, export_failure
+from tools.public_failure.render import render_failure_report
+from tools.public_failure.safety import PublicFailureSafetyError, assert_public_payload_safe
+from tools.public_failure import build_failure_artifacts
+from tools.public_failure.__main__ import main as public_failure_main
+
+
+HEAD_SHA = "a" * 40
+BASE_SHA = "b" * 40
+
+
+def _context(*, result: str = "failure") -> ExportContext:
+    return ExportContext(
+        repository="NVIDIA/TensorRT-Model-Connect",
+        pr_number=123,
+        head_sha=HEAD_SHA,
+        base_sha=BASE_SHA,
+        tested_revision=HEAD_SHA,
+        run_attempt=1,
+        result=result,
+        generated_at="2026-08-26T00:00:00Z",
+    )
+
+
+def _comparison_failure() -> dict[str, object]:
+    return {
+        "failure_type": "compare_fail",
+        "stage": "model-proof",
+        "model": "patchtsmixer",
+        "backend": "native",
+        "gpu_type": "H100",
+        "test_id": "tests/e2e/models/patchtsmixer/test_e2e.py::test_forecast",
+        "reason_code": "metric_threshold_exceeded",
+        "metric": {
+            "name": "max_relative_l2",
+            "observed": 0.021,
+            "operator": "<=",
+            "threshold": 0.010,
+        },
+    }
+
+
+def _comparison_report() -> dict[str, object]:
+    return export_failure({"failures": [_comparison_failure()]}, _context())
+
+
+def _build_failure(*, test_id: str) -> dict[str, object]:
+    return {
+        "failure_type": "build_fail",
+        "stage": "build",
+        "model": "llama",
+        "backend": "native",
+        "gpu_type": "H100",
+        "test_id": test_id,
+        "reason_code": "build_failed",
+    }
+
+
+def test_export_failure_rebuilds_a_public_result_from_approved_fields() -> None:
+    failure = _comparison_failure()
+    failure["raw_log"] = "Bearer must-not-escape"
+    failure["command"] = "private-runner --internal-only"
+    report = export_failure(
+        {"failures": [failure], "jenkins_url": "http://jenkins.internal/job/123"},
+        _context(),
+    )
+
+    assert report == {
+        "schema_version": 1,
+        "policy_version": "2026-08-26",
+        "report_id": f"trtmc-pr123-{HEAD_SHA[:7]}-attempt1",
+        "repository": "NVIDIA/TensorRT-Model-Connect",
+        "pr_number": 123,
+        "head_sha": HEAD_SHA,
+        "base_sha": BASE_SHA,
+        "tested_revision": HEAD_SHA,
+        "tested_revision_kind": "head",
+        "run_attempt": 1,
+        "result": "failure",
+        "failures": [
+            {
+                "public_stage": "model-proof",
+                "model": "patchtsmixer",
+                "backend": "native",
+                "gpu_type": "H100",
+                "test_id": "tests/e2e/models/patchtsmixer/test_e2e.py::test_forecast",
+                "failure_class": "accuracy_regression",
+                "reason_code": "metric_threshold_exceeded",
+                "metric": {
+                    "name": "max_relative_l2",
+                    "observed": 0.021,
+                    "operator": "<=",
+                    "threshold": 0.010,
+                },
+                "disclosure": "full",
+            }
+        ],
+        "omitted_failure_count": 0,
+        "generated_at": "2026-08-26T00:00:00Z",
+    }
+
+
+def test_unknown_sensitive_internal_fields_do_not_change_public_bytes() -> None:
+    internal = {"failures": [_comparison_failure()]}
+    poisoned = deepcopy(internal)
+    poisoned["access_token"] = "ghp_FAKE_SECRET"
+    poisoned["internal_url"] = "http://jenkins.internal/job/123"
+    poisoned["employee_email"] = "someone@nvidia.com"
+    poisoned["failures"][0]["raw_log"] = "Authorization: Bearer JWT"
+    poisoned["failures"][0]["workspace"] = "PRIVATE_WORKSPACE_VALUE"
+    poisoned["failures"][0]["metric"]["debug_payload"] = "long-base64-secret"
+    context = _context()
+
+    clean_bytes = serialize_public_failure(export_failure(internal, context))
+    poisoned_bytes = serialize_public_failure(export_failure(poisoned, context))
+
+    assert poisoned_bytes == clean_bytes
+
+
+def test_exported_report_satisfies_the_public_contract() -> None:
+    report = export_failure({"failures": []}, _context(result="error"))
+
+    validate_public_failure(report)
+
+
+@pytest.mark.parametrize("level", ["report", "failure", "metric"])
+def test_public_contract_rejects_unknown_fields_at_every_level(level: str) -> None:
+    report = _comparison_report()
+    target = {
+        "report": report,
+        "failure": report["failures"][0],
+        "metric": report["failures"][0]["metric"],
+    }[level]
+    target["unexpected"] = "must be rejected"
+
+    with pytest.raises(PublicFailureValidationError, match="unknown fields"):
+        validate_public_failure(report)
+
+
+@pytest.mark.parametrize(
+    ("path", "invalid_value"),
+    [
+        (("result",), "success"),
+        (("head_sha",), "A" * 40),
+        (("pr_number",), True),
+        (("failures", 0, "failure_class"), "private_exception_name"),
+        (("failures", 0, "test_id"), "../../internal/test.py::test_secret"),
+        (("failures", 0, "metric", "observed"), float("nan")),
+    ],
+)
+def test_public_contract_rejects_values_outside_the_closed_schema(
+    path: tuple[object, ...], invalid_value: object
+) -> None:
+    report = _comparison_report()
+    target = report
+    for part in path[:-1]:
+        target = target[part]
+    target[path[-1]] = invalid_value
+
+    with pytest.raises(PublicFailureValidationError):
+        validate_public_failure(report)
+
+
+def test_unknown_internal_values_become_fixed_placeholders_without_leaking() -> None:
+    private_failure_type = "InternalSchedulerSecretException"
+    private_test_id = "../../private/test.py::test_token"
+    report = export_failure(
+        {
+            "failures": [
+                {
+                    "failure_type": private_failure_type,
+                    "stage": "slurm-gb300-secret-pool",
+                    "model": "unannounced-model",
+                    "backend": "private-backend",
+                    "gpu_type": "engineering-sample-serial-123",
+                    "test_id": private_test_id,
+                    "reason_code": "private_reason_with_hostname",
+                    "metric": {
+                        "name": "secret_internal_metric",
+                        "observed": "host.internal",
+                        "operator": "approximately",
+                        "threshold": "token",
+                    },
+                }
+            ]
+        },
+        _context(result="error"),
+    )
+
+    validate_public_failure(report)
+    assert report["failures"] == [
+        {
+            "public_stage": "protected-ci",
+            "model": "other-model",
+            "backend": "other-backend",
+            "gpu_type": "protected-gpu",
+            "test_id": "withheld",
+            "failure_class": "unknown",
+            "reason_code": "unknown",
+            "disclosure": "withheld",
+        }
+    ]
+    public_bytes = serialize_public_failure(report)
+    assert private_failure_type.encode() not in public_bytes
+    assert private_test_id.encode() not in public_bytes
+
+
+def test_json_schema_accepts_the_exported_report_and_is_itself_valid() -> None:
+    schema_path = (
+        Path(__file__).parents[2] / "tools/public_failure/assets/public-failure-v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    report = export_failure({"failures": []}, _context(result="error"))
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(report)
+
+
+def test_renderer_produces_deterministic_self_contained_html() -> None:
+    report = _comparison_report()
+
+    first = render_failure_report(report)
+    second = render_failure_report(report)
+
+    assert first == second
+    document = first.decode("utf-8")
+    assert "TRTMC Protected CI failure report" in document
+    assert "patchtsmixer" in document
+    assert "max_relative_l2" in document
+    assert "0.021" in document
+    assert "&lt;=" in document
+    assert "default-src 'none'" in document
+    assert '<span class="status">FAILED</span>' in document
+    assert '<table class="run-meta">' in document
+    assert '<table class="failure-table">' in document
+    lowered = document.lower()
+    assert 'class="banner"' not in lowered
+    assert 'class="card"' not in lowered
+    assert 'class="eyebrow"' not in lowered
+    assert "<script" not in lowered
+    assert "<link" not in lowered
+    assert "<img" not in lowered
+    assert "http://" not in lowered
+    assert "https://" not in lowered
+
+
+def test_poison_scan_rejects_sensitive_text_even_when_schema_allows_the_characters() -> None:
+    report = export_failure(
+        {
+            "failures": [
+                _build_failure(test_id="tests/e2e/test_ghp_FAKESECRET123456789.py::test_build")
+            ]
+        },
+        _context(),
+    )
+    document = render_failure_report(report)
+
+    with pytest.raises(PublicFailureSafetyError, match="credential-like token"):
+        assert_public_payload_safe(report, document)
+
+
+def test_build_failure_artifacts_runs_the_complete_local_pipeline() -> None:
+    artifacts = build_failure_artifacts(
+        {
+            "failures": [
+                _build_failure(test_id="tests/e2e/models/llama/test_llama_e2e.py::test_model_e2e")
+            ]
+        },
+        _context(),
+    )
+
+    assert json.loads(artifacts.json_bytes) == artifacts.report
+    assert b"TRTMC Protected CI failure report" in artifacts.html_bytes
+    assert b"Raw logs and internal diagnostics are not included" in artifacts.html_bytes
+
+
+def test_local_cli_writes_preview_files_without_publishing(tmp_path: Path) -> None:
+    input_path = tmp_path / "internal.json"
+    context_path = tmp_path / "context.json"
+    output_dir = tmp_path / "preview"
+    input_path.write_text(
+        json.dumps(
+            {
+                "failures": [
+                    _build_failure(
+                        test_id="tests/e2e/models/llama/test_llama_e2e.py::test_model_e2e"
+                    )
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    context_path.write_text(json.dumps(asdict(_context())), encoding="utf-8")
+
+    exit_code = public_failure_main(
+        [
+            "--input",
+            str(input_path),
+            "--context",
+            str(context_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads((output_dir / "public-failure.json").read_text())["result"] == "failure"
+    assert "TRTMC Protected CI failure report" in (output_dir / "report.html").read_text()

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1841,6 +1841,17 @@ class TestUnitTiers:
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False
 
+    def test_public_failure_report_tool_triggers_tools_tier(self, imap):
+        """Protected-failure report edits run tools tests without model E2E."""
+        match = test_impact.classify_file(
+            "tools/public_failure/assets/public-failure-v1.schema.json", imap
+        )
+
+        assert match.rule == "public_failure_report_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
     @pytest.mark.parametrize(
         "path",
         [

--- a/tools/public_failure/README.md
+++ b/tools/public_failure/README.md
@@ -1,0 +1,42 @@
+# Protected CI failure report prototype
+
+This package builds a local preview of the limited information that protected
+CI may disclose after a failed run. It is a P0/shadow implementation: no Source
+workflow imports it, and it has no storage, GitHub status, or PR comment client.
+
+The pipeline is deterministic:
+
+1. `export_failure` constructs a new object from explicitly approved fields.
+2. `validate_public_failure` enforces the closed `public-failure-v1` contract.
+3. `render_failure_report` produces one script-free, self-contained HTML file.
+4. `assert_public_payload_safe` scans the JSON and decoded HTML as a final
+   defense-in-depth check.
+
+Unknown input fields are ignored. Unknown names and unsafe test IDs become
+fixed placeholders. Raw logs, commands, stack traces, environment data, paths,
+URLs, and arbitrary messages are not part of the contract.
+
+## Local preview
+
+Generate the synthetic review sample:
+
+```bash
+python3 -m tools.public_failure \
+  --input tests/tools/fixtures/public_failure/internal-failure.json \
+  --context tests/tools/fixtures/public_failure/context.json \
+  --output-dir /tmp/trtmc-public-failure-preview
+```
+
+The command writes `public-failure.json` and `report.html` only to the selected
+local directory. It does not publish either file.
+
+The synthetic input intentionally contains fake internal-looking values. The
+tests prove that adding those unknown fields does not change the serialized
+public output.
+
+## Integration boundary
+
+A future private-CI finalizer may call `build_failure_artifacts` from a pinned,
+merged Source revision. Upload, anonymous verification, stale-SHA checks,
+required-status updates, and failure-comment upsert belong to that private
+integration and are deliberately absent here.

--- a/tools/public_failure/__init__.py
+++ b/tools/public_failure/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a minimal public failure report from protected CI artifacts."""
+
+from .build import PublicFailureArtifacts, build_failure_artifacts
+from .contract import PublicFailureValidationError
+from .export import ExportContext
+from .safety import PublicFailureSafetyError
+
+__all__ = [
+    "ExportContext",
+    "PublicFailureArtifacts",
+    "PublicFailureSafetyError",
+    "PublicFailureValidationError",
+    "build_failure_artifacts",
+]

--- a/tools/public_failure/__main__.py
+++ b/tools/public_failure/__main__.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate a local-only protected CI failure preview."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from .build import build_failure_artifacts
+from .export import ExportContext
+
+
+def _load_object(path: Path) -> Mapping[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def _context_from_object(value: Mapping[str, object]) -> ExportContext:
+    return ExportContext(
+        repository=value.get("repository"),
+        pr_number=value.get("pr_number"),
+        head_sha=value.get("head_sha"),
+        base_sha=value.get("base_sha"),
+        tested_revision=value.get("tested_revision"),
+        run_attempt=value.get("run_attempt"),
+        result=value.get("result"),
+        generated_at=value.get("generated_at"),
+        tested_revision_kind=value.get("tested_revision_kind", "head"),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate local public-failure-v1 JSON and HTML. Nothing is uploaded."
+    )
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--context", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    internal = _load_object(args.input)
+    context = _context_from_object(_load_object(args.context))
+    artifacts = build_failure_artifacts(internal, context)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "public-failure.json").write_bytes(artifacts.json_bytes)
+    (args.output_dir / "report.html").write_bytes(artifacts.html_bytes)
+    print(f"Local preview written to {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/public_failure/assets/public-failure-v1.schema.json
+++ b/tools/public_failure/assets/public-failure-v1.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/NVIDIA/TensorRT-Model-Connect/schemas/public-failure-v1.json",
+  "title": "TRTMC public failure report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_version",
+    "report_id",
+    "repository",
+    "pr_number",
+    "head_sha",
+    "base_sha",
+    "tested_revision",
+    "tested_revision_kind",
+    "run_attempt",
+    "result",
+    "failures",
+    "omitted_failure_count",
+    "generated_at"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "policy_version": { "const": "2026-08-26" },
+    "report_id": {
+      "type": "string",
+      "maxLength": 100,
+      "pattern": "^trtmc-pr[1-9][0-9]*-[0-9a-f]{7}-attempt[1-9][0-9]*$"
+    },
+    "repository": { "const": "NVIDIA/TensorRT-Model-Connect" },
+    "pr_number": { "type": "integer", "minimum": 1, "maximum": 2147483647 },
+    "head_sha": { "$ref": "#/$defs/sha" },
+    "base_sha": { "$ref": "#/$defs/sha" },
+    "tested_revision": { "$ref": "#/$defs/sha" },
+    "tested_revision_kind": { "const": "head" },
+    "run_attempt": { "type": "integer", "minimum": 1, "maximum": 1000 },
+    "result": { "enum": ["failure", "error"] },
+    "failures": {
+      "type": "array",
+      "maxItems": 20,
+      "items": { "$ref": "#/$defs/failure" }
+    },
+    "omitted_failure_count": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "generated_at": {
+      "type": "string",
+      "maxLength": 20,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    }
+  },
+  "$defs": {
+    "sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "observed", "operator", "threshold"],
+      "properties": {
+        "name": {
+          "enum": [
+            "max_absolute_error",
+            "max_relative_l2",
+            "mean_relative_l2",
+            "prediction_agreement_rate",
+            "sample_agreement_rate"
+          ]
+        },
+        "observed": { "type": "number" },
+        "operator": { "enum": ["<", "<=", "==", ">=", ">"] },
+        "threshold": { "type": "number" }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "public_stage",
+        "model",
+        "backend",
+        "gpu_type",
+        "test_id",
+        "failure_class",
+        "reason_code",
+        "disclosure"
+      ],
+      "properties": {
+        "public_stage": {
+          "enum": [
+            "precheck",
+            "build",
+            "trt-run",
+            "reference-run",
+            "comparison",
+            "determinism",
+            "artifact-write",
+            "model-proof",
+            "protected-ci"
+          ]
+        },
+        "model": {
+          "enum": [
+            "chronos_bolt",
+            "codegen",
+            "llama",
+            "patchtsmixer",
+            "personaplex",
+            "sam3",
+            "segformer",
+            "other-model"
+          ]
+        },
+        "backend": { "enum": ["native", "tensorrt", "trtfb", "other-backend"] },
+        "gpu_type": {
+          "enum": ["A100", "H100", "H200", "L4", "GB200", "GB300", "protected-gpu"]
+        },
+        "test_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 300,
+          "pattern": "^[A-Za-z0-9_./:\\[\\],=+\\-]+$",
+          "not": { "pattern": "(^/|\\.\\.|\\\\)" }
+        },
+        "failure_class": {
+          "enum": [
+            "accuracy_regression",
+            "determinism_failure",
+            "build_error",
+            "runtime_error",
+            "reference_error",
+            "harness_error",
+            "infrastructure_error",
+            "timeout",
+            "out_of_memory",
+            "unknown"
+          ]
+        },
+        "reason_code": {
+          "enum": [
+            "artifact_write_failed",
+            "build_failed",
+            "determinism_check_failed",
+            "infrastructure_failed",
+            "metric_threshold_exceeded",
+            "out_of_memory",
+            "reference_failed",
+            "runtime_failed",
+            "timed_out",
+            "unknown"
+          ]
+        },
+        "metric": { "$ref": "#/$defs/metric" },
+        "disclosure": { "enum": ["full", "truncated", "withheld"] }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "disclosure": { "const": "full" } },
+            "required": ["disclosure"]
+          },
+          "then": { "required": ["metric"] }
+        }
+      ]
+    }
+  }
+}

--- a/tools/public_failure/build.py
+++ b/tools/public_failure/build.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One safe entry point for building local public failure artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .contract import serialize_public_failure, validate_public_failure
+from .export import ExportContext, export_failure
+from .render import render_failure_report
+from .safety import assert_public_payload_safe
+
+
+@dataclass(frozen=True)
+class PublicFailureArtifacts:
+    """Validated report data and deterministic serialized representations."""
+
+    report: dict[str, Any]
+    json_bytes: bytes
+    html_bytes: bytes
+
+
+def build_failure_artifacts(
+    internal_artifacts: Mapping[str, object], context: ExportContext
+) -> PublicFailureArtifacts:
+    """Export, validate, render, and poison-scan one protected CI failure."""
+    report = export_failure(internal_artifacts, context)
+    validate_public_failure(report)
+    json_bytes = serialize_public_failure(report)
+    html_bytes = render_failure_report(report)
+    assert_public_payload_safe(report, html_bytes)
+    return PublicFailureArtifacts(
+        report=report,
+        json_bytes=json_bytes,
+        html_bytes=html_bytes,
+    )

--- a/tools/public_failure/contract.py
+++ b/tools/public_failure/contract.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation and deterministic serialization for public-failure-v1."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import Collection, Mapping
+
+from .policy import (
+    FAILURE_CLASS_BY_INTERNAL_TYPE,
+    POLICY_VERSION,
+    PUBLIC_BACKENDS,
+    PUBLIC_GPU_TYPES,
+    PUBLIC_METRIC_NAMES,
+    PUBLIC_METRIC_OPERATORS,
+    PUBLIC_MODELS,
+    PUBLIC_REASON_CODES,
+    PUBLIC_STAGE_BY_INTERNAL_STAGE,
+)
+
+
+REPORT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "policy_version",
+        "report_id",
+        "repository",
+        "pr_number",
+        "head_sha",
+        "base_sha",
+        "tested_revision",
+        "tested_revision_kind",
+        "run_attempt",
+        "result",
+        "failures",
+        "omitted_failure_count",
+        "generated_at",
+    }
+)
+FAILURE_FIELDS = frozenset(
+    {
+        "public_stage",
+        "model",
+        "backend",
+        "gpu_type",
+        "test_id",
+        "failure_class",
+        "reason_code",
+        "metric",
+        "disclosure",
+    }
+)
+METRIC_FIELDS = frozenset({"name", "observed", "operator", "threshold"})
+FAILURE_REQUIRED_FIELDS = FAILURE_FIELDS - {"metric"}
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+REPORT_ID_PATTERN = re.compile(r"trtmc-pr[1-9][0-9]*-[0-9a-f]{7}-attempt[1-9][0-9]*\Z")
+TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\Z")
+TEST_ID_PATTERN = re.compile(r"[A-Za-z0-9_./:\[\],=+-]+\Z")
+PUBLIC_FAILURE_CLASSES = frozenset(FAILURE_CLASS_BY_INTERNAL_TYPE.values()) | {"unknown"}
+PUBLIC_STAGES = frozenset(PUBLIC_STAGE_BY_INTERNAL_STAGE.values()) | {"protected-ci"}
+PUBLIC_MODEL_NAMES = PUBLIC_MODELS | {"other-model"}
+PUBLIC_BACKEND_NAMES = PUBLIC_BACKENDS | {"other-backend"}
+PUBLIC_GPU_NAMES = PUBLIC_GPU_TYPES | {"protected-gpu"}
+
+
+class PublicFailureValidationError(ValueError):
+    """Raised when an object violates public-failure-v1."""
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, object], allowed: Collection[str], path: str
+) -> None:
+    unknown = sorted(set(value) - set(allowed))
+    if unknown:
+        raise PublicFailureValidationError(f"{path} has unknown fields: {unknown}")
+
+
+def _require_fields(value: Mapping[str, object], required: Collection[str], path: str) -> None:
+    missing = sorted(set(required) - set(value))
+    if missing:
+        raise PublicFailureValidationError(f"{path} is missing fields: {missing}")
+
+
+def _require_enum(value: object, allowed: Collection[str], path: str) -> None:
+    if not isinstance(value, str) or value not in allowed:
+        raise PublicFailureValidationError(f"{path} is not an approved value")
+
+
+def _require_string(
+    value: object, path: str, *, max_length: int, pattern: re.Pattern[str] | None = None
+) -> str:
+    if not isinstance(value, str) or not value or len(value) > max_length:
+        raise PublicFailureValidationError(f"{path} must be a bounded non-empty string")
+    if pattern is not None and pattern.fullmatch(value) is None:
+        raise PublicFailureValidationError(f"{path} has an invalid format")
+    return value
+
+
+def _require_integer(value: object, path: str, *, minimum: int, maximum: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum or value > maximum:
+        raise PublicFailureValidationError(f"{path} must be a bounded integer")
+
+
+def _validate_metric(metric: Mapping[str, object], path: str) -> None:
+    _reject_unknown_fields(metric, METRIC_FIELDS, path)
+    _require_fields(metric, METRIC_FIELDS, path)
+    _require_enum(metric.get("name"), PUBLIC_METRIC_NAMES, f"{path}.name")
+    _require_enum(metric.get("operator"), PUBLIC_METRIC_OPERATORS, f"{path}.operator")
+    for key in ("observed", "threshold"):
+        number = metric.get(key)
+        if (
+            isinstance(number, bool)
+            or not isinstance(number, (int, float))
+            or not math.isfinite(float(number))
+        ):
+            raise PublicFailureValidationError(f"{path}.{key} must be finite")
+
+
+def _validate_failure(failure: Mapping[str, object], index: int) -> None:
+    path = f"failures[{index}]"
+    _reject_unknown_fields(failure, FAILURE_FIELDS, path)
+    _require_fields(failure, FAILURE_REQUIRED_FIELDS, path)
+    _require_enum(failure.get("public_stage"), PUBLIC_STAGES, f"{path}.public_stage")
+    _require_enum(failure.get("model"), PUBLIC_MODEL_NAMES, f"{path}.model")
+    _require_enum(failure.get("backend"), PUBLIC_BACKEND_NAMES, f"{path}.backend")
+    _require_enum(failure.get("gpu_type"), PUBLIC_GPU_NAMES, f"{path}.gpu_type")
+    _require_enum(failure.get("failure_class"), PUBLIC_FAILURE_CLASSES, f"{path}.failure_class")
+    _require_enum(failure.get("reason_code"), PUBLIC_REASON_CODES, f"{path}.reason_code")
+    _require_enum(
+        failure.get("disclosure"),
+        {"full", "truncated", "withheld"},
+        f"{path}.disclosure",
+    )
+    test_id = _require_string(
+        failure.get("test_id"),
+        f"{path}.test_id",
+        max_length=300,
+        pattern=TEST_ID_PATTERN,
+    )
+    if test_id.startswith("/") or ".." in test_id or "\\" in test_id:
+        raise PublicFailureValidationError(f"{path}.test_id is not a safe relative test ID")
+    metric = failure.get("metric")
+    if metric is None:
+        if failure.get("disclosure") == "full":
+            raise PublicFailureValidationError(f"{path}.metric is required for full disclosure")
+        return
+    if not isinstance(metric, Mapping):
+        raise PublicFailureValidationError(f"{path}.metric must be an object")
+    _validate_metric(metric, f"{path}.metric")
+
+
+def validate_public_failure(report: Mapping[str, object]) -> None:
+    """Reject values that do not satisfy public-failure-v1."""
+    if not isinstance(report, Mapping):
+        raise PublicFailureValidationError("report must be an object")
+    _reject_unknown_fields(report, REPORT_FIELDS, "report")
+    _require_fields(report, REPORT_FIELDS, "report")
+    if report.get("schema_version") != 1 or isinstance(report.get("schema_version"), bool):
+        raise PublicFailureValidationError("schema_version must be 1")
+    if report.get("policy_version") != POLICY_VERSION:
+        raise PublicFailureValidationError("policy_version is not supported")
+    if report.get("repository") != "NVIDIA/TensorRT-Model-Connect":
+        raise PublicFailureValidationError("repository is not supported")
+    _require_string(
+        report.get("report_id"),
+        "report_id",
+        max_length=100,
+        pattern=REPORT_ID_PATTERN,
+    )
+    _require_integer(report.get("pr_number"), "pr_number", minimum=1, maximum=2**31 - 1)
+    _require_integer(report.get("run_attempt"), "run_attempt", minimum=1, maximum=1000)
+    _require_integer(
+        report.get("omitted_failure_count"),
+        "omitted_failure_count",
+        minimum=0,
+        maximum=2**31 - 1,
+    )
+    for key in ("head_sha", "base_sha", "tested_revision"):
+        _require_string(report.get(key), key, max_length=40, pattern=SHA_PATTERN)
+    _require_enum(report.get("tested_revision_kind"), {"head"}, "tested_revision_kind")
+    _require_enum(report.get("result"), {"failure", "error"}, "result")
+    _require_string(
+        report.get("generated_at"),
+        "generated_at",
+        max_length=20,
+        pattern=TIMESTAMP_PATTERN,
+    )
+    failures = report.get("failures")
+    if not isinstance(failures, list) or len(failures) > 20:
+        raise PublicFailureValidationError("failures must be an array")
+    for index, failure in enumerate(failures):
+        if not isinstance(failure, Mapping):
+            raise PublicFailureValidationError(f"failures[{index}] must be an object")
+        _validate_failure(failure, index)
+
+
+def serialize_public_failure(report: Mapping[str, object]) -> bytes:
+    """Serialize a public report deterministically for audits and hashing."""
+    return (
+        json.dumps(report, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")

--- a/tools/public_failure/export.py
+++ b/tools/public_failure/export.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Explicit allowlist conversion from protected artifacts to public data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Any, Mapping
+
+from .policy import (
+    POLICY_VERSION,
+    PUBLIC_METRIC_NAMES,
+    PUBLIC_METRIC_OPERATORS,
+    public_backend,
+    public_failure_class,
+    public_gpu_type,
+    public_model,
+    public_reason_code,
+    public_stage,
+)
+
+
+MAX_PUBLIC_FAILURES = 20
+SAFE_TEST_ID_PATTERN = re.compile(r"[A-Za-z0-9_./:\[\],=+-]{1,300}\Z")
+
+
+@dataclass(frozen=True)
+class ExportContext:
+    """Trusted run identity supplied by the private CI finalizer."""
+
+    repository: str
+    pr_number: int
+    head_sha: str
+    base_sha: str
+    tested_revision: str
+    run_attempt: int
+    result: str
+    generated_at: str
+    tested_revision_kind: str = "head"
+
+
+def _export_metric(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    name = value.get("name")
+    operator = value.get("operator")
+    observed = value.get("observed")
+    threshold = value.get("threshold")
+    if name not in PUBLIC_METRIC_NAMES or operator not in PUBLIC_METRIC_OPERATORS:
+        return None
+    for number in (observed, threshold):
+        if (
+            isinstance(number, bool)
+            or not isinstance(number, (int, float))
+            or not math.isfinite(float(number))
+        ):
+            return None
+    return {
+        "name": name,
+        "observed": observed,
+        "operator": operator,
+        "threshold": threshold,
+    }
+
+
+def _export_test_id(value: object) -> str:
+    if not isinstance(value, str) or SAFE_TEST_ID_PATTERN.fullmatch(value) is None:
+        return "withheld"
+    if value.startswith("/") or ".." in value or "\\" in value:
+        return "withheld"
+    return value
+
+
+def _export_one_failure(value: Mapping[str, object]) -> dict[str, Any]:
+    metric = _export_metric(value.get("metric"))
+    public = {
+        "public_stage": public_stage(value.get("stage")),
+        "model": public_model(value.get("model")),
+        "backend": public_backend(value.get("backend")),
+        "gpu_type": public_gpu_type(value.get("gpu_type")),
+        "test_id": _export_test_id(value.get("test_id")),
+        "failure_class": public_failure_class(value.get("failure_type")),
+        "reason_code": public_reason_code(value.get("reason_code")),
+        "disclosure": "full" if metric is not None else "withheld",
+    }
+    if metric is not None:
+        public["metric"] = metric
+    return public
+
+
+def export_failure(
+    internal_artifacts: Mapping[str, object], context: ExportContext
+) -> dict[str, Any]:
+    """Return a new public object; never copy unknown internal fields."""
+    raw_failures = internal_artifacts.get("failures")
+    failures = raw_failures if isinstance(raw_failures, list) else []
+    approved_failures = [item for item in failures if isinstance(item, Mapping)]
+    visible_failures = approved_failures[:MAX_PUBLIC_FAILURES]
+    return {
+        "schema_version": 1,
+        "policy_version": POLICY_VERSION,
+        "report_id": (
+            f"trtmc-pr{context.pr_number}-{context.head_sha[:7]}-attempt{context.run_attempt}"
+        ),
+        "repository": context.repository,
+        "pr_number": context.pr_number,
+        "head_sha": context.head_sha,
+        "base_sha": context.base_sha,
+        "tested_revision": context.tested_revision,
+        "tested_revision_kind": context.tested_revision_kind,
+        "run_attempt": context.run_attempt,
+        "result": context.result,
+        "failures": [_export_one_failure(item) for item in visible_failures],
+        "omitted_failure_count": len(approved_failures) - len(visible_failures),
+        "generated_at": context.generated_at,
+    }

--- a/tools/public_failure/policy.py
+++ b/tools/public_failure/policy.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Closed public-name mappings for protected CI failure reports."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+POLICY_VERSION: Final = "2026-08-26"
+
+FAILURE_CLASS_BY_INTERNAL_TYPE: Final = {
+    "compare_fail": "accuracy_regression",
+    "determinism_fail": "determinism_failure",
+    "build_fail": "build_error",
+    "trt_run_fail": "runtime_error",
+    "reference_run_fail": "reference_error",
+    "artifact_write_fail": "harness_error",
+    "infrastructure_error": "infrastructure_error",
+    "timeout": "timeout",
+    "out_of_memory": "out_of_memory",
+}
+
+PUBLIC_STAGE_BY_INTERNAL_STAGE: Final = {
+    "precheck": "precheck",
+    "build": "build",
+    "trt_run": "trt-run",
+    "reference_run": "reference-run",
+    "compare": "comparison",
+    "determinism": "determinism",
+    "artifact_write": "artifact-write",
+    "model-proof": "model-proof",
+}
+
+# This intentionally starts small. Adding a value is a disclosure-policy change.
+PUBLIC_MODELS: Final = frozenset(
+    {
+        "chronos_bolt",
+        "codegen",
+        "llama",
+        "patchtsmixer",
+        "personaplex",
+        "sam3",
+        "segformer",
+    }
+)
+PUBLIC_BACKENDS: Final = frozenset({"native", "tensorrt", "trtfb"})
+PUBLIC_GPU_TYPES: Final = frozenset({"A100", "H100", "H200", "L4", "GB200", "GB300"})
+
+PUBLIC_REASON_CODES: Final = frozenset(
+    {
+        "artifact_write_failed",
+        "build_failed",
+        "determinism_check_failed",
+        "infrastructure_failed",
+        "metric_threshold_exceeded",
+        "out_of_memory",
+        "reference_failed",
+        "runtime_failed",
+        "timed_out",
+        "unknown",
+    }
+)
+
+PUBLIC_METRIC_NAMES: Final = frozenset(
+    {
+        "max_absolute_error",
+        "max_relative_l2",
+        "mean_relative_l2",
+        "prediction_agreement_rate",
+        "sample_agreement_rate",
+    }
+)
+PUBLIC_METRIC_OPERATORS: Final = frozenset({"<", "<=", "==", ">=", ">"})
+
+
+def public_failure_class(value: object) -> str:
+    return FAILURE_CLASS_BY_INTERNAL_TYPE.get(str(value), "unknown")
+
+
+def public_stage(value: object) -> str:
+    return PUBLIC_STAGE_BY_INTERNAL_STAGE.get(str(value), "protected-ci")
+
+
+def public_model(value: object) -> str:
+    candidate = str(value)
+    return candidate if candidate in PUBLIC_MODELS else "other-model"
+
+
+def public_backend(value: object) -> str:
+    candidate = str(value)
+    return candidate if candidate in PUBLIC_BACKENDS else "other-backend"
+
+
+def public_gpu_type(value: object) -> str:
+    candidate = str(value)
+    return candidate if candidate in PUBLIC_GPU_TYPES else "protected-gpu"
+
+
+def public_reason_code(value: object) -> str:
+    candidate = str(value)
+    return candidate if candidate in PUBLIC_REASON_CODES else "unknown"

--- a/tools/public_failure/render.py
+++ b/tools/public_failure/render.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render validated public-failure-v1 data as one self-contained HTML file."""
+
+from __future__ import annotations
+
+import html
+from typing import Mapping
+
+from .contract import validate_public_failure
+
+
+STYLES = """
+:root { color-scheme: light; font-family: Arial, Helvetica, sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; color: #202020; background: #fff; font-size: 14px; line-height: 1.45; }
+main { width: min(1120px, calc(100% - 40px)); margin: 0 auto; padding: 32px 0; }
+.report-header { padding: 18px 0 16px; border-top: 5px solid #c62828;
+  border-bottom: 1px solid #8c8c8c; }
+.product { margin: 0 0 7px; color: #555; font-size: 12px; font-weight: 700;
+  letter-spacing: .06em; text-transform: uppercase; }
+.title-row { display: flex; gap: 18px; align-items: center; justify-content: space-between; }
+h1 { margin: 0; font-size: 27px; font-weight: 600; line-height: 1.2; }
+.status { display: inline-block; padding: 5px 10px; border: 1px solid #9f1f1f;
+  color: #8f1818; background: #fff; font-size: 12px; font-weight: 700;
+  letter-spacing: .06em; }
+.notice { margin: 18px 0; padding: 10px 12px; border-left: 3px solid #686868;
+  color: #4d4d4d; background: #f5f5f5; }
+h2 { margin: 26px 0 8px; font-size: 17px; font-weight: 600; }
+table { width: 100%; border-collapse: collapse; }
+.run-meta { border-top: 1px solid #b4b4b4; }
+.run-meta th, .run-meta td { padding: 8px 10px; border-bottom: 1px solid #d4d4d4;
+  text-align: left; vertical-align: top; }
+.run-meta th { width: 180px; color: #4b4b4b; background: #f3f3f3; font-weight: 600; }
+.table-wrap { width: 100%; overflow-x: auto; border-top: 2px solid #555; }
+.failure-table { min-width: 900px; }
+.failure-table th, .failure-table td { padding: 9px 10px; border-right: 1px solid #d4d4d4;
+  border-bottom: 1px solid #bdbdbd; text-align: left; vertical-align: top; }
+.failure-table th:last-child, .failure-table td:last-child { border-right: 0; }
+.failure-table th { color: #333; background: #ededed; font-size: 12px; font-weight: 700; }
+.failure-table tbody tr:nth-child(even) { background: #fafafa; }
+.failure-index { width: 44px; text-align: center !important; }
+.classification { width: 185px; }
+.location { width: 175px; }
+.test-id { min-width: 270px; overflow-wrap: anywhere; }
+.evidence { min-width: 220px; }
+.secondary { display: block; margin-top: 3px; color: #5f5f5f; font-size: 12px; }
+.withheld { color: #5f5f5f; font-style: italic; }
+.omitted { margin: 9px 0 0; color: #555; }
+footer { margin-top: 28px; padding-top: 10px; border-top: 1px solid #aaa;
+  color: #555; font-size: 12px; }
+code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+@media (max-width: 600px) {
+  main { width: min(100% - 24px, 1120px); padding-top: 18px; }
+  .title-row { display: block; }
+  .status { margin-top: 12px; }
+  .run-meta th { width: 120px; }
+}
+""".strip()
+
+
+def _escape(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _format_number(value: object) -> str:
+    return format(float(value), ".8g")
+
+
+def _failure_row(failure: Mapping[str, object], index: int) -> str:
+    metric = failure.get("metric")
+    if isinstance(metric, Mapping):
+        evidence = (
+            f"<code>{_escape(metric['name'])}</code>"
+            f'<span class="secondary">Observed: {_format_number(metric["observed"])}; '
+            f"Requirement: {_escape(metric['operator'])} "
+            f"{_format_number(metric['threshold'])}</span>"
+        )
+    else:
+        evidence = '<span class="withheld">Details withheld</span>'
+    return (
+        "<tr>"
+        f'<td class="failure-index">{index}</td>'
+        '<td class="classification">'
+        f"<strong>{_escape(failure['failure_class'])}</strong>"
+        f'<span class="secondary">{_escape(failure["reason_code"])}</span></td>'
+        '<td class="location">'
+        f"{_escape(failure['public_stage'])}"
+        f'<span class="secondary">{_escape(failure["model"])} · '
+        f"{_escape(failure['backend'])} · {_escape(failure['gpu_type'])}</span></td>"
+        f'<td class="test-id"><code>{_escape(failure["test_id"])}</code></td>'
+        f'<td class="evidence">{evidence}</td>'
+        "</tr>"
+    )
+
+
+def render_failure_report(report: Mapping[str, object]) -> bytes:
+    """Validate and render one deterministic, script-free HTML document."""
+    validate_public_failure(report)
+    failures = report["failures"]
+    rows = "".join(_failure_row(failure, index) for index, failure in enumerate(failures, start=1))
+    if not rows:
+        rows = (
+            '<tr><td colspan="5" class="withheld">No structured failure details were '
+            "safe to disclose.</td></tr>"
+        )
+    omitted = int(report["omitted_failure_count"])
+    omitted_note = (
+        f'<p class="omitted">{omitted} additional failure(s) were omitted.</p>' if omitted else ""
+    )
+    status = "FAILED" if report["result"] == "failure" else "ERROR"
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; script-src 'none'; connect-src 'none'; font-src 'none'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'">
+  <title>TRTMC Protected CI failure</title>
+  <style>{STYLES}</style>
+</head>
+<body>
+<main>
+  <header class="report-header">
+    <p class="product">TensorRT Model Connect / Protected CI</p>
+    <div class="title-row">
+      <h1>TRTMC Protected CI failure report</h1>
+      <span class="status">{status}</span>
+    </div>
+  </header>
+  <p class="notice">This report contains only approved structured fields. Raw logs and internal diagnostics are not included.</p>
+  <h2>Run identification</h2>
+  <table class="run-meta">
+    <tbody>
+      <tr><th scope="row">Repository</th><td>{_escape(report["repository"])}</td></tr>
+      <tr><th scope="row">Pull request</th><td>#{_escape(report["pr_number"])}</td></tr>
+      <tr><th scope="row">Head commit</th><td><code>{_escape(report["head_sha"])}</code></td></tr>
+      <tr><th scope="row">Tested revision</th><td><code>{_escape(report["tested_revision"])}</code> ({_escape(report["tested_revision_kind"])})</td></tr>
+      <tr><th scope="row">Run attempt</th><td>{_escape(report["run_attempt"])}</td></tr>
+      <tr><th scope="row">Generated at</th><td>{_escape(report["generated_at"])}</td></tr>
+      <tr><th scope="row">Disclosure policy</th><td>{_escape(report["policy_version"])}</td></tr>
+    </tbody>
+  </table>
+  <h2>Failure summary</h2>
+  <div class="table-wrap">
+    <table class="failure-table">
+      <thead><tr><th class="failure-index">#</th><th>Classification</th><th>Location</th><th>Test</th><th>Evidence</th></tr></thead>
+      <tbody>{rows}</tbody>
+    </table>
+  </div>
+  {omitted_note}
+  <footer>Report ID: <code>{_escape(report["report_id"])}</code></footer>
+</main>
+</body>
+</html>
+"""
+    return document.encode("utf-8")

--- a/tools/public_failure/safety.py
+++ b/tools/public_failure/safety.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Defense-in-depth scans for data that a public report must never contain."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Mapping
+
+from .contract import serialize_public_failure
+
+
+class PublicFailureSafetyError(ValueError):
+    """Raised when an otherwise valid payload resembles protected data."""
+
+
+SENSITIVE_PATTERNS = (
+    (
+        "credential-like token",
+        re.compile(
+            r"(?<![A-Za-z0-9])(?:gh[pousr]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,}|"
+            r"glpat-[A-Za-z0-9_-]{12,}|sk-[A-Za-z0-9_-]{16,})"
+        ),
+    ),
+    ("authorization header", re.compile(r"\b(?:authorization|bearer)\s*[: ]", re.I)),
+    ("private key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("JWT", re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")),
+    ("email address", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
+    ("URL", re.compile(r"\bhttps?://", re.I)),
+    ("internal hostname", re.compile(r"\b[A-Za-z0-9.-]+\.(?:internal|nvidia\.com)\b", re.I)),
+    ("IP address", re.compile(r"(?<![0-9])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9])")),
+    ("internal filesystem path", re.compile(r"/(?:home|workspace|mnt|var|tmp|builds|opt)/")),
+    ("internal CI name", re.compile(r"\b(?:jenkins|slurm)\b", re.I)),
+    ("long base64-like value", re.compile(r"\b[A-Za-z0-9+/]{80,}={0,2}\b")),
+)
+
+
+def assert_public_payload_safe(report: Mapping[str, object], document: bytes) -> None:
+    """Scan canonical JSON and decoded HTML without echoing a matched secret."""
+    candidates = (
+        serialize_public_failure(report).decode("utf-8"),
+        html.unescape(document.decode("utf-8")),
+    )
+    for candidate in candidates:
+        for label, pattern in SENSITIVE_PATTERNS:
+            if pattern.search(candidate):
+                raise PublicFailureSafetyError(f"public failure payload contains a {label}")

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1942,6 +1942,17 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             ),
         ),
         ClassificationRule(
+            priority=481,
+            name="public_failure_report_tool",
+            matcher=_path_startswith("tools/public_failure/"),
+            resolver=_match_result(
+                "public_failure_report_tool", _no_models, ["tools"], False
+            ),
+            covered_by=(
+                "TestUnitTiers.test_public_failure_report_tool_triggers_tools_tier",
+            ),
+        ),
+        ClassificationRule(
             priority=485,
             name="model_ci_tool",
             matcher=_path_equals("tools/model_ci.py"),

--- a/website/docs/reference/testing.md
+++ b/website/docs/reference/testing.md
@@ -23,6 +23,28 @@ Source has no separate pull-request documentation-validation workflow. The
 Pages workflow builds the site before deployment from `main`, but it is not a
 pull-request documentation gate.
 
+### Local protected-failure report prototype
+
+`tools/public_failure/` contains a local-only P0 implementation for reviewing a
+possible sanitized protected-CI failure report. It rebuilds a new object from a
+closed allowlist, validates `public-failure-v1`, renders a deterministic
+script-free HTML file, and scans the JSON and HTML for sensitive-looking data.
+
+Generate the synthetic preview locally:
+
+```bash
+python3 -m tools.public_failure \
+  --input tests/tools/fixtures/public_failure/internal-failure.json \
+  --context tests/tools/fixtures/public_failure/context.json \
+  --output-dir /tmp/trtmc-public-failure-preview
+```
+
+This command only writes files under the selected local directory. No Source
+workflow calls it, and it cannot upload a report, update a GitHub status, or
+write a PR comment. Its presence is not evidence that protected failure details
+are currently public. Raw logs and arbitrary diagnostic text remain outside the
+public contract.
+
 ## Local documentation validation
 
 Use the checks that are present on this snapshot. The following is a


### PR DESCRIPTION
## Background

Protected CI currently exposes only the exact-head status; raw artifacts remain private. This draft introduces a reviewable P0 implementation for producing a minimal sanitized failure report without enabling publication.

## Exit Criteria

- Build `public-failure-v1` only from approved structured fields.
- Reject unknown public fields and invalid values, while ensuring unknown internal fields cannot change public output bytes.
- Render deterministic, self-contained, script-free HTML.
- Keep upload, status/comment writes, and private finalizer integration out of scope.

## Implementation

- Add the `tools.public_failure` pipeline: allowlist export, closed-schema validation, deterministic JSON/HTML rendering, poison scanning, and a local CLI.
- Add synthetic fixtures containing internal-looking fields and tests proving those fields cannot affect public output bytes.
- Route relevant changes to the tools test suite and document the local-only boundary.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public Python API
- [ ] C++ or CUDA code
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

The dependency change adds `jsonschema>=4.23,<5` to test extras only.

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_public_failure.py tests/tools/test_test_impact.py tests/tools/test_community_ci.py`
  - Result: `314 passed`.
- `python3 -m ruff check --config ruff.toml tools/public_failure tools/test_impact.py tests/tools/test_public_failure.py tests/tools/test_test_impact.py`
  - Result: passed.
- `python3 tools/check_doc_file_references.py --strict website/docs/reference`
  - Result: passed with 0 errors and 0 stale warnings.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`
  - Result: validation passed; existing broad-fallback and core-strategy warnings were emitted.
- `python3 tools/legal_headers.py --check --verbose`
  - Result: passed with 0 findings.
- `git diff --check`
  - Result: passed.
- `python3 -m tools.public_failure --input tests/tools/fixtures/public_failure/internal-failure.json --context tests/tools/fixtures/public_failure/context.json --output-dir <local-preview-directory>`
  - Result: generated the local JSON and HTML preview; sensitive fixture markers were absent from both outputs.

### Hardware, Environment, and Revisions

- Validated commit: `86afc905aefcba00bde899eab77c553d24f67fa7`.
- This is host-only Python/CPU report tooling; no GPU, TensorRT, or model execution is required.

### Not Run / Remaining Gaps

- GitHub CI and protected premerge have not run yet.
- Private finalizer integration, upload, anonymous-fetch verification, and status/comment paths are absent by design and therefore were not tested.

## Notes For Future Readers

- Suggested review order: README, schema and policy, exporter and contract, renderer and safety checks, then tests.
- This draft does not publish reports and does not modify CI workflows.
- A future private-CI integration must separately pin the merged revision, reject stale SHAs, verify uploaded bytes, and expose only failure results.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The disclosure boundary is security-sensitive, but this implementation is disabled outside explicit local invocation and has no workflow integration.
