### PR TITLE
fix(qwen-vl): serialize Qwen3 decoder config

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -372,6 +372,22 @@ class QwenVLPlugin:
 
         return vl_cfg
 
+    def get_bundle_config_overrides(
+        self, config: ModelConfig
+    ) -> dict[str, int] | None:
+        """Expose Qwen3-VL's nested text decoder contract at bundle scope."""
+        if not _is_qwen3_vl(config):
+            return None
+        return {
+            "vocab_size": config.vocab_size,
+            "hidden_size": config.hidden_size,
+            "num_hidden_layers": config.num_hidden_layers,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+            "bos_token_id": config.bos_token_id,
+        }
+
     def get_lora_config(self, config: ModelConfig) -> dict[str, object]:
         """Persist the dynamic binding contract in the bundle config."""
         return DynamicLoraConfig.from_model_config(config).bundle_config()

--- a/src/runtime/models/qwen_vl/MODEL.toml
+++ b/src/runtime/models/qwen_vl/MODEL.toml
@@ -6,6 +6,7 @@ runtime_library = "libtrtmc_model_qwen_vl.so"
 runtime_plugins = ["plugin.cpp|register_qwen_vl_plugin"]
 runtime_strategies = ["qwen_vl_vision_language"]
 runtime_tests = [
+  "test_qwen_vl_runtime_config_contract|test_qwen_vl_runtime_config_contract.cpp|_|_|_",
   "test_qwen_vl_sampler|test_qwen_vl_sampler.cpp|trtmc_model_qwen_vl|_|_",
-  "test_qwen_vl_vl_pipeline|test_qwen_vl_vl_pipeline.cpp|trtmc_model_qwen_vl,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_qwen_vl_vl_pipeline|test_qwen_vl_vl_pipeline.cpp|trtmc_model_qwen_vl,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_runtime_config_contract.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_runtime_config_contract.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for Qwen3-VL's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // The nested objects mirror Qwen/Qwen3-VL-2B-Instruct at the pinned
+    // 89644892e4d85e24eaac8bacfd4f463576704203 revision. The duplicated
+    // top-level decoder fields are the final bundle contract consumed by the
+    // strict production C++ parser. The top-level EOS list comes from the
+    // pinned generation_config.json and must not be replaced by the nested
+    // scalar value.
+    const std::string config = R"({
+        "vocab_size": 151936,
+        "hidden_size": 2048,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "bos_token_id": 151643,
+        "eos_token_id": [151645, 151643],
+        "model_type": "qwen3_vl",
+        "text_config": {
+            "model_type": "qwen3_vl_text",
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "intermediate_size": 6144,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "bos_token_id": 151643,
+            "eos_token_id": 151645,
+            "max_position_embeddings": 262144,
+            "rope_theta": 5000000,
+            "rope_scaling": {
+                "mrope_interleaved": true,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default"
+            }
+        },
+        "vision_config": {
+            "model_type": "qwen3_vl",
+            "depth": 24,
+            "hidden_size": 1024,
+            "intermediate_size": 4096,
+            "num_heads": 16,
+            "patch_size": 16,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "deepstack_visual_indexes": [5, 11, 17]
+        },
+        "runtime_strategy": "qwen_vl_vision_language",
+        "precision": "bf16",
+        "tokenizer_add_special_tokens": 0
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "qwen_vl_vision_language", "runtime strategy");
+    check(parsed.precision == "bf16", "precision");
+    check(parsed.vocab_size == 151936, "vocabulary size");
+    check(parsed.hidden_size == 2048, "hidden size");
+    check(parsed.num_layers == 28, "layer count");
+    check(parsed.num_heads == 16, "attention head count");
+    check(parsed.num_kv_heads == 8, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.attention_size == 2048, "attention width");
+    check(parsed.num_kv_heads * parsed.head_dim == 1024, "KV cache width");
+    check(parsed.max_cache_length == 256, "cache length override");
+    check(parsed.id_bos == 151643, "BOS token");
+    check(parsed.id_eos == 151645, "EOS token");
+    check(parsed.id_eos_ids == std::vector<int32_t>({151645, 151643}), "EOS token list");
+    check(parsed.tokenizer_add_special_tokens_present, "tokenizer flag presence");
+    check(!parsed.tokenizer_add_special_tokens, "tokenizer flag value");
+    return ok ? 0 : 1;
+}

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
@@ -9,6 +9,9 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
+
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
     _rand,
@@ -68,6 +71,7 @@ class TestQwenVLPlugin:
             assert f"layer.{i}.w_q" in weights
         assert "final_norm" in weights
         assert "w_out" in weights
+        assert plugin.get_bundle_config_overrides(cfg) is None
 
     def test_qwen3_vl_language_model_prefix(self, tmp_path):
         """Qwen3-VL uses model.language_model.layers.{i} prefix."""
@@ -179,3 +183,124 @@ class TestQwenVLPlugin:
             assert not key.startswith("visual."), f"Vision key leaked: {key}"
             assert not key.startswith("model.visual."), \
                 f"Vision key leaked: {key}"
+
+    def test_qwen3_vl_mock_bundle_serializes_decoder_geometry_at_top_level(
+        self,
+        tmp_path,
+    ):
+        """Exercise the pinned Qwen3-VL producer contract with mocked engines."""
+        from tensorrt_model_connect.engine_builder import build_bundle
+        from tensorrt_model_connect.families.qwen_vl.plugin import (
+            plugin as production_plugin,
+        )
+
+        # Qwen/Qwen3-VL-2B-Instruct at
+        # 89644892e4d85e24eaac8bacfd4f463576704203.
+        source_config = {
+            "architectures": ["Qwen3VLForConditionalGeneration"],
+            "image_token_id": 151655,
+            "model_type": "qwen3_vl",
+            "text_config": {
+                "bos_token_id": 151643,
+                "eos_token_id": 151645,
+                "head_dim": 128,
+                "hidden_size": 2048,
+                "intermediate_size": 6144,
+                "max_position_embeddings": 262144,
+                "model_type": "qwen3_vl_text",
+                "num_attention_heads": 16,
+                "num_hidden_layers": 28,
+                "num_key_value_heads": 8,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 5000000,
+                "vocab_size": 151936,
+            },
+            "vision_config": {
+                "deepstack_visual_indexes": [5, 11, 17],
+                "hidden_size": 1024,
+                "out_hidden_size": 2048,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+            },
+        }
+        _write_config(tmp_path, source_config)
+        (tmp_path / "generation_config.json").write_text(
+            json.dumps(
+                {
+                    "bos_token_id": 151643,
+                    "eos_token_id": [151645, 151643],
+                    "pad_token_id": 151643,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        class MockQwenVLPlugin:
+            name = "qwen_vl"
+            runtime_strategy = "qwen_vl_vision_language"
+            embed_input = True
+            requires_tokenizer = False
+
+            @staticmethod
+            def load_weights(_model_dir, _config):
+                return {}
+
+            @staticmethod
+            def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+                return b"MOCK_DECODER_PLAN"
+
+            @staticmethod
+            def build_vision_engine(_model_dir, _config, _weights, **_kwargs):
+                return b"MOCK_VISION_PLAN"
+
+            @staticmethod
+            def get_vl_config(config):
+                return production_plugin.get_vl_config(config)
+
+            @staticmethod
+            def get_bundle_config_overrides(config):
+                return production_plugin.get_bundle_config_overrides(config)
+
+        with (
+            patch(
+                "tensorrt_model_connect.engine_builder.find_plugin",
+                return_value=MockQwenVLPlugin(),
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_trt_version",
+                return_value="11.1.0",
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="CPU unit mock",
+            ),
+            patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+        ):
+            build_bundle(
+                str(tmp_path),
+                str(tmp_path / "qwen3-vl-2b.bundle"),
+                max_cache_length=256,
+            )
+
+        sections = {
+            section.name: section.data for section in write_bundle.call_args.args[2]
+        }
+        runtime_config = json.loads(sections["config.json"])
+        decoder_config = source_config["text_config"]
+        assert runtime_config["text_config"] == decoder_config
+        decoder_contract = {
+            key: decoder_config[key]
+            for key in (
+                "vocab_size",
+                "hidden_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "head_dim",
+                "bos_token_id",
+            )
+        }
+        assert all(key not in source_config for key in decoder_contract)
+        assert {key: runtime_config[key] for key in decoder_contract} == decoder_contract
+        assert runtime_config["eos_token_id"] == [151645, 151643]


### PR DESCRIPTION
## Background

Qwen3-VL stores its decoder geometry under `text_config`, but the native runtime consumes those fields from the top-level bundle config. The family previously supplied no bundle override, causing invalid repeated-token generation under the strict JSON parser. Flat Qwen2.5-VL configurations do not have this defect.

This PR isolates the Qwen-VL-owned fix from the CPU-frontloading CI work previously combined in #1062.

## Exit Criteria

- Only Qwen3-VL materializes nested decoder geometry and BOS at bundle scope.
- Flat Qwen2.5-VL behavior remains unchanged.
- The Qwen3-VL multi-EOS list from `generation_config.json` remains intact.
- CPU producer and C++ consumer contracts cover the final serialized boundary without shared changes.

## Implementation

- Add a Qwen3-VL-only `get_bundle_config_overrides()` path; Qwen2.5-VL returns `None`.
- Leave EOS ownership to the generic Hugging Face generation-config mechanic so `[151645, 151643]` is not reduced to a scalar.
- Exercise real `build_bundle()` with engine/GPU work mocked and parse the final shape through production `parse_base_config()`.
- Register the new model-owned CPU contract and mark the existing GPU pipeline test explicitly so all-CPU collection excludes only that GPU-dependent test.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py -q -p no:cacheprovider --import-mode=importlib`: `4 passed`.
- Focused CMake build of `test_qwen_vl_runtime_config_contract`, followed by `ctest -R '^test_qwen_vl_runtime_config_contract$'`: `1/1 passed`.
- `python3 -m tools.community_ci source-quality --base github/main`: passed complexity, changed-file lint/formatting, and `158` architecture contracts.
- Ruff, clang-format dry-run, and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `a9e0e8e33918b9483fc53fb01af1ae76158187e4`, based directly on `github/main@e323d54ea8953cf496e56717f370be500d06c072`.
- Local validation used the pinned Linux aarch64 Community CPU image with TensorRT/CUDA SDK headers, no GPU device, and no network during test execution.
- The fixture mirrors `Qwen/Qwen3-VL-2B-Instruct@89644892e4d85e24eaac8bacfd4f463576704203` and its generation config.

### Not Run / Remaining Gaps

- GPU generation/model proof was not run locally because no GPU is available. Exact-head protected premerge remains required before merge.

## Notes For Future Readers

- Do not add a scalar family EOS override: Qwen3-VL has two terminal token IDs.
- This family fix is independent of the separate CPU-frontloading PR.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the change is limited to Qwen3-VL bundle metadata and preserves Qwen2.5-VL and multi-EOS behavior.
