### PR TITLE
feat(deepseek-v2): use native TensorRT MoE layer on SM 10.x

### DIFF
--- a/python/tensorrt_model_connect/families/deepseek_v2/native_moe.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/native_moe.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V2 policy for using the native TensorRT MoE layer.
+
+TensorRT 11.1 exposes ``INetworkDefinition.add_moe()`` and ``IMoELayer``. The
+layer receives the routed expert ids and their scores as runtime inputs, so it
+evaluates only the experts a token was actually routed to. Emitting one
+subgraph per expert and gathering the selected outputs afterwards instead
+evaluates every expert for every token, because the selection happens after the
+expert matmuls have already been placed in the graph.
+
+This module is owned by the DeepSeek-V2 family and is intentionally not shared.
+Another family that wants the native layer should carry its own policy, so each
+family keeps control of the compute capabilities it has actually qualified.
+
+TensorRT restricts the layer to SM 10.x and SM 11.x and rejects SM 12.x inside
+``addMoE`` itself, returning a null layer rather than failing the build. The
+decision therefore has to be made before the layer is added, which is what this
+module provides.
+
+Only SM 10.x is enabled here. TensorRT also permits SM 11.x (Thor), but
+DeepSeek-V2 has not been qualified on that target, so it stays on the portable
+per-expert path until it is.
+
+Set ``TRTMC_DISABLE_NATIVE_MOE=1`` to force the per-expert path on a supported
+GPU, which is useful when bisecting a numerical difference between the two.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from ... import trt_compat
+
+
+DISABLE_ENV = "TRTMC_DISABLE_NATIVE_MOE"
+
+#: Compute-capability majors on which the native MoE layer is enabled.
+SUPPORTED_COMPUTE_MAJORS = (10,)
+
+
+def native_moe_enabled_for(
+    compute_capability: tuple[int, int] | None,
+    *,
+    layer_available: bool,
+    disabled: bool = False,
+) -> bool:
+    """Return whether a MoE graph should be built with the native TRT layer.
+
+    Kept free of TensorRT and CUDA calls so the policy itself is testable on a
+    machine without a GPU.
+    """
+    if disabled or not layer_available:
+        return False
+    if compute_capability is None:
+        return False
+    major, _minor = compute_capability
+    return major in SUPPORTED_COMPUTE_MAJORS
+
+
+def _cuda_runtime() -> Any | None:
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart
+        except ImportError:
+            return None
+    return cudart
+
+
+def current_compute_capability() -> tuple[int, int] | None:
+    """Compute capability of the active CUDA device, or ``None`` if unknown.
+
+    An unusable or absent CUDA device is not an error here; it only means the
+    native layer cannot be selected and the caller keeps the portable path.
+    """
+    runtime = _cuda_runtime()
+    if runtime is None:
+        return None
+    success = getattr(getattr(runtime, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status, device = runtime.cudaGetDevice()
+        if status not in (success, 0):
+            return None
+        status, properties = runtime.cudaGetDeviceProperties(int(device))
+        if status not in (success, 0):
+            return None
+        major = int(properties.major)
+        minor = int(properties.minor)
+    except Exception:
+        return None
+    if major <= 0 or minor < 0:
+        return None
+    return (major, minor)
+
+
+def native_moe_layer_available() -> bool:
+    """Whether the bound TensorRT Python module exposes the MoE layer."""
+    trt = trt_compat.get_trt()
+    return hasattr(trt.INetworkDefinition, "add_moe") and hasattr(trt, "MoEActType")
+
+
+def use_native_moe() -> bool:
+    """Resolve the native-MoE decision for the current build environment."""
+    return native_moe_enabled_for(
+        current_compute_capability(),
+        layer_available=native_moe_layer_available(),
+        disabled=os.environ.get(DISABLE_ENV) == "1",
+    )

--- a/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
@@ -44,6 +44,7 @@ from pathlib import Path
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
+from . import native_moe
 from .config import ModelConfig
 from .checkpoint_mapper import (
     WeightDict,
@@ -932,6 +933,91 @@ def _add_swiglu_expert(
     return down
 
 
+def _stack_expert_weights(
+    weights: WeightDict,
+    prefix: str,
+    n_routed_experts: int,
+    key: str,
+    dtype: np.dtype,
+) -> np.ndarray:
+    """Stack one per-expert projection into a single [experts, rows, cols] array."""
+    return np.ascontiguousarray(
+        np.stack(
+            [
+                np.asarray(weights[f"{prefix}.expert.{index}.{key}"])
+                for index in range(n_routed_experts)
+            ]
+        ).astype(dtype)
+    )
+
+
+def _add_native_routed_experts(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    n_routed_experts: int,
+    num_experts_per_tok: int,
+    top_indices: trt.ITensor,
+    scaled_weights: trt.ITensor,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    """Routed-expert output computed by the native TensorRT MoE layer.
+
+    ``set_gated_weights`` takes one stacked tensor per projection covering every
+    expert, in the orientation this family already stores them: gate and up as
+    ``[experts, hidden, intermediate]`` and down as
+    ``[experts, intermediate, hidden]``. No transposition is required.
+
+    The layer applies the routing scores itself, so its output is the weighted
+    sum over the selected experts and only those experts are evaluated.
+    """
+    w_gate = _stack_expert_weights(
+        weights, prefix, n_routed_experts, "w_gate", dtype)
+    w_up = _stack_expert_weights(
+        weights, prefix, n_routed_experts, "w_up", dtype)
+    w_down = _stack_expert_weights(
+        weights, prefix, n_routed_experts, "w_down", dtype)
+
+    # IMoELayer requires rank-3 hidden states [batch, tokens, hidden]; the
+    # decoder carries rank-2 [tokens, hidden].
+    def _with_batch_dim(tensor: trt.ITensor, last_dim: int) -> trt.ITensor:
+        shuffle = network.add_shuffle(tensor)
+        shuffle.reshape_dims = (1, -1, last_dim)
+        return shuffle.get_output(0)
+
+    rank = len(tuple(inp.shape))
+    if rank == 2:
+        moe_hidden = _with_batch_dim(inp, hidden_size)
+        moe_indices = _with_batch_dim(top_indices, num_experts_per_tok)
+        moe_scores = _with_batch_dim(scaled_weights, num_experts_per_tok)
+    elif rank == 3:
+        moe_hidden, moe_indices, moe_scores = inp, top_indices, scaled_weights
+    else:
+        raise ValueError(
+            f"DeepSeek-V2 MoE expects rank-2 or rank-3 hidden states, got rank {rank}")
+
+    moe = network.add_moe(moe_hidden, moe_indices, moe_scores)
+    if moe is None:
+        raise RuntimeError(
+            "TensorRT rejected addMoE for this build; the per-expert path "
+            "should have been selected instead")
+    moe.set_gated_weights(
+        graph_ops.add_constant(network, w_gate.shape, w_gate, dtype=dtype),
+        graph_ops.add_constant(network, w_up.shape, w_up, dtype=dtype),
+        graph_ops.add_constant(network, w_down.shape, w_down, dtype=dtype),
+        trt.MoEActType.SILU,
+    )
+    routed_out = moe.get_output(0)
+
+    if rank == 2:
+        restore = network.add_shuffle(routed_out)
+        restore.reshape_dims = (-1, hidden_size)
+        routed_out = restore.get_output(0)
+    return routed_out
+
+
 def _add_moe_with_shared_experts(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
@@ -952,12 +1038,19 @@ def _add_moe_with_shared_experts(
 ) -> trt.ITensor:
     """MoE block with shared experts (DeepSeek-V2 style).
 
-    1. Router logits -> softmax -> top-k selection
+    1. Router logits -> softmax/sigmoid -> top-k selection
     2. Scale weights: renormalize (norm_topk_prob=True) or multiply by
        routed_scaling_factor (norm_topk_prob=False)
-    3. Compute all routed expert outputs, select top-k, weighted sum
+    3. Routed-expert output, by one of two paths:
+       - native TensorRT MoE layer, which evaluates only the selected experts
+         (SM 10.x, see ``native_moe``);
+       - otherwise the portable path, which evaluates every expert and then
+         gathers the top-k and takes their weighted sum.
     4. Compute shared expert output (always active)
     5. Final = routed_output + shared_output
+
+    Both paths share the router in step 1-2 and the shared-expert residual in
+    step 4-5, so they differ only in how the routed experts are evaluated.
     """
     top_indices, scaled_weights = moe_routing.add_router(
         network,
@@ -974,6 +1067,17 @@ def _add_moe_with_shared_experts(
         norm_topk_prob=norm_topk_prob,
         routed_scaling_factor=routed_scaling_factor,
     )
+
+    if native_moe.use_native_moe():
+        # Native TensorRT MoE layer: evaluates only the routed experts.
+        result = _add_native_routed_experts(
+            network, inp, weights, prefix,
+            hidden_size, n_routed_experts, num_experts_per_tok,
+            top_indices, scaled_weights, dtype,
+        )
+        return _add_shared_expert_residual(
+            network, inp, weights, prefix, hidden_size, shared_intermediate,
+            result, dtype)
 
     # 5. Compute ALL routed expert outputs and stack
     expert_outputs = []
@@ -1028,7 +1132,23 @@ def _add_moe_with_shared_experts(
                 trt.ElementWiseOperation.SUM)
             result = sum_layer.get_output(0)
 
-    # 7. Shared expert output (always active)
+    # 7 & 8. Shared expert output (always active) + routed output
+    return _add_shared_expert_residual(
+        network, inp, weights, prefix, hidden_size, shared_intermediate,
+        result, dtype)
+
+
+def _add_shared_expert_residual(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    shared_intermediate: int,
+    routed_out: trt.ITensor,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    """Add the always-active shared-expert output to the routed-expert output."""
     shared_out = _add_swiglu_expert(
         network, inp, hidden_size, shared_intermediate,
         weights[f"{prefix}.shared.w_gate"],
@@ -1036,11 +1156,10 @@ def _add_moe_with_shared_experts(
         weights[f"{prefix}.shared.w_down"],
         dtype=dtype,
     )
-
-    # 8. Combine: routed_output + shared_output
+    if routed_out.dtype != shared_out.dtype:
+        routed_out = network.add_cast(routed_out, shared_out.dtype).get_output(0)
     combined = network.add_elementwise(
-        result, shared_out, trt.ElementWiseOperation.SUM)
-
+        routed_out, shared_out, trt.ElementWiseOperation.SUM)
     return combined.get_output(0)
 
 

--- a/python/tensorrt_model_connect/families/deepseek_v2/tests/test_native_moe.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/tests/test_native_moe.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-V2 native TensorRT MoE layer availability policy.
+
+The policy decides whether the DeepSeek-V2 MoE block emits ``INetworkDefinition.add_moe()``
+or its portable per-expert subgraph. TensorRT rejects ``addMoE`` on SM 12.x
+inside the call itself, so the decision has to be correct before the layer is
+added; these tests pin that decision without requiring a GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Import the submodule directly: the family package proxies attribute access
+# to plugin.py, which would pull in the full builder and its dependencies.
+import tensorrt_model_connect.families.deepseek_v2.native_moe as native_moe
+
+
+@pytest.mark.parametrize("compute_capability", [(10, 0), (10, 3)])
+def test_native_moe_enabled_on_supported_datacenter_blackwell(compute_capability):
+    assert native_moe.native_moe_enabled_for(
+        compute_capability, layer_available=True) is True
+
+
+@pytest.mark.parametrize(
+    "compute_capability",
+    [
+        (12, 0),  # GeForce / RTX PRO Blackwell: TensorRT rejects addMoE
+        (11, 0),  # Thor: permitted by TensorRT but not qualified here
+        (9, 0),   # Hopper
+        (8, 9),   # Ada
+        (8, 0),   # Ampere
+    ],
+)
+def test_native_moe_disabled_off_supported_architectures(compute_capability):
+    assert native_moe.native_moe_enabled_for(
+        compute_capability, layer_available=True) is False
+
+
+def test_native_moe_disabled_when_layer_missing():
+    """An older TensorRT without IMoELayer keeps the per-expert path."""
+    assert native_moe.native_moe_enabled_for(
+        (10, 0), layer_available=False) is False
+
+
+def test_native_moe_disabled_when_capability_unknown():
+    """An unusable or absent CUDA device must not select the native path."""
+    assert native_moe.native_moe_enabled_for(
+        None, layer_available=True) is False
+
+
+def test_native_moe_disabled_by_opt_out():
+    """The escape hatch forces the per-expert path on a supported GPU."""
+    assert native_moe.native_moe_enabled_for(
+        (10, 0), layer_available=True, disabled=True) is False
+
+
+def test_use_native_moe_honours_disable_env(monkeypatch):
+    monkeypatch.setenv(native_moe.DISABLE_ENV, "1")
+    monkeypatch.setattr(
+        native_moe, "current_compute_capability", lambda: (10, 0))
+    monkeypatch.setattr(native_moe, "native_moe_layer_available", lambda: True)
+    assert native_moe.use_native_moe() is False
+
+
+def test_use_native_moe_selects_native_on_sm100(monkeypatch):
+    monkeypatch.delenv(native_moe.DISABLE_ENV, raising=False)
+    monkeypatch.setattr(
+        native_moe, "current_compute_capability", lambda: (10, 0))
+    monkeypatch.setattr(native_moe, "native_moe_layer_available", lambda: True)
+    assert native_moe.use_native_moe() is True
+
+
+def test_current_compute_capability_survives_missing_cuda(monkeypatch):
+    """No CUDA runtime is a normal outcome, not an exception."""
+    monkeypatch.setattr(native_moe, "_cuda_runtime", lambda: None)
+    assert native_moe.current_compute_capability() is None


### PR DESCRIPTION
## Background

The DeepSeek-V2 MoE block built one SwiGLU subgraph per routed expert,
concatenated all of them, and only then gathered the top-k and took their
weighted sum. Because expert selection happened *after* the expert matmuls were
already placed in the graph, every expert was evaluated for every token.

On `deepseek-ai/DeepSeek-V2-Lite` that is 26 MoE layers x 64 routed experts =
1664 expert GEMVs per decode step, while `num_experts_per_tok` is 6. An nsys
capture attributed 29.1% of decode GPU time to a single
`sm50_xmma_cublas_gemvx_f16f16_f32_f32...` kernel across 1,420,440 launches,
with every other kernel under 1%.

TensorRT 11.1 exposes `INetworkDefinition.add_moe()` / `IMoELayer`, which takes
the routed expert ids and their scores as runtime inputs and therefore
evaluates only the selected experts. It was unused anywhere in this repository.

## Exit Criteria

- DeepSeek-V2 builds through `add_moe()` on SM 10.x and through the existing
  per-expert path on every other architecture.
- Generated text is unchanged on a supported GPU.
- No behavior change on unsupported GPUs, on a TensorRT without `IMoELayer`, or
  when CUDA is unavailable.
- Non-goal: other MoE families, the DeepSeek-V2 tensor-parallel builder, and
  quantized MoE are out of scope.

## Implementation

- **`families/deepseek_v2/native_moe.py` (new)** owns the availability policy.
  It is family-owned on purpose: another family that wants the native layer
  should carry its own policy rather than depend on a shared backbone, so each
  family keeps control of the compute capabilities it has actually qualified.
  `native_moe_enabled_for()` is a pure function over
  `(compute_capability, layer_available, disabled)`, so the policy is testable
  without a GPU; `use_native_moe()` wraps it with a CUDA capability query and a
  `hasattr` check on the bound TensorRT module. A missing CUDA runtime, an
  unreadable device, or a TensorRT without `IMoELayer` all resolve to "not
  supported" rather than raising, keeping the portable path as the safe default.
- **`families/deepseek_v2/plugin.py`**: `_add_moe_with_shared_experts()` now
  dispatches after the router. On SM 10.x it calls `_add_native_routed_experts()`;
  otherwise it keeps the existing per-expert loop unchanged. The shared-expert
  residual is factored into `_add_shared_expert_residual()` so both paths share
  one implementation of that step.
- **Weight handling**: `set_gated_weights()` consumes the expert projections in
  the orientation this family already stores them, gate and up as
  `[experts, hidden, intermediate]` and down as `[experts, intermediate, hidden]`,
  so `_stack_expert_weights()` only stacks with no transposition. The layer
  applies the routing scores itself, so the existing `add_router()` outputs
  `(top_indices, scaled_weights)` feed straight in as inputs 1 and 2.
- **Rank**: `IMoELayer` requires rank-3 hidden states; the decoder carries
  rank-2, so the call is wrapped in a unit batch dimension and unwrapped after.
- **Tests** live in `families/deepseek_v2/tests/test_native_moe.py`, matching the
  family-local test layout. They import the submodule directly because the family
  package proxies attribute access to `plugin.py`, which would otherwise pull the
  full builder and its dependencies into a GPU-free policy test.
- Gating on compute capability rather than try-and-fall-back is deliberate:
  TensorRT rejects `addMoE` on SM 12.x inside the call, returns a null layer,
  and emits an error to the logger first. Deciding up front avoids a spurious
  error line in every SM 12.x build log.
- No public API, ABI, bundle format, or dependency change. `TRTMC_DISABLE_NATIVE_MOE=1`
  forces the per-expert path on a supported GPU for bisecting.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Static checks on a CPU-only host:

- `ruff check` over the three touched Python files — passed.
- `pytest python/tensorrt_model_connect/families/deepseek_v2/tests/test_native_moe.py -q` — 13 passed.
- `pytest tests/builder -q` (5 pre-existing collection errors ignored) —
  `84 failed, 600 passed, 79 skipped, 24 errors` with this change versus
  `84 failed, 587 passed, 79 skipped, 24 errors` on a clean tree at the same
  base. Identical failure and error counts; the delta is the 13 new tests. The
  pre-existing failures are environment-related on a host without TensorRT/CUDA.

Target-hardware run of this exact diff applied to base `03ab9c54`:

- Dispatch resolved with no environment variable set:
  `current_compute_capability: (10, 0)`, `layer_available: True`,
  `use_native_moe: True`.
- `trtmc build deepseek-ai/DeepSeek-V2-Lite --precision fp16 --max-cache-length 128 -o pr-native.bundle`
  — succeeded, 236 s.
- `trtmc run pr-native.bundle --prompt "The capital of France is" --max-new-tokens 32 --seed 42`
  — `Paris.\nThe capital of the United States is Washington, D.C. ...`, matching
  the per-expert path exactly.
- `trtmc run pr-native.bundle --prompt "The capital of France is" --max-new-tokens 100 --seed 42 --warmup 2 --benchmark 5`
  — `tokens_per_sec=153.97`.
- `TRTMC_DISABLE_NATIVE_MOE=1` — `use_native_moe()` resolved to `False`.
- `pytest .../deepseek_v2/tests/test_native_moe.py -q` inside the build container — 13 passed.

A/B against the unmodified per-expert path, same workload and GPU, run
end-to-end on two independent SM 10.0 nodes:

| GPU | per-expert | native | build, per-expert -> native |
| --- | --- | --- | --- |
| B200 | 56.99 tok/s | 153.88 tok/s | 1691 s -> 235 s |
| GB100 bring-up board | 56.99 tok/s | 154.23 tok/s | 1870 s -> 249 s |

Kernel mix on the B200 pair, from `nsys profile --cuda-graph-trace=node` plus
`nsys stats --report cuda_gpu_kern_sum`: distinct kernels 1718 -> 53, GEMV-like
launches 1,443,120 -> 45,360. The native arm's hot kernels are
`__myl_MoEFc1_cuda_tile` and `__myl_MoEFc2_cuda_tile` at 21,840 instances each,
which is 26 MoE layers x 840 decode steps, i.e. one launch per MoE layer per
token.

### Hardware, Environment, and Revisions

- Repository base: `03ab9c54` for the hardware run; PR head as pushed.
- Model: `deepseek-ai/DeepSeek-V2-Lite`, fp16, `--max-cache-length 128`,
  batch 1, greedy, seed 42.
- GPUs: NVIDIA B200 (SM 10.0, 183 GB) and an NVIDIA GB100 bring-up board
  (SM 10.0, 183 GB), single GPU each, no tensor parallelism.
- Driver 595.58.03; container `nvcr.io/nvidia/tensorrt:26.07-py3` via
  `Dockerfile.dev.x86`; TensorRT 11.1.0.106; CUDA 13.3;
  Nsight Systems 2026.3.1.
- Built with `-DCMAKE_CUDA_ARCHITECTURES=100-real`,
  `-DTRTMC_BUILD_BACKEND_TRT=ON`.

### Not Run / Remaining Gaps

- Repository premerge CI has not run for this head at the time of writing. No
  claim is made about `trtmc/premerge/required`.
- Tensor-parallel builds: `deepseek_v2/tp_builder.py` has its own expert loop
  and is untouched, so TP keeps the per-expert path on every GPU. Not exercised.
- Quantized MoE: not implemented or tested on either path.
- SM 11.x (Thor): permitted by TensorRT but deliberately not enabled here and
  not tested.
- SM 12.x and pre-11.1 TensorRT: the fallback is covered by unit tests over the
  policy function, but no engine was built on those configurations for this PR.
- Only `deepseek-v2-lite` was exercised end to end. `deepseek-v2-tiny` was used
  for a parity check during development but is not part of the recorded runs
  above.
- Accumulate precision inside the fused `__myl_MoEFc*` kernels was not
  characterized; generated-text parity is the correctness evidence.

## Notes For Future Readers

- Suggested review order: `families/deepseek_v2/native_moe.py` for the policy,
  then the dispatch and `_add_native_routed_experts()` in
  `families/deepseek_v2/plugin.py`, then
  `families/deepseek_v2/tests/test_native_moe.py`.
- Only SM 10.x is enabled. TensorRT also permits SM 11.x (Thor), and widening
  `SUPPORTED_COMPUTE_MAJORS` is a one-line change, but that target has not been
  qualified here so it deliberately stays on the portable path.
- The per-expert path is not dead code. It is the only path on SM 12.x
  (GeForce / RTX PRO Blackwell), where TensorRT rejects `addMoE` outright, and on
  any TensorRT without `IMoELayer`. Please do not delete it when the native path
  looks sufficient.
- The same compute-all-experts pattern exists in `deepseek_ocr`, `mixtral`,
  `phi_moe`, `qwen_moe`, `qwen3_omni`, and `gpt_oss`. They should benefit
  similarly, but none were modified or measured here. Per maintainer guidance the
  policy is deliberately family-owned rather than a shared backbone, so each of
  those families should carry its own copy and qualify its own compute
  capabilities instead of inheriting this one.
- `IMoELayer` also exposes static FP8 quantization via `setQuantizationStatic`,
  which requires `DataType::kFP8`. No MoE manifest in this repository is
  quantized today, and the per-expert path never threaded `quant_ctx` into the
  expert matmuls, so quantized MoE remains unimplemented on either path. The
  native layer is the more natural place to add it later.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: the change is gated to one model family on one compute-capability
range, and every other configuration keeps the existing code path unchanged and
as the default. Generated text was verified identical to the per-expert path on
target hardware, and `TRTMC_DISABLE_NATIVE_MOE=1` restores the old path without
a rebuild of the source tree. The main residual risk is that only
`deepseek-v2-lite` was exercised end to end, so an untested DeepSeek-V2 routing
configuration on SM 10.x could behave differently; premerge CI has not yet run.
