### PR TITLE
docs(agents): require DCO sign-offs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@
   `main`.
 - Wait for GitHub CI before merging.
 - Merge with squash or rebase, matching the repository ruleset.
+- Sign off every commit introduced by a pull request with DCO using
+  `git commit --signoff`; ensure the `Signed-off-by` email matches the commit
+  author.
+- Preserve or re-add valid sign-offs when amending, rebasing, or cherry-picking
+  commits, and never sign off on another author's behalf.
 - Avoid commit messages containing `Claude`; the GitHub ruleset rejects them.
 
 ## GitHub Pages


### PR DESCRIPTION
## Background

Repository contributor guidance already requires DCO sign-offs, but the root agent instructions did not state that requirement. Agent-created commits could therefore discover the DCO gate only after they were pushed.

## Exit Criteria

- Every repository agent sees the DCO requirement before creating a commit.
- Agents preserve valid author sign-offs across history rewrites.
- Agents do not sign off on another author’s behalf.

## Implementation

- Require git commit --signoff for every commit introduced by a pull request.
- Require the Signed-off-by email to match the commit author.
- Cover amend, rebase, and cherry-pick workflows explicitly.
- No public API, ABI, runtime, bundle, dependency, compatibility, migration, or rollout behavior changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `git diff --check github/main...HEAD` — passed.
- `git show --no-patch --format=fuller HEAD` — confirmed commit author and Signed-off-by identities match.

### Hardware, Environment, and Revisions

- Base: `github/main@05b4930ca`; head: `2145e0a83`.
- Hardware, CUDA, TensorRT, model, checkpoint, and dataset revisions are not applicable to this agent-instruction-only change.

### Not Run / Remaining Gaps

- Runtime and unit tests were not run because only the root Markdown agent instructions changed.
- GitHub checks are expected to validate PR metadata, DCO, and source quality on the exact head.

## Notes For Future Readers

Keep this instruction aligned with `CONTRIBUTING.md` and `.github/dco.yml` if the repository DCO policy changes.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Low risk: this changes agent guidance only and does not affect product or CI execution behavior.