### PR TITLE
ci: cover protected runner queue time

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -132,7 +132,8 @@ jobs:
     environment:
       name: ci-dispatch
       deployment: false
-    timeout-minutes: 60
+    # Cover protected runner queueing plus the longest 180-minute model proof.
+    timeout-minutes: 360
     permissions:
       contents: read
       pull-requests: read
@@ -217,7 +218,9 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]
-          for _ in $(seq 1 220); do
+          # Leave ten minutes for artifact download, validation, and status
+          # publication before the six-hour job timeout.
+          for _ in $(seq 1 1400); do
             run="$(
               gh api --method GET \
                 "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/runs/$RUN_ID"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -376,6 +376,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
         "name": "ci-dispatch",
         "deployment": False,
     }
+    assert workflow_config["jobs"]["dispatch"]["timeout-minutes"] == 360
     secret_references = set(re.findall(r"secrets\.([A-Z][A-Z0-9_]*)", workflow))
     assert secret_references == {
         "TRTMC_CI_DISPATCH_TOKEN",
@@ -421,6 +422,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert ".created_at >= $dispatched_at" not in dispatch
     assert "actions/workflows/premerge.yml/runs?event=workflow_dispatch" in dispatch
     assert "actions/runs/$RUN_ID" in dispatch
+    assert "for _ in $(seq 1 1400); do" in dispatch
     assert "--name public-failure-payload" in dispatch
     assert "--log" not in dispatch
     assert "validate_public_failure(report)" in dispatch


### PR DESCRIPTION
## Background

The first post-merge live validation on the dedicated external-contributor PR #1056 exposed a real runner-queue timeout. Public bridge run `33080320518` correctly correlated private run `33080349314` by nonce, but its `Wait for the exact Internal CI result` step failed after 56m53s while the selected `fast_foundation_stereo` GPU job was still queued with no steps started. The failure was therefore in the bridge waiting budget, not in nonce correlation, artifact generation, or failure-log rendering.

## Exit Criteria

- The public bridge wait budget covers protected runner queueing plus the longest supported Internal model proof.
- The bridge retains time after the private run completes to download, validate, print, upload, and publish the failure result.
- The exact-run nonce correlation and fail-closed behavior remain unchanged.
- A deterministic workflow test locks down the timeout and polling budget.

## Implementation

- Raises the trusted dispatch job timeout from 60 to 360 minutes.
- Raises the exact private-run polling window from 220 to 1,400 15-second polls, or 350 minutes.
- Reserves the final 10 minutes for artifact transfer, closed-contract validation, public `.log` publication, and status update.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- Regression test before the workflow change: failed because the dispatch timeout was 60 rather than 360 minutes.
- Focused bridge test after the change: 1 passed.
- `python3 -m tools.community_ci source-quality --base github/main`: passed; 158 tests passed, changed-file lint/formatting passed, and the complexity gate passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `870bf4087921acaac9c8f4a8edf138fa6093b8b8`.
- Source base: `7aa0b211e52ad17f6d827d4c33022b36130e7f01`.
- Live evidence: public bridge `33080320518`, private Internal run `33080349314`, Source PR #1056 head `d3b8f6650f110773a6a54c6d37fcf00203bffb80`.
- The private GPU job remained queued for more than 55 minutes with no steps, reproducing the budget failure without executing contributor code in the public workflow.

### Not Run / Remaining Gaps

The complete public failure-log handoff could not run because the original bridge exhausted its 55-minute polling window before a protected GPU runner became available. After this change reaches `main`, rerun only #1056 and verify the nonce-correlated artifact, printed `.log`, status target, root CTest failure block, and sensitive-data checks end to end.

## Notes For Future Readers

The longest Internal model proof currently has a 180-minute job timeout. The 350-minute polling window covers that execution budget plus substantial protected-runner queueing while staying within GitHub's six-hour hosted-job limit. If Internal model timeouts grow beyond 180 minutes, revisit both budgets together.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: this changes only how long the trusted bridge waits for an already exact, nonce-correlated private run. Permissions, payload contents, publication checks, and status context are unchanged.
