### PR TITLE
fix(ci): mask private correlation identifiers

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -157,6 +157,7 @@ jobs:
           umask 077
           dispatch_nonce="$(openssl rand -hex 16)"
           [[ "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]
+          echo "::add-mask::$dispatch_nonce"
           payload="$RUNNER_TEMP/internal-ci-dispatch.json"
           trap 'rm -f "$payload"' EXIT
           jq -n \
@@ -202,6 +203,7 @@ jobs:
             echo "::error::The exact dispatched Internal CI run was not found."
             exit 1
           fi
+          echo "::add-mask::$run_id"
           {
             echo "run_id=$run_id"
             echo "dispatch_nonce=$dispatch_nonce"

--- a/tests/tools/test_public_failure.py
+++ b/tests/tools/test_public_failure.py
@@ -567,6 +567,23 @@ def test_internal_ci_bridge_publishes_the_private_sanitized_artifact() -> None:
     )
 
 
+def test_internal_ci_bridge_masks_private_correlation_identifiers() -> None:
+    workflow = (Path(__file__).parents[2] / ".github/workflows/internal-ci-bridge.yml").read_text(
+        encoding="utf-8"
+    )
+
+    nonce_mask = 'echo "::add-mask::$dispatch_nonce"'
+    run_id_mask = 'echo "::add-mask::$run_id"'
+
+    assert nonce_mask in workflow
+    assert workflow.index('[[ "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]') < workflow.index(nonce_mask)
+    assert workflow.index(nonce_mask) < workflow.index('--arg dispatch_nonce "$dispatch_nonce"')
+
+    assert run_id_mask in workflow
+    assert workflow.index('if ! [[ "$run_id" =~ ^[1-9][0-9]*$ ]]') < workflow.index(run_id_mask)
+    assert workflow.index(run_id_mask) < workflow.index('echo "run_id=$run_id"')
+
+
 def test_poison_scan_rejects_sensitive_text_even_when_schema_allows_the_characters() -> None:
     report = export_failure(
         {


### PR DESCRIPTION
## Background

The public Internal CI bridge correctly sanitizes the generated failure report, but the surrounding public Actions log can still show the protected Actions run ID and one-time dispatch nonce when step outputs are expanded into later step environments.

## Exit Criteria

- Keep exact-run and exact-dispatch correlation checks unchanged.
- Mask both correlation identifiers before they can appear in public bridge logs.
- Preserve the existing public failure log and automated status behavior.

## Implementation

- Register the generated dispatch nonce with GitHub Actions `add-mask` before it is used or written as a step output.
- Validate the resolved protected run ID, then register it with `add-mask` before it is written as a step output.
- Add workflow regression coverage that locks in both masks and their ordering.
- No public API, ABI, artifact format, dependency, compatibility, or migration behavior changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest -q tests/tools/test_public_failure.py tests/tools/test_github_actions_ci.py`: 118 tests passed.
- `python3 -m ruff check tests/tools/test_public_failure.py`: passed.
- `python3 -m ruff format --check tests/tools/test_public_failure.py`: passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `31fb3d5adfd793930d7c4a277801f8a47e957584`.
- Static and Python validation ran on the local Linux development host. GPU, CUDA, TensorRT, model, and precision are not applicable to this workflow-only change.

### Not Run / Remaining Gaps

- `actionlint` was not available in the local environment; GitHub workflow checks remain the parser-level validation.
- End-to-end log redaction cannot run from the PR head because `pull_request_target` intentionally executes the trusted workflow from `main`. After merge, rerun the dedicated intentional-failure probe and confirm both identifiers render as `***` in the public log.

## Notes For Future Readers

- Review the two `add-mask` calls first, then the ordering assertions in the regression test.
- The correlation values remain available inside the job and continue to bind the exact dispatch and protected run; only their public log rendering changes.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this is a two-line masking change with focused regression coverage, but it touches the trusted dispatch bridge and requires post-merge end-to-end verification of GitHub runner behavior.
