### PR TITLE
test(internvl): cover runtime config boundary

### DIFF
--- a/src/runtime/models/internvl/MODEL.toml
+++ b/src/runtime/models/internvl/MODEL.toml
@@ -6,5 +6,6 @@ runtime_library = "libtrtmc_model_internvl.so"
 runtime_plugins = ["plugin.cpp|register_internvl_plugin"]
 runtime_strategies = ["internvl_vision_language"]
 runtime_tests = [
-  "test_internvl_vl_pipeline|test_internvl_vl_pipeline.cpp|trtmc_model_internvl,trtmc_backend_trt|_|REQUIRES_TRT",
+  "test_internvl_runtime_config_contract|test_internvl_runtime_config_contract.cpp|_|_|_",
+  "test_internvl_vl_pipeline|test_internvl_vl_pipeline.cpp|trtmc_model_internvl,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/tests/cpp/models/internvl/test_internvl_runtime_config_contract.cpp
+++ b/tests/cpp/models/internvl/test_internvl_runtime_config_contract.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for InternVL's serialized runtime config.
+
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <iostream>
+#include <string>
+
+int main() {
+    const std::string config = R"({
+        "model_type": "internvl",
+        "text_config": {
+            "vocab_size": 151674,
+            "hidden_size": 1536,
+            "num_hidden_layers": 28,
+            "num_attention_heads": 12,
+            "num_key_value_heads": 2,
+            "head_dim": 128,
+            "bos_token_id": 151643
+        },
+        "vocab_size": 151674,
+        "hidden_size": 1536,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 12,
+        "num_key_value_heads": 2,
+        "head_dim": 128,
+        "bos_token_id": 151643,
+        "runtime_strategy": "internvl_vision_language"
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 256);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "internvl_vision_language", "runtime strategy");
+    check(parsed.vocab_size == 151674, "vocabulary size");
+    check(parsed.hidden_size == 1536, "hidden size");
+    check(parsed.num_layers == 28, "layer count");
+    check(parsed.num_heads == 12, "attention head count");
+    check(parsed.num_kv_heads == 2, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.id_bos == 151643, "BOS token");
+    check(parsed.attention_size == 1536, "attention width");
+    return ok ? 0 : 1;
+}

--- a/tests/e2e/models/internvl/test_internvl_family_plugin_weights.py
+++ b/tests/e2e/models/internvl/test_internvl_family_plugin_weights.py
@@ -9,7 +9,8 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
-
+import json
+from unittest.mock import patch
 
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
@@ -264,6 +265,94 @@ class TestInternVLPlugin:
             "head_dim": 128,
             "bos_token_id": 151643,
         }
+
+    def test_mock_bundle_serializes_decoder_geometry_at_top_level(self, tmp_path):
+        """Mock engines while exercising the real InternVL bundle boundary."""
+        from tensorrt_model_connect.engine_builder import build_bundle
+        from tensorrt_model_connect.families.internvl.plugin import (
+            plugin as production_plugin,
+        )
+
+        source_config = {
+            "model_type": "internvl",
+            "text_config": {
+                "vocab_size": 151674,
+                "hidden_size": 1536,
+                "num_hidden_layers": 28,
+                "num_attention_heads": 12,
+                "num_key_value_heads": 2,
+                "head_dim": 128,
+                "bos_token_id": 151643,
+            },
+            "vision_config": {
+                "hidden_size": 1024,
+                "num_hidden_layers": 24,
+                "patch_size": 14,
+            },
+        }
+        _write_config(tmp_path, source_config)
+
+        class MockInternVLPlugin:
+            name = "internvl"
+            runtime_strategy = "internvl_vision_language"
+            requires_tokenizer = False
+
+            @staticmethod
+            def load_weights(_model_dir, _config):
+                return {}
+
+            @staticmethod
+            def build_engine(_config, _weights, _max_cache_length, **_kwargs):
+                return b"MOCK_DECODER_PLAN"
+
+            @staticmethod
+            def build_vision_engine(_model_dir, _config, _weights, **_kwargs):
+                return b"MOCK_VISION_PLAN"
+
+            @staticmethod
+            def get_vl_config(config):
+                return production_plugin.get_vl_config(config)
+
+            @staticmethod
+            def get_bundle_config_overrides(config):
+                return production_plugin.get_bundle_config_overrides(config)
+
+        with (
+            patch(
+                "tensorrt_model_connect.engine_builder.find_plugin",
+                return_value=MockInternVLPlugin(),
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_trt_version",
+                return_value="11.1.0",
+            ),
+            patch(
+                "tensorrt_model_connect.engine_builder._get_gpu_name",
+                return_value="CPU unit mock",
+            ),
+            patch("tensorrt_model_connect.engine_builder.write_bundle") as write_bundle,
+        ):
+            build_bundle(
+                str(tmp_path),
+                str(tmp_path / "internvl.bundle"),
+                max_cache_length=256,
+            )
+
+        sections = {section.name: section.data for section in write_bundle.call_args.args[2]}
+        runtime_config = json.loads(sections["config.json"])
+        assert runtime_config["text_config"] == source_config["text_config"]
+        assert {
+            key: runtime_config[key]
+            for key in (
+                "vocab_size",
+                "hidden_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "head_dim",
+                "bos_token_id",
+            )
+        } == source_config["text_config"]
 
     def test_no_vl_config_without_vision(self, tmp_path):
         """get_vl_config returns None when no vision_config present."""


### PR DESCRIPTION
## Background

#1055 fixed InternVL's family-owned decoder materialization, but its unit test called the override directly. That did not prove the hook survived real bundle assembly or that the strict C++ runtime parser consumed the resulting top-level fields.

This test-only follow-up isolates the producer/consumer mitigation from the CPU-frontloading CI work previously combined in #1062.

## Exit Criteria

- A mocked-engine test runs production `build_bundle()` and inspects the final serialized `config.json`.
- A CPU C++ test parses the production-shaped config through `parse_base_config()`.
- No production implementation, shared parser, CI policy, or other family changes.

## Implementation

- Add a real bundle-boundary producer regression around the existing InternVL override.
- Add and register a model-owned CPU consumer contract with pinned InternVL decoder geometry; explicitly classify the existing pipeline as GPU-dependent.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tests/e2e/models/internvl/test_internvl_family_plugin_weights.py -q -p no:cacheprovider --import-mode=importlib`: `8 passed`.
- Focused CMake build of `test_internvl_runtime_config_contract`, followed by `ctest --test-dir /work/build --output-on-failure -R '^test_internvl_runtime_config_contract$'`: `1/1 passed`.
- `python3 -m tools.community_ci source-quality --base github/main`: passed complexity, changed-file lint/formatting, and `158` architecture contracts.
- Ruff, clang-format dry-run, and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `05b9d7257cd3560471a86555fc8d515a5ca5dd68`, based directly on `github/main@e323d54ea8953cf496e56717f370be500d06c072`.
- Validation used the pinned Linux aarch64 Community CPU image with TensorRT/CUDA SDK headers, no GPU device, and no network during test execution.

### Not Run / Remaining Gaps

- GPU model proof was not run locally because this PR changes tests only. Exact-head protected premerge remains required before merge.

## Notes For Future Readers

- The production fix remains #1055. This PR exists to cover the serialization boundary that the original direct-hook test skipped.
- The separate CPU-frontloading PR will make this model-owned CPU contract run on every contribution.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: test-only family-owned coverage with no runtime behavior change.
