### PR TITLE
fix(whisper): harden runner initialization

### DIFF
--- a/python/tensorrt_model_connect/families/whisper/debug_runner.py
+++ b/python/tensorrt_model_connect/families/whisper/debug_runner.py
@@ -317,17 +317,22 @@ class WhisperTrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask, self._d_logits,
-                self._d_mel, self._d_enc_out]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        bufs.extend(self._d_cross_k)
-        bufs.extend(self._d_cross_v)
-        for d_ptr in bufs:
-            cudart.cudaFree(d_ptr)
-        if hasattr(self, "stream"):
-            cudart.cudaStreamDestroy(self.stream)
+        scalar_buffers = (
+            "_d_token_id", "_d_position_id", "_d_mask", "_d_logits", "_d_mel", "_d_enc_out",
+        )
+        list_buffers = (
+            "_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v", "_d_cross_k", "_d_cross_v",
+        )
+        for name in scalar_buffers:
+            d_ptr = getattr(self, name, None)
+            if d_ptr is not None:
+                cudart.cudaFree(d_ptr)
+                setattr(self, name, None)
+        for name in list_buffers:
+            for d_ptr in getattr(self, name, ()):
+                cudart.cudaFree(d_ptr)
+            setattr(self, name, [])
+        stream = getattr(self, "stream", None)
+        if stream is not None:
+            cudart.cudaStreamDestroy(stream)
+            self.stream = None

--- a/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/whisper/decoder_tp_builder.py
@@ -14,18 +14,19 @@ This intentionally mirrors the single-device Whisper decoder graph in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import importlib
 import sys
+from typing import TYPE_CHECKING
 
 import numpy as np
 from tensorrt_model_connect import trt_compat
 
-from . import graph_ops
 from ...parallel_config import (
     add_all_reduce_sum,
     normalize_parallel_config,
 )
 
+graph_ops = importlib.import_module(f"{__package__}.graph_ops")
 trt = trt_compat.get_trt()
 
 if TYPE_CHECKING:

--- a/src/runtime/models/whisper/MODEL.toml
+++ b/src/runtime/models/whisper/MODEL.toml
@@ -9,5 +9,5 @@ runtime_tests = [
   "test_whisper_mel_spectrogram|test_whisper_mel_spectrogram.cpp|_|whisper_mel_spectrogram.cpp|_",
   "test_whisper_host_plan|test_whisper_host_plan.cpp|_|_|_",
   "test_whisper_decode_policy|test_whisper_decode_policy.cpp|_|_|_",
-  "test_whisper_pipeline|test_whisper_pipeline.cpp|trtmc_model_whisper|_|REQUIRES_TRT",
+  "test_whisper_pipeline|test_whisper_pipeline.cpp|trtmc_model_whisper|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/tests/e2e/models/whisper/test_whisper_builder_engine.py
+++ b/tests/e2e/models/whisper/test_whisper_builder_engine.py
@@ -34,6 +34,8 @@ Postconditions: All encoder (enc_layer.*), decoder (layer.*), and cross-attentio
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pytest
 
@@ -118,9 +120,8 @@ def _make_whisper_tp_weights(
 
 
 def _whisper_tp_builder_module():
-    return pytest.importorskip(
-        "tensorrt_model_connect.families.whisper.decoder_tp_builder",
-        reason="TensorRT is required for Whisper TP builder tests",
+    return importlib.import_module(
+        "tensorrt_model_connect.families.whisper.decoder_tp_builder"
     )
 
 


### PR DESCRIPTION
## Background

Broad CPU-family collection exposed two Whisper-local lifecycle defects: cleanup assumed full CUDA-buffer initialization, and the TP builder depended on lazy package state when importing `graph_ops`. A partially initialized runner could therefore emit an unraisable destructor error, while isolated test order could leave the TP import in a half-initialized state.

This PR isolates those Whisper-owned fixes from the CPU-frontloading CI work previously combined in #1062.

## Exit Criteria

- Cleanup safely handles partial initialization and repeated destruction.
- The TP builder imports its family graph module without relying on lazy package state.
- Focused Whisper CPU tests pass without changing test criteria.
- No shared code or other family changes.

## Implementation

- Discover scalar and list CUDA buffers with guarded attribute access, free only initialized pointers, and clear released state.
- Destroy the CUDA stream only when initialized and clear it after release.
- Import `whisper.graph_ops` directly via `importlib`; update the family test helper to exercise the same import path.
- Mark the existing Whisper pipeline test explicitly as GPU-dependent so all-CPU collection excludes only that test.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tests/e2e/models/whisper/test_whisper_builder_engine.py tests/e2e/models/whisper/test_whisper_debug_runner.py -q -p no:cacheprovider --import-mode=importlib -m 'not gpu and not trt and not e2e and not model_proof_allocator'`: `31 passed, 3 skipped`.
- `python3 -m tools.community_ci source-quality --base github/main`: passed complexity, changed-file lint/formatting, and `158` architecture contracts.
- Ruff and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source head: `1b65a94747ab9294e11770629be3e20debf7972b`, based directly on `github/main@e323d54ea8953cf496e56717f370be500d06c072`.
- Validation used the pinned Linux aarch64 Community CPU image, no GPU device, and no network during test execution.

### Not Run / Remaining Gaps

- Real GPU engine execution was not run locally. The changes affect cleanup/import behavior and exact-head protected premerge remains required before merge.

## Notes For Future Readers

- This fix does not broaden shared abstractions; both lifecycle behaviors remain Whisper-owned.
- No test marker, threshold, or passing criterion was relaxed.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: narrowly defensive cleanup and import isolation within one family, covered by existing CPU tests.
