### PR TITLE
fix(model-checks): preserve qualification evidence identity

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -58,6 +58,24 @@ python3 tools/perf_matrix.py run \
   --entry gpt2.generate
 ```
 
+For a source-bound qualification, materialize bundles before the campaign and
+then disable builds during measurement:
+
+```bash
+export TRTMC_PERF_SOURCE_REVISION=<40-character-commit-sha>
+export TRTMC_ENGINE_BUILD_REVISION=$TRTMC_PERF_SOURCE_REVISION
+python3 tools/perf_matrix.py prepare \
+  benchmarks/performance/release.yaml \
+  --environment benchmarks/performance/environments/gb300.yaml \
+  --entry gpt2.generate \
+  --output artifacts/perf/bundle-preparation.json
+python3 tools/perf_matrix.py run \
+  benchmarks/performance/release.yaml \
+  --environment benchmarks/performance/environments/gb300.yaml \
+  --entry gpt2.generate \
+  --no-build
+```
+
 Run every release entry bound to one or more canonical model names:
 
 ```bash
@@ -211,11 +229,13 @@ TRTMC_PERF_RUNTIME_DIRS
 ```
 
 Bundles below the managed cache are reusable only when their cache key matches
-the current model manifest, build options and assets, TensorRT platform, and
-generic plus family-owned builder sources. A stale managed bundle discovered
-through a bundle root is preserved but ignored while the current bundle is
-built. Bundles outside the managed cache are explicit prebuilt inputs and are
-therefore trusted as supplied.
+the current model manifest, build options and assets, TensorRT platform,
+generic plus family-owned builder sources, and any exact source revision
+supplied through `TRTMC_ENGINE_BUILD_REVISION`. A stale managed bundle
+discovered through a bundle root is preserved but ignored while the current
+bundle is built. When an exact build revision is supplied, bundles outside the
+managed cache must embed the same revision in `config.json`; missing or
+mismatched provenance is rejected.
 
 The script expands these values before preflight and records the resolved
 environment, source path, and configuration SHA-256 in `results.json`. Missing

--- a/python/tensorrt_model_connect/benchmark/builder.py
+++ b/python/tensorrt_model_connect/benchmark/builder.py
@@ -21,6 +21,7 @@ import time
 from typing import Any, Iterable, Mapping, Sequence
 
 from .. import trt_compat
+from ..bundle_writer import bundle_source_revision
 from .types import BenchmarkError, ModelDescriptor, ResolvedCase
 
 
@@ -38,6 +39,7 @@ class BundlePreparation:
     stderr_log: Path | None = None
     builder_tensorrt_version: str | None = None
     runtime_backend_abi: str | None = None
+    source_revision: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -51,6 +53,7 @@ class BundlePreparation:
             "stderr_log": str(self.stderr_log) if self.stderr_log else None,
             "builder_tensorrt_version": self.builder_tensorrt_version,
             "runtime_backend_abi": self.runtime_backend_abi,
+            "source_revision": self.source_revision,
             "included_in_performance_metrics": False,
         }
 
@@ -82,6 +85,7 @@ class _BuildPlan:
     environment: Mapping[str, str]
     timeout_s: int
     runtime: _BuilderRuntime
+    source_revision: str | None
 
 
 class BundleBuilder:
@@ -143,14 +147,30 @@ class BundleBuilder:
         requested_bundle = requested_bundle.expanduser().resolve()
         requested_is_managed = _is_relative_to(requested_bundle, self.cache_root)
         if requested_bundle.is_file() and not requested_is_managed and not rebuild:
-            return None, BundlePreparation(model.name, "reused", requested_bundle)
+            actual_revision = bundle_source_revision(requested_bundle)
+            expected_revision = _expected_source_revision()
+            if expected_revision and actual_revision != expected_revision:
+                raise BenchmarkError(
+                    f"external bundle {requested_bundle} source revision "
+                    f"{actual_revision or '<missing>'} does not match {expected_revision}"
+                )
+            return None, BundlePreparation(
+                model.name,
+                "reused",
+                requested_bundle,
+                source_revision=actual_revision or None,
+            )
         if requested_bundle.is_file() and not requested_is_managed:
             raise BenchmarkError(
                 f"--rebuild cannot overwrite explicit/external bundle {requested_bundle}; "
                 "omit --bundle to rebuild the managed cache"
             )
         plan = self._plan(model, cases)
-        if plan.bundle.is_file() and not rebuild:
+        bundle_matches_revision = (
+            not plan.source_revision
+            or bundle_source_revision(plan.bundle) == plan.source_revision
+        )
+        if plan.bundle.is_file() and not rebuild and bundle_matches_revision:
             return plan.bundle, BundlePreparation(
                 model.name,
                 "cache_hit",
@@ -158,6 +178,7 @@ class BundleBuilder:
                 plan.cache_key,
                 builder_tensorrt_version=plan.runtime.version,
                 runtime_backend_abi=plan.runtime.backend_abi,
+                source_revision=plan.source_revision,
             )
         if not allow_build:
             raise BenchmarkError(
@@ -166,7 +187,11 @@ class BundleBuilder:
             )
         if dry_run:
             return plan.bundle, BundlePreparation(
-                model.name, "would_build", plan.bundle, plan.cache_key
+                model.name,
+                "would_build",
+                plan.bundle,
+                plan.cache_key,
+                source_revision=plan.source_revision,
             )
         return plan.bundle, self._build(plan)
 
@@ -177,6 +202,7 @@ class BundleBuilder:
         identity_options = dict(options)
         if "fp8_scales" in identity_options:
             identity_options["fp8_scales"] = model.build_settings["fp8_scales"]
+        source_revision = _expected_source_revision()
         identity = {
             "schema_version": "trtmc.benchmark-bundle-cache/v2",
             "model": model.identity(),
@@ -186,6 +212,8 @@ class BundleBuilder:
             "builder_sources_sha256": _builder_source_digest(model.family),
             "platform": _platform_identity(runtime),
         }
+        if source_revision:
+            identity["source_revision"] = source_revision
         encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
         cache_key = hashlib.sha256(encoded).hexdigest()[:16]
         bundle = self.cache_root / model.name / cache_key / model.bundle_name
@@ -193,7 +221,16 @@ class BundleBuilder:
         timeout = int(model.build_settings.get("build_timeout_s", 3600))
         if timeout <= 0:
             raise BenchmarkError(f"build_timeout_s for {model.name} must be positive")
-        return _BuildPlan(model, bundle, cache_key, command, environment, timeout, runtime)
+        return _BuildPlan(
+            model,
+            bundle,
+            cache_key,
+            command,
+            environment,
+            timeout,
+            runtime,
+            source_revision,
+        )
 
     def _build(self, plan: _BuildPlan) -> BundlePreparation:
         plan.bundle.parent.mkdir(parents=True, exist_ok=True)
@@ -249,6 +286,16 @@ class BundleBuilder:
                 ),
             )
         os.replace(temporary, plan.bundle)
+        actual_revision = bundle_source_revision(plan.bundle)
+        if plan.source_revision and actual_revision != plan.source_revision:
+            plan.bundle.unlink()
+            raise BenchmarkError(
+                f"bundle build for {plan.model.name} produced source revision "
+                f"{actual_revision or '<missing>'}; expected {plan.source_revision}",
+                stage="build",
+                domain="harness/unknown",
+                code="bundle_source_revision_mismatch",
+            )
         record = BundlePreparation(
             model=plan.model.name,
             status="built",
@@ -260,6 +307,7 @@ class BundleBuilder:
             stderr_log=stderr_log,
             builder_tensorrt_version=plan.runtime.version,
             runtime_backend_abi=plan.runtime.backend_abi,
+            source_revision=plan.source_revision,
         )
         (plan.bundle.parent / "build.json").write_text(
             json.dumps(record.to_json(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -278,6 +326,15 @@ class BundleBuilder:
             env=dict(environment),
             check=False,
         )
+
+
+def _expected_source_revision() -> str | None:
+    revision = os.environ.get("TRTMC_ENGINE_BUILD_REVISION", "").strip().lower()
+    if not revision:
+        return None
+    if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise BenchmarkError("TRTMC_ENGINE_BUILD_REVISION must be an exact Git SHA")
+    return revision
 
 
 def default_bundle_cache() -> Path:

--- a/python/tensorrt_model_connect/benchmark/cli.py
+++ b/python/tensorrt_model_connect/benchmark/cli.py
@@ -72,6 +72,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="result directory; an existing explicit directory is replaced",
     )
     run.add_argument("--dry-run", action="store_true", help="print resolved cases only")
+    run.add_argument(
+        "--prepare-only",
+        action="store_true",
+        help="materialize selected bundles and emit JSON evidence without measuring",
+    )
 
     list_command = subparsers.add_parser("list", help="list benchmark catalog entries")
     list_subparsers = list_command.add_subparsers(dest="list_command", required=True)
@@ -171,6 +176,8 @@ def _report(arguments: argparse.Namespace) -> int:
 
 
 def _run(arguments: argparse.Namespace) -> int:
+    if arguments.dry_run and arguments.prepare_only:
+        raise BenchmarkError("--dry-run and --prepare-only cannot be combined")
     spec = _load_spec(arguments.config)
     catalog = ManifestCatalog(arguments.manifest_root)
     worker: Path | None = None
@@ -192,6 +199,15 @@ def _run(arguments: argparse.Namespace) -> int:
     )
     if arguments.dry_run:
         print(json.dumps([case.to_json() for case in cases], indent=2, sort_keys=True))
+        return 0
+    if arguments.prepare_only:
+        print(
+            json.dumps(
+                {"bundles": [record.to_json() for record in bundle_preparation]},
+                indent=2,
+                sort_keys=True,
+            )
+        )
         return 0
     output = _absolute_path(arguments.output or default_output_dir())
     working_output = _working_output(output, overwrite=arguments.output is not None)

--- a/python/tensorrt_model_connect/bundle_writer.py
+++ b/python/tensorrt_model_connect/bundle_writer.py
@@ -24,6 +24,7 @@ from typing import Any, cast
 
 BUNDLE_MAGIC = b"BUNDLE\x01\x00"
 _MAX_BUNDLE_HEADER_SIZE = 100 * 1024 * 1024
+_EXACT_SOURCE_REVISION_LENGTH = 40
 
 
 @dataclass
@@ -70,6 +71,82 @@ class _FileBundleSection:
     name: str
     source_path: Path
     expected_sha256: str | None
+
+
+def read_bundle_section(path: str | Path, section_name: str) -> bytes:
+    """Read one named section from a TRTMC bundle."""
+    bundle_path = Path(path)
+    with bundle_path.open("rb") as bundle:
+        if bundle.read(8) != BUNDLE_MAGIC:
+            raise ValueError(f"{bundle_path} is not a TRTMC bundle")
+        raw_header_size = bundle.read(8)
+        if len(raw_header_size) != 8:
+            raise ValueError(f"{bundle_path} has a truncated header size")
+        header_size = struct.unpack("<Q", raw_header_size)[0]
+        if header_size > _MAX_BUNDLE_HEADER_SIZE:
+            raise ValueError(
+                f"{bundle_path} header exceeds {_MAX_BUNDLE_HEADER_SIZE} bytes"
+            )
+        raw_header = bundle.read(header_size)
+        if len(raw_header) != header_size:
+            raise ValueError(f"{bundle_path} has a truncated JSON header")
+        header = json.loads(raw_header)
+        sections = header.get("sections", {})
+        section = sections.get(section_name) if isinstance(sections, dict) else None
+        if not isinstance(section, dict):
+            raise ValueError(f"{bundle_path} has no {section_name!r} section")
+        offset = int(section.get("offset", -1))
+        size = int(section.get("size", -1))
+        data_start = 16 + header_size
+        if offset < 0 or size < 0 or data_start + offset + size > bundle_path.stat().st_size:
+            raise ValueError(f"{bundle_path} has an invalid {section_name!r} section range")
+        bundle.seek(data_start + offset)
+        data = bundle.read(size)
+        if len(data) != size:
+            raise ValueError(f"{bundle_path} has a truncated {section_name!r} section")
+        return data
+
+
+def bundle_source_revision(path: str | Path) -> str:
+    """Return the exact source revision embedded in a bundle, or an empty string."""
+    try:
+        config = json.loads(read_bundle_section(path, "config.json").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return ""
+    if not isinstance(config, dict):
+        return ""
+    revision = str(config.get("source_revision", "") or "").strip().lower()
+    if len(revision) != _EXACT_SOURCE_REVISION_LENGTH:
+        return ""
+    return revision if all(character in "0123456789abcdef" for character in revision) else ""
+
+
+def _source_bound_sections(sections: list[BundleSection]) -> list[BundleSection]:
+    revision = os.environ.get("TRTMC_ENGINE_BUILD_REVISION", "").strip().lower()
+    if not revision:
+        return sections
+    if len(revision) != _EXACT_SOURCE_REVISION_LENGTH or any(
+        character not in "0123456789abcdef" for character in revision
+    ):
+        raise ValueError("TRTMC_ENGINE_BUILD_REVISION must be an exact Git SHA")
+    updated = list(sections)
+    for index, section in enumerate(updated):
+        if section.name != "config.json":
+            continue
+        raw = (
+            section.source_path.read_bytes()
+            if isinstance(section, _FileBundleSection)
+            else section.data
+        )
+        config = json.loads(raw)
+        if not isinstance(config, dict):
+            raise ValueError("Bundle config.json must contain an object")
+        config["source_revision"] = revision
+        updated[index] = BundleSection(
+            "config.json", json.dumps(config, indent=2).encode("utf-8")
+        )
+        return updated
+    raise ValueError("source-bound bundle requires a config.json section")
 
 
 def _bundle_section_from_file(
@@ -267,6 +344,7 @@ def write_bundle(
     sections: list[BundleSection],
 ) -> None:
     """Write a .bundle artifact file."""
+    sections = _source_bound_sections(sections)
     if any(isinstance(section, _FileBundleSection) for section in sections):
         _write_file_backed_bundle(path, info, sections)
         return

--- a/tests/builder/test_bundle_writer.py
+++ b/tests/builder/test_bundle_writer.py
@@ -43,6 +43,21 @@ def test_bundle_section_public_constructor_remains_name_and_bytes_only():
     assert not hasattr(BundleSection, "from_file")
 
 
+def test_write_bundle_embeds_exact_build_source_revision(tmp_path, monkeypatch):
+    revision = "a" * 40
+    output = tmp_path / "source-bound.bundle"
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", revision)
+
+    write_bundle(
+        output,
+        BundleInfo(),
+        [BundleSection("config.json", b'{"model_type": "synthetic_decoder"}')],
+    )
+
+    _header, sections = read_bundle_file(output)
+    assert json.loads(sections["config.json"])["source_revision"] == revision
+
+
 class TestWriteBundle:
     def _read_bundle(self, path: str) -> tuple[dict, dict[str, bytes]]:
         return read_bundle_file(path)

--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -54,7 +54,7 @@ model in `tests/validation/model_workloads.yaml`.
 
 ## Run
 
-By default, `run` is a formal qualification run. It freezes source identity,
+By default, `run` is a formal qualification run. Each execution attempt freezes source identity,
 prepares missing dependencies, runs preflight, and then switches measurement to
 prebuilt-only mode. During development, add `--debug` to allow a dirty worktree
 and on-demand dependency creation. Every run still resolves the active worktree
@@ -94,8 +94,11 @@ checkouts, and Perf bundles before measurement. Measurement then runs with
 dependency creation and Perf bundle builds disabled. Qualification also rejects
 a dirty worktree, imports outside the active worktree, and a requested revision
 different from HEAD. It rechecks that identity after preparation and before and
-after every task, so a mid-run edit invalidates the campaign. Accuracy and Perf
-receive the same frozen SHA; native workers and bundles must report that SHA.
+after every task, so evidence from an attempt cannot silently cross a mid-run
+edit. Accuracy and Perf receipts record the exact SHA tested; native workers and
+bundles must report that SHA. A campaign may be resumed on a later commit, but
+all final Accuracy and Perf receipts for one model must agree on one SHA. Other
+models may complete on different SHAs.
 
 Run full Accuracy and Perf on separate GB300 machines:
 
@@ -135,7 +138,8 @@ Results are written below:
 ${TRTMC_CHECK_STORAGE_ROOT}/results/<run-id>/
 ```
 
-Resume with the same selection, intent, exact HEAD, and run ID:
+Resume with the same selection, intent, and run ID. Interrupted and retryable
+cases run again; terminal cases remain intact even when HEAD has advanced:
 
 ```bash
 $TRTMC_CHECK_PYTHON tools/model_checks.py run \
@@ -145,6 +149,25 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
   --run-id gb300-accuracy-all \
   --resume
 ```
+
+After changing code that affects one model, invalidate that model as a unit so
+all of its selected Accuracy and Perf evidence is regenerated on the current
+HEAD:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py run \
+  --platform gb300 \
+  --all \
+  --run-id gb300-all \
+  --resume \
+  --invalidate-model distilgpt2
+```
+
+`--invalidate-model` is repeatable. It does not discard other models' evidence.
+Managed stale engines and Perf bundles are rebuilt automatically when their
+recorded source revision differs; Accuracy's lower-level `--force-build` remains
+available for cache diagnosis, but forcing a build does not replace model-level
+evidence invalidation.
 
 ## Shard a campaign
 
@@ -171,7 +194,8 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py consolidate \
 
 The immutable campaign inventory determines assignment by case order modulo
 the shard count. Resume one failed shard with the same selection, `--shard`,
-run ID, and `--resume`. A shard uses its own writable Perf bundle cache, so
+run ID, and `--resume`; use the same `--invalidate-model` on every shard that
+owns cases for the changed model. A shard uses its own writable Perf bundle cache, so
 independent workers never build into the same cache directory.
 
 ## Platforms

--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -23,8 +23,8 @@ export TRTMC_CHECK_PYTHON=/opt/venv/bin/python3
 the Accuracy binaries, model plugins, TensorRT backend, Perf worker, and Perf
 bundle cache from this directory and `TRTMC_CHECK_STORAGE_ROOT`.
 
-The controller Python must contain the repository's base dependencies. Missing
-family build, reference, and scoring profiles are created under
+The controller Python must contain the repository's base dependencies. Debug
+runs create missing family build, reference, and scoring profiles under
 `${TRTMC_CHECK_STORAGE_ROOT}/python-profiles` when first needed.
 
 ## Select
@@ -54,7 +54,14 @@ model in `tests/validation/model_workloads.yaml`.
 
 ## Run
 
-Run one model through Accuracy and then Perf:
+By default, `run` is a formal qualification run. It freezes source identity,
+prepares missing dependencies, runs preflight, and then switches measurement to
+prebuilt-only mode. During development, add `--debug` to allow a dirty worktree
+and on-demand dependency creation. Every run still resolves the active worktree
+HEAD to a 40-character commit SHA and places the current repository Python paths
+first in each child process.
+
+Run one model through formal Accuracy and then Perf qualification:
 
 ```bash
 $TRTMC_CHECK_PYTHON tools/model_checks.py run \
@@ -62,6 +69,33 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
   --model distilgpt2 \
   --run-id gb300-distilgpt2-smoke
 ```
+
+The single command owns both preparation and frozen measurement:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py run \
+  --platform gb300 \
+  --model distilgpt2 \
+  --run-id gb300-distilgpt2-qualification
+```
+
+For an editable debug run:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py run \
+  --platform gb300 \
+  --model distilgpt2 \
+  --debug \
+  --run-id gb300-distilgpt2-debug
+```
+
+The controller creates missing Python profiles, pinned reference-source
+checkouts, and Perf bundles before measurement. Measurement then runs with
+dependency creation and Perf bundle builds disabled. Qualification also rejects
+a dirty worktree, imports outside the active worktree, and a requested revision
+different from HEAD. It rechecks that identity after preparation and before and
+after every task, so a mid-run edit invalidates the campaign. Accuracy and Perf
+receive the same frozen SHA; native workers and bundles must report that SHA.
 
 Run full Accuracy and Perf on separate GB300 machines:
 
@@ -101,7 +135,7 @@ Results are written below:
 ${TRTMC_CHECK_STORAGE_ROOT}/results/<run-id>/
 ```
 
-Resume with the same selection and run ID:
+Resume with the same selection, intent, exact HEAD, and run ID:
 
 ```bash
 $TRTMC_CHECK_PYTHON tools/model_checks.py run \

--- a/tests/tools/test_case_evidence.py
+++ b/tests/tools/test_case_evidence.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tools import case_evidence
+
+
+REVISION_A = "a" * 40
+REVISION_B = "b" * 40
+
+
+def test_stamp_case_rejects_conflicting_source_revision() -> None:
+    with pytest.raises(case_evidence.CaseEvidenceError, match="source revision conflict"):
+        case_evidence.stamp_case(
+            {"id": "model-a::accuracy", "source_revision": REVISION_A},
+            REVISION_B,
+        )
+
+
+def test_model_revision_summary_allows_different_models_on_different_revisions() -> None:
+    summary = case_evidence.summarize_model_revisions(
+        [
+            {
+                "id": "model-a::accuracy",
+                "model": "model-a",
+                "task": "accuracy",
+                "state": "terminal",
+                "source_revision": REVISION_A,
+            },
+            {
+                "id": "model-a::perf",
+                "model": "model-a",
+                "task": "perf",
+                "state": "terminal",
+                "source_revision": REVISION_A,
+            },
+            {
+                "id": "model-b::accuracy",
+                "model": "model-b",
+                "task": "accuracy",
+                "state": "terminal",
+                "source_revision": REVISION_B,
+            },
+            {
+                "id": "model-b::perf",
+                "model": "model-b",
+                "task": "perf",
+                "state": "terminal",
+                "source_revision": REVISION_B,
+            },
+        ]
+    )
+
+    assert summary["consistent"] is True
+    assert summary["source_revisions"] == [REVISION_A, REVISION_B]
+    assert summary["models"]["model-a"]["source_revision"] == REVISION_A
+    assert summary["models"]["model-b"]["source_revision"] == REVISION_B
+
+
+def test_model_revision_summary_rejects_mixed_revisions_within_one_model() -> None:
+    summary = case_evidence.summarize_model_revisions(
+        [
+            {
+                "id": "model-a::accuracy",
+                "model": "model-a",
+                "task": "accuracy",
+                "state": "terminal",
+                "source_revision": REVISION_A,
+            },
+            {
+                "id": "model-a::perf",
+                "model": "model-a",
+                "task": "perf",
+                "state": "terminal",
+                "source_revision": REVISION_B,
+            },
+        ]
+    )
+
+    assert summary["consistent"] is False
+    assert summary["models"]["model-a"] == {
+        "status": "mixed",
+        "source_revision": None,
+        "source_revisions": [REVISION_A, REVISION_B],
+        "case_ids": ["model-a::accuracy", "model-a::perf"],
+        "tasks": ["accuracy", "perf"],
+    }
+
+
+def test_model_revision_summary_rejects_terminal_case_without_provenance() -> None:
+    summary = case_evidence.summarize_model_revisions(
+        [
+            {
+                "id": "legacy",
+                "model": "model-a",
+                "task": "accuracy",
+                "state": "terminal",
+            }
+        ]
+    )
+
+    assert summary["consistent"] is False
+    assert summary["models"]["model-a"]["status"] == "missing"
+    assert summary["models"]["model-a"]["source_revision"] is None

--- a/tests/tools/test_execution_ledger.py
+++ b/tests/tools/test_execution_ledger.py
@@ -234,6 +234,47 @@ def test_explicit_resume_reopens_only_retryable_white_results(tmp_path) -> None:
     assert ledger.receipt("model-b::task-b")["state"] == "terminal"
 
 
+def test_selective_rerun_reopens_only_requested_terminal_cases(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+    for case_id in ("model-a::task-a", "model-b::task-b"):
+        ledger.begin(case_id, stage="compare")
+        ledger.finish(
+            case_id,
+            result="green",
+            payload={"status": "passed", "source_revision": "a" * 40},
+        )
+
+    assert ledger.reopen_cases(
+        ["model-a::task-a"],
+        reason="source_change",
+        evidence={"requested_revision": "b" * 40},
+    ) == ["model-a::task-a"]
+
+    reopened = ledger.receipt("model-a::task-a")
+    assert reopened["state"] == "pending"
+    assert reopened["result"] is None
+    assert reopened["previous_results"] == [
+        {
+            "attempt": 1,
+            "result": "green",
+            "payload": {"status": "passed", "source_revision": "a" * 40},
+            "finished_at": reopened["previous_results"][0]["finished_at"],
+            "reopen_reason": "source_change",
+            "reopen_evidence": {"requested_revision": "b" * 40},
+        }
+    ]
+    assert ledger.receipt("model-b::task-b")["state"] == "terminal"
+
+
+def test_selective_rerun_rejects_unknown_or_nonterminal_cases(tmp_path) -> None:
+    ledger = _ledger(tmp_path)
+
+    with pytest.raises(ExecutionLedgerError, match="unknown case"):
+        ledger.reopen_cases(["missing"], reason="source_change")
+    with pytest.raises(ExecutionLedgerError, match="not terminal"):
+        ledger.reopen_cases(["model-a::task-a"], reason="source_change")
+
+
 def test_load_rejects_conflicting_case_and_attempt_stage(tmp_path) -> None:
     ledger = _ledger(tmp_path)
     ledger.begin("model-a::task-a", stage="candidate")

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -18,6 +18,10 @@ from tools.execution_ledger import ExecutionLedger
 PREPARE_QUALIFICATION_DEPENDENCIES = model_checks._prepare_qualification_dependencies
 
 
+def _consistent_source_identity(*_args, **_kwargs):
+    return {"consistent": True, "source_revisions": [], "models": {}}
+
+
 @pytest.fixture(autouse=True)
 def _clean_model_checks_worktree(monkeypatch):
     monkeypatch.setattr(model_checks, "_worktree_changes", lambda: ())
@@ -33,6 +37,95 @@ def test_model_checks_uses_public_qualification_interfaces() -> None:
 
     assert "perf_matrix._" not in source
     assert "trtmc_validate._" not in source
+
+
+def test_resume_prepares_only_retryable_or_invalidated_models(tmp_path) -> None:
+    output = tmp_path / "accuracy"
+    bindings = [
+        {"model": "model-a", "workload": "suite-a"},
+        {"model": "model-b", "workload": "suite-b"},
+    ]
+    ledger = ExecutionLedger.open(
+        output,
+        campaign_id="campaign",
+        task_kind="accuracy",
+        fingerprint="fixture",
+        cases=[
+            {"id": "model-a::suite-a", "report": {}},
+            {"id": "model-b::suite-b", "report": {}},
+        ],
+    )
+    ledger.begin("model-a::suite-a", stage="compare")
+    ledger.finish("model-a::suite-a", result="green", payload={"ok": True})
+    ledger.begin("model-b::suite-b", stage="compare")
+    ledger.finish(
+        "model-b::suite-b",
+        result="white",
+        payload={"ok": False},
+        attempt_outcome="failed",
+        evidence={"retryable": True},
+    )
+
+    retryable = model_checks._resume_preparation_bindings(
+        tmp_path, {"accuracy": bindings}, set()
+    )
+    invalidated = model_checks._resume_preparation_bindings(
+        tmp_path, {"accuracy": bindings}, {"model-a"}
+    )
+
+    assert [row["model"] for row in retryable["accuracy"]] == ["model-b"]
+    assert [row["model"] for row in invalidated["accuracy"]] == ["model-a", "model-b"]
+
+
+def test_model_source_identity_rejects_mixed_accuracy_and_perf_revisions(tmp_path) -> None:
+    accuracy = tmp_path / "accuracy"
+    perf = tmp_path / "perf/results/run-a"
+    accuracy.mkdir(parents=True)
+    perf.mkdir(parents=True)
+    (accuracy / "report.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "id": "model-a::suite-a",
+                        "model": "model-a",
+                        "state": "terminal",
+                        "result": "green",
+                        "source_revision": "a" * 40,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    ExecutionLedger.open(
+        perf,
+        campaign_id="perf",
+        task_kind="performance",
+        fingerprint="fixture",
+        cases=[{"id": "model-a.perf", "report": {}}],
+    )
+    (perf / "report.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "id": "model-a.perf",
+                        "model": "model-a",
+                        "state": "terminal",
+                        "result": "green",
+                        "source_revision": "b" * 40,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    identity = model_checks._model_source_identity(tmp_path, ["accuracy", "perf"])
+
+    assert identity["consistent"] is False
+    assert identity["models"]["model-a"]["status"] == "mixed"
 
 
 def _platform(*, serial: bool = True, excluded_models=()):
@@ -1027,6 +1120,7 @@ def test_shard_resume_reuses_the_same_member_directory(tmp_path, monkeypatch):
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
     selection = [
         "run",
         "--platform",
@@ -1156,6 +1250,7 @@ def test_run_verbose_prints_and_forwards_detailed_commands(tmp_path, monkeypatch
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
     commands = []
 
     def run(command, **_kwargs):
@@ -1195,6 +1290,7 @@ def test_run_forwards_exact_source_revision_to_accuracy_and_perf(tmp_path, monke
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision.lower())
+    monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
     child_environments = []
     identity_checks = []
 
@@ -1276,6 +1372,7 @@ def test_run_defaults_to_qualification_and_uses_only_prepared_dependencies(tmp_p
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda value: revision)
+    monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
     events = []
 
     def prepare(*_args, **_kwargs):
@@ -1504,12 +1601,39 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
 
     def run(command, **kwargs):
         commands.append(command)
+        report = storage / "results/resume-unit/accuracy/report.json"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "id": "qwen25vl-3b::vlm_mmmu_pro_vision_fixed_mcq",
+                            "model": "qwen25vl-3b",
+                            "state": "terminal",
+                            "result": "green",
+                            "source_revision": "a" * 40,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(model_checks.subprocess, "run", run)
 
-    assert model_checks.main([*selection, "--resume"]) == 0
-    assert commands[-1][-1] == "--resume-existing"
+    assert (
+        model_checks.main(
+            [*selection, "--resume", "--invalidate-model", "qwen25vl-3b"]
+        )
+        == 0
+    )
+    assert commands[-1][-3:] == [
+        "--resume-existing",
+        "--invalidate-model",
+        "qwen25vl-3b",
+    ]
     result = json.loads((storage / "results/resume-unit/result.json").read_text(encoding="utf-8"))
     assert result["resumed"] is True
 
@@ -1533,11 +1657,11 @@ def test_unsharded_resume_rejects_request_without_the_frozen_revision(tmp_path):
     path = tmp_path / "request.json"
     path.write_text(json.dumps(previous), encoding="utf-8")
 
-    with pytest.raises(model_checks.ModelCheckError, match="resolved revision changed"):
+    with pytest.raises(model_checks.ModelCheckError, match="exact recorded execution revision"):
         model_checks._verify_resume_request(path, request)
 
 
-def test_unsharded_resume_rejects_a_different_frozen_revision(tmp_path):
+def test_unsharded_resume_allows_a_new_execution_revision(tmp_path):
     request = {
         "schema_version": "trtmc.model-check-run/v1",
         "run_id": "qualification",
@@ -1558,8 +1682,7 @@ def test_unsharded_resume_rejects_a_different_frozen_revision(tmp_path):
     path = tmp_path / "request.json"
     path.write_text(json.dumps(previous), encoding="utf-8")
 
-    with pytest.raises(model_checks.ModelCheckError, match="resolved revision changed"):
-        model_checks._verify_resume_request(path, request)
+    model_checks._verify_resume_request(path, request)
 
 
 def test_perf_resume_command_requires_one_existing_run(tmp_path):

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -1057,6 +1057,7 @@ def test_consolidator_preserves_campaign_order_and_receipt_results(tmp_path, mon
         label = campaign_shards.shard_name(index, 2)
         shard_root = run_root / "shards" / label
         output = shard_root / "accuracy"
+        result = "green" if index == 0 else "red"
         shard_root.mkdir(parents=True)
         (shard_root / "request.json").write_text(
             json.dumps(
@@ -1070,6 +1071,17 @@ def test_consolidator_preserves_campaign_order_and_receipt_results(tmp_path, mon
             ),
             encoding="utf-8",
         )
+        (shard_root / "result.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "trtmc.model-check-run-result/v1",
+                    "run_id": "campaign",
+                    "execution_revision": "a" * 40,
+                    "status": "passed" if result == "green" else "failed",
+                }
+            ),
+            encoding="utf-8",
+        )
         ledger = ExecutionLedger.open(
             output,
             campaign_id=label,
@@ -1077,7 +1089,6 @@ def test_consolidator_preserves_campaign_order_and_receipt_results(tmp_path, mon
             fingerprint="fixture",
             cases=[{"id": case["id"], "report": case["report"]}],
         )
-        result = "green" if index == 0 else "red"
         ledger.begin(case["id"], stage="compare")
         ledger.finish(case["id"], result=result, payload={"fixture": True})
         qualification_report.materialize_report(
@@ -1092,6 +1103,7 @@ def test_consolidator_preserves_campaign_order_and_receipt_results(tmp_path, mon
                     "id": case["id"],
                     "state": "terminal",
                     "result": result,
+                    "source_revision": "a" * 40,
                     "precision": {"reference": "fp16", "candidate": "fp16"},
                     "debug": {"logs": [], "command_artifacts": []},
                 }
@@ -1110,6 +1122,14 @@ def test_consolidator_preserves_campaign_order_and_receipt_results(tmp_path, mon
         "yellow": 0,
     }
     assert set(report["receipt_sources"]) == {case["id"] for case in cases}
+    result = json.loads((run_root / "result.json").read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert (
+        model_checks._consolidate(
+            SimpleNamespace(run_root=run_root, interval_seconds=1, watch=False)
+        )
+        == 1
+    )
     assert campaign["schema_version"] == campaign_shards.CAMPAIGN_SCHEMA
 
 

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -15,12 +15,24 @@ import yaml
 from tools import campaign_shards, model_checks, qualification_report
 from tools.execution_ledger import ExecutionLedger
 
+PREPARE_QUALIFICATION_DEPENDENCIES = model_checks._prepare_qualification_dependencies
+
+
+@pytest.fixture(autouse=True)
+def _clean_model_checks_worktree(monkeypatch):
+    monkeypatch.setattr(model_checks, "_worktree_changes", lambda: ())
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_qualification_dependencies",
+        lambda *_args, **_kwargs: {},
+    )
+
 
 def test_model_checks_uses_public_qualification_interfaces() -> None:
     source = (model_checks.REPOSITORY / "tools" / "model_checks.py").read_text(encoding="utf-8")
 
     assert "perf_matrix._" not in source
-    assert "trtmc_validate._validation_models" not in source
+    assert "trtmc_validate._" not in source
 
 
 def _platform(*, serial: bool = True, excluded_models=()):
@@ -420,6 +432,21 @@ def test_task_environment_uses_shared_profiles_and_allows_missing_profiles(
     assert os.environ["TRTMC_PYTHON_PROFILE_PREBUILT_ONLY"] == "1"
 
 
+def test_task_environment_freezes_prepared_dependencies_for_qualification(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("TRTMC_REFERENCE_SOURCES_PREBUILT_ONLY", raising=False)
+
+    environment = model_checks._task_environment(
+        {"storage": {"python_profiles_root": str(tmp_path / "profiles")}},
+        allow_dependency_creation=False,
+    )
+
+    assert environment["TRTMC_PYTHON_PROFILE_PREBUILT_ONLY"] == "1"
+    assert environment["TRTMC_REFERENCE_SOURCES_PREBUILT_ONLY"] == "1"
+
+
 def test_task_environment_prepends_configured_runtime_libraries(
     tmp_path,
     monkeypatch,
@@ -471,7 +498,12 @@ def test_task_environment_prepends_configured_python_directories(
         }
     )
 
-    assert environment["PYTHONPATH"] == (f"{runtime_python}{os.pathsep}/system/python")
+    assert environment["PYTHONPATH"].split(os.pathsep) == [
+        str(model_checks.PYTHON_SOURCE),
+        str(model_checks.REPOSITORY),
+        str(runtime_python),
+        "/system/python",
+    ]
 
 
 def test_task_environment_exports_checked_in_environment_variables(
@@ -1069,6 +1101,7 @@ def test_run_default_output_is_concise_and_ends_with_task_summary(
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(runtime))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setenv("TRTMC_PYTHON_PROFILE_PREBUILT_ONLY", "1")
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
     returncodes = iter((1, 0))
     commands = []
     child_environments = []
@@ -1089,6 +1122,7 @@ def test_run_default_output_is_concise_and_ends_with_task_summary(
             "distilgpt2",
             "--run-id",
             "concise-unit",
+            "--debug",
         ]
     )
 
@@ -1121,6 +1155,7 @@ def test_run_verbose_prints_and_forwards_detailed_commands(tmp_path, monkeypatch
     monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
     commands = []
 
     def run(command, **_kwargs):
@@ -1159,7 +1194,15 @@ def test_run_forwards_exact_source_revision_to_accuracy_and_perf(tmp_path, monke
     monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision.lower())
     child_environments = []
+    identity_checks = []
+
+    def source_identity(source_revision, *, require_clean=False):
+        identity_checks.append((source_revision, require_clean))
+        return {"revision": source_revision, "imports": {}}
+
+    monkeypatch.setattr(model_checks, "_source_identity", source_identity)
 
     def run(_command, **kwargs):
         child_environments.append(kwargs["env"])
@@ -1185,9 +1228,241 @@ def test_run_forwards_exact_source_revision_to_accuracy_and_perf(tmp_path, monke
     )
 
     assert len(child_environments) == 2
+    assert identity_checks == [(revision.lower(), True)] * 6
     for child in child_environments:
         assert child["TRTMC_VALIDATION_SOURCE_REVISION"] == revision.lower()
         assert child["TRTMC_PERF_SOURCE_REVISION"] == revision.lower()
+        assert child["TRTMC_ENGINE_BUILD_REVISION"] == revision.lower()
+
+
+def test_unsharded_run_resolves_head_before_writing_request(tmp_path, monkeypatch):
+    storage = tmp_path / "storage"
+    revision = "b" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda value: revision)
+
+    assert (
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--task",
+                "accuracy",
+                "--model",
+                "distilgpt2",
+                "--run-id",
+                "exact-source-unit",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+
+    request = json.loads(
+        (storage / "results/exact-source-unit/request.json").read_text(encoding="utf-8")
+    )
+    assert request["revision"] == revision
+
+
+def test_run_defaults_to_qualification_and_uses_only_prepared_dependencies(tmp_path, monkeypatch):
+    storage = tmp_path / "storage"
+    revision = "c" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda value: revision)
+    events = []
+
+    def prepare(*_args, **_kwargs):
+        events.append("prepare")
+        return {}
+
+    monkeypatch.setattr(model_checks, "_prepare_qualification_dependencies", prepare)
+
+    def run(_command, **kwargs):
+        events.append(kwargs["env"])
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(model_checks.subprocess, "run", run)
+
+    assert (
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--task",
+                "accuracy",
+                "--model",
+                "distilgpt2",
+                "--run-id",
+                "qualification-unit",
+            ]
+        )
+        == 0
+    )
+
+    assert events[0] == "prepare"
+    assert events[1]["TRTMC_PYTHON_PROFILE_PREBUILT_ONLY"] == "1"
+    assert events[1]["TRTMC_REFERENCE_SOURCES_PREBUILT_ONLY"] == "1"
+    request = json.loads(
+        (storage / "results/qualification-unit/request.json").read_text(encoding="utf-8")
+    )
+    assert request["intent"] == "qualification"
+
+
+def test_qualification_rechecks_source_identity_after_preparation(tmp_path, monkeypatch):
+    storage = tmp_path / "storage"
+    revision = "d" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _value: revision)
+    calls = 0
+
+    def source_identity(_revision, *, require_clean=False):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"revision": revision, "imports": {}}
+        raise model_checks.ModelCheckError("qualification source identity changed")
+
+    monkeypatch.setattr(model_checks, "_source_identity", source_identity)
+    monkeypatch.setattr(
+        model_checks.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("measurement must not start"),
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--task",
+                "accuracy",
+                "--model",
+                "distilgpt2",
+                "--run-id",
+                "source-drift-unit",
+            ]
+        )
+
+    assert calls == 2
+
+
+def test_qualification_prepare_phase_runs_accuracy_and_perf_bundle_preparation(
+    tmp_path, monkeypatch
+):
+    events = []
+    environment = {
+        "storage": {"python_profiles_root": str(tmp_path / "profiles")},
+        "tasks": {"perf": {"runner_python": sys.executable}},
+    }
+    arguments = SimpleNamespace(
+        models_dir=tmp_path / "models",
+        revision="a" * 40,
+        verbose=False,
+    )
+    task_bindings = {
+        "accuracy": [{"model": "model-a", "workload": "suite-a"}],
+        "perf": [{"entry": "entry-a"}],
+    }
+
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_accuracy_dependencies",
+        lambda *_args, **_kwargs: events.append("accuracy"),
+    )
+    monkeypatch.setattr(
+        model_checks,
+        "_selected_perf_reference_contracts",
+        lambda *_args, **_kwargs: (),
+    )
+
+    def prepare_references(*_args, **_kwargs):
+        events.append("references")
+        return {}
+
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_perf_reference_dependencies",
+        prepare_references,
+    )
+    monkeypatch.setattr(
+        model_checks,
+        "_perf_prepare_command",
+        lambda *_args, **_kwargs: [sys.executable, "perf_matrix.py", "prepare"],
+    )
+
+    def run(*_args, **_kwargs):
+        events.append("perf-prepare")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(model_checks.subprocess, "run", run)
+
+    result = PREPARE_QUALIFICATION_DEPENDENCIES(
+        {},
+        environment,
+        arguments,
+        task_bindings=task_bindings,
+        perf_environment=tmp_path / "perf-environment.yaml",
+        perf_preparation_receipt=tmp_path / "perf-preparation.json",
+        model_reference_cache_root=tmp_path / "references",
+    )
+
+    assert result == {}
+    assert events == ["accuracy", "references", "perf-prepare"]
+
+
+def test_qualification_perf_commands_require_prebuilt_bundles(tmp_path):
+    plan = {"models": []}
+    environment = {"tasks": {"perf": {"runner_python": sys.executable, "suite": tmp_path}}}
+    run = tmp_path / "results" / "run-a"
+    run.mkdir(parents=True)
+    (run / "results.json").write_text("{}", encoding="utf-8")
+
+    command = model_checks._perf_command(
+        plan,
+        environment,
+        tmp_path / "environment.yaml",
+        bindings=[{"entry": "entry-a"}],
+        require_prebuilt=True,
+    )
+    resume = model_checks._perf_resume_command(
+        environment,
+        tmp_path / "results",
+        require_prebuilt=True,
+    )
+
+    assert command is not None and "--no-build" in command
+    assert resume is not None and "--no-build" in resume
+
+
+def test_source_identity_rejects_import_from_another_checkout(monkeypatch):
+    monkeypatch.setattr(model_checks.perf_matrix, "__file__", "/tmp/other/tools/perf_matrix.py")
+
+    with pytest.raises(model_checks.ModelCheckError, match="outside the active worktree"):
+        model_checks._source_identity("a" * 40)
+
+
+def test_source_identity_rejects_dirty_qualification_worktree(monkeypatch):
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(
+        model_checks,
+        "_worktree_changes",
+        lambda: (" M tools/model_checks.py",),
+    )
+
+    with pytest.raises(model_checks.ModelCheckError, match="clean worktree"):
+        model_checks._source_identity("a" * 40, require_clean=True)
 
 
 def test_task_environment_does_not_export_symbolic_revision(tmp_path, monkeypatch):
@@ -1211,6 +1486,7 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
     monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
     selection = [
         "run",
         "--platform",
@@ -1238,7 +1514,7 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
     assert result["resumed"] is True
 
 
-def test_unsharded_resume_accepts_request_written_before_shard_fields(tmp_path):
+def test_unsharded_resume_rejects_request_without_the_frozen_revision(tmp_path):
     request = {
         "schema_version": "trtmc.model-check-run/v1",
         "run_id": "legacy",
@@ -1257,7 +1533,33 @@ def test_unsharded_resume_accepts_request_written_before_shard_fields(tmp_path):
     path = tmp_path / "request.json"
     path.write_text(json.dumps(previous), encoding="utf-8")
 
-    model_checks._verify_resume_request(path, request)
+    with pytest.raises(model_checks.ModelCheckError, match="resolved revision changed"):
+        model_checks._verify_resume_request(path, request)
+
+
+def test_unsharded_resume_rejects_a_different_frozen_revision(tmp_path):
+    request = {
+        "schema_version": "trtmc.model-check-run/v1",
+        "run_id": "qualification",
+        "revision": "b" * 40,
+        "intent": "qualification",
+        "source_identity": {"revision": "b" * 40, "imports": {}},
+        "platform": "gb300",
+        "platform_source": "platform.yaml",
+        "platform_config": {},
+        "environment_source": "environment.yaml",
+        "environment_config": {},
+        "perf_environment_config": None,
+        "selection": {},
+        "commands": {},
+        "shard": None,
+    }
+    previous = {**request, "revision": "a" * 40}
+    path = tmp_path / "request.json"
+    path.write_text(json.dumps(previous), encoding="utf-8")
+
+    with pytest.raises(model_checks.ModelCheckError, match="resolved revision changed"):
+        model_checks._verify_resume_request(path, request)
 
 
 def test_perf_resume_command_requires_one_existing_run(tmp_path):

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -2355,6 +2355,79 @@ def test_check_runs_preflight_without_creating_results(
     assert not scratch_root.exists()
 
 
+def test_prepare_materializes_bundles_without_starting_campaign(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    revision = "a" * 40
+    output = tmp_path / "preparation.json"
+    selected = [
+        {
+            "id": "gpt2.generate",
+            "family": "gpt2",
+            "model": "distilgpt2",
+            "workload": {"testcase": "distilgpt2"},
+            "measurement": {"warmup": 1, "iterations": 2},
+            "baseline": {"runner": "hf-transformers", "asset_loading_included": False},
+        }
+    ]
+    environment = {
+        "storage": {"results_root": str(tmp_path / "results")},
+    }
+    options = Namespace(
+        output=tmp_path / "results",
+        scratch_root=tmp_path / "scratch",
+        trtmc_bench="trtmc-bench",
+        trtmc_worker=None,
+        bundle_cache=tmp_path / "bundles",
+        bundle_roots=(),
+        runtime_dirs=(),
+        timeout_seconds=30,
+        require_prebuilt_bundles=False,
+    )
+    monkeypatch.setattr(
+        perf_matrix,
+        "_load_suite_request",
+        lambda _arguments: (None, selected, environment),
+    )
+    monkeypatch.setattr(perf_matrix, "_run_options", lambda *_args, **_kwargs: options)
+    monkeypatch.setattr(perf_matrix, "_environment_preflight", lambda *_args: {})
+    monkeypatch.setattr(perf_matrix, "_preflight_worker", lambda *_args: {})
+    monkeypatch.setattr(
+        perf_matrix,
+        "_preflight_candidates",
+        lambda cases, _options: ({cases[0]["id"]: ({}, [], {})}, {}),
+    )
+    monkeypatch.setattr(perf_matrix, "_git_commit", lambda: revision)
+
+    def run(command, *_args):
+        assert "--prepare-only" in command
+        return {
+            "exit_code": 0,
+            "stdout": json.dumps(
+                {
+                    "bundles": [
+                        {
+                            "model": "distilgpt2",
+                            "status": "built",
+                            "bundle": str(tmp_path / "bundles/distilgpt2.bundle"),
+                            "build_time_s": 1.0,
+                            "source_revision": revision,
+                            "included_in_performance_metrics": False,
+                        }
+                    ]
+                }
+            ),
+            "stderr_tail": "",
+        }
+
+    monkeypatch.setattr(perf_matrix, "_run_command", run)
+
+    assert perf_matrix._prepare(Namespace(output=output)) == 0
+    receipt = json.loads(output.read_text(encoding="utf-8"))
+    assert receipt["git_commit"] == revision
+    assert receipt["bundles"][0]["source_revision"] == revision
+
+
 def test_run_records_preflight_failure_and_finishes_campaign(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2590,6 +2663,27 @@ def test_candidate_command_forwards_workload_runtime_overrides(tmp_path: Path) -
     argv = perf_matrix._candidate_base_argv(case, options)
 
     assert "runtime.cuda_graphs=true" in argv
+
+
+def test_candidate_command_requires_prebuilt_bundle_when_requested(tmp_path: Path) -> None:
+    case = {
+        "id": "gpt2.generate",
+        "family": "gpt2",
+        "model": "distilgpt2",
+        "workload": {"testcase": "distilgpt2"},
+        "measurement": {"warmup": 2, "iterations": 10},
+        "baseline": {"runner": "hf-transformers", "asset_loading_included": False},
+    }
+    options = Namespace(
+        trtmc_bench="trtmc-bench",
+        trtmc_worker=None,
+        bundle_cache=None,
+        bundle_roots=(),
+        runtime_dirs=(),
+        require_prebuilt_bundles=True,
+    )
+
+    assert "--no-build" in perf_matrix._candidate_base_argv(case, options)
 
 
 def test_task_reference_can_require_local_model_files_per_case(tmp_path: Path) -> None:

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -1120,15 +1120,44 @@ def test_performance_projection_rejects_receipt_classification_drift(tmp_path) -
         )
 
 
-def test_performance_adapter_resumes_an_interrupted_case_as_a_new_attempt(
-    tmp_path, monkeypatch
-) -> None:
+def test_performance_ledger_contract_is_independent_of_execution_revision(tmp_path) -> None:
     case = next(
         row for row in performance_catalog.load_suite(SUITE).cases if row["id"] == "gpt2.generate"
     )
     results = {
         "run_id": "run-1",
-        "git_commit": "revision-1",
+        "git_commit": "a" * 40,
+        "suite_sha256": "suite-1",
+        "environment_config": {"sha256": "environment-1"},
+    }
+
+    perf_matrix._open_perf_ledger(tmp_path, [case], results)
+    perf_matrix._open_perf_ledger(
+        tmp_path,
+        [case],
+        {**results, "git_commit": "b" * 40},
+    )
+
+
+def test_performance_resume_accepts_model_invalidation() -> None:
+    arguments = perf_matrix.build_parser().parse_args(
+        ["resume", "run", "--invalidate-model", "model-a"]
+    )
+
+    assert arguments.invalidate_model == ["model-a"]
+
+
+def test_performance_adapter_resumes_an_interrupted_case_as_a_new_attempt(
+    tmp_path, monkeypatch
+) -> None:
+    revision = "a" * 40
+    monkeypatch.setattr(perf_matrix, "_git_commit", lambda: revision)
+    case = next(
+        row for row in performance_catalog.load_suite(SUITE).cases if row["id"] == "gpt2.generate"
+    )
+    results = {
+        "run_id": "run-1",
+        "git_commit": revision,
         "suite_sha256": "suite-1",
         "environment_config": {"sha256": "environment-1"},
         "selected_entry_ids": [case["id"]],
@@ -2056,15 +2085,16 @@ def test_public_perf_progress_has_no_traffic_light(status: str) -> None:
 def test_run_consolidates_results_and_records_replayable_commands(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    revision = "a" * 40
     fake_trtmc = tmp_path / "trtmc-bench"
     fake_worker = tmp_path / "trtmc_benchmark_worker"
     fake_baseline = tmp_path / "hf_transformers.py"
     results_root = tmp_path / "results"
     scratch_root = tmp_path / "scratch"
     environment = tmp_path / "gb300.yaml"
-    monkeypatch.setenv("TRTMC_PERF_SOURCE_REVISION", "tested-commit")
+    monkeypatch.setenv("TRTMC_PERF_SOURCE_REVISION", revision)
     _write_fake_trtmc(fake_trtmc)
-    _write_fake_worker(fake_worker, "tested-commit")
+    _write_fake_worker(fake_worker, revision)
     _write_fake_baseline(fake_baseline)
     _write_environment(
         environment,
@@ -2178,9 +2208,9 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert results["reference_preflight"]["entry_count"] == 1
     assert results["candidate_worker_preflight"]["build"] == {
         "configuration": "Release",
-        "source_revision": "tested-commit",
+        "source_revision": revision,
     }
-    assert results["candidate_worker_preflight"]["validated_against"] == "tested-commit"
+    assert results["candidate_worker_preflight"]["validated_against"] == revision
     assert rows["gpt2.generate"]["status"] == "green"
     assert rows["gpt2.generate"]["candidate"]["backend"] == "trtmc-bench"
     assert rows["gpt2.generate"]["candidate"]["preparation"] == {
@@ -2431,15 +2461,16 @@ def test_prepare_materializes_bundles_without_starting_campaign(
 def test_run_records_preflight_failure_and_finishes_campaign(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    revision = "a" * 40
     fake_trtmc = tmp_path / "trtmc-bench"
     fake_worker = tmp_path / "trtmc_benchmark_worker"
     fake_baseline = tmp_path / "hf_transformers.py"
     results_root = tmp_path / "results"
     scratch_root = tmp_path / "scratch"
     environment = tmp_path / "gb300.yaml"
-    monkeypatch.setenv("TRTMC_PERF_SOURCE_REVISION", "tested-commit")
+    monkeypatch.setenv("TRTMC_PERF_SOURCE_REVISION", revision)
     _write_fake_trtmc(fake_trtmc)
-    _write_fake_worker(fake_worker, "tested-commit")
+    _write_fake_worker(fake_worker, revision)
     _write_fake_baseline(fake_baseline)
     _write_environment(
         environment,

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1814,6 +1814,7 @@ class TestUnitTiers:
     @pytest.mark.parametrize(
         "path",
         [
+            "tools/case_evidence.py",
             "tools/execution_ledger.py",
             "tools/performance/__init__.py",
             "tools/performance/catalog.py",

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -26,9 +26,11 @@ from tensorrt_model_connect.benchmark.catalog import (
 from tensorrt_model_connect.benchmark.cli import main
 from tensorrt_model_connect.benchmark.metrics import reduce_metrics
 from tensorrt_model_connect.benchmark.operations import registered_operations
+from tensorrt_model_connect.benchmark.service import BenchmarkService
 from tensorrt_model_connect.benchmark.task_adapters import registered_task_adapters
 from tensorrt_model_connect.benchmark.types import BenchmarkError
 from tensorrt_model_connect.benchmark.worker import worker_backend_abi, worker_metadata
+from tensorrt_model_connect.bundle_writer import BundleInfo, BundleSection, write_bundle
 
 
 pytestmark = pytest.mark.unit
@@ -818,6 +820,86 @@ def test_builder_source_digest_participates_in_bundle_cache_identity(
     second = builder._plan(model, (case,))
 
     assert first.cache_key != second.cache_key
+
+
+def test_source_revision_participates_in_bundle_cache_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model = ManifestCatalog().resolve("distilgpt2")
+    case = resolve_case(model, tmp_path / "pending.bundle")
+    builder = BundleBuilder(tmp_path / "cache")
+
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", "a" * 40)
+    first = builder._plan(model, (case,))
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", "b" * 40)
+    second = builder._plan(model, (case,))
+
+    assert first.cache_key != second.cache_key
+
+
+def test_external_bundle_must_match_requested_source_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    revision = "a" * 40
+    bundle = tmp_path / "external.bundle"
+    write_bundle(
+        bundle,
+        BundleInfo(),
+        [BundleSection("config.json", json.dumps({"source_revision": "b" * 40}).encode())],
+    )
+    model = ManifestCatalog().resolve("distilgpt2")
+    case = resolve_case(model, bundle)
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", revision)
+
+    with pytest.raises(BenchmarkError, match="source revision"):
+        BundleBuilder(tmp_path / "cache").prepare(
+            (case,), allow_build=False, rebuild=False, dry_run=False
+        )
+
+
+def test_prepare_only_builds_bundle_without_starting_measurement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    revision = "a" * 40
+    worker = _worker(tmp_path)
+    cache = tmp_path / "cache"
+
+    def fake_build(command, _environment, _timeout_s):
+        output = Path(command[command.index("-o") + 1])
+        write_bundle(
+            output,
+            BundleInfo(),
+            [BundleSection("config.json", json.dumps({"source_revision": revision}).encode())],
+        )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", revision)
+    monkeypatch.setenv("TRTMC_BENCH_BUILD_PLATFORM", "test-sm80")
+    monkeypatch.setattr(BundleBuilder, "_execute", staticmethod(fake_build))
+    monkeypatch.setattr(
+        BenchmarkService,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("measurement must not start"),
+    )
+
+    assert (
+        main(
+            [
+                "run",
+                "--model",
+                "distilgpt2",
+                "--bundle-cache",
+                str(cache),
+                "--worker",
+                str(worker),
+                "--prepare-only",
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["bundles"][0]["status"] == "built"
+    assert receipt["bundles"][0]["source_revision"] == revision
 
 
 def test_image_rate_and_seconds_per_image_account_for_batch_size() -> None:

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -797,7 +797,11 @@ def test_binding_scoped_engines_are_isolated_across_suites_and_deleted_on_pass(
     monkeypatch.setattr(
         trtmc_validate,
         "write_report",
-        lambda output: (output / "report.json", output / "report.html", {}),
+        lambda output: (
+            output / "report.json",
+            output / "report.html",
+            {"model_source_identity": {"consistent": True}},
+        ),
     )
     monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
 
@@ -1085,6 +1089,7 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
     tmp_path,
     monkeypatch,
 ):
+    revision = "a" * 40
     output = tmp_path / "results"
     arguments = trtmc_validate.build_parser().parse_args(
         [
@@ -1107,7 +1112,7 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
     (output / "run.json").write_text(
         json.dumps(
             {
-                "source_revision": "same-revision",
+                    "source_revision": revision,
                 "command": "tools/trtmc_validate.py --binding model-a=suite-a "
                 f"--output {output} --model-work-dir {tmp_path / 'work'} "
                 "--engine-retention delete_on_pass "
@@ -1119,8 +1124,9 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
     (case_dir / "comparison.json").write_text(
         json.dumps(
             {
-                "model": "model-a",
-                "workload": "suite-a",
+                    "model": "model-a",
+                    "workload": "suite-a",
+                    "source_revision": revision,
                 "execution": {"status": "completed"},
                 "validation": {"status": "passed"},
             }
@@ -1128,7 +1134,7 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "same-revision")
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: revision)
     monkeypatch.setattr(
         trtmc_validate.sys,
         "argv",
@@ -1157,7 +1163,11 @@ def test_resume_existing_keeps_terminal_binding_without_rerunning_worker(
     monkeypatch.setattr(
         trtmc_validate,
         "write_report",
-        lambda output: (output / "report.json", output / "report.html", {}),
+        lambda output: (
+            output / "report.json",
+            output / "report.html",
+            {"model_source_identity": {"consistent": True}},
+        ),
     )
     monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
 
@@ -1574,17 +1584,33 @@ def test_accuracy_adapter_records_each_worker_retry_and_reference_stage(
     assert report["results"][0]["issue"]["stage"] == "reference"
 
 
-def test_resume_existing_rejects_different_source_revision(tmp_path, monkeypatch):
+def test_resume_existing_allows_a_new_execution_revision(tmp_path, monkeypatch):
     output = tmp_path / "results"
     output.mkdir()
     (output / "run.json").write_text(
-        json.dumps({"source_revision": "old-revision"}),
+        json.dumps(
+            {
+                "source_revision": "a" * 40,
+                "command": "tools/trtmc_validate.py --model model-a",
+            }
+        ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "new-revision")
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "b" * 40)
+    monkeypatch.setattr(
+        trtmc_validate.sys,
+        "argv",
+        ["tools/trtmc_validate.py", "--model", "model-a", "--resume-existing"],
+    )
 
-    with pytest.raises(trtmc_validate.ValidationError, match="different source revision"):
-        trtmc_validate._validate_resume_request(output)
+    trtmc_validate._validate_resume_request(output)
+
+
+def test_resume_command_ignores_model_invalidation_control() -> None:
+    assert trtmc_validate._resume_command(
+        "tools/trtmc_validate.py --model model-a --resume-existing "
+        "--invalidate-model model-a --verbose"
+    ) == ["tools/trtmc_validate.py", "--model", "model-a"]
 
 
 def test_resume_existing_rejects_different_command(tmp_path, monkeypatch):
@@ -1976,7 +2002,7 @@ def test_all_supervisor_applies_model_failure_policy(
         lambda output: (
             output / "report.json",
             output / "report.html",
-            {},
+            {"model_source_identity": {"consistent": True}},
         ),
     )
     monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
@@ -2250,7 +2276,7 @@ def test_all_supervisor_records_not_compared_without_launching_worker(
         lambda output: (
             output / "report.json",
             output / "report.html",
-            {},
+            {"model_source_identity": {"consistent": True}},
         ),
     )
     monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -2599,7 +2599,7 @@ def test_default_reference_backends_share_common_environment(reference_backend):
 
 
 def test_model_specific_reference_environment_keeps_common_validation_base() -> None:
-    profiles = trtmc_validate._binding_profiles(
+    profiles = trtmc_validate.binding_profiles(
         trtmc_validate.Binding("elf", "dataset"),
         task_models={
             "elf": {
@@ -2617,7 +2617,7 @@ def test_model_specific_reference_environment_keeps_common_validation_base() -> 
 
 
 def test_suite_specific_scorer_environment_is_materialized_on_demand() -> None:
-    profiles = trtmc_validate._binding_profiles(
+    profiles = trtmc_validate.binding_profiles(
         trtmc_validate.Binding("personaplex-7b", "full-duplex"),
         task_models={
             "personaplex-7b": {
@@ -2706,6 +2706,21 @@ def test_reference_sources_create_once_then_reuse(
     assert f"Using reference source: {cold}" in cold_output
     assert "Creating reference source" not in warm_output
     assert f"Using reference source: {warm}" in warm_output
+
+
+def test_reference_source_prebuilt_only_rejects_a_missing_checkout(tmp_path: Path) -> None:
+    source = trtmc_validate.ReferenceSource(
+        name="ELF",
+        repository="https://example.invalid/ELF.git",
+        revision="0123456789abcdef",
+        relative_checkout=Path("elf/reference/ELF-0123456789ab"),
+        entrypoint=Path("src/entrypoint.py"),
+    )
+
+    with pytest.raises(trtmc_validate.ValidationError, match="prepare"):
+        trtmc_validate._ensure_reference_source(source, tmp_path, prebuilt_only=True)
+
+    assert not (tmp_path / source.relative_checkout).exists()
 
 
 def test_elf_reference_source_is_pinned_to_upstream_pytorch_implementation() -> None:

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -7395,6 +7395,7 @@ def test_flux_fp8_build_command_resolves_model_owned_scales(tmp_path: Path) -> N
 def test_eval_one_model_diffusion_uses_clip_parity_summary(
     tmp_path: Path, monkeypatch
 ) -> None:
+    revision = "a" * 40
     dataset = tmp_path / "dpg_bench.json"
     dataset.write_text(json.dumps({"dataset": "DPG-Bench", "requests": [{
         "sample_id": "dpg_bench_000000",
@@ -7417,6 +7418,7 @@ def test_eval_one_model_diffusion_uses_clip_parity_summary(
         }])
 
     def fake_bundle(*_args, **kwargs):
+        assert kwargs["expected_source_revision"] == revision
         return kwargs["bundle_path"], True
 
     def fake_trt(args):
@@ -7444,6 +7446,7 @@ def test_eval_one_model_diffusion_uses_clip_parity_summary(
     monkeypatch.setattr(validation_engine, "run_hf_reference_subprocess", fake_hf)
     monkeypatch.setattr(validation_engine, "ensure_bundle", fake_bundle)
     monkeypatch.setattr(validation_engine, "run_bundle", fake_trt)
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", revision)
     monkeypatch.setattr(validation_engine, "compare_diffusion_image_predictions", fake_compare)
     monkeypatch.setattr(
         validation_engine,

--- a/tools/campaign_shards.py
+++ b/tools/campaign_shards.py
@@ -14,11 +14,11 @@ from pathlib import Path
 import shutil
 from typing import Any, Mapping, Sequence
 
-from tools import qualification_report
+from tools import case_evidence, qualification_report
 from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError
 
 
-CAMPAIGN_SCHEMA = "trtmc.model-check-sharded-campaign/v1"
+CAMPAIGN_SCHEMA = "trtmc.model-check-sharded-campaign/v2"
 
 
 class CampaignShardError(ValueError):
@@ -327,8 +327,18 @@ def merge_receipt_reports(
             }
         )
 
+    ordered_rows = [rows[case_id] for case_id in expected_ids]
+    try:
+        revision_summary = case_evidence.summarize_model_revisions(
+            {**row, "task": task_kind} for row in ordered_rows
+        )
+    except case_evidence.CaseEvidenceError as error:
+        raise CampaignShardError(str(error)) from error
+    source_revisions = revision_summary["source_revisions"]
+    source_revision = source_revisions[0] if len(source_revisions) == 1 else None
     public_run = {
-        "source_revision": campaign.get("revision"),
+        "source_revision": source_revision,
+        "source_revisions": source_revisions,
         "platform": campaign.get("platform"),
         "hostname": "multiple shards",
         "shards": shard_runs,
@@ -336,7 +346,7 @@ def merge_receipt_reports(
     public_identity = {
         "run_id": campaign.get("run_id"),
         "disposition": "completed",
-        "source_revision": campaign.get("revision"),
+        "source_revision": source_revision,
     }
     if any(row["state"] != "terminal" for row in rows.values()):
         public_identity["disposition"] = "running"
@@ -350,12 +360,13 @@ def merge_receipt_reports(
         ),
         identity=public_identity,
         run=public_run,
-        results=[rows[case_id] for case_id in expected_ids],
+        results=ordered_rows,
         metadata={
             "campaign": {
                 "schema_version": CAMPAIGN_SCHEMA,
                 "shard_count": campaign.get("shard_count"),
             },
+            "model_source_identity": revision_summary,
             "receipt_sources": receipt_sources,
         },
     )

--- a/tools/case_evidence.py
+++ b/tools/case_evidence.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Case-level source provenance and per-model qualification identity."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+from typing import Any, Iterable, Mapping
+
+
+EXACT_SOURCE_REVISION = re.compile(r"^[0-9a-f]{40}$")
+
+
+class CaseEvidenceError(ValueError):
+    """Case provenance cannot support a trustworthy qualification result."""
+
+
+def exact_source_revision(value: Any, *, label: str = "source revision") -> str:
+    revision = str(value or "").strip().lower()
+    if EXACT_SOURCE_REVISION.fullmatch(revision) is None:
+        raise CaseEvidenceError(f"{label} must be an exact 40-character Git SHA")
+    return revision
+
+
+def stamp_case(payload: Mapping[str, Any], source_revision: str) -> dict[str, Any]:
+    """Return one case payload bound to exactly one observed source revision."""
+
+    revision = exact_source_revision(source_revision)
+    stamped = deepcopy(dict(payload))
+    embedded = str(stamped.get("source_revision", "") or "").strip().lower()
+    if embedded and embedded != revision:
+        raise CaseEvidenceError(
+            "case source revision conflict: "
+            f"embedded={embedded}, execution={revision}"
+        )
+    stamped["source_revision"] = revision
+    return stamped
+
+
+def summarize_model_revisions(
+    cases: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Summarize whether every terminal case for each model uses one revision."""
+
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for case in cases:
+        model = str(case.get("model", "") or "").strip()
+        if not model:
+            raise CaseEvidenceError("qualification case is missing its model identity")
+        grouped.setdefault(model, []).append(case)
+
+    models: dict[str, dict[str, Any]] = {}
+    campaign_revisions: set[str] = set()
+    for model in sorted(grouped):
+        model_cases = grouped[model]
+        revisions: set[str] = set()
+        missing = False
+        incomplete = False
+        case_ids: list[str] = []
+        tasks: set[str] = set()
+        for case in model_cases:
+            case_ids.append(str(case.get("id", "") or ""))
+            task = str(case.get("task", "") or "").strip()
+            if task:
+                tasks.add(task)
+            if case.get("state") != "terminal":
+                incomplete = True
+                continue
+            revision = str(case.get("source_revision", "") or "").strip().lower()
+            if EXACT_SOURCE_REVISION.fullmatch(revision) is None:
+                missing = True
+                continue
+            revisions.add(revision)
+
+        campaign_revisions.update(revisions)
+        if incomplete:
+            status = "incomplete"
+        elif missing:
+            status = "missing"
+        elif len(revisions) != 1:
+            status = "mixed"
+        else:
+            status = "consistent"
+        models[model] = {
+            "status": status,
+            "source_revision": next(iter(revisions)) if status == "consistent" else None,
+            "source_revisions": sorted(revisions),
+            "case_ids": case_ids,
+            "tasks": sorted(tasks),
+        }
+
+    return {
+        "consistent": all(record["status"] == "consistent" for record in models.values()),
+        "source_revisions": sorted(campaign_revisions),
+        "models": models,
+    }

--- a/tools/execution_ledger.py
+++ b/tools/execution_ledger.py
@@ -327,6 +327,47 @@ class ExecutionLedger:
             reopened.append(case_id)
         return reopened
 
+    def reopen_cases(
+        self,
+        case_ids: Sequence[str],
+        *,
+        reason: str,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> list[str]:
+        """Reopen explicitly selected terminal cases without touching other receipts."""
+
+        selected = list(dict.fromkeys(str(case_id) for case_id in case_ids))
+        if not str(reason).strip():
+            raise ExecutionLedgerError("case reopen reason must be non-empty")
+        receipts: dict[str, dict[str, Any]] = {}
+        for case_id in selected:
+            receipt = self.receipt(case_id)
+            if receipt["state"] != "terminal":
+                raise ExecutionLedgerError(f"case {case_id!r} is not terminal")
+            receipts[case_id] = receipt
+
+        reopened: list[str] = []
+        for case_id in selected:
+            receipt = receipts[case_id]
+            receipt["previous_results"].append(
+                {
+                    "attempt": receipt["attempts"][-1]["attempt"],
+                    "result": receipt["result"],
+                    "payload": receipt["payload"],
+                    "finished_at": receipt["updated_at"],
+                    "reopen_reason": str(reason),
+                    "reopen_evidence": deepcopy(dict(evidence or {})),
+                }
+            )
+            receipt["state"] = "pending"
+            receipt["stage"] = None
+            receipt["result"] = None
+            receipt["payload"] = None
+            receipt["updated_at"] = _now()
+            self._write_receipt(case_id, receipt)
+            reopened.append(case_id)
+        return reopened
+
     def _pending_receipt(self, case_id: str) -> dict[str, Any]:
         return {
             "schema_version": SCHEMA_VERSION,
@@ -387,7 +428,7 @@ class ExecutionLedger:
         previous_results = receipt.get("previous_results")
         if not isinstance(previous_results, list) or any(
             not isinstance(previous, Mapping)
-            or previous.get("result") != "white"
+            or previous.get("result") not in TERMINAL_RESULTS
             or not isinstance(previous.get("payload"), Mapping)
             for previous in previous_results
         ):
@@ -409,7 +450,13 @@ class ExecutionLedger:
                 "failed",
                 "timed_out",
             }:
-                raise ExecutionLedgerError(f"pending case {case_id!r} has no retryable attempt")
+                explicitly_reopened = bool(previous_results) and previous_results[-1].get(
+                    "attempt"
+                ) == attempts[-1].get("attempt")
+                if not explicitly_reopened:
+                    raise ExecutionLedgerError(
+                        f"pending case {case_id!r} has no retryable attempt"
+                    )
         if state in {"running", "terminal"} and receipt.get("stage") != attempts[-1].get(
             "stage"
         ):

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -64,6 +64,7 @@ MANAGED_TASK_ENVIRONMENT_VARIABLES = frozenset(
         PROFILE_ROOT_ENV,
         PREBUILT_ONLY_ENV,
         "TRTMC_PERF_SOURCE_REVISION",
+        trtmc_validate.REFERENCE_SOURCES_PREBUILT_ONLY_ENV,
         "TRTMC_VALIDATION_SOURCE_REVISION",
     }
 )
@@ -107,6 +108,11 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--environment",
         help="execution environment ID or YAML; defaults to the platform ID",
+    )
+    run.add_argument(
+        "--debug",
+        action="store_true",
+        help="allow missing dependencies to be prepared during this non-qualification run",
     )
     run.add_argument("--run-id", help="stable output directory name")
     run.add_argument("--dry-run", action="store_true", help="write and print commands only")
@@ -418,11 +424,17 @@ def _task_environment(
     overrides: Mapping[str, str] | None = None,
     *,
     source_revision: str = "",
+    allow_dependency_creation: bool = True,
 ) -> dict[str, str]:
-    """Use a managed shared profile cache and create missing profiles on demand."""
+    """Build a child environment rooted in this worktree and its managed caches."""
     child = os.environ.copy()
     child[PROFILE_ROOT_ENV] = str(environment["storage"]["python_profiles_root"])
-    child.pop(PREBUILT_ONLY_ENV, None)
+    if allow_dependency_creation:
+        child.pop(PREBUILT_ONLY_ENV, None)
+        child.pop(trtmc_validate.REFERENCE_SOURCES_PREBUILT_ONLY_ENV, None)
+    else:
+        child[PREBUILT_ONLY_ENV] = "1"
+        child[trtmc_validate.REFERENCE_SOURCES_PREBUILT_ONLY_ENV] = "1"
     library_dirs = [str(path) for path in environment.get("library_dirs", [])]
     missing_library_dirs = [path for path in library_dirs if not Path(path).is_dir()]
     if missing_library_dirs:
@@ -446,17 +458,17 @@ def _task_environment(
         executable_dirs.append(inherited_path)
     if executable_dirs:
         child["PATH"] = os.pathsep.join(executable_dirs)
-    python_dirs = [str(path) for path in environment.get("python_dirs", [])]
-    missing_python_dirs = [path for path in python_dirs if not Path(path).is_dir()]
+    configured_python_dirs = [str(path) for path in environment.get("python_dirs", [])]
+    missing_python_dirs = [path for path in configured_python_dirs if not Path(path).is_dir()]
     if missing_python_dirs:
         raise ModelCheckError(
             "model-check Python runtime directory does not exist: " + ", ".join(missing_python_dirs)
         )
+    python_dirs = [str(PYTHON_SOURCE), str(REPOSITORY), *configured_python_dirs]
     inherited_python_path = child.get("PYTHONPATH", "")
     if inherited_python_path:
-        python_dirs.append(inherited_python_path)
-    if python_dirs:
-        child["PYTHONPATH"] = os.pathsep.join(python_dirs)
+        python_dirs.extend(inherited_python_path.split(os.pathsep))
+    child["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(filter(None, python_dirs)))
     child.update(
         {
             str(name): str(value)
@@ -467,6 +479,7 @@ def _task_environment(
         revision = source_revision.lower()
         child["TRTMC_VALIDATION_SOURCE_REVISION"] = revision
         child["TRTMC_PERF_SOURCE_REVISION"] = revision
+        child["TRTMC_ENGINE_BUILD_REVISION"] = revision
     child.update(overrides or {})
     return child
 
@@ -1179,6 +1192,7 @@ def _perf_command(
     resolved_environment: Path,
     *,
     bindings: Sequence[Mapping[str, Any]] | None = None,
+    require_prebuilt: bool = False,
 ) -> list[str] | None:
     bindings = list(bindings) if bindings is not None else _task_bindings(plan, "perf")
     if not bindings:
@@ -1194,12 +1208,43 @@ def _perf_command(
     ]
     for binding in bindings:
         command.extend(["--entry", str(binding["entry"])])
+    if require_prebuilt:
+        command.append("--no-build")
+    return command
+
+
+def _perf_prepare_command(
+    plan: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    resolved_environment: Path,
+    receipt: Path,
+    *,
+    bindings: Sequence[Mapping[str, Any]] | None = None,
+) -> list[str] | None:
+    bindings = list(bindings) if bindings is not None else _task_bindings(plan, "perf")
+    if not bindings:
+        return None
+    config = environment["tasks"]["perf"]
+    command = [
+        str(config["runner_python"]),
+        str(REPOSITORY / "tools" / "perf_matrix.py"),
+        "prepare",
+        str(config["suite"]),
+        "--environment",
+        str(resolved_environment),
+        "--output",
+        str(receipt),
+    ]
+    for binding in bindings:
+        command.extend(["--entry", str(binding["entry"])])
     return command
 
 
 def _perf_resume_command(
     environment: Mapping[str, Any],
     results_root: Path,
+    *,
+    require_prebuilt: bool = False,
 ) -> list[str] | None:
     if not results_root.is_dir():
         return None
@@ -1213,12 +1258,15 @@ def _perf_resume_command(
             f"cannot identify one Perf run to resume below {results_root}: found {len(candidates)}"
         )
     config = environment["tasks"]["perf"]
-    return [
+    command = [
         str(config["runner_python"]),
         str(REPOSITORY / "tools" / "perf_matrix.py"),
         "resume",
         str(candidates[0]),
     ]
+    if require_prebuilt:
+        command.append("--no-build")
+    return command
 
 
 def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
@@ -1233,6 +1281,9 @@ def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
     for field in (
         "schema_version",
         "run_id",
+        "revision",
+        "intent",
+        "source_identity",
         "platform",
         "platform_source",
         "platform_config",
@@ -1244,10 +1295,8 @@ def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
     ):
         if previous.get(field) != request.get(field):
             raise ModelCheckError(f"cannot resume because the resolved {field} changed")
-    if request.get("shard") is not None:
-        for field in ("revision", "shard"):
-            if previous.get(field) != request.get(field):
-                raise ModelCheckError(f"cannot resume because the resolved {field} changed")
+    if previous.get("shard") != request.get("shard"):
+        raise ModelCheckError("cannot resume because the resolved shard changed")
 
 
 def _perf_shard_output(shard_root: Path) -> Path | None:
@@ -1410,12 +1459,186 @@ def _resolved_revision(revision: str) -> str:
     return value
 
 
+def _worktree_changes() -> tuple[str, ...]:
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=REPOSITORY,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode:
+        raise ModelCheckError("cannot inspect the active worktree state")
+    return tuple(line for line in status.stdout.splitlines() if line)
+
+
+def _source_identity(revision: str, *, require_clean: bool = False) -> dict[str, Any]:
+    modules = {
+        "model_checks": sys.modules[__name__],
+        "perf_matrix": perf_matrix,
+        "trtmc_validate": trtmc_validate,
+        "performance_catalog": performance_catalog,
+        "validation_catalog": validation_catalog,
+        "python_profiles": sys.modules["tensorrt_model_connect.python_profiles"],
+    }
+    imports: dict[str, str] = {}
+    for name, module in modules.items():
+        module_path = Path(str(module.__file__)).resolve()
+        try:
+            imports[name] = str(module_path.relative_to(REPOSITORY))
+        except ValueError as exc:
+            raise ModelCheckError(
+                f"{name} was imported from outside the active worktree: {module_path}"
+            ) from exc
+    head = _resolved_revision("HEAD")
+    if revision != head:
+        raise ModelCheckError(
+            "requested source revision does not match the active worktree HEAD: "
+            f"requested={revision}, HEAD={head}"
+        )
+    if require_clean:
+        changes = _worktree_changes()
+        if changes:
+            raise ModelCheckError(
+                "qualification requires a clean worktree; commit or remove local changes"
+            )
+    return {"revision": revision, "imports": imports}
+
+
+def _revalidate_qualification_source(
+    revision: str,
+    expected: Mapping[str, Any],
+) -> None:
+    current = _source_identity(revision, require_clean=True)
+    if current != expected:
+        raise ModelCheckError("qualification source identity changed during the run")
+
+
+def _prepare_accuracy_dependencies(
+    plan: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    arguments: argparse.Namespace,
+    *,
+    bindings: Sequence[Mapping[str, Any]] | None = None,
+) -> None:
+    bindings = list(bindings) if bindings is not None else _task_bindings(plan, "accuracy")
+    if not bindings:
+        return
+    task_models = validation_catalog.load_manifest_records_by_name(arguments.models_dir)
+    suites = {suite["id"]: suite for suite in validation_catalog.load_suites(arguments.suites)}
+    profile_names: list[str] = []
+    for binding in bindings:
+        selected = trtmc_validate.Binding(
+            str(binding["model"]),
+            str(binding["workload"]),
+        )
+        profile_names.extend(
+            trtmc_validate.binding_profiles(
+                selected,
+                task_models=task_models,
+                suites=suites,
+            )
+        )
+
+    config = environment["tasks"]["accuracy"]
+    options = config.get("options", {})
+    profile_root = str(environment["storage"]["python_profiles_root"])
+    previous_profile_root = os.environ.get(PROFILE_ROOT_ENV)
+    previous_prebuilt = os.environ.get(PREBUILT_ONLY_ENV)
+    os.environ[PROFILE_ROOT_ENV] = profile_root
+    os.environ.pop(PREBUILT_ONLY_ENV, None)
+    try:
+        trtmc_validate.ensure_environments(
+            tuple(dict.fromkeys(profile_names)),
+            str(options.get("hf-python", config["runner_python"])),
+        )
+    finally:
+        if previous_profile_root is None:
+            os.environ.pop(PROFILE_ROOT_ENV, None)
+        else:
+            os.environ[PROFILE_ROOT_ENV] = previous_profile_root
+        if previous_prebuilt is None:
+            os.environ.pop(PREBUILT_ONLY_ENV, None)
+        else:
+            os.environ[PREBUILT_ONLY_ENV] = previous_prebuilt
+
+    prepared_models: set[str] = set()
+    for binding in bindings:
+        model = str(binding["model"])
+        if model in prepared_models:
+            continue
+        prepared_models.add(model)
+        record = task_models[model]
+        trtmc_validate.ensure_reference_sources(
+            str(record.get("family", "") or ""),
+            Path(str(options["reference-cache-dir"])),
+            record.get("model_reference_cache"),
+            source_cache_root=Path(str(environment["storage"]["model_reference_cache_root"])),
+            prebuilt_only=False,
+        )
+
+
+def _prepare_qualification_dependencies(
+    plan: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    arguments: argparse.Namespace,
+    *,
+    task_bindings: Mapping[str, Sequence[Mapping[str, Any]]],
+    perf_environment: Path | None,
+    perf_preparation_receipt: Path | None,
+    model_reference_cache_root: Path,
+) -> dict[str, str]:
+    print("\nPreparing qualification dependencies", flush=True)
+    _prepare_accuracy_dependencies(
+        plan,
+        environment,
+        arguments,
+        bindings=task_bindings.get("accuracy", ()),
+    )
+    contracts = _selected_perf_reference_contracts(
+        plan,
+        arguments.models_dir,
+        bindings=task_bindings.get("perf", ()),
+    )
+    reference_environment = _prepare_perf_reference_dependencies(
+        contracts,
+        model_reference_cache_root,
+    )
+    if perf_environment is not None and perf_preparation_receipt is not None:
+        command = _perf_prepare_command(
+            plan,
+            environment,
+            perf_environment,
+            perf_preparation_receipt,
+            bindings=task_bindings.get("perf", ()),
+        )
+        if command is not None:
+            completed = subprocess.run(
+                _detailed_command(command, verbose=arguments.verbose),
+                cwd=REPOSITORY,
+                check=False,
+                env=_task_environment(
+                    environment,
+                    reference_environment,
+                    source_revision=arguments.revision,
+                ),
+            )
+            if completed.returncode:
+                raise ModelCheckError("Perf bundle preparation failed")
+    print("Qualification dependencies prepared; starting frozen measurement", flush=True)
+    return reference_environment
+
+
 def _run(arguments: argparse.Namespace) -> int:
+    arguments.intent = "debug" if arguments.debug else "qualification"
     shard = campaign_shards.parse_shard(arguments.shard) if arguments.shard else None
-    if shard is not None:
-        if not arguments.run_id:
-            raise ModelCheckError("--shard requires an explicit shared --run-id")
-        arguments.revision = _resolved_revision(arguments.revision)
+    if shard is not None and not arguments.run_id:
+        raise ModelCheckError("--shard requires an explicit shared --run-id")
+    arguments.revision = _resolved_revision(arguments.revision)
+    source_identity = _source_identity(
+        arguments.revision,
+        require_clean=arguments.intent == "qualification",
+    )
     platform = load_platform(arguments.platform)
     environment = load_execution_environment(
         arguments.environment or str(platform["id"]),
@@ -1503,6 +1726,8 @@ def _run(arguments: argparse.Namespace) -> int:
                     "run_id": run_id,
                     "platform": platform["id"],
                     "revision": arguments.revision,
+                    "intent": arguments.intent,
+                    "source_identity": source_identity,
                     "shard_count": shard[1],
                     "selection": stable_selection,
                     "cases": campaign_cases,
@@ -1536,6 +1761,9 @@ def _run(arguments: argparse.Namespace) -> int:
             scratch_root=execution_root / "work" / "perf",
             bundle_cache=(execution_root / "cache" / "perf" if shard else None),
         )
+    perf_preparation_receipt = (
+        execution_root / "perf-bundle-preparation.json" if perf_environment is not None else None
+    )
     commands: list[tuple[str, list[str] | None]] = []
     for task in plan["execution"]["task_order"]:
         if task == "accuracy":
@@ -1553,6 +1781,7 @@ def _run(arguments: argparse.Namespace) -> int:
                     environment,
                     perf_environment,
                     bindings=task_bindings[task],
+                    require_prebuilt=arguments.intent == "qualification",
                 )
                 if perf_environment is not None
                 else None
@@ -1562,6 +1791,8 @@ def _run(arguments: argparse.Namespace) -> int:
         "schema_version": "trtmc.model-check-run/v1",
         "run_id": run_id,
         "revision": arguments.revision,
+        "intent": arguments.intent,
+        "source_identity": source_identity,
         "platform": platform["id"],
         "platform_source": platform["source"],
         "platform_config": platform,
@@ -1608,6 +1839,7 @@ def _run(arguments: argparse.Namespace) -> int:
                 resume_command = _perf_resume_command(
                     environment,
                     execution_root / "perf" / "results",
+                    require_prebuilt=arguments.intent == "qualification",
                 )
                 execution_commands.append((task, resume_command or command))
     print(_render_run_header(plan, run_id=run_id, run_root=execution_root))
@@ -1616,7 +1848,12 @@ def _run(arguments: argparse.Namespace) -> int:
             f"Shard: {shard[0]}/{shard[1]} · "
             f"{sum(len(bindings) for bindings in task_bindings.values())} bindings"
         )
-    print(f"Python profiles: {python_profiles_root} (shared; creates missing profiles)")
+    profile_policy = (
+        "shared; creates missing profiles"
+        if arguments.intent == "debug"
+        else "prepared before measurement; prebuilt during measurement"
+    )
+    print(f"Python profiles: {python_profiles_root} ({profile_policy})")
     if arguments.verbose or arguments.dry_run:
         print("\nCommands:")
         for task, command in execution_commands:
@@ -1629,24 +1866,33 @@ def _run(arguments: argparse.Namespace) -> int:
     if arguments.dry_run:
         return 0
 
-    reference_environment: dict[str, str] = {}
-    reference_contracts = _selected_perf_reference_contracts(
-        plan,
-        arguments.models_dir,
-        bindings=task_bindings.get("perf", ()),
-    )
-    reference_environment.update(
-        _prepare_perf_reference_dependencies(
+    if arguments.intent == "qualification":
+        reference_environment = _prepare_qualification_dependencies(
+            plan,
+            environment,
+            arguments,
+            task_bindings=task_bindings,
+            perf_environment=perf_environment,
+            perf_preparation_receipt=perf_preparation_receipt,
+            model_reference_cache_root=model_reference_cache_root,
+        )
+        _revalidate_qualification_source(arguments.revision, source_identity)
+    else:
+        reference_contracts = _selected_perf_reference_contracts(
+            plan,
+            arguments.models_dir,
+            bindings=task_bindings.get("perf", ()),
+        )
+        reference_environment = _prepare_perf_reference_dependencies(
             reference_contracts,
             model_reference_cache_root,
         )
-    )
-    if reference_contracts:
-        print(
-            f"Prepared external model sources: {len(reference_contracts)} "
-            f"under {model_reference_cache_root}",
-            flush=True,
-        )
+        if reference_contracts:
+            print(
+                f"Prepared external model sources: {len(reference_contracts)} "
+                f"under {model_reference_cache_root}",
+                flush=True,
+            )
 
     task_results: dict[str, int] = {}
     runnable = [(task, command) for task, command in execution_commands if command is not None]
@@ -1655,6 +1901,8 @@ def _run(arguments: argparse.Namespace) -> int:
         print(f"\n[{index}/{len(runnable)}] {label}", flush=True)
         if command is None:
             continue
+        if arguments.intent == "qualification":
+            _revalidate_qualification_source(arguments.revision, source_identity)
         completed = subprocess.run(
             _detailed_command(command, verbose=arguments.verbose),
             cwd=REPOSITORY,
@@ -1663,8 +1911,27 @@ def _run(arguments: argparse.Namespace) -> int:
                 environment,
                 reference_environment,
                 source_revision=arguments.revision,
+                allow_dependency_creation=arguments.intent == "debug",
             ),
         )
+        if arguments.intent == "qualification":
+            _revalidate_qualification_source(arguments.revision, source_identity)
+        if (
+            task == "perf"
+            and completed.returncode == 0
+            and perf_preparation_receipt is not None
+            and perf_preparation_receipt.is_file()
+        ):
+            perf_output = _perf_shard_output(execution_root)
+            if perf_output is None:
+                raise ModelCheckError("cannot locate completed Perf output")
+            try:
+                perf_matrix.write_report(
+                    perf_output,
+                    preparation_receipt=perf_preparation_receipt,
+                )
+            except perf_matrix.PerfMatrixError as error:
+                raise ModelCheckError(str(error)) from error
         task_results[task] = completed.returncode
         status = "PASSED" if completed.returncode == 0 else "FAILED"
         print(f"[{index}/{len(runnable)}] {label}: {status}", flush=True)

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -1453,10 +1453,10 @@ def _validate_shard_member(
     label: str,
     index: int,
     campaign: Mapping[str, Any],
-) -> bool:
+) -> dict[str, Any] | None:
     request_path = shard_root / "request.json"
     if not request_path.is_file():
-        return False
+        return None
     try:
         request = json.loads(request_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -1480,7 +1480,30 @@ def _validate_shard_member(
         or stable_selection != campaign.get("selection")
     ):
         raise ModelCheckError(f"shard {label} does not belong to this campaign")
-    return True
+    return dict(request)
+
+
+def _shard_result_status(
+    shard_root: Path,
+    request: Mapping[str, Any],
+) -> str | None:
+    result_path = shard_root / "result.json"
+    if not result_path.is_file():
+        return None
+    try:
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ModelCheckError(f"cannot read shard result {result_path}: {error}") from error
+    if not isinstance(result, Mapping) or result.get("run_id") != request.get("run_id"):
+        raise ModelCheckError(f"shard result does not belong to its request: {result_path}")
+    if result.get("execution_revision") != request.get("revision"):
+        return None
+    status = result.get("status")
+    if status == "running":
+        return None
+    if status not in {"passed", "failed"}:
+        raise ModelCheckError(f"shard result has invalid status: {result_path}")
+    return str(status)
 
 
 def _consolidate_once(run_root: Path) -> bool:
@@ -1493,18 +1516,23 @@ def _consolidate_once(run_root: Path) -> bool:
     if not isinstance(cases, list) or not isinstance(shard_count, int) or shard_count < 1:
         raise ModelCheckError("sharded campaign inventory is invalid")
     shards = []
+    shard_results_complete = True
+    shards_passed = True
     for index in range(shard_count):
         label = campaign_shards.shard_name(index, shard_count)
         shard_root = run_root / "shards" / label
-        ready = False
+        request = None
         if shard_root.exists():
-            ready = _validate_shard_member(
+            request = _validate_shard_member(
                 shard_root,
                 label=label,
                 index=index,
                 campaign=campaign,
             )
-        shards.append((index, label, shard_root, ready))
+        status = _shard_result_status(shard_root, request) if request is not None else None
+        shard_results_complete = shard_results_complete and status is not None
+        shards_passed = shards_passed and status == "passed"
+        shards.append((index, label, shard_root, request is not None))
 
     all_terminal = True
     for task, report_kind in (
@@ -1546,6 +1574,7 @@ def _consolidate_once(run_root: Path) -> bool:
             f"terminal · {run_root / task / 'report.json'}",
             flush=True,
         )
+    all_terminal = all_terminal and shard_results_complete
     if all_terminal:
         combined_rows: list[dict[str, Any]] = []
         for task in TASKS:
@@ -1566,7 +1595,11 @@ def _consolidate_once(run_root: Path) -> bool:
                 "schema_version": "trtmc.model-check-run-result/v1",
                 "run_id": campaign.get("run_id"),
                 "model_source_identity": source_identity,
-                "status": "passed" if source_identity["consistent"] else "failed",
+                "status": (
+                    "passed"
+                    if shards_passed and source_identity["consistent"]
+                    else "failed"
+                ),
             },
         )
     return all_terminal
@@ -2037,6 +2070,17 @@ def _run(arguments: argparse.Namespace) -> int:
     if arguments.dry_run:
         return 0
 
+    if shard is not None:
+        _write_request(
+            execution_root / "result.json",
+            {
+                "schema_version": "trtmc.model-check-run-result/v1",
+                "run_id": run_id,
+                "execution_revision": arguments.revision,
+                "status": "running",
+            },
+        )
+
     preparation_bindings = (
         _resume_preparation_bindings(
             execution_root,
@@ -2134,10 +2178,7 @@ def _run(arguments: argparse.Namespace) -> int:
         "model_source_identity": model_source_identity,
         "status": "passed" if tasks_passed and identity_passed else "failed",
     }
-    (execution_root / "result.json").write_text(
-        json.dumps(result, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    _write_request(execution_root / "result.json", result)
     print(f"\nOverall: {result['status'].upper()}")
     for task, returncode in task_results.items():
         status = "PASSED" if returncode == 0 else "FAILED"

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -29,11 +29,12 @@ for source_root in (REPOSITORY, PYTHON_SOURCE):
     if str(source_root) not in sys.path:
         sys.path.insert(0, str(source_root))
 
-from tools import campaign_shards  # noqa: E402
+from tools import campaign_shards, case_evidence  # noqa: E402
 from tools import model_ci  # noqa: E402
 from tools import model_selection  # noqa: E402
 from tools import perf_matrix  # noqa: E402
 from tools import trtmc_validate  # noqa: E402
+from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools.ci.context import CiContext  # noqa: E402
 from tools.ci.model_reference_cache import (  # noqa: E402
     ModelReferenceCacheWarmer,
@@ -125,6 +126,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--resume",
         action="store_true",
         help="resume the existing --run-id after verifying its request",
+    )
+    run.add_argument(
+        "--invalidate-model",
+        action="append",
+        default=[],
+        help=(
+            "with --resume, re-run every selected Accuracy and Perf case for this "
+            "model; repeatable"
+        ),
     )
     run.add_argument(
         "--hf-cache-seed-dir",
@@ -1269,7 +1279,7 @@ def _perf_resume_command(
     return command
 
 
-def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
+def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> dict[str, Any]:
     try:
         previous = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
@@ -1278,12 +1288,17 @@ def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
         raise ModelCheckError(f"cannot read resume request {path}: {exc}") from exc
     if not isinstance(previous, Mapping):
         raise ModelCheckError(f"resume request must contain a JSON object: {path}")
+    previous_revision = previous.get("revision")
+    try:
+        case_evidence.exact_source_revision(
+            previous_revision, label="exact recorded execution revision"
+        )
+    except case_evidence.CaseEvidenceError as error:
+        raise ModelCheckError(str(error)) from error
     for field in (
         "schema_version",
         "run_id",
-        "revision",
         "intent",
-        "source_identity",
         "platform",
         "platform_source",
         "platform_config",
@@ -1297,6 +1312,32 @@ def _verify_resume_request(path: Path, request: Mapping[str, Any]) -> None:
             raise ModelCheckError(f"cannot resume because the resolved {field} changed")
     if previous.get("shard") != request.get("shard"):
         raise ModelCheckError("cannot resume because the resolved shard changed")
+    return dict(previous)
+
+
+def _write_request(path: Path, request: Mapping[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(request, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _record_execution_attempt(
+    request: dict[str, Any],
+    *,
+    revision: str,
+    source_identity: Mapping[str, Any],
+) -> None:
+    attempts = request.setdefault("execution_attempts", [])
+    if not isinstance(attempts, list):
+        raise ModelCheckError("cannot resume with invalid execution attempt history")
+    attempts.append(
+        {
+            "revision": revision,
+            "source_identity": dict(source_identity),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "dry_run": bool(request.get("dry_run")),
+        }
+    )
 
 
 def _perf_shard_output(shard_root: Path) -> Path | None:
@@ -1307,6 +1348,85 @@ def _perf_shard_output(shard_root: Path) -> Path | None:
     if len(candidates) > 1:
         raise ModelCheckError(f"shard has multiple Performance runs: {shard_root}")
     return candidates[0] if candidates else None
+
+
+def _resume_preparation_bindings(
+    execution_root: Path,
+    task_bindings: Mapping[str, Sequence[Mapping[str, Any]]],
+    invalidated_models: set[str],
+) -> dict[str, list[Mapping[str, Any]]]:
+    active: dict[str, list[Mapping[str, Any]]] = {}
+    for task, bindings in task_bindings.items():
+        bindings = list(bindings)
+        output = (
+            execution_root / "accuracy"
+            if task == "accuracy"
+            else _perf_shard_output(execution_root)
+        )
+        if output is None or not (output / "ledger" / "campaign.json").is_file():
+            active[task] = bindings
+            continue
+        try:
+            ledger = ExecutionLedger.load(
+                output,
+                task_kind="performance" if task == "perf" else "accuracy",
+            )
+        except ExecutionLedgerError as error:
+            raise ModelCheckError(str(error)) from error
+        selected: list[Mapping[str, Any]] = []
+        for binding in bindings:
+            case_id = (
+                f"{binding['model']}::{binding['workload']}"
+                if task == "accuracy"
+                else str(binding["entry"])
+            )
+            receipt = ledger.receipt(case_id)
+            attempts = receipt.get("attempts", [])
+            evidence = attempts[-1].get("evidence", {}) if attempts else {}
+            retryable = (
+                receipt.get("result") == "white"
+                and isinstance(evidence, Mapping)
+                and evidence.get("retryable") is True
+            )
+            if (
+                str(binding["model"]) in invalidated_models
+                or receipt.get("state") != "terminal"
+                or retryable
+            ):
+                selected.append(binding)
+        active[task] = selected
+    return active
+
+
+def _model_source_identity(
+    execution_root: Path,
+    tasks: Iterable[str],
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for task in tasks:
+        output = (
+            execution_root / "accuracy"
+            if task == "accuracy"
+            else _perf_shard_output(execution_root)
+        )
+        report_path = output / "report.json" if output is not None else None
+        if report_path is None or not report_path.is_file():
+            raise ModelCheckError(f"completed {_task_label(task)} task has no report.json")
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise ModelCheckError(f"cannot read {_task_label(task)} report: {error}") from error
+        report_rows = report.get("results") if isinstance(report, Mapping) else None
+        if not isinstance(report_rows, list):
+            raise ModelCheckError(f"{_task_label(task)} report has no result rows")
+        for row in report_rows:
+            if not isinstance(row, Mapping):
+                raise ModelCheckError(f"{_task_label(task)} report contains an invalid row")
+            rows.append({**dict(row), "task": task})
+    try:
+        return case_evidence.summarize_model_revisions(rows)
+    except case_evidence.CaseEvidenceError as error:
+        raise ModelCheckError(str(error)) from error
 
 
 def _refresh_shard_report(task: str, output: Path) -> None:
@@ -1355,7 +1475,6 @@ def _validate_shard_member(
     if (
         not isinstance(request, Mapping)
         or request.get("run_id") != campaign.get("run_id")
-        or request.get("revision") != campaign.get("revision")
         or request.get("platform") != campaign.get("platform")
         or request.get("shard") != expected_shard
         or stable_selection != campaign.get("selection")
@@ -1427,6 +1546,29 @@ def _consolidate_once(run_root: Path) -> bool:
             f"terminal · {run_root / task / 'report.json'}",
             flush=True,
         )
+    if all_terminal:
+        combined_rows: list[dict[str, Any]] = []
+        for task in TASKS:
+            report_path = run_root / task / "report.json"
+            if not report_path.is_file():
+                continue
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            for row in report.get("results", []):
+                if isinstance(row, Mapping):
+                    combined_rows.append({**dict(row), "task": task})
+        try:
+            source_identity = case_evidence.summarize_model_revisions(combined_rows)
+        except case_evidence.CaseEvidenceError as error:
+            raise ModelCheckError(str(error)) from error
+        _write_request(
+            run_root / "result.json",
+            {
+                "schema_version": "trtmc.model-check-run-result/v1",
+                "run_id": campaign.get("run_id"),
+                "model_source_identity": source_identity,
+                "status": "passed" if source_identity["consistent"] else "failed",
+            },
+        )
     return all_terminal
 
 
@@ -1439,7 +1581,12 @@ def _consolidate(arguments: argparse.Namespace) -> int:
             while True:
                 complete = _consolidate_once(run_root)
                 if complete or not arguments.watch:
-                    return 0
+                    if not complete:
+                        return 0
+                    result = json.loads(
+                        (run_root / "result.json").read_text(encoding="utf-8")
+                    )
+                    return 0 if result.get("status") == "passed" else 1
                 time.sleep(arguments.interval_seconds)
     except campaign_shards.CampaignShardError as error:
         raise ModelCheckError(str(error)) from error
@@ -1649,6 +1796,16 @@ def _run(arguments: argparse.Namespace) -> int:
     if plan["summary"]["blocker_count"]:
         print(_render(plan))
         raise ModelCheckError("selection has unconfigured task bindings")
+    invalidated_models = set(arguments.invalidate_model)
+    if invalidated_models and not arguments.resume:
+        raise ModelCheckError("--invalidate-model requires --resume")
+    selected_models = {str(model["model"]) for model in plan["models"]}
+    unknown_invalidations = sorted(invalidated_models - selected_models)
+    if unknown_invalidations:
+        raise ModelCheckError(
+            "cannot invalidate models outside this run: "
+            + ", ".join(unknown_invalidations)
+        )
 
     run_id = arguments.run_id or _default_run_id(str(platform["id"]))
     if not RUN_ID_PATTERN.fullmatch(run_id):
@@ -1725,9 +1882,7 @@ def _run(arguments: argparse.Namespace) -> int:
                 {
                     "run_id": run_id,
                     "platform": platform["id"],
-                    "revision": arguments.revision,
                     "intent": arguments.intent,
-                    "source_identity": source_identity,
                     "shard_count": shard[1],
                     "selection": stable_selection,
                     "cases": campaign_cases,
@@ -1818,14 +1973,19 @@ def _run(arguments: argparse.Namespace) -> int:
     }
     request_path = execution_root / "request.json"
     if arguments.resume:
-        _verify_resume_request(request_path, request)
+        previous_request = _verify_resume_request(request_path, request)
+        previous_attempts = previous_request.get("execution_attempts", [])
+        if not isinstance(previous_attempts, list):
+            raise ModelCheckError("cannot resume with invalid execution attempt history")
+        request["execution_attempts"] = list(previous_attempts)
     else:
-        temporary_request = request_path.with_name(f".{request_path.name}.{os.getpid()}.tmp")
-        temporary_request.write_text(
-            json.dumps(request, indent=2) + "\n",
-            encoding="utf-8",
-        )
-        temporary_request.replace(request_path)
+        request["execution_attempts"] = []
+    _record_execution_attempt(
+        request,
+        revision=arguments.revision,
+        source_identity=source_identity,
+    )
+    _write_request(request_path, request)
 
     execution_commands = list(commands)
     if arguments.resume:
@@ -1834,14 +1994,25 @@ def _run(arguments: argparse.Namespace) -> int:
             if command is None:
                 execution_commands.append((task, None))
             elif task == "accuracy":
-                execution_commands.append((task, [*command, "--resume-existing"]))
+                resumed = [*command, "--resume-existing"]
+                task_models = {str(binding["model"]) for binding in task_bindings[task]}
+                for model in sorted(invalidated_models & task_models):
+                    resumed.extend(["--invalidate-model", model])
+                execution_commands.append((task, resumed))
             else:
                 resume_command = _perf_resume_command(
                     environment,
                     execution_root / "perf" / "results",
                     require_prebuilt=arguments.intent == "qualification",
                 )
-                execution_commands.append((task, resume_command or command))
+                resumed = resume_command or command
+                if resume_command is not None:
+                    task_models = {
+                        str(binding["model"]) for binding in task_bindings[task]
+                    }
+                    for model in sorted(invalidated_models & task_models):
+                        resumed.extend(["--invalidate-model", model])
+                execution_commands.append((task, resumed))
     print(_render_run_header(plan, run_id=run_id, run_root=execution_root))
     if shard is not None:
         print(
@@ -1866,12 +2037,21 @@ def _run(arguments: argparse.Namespace) -> int:
     if arguments.dry_run:
         return 0
 
+    preparation_bindings = (
+        _resume_preparation_bindings(
+            execution_root,
+            task_bindings,
+            invalidated_models,
+        )
+        if arguments.resume
+        else task_bindings
+    )
     if arguments.intent == "qualification":
         reference_environment = _prepare_qualification_dependencies(
             plan,
             environment,
             arguments,
-            task_bindings=task_bindings,
+            task_bindings=preparation_bindings,
             perf_environment=perf_environment,
             perf_preparation_receipt=perf_preparation_receipt,
             model_reference_cache_root=model_reference_cache_root,
@@ -1881,7 +2061,7 @@ def _run(arguments: argparse.Namespace) -> int:
         reference_contracts = _selected_perf_reference_contracts(
             plan,
             arguments.models_dir,
-            bindings=task_bindings.get("perf", ()),
+            bindings=preparation_bindings.get("perf", ()),
         )
         reference_environment = _prepare_perf_reference_dependencies(
             reference_contracts,
@@ -1919,6 +2099,7 @@ def _run(arguments: argparse.Namespace) -> int:
         if (
             task == "perf"
             and completed.returncode == 0
+            and preparation_bindings.get("perf")
             and perf_preparation_receipt is not None
             and perf_preparation_receipt.is_file()
         ):
@@ -1935,12 +2116,23 @@ def _run(arguments: argparse.Namespace) -> int:
         task_results[task] = completed.returncode
         status = "PASSED" if completed.returncode == 0 else "FAILED"
         print(f"[{index}/{len(runnable)}] {label}: {status}", flush=True)
+    tasks_passed = all(code == 0 for code in task_results.values())
+    model_source_identity = (
+        _model_source_identity(execution_root, task_results)
+        if tasks_passed and task_results
+        else None
+    )
+    identity_passed = (
+        model_source_identity is None or model_source_identity["consistent"]
+    )
     result = {
         "schema_version": "trtmc.model-check-run-result/v1",
         "run_id": run_id,
         "resumed": bool(arguments.resume),
+        "execution_revision": arguments.revision,
         "task_exit_codes": task_results,
-        "status": "passed" if all(code == 0 for code in task_results.values()) else "failed",
+        "model_source_identity": model_source_identity,
+        "status": "passed" if tasks_passed and identity_passed else "failed",
     }
     (execution_root / "result.json").write_text(
         json.dumps(result, indent=2) + "\n",
@@ -1950,6 +2142,13 @@ def _run(arguments: argparse.Namespace) -> int:
     for task, returncode in task_results.items():
         status = "PASSED" if returncode == 0 else "FAILED"
         print(f"  {_task_label(task)}: {status}")
+    if model_source_identity is not None and not identity_passed:
+        inconsistent = [
+            model
+            for model, evidence in model_source_identity["models"].items()
+            if evidence["status"] != "consistent"
+        ]
+        print("  Source identity: FAILED · " + ", ".join(inconsistent))
     print(f"Run root: {execution_root}")
     return 0 if result["status"] == "passed" else 1
 
@@ -1968,6 +2167,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (
         ModelCheckError,
         campaign_shards.CampaignShardError,
+        case_evidence.CaseEvidenceError,
         model_ci.ModelCIError,
         model_selection.ModelSelectionError,
         perf_matrix.PerfMatrixError,

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -74,6 +74,7 @@ from tools import qualification_report  # noqa: E402
 RESULT_SCHEMA = "trtmc.perf-matrix/v1"
 PREPARATION_SCHEMA = "trtmc.perf-bundle-preparation/v1"
 ENVIRONMENT_SCHEMA = "trtmc.perf-environment/v1"
+EXACT_SOURCE_REVISION_PATTERN = re.compile(r"[0-9a-fA-F]{40}")
 SEQUENCE_RUNTIME_MARKERS = ("bart_", "marian_", "m2m_100_", "t5_")
 REPRODUCTION_ENVIRONMENT_NAMES = (
     "CUDA_VISIBLE_DEVICES",
@@ -125,6 +126,7 @@ class RunOptions:
     hf_cache_mode: str = "shared"
     hf_cache_retention: str = "retain"
     verbose: bool = False
+    require_prebuilt_bundles: bool = False
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -132,6 +134,7 @@ def build_parser() -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="command", required=True)
     for name, help_text in (
         ("check", "resolve and validate the selected matrix entries"),
+        ("prepare", "materialize selected bundles without measuring them"),
         ("run", "run the selected matrix entries"),
     ):
         command = commands.add_parser(name, help=help_text)
@@ -167,12 +170,30 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="print full TRTMC and reference commands",
         )
+        if name == "prepare":
+            command.add_argument(
+                "--output",
+                required=True,
+                type=Path,
+                help="write bundle preparation evidence to this JSON file",
+            )
+        if name == "run":
+            command.add_argument(
+                "--no-build",
+                action="store_true",
+                help="require bundles prepared before the performance campaign",
+            )
     resume = commands.add_parser("resume", help="continue an incomplete run")
     resume.add_argument("run_directory", type=Path)
     resume.add_argument(
         "--verbose",
         action="store_true",
         help="print full TRTMC and reference commands",
+    )
+    resume.add_argument(
+        "--no-build",
+        action="store_true",
+        help="require bundles prepared before the resumed campaign",
     )
     report = commands.add_parser(
         "report",
@@ -400,6 +421,7 @@ def _run_options(
     output: Path,
     *,
     verbose: bool = False,
+    require_prebuilt_bundles: bool = False,
 ) -> RunOptions:
     tools = environment["tools"]
     storage = environment["storage"]
@@ -423,6 +445,7 @@ def _run_options(
         hf_cache_mode=str(execution["hf_cache_mode"]),
         hf_cache_retention=str(execution["hf_cache_retention"]),
         verbose=verbose,
+        require_prebuilt_bundles=require_prebuilt_bundles,
     )
 
 
@@ -629,6 +652,8 @@ def _candidate_base_argv(case: Mapping[str, Any], options: RunOptions) -> list[s
         argv.extend(["--bundle-cache", str(options.bundle_cache.resolve())])
     if options.trtmc_worker is not None:
         argv.extend(["--worker", str(options.trtmc_worker.resolve())])
+    if getattr(options, "require_prebuilt_bundles", False):
+        argv.append("--no-build")
     for root in options.bundle_roots:
         argv.extend(["--bundle-root", str(root.resolve())])
     for directory in options.runtime_dirs:
@@ -3607,6 +3632,68 @@ def _check(arguments: argparse.Namespace) -> int:
     return 1 if failures else 0
 
 
+def _prepare(arguments: argparse.Namespace) -> int:
+    _, selected, environment = _load_suite_request(arguments)
+    options = _run_options(environment, Path(str(environment["storage"]["results_root"])))
+    _environment_preflight(environment, options)
+    _preflight_worker(options)
+    _preflight, failures = _preflight_candidates(selected, options)
+    if failures:
+        for case_id, failure in sorted(failures.items()):
+            print(f"[{case_id}] {failure['stage']}: {failure['reason']}", file=sys.stderr)
+        return 1
+
+    revision = str(_git_commit() or "").strip().lower()
+    if EXACT_SOURCE_REVISION_PATTERN.fullmatch(revision) is None:
+        raise PerfMatrixError("bundle preparation requires an exact 40-character source revision")
+    bundles: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for case in selected:
+        case_id = str(case["id"])
+        print(f"[{case_id}] bundle preparation", flush=True)
+        command = _run_command(
+            [*_candidate_base_argv(case, options), "--prepare-only"],
+            _command_environment(),
+            options.timeout_seconds,
+        )
+        if command["exit_code"] != 0:
+            raise PerfMatrixError(
+                f"bundle preparation failed for {case_id}: {command['stderr_tail']}"
+            )
+        try:
+            receipt = json.loads(command["stdout"])
+        except json.JSONDecodeError as exc:
+            raise PerfMatrixError(
+                f"trtmc-bench returned invalid bundle preparation JSON for {case_id}"
+            ) from exc
+        records = receipt.get("bundles") if isinstance(receipt, Mapping) else None
+        if not isinstance(records, list) or not records:
+            raise PerfMatrixError(f"trtmc-bench prepared no bundle for {case_id}")
+        for record in records:
+            if not isinstance(record, Mapping):
+                raise PerfMatrixError(f"trtmc-bench returned invalid bundle evidence for {case_id}")
+            if record.get("source_revision") != revision:
+                raise PerfMatrixError(
+                    f"bundle for {case_id} does not match source revision {revision}"
+                )
+            key = (str(record.get("model", "")), str(record.get("bundle", "")))
+            if key not in seen:
+                seen.add(key)
+                bundles.append(dict(record))
+    _write_json(
+        arguments.output.resolve(),
+        {
+            "schema_version": PREPARATION_SCHEMA,
+            "scope": "test_task",
+            "git_commit": revision,
+            "included_in_performance_metrics": False,
+            "bundles": bundles,
+        },
+    )
+    print(f"Bundle preparation: {arguments.output.resolve()}")
+    return 0
+
+
 def _run_new(arguments: argparse.Namespace) -> int:
     suite, selected, environment = _load_suite_request(arguments)
     results_root = Path(str(environment["storage"]["results_root"]))
@@ -3614,11 +3701,17 @@ def _run_new(arguments: argparse.Namespace) -> int:
         environment,
         results_root,
         verbose=arguments.verbose,
+        require_prebuilt_bundles=arguments.no_build,
     )
     storage = _environment_preflight(environment, preliminary_options)
     worker = _preflight_worker(preliminary_options)
     run_id, output = _new_run_directory(results_root, suite.definition)
-    options = _run_options(environment, output, verbose=arguments.verbose)
+    options = _run_options(
+        environment,
+        output,
+        verbose=arguments.verbose,
+        require_prebuilt_bundles=arguments.no_build,
+    )
     results = _initial_results(suite, selected, environment)
     results["run_id"] = run_id
     ledger = _open_perf_ledger(output, selected, results)
@@ -3670,7 +3763,12 @@ def _resume(arguments: argparse.Namespace) -> int:
     environment = _read_environment(environment_path)
     if environment != environment_record:
         raise PerfMatrixError("cannot resume because the resolved environment values changed")
-    options = _run_options(environment, output, verbose=arguments.verbose)
+    options = _run_options(
+        environment,
+        output,
+        verbose=arguments.verbose,
+        require_prebuilt_bundles=arguments.no_build,
+    )
     ledger = _open_perf_ledger(output, selected, results)
     ledger.recover_interrupted()
     ledger.reopen_retryable()
@@ -3695,6 +3793,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         arguments = build_parser().parse_args(argv)
         if arguments.command == "check":
             return _check(arguments)
+        if arguments.command == "prepare":
+            return _prepare(arguments)
         if arguments.command == "run":
             return _run_new(arguments)
         if arguments.command == "resume":

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -65,7 +65,7 @@ from tools.reporting_html import (  # noqa: E402
     sorted_filter_values,
     task_type_label,
 )
-from tools import model_selection  # noqa: E402
+from tools import case_evidence, model_selection  # noqa: E402
 from tools.performance import catalog as performance_catalog  # noqa: E402
 from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import qualification_report  # noqa: E402
@@ -194,6 +194,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-build",
         action="store_true",
         help="require bundles prepared before the resumed campaign",
+    )
+    resume.add_argument(
+        "--invalidate-model",
+        action="append",
+        default=[],
+        help=(
+            "re-run every selected Performance case for this model; repeatable and "
+            "only valid while resuming"
+        ),
     )
     report = commands.add_parser(
         "report",
@@ -478,6 +487,15 @@ def _git_commit() -> str | None:
         return None
 
 
+def _execution_revision() -> str:
+    try:
+        return case_evidence.exact_source_revision(
+            _git_commit(), label="repository revision"
+        )
+    except case_evidence.CaseEvidenceError as error:
+        raise PerfMatrixError(str(error)) from error
+
+
 def _gpu_environment() -> dict[str, Any]:
     executable = shutil.which("nvidia-smi")
     if executable is None:
@@ -524,6 +542,8 @@ def _initial_results(
         "nvidia_visible_devices": os.environ.get("NVIDIA_VISIBLE_DEVICES", ""),
         **_gpu_environment(),
     }
+    started_at = _now()
+    revision = _execution_revision()
     return {
         "schema_version": RESULT_SCHEMA,
         "status": "running",
@@ -531,8 +551,16 @@ def _initial_results(
         "suite_name": str(suite.get("name", suite_path.stem)),
         "suite_sha256": _sha256_file(suite_path),
         "repository_root": str(REPOSITORY),
-        "git_commit": _git_commit(),
-        "started_at": _now(),
+        "git_commit": revision,
+        "source_revisions": [revision],
+        "execution_attempts": [
+            {
+                "source_revision": revision,
+                "started_at": started_at,
+                "finished_at": None,
+            }
+        ],
+        "started_at": started_at,
         "environment": environment,
         "environment_config": deepcopy(dict(environment_config)),
         "catalog_coverage": {
@@ -577,7 +605,6 @@ def _open_perf_ledger(
     results: Mapping[str, Any],
 ) -> ExecutionLedger:
     fingerprint_input = {
-        "git_commit": results.get("git_commit"),
         "suite_sha256": results.get("suite_sha256"),
         "environment_sha256": results.get("environment_config", {}).get("sha256"),
     }
@@ -608,6 +635,48 @@ def _load_resume(path: Path) -> dict[str, Any]:
     value["status"] = "running"
     value.pop("finished_at", None)
     return value
+
+
+def _record_execution_attempt(
+    results: MutableMapping[str, Any], source_revision: str
+) -> None:
+    previous_revision = str(results.get("git_commit", "") or "").strip().lower()
+    revisions = results.setdefault("source_revisions", [])
+    if not isinstance(revisions, list):
+        raise PerfMatrixError("cannot resume with invalid source revision history")
+    if (
+        case_evidence.EXACT_SOURCE_REVISION.fullmatch(previous_revision)
+        and previous_revision not in revisions
+    ):
+        revisions.append(previous_revision)
+    if source_revision not in revisions:
+        revisions.append(source_revision)
+    attempts = results.setdefault("execution_attempts", [])
+    if not isinstance(attempts, list):
+        raise PerfMatrixError("cannot resume with invalid execution attempt history")
+    if not attempts and case_evidence.EXACT_SOURCE_REVISION.fullmatch(previous_revision):
+        attempts.append(
+            {
+                "source_revision": previous_revision,
+                "started_at": results.get("started_at"),
+                "finished_at": results.get("finished_at"),
+                "legacy": True,
+            }
+        )
+    attempts.append(
+        {
+            "source_revision": source_revision,
+            "started_at": _now(),
+            "finished_at": None,
+        }
+    )
+    results["git_commit"] = source_revision
+
+
+def _finish_execution_attempt(results: MutableMapping[str, Any]) -> None:
+    attempts = results.get("execution_attempts")
+    if isinstance(attempts, list) and attempts and isinstance(attempts[-1], MutableMapping):
+        attempts[-1]["finished_at"] = _now()
 
 
 def _result_rows(
@@ -1345,6 +1414,7 @@ def _perf_attempt_evidence(
                 }
             )
     return {
+        "source_revision": _execution_revision(),
         "commands": {"resolve": deepcopy(dict(resolve_command))},
         "logs": logs,
         "environment": {
@@ -2566,10 +2636,17 @@ def _materialize_public_perf_report(
     output: Path,
     results: Mapping[str, Any],
 ) -> tuple[Path, Path, dict[str, Any]]:
+    public_results = _public_perf_results(results)
+    revision_summary = case_evidence.summarize_model_revisions(
+        {**row, "task": "performance"} for row in public_results
+    )
+    source_revisions = revision_summary["source_revisions"]
+    report_revision = source_revisions[0] if len(source_revisions) == 1 else None
     environment = results.get("environment", {})
     environment = environment if isinstance(environment, Mapping) else {}
     run = {
-        "source_revision": results.get("git_commit"),
+        "source_revision": report_revision,
+        "source_revisions": source_revisions,
         "hostname": environment.get("hostname"),
         "gpu": environment.get("gpu"),
         "gpu_uuid": environment.get("gpu_uuid"),
@@ -2589,16 +2666,17 @@ def _materialize_public_perf_report(
         identity={
             "run_id": output.name,
             "disposition": results.get("status", "running"),
-            "source_revision": results.get("git_commit"),
+            "source_revision": report_revision,
         },
         run=run,
-        results=_public_perf_results(results),
+        results=public_results,
         metadata={
             "campaign": {
                 "suite_name": results.get("suite_name"),
                 "suite_sha256": results.get("suite_sha256"),
                 "status": results.get("status", "running"),
-            }
+            },
+            "model_source_identity": revision_summary,
         },
     )
 
@@ -3401,6 +3479,11 @@ def _execute_campaign(
     worker: Mapping[str, Any],
     storage_preflight: Mapping[str, Any],
 ) -> int:
+    execution_revision = _execution_revision()
+    if results.get("git_commit") != execution_revision:
+        raise PerfMatrixError(
+            "performance execution revision changed after campaign initialization"
+        )
     ledger = _open_perf_ledger(options.output, selected, results)
     ledger.recover_interrupted()
     results["candidate_worker_preflight"] = dict(worker)
@@ -3419,6 +3502,15 @@ def _execute_campaign(
         receipt = ledger.receipt(case_id)
         if receipt["state"] == "terminal" or not _should_skip(rows[case_id]):
             continue
+        try:
+            prior_revision = case_evidence.exact_source_revision(
+                rows[case_id].get("source_revision"),
+                f"Performance case {case_id} source revision",
+            )
+        except case_evidence.CaseEvidenceError:
+            continue
+        if prior_revision != execution_revision:
+            continue
         ledger.begin(
             case_id,
             stage="legacy-import",
@@ -3430,7 +3522,11 @@ def _execute_campaign(
         state, result = _perf_state_and_result(rows[case_id])
         if state != "terminal" or result is None:
             raise PerfMatrixError(f"cannot import incomplete result for {case_id!r}")
-        ledger.finish(case_id, result=result, payload=rows[case_id])
+        ledger.finish(
+            case_id,
+            result=result,
+            payload=case_evidence.stamp_case(rows[case_id], prior_revision),
+        )
     _sync_perf_results_from_ledger(results, ledger)
     rows = _result_rows(results)
     work_root = options.scratch_root / options.output.name
@@ -3441,7 +3537,9 @@ def _execute_campaign(
         receipt = ledger.receipt(case_id)
         if failure is None or receipt["state"] == "terminal":
             continue
-        failure_row = _resolution_failure_row(case, failure)
+        failure_row = case_evidence.stamp_case(
+            _resolution_failure_row(case, failure), execution_revision
+        )
         ledger.begin(
             case_id,
             stage="preflight",
@@ -3531,6 +3629,7 @@ def _execute_campaign(
         state, result = _perf_state_and_result(row)
         if state != "terminal" or result is None:
             raise PerfMatrixError(f"Performance case {case_id!r} did not finish")
+        row = case_evidence.stamp_case(row, execution_revision)
         ledger.finish(
             case_id,
             result=result,
@@ -3559,7 +3658,8 @@ def _execute_campaign(
     selected_ids = {str(case["id"]) for case in selected}
     results["finished_at"] = _now()
     results["status"] = _final_status(_selected_rows(results, selected_ids))
-    _write_artifacts(options.output, results, ledger)
+    _finish_execution_attempt(results)
+    _, _, final_report = _write_artifacts(options.output, results, ledger)
     try:
         work_root.rmdir()
     except OSError:
@@ -3571,7 +3671,14 @@ def _execute_campaign(
     print(f"Results: {options.output / 'results.json'}")
     print(f"Report data: {options.output / 'report.json'}")
     print(f"Report: {options.output / 'report.html'}")
-    return 1 if _campaign_failed(results, selected_ids) else 0
+    source_identity_failed = not final_report["model_source_identity"]["consistent"]
+    if source_identity_failed:
+        print(
+            "Performance source identity is mixed, missing, or incomplete; "
+            "re-run the affected model with --invalidate-model",
+            file=sys.stderr,
+        )
+    return 1 if _campaign_failed(results, selected_ids) or source_identity_failed else 0
 
 
 def _load_suite_request(
@@ -3748,8 +3855,6 @@ def _resume(arguments: argparse.Namespace) -> int:
         raise PerfMatrixError("cannot resume because the suite content changed")
     if environment_record.get("sha256") != _sha256_file(environment_path):
         raise PerfMatrixError("cannot resume because the environment content changed")
-    if results.get("git_commit") != _git_commit():
-        raise PerfMatrixError("cannot resume because the repository revision changed")
     suite = _load_performance_suite(suite_path)
     selected_ids = results.get("selected_entry_ids")
     if not isinstance(selected_ids, list) or not all(
@@ -3763,6 +3868,15 @@ def _resume(arguments: argparse.Namespace) -> int:
     environment = _read_environment(environment_path)
     if environment != environment_record:
         raise PerfMatrixError("cannot resume because the resolved environment values changed")
+    execution_revision = _execution_revision()
+    invalidated_models = set(getattr(arguments, "invalidate_model", []))
+    selected_models = {str(case["model"]) for case in selected}
+    unknown_models = sorted(invalidated_models - selected_models)
+    if unknown_models:
+        raise PerfMatrixError(
+            "cannot invalidate models outside this run: " + ", ".join(unknown_models)
+        )
+    _record_execution_attempt(results, execution_revision)
     options = _run_options(
         environment,
         output,
@@ -3772,6 +3886,26 @@ def _resume(arguments: argparse.Namespace) -> int:
     ledger = _open_perf_ledger(output, selected, results)
     ledger.recover_interrupted()
     ledger.reopen_retryable()
+    invalidated_case_ids = [
+        str(case["id"])
+        for case in selected
+        if str(case["model"]) in invalidated_models
+        and ledger.receipt(str(case["id"]))["state"] == "terminal"
+    ]
+    if invalidated_case_ids:
+        ledger.reopen_cases(
+            invalidated_case_ids,
+            reason="model_invalidation",
+            evidence={
+                "models": sorted(invalidated_models),
+                "requested_revision": execution_revision,
+            },
+        )
+    if invalidated_models:
+        rows = _result_rows(results)
+        for case in selected:
+            if str(case["model"]) in invalidated_models:
+                rows[str(case["id"])] = _pending_perf_row(case)
     _write_artifacts(output, results, ledger)
     storage = _environment_preflight(environment, options)
     worker = _preflight_worker(options)
@@ -3802,7 +3936,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if arguments.command == "report":
             return _report_existing(arguments)
         raise PerfMatrixError(f"unsupported command: {arguments.command}")
-    except PerfMatrixError as exc:
+    except (PerfMatrixError, case_evidence.CaseEvidenceError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1911,6 +1911,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             name="report_generation_tool",
             matcher=_path_in(
                 {
+                    "tools/case_evidence.py",
                     "tools/execution_ledger.py",
                     "tools/performance/__init__.py",
                     "tools/performance/catalog.py",

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -554,7 +554,7 @@ def _declared_profile(
     return profile
 
 
-def _binding_profiles(
+def binding_profiles(
     binding: Binding,
     *,
     task_models: Mapping[str, dict[str, Any]],
@@ -612,7 +612,15 @@ def ensure_environments(
     )
 
 
-def _ensure_reference_source(source: ReferenceSource, cache_root: Path) -> Path:
+REFERENCE_SOURCES_PREBUILT_ONLY_ENV = "TRTMC_REFERENCE_SOURCES_PREBUILT_ONLY"
+
+
+def _ensure_reference_source(
+    source: ReferenceSource,
+    cache_root: Path,
+    *,
+    prebuilt_only: bool = False,
+) -> Path:
     checkout = cache_root / source.relative_checkout
     entrypoint = checkout / source.entrypoint
     if entrypoint.exists():
@@ -620,6 +628,11 @@ def _ensure_reference_source(source: ReferenceSource, cache_root: Path) -> Path:
         return checkout
     if checkout.exists():
         raise ValidationError(f"Incomplete cached {source.name} reference: {checkout}")
+    if prebuilt_only:
+        raise ValidationError(
+            f"Missing prepared {source.name} reference source: {checkout}; "
+            "qualification prepare phase did not materialize it"
+        )
 
     checkout.parent.mkdir(parents=True, exist_ok=True)
     print(f"Creating reference source: {source.name}", flush=True)
@@ -671,9 +684,18 @@ def ensure_reference_sources(
     model_reference_cache: Mapping[str, Any] | None = None,
     *,
     source_cache_root: Path | None = None,
+    prebuilt_only: bool | None = None,
 ) -> ReferenceSourceSelection:
     environment = {"TRTMC_STORAGE_ROOT": str(cache_root)}
     checkout_root = source_cache_root or cache_root
+    if prebuilt_only is None:
+        prebuilt_only = os.environ.get(REFERENCE_SOURCES_PREBUILT_ONLY_ENV) == "1"
+
+    def prepare(source: ReferenceSource) -> Path:
+        if prebuilt_only:
+            return _ensure_reference_source(source, checkout_root, prebuilt_only=True)
+        return _ensure_reference_source(source, checkout_root)
+
     declared_source = None
     if model_reference_cache:
         required = ("repository", "revision", "relative_path", "entrypoint")
@@ -689,7 +711,7 @@ def ensure_reference_sources(
             relative_checkout=Path(str(model_reference_cache["relative_path"])),
             entrypoint=Path(str(model_reference_cache["entrypoint"])),
         )
-        checkout = _ensure_reference_source(declared_source, checkout_root)
+        checkout = prepare(declared_source)
         environment_variable = str(
             model_reference_cache.get("environment_variable", "") or ""
         ).strip()
@@ -702,7 +724,7 @@ def ensure_reference_sources(
             environment[environment_variable] = str(checkout)
 
     if family == "elf_flow":
-        checkout = _ensure_reference_source(ELF_SOURCE, checkout_root)
+        checkout = prepare(ELF_SOURCE)
         return ReferenceSourceSelection(
             environment=environment,
             elf_reference_repo=checkout,
@@ -710,7 +732,7 @@ def ensure_reference_sources(
     if family == "sana_wm":
         if declared_source is None:
             declared_source = SANA_WM_SOURCE
-            checkout = _ensure_reference_source(declared_source, checkout_root)
+            checkout = prepare(declared_source)
         environment["SANA_WM_SCRIPT"] = str(checkout / declared_source.entrypoint)
     return ReferenceSourceSelection(environment=environment)
 
@@ -1828,7 +1850,7 @@ def run_binding(
             encoding="utf-8",
         )
         return result
-    profiles = _binding_profiles(
+    profiles = binding_profiles(
         binding,
         task_models=task_models,
         suites=suites,

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -60,6 +60,7 @@ from tools.reporting_html import (  # noqa: E402
 )
 from tools.validation import catalog as validation_catalog  # noqa: E402
 from tools.validation.gate_census import build_gate_census  # noqa: E402
+from tools import case_evidence  # noqa: E402
 from tools import trtmc_disagreements  # noqa: E402
 from tools.execution_ledger import ExecutionLedger, ExecutionLedgerError  # noqa: E402
 from tools import model_selection  # noqa: E402
@@ -3629,6 +3630,13 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             summary["duration_seconds"] = duration_seconds
     if any(row["state"] != "terminal" for row in public_results):
         validation_status = "running"
+    revision_summary = case_evidence.summarize_model_revisions(
+        {**row, "task": "accuracy"} for row in public_results
+    )
+    source_revisions = revision_summary["source_revisions"]
+    report_revision = source_revisions[0] if len(source_revisions) == 1 else None
+    run["source_revision"] = report_revision
+    run["source_revisions"] = source_revisions
     return qualification_report.materialize_report(
         output,
         report_kind="accuracy",
@@ -3636,13 +3644,14 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
         identity={
             "run_id": output.name,
             "disposition": validation_status,
-            "source_revision": run.get("source_revision"),
+            "source_revision": report_revision,
         },
         run=run,
         results=public_results,
         metadata={
             "validation_status": validation_status,
             "summary": summary,
+            "model_source_identity": revision_summary,
         },
     )
 
@@ -3821,8 +3830,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--resume-existing",
         action="store_true",
         help=(
-            "keep terminal results for exact bindings in an existing output "
-            "from the same source revision"
+            "keep terminal results for exact bindings and retry interrupted or "
+            "retryable cases in an existing output"
+        ),
+    )
+    parser.add_argument(
+        "--invalidate-model",
+        action="append",
+        default=[],
+        help=(
+            "with --resume-existing, reopen every selected Accuracy case for this "
+            "model; repeatable"
         ),
     )
     parser.add_argument("--list", action="store_true", help="list model-first workloads")
@@ -4300,6 +4318,7 @@ def _accuracy_worker_attempt_evidence(
     worker_command = _worker_command(binding, arguments)
     worker_environment = _worker_environment(arguments)
     return {
+        "source_revision": case_evidence.exact_source_revision(_source_revision()),
         "commands": {
             "worker": {
                 "argv": worker_command,
@@ -4732,6 +4751,10 @@ def _resumable_binding_result(
         "skipped",
     }:
         return None
+    try:
+        case_evidence.exact_source_revision(result.get("source_revision"))
+    except case_evidence.CaseEvidenceError:
+        return None
     return result
 
 
@@ -4740,8 +4763,21 @@ def _resume_command(command: str) -> list[str]:
         arguments = shlex.split(command)
     except ValueError as exc:
         raise ValidationError(f"cannot parse recorded Accuracy command: {exc}") from exc
-    presentation_only = {"--resume-existing", "--verbose"}
-    return [argument for argument in arguments if argument not in presentation_only]
+    normalized: list[str] = []
+    skip_value = False
+    for argument in arguments:
+        if skip_value:
+            skip_value = False
+            continue
+        if argument in {"--resume-existing", "--verbose"}:
+            continue
+        if argument == "--invalidate-model":
+            skip_value = True
+            continue
+        normalized.append(argument)
+    if skip_value:
+        raise ValidationError("--invalidate-model requires a model name")
+    return normalized
 
 
 def _validate_resume_request(output: Path) -> None:
@@ -4754,13 +4790,6 @@ def _validate_resume_request(output: Path) -> None:
         raise ValidationError(f"cannot read resume metadata {run_path}: {exc}") from exc
     if not isinstance(run, Mapping):
         raise ValidationError(f"resume metadata must contain a JSON object: {run_path}")
-    previous = str(run.get("source_revision", "") or "")
-    current = _source_revision()
-    if not previous or previous != current:
-        raise ValidationError(
-            "cannot resume Accuracy results from a different source revision: "
-            f"recorded={previous or '<missing>'}, current={current or '<missing>'}"
-        )
     recorded_command = str(run.get("command", "") or "")
     current_command = shlex.join(sys.argv)
     if not recorded_command or _resume_command(recorded_command) != _resume_command(
@@ -4778,10 +4807,7 @@ def _open_accuracy_ledger(
     arguments: argparse.Namespace,
     catalog: Mapping[str, Any],
 ) -> ExecutionLedger:
-    fingerprint_input = {
-        "source_revision": _source_revision(),
-        "command": _resume_command(shlex.join(sys.argv)),
-    }
+    fingerprint_input = {"command": _resume_command(shlex.join(sys.argv))}
     fingerprint = hashlib.sha256(
         json.dumps(fingerprint_input, sort_keys=True).encode("utf-8")
     ).hexdigest()
@@ -4821,6 +4847,17 @@ def _run_all_bindings(
     catalog: Mapping[str, Any],
 ) -> int:
     bindings = tuple(bindings)
+    selected_models = {binding.model for binding in bindings}
+    invalidated_models = set(arguments.invalidate_model)
+    if invalidated_models and not arguments.resume_existing:
+        raise ValidationError("--invalidate-model requires --resume-existing")
+    unknown_invalidations = sorted(invalidated_models - selected_models)
+    if unknown_invalidations:
+        raise ValidationError(
+            "--invalidate-model is not selected by this Accuracy run: "
+            + ", ".join(unknown_invalidations)
+        )
+    execution_revision = case_evidence.exact_source_revision(_source_revision())
     _prepare_run_directories(arguments)
     _reused_bundle_revalidation_budget(arguments)
     if arguments.resume_existing:
@@ -4832,6 +4869,22 @@ def _run_all_bindings(
     ledger = _open_accuracy_ledger(bindings, arguments, catalog)
     if arguments.resume_existing:
         ledger.recover_interrupted()
+        ledger.reopen_retryable()
+        invalidated_case_ids = [
+            _accuracy_case_id(binding)
+            for binding in bindings
+            if binding.model in invalidated_models
+            and ledger.receipt(_accuracy_case_id(binding))["state"] == "terminal"
+        ]
+        if invalidated_case_ids:
+            ledger.reopen_cases(
+                invalidated_case_ids,
+                reason="model_invalidation",
+                evidence={
+                    "models": sorted(invalidated_models),
+                    "requested_revision": execution_revision,
+                },
+            )
     write_report(arguments.output)
     failed = False
     not_compared = False
@@ -4855,7 +4908,11 @@ def _run_all_bindings(
                     binding,
                     arguments.output,
                 )
-                normalized = _normalize_result(result)
+                normalized = case_evidence.stamp_case(result, execution_revision)
+                comparison.write_text(
+                    json.dumps(normalized, indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
                 ledger.finish(
                     case_id,
                     result=_traffic_light_status(normalized),
@@ -4903,6 +4960,8 @@ def _run_all_bindings(
         result = (
             _resumable_binding_result(arguments.output, binding)
             if arguments.resume_existing
+            and binding.model not in invalidated_models
+            and not receipt["attempts"]
             else None
         )
         if result is None:
@@ -4982,6 +5041,7 @@ def _run_all_bindings(
             for resource in (cleanup["engine"], cleanup["hf_cache"])
         )
         failed = failed or cleanup_failed
+        result = case_evidence.stamp_case(result, execution_revision)
         comparison = _case_directory(arguments.output, binding) / "comparison.json"
         comparison.parent.mkdir(parents=True, exist_ok=True)
         comparison.write_text(
@@ -5022,8 +5082,15 @@ def _run_all_bindings(
             )
             break
     finalize_run_metadata(arguments.output)
-    write_report(arguments.output)
-    if failed:
+    _, _, final_report = write_report(arguments.output)
+    source_identity_failed = not final_report["model_source_identity"]["consistent"]
+    if source_identity_failed:
+        print(
+            "Accuracy source identity is mixed, missing, or incomplete; "
+            "re-run the affected model with --invalidate-model",
+            file=sys.stderr,
+        )
+    if failed or source_identity_failed:
         return 1
     return 2 if not_compared and not arguments.all else 0
 

--- a/tools/validation/engine.py
+++ b/tools/validation/engine.py
@@ -11460,7 +11460,9 @@ def eval_one_model(
         log_path=work_dir / "build.log",
         cuda_visible_devices=args.cuda_visible_devices,
         expected_source_revision=str(
-            validation_config.get("reference_source_revision", "") or ""
+            os.environ.get("TRTMC_ENGINE_BUILD_REVISION", "").strip()
+            or validation_config.get("reference_source_revision", "")
+            or ""
         ),
     )
 


### PR DESCRIPTION
## Background

Formal model checks previously treated an entire campaign as if it had one immutable source revision. That protected provenance, but it also meant a harness or environment fix could force every completed model to run again. The lower-level runners also lacked a shared case-level rule for deciding whether resumed Accuracy and Performance evidence was still sign-off eligible.

## Exit Criteria

- Bind every terminal Accuracy and Performance receipt to an exact 40-character tested SHA and reject worker, engine, or bundle provenance that does not match the active execution attempt.
- Allow a stable campaign inventory to resume on a later commit without discarding unrelated terminal cases.
- Re-run a changed model as one unit across all selected Accuracy and Performance cases.
- Permit different models to finish on different commits, but require all final evidence for one model to use one identical commit before sign-off.
- Preserve the Accuracy and Performance runners' existing pass/fail semantics, including for consolidated shards.
- Keep preparation inside the public `model_checks.py run` workflow and do not change Accuracy or Performance pass/fail thresholds.

## Implementation

- Resolve each execution attempt to the clean active worktree HEAD, record attempt history, and export that exact SHA to Accuracy, Performance, engine builders, and native worker validation.
- Add a shared case-evidence module that stamps terminal receipts and computes per-model source consistency across Accuracy, Performance, and consolidated shards.
- Add repeatable `--invalidate-model` support to `model_checks.py run --resume` and both lower-level adapters. It reopens every selected case for that model while preserving other models and their prior evidence.
- Make resume fingerprints describe the stable test contract instead of the current commit. Interrupted and retryable cases reopen automatically; legacy results without exact case provenance are rerun rather than silently promoted.
- Limit resumed dependency and bundle preparation to interrupted, retryable, or explicitly invalidated models.
- Bind every Accuracy engine reuse decision to `TRTMC_ENGINE_BUILD_REVISION`. A stale or unproven engine is rebuilt or rejected before its case receipt can be stamped with the active attempt SHA; lower-level `--force-build` remains an optional cache diagnostic, not a provenance requirement.
- Require every shard to publish a terminal `result.json` for its current execution revision. Consolidated qualification passes only when all shard task results pass and per-model source identity is consistent.
- Keep the sharded campaign inventory revision-independent and derive public report identity from case receipts. Sharded campaign schema v2 intentionally rejects old v1 manifests whose global-revision contract cannot prove case-level provenance.
- Expose Accuracy binding profile selection as the narrow public `trtmc_validate.binding_profiles()` interface instead of importing a private helper.
- Classify shared case evidence under the tools test tier so public CPU CI exercises its consumers.

### Change categories

- [ ] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [x] Bundle or artifact provenance
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_case_evidence.py tests/tools/test_execution_ledger.py tests/tools/test_model_checks.py tests/tools/test_perf_matrix.py tests/tools/test_trtmc_bench.py tests/tools/test_trtmc_validate.py tests/tools/test_validation_engine.py tests/tools/test_test_impact.py tests/builder/test_bundle_writer.py`: 1046 passed.
- `PYTHONPATH=python:. python3 -m tools.community_ci source-quality --base github/main`: passed, including changed-file lint and 158 model architecture contract tests.
- `python3 tools/test_impact.py --validate`: passed; 221 models, 12 core models, and 84 families classified.
- `ruff check tools/model_checks.py tools/validation/engine.py tests/tools/test_model_checks.py tests/tools/test_validation_engine.py`: passed.
- `ruff check tools/test_impact.py tests/tools/test_test_impact.py`: passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Repository head: `8e94bdef28cc9152a5464b34ccb6510e0f816cb4`.
- Validation exercised controller, ledger, engine provenance, report, resume, test-impact, and shard consolidation behavior on CPU.
- No model, checkpoint, dataset, CUDA, TensorRT, Accuracy, or Performance result is claimed by this PR.

### Not Run / Remaining Gaps

- GPU Accuracy and Performance benchmarks were not run; this PR does not claim target-hardware qualification evidence.
- GitHub checks for exact head `8e94bdef28cc9152a5464b34ccb6510e0f816cb4` passed, including Community CPU Required, Unit, Source quality, Docs, Ownership, PR Metadata, DCO, and CodeRabbit.
- Source checks detect ordinary worktree drift around preparation and tasks; they do not make the filesystem physically immutable against a process that changes and restores files entirely between checks.

## Notes For Future Readers

- Review `tools/case_evidence.py` and `tools/execution_ledger.py` first, then the Accuracy and Performance adapters, and finally `tools/model_checks.py` plus shard consolidation.
- A source change does not automatically guess affected files or models. Resume normally for infrastructure-only failures; after a model-affecting fix, pass `--invalidate-model <model>` so all selected Accuracy and Performance evidence for that model converges on the new SHA.
- Different models may retain evidence from different commits, but one model cannot sign off with mixed Accuracy and Performance revisions.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the change alters resume, engine provenance, and shard sign-off semantics and rejects legacy evidence that lacks exact case provenance. The behavior is covered by receipt, adapter, orchestration, and consolidation regression tests.

