### PR TITLE
ci(premerge): frontload CPU unit tests

### DIFF
--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -110,31 +110,12 @@ jobs:
 
   unit:
     name: Community CPU / Unit / C++ and Python
-    if: ${{ !cancelled() }}
-    needs: ownership-impact
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read
     steps:
-      - name: Require successful impact analysis
-        if: ${{ needs.ownership-impact.result != 'success' }}
-        env:
-          IMPACT_RESULT: ${{ needs.ownership-impact.result }}
-        run: |
-          echo "::error::Ownership and impact did not succeed: $IMPACT_RESULT"
-          exit 1
-
-      - name: Explain an empty unit scope
-        if: >-
-          needs.ownership-impact.result == 'success' &&
-          needs.ownership-impact.outputs.run_unit_tests != 'true'
-        run: echo "No source-only C++ or Python unit tests are required for this change."
-
       - name: Check out the exact PR merge
-        if: >-
-          needs.ownership-impact.result == 'success' &&
-          needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.sha }}
@@ -142,22 +123,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        if: >-
-          needs.ownership-impact.result == 'success' &&
-          needs.ownership-impact.outputs.run_unit_tests == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
       - name: Run hardened source-only units
-        if: >-
-          needs.ownership-impact.result == 'success' &&
-          needs.ownership-impact.outputs.run_unit_tests == 'true'
-        env:
-          TRTMC_UNIT_SCOPE: ${{ needs.ownership-impact.outputs.unit_scope }}
-          TRTMC_PREMERGE_PYTHON_TEST_TARGETS: >-
-            ${{ needs.ownership-impact.outputs.python_test_targets }}
-        run: python3 -m tools.community_ci unit --scope "$TRTMC_UNIT_SCOPE"
+        run: python3 -m tools.community_ci unit --scope all
 
   required:
     name: Community CPU / Required

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -722,6 +722,7 @@ if(TRTMC_BUILD_TESTS)
 enable_testing()
 add_custom_target(trtmc_cpp_tests)
 add_custom_target(trtmc_platform_cpp_tests)
+add_custom_target(trtmc_cpu_cpp_tests)
 
 # Generic capsule test doubles. The good and wrong-identity DSOs intentionally
 # have the same filename in different directories so tests can prove that the
@@ -784,8 +785,8 @@ set_target_properties(trtmc_test_optimized_embedding PROPERTIES
 # Usage:
 #   trtmc_add_test(test_name)               -- links trtmc_core, adds src/ include
 #   trtmc_add_test(test_name REQUIRES_TRT)  -- also links TensorRT test deps
-#   trtmc_add_test(test_name MODEL_OWNED)    -- excludes it from platform units
-#   trtmc_add_test(test_name REQUIRES_GPU)   -- excludes it from CPU platform units
+#   trtmc_add_test(test_name MODEL_OWNED)    -- labels model ownership independently
+#   trtmc_add_test(test_name REQUIRES_GPU)   -- excludes it from all CPU unit targets
 function(trtmc_add_test TEST_NAME)
   cmake_parse_arguments(
     ARG
@@ -830,13 +831,23 @@ function(trtmc_add_test TEST_NAME)
   endif()
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
   if(ARG_MODEL_OWNED)
-    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "model")
-  elseif(ARG_REQUIRES_GPU)
-    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "gpu")
+    set(_trtmc_test_owner_label "model")
   else()
-    add_dependencies(trtmc_platform_cpp_tests ${TEST_NAME})
-    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "platform")
+    set(_trtmc_test_owner_label "platform")
   endif()
+  if(ARG_REQUIRES_GPU)
+    set(_trtmc_test_resource_label "gpu")
+  else()
+    set(_trtmc_test_resource_label "cpu")
+    add_dependencies(trtmc_cpu_cpp_tests ${TEST_NAME})
+  endif()
+  if(NOT ARG_MODEL_OWNED AND NOT ARG_REQUIRES_GPU)
+    add_dependencies(trtmc_platform_cpp_tests ${TEST_NAME})
+  endif()
+  set_tests_properties(
+    ${TEST_NAME}
+    PROPERTIES LABELS "${_trtmc_test_owner_label};${_trtmc_test_resource_label}"
+  )
 endfunction()
 
 function(_trtmc_manifest_csv_to_list VALUE OUTPUT_VAR)
@@ -931,7 +942,10 @@ if(_trtmc_python)
   )
   add_custom_target(test_optimized_runtime_bundle_contract
     DEPENDS test_optimized_runtime_host trtmc_test_optimized_runtime)
-  set_tests_properties(test_optimized_runtime_bundle_contract PROPERTIES LABELS "platform")
+  set_tests_properties(
+    test_optimized_runtime_bundle_contract
+    PROPERTIES LABELS "platform;cpu"
+  )
 endif()
 # C ABI
 trtmc_add_test(test_c_abi_entry                NO_SRC_INCLUDE)

--- a/Dockerfile.community-cpu
+++ b/Dockerfile.community-cpu
@@ -30,6 +30,7 @@ RUN apt-get update && \
       python3.12-dev \
       python3.12-venv \
       libcublas-dev-13-3 \
+      libcurand-dev-13-3 \
       "libnvinfer-dev=${TENSORRT_APT_VERSION}" \
       "libnvinfer-headers-dev=${TENSORRT_APT_VERSION}" \
       "libnvinfer-headers-plugin-dev=${TENSORRT_APT_VERSION}" \

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -1659,23 +1659,15 @@ def build_bundle(
             lora_cfg = get_lora_config(config)
             if lora_cfg is not None:
                 cfg_dict.update(lora_cfg)
-        # Inject generic config overrides from plugin.
-        # Build the final dict so overrides appear FIRST in the
-        # serialized JSON.  The C++ fast_path_config parser uses
-        # flat text search (text.find) which picks up the first
-        # occurrence of a key.  For models with nested configs, a nested
-        # copy of "hidden_size" etc. would otherwise shadow the
-        # top-level value.
+        # Inject generic config overrides from the owning plugin. Composite
+        # model families use this hook to materialize their runtime fields at
+        # the top level consumed by the strict C++ JSON parser.
         get_overrides = getattr(plugin, 'get_bundle_config_overrides', None)
         if get_overrides is not None:
             overrides = get_overrides(config)
             if overrides is not None:
-                # Put overrides first, then original dict.  Dict
-                # union preserves insertion order; overrides keys
-                # appear before any nested dicts.
                 merged = dict(overrides)
                 merged.update(cfg_dict)
-                # Ensure overrides win for top-level keys.
                 merged.update(overrides)
                 cfg_dict = merged
         return json.dumps(cfg_dict, indent=2).encode("utf-8")

--- a/python/tensorrt_model_connect/families/locateanything/plugin.py
+++ b/python/tensorrt_model_connect/families/locateanything/plugin.py
@@ -170,6 +170,14 @@ class LocateAnythingPlugin:
             "model_type": "locateanything",
             "runtime_strategy": "locateanything_vision_language",
             "embed_input": True,
+            "vocab_size": config.vocab_size,
+            "hidden_size": config.hidden_size,
+            "num_hidden_layers": config.num_hidden_layers,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+            "bos_token_id": config.bos_token_id,
+            "eos_token_id": config.eos_token_id,
         }
 
 

--- a/python/tensorrt_model_connect/families/minimax_h3/tests/test_trt_builders.py
+++ b/python/tensorrt_model_connect/families/minimax_h3/tests/test_trt_builders.py
@@ -130,6 +130,17 @@ def test_builders_apply_default_or_overridden_workspace(
         observed.update(supplied=supplied, default_bytes=default_bytes)
         raise WorkspaceConfigured
 
+    class FakeBuilder:
+        @staticmethod
+        def create_network(_flags):
+            return object()
+
+        @staticmethod
+        def create_builder_config():
+            return object()
+
+    monkeypatch.setattr(trt, "Builder", lambda _logger: FakeBuilder())
+    monkeypatch.setattr(op, "configure_builder", lambda _config: None)
     monkeypatch.setattr(op, "configure_workspace", capture)
     kwargs = {"workspace_bytes": workspace_bytes}
     if builder is build_text_encoder_engine:
@@ -303,6 +314,8 @@ def test_native_linear_serializes_checkpoint_bf16_without_fp32_constant() -> Non
     assert plan
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_native_network_contract_counts_iattention_and_fails_closed() -> None:
     logger = trt.Logger(trt.Logger.WARNING)
     builder = trt.Builder(logger)

--- a/python/tensorrt_model_connect/families/qwen3_5/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_5/plugin.py
@@ -711,6 +711,14 @@ class Qwen35Plugin:
         num_attn = sum(1 for lt in layer_types if lt == "attention")
 
         return {
+            "vocab_size": config.vocab_size,
+            "hidden_size": config.hidden_size,
+            "num_hidden_layers": config.num_hidden_layers,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+            "bos_token_id": config.bos_token_id,
+            "eos_token_id": config.eos_token_id,
             "layer_types": layer_types,
             "num_mamba_layers": num_mamba,
             "num_attention_layers": num_attn,

--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -942,13 +942,9 @@ class Qwen3OmniPlugin:
         All fields must be flat (no nested dicts) since the C++ parser
         uses extract_json_int/string on the top-level config.json.
 
-        IMPORTANT: The C++ fast_path_config parser does flat text search
-        (``extract_json_int(text, "hidden_size", 0)``) which finds the
-        FIRST occurrence of the key in the JSON text.  For Qwen3-Omni the
-        original HF config.json has these critical fields nested inside
-        ``thinker_config.text_config``, so they must be injected as
-        top-level overrides and placed before any nested dicts in the
-        serialized JSON (engine_builder.py handles this).
+        The C++ parser resolves these keys only from the top-level JSON object.
+        Qwen3-Omni stores them under ``thinker_config.text_config``, so this
+        family must materialize them as top-level bundle overrides.
         """
         overrides = {}
 

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -372,6 +372,22 @@ class QwenVLPlugin:
 
         return vl_cfg
 
+    def get_bundle_config_overrides(
+        self, config: ModelConfig
+    ) -> dict[str, int] | None:
+        """Expose Qwen3-VL's nested text decoder contract at bundle scope."""
+        if not _is_qwen3_vl(config):
+            return None
+        return {
+            "vocab_size": config.vocab_size,
+            "hidden_size": config.hidden_size,
+            "num_hidden_layers": config.num_hidden_layers,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+            "bos_token_id": config.bos_token_id,
+        }
+
     def get_lora_config(self, config: ModelConfig) -> dict[str, object]:
         """Persist the dynamic binding contract in the bundle config."""
         return DynamicLoraConfig.from_model_config(config).bundle_config()

--- a/python/tensorrt_model_connect/families/sana_wm/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/sana_wm/tests/test_family.py
@@ -42,7 +42,7 @@ _SANA_WM_ENV_VARS = (
 
 
 @pytest.fixture(autouse=True)
-def _clear_sana_wm_env(monkeypatch) -> None:
+def _clear_sana_wm_env(monkeypatch, tmp_path) -> None:
     for name in _SANA_WM_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr(
@@ -50,6 +50,17 @@ def _clear_sana_wm_env(monkeypatch) -> None:
         "_cached_stage1_text_encoder_dir",
         lambda _raw_config: None,
     )
+    native_plugin = tmp_path / "libtrtmc_sana_wm_native_plugin.so"
+    native_plugin.write_bytes(b"CPU unit native plugin fixture")
+    native_plugin_builder = importlib.import_module(
+        "tensorrt_model_connect.families.sana_wm.native_plugin_builder"
+    )
+    monkeypatch.setattr(
+        native_plugin_builder,
+        "ensure_native_plugin",
+        lambda **_kwargs: native_plugin,
+    )
+    monkeypatch.setattr(sana_wm_plugin_mod.ctypes, "CDLL", lambda *_args, **_kwargs: object())
 
 
 def _sana_yaml() -> str:

--- a/python/tensorrt_model_connect/families/whisper/debug_runner.py
+++ b/python/tensorrt_model_connect/families/whisper/debug_runner.py
@@ -317,17 +317,22 @@ class WhisperTrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask, self._d_logits,
-                self._d_mel, self._d_enc_out]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        bufs.extend(self._d_cross_k)
-        bufs.extend(self._d_cross_v)
-        for d_ptr in bufs:
-            cudart.cudaFree(d_ptr)
-        if hasattr(self, "stream"):
-            cudart.cudaStreamDestroy(self.stream)
+        scalar_buffers = (
+            "_d_token_id", "_d_position_id", "_d_mask", "_d_logits", "_d_mel", "_d_enc_out",
+        )
+        list_buffers = (
+            "_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v", "_d_cross_k", "_d_cross_v",
+        )
+        for name in scalar_buffers:
+            d_ptr = getattr(self, name, None)
+            if d_ptr is not None:
+                cudart.cudaFree(d_ptr)
+                setattr(self, name, None)
+        for name in list_buffers:
+            for d_ptr in getattr(self, name, ()):
+                cudart.cudaFree(d_ptr)
+            setattr(self, name, [])
+        stream = getattr(self, "stream", None)
+        if stream is not None:
+            cudart.cudaStreamDestroy(stream)
+            self.stream = None

--- a/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
@@ -14,18 +14,19 @@ This intentionally mirrors the single-device Whisper decoder graph in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import importlib
 import sys
+from typing import TYPE_CHECKING
 
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
-from . import graph_ops
 from ...parallel_config import (
     add_all_reduce_sum,
     normalize_parallel_config,
 )
 
+graph_ops = importlib.import_module(f"{__package__}.graph_ops")
 trt = trt_compat.get_trt()
 
 if TYPE_CHECKING:

--- a/src/runtime/models/albert/MODEL.toml
+++ b/src/runtime/models/albert/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_albert.so"
 runtime_plugins = ["plugin.cpp|register_albert_plugin"]
 runtime_strategies = ["albert_encoder_only"]
 runtime_tests = [
-  "test_albert_encoder_pipeline|test_albert_encoder_pipeline.cpp|trtmc_model_albert,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_albert_encoder_pipeline|test_albert_encoder_pipeline.cpp|trtmc_model_albert,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/bark/MODEL.toml
+++ b/src/runtime/models/bark/MODEL.toml
@@ -10,5 +10,5 @@ legacy_runtime_strategy_aliases = ["text_to_audio|default|_|_|text_to_audio_bark
 runtime_tests = [
   "test_bark_config_schema|test_bark_config_schema.cpp|trtmc_model_bark|_|_",
   "test_bark_generation_plan|test_bark_generation_plan.cpp|_|_|_",
-  "test_bark_pipeline|test_bark_pipeline.cpp|trtmc_model_bark|_|REQUIRES_TRT",
+  "test_bark_pipeline|test_bark_pipeline.cpp|trtmc_model_bark|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/bert/MODEL.toml
+++ b/src/runtime/models/bert/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_bert.so"
 runtime_plugins = ["plugin.cpp|register_bert_plugin"]
 runtime_strategies = ["bert_encoder_only"]
 runtime_tests = [
-  "test_bert_encoder_pipeline|test_bert_encoder_pipeline.cpp|trtmc_model_bert,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_bert_encoder_pipeline|test_bert_encoder_pipeline.cpp|trtmc_model_bert,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/canary/MODEL.toml
+++ b/src/runtime/models/canary/MODEL.toml
@@ -9,5 +9,5 @@ runtime_tests = [
   "test_canary_mel_spectrogram|test_canary_mel_spectrogram.cpp|_|canary_mel_spectrogram.cpp|_",
   "test_canary_host_plan|test_canary_host_plan.cpp|_|_|_",
   "test_canary_decode_policy|test_canary_decode_policy.cpp|_|_|_",
-  "test_canary_pipeline|test_canary_pipeline.cpp|trtmc_model_canary|_|REQUIRES_TRT",
+  "test_canary_pipeline|test_canary_pipeline.cpp|trtmc_model_canary|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/convbert/MODEL.toml
+++ b/src/runtime/models/convbert/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_convbert.so"
 runtime_plugins = ["plugin.cpp|register_convbert_plugin"]
 runtime_strategies = ["convbert_encoder_only"]
 runtime_tests = [
-  "test_convbert_encoder_pipeline|test_convbert_encoder_pipeline.cpp|trtmc_model_convbert,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_convbert_encoder_pipeline|test_convbert_encoder_pipeline.cpp|trtmc_model_convbert,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/deberta/MODEL.toml
+++ b/src/runtime/models/deberta/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_deberta.so"
 runtime_plugins = ["plugin.cpp|register_deberta_plugin"]
 runtime_strategies = ["deberta_encoder_only"]
 runtime_tests = [
-  "test_deberta_encoder_pipeline|test_deberta_encoder_pipeline.cpp|trtmc_model_deberta,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_deberta_encoder_pipeline|test_deberta_encoder_pipeline.cpp|trtmc_model_deberta,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/deepseek_ocr/MODEL.toml
+++ b/src/runtime/models/deepseek_ocr/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_deepseek_ocr.so"
 runtime_plugins = ["plugin.cpp|register_deepseek_ocr_plugin"]
 runtime_strategies = ["deepseek_ocr_vision_language"]
 runtime_tests = [
-  "test_deepseek_ocr_vl_pipeline|test_deepseek_ocr_vl_pipeline.cpp|trtmc_model_deepseek_ocr,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_deepseek_ocr_vl_pipeline|test_deepseek_ocr_vl_pipeline.cpp|trtmc_model_deepseek_ocr,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/distilbert/MODEL.toml
+++ b/src/runtime/models/distilbert/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_distilbert.so"
 runtime_plugins = ["plugin.cpp|register_distilbert_plugin"]
 runtime_strategies = ["distilbert_encoder_only"]
 runtime_tests = [
-  "test_distilbert_encoder_pipeline|test_distilbert_encoder_pipeline.cpp|trtmc_model_distilbert,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_distilbert_encoder_pipeline|test_distilbert_encoder_pipeline.cpp|trtmc_model_distilbert,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/dpr/MODEL.toml
+++ b/src/runtime/models/dpr/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_dpr.so"
 runtime_plugins = ["plugin.cpp|register_dpr_plugin"]
 runtime_strategies = ["dpr_encoder_only"]
 runtime_tests = [
-  "test_dpr_encoder_pipeline|test_dpr_encoder_pipeline.cpp|trtmc_model_dpr,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_dpr_encoder_pipeline|test_dpr_encoder_pipeline.cpp|trtmc_model_dpr,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/eagle_vlm/MODEL.toml
+++ b/src/runtime/models/eagle_vlm/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_eagle_vlm.so"
 runtime_plugins = ["plugin.cpp|register_eagle_vlm_plugin"]
 runtime_strategies = ["eagle_vlm_embedding", "eagle_vlm_reranking"]
 runtime_tests = [
-  "test_eagle_vlm_encoder_pipeline|test_eagle_vlm_encoder_pipeline.cpp|trtmc_model_eagle_vlm,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_eagle_vlm_encoder_pipeline|test_eagle_vlm_encoder_pipeline.cpp|trtmc_model_eagle_vlm,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/electra/MODEL.toml
+++ b/src/runtime/models/electra/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_electra.so"
 runtime_plugins = ["plugin.cpp|register_electra_plugin"]
 runtime_strategies = ["electra_encoder_only"]
 runtime_tests = [
-  "test_electra_encoder_pipeline|test_electra_encoder_pipeline.cpp|trtmc_model_electra,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_electra_encoder_pipeline|test_electra_encoder_pipeline.cpp|trtmc_model_electra,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/elf_flow/MODEL.toml
+++ b/src/runtime/models/elf_flow/MODEL.toml
@@ -7,6 +7,6 @@ runtime_plugins = ["plugin.cpp|register_elf_flow_plugin"]
 runtime_strategies = ["elf_flow"]
 runtime_tests = [
   "test_elf_flow_pipeline|test_elf_flow_pipeline.cpp|trtmc_model_elf_flow|_|_",
-  "test_elf_flow_sampling_kernels|test_elf_flow_sampling_kernels.cpp|trtmc_model_elf_flow|_|REQUIRES_TRT",
+  "test_elf_flow_sampling_kernels|test_elf_flow_sampling_kernels.cpp|trtmc_model_elf_flow|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
 task_strategy = "diffusion_text_generation"

--- a/src/runtime/models/flux/MODEL.toml
+++ b/src/runtime/models/flux/MODEL.toml
@@ -8,7 +8,8 @@ runtime_strategies = ["diffusion_flux"]
 legacy_runtime_strategy_aliases = ["diffusion|contains|diffusion_backend_type|flux|diffusion_flux"]
 runtime_link_libraries = ["cublas"]
 runtime_tests = [
-  "test_flux_pipeline|test_flux_pipeline.cpp|trtmc_model_flux|_|_",
+  "test_flux_host_contracts|test_flux_host_contracts.cpp|_|_|_",
+  "test_flux_pipeline|test_flux_pipeline.cpp|trtmc_model_flux|_|REQUIRES_GPU",
   "test_flux_generation_plan|test_flux_generation_plan.cpp|_|_|_",
   "test_flux_denoising_step_seam|test_flux_denoising_step_seam.cpp|_|_|_",
   "test_flux_batch_utils|test_flux_batch_utils.cpp|_|_|_",

--- a/src/runtime/models/fnet/MODEL.toml
+++ b/src/runtime/models/fnet/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_fnet.so"
 runtime_plugins = ["plugin.cpp|register_fnet_plugin"]
 runtime_strategies = ["fnet_encoder_only"]
 runtime_tests = [
-  "test_fnet_encoder_pipeline|test_fnet_encoder_pipeline.cpp|trtmc_model_fnet,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_fnet_encoder_pipeline|test_fnet_encoder_pipeline.cpp|trtmc_model_fnet,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/internlm/MODEL.toml
+++ b/src/runtime/models/internlm/MODEL.toml
@@ -5,10 +5,10 @@ id = "internlm"
 runtime_library = "libtrtmc_model_internlm.so"
 runtime_plugins = ["plugin.cpp|register_internlm_plugin"]
 runtime_strategies = ["internlm_decoder_kv_cache"]
-[validation_profiles]
-decoder_debug = ["internlm_decoder_kv_cache"]
-
 runtime_tests = [
   "test_internlm_chat_template|test_internlm_chat_template.cpp|trtmc_model_internlm|_|_",
   "test_internlm_pipeline|test_internlm_pipeline.cpp|trtmc_model_internlm|_|REQUIRES_GPU",
 ]
+
+[validation_profiles]
+decoder_debug = ["internlm_decoder_kv_cache"]

--- a/src/runtime/models/internvl/MODEL.toml
+++ b/src/runtime/models/internvl/MODEL.toml
@@ -6,5 +6,6 @@ runtime_library = "libtrtmc_model_internvl.so"
 runtime_plugins = ["plugin.cpp|register_internvl_plugin"]
 runtime_strategies = ["internvl_vision_language"]
 runtime_tests = [
-  "test_internvl_vl_pipeline|test_internvl_vl_pipeline.cpp|trtmc_model_internvl,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_internvl_runtime_config_contract|test_internvl_runtime_config_contract.cpp|_|_|_",
+  "test_internvl_vl_pipeline|test_internvl_vl_pipeline.cpp|trtmc_model_internvl,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/lance/MODEL.toml
+++ b/src/runtime/models/lance/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_lance.so"
 runtime_plugins = ["plugin.cpp|register_lance_plugin"]
 runtime_strategies = ["lance_vision_language"]
 runtime_tests = [
-  "test_lance_vl_pipeline|test_lance_vl_pipeline.cpp|trtmc_model_lance,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_lance_vl_pipeline|test_lance_vl_pipeline.cpp|trtmc_model_lance,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/llama/MODEL.toml
+++ b/src/runtime/models/llama/MODEL.toml
@@ -5,12 +5,12 @@ id = "llama"
 runtime_library = "libtrtmc_model_llama.so"
 runtime_plugins = ["plugin.cpp|register_llama_plugin"]
 runtime_strategies = ["llama_decoder_kv_cache"]
-[validation_profiles]
-decoder_debug = ["llama_decoder_kv_cache"]
-
 runtime_tests = [
   "test_llama_plugin_helpers|test_llama_plugin_helpers.cpp|_|plugin_helpers.cpp|_",
   "test_llama_chat_template|test_llama_chat_template.cpp|trtmc_model_llama|_|_",
-  "test_llama_pipeline|test_llama_pipeline.cpp|trtmc_model_llama,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_llama_pipeline|test_llama_pipeline.cpp|trtmc_model_llama,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
   "test_llama_native_kv_cache|test_llama_native_kv_cache.cpp|trtmc_model_llama|_|REQUIRES_GPU",
 ]
+
+[validation_profiles]
+decoder_debug = ["llama_decoder_kv_cache"]

--- a/src/runtime/models/locateanything/MODEL.toml
+++ b/src/runtime/models/locateanything/MODEL.toml
@@ -6,5 +6,6 @@ runtime_library = "libtrtmc_model_locateanything.so"
 runtime_plugins = ["plugin.cpp|register_locateanything_plugin"]
 runtime_strategies = ["locateanything_vision_language"]
 runtime_tests = [
-  "test_locateanything_vl_pipeline|test_locateanything_vl_pipeline.cpp|trtmc_model_locateanything,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_locateanything_runtime_config_contract|test_locateanything_runtime_config_contract.cpp|_|_|_",
+  "test_locateanything_vl_pipeline|test_locateanything_vl_pipeline.cpp|trtmc_model_locateanything,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/magpie/MODEL.toml
+++ b/src/runtime/models/magpie/MODEL.toml
@@ -15,5 +15,5 @@ runtime_tests = [
   "test_magpie_generation_plan|test_magpie_generation_plan.cpp|_|_|_",
   "test_magpie_text_completion_policy|test_magpie_text_completion_policy.cpp|_|_|_",
   "test_magpie_codec_plan|test_magpie_codec_plan.cpp|_|_|_",
-  "test_magpie_pipeline|test_magpie_pipeline.cpp|trtmc_model_magpie|_|REQUIRES_TRT",
+  "test_magpie_pipeline|test_magpie_pipeline.cpp|trtmc_model_magpie|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/mamba/MODEL.toml
+++ b/src/runtime/models/mamba/MODEL.toml
@@ -5,10 +5,10 @@ id = "mamba"
 runtime_library = "libtrtmc_model_mamba.so"
 runtime_plugins = ["plugin.cpp|register_mamba_plugin"]
 runtime_strategies = ["mamba_ssm_recurrent"]
-[validation_profiles]
-decoder_debug = ["mamba_ssm_recurrent"]
-
 runtime_tests = [
   "test_mamba_recurrent_output_initializers|test_mamba_recurrent_output_initializers.cpp|_|_|_",
-  "test_mamba_recurrent_pipeline|test_mamba_recurrent_pipeline.cpp|trtmc_model_mamba,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_mamba_recurrent_pipeline|test_mamba_recurrent_pipeline.cpp|trtmc_model_mamba,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
+
+[validation_profiles]
+decoder_debug = ["mamba_ssm_recurrent"]

--- a/src/runtime/models/modernbert/MODEL.toml
+++ b/src/runtime/models/modernbert/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_modernbert.so"
 runtime_plugins = ["plugin.cpp|register_modernbert_plugin"]
 runtime_strategies = ["modernbert_encoder_only"]
 runtime_tests = [
-  "test_modernbert_encoder_pipeline|test_modernbert_encoder_pipeline.cpp|trtmc_model_modernbert,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_modernbert_encoder_pipeline|test_modernbert_encoder_pipeline.cpp|trtmc_model_modernbert,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/mpnet/MODEL.toml
+++ b/src/runtime/models/mpnet/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_mpnet.so"
 runtime_plugins = ["plugin.cpp|register_mpnet_plugin"]
 runtime_strategies = ["mpnet_encoder_only"]
 runtime_tests = [
-  "test_mpnet_encoder_pipeline|test_mpnet_encoder_pipeline.cpp|trtmc_model_mpnet,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_mpnet_encoder_pipeline|test_mpnet_encoder_pipeline.cpp|trtmc_model_mpnet,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/nemotron_h/MODEL.toml
+++ b/src/runtime/models/nemotron_h/MODEL.toml
@@ -5,11 +5,11 @@ id = "nemotron_h"
 runtime_library = "libtrtmc_model_nemotron_h.so"
 runtime_plugins = ["plugin.cpp|register_nemotron_h_plugin"]
 runtime_strategies = ["nemotron_h_hybrid_mamba_attention"]
-[validation_profiles]
-decoder_debug = ["nemotron_h_hybrid_mamba_attention"]
-
 runtime_tests = [
   "test_nemotron_h_backend_cuda_graph|test_nemotron_h_backend_cuda_graph.cpp|trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
   "test_nemotron_h_recurrent_output_initializers|test_nemotron_h_recurrent_output_initializers.cpp|_|_|_",
-  "test_nemotron_h_recurrent_pipeline|test_nemotron_h_recurrent_pipeline.cpp|trtmc_model_nemotron_h,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_nemotron_h_recurrent_pipeline|test_nemotron_h_recurrent_pipeline.cpp|trtmc_model_nemotron_h,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
+
+[validation_profiles]
+decoder_debug = ["nemotron_h_hybrid_mamba_attention"]

--- a/src/runtime/models/nemotron_labs_diffusion/MODEL.toml
+++ b/src/runtime/models/nemotron_labs_diffusion/MODEL.toml
@@ -5,9 +5,9 @@ id = "nemotron_labs_diffusion"
 runtime_library = "libtrtmc_model_nemotron_labs_diffusion.so"
 runtime_plugins = ["plugin.cpp|register_nemotron_labs_diffusion_plugin"]
 runtime_strategies = ["nemotron_labs_diffusion"]
-[validation_profiles]
-decoder_debug = ["nemotron_labs_diffusion"]
-
 runtime_tests = [
   "test_nemotron_labs_diffusion_chat_template|test_nemotron_labs_diffusion_chat_template.cpp|trtmc_model_nemotron_labs_diffusion|_|_",
 ]
+
+[validation_profiles]
+decoder_debug = ["nemotron_labs_diffusion"]

--- a/src/runtime/models/personaplex/MODEL.toml
+++ b/src/runtime/models/personaplex/MODEL.toml
@@ -16,6 +16,6 @@ runtime_tests = [
   "test_personaplex_speech_temporal_embed_plan|test_personaplex_speech_temporal_embed_plan.cpp|_|_|_",
   "test_personaplex_speech_mimi_decode_plan|test_personaplex_speech_mimi_decode_plan.cpp|_|_|_",
   "test_personaplex_decode_runtime|test_personaplex_decode_runtime.cpp|_|decode_runtime.cpp|_",
-  "test_personaplex_sampling_kernels|test_personaplex_sampling_kernels.cpp|trtmc_model_personaplex|_|REQUIRES_TRT",
-  "test_personaplex_speech_pipeline|test_personaplex_speech_pipeline.cpp|trtmc_model_personaplex|_|REQUIRES_TRT",
+  "test_personaplex_sampling_kernels|test_personaplex_sampling_kernels.cpp|trtmc_model_personaplex|_|REQUIRES_TRT,REQUIRES_GPU",
+  "test_personaplex_speech_pipeline|test_personaplex_speech_pipeline.cpp|trtmc_model_personaplex|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/phi4_multimodal/MODEL.toml
+++ b/src/runtime/models/phi4_multimodal/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_phi4_multimodal.so"
 runtime_plugins = ["plugin.cpp|register_phi4_multimodal_plugin"]
 runtime_strategies = ["phi4_multimodal_vision_language"]
 runtime_tests = [
-  "test_phi4_multimodal_vl_pipeline|test_phi4_multimodal_vl_pipeline.cpp|trtmc_model_phi4_multimodal,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_phi4_multimodal_vl_pipeline|test_phi4_multimodal_vl_pipeline.cpp|trtmc_model_phi4_multimodal,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/qwen/MODEL.toml
+++ b/src/runtime/models/qwen/MODEL.toml
@@ -6,7 +6,7 @@ runtime_library = "libtrtmc_model_qwen.so"
 runtime_plugins = ["plugin.cpp|register_qwen_plugin"]
 runtime_strategies = ["qwen_decoder_kv_cache"]
 runtime_tests = [
-  "test_c_abi_runtime_regression|test_c_abi_runtime_regression.cpp|trtmc_model_qwen|_|_",
+  "test_c_abi_runtime_regression|test_c_abi_runtime_regression.cpp|trtmc_model_qwen|_|REQUIRES_GPU",
   "test_qwen_tensor_names|test_qwen_tensor_names.cpp|_|_|_",
   "test_qwen_sampler|test_qwen_sampler.cpp|trtmc_model_qwen|_|_",
   "test_qwen_native_kv_cache_dtype|test_qwen_native_kv_cache_dtype.cpp|trtmc_model_qwen|_|_",

--- a/src/runtime/models/qwen3_5/MODEL.toml
+++ b/src/runtime/models/qwen3_5/MODEL.toml
@@ -5,10 +5,11 @@ id = "qwen3_5"
 runtime_library = "libtrtmc_model_qwen3_5.so"
 runtime_plugins = ["plugin.cpp|register_qwen3_5_plugin"]
 runtime_strategies = ["qwen3_5_hybrid_mamba_attention"]
+runtime_tests = [
+  "test_qwen3_5_runtime_config_contract|test_qwen3_5_runtime_config_contract.cpp|_|_|_",
+  "test_qwen3_5_recurrent_output_initializers|test_qwen3_5_recurrent_output_initializers.cpp|_|_|_",
+  "test_qwen3_5_recurrent_pipeline|test_qwen3_5_recurrent_pipeline.cpp|trtmc_model_qwen3_5,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
+]
+
 [validation_profiles]
 decoder_debug = ["qwen3_5_hybrid_mamba_attention"]
-
-runtime_tests = [
-  "test_qwen3_5_recurrent_output_initializers|test_qwen3_5_recurrent_output_initializers.cpp|_|_|_",
-  "test_qwen3_5_recurrent_pipeline|test_qwen3_5_recurrent_pipeline.cpp|trtmc_model_qwen3_5,trtmc_backend_trt|_|REQUIRES_TRT",
-]

--- a/src/runtime/models/qwen3_omni/MODEL.toml
+++ b/src/runtime/models/qwen3_omni/MODEL.toml
@@ -8,5 +8,5 @@ runtime_strategies = ["qwen3_omni_multimodal"]
 runtime_tests = [
   "test_qwen3_omni_audio_plan|test_qwen3_omni_audio_plan.cpp|_|_|_",
   "test_qwen3_omni_talker_runtime|test_qwen3_omni_talker_runtime.cpp|_|talker_runtime.cpp|_",
-  "test_qwen3_omni_pipeline|test_qwen3_omni_pipeline.cpp|trtmc_model_qwen3_omni|_|REQUIRES_TRT",
+  "test_qwen3_omni_pipeline|test_qwen3_omni_pipeline.cpp|trtmc_model_qwen3_omni|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/qwen_vl/MODEL.toml
+++ b/src/runtime/models/qwen_vl/MODEL.toml
@@ -6,6 +6,7 @@ runtime_library = "libtrtmc_model_qwen_vl.so"
 runtime_plugins = ["plugin.cpp|register_qwen_vl_plugin"]
 runtime_strategies = ["qwen_vl_vision_language"]
 runtime_tests = [
+  "test_qwen_vl_runtime_config_contract|test_qwen_vl_runtime_config_contract.cpp|_|_|_",
   "test_qwen_vl_sampler|test_qwen_vl_sampler.cpp|trtmc_model_qwen_vl|_|_",
-  "test_qwen_vl_vl_pipeline|test_qwen_vl_vl_pipeline.cpp|trtmc_model_qwen_vl,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_qwen_vl_vl_pipeline|test_qwen_vl_vl_pipeline.cpp|trtmc_model_qwen_vl,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/roberta/MODEL.toml
+++ b/src/runtime/models/roberta/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_roberta.so"
 runtime_plugins = ["plugin.cpp|register_roberta_plugin"]
 runtime_strategies = ["roberta_encoder_only"]
 runtime_tests = [
-  "test_roberta_encoder_pipeline|test_roberta_encoder_pipeline.cpp|trtmc_model_roberta,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_roberta_encoder_pipeline|test_roberta_encoder_pipeline.cpp|trtmc_model_roberta,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/rwkv/MODEL.toml
+++ b/src/runtime/models/rwkv/MODEL.toml
@@ -5,10 +5,10 @@ id = "rwkv"
 runtime_library = "libtrtmc_model_rwkv.so"
 runtime_plugins = ["plugin.cpp|register_rwkv_plugin"]
 runtime_strategies = ["rwkv_recurrent"]
-[validation_profiles]
-decoder_debug = ["rwkv_recurrent"]
-
 runtime_tests = [
   "test_rwkv_recurrent_output_initializers|test_rwkv_recurrent_output_initializers.cpp|_|_|_",
-  "test_rwkv_recurrent_pipeline|test_rwkv_recurrent_pipeline.cpp|trtmc_model_rwkv,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_rwkv_recurrent_pipeline|test_rwkv_recurrent_pipeline.cpp|trtmc_model_rwkv,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]
+
+[validation_profiles]
+decoder_debug = ["rwkv_recurrent"]

--- a/src/runtime/models/sam/MODEL.toml
+++ b/src/runtime/models/sam/MODEL.toml
@@ -8,5 +8,5 @@ runtime_strategies = ["sam_prompted_segmentation"]
 runtime_tests = [
   "test_sam_prompt_seam|test_sam_prompt_seam.cpp|trtmc_model_sam|_|_",
   "test_sam_image_preprocess_seam|test_sam_image_preprocess_seam.cpp|trtmc_model_sam|_|_",
-  "test_sam_pipeline|test_sam_pipeline.cpp|trtmc_model_sam|_|REQUIRES_TRT",
+  "test_sam_pipeline|test_sam_pipeline.cpp|trtmc_model_sam|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/sam3/MODEL.toml
+++ b/src/runtime/models/sam3/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_sam3.so"
 runtime_plugins = ["plugin.cpp|register_sam3_plugin"]
 runtime_strategies = ["sam3_prompted_segmentation"]
 runtime_tests = [
-  "test_sam3_pipeline|test_sam3_pipeline.cpp|trtmc_model_sam3|_|_",
+  "test_sam3_pipeline|test_sam3_pipeline.cpp|trtmc_model_sam3|_|REQUIRES_GPU",
 ]

--- a/src/runtime/models/segformer/MODEL.toml
+++ b/src/runtime/models/segformer/MODEL.toml
@@ -8,5 +8,5 @@ runtime_strategies = ["segformer_segmentation"]
 runtime_tests = [
   "test_segformer_preprocess_seam|test_segformer_preprocess_seam.cpp|trtmc_model_segformer|_|_",
   "test_segformer_postprocess_seam|test_segformer_postprocess_seam.cpp|_|_|_",
-  "test_segformer_segment_pipeline|test_segformer_segment_pipeline.cpp|trtmc_model_segformer|_|REQUIRES_TRT",
+  "test_segformer_segment_pipeline|test_segformer_segment_pipeline.cpp|trtmc_model_segformer|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/starcoder2/MODEL.toml
+++ b/src/runtime/models/starcoder2/MODEL.toml
@@ -5,9 +5,9 @@ id = "starcoder2"
 runtime_library = "libtrtmc_model_starcoder2.so"
 runtime_plugins = ["plugin.cpp|register_starcoder2_plugin"]
 runtime_strategies = ["starcoder2_decoder_kv_cache"]
-[validation_profiles]
-decoder_debug = ["starcoder2_decoder_kv_cache"]
-
 runtime_tests = [
   "test_starcoder2_tokenizer_contract|test_starcoder2_tokenizer_contract.cpp|_|_|_",
 ]
+
+[validation_profiles]
+decoder_debug = ["starcoder2_decoder_kv_cache"]

--- a/src/runtime/models/wan/MODEL.toml
+++ b/src/runtime/models/wan/MODEL.toml
@@ -10,7 +10,7 @@ gnu_warning_suppressed_sources = ["pipeline.cpp"]
 runtime_link_libraries = ["cublas"]
 runtime_tests = [
   "test_wan_pipeline|test_wan_pipeline.cpp|trtmc_model_wan|_|_",
-  "test_wan_c_abi_runtime_regression|test_wan_c_abi_runtime_regression.cpp|trtmc_model_wan|_|_",
+  "test_wan_c_abi_runtime_regression|test_wan_c_abi_runtime_regression.cpp|trtmc_model_wan|_|REQUIRES_GPU",
   "test_wan_generation_plan|test_wan_generation_plan.cpp|_|_|_",
   "test_wan_generation_conditioning|test_wan_generation_conditioning.cpp|_|_|_",
   "test_wan_denoising_step_seam|test_wan_denoising_step_seam.cpp|_|_|_",

--- a/src/runtime/models/whisper/MODEL.toml
+++ b/src/runtime/models/whisper/MODEL.toml
@@ -9,5 +9,5 @@ runtime_tests = [
   "test_whisper_mel_spectrogram|test_whisper_mel_spectrogram.cpp|_|whisper_mel_spectrogram.cpp|_",
   "test_whisper_host_plan|test_whisper_host_plan.cpp|_|_|_",
   "test_whisper_decode_policy|test_whisper_decode_policy.cpp|_|_|_",
-  "test_whisper_pipeline|test_whisper_pipeline.cpp|trtmc_model_whisper|_|REQUIRES_TRT",
+  "test_whisper_pipeline|test_whisper_pipeline.cpp|trtmc_model_whisper|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/src/runtime/models/xlnet/MODEL.toml
+++ b/src/runtime/models/xlnet/MODEL.toml
@@ -6,5 +6,5 @@ runtime_library = "libtrtmc_model_xlnet.so"
 runtime_plugins = ["plugin.cpp|register_xlnet_plugin"]
 runtime_strategies = ["xlnet_encoder_only"]
 runtime_tests = [
-  "test_xlnet_encoder_pipeline|test_xlnet_encoder_pipeline.cpp|trtmc_model_xlnet,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_xlnet_encoder_pipeline|test_xlnet_encoder_pipeline.cpp|trtmc_model_xlnet,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/tests/cpp/models/flux/test_flux_host_contracts.cpp
+++ b/tests/cpp/models/flux/test_flux_host_contracts.cpp
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/flux/flux_clip_helpers.h"
+#include "runtime/models/flux/flux_rope_helpers.h"
+#include "runtime/models/flux/flux_text_helpers.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+class PadTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override { return {}; }
+    std::string decode(const std::vector<int32_t>&) const override { return {}; }
+    int32_t id_for_token(std::string_view token) const override {
+        return token == "<pad>" ? 11 : -1;
+    }
+    std::string token_for_id(int32_t) const override { return {}; }
+};
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+void test_clip_padding_preserves_eos_when_truncated() {
+    using trtmc::diffusion::flux_clip::pad_and_truncate_ids;
+
+    check(pad_and_truncate_ids({10, 1, 11}, 5, 11, 11) == std::vector<int32_t>({10, 1, 11, 11, 11}),
+          "CLIP short input pads with EOS");
+    check(pad_and_truncate_ids({10, 1, 2, 3, 11}, 5, 11, 11) ==
+              std::vector<int32_t>({10, 1, 2, 3, 11}),
+          "CLIP exact input preserves EOS");
+    check(pad_and_truncate_ids({10, 1, 2, 3, 4, 11}, 5, 11, 11) ==
+              std::vector<int32_t>({10, 1, 2, 3, 11}),
+          "CLIP truncated input restores EOS");
+}
+
+void test_flux2_text_padding_matches_tokenizer_contract() {
+    using trtmc::diffusion::flux_text::clear_padding_rows;
+    using trtmc::diffusion::flux_text::prepare_inputs;
+    using trtmc::diffusion::flux_text::resolve_pad_token_id;
+
+    PadTokenizer tokenizer;
+    check(resolve_pad_token_id(&tokenizer, true) == 11, "FLUX.2 resolves tokenizer pad id");
+    check(resolve_pad_token_id(&tokenizer, false) == 0, "FLUX.1 retains legacy pad id");
+
+    const auto prepared = prepare_inputs({12, 0, 13}, 5, 11);
+    check(prepared.input_ids == std::vector<int32_t>({12, 0, 13, 11, 11}),
+          "FLUX.2 text uses tokenizer pad id");
+    check(prepared.attention_mask == std::vector<float>({0.0F, 0.0F, 0.0F, -1e9F, -1e9F}),
+          "FLUX.2 text mask follows input length rather than token value");
+
+    std::vector<float> embeddings(10, 1.0F);
+    clear_padding_rows(embeddings, {3}, 5, 2, true);
+    check(std::all_of(embeddings.begin(), embeddings.end(),
+                      [](float value) { return value == 1.0F; }),
+          "FLUX.2 preserves padded query embeddings");
+    clear_padding_rows(embeddings, {3}, 5, 2, false);
+    check(embeddings ==
+              std::vector<float>({1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F}),
+          "FLUX.1 clears padded query embeddings");
+}
+
+void test_flux2_rope_coordinates_match_diffusers_contract() {
+    using trtmc::diffusion::flux_rope::axis_position;
+
+    check(axis_position(0, 0, 0, 0, 17) == 0, "FLUX.2 text temporal coordinate");
+    check(axis_position(1, 0, 0, 0, 17) == 0, "FLUX.2 text height coordinate");
+    check(axis_position(2, 0, 0, 0, 17) == 0, "FLUX.2 text width coordinate");
+    check(axis_position(3, 0, 0, 0, 17) == 17, "FLUX.2 text sequence coordinate");
+
+    check(axis_position(0, 0, 5, 7, 0) == 0, "FLUX.2 image temporal coordinate");
+    check(axis_position(1, 0, 5, 7, 0) == 5, "FLUX.2 image height coordinate");
+    check(axis_position(2, 0, 5, 7, 0) == 7, "FLUX.2 image width coordinate");
+    check(axis_position(3, 0, 5, 7, 0) == 0, "FLUX.2 image sequence coordinate");
+}
+
+} // namespace
+
+int main() {
+    test_clip_padding_preserves_eos_when_truncated();
+    test_flux2_text_padding_matches_tokenizer_contract();
+    test_flux2_rope_coordinates_match_diffusers_contract();
+    if (failures > 0) {
+        std::cerr << failures << " flux host contract test(s) FAILED\n";
+    }
+    return failures;
+}

--- a/tests/cpp/models/flux/test_flux_pipeline.cpp
+++ b/tests/cpp/models/flux/test_flux_pipeline.cpp
@@ -3,28 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "runtime/models/flux/flux_clip_helpers.h"
-#include "runtime/models/flux/flux_rope_helpers.h"
-#include "runtime/models/flux/flux_text_helpers.h"
 #include "runtime/models/flux/pipeline.h"
 
-#include <algorithm>
 #include <iostream>
 #include <string>
 
 namespace {
 
 int failures = 0;
-
-class PadTokenizer final : public trtmc::ITokenizer {
-  public:
-    std::vector<int32_t> encode(const std::string&) const override { return {}; }
-    std::string decode(const std::vector<int32_t>&) const override { return {}; }
-    int32_t id_for_token(std::string_view token) const override {
-        return token == "<pad>" ? 11 : -1;
-    }
-    std::string token_for_id(int32_t) const override { return {}; }
-};
 
 void check(bool condition, const char* name) {
     if (!condition) {
@@ -57,67 +43,11 @@ void test_flux_with_custom_config() {
           "FluxPipeline custom config pipeline_type");
 }
 
-void test_clip_padding_preserves_eos_when_truncated() {
-    using trtmc::diffusion::flux_clip::pad_and_truncate_ids;
-
-    check(pad_and_truncate_ids({10, 1, 11}, 5, 11, 11) == std::vector<int32_t>({10, 1, 11, 11, 11}),
-          "CLIP short input pads with EOS");
-    check(pad_and_truncate_ids({10, 1, 2, 3, 11}, 5, 11, 11) ==
-              std::vector<int32_t>({10, 1, 2, 3, 11}),
-          "CLIP exact input preserves EOS");
-    check(pad_and_truncate_ids({10, 1, 2, 3, 4, 11}, 5, 11, 11) ==
-              std::vector<int32_t>({10, 1, 2, 3, 11}),
-          "CLIP truncated input restores EOS");
-}
-
-void test_flux2_text_padding_matches_tokenizer_contract() {
-    using trtmc::diffusion::flux_text::clear_padding_rows;
-    using trtmc::diffusion::flux_text::prepare_inputs;
-    using trtmc::diffusion::flux_text::resolve_pad_token_id;
-
-    PadTokenizer tokenizer;
-    check(resolve_pad_token_id(&tokenizer, true) == 11, "FLUX.2 resolves tokenizer pad id");
-    check(resolve_pad_token_id(&tokenizer, false) == 0, "FLUX.1 retains legacy pad id");
-
-    const auto prepared = prepare_inputs({12, 0, 13}, 5, 11);
-    check(prepared.input_ids == std::vector<int32_t>({12, 0, 13, 11, 11}),
-          "FLUX.2 text uses tokenizer pad id");
-    check(prepared.attention_mask == std::vector<float>({0.0F, 0.0F, 0.0F, -1e9F, -1e9F}),
-          "FLUX.2 text mask follows input length rather than token value");
-
-    std::vector<float> embeddings(10, 1.0F);
-    clear_padding_rows(embeddings, {3}, 5, 2, true);
-    check(std::all_of(embeddings.begin(), embeddings.end(),
-                      [](float value) { return value == 1.0F; }),
-          "FLUX.2 preserves padded query embeddings");
-    clear_padding_rows(embeddings, {3}, 5, 2, false);
-    check(embeddings ==
-              std::vector<float>({1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F}),
-          "FLUX.1 clears padded query embeddings");
-}
-
-void test_flux2_rope_coordinates_match_diffusers_contract() {
-    using trtmc::diffusion::flux_rope::axis_position;
-
-    check(axis_position(0, 0, 0, 0, 17) == 0, "FLUX.2 text temporal coordinate");
-    check(axis_position(1, 0, 0, 0, 17) == 0, "FLUX.2 text height coordinate");
-    check(axis_position(2, 0, 0, 0, 17) == 0, "FLUX.2 text width coordinate");
-    check(axis_position(3, 0, 0, 0, 17) == 17, "FLUX.2 text sequence coordinate");
-
-    check(axis_position(0, 0, 5, 7, 0) == 0, "FLUX.2 image temporal coordinate");
-    check(axis_position(1, 0, 5, 7, 0) == 5, "FLUX.2 image height coordinate");
-    check(axis_position(2, 0, 5, 7, 0) == 7, "FLUX.2 image width coordinate");
-    check(axis_position(3, 0, 5, 7, 0) == 0, "FLUX.2 image sequence coordinate");
-}
-
 } // namespace
 
 int main() {
     test_flux_construction();
     test_flux_with_custom_config();
-    test_clip_padding_preserves_eos_when_truncated();
-    test_flux2_text_padding_matches_tokenizer_contract();
-    test_flux2_rope_coordinates_match_diffusers_contract();
     if (failures > 0) {
         std::cerr << failures << " flux pipeline test(s) FAILED\n";
     }

--- a/tests/cpp/models/internvl/test_internvl_runtime_config_contract.cpp
+++ b/tests/cpp/models/internvl/test_internvl_runtime_config_contract.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for InternVL's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <iostream>
+#include <string>
+
+int main() {
+    const std::string config = R"({
+        "model_type": "internvl",
+        "text_config": {
+            "vocab_size": 151674,
+            "hidden_size": 1536,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 12,
+            "num_key_value_heads": 2,
+            "head_dim": 128,
+            "bos_token_id": 151643
+        },
+        "vocab_size": 151674,
+        "hidden_size": 1536,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 12,
+        "num_key_value_heads": 2,
+        "head_dim": 128,
+        "bos_token_id": 151643,
+        "runtime_strategy": "internvl_vision_language"
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "internvl_vision_language", "runtime strategy");
+    check(parsed.vocab_size == 151674, "vocabulary size");
+    check(parsed.hidden_size == 1536, "hidden size");
+    check(parsed.num_layers == 28, "layer count");
+    check(parsed.num_heads == 12, "attention head count");
+    check(parsed.num_kv_heads == 2, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.id_bos == 151643, "BOS token");
+    check(parsed.attention_size == 1536, "attention width");
+    return ok ? 0 : 1;
+}

--- a/tests/cpp/models/locateanything/test_locateanything_runtime_config_contract.cpp
+++ b/tests/cpp/models/locateanything/test_locateanything_runtime_config_contract.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for LocateAnything's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // The nested objects mirror nvidia/LocateAnything-3B's Hugging Face config.
+    // The duplicated top-level decoder fields are the final bundle contract
+    // consumed by the strict production C++ parser.
+    const std::string config = R"({
+        "vocab_size": 152681,
+        "hidden_size": 2048,
+        "num_hidden_layers": 36,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 2,
+        "head_dim": 128,
+        "bos_token_id": 151643,
+        "eos_token_id": 151645,
+        "model_type": "locateanything",
+        "text_config": {
+            "model_type": "qwen2",
+            "vocab_size": 152681,
+            "hidden_size": 2048,
+            "intermediate_size": 11008,
+            "num_hidden_layers": 36,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "bos_token_id": 151643,
+            "eos_token_id": 151645,
+            "max_position_embeddings": 32768,
+            "rope_theta": 1000000.0
+        },
+        "vision_config": {
+            "model_type": "moonvit",
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_hidden_layers": 27,
+            "num_attention_heads": 16,
+            "patch_size": 14,
+            "merge_kernel_size": [2, 2]
+        },
+        "runtime_strategy": "locateanything_vision_language",
+        "precision": "fp16",
+        "tokenizer_add_special_tokens": 0
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 384);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "locateanything_vision_language", "runtime strategy");
+    check(parsed.precision == "fp16", "precision");
+    check(parsed.vocab_size == 152681, "vocabulary size");
+    check(parsed.hidden_size == 2048, "hidden size");
+    check(parsed.num_layers == 36, "layer count");
+    check(parsed.num_heads == 16, "attention head count");
+    check(parsed.num_kv_heads == 2, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.attention_size == 2048, "attention width");
+    check(parsed.max_cache_length == 384, "cache length override");
+    check(parsed.id_bos == 151643, "BOS token");
+    check(parsed.id_eos == 151645, "EOS token");
+    check(parsed.id_eos_ids == std::vector<int32_t>({151645}), "EOS token list");
+    check(parsed.tokenizer_add_special_tokens_present, "tokenizer flag presence");
+    check(!parsed.tokenizer_add_special_tokens, "tokenizer flag value");
+    return ok ? 0 : 1;
+}

--- a/tests/cpp/models/qwen3_5/test_qwen3_5_runtime_config_contract.cpp
+++ b/tests/cpp/models/qwen3_5/test_qwen3_5_runtime_config_contract.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for Qwen3.5's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // The nested objects mirror Qwen/Qwen3.5-9B at the catalog-pinned
+    // c202236235762e1c871ad0ccb60c8ee5ba337b9a revision. The duplicated
+    // top-level decoder fields are the final bundle contract consumed by the
+    // strict production C++ parser.
+    const std::string config = R"({
+        "vocab_size": 248320,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "head_dim": 256,
+        "bos_token_id": -1,
+        "eos_token_id": 248044,
+        "model_type": "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "vocab_size": 248320,
+            "hidden_size": 4096,
+            "intermediate_size": 12288,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "eos_token_id": 248044,
+            "max_position_embeddings": 262144,
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "linear_value_head_dim": 128,
+            "rope_parameters": {
+                "mrope_interleaved": true,
+                "mrope_section": [11, 11, 10],
+                "rope_type": "default",
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25
+            }
+        },
+        "vision_config": {
+            "model_type": "qwen3_5",
+            "depth": 27,
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_heads": 16,
+            "out_hidden_size": 4096,
+            "patch_size": 16,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "deepstack_visual_indexes": []
+        },
+        "num_mamba_layers": 24,
+        "num_attention_layers": 8,
+        "d_inner": 4096,
+        "mamba_d_state": 128,
+        "mamba_d_conv": 4,
+        "mamba_nheads": 32,
+        "mamba_head_dim": 128,
+        "conv_dim": 8192,
+        "runtime_strategy": "qwen3_5_hybrid_mamba_attention",
+        "precision": "fp16",
+        "tokenizer_add_special_tokens": 0
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "qwen3_5_hybrid_mamba_attention", "runtime strategy");
+    check(parsed.precision == "fp16", "precision");
+    check(parsed.vocab_size == 248320, "vocabulary size");
+    check(parsed.hidden_size == 4096, "hidden size");
+    check(parsed.num_layers == 32, "layer count");
+    check(parsed.num_heads == 16, "attention head count");
+    check(parsed.num_kv_heads == 4, "KV head count");
+    check(parsed.head_dim == 256, "head dimension");
+    check(parsed.attention_size == 4096, "attention width");
+    check(parsed.num_kv_heads * parsed.head_dim == 1024, "KV cache width");
+    check(parsed.max_cache_length == 256, "cache length override");
+    check(parsed.id_bos == -1, "absent BOS token contract");
+    check(parsed.id_eos == 248044, "EOS token");
+    check(parsed.id_eos_ids == std::vector<int32_t>({248044}), "EOS token list");
+    check(parsed.tokenizer_add_special_tokens_present, "tokenizer flag presence");
+    check(!parsed.tokenizer_add_special_tokens, "tokenizer flag value");
+    return ok ? 0 : 1;
+}

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_runtime_config_contract.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_runtime_config_contract.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for Qwen3-VL's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // The nested objects mirror Qwen/Qwen3-VL-2B-Instruct at the pinned
+    // 89644892e4d85e24eaac8bacfd4f463576704203 revision. The duplicated
+    // top-level decoder fields are the final bundle contract consumed by the
+    // strict production C++ parser. The top-level EOS list comes from the
+    // pinned generation_config.json and must not be replaced by the nested
+    // scalar value.
+    const std::string config = R"({
+        "vocab_size": 151936,
+        "hidden_size": 2048,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "bos_token_id": 151643,
+        "eos_token_id": [151645, 151643],
+        "model_type": "qwen3_vl",
+        "text_config": {
+            "model_type": "qwen3_vl_text",
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "intermediate_size": 6144,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "bos_token_id": 151643,
+            "eos_token_id": 151645,
+            "max_position_embeddings": 262144,
+            "rope_theta": 5000000,
+            "rope_scaling": {
+                "mrope_interleaved": true,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default"
+            }
+        },
+        "vision_config": {
+            "model_type": "qwen3_vl",
+            "depth": 24,
+            "hidden_size": 1024,
+            "intermediate_size": 4096,
+            "num_heads": 16,
+            "patch_size": 16,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "deepstack_visual_indexes": [5, 11, 17]
+        },
+        "runtime_strategy": "qwen_vl_vision_language",
+        "precision": "bf16",
+        "tokenizer_add_special_tokens": 0
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "qwen_vl_vision_language", "runtime strategy");
+    check(parsed.precision == "bf16", "precision");
+    check(parsed.vocab_size == 151936, "vocabulary size");
+    check(parsed.hidden_size == 2048, "hidden size");
+    check(parsed.num_layers == 28, "layer count");
+    check(parsed.num_heads == 16, "attention head count");
+    check(parsed.num_kv_heads == 8, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.attention_size == 2048, "attention width");
+    check(parsed.num_kv_heads * parsed.head_dim == 1024, "KV cache width");
+    check(parsed.max_cache_length == 256, "cache length override");
+    check(parsed.id_bos == 151643, "BOS token");
+    check(parsed.id_eos == 151645, "EOS token");
+    check(parsed.id_eos_ids == std::vector<int32_t>({151645, 151643}), "EOS token list");
+    check(parsed.tokenizer_add_special_tokens_present, "tokenizer flag presence");
+    check(!parsed.tokenizer_add_special_tokens, "tokenizer flag value");
+    return ok ? 0 : 1;
+}

--- a/tests/cpp/test_json_helpers.cpp
+++ b/tests/cpp/test_json_helpers.cpp
@@ -19,12 +19,10 @@
 // =============================================================================
 //
 // Purpose:
-//   Validates the lightweight, regex-free JSON extraction functions used
-//   throughout the codebase to parse HuggingFace config.json and
-//   generation_config.json files. These extractors operate on raw JSON strings
-//   (no DOM parser) and must correctly handle common JSON patterns including
-//   nested objects, arrays, negative integers, scientific-notation floats,
-//   and missing keys (fallback values).
+//   Validates the strict JSON extraction functions used throughout the
+//   codebase to parse HuggingFace config.json and generation_config.json.
+//   Ordinary field lookup is deliberately scoped to the top-level object;
+//   callers must explicitly extract an object before reading nested fields.
 //
 // Dependencies:
 //   - utils/json_helpers.h (extract_json_string, extract_json_int,
@@ -156,6 +154,20 @@ bool test_extract_json_int_missing() {
         return false;
     }
     return true;
+}
+
+// Intention: Lock strict top-level lookup so nested model fields cannot be
+//            consumed accidentally as if they were bundle runtime fields.
+bool test_extract_json_int_nested_only_uses_fallback() {
+    const std::string json = R"({"text_config": {"hidden_size": 1536}})";
+    return trtmc::extract_json_int(json, "hidden_size", -99) == -99;
+}
+
+// Intention: When a composite config contains both nested source metadata and
+//            a materialized runtime field, the top-level field is authoritative.
+bool test_extract_json_int_top_level_wins_over_nested() {
+    const std::string json = R"({"text_config": {"hidden_size": 4096}, "hidden_size": 1536})";
+    return trtmc::extract_json_int(json, "hidden_size", -99) == 1536;
 }
 
 // Intention: Verify the behavior of extract_json_int when the value is a
@@ -516,6 +528,8 @@ int main() {
     run("extract_json_int_positive", test_extract_json_int_positive);
     run("extract_json_int_negative", test_extract_json_int_negative);
     run("extract_json_int_missing", test_extract_json_int_missing);
+    run("extract_json_int_nested_only", test_extract_json_int_nested_only_uses_fallback);
+    run("extract_json_int_top_level_wins", test_extract_json_int_top_level_wins_over_nested);
     run("extract_json_int_float_value", test_extract_json_int_float_value);
     run("int_or_first_array_scalar", test_extract_json_int_or_first_array_scalar);
     run("int_or_first_array_array", test_extract_json_int_or_first_array_array);

--- a/tests/e2e/models/albert/test_albert_build_engine_integration.py
+++ b/tests/e2e/models/albert/test_albert_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/bart/test_bart_build_engine_integration.py
+++ b/tests/e2e/models/bart/test_bart_build_engine_integration.py
@@ -108,6 +108,8 @@ class TestBartBuildEngine:
             t[f"{pfx}.final_layer_norm.bias"] = _rand(hidden)
         return t
 
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_build_engine(self, tmp_path):
         from tensorrt_model_connect.families.bart import plugin
         config = {

--- a/tests/e2e/models/codegen/test_codegen_build_engine_integration.py
+++ b/tests/e2e/models/codegen/test_codegen_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/deberta/test_deberta_build_engine_integration.py
+++ b/tests/e2e/models/deberta/test_deberta_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
@@ -482,6 +482,8 @@ def test_deepseek_ocr_bounds_sequence_prefill_profile(
     assert sequence_prefill_profile_lengths(max_cache_length) == expected
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_deepseek_ocr_decomposes_multirow_sequence_attention() -> None:
     trt = trt_compat.get_trt()
     builder = trt.Builder(trt.Logger(trt.Logger.ERROR))

--- a/tests/e2e/models/dinov3/test_dinov3_convnext_builder.py
+++ b/tests/e2e/models/dinov3/test_dinov3_convnext_builder.py
@@ -22,6 +22,8 @@ def _load_builder(monkeypatch: pytest.MonkeyPatch):
     return importlib.import_module("tensorrt_model_connect.families.dinov3.convnext_builder")
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 @pytest.mark.parametrize("precision", ["fp32", "fp16"])
 def test_real_tensorrt_build_marks_hf_outputs(precision: str) -> None:
     trt = pytest.importorskip("tensorrt")
@@ -317,6 +319,8 @@ def test_build_source_is_native_and_marks_hf_outputs(
     assert "onnx" not in source.lower()
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_real_convnext_fp32_matches_transformers(tmp_path) -> None:
     trt = pytest.importorskip("tensorrt")
     torch = pytest.importorskip("torch")

--- a/tests/e2e/models/dinov3/test_dinov3_vit_builder.py
+++ b/tests/e2e/models/dinov3/test_dinov3_vit_builder.py
@@ -286,6 +286,8 @@ def test_timm_dinov3_qkvb_config_normalizes_before_metadata(tmp_path: Path) -> N
     assert metadata["num_attention_heads"] == 6
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_real_tensorrt_timm_mapped_vit_build(tmp_path: Path) -> None:
     _write_tiny_timm_vit(tmp_path)
     config = ModelConfig.from_dir(tmp_path)
@@ -319,6 +321,8 @@ def test_vit_config_and_bundle_metadata_preserve_hf_contract(tmp_path: Path) -> 
     assert plugin.default_max_cache_length(config) == 1
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 @pytest.mark.parametrize("precision", ["fp32", "fp16"])
 def test_real_tensorrt_vit_build_marks_hf_outputs(tmp_path: Path, precision: str) -> None:
     _write_tiny_vit(tmp_path)
@@ -337,6 +341,8 @@ def test_real_tensorrt_vit_build_marks_hf_outputs(tmp_path: Path, precision: str
     assert engine.get_tensor_dtype("pooler_output") == trt.float32
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_real_tensorrt_vit_fp32_matches_transformers(tmp_path: Path) -> None:
     torch = pytest.importorskip("torch")
     transformers = pytest.importorskip("transformers")

--- a/tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py
+++ b/tests/e2e/models/distilbert/test_distilbert_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/dpr/test_dpr_build_engine_integration.py
+++ b/tests/e2e/models/dpr/test_dpr_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
+++ b/tests/e2e/models/eagle_vlm/test_eagle_vlm_builder_tp.py
@@ -90,6 +90,8 @@ def test_eagle_vlm_prefers_rope_parameters_over_legacy_alias() -> None:
     assert plugin_module._resolve_rope_scaling(Config())["factor"] == 8.0
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
     monkeypatch,
 ) -> None:
@@ -223,6 +225,8 @@ def test_eagle_vlm_fp16_reranker_keeps_residual_and_norms_in_fp32(
     assert mlp_fp32_down_projection == expected_fp32_down
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_eagle_vlm_reranker_executes_actual_sequence_length() -> None:
     import tensorrt as trt
 

--- a/tests/e2e/models/electra/test_electra_build_engine_integration.py
+++ b/tests/e2e/models/electra/test_electra_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/fnet/test_fnet_build_engine_integration.py
+++ b/tests/e2e/models/fnet/test_fnet_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/gpt2/test_gpt2_build_engine_integration.py
+++ b/tests/e2e/models/gpt2/test_gpt2_build_engine_integration.py
@@ -79,6 +79,8 @@ class TestGPT2BuildEngine:
         t["lm_head.weight"] = _rand(vocab, hidden)
         return t
 
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_build_engine(self, tmp_path):
         from tensorrt_model_connect.families.gpt2 import plugin
         config = {

--- a/tests/e2e/models/gpt_neo/test_gpt_neo_build_engine_integration.py
+++ b/tests/e2e/models/gpt_neo/test_gpt_neo_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/gpt_neox/test_gpt_neox_build_engine_integration.py
+++ b/tests/e2e/models/gpt_neox/test_gpt_neox_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/gpt_oss/test_gpt_oss_rope_and_sliding.py
+++ b/tests/e2e/models/gpt_oss/test_gpt_oss_rope_and_sliding.py
@@ -247,6 +247,8 @@ def _require_cuda() -> None:
         pytest.skip("No CUDA device available for engine execution tests")
 
 
+@pytest.mark.gpu
+@pytest.mark.trt
 def test_sliding_layers_restrict_attention_to_window():
     """Engines with sliding layer_types must diverge from all-full engines
     exactly when the prompt outgrows the sliding window."""

--- a/tests/e2e/models/internlm/test_internlm_build_engine_integration.py
+++ b/tests/e2e/models/internlm/test_internlm_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/internvl/test_internvl_family_plugin_weights.py
+++ b/tests/e2e/models/internvl/test_internvl_family_plugin_weights.py
@@ -9,6 +9,8 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
 
 
 from tests.builder.family_plugin_test_support import (
@@ -264,6 +266,94 @@ class TestInternVLPlugin:
             "head_dim": 128,
             "bos_token_id": 151643,
         }
+
+    def test_mock_bundle_serializes_decoder_geometry_at_top_level(self, tmp_path):
+        """Mock engines while exercising the real InternVL bundle boundary."""
+        from tensorrt_model_connect.engine_builder import build_bundle
+        from tensorrt_model_connect.families.internvl.plugin import (
+            plugin as production_plugin,
+        )
+
+        source_config = {
+            "model_type": "internvl",
+            "text_config": {
+                "vocab_size": 151674,
+                "hidden_size": 1536,
+                "num_hidden_layers": 28,
+                "num_attention_heads": 12,
+                "num_key_value_heads": 2,
+                "head_dim": 128,
+                "bos_token_id": 151643,
+            },
+            "vision_config": {
+                "hidden_size": 1024,
+                "num_hidden_layers": 24,
+                "patch_size": 14,
+            },
+        }
+        _write_config(tmp_path, source_config)
+
+        class MockInternVLPlugin:
+            name = "internvl"
+            runtime_strategy = "internvl_vision_language"
+            requires_tokenizer = False
+
+            @staticmethod
+            def load_weights(_model_dir, _config):
+                return {}
+
+            @staticmethod
+            def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+                return b"MOCK_DECODER_PLAN"
+
+            @staticmethod
+            def build_vision_engine(_model_dir, _config, _weights, **_kwargs):
+                return b"MOCK_VISION_PLAN"
+
+            @staticmethod
+            def get_vl_config(config):
+                return production_plugin.get_vl_config(config)
+
+            @staticmethod
+            def get_bundle_config_overrides(config):
+                return production_plugin.get_bundle_config_overrides(config)
+
+        with (
+            patch(
+                "tensorrt_model_connect.engine_builder.find_plugin",
+                return_value=MockInternVLPlugin(),
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_trt_version",
+                return_value="11.1.0",
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="CPU unit mock",
+            ),
+            patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+        ):
+            build_bundle(
+                str(tmp_path),
+                str(tmp_path / "internvl.bundle"),
+                max_cache_length=256,
+            )
+
+        sections = {section.name: section.data for section in write_bundle.call_args.args[2]}
+        runtime_config = json.loads(sections["config.json"])
+        assert runtime_config["text_config"] == source_config["text_config"]
+        assert {
+            key: runtime_config[key]
+            for key in (
+                "vocab_size",
+                "hidden_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "head_dim",
+                "bos_token_id",
+            )
+        } == source_config["text_config"]
 
     def test_no_vl_config_without_vision(self, tmp_path):
         """get_vl_config returns None when no vision_config present."""

--- a/tests/e2e/models/locateanything/test_locateanything_family_plugin_weights.py
+++ b/tests/e2e/models/locateanything/test_locateanything_family_plugin_weights.py
@@ -10,6 +10,8 @@ Shared test code is limited to filesystem and serialization helpers.
 from __future__ import annotations
 
 import importlib
+import json
+from unittest.mock import patch
 
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
@@ -82,6 +84,8 @@ class TestLocateAnythingPlugin:
                 "num_hidden_layers": self.LAYERS,
                 "num_attention_heads": self.HEADS,
                 "num_key_value_heads": self.KV_HEADS,
+                "bos_token_id": 151643,
+                "eos_token_id": 151645,
                 "rms_norm_eps": 1e-6,
                 "rope_theta": 1000000.0,
                 "max_position_embeddings": 32768,
@@ -162,3 +166,81 @@ class TestLocateAnythingPlugin:
         assert vl_cfg["box_start_token_id"] == 151668
         assert "{image_pads}" in vl_cfg["vl_prompt_template"]
         assert "{prompt}" in vl_cfg["vl_prompt_template"]
+
+    def test_mock_bundle_serializes_decoder_geometry_at_top_level(self, tmp_path):
+        """Mock engines while exercising the real LocateAnything bundle boundary."""
+        from tensorrt_model_connect.engine_builder import build_bundle
+        from tensorrt_model_connect.families.locateanything.plugin import (
+            plugin as production_plugin,
+        )
+
+        self._write_locateanything_config(tmp_path)
+        source_config = json.loads(
+            (tmp_path / "config.json").read_text(encoding="utf-8")
+        )
+
+        class MockLocateAnythingPlugin:
+            name = "locateanything"
+            runtime_strategy = "locateanything_vision_language"
+            embed_input = True
+            requires_tokenizer = False
+
+            @staticmethod
+            def load_weights(_model_dir, _config):
+                return {}
+
+            @staticmethod
+            def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+                return b"MOCK_DECODER_PLAN"
+
+            @staticmethod
+            def build_vision_engine(_model_dir, _config, _weights, **_kwargs):
+                return b"MOCK_VISION_PLAN"
+
+            @staticmethod
+            def get_vl_config(config):
+                return production_plugin.get_vl_config(config)
+
+            @staticmethod
+            def get_bundle_config_overrides(config):
+                return production_plugin.get_bundle_config_overrides(config)
+
+        with (
+            patch(
+                "tensorrt_model_connect.engine_builder.find_plugin",
+                return_value=MockLocateAnythingPlugin(),
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_trt_version",
+                return_value="11.1.0",
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="CPU unit mock",
+            ),
+            patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+        ):
+            build_bundle(
+                str(tmp_path),
+                str(tmp_path / "locateanything.bundle"),
+                max_cache_length=384,
+            )
+
+        sections = {
+            section.name: section.data for section in write_bundle.call_args.args[2]
+        }
+        runtime_config = json.loads(sections["config.json"])
+        decoder_config = source_config["text_config"]
+        assert runtime_config["text_config"] == decoder_config
+        decoder_contract = {
+            "vocab_size": self.VOCAB,
+            "hidden_size": self.HIDDEN,
+            "num_hidden_layers": self.LAYERS,
+            "num_attention_heads": self.HEADS,
+            "num_key_value_heads": self.KV_HEADS,
+            "head_dim": self.HIDDEN // self.HEADS,
+            "bos_token_id": 151643,
+            "eos_token_id": 151645,
+        }
+        assert all(key not in source_config for key in decoder_contract)
+        assert {key: runtime_config[key] for key in decoder_contract} == decoder_contract

--- a/tests/e2e/models/m2m_100/test_m2m_100_build_engine_integration.py
+++ b/tests/e2e/models/m2m_100/test_m2m_100_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py
+++ b/tests/e2e/models/modernbert/test_modernbert_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/olmo2/test_olmo2_build_engine_integration.py
+++ b/tests/e2e/models/olmo2/test_olmo2_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
+++ b/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
@@ -519,6 +519,8 @@ class TestPhi4MultimodalPlugin:
         w_out = weights["w_out"]
         np.testing.assert_allclose(w_out, embedding.T, atol=1e-6)
 
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_selected_fp32_decoder_layer_builds_in_fp16_engine(self, tmp_path):
         from tensorrt_model_connect.families.phi4_multimodal import plugin
 

--- a/tests/e2e/models/qwen/test_perf_parity.py
+++ b/tests/e2e/models/qwen/test_perf_parity.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt, pytest.mark.e2e]
+
 PROJECT_DIR = Path(__file__).resolve().parents[4]
 DEFAULT_ENGINE_DIR = Path("/mnt/storage/tensorrt-model-connect/engines")
 DEFAULT_BINARY = PROJECT_DIR / "build" / "trtmc"

--- a/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
+++ b/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
@@ -11,6 +11,9 @@ Postconditions: Layer type aliases are normalized correctly and branch-specific 
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -291,3 +294,124 @@ def test_get_bundle_config_overrides_normalizes_hybrid_fields():
     assert overrides["mamba_nheads"] == 3
     assert overrides["mamba_head_dim"] == 4
     assert overrides["conv_dim"] == 20
+    assert overrides["vocab_size"] == 5
+    assert overrides["hidden_size"] == 12
+    assert overrides["num_hidden_layers"] == 3
+    assert overrides["num_attention_heads"] == 3
+    assert overrides["num_key_value_heads"] == 1
+    assert overrides["head_dim"] == 4
+    assert overrides["bos_token_id"] == -1
+    assert overrides["eos_token_id"] == -1
+
+
+def test_mock_bundle_serializes_pinned_decoder_and_hybrid_config(tmp_path):
+    """Exercise Qwen3.5's pinned producer contract with mocked engines."""
+    from tensorrt_model_connect.engine_builder import build_bundle
+
+    layer_types = [
+        "full_attention" if (index + 1) % 4 == 0 else "linear_attention"
+        for index in range(32)
+    ]
+    # Qwen/Qwen3.5-9B at c202236235762e1c871ad0ccb60c8ee5ba337b9a.
+    source_config = {
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "image_token_id": 248056,
+        "model_type": "qwen3_5",
+        "text_config": {
+            "eos_token_id": 248044,
+            "head_dim": 256,
+            "hidden_size": 4096,
+            "intermediate_size": 12288,
+            "layer_types": layer_types,
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "linear_value_head_dim": 128,
+            "max_position_embeddings": 262144,
+            "model_type": "qwen3_5_text",
+            "num_attention_heads": 16,
+            "num_hidden_layers": 32,
+            "num_key_value_heads": 4,
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 10000000,
+            },
+            "vocab_size": 248320,
+        },
+    }
+    (tmp_path / "config.json").write_text(
+        json.dumps(source_config),
+        encoding="utf-8",
+    )
+
+    class MockQwen35Plugin:
+        name = "qwen3_5"
+        runtime_strategy = "qwen3_5_hybrid_mamba_attention"
+        requires_tokenizer = False
+
+        @staticmethod
+        def load_weights(_model_dir, _config):
+            return {}
+
+        @staticmethod
+        def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+            return b"MOCK_HYBRID_PLAN"
+
+        @staticmethod
+        def get_bundle_config_overrides(config):
+            return qwen3_5.plugin.get_bundle_config_overrides(config)
+
+    with (
+        patch(
+            "tensorrt_model_connect.engine_builder.find_plugin",
+            return_value=MockQwen35Plugin(),
+        ),
+        patch(
+            "tensorrt_model_connect.engine_builder._get_trt_version",
+            return_value="11.1.0",
+        ),
+        patch(
+            "tensorrt_model_connect.engine_builder._get_gpu_name",
+            return_value="CPU unit mock",
+        ),
+        patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+    ):
+        build_bundle(
+            str(tmp_path),
+            str(tmp_path / "qwen35-9b.bundle"),
+            max_cache_length=256,
+        )
+
+    sections = {
+        section.name: section.data for section in write_bundle.call_args.args[2]
+    }
+    runtime_config = json.loads(sections["config.json"])
+    decoder_config = source_config["text_config"]
+    assert "bos_token_id" not in decoder_config
+    assert runtime_config["text_config"] == decoder_config
+    decoder_contract = {
+        "vocab_size": 248320,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "head_dim": 256,
+        "bos_token_id": -1,
+        "eos_token_id": 248044,
+    }
+    assert all(key not in source_config for key in decoder_contract)
+    assert {key: runtime_config[key] for key in decoder_contract} == decoder_contract
+    assert runtime_config["layer_types"] == [
+        "attention" if layer_type == "full_attention" else "deltanet"
+        for layer_type in layer_types
+    ]
+    assert runtime_config["num_mamba_layers"] == 24
+    assert runtime_config["num_attention_layers"] == 8
+    assert runtime_config["d_inner"] == 4096
+    assert runtime_config["mamba_d_state"] == 128
+    assert runtime_config["mamba_d_conv"] == 4
+    assert runtime_config["mamba_nheads"] == 32
+    assert runtime_config["mamba_head_dim"] == 128
+    assert runtime_config["conv_dim"] == 8192

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-import io
 import importlib
+import io
+import json
 import struct
 
 import numpy as np
@@ -181,6 +182,38 @@ def test_bundle_config_persists_portable_talker_locator() -> None:
 
     assert overrides["omni_talker_model_id"] == "Qwen/Qwen3-Omni-30B-A3B-Instruct"
     assert overrides["omni_talker_model_revision"] == "abc123"
+
+
+def test_bundle_config_materializes_nested_thinker_decoder_contract() -> None:
+    source_config = {
+        "model_type": "qwen3_omni",
+        "thinker_config": {
+            "text_config": {
+                "vocab_size": 32,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 4,
+            }
+        },
+    }
+    config = ModelConfig.from_json(json.dumps(source_config))
+
+    overrides = Qwen3OmniPlugin().get_bundle_config_overrides(config)
+    decoder_contract = {
+        "vocab_size": 32,
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 4,
+    }
+
+    assert all(key not in source_config for key in decoder_contract)
+    assert {key: overrides[key] for key in decoder_contract} == decoder_contract
 
 
 def test_thinker_load_weights_preserves_bf16_storage(monkeypatch, tmp_path) -> None:

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
@@ -9,6 +9,9 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
+
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
     _rand,
@@ -68,6 +71,7 @@ class TestQwenVLPlugin:
             assert f"layer.{i}.w_q" in weights
         assert "final_norm" in weights
         assert "w_out" in weights
+        assert plugin.get_bundle_config_overrides(cfg) is None
 
     def test_qwen3_vl_language_model_prefix(self, tmp_path):
         """Qwen3-VL uses model.language_model.layers.{i} prefix."""
@@ -179,3 +183,124 @@ class TestQwenVLPlugin:
             assert not key.startswith("visual."), f"Vision key leaked: {key}"
             assert not key.startswith("model.visual."), \
                 f"Vision key leaked: {key}"
+
+    def test_qwen3_vl_mock_bundle_serializes_decoder_geometry_at_top_level(
+        self,
+        tmp_path,
+    ):
+        """Exercise the pinned Qwen3-VL producer contract with mocked engines."""
+        from tensorrt_model_connect.engine_builder import build_bundle
+        from tensorrt_model_connect.families.qwen_vl.plugin import (
+            plugin as production_plugin,
+        )
+
+        # Qwen/Qwen3-VL-2B-Instruct at
+        # 89644892e4d85e24eaac8bacfd4f463576704203.
+        source_config = {
+            "architectures": ["Qwen3VLForConditionalGeneration"],
+            "image_token_id": 151655,
+            "model_type": "qwen3_vl",
+            "text_config": {
+                "bos_token_id": 151643,
+                "eos_token_id": 151645,
+                "head_dim": 128,
+                "hidden_size": 2048,
+                "intermediate_size": 6144,
+                "max_position_embeddings": 262144,
+                "model_type": "qwen3_vl_text",
+                "num_attention_heads": 16,
+                "num_hidden_layers": 28,
+                "num_key_value_heads": 8,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 5000000,
+                "vocab_size": 151936,
+            },
+            "vision_config": {
+                "deepstack_visual_indexes": [5, 11, 17],
+                "hidden_size": 1024,
+                "out_hidden_size": 2048,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+            },
+        }
+        _write_config(tmp_path, source_config)
+        (tmp_path / "generation_config.json").write_text(
+            json.dumps(
+                {
+                    "bos_token_id": 151643,
+                    "eos_token_id": [151645, 151643],
+                    "pad_token_id": 151643,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        class MockQwenVLPlugin:
+            name = "qwen_vl"
+            runtime_strategy = "qwen_vl_vision_language"
+            embed_input = True
+            requires_tokenizer = False
+
+            @staticmethod
+            def load_weights(_model_dir, _config):
+                return {}
+
+            @staticmethod
+            def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+                return b"MOCK_DECODER_PLAN"
+
+            @staticmethod
+            def build_vision_engine(_model_dir, _config, _weights, **_kwargs):
+                return b"MOCK_VISION_PLAN"
+
+            @staticmethod
+            def get_vl_config(config):
+                return production_plugin.get_vl_config(config)
+
+            @staticmethod
+            def get_bundle_config_overrides(config):
+                return production_plugin.get_bundle_config_overrides(config)
+
+        with (
+            patch(
+                "tensorrt_model_connect.engine_builder.find_plugin",
+                return_value=MockQwenVLPlugin(),
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_trt_version",
+                return_value="11.1.0",
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="CPU unit mock",
+            ),
+            patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+        ):
+            build_bundle(
+                str(tmp_path),
+                str(tmp_path / "qwen3-vl-2b.bundle"),
+                max_cache_length=256,
+            )
+
+        sections = {
+            section.name: section.data for section in write_bundle.call_args.args[2]
+        }
+        runtime_config = json.loads(sections["config.json"])
+        decoder_config = source_config["text_config"]
+        assert runtime_config["text_config"] == decoder_config
+        decoder_contract = {
+            key: decoder_config[key]
+            for key in (
+                "vocab_size",
+                "hidden_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "head_dim",
+                "bos_token_id",
+            )
+        }
+        assert all(key not in source_config for key in decoder_contract)
+        assert {key: runtime_config[key] for key in decoder_contract} == decoder_contract
+        assert runtime_config["eos_token_id"] == [151645, 151643]

--- a/tests/e2e/models/t5/test_t5_build_engine_integration.py
+++ b/tests/e2e/models/t5/test_t5_build_engine_integration.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
 pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
 
 

--- a/tests/e2e/models/whisper/test_whisper_builder_engine.py
+++ b/tests/e2e/models/whisper/test_whisper_builder_engine.py
@@ -34,6 +34,8 @@ Postconditions: All encoder (enc_layer.*), decoder (layer.*), and cross-attentio
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pytest
 
@@ -118,9 +120,8 @@ def _make_whisper_tp_weights(
 
 
 def _whisper_tp_builder_module():
-    return pytest.importorskip(
-        "tensorrt_model_connect.families.whisper.decoder_tp_builder",
-        reason="TensorRT is required for Whisper TP builder tests",
+    return importlib.import_module(
+        "tensorrt_model_connect.families.whisper.decoder_tp_builder"
     )
 
 

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -108,7 +108,7 @@ def test_impact_publishes_only_the_public_cpu_scope(
         lambda *_args, **_kwargs: {
             "mode": "unit",
             "run_unit_tests": True,
-            "unit_scope": "cli",
+            "unit_scope": "all",
             "changes": [
                 {
                     "classifications": [
@@ -138,14 +138,14 @@ def test_impact_publishes_only_the_public_cpu_scope(
 
     result = runner.impact(None)
 
-    assert result["unit_scope"] == "cli"
+    assert result["unit_scope"] == "all"
     assert github_output.read_text(encoding="utf-8") == (
         "run_unit_tests=true\n"
-        "unit_scope=cli\n"
+        "unit_scope=all\n"
         'python_test_targets=["tests/e2e/models/qwen/test_qwen_native_kv_routing.py"]\n'
     )
     summary = github_summary.read_text(encoding="utf-8")
-    assert "Unit scope: `cli`" in summary
+    assert "Unit scope: `all`" in summary
     assert "src/runtime/config/cli_support.cpp" in summary
 
 
@@ -189,15 +189,22 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert all(job["runs-on"] == "ubuntu-24.04" for job in jobs.values())
     for job_name in ("source-quality", "docs", "ownership-impact", "unit"):
         assert jobs[job_name]["permissions"] == {"contents": "read"}
-    assert jobs["unit"]["if"] == "${{ !cancelled() }}"
-    assert jobs["unit"]["needs"] == "ownership-impact"
+    assert "if" not in jobs["unit"]
+    assert "needs" not in jobs["unit"]
     assert jobs["ownership-impact"]["outputs"]["python_test_targets"] == (
         "${{ steps.impact.outputs.python_test_targets }}"
     )
     unit_steps = {step["name"]: step for step in jobs["unit"]["steps"]}
-    assert unit_steps["Run hardened source-only units"]["env"][
-        "TRTMC_PREMERGE_PYTHON_TEST_TARGETS"
-    ] == "${{ needs.ownership-impact.outputs.python_test_targets }}"
+    assert list(unit_steps) == [
+        "Check out the exact PR merge",
+        "Set up Python",
+        "Run hardened source-only units",
+    ]
+    assert unit_steps["Run hardened source-only units"] == {
+        "name": "Run hardened source-only units",
+        "run": "python3 -m tools.community_ci unit --scope all",
+    }
+    assert all("if" not in step for step in unit_steps.values())
     assert jobs["required"]["needs"] == [
         "source-quality",
         "docs",
@@ -257,7 +264,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
         ("failure", "success", "success", "success", 1),
         ("success", "failure", "success", "success", 1),
         ("success", "skipped", "success", "success", 1),
-        ("success", "success", "failure", "failure", 1),
+        ("success", "success", "failure", "success", 1),
     ],
 )
 def test_public_required_job_fails_closed(
@@ -306,6 +313,7 @@ def test_cpu_image_installs_the_same_pinned_community_requirements() -> None:
     assert "COPY community-ci.txt" in dockerfile
     assert "pip install --requirement /tmp/trtmc-community-ci.txt" in dockerfile
     assert '"libnvinfer11=${TENSORRT_APT_VERSION}"' in dockerfile
+    assert "libcurand-dev-13-3" in dockerfile
     assert "pip install --no-deps" in dockerfile
     assert '"tensorrt_cu13_bindings==${TENSORRT_VERSION}"' in dockerfile
     assert '"tensorrt==${TENSORRT_VERSION}"' not in dockerfile

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1227,7 +1227,7 @@ def test_source_quality_lint_uses_resolved_ci_base_ref() -> None:
 
 
 
-def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
+def test_premerge_unit_stage_runs_all_cpu_tests_without_native_wheel() -> None:
     script = _ci_source("quality.py")
     stage = script.split("def premerge", maxsplit=1)[1].split("def _premerge_scope", maxsplit=1)[0]
     cmake = (REPO_ROOT / "CMakeLists.txt").read_text()
@@ -1240,15 +1240,22 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert '"not gpu and not trt and not e2e and not model_proof_allocator"' in stage
     assert "tests/builder/" in stage
     assert "tests/tools/" in stage
-    assert 'glob("test_*.py")' in script
+    assert "tests/e2e/models" in script
+    assert "python/tensorrt_model_connect/families" in script
+    assert "tests/test_e2e_selection.py" in script
+    assert "tests/e2e/test_diffusion_image_parity_inputs.py" in script
+    assert "tests/e2e/test_error_handling.py" in stage
+    assert '"--ignore-glob=*_e2e.py"' in stage
     assert '"-q"' in stage and '"-x"' in stage
     assert '"--dist=worksteal"' in stage
+    assert '"--import-mode=importlib"' in stage
     assert 'if scope == "community-all"' in stage
     assert "test_distinct_explicit_hf_cache_paths_reach_both_containers" in stage
     assert 'not model_proof_allocator"' in stage
     assert '"-m"' in stage and '"model_proof_allocator"' in stage
     assert '["trtmc", "test_cli_args", "test_config_cli_support"]' in script
-    assert '["trtmc", "trtmc_platform_cpp_tests"]' in script
+    assert '["trtmc", "trtmc_cpu_cpp_tests"]' in script
+    assert '["-L", "cpu"]' in script
     assert '"TRTMC_PREMERGE_UNIT_SCOPE", "all"' in stage
     assert "tests/builder/test_cli.py" in script
     assert 'if scope == "builder"' in script
@@ -1257,7 +1264,6 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert '[build / "trtmc", "version"]' in stage
     assert '[build / "trtmc", "--help"]' in stage
     assert "--stop-on-failure" in stage
-    assert "libtrtmc_model_*.so*" in stage
     assert "-DTRTMC_ENABLE_TRT=OFF" not in stage
     assert "-DTRTMC_BUILD_BACKEND_TRT=OFF" not in stage
     assert "-DTRTMC_ENABLE_TVM_FFI=OFF" not in stage
@@ -1265,10 +1271,13 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert "build_pip_package" not in stage
     assert "trtmc_model_plugins" not in stage
     assert "add_custom_target(trtmc_platform_cpp_tests)" in cmake
+    assert "add_custom_target(trtmc_cpu_cpp_tests)" in cmake
+    assert '"${_trtmc_test_owner_label};${_trtmc_test_resource_label}"' in cmake
     assert "trtmc_add_test(test_model_plugin_loader MODEL_OWNED)" in cmake
     assert "test_c_abi_runtime_regression" not in cmake
     assert (
-        "test_c_abi_runtime_regression|test_c_abi_runtime_regression.cpp|trtmc_model_qwen|_|_"
+        "test_c_abi_runtime_regression|test_c_abi_runtime_regression.cpp|"
+        "trtmc_model_qwen|_|REQUIRES_GPU"
         in qwen_manifest
     )
     assert "MODEL_OWNED\n        ${_trtmc_test_options}" in cmake
@@ -1326,6 +1335,70 @@ def test_builder_unit_scope_runs_python_without_native_build(tmp_path: Path) -> 
     assert not [
         command for command in context.commands if command[0] in {"cmake", "ctest"}
     ]
+
+
+def test_all_unit_scope_isolates_shared_and_family_python_suites(tmp_path: Path) -> None:
+    class RecordingContext:
+        repository = tmp_path
+        env = {
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "TRTMC_PREMERGE_UNIT_SCOPE": "community-all",
+            "TRTMC_UNIT_BUILD_JOBS": "8",
+            "TRTMC_UNIT_TEST_JOBS": "8",
+        }
+
+        def __init__(self) -> None:
+            self.commands: list[list[object]] = []
+
+        def positive_integer(self, value: str, _name: str) -> int:
+            return int(value)
+
+        def run(self, command: list[object], **_kwargs: object) -> subprocess.CompletedProcess:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    context = RecordingContext()
+    UnitTestRunner(context).premerge()
+
+    pytest_commands = [
+        command
+        for command in context.commands
+        if command[:3] == ["python", "-m", "pytest"]
+    ]
+    source_commands = [
+        command
+        for command in pytest_commands
+        if "model_proof_allocator" not in command
+        and "tests/e2e/test_error_handling.py" not in command
+    ]
+    assert len(source_commands) == 2
+    shared, family = source_commands
+    assert all(
+        target in shared for target in ("tests/builder/", "tests/tools/", "tests/e2e_harness/")
+    )
+    assert "tests/e2e/models/" not in shared
+    assert "--ignore-glob=*_e2e.py" not in shared
+    assert all(
+        target in family
+        for target in (
+            "tests/e2e/models/",
+            "python/tensorrt_model_connect/families/",
+            "tests/test_e2e_selection.py",
+            "tests/e2e/test_diffusion_image_parity_inputs.py",
+        )
+    )
+    assert "--ignore-glob=*_e2e.py" in family
+    for command in source_commands:
+        assert "--import-mode=importlib" in command
+        assert "not gpu and not trt and not e2e and not model_proof_allocator" in command
+
+    build_command = next(
+        command for command in context.commands if command[:2] == ["cmake", "--build"]
+    )
+    assert "trtmc_cpu_cpp_tests" in build_command
+    ctest_command = next(command for command in context.commands if command[0] == "ctest")
+    label_index = ctest_command.index("-L")
+    assert ctest_command[label_index : label_index + 2] == ["-L", "cpu"]
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -423,7 +423,7 @@ def test_impact_selects_only_model_a(tmp_path: Path) -> None:
     assert result["fallback_models"] == []
     assert result["matrix"] == {"include": [{"model": "model_a", "selection_kind": "direct"}]}
     assert result["run_unit_tests"] is True
-    assert result["unit_scope"] == "builder"
+    assert result["unit_scope"] == "all"
 
 
 @pytest.mark.parametrize(
@@ -437,7 +437,7 @@ def test_impact_selects_only_model_a(tmp_path: Path) -> None:
         "src/runtime/models/model_a/model_a.cpp",
     ),
 )
-def test_model_owned_change_runs_builder_units(
+def test_model_owned_change_runs_all_cpu_units(
     tmp_path: Path,
     path: str,
 ) -> None:
@@ -451,10 +451,10 @@ def test_model_owned_change_runs_builder_units(
     assert result["affected_models"] == ["model_a"]
     assert result["direct_models"] == ["model_a"]
     assert result["run_unit_tests"] is True
-    assert result["unit_scope"] == "builder"
+    assert result["unit_scope"] == "all"
 
 
-def test_model_owned_deletion_runs_builder_units(tmp_path: Path) -> None:
+def test_model_owned_deletion_runs_all_cpu_units(tmp_path: Path) -> None:
     repo, _ = _make_repo(tmp_path)
     path = "python/tensorrt_model_connect/families/model_a/graph_ops.py"
     _write(repo, path, "# graph implementation\n")
@@ -467,7 +467,7 @@ def test_model_owned_deletion_runs_builder_units(tmp_path: Path) -> None:
     assert result["mode"] == "models"
     assert result["affected_models"] == ["model_a"]
     assert result["run_unit_tests"] is True
-    assert result["unit_scope"] == "builder"
+    assert result["unit_scope"] == "all"
 
 
 def test_mixed_model_and_cli_change_runs_all_units(tmp_path: Path) -> None:
@@ -597,8 +597,8 @@ def test_impact_treats_legal_and_docs_as_no_model_change(tmp_path: Path) -> None
     assert result["mode"] == "none"
     assert result["has_models"] is False
     assert result["matrix"] == {"include": []}
-    assert result["run_unit_tests"] is False
-    assert result["unit_scope"] == "none"
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
 
 
 @pytest.mark.parametrize(
@@ -606,7 +606,7 @@ def test_impact_treats_legal_and_docs_as_no_model_change(tmp_path: Path) -> None
     (
         (
             "website/docs/wiki/Agentic-Quantization-Core-Minimal-Plan.md",
-            "builder",
+            "all",
             "unit_builder",
         ),
         ("tools/ci/README.md", "all", "unit_tests"),
@@ -801,10 +801,10 @@ def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> Non
 @pytest.mark.parametrize(
     "path, expected_scope",
     (
-        ("src/runtime/config/cli_support.cpp", "cli"),
-        ("include/trtmc/config/cli_support.h", "cli"),
-        ("python/tensorrt_model_connect/build_cli.py", "cli"),
-        ("python/tensorrt_model_connect/runtime_config/cli_support.py", "cli"),
+        ("src/runtime/config/cli_support.cpp", "all"),
+        ("include/trtmc/config/cli_support.h", "all"),
+        ("python/tensorrt_model_connect/build_cli.py", "all"),
+        ("python/tensorrt_model_connect/runtime_config/cli_support.py", "all"),
         ("tests/builder/test_cli.py", "all"),
         ("tests/cpp/test_cli_args.cpp", "all"),
         ("tests/tools/test_cli_contract.py", "all"),

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -17,6 +17,11 @@ import json
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 uses the declared tomli dependency.
+    import tomli as tomllib
+
 from tests.e2e_harness.threshold_policy import requires_threshold_sidecar
 
 
@@ -1138,6 +1143,28 @@ def test_top_level_cmake_does_not_hardcode_model_owned_cpp_tests() -> None:
         manifest = RUNTIME_MODELS / model / "MODEL.toml"
         if entry not in manifest.read_text(encoding="utf-8"):
             violations.append((manifest, 0, f"missing model-owned C++ test {entry}"))
+
+    assert not violations, _format_violations(violations)
+
+
+def test_runtime_tests_are_top_level_toml_contracts() -> None:
+    """Keep CMake discovery and selective model-proof discovery identical."""
+    violations = []
+    for manifest in sorted(RUNTIME_MODELS.glob("*/MODEL.toml")):
+        text = manifest.read_text(encoding="utf-8")
+        data = tomllib.loads(text)
+        if re.search(r"(?m)^runtime_tests\s*=", text) and "runtime_tests" not in data:
+            violations.append(
+                (
+                    manifest,
+                    0,
+                    "runtime_tests must be top-level, not nested under a preceding TOML table",
+                )
+            )
+            continue
+        entries = data.get("runtime_tests", [])
+        if not isinstance(entries, list) or not all(isinstance(entry, str) for entry in entries):
+            violations.append((manifest, 0, "runtime_tests must be a top-level string array"))
 
     assert not violations, _format_violations(violations)
 

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -58,14 +58,12 @@ that enters the run-owned container and invokes `pipeline` there.
 
 Opening a pull request or pushing a new commit automatically starts Community
 CPU against GitHub's exact pull-request merge revision. Source quality,
-ownership and impact, and selected source-only units run as separate jobs on
-GitHub-hosted public CPU runners.
-
-Impact analysis also passes directly changed, non-E2E Python test files to the
-unit job. The unit job adds those exact targets to its normal scope, so a
-model-owned CPU test under `tests/e2e/models/` is not hidden merely because the
-normal `builder` scope starts at `tests/builder/`. Pytest still excludes tests
-marked `gpu`, `trt`, or `e2e`; the public runner does not execute GPU inference.
+ownership and impact, and the complete source-only CPU unit suite run as
+separate jobs on GitHub-hosted public CPU runners. The unit job does not wait
+for impact analysis: every PR runs all CPU-safe Python tests and all CTests
+labeled `cpu`, including model-owned mock and contract tests. Pytest still
+excludes tests marked `gpu`, `trt`, or `e2e`; the public runner does not execute
+GPU inference.
 
 The jobs check out only the event's immutable merge SHA with read-only
 repository permission, no persisted checkout credentials, and no secrets.
@@ -106,15 +104,14 @@ the tested merge revision's first parent and the exact tested merge. It emits:
 - directly affected models;
 - representative fallback models for shared-platform changes;
 - the dynamic model matrix;
-- whether source-only units are required and their scope.
+- the non-selective `all` CPU unit scope used by protected premerge.
 
 This is why a model-only change validates that model, while a CI-platform change
 selects a small representative set instead of all models.
 
-Every model-owned change also selects the `builder` unit scope. That scope runs
-the Python `tests/builder/` suite without a native build. CLI-only changes
-select `cli`; changes that need both scopes, or any broad source/tooling change,
-select `all`.
+Every non-empty PR diff emits the `all` CPU unit scope. Community CPU runs that
+same scope unconditionally and in parallel with impact analysis. Impact
+classification remains selective only for the GPU model-proof matrix.
 
 ### 3. Reject cheap failures first
 

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -191,7 +191,18 @@ class UnitTestRunner:
         )
         scope = self.context.env.get("TRTMC_PREMERGE_UNIT_SCOPE", "all")
         python_tests, native_targets, ctest_selector = self._premerge_scope(scope)
-        python_tests.extend(self._selected_python_test_targets(python_tests))
+        if scope in {"all", "community-all"}:
+            self._selected_python_test_targets(
+                [
+                    *python_tests,
+                    "tests/e2e/models/",
+                    "python/tensorrt_model_connect/families/",
+                    "tests/test_e2e_selection.py",
+                    "tests/e2e/test_diffusion_image_parity_inputs.py",
+                ]
+            )
+        else:
+            python_tests.extend(self._selected_python_test_targets(python_tests))
         print(f"Premerge unit scope: {scope}")
 
         selected_wheel = SelectedWheelRuntime.prepare(
@@ -222,6 +233,7 @@ class UnitTestRunner:
             "-n",
             str(test_jobs),
             "--dist=worksteal",
+            "--import-mode=importlib",
             "-p",
             "no:cacheprovider",
             "-m",
@@ -236,13 +248,36 @@ class UnitTestRunner:
                 "--deselect=tests/tools/test_model_proof_runner.py::"
                 "test_distinct_explicit_hf_cache_paths_reach_both_containers"
             )
-        if selected_wheel:
-            pytest.append("--import-mode=importlib")
         self.context.run(
             pytest,
             limit=self.context.env.get("PYTHON_BUILDER_TIMEOUT", "20m"),
             updates=python_environment,
         )
+        if scope in {"all", "community-all"}:
+            self.context.run(
+                [
+                    python,
+                    "-m",
+                    "pytest",
+                    "tests/e2e/models/",
+                    "python/tensorrt_model_connect/families/",
+                    "tests/test_e2e_selection.py",
+                    "tests/e2e/test_diffusion_image_parity_inputs.py",
+                    "-q",
+                    "-x",
+                    "-n",
+                    str(test_jobs),
+                    "--dist=worksteal",
+                    "--import-mode=importlib",
+                    "-p",
+                    "no:cacheprovider",
+                    "-m",
+                    "not gpu and not trt and not e2e and not model_proof_allocator",
+                    "--ignore-glob=*_e2e.py",
+                ],
+                limit=self.context.env.get("PYTHON_BUILDER_TIMEOUT", "20m"),
+                updates=python_environment,
+            )
         if scope in {"all", "community-all"}:
             allocator = [
                 python,
@@ -299,9 +334,6 @@ class UnitTestRunner:
             if scope == "cli":
                 self.context.run([build / "trtmc", "version"], limit="1m")
                 self.context.run([build / "trtmc", "--help"], limit="1m")
-            leaked = next(build.rglob("libtrtmc_model_*.so*"), None)
-            if leaked:
-                raise CiError(f"source-only unit build produced a model plugin: {leaked}")
             self.context.run(
                 [
                     "ctest",
@@ -315,6 +347,26 @@ class UnitTestRunner:
                 ],
                 limit=self.context.env.get("CPP_UNIT_TIMEOUT", "20m"),
             )
+            if scope in {"all", "community-all"}:
+                self.context.run(
+                    [
+                        python,
+                        "-m",
+                        "pytest",
+                        "tests/e2e/test_error_handling.py",
+                        "-q",
+                        "-x",
+                        "-p",
+                        "no:cacheprovider",
+                        "--import-mode=importlib",
+                        "-m",
+                        "not gpu and not trt and not e2e",
+                        "--trtmc-binary",
+                        build / "trtmc",
+                    ],
+                    limit=self.context.env.get("PYTHON_BUILDER_TIMEOUT", "20m"),
+                    updates=python_environment,
+                )
 
     def _premerge_scope(self, scope: str) -> tuple[list[str], list[str], list[str]]:
         if scope == "builder":
@@ -333,16 +385,10 @@ class UnitTestRunner:
                 ["-R", "^(test_cli_args|test_config_cli_support)$"],
             )
         if scope in {"all", "community-all"}:
-            harness_tests = [
-                str(path.relative_to(self.context.repository))
-                for path in sorted(
-                    (self.context.repository / "tests/e2e_harness").glob("test_*.py")
-                )
-            ]
             return (
-                ["tests/builder/", "tests/tools/", *harness_tests],
-                ["trtmc", "trtmc_platform_cpp_tests"],
-                ["-L", "platform"],
+                ["tests/builder/", "tests/tools/", "tests/e2e_harness/"],
+                ["trtmc", "trtmc_cpu_cpp_tests"],
+                ["-L", "cpu"],
             )
         raise CiError(
             "TRTMC_PREMERGE_UNIT_SCOPE must be builder, cli, all, or community-all"

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -1055,6 +1055,10 @@ def calculate_impact(
             }
         )
     direct_affected = set(affected)
+    # CPU unit tests are intentionally not selective. Impact analysis still
+    # owns the model-proof matrix, but every non-empty PR diff frontloads the
+    # complete source-only CPU suite before any selective GPU proof starts.
+    frontload_cpu_units = bool(serialized_changes)
     if (
         affected - set(head_catalog.models)
         or affected.intersection(base_catalog.legacy_shared_runtime)
@@ -1104,8 +1108,8 @@ def calculate_impact(
         matrix_models=matrix_models,
         direct_models=direct_affected,
         fallback_models=fallback_selected,
-        run_unit_tests=unit_scope != "none" or broad_change,
-        unit_scope="all" if broad_change else unit_scope,
+        run_unit_tests=frontload_cpu_units,
+        unit_scope="all" if frontload_cpu_units else "none",
     )
     result["base_revision"] = base_catalog.revision
     result["head_revision"] = head_catalog.revision

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -51,7 +51,7 @@ depending on host-installed binaries.
 
 The local hook intentionally stays lightweight and does not build the CLI or
 run the complete CPU suite. After pushing, the pull request automatically runs
-source quality, ownership analysis, and the selected source-only C++ and Python
+source quality, ownership analysis, and all source-only CPU-safe C++ and Python
 units on GitHub-hosted public CPU runners. The protected suite retains
 the filesystem-specific cache-reflink contract that public runners cannot
 portably execute.
@@ -154,9 +154,9 @@ exact pull-request merge revision. Separate jobs run source quality, ownership
 and impact, and source-only C++ and Python units. No comment or maintainer action
 is required.
 
-For directly changed Python unit tests, impact analysis also passes the exact
-test files to the CPU unit job. This includes non-E2E model-owned tests under
-`tests/e2e/models/`; tests marked `gpu`, `trt`, or `e2e` remain excluded.
+The CPU unit job is intentionally non-selective: every pull request runs all
+CPU-safe Python tests and all CTests labeled `cpu`, including model-owned mock
+and contract tests. Tests marked `gpu`, `trt`, or `e2e` remain excluded.
 
 The test jobs have read-only repository permission and no access to private
 runners, secrets, or GPUs, and every public job uses a GitHub-hosted


### PR DESCRIPTION
## Background

The protected premerge run for #1053 exposed an existing InternVL decoder regression: native generation produced invalid text while the external reference remained correct. #1055 fixed the family-owned bundle metadata, but the follow-up audit found that CPU unit execution itself was still selective:

- model-owned changes normally selected the Python `builder` scope and configured no C++ tests;
- even `all` ran only 40 platform CTests and omitted every model-owned CPU CTest;
- family production changes did not reliably select existing family Python tests unless the test file also changed; and
- docs/legal changes could make the unit job a no-op.

Selective GPU E2E remains appropriate. CPU unit tests are the cheap contract layer and should run before selective model proof on every pull request.

The first two exact-head protected runs of this PR then demonstrated the expanded contract: correcting C++ resource metadata selected LocateAnything and Qwen3-VL model proofs and exposed two more pre-existing nested-config regressions. Their vision and native C++ checks passed, but generation returned invalid repeated tokens because neither family had serialized its nested decoder metadata at bundle scope. At the time of each failure this PR had changed only that family's test metadata, not its builder or runtime implementation. A repo-wide composite-family audit then found the same defect in Qwen3.5 before another GPU run was needed.

## RCCA

### Impact

- The strict JSON parser change in #1012 could pass its shared helper tests while an InternVL composite config silently lost decoder geometry at the Python bundle-to-C++ runtime boundary.
- LocateAnything had the same latent producer defect: its pinned Hugging Face config stores decoder geometry and BOS/EOS only under `text_config`, while its family override serialized none of those fields at the bundle top level.
- Qwen3-VL serialized no nested decoder fields at bundle scope; Qwen3.5 serialized only hybrid/DeltaNet fields and omitted the base decoder contract.
- A production-only family change could merge without running that family's existing Python units or model-owned C++ units.
- Model-proof C++ discovery silently omitted 17 runtime tests in eight families whose `runtime_tests` key was nested under `[validation_profiles]` by TOML section ordering.

### Root Cause

- #1012 correctly changed ordinary JSON lookup from the old whole-text scan to strict top-level object lookup. The defect was not the new parser behavior.
- No unit test covered the complete consumer contract:

  `nested HF text_config -> family-owned bundle config.json top-level fields -> C++ parse_base_config`

- InternVL, LocateAnything, Qwen3-VL, and Qwen3.5 parsed nested decoder fields into their Python `ModelConfig`, but their native runtime consumers only accept those fields at the serialized bundle top level. Their family overrides were absent or incomplete.
- Qwen3-VL also has a multi-EOS generation contract. Its family override must leave EOS ownership to `generation_config.json` so `[151645, 151643]` survives serialization instead of being reduced to one scalar.

- Impact analysis was also deciding whether and how much CPU unit work ran. Ownership and execution capability were conflated: `MODEL_OWNED` CTests were automatically excluded from the platform CPU aggregate.
- Python's `all` baseline did not include the model/family test roots, and Community impact analysis had no coverage map from which to infer production-to-test ownership.

### Why Existing CI Missed It

- #1012 received broad unit scope and ran `test_json_helpers`; those tests correctly proved strict parser behavior but had no real composite-config consumer.
- Existing InternVL C++ tests constructed config objects or flat JSON directly, bypassing the Python serialization boundary.
- Existing LocateAnything Python tests validated weight loading and vision metadata, while its C++ test constructed the GPU pipeline. Neither side exercised the serialized producer-to-consumer boundary.
- Existing Qwen3-VL tests covered weights, vision, prompts, and registry routing; the Qwen3.5 override test covered only hybrid fields. Neither ran real bundle assembly into `parse_base_config()`.
- #1055's direct family override assertion was selected because that PR changed the test itself. It did not make future production-only changes run the complete family unit inventory.
- CMake assigned one mutually exclusive label for ownership or GPU capability, so model-owned CPU tests never entered `trtmc_platform_cpp_tests`.

### Correction And Prevention

- Keep the strict shared JSON parser unchanged and lock its top-level lookup semantics with model-agnostic C++ tests.
- Add an InternVL-owned mock packaging test that runs the real `build_bundle()` path and production family overrides, captures the final `config.json`, and verifies all decoder fields are top-level.
- Add an InternVL-owned C++ consumer test that parses that runtime shape through `parse_base_config()` without a GPU.
- Materialize LocateAnything decoder geometry and BOS/EOS in its family-owned bundle override, and add the same real-`build_bundle()` mock producer plus CPU C++ consumer contracts using the pinned model's config shape.
- Materialize Qwen3-VL geometry and BOS only for the nested Qwen3 variant while preserving its generic multi-EOS generation config; add matching producer and consumer contracts.
- Extend Qwen3.5's existing hybrid override with decoder geometry and EOS, and add matching producer and consumer contracts. Qwen3-Omni already had correct nested materialization; strengthen its direct nested-config unit and correct its stale parser documentation.
- Make Community CPU units unconditional and parallel with impact analysis; make protected premerge emit `unit_scope=all` for every non-empty diff.
- Separate CTest ownership labels (`model`/`platform`) from resource labels (`cpu`/`gpu`) and build the new `trtmc_cpu_cpp_tests` aggregate.

## Exit Criteria

- Every pull request runs all Python tests admitted by the CPU marker contract and every CTest declared `cpu`.
- GPU model proof and full-model E2E remain selective.
- A regression at the InternVL, LocateAnything, Qwen3-VL, or Qwen3.5 nested-config producer/consumer boundary fails in Community CPU without model weights or a GPU.
- Test assertions and pass thresholds remain unchanged; only resource metadata and mock isolation are corrected.

## Implementation

### CPU Unit Policy

- Run Community CPU `all` scope unconditionally instead of reading an impact-selected unit scope.
- Emit `run_unit_tests=true` and `unit_scope=all` for every non-empty protected-premerge diff while preserving the selective model matrix.
- Run shared builder/tools/harness tests and model/family tests in separate pytest processes to prevent lazy-family module state from leaking across suites.
- Add the two orphan CPU contract files and run eight native CLI error-path tests after the `trtmc` binary is built.

### C++ Inventory

- Add orthogonal owner/resource CTest labels and `trtmc_cpu_cpp_tests`.
- Correct 38 stale GPU declarations found by running the aggregate in the no-GPU Community container.
- Move `runtime_tests` back to the TOML top level in eight manifests and add a static schema contract so CMake and model proof see the same tests.
- Add the CURAND development header required to compile model DSOs used by CPU tests.

### Python Test Hygiene

- Add precise `gpu`/`trt` markers only to tests that create real TensorRT/CUDA execution state.
- Keep SANA-WM orchestration tests in the CPU lane by supplying a fake native-plugin artifact instead of compiling one during pytest.
- Make Whisper cleanup safe for partial initialization and make its TP builder import independent of lazy package initialization.

### Nested JSON Contracts

- Keep shared JSON lookup strict and model-agnostic.
- Make InternVL, LocateAnything, Qwen3-VL, and Qwen3.5 explicitly materialize their nested decoder contracts in family-owned overrides.
- Exercise each producer through real bundle assembly with engine/GPU work mocked, then exercise the serialized shape through production `parse_base_config()` in a model-owned CPU CTest.
- Preserve Qwen3-VL's two-token EOS list from `generation_config.json`; leave flat Qwen2.5-VL behavior unchanged.

### Change Categories

- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] CI or developer tooling
- [x] Tests and test metadata
- [x] Documentation

## Validation

### Commands and Results

- `python3 -m tools.community_ci unit --scope all`: passed in the hardened, network-disabled, GPU-free Community container.
  - shared Python: `3637 passed, 2 skipped`;
  - model/family Python: `2622 passed, 21 skipped`;
  - allocator: `20 passed, 142 deselected`;
  - C++: `133/133` passed (`93 model`, `40 platform`);
  - native CLI error paths: `8 passed, 221 deselected`.
- `python3 -m tools.community_ci source-quality --base github/main`: passed complexity, changed-file lint/formatting, and `159` architecture contracts.
- Focused impact/workflow/InternVL/test-hygiene pytest suite: `433 passed, 3 skipped`.
- GPU-free focused FLUX host-contract build and CTest: `1/1` passed after splitting GPU construction cases from host-only assertions.
- LocateAnything family producer tests: `5 passed`; its focused CPU C++ consumer CTest: `1/1` passed with labels `cpu;model`.
- Qwen3-VL and Qwen3.5 producer files: `9 passed`; Qwen3-Omni nested override file: `13 passed`; both new focused CPU C++ consumer CTests passed with labels `cpu;model`.
- `python3 tools/model_ci.py validate --revision HEAD`: passed for `84` families at `61fa980c863e9bf13abe77bbd40be9917684e58e`.
- `python3 tools/test_impact.py --validate`: passed with the repository's existing warnings (`221` models, `12` core, `84` families).
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `python3 tools/check_doc_file_references.py --strict`: passed.
- Ruff, clang-format dry-run, and `git diff --check`: passed.
- Exact-head public `Community CPU / Required` and the sanitized protected premerge status: passed at `61fa980c863e9bf13abe77bbd40be9917684e58e`.

### Hardware, Environment, and Revisions

- Validation used the pinned Linux aarch64 Community image with CPU-only PyTorch, TensorRT/CUDA SDK headers for compilation, no GPU device, and no network during test execution.
- Source head: `61fa980c863e9bf13abe77bbd40be9917684e58e`, based directly on `github/main@6464865960019301a2728196ee4ebddf5f90ba1f`.

### Not Run / Remaining Gaps

- GPU E2E/model proof was not run locally because no GPU device is available in the local validation environment. The exact remote head passed public Community CPU and the sanitized protected premerge status.
- A few C++ binaries mix host-only assertions with real GPU cases and therefore remain declared GPU as a whole. Splitting those binaries can frontload additional host assertions later; this PR does not claim every assertion inside a mixed GPU binary.

## Notes For Future Readers

- Review `tools/ci/quality.py` and `CMakeLists.txt` first for the execution contract, then the InternVL, LocateAnything, Qwen3-VL, and Qwen3.5 Python/C++ tests for the incident-specific mitigation.
- Do not reintroduce CPU unit selection into impact analysis. Impact remains responsible for the selective GPU model matrix.
- The two ordinary Python suites intentionally use separate processes; combining them reintroduces lazy-family module state pollution.
- Shared JSON parsing remains strict and model-agnostic. Composite-config materialization remains family-owned.
- LocateAnything and Qwen3-VL are included because this PR's corrected model selection exposed their latent producer/consumer defects before the gate could pass; the repo-wide audit found Qwen3.5 by the same static signature. None of these fixes restores the rejected shared canonicalization workaround.

### Risk Level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the change broadens required CPU execution and corrects resource metadata across the repository, but does not change public APIs, ABI, artifact formats, model thresholds, or GPU E2E selection. The final hardened all-scope run passed on the exact local diff.
