### PR TITLE
fix(qwen): allocate KV before memory diagnostics

### DIFF
--- a/src/runtime/models/qwen/plugin.cpp
+++ b/src/runtime/models/qwen/plugin.cpp
@@ -271,31 +271,20 @@ std::uint64_t checked_multiply(std::uint64_t lhs, std::uint64_t rhs) {
     return lhs * rhs;
 }
 
-void admit_native_kv_allocation(const PipelineContext& ctx, bool native_kv,
-                                const KvCacheRuntimeSizing& sizing) {
-    if (!native_kv)
-        return;
-
+std::runtime_error qwen_kv_cache_allocation_failure(const KvCacheRuntimeSizing& sizing) {
+    std::ostringstream message;
+    message << "Qwen KV cache allocation failed after attempting "
+            << format_bytes(sizing.cache_bytes) << " for " << sizing.runtime_rows << " rows";
     std::size_t free_bytes = 0;
     std::size_t total_bytes = 0;
     const cudaError_t status = cudaMemGetInfo(&free_bytes, &total_bytes);
-    if (status != cudaSuccess) {
-        throw std::runtime_error(std::string("Qwen native KV CUDA memory query failed: ") +
-                                 cudaGetErrorString(status));
+    if (status == cudaSuccess) {
+        message << "; free after failure=" << format_bytes(static_cast<std::uint64_t>(free_bytes))
+                << ", total=" << format_bytes(static_cast<std::uint64_t>(total_bytes));
+    } else {
+        message << "; CUDA memory diagnostics failed: " << cudaGetErrorString(status);
     }
-
-    constexpr std::uint64_t kTwoGiB = 2ULL << 30;
-    const auto free = static_cast<std::uint64_t>(free_bytes);
-    const auto total = static_cast<std::uint64_t>(total_bytes);
-    const auto reserve = std::max(kTwoGiB, total / 10);
-    const auto available = free > reserve ? free - reserve : 0;
-    if (sizing.cache_bytes > available) {
-        throw std::runtime_error(
-            "Qwen native KV cache admission failed before allocation: capacity=" +
-            std::to_string(ctx.config.max_cache_length) +
-            " tokens, required=" + format_bytes(sizing.cache_bytes) +
-            ", free=" + format_bytes(free) + ", reserve=" + format_bytes(reserve));
-    }
+    return std::runtime_error(message.str());
 }
 
 void reject_native_kv_size_override(const PipelineContext& ctx) {
@@ -429,10 +418,6 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
                 prefill_module = std::move(split_prefill_module);
         }
 
-        // Split prefill deserialization can consume additional execution-context
-        // memory. Admit the KV allocation against the free memory that remains
-        // after every engine/context needed by this pipeline has been loaded.
-        admit_native_kv_allocation(ctx, native_kv, sizing);
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
         log_kv_cache_sizing(ctx, sizing, state.get());
@@ -627,7 +612,7 @@ class QwenDecoderPlugin final : public IPipelinePlugin {
                                                   kv_dim, stream, cache_dtype, std::move(kv_names));
         }
         if (!state->ok())
-            throw std::runtime_error("Failed to create QwenKvCache");
+            throw qwen_kv_cache_allocation_failure(sizing);
         return state;
     }
 

--- a/tests/e2e/models/qwen/test_qwen_native_kv_allocation.py
+++ b/tests/e2e/models/qwen/test_qwen_native_kv_allocation.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source contract for allocation-first Qwen native-KV error handling."""
+
+from pathlib import Path
+
+
+PLUGIN = Path(__file__).parents[4] / "src" / "runtime" / "models" / "qwen" / "plugin.cpp"
+
+
+def test_qwen_reports_memory_only_after_allocation_failure() -> None:
+    source = PLUGIN.read_text(encoding="utf-8")
+
+    assert "admit_native_kv_allocation" not in source
+    assert "admission failed before allocation" not in source
+    assert source.count("cudaMemGetInfo") == 1
+    assert source.count("qwen_kv_cache_allocation_failure(") == 2
+
+    allocation = source.rsplit("build_inference_state", maxsplit=1)[1].split(
+        "static void log_kv_cache_sizing", maxsplit=1
+    )[0]
+    assert (
+        allocation.index("std::make_unique<QwenKvCache>")
+        < allocation.index("if (!state->ok())")
+        < allocation.index("throw qwen_kv_cache_allocation_failure(sizing)")
+    )
+
+    reporter = source.split("std::runtime_error qwen_kv_cache_allocation_failure", maxsplit=1)[
+        1
+    ].split("void reject_native_kv_size_override", maxsplit=1)[0]
+    assert "cudaMemGetInfo" in reporter
+    assert "free after failure=" in reporter
+    assert "CUDA memory diagnostics failed" in reporter


### PR DESCRIPTION
## Background

A nightly installed-wheel smoke built and installed the TensorRT 11.1 wheel successfully, then Qwen rejected a 7 MiB native KV cache before allocation because raw `cudaMemGetInfo` free memory was below a percentage-based reserve. Raw free can understate what CUDA can allocate when reclaimable file cache is charged to coherent HBM.

## Exit Criteria

- Real Qwen KV buffer allocation is authoritative; raw memory telemetry cannot reject the request first.
- Memory telemetry is collected only after Qwen KV cache creation actually fails.
- Protected premerge contains a Qwen-owned contract for the allocation-before-diagnostics order.
- No Llama, shared runtime, CI orchestration, public API, ABI, bundle, dependency, migration, or rollout change is introduced.

## Implementation

- Remove the Qwen pre-allocation `free - reserve` admission check.
- Construct the Qwen inference state first. If its DeviceTensor allocations leave `state->ok() == false`, report the requested cache bytes and rows plus post-failure raw free and total memory. If the diagnostic query itself fails, report that separately.
- Add a Qwen-owned source contract that prevents `cudaMemGetInfo` from moving back before allocation.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed; complexity, changed-file lint/formatting, architecture contracts, and 158 tests succeeded.
- `PYTHONPATH=python:. python3 -m pytest tests/e2e/models/qwen/test_qwen_native_kv_allocation.py tests/e2e/models/qwen/test_qwen_native_kv_routing.py -q`: 28 passed, 17 skipped.
- `python3 -m pytest tests/tools/test_family_source_isolation.py tests/tools/test_model_plugin_isolation.py tests/tools/test_model_plugin_encapsulation_static.py -q`: 284 passed.
- `cmake --build /tmp/trtmc-native-kv-cmake --target trtmc_model_qwen -j2`: Qwen model DSO compiled and linked successfully.
- `python3 tools/model_ci.py impact --base github/main --head HEAD --platform-change-policy fallback --fallback-model segformer --fallback-model whisper --fallback-model deepseek_v2 --fallback-model patchtsmixer`: selected only direct model `qwen`; no fallback models.
- `python3 tools/model_ci.py project --model qwen --revision HEAD --output-dir /tmp/trtmc-qwen-allocation-projection --clean`: the new Qwen regression was included in the isolated model projection.

### Hardware, Environment, and Revisions

Repository head `37d431dd2d66466a6256c72c1909a983ded6d38b`, based on `github/main@49aa14fa91d269a37ba8e6d60950aac050e6a2d5`. Local compilation used AArch64 Ubuntu 24.04 with CUDA 13.0.88. TensorRT was disabled because the local host had no TensorRT SDK.

### Not Run / Remaining Gaps

Full TensorRT 11.1 installed-wheel smoke, live GPU allocation, protected premerge, and Nightly have not run on this rewritten head. The force-pushed head invalidates every CI result from the prior implementation; exact-head CI must run again.

## Notes For Future Readers

Review `src/runtime/models/qwen/plugin.cpp` first, then the small source-order contract. This change does not shrink the fixed native KV capacity or fall back to legacy execution after a real OOM; it reports the failure after the authoritative allocation attempt.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Medium risk: Qwen memory-admission behavior changes, while current-head TensorRT/GPU proof still depends on protected CI. Scope is limited to Qwen and preserves fail-closed behavior after an actual allocation failure.