### PR TITLE
fix(ci): wait for exact private result

### DIFF
--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -177,7 +177,7 @@ jobs:
     environment:
       name: ci-dispatch
       deployment: false
-    timeout-minutes: 75
+    timeout-minutes: 360
     permissions:
       contents: read
     outputs:
@@ -263,7 +263,10 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]
-          for _ in $(seq 1 220); do
+          # The exact private run can queue behind GPU work. Let the job-level
+          # timeout bound this wait instead of misreporting queue delay as a
+          # terminal Internal CI failure.
+          while true; do
             run="$(
               gh api --method GET \
                 "/repos/$PRIVATE_CI_OWNER/$PRIVATE_CI_REPOSITORY/actions/runs/$RUN_ID"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -328,6 +328,7 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
         "statuses": "write",
     }
     assert workflow_config["jobs"]["dispatch"]["permissions"] == {"contents": "read"}
+    assert workflow_config["jobs"]["dispatch"]["timeout-minutes"] == 360
     assert workflow_config["jobs"]["publish"]["permissions"] == {
         "actions": "read",
         "contents": "read",
@@ -422,6 +423,8 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert ".created_at >= $dispatched_at" not in dispatch
     assert "actions/workflows/premerge.yml/runs?event=workflow_dispatch" in dispatch
     assert "actions/runs/$RUN_ID" in dispatch
+    assert "while true; do" in dispatch
+    assert "seq 1 220" not in dispatch
     assert "--name public-failure-payload" in dispatch
     assert "--log" not in dispatch
     assert "validate_public_failure(report)" in dispatch


### PR DESCRIPTION
## Background

The public Internal CI bridge stopped polling after 55 minutes on PR #926 and published a terminal failure before the exact private run completed. Queue delay should not be classified as a protected CI failure.

## Exit Criteria

- Keep polling the exact dispatched private run until it reaches a terminal state.
- Leave the private Internal CI repository and its result contract unchanged.
- Retain an explicit platform-level bound so a permanently stuck run cannot hold a hosted job forever.

## Implementation

- Replace the fixed 220-attempt polling loop with a terminal-state loop.
- Extend the dispatch job to GitHub Actions' six-hour job maximum.
- Add workflow contract assertions for the timeout and removal of the shorter loop bound.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m tools.community_ci source-quality --base 91860c5c34223cfcfe5548bc203564aae5f0f9e5`: passed; 158 tests passed, changed-file lint and formatting passed, and the complexity gate passed.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_github_actions_ci.py -q`: passed; 70 tests passed.
- YAML parse of `.github/workflows/internal-ci-bridge.yml`: passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Source base: `91860c5c34223cfcfe5548bc203564aae5f0f9e5`.
- Source head: `812d4de8827433a4723e3ffd08f73b7ddc8d00e8`.
- Validation environment: Linux development workspace with Python 3.12; no GPU, CUDA, TensorRT, model, checkpoint, or dataset is involved in this workflow-only change.

### Not Run / Remaining Gaps

- Protected Internal CI was not triggered from this draft. The public workflow change is covered by static workflow contracts; one post-merge long-running protected dispatch will exercise the extended wait end to end.

## Notes For Future Readers

- The six-hour GitHub-hosted job limit remains the outer infrastructure timeout.
- This change does not modify private CI, model selection, protected test criteria, or failure-payload handling.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this is a small Source-only workflow change, but it affects the required protected-CI relay and can hold a hosted runner longer when the private fleet is saturated.
