### PR TITLE
fix(tvm-ffi): validate shape input indices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1008,6 +1008,8 @@ trtmc_add_test(test_decoder_config)
 
 # TVM-FFI plugin
 if(_trtmc_has_tvm_ffi)
+  trtmc_add_test(test_tvm_ffi_shape_spec REQUIRES_TRT)
+
   add_library(trtmc_test_tvm_ffi_runtime_kernel SHARED EXCLUDE_FROM_ALL
     tests/cpp/test_tvm_ffi_runtime_bindings.cpp
   )

--- a/src/plugins/tvm_ffi_kernel_plugin.cpp
+++ b/src/plugins/tvm_ffi_kernel_plugin.cpp
@@ -11,6 +11,7 @@
 
 #include "plugins/tvm_ffi_runtime_bindings.h"
 
+#include <charconv>
 #include <cstdint>
 #include <cstring>
 #include <cuda_runtime_api.h>
@@ -77,15 +78,24 @@ TvmFfiKernelPlugin::~TvmFfiKernelPlugin() = default;
 
 namespace {
 
+/// @brief Parse and validate a same-as-input dimension reference.
+static int32_t parse_input_index(const std::string& dims) {
+    const char* first = dims.data() + 14;
+    const char* last = dims.data() + dims.size();
+    int32_t input_index = -1;
+    const auto [end, error] = std::from_chars(first, last, input_index);
+    if (first == last || error != std::errc{} || end != last || input_index < 0) {
+        throw std::runtime_error("Invalid TvmFfiKernelPlugin output input index");
+    }
+    return input_index;
+}
+
+/// @brief Decode inherited or fixed output dimensions from JSON.
 static void parse_dims(TvmFfiOutputSpec& spec, const nlohmann::json& dims_obj) {
     if (dims_obj.is_string()) {
         std::string dims_str = dims_obj.get<std::string>();
         if (dims_str.find("same_as_input_") == 0) {
-            try {
-                spec.same_as_input_index = static_cast<int32_t>(std::stoi(dims_str.substr(14)));
-            } catch (...) {
-                spec.same_as_input_index = -1;
-            }
+            spec.same_as_input_index = parse_input_index(dims_str);
         } else {
             spec.same_as_input_index = -1;
         }

--- a/tests/cpp/test_tvm_ffi_shape_spec.cpp
+++ b/tests/cpp/test_tvm_ffi_shape_spec.cpp
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "plugins/tvm_ffi_kernel_plugin.h"
+
+#include <NvInfer.h>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+/// @brief Record a named assertion failure.
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+/// @brief Verify that an operation rejects an invalid shape specification.
+template <typename Fn>
+void check_throws(Fn&& fn, const char* name) {
+    try {
+        fn();
+        check(false, name);
+    } catch (const std::exception&) {
+        check(true, name);
+    }
+}
+
+/// @brief Cover nested JSON, output metadata, and serialization.
+void test_shape_spec_parsing() {
+    const std::string kernel_name = "test.shape_spec";
+    const std::string shape_spec = R"({
+        "num_inputs": 2,
+        "num_outputs": 2,
+        "outputs": [
+            {
+                "dims": "same_as_input_1",
+                "dtype": "inherit",
+                "metadata": {"nested": [1, {"text": "escaped \" ] }"}]}
+            },
+            {"dims": [2, 3], "dtype": "int32", "unused": [[], {}]}
+        ],
+        "workspace_bytes": 4096,
+        "extra_args": [
+            {"type": "int", "value": 7, "metadata": {"nested": [1, 2]}},
+            {"type": "float", "value": 1.25, "label": "escaped \" ] }"}
+        ],
+        "extra": {"nested": {"array": [1, 2, 3]}}
+    })";
+
+    trtmc::TvmFfiKernelPlugin plugin(kernel_name, shape_spec);
+    check(plugin.getNbOutputs() == 2, "shape spec output count");
+    check(plugin.getWorkspaceSize(nullptr, 0, nullptr, 0) == 4096, "shape spec workspace size");
+
+    const nvinfer1::DataType input_types[] = {nvinfer1::DataType::kFLOAT,
+                                              nvinfer1::DataType::kHALF};
+    check(plugin.getOutputDataType(0, input_types, 2) == nvinfer1::DataType::kHALF,
+          "shape spec inherited output type");
+    check(plugin.getOutputDataType(1, input_types, 2) == nvinfer1::DataType::kINT32,
+          "shape spec explicit output type");
+
+    std::vector<char> serialized(plugin.getSerializationSize());
+    plugin.serialize(serialized.data());
+    check(serialized.size() == sizeof(uint32_t) * 2 + kernel_name.size() + shape_spec.size(),
+          "shape spec serialization size");
+
+    const char* cursor = serialized.data();
+    uint32_t serialized_kernel_length = 0;
+    std::memcpy(&serialized_kernel_length, cursor, sizeof(serialized_kernel_length));
+    cursor += sizeof(serialized_kernel_length);
+    check(serialized_kernel_length == kernel_name.size(), "serialized kernel name length");
+    check(std::string(cursor, serialized_kernel_length) == kernel_name, "serialized kernel name");
+    cursor += serialized_kernel_length;
+    uint32_t serialized_spec_length = 0;
+    std::memcpy(&serialized_spec_length, cursor, sizeof(serialized_spec_length));
+    cursor += sizeof(serialized_spec_length);
+    check(serialized_spec_length == shape_spec.size(), "serialized shape spec length");
+    check(std::string(cursor, serialized_spec_length) == shape_spec, "serialized shape spec");
+
+    trtmc::TvmFfiKernelPlugin restored(serialized.data(), serialized.size());
+    check(restored.getNbOutputs() == 2, "deserialized shape spec output count");
+    check(restored.getWorkspaceSize(nullptr, 0, nullptr, 0) == 4096,
+          "deserialized shape spec workspace size");
+    check(restored.getSerializationSize() == serialized.size(),
+          "shape spec serialization ABI preserved");
+}
+
+/// @brief Verify defaults for omitted and syntactically incomplete JSON.
+void test_shape_spec_defaults_and_malformed_json() {
+    const nvinfer1::DataType input_types[] = {nvinfer1::DataType::kHALF};
+    for (const std::string& shape_spec : {
+             std::string{"{}"},
+             std::string{R"({"num_inputs": 2, "outputs": [)"},
+             std::string{R"({"num_inputs": 2, "outputs": [{"dims": [2, 3]})"},
+         }) {
+        trtmc::TvmFfiKernelPlugin plugin("test.defaults", shape_spec);
+        check(plugin.getNbOutputs() == 1, "malformed shape spec default output count");
+        check(plugin.getWorkspaceSize(nullptr, 0, nullptr, 0) == 0,
+              "malformed shape spec default workspace");
+        check(plugin.getOutputDataType(0, input_types, 1) == nvinfer1::DataType::kHALF,
+              "malformed shape spec default output type");
+    }
+}
+
+/// @brief Verify invalid counts, workspace, dimensions, and input references.
+void test_shape_spec_validation() {
+    check_throws([] { trtmc::TvmFfiKernelPlugin("test.invalid", R"({"num_inputs":0})"); },
+                 "reject zero inputs");
+    check_throws([] { trtmc::TvmFfiKernelPlugin("test.invalid", R"({"num_outputs":0})"); },
+                 "reject zero outputs");
+    check_throws([] { trtmc::TvmFfiKernelPlugin("test.invalid", R"({"workspace_bytes":-1})"); },
+                 "reject negative workspace");
+    check_throws(
+        [] {
+            trtmc::TvmFfiKernelPlugin("test.invalid",
+                                      R"({"num_inputs":1,"outputs":[{"dims":"same_as_input_1"}]})");
+        },
+        "reject out-of-range input index");
+    check_throws(
+        [] {
+            trtmc::TvmFfiKernelPlugin(
+                "test.invalid", R"({"outputs":[{"dims":"same_as_input_999999999999999999999"}]})");
+        },
+        "reject overflowing input index");
+    check_throws(
+        [] {
+            trtmc::TvmFfiKernelPlugin("test.invalid",
+                                      R"({"outputs":[{"dims":"same_as_input_-1"}]})");
+        },
+        "reject negative input index");
+    check_throws(
+        [] {
+            trtmc::TvmFfiKernelPlugin("test.invalid",
+                                      R"({"outputs":[{"dims":"same_as_input_0suffix"}]})");
+        },
+        "reject malformed input index");
+    check_throws(
+        [] { trtmc::TvmFfiKernelPlugin("test.invalid", R"({"outputs":[{"dims":[2,0,3]}]})"); },
+        "reject non-positive fixed dimension");
+}
+
+} // namespace
+
+/// @brief Run the TVM-FFI shape-specification unit tests.
+int main() {
+    test_shape_spec_parsing();
+    test_shape_spec_defaults_and_malformed_json();
+    test_shape_spec_validation();
+
+    if (failures != 0) {
+        std::cerr << failures << " FAILED\n";
+        return 1;
+    }
+    std::cerr << "All TVM-FFI shape specification tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Background

PR #1013 completed #972's nlohmann/json migration and scanner removal, but invalid `same_as_input_...` suffixes could still become `-1`, and the requested edge cases were untested.

## Exit Criteria

Reject invalid indices and cover defaults, malformed JSON, and serialization. No API, ABI, dependency, migration, or rollout changes.

## Implementation

Parse indices strictly with `std::from_chars` and add a focused TVM-FFI shape-spec test target. Existing typed JSON parsing and serialization remain unchanged.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python;. python tools/model_ci.py validate`: passed.
- `PYTHONPATH=python;. python tools/test_impact.py --validate`: passed (221 models, 84 families).
- `git diff --check`: passed.
- `python -m pre_commit run --from-ref upstream/main --to-ref HEAD`: passed.
- `python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 158 passed.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed; maximum CCN 10.
- `python tools/test_impact.py --base upstream/main --head HEAD --json`: passed; C++ unit tier selected.
- [Community CPU run 33119819451](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/33119819451): required check passed; `test_tvm_ffi_shape_spec` passed in 0.06 s.

### Hardware, Environment, and Revisions

Head `7fdf345ce993fa217eee3c6cc452969b1643a355`; local base `7e6325412b2ab9a5e04aa9fe1b3f73cdcbb53c45`. Local: Windows, Python 3.14.5, CPU-only. Public CI: Ubuntu 24.04, Python 3.12, TensorRT 11.1.0.106, TVM-FFI 0.1.12. Model, checkpoint, dataset, and precision revisions are not applicable.

### Not Run / Remaining Gaps

Local TensorRT/TVM-FFI build was not run because those SDKs are unavailable locally; public CI supplied that coverage. Protected premerge, GPU inference, parity, performance, and hardware qualification have not run; model execution is unchanged.

## Notes For Future Readers

Valid shape specs and serialized bytes are unchanged. No third-party material, migration, or rollout is involved.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Only invalid indices change behavior.

Closes #972