### PR TITLE
ci: relay protected failures as text logs

### DIFF
--- a/.github/workflows/internal-ci-failure-log.yml
+++ b/.github/workflows/internal-ci-failure-log.yml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: TRTMC Internal CI Failure Log
+
+run-name: >-
+  PR #${{ github.event.client_payload.report.pr_number }} · public failure log
+
+on:
+  repository_dispatch:
+    types: [trtmc-public-failure-v1]
+
+permissions: {}
+
+concurrency:
+  group: >-
+    trtmc-public-failure-${{ github.event.client_payload.report.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish public-failure.log
+    if: github.repository == 'NVIDIA/TensorRT-Model-Connect'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+
+    steps:
+      # repository_dispatch always executes the workflow from the default
+      # branch. Contributor code is never checked out or executed here.
+      - name: Check out trusted failure-report tooling
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+
+      - name: Validate payload and render public-failure.log
+        id: render
+        env:
+          PUBLIC_FAILURE_LOG: ${{ runner.temp }}/public-failure.log
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from tools.public_failure.contract import validate_public_failure
+          from tools.public_failure.render import render_failure_report
+          from tools.public_failure.safety import assert_public_payload_safe
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          payload = event.get("client_payload")
+          if not isinstance(payload, dict) or set(payload) != {"report"}:
+              raise SystemExit("client_payload must contain only report")
+          report = payload["report"]
+          validate_public_failure(report)
+          document = render_failure_report(report)
+          assert_public_payload_safe(report, document)
+          Path(os.environ["PUBLIC_FAILURE_LOG"]).write_bytes(document)
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"head_sha={report['head_sha']}\n")
+              output.write(f"pr_number={report['pr_number']}\n")
+          print(document.decode("utf-8"), end="")
+          PY
+
+      - name: Confirm the exact open pull-request head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.render.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.render.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -er '.state' <<<"$pull")" = "open"
+          test "$(jq -er '.base.repo.full_name' <<<"$pull")" = "$GITHUB_REPOSITORY"
+          test "$(jq -er '.base.ref' <<<"$pull")" = "main"
+          test "$(jq -er '.head.sha' <<<"$pull")" = "$HEAD_SHA"
+
+      - name: Upload public-failure.log
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: public-failure-log
+          path: ${{ runner.temp }}/public-failure.log
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish the automated failure status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.render.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.render.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=failure \
+            -f context="TRTMC Internal CI / Automated premerge gate" \
+            -f description="Automated internal CI failed; open the public failure log" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/internal-ci-failure-log.yml
+++ b/.github/workflows/internal-ci-failure-log.yml
@@ -62,7 +62,6 @@ jobs:
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               output.write(f"head_sha={report['head_sha']}\n")
               output.write(f"pr_number={report['pr_number']}\n")
-          print(document.decode("utf-8"), end="")
           PY
 
       - name: Confirm the exact open pull-request head
@@ -77,6 +76,9 @@ jobs:
           test "$(jq -er '.base.repo.full_name' <<<"$pull")" = "$GITHUB_REPOSITORY"
           test "$(jq -er '.base.ref' <<<"$pull")" = "main"
           test "$(jq -er '.head.sha' <<<"$pull")" = "$HEAD_SHA"
+
+      - name: Print public-failure.log
+        run: cat "${{ runner.temp }}/public-failure.log"
 
       - name: Upload public-failure.log
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -231,6 +231,7 @@ def test_source_workflow_inventory_does_not_repeat_premerge_after_merge() -> Non
     assert sorted(path.name for path in workflow_files) == [
         "community-cpu.yml",
         "internal-ci-bridge.yml",
+        "internal-ci-failure-log.yml",
         "pages.yml",
         "pr-metadata.yml",
     ]

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -223,6 +223,51 @@ def test_unknown_internal_values_become_fixed_placeholders_without_leaking() -> 
     assert private_test_id.encode() not in public_bytes
 
 
+def test_metric_failure_without_valid_metric_is_withheld_as_unknown() -> None:
+    failure = _comparison_failure()
+    failure["metric"] = {"name": "private_metric", "observed": "invalid"}
+    failure["excerpt"] = ["E   comparison failed"]
+
+    report = export_failure({"failures": [failure]}, _context())
+
+    validate_public_failure(report)
+    assert report["failures"][0]["reason_code"] == "unknown"
+    assert report["failures"][0]["disclosure"] == "withheld"
+    assert "metric" not in report["failures"][0]
+    assert "excerpt" not in report["failures"][0]
+
+
+def test_unknown_reason_never_exports_an_excerpt() -> None:
+    failure = _build_failure(test_id="tests/e2e/test_build.py::test_build")
+    failure["reason_code"] = "private_failure_reason"
+    failure["excerpt"] = ["E   safe-looking but unclassified failure detail"]
+
+    report = export_failure({"failures": [failure]}, _context())
+
+    validate_public_failure(report)
+    assert report["failures"][0]["reason_code"] == "unknown"
+    assert report["failures"][0]["disclosure"] == "withheld"
+    assert "excerpt" not in report["failures"][0]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda failure: failure.pop("metric"),
+        lambda failure: failure.update(reason_code="unknown", disclosure="truncated"),
+        lambda failure: failure.update(
+            reason_code="unknown", disclosure="withheld", excerpt=["E   detail"]
+        ),
+    ],
+)
+def test_public_contract_rejects_invalid_reason_disclosure_invariants(mutation) -> None:
+    report = _comparison_report()
+    mutation(report["failures"][0])
+
+    with pytest.raises(PublicFailureValidationError):
+        validate_public_failure(report)
+
+
 def test_json_schema_accepts_the_exported_report_and_is_itself_valid() -> None:
     schema_path = (
         Path(__file__).parents[2] / "tools/public_failure/assets/public-failure-v1.schema.json"
@@ -232,6 +277,27 @@ def test_json_schema_accepts_the_exported_report_and_is_itself_valid() -> None:
 
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(report)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda failure: failure.pop("metric"),
+        lambda failure: failure.update(reason_code="unknown", disclosure="truncated"),
+        lambda failure: failure.update(
+            reason_code="unknown", disclosure="withheld", excerpt=["E   detail"]
+        ),
+    ],
+)
+def test_json_schema_enforces_reason_disclosure_invariants(mutation) -> None:
+    schema_path = (
+        Path(__file__).parents[2] / "tools/public_failure/assets/public-failure-v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    report = _comparison_report()
+    mutation(report["failures"][0])
+
+    assert list(Draft202012Validator(schema).iter_errors(report))
 
 
 def test_renderer_produces_deterministic_plain_text() -> None:
@@ -308,6 +374,16 @@ def test_safety_scan_rejects_an_unredacted_registry_image_reference() -> None:
 
     with pytest.raises(PublicFailureSafetyError, match="registry image reference"):
         assert_public_payload_safe(report, document)
+
+
+def test_safety_scan_allows_a_dotted_relative_test_path() -> None:
+    report = export_failure(
+        {"failures": [_build_failure(test_id="docs/schema.json/examples")]},
+        _context(),
+    )
+    document = render_failure_report(report)
+
+    assert_public_payload_safe(report, document)
 
 
 @pytest.mark.parametrize(
@@ -438,6 +514,9 @@ def test_public_failure_relay_uses_the_existing_status_context() -> None:
     assert workflow.count("TRTMC Internal CI / Automated premerge gate") == 1
     assert "actions/runs/$GITHUB_RUN_ID" in workflow
     assert "pulls/$PR_NUMBER" in workflow
+    assert workflow.index("- name: Confirm the exact open pull-request head") < workflow.index(
+        "- name: Print public-failure.log"
+    )
 
 
 def test_poison_scan_rejects_sensitive_text_even_when_schema_allows_the_characters() -> None:
@@ -487,6 +566,8 @@ def test_local_cli_writes_preview_files_without_publishing(tmp_path: Path) -> No
         encoding="utf-8",
     )
     context_path.write_text(json.dumps(asdict(_context())), encoding="utf-8")
+    output_dir.mkdir()
+    (output_dir / "report.html").write_text("stale legacy output", encoding="utf-8")
 
     exit_code = public_failure_main(
         [

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -85,7 +85,7 @@ def test_export_failure_rebuilds_a_public_result_from_approved_fields() -> None:
 
     assert report == {
         "schema_version": 1,
-        "policy_version": "2026-08-26",
+        "policy_version": "2026-08-27",
         "report_id": f"trtmc-pr123-{HEAD_SHA[:7]}-attempt1",
         "repository": "NVIDIA/TensorRT-Model-Connect",
         "pr_number": 123,
@@ -234,7 +234,7 @@ def test_json_schema_accepts_the_exported_report_and_is_itself_valid() -> None:
     Draft202012Validator(schema).validate(report)
 
 
-def test_renderer_produces_deterministic_self_contained_html() -> None:
+def test_renderer_produces_deterministic_plain_text() -> None:
     report = _comparison_report()
 
     first = render_failure_report(report)
@@ -242,24 +242,202 @@ def test_renderer_produces_deterministic_self_contained_html() -> None:
 
     assert first == second
     document = first.decode("utf-8")
-    assert "TRTMC Protected CI failure report" in document
+    assert "TRTMC Protected CI failure" in document
     assert "patchtsmixer" in document
     assert "max_relative_l2" in document
     assert "0.021" in document
-    assert "&lt;=" in document
-    assert "default-src 'none'" in document
-    assert '<span class="status">FAILED</span>' in document
-    assert '<table class="run-meta">' in document
-    assert '<table class="failure-table">' in document
+    assert "Requirement: <= 0.01" in document
+    assert "Status: FAILED" in document
     lowered = document.lower()
-    assert 'class="banner"' not in lowered
-    assert 'class="card"' not in lowered
-    assert 'class="eyebrow"' not in lowered
-    assert "<script" not in lowered
-    assert "<link" not in lowered
-    assert "<img" not in lowered
+    assert "<!doctype" not in lowered
+    assert "<html" not in lowered
     assert "http://" not in lowered
     assert "https://" not in lowered
+
+
+def test_renderer_includes_a_bounded_sanitized_failed_step_tail() -> None:
+    failure = _comparison_failure()
+    failure["excerpt"] = [
+        "E   AssertionError: output mismatch",
+        "FAILED tests/e2e/models/patchtsmixer/test_e2e.py::test_forecast",
+    ]
+    report = export_failure({"failures": [failure]}, _context())
+
+    validate_public_failure(report)
+    document = render_failure_report(report).decode("utf-8")
+
+    assert report["failures"][0]["disclosure"] == "truncated"
+    assert "Sanitized failed-step excerpt (tail):" in document
+    assert "E   AssertionError: output mismatch" in document
+    assert "FAILED tests/e2e/models/patchtsmixer/test_e2e.py::test_forecast" in document
+
+
+@pytest.mark.parametrize(
+    "excerpt",
+    [
+        [],
+        ["x"] * 21,
+        ["line with\nnewline"],
+        ["x" * 241],
+        ["x" * 201] * 20,
+    ],
+)
+def test_public_contract_rejects_invalid_excerpts(excerpt: list[str]) -> None:
+    report = _comparison_report()
+    report["failures"][0]["excerpt"] = excerpt
+
+    with pytest.raises(PublicFailureValidationError):
+        validate_public_failure(report)
+
+
+def test_safety_scan_rejects_a_sensitive_excerpt() -> None:
+    failure = _comparison_failure()
+    failure["excerpt"] = ["request failed at https://runner.internal/log"]
+    report = export_failure({"failures": [failure]}, _context())
+    document = render_failure_report(report)
+
+    with pytest.raises(PublicFailureSafetyError, match="URL"):
+        assert_public_payload_safe(report, document)
+
+
+def test_safety_scan_rejects_an_unredacted_registry_image_reference() -> None:
+    failure = _comparison_failure()
+    failure["excerpt"] = ["pull nvcr.io/private/image:build failed"]
+    report = export_failure({"failures": [failure]}, _context())
+    document = render_failure_report(report)
+
+    with pytest.raises(PublicFailureSafetyError, match="registry image reference"):
+        assert_public_payload_safe(report, document)
+
+
+@pytest.mark.parametrize(
+    ("internal_failure", "expected_lines"),
+    [
+        (
+            {
+                "failure_type": "unit_fail",
+                "stage": "unit",
+                "test_id": "tests/tools/test_public_failure.py::collection",
+                "reason_code": "python_dependency_missing",
+                "subject": "jsonschema",
+            },
+            (
+                "Cause: A required Python dependency is unavailable.",
+                "Subject: jsonschema",
+                "Test: tests/tools/test_public_failure.py::collection",
+            ),
+        ),
+        (
+            {
+                "failure_type": "legal_fail",
+                "stage": "legal",
+                "test_id": "bindings/nodejs/example.js",
+                "reason_code": "spdx_preamble_invalid",
+            },
+            (
+                "Cause: An SPDX directive is outside the approved file preamble.",
+                "Test: bindings/nodejs/example.js",
+            ),
+        ),
+        (
+            {
+                "failure_type": "source_quality_fail",
+                "stage": "source-quality",
+                "test_id": "cpp/src/example.cpp:42",
+                "reason_code": "source_formatting_failed",
+            },
+            (
+                "Cause: Source formatting validation failed.",
+                "Test: cpp/src/example.cpp:42",
+            ),
+        ),
+        (
+            {
+                "failure_type": "infrastructure_error",
+                "stage": "runtime-control",
+                "test_id": "runtime-catalog",
+                "reason_code": "runtime_catalog_miss",
+            },
+            (
+                "Cause: No qualified runtime exists for this exact Source revision.",
+                "Test: runtime-catalog",
+            ),
+        ),
+        (
+            {
+                "failure_type": "compare_fail",
+                "stage": "model-proof",
+                "model": "internvl3-2b",
+                "test_id": "internvl3-2b::full_generation",
+                "reason_code": "model_output_mismatch",
+            },
+            (
+                "Cause: Model output did not match the required reference.",
+                "Test: internvl3-2b::full_generation",
+            ),
+        ),
+        (
+            {
+                "failure_type": "package_fail",
+                "stage": "package",
+                "test_id": "python-wheel::import",
+                "reason_code": "python_package_import_failed",
+                "subject": "tensorrt_model_connect",
+            },
+            (
+                "Cause: The built Python package could not be imported.",
+                "Subject: tensorrt_model_connect",
+            ),
+        ),
+        (
+            {
+                "failure_type": "infrastructure_error",
+                "stage": "model-cache",
+                "test_id": "model-cache",
+                "reason_code": "model_cache_warm_failed",
+            },
+            (
+                "Cause: A required public model cache could not be warmed.",
+                "Test: model-cache",
+            ),
+        ),
+        (
+            {
+                "failure_type": "infrastructure_error",
+                "stage": "model-proof",
+                "test_id": "qwen3_omni::gpu-admission",
+                "reason_code": "gpu_capacity_unavailable",
+            },
+            (
+                "Cause: The protected GPU did not have enough allocatable capacity.",
+                "Test: qwen3_omni::gpu-admission",
+            ),
+        ),
+    ],
+)
+def test_real_internal_ci_failure_classes_render_actionable_text(
+    internal_failure: dict[str, object], expected_lines: tuple[str, ...]
+) -> None:
+    artifacts = build_failure_artifacts({"failures": [internal_failure]}, _context())
+    document = artifacts.log_bytes.decode("utf-8")
+
+    for line in expected_lines:
+        assert line in document
+
+
+def test_public_failure_relay_uses_the_existing_status_context() -> None:
+    workflow = (
+        Path(__file__).parents[2] / ".github/workflows/internal-ci-failure-log.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "repository_dispatch:" in workflow
+    assert "types: [trtmc-public-failure-v1]" in workflow
+    assert "Publish public-failure.log" in workflow
+    assert "validate_public_failure(report)" in workflow
+    assert "assert_public_payload_safe(report, document)" in workflow
+    assert workflow.count("TRTMC Internal CI / Automated premerge gate") == 1
+    assert "actions/runs/$GITHUB_RUN_ID" in workflow
+    assert "pulls/$PR_NUMBER" in workflow
 
 
 def test_poison_scan_rejects_sensitive_text_even_when_schema_allows_the_characters() -> None:
@@ -288,8 +466,8 @@ def test_build_failure_artifacts_runs_the_complete_local_pipeline() -> None:
     )
 
     assert json.loads(artifacts.json_bytes) == artifacts.report
-    assert b"TRTMC Protected CI failure report" in artifacts.html_bytes
-    assert b"Raw logs and internal diagnostics are not included" in artifacts.html_bytes
+    assert b"TRTMC Protected CI failure" in artifacts.log_bytes
+    assert b"approved structured fields" in artifacts.log_bytes
 
 
 def test_local_cli_writes_preview_files_without_publishing(tmp_path: Path) -> None:
@@ -323,4 +501,7 @@ def test_local_cli_writes_preview_files_without_publishing(tmp_path: Path) -> No
 
     assert exit_code == 0
     assert json.loads((output_dir / "public-failure.json").read_text())["result"] == "failure"
-    assert "TRTMC Protected CI failure report" in (output_dir / "report.html").read_text()
+    assert "TRTMC Protected CI failure" in (
+        output_dir / "public-failure.log"
+    ).read_text()
+    assert not (output_dir / "report.html").exists()

--- a/tools/public_failure/README.md
+++ b/tools/public_failure/README.md
@@ -1,15 +1,15 @@
 # Protected CI failure report prototype
 
-This package builds a local preview of the limited information that protected
-CI may disclose after a failed run. It is a P0/shadow implementation: no Source
-workflow imports it, and it has no storage, GitHub status, or PR comment client.
+This package builds the limited information that protected CI may disclose
+after a failed run. The same validator and renderer are used by the local CLI
+and the trusted Source relay workflow.
 
 The pipeline is deterministic:
 
 1. `export_failure` constructs a new object from explicitly approved fields.
 2. `validate_public_failure` enforces the closed `public-failure-v1` contract.
-3. `render_failure_report` produces one script-free, self-contained HTML file.
-4. `assert_public_payload_safe` scans the JSON and decoded HTML as a final
+3. `render_failure_report` produces one deterministic UTF-8 text log.
+4. `assert_public_payload_safe` scans the JSON and rendered text as a final
    defense-in-depth check.
 
 Unknown input fields are ignored. Unknown names and unsafe test IDs become
@@ -27,8 +27,9 @@ python3 -m tools.public_failure \
   --output-dir /tmp/trtmc-public-failure-preview
 ```
 
-The command writes `public-failure.json` and `report.html` only to the selected
-local directory. It does not publish either file.
+The command writes `public-failure.json` and `public-failure.log` only to the
+selected local directory. The text log is the user-facing representation; no
+HTML renderer is required. It does not publish either file.
 
 The synthetic input intentionally contains fake internal-looking values. The
 tests prove that adding those unknown fields does not change the serialized
@@ -36,7 +37,8 @@ public output.
 
 ## Integration boundary
 
-A future private-CI finalizer may call `build_failure_artifacts` from a pinned,
-merged Source revision. Upload, anonymous verification, stale-SHA checks,
-required-status updates, and failure-comment upsert belong to that private
-integration and are deliberately absent here.
+The Source relay workflow accepts only the closed report contract, revalidates
+it on the default branch, prints `public-failure.log` into a public Actions log,
+and updates the existing automated status context for the exact PR head. The
+private finalizer must send already structured fields; raw protected logs are
+never accepted by the relay.

--- a/tools/public_failure/__main__.py
+++ b/tools/public_failure/__main__.py
@@ -51,6 +51,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     context = _context_from_object(_load_object(args.context))
     artifacts = build_failure_artifacts(internal, context)
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "report.html").unlink(missing_ok=True)
     (args.output_dir / "public-failure.json").write_bytes(artifacts.json_bytes)
     (args.output_dir / "public-failure.log").write_bytes(artifacts.log_bytes)
     print(f"Local preview written to {args.output_dir}")

--- a/tools/public_failure/__main__.py
+++ b/tools/public_failure/__main__.py
@@ -37,7 +37,7 @@ def _context_from_object(value: Mapping[str, object]) -> ExportContext:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Generate local public-failure-v1 JSON and HTML. Nothing is uploaded."
+        description="Generate local public-failure-v1 JSON and text log. Nothing is uploaded."
     )
     parser.add_argument("--input", type=Path, required=True)
     parser.add_argument("--context", type=Path, required=True)
@@ -52,7 +52,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifacts = build_failure_artifacts(internal, context)
     args.output_dir.mkdir(parents=True, exist_ok=True)
     (args.output_dir / "public-failure.json").write_bytes(artifacts.json_bytes)
-    (args.output_dir / "report.html").write_bytes(artifacts.html_bytes)
+    (args.output_dir / "public-failure.log").write_bytes(artifacts.log_bytes)
     print(f"Local preview written to {args.output_dir}")
     return 0
 

--- a/tools/public_failure/assets/public-failure-v1.schema.json
+++ b/tools/public_failure/assets/public-failure-v1.schema.json
@@ -22,7 +22,7 @@
   ],
   "properties": {
     "schema_version": { "const": 1 },
-    "policy_version": { "const": "2026-08-26" },
+    "policy_version": { "const": "2026-08-27" },
     "report_id": {
       "type": "string",
       "maxLength": 100,
@@ -33,7 +33,7 @@
     "head_sha": { "$ref": "#/$defs/sha" },
     "base_sha": { "$ref": "#/$defs/sha" },
     "tested_revision": { "$ref": "#/$defs/sha" },
-    "tested_revision_kind": { "const": "head" },
+    "tested_revision_kind": { "enum": ["head", "merge"] },
     "run_attempt": { "type": "integer", "minimum": 1, "maximum": 1000 },
     "result": { "enum": ["failure", "error"] },
     "failures": {
@@ -100,6 +100,12 @@
             "determinism",
             "artifact-write",
             "model-proof",
+            "unit",
+            "source-quality",
+            "legal",
+            "package",
+            "runtime-control",
+            "model-cache",
             "protected-ci"
           ]
         },
@@ -137,6 +143,11 @@
             "infrastructure_error",
             "timeout",
             "out_of_memory",
+            "test_failure",
+            "source_quality_error",
+            "legal_error",
+            "package_error",
+            "contract_error",
             "unknown"
           ]
         },
@@ -151,21 +162,39 @@
             "reference_failed",
             "runtime_failed",
             "timed_out",
+            "canonical_document_mismatch",
+            "complexity_limit_exceeded",
+            "model_contract_failed",
+            "model_output_mismatch",
+            "python_dependency_missing",
+            "python_package_import_failed",
+            "runtime_catalog_miss",
+            "runtime_image_pull_timeout",
+            "source_formatting_failed",
+            "source_revision_mismatch",
+            "spdx_preamble_invalid",
+            "test_failed",
+            "github_automation_permission_denied",
+            "gpu_capacity_unavailable",
+            "model_cache_warm_failed",
             "unknown"
           ]
         },
         "metric": { "$ref": "#/$defs/metric" },
+        "subject": { "enum": ["jsonschema", "tensorrt_model_connect"] },
+        "excerpt": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 240,
+            "pattern": "^[ -~]+$"
+          }
+        },
         "disclosure": { "enum": ["full", "truncated", "withheld"] }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": { "disclosure": { "const": "full" } },
-            "required": ["disclosure"]
-          },
-          "then": { "required": ["metric"] }
-        }
-      ]
+      }
     }
   }
 }

--- a/tools/public_failure/assets/public-failure-v1.schema.json
+++ b/tools/public_failure/assets/public-failure-v1.schema.json
@@ -194,7 +194,26 @@
           }
         },
         "disclosure": { "enum": ["full", "truncated", "withheld"] }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "reason_code": { "const": "metric_threshold_exceeded" } },
+            "required": ["reason_code"]
+          },
+          "then": { "required": ["metric"] }
+        },
+        {
+          "if": {
+            "properties": { "reason_code": { "const": "unknown" } },
+            "required": ["reason_code"]
+          },
+          "then": {
+            "properties": { "disclosure": { "const": "withheld" } },
+            "not": { "required": ["excerpt"] }
+          }
+        }
+      ]
     }
   }
 }

--- a/tools/public_failure/build.py
+++ b/tools/public_failure/build.py
@@ -20,7 +20,7 @@ class PublicFailureArtifacts:
 
     report: dict[str, Any]
     json_bytes: bytes
-    html_bytes: bytes
+    log_bytes: bytes
 
 
 def build_failure_artifacts(
@@ -30,10 +30,10 @@ def build_failure_artifacts(
     report = export_failure(internal_artifacts, context)
     validate_public_failure(report)
     json_bytes = serialize_public_failure(report)
-    html_bytes = render_failure_report(report)
-    assert_public_payload_safe(report, html_bytes)
+    log_bytes = render_failure_report(report)
+    assert_public_payload_safe(report, log_bytes)
     return PublicFailureArtifacts(
         report=report,
         json_bytes=json_bytes,
-        html_bytes=html_bytes,
+        log_bytes=log_bytes,
     )

--- a/tools/public_failure/contract.py
+++ b/tools/public_failure/contract.py
@@ -19,6 +19,7 @@ from .policy import (
     PUBLIC_METRIC_OPERATORS,
     PUBLIC_MODELS,
     PUBLIC_REASON_CODES,
+    PUBLIC_SUBJECTS,
     PUBLIC_STAGE_BY_INTERNAL_STAGE,
 )
 
@@ -51,15 +52,18 @@ FAILURE_FIELDS = frozenset(
         "failure_class",
         "reason_code",
         "metric",
+        "subject",
+        "excerpt",
         "disclosure",
     }
 )
 METRIC_FIELDS = frozenset({"name", "observed", "operator", "threshold"})
-FAILURE_REQUIRED_FIELDS = FAILURE_FIELDS - {"metric"}
+FAILURE_REQUIRED_FIELDS = FAILURE_FIELDS - {"metric", "subject", "excerpt"}
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
 REPORT_ID_PATTERN = re.compile(r"trtmc-pr[1-9][0-9]*-[0-9a-f]{7}-attempt[1-9][0-9]*\Z")
 TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\Z")
 TEST_ID_PATTERN = re.compile(r"[A-Za-z0-9_./:\[\],=+-]+\Z")
+EXCERPT_LINE_PATTERN = re.compile(r"[\x20-\x7e]{1,240}\Z")
 PUBLIC_FAILURE_CLASSES = frozenset(FAILURE_CLASS_BY_INTERNAL_TYPE.values()) | {"unknown"}
 PUBLIC_STAGES = frozenset(PUBLIC_STAGE_BY_INTERNAL_STAGE.values()) | {"protected-ci"}
 PUBLIC_MODEL_NAMES = PUBLIC_MODELS | {"other-model"}
@@ -130,6 +134,25 @@ def _validate_failure(failure: Mapping[str, object], index: int) -> None:
     _require_enum(failure.get("gpu_type"), PUBLIC_GPU_NAMES, f"{path}.gpu_type")
     _require_enum(failure.get("failure_class"), PUBLIC_FAILURE_CLASSES, f"{path}.failure_class")
     _require_enum(failure.get("reason_code"), PUBLIC_REASON_CODES, f"{path}.reason_code")
+    if "subject" in failure:
+        _require_enum(failure.get("subject"), PUBLIC_SUBJECTS, f"{path}.subject")
+    if "excerpt" in failure:
+        excerpt = failure.get("excerpt")
+        if not isinstance(excerpt, list) or not excerpt or len(excerpt) > 20:
+            raise PublicFailureValidationError(
+                f"{path}.excerpt must be a non-empty array of at most 20 lines"
+            )
+        if sum(len(line) for line in excerpt if isinstance(line, str)) > 4000:
+            raise PublicFailureValidationError(
+                f"{path}.excerpt must contain at most 4000 characters"
+            )
+        for line_index, line in enumerate(excerpt):
+            _require_string(
+                line,
+                f"{path}.excerpt[{line_index}]",
+                max_length=240,
+                pattern=EXCERPT_LINE_PATTERN,
+            )
     _require_enum(
         failure.get("disclosure"),
         {"full", "truncated", "withheld"},
@@ -144,9 +167,9 @@ def _validate_failure(failure: Mapping[str, object], index: int) -> None:
     if test_id.startswith("/") or ".." in test_id or "\\" in test_id:
         raise PublicFailureValidationError(f"{path}.test_id is not a safe relative test ID")
     metric = failure.get("metric")
+    if failure.get("reason_code") == "unknown" and failure.get("disclosure") == "full":
+        raise PublicFailureValidationError(f"{path} cannot fully disclose an unknown reason")
     if metric is None:
-        if failure.get("disclosure") == "full":
-            raise PublicFailureValidationError(f"{path}.metric is required for full disclosure")
         return
     if not isinstance(metric, Mapping):
         raise PublicFailureValidationError(f"{path}.metric must be an object")
@@ -181,7 +204,7 @@ def validate_public_failure(report: Mapping[str, object]) -> None:
     )
     for key in ("head_sha", "base_sha", "tested_revision"):
         _require_string(report.get(key), key, max_length=40, pattern=SHA_PATTERN)
-    _require_enum(report.get("tested_revision_kind"), {"head"}, "tested_revision_kind")
+    _require_enum(report.get("tested_revision_kind"), {"head", "merge"}, "tested_revision_kind")
     _require_enum(report.get("result"), {"failure", "error"}, "result")
     _require_string(
         report.get("generated_at"),

--- a/tools/public_failure/contract.py
+++ b/tools/public_failure/contract.py
@@ -166,9 +166,15 @@ def _validate_failure(failure: Mapping[str, object], index: int) -> None:
     )
     if test_id.startswith("/") or ".." in test_id or "\\" in test_id:
         raise PublicFailureValidationError(f"{path}.test_id is not a safe relative test ID")
+    reason_code = failure.get("reason_code")
     metric = failure.get("metric")
-    if failure.get("reason_code") == "unknown" and failure.get("disclosure") == "full":
-        raise PublicFailureValidationError(f"{path} cannot fully disclose an unknown reason")
+    if reason_code == "metric_threshold_exceeded" and metric is None:
+        raise PublicFailureValidationError(f"{path} must include metric threshold evidence")
+    if reason_code == "unknown":
+        if failure.get("disclosure") != "withheld":
+            raise PublicFailureValidationError(f"{path} must withhold an unknown reason")
+        if "excerpt" in failure:
+            raise PublicFailureValidationError(f"{path} cannot excerpt an unknown reason")
     if metric is None:
         return
     if not isinstance(metric, Mapping):

--- a/tools/public_failure/export.py
+++ b/tools/public_failure/export.py
@@ -20,11 +20,13 @@ from .policy import (
     public_model,
     public_reason_code,
     public_stage,
+    public_subject,
 )
 
 
 MAX_PUBLIC_FAILURES = 20
 SAFE_TEST_ID_PATTERN = re.compile(r"[A-Za-z0-9_./:\[\],=+-]{1,300}\Z")
+SAFE_EXCERPT_LINE_PATTERN = re.compile(r"[\x20-\x7e]{1,240}\Z")
 
 
 @dataclass(frozen=True)
@@ -74,8 +76,24 @@ def _export_test_id(value: object) -> str:
     return value
 
 
+def _export_excerpt(value: object) -> list[str] | None:
+    if not isinstance(value, list) or not value or len(value) > 20:
+        return None
+    lines: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or SAFE_EXCERPT_LINE_PATTERN.fullmatch(item) is None:
+            return None
+        lines.append(item)
+    if sum(len(line) for line in lines) > 4000:
+        return None
+    return lines
+
+
 def _export_one_failure(value: Mapping[str, object]) -> dict[str, Any]:
     metric = _export_metric(value.get("metric"))
+    reason_code = public_reason_code(value.get("reason_code"))
+    subject = public_subject(value.get("subject"))
+    excerpt = _export_excerpt(value.get("excerpt"))
     public = {
         "public_stage": public_stage(value.get("stage")),
         "model": public_model(value.get("model")),
@@ -83,11 +101,21 @@ def _export_one_failure(value: Mapping[str, object]) -> dict[str, Any]:
         "gpu_type": public_gpu_type(value.get("gpu_type")),
         "test_id": _export_test_id(value.get("test_id")),
         "failure_class": public_failure_class(value.get("failure_type")),
-        "reason_code": public_reason_code(value.get("reason_code")),
-        "disclosure": "full" if metric is not None else "withheld",
+        "reason_code": reason_code,
+        "disclosure": (
+            "truncated"
+            if excerpt is not None
+            else "full"
+            if reason_code != "unknown"
+            else "withheld"
+        ),
     }
     if metric is not None:
         public["metric"] = metric
+    if subject is not None:
+        public["subject"] = subject
+    if excerpt is not None:
+        public["excerpt"] = excerpt
     return public
 
 

--- a/tools/public_failure/export.py
+++ b/tools/public_failure/export.py
@@ -94,6 +94,12 @@ def _export_one_failure(value: Mapping[str, object]) -> dict[str, Any]:
     reason_code = public_reason_code(value.get("reason_code"))
     subject = public_subject(value.get("subject"))
     excerpt = _export_excerpt(value.get("excerpt"))
+    if reason_code == "metric_threshold_exceeded" and metric is None:
+        reason_code = "unknown"
+    if reason_code == "unknown":
+        metric = None
+        subject = None
+        excerpt = None
     public = {
         "public_stage": public_stage(value.get("stage")),
         "model": public_model(value.get("model")),
@@ -102,13 +108,11 @@ def _export_one_failure(value: Mapping[str, object]) -> dict[str, Any]:
         "test_id": _export_test_id(value.get("test_id")),
         "failure_class": public_failure_class(value.get("failure_type")),
         "reason_code": reason_code,
-        "disclosure": (
-            "truncated"
-            if excerpt is not None
-            else "full"
-            if reason_code != "unknown"
-            else "withheld"
-        ),
+        "disclosure": "withheld"
+        if reason_code == "unknown"
+        else "truncated"
+        if excerpt is not None
+        else "full",
     }
     if metric is not None:
         public["metric"] = metric

--- a/tools/public_failure/policy.py
+++ b/tools/public_failure/policy.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Final
 
 
-POLICY_VERSION: Final = "2026-08-26"
+POLICY_VERSION: Final = "2026-08-27"
 
 FAILURE_CLASS_BY_INTERNAL_TYPE: Final = {
     "compare_fail": "accuracy_regression",
@@ -20,6 +20,11 @@ FAILURE_CLASS_BY_INTERNAL_TYPE: Final = {
     "infrastructure_error": "infrastructure_error",
     "timeout": "timeout",
     "out_of_memory": "out_of_memory",
+    "unit_fail": "test_failure",
+    "source_quality_fail": "source_quality_error",
+    "legal_fail": "legal_error",
+    "package_fail": "package_error",
+    "contract_fail": "contract_error",
 }
 
 PUBLIC_STAGE_BY_INTERNAL_STAGE: Final = {
@@ -31,6 +36,12 @@ PUBLIC_STAGE_BY_INTERNAL_STAGE: Final = {
     "determinism": "determinism",
     "artifact_write": "artifact-write",
     "model-proof": "model-proof",
+    "unit": "unit",
+    "source-quality": "source-quality",
+    "legal": "legal",
+    "package": "package",
+    "runtime-control": "runtime-control",
+    "model-cache": "model-cache",
 }
 
 # This intentionally starts small. Adding a value is a disclosure-policy change.
@@ -60,8 +71,25 @@ PUBLIC_REASON_CODES: Final = frozenset(
         "runtime_failed",
         "timed_out",
         "unknown",
+        "canonical_document_mismatch",
+        "complexity_limit_exceeded",
+        "model_contract_failed",
+        "model_output_mismatch",
+        "python_dependency_missing",
+        "python_package_import_failed",
+        "runtime_catalog_miss",
+        "runtime_image_pull_timeout",
+        "source_formatting_failed",
+        "source_revision_mismatch",
+        "spdx_preamble_invalid",
+        "test_failed",
+        "github_automation_permission_denied",
+        "gpu_capacity_unavailable",
+        "model_cache_warm_failed",
     }
 )
+
+PUBLIC_SUBJECTS: Final = frozenset({"jsonschema", "tensorrt_model_connect"})
 
 PUBLIC_METRIC_NAMES: Final = frozenset(
     {
@@ -101,3 +129,8 @@ def public_gpu_type(value: object) -> str:
 def public_reason_code(value: object) -> str:
     candidate = str(value)
     return candidate if candidate in PUBLIC_REASON_CODES else "unknown"
+
+
+def public_subject(value: object) -> str | None:
+    candidate = str(value)
+    return candidate if candidate in PUBLIC_SUBJECTS else None

--- a/tools/public_failure/render.py
+++ b/tools/public_failure/render.py
@@ -1,157 +1,121 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Render validated public-failure-v1 data as one self-contained HTML file."""
+"""Render validated public-failure-v1 data as deterministic plain text."""
 
 from __future__ import annotations
 
-import html
 from typing import Mapping
 
 from .contract import validate_public_failure
 
 
-STYLES = """
-:root { color-scheme: light; font-family: Arial, Helvetica, sans-serif; }
-* { box-sizing: border-box; }
-body { margin: 0; color: #202020; background: #fff; font-size: 14px; line-height: 1.45; }
-main { width: min(1120px, calc(100% - 40px)); margin: 0 auto; padding: 32px 0; }
-.report-header { padding: 18px 0 16px; border-top: 5px solid #c62828;
-  border-bottom: 1px solid #8c8c8c; }
-.product { margin: 0 0 7px; color: #555; font-size: 12px; font-weight: 700;
-  letter-spacing: .06em; text-transform: uppercase; }
-.title-row { display: flex; gap: 18px; align-items: center; justify-content: space-between; }
-h1 { margin: 0; font-size: 27px; font-weight: 600; line-height: 1.2; }
-.status { display: inline-block; padding: 5px 10px; border: 1px solid #9f1f1f;
-  color: #8f1818; background: #fff; font-size: 12px; font-weight: 700;
-  letter-spacing: .06em; }
-.notice { margin: 18px 0; padding: 10px 12px; border-left: 3px solid #686868;
-  color: #4d4d4d; background: #f5f5f5; }
-h2 { margin: 26px 0 8px; font-size: 17px; font-weight: 600; }
-table { width: 100%; border-collapse: collapse; }
-.run-meta { border-top: 1px solid #b4b4b4; }
-.run-meta th, .run-meta td { padding: 8px 10px; border-bottom: 1px solid #d4d4d4;
-  text-align: left; vertical-align: top; }
-.run-meta th { width: 180px; color: #4b4b4b; background: #f3f3f3; font-weight: 600; }
-.table-wrap { width: 100%; overflow-x: auto; border-top: 2px solid #555; }
-.failure-table { min-width: 900px; }
-.failure-table th, .failure-table td { padding: 9px 10px; border-right: 1px solid #d4d4d4;
-  border-bottom: 1px solid #bdbdbd; text-align: left; vertical-align: top; }
-.failure-table th:last-child, .failure-table td:last-child { border-right: 0; }
-.failure-table th { color: #333; background: #ededed; font-size: 12px; font-weight: 700; }
-.failure-table tbody tr:nth-child(even) { background: #fafafa; }
-.failure-index { width: 44px; text-align: center !important; }
-.classification { width: 185px; }
-.location { width: 175px; }
-.test-id { min-width: 270px; overflow-wrap: anywhere; }
-.evidence { min-width: 220px; }
-.secondary { display: block; margin-top: 3px; color: #5f5f5f; font-size: 12px; }
-.withheld { color: #5f5f5f; font-style: italic; }
-.omitted { margin: 9px 0 0; color: #555; }
-footer { margin-top: 28px; padding-top: 10px; border-top: 1px solid #aaa;
-  color: #555; font-size: 12px; }
-code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
-@media (max-width: 600px) {
-  main { width: min(100% - 24px, 1120px); padding-top: 18px; }
-  .title-row { display: block; }
-  .status { margin-top: 12px; }
-  .run-meta th { width: 120px; }
+REASON_SUMMARIES = {
+    "artifact_write_failed": "The test harness could not write its result artifact.",
+    "build_failed": "The tested source failed to build.",
+    "canonical_document_mismatch": "A canonical repository document does not match policy.",
+    "complexity_limit_exceeded": "Source complexity exceeds the configured limit.",
+    "determinism_check_failed": "The determinism check failed.",
+    "github_automation_permission_denied": "GitHub Actions is not allowed to create the required pull request.",
+    "gpu_capacity_unavailable": "The protected GPU did not have enough allocatable capacity.",
+    "infrastructure_failed": "Protected CI infrastructure failed.",
+    "metric_threshold_exceeded": "A correctness metric exceeded its allowed threshold.",
+    "model_contract_failed": "A model-specific regression contract failed.",
+    "model_cache_warm_failed": "A required public model cache could not be warmed.",
+    "model_output_mismatch": "Model output did not match the required reference.",
+    "out_of_memory": "The test ran out of memory.",
+    "python_dependency_missing": "A required Python dependency is unavailable.",
+    "python_package_import_failed": "The built Python package could not be imported.",
+    "reference_failed": "The reference implementation failed.",
+    "runtime_catalog_miss": "No qualified runtime exists for this exact Source revision.",
+    "runtime_failed": "The tested runtime execution failed.",
+    "runtime_image_pull_timeout": "The qualified runtime image could not be fetched in time.",
+    "source_formatting_failed": "Source formatting validation failed.",
+    "source_revision_mismatch": "The selected runtime does not match the tested Source inputs.",
+    "spdx_preamble_invalid": "An SPDX directive is outside the approved file preamble.",
+    "test_failed": "A named test failed.",
+    "timed_out": "The test exceeded its time limit.",
+    "unknown": "No structured failure detail was safe to disclose.",
 }
-""".strip()
-
-
-def _escape(value: object) -> str:
-    return html.escape(str(value), quote=True)
 
 
 def _format_number(value: object) -> str:
     return format(float(value), ".8g")
 
 
-def _failure_row(failure: Mapping[str, object], index: int) -> str:
+def _failure_lines(failure: Mapping[str, object], index: int) -> list[str]:
+    lines = [
+        f"Failure {index}",
+        f"  Class: {failure['failure_class']}",
+        f"  Reason: {failure['reason_code']}",
+        f"  Cause: {REASON_SUMMARIES[str(failure['reason_code'])]}",
+        f"  Stage: {failure['public_stage']}",
+        f"  Model: {failure['model']}",
+        f"  Backend: {failure['backend']}",
+        f"  GPU: {failure['gpu_type']}",
+        f"  Test: {failure['test_id']}",
+    ]
+    if "subject" in failure:
+        lines.append(f"  Subject: {failure['subject']}")
     metric = failure.get("metric")
     if isinstance(metric, Mapping):
-        evidence = (
-            f"<code>{_escape(metric['name'])}</code>"
-            f'<span class="secondary">Observed: {_format_number(metric["observed"])}; '
-            f"Requirement: {_escape(metric['operator'])} "
-            f"{_format_number(metric['threshold'])}</span>"
+        lines.extend(
+            [
+                f"  Metric: {metric['name']}",
+                f"  Observed: {_format_number(metric['observed'])}",
+                (
+                    f"  Requirement: {metric['operator']} "
+                    f"{_format_number(metric['threshold'])}"
+                ),
+            ]
         )
-    else:
-        evidence = '<span class="withheld">Details withheld</span>'
-    return (
-        "<tr>"
-        f'<td class="failure-index">{index}</td>'
-        '<td class="classification">'
-        f"<strong>{_escape(failure['failure_class'])}</strong>"
-        f'<span class="secondary">{_escape(failure["reason_code"])}</span></td>'
-        '<td class="location">'
-        f"{_escape(failure['public_stage'])}"
-        f'<span class="secondary">{_escape(failure["model"])} · '
-        f"{_escape(failure['backend'])} · {_escape(failure['gpu_type'])}</span></td>"
-        f'<td class="test-id"><code>{_escape(failure["test_id"])}</code></td>'
-        f'<td class="evidence">{evidence}</td>'
-        "</tr>"
-    )
+    elif failure["disclosure"] == "withheld":
+        lines.append("  Evidence: details withheld")
+    excerpt = failure.get("excerpt")
+    if isinstance(excerpt, list):
+        lines.append("  Sanitized failed-step excerpt (tail):")
+        lines.extend(f"    {line}" for line in excerpt)
+    return lines
 
 
 def render_failure_report(report: Mapping[str, object]) -> bytes:
-    """Validate and render one deterministic, script-free HTML document."""
+    """Validate and render one deterministic UTF-8 ``public-failure.log``."""
     validate_public_failure(report)
-    failures = report["failures"]
-    rows = "".join(_failure_row(failure, index) for index, failure in enumerate(failures, start=1))
-    if not rows:
-        rows = (
-            '<tr><td colspan="5" class="withheld">No structured failure details were '
-            "safe to disclose.</td></tr>"
-        )
-    omitted = int(report["omitted_failure_count"])
-    omitted_note = (
-        f'<p class="omitted">{omitted} additional failure(s) were omitted.</p>' if omitted else ""
-    )
     status = "FAILED" if report["result"] == "failure" else "ERROR"
-    document = f"""<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; script-src 'none'; connect-src 'none'; font-src 'none'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'">
-  <title>TRTMC Protected CI failure</title>
-  <style>{STYLES}</style>
-</head>
-<body>
-<main>
-  <header class="report-header">
-    <p class="product">TensorRT Model Connect / Protected CI</p>
-    <div class="title-row">
-      <h1>TRTMC Protected CI failure report</h1>
-      <span class="status">{status}</span>
-    </div>
-  </header>
-  <p class="notice">This report contains only approved structured fields. Raw logs and internal diagnostics are not included.</p>
-  <h2>Run identification</h2>
-  <table class="run-meta">
-    <tbody>
-      <tr><th scope="row">Repository</th><td>{_escape(report["repository"])}</td></tr>
-      <tr><th scope="row">Pull request</th><td>#{_escape(report["pr_number"])}</td></tr>
-      <tr><th scope="row">Head commit</th><td><code>{_escape(report["head_sha"])}</code></td></tr>
-      <tr><th scope="row">Tested revision</th><td><code>{_escape(report["tested_revision"])}</code> ({_escape(report["tested_revision_kind"])})</td></tr>
-      <tr><th scope="row">Run attempt</th><td>{_escape(report["run_attempt"])}</td></tr>
-      <tr><th scope="row">Generated at</th><td>{_escape(report["generated_at"])}</td></tr>
-      <tr><th scope="row">Disclosure policy</th><td>{_escape(report["policy_version"])}</td></tr>
-    </tbody>
-  </table>
-  <h2>Failure summary</h2>
-  <div class="table-wrap">
-    <table class="failure-table">
-      <thead><tr><th class="failure-index">#</th><th>Classification</th><th>Location</th><th>Test</th><th>Evidence</th></tr></thead>
-      <tbody>{rows}</tbody>
-    </table>
-  </div>
-  {omitted_note}
-  <footer>Report ID: <code>{_escape(report["report_id"])}</code></footer>
-</main>
-</body>
-</html>
-"""
-    return document.encode("utf-8")
+    lines = [
+        "TRTMC Protected CI failure",
+        "==========================",
+        "",
+        (
+            "This log contains approved structured fields and, when safe, a "
+            "bounded sanitized excerpt from the failed step."
+        ),
+        "",
+        f"Status: {status}",
+        f"Repository: {report['repository']}",
+        f"Pull request: #{report['pr_number']}",
+        f"Head commit: {report['head_sha']}",
+        (
+            f"Tested revision: {report['tested_revision']} "
+            f"({report['tested_revision_kind']})"
+        ),
+        f"Run attempt: {report['run_attempt']}",
+        f"Generated at: {report['generated_at']}",
+        f"Disclosure policy: {report['policy_version']}",
+        "",
+        "Failure summary",
+        "---------------",
+    ]
+    failures = report["failures"]
+    if failures:
+        for index, failure in enumerate(failures, start=1):
+            if index > 1:
+                lines.append("")
+            lines.extend(_failure_lines(failure, index))
+    else:
+        lines.append("No structured failure details were safe to disclose.")
+    omitted = int(report["omitted_failure_count"])
+    if omitted:
+        lines.extend(["", f"{omitted} additional failure(s) were omitted."])
+    lines.extend(["", f"Report ID: {report['report_id']}"])
+    return ("\n".join(lines) + "\n").encode("utf-8")

--- a/tools/public_failure/safety.py
+++ b/tools/public_failure/safety.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import html
 import re
 from typing import Mapping
 
@@ -29,7 +28,20 @@ SENSITIVE_PATTERNS = (
     ("JWT", re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")),
     ("email address", re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
     ("URL", re.compile(r"\bhttps?://", re.I)),
-    ("internal hostname", re.compile(r"\b[A-Za-z0-9.-]+\.(?:internal|nvidia\.com)\b", re.I)),
+    (
+        "internal hostname",
+        re.compile(
+            r"\b[A-Za-z0-9.-]+\.(?:internal|local|corp|lan|cluster|nvidia\.com)\b",
+            re.I,
+        ),
+    ),
+    (
+        "registry image reference",
+        re.compile(
+            r"\b[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::[0-9]+)?/"
+            r"[A-Za-z0-9._/@:+-]+"
+        ),
+    ),
     ("IP address", re.compile(r"(?<![0-9])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9])")),
     ("internal filesystem path", re.compile(r"/(?:home|workspace|mnt|var|tmp|builds|opt)/")),
     ("internal CI name", re.compile(r"\b(?:jenkins|slurm)\b", re.I)),
@@ -38,10 +50,10 @@ SENSITIVE_PATTERNS = (
 
 
 def assert_public_payload_safe(report: Mapping[str, object], document: bytes) -> None:
-    """Scan canonical JSON and decoded HTML without echoing a matched secret."""
+    """Scan canonical JSON and rendered text without echoing a matched secret."""
     candidates = (
         serialize_public_failure(report).decode("utf-8"),
-        html.unescape(document.decode("utf-8")),
+        document.decode("utf-8"),
     )
     for candidate in candidates:
         for label, pattern in SENSITIVE_PATTERNS:

--- a/tools/public_failure/safety.py
+++ b/tools/public_failure/safety.py
@@ -15,6 +15,11 @@ class PublicFailureSafetyError(ValueError):
     """Raised when an otherwise valid payload resembles protected data."""
 
 
+REGISTRY_IMAGE_REFERENCE_PATTERN = re.compile(
+    r"\b[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::[0-9]+)?/[A-Za-z0-9._/@:+-]+"
+)
+
+
 SENSITIVE_PATTERNS = (
     (
         "credential-like token",
@@ -35,13 +40,6 @@ SENSITIVE_PATTERNS = (
             re.I,
         ),
     ),
-    (
-        "registry image reference",
-        re.compile(
-            r"\b[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::[0-9]+)?/"
-            r"[A-Za-z0-9._/@:+-]+"
-        ),
-    ),
     ("IP address", re.compile(r"(?<![0-9])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9])")),
     ("internal filesystem path", re.compile(r"/(?:home|workspace|mnt|var|tmp|builds|opt)/")),
     ("internal CI name", re.compile(r"\b(?:jenkins|slurm)\b", re.I)),
@@ -59,3 +57,16 @@ def assert_public_payload_safe(report: Mapping[str, object], document: bytes) ->
         for label, pattern in SENSITIVE_PATTERNS:
             if pattern.search(candidate):
                 raise PublicFailureSafetyError(f"public failure payload contains a {label}")
+    for failure in report.get("failures", ()):
+        if not isinstance(failure, Mapping):
+            continue
+        excerpt = failure.get("excerpt", ())
+        if not isinstance(excerpt, list):
+            continue
+        if any(
+            isinstance(line, str) and REGISTRY_IMAGE_REFERENCE_PATTERN.search(line)
+            for line in excerpt
+        ):
+            raise PublicFailureSafetyError(
+                "public failure payload contains a registry image reference"
+            )


### PR DESCRIPTION
## Background

#1043 established a closed local failure-report contract, but its HTML preview was not connected to a contributor-visible channel. Protected CI logs contain actionable diagnostics alongside internal paths, runner details, image coordinates, and URLs, so publishing raw logs is not safe.

## Exit Criteria

- Failed protected CI can expose a sanitized `public-failure.log` through a public Source Actions run and downloadable artifact.
- The log can include a bounded tail from the exact failed step after environment, command echo, credentials, URLs, hosts, paths, image references, and opaque identifiers are removed or replaced.
- The existing `TRTMC Internal CI / Automated premerge gate` context is updated instead of creating a second status name.
- The relay executes only trusted default-branch code, validates the exact open PR head, and rejects fields outside the closed contract.
- No GitHub App installation, GitHub Pages publication, raw protected log, unsanitized exception text, or PR-head code execution is introduced.

## Implementation

- Replaces the HTML renderer with deterministic UTF-8 text output and keeps JSON as the machine-to-machine contract.
- Adds an optional closed `excerpt` field: at most 20 printable lines, 240 characters per line and 4,000 characters total, sourced only from the final failed step's metadata time window.
- Extends the closed reason vocabulary for failure shapes observed in protected CI, while allowing only two explicitly approved package subjects.
- Adds a `repository_dispatch` relay that revalidates and poison-scans both structured fields and excerpts, prints the text in a public Actions log, uploads `public-failure.log`, verifies the exact open PR head, and publishes the existing automated status context with the public run as its target.
- Adds replay coverage for unit collection, legal, source-quality, runtime catalog, package import, model comparison, model-cache, and GPU-capacity failures.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [x] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest -q tests/tools/test_github_actions_ci.py::test_source_workflow_inventory_does_not_repeat_premerge_after_merge tests/tools/test_public_failure.py tests/tools/test_test_impact.py -k 'source_workflow_inventory or public_failure'`: 35 passed, 290 deselected.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; 158 selected tests passed and changed-file lint/formatting passed.
- `git diff --cached --check`: passed.
- Private live replay, with no raw logs copied into this PR: 30 recent failed runs sampled across premerge, nightly, and runtime-candidate; all 30 downloaded and passed the complete Source export/render/safety pipeline. The 31 primary failure records produced 29 failed-step excerpts and 462 public lines with zero residual sensitive-pattern matches; the other two historical job logs were empty. Six of eight `unknown` records gained bounded context.
- Historical #1043 replay rendered the actual `jsonschema` collection traceback, `python_dependency_missing`, and `tests/tools/test_public_failure.py::collection` in `public-failure.log`; the environment block and protected absolute paths were removed or replaced.

### Hardware, Environment, and Revisions

- Source head: `8a1b78c8814051894fe1e3a34161fa4d23c2e60f`.
- Local validation: Linux host, Python 3.12; no GPU, CUDA, TensorRT, model checkpoint, or dataset is involved in the relay/renderer path.
- Protected replay sample: current Internal CI logs available on 2026-08-27; only aggregate and closed sanitized fields are recorded here.

### Not Run / Remaining Gaps

- The public `repository_dispatch` path cannot be exercised until this workflow exists on Source `main`.
- The paired Internal CI producer must then be merged and one intentionally failed premerge must be run to prove the public status target, log visibility, artifact download, and token permission end to end.

## Notes For Future Readers

- Merge this Source PR before the paired Internal CI producer PR. A `repository_dispatch` workflow can receive events only after the workflow exists on the Source default branch.
- The Internal CI status token must be able to dispatch repository events to this repository. The paired producer retains the current direct failure-status path as a fail-closed fallback if dispatch is unavailable.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this changes a required-status target and introduces a cross-repository relay, but the payload is closed and revalidated on trusted Source `main`, exact-head checks are fail-closed, and Internal CI retains the prior direct failure-status fallback.
