### PR TITLE
fix(qwen3_5): serialize decoder config

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_5/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_5/plugin.py
@@ -711,6 +711,14 @@ class Qwen35Plugin:
         num_attn = sum(1 for lt in layer_types if lt == "attention")
 
         return {
+            "vocab_size": config.vocab_size,
+            "hidden_size": config.hidden_size,
+            "num_hidden_layers": config.num_hidden_layers,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+            "bos_token_id": config.bos_token_id,
+            "eos_token_id": config.eos_token_id,
             "layer_types": layer_types,
             "num_mamba_layers": num_mamba,
             "num_attention_layers": num_attn,

--- a/src/runtime/models/qwen3_5/MODEL.toml
+++ b/src/runtime/models/qwen3_5/MODEL.toml
@@ -5,10 +5,11 @@ id = "qwen3_5"
 runtime_library = "libtrtmc_model_qwen3_5.so"
 runtime_plugins = ["plugin.cpp|register_qwen3_5_plugin"]
 runtime_strategies = ["qwen3_5_hybrid_mamba_attention"]
+runtime_tests = [
+  "test_qwen3_5_runtime_config_contract|test_qwen3_5_runtime_config_contract.cpp|_|_|_",
+  "test_qwen3_5_recurrent_output_initializers|test_qwen3_5_recurrent_output_initializers.cpp|_|_|_",
+  "test_qwen3_5_recurrent_pipeline|test_qwen3_5_recurrent_pipeline.cpp|trtmc_model_qwen3_5,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
+]
+
 [validation_profiles]
 decoder_debug = ["qwen3_5_hybrid_mamba_attention"]
-
-runtime_tests = [
-  "test_qwen3_5_recurrent_output_initializers|test_qwen3_5_recurrent_output_initializers.cpp|_|_|_",
-  "test_qwen3_5_recurrent_pipeline|test_qwen3_5_recurrent_pipeline.cpp|trtmc_model_qwen3_5,trtmc_backend_trt|_|REQUIRES_TRT",
-]

--- a/tests/cpp/models/qwen3_5/test_qwen3_5_runtime_config_contract.cpp
+++ b/tests/cpp/models/qwen3_5/test_qwen3_5_runtime_config_contract.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for Qwen3.5's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // The nested objects mirror Qwen/Qwen3.5-9B at
+    // c202236235762e1c871ad0ccb60c8ee5ba337b9a. The duplicated top-level
+    // decoder fields are the final bundle contract consumed by the strict
+    // production C++ parser.
+    const std::string config = R"({
+        "vocab_size": 248320,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "head_dim": 256,
+        "bos_token_id": -1,
+        "eos_token_id": 248044,
+        "model_type": "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "vocab_size": 248320,
+            "hidden_size": 4096,
+            "intermediate_size": 12288,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "eos_token_id": 248044,
+            "max_position_embeddings": 262144,
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "linear_value_head_dim": 128,
+            "rope_parameters": {
+                "mrope_interleaved": true,
+                "mrope_section": [11, 11, 10],
+                "rope_type": "default",
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25
+            }
+        },
+        "vision_config": {
+            "model_type": "qwen3_5",
+            "depth": 27,
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_heads": 16,
+            "out_hidden_size": 4096,
+            "patch_size": 16,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "deepstack_visual_indexes": []
+        },
+        "num_mamba_layers": 24,
+        "num_attention_layers": 8,
+        "d_inner": 4096,
+        "mamba_d_state": 128,
+        "mamba_d_conv": 4,
+        "mamba_nheads": 32,
+        "mamba_head_dim": 128,
+        "conv_dim": 8192,
+        "runtime_strategy": "qwen3_5_hybrid_mamba_attention",
+        "precision": "fp16",
+        "tokenizer_add_special_tokens": 0
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "qwen3_5_hybrid_mamba_attention", "runtime strategy");
+    check(parsed.precision == "fp16", "precision");
+    check(parsed.vocab_size == 248320, "vocabulary size");
+    check(parsed.hidden_size == 4096, "hidden size");
+    check(parsed.num_layers == 32, "layer count");
+    check(parsed.num_heads == 16, "attention head count");
+    check(parsed.num_kv_heads == 4, "KV head count");
+    check(parsed.head_dim == 256, "head dimension");
+    check(parsed.attention_size == 4096, "attention width");
+    check(parsed.num_kv_heads * parsed.head_dim == 1024, "KV cache width");
+    check(parsed.max_cache_length == 256, "cache length override");
+    check(parsed.id_bos == -1, "absent BOS token contract");
+    check(parsed.id_eos == 248044, "EOS token");
+    check(parsed.id_eos_ids == std::vector<int32_t>({248044}), "EOS token list");
+    check(parsed.tokenizer_add_special_tokens_present, "tokenizer flag presence");
+    check(!parsed.tokenizer_add_special_tokens, "tokenizer flag value");
+    return ok ? 0 : 1;
+}

--- a/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
+++ b/tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py
@@ -11,6 +11,9 @@ Postconditions: Layer type aliases are normalized correctly and branch-specific 
 
 from __future__ import annotations
 
+import json
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -291,3 +294,124 @@ def test_get_bundle_config_overrides_normalizes_hybrid_fields():
     assert overrides["mamba_nheads"] == 3
     assert overrides["mamba_head_dim"] == 4
     assert overrides["conv_dim"] == 20
+    assert overrides["vocab_size"] == 5
+    assert overrides["hidden_size"] == 12
+    assert overrides["num_hidden_layers"] == 3
+    assert overrides["num_attention_heads"] == 3
+    assert overrides["num_key_value_heads"] == 1
+    assert overrides["head_dim"] == 4
+    assert overrides["bos_token_id"] == -1
+    assert overrides["eos_token_id"] == -1
+
+
+def test_mock_bundle_serializes_decoder_and_hybrid_config(tmp_path):
+    """Exercise Qwen3.5's nested producer contract with mocked engines."""
+    from tensorrt_model_connect.engine_builder import build_bundle
+
+    layer_types = [
+        "full_attention" if (index + 1) % 4 == 0 else "linear_attention"
+        for index in range(32)
+    ]
+    # Qwen/Qwen3.5-9B at c202236235762e1c871ad0ccb60c8ee5ba337b9a.
+    source_config = {
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "image_token_id": 248056,
+        "model_type": "qwen3_5",
+        "text_config": {
+            "eos_token_id": 248044,
+            "head_dim": 256,
+            "hidden_size": 4096,
+            "intermediate_size": 12288,
+            "layer_types": layer_types,
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "linear_value_head_dim": 128,
+            "max_position_embeddings": 262144,
+            "model_type": "qwen3_5_text",
+            "num_attention_heads": 16,
+            "num_hidden_layers": 32,
+            "num_key_value_heads": 4,
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 10000000,
+            },
+            "vocab_size": 248320,
+        },
+    }
+    (tmp_path / "config.json").write_text(
+        json.dumps(source_config),
+        encoding="utf-8",
+    )
+
+    class MockQwen35Plugin:
+        name = "qwen3_5"
+        runtime_strategy = "qwen3_5_hybrid_mamba_attention"
+        requires_tokenizer = False
+
+        @staticmethod
+        def load_weights(_model_dir, _config):
+            return {}
+
+        @staticmethod
+        def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+            return b"MOCK_HYBRID_PLAN"
+
+        @staticmethod
+        def get_bundle_config_overrides(config):
+            return qwen3_5.plugin.get_bundle_config_overrides(config)
+
+    with (
+        patch(
+            "tensorrt_model_connect.engine_builder.find_plugin",
+            return_value=MockQwen35Plugin(),
+        ),
+        patch(
+            "tensorrt_model_connect.engine_builder._get_trt_version",
+            return_value="11.1.0",
+        ),
+        patch(
+            "tensorrt_model_connect.engine_builder._get_gpu_name",
+            return_value="CPU unit mock",
+        ),
+        patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+    ):
+        build_bundle(
+            str(tmp_path),
+            str(tmp_path / "qwen35-9b.bundle"),
+            max_cache_length=256,
+        )
+
+    sections = {
+        section.name: section.data for section in write_bundle.call_args.args[2]
+    }
+    runtime_config = json.loads(sections["config.json"])
+    decoder_config = source_config["text_config"]
+    assert "bos_token_id" not in decoder_config
+    assert runtime_config["text_config"] == decoder_config
+    decoder_contract = {
+        "vocab_size": 248320,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "head_dim": 256,
+        "bos_token_id": -1,
+        "eos_token_id": 248044,
+    }
+    assert all(key not in source_config for key in decoder_contract)
+    assert {key: runtime_config[key] for key in decoder_contract} == decoder_contract
+    assert runtime_config["layer_types"] == [
+        "attention" if layer_type == "full_attention" else "deltanet"
+        for layer_type in layer_types
+    ]
+    assert runtime_config["num_mamba_layers"] == 24
+    assert runtime_config["num_attention_layers"] == 8
+    assert runtime_config["d_inner"] == 4096
+    assert runtime_config["mamba_d_state"] == 128
+    assert runtime_config["mamba_d_conv"] == 4
+    assert runtime_config["mamba_nheads"] == 32
+    assert runtime_config["mamba_head_dim"] == 128
+    assert runtime_config["conv_dim"] == 8192


### PR DESCRIPTION
## Background

Qwen3.5 stores its decoder geometry and EOS under Hugging Face `text_config`. Its existing family hook serialized the hybrid/DeltaNet fields but omitted the base decoder contract consumed by the strict top-level C++ parser. A repo-wide audit identified this as the same deterministic failure mode exposed in other composite families.

This PR isolates the Qwen3.5-owned fix from the CPU-frontloading CI work previously combined in #1062.

## Exit Criteria

- Qwen3.5 materializes decoder geometry and BOS/EOS alongside its existing hybrid fields.
- A mocked real-bundle producer test covers the 24 DeltaNet plus 8 attention layout.
- A CPU C++ consumer test validates production `parse_base_config()`.
- The runtime-test manifest is valid top-level TOML and no shared or cross-family code changes.

## Implementation

- Extend the existing Qwen3.5 bundle override with the base decoder fields already parsed by the family `ModelConfig`.
- Run real `build_bundle()` with engine/GPU work mocked and assert both decoder and hybrid fields in final `config.json`.
- Add a CPU runtime-config consumer contract, mark the existing pipeline as GPU-dependent, and move the runtime-test block before `[validation_profiles]` so standard TOML readers discover it.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tests/e2e/models/qwen3_5/test_qwen3_5_family_plugin.py -q -p no:cacheprovider --import-mode=importlib`: `5 passed`.
- Focused CMake build of `test_qwen3_5_runtime_config_contract`, followed by `ctest -R '^test_qwen3_5_runtime_config_contract$'`: `1/1 passed`.
- `python3 -m tools.community_ci source-quality --base github/main`: passed complexity, changed-file lint/formatting, and `158` architecture contracts.
- Ruff, clang-format dry-run, and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `3be89adfd4fbefba0e0ccd4ea52d935e4f7b2e98`, based directly on `github/main@e323d54ea8953cf496e56717f370be500d06c072`.
- Local validation used the pinned Linux aarch64 Community CPU image with TensorRT/CUDA SDK headers, no GPU device, and no network during test execution.
- The fixture mirrors `Qwen/Qwen3.5-9B@c202236235762e1c871ad0ccb60c8ee5ba337b9a`.

### Not Run / Remaining Gaps

- GPU generation/model proof was not run locally because no GPU is available. Exact-head protected premerge remains required before merge.

## Notes For Future Readers

- Keep the decoder and hybrid serialization logic inside the Qwen3.5 family; do not add shared model canonicalization.
- The separate CPU-frontloading PR will make this model-owned CPU contract run on every contribution.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the change corrects one family's runtime metadata and manifest placement without changing APIs, ABI, topology, or thresholds.
