### PR TITLE
fix(build): build dev images from the requirements context

### DIFF
--- a/Dockerfile.dev.aarch64
+++ b/Dockerfile.dev.aarch64
@@ -30,7 +30,7 @@ RUN python3.12 -m venv --system-site-packages ${VIRTUAL_ENV} && \
     ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt
+COPY community-ci.txt /tmp/trtmc-community-ci.txt
 
 RUN pip install -U pip && \
     pip install \

--- a/Dockerfile.dev.x86
+++ b/Dockerfile.dev.x86
@@ -30,7 +30,7 @@ RUN python3.12 -m venv --system-site-packages ${VIRTUAL_ENV} && \
     ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt
+COPY community-ci.txt /tmp/trtmc-community-ci.txt
 
 RUN pip install -U pip && \
     pip install \

--- a/tests/tools/test_docker_build_context.py
+++ b/tests/tools/test_docker_build_context.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep community-ci.txt consumers on the minimal requirements build context.
+
+.dockerignore deliberately excludes ``requirements/`` from the repository-root
+context, so an image that needs ``community-ci.txt`` must build from
+``requirements/`` itself and copy the file by its bare name. No CI job builds
+the development images, so this contract is only checked here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Dockerfiles that install the pinned community CI profile.
+COMMUNITY_PROFILE_DOCKERFILES = (
+    "Dockerfile.community-cpu",
+    "Dockerfile.dev.x86",
+    "Dockerfile.dev.aarch64",
+)
+
+SOURCE_BUILD_DOC = REPO_ROOT / "website/docs/getting-started/source-build.md"
+
+
+def _copy_sources(dockerfile: Path) -> list[str]:
+    """Context-relative sources of every COPY that reads the build context."""
+    sources: list[str] = []
+    for line in dockerfile.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("COPY "):
+            continue
+        parts = stripped.split()[1:]
+        if any(part.startswith("--from=") for part in parts):
+            continue  # copies from an earlier stage, not the context
+        parts = [part for part in parts if not part.startswith("--")]
+        sources.extend(parts[:-1])  # last argument is the destination
+    return sources
+
+
+def test_community_profile_images_copy_by_bare_name() -> None:
+    """Intent: requirements/ is excluded from the root context by design.
+    Preconditions: each image installs the pinned community CI profile.
+    Postconditions: every such COPY names community-ci.txt without a directory.
+    """
+    offenders = []
+    for name in COMMUNITY_PROFILE_DOCKERFILES:
+        dockerfile = REPO_ROOT / name
+        assert dockerfile.is_file(), f"{name} is declared here but does not exist"
+        for source in _copy_sources(dockerfile):
+            if Path(source).name == "community-ci.txt" and source != "community-ci.txt":
+                offenders.append(f"{name}: COPY {source}")
+
+    assert not offenders, (
+        "these Dockerfiles copy community-ci.txt by a root-relative path, which "
+        "cannot resolve because .dockerignore excludes requirements/ from the "
+        "root context: " + "; ".join(offenders)
+    )
+
+
+def test_requirements_stays_out_of_the_root_context() -> None:
+    """Intent: keep the repository-root daemon context minimal.
+    Preconditions: .dockerignore excludes everything and re-includes an allowlist.
+    Postconditions: requirements/ is never re-included at the root.
+    """
+    dockerignore = (REPO_ROOT / ".dockerignore").read_text(encoding="utf-8")
+
+    assert "!requirements/" not in dockerignore
+    assert "!requirements/community-ci.txt" not in dockerignore
+
+
+def test_source_build_doc_uses_the_minimal_requirements_context() -> None:
+    """Intent: the documented build must actually succeed.
+    Preconditions: source-build.md builds a development image.
+    Postconditions: it passes requirements as the build context.
+    """
+    doc = SOURCE_BUILD_DOC.read_text(encoding="utf-8")
+    command = re.search(r"docker build \\\n(?:\s+[^\n]*\\\n)*\s+[^\n]*\n", doc)
+
+    assert command is not None, "no docker build invocation found in source-build.md"
+    assert command.group(0).rstrip().endswith("requirements"), (
+        "source-build.md must build the development image from the requirements "
+        f"context, got: {command.group(0).strip()!r}"
+    )

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -775,7 +775,7 @@ def test_source_ci_image_uses_common_and_parameterized_tensorrt_overlay() -> Non
     )
     for architecture, source_dockerfile in source_dockerfiles.items():
         assert "FROM ${TENSORRT_IMAGE}" in source_dockerfile
-        assert "COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt" in source_dockerfile
+        assert "COPY community-ci.txt /tmp/trtmc-community-ci.txt" in source_dockerfile
         assert "pip install --requirement /tmp/trtmc-community-ci.txt" in source_dockerfile
         assert "pre-commit>=" not in source_dockerfile
         assert "https://download.pytorch.org/whl/cpu" in source_dockerfile

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -29,7 +29,7 @@ esac
 
 docker build \
   -f "$DOCKERFILE" \
-  -t "$IMAGE" .
+  -t "$IMAGE" requirements
 
 SOURCE_DIR="$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
## Background

`.dockerignore` deliberately keeps `requirements/` out of the repository-root build
context.

So, `Dockerfile.community-cpu` copies `community-ci.txt` by name from a `requirements/` context. 

But, `Dockerfile.dev.x86` and `Dockerfile.dev.aarch64` instead copy `requirements/community-ci.txt` from the root
context, so both development images fail with `"requirements/community-ci.txt": not found`, since `requirements/` is ignored.

Build from Source is the only supported x86_64 path today (release wheels are aarch64-only), so the first step of `website/docs/getting-started/source-build.md` cannot complete on a clean checkout. 

No linked issue; found while building the development image from source for Qwen3.5.

## Manually repro the docker issue
Commands:
```
    git checkout -b tmp/repro_docker_issue 91860c5c34223cfcfe5548bc203564aae5f0f9e5
    docker build -f Dockerfile.dev.x86 -t repro-broken .
```
Then, you can see the error:
```
$ docker build -f Dockerfile.dev.x86 -t repro-broken .
[+] Building 0.2s (8/11)                                                                                                                                                                  docker:default
 => [internal] load build definition from Dockerfile.dev.x86                                                                                                                                        0.0s
 => => transferring dockerfile: 2.33kB                                                                                                                                                              0.0s
 => [internal] load metadata for nvcr.io/nvidia/tensorrt:26.07-py3@sha256:b82db1abc23750ab0069abc99bbe4ea29138dbdc23ea39861199e2346638b48a                                                          0.2s
 => [internal] load .dockerignore                                                                                                                                                                   0.0s
 => => transferring context: 1.10kB                                                                                                                                                                 0.0s
 => [1/7] FROM nvcr.io/nvidia/tensorrt:26.07-py3@sha256:b82db1abc23750ab0069abc99bbe4ea29138dbdc23ea39861199e2346638b48a                                                                            0.0s
 => [internal] load build context                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                     0.0s
 => CACHED [2/7] RUN apt-get update &&     apt-get install -y --no-install-recommends       build-essential       cmake       git       ninja-build       nlohmann-json3-dev       patchelf         0.0s
 => CACHED [3/7] RUN python3.12 -m venv --system-site-packages /opt/venv &&     ln -s /usr/bin/cmake /opt/venv/bin/cmake                                                                            0.0s
 => ERROR [4/7] COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt                                                                                                                      0.0s
------
 > [4/7] COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt:
------
Dockerfile.dev.x86:33
--------------------
  31 |     ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
  32 |     
  33 | >>> COPY requirements/community-ci.txt /tmp/trtmc-community-ci.txt
  34 |     
  35 |     RUN pip install -U pip && \
--------------------
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref 5e40b510-4bf9-42b0-aacb-e0ab4f5ec041::n758ywzql7s47qljo4cwcz6ut: "/requirements/community-ci.txt": not found
```

## Manually verify the fix
Use this PR
Commands
```
docker build -f Dockerfile.dev.x86 -t verify-fixed requirements
docker run --rm -v "$PWD":/src -w /src \
    -e PYTHONPATH=/src -e PYTHONDONTWRITEBYTECODE=1 verify-fixed \
    bash -c 'git config --global --add safe.directory /src
             python -m pytest -q -p no:cacheprovider \
               tests/tools/test_docker_build_context.py \
               tests/tools/test_community_ci.py'
```
Then, we can see:
```
$ docker run --rm -v "$PWD":/src -w /src \
    -e PYTHONPATH=/src -e PYTHONDONTWRITEBYTECODE=1 verify-fixed \
    bash -c 'git config --global --add safe.directory /src
             python -m pytest -q -p no:cacheprovider \
               tests/tools/test_docker_build_context.py \
               tests/tools/test_community_ci.py'

=====================
== NVIDIA TensorRT ==
=====================

NVIDIA Release 26.07 (build 373437255)
NVIDIA TensorRT Version 11.1.0
Copyright (c) 2016-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
Container image Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

https://developer.nvidia.com/tensorrt

Various files include modifications (c) NVIDIA CORPORATION & AFFILIATES.  All rights reserved.

GOVERNING TERMS: The software and materials are governed by the NVIDIA Software License Agreement
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/)
and the Product-Specific Terms for NVIDIA AI Products
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/).
To install the open-source samples corresponding to this TensorRT release version
run /opt/tensorrt/install_opensource.sh.  To build the open source parsers,
plugins, and samples for current top-of-tree on master or a different branch,
run /opt/tensorrt/install_opensource.sh -b <branch>
See https://github.com/NVIDIA/TensorRT for more information.

WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
   Use the NVIDIA Container Toolkit to start this container with GPU support; see
   https://docs.nvidia.com/datacenter/cloud-native/ .

...............                                                          [100%]
15 passed in 0.91s
```

## Exit Criteria

- The build command documented in `source-build.md` succeeds on a clean checkout.
- `requirements/` stays excluded from the repository-root context.
- A test fails if an image that installs the pinned profile copies it by a directory-qualified path, or if the documented build context regresses.
- Non-goal: no change to `.dockerignore`, to the release `Dockerfile`, or to any installed package versions.

## Implementation

- `Dockerfile.dev.x86` and `Dockerfile.dev.aarch64` copy `community-ci.txt` by its bare name, matching `Dockerfile.community-cpu`.
- `source-build.md` builds those images from the `requirements` context.
- `tests/tools/test_docker_build_context.py` asserts that all three images installing the pinned profile copy it by bare name, that `requirements/` is never re-included at the root, and that the documented build context is `requirements`.

An earlier revision of this PR instead widened the `.dockerignore` allowlist. That breaks the minimal-context contract asserted by `test_cpu_image_installs_the_same_pinned_community_requirements`, and Community CPU correctly rejected it. Image contents are unchanged under either approach.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `docker build -f Dockerfile.dev.x86 -t trtmc-devfix requirements` — succeeds. This is the command `source-build.md` now documents.
- Control, with these changes stashed: `docker build -f Dockerfile.dev.x86 -t <tag> .` still fails with `failed to compute cache key: "/requirements/community-ci.txt": not found`.
- `pytest tests/tools/test_community_ci.py` — 12 passed, including `test_cpu_image_installs_the_same_pinned_community_requirements`.
- `pytest tests/tools/test_docker_build_context.py` — 3 passed.
- `pytest tests/tools/{test_community_ci,test_docker_build_context,test_check_doc_file_references,test_public_source_hygiene}.py` — 26 passed.
- `ruff check tests/tools/test_docker_build_context.py` — passed.

Source-quality and image-build claims only. No compilation, inference, parity, performance, or qualification claim is made.

**Community CPU is currently red on this head.** `Unit / C++ and Python` fails at `tests/tools/test_github_actions_ci.py:778`, which asserts the dev Dockerfiles contain `COPY requirements/community-ci.txt`. See Notes below; this needs a maintainer decision before the PR can go green.

### Hardware, Environment, and Revisions

- x86_64, Ubuntu 24.04, Docker 27.0.3.
- Image base `nvcr.io/nvidia/tensorrt:26.07-py3`; tests run inside the rebuilt image.
- Branch based on `upstream/main` at `91860c5c`.

### Not Run / Remaining Gaps

- `Dockerfile.dev.aarch64` was not built; only x86_64 hardware was available. The new test covers its `COPY` statically.
- The release `Dockerfile` is untouched and was not rebuilt; it is aarch64-only.
- No GPU path is touched, so no premerge GPU evidence is included here.

## Notes For Future Readers

- **Open question for maintainers.** Two existing assertions currently contradict each other, and satisfying both makes the development images unbuildable:
  - `tests/tools/test_community_ci.py:318` asserts `"!requirements/" not in dockerignore`
  - `tests/tools/test_github_actions_ci.py:778` asserts
    `"COPY requirements/community-ci.txt ..." in source_dockerfile`

  No workflow builds `Dockerfile.dev.*` — `tools/model_ci.py` references them only for test selection — so nothing detected the conflict. This PR takes the first contract as authoritative and aligns the dev images with `Dockerfile.community-cpu`, which means `test_github_actions_ci.py:778` must be updated to expect `COPY community-ci.txt`. Per `AGENTS.md`, that test change is not made here and is raised for a maintainer decision instead.
- The tempting alternative fix is to add `!requirements/` to `.dockerignore`. That keeps `test_github_actions_ci.py` green but breaks the minimal-context contract, and was already rejected by CI on an earlier head of this PR.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Two `COPY` paths, one documented build context, and a CPU-only test. No runtime, model, API, ABI, or dependency change; `.dockerignore`, the release `Dockerfile`, and all package versions are untouched.
