### PR TITLE
perf(fast-foundation-stereo): reduce pipeline overhead

### DIFF
--- a/src/runtime/models/fast_foundation_stereo/native_plugins/gwc_plugin.cu
+++ b/src/runtime/models/fast_foundation_stereo/native_plugins/gwc_plugin.cu
@@ -50,76 +50,116 @@ __global__ void combined_volume_dhwc8_kernel(const __half* reference, const __ha
                                              const __half* right_projected,
                                              const __half* reference_norm,
                                              const __half* target_norm, __half* output) {
-    // Compute along X so reads from the NCHW inputs remain coalesced, then
-    // transpose through shared memory so the kDHWC8 output writes are also
-    // coalesced. The extra column removes shared-memory bank conflicts during
-    // the channel-minor store phase.
+    // Keep each (height, X tile) block resident across all disparities. Inputs
+    // that do not depend on disparity are loaded once and reused from shared memory.
+    __shared__ __half reference_tile[kFeatureChannels][kOutputXTile + 1];
+    __shared__ __half left_projected_tile[kProjectedChannels][kOutputXTile + 1];
+    __shared__ __half reference_norm_tile[kGroups][kOutputXTile + 1];
     __shared__ __half output_tile[kCombinedChannels][kOutputXTile + 1];
 
-    int32_t remaining_block = blockIdx.x;
-    const int32_t tile_index = remaining_block % kOutputXTiles;
-    remaining_block /= kOutputXTiles;
-    const int32_t height_index = remaining_block % kHeight;
-    const int32_t disparity = remaining_block / kHeight;
-    const int32_t output_channel = threadIdx.x / kOutputXTile;
-    const int32_t tile_width = threadIdx.x % kOutputXTile;
-    const int32_t width_index = tile_index * kOutputXTile + tile_width;
+    const int32_t tile_index = blockIdx.x % kOutputXTiles;
+    const int32_t height_index = blockIdx.x / kOutputXTiles;
+    for (int32_t index = threadIdx.x; index < kFeatureChannels * kOutputXTile;
+         index += blockDim.x) {
+        const int32_t channel = index / kOutputXTile;
+        const int32_t tile_width = index % kOutputXTile;
+        const int32_t width_index = tile_index * kOutputXTile + tile_width;
+        __half value = __float2half_rn(0.0F);
+        if (width_index < kWidth) {
+            const int32_t input_index = (channel * kHeight + height_index) * kWidth + width_index;
+            value = reference[input_index];
+        }
+        reference_tile[channel][tile_width] = value;
+    }
+    for (int32_t index = threadIdx.x; index < kProjectedChannels * kOutputXTile;
+         index += blockDim.x) {
+        const int32_t channel = index / kOutputXTile;
+        const int32_t tile_width = index % kOutputXTile;
+        const int32_t width_index = tile_index * kOutputXTile + tile_width;
+        __half value = __float2half_rn(0.0F);
+        if (width_index < kWidth) {
+            const int32_t input_index = (channel * kHeight + height_index) * kWidth + width_index;
+            value = left_projected[input_index];
+        }
+        left_projected_tile[channel][tile_width] = value;
+    }
+    for (int32_t index = threadIdx.x; index < kGroups * kOutputXTile; index += blockDim.x) {
+        const int32_t group = index / kOutputXTile;
+        const int32_t tile_width = index % kOutputXTile;
+        const int32_t width_index = tile_index * kOutputXTile + tile_width;
+        __half value = __float2half_rn(0.0F);
+        if (width_index < kWidth) {
+            const int32_t norm_index = (group * kHeight + height_index) * kWidth + width_index;
+            value = reference_norm[norm_index];
+        }
+        reference_norm_tile[group][tile_width] = value;
+    }
+    __syncthreads();
 
-    __half value = __float2half_rn(0.0F);
-    if (width_index < kWidth) {
-        if (output_channel >= kGroups) {
-            int32_t projected_channel = output_channel - kGroups;
-            const __half* projected = left_projected;
-            int32_t projected_width = width_index;
-            if (projected_channel >= kProjectedChannels) {
-                projected_channel -= kProjectedChannels;
-                projected = right_projected;
-                projected_width -= disparity;
+    for (int32_t disparity = 0; disparity < kDisparities; ++disparity) {
+        const int32_t projection_index = threadIdx.x;
+        if (projection_index < 2 * kProjectedChannels * kOutputXTile) {
+            int32_t projected_channel = projection_index / kOutputXTile;
+            const int32_t tile_width = projection_index % kOutputXTile;
+            const int32_t width_index = tile_index * kOutputXTile + tile_width;
+            const int32_t output_channel = kGroups + projected_channel;
+            __half value = __float2half_rn(0.0F);
+            if (width_index < kWidth) {
+                if (projected_channel < kProjectedChannels) {
+                    value = left_projected_tile[projected_channel][tile_width];
+                } else {
+                    projected_channel -= kProjectedChannels;
+                    const int32_t projected_width = width_index - disparity;
+                    if (projected_width >= 0) {
+                        const int32_t projected_input_index =
+                            (projected_channel * kHeight + height_index) * kWidth + projected_width;
+                        value = right_projected[projected_input_index];
+                    }
+                }
             }
-            if (projected_width >= 0) {
-                const int32_t projected_index =
-                    (projected_channel * kHeight + height_index) * kWidth + projected_width;
-                value = projected[projected_index];
-            }
-        } else {
-            const int32_t group = output_channel;
+            output_tile[output_channel][tile_width] = value;
+        }
+
+        // One thread retains the original channel accumulation order for each
+        // correlation value, keeping results bitwise identical to the old kernel.
+        const int32_t correlation_index = threadIdx.x;
+        if (correlation_index < kGroups * kOutputXTile) {
+            const int32_t group = correlation_index / kOutputXTile;
+            const int32_t tile_width = correlation_index % kOutputXTile;
+            const int32_t width_index = tile_index * kOutputXTile + tile_width;
             const int32_t target_width = width_index - disparity;
-            if (target_width >= 0) {
+            __half value = __float2half_rn(0.0F);
+            if (width_index < kWidth && target_width >= 0) {
                 float dot = 0.0F;
                 for (int32_t channel = 0; channel < kChannelsPerGroup; ++channel) {
                     const int32_t channel_index = group * kChannelsPerGroup + channel;
-                    const int32_t reference_index =
-                        (channel_index * kHeight + height_index) * kWidth + width_index;
                     const int32_t target_index =
                         (channel_index * kHeight + height_index) * kWidth + target_width;
-                    dot += __half2float(reference[reference_index]) *
+                    dot += __half2float(reference_tile[channel_index][tile_width]) *
                            __half2float(target[target_index]);
                 }
-                const int32_t reference_norm_index =
-                    (group * kHeight + height_index) * kWidth + width_index;
                 const int32_t target_norm_index =
                     (group * kHeight + height_index) * kWidth + target_width;
-                const float denominator = __half2float(reference_norm[reference_norm_index]) *
+                const float denominator = __half2float(reference_norm_tile[group][tile_width]) *
                                               __half2float(target_norm[target_norm_index]) +
                                           1.0e-5F;
                 value = __float2half_rn(dot / denominator);
             }
+            output_tile[group][tile_width] = value;
         }
-    }
-    output_tile[output_channel][tile_width] = value;
-    __syncthreads();
+        __syncthreads();
 
-    // TensorRT's kDHWC8 format stores the vectorized channel dimension minor.
-    // kCombinedChannels is exactly divisible by eight, so there is no padding.
-    const int32_t store_width = threadIdx.x / kCombinedChannels;
-    const int32_t store_channel = threadIdx.x % kCombinedChannels;
-    const int32_t global_store_width = tile_index * kOutputXTile + store_width;
-    if (global_store_width < kWidth) {
-        const int32_t output_index =
-            ((disparity * kHeight + height_index) * kWidth + global_store_width) *
-                kCombinedChannels +
-            store_channel;
-        output[output_index] = output_tile[store_channel][store_width];
+        const int32_t store_width = threadIdx.x / kCombinedChannels;
+        const int32_t store_channel = threadIdx.x % kCombinedChannels;
+        const int32_t global_store_width = tile_index * kOutputXTile + store_width;
+        if (global_store_width < kWidth) {
+            const int32_t output_index =
+                ((disparity * kHeight + height_index) * kWidth + global_store_width) *
+                    kCombinedChannels +
+                store_channel;
+            output[output_index] = output_tile[store_channel][store_width];
+        }
+        __syncthreads();
     }
 }
 
@@ -253,8 +293,7 @@ FastFoundationStereoCombinedVolumePlugin::enqueue(nvinfer1::PluginTensorDesc con
                         stream>>>(static_cast<const __half*>(inputs[1]), target_norm);
     if (cudaGetLastError() != cudaSuccess)
         return -1;
-    combined_volume_dhwc8_kernel<<<kDisparities * kHeight * kOutputXTiles, kOutputThreads, 0,
-                                   stream>>>(
+    combined_volume_dhwc8_kernel<<<kHeight * kOutputXTiles, kOutputThreads, 0, stream>>>(
         static_cast<const __half*>(inputs[0]), static_cast<const __half*>(inputs[1]),
         static_cast<const __half*>(inputs[2]), static_cast<const __half*>(inputs[3]),
         reference_norm, target_norm, static_cast<__half*>(outputs[0]));

--- a/src/runtime/models/fast_foundation_stereo/stereo_pipeline.cpp
+++ b/src/runtime/models/fast_foundation_stereo/stereo_pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/fast_foundation_stereo/stereo_pipeline.h"
 
 #include <algorithm>
+#include <cstring>
 #include <cuda_runtime_api.h>
 #include <stdexcept>
 #include <utility>
@@ -28,14 +29,6 @@ void check_cuda(const char* operation, cudaError_t status) {
     }
 }
 
-Tensor input_tensor(std::vector<float>& data) {
-    Tensor tensor;
-    tensor.data = data.data();
-    tensor.shape = {1, 3, kEngineHeight, kEngineWidth};
-    tensor.dtype = DType::kFloat32;
-    return tensor;
-}
-
 } // namespace
 
 void prepare_fast_foundation_stereo_image(const float* pixels, int32_t height, int32_t width,
@@ -46,17 +39,41 @@ void prepare_fast_foundation_stereo_image(const float* pixels, int32_t height, i
         throw std::invalid_argument("Fast Foundation Stereo requires 700x700 rectified images");
     }
     output.resize(static_cast<std::size_t>(3) * kEngineHeight * kEngineWidth);
+    const std::size_t channel_size = static_cast<std::size_t>(kEngineHeight) * kEngineWidth;
+    for (int32_t source_y = 0; source_y < height; ++source_y) {
+        const float* source_row = pixels + static_cast<std::size_t>(source_y) * width * 3;
+        float* output_rows[3] = {
+            output.data() + static_cast<std::size_t>(source_y + kPadTop) * kEngineWidth,
+            output.data() + channel_size +
+                static_cast<std::size_t>(source_y + kPadTop) * kEngineWidth,
+            output.data() + 2 * channel_size +
+                static_cast<std::size_t>(source_y + kPadTop) * kEngineWidth,
+        };
+        for (int32_t source_x = 0; source_x < width; ++source_x) {
+            const std::size_t source_offset = static_cast<std::size_t>(source_x) * 3;
+            const int32_t output_x = source_x + kPadLeft;
+            output_rows[0][output_x] = source_row[source_offset] * 255.0F;
+            output_rows[1][output_x] = source_row[source_offset + 1] * 255.0F;
+            output_rows[2][output_x] = source_row[source_offset + 2] * 255.0F;
+        }
+        for (float* output_row : output_rows) {
+            std::fill_n(output_row, kPadLeft, output_row[kPadLeft]);
+            std::fill_n(output_row + kPadLeft + width, kEngineWidth - kPadLeft - width,
+                        output_row[kPadLeft + width - 1]);
+        }
+    }
     for (int32_t channel = 0; channel < 3; ++channel) {
-        for (int32_t y = 0; y < kEngineHeight; ++y) {
-            const int32_t source_y = std::clamp(y - kPadTop, 0, height - 1);
-            for (int32_t x = 0; x < kEngineWidth; ++x) {
-                const int32_t source_x = std::clamp(x - kPadLeft, 0, width - 1);
-                const auto source_index =
-                    (static_cast<std::size_t>(source_y) * width + source_x) * 3 + channel;
-                const auto output_index =
-                    (static_cast<std::size_t>(channel) * kEngineHeight + y) * kEngineWidth + x;
-                output[output_index] = pixels[source_index] * 255.0F;
-            }
+        float* channel_output = output.data() + static_cast<std::size_t>(channel) * channel_size;
+        const std::size_t row_bytes = static_cast<std::size_t>(kEngineWidth) * sizeof(float);
+        const float* first_source_row = channel_output + kPadTop * kEngineWidth;
+        for (int32_t y = 0; y < kPadTop; ++y) {
+            std::memcpy(channel_output + static_cast<std::size_t>(y) * kEngineWidth,
+                        first_source_row, row_bytes);
+        }
+        const float* last_source_row = channel_output + (kPadTop + height - 1) * kEngineWidth;
+        for (int32_t y = kPadTop + height; y < kEngineHeight; ++y) {
+            std::memcpy(channel_output + static_cast<std::size_t>(y) * kEngineWidth,
+                        last_source_row, row_bytes);
         }
     }
 }
@@ -76,6 +93,33 @@ FastFoundationStereoPipeline::FastFoundationStereoPipeline(std::unique_ptr<ITrtM
         throw std::runtime_error(
             "FastFoundationStereoPipeline: disparity output contract mismatch");
     }
+}
+
+FastFoundationStereoPipeline::~FastFoundationStereoPipeline() {
+    if (left_input_pinned_)
+        cudaHostUnregister(left_input_.data());
+    if (right_input_pinned_)
+        cudaHostUnregister(right_input_.data());
+}
+
+void FastFoundationStereoPipeline::pin_input(std::vector<float>& input, bool& pinned,
+                                             const char* name) {
+    if (pinned)
+        return;
+    check_cuda(name, cudaHostRegister(input.data(), input.size() * sizeof(float),
+                                      cudaHostRegisterDefault));
+    pinned = true;
+}
+
+void FastFoundationStereoPipeline::upload_feature_input(const char* name,
+                                                        const std::vector<float>& input) {
+    void* destination = feature_->device_ptr(name);
+    if (destination == nullptr) {
+        throw std::runtime_error(
+            std::string("FastFoundationStereoPipeline: missing feature input ") + name);
+    }
+    check_cuda(name, cudaMemcpyAsync(destination, input.data(), input.size() * sizeof(float),
+                                     cudaMemcpyHostToDevice, feature_->stream()));
 }
 
 void FastFoundationStereoPipeline::bind_post_inputs() {
@@ -110,9 +154,12 @@ StereoDisparityResult FastFoundationStereoPipeline::estimate_disparity(const flo
                                                                        int32_t height,
                                                                        int32_t width) {
     prepare_fast_foundation_stereo_image(left_pixels, height, width, left_input_);
+    pin_input(left_input_, left_input_pinned_, "left input pinning");
+    upload_feature_input("left", left_input_);
     prepare_fast_foundation_stereo_image(right_pixels, height, width, right_input_);
-    feature_->forward_async(
-        {{"left", input_tensor(left_input_)}, {"right", input_tensor(right_input_)}});
+    pin_input(right_input_, right_input_pinned_, "right input pinning");
+    upload_feature_input("right", right_input_);
+    feature_->forward_async({});
     if (!post_inputs_bound_)
         bind_post_inputs();
     post_->forward_async({});

--- a/src/runtime/models/fast_foundation_stereo/stereo_pipeline.h
+++ b/src/runtime/models/fast_foundation_stereo/stereo_pipeline.h
@@ -22,6 +22,7 @@ class FastFoundationStereoPipeline final : public IPipeline {
   public:
     FastFoundationStereoPipeline(std::unique_ptr<ITrtModule> feature,
                                  std::unique_ptr<ITrtModule> post, std::string model_id);
+    ~FastFoundationStereoPipeline() override;
 
     StereoDisparityResult estimate_disparity(const float* left_pixels, const float* right_pixels,
                                              int32_t height, int32_t width) override;
@@ -31,6 +32,8 @@ class FastFoundationStereoPipeline final : public IPipeline {
 
   private:
     void bind_post_inputs();
+    void pin_input(std::vector<float>& input, bool& pinned, const char* name);
+    void upload_feature_input(const char* name, const std::vector<float>& input);
 
     std::unique_ptr<ITrtModule> feature_;
     std::unique_ptr<ITrtModule> post_;
@@ -39,6 +42,8 @@ class FastFoundationStereoPipeline final : public IPipeline {
     std::vector<float> padded_output_;
     std::string model_id_;
     bool post_inputs_bound_{false};
+    bool left_input_pinned_{false};
+    bool right_input_pinned_{false};
 };
 
 } // namespace trtmc

--- a/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_preprocess.cpp
+++ b/tests/cpp/models/fast_foundation_stereo/test_fast_foundation_stereo_preprocess.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -105,6 +106,42 @@ void test_preprocess_matches_rgb_chw_replication_contract() {
                 "stereo green bottom-right replicate");
 }
 
+void test_preprocess_is_bitwise_equivalent_to_reference() {
+    constexpr int32_t height = 700;
+    constexpr int32_t width = 700;
+    constexpr int32_t engine_height = 704;
+    constexpr int32_t engine_width = 704;
+    constexpr int32_t pad_top = 2;
+    constexpr int32_t pad_left = 2;
+    std::vector<float> pixels(static_cast<std::size_t>(height) * width * 3);
+    for (std::size_t index = 0; index < pixels.size(); ++index) {
+        pixels[index] = static_cast<float>((index * 17 + 5) % 1021) / 1021.0F;
+    }
+
+    std::vector<float> expected(static_cast<std::size_t>(3) * engine_height * engine_width);
+    for (int32_t channel = 0; channel < 3; ++channel) {
+        for (int32_t y = 0; y < engine_height; ++y) {
+            const int32_t source_y = std::clamp(y - pad_top, 0, height - 1);
+            for (int32_t x = 0; x < engine_width; ++x) {
+                const int32_t source_x = std::clamp(x - pad_left, 0, width - 1);
+                const auto source_index =
+                    (static_cast<std::size_t>(source_y) * width + source_x) * 3 + channel;
+                const auto output_index =
+                    (static_cast<std::size_t>(channel) * engine_height + y) * engine_width + x;
+                expected[output_index] = pixels[source_index] * 255.0F;
+            }
+        }
+    }
+
+    std::vector<float> actual;
+    trtmc::prepare_fast_foundation_stereo_image(pixels.data(), height, width, actual);
+    check(actual.size() == expected.size(), "stereo preprocess bitwise reference size");
+    if (actual.size() == expected.size()) {
+        check(std::memcmp(actual.data(), expected.data(), expected.size() * sizeof(float)) == 0,
+              "stereo preprocess bitwise reference values");
+    }
+}
+
 void test_preprocess_rejects_invalid_input() {
     std::vector<float> output;
     bool null_threw = false;
@@ -155,6 +192,7 @@ void test_pipeline_validates_disparity_engine_contract() {
 
 int main() {
     test_preprocess_matches_rgb_chw_replication_contract();
+    test_preprocess_is_bitwise_equivalent_to_reference();
     test_preprocess_rejects_invalid_input();
     test_pipeline_validates_disparity_engine_contract();
     if (failures == 0)


### PR DESCRIPTION
## Background

Fast-FoundationStereo's TensorRT path is output-stable, but the combined-volume kernel reloads disparity-invariant inputs for every disparity and the public pipeline performs avoidable host preprocessing and transfer serialization. This PR reduces those costs while keeping the existing model build and inference workflows unchanged.

## Exit Criteria

- Reduce end-to-end `public_pipeline_call_wall` latency by a meaningful amount.
- Preserve the model, engine bindings, public pipeline API, CLI build/run flow, and FP16 inference configuration.
- Keep changed preprocessing and correlation results bitwise equivalent to the previous implementation.

## Implementation

- Keeps each GWC output tile resident across disparities and caches the reference features, left projection, and reference norm in shared memory.
- Preserves the original per-channel correlation accumulation order; no reduction reassociation or precision change is introduced.
- Converts, scales, lays out, and edge-pads RGB input in one pass while retaining the exact prior CHW result.
- Registers the reusable host input buffers and starts the left H2D copy before preprocessing the right image. Both transfers and feature inference remain ordered on the existing feature stream.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `clang-format --dry-run --Werror <changed C++/CUDA files>`: passed.
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=86-real ...` followed by `cmake --build build --target test_fast_foundation_stereo_preprocess`: passed at exact head `6fca7d34e` on RTX 3090.
- Native plugin Release build with TensorRT 11.1.0.106 and SM86: passed at exact head `6fca7d34e`.
- `test_fast_foundation_stereo_preprocess`: passed, including the new byte-for-byte reference comparison.
- Pre-transplant model validation of the same runtime implementation: Middlebury-Q passed 15/15 scenes on RTX 3090, RTX 5090, and GB300; controlled outputs remained bitwise identical to each platform's unoptimized implementation.

RTX 3090, TensorRT 11.1.0.106, FP16, batch 1, max disparity 192, 8 update iterations, CUDA graphs, 10 warmups, 30 measured iterations:

| Input | Previous p50 | Optimized p50 | Result |
| --- | ---: | ---: | --- |
| 640x480 | 19.412 ms | 18.674-18.797 ms | 3.2-3.8% faster; bitwise identical |
| 700x700 | 32.111-32.243 ms | 29.725-29.815 ms | 7.2-7.8% faster; bitwise identical |

Source-identical pre-transplant 700x700 hardware validation used the same FP16, batch, disparity, iteration, CUDA graph, warmup, measurement-count, and timing-scope settings:

| Platform | TensorRT | Previous p50 | Optimized p50 | Improvement | Output parity |
| --- | --- | ---: | ---: | ---: | --- |
| RTX 3090 | 11.1.0.106 | 32.111-32.243 ms | 29.725-29.815 ms | 7.2-7.8% | Bitwise identical |
| RTX 5090 | 11.1.0.106 | 17.309-17.337 ms | 15.859-15.882 ms | 8.2-8.5% | Bitwise identical |
| GB300 | 11.2.0.113 | 12.721-12.880 ms | 11.936-11.999 ms | 5.7-7.3% | Bitwise identical |

Middlebury-Q task accuracy for those optimized runtime builds:

| Platform | Scenes | Candidate / reference EPE | Candidate / reference BP2 | Result |
| --- | ---: | ---: | ---: | --- |
| RTX 3090 | 15/15 | 0.443300 / 0.440444 | 0.029811 / 0.028794 | Pass |
| RTX 5090 | 15/15 | 0.441992 / 0.440257 | 0.029394 / 0.028795 | Pass |
| GB300 | 15/15 | 0.442788 / 0.440204 | 0.029462 / 0.028752 | Pass |

### Hardware, Environment, and Revisions

- Exact PR head: `6fca7d34e26b122b394c550e802e27fcfa13f6ec`.
- Exact-head compilation/test target: NVIDIA GeForce RTX 3090, driver 580.173.02, CUDA 13.3, TensorRT 11.1.0.106, SM86 Release build.
- Pre-transplant RTX 5090 target: driver 595.84, CUDA 13.0, TensorRT 11.1.0.106, SM120 Release build.
- Pre-transplant GB300 target: driver 595.58.03, CUDA 13.0, TensorRT 11.2.0.113, aarch64 Release build.
- Model revision: `9b446878c81ddb27593036767b29b2859d46103e`; FP16, batch 1, maximum disparity 192, 8 update iterations.
- Performance scope: `public_pipeline_call_wall`, CUDA graphs enabled, asset loading excluded, telemetry disabled.
- The pre-transplant workers record their qualification-branch base revisions rather than PR #1086's head; the tables above are source-identical optimization evidence, not exact-head CI evidence.

### Not Run / Remaining Gaps

- Exact-head end-to-end Accuracy and Perf were not rerun on RTX 5090 or GB300 after transplanting the optimization onto current `main`; exact-head GitHub CI is pending.
- The full repository test suite was not run locally. Changed-area formatting, exact-head Release builds, the model-owned C++ regression test, and pre-transplant model Accuracy/Perf were run.

## Notes For Future Readers

- Review the GWC accumulation-order preservation first, followed by the bitwise preprocessing test and the pinned-buffer stream ordering.
- PR #1071 adds the repository-owned Fast-FoundationStereo accuracy/performance qualification workflow. Its changes are intentionally not duplicated here; this PR is based directly on `main` and contains only the runtime optimization.
- More aggressive cooperative correlation reduction was faster but was rejected because it changed accumulation order and slightly regressed Middlebury metrics.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this changes a CUDA kernel's execution structure and host-transfer scheduling without changing its interfaces or operation order. Bitwise output checks and model validation reduce the numerical risk, while exact-head cross-architecture CI remains the final portability gate.

Refs: #1045
