### PR TITLE
feat(whisper): add whisper-small profile

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -1074,5 +1074,7 @@ additional_profiles:
     inherit: llama.generate
   - model: whisper-large-v3-turbo
     inherit: whisper.transcribe
+  - model: whisper-small-fp16
+    inherit: whisper.transcribe
   - model: xlm-roberta-base
     inherit: roberta.encode

--- a/tests/e2e/models/whisper/MODEL.toml
+++ b/tests/e2e/models/whisper/MODEL.toml
@@ -6,6 +6,7 @@ plugin = "whisper"
 test_manifests = [
   "manifests/whisper-large-v3-turbo-tp4.json",
   "manifests/whisper-large-v3-turbo.json",
+  "manifests/whisper-small-fp16.json",
   "manifests/whisper-tiny-fp16-tp2.json",
   "manifests/whisper-tiny-fp16.json",
 ]

--- a/tests/e2e/models/whisper/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/whisper/e2e_plugins/references/hf_transformers.py
@@ -812,6 +812,7 @@ class HfTransformersReference:
         audio_path = self._resolve_image_path(case.inputs.get("audio", ""))
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
+        revision = getattr(case, "hf_revision", "") or None
         torch_dtype_expr = _torch_dtype_for_case(case)
         max_new_tokens = int(case.inputs.get("max_new_tokens", 100))
 
@@ -821,15 +822,16 @@ class HfTransformersReference:
             import scipy.io.wavfile as wav
 
             hf_id = {hf_id!r}
+            revision = {revision!r}
             audio_path = {audio_path!r}
             trust_remote_code = {trust_remote_code!r}
             output_path = {output_path!r}
             max_new_tokens = {max_new_tokens}
 
             processor = AutoProcessor.from_pretrained(
-                hf_id, trust_remote_code=trust_remote_code)
+                hf_id, revision=revision, trust_remote_code=trust_remote_code)
             model = AutoModelForSpeechSeq2Seq.from_pretrained(
-                hf_id, trust_remote_code=trust_remote_code,
+                hf_id, revision=revision, trust_remote_code=trust_remote_code,
                 torch_dtype={torch_dtype_expr})
             model.eval()
 
@@ -877,6 +879,7 @@ class HfTransformersReference:
             env=_reference_env(ctx),
             output_readers=(_json_output_reader(output_path),),
             text_reader=_json_text_reader(output_path),
+            metadata={"hf_id": hf_id, "hf_revision": revision or ""},
             failure_label="HF speech-to-text",
         )
 

--- a/tests/e2e/models/whisper/manifests/whisper-small-fp16.json
+++ b/tests/e2e/models/whisper/manifests/whisper-small-fp16.json
@@ -1,0 +1,27 @@
+{
+  "name": "whisper-small-fp16",
+  "hf_id": "openai/whisper-small",
+  "hf_revision": "973afd24965f72e36ca33b3055d56a652f456b4d",
+  "bundle": "whisper-small-fp16.bundle",
+  "family": "whisper",
+  "runtime_strategy": "whisper_speech_to_text",
+  "task_strategy": "speech_to_text",
+  "precision": "fp16",
+  "fp32_layers": [0],
+  "max_cache_length": 128,
+  "trust_remote_code": false,
+  "e2e_parallel_resource": "exclusive_gpu",
+  "testcases": [
+    {
+      "name": "whisper-small-fp16",
+      "trace_id": "IT-E2E-WHSPS-FP16-01",
+      "reference_family": "asr_whisper",
+      "user_contract": "exact_transcript",
+      "reference_precision": "fp32",
+      "test_type": "transcription",
+      "prompt": "test",
+      "max_new_tokens": 20,
+      "test_input_audio": "data/Recording.wav"
+    }
+  ]
+}

--- a/tests/e2e/models/whisper/perf_validation.json
+++ b/tests/e2e/models/whisper/perf_validation.json
@@ -1,6 +1,17 @@
 {
   "models": [
     {
+      "model": "openai/whisper-small",
+      "pipeline_type": "speech_to_text",
+      "label": "C1-whisper-small",
+      "benchmark": {
+        "label": "CPU argmax",
+        "gpu_argmax_label": "GPU argmax",
+        "metric": "pipeline_ms",
+        "command": ["{binary}", "transcribe", "{bundle}", "--audio", "{repo_root}/tests/e2e/models/whisper/data/Recording.wav", "--max-new-tokens", "{max_tokens}", "{hf_python_args}"]
+      }
+    },
+    {
       "model": "openai/whisper-tiny",
       "pipeline_type": "speech_to_text",
       "label": "C1-whisper",

--- a/tests/e2e/models/whisper/test_whisper_accuracy_contract.py
+++ b/tests/e2e/models/whisper/test_whisper_accuracy_contract.py
@@ -25,6 +25,7 @@ WHISPER_DIR = Path(__file__).resolve().parent
 LONG_AUDIO_SHA256 = (
     "166d138dc95c706e4eedbebb48f4ac4c8cb1b77ea796c0bc650da518308657e2"
 )
+WHISPER_SMALL_REVISION = "973afd24965f72e36ca33b3055d56a652f456b4d"
 
 
 def _model_config(model_dir: Path, **raw) -> ModelConfig:
@@ -117,6 +118,73 @@ def test_hf_reference_uses_the_manifest_generation_budget(
     )
     assert "skip_special_tokens=True)[0].strip()" in script
     assert "torch_dtype=torch.float32" in script
+
+
+def test_whisper_small_pins_build_and_reference_to_one_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = json.loads(
+        (
+            WHISPER_DIR / "manifests" / "whisper-small-fp16.json"
+        ).read_text(encoding="utf-8")
+    )
+    testcase = manifest["testcases"][0]
+
+    assert manifest["hf_id"] == "openai/whisper-small"
+    assert manifest["hf_revision"] == WHISPER_SMALL_REVISION
+    assert manifest["runtime_strategy"] == "whisper_speech_to_text"
+    assert manifest["task_strategy"] == "speech_to_text"
+    assert manifest["precision"] == "fp16"
+    assert manifest["fp32_layers"] == [0]
+    assert testcase["reference_precision"] == "fp32"
+    assert manifest["max_cache_length"] >= 4 + testcase["max_new_tokens"]
+    thresholds = json.loads(
+        (
+            WHISPER_DIR / "thresholds" / "whisper-small-fp16.json"
+        ).read_text(encoding="utf-8")
+    )["threshold_overrides"]
+    assert thresholds["contract_ned_threshold"] == 0.0
+    assert thresholds["contract_wer_threshold"] == 0.0
+
+    captured: dict = {}
+    marker = object()
+
+    def _capture_reference(**kwargs):
+        captured.update(kwargs)
+        return marker
+
+    monkeypatch.setattr(
+        hf_transformers, "run_reference_subprocess", _capture_reference
+    )
+    case = SimpleNamespace(
+        metadata={
+            "reference_precision": testcase["reference_precision"],
+            "trust_remote_code": manifest["trust_remote_code"],
+        },
+        inputs={
+            "audio": str(tmp_path / "input.wav"),
+            "max_new_tokens": testcase["max_new_tokens"],
+        },
+        hf_id=manifest["hf_id"],
+        hf_revision=manifest["hf_revision"],
+        name=manifest["name"],
+    )
+    stage = SimpleNamespace(name="full_generation")
+    ctx = SimpleNamespace(
+        artifacts_dir=str(tmp_path),
+        ld_library_path="",
+        reference_python_path=lambda: None,
+    )
+
+    result = hf_transformers.HfTransformersReference()._run_speech_to_text_ref(
+        case, stage, ctx
+    )
+
+    assert result is marker
+    script = captured["command"][2]
+    assert f"revision = {WHISPER_SMALL_REVISION!r}" in script
+    assert script.count("revision=revision") == 2
+    assert captured["metadata"]["hf_revision"] == WHISPER_SMALL_REVISION
 
 
 def test_long_audio_sentinel_has_pinned_qa_provenance() -> None:

--- a/tests/e2e/models/whisper/thresholds/whisper-small-fp16.json
+++ b/tests/e2e/models/whisper/thresholds/whisper-small-fp16.json
@@ -1,0 +1,16 @@
+{
+  "threshold_overrides": {
+    "cer": 0.0,
+    "contract_cer_threshold": 0.0,
+    "contract_ned_threshold": 0.0,
+    "contract_wer_threshold": 0.0,
+    "layer_atol": 0.5,
+    "logit_atol": 1.0,
+    "logit_cosine_p5": 0.0,
+    "normalized_text_edit_distance": 0.0,
+    "stable_top1_match_rate": 0.0,
+    "timestamp_tolerance_s": 0.5,
+    "token_agreement_rate": 0.0,
+    "wer": 0.0
+  }
+}

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -895,9 +895,10 @@ def test_whisper_nightly_selection_leases_one_complete_gpu(
         },
     )
 
-    assert len(selection["e2e_cases"]) == 16
+    assert len(selection["e2e_cases"]) == 17
     assert {case["manifest"] for case in selection["e2e_cases"]} == {
         "whisper-large-v3-turbo.json",
+        "whisper-small-fp16.json",
         "whisper-tiny-fp16.json",
     }
     assert {case["resource_class"] for case in selection["e2e_cases"]} == {"exclusive_gpu"}

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -274,9 +274,9 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
 
     performance_catalog.validate_release_coverage(cases, excluded_profiles)
 
-    assert len(cases) == 108
+    assert len(cases) == 109
     assert len(raw_entries) == 79
-    assert len(raw_additional) == 29
+    assert len(raw_additional) == 30
     assert excluded_profiles == {
         "fast-foundation-stereo": FAST_FOUNDATION_STEREO_EXCLUSION_REASON,
         "lfm2-1.2b": LFM2_EXCLUSION_REASON,
@@ -301,7 +301,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
         "rerank",
     ]
     assert Counter(perf_matrix._candidate_timing_scope(case) for case in cases) == {
-        "model_call_wall": 24,
+        "model_call_wall": 25,
         "public_pipeline_call_wall": 84,
     }
     assert {case["id"] for case in cases if case["baseline"]["asset_loading_included"]} == {
@@ -2122,7 +2122,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert not scratch_root.exists()
     results = json.loads((output / "results.json").read_text(encoding="utf-8"))
     rows = {row["id"]: row for row in results["cases"]}
-    assert len(rows) == 108
+    assert len(rows) == 109
     assert results["environment_config"]["name"] == "test-gb300"
     assert results["environment_config"]["execution"]["minimum_gpu_free_fraction"] == 0.0
     assert results["environment_config"]["source"] == str(environment.resolve())

--- a/tests/tools/test_performance_catalog.py
+++ b/tests/tools/test_performance_catalog.py
@@ -18,7 +18,7 @@ def test_release_suite_loads_and_selects_models_in_request_order() -> None:
     selected = suite.select(models=["distilgpt2", "gpt2-125m"])
 
     assert [case["model"] for case in selected] == ["distilgpt2", "gpt2-125m"]
-    assert len(suite.cases) == 108
+    assert len(suite.cases) == 109
 
 
 def test_release_suite_exposes_explicit_exclusions() -> None:

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -163,6 +163,7 @@ def test_catalog_reuses_existing_model_manifests_for_different_tasks(tmp_path: P
         "flux-schnell-l0": ("generate_image", 1, 5),
         "chronos-bolt-tiny-official": ("solve", 50, 500),
         "nemotron-embed-vl-1b-v2": ("embed", 50, 500),
+        "whisper-small-fp16": ("transcribe", 1, 10),
         "whisper-tiny-fp16": ("transcribe", 1, 10),
         "fast-foundation-stereo": ("disparity", 3, 100),
     }

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -45,7 +45,7 @@ def test_model_workload_catalog_covers_every_ready_model():
         task_models=task_models,
     )
 
-    assert len(catalog["models"]) == len(ready_models) == 116
+    assert len(catalog["models"]) == len(ready_models) == 117
     assert sum("not_compared_reason" in spec for spec in catalog["models"].values()) == 0
     assert all("e2e" not in spec.get("workloads", []) for spec in catalog["models"].values())
     assert "reference_cache_identity" not in catalog["models"]["personaplex-7b"]
@@ -64,7 +64,7 @@ def test_model_workload_catalog_covers_every_ready_model():
     }
     assert len(qwen_identities) == 1
     bindings = trtmc_validate.resolve_bindings(catalog, catalog["models"])
-    assert len(bindings) == 116
+    assert len(bindings) == 117
     assert {
         binding.model for binding in bindings if binding.workload == "mmlu_continuation_parity"
     } >= {
@@ -245,7 +245,7 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 116
+    assert len({model for model, _workload in bindings}) == 117
 
 
 def test_resolve_binding_requires_an_explicit_choice_for_multi_workload_model():

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -1845,16 +1845,25 @@ def test_plan_selects_refcoco_locateanything_model() -> None:
 def test_plan_selects_librispeech_asr_models() -> None:
     suites = validation_engine.load_suites()
     models = validation_engine.load_manifest_records()
+    whisper_small = next(
+        model for model in models if model["name"] == "whisper-small-fp16"
+    )
+
+    assert whisper_small["hf_revision"] == (
+        "973afd24965f72e36ca33b3055d56a652f456b4d"
+    )
 
     rows = validation_engine.build_plan(suites, models, suite_id="librispeech_clean_asr")
 
     selected = {row["model"]: row for row in rows}
     assert "whisper-tiny-fp16" in selected
     assert selected["whisper-tiny-fp16"]["runtime_strategy"] == "whisper_speech_to_text"
+    assert selected["whisper-small-fp16"]["runtime_strategy"] == "whisper_speech_to_text"
     assert "canary-1b-v2" in selected
     assert selected["canary-1b-v2"]["runtime_strategy"] == "canary_speech_to_text"
     assert set(selected) == {
         "whisper-tiny-fp16",
+        "whisper-small-fp16",
         "whisper-large-v3-turbo",
         "canary-1b-v2",
     }

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -283,6 +283,8 @@ models:
     workloads: [vbench_ti2v_official_profile_parity]
   whisper-large-v3-turbo:
     workloads: [librispeech_clean_asr]
+  whisper-small-fp16:
+    workloads: [librispeech_clean_asr]
   whisper-tiny-fp16:
     workloads: [librispeech_clean_asr]
   xglm-564m:

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -717,6 +717,7 @@ suites:
     user_contract: exact_transcript
     default_model_names:
       - whisper-tiny-fp16
+      - whisper-small-fp16
       - whisper-large-v3-turbo
       - canary-1b-v2
     dataset:

--- a/website/data/hf-model-metadata.json
+++ b/website/data/hf-model-metadata.json
@@ -1151,6 +1151,17 @@
       "architecture_source": "config.architectures"
     },
     {
+      "hf_id": "openai/whisper-small",
+      "revision": "973afd24965f72e36ca33b3055d56a652f456b4d",
+      "revision_source": "declared",
+      "metadata_file": "config.json",
+      "model_type": "whisper",
+      "architectures": [
+        "WhisperForConditionalGeneration"
+      ],
+      "architecture_source": "config.architectures"
+    },
+    {
       "hf_id": "openai/whisper-tiny",
       "revision": "169d4a4341b33bc18d8881c4b69c2e104e1cc0af",
       "revision_source": "resolved",


### PR DESCRIPTION
## Background

The native Whisper family lacks a pinned `openai/whisper-small` qualification profile. This adds the checkpoint to the existing family and wires it into public validation, release benchmarking, and model metadata.

## Exit Criteria

- Build and run the immutable Whisper-small checkpoint through the native speech-to-text runtime in FP16.
- Compare against an FP32 Hugging Face reference at the same immutable revision.
- Register the model consistently across E2E, validation, release, and website inventories.

## Implementation

- Add the Whisper-small manifest, strict transcript thresholds, and performance-validation metadata.
- Propagate the manifest revision into both Hugging Face processor and model loading.
- Add the model to validation workloads, release benchmarking, proof selection, and website metadata.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- Focused changed-node suite: 9 passed.
- Directly affected performance, validation, and repository-contract test files: 299 passed.
- `python3 tools/model_ci.py validate`: passed at `a38a49a2bf35b5e9cf0b2b99a5b01860cb75e5cb`.
- `python3 tools/test_impact.py --validate`: passed.
- Repository trailing-whitespace, EOF, YAML, Ruff 0.16.4, and clang-format 22.1.8 hooks: passed on every changed file.
- Release/CUDA SM120 build at runtime-identical predecessor `b2ef3159f6c2571a137e1e065727fb7c50efa011`, including the TensorRT backend and Whisper model plugin: passed; the final head changes only one repository test inventory count.
- Pinned-checkpoint TensorRT FP16 vs. Hugging Face FP32 E2E at that runtime-identical predecessor on an RTX 5080: 1 passed with the strict transcript contract.

### Hardware, Environment, and Revisions

- Head `a38a49a2bf35b5e9cf0b2b99a5b01860cb75e5cb`; base `6464865960019301a2728196ee4ebddf5f90ba1f`.
- Checkpoint `openai/whisper-small@973afd24965f72e36ca33b3055d56a652f456b4d`.
- RTX 5080 (SM120), Docker Desktop, `nvcr.io/nvidia/tensorrt:26.07-py3`, TensorRT 11.1.0.106; TensorRT FP16 vs. Hugging Face FP32.

### Not Run / Remaining Gaps

- Protected premerge and internal GPU CI have not run. The broad local proof-runner result and its two environment-invalid reflink cases plus upstream-control FIFO failure are documented below; multi-GPU and performance qualification were not run.

## Notes For Future Readers

- A broader local proof-runner suite produced 511 passes and 1 skip. Two cache-test parameterizations are environment-invalid because Docker Desktop does not support `cp --reflink=always`; the remaining FIFO-order failure reproduces on the exact upstream `8fb1b89d447d12067930d19d1a7d1d1340ffc77f` control. The branch-specific nodes above all pass.
- Protected premerge CI has not run on this head yet.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The implementation adds a pinned profile to the existing Whisper family; it does not change the native Whisper runtime or public interfaces.
