### PR TITLE
fix(ci): warm premerge HF cache online

### DIFF
--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -1397,8 +1397,9 @@ def test_runner_declares_the_hermetic_container_boundary() -> None:
         assert contract in text
     assert "scratch build produced" in inner
     assert "staged plugin DSO does not byte-match" in inner
-    assert '"--network"' in warm and '"none"' in warm
-    assert "dst=/hf-cache/hub,readonly" in warm
+    assert '"bridge" if online_cache_warm else "none"' in warm
+    assert 'cache_mount = f"type=bind,src={hub},dst=/hf-cache/hub"' in warm
+    assert 'cache_mount += ",readonly"' in warm
     assert "dst=/hf-cache/modules" not in warm
     assert '"HF_HOME=/tmp/hf-home"' in warm
     assert '"HF_MODULES_CACHE=/tmp/hf-modules"' in warm
@@ -1435,10 +1436,12 @@ def test_runner_warms_the_exact_shared_selection_before_the_proof() -> None:
     assert "cache-check-models.txt" in warm
     assert "scripts/warm_hf_cache.py" in warm
     assert '"--models-file"' in warm and '"/artifacts/cache-check-models.txt"' in warm
+    assert 'online_cache_warm = self.request.suite == "premerge"' in warm
     assert '"--local-only"' in warm and '"--strict"' in warm
     assert '"--emit-cache-repos"' in warm and '"/artifacts/hf-cache-repos.json"' in warm
     assert host.index("_prepare_hf_cache") < host.index("_run_proof_container")
-    assert "offline HF cache readiness check failed" in warm
+    assert "online HF cache warm" in warm
+    assert "offline HF cache readiness check" in warm
 
 
 
@@ -1849,7 +1852,43 @@ def test_host_projection_failure_preserves_error_and_html(tmp_path: Path) -> Non
     assert status["exit_code"] == result.returncode
 
 
-def test_strict_cache_warm_failure_stops_before_hermetic_proof(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    (
+        "suite",
+        "expected_error",
+        "expected_network",
+        "expected_local_only",
+        "expected_readonly",
+        "expected_online_environment",
+    ),
+    [
+        (
+            "premerge",
+            "online HF cache warm failed for convbert",
+            "bridge",
+            False,
+            False,
+            True,
+        ),
+        (
+            "nightly",
+            "offline HF cache readiness check failed for convbert",
+            "none",
+            True,
+            True,
+            False,
+        ),
+    ],
+)
+def test_strict_cache_preparation_failure_stops_before_hermetic_proof(
+    tmp_path: Path,
+    suite: str,
+    expected_error: str,
+    expected_network: str,
+    expected_local_only: bool,
+    expected_readonly: bool,
+    expected_online_environment: bool,
+) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     docker_log = tmp_path / "docker.log"
@@ -1864,8 +1903,7 @@ def test_strict_cache_warm_failure_stops_before_hermetic_proof(tmp_path: Path) -
     )
     docker.chmod(0o755)
     output = tmp_path / "proof"
-    (tmp_path / "hf-cache" / "hub").mkdir(parents=True)
-    (tmp_path / "hf-cache" / "modules").mkdir(parents=True)
+    hub_cache = tmp_path / "hf-cache" / "hub"
     env = os.environ.copy()
     env.update(
         {
@@ -1880,6 +1918,8 @@ def test_strict_cache_warm_failure_stops_before_hermetic_proof(tmp_path: Path) -
             *RUNNER_COMMAND,
             "--model",
             "convbert",
+            "--suite",
+            suite,
             "--revision",
             "HEAD",
             "--output-dir",
@@ -1893,7 +1933,8 @@ def test_strict_cache_warm_failure_stops_before_hermetic_proof(tmp_path: Path) -
     )
 
     assert result.returncode != 0
-    assert "offline HF cache readiness check failed for convbert" in result.stderr
+    assert expected_error in result.stderr
+    assert hub_cache.exists() is (suite == "premerge")
     assert (output / "artifacts" / "cache-check-models.txt").read_text().splitlines() == [
         "convbert-base"
     ]
@@ -1904,9 +1945,16 @@ def test_strict_cache_warm_failure_stops_before_hermetic_proof(tmp_path: Path) -
     ]
     assert len(docker_runs) == 1
     assert "scripts/warm_hf_cache.py" in docker_runs[0]
-    assert "--local-only" in docker_runs[0]
+    assert "--read-only" in docker_runs[0]
+    assert ("--local-only" in docker_runs[0]) is expected_local_only
     assert "--strict" in docker_runs[0]
-    assert "--network none" in docker_runs[0]
+    assert "--emit-cache-repos /artifacts/hf-cache-repos.json" in docker_runs[0]
+    assert f"--network {expected_network}" in docker_runs[0]
+    online_environment = "env -u HF_HUB_OFFLINE -u TRANSFORMERS_OFFLINE"
+    assert (online_environment in docker_runs[0]) is expected_online_environment
+    cache_mount = f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub"
+    assert cache_mount in docker_runs[0]
+    assert (f"{cache_mount},readonly" in docker_runs[0]) is expected_readonly
 
 
 def test_host_cache_uses_full_hub_only_for_check_and_positive_view_for_proof() -> None:
@@ -1921,7 +1969,8 @@ def test_host_cache_uses_full_hub_only_for_check_and_positive_view_for_proof() -
     assert "HF Hub cache directory does not exist" not in host
     assert 'hub in {Path("/"), self.context.repository}' in host
     assert "hf_modules_cache" not in host
-    assert 'f"type=bind,src={hub},dst=/hf-cache/hub,readonly"' in cache_check
+    assert 'cache_mount = f"type=bind,src={hub},dst=/hf-cache/hub"' in cache_check
+    assert 'cache_mount += ",readonly"' in cache_check
     assert "dst=/hf-cache/modules" not in cache_check
     assert 'f"type=bind,src={private_hub},dst=/hf-cache/hub"' in proof
     assert "src={private_hub},dst=/hf-cache/hub,readonly" not in proof
@@ -2101,8 +2150,26 @@ def test_sana_reference_cache_wrong_revision_fails_before_docker(
         )
 
 
+@pytest.mark.parametrize(
+    (
+        "suite",
+        "expected_network",
+        "expected_local_only",
+        "expected_readonly",
+        "expected_online_environment",
+    ),
+    [
+        ("premerge", "bridge", False, False, True),
+        ("nightly", "none", True, True, False),
+    ],
+)
 def test_distinct_explicit_hf_cache_paths_reach_both_containers(
     tmp_path: Path,
+    suite: str,
+    expected_network: str,
+    expected_local_only: bool,
+    expected_readonly: bool,
+    expected_online_environment: bool,
 ) -> None:
     fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
     output = tmp_path / "proof"
@@ -2125,6 +2192,8 @@ def test_distinct_explicit_hf_cache_paths_reach_both_containers(
             *RUNNER_COMMAND,
             "--model",
             "convbert",
+            "--suite",
+            suite,
             "--revision",
             "HEAD",
             "--output-dir",
@@ -2145,7 +2214,16 @@ def test_distinct_explicit_hf_cache_paths_reach_both_containers(
     ]
     assert len(docker_runs) == 3
     warm, cache_copy, proof = docker_runs
-    assert f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub,readonly" in warm
+    cache_mount = f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub"
+    assert cache_mount in warm
+    assert (f"{cache_mount},readonly" in warm) is expected_readonly
+    assert f"--network {expected_network}" in warm
+    online_environment = "env -u HF_HUB_OFFLINE -u TRANSFORMERS_OFFLINE"
+    assert (online_environment in warm) is expected_online_environment
+    assert "--read-only" in warm
+    assert ("--local-only" in warm) is expected_local_only
+    assert "--strict" in warm
+    assert "--emit-cache-repos /artifacts/hf-cache-repos.json" in warm
     assert f"src={modules_cache}" not in warm
     assert f"--mount type=bind,src={selected_repo},dst=/selected-hf-repo,readonly" in cache_copy
     private_repo = output / "work" / "hf-private" / "hub" / "models--fixture--model"
@@ -2158,6 +2236,7 @@ def test_distinct_explicit_hf_cache_paths_reach_both_containers(
     assert f"src={hub_cache},dst=/hf-cache/hub" not in proof
     assert f"src={selected_repo}" not in proof
     assert f"src={modules_cache}" not in proof
+    assert "--network none" in proof
     private_hub = output / "work" / "hf-private" / "hub"
     assert f"--mount type=bind,src={private_hub},dst=/hf-cache/hub" in proof
     assert f"src={private_hub},dst=/hf-cache/hub,readonly" not in proof
@@ -2303,7 +2382,7 @@ def test_selected_hf_cache_evidence_rejects_path_escape_before_proof(
     assert "warm_hf_cache.py" in docker_runs[0]
 
 
-def test_docker_bind_mount_fails_closed_when_host_cache_source_is_absent(
+def test_premerge_online_warm_creates_missing_host_cache_source(
     tmp_path: Path,
 ) -> None:
     fake_bin = tmp_path / "bin"
@@ -2349,16 +2428,19 @@ def test_docker_bind_mount_fails_closed_when_host_cache_source_is_absent(
     )
 
     assert result.returncode != 0
-    assert "offline HF cache readiness check failed for convbert" in result.stderr
+    assert "online HF cache warm failed for convbert" in result.stderr
+    assert hub_cache.is_dir()
     docker_runs = [
         line
         for line in docker_log.read_text(encoding="utf-8").splitlines()
         if line.startswith("run ")
     ]
     assert len(docker_runs) == 1
-    assert f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub,readonly" in docker_runs[0]
+    assert f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub" in docker_runs[0]
+    assert "dst=/hf-cache/hub,readonly" not in docker_runs[0]
     assert "dst=/hf-cache/modules" not in docker_runs[0]
-    assert "--network none" in docker_runs[0]
+    assert "--network bridge" in docker_runs[0]
+    assert "--local-only" not in docker_runs[0]
 
 
 def test_explicit_runner_gpu_id_still_acquires_a_slot_lease(tmp_path: Path) -> None:

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -519,6 +519,30 @@ def test_selective_warm_of_cached_snapshot_makes_no_network_download() -> None:
     assert downloads == []
 
 
+def test_selective_warm_of_uncached_public_snapshot_downloads() -> None:
+    helpers = _load_cache_helpers()
+    downloads: list[tuple[str, str, str]] = []
+    helpers["_is_cached"] = lambda _hf_id, **_kwargs: False
+
+    def fake_download(operation: str, hf_id: str, **kwargs):
+        downloads.append((operation, hf_id, kwargs["revision"]))
+        return "/cache/snapshot", "downloaded once"
+
+    helpers["_run_download_attempts"] = fake_download
+
+    status, detail = helpers["_warm_snapshot"](
+        "org/model",
+        revision="0123456789abcdef",
+        gated=False,
+        token_available=False,
+        selective=True,
+        local_only=False,
+    )
+
+    assert (status, detail) == ("downloaded", "downloaded once")
+    assert downloads == [("snapshot", "org/model", "0123456789abcdef")]
+
+
 def test_uncached_gated_snapshot_without_token_fails_before_download() -> None:
     helpers = _load_cache_helpers()
     downloads: list[str] = []

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -157,8 +157,10 @@ The host half, `ModelProofRunner`, performs trusted setup:
    platform files, but no peer model source.
 3. Select the model-owned runtime, Python tests, E2E cases, resource class, and
    optional reference checkout.
-4. Warm only the selected Hugging Face repositories and reflink them into a
-   proof-private cache view.
+4. Prepare only the selected Hugging Face repositories and reflink them into a
+   proof-private cache view. Premerge downloads a missing snapshot into the
+   current host cache; nightly model proofs reuse the cache prepared by the
+   separate Nightly cache-warm job.
 5. Acquire either shared GPU slots or a whole GPU through `GpuLease`.
 6. Start a read-only, network-disabled proof container.
 

--- a/tools/ci/model_proof.py
+++ b/tools/ci/model_proof.py
@@ -423,6 +423,22 @@ class ModelProofRunner:
         hub = Path(self.context.env.get("TRTMC_HF_HUB_CACHE", str(Path(root) / "hub"))).resolve()
         if hub in {Path("/"), self.context.repository}:
             raise CiError("unsafe HF Hub cache path")
+        # Premerge fills the current runner's cache on first use. Nightly keeps
+        # this per-model step offline after its separate cache-warm job.
+        online_cache_warm = self.request.suite == "premerge"
+        if online_cache_warm:
+            try:
+                hub.mkdir(parents=True, exist_ok=True)
+            except OSError as error:
+                raise CiError(f"could not prepare writable HF Hub cache: {hub}") from error
+        cache_mount = f"type=bind,src={hub},dst=/hf-cache/hub"
+        if not online_cache_warm:
+            cache_mount += ",readonly"
+        online_environment = (
+            ["env", "-u", "HF_HUB_OFFLINE", "-u", "TRANSFORMERS_OFFLINE"]
+            if online_cache_warm
+            else []
+        )
         name = self._base_container_name() + "-cache-check"
         self.container_name = name
         self.context.run(["docker", "rm", "-f", name], check=False, capture_output=True)
@@ -435,7 +451,7 @@ class ModelProofRunner:
             *self._job_labels(),
             "--read-only",
             "--network",
-            "none",
+            "bridge" if online_cache_warm else "none",
             "--cap-drop",
             "ALL",
             "--security-opt",
@@ -447,7 +463,7 @@ class ModelProofRunner:
             "--mount",
             f"type=bind,src={self.artifacts_dir},dst=/artifacts",
             "--mount",
-            f"type=bind,src={hub},dst=/hf-cache/hub,readonly",
+            cache_mount,
             "--tmpfs",
             "/tmp:rw,exec,nosuid,nodev,size=1g",
             "--workdir",
@@ -465,19 +481,25 @@ class ModelProofRunner:
             "-e",
             "PYTHONDONTWRITEBYTECODE=1",
             image,
+            *online_environment,
             "/opt/venv/bin/python",
             "/src/scripts/warm_hf_cache.py",
             "--models-file",
             "/artifacts/cache-check-models.txt",
-            "--local-only",
+            *([] if online_cache_warm else ["--local-only"]),
             "--strict",
             "--emit-cache-repos",
             "/artifacts/hf-cache-repos.json",
         ]
         result = self._run_logged(command, self.artifacts_dir / "cache-check.log")
         if result:
+            action = (
+                "online HF cache warm"
+                if online_cache_warm
+                else "offline HF cache readiness check"
+            )
             raise CiError(
-                f"offline HF cache readiness check failed for {self.request.model} (exit {result})"
+                f"{action} failed for {self.request.model} (exit {result})"
             )
         try:
             evidence = self._validated_cache_evidence(hub)


### PR DESCRIPTION
## Background

PR #926 exposed a first-use gap in protected premerge: impact selection correctly chose the new L0 model, but isolated model proof only checked an already-populated Hugging Face cache. A public model missing from the current runner therefore failed before GPU execution.

## Exit Criteria

- Premerge downloads a missing selected public-model snapshot into the current runner's persistent HF cache.
- A cached snapshot remains a zero-download fast path.
- Nightly cache warming and Nightly model-proof cache checks remain unchanged.
- The final isolated GPU proof remains network-disabled, and no HF credential is forwarded to the premerge cache container.

## Implementation

- Route selected HF cache preparation by suite:
  - premerge uses bridge networking, a writable host Hub mount, and clears inherited offline flags;
  - nightly keeps `--network none`, a read-only Hub mount, and `--local-only`.
- Create the host Hub directory on first premerge use.
- Preserve strict selected-repository evidence, the proof-private reflink copy, the unprivileged/read-only cache container controls, and the fully offline proof container.
- Document the premerge-versus-Nightly ownership boundary and cover both suite command shapes.
- Public API, ABI, bundle format, dependencies, model behavior, and the private Nightly workflow are unchanged.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_model_proof_runner.py tests/tools/test_warm_hf_cache_static.py`: 204 passed.
- `ruff 0.16.4 check --config ruff.toml tools/ci/model_proof.py tests/tools/test_model_proof_runner.py tests/tools/test_warm_hf_cache_static.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with 0 findings.
- `PYTHONPATH=python:. python3 tools/model_ci.py validate`: passed for the 84-owner inventory.
- `PYTHONPATH=python:. python3 tools/test_impact.py --validate`: passed with the existing inventory/allowlist warnings.
- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_model_ci.py::test_impact_runs_units_for_test_consumed_docs`: 2 passed.
- `git diff --check`: passed.
- Community CPU run `33021618323`: Source quality, Docs, Ownership and impact, Unit / C++ and Python, and Required all passed on head `95e21ebc`.

### Hardware, Environment, and Revisions

- Source base: `NVIDIA/TensorRT-Model-Connect@49aa14fa91d269a37ba8e6d60950aac050e6a2d5`.
- Tested head: `95e21ebca6ef94b04816adc5a1e86bfc59a93486`.
- Local validation: Linux aarch64, Python 3.12, pytest, and Ruff 0.16.4.
- Community CPU: GitHub-hosted Ubuntu 24.04 merge-revision validation.
- GPU, CUDA, TensorRT, model checkpoint, dataset, and precision are not applicable to the source-only local tests.

### Not Run / Remaining Gaps

- A real Hugging Face download was not run locally; protected premerge is the intended target-environment validation.
- An uncached gated model was not downloaded. This path deliberately forwards no HF token and must continue to fail closed.
- No Nightly run was started because the private Nightly workflow is intentionally unchanged.
- No GPU model build or inference was run because this change stops at cache preparation and leaves the existing proof path unchanged.

## Notes For Future Readers

- The cache is host-local. If a retry lands on another proof host, that host downloads the snapshot once.
- Public models download anonymously. An uncached gated model still fails closed because this path deliberately forwards no HF token.
- This intentionally gives only the premerge cache-preparation container network access and a writable shared Hub. It remains non-root with a read-only root filesystem, dropped capabilities, and no secrets; the later cache copy and GPU proof remain offline.
- Review `tools/ci/model_proof.py` first, then the parameterized premerge/Nightly command tests.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this is CI-only and forwards no credentials, but it intentionally changes the premerge cache-preparation container from offline/read-only cache access to networked/writable cache access. The final proof and Nightly paths remain unchanged and offline.
