### PR TITLE
ci: publish failure logs from bridge artifacts

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -132,11 +132,15 @@ jobs:
     environment:
       name: ci-dispatch
       deployment: false
-    timeout-minutes: 5
-    permissions: {}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
 
     steps:
       - name: Dispatch internal premerge CI
+        id: private_run
         env:
           # Fine-grained PAT scoped only to the internal CI repository with
           # Actions: write. The protected environment owns this secret.
@@ -151,6 +155,7 @@ jobs:
           [[ "$PRIVATE_CI_REPOSITORY" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$ ]]
 
           umask 077
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           payload="$RUNNER_TEMP/internal-ci-dispatch.json"
           trap 'rm -f "$payload"' EXIT
           jq -n \
@@ -166,3 +171,158 @@ jobs:
           gh api --silent --method POST \
             "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches" \
             --input "$payload"
+
+          expected_title="Source PR #$PR_NUMBER · $HEAD_SHA"
+          run_id=""
+          for _ in $(seq 1 20); do
+            runs="$(
+              gh api --method GET \
+                "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/runs?event=workflow_dispatch&per_page=100"
+            )"
+            run_id="$(
+              jq -r \
+                --arg title "$expected_title" \
+                --arg dispatched_at "$dispatched_at" \
+                '[
+                  .workflow_runs[]
+                  | select(
+                      .display_title == $title and
+                      .created_at >= $dispatched_at
+                    )
+                ]
+                | sort_by(.created_at)
+                | last
+                | .id // empty' <<<"$runs"
+            )"
+            if [[ "$run_id" =~ ^[1-9][0-9]*$ ]]; then
+              break
+            fi
+            sleep 3
+          done
+          if ! [[ "$run_id" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::The exact dispatched Internal CI run was not found."
+            exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the exact Internal CI result
+        id: private_result
+        env:
+          GH_TOKEN: ${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}
+          PRIVATE_CI_OWNER: ${{ secrets.TRTMC_PRIVATE_CI_OWNER }}
+          PRIVATE_CI_REPOSITORY: ${{ secrets.TRTMC_PRIVATE_CI_REPOSITORY }}
+          RUN_ID: ${{ steps.private_run.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          for _ in $(seq 1 220); do
+            run="$(
+              gh api --method GET \
+                "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/runs/$RUN_ID"
+            )"
+            status="$(jq -er '.status' <<<"$run")"
+            if [ "$status" = "completed" ]; then
+              conclusion="$(jq -er '.conclusion' <<<"$run")"
+              echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for the exact Internal CI run."
+          exit 1
+
+      - name: Download closed public failure payload
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}
+          PRIVATE_CI_OWNER: ${{ secrets.TRTMC_PRIVATE_CI_OWNER }}
+          PRIVATE_CI_REPOSITORY: ${{ secrets.TRTMC_PRIVATE_CI_REPOSITORY }}
+          RUN_ID: ${{ steps.private_run.outputs.run_id }}
+          PAYLOAD_DIR: ${{ runner.temp }}/private-public-failure
+        run: |
+          set -euo pipefail
+          mkdir -p "$PAYLOAD_DIR"
+          gh run download "$RUN_ID" \
+            --repo "$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY" \
+            --name public-failure-payload \
+            --dir "$PAYLOAD_DIR"
+          test -s "$PAYLOAD_DIR/public-failure.json"
+
+      - name: Check out trusted failure-report tooling
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+
+      - name: Validate payload and render public-failure.log
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        id: render
+        env:
+          PUBLIC_FAILURE_JSON: ${{ runner.temp }}/private-public-failure/public-failure.json
+          PUBLIC_FAILURE_LOG: ${{ runner.temp }}/public-failure.log
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from tools.public_failure.contract import validate_public_failure
+          from tools.public_failure.render import render_failure_report
+          from tools.public_failure.safety import assert_public_payload_safe
+
+          report = json.loads(
+              Path(os.environ["PUBLIC_FAILURE_JSON"]).read_text(encoding="utf-8")
+          )
+          validate_public_failure(report)
+          document = render_failure_report(report)
+          assert_public_payload_safe(report, document)
+          Path(os.environ["PUBLIC_FAILURE_LOG"]).write_bytes(document)
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"head_sha={report['head_sha']}\n")
+              output.write(f"pr_number={report['pr_number']}\n")
+          PY
+
+      - name: Confirm the exact open pull-request head
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.render.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.render.outputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXPECTED_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          test "$HEAD_SHA" = "$EXPECTED_HEAD_SHA"
+          test "$PR_NUMBER" = "$EXPECTED_PR_NUMBER"
+          pull="$(gh api --method GET "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -er '.state' <<<"$pull")" = "open"
+          test "$(jq -er '.base.repo.full_name' <<<"$pull")" = "$GITHUB_REPOSITORY"
+          test "$(jq -er '.base.ref' <<<"$pull")" = "main"
+          test "$(jq -er '.head.sha' <<<"$pull")" = "$HEAD_SHA"
+
+      - name: Print public-failure.log
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        run: cat "${{ runner.temp }}/public-failure.log"
+
+      - name: Upload public-failure.log
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: public-failure-log
+          path: ${{ runner.temp }}/public-failure.log
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish the automated failure status
+        if: ${{ steps.private_result.outputs.conclusion != 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.render.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh api --silent --method POST \
+            "/repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=failure \
+            -f context="TRTMC Internal CI / Automated premerge gate" \
+            -f description="Automated internal CI failed; open the public failure log" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -155,24 +155,27 @@ jobs:
           [[ "$PRIVATE_CI_REPOSITORY" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$ ]]
 
           umask 077
-          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          dispatch_nonce="$(openssl rand -hex 16)"
+          [[ "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]
           payload="$RUNNER_TEMP/internal-ci-dispatch.json"
           trap 'rm -f "$payload"' EXIT
           jq -n \
             --arg pr_number "$PR_NUMBER" \
             --arg head_sha "$HEAD_SHA" \
+            --arg dispatch_nonce "$dispatch_nonce" \
             '{
               ref: "main",
               inputs: {
                 pr_number: $pr_number,
-                head_sha: $head_sha
+                head_sha: $head_sha,
+                dispatch_nonce: $dispatch_nonce
               }
             }' > "$payload"
           gh api --silent --method POST \
             "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches" \
             --input "$payload"
 
-          expected_title="Source PR #$PR_NUMBER · $HEAD_SHA"
+          expected_title="Source PR #$PR_NUMBER · $HEAD_SHA · dispatch $dispatch_nonce"
           run_id=""
           for _ in $(seq 1 20); do
             runs="$(
@@ -182,13 +185,9 @@ jobs:
             run_id="$(
               jq -r \
                 --arg title "$expected_title" \
-                --arg dispatched_at "$dispatched_at" \
                 '[
                   .workflow_runs[]
-                  | select(
-                      .display_title == $title and
-                      .created_at >= $dispatched_at
-                    )
+                  | select(.display_title == $title)
                 ]
                 | sort_by(.created_at)
                 | last
@@ -203,7 +202,10 @@ jobs:
             echo "::error::The exact dispatched Internal CI run was not found."
             exit 1
           fi
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          {
+            echo "run_id=$run_id"
+            echo "dispatch_nonce=$dispatch_nonce"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Wait for the exact Internal CI result
         id: private_result
@@ -260,6 +262,7 @@ jobs:
         env:
           PUBLIC_FAILURE_JSON: ${{ runner.temp }}/private-public-failure/public-failure.json
           PUBLIC_FAILURE_LOG: ${{ runner.temp }}/public-failure.log
+          EXPECTED_DISPATCH_NONCE: ${{ steps.private_run.outputs.dispatch_nonce }}
         run: |
           python3 - <<'PY'
           import json
@@ -274,6 +277,8 @@ jobs:
               Path(os.environ["PUBLIC_FAILURE_JSON"]).read_text(encoding="utf-8")
           )
           validate_public_failure(report)
+          if report.get("dispatch_nonce") != os.environ["EXPECTED_DISPATCH_NONCE"]:
+              raise SystemExit("The failure payload does not match this dispatch.")
           document = render_failure_report(report)
           assert_public_payload_safe(report, document)
           Path(os.environ["PUBLIC_FAILURE_LOG"]).write_bytes(document)

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -332,7 +332,9 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert authorize_permissions.strip() == (
         "actions: read\n      contents: read\n      pull-requests: write"
     )
-    assert dispatch_permissions.strip() == "{}"
+    assert dispatch_permissions.strip() == (
+        "contents: read\n      pull-requests: read\n      statuses: write"
+    )
 
     assert "collaborators/$ACTOR/permission" in authorize
     assert "--jq '.role_name'" in authorize
@@ -391,16 +393,20 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     for secret in secret_references:
         assert secret not in authorize
         assert secret in dispatch
-    assert workflow.count("${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}") == 1
+    assert workflow.count("${{ secrets.TRTMC_CI_DISPATCH_TOKEN }}") == 3
 
     assert "actions/create-github-app-token@" not in workflow
     assert "permission-checks:" not in workflow
-    assert "actions/checkout@" not in workflow
+    assert (
+        "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
+        in workflow
+    )
+    assert "persist-credentials: false" in dispatch
     assert "private_ci_bridge.py" not in workflow
     assert "self-hosted" not in workflow
     assert "secrets: inherit" not in workflow
     assert "report-guard-failure" not in workflow
-    assert "/statuses/" not in workflow
+    assert workflow.count("/statuses/") == 1
     assert "/comments" not in workflow
     assert (
         "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/"
@@ -412,12 +418,28 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert 'echo "$PRIVATE_CI_' not in dispatch
     assert "GITHUB_STEP_SUMMARY" not in dispatch
 
-    assert dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") == 1
+    assert dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") >= 1
 
     assert 'ref: "main"' in dispatch
     for name in ("pr_number", "head_sha"):
         assert f"{name}: ${name}" in dispatch
     assert "umask 077" in dispatch
+    assert 'expected_title="Source PR #$PR_NUMBER · $HEAD_SHA"' in dispatch
+    assert ".display_title == $title" in dispatch
+    assert ".created_at >= $dispatched_at" in dispatch
+    assert "actions/workflows/premerge.yml/runs?event=workflow_dispatch" in dispatch
+    assert "actions/runs/$RUN_ID" in dispatch
+    assert "--name public-failure-payload" in dispatch
+    assert "--log" not in dispatch
+    assert "validate_public_failure(report)" in dispatch
+    assert "assert_public_payload_safe(report, document)" in dispatch
+    assert "name: public-failure-log" in dispatch
+    assert "Automated internal CI failed; open the public failure log" in dispatch
+    assert "TRTMC Internal CI / Automated premerge gate" in dispatch
+    assert "actions/runs/$GITHUB_RUN_ID" in dispatch
+    assert dispatch.index("- name: Confirm the exact open pull-request head") < (
+        dispatch.index("- name: Print public-failure.log")
+    )
     assert 'trap \'rm -f "$payload"\' EXIT' in dispatch
     assert 'if: ${{ failure() }}' not in dispatch
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -102,15 +102,11 @@ else:
 
 def _internal_ci_snapshot_script() -> str:
     workflow = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
-            encoding="utf-8"
-        )
+        (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(encoding="utf-8")
     )
     steps = workflow["jobs"]["authorize"]["steps"]
     return next(
-        step["run"]
-        for step in steps
-        if step["name"] == "Capture the exact pull-request head"
+        step["run"] for step in steps if step["name"] == "Capture the exact pull-request head"
     )
 
 
@@ -273,9 +269,7 @@ def test_only_pages_workflow_creates_deployment_objects() -> None:
 def test_community_docs_gate_matches_pages_predeploy_contract() -> None:
     workflows = REPO_ROOT / ".github" / "workflows"
     pages = yaml.safe_load((workflows / "pages.yml").read_text(encoding="utf-8"))
-    community = yaml.safe_load(
-        (workflows / "community-cpu.yml").read_text(encoding="utf-8")
-    )
+    community = yaml.safe_load((workflows / "community-cpu.yml").read_text(encoding="utf-8"))
 
     pages_build = pages["jobs"]["build"]
     pages_steps = {step["name"]: step for step in pages_build["steps"]}
@@ -303,17 +297,17 @@ def test_community_docs_gate_matches_pages_predeploy_contract() -> None:
 
 
 def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
+        encoding="utf-8"
+    )
     workflow_config = yaml.safe_load(workflow)
-    authorize = workflow.split("\n  authorize:", maxsplit=1)[1].split(
-        "\n  dispatch:", maxsplit=1
-    )[0]
+    authorize = workflow.split("\n  authorize:", maxsplit=1)[1].split("\n  dispatch:", maxsplit=1)[
+        0
+    ]
     dispatch = workflow.split("\n  dispatch:", maxsplit=1)[1]
-    authorize_permissions = authorize.split(
-        "    permissions:", maxsplit=1
-    )[1].split("\n    outputs:", maxsplit=1)[0]
+    authorize_permissions = authorize.split("    permissions:", maxsplit=1)[1].split(
+        "\n    outputs:", maxsplit=1
+    )[0]
     dispatch_permissions = dispatch.split("    permissions:", maxsplit=1)[1].split(
         "\n\n", maxsplit=1
     )[0]
@@ -373,9 +367,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
         "EVENT_BASE_SHA",
     ):
         assert legacy not in workflow
-    assert (
-        "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci"
-    ) in authorize
+    assert ("/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/run-internal-ci") in authorize
     assert "gh api --silent --method DELETE" in authorize
     assert "success() && github.event_name == 'pull_request_target'" in authorize
 
@@ -397,10 +389,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
 
     assert "actions/create-github-app-token@" not in workflow
     assert "permission-checks:" not in workflow
-    assert (
-        "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
-        in workflow
-    )
+    assert "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803" in workflow
     assert "persist-credentials: false" in dispatch
     assert "private_ci_bridge.py" not in workflow
     assert "self-hosted" not in workflow
@@ -409,8 +398,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert workflow.count("/statuses/") == 1
     assert "/comments" not in workflow
     assert (
-        "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/"
-        "actions/workflows/premerge.yml/dispatches"
+        "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/workflows/premerge.yml/dispatches"
     ) in workflow
     assert re.search(r'"/repos/[A-Za-z0-9]', workflow) is None
     assert '[[ "$PRIVATE_CI_OWNER" =~ ^[A-Za-z0-9]' in workflow
@@ -421,17 +409,23 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert dispatch.count("HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}") >= 1
 
     assert 'ref: "main"' in dispatch
-    for name in ("pr_number", "head_sha"):
+    for name in ("pr_number", "head_sha", "dispatch_nonce"):
         assert f"{name}: ${name}" in dispatch
     assert "umask 077" in dispatch
-    assert 'expected_title="Source PR #$PR_NUMBER · $HEAD_SHA"' in dispatch
+    assert "openssl rand -hex 16" in dispatch
+    assert '[[ "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]' in dispatch
+    assert (
+        'expected_title="Source PR #$PR_NUMBER · $HEAD_SHA · dispatch $dispatch_nonce"' in dispatch
+    )
     assert ".display_title == $title" in dispatch
-    assert ".created_at >= $dispatched_at" in dispatch
+    assert ".created_at >= $dispatched_at" not in dispatch
     assert "actions/workflows/premerge.yml/runs?event=workflow_dispatch" in dispatch
     assert "actions/runs/$RUN_ID" in dispatch
     assert "--name public-failure-payload" in dispatch
     assert "--log" not in dispatch
     assert "validate_public_failure(report)" in dispatch
+    assert "EXPECTED_DISPATCH_NONCE" in dispatch
+    assert 'report.get("dispatch_nonce")' in dispatch
     assert "assert_public_payload_safe(report, document)" in dispatch
     assert "name: public-failure-log" in dispatch
     assert "Automated internal CI failed; open the public failure log" in dispatch
@@ -440,8 +434,8 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert dispatch.index("- name: Confirm the exact open pull-request head") < (
         dispatch.index("- name: Print public-failure.log")
     )
-    assert 'trap \'rm -f "$payload"\' EXIT' in dispatch
-    assert 'if: ${{ failure() }}' not in dispatch
+    assert "trap 'rm -f \"$payload\"' EXIT" in dispatch
+    assert "if: ${{ failure() }}" not in dispatch
 
 
 def test_internal_ci_bridge_rejects_a_new_push_after_label(
@@ -584,9 +578,7 @@ def test_internal_ci_bridge_tests_do_not_depend_on_host_jq(tmp_path: Path) -> No
 
 def test_internal_ci_trigger_label_is_consumed_only_after_authorization() -> None:
     workflow = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(
-            encoding="utf-8"
-        )
+        (REPO_ROOT / ".github" / "workflows" / "internal-ci-bridge.yml").read_text(encoding="utf-8")
     )
     step = next(
         item
@@ -594,9 +586,7 @@ def test_internal_ci_trigger_label_is_consumed_only_after_authorization() -> Non
         if item["name"] == "Consume the trusted trigger label"
     )
 
-    assert step["if"] == (
-        "${{ success() && github.event_name == 'pull_request_target' }}"
-    )
+    assert step["if"] == ("${{ success() && github.event_name == 'pull_request_target' }}")
     assert step["env"]["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
 
 
@@ -635,6 +625,7 @@ def test_ci_orchestration_uses_the_class_based_python_entrypoint() -> None:
         "ContainerStageRunner",
     ):
         assert f"class {class_name}" in source
+
 
 def test_ci_modules_have_minimal_role_comments_and_a_complete_tutorial() -> None:
     ci_directory = REPO_ROOT / "tools" / "ci"
@@ -684,14 +675,11 @@ def test_source_quality_pipeline_keeps_the_full_static_gate() -> None:
     assert '"Check model architecture contracts"' in source_quality
     assert "self.quality.architecture_contracts" in source_quality
 
-    architecture_contract = source.split(
-        "def architecture_contracts", maxsplit=1
-    )[1].split("def _changed_files", maxsplit=1)[0]
+    architecture_contract = source.split("def architecture_contracts", maxsplit=1)[1].split(
+        "def _changed_files", maxsplit=1
+    )[0]
     assert '"pytest"' in architecture_contract
-    assert (
-        "tests/tools/test_model_plugin_encapsulation_static.py"
-        in architecture_contract
-    )
+    assert "tests/tools/test_model_plugin_encapsulation_static.py" in architecture_contract
     assert '"-q"' in architecture_contract
     assert '"no:cacheprovider"' in architecture_contract
 
@@ -700,8 +688,7 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
     assert (
         "ARG CUDA_IMAGE=nvidia/cuda:13.3.0-devel-ubuntu24.04"
-        "@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52"
-        in dockerfile
+        "@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52" in dockerfile
     )
     assert dockerfile.count("ARG TENSORRT_VERSION=11.1.0.106") == 1
     assert dockerfile.count("ARG TENSORRT_APT_VERSION=11.1.0.106-1+cuda13.3") == 1
@@ -711,18 +698,13 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     assert "--system-site-packages" not in dockerfile
     assert "ENV TRT_ROOT=" not in dockerfile
     assert "ENV PIP_FIND_LINKS=" not in dockerfile
-    assert (
-        "ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs"
-        in dockerfile
-    )
+    assert "ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs" in dockerfile
     assert "ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu" in dockerfile
     assert "ghcr.io" not in dockerfile
     assert "TENSORRT_SDK_IMAGE" not in dockerfile
     assert "/opt/tensorrt/python" not in dockerfile
 
-    from_lines = [
-        line for line in dockerfile.splitlines() if line.startswith("FROM ")
-    ]
+    from_lines = [line for line in dockerfile.splitlines() if line.startswith("FROM ")]
     assert from_lines == [
         "FROM ${CUDA_IMAGE} AS ci-common-base",
         "FROM ci-common-base AS python-profile-builder",
@@ -774,12 +756,8 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     assert "c++ -x c++" in overlay
 
     source_dockerfiles = {
-        "aarch64": (REPO_ROOT / "Dockerfile.dev.aarch64").read_text(
-            encoding="utf-8"
-        ),
-        "x86_64": (REPO_ROOT / "Dockerfile.dev.x86").read_text(
-            encoding="utf-8"
-        ),
+        "aarch64": (REPO_ROOT / "Dockerfile.dev.aarch64").read_text(encoding="utf-8"),
+        "x86_64": (REPO_ROOT / "Dockerfile.dev.x86").read_text(encoding="utf-8"),
     }
     assert (
         "@sha256:f794a79e8b996d16dbc2e5884e19d8e2269a51c960106c9b49b0061a6926c541"
@@ -791,14 +769,8 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     )
     for architecture, source_dockerfile in source_dockerfiles.items():
         assert "FROM ${TENSORRT_IMAGE}" in source_dockerfile
-        assert (
-            "COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt"
-            in source_dockerfile
-        )
-        assert (
-            "pip install --requirement /tmp/trtmc-community-ci.txt"
-            in source_dockerfile
-        )
+        assert "COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt" in source_dockerfile
+        assert "pip install --requirement /tmp/trtmc-community-ci.txt" in source_dockerfile
         assert "pre-commit>=" not in source_dockerfile
         assert "https://download.pytorch.org/whl/cpu" in source_dockerfile
         assert "torch.version.cuda is None" in source_dockerfile
@@ -807,19 +779,13 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
         assert "nemo_toolkit" not in source_dockerfile
         assert "ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake" in source_dockerfile
         assert "RUN cmake --version" in source_dockerfile
-        assert (
-            f"ENV TRT_LIB_DIR=/usr/lib/{architecture}-linux-gnu"
-            in source_dockerfile
-        )
-        assert (
-            f"ENV TRT_INC_DIR=/usr/include/{architecture}-linux-gnu"
-            in source_dockerfile
-        )
+        assert f"ENV TRT_LIB_DIR=/usr/lib/{architecture}-linux-gnu" in source_dockerfile
+        assert f"ENV TRT_INC_DIR=/usr/include/{architecture}-linux-gnu" in source_dockerfile
     assert "x86_64-linux-gnu" not in dockerfile
 
-    source_build = (
-        REPO_ROOT / "website/docs/getting-started/source-build.md"
-    ).read_text(encoding="utf-8")
+    source_build = (REPO_ROOT / "website/docs/getting-started/source-build.md").read_text(
+        encoding="utf-8"
+    )
     assert "Dockerfile.dev.aarch64" in source_build
     assert "Dockerfile.dev.x86" in source_build
     assert "trtmc_model_qwen" in source_build
@@ -827,9 +793,7 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     assert "TRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF" in source_build
     assert "TRTMC_TORCH_CUDA_ARCH_LIST" not in source_build
 
-    ci_docker_build = (REPO_ROOT / "scripts/docker_build_gb300.sh").read_text(
-        encoding="utf-8"
-    )
+    ci_docker_build = (REPO_ROOT / "scripts/docker_build_gb300.sh").read_text(encoding="utf-8")
     assert '"$REPO_ROOT/Dockerfile"' in ci_docker_build
     assert "Dockerfile.dev.aarch64" not in ci_docker_build
     assert "Dockerfile.dev.x86" not in ci_docker_build
@@ -903,12 +867,7 @@ def test_hardened_unit_container_is_unprivileged_offline_and_cpu_only() -> None:
     assert "HUGGING_FACE_HUB_TOKEN" not in common
 
     stage = _ci_source("stage.py")
-    assert (
-        "COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT"
-        in stage
-    )
-
-
+    assert "COMMON_ENVIRONMENT if self.config.hardened else TRUSTED_ENVIRONMENT" in stage
 
 
 def test_github_stage_wrapper_mounts_and_exports_hf_cache_env() -> None:
@@ -1061,9 +1020,7 @@ def test_github_container_only_exports_nonempty_tuning_controls(tmp_path: Path) 
                 env[name] = value
             arguments = CiContainer(env)._environment_arguments()
             forwarded = [
-                arguments[index + 1]
-                for index, item in enumerate(arguments[:-1])
-                if item == "-e"
+                arguments[index + 1] for index, item in enumerate(arguments[:-1]) if item == "-e"
             ]
             stage_command = ContainerStageRunner("package", env)._docker_command()
             if value == "3":
@@ -1171,12 +1128,8 @@ def test_diffusion_vlm_shared_ci_has_no_model_owned_default() -> None:
 
 def test_full_python_builder_preserves_parallel_and_allocator_coverage() -> None:
     text = _ci_source("coverage.py")
-    builder = text.split("def python_builder_tests", maxsplit=1)[1].split(
-        "def cpp", maxsplit=1
-    )[0]
-    builder_conftest = (
-        REPO_ROOT / "tests" / "builder" / "conftest.py"
-    ).read_text(encoding="utf-8")
+    builder = text.split("def python_builder_tests", maxsplit=1)[1].split("def cpp", maxsplit=1)[0]
+    builder_conftest = (REPO_ROOT / "tests" / "builder" / "conftest.py").read_text(encoding="utf-8")
 
     assert 'glob("test_*.py")' in builder
     assert "--ignore=tests/builder/test_cli.py" not in builder
@@ -1188,14 +1141,9 @@ def test_full_python_builder_preserves_parallel_and_allocator_coverage() -> None
     assert '"TRTMC_TEST_INSTALLED_WHEEL": "1"' in builder
     assert "source_pkgs =" in text
     assert "tensorrt_model_connect" in text
-    assert (
-        'os.environ.get("TRTMC_TEST_INSTALLED_WHEEL") == "1"'
-        in builder_conftest
-    )
+    assert 'os.environ.get("TRTMC_TEST_INSTALLED_WHEEL") == "1"' in builder_conftest
     assert "imported tensorrt_model_connect" in builder_conftest
-    assert builder.index('"-n", "auto"') < builder.index(
-        '"tests/tools/test_model_proof_runner.py"'
-    )
+    assert builder.index('"-n", "auto"') < builder.index('"tests/tools/test_model_proof_runner.py"')
 
 
 def test_selective_python_always_runs_static_ci_smoke_tests() -> None:
@@ -1246,8 +1194,6 @@ def test_qwen_flashinfer_scripts_skip_pytest_collection() -> None:
 def test_source_quality_lint_uses_resolved_ci_base_ref() -> None:
     text = _ci_source("quality.py")
     assert "f\"origin/{self.context.env.get('GITHUB_REF_NAME', 'main')}\"" in text
-
-
 
 
 def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
@@ -1339,16 +1285,12 @@ def test_builder_unit_scope_runs_python_without_native_build(tmp_path: Path) -> 
     UnitTestRunner(context).premerge()
 
     pytest_commands = [
-        command
-        for command in context.commands
-        if command[:3] == ["python", "-m", "pytest"]
+        command for command in context.commands if command[:3] == ["python", "-m", "pytest"]
     ]
     assert len(pytest_commands) == 1
     assert "tests/builder/" in pytest_commands[0]
     assert selected_test in pytest_commands[0]
-    assert not [
-        command for command in context.commands if command[0] in {"cmake", "ctest"}
-    ]
+    assert not [command for command in context.commands if command[0] in {"cmake", "ctest"}]
 
 
 @pytest.mark.parametrize(
@@ -1383,8 +1325,6 @@ def test_premerge_rejects_an_unsafe_selected_python_test(
         UnitTestRunner(RecordingContext()).premerge()
 
 
-
-
 def test_unowned_gpu_only_builder_suites_are_excluded_from_cpu_units() -> None:
     stage = _ci_source("quality.py")
     for relative in (
@@ -1399,8 +1339,6 @@ def test_unowned_gpu_only_builder_suites_are_excluded_from_cpu_units() -> None:
     ].split("class TestEngineBuilderKernelArtifacts:", maxsplit=1)[0]
     assert flashinfer_section.count("@pytest.mark.gpu") == 3
     assert flashinfer_section.count("@pytest.mark.trt") == 3
-
-
 
 
 def test_package_stage_builds_py310_and_py312_wheels() -> None:
@@ -1421,9 +1359,7 @@ def test_package_reuses_conan_cmake_build_directory(tmp_path: Path) -> None:
     release.mkdir(parents=True)
     (release / "CMakeCache.txt").touch()
 
-    assert WheelPackageManager(object())._conan_cmake_build_dir(
-        tmp_path / "conan_out"
-    ) == release
+    assert WheelPackageManager(object())._conan_cmake_build_dir(tmp_path / "conan_out") == release
 
 
 def test_package_smoke_default_is_model_owned() -> None:
@@ -1780,9 +1716,11 @@ def test_wheel_model_smoke_checks_py312_wheel_only() -> None:
     assert '"PATH"' not in smoke_block
     assert 'trtmc,\n                "build"' in smoke_block
     assert "InstalledWheelValidator.require_elf(trtmc)" in smoke_block
-    assert smoke_block.index("self._create_venv(venv, wheel)") < smoke_block.index(
-        "self._install_model_smoke_dependencies(python)"
-    ) < smoke_block.index('self.context.run([python, "-m", "pip", "check"])')
+    assert (
+        smoke_block.index("self._create_venv(venv, wheel)")
+        < smoke_block.index("self._install_model_smoke_dependencies(python)")
+        < smoke_block.index('self.context.run([python, "-m", "pip", "check"])')
+    )
 
 
 def test_wheel_model_smoke_installs_pinned_cpu_torch() -> None:
@@ -1843,9 +1781,7 @@ def test_selective_e2e_zero_model_path_still_generates_report_input_dir() -> Non
 
 def test_etth1_model_proofs_use_the_single_validation_engine_entry_point() -> None:
     stage = _ci_source("validation.py", "model_proof.py", "model_proof_inner.py")
-    validation_engine = (
-        REPO_ROOT / "tools" / "validation" / "engine.py"
-    ).read_text()
+    validation_engine = (REPO_ROOT / "tools" / "validation" / "engine.py").read_text()
 
     assert '"/src/tools/validation/engine.py"' in stage
     assert '"prepare-ci-dataset"' in stage

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -25,6 +25,7 @@ from tools.public_failure.__main__ import main as public_failure_main
 
 HEAD_SHA = "a" * 40
 BASE_SHA = "b" * 40
+DISPATCH_NONCE = "c" * 32
 
 
 def _context(*, result: str = "failure") -> ExportContext:
@@ -34,6 +35,7 @@ def _context(*, result: str = "failure") -> ExportContext:
         head_sha=HEAD_SHA,
         base_sha=BASE_SHA,
         tested_revision=HEAD_SHA,
+        dispatch_nonce=DISPATCH_NONCE,
         run_attempt=1,
         result=result,
         generated_at="2026-08-26T00:00:00Z",
@@ -114,6 +116,7 @@ def test_export_failure_rebuilds_a_public_result_from_approved_fields() -> None:
         "base_sha": BASE_SHA,
         "tested_revision": HEAD_SHA,
         "tested_revision_kind": "head",
+        "dispatch_nonce": DISPATCH_NONCE,
         "run_attempt": 1,
         "result": "failure",
         "failures": [
@@ -181,6 +184,7 @@ def test_public_contract_rejects_unknown_fields_at_every_level(level: str) -> No
     [
         (("result",), "success"),
         (("head_sha",), "A" * 40),
+        (("dispatch_nonce",), "not-a-nonce"),
         (("pr_number",), True),
         (("failures", 0, "failure_class"), "private_exception_name"),
         (("failures", 0, "test_id"), "../../internal/test.py::test_secret"),
@@ -541,12 +545,18 @@ def test_public_failure_relay_uses_the_existing_status_context() -> None:
 
 
 def test_internal_ci_bridge_publishes_the_private_sanitized_artifact() -> None:
-    workflow = (
-        Path(__file__).parents[2] / ".github/workflows/internal-ci-bridge.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (Path(__file__).parents[2] / ".github/workflows/internal-ci-bridge.yml").read_text(
+        encoding="utf-8"
+    )
 
     assert "--name public-failure-payload" in workflow
     assert "--log" not in workflow
+    assert "openssl rand -hex 16" in workflow
+    assert "dispatch_nonce: $dispatch_nonce" in workflow
+    assert (
+        'expected_title="Source PR #$PR_NUMBER · $HEAD_SHA · dispatch $dispatch_nonce"' in workflow
+    )
+    assert 'report.get("dispatch_nonce") != os.environ["EXPECTED_DISPATCH_NONCE"]' in workflow
     assert "validate_public_failure(report)" in workflow
     assert "assert_public_payload_safe(report, document)" in workflow
     assert "name: public-failure-log" in workflow
@@ -620,7 +630,5 @@ def test_local_cli_writes_preview_files_without_publishing(tmp_path: Path) -> No
 
     assert exit_code == 0
     assert json.loads((output_dir / "public-failure.json").read_text())["result"] == "failure"
-    assert "TRTMC Protected CI failure" in (
-        output_dir / "public-failure.log"
-    ).read_text()
+    assert "TRTMC Protected CI failure" in (output_dir / "public-failure.log").read_text()
     assert not (output_dir / "report.html").exists()

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -74,6 +74,27 @@ def _build_failure(*, test_id: str) -> dict[str, object]:
     }
 
 
+def test_fast_foundation_stereo_failure_keeps_the_public_model_name() -> None:
+    report = export_failure(
+        {
+            "failures": [
+                {
+                    "failure_type": "unit_fail",
+                    "stage": "unit",
+                    "model": "fast_foundation_stereo",
+                    "backend": "other-backend",
+                    "gpu_type": "protected-gpu",
+                    "test_id": "ctest::test_fast_foundation_stereo_native_plugins",
+                    "reason_code": "test_failed",
+                }
+            ]
+        },
+        _context(),
+    )
+
+    assert report["failures"][0]["model"] == "fast_foundation_stereo"
+
+
 def test_export_failure_rebuilds_a_public_result_from_approved_fields() -> None:
     failure = _comparison_failure()
     failure["raw_log"] = "Bearer must-not-escape"
@@ -514,6 +535,23 @@ def test_public_failure_relay_uses_the_existing_status_context() -> None:
     assert workflow.count("TRTMC Internal CI / Automated premerge gate") == 1
     assert "actions/runs/$GITHUB_RUN_ID" in workflow
     assert "pulls/$PR_NUMBER" in workflow
+    assert workflow.index("- name: Confirm the exact open pull-request head") < workflow.index(
+        "- name: Print public-failure.log"
+    )
+
+
+def test_internal_ci_bridge_publishes_the_private_sanitized_artifact() -> None:
+    workflow = (
+        Path(__file__).parents[2] / ".github/workflows/internal-ci-bridge.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "--name public-failure-payload" in workflow
+    assert "--log" not in workflow
+    assert "validate_public_failure(report)" in workflow
+    assert "assert_public_payload_safe(report, document)" in workflow
+    assert "name: public-failure-log" in workflow
+    assert workflow.count("TRTMC Internal CI / Automated premerge gate") == 1
+    assert "actions/runs/$GITHUB_RUN_ID" in workflow
     assert workflow.index("- name: Confirm the exact open pull-request head") < workflow.index(
         "- name: Print public-failure.log"
     )

--- a/tools/public_failure/__main__.py
+++ b/tools/public_failure/__main__.py
@@ -28,6 +28,7 @@ def _context_from_object(value: Mapping[str, object]) -> ExportContext:
         head_sha=value.get("head_sha"),
         base_sha=value.get("base_sha"),
         tested_revision=value.get("tested_revision"),
+        dispatch_nonce=value.get("dispatch_nonce"),
         run_attempt=value.get("run_attempt"),
         result=value.get("result"),
         generated_at=value.get("generated_at"),

--- a/tools/public_failure/assets/public-failure-v1.schema.json
+++ b/tools/public_failure/assets/public-failure-v1.schema.json
@@ -34,6 +34,11 @@
     "base_sha": { "$ref": "#/$defs/sha" },
     "tested_revision": { "$ref": "#/$defs/sha" },
     "tested_revision_kind": { "enum": ["head", "merge"] },
+    "dispatch_nonce": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^[0-9a-f]{32}$"
+    },
     "run_attempt": { "type": "integer", "minimum": 1, "maximum": 1000 },
     "result": { "enum": ["failure", "error"] },
     "failures": {
@@ -113,6 +118,7 @@
           "enum": [
             "chronos_bolt",
             "codegen",
+            "fast_foundation_stereo",
             "llama",
             "patchtsmixer",
             "personaplex",

--- a/tools/public_failure/contract.py
+++ b/tools/public_failure/contract.py
@@ -35,6 +35,7 @@ REPORT_FIELDS = frozenset(
         "base_sha",
         "tested_revision",
         "tested_revision_kind",
+        "dispatch_nonce",
         "run_attempt",
         "result",
         "failures",
@@ -42,6 +43,7 @@ REPORT_FIELDS = frozenset(
         "generated_at",
     }
 )
+REPORT_REQUIRED_FIELDS = REPORT_FIELDS - {"dispatch_nonce"}
 FAILURE_FIELDS = frozenset(
     {
         "public_stage",
@@ -60,6 +62,7 @@ FAILURE_FIELDS = frozenset(
 METRIC_FIELDS = frozenset({"name", "observed", "operator", "threshold"})
 FAILURE_REQUIRED_FIELDS = FAILURE_FIELDS - {"metric", "subject", "excerpt"}
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+DISPATCH_NONCE_PATTERN = re.compile(r"[0-9a-f]{32}\Z")
 REPORT_ID_PATTERN = re.compile(r"trtmc-pr[1-9][0-9]*-[0-9a-f]{7}-attempt[1-9][0-9]*\Z")
 TIMESTAMP_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\Z")
 TEST_ID_PATTERN = re.compile(r"[A-Za-z0-9_./:\[\],=+-]+\Z")
@@ -187,7 +190,7 @@ def validate_public_failure(report: Mapping[str, object]) -> None:
     if not isinstance(report, Mapping):
         raise PublicFailureValidationError("report must be an object")
     _reject_unknown_fields(report, REPORT_FIELDS, "report")
-    _require_fields(report, REPORT_FIELDS, "report")
+    _require_fields(report, REPORT_REQUIRED_FIELDS, "report")
     if report.get("schema_version") != 1 or isinstance(report.get("schema_version"), bool):
         raise PublicFailureValidationError("schema_version must be 1")
     if report.get("policy_version") != POLICY_VERSION:
@@ -210,6 +213,13 @@ def validate_public_failure(report: Mapping[str, object]) -> None:
     )
     for key in ("head_sha", "base_sha", "tested_revision"):
         _require_string(report.get(key), key, max_length=40, pattern=SHA_PATTERN)
+    if "dispatch_nonce" in report:
+        _require_string(
+            report.get("dispatch_nonce"),
+            "dispatch_nonce",
+            max_length=32,
+            pattern=DISPATCH_NONCE_PATTERN,
+        )
     _require_enum(report.get("tested_revision_kind"), {"head", "merge"}, "tested_revision_kind")
     _require_enum(report.get("result"), {"failure", "error"}, "result")
     _require_string(

--- a/tools/public_failure/export.py
+++ b/tools/public_failure/export.py
@@ -38,6 +38,7 @@ class ExportContext:
     head_sha: str
     base_sha: str
     tested_revision: str
+    dispatch_nonce: str | None
     run_attempt: int
     result: str
     generated_at: str
@@ -131,7 +132,7 @@ def export_failure(
     failures = raw_failures if isinstance(raw_failures, list) else []
     approved_failures = [item for item in failures if isinstance(item, Mapping)]
     visible_failures = approved_failures[:MAX_PUBLIC_FAILURES]
-    return {
+    report = {
         "schema_version": 1,
         "policy_version": POLICY_VERSION,
         "report_id": (
@@ -149,3 +150,6 @@ def export_failure(
         "omitted_failure_count": len(approved_failures) - len(visible_failures),
         "generated_at": context.generated_at,
     }
+    if context.dispatch_nonce is not None:
+        report["dispatch_nonce"] = context.dispatch_nonce
+    return report

--- a/tools/public_failure/policy.py
+++ b/tools/public_failure/policy.py
@@ -49,6 +49,7 @@ PUBLIC_MODELS: Final = frozenset(
     {
         "chronos_bolt",
         "codegen",
+        "fast_foundation_stereo",
         "llama",
         "patchtsmixer",
         "personaplex",


### PR DESCRIPTION
## Background

The live external-contributor validation on #1056 proved that the first relay generated a sanitized payload but could not create a Source `repository_dispatch`: the existing status token intentionally lacks Source contents permission. Expanding that token would be broader than necessary.

## Exit Criteria

- The trusted Source bridge remains attached to the exact Internal CI run it dispatches.
- A failed run exposes `public-failure.log` in the public bridge log and as a seven-day artifact.
- Only the private sanitized JSON artifact crosses the repository boundary; raw protected logs never do.
- The existing `TRTMC Internal CI / Automated premerge gate` context points to the public Source run.
- The exact open PR/head is revalidated before any text is printed.
- No GitHub App, GitHub Pages, Source contents-write PAT, PR-head execution, or duplicate status context is introduced.

## Implementation

- Generates a 128-bit dispatch nonce and resolves one Internal workflow run by the exact PR, head, and nonce-bearing run title.
- Waits for that exact run with the existing Internal Actions-only token.
- On failure, downloads only the private `public-failure-payload` artifact; it never requests job logs.
- Revalidates the closed JSON contract and safety policy on trusted Source default-branch code.
- Requires the closed payload to carry the exact nonce generated by this bridge run before rendering or disclosure.
- Prints and uploads `public-failure.log`, then updates the existing automated status to target this public bridge run.
- Adds `fast_foundation_stereo` to the closed public model vocabulary because the model name and test path are already public in #1056.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m tools.community_ci source-quality --base github/main`: passed; 158 tests passed, changed-file lint/formatting passed, and the complexity gate passed.
- Dispatch-correlation and failure-log focused suite after review fixes: 117 passed.
- Bridge/failure-log focused suite: 55 passed before the final policy assertion; complete failure suite: 46 passed after it.
- Dedicated #1056 replay produced a 48-line, 1,792-byte log containing `Model: fast_foundation_stereo`, `Test: ctest::test_fast_foundation_stereo_native_plugins`, the intentional GPU-log probe, and the final CTest failure line.
- The replay contained no artifact-upload tail, checkout cleanup, private URL/path, email, IP, or credential.

### Hardware, Environment, and Revisions

- Source head: `dc9785876a688a095d50f296bc7d46d35a02dbbb`.
- Internal producer head: `df79db0ec39e4298fe52a45b7b747b97da186a32`.
- Live failure evidence came from the protected GPU run dispatched for external-contributor PR #1056 at head `d3b8f6650f110773a6a54c6d37fcf00203bffb80`.
- Source-only validation ran on Ubuntu with Python 3.12; the replay used the sanitized payload extracted from the actual Internal CI GPU failure.

### Not Run / Remaining Gaps

The final cross-repository artifact handoff cannot be exercised from an unmerged `pull_request_target` workflow because GitHub runs that workflow from the default branch. After the paired Internal producer and this Source consumer are merged, rerun only #1056 to verify the public step, `.log` artifact, status target, and absence of duplicate contexts end to end.

## Notes For Future Readers

Merge the paired Internal CI artifact-producer PR first, then merge this Source bridge consumer. The Internal nonce input is temporarily optional for deployment compatibility; the new Source bridge always supplies it and refuses to publish a payload without an exact match. Preserve the closed payload vocabulary and exact PR/head/nonce checks when extending the report.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the public bridge now waits for a private run, but it uses the existing protected Actions-only token, consumes only a pre-sanitized artifact from the exact nonce-correlated run it dispatched, and revalidates the exact Source PR/head before disclosure.
