### PR TITLE
feat(voicechat): add full-duplex microphone example

### DIFF
--- a/examples/models/nemotron_voicechat/full_duplex/CMakeLists.txt
+++ b/examples/models/nemotron_voicechat/full_duplex/CMakeLists.txt
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+project(trtmc_voicechat_full_duplex_example LANGUAGES CXX)
+
+get_filename_component(_trtmc_default_source_dir "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+set(TRTMC_SOURCE_DIR "${_trtmc_default_source_dir}" CACHE PATH
+    "TensorRT-Model-Connect source directory")
+if(NOT EXISTS "${TRTMC_SOURCE_DIR}/include/trtmc/speech_session.h")
+  message(FATAL_ERROR "TRTMC_SOURCE_DIR is not a TensorRT-Model-Connect source tree")
+endif()
+
+# Keep this example build focused on the runtime, the VoiceChat DSO, and this
+# executable. The Docker build selects the concrete targets it needs.
+set(TRTMC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL OFF CACHE BOOL "" FORCE)
+set(TRTMC_ENABLE_TVM_FFI OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_BACKEND_RTX OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_DIFFUSION_KERNELS OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_BACKEND_TRT ON CACHE BOOL "" FORCE)
+
+find_package(ALSA REQUIRED)
+find_package(Threads REQUIRED)
+
+add_subdirectory("${TRTMC_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/trtmc")
+
+add_executable(trtmc_voicechat_full_duplex main.cpp)
+target_compile_features(trtmc_voicechat_full_duplex PRIVATE cxx_std_17)
+target_compile_options(trtmc_voicechat_full_duplex PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(trtmc_voicechat_full_duplex PRIVATE
+  trtmc_core
+  ALSA::ALSA
+  Threads::Threads
+)
+set_target_properties(trtmc_voicechat_full_duplex PROPERTIES
+  BUILD_RPATH "\$ORIGIN"
+  BUILD_RPATH_USE_ORIGIN TRUE
+)
+
+option(TRTMC_VOICECHAT_BUILD_QUEUE_TEST "Build the device-free playback queue test" ON)
+if(TRTMC_VOICECHAT_BUILD_QUEUE_TEST)
+  enable_testing()
+  add_executable(test_trtmc_voicechat_playback_queue test_playback_queue.cpp)
+  target_compile_features(test_trtmc_voicechat_playback_queue PRIVATE cxx_std_17)
+  target_compile_options(test_trtmc_voicechat_playback_queue PRIVATE -Wall -Wextra -Wpedantic)
+  target_link_libraries(test_trtmc_voicechat_playback_queue PRIVATE Threads::Threads)
+  add_test(NAME trtmc_voicechat_playback_queue COMMAND test_trtmc_voicechat_playback_queue)
+endif()

--- a/examples/models/nemotron_voicechat/full_duplex/Dockerfile
+++ b/examples/models/nemotron_voicechat/full_duplex/Dockerfile
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This digest is the repository-pinned aarch64 TensorRT 11.1 development image.
+# The README gives the matching pinned x86_64 override.
+ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt:26.07-py3@sha256:f794a79e8b996d16dbc2e5884e19d8e2269a51c960106c9b49b0061a6926c541
+
+FROM ${TENSORRT_IMAGE} AS builder
+
+ARG TRTMC_CUDA_ARCHITECTURES=103-real
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      libasound2-dev \
+      ninja-build \
+      nlohmann-json3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# Dockerfile.dockerignore projects the native source tree while excluding every
+# other model family. TRTMC_MODEL_PROOF_MODEL makes that model isolation a
+# configure-time invariant instead of relying on the build target alone.
+RUN cmake \
+      -S /src/examples/models/nemotron_voicechat/full_duplex \
+      -B /build \
+      -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES="${TRTMC_CUDA_ARCHITECTURES}" \
+      -DTRTMC_BUILD_BACKEND_TRT=ON \
+      -DTRTMC_BUILD_BACKEND_RTX=OFF \
+      -DTRTMC_BUILD_TESTS=OFF \
+      -DTRTMC_BUILD_BENCHMARKS=OFF \
+      -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF \
+      -DTRTMC_ENABLE_TVM_FFI=OFF \
+      -DTRTMC_BUILD_DIFFUSION_KERNELS=OFF \
+      -DTRTMC_DISTRIBUTABLE_BUILD=ON \
+      -DTRTMC_MODEL_PROOF_MODEL=nemotron_voicechat && \
+    cmake --build /build --parallel --target \
+      trtmc_voicechat_full_duplex \
+      test_trtmc_voicechat_playback_queue \
+      trtmc_backend_trt \
+      trtmc_model_nemotron_voicechat && \
+    ctest --test-dir /build --output-on-failure \
+      --tests-regex '^trtmc_voicechat_playback_queue$' && \
+    /build/trtmc_voicechat_full_duplex --help >/dev/null
+
+FROM ${TENSORRT_IMAGE} AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libasound2-data \
+      libasound2t64 && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /opt/trtmc/bin /opt/trtmc/licenses
+
+# The repository-wide install target includes every model DSO. Stage only the
+# application and the three native runtime layers this example actually uses.
+COPY --from=builder /build/trtmc_voicechat_full_duplex /opt/trtmc/bin/
+COPY --from=builder /build/trtmc/libtrtmc_core.so /opt/trtmc/bin/
+COPY --from=builder /build/libtrtmc_backend_trt.so /opt/trtmc/bin/
+COPY --from=builder /build/libtrtmc_backend_trt_11_1.so /opt/trtmc/bin/
+COPY --from=builder /build/models/nemotron_voicechat/libtrtmc_model_nemotron_voicechat.so /opt/trtmc/bin/
+COPY --from=builder /src/LICENSE /src/NOTICE /opt/trtmc/licenses/
+
+ENV PATH="/opt/trtmc/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/trtmc/bin:${LD_LIBRARY_PATH}" \
+    TRTMC_MODEL_PLUGIN_DIR=/opt/trtmc/bin \
+    TRTMC_MODEL_PLUGIN_STRICT=1
+
+ARG TRTMC_SOURCE_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/TensorRT-Model-Connect" \
+      org.opencontainers.image.revision="${TRTMC_SOURCE_REVISION}"
+
+WORKDIR /models
+
+ENTRYPOINT ["/opt/trtmc/bin/trtmc_voicechat_full_duplex"]
+CMD ["/models/model.bundle"]

--- a/examples/models/nemotron_voicechat/full_duplex/Dockerfile.dockerignore
+++ b/examples/models/nemotron_voicechat/full_duplex/Dockerfile.dockerignore
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Start empty. The application image needs native runtime sources only; model
+# checkpoints, bundles, caches, Python builders, tests, and repository metadata
+# must not enter the Docker build context.
+*
+
+!CMakeLists.txt
+!LICENSE
+!NOTICE
+
+!cmake/
+!cmake/**
+
+!include/
+!include/**
+
+!src/
+!src/**
+src/runtime/models/**
+!src/runtime/models/nemotron_voicechat/
+!src/runtime/models/nemotron_voicechat/**
+
+!third_party/
+third_party/**
+!third_party/stb/
+!third_party/stb/**
+
+# Runtime manifests validate their declared C++ test source paths during CMake
+# configuration even when test targets are disabled.
+!tests/
+tests/**
+!tests/cpp/
+tests/cpp/**
+!tests/cpp/models/
+tests/cpp/models/**
+!tests/cpp/models/nemotron_voicechat/
+!tests/cpp/models/nemotron_voicechat/**
+
+!examples/
+examples/**
+!examples/models/
+!examples/models/nemotron_voicechat/
+!examples/models/nemotron_voicechat/full_duplex/
+!examples/models/nemotron_voicechat/full_duplex/**
+
+# Guard against basename negations above matching similarly named directories
+# below unrelated source trees.
+python/**
+website/**

--- a/examples/models/nemotron_voicechat/full_duplex/README.md
+++ b/examples/models/nemotron_voicechat/full_duplex/README.md
@@ -1,0 +1,139 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Nemotron VoiceChat full-duplex microphone example
+
+This example runs one local, in-process `ISpeechSession`. It continuously
+captures a Linux ALSA microphone while playing the agent's audio, so a user can
+interrupt the agent without waiting for playback to finish. It does not start a
+server, open a network port, or use WebSocket or Python at runtime.
+
+On top of the repository-pinned TensorRT base, the application layer adds only
+the example executable, `trtmc_core`, the TensorRT backend, the Nemotron
+VoiceChat model DSO, and ALSA runtime packages. It does not contain the
+checkpoint or a bundle.
+
+## Requirements
+
+- Linux with a current Docker Engine using BuildKit, NVIDIA Container Toolkit,
+  and a compatible NVIDIA driver;
+- a local ALSA capture and playback device under `/dev/snd`;
+- one GPU with enough memory for the bundle (the repository qualification uses
+  at least 90,000 MiB of free GPU memory); and
+- a prebuilt `nemotron_voicechat` bundle for the same GPU architecture and
+  TensorRT 11.1 runtime used by this image.
+
+The qualified FP32 VoiceChat bundle is about 46.5 GB. Keep it outside the image
+and mount it read-only at runtime.
+
+## Build the image once
+
+Run the build from the repository root. The default Docker base and CUDA target
+are the repository-pinned aarch64 TensorRT 26.07 image and GB300 SM 10.3:
+
+```bash
+VOICECHAT_SOURCE_REVISION="$(git rev-parse HEAD)"
+
+docker build \
+  --platform linux/arm64 \
+  --file examples/models/nemotron_voicechat/full_duplex/Dockerfile \
+  --build-arg TRTMC_SOURCE_REVISION="${VOICECHAT_SOURCE_REVISION}" \
+  --tag trtmc-voicechat-full-duplex:local \
+  .
+```
+
+The Dockerfile uses its adjacent `Dockerfile.dockerignore` to project the
+native source tree while excluding every other model family. Docker's retired
+legacy builder does not support Dockerfile-specific ignore files; enable
+BuildKit or use a current Docker release.
+
+For a native x86_64 build, override both the pinned architecture-specific base
+digest and the CUDA architecture. Derive the latter from the GPU that the
+bundle targets; this example shows a B200 (`sm_100`):
+
+```bash
+VOICECHAT_SOURCE_REVISION="$(git rev-parse HEAD)"
+
+docker build \
+  --platform linux/amd64 \
+  --file examples/models/nemotron_voicechat/full_duplex/Dockerfile \
+  --build-arg TENSORRT_IMAGE='nvcr.io/nvidia/tensorrt:26.07-py3@sha256:b82db1abc23750ab0069abc99bbe4ea29138dbdc23ea39861199e2346638b48a' \
+  --build-arg TRTMC_CUDA_ARCHITECTURES=100-real \
+  --build-arg TRTMC_SOURCE_REVISION="${VOICECHAT_SOURCE_REVISION}" \
+  --tag trtmc-voicechat-full-duplex:local \
+  .
+```
+
+Build natively for the host architecture. Changing the application image's
+CUDA architecture does not make an existing TensorRT bundle portable: rebuild
+the bundle for the target GPU as well.
+
+## Start a conversation
+
+After the one-time image build, each conversation starts with one `docker run`:
+
+```bash
+VOICECHAT_BUNDLE="$(realpath nemotron-voicechat-11b.bundle)"
+
+docker run --rm --interactive --tty \
+  --network none \
+  --gpus 'device=0' \
+  --device /dev/snd:/dev/snd \
+  --mount "type=bind,src=${VOICECHAT_BUNDLE},dst=/models/model.bundle,readonly" \
+  trtmc-voicechat-full-duplex:local
+```
+
+The image's default command opens `/models/model.bundle`, the ALSA `default`
+capture device, and the ALSA `default` playback device. Press Ctrl-C to stop.
+No `--privileged`, host IPC, network access, checkpoint mount, or credentials
+are required.
+
+List ALSA devices without loading a bundle:
+
+```bash
+docker run --rm --interactive --tty \
+  --network none \
+  --device /dev/snd:/dev/snd \
+  trtmc-voicechat-full-duplex:local \
+  --list-devices
+```
+
+Select devices explicitly when `default` is not the desired hardware endpoint:
+
+```bash
+VOICECHAT_BUNDLE="$(realpath nemotron-voicechat-11b.bundle)"
+
+docker run --rm --interactive --tty \
+  --network none \
+  --gpus 'device=0' \
+  --device /dev/snd:/dev/snd \
+  --mount "type=bind,src=${VOICECHAT_BUNDLE},dst=/models/model.bundle,readonly" \
+  trtmc-voicechat-full-duplex:local \
+  --capture-device 'plughw:CARD=Headset,DEV=0' \
+  --playback-device 'plughw:CARD=Headset,DEV=0' \
+  /models/model.bundle
+```
+
+Run `docker run --rm trtmc-voicechat-full-duplex:local --help` for the complete
+CLI surface.
+
+## Audio and container boundaries
+
+- Use a headset or hardware acoustic echo cancellation. ALSA and this example
+  do not provide AEC; speaker output captured by the microphone can otherwise
+  look like a user interruption.
+- The minimal container contract passes physical ALSA devices directly through
+  `/dev/snd`. A desktop's PipeWire or PulseAudio `default` device is not
+  automatically forwarded into the container. Use an explicit `plughw` device,
+  or configure desktop audio socket forwarding separately.
+- The host audio device must support simultaneous capture and playback. USB
+  headsets are generally easier to isolate than a shared desktop sound card.
+- Docker Desktop on macOS or Windows, remote GPU machines without `/dev/snd`,
+  and rootless Docker configurations that cannot pass GPU/audio devices do not
+  satisfy this direct-device contract.
+- The runtime is deliberately offline. Build or obtain the model bundle before
+  starting the container; do not pass Hugging Face tokens or model credentials
+  to the application image.
+- A Dockerfile in the repository supports a one-time local image build followed
+  by one-command runs. A literal pull-and-run experience on a fresh machine
+  additionally requires publishing this image to a container registry.

--- a/examples/models/nemotron_voicechat/full_duplex/main.cpp
+++ b/examples/models/nemotron_voicechat/full_duplex/main.cpp
@@ -1,0 +1,607 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "playback_queue.h"
+#include "trtmc/speech_session.h"
+
+#include <algorithm>
+#include <alsa/asoundlib.h>
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using trtmc::SpeechSessionEvent;
+using trtmc::SpeechSessionEventKind;
+using trtmc::examples::voicechat::float_to_pcm16;
+using trtmc::examples::voicechat::pcm16_to_float;
+using trtmc::examples::voicechat::PlaybackQueue;
+using trtmc::examples::voicechat::PlaybackQueueItemKind;
+
+constexpr int kCaptureChunkMs = 20;
+constexpr int kCaptureWaitMs = 50;
+constexpr int kPlaybackQueueSeconds = 4;
+constexpr int kEventWaitMs = 50;
+
+volatile std::sig_atomic_t g_signal_requested = 0;
+
+void signal_handler(int) {
+    g_signal_requested = 1;
+}
+
+struct Options {
+    std::string bundle_path;
+    std::string capture_device{"default"};
+    std::string playback_device{"default"};
+    std::string system_prompt;
+    int input_rate{16000};
+    int output_rate{48000};
+    int latency_ms{80};
+    int seed{0};
+    bool help{false};
+    bool list_devices{false};
+};
+
+class CliError : public std::invalid_argument {
+  public:
+    using std::invalid_argument::invalid_argument;
+};
+
+void print_usage(std::ostream& output, const char* program) {
+    output << "Usage: " << program << " [OPTIONS] MODEL.bundle\n\n"
+           << "Run a local full-duplex Nemotron VoiceChat session with ALSA.\n\n"
+           << "Options:\n"
+           << "  --capture-device NAME   ALSA capture PCM (default: default)\n"
+           << "  --playback-device NAME  ALSA playback PCM (default: default)\n"
+           << "  --input-rate HZ         Capture/session rate (default: 16000)\n"
+           << "  --output-rate HZ        Session/playback rate (default: 48000)\n"
+           << "  --latency-ms MS         ALSA target latency (default: 80)\n"
+           << "  --seed N                Deterministic speech seed (default: 0)\n"
+           << "  --system-prompt TEXT    Optional system prompt\n"
+           << "  --list-devices          List ALSA PCM names and exit\n"
+           << "  -h, --help              Show this help and exit\n\n"
+           << "Use a headset to prevent speaker echo from triggering barge-in.\n";
+}
+
+int parse_integer(const std::string& value, const char* option, int minimum, int maximum) {
+    std::size_t consumed = 0;
+    long long parsed = 0;
+    try {
+        parsed = std::stoll(value, &consumed, 10);
+    } catch (const std::exception&) {
+        throw CliError(std::string(option) + " requires an integer");
+    }
+    if (consumed != value.size() || parsed < minimum || parsed > maximum)
+        throw CliError(std::string(option) + " is outside its supported range");
+    return static_cast<int>(parsed);
+}
+
+std::string take_option_value(int& index, int argc, char** argv, const char* option) {
+    if (++index >= argc)
+        throw CliError(std::string(option) + " requires a value");
+    return argv[index];
+}
+
+bool parse_value_option(const std::string& argument, int& index, int argc, char** argv,
+                        Options& options) {
+    if (argument == "--capture-device") {
+        options.capture_device = take_option_value(index, argc, argv, "--capture-device");
+        return true;
+    }
+    if (argument == "--playback-device") {
+        options.playback_device = take_option_value(index, argc, argv, "--playback-device");
+        return true;
+    }
+    if (argument == "--input-rate") {
+        options.input_rate = parse_integer(take_option_value(index, argc, argv, "--input-rate"),
+                                           "--input-rate", 8000, 192000);
+        return true;
+    }
+    if (argument == "--output-rate") {
+        options.output_rate = parse_integer(take_option_value(index, argc, argv, "--output-rate"),
+                                            "--output-rate", 8000, 192000);
+        return true;
+    }
+    if (argument == "--latency-ms") {
+        options.latency_ms = parse_integer(take_option_value(index, argc, argv, "--latency-ms"),
+                                           "--latency-ms", 10, 1000);
+        return true;
+    }
+    if (argument == "--seed") {
+        options.seed = parse_integer(take_option_value(index, argc, argv, "--seed"), "--seed", 0,
+                                     std::numeric_limits<int>::max());
+        return true;
+    }
+    if (argument == "--system-prompt") {
+        options.system_prompt = take_option_value(index, argc, argv, "--system-prompt");
+        return true;
+    }
+    return false;
+}
+
+void set_bundle_path(const std::string& argument, Options& options) {
+    if (!options.bundle_path.empty())
+        throw CliError("only one model bundle may be specified");
+    options.bundle_path = argument;
+}
+
+bool parse_flag(const std::string& argument, Options& options) {
+    if (argument == "-h" || argument == "--help") {
+        options.help = true;
+        return true;
+    }
+    if (argument == "--list-devices") {
+        options.list_devices = true;
+        return true;
+    }
+    return false;
+}
+
+void validate_options(const Options& options) {
+    if (!options.help && !options.list_devices && options.bundle_path.empty())
+        throw CliError("MODEL.bundle is required");
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    bool positional_only = false;
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (positional_only) {
+            set_bundle_path(argument, options);
+            continue;
+        }
+        if (argument == "--") {
+            positional_only = true;
+            continue;
+        }
+        if (parse_flag(argument, options))
+            continue;
+        if (parse_value_option(argument, index, argc, argv, options))
+            continue;
+        if (!argument.empty() && argument.front() == '-')
+            throw CliError("unknown option: " + argument);
+        set_bundle_path(argument, options);
+    }
+    validate_options(options);
+    return options;
+}
+
+[[noreturn]] void throw_alsa_error(const std::string& operation, int error) {
+    throw std::runtime_error(operation + ": " + snd_strerror(error));
+}
+
+class AlsaPcm {
+  public:
+    AlsaPcm(const std::string& device, snd_pcm_stream_t stream, unsigned int sample_rate,
+            unsigned int latency_ms)
+        : stream_(stream) {
+        const int open_mode = stream == SND_PCM_STREAM_CAPTURE ? SND_PCM_NONBLOCK : 0;
+        int status = snd_pcm_open(&handle_, device.c_str(), stream, open_mode);
+        if (status < 0)
+            throw_alsa_error("cannot open ALSA device '" + device + "'", status);
+        status = snd_pcm_set_params(handle_, SND_PCM_FORMAT_S16_LE, SND_PCM_ACCESS_RW_INTERLEAVED,
+                                    1, sample_rate, 1, latency_ms * 1000U);
+        if (status < 0) {
+            snd_pcm_close(handle_);
+            handle_ = nullptr;
+            throw_alsa_error("cannot configure ALSA device '" + device + "'", status);
+        }
+    }
+
+    ~AlsaPcm() {
+        if (handle_ != nullptr)
+            snd_pcm_close(handle_);
+    }
+
+    AlsaPcm(const AlsaPcm&) = delete;
+    AlsaPcm& operator=(const AlsaPcm&) = delete;
+
+    std::size_t read_frames(std::int16_t* samples, std::size_t capacity) {
+        while (true) {
+            const auto result = snd_pcm_readi(handle_, samples, capacity);
+            if (result >= 0)
+                return static_cast<std::size_t>(result);
+            if (result == -EINTR)
+                return 0;
+            if (result == -EAGAIN) {
+                const int wait_status = snd_pcm_wait(handle_, kCaptureWaitMs);
+                if (wait_status > 0)
+                    continue;
+                if (wait_status == 0 || wait_status == -EINTR)
+                    return 0;
+                recover_or_throw(wait_status, "ALSA capture wait failed");
+                continue;
+            }
+            recover_or_throw(static_cast<int>(result), "ALSA capture failed");
+        }
+    }
+
+    std::size_t write_frames(const std::int16_t* samples, std::size_t count) {
+        while (true) {
+            const auto result = snd_pcm_writei(handle_, samples, count);
+            if (result >= 0)
+                return static_cast<std::size_t>(result);
+            if (result == -EINTR)
+                return 0;
+            recover_or_throw(static_cast<int>(result), "ALSA playback failed");
+        }
+    }
+
+    void flush_playback() {
+        if (stream_ != SND_PCM_STREAM_PLAYBACK)
+            throw std::logic_error("cannot flush a capture PCM");
+        const int drop_status = snd_pcm_drop(handle_);
+        if (drop_status < 0 && drop_status != -EBADFD)
+            throw_alsa_error("cannot drop stale ALSA playback", drop_status);
+        const int prepare_status = snd_pcm_prepare(handle_);
+        if (prepare_status < 0)
+            throw_alsa_error("cannot prepare ALSA playback after flush", prepare_status);
+    }
+
+    void discard_noexcept() noexcept {
+        if (handle_ != nullptr && stream_ == SND_PCM_STREAM_PLAYBACK)
+            (void)snd_pcm_drop(handle_);
+    }
+
+  private:
+    void recover_or_throw(int error, const char* operation) {
+        // alsa-lib may wait indefinitely while recovering a suspended device.
+        // Fail the session so Ctrl-C/docker stop keeps a bounded shutdown path.
+        if (error == -ESTRPIPE)
+            throw_alsa_error(operation, error);
+        const int recovered = snd_pcm_recover(handle_, error, 1);
+        if (recovered < 0)
+            throw_alsa_error(operation, recovered);
+    }
+
+    snd_pcm_t* handle_{nullptr};
+    snd_pcm_stream_t stream_;
+};
+
+class RunState {
+  public:
+    bool stopping() const noexcept { return stopping_.load(); }
+
+    void request_stop() noexcept { stopping_.store(true); }
+
+    void fail(std::exception_ptr failure) noexcept {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!failure_)
+                failure_ = std::move(failure);
+        }
+        request_stop();
+    }
+
+    void rethrow_if_failed() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (failure_)
+            std::rethrow_exception(failure_);
+    }
+
+  private:
+    std::atomic<bool> stopping_{false};
+    mutable std::mutex mutex_;
+    std::exception_ptr failure_;
+};
+
+void list_alsa_devices() {
+    void** hints = nullptr;
+    const int status = snd_device_name_hint(-1, "pcm", &hints);
+    if (status < 0)
+        throw_alsa_error("cannot enumerate ALSA PCM devices", status);
+    std::cout << "NAME\tDIRECTION\tDESCRIPTION\n";
+    for (void** current = hints; current != nullptr && *current != nullptr; ++current) {
+        char* name = snd_device_name_get_hint(*current, "NAME");
+        char* direction = snd_device_name_get_hint(*current, "IOID");
+        char* description = snd_device_name_get_hint(*current, "DESC");
+        if (name != nullptr) {
+            std::string clean_description = description == nullptr ? "" : description;
+            std::replace(clean_description.begin(), clean_description.end(), '\n', ' ');
+            std::cout << name << '\t' << (direction == nullptr ? "Input/Output" : direction) << '\t'
+                      << clean_description << '\n';
+        }
+        std::free(name);
+        std::free(direction);
+        std::free(description);
+    }
+    snd_device_name_free_hint(hints);
+}
+
+void capture_loop(AlsaPcm& capture, trtmc::ISpeechSession& session, int sample_rate,
+                  RunState& state, PlaybackQueue& playback_queue) noexcept {
+    try {
+        const auto chunk_samples =
+            static_cast<std::size_t>(std::max(1, sample_rate * kCaptureChunkMs / 1000));
+        std::vector<std::int16_t> pcm(chunk_samples);
+        std::vector<float> audio(chunk_samples);
+        while (!state.stopping()) {
+            const auto count = capture.read_frames(pcm.data(), pcm.size());
+            if (count == 0 || state.stopping())
+                continue;
+            std::transform(pcm.begin(), pcm.begin() + static_cast<std::ptrdiff_t>(count),
+                           audio.begin(), pcm16_to_float);
+            session.append_audio(audio.data(), static_cast<std::int32_t>(count));
+        }
+    } catch (...) {
+        if (!state.stopping())
+            state.fail(std::current_exception());
+        playback_queue.stop();
+    }
+}
+
+void playback_loop(AlsaPcm& playback, PlaybackQueue& queue, int sample_rate,
+                   RunState& state) noexcept {
+    try {
+        const auto write_chunk =
+            static_cast<std::size_t>(std::max(1, sample_rate * kCaptureChunkMs / 1000));
+        while (true) {
+            auto item = queue.wait_pop();
+            if (item.kind == PlaybackQueueItemKind::kStopped) {
+                playback.discard_noexcept();
+                return;
+            }
+            if (item.kind == PlaybackQueueItemKind::kFlush) {
+                playback.flush_playback();
+                continue;
+            }
+
+            std::size_t offset = 0;
+            while (offset < item.samples.size() && !state.stopping() &&
+                   queue.generation_is_current(item.generation)) {
+                const auto count = std::min(write_chunk, item.samples.size() - offset);
+                const auto written = playback.write_frames(item.samples.data() + offset, count);
+                offset += written;
+            }
+        }
+    } catch (...) {
+        if (!state.stopping())
+            state.fail(std::current_exception());
+        queue.stop();
+    }
+}
+
+struct SessionThreads {
+    std::thread playback;
+    std::thread capture;
+};
+
+SessionThreads start_session_threads(AlsaPcm& playback, AlsaPcm& capture,
+                                     PlaybackQueue& playback_queue, trtmc::ISpeechSession& session,
+                                     int output_rate, int input_rate, RunState& state) {
+    SessionThreads threads;
+    try {
+        threads.playback = std::thread(playback_loop, std::ref(playback), std::ref(playback_queue),
+                                       output_rate, std::ref(state));
+        threads.capture = std::thread(capture_loop, std::ref(capture), std::ref(session),
+                                      input_rate, std::ref(state), std::ref(playback_queue));
+    } catch (...) {
+        state.request_stop();
+        playback_queue.stop();
+        if (threads.capture.joinable())
+            threads.capture.join();
+        if (threads.playback.joinable())
+            threads.playback.join();
+        throw;
+    }
+    return threads;
+}
+
+class TranscriptPrinter {
+  public:
+    void agent_text(const SpeechSessionEvent& event) {
+        if (event.epoch != agent_epoch_) {
+            finish_agent_line();
+            agent_epoch_ = event.epoch;
+            saw_agent_delta_ = false;
+        }
+        if (!agent_line_open_) {
+            std::cout << "agent> " << std::flush;
+            agent_line_open_ = true;
+        }
+        if (!event.is_final) {
+            std::cout << event.text << std::flush;
+            saw_agent_delta_ = true;
+        } else {
+            if (!saw_agent_delta_)
+                std::cout << event.text;
+            finish_agent_line();
+        }
+    }
+
+    void user_text(const SpeechSessionEvent& event) {
+        if (!event.is_final || event.text.empty())
+            return;
+        finish_agent_line();
+        std::cout << "user> " << event.text << '\n';
+    }
+
+    void status(const std::string& text) {
+        finish_agent_line();
+        std::cout << '[' << text << "]\n";
+    }
+
+    void finish_agent_line() {
+        if (agent_line_open_)
+            std::cout << '\n';
+        agent_line_open_ = false;
+        saw_agent_delta_ = false;
+    }
+
+  private:
+    std::uint64_t agent_epoch_{0};
+    bool agent_line_open_{false};
+    bool saw_agent_delta_{false};
+};
+
+void enqueue_agent_audio(const SpeechSessionEvent& event, int expected_sample_rate,
+                         PlaybackQueue& queue) {
+    if (event.sample_rate != expected_sample_rate)
+        throw std::runtime_error("speech session changed its output sample rate");
+    std::vector<std::int16_t> pcm;
+    pcm.reserve(event.audio_samples.size());
+    std::transform(event.audio_samples.begin(), event.audio_samples.end(), std::back_inserter(pcm),
+                   float_to_pcm16);
+    if (!queue.try_push(std::move(pcm)))
+        throw std::runtime_error("playback queue exceeded its four-second bound");
+}
+
+bool consume_payload_event(const SpeechSessionEvent& event, int output_rate, PlaybackQueue& queue,
+                           TranscriptPrinter& printer) {
+    switch (event.kind) {
+    case SpeechSessionEventKind::kAgentAudio:
+        enqueue_agent_audio(event, output_rate, queue);
+        return true;
+    case SpeechSessionEventKind::kAgentText:
+        printer.agent_text(event);
+        return true;
+    case SpeechSessionEventKind::kUserTranscript:
+        printer.user_text(event);
+        return true;
+    default:
+        return false;
+    }
+}
+
+void consume_lifecycle_event(const SpeechSessionEvent& event, PlaybackQueue& queue,
+                             TranscriptPrinter& printer, RunState& state) {
+    switch (event.kind) {
+    case SpeechSessionEventKind::kYielded:
+        (void)queue.request_flush();
+        printer.status(event.text.empty() ? "yielded" : "yielded: " + event.text);
+        break;
+    case SpeechSessionEventKind::kCancelled:
+        (void)queue.request_flush();
+        printer.status("cancelled");
+        state.request_stop();
+        break;
+    case SpeechSessionEventKind::kReset:
+        (void)queue.request_flush();
+        printer.status("reset");
+        break;
+    case SpeechSessionEventKind::kError:
+        (void)queue.request_flush();
+        throw std::runtime_error(event.text.empty() ? "speech session failed" : event.text);
+    case SpeechSessionEventKind::kInputFinished:
+        state.request_stop();
+        break;
+    case SpeechSessionEventKind::kTurnFinished:
+        printer.finish_agent_line();
+        break;
+    default:
+        break;
+    }
+}
+
+void consume_event(const SpeechSessionEvent& event, int output_rate, PlaybackQueue& queue,
+                   TranscriptPrinter& printer, RunState& state) {
+    if (!consume_payload_event(event, output_rate, queue, printer))
+        consume_lifecycle_event(event, queue, printer, state);
+}
+
+int run(const Options& options) {
+    // Fail on an unavailable host audio device before loading the large model.
+    AlsaPcm capture(options.capture_device, SND_PCM_STREAM_CAPTURE,
+                    static_cast<unsigned int>(options.input_rate),
+                    static_cast<unsigned int>(options.latency_ms));
+    AlsaPcm playback(options.playback_device, SND_PCM_STREAM_PLAYBACK,
+                     static_cast<unsigned int>(options.output_rate),
+                     static_cast<unsigned int>(options.latency_ms));
+
+    auto pipeline = trtmc::load(options.bundle_path);
+    auto* provider = dynamic_cast<trtmc::ISpeechSessionProvider*>(pipeline.get());
+    if (provider == nullptr)
+        throw std::runtime_error("bundle does not support persistent speech sessions");
+
+    trtmc::SpeechSessionConfig config;
+    config.input_sample_rate = options.input_rate;
+    config.output_sample_rate = options.output_rate;
+    config.system_prompt = options.system_prompt;
+    config.emit_agent_audio = true;
+    config.emit_agent_text = true;
+    config.emit_user_transcript = true;
+    config.enable_barge_in = true;
+    config.seed = options.seed;
+    auto session = provider->create_speech_session(config);
+    const auto actual_config = session->config();
+    if (actual_config.output_sample_rate <= 0)
+        throw std::runtime_error("speech session returned an invalid output sample rate");
+
+    const auto playback_capacity = static_cast<std::size_t>(actual_config.output_sample_rate) *
+                                   static_cast<std::size_t>(kPlaybackQueueSeconds);
+    PlaybackQueue playback_queue(playback_capacity);
+    RunState state;
+    TranscriptPrinter printer;
+
+    auto threads = start_session_threads(playback, capture, playback_queue, *session,
+                                         actual_config.output_sample_rate,
+                                         actual_config.input_sample_rate, state);
+
+    std::cout << "Listening on '" << options.capture_device << "'; playing on '"
+              << options.playback_device << "'. Press Ctrl-C to stop.\n";
+    try {
+        while (!state.stopping() && g_signal_requested == 0) {
+            for (const auto& event : session->wait_events(kEventWaitMs))
+                consume_event(event, actual_config.output_sample_rate, playback_queue, printer,
+                              state);
+        }
+    } catch (...) {
+        state.fail(std::current_exception());
+    }
+
+    state.request_stop();
+    playback_queue.stop();
+    try {
+        session->cancel();
+    } catch (...) {
+        state.fail(std::current_exception());
+    }
+    threads.capture.join();
+    threads.playback.join();
+    printer.finish_agent_line();
+    state.rethrow_if_failed();
+    return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const auto options = parse_options(argc, argv);
+        if (options.help) {
+            print_usage(std::cout, argv[0]);
+            return EXIT_SUCCESS;
+        }
+        if (options.list_devices) {
+            list_alsa_devices();
+            return EXIT_SUCCESS;
+        }
+        std::signal(SIGINT, signal_handler);
+        std::signal(SIGTERM, signal_handler);
+        return run(options);
+    } catch (const CliError& error) {
+        std::cerr << "Error: " << error.what() << "\n\n";
+        print_usage(std::cerr, argv[0]);
+        return 2;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/examples/models/nemotron_voicechat/full_duplex/playback_queue.h
+++ b/examples/models/nemotron_voicechat/full_duplex/playback_queue.h
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace trtmc::examples::voicechat {
+
+inline std::int16_t float_to_pcm16(float sample) noexcept {
+    if (!std::isfinite(sample))
+        return 0;
+    if (sample <= -1.0F)
+        return std::numeric_limits<std::int16_t>::min();
+    if (sample >= 1.0F)
+        return std::numeric_limits<std::int16_t>::max();
+    return static_cast<std::int16_t>(std::lrint(sample * 32767.0F));
+}
+
+inline float pcm16_to_float(std::int16_t sample) noexcept {
+    return static_cast<float>(sample) / 32768.0F;
+}
+
+enum class PlaybackQueueItemKind {
+    kAudio,
+    kFlush,
+    kStopped,
+};
+
+struct PlaybackQueueItem {
+    PlaybackQueueItemKind kind{PlaybackQueueItemKind::kStopped};
+    std::uint64_t generation{0};
+    std::vector<std::int16_t> samples;
+};
+
+// A bounded hand-off between the session event consumer and the one thread
+// that owns the ALSA playback handle. A flush changes the generation so the
+// playback thread can abandon a chunk that it has already popped.
+class PlaybackQueue {
+  public:
+    explicit PlaybackQueue(std::size_t capacity_samples) : capacity_samples_(capacity_samples) {
+        if (capacity_samples_ == 0)
+            throw std::invalid_argument("playback queue capacity must be positive");
+    }
+
+    PlaybackQueue(const PlaybackQueue&) = delete;
+    PlaybackQueue& operator=(const PlaybackQueue&) = delete;
+
+    bool try_push(std::vector<std::int16_t> samples) {
+        if (samples.empty())
+            return true;
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopped_ || samples.size() > capacity_samples_ - queued_samples_)
+            return false;
+        queued_samples_ += samples.size();
+        queue_.push_back(
+            PlaybackQueueItem{PlaybackQueueItemKind::kAudio, generation_, std::move(samples)});
+        cv_.notify_one();
+        return true;
+    }
+
+    std::uint64_t request_flush() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopped_)
+            return generation_;
+        if (++generation_ == 0)
+            ++generation_;
+        queue_.clear();
+        queued_samples_ = 0;
+        flush_pending_ = true;
+        cv_.notify_all();
+        return generation_;
+    }
+
+    PlaybackQueueItem wait_pop() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return stopped_ || flush_pending_ || !queue_.empty(); });
+        if (flush_pending_) {
+            flush_pending_ = false;
+            return {PlaybackQueueItemKind::kFlush, generation_, {}};
+        }
+        if (stopped_)
+            return {PlaybackQueueItemKind::kStopped, generation_, {}};
+        PlaybackQueueItem item = std::move(queue_.front());
+        queue_.pop_front();
+        queued_samples_ -= item.samples.size();
+        return item;
+    }
+
+    bool generation_is_current(std::uint64_t generation) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return !stopped_ && generation == generation_;
+    }
+
+    void stop() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopped_)
+            return;
+        stopped_ = true;
+        if (++generation_ == 0)
+            ++generation_;
+        queue_.clear();
+        queued_samples_ = 0;
+        flush_pending_ = false;
+        cv_.notify_all();
+    }
+
+    std::size_t queued_samples() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return queued_samples_;
+    }
+
+  private:
+    const std::size_t capacity_samples_;
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::deque<PlaybackQueueItem> queue_;
+    std::size_t queued_samples_{0};
+    std::uint64_t generation_{1};
+    bool flush_pending_{false};
+    bool stopped_{false};
+};
+
+} // namespace trtmc::examples::voicechat

--- a/examples/models/nemotron_voicechat/full_duplex/test_playback_queue.cpp
+++ b/examples/models/nemotron_voicechat/full_duplex/test_playback_queue.cpp
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "playback_queue.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using trtmc::examples::voicechat::float_to_pcm16;
+using trtmc::examples::voicechat::pcm16_to_float;
+using trtmc::examples::voicechat::PlaybackQueue;
+using trtmc::examples::voicechat::PlaybackQueueItemKind;
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void test_pcm_conversion() {
+    check(float_to_pcm16(-2.0F) == std::numeric_limits<std::int16_t>::min(),
+          "negative PCM conversion saturates");
+    check(float_to_pcm16(2.0F) == std::numeric_limits<std::int16_t>::max(),
+          "positive PCM conversion saturates");
+    check(float_to_pcm16(std::numeric_limits<float>::quiet_NaN()) == 0,
+          "non-finite PCM conversion is silent");
+    check(pcm16_to_float(std::numeric_limits<std::int16_t>::min()) == -1.0F,
+          "capture conversion preserves negative full scale");
+}
+
+void test_bound_and_fifo() {
+    PlaybackQueue queue(4);
+    check(queue.try_push({1, 2}), "first audio chunk is accepted");
+    check(queue.try_push({3, 4}), "queue accepts samples up to its bound");
+    check(!queue.try_push({5}), "queue rejects samples beyond its bound");
+    check(queue.queued_samples() == 4, "queue accounts for pending samples");
+
+    auto first = queue.wait_pop();
+    auto second = queue.wait_pop();
+    check(first.kind == PlaybackQueueItemKind::kAudio &&
+              first.samples == std::vector<std::int16_t>({1, 2}),
+          "queue preserves first audio chunk");
+    check(second.kind == PlaybackQueueItemKind::kAudio &&
+              second.samples == std::vector<std::int16_t>({3, 4}),
+          "queue preserves FIFO order");
+    check(queue.queued_samples() == 0, "pop releases queue capacity");
+}
+
+void test_flush_invalidates_popped_and_pending_audio() {
+    PlaybackQueue queue(8);
+    check(queue.try_push({1, 2}), "popped audio is accepted");
+    auto popped = queue.wait_pop();
+    check(queue.try_push({3, 4}), "pending stale audio is accepted");
+
+    const auto next_generation = queue.request_flush();
+    auto flush = queue.wait_pop();
+    check(flush.kind == PlaybackQueueItemKind::kFlush && flush.generation == next_generation,
+          "flush is observable by the playback owner");
+    check(!queue.generation_is_current(popped.generation),
+          "flush invalidates audio already owned by playback");
+    check(queue.queued_samples() == 0, "flush discards pending audio");
+    check(queue.try_push({9}), "replacement audio is accepted after flush");
+    auto replacement = queue.wait_pop();
+    check(replacement.kind == PlaybackQueueItemKind::kAudio &&
+              replacement.generation == next_generation,
+          "replacement audio uses the new generation");
+}
+
+void test_wait_and_stop() {
+    PlaybackQueue queue(4);
+    std::atomic<bool> waiting{false};
+    PlaybackQueueItemKind observed = PlaybackQueueItemKind::kAudio;
+    std::thread consumer([&] {
+        waiting.store(true);
+        observed = queue.wait_pop().kind;
+    });
+    while (!waiting.load())
+        std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    queue.stop();
+    consumer.join();
+    check(observed == PlaybackQueueItemKind::kStopped, "stop wakes a blocked playback owner");
+    check(!queue.try_push({1}), "stopped queue rejects new audio");
+}
+
+} // namespace
+
+int main() {
+    test_pcm_conversion();
+    test_bound_and_fifo();
+    test_flush_invalidates_popped_and_pending_audio();
+    test_wait_and_stop();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -808,6 +808,9 @@ def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> Non
         ("tests/builder/test_cli.py", "all"),
         ("tests/cpp/test_cli_args.cpp", "all"),
         ("tests/tools/test_cli_contract.py", "all"),
+        ("examples/models/nemotron_voicechat/full_duplex/main.cpp", "all"),
+        ("examples/models/nemotron_voicechat/full_duplex/Dockerfile", "all"),
+        ("examples/models/nemotron_voicechat/full_duplex/CMakeLists.txt", "all"),
     ),
 )
 def test_cli_and_unit_test_changes_run_units_without_model_proofs(

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -273,6 +273,13 @@ class TorchReference:
             "hf_id": "example/speech-streaming-case",
         },
         {
+            "name": "voicechat-case",
+            "family": "nemotron_voicechat",
+            "runtime_strategy": "nemotron_voicechat_full_duplex",
+            "task_strategy": "speech_to_speech",
+            "hf_id": "example/voicechat-case",
+        },
+        {
             "name": "media-core",
             "family": "media_family",
             "runtime_strategy": "diffusion_media_primary",
@@ -1922,6 +1929,27 @@ class TestUnitTiers:
         assert match.rule == "cpp_example_tool"
         assert match.models == []
         assert match.unit_tiers == ["cpp"]
+        assert match.rebuild_cpp is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "examples/models/nemotron_voicechat/full_duplex/main.cpp",
+            "examples/models/nemotron_voicechat/full_duplex/playback_queue.h",
+            "examples/models/nemotron_voicechat/full_duplex/test_playback_queue.cpp",
+            "examples/models/nemotron_voicechat/full_duplex/Dockerfile",
+            "examples/models/nemotron_voicechat/full_duplex/Dockerfile.dockerignore",
+            "examples/models/nemotron_voicechat/full_duplex/CMakeLists.txt",
+            "examples/models/nemotron_voicechat/full_duplex/README.md",
+        ],
+    )
+    def test_voicechat_full_duplex_example_is_model_owned(self, imap, path):
+        """The live example runs VoiceChat plus its host-side C++ and tools checks."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "nemotron_voicechat_full_duplex_example"
+        assert match.models == ["voicechat-case"]
+        assert match.unit_tiers == ["cpp", "tools"]
         assert match.rebuild_cpp is True
 
     @pytest.mark.parametrize(

--- a/tests/tools/test_voicechat_full_duplex_example.py
+++ b/tests/tools/test_voicechat_full_duplex_example.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-only contracts for the local Nemotron VoiceChat microphone example."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = REPO_ROOT / "examples" / "models" / "nemotron_voicechat" / "full_duplex"
+
+
+def _text(name: str) -> str:
+    return (EXAMPLE / name).read_text(encoding="utf-8")
+
+
+def _docker_from_images(source: str) -> list[str]:
+    arguments: dict[str, str] = {}
+    images: list[str] = []
+    for raw_line in source.splitlines():
+        line = raw_line.strip()
+        if line.startswith("ARG ") and "=" in line:
+            name, value = line.removeprefix("ARG ").split("=", 1)
+            arguments[name] = value
+        if not line.startswith("FROM "):
+            continue
+        image = line.split()[1]
+        variable = re.fullmatch(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", image)
+        images.append(arguments.get(variable.group(1), "") if variable else image)
+    return images
+
+
+def _shell_blocks(markdown: str) -> list[str]:
+    return re.findall(r"```(?:bash|sh)\n(.*?)```", markdown, flags=re.DOTALL)
+
+
+def test_docker_contract_is_pinned_and_starts_the_example() -> None:
+    dockerfile = _text("Dockerfile")
+    images = _docker_from_images(dockerfile)
+
+    assert images
+    assert all(re.fullmatch(r"\S+@sha256:[0-9a-f]{64}", image) for image in images)
+
+    entrypoint_match = re.search(r"(?m)^ENTRYPOINT\s+(\[[^\n]+\])$", dockerfile)
+    command_match = re.search(r"(?m)^CMD\s+(\[[^\n]+\])$", dockerfile)
+    assert entrypoint_match is not None
+    assert command_match is not None
+    assert json.loads(entrypoint_match.group(1)) == ["/opt/trtmc/bin/trtmc_voicechat_full_duplex"]
+    assert json.loads(command_match.group(1)) == ["/models/model.bundle"]
+
+
+def test_readme_documents_one_off_build_and_offline_device_scoped_run() -> None:
+    readme = _text("README.md")
+    blocks = _shell_blocks(readme)
+    build_blocks = [block for block in blocks if "docker build" in block]
+    run_blocks = [block for block in blocks if "docker run" in block]
+    conversation_blocks = [block for block in run_blocks if "--gpus" in block]
+
+    assert build_blocks
+    assert conversation_blocks
+    assert readme.index("docker build") < readme.index("docker run")
+    for block in run_blocks:
+        assert "--privileged" not in block
+    for block in conversation_blocks:
+        assert "--network none" in block
+        assert "--device /dev/snd:/dev/snd" in block
+        assert "readonly" in block or ":ro" in block
+    assert "headset" in readme.lower()
+
+
+def test_application_wires_alsa_capture_session_events_and_barge_in_flush() -> None:
+    cmake = _text("CMakeLists.txt")
+    source = _text("main.cpp")
+
+    assert "find_package(ALSA REQUIRED)" in cmake
+    assert "find_package(Threads REQUIRED)" in cmake
+    assert "ALSA::ALSA" in cmake
+    assert "Threads::Threads" in cmake
+
+    for symbol in (
+        "snd_pcm_open",
+        "SND_PCM_NONBLOCK",
+        "snd_pcm_set_params",
+        "snd_pcm_readi",
+        "snd_pcm_wait",
+        "snd_pcm_writei",
+        "snd_pcm_recover",
+        "-ESTRPIPE",
+        "snd_pcm_drop",
+        "snd_pcm_prepare",
+        "ISpeechSessionProvider",
+        "create_speech_session",
+        "SpeechSessionEventKind::kYielded",
+    ):
+        assert symbol in source
+    assert source.count("std::thread") >= 2
+    assert source.count("joinable()") >= 2
+    assert re.search(
+        r"SpeechSessionEventKind::kYielded[\s\S]{0,800}request_flush\s*\(",
+        source,
+    )
+    assert re.search(
+        r"PlaybackQueueItemKind::kFlush[\s\S]{0,800}playback\.flush_playback\s*\(",
+        source,
+    )
+    flush_method = re.search(
+        r"void\s+flush_playback\s*\(\)\s*\{([\s\S]{0,1200}?)\n    \}",
+        source,
+    )
+    assert flush_method is not None
+    assert "snd_pcm_drop" in flush_method.group(1)
+    assert "snd_pcm_prepare" in flush_method.group(1)
+
+
+def test_playback_queue_is_pure_cpp_and_runs_without_alsa(tmp_path: Path) -> None:
+    header = _text("playback_queue.h")
+    test_source = _text("test_playback_queue.cpp")
+    for source in (header, test_source):
+        assert "alsa/" not in source
+        assert "snd_pcm_" not in source
+
+    compiler_command = shlex.split(os.environ.get("CXX", "c++"))
+    if not compiler_command or shutil.which(compiler_command[0]) is None:
+        pytest.skip("a C++ compiler is not installed")
+
+    executable = tmp_path / "test_playback_queue"
+    compile_result = subprocess.run(
+        [
+            *compiler_command,
+            "-std=c++17",
+            "-pthread",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(EXAMPLE),
+            str(EXAMPLE / "test_playback_queue.cpp"),
+            "-o",
+            str(executable),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    run_result = subprocess.run(
+        [str(executable)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -189,6 +189,7 @@ FULL_UNIT_TEST_ONLY_EXACT = frozenset(
     }
 )
 UNIT_TEST_ONLY_PREFIXES = (
+    "examples/models/nemotron_voicechat/full_duplex/",
     "tests/builder/",
     "tests/cpp/",
     "tests/validation/",

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1845,6 +1845,18 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestNoImpact.test_local_qwen3_fixture_scopes_to_qwen3",),
         ),
         ClassificationRule(
+            priority=454,
+            name="nemotron_voicechat_full_duplex_example",
+            matcher=_regex_rule(r"examples/models/(nemotron_voicechat)/full_duplex/.+$"),
+            resolver=_match_result(
+                "nemotron_voicechat_full_duplex_example",
+                _family_models,
+                ["cpp", "tools"],
+                True,
+            ),
+            covered_by=("TestUnitTiers.test_voicechat_full_duplex_example_is_model_owned",),
+        ),
+        ClassificationRule(
             priority=455,
             name="cpp_example_tool",
             matcher=_regex_rule(r"examples/.+\.cpp$"),

--- a/website/docs/user-guides/multimodal-speech.md
+++ b/website/docs/user-guides/multimodal-speech.md
@@ -107,6 +107,36 @@ commit/clear and response create/cancel/truncate; tool-enabled sessions expose
 `ISpeechToolSession`. Finite WAV inference uses `ISpeechBatchSessionProvider`,
 so this live path does not change the model-card `trtmc speak` result.
 
+### Full-duplex microphone example
+
+The repository includes a local Linux ALSA
+[microphone application](https://github.com/NVIDIA/TensorRT-Model-Connect/tree/main/examples/models/nemotron_voicechat/full_duplex).
+Build its image once from the repository root; the example README documents
+the pinned x86_64 override:
+
+```bash
+docker build --platform linux/arm64 \
+  --file examples/models/nemotron_voicechat/full_duplex/Dockerfile \
+  --tag trtmc-voicechat-full-duplex:local \
+  .
+```
+
+After that build, start each conversation with one offline `docker run`. The
+bundle remains a read-only host file and is not copied into the image:
+
+```bash
+docker run --rm --interactive --tty \
+  --network none \
+  --gpus 'device=0' \
+  --device /dev/snd:/dev/snd \
+  --mount "type=bind,src=$PWD/nemotron-voicechat-11b.bundle,dst=/models/model.bundle,readonly" \
+  trtmc-voicechat-full-duplex:local
+```
+
+Use a headset or hardware acoustic echo cancellation so speaker output does
+not look like a user interruption. See the example README for explicit ALSA
+devices, x86_64 builds, and desktop audio boundaries.
+
 For an opt-in real-engine lifecycle check, build the standalone model-owned
 probe and run it against a prebuilt bundle and the pinned public sample:
 


### PR DESCRIPTION
## Background

PR #1004 added the native persistent VoiceChat session API, but users still had
to write their own microphone and speaker host. This follow-up provides one
model-owned Linux CLI that exercises that API without adding a server or
network transport.

## Exit Criteria

- Capture microphone audio continuously while agent audio is playing.
- Flush stale user-space and ALSA playback after model-confirmed barge-in.
- Keep capture, event draining, and playback bounded and independently
  stoppable.
- Start from a prebuilt read-only bundle with one `docker run` after the image
  is built.
- Keep checkpoints, credentials, Python, and network services out of the
  runtime image.

## Implementation

- Adds an ALSA S16 mono CLI with dedicated capture and playback threads plus a
  session-event loop. Capture uses nonblocking finite ALSA waits; playback uses
  a four-second bounded generation queue, and `kYielded` drops stale ALSA audio.
- Adds a model-isolated, digest-pinned TensorRT Docker image. The final stage
  contains the application, core runtime, TRT backend, VoiceChat DSO, and
  licenses; the bundle is mounted read-only and runtime networking is disabled.
- Adds queue/source contracts and precise CI routing for the model-owned
  example, plus canonical microphone/Docker usage documentation.
- No public API, ABI, runtime strategy, bundle format, or existing runtime
  behavior changes. ALSA is confined to the opt-in example build/image.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest -q tests/tools/test_voicechat_full_duplex_example.py tests/tools/test_test_impact.py tests/tools/test_model_ci.py`: 379 passed.
- `python3 tools/model_ci.py validate`: passed with 84 families.
- `python3 tools/test_impact.py --validate`: passed.
- `python3 tools/check_doc_file_references.py --strict website/docs`: passed with zero errors or warnings.
- `python3 tools/check_cyclomatic_complexity.py examples/models/nemotron_voicechat/full_duplex --max-ccn 10`: passed, maximum CCN 9.
- Public-source/legal tests and `python3 tools/legal_headers.py --check`: passed with zero findings.
- Exact aarch64 multi-stage Docker build: passed for the app, core, TRT 11.1 backend, VoiceChat DSO, queue CTest, and CLI help smoke.
- Runtime image `--list-devices`: passed and reported the ALSA `null` endpoint.
- ALSA `null` capture/playback preflight with a missing bundle: opened audio successfully and failed closed on the missing bundle as expected.

### Hardware, Environment, and Revisions

- Repository head: `418d7cd03c9882a4b532329442ef9aad7a4ea006`.
- Base: `github/main@6d38ac71567cc20d24a451439700ef1630ef0689`.
- Container: repository-pinned aarch64 `nvcr.io/nvidia/tensorrt:26.07-py3` digest, Ubuntu 24.04, CUDA 13.3, TensorRT 11.1.0.106.
- Native build target: `CMAKE_CUDA_ARCHITECTURES=103-real` for GB300-class deployment.
- Image OCI revision equals the repository head. The runtime bundle is not included in the image.

### Not Run / Remaining Gaps

- Physical microphone + speaker + GPU inference was not run on this host because it exposes neither `/dev/snd` nor a working NVIDIA driver.
- The full VoiceChat model bundle was not loaded by this application on this host. Native model/session behavior remains covered by #1004's exact-head protected lifecycle proof.
- The pinned x86_64 image override, PipeWire/PulseAudio socket forwarding, rootless Docker, and a registry-published pull-and-run image were not executed.

## Notes For Future Readers

- No ADR was added: this is a model-owned example over existing public interfaces and does not add a runtime strategy, schema, or shared API.
- The image build is one-time; each conversation then starts with the documented single offline `docker run`. A fresh-host pull-and-run experience additionally requires publishing the image to a registry.
- Direct `/dev/snd` passthrough has no acoustic echo cancellation. Use a headset or hardware AEC, and choose explicit ALSA devices when a desktop PipeWire/PulseAudio `default` device is unavailable inside the container.
- Suggested review order: playback queue and thread ownership, ALSA CLI lifecycle, Docker projection/staging, then CI routing and docs.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the change is example-only and leaves shared runtime/API behavior unchanged, but the physical microphone + speaker + GPU path could not be exercised on this host. The bounded queue, cancellation, container build, and device-free contracts are covered; target-host audio remains the residual integration risk.
