### PR TITLE
fix(whisper): keep the encoder mel input at FP32

### DIFF
--- a/python/tensorrt_model_connect/families/whisper/plugin.py
+++ b/python/tensorrt_model_connect/families/whisper/plugin.py
@@ -571,7 +571,14 @@ def _build_whisper_encoder(config, weights, *, precision="fp32", verbose=False):
     eps_tensor = graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype), dtype=work_np_dtype
     )
-    mel_input = network.add_input("mel_features", work_trt_dtype, (num_mel_bins, mel_length))
+    # The mel edge stays FP32 whatever the encoder's compute precision. The
+    # runtime copies host tensors into engine buffers with an untyped memcpy, so
+    # a half input would reinterpret the FP32 mel values the pipeline supplies
+    # rather than converting them. One chunk is under a megabyte, so holding
+    # this edge at FP32 costs nothing measurable.
+    mel_input = network.add_input("mel_features", trt.float32, (num_mel_bins, mel_length))
+    if work_trt_dtype != trt.float32:
+        mel_input = network.add_cast(mel_input, work_trt_dtype).get_output(0)
 
     # TRT requires 2D+ convolutions; reshape 1D conv weights [out, in, k] -> [out, in, 1, k]
     # and input from [1, C, L] -> [1, C, 1, L]


### PR DESCRIPTION
## Background

Building Whisper through the documented public CLI at FP16 produces a bundle
that transcribes punctuation instead of speech:

```
$ trtmc build openai/whisper-tiny --precision fp16 -o whisper-tiny.bundle
$ trtmc transcribe whisper-tiny.bundle --audio librispeech-test-clean-...wav
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

`_build_whisper_encoder` declares `mel_features` at the build precision, so an
FP16 build declares a half input. Both consumers supply FP32:
`WhisperPipeline::run_encoder` sets `mel_tensor.dtype = DType::kFloat32`
(`src/runtime/models/whisper/pipeline.cpp:223`), and the debug runner casts with
`np.ascontiguousarray(mel_features, dtype=np.float32)`
(`whisper/debug_runner.py:225`). `TrtModuleImpl::forward_async`
(`src/runtime/backend/trt_module_impl.cpp:613-615`) copies host tensors into
engine buffers with an untyped `cudaMemcpy` of
`min(tensor.nbytes(), entry.nbytes)` bytes, so the FP32 mel values are
reinterpreted as half rather than converted and the encoder consumes noise.

**Whisper is the only audio family that ties this edge to the build
precision.** Every sibling declares it unconditionally FP32:

| family | declaration |
| --- | --- |
| `canary` | `net.add_input("mel_features", trt.float32, ...)` |
| `nemotron_speech_streaming` | `network.add_input("mel_features", trt.float32, ...)` |
| `nemotron_voicechat` | `network.add_input("mel_features", trt.float32, ...)` |
| `qwen3_omni` | `network.add_input("mel_features", trt.float32, ...)`, documented as float32 |
| `whisper` | `network.add_input("mel_features", work_trt_dtype, ...)` |

No declared profile covers this. Every FP16 whisper manifest sets
`fp32_layers: [0]`, which `_encoder_precision` turns into a fully FP32 encoder
and which incidentally makes the input edge FP32 as well. The default CLI path
has no such guard, so the failure only appears outside the test matrix.

No issue is linked; the failure was found while building an unrelated audio
model against the same runtime contract.

## Exit Criteria

- `trtmc build openai/whisper-tiny --precision fp16` without `--fp32-layers`
  produces a bundle whose transcript matches the `--fp32-layers 0` bundle.
- The declared `whisper-tiny-fp16` E2E profile still passes.
- Non-goals: no change to `fp32_layers` semantics, to the runtime's host-to-
  device copy, or to any other family that binds tensors the same way.

## Implementation

Declare `mel_features` as FP32 at every build precision and cast it to the work
dtype inside the graph, which is what the four sibling audio families already
do. Both whisper consumers already supply FP32 mel data, so the engine's input
edge now matches unconditionally instead of depending on how the engine was
compiled. This aligns whisper with an existing convention rather than
introducing a new one.

One mel chunk is 80x3000 floats, under a megabyte, so holding this edge at FP32
is not a measurable transfer cost. Profiles that pin `fp32_layers: [0]` are
unaffected, because their encoder was already FP32 throughout.

The alternative, converting on the runtime side, would also fix bundles that
are already built. It was not taken here because it puts a precision conversion
in the pipeline for a contract the builder can simply state correctly, and
because the existing precedent in this repository for a dtype mismatch is to
refuse it (`lfm2/pipeline.cpp:166`, `elf_flow/pipeline.cpp:780`) rather than to
convert silently.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Reproduction and fix, same audio and token budget throughout:

```
# before, guarded by the flag every manifest sets
$ trtmc build openai/whisper-tiny --precision fp16 --fp32-layers 0 -o guarded.bundle
$ trtmc transcribe guarded.bundle --audio <librispeech> --max-new-tokens 60
 From the respect paid her on all sides, she seemed like a queen. And from the
 adoration with which she was treated by two or three, she appeared in object of
 worship. The queen mother gave the French the most affectionate reception. ...

# before, the default CLI path
$ trtmc build openai/whisper-tiny --precision fp16 -o plain.bundle
$ trtmc transcribe plain.bundle --audio <librispeech> --max-new-tokens 60
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

# after, the default CLI path
$ trtmc build openai/whisper-tiny --precision fp16 -o fixed.bundle
$ trtmc transcribe fixed.bundle --audio <librispeech> --max-new-tokens 60
 From the respect paid her on all sides, she seemed like a queen. And from the
 adoration with which she was treated by two or three, she appeared in object of
 worship. The queen mother gave the French the most affectionate reception. ...
```

The fixed default-path transcript is identical to the `--fp32-layers 0`
transcript.

Declared E2E profile, rebuilt from scratch on the branch:

```
$ PYTHONPATH=python:. python3 -m pytest \
    "tests/e2e/models/whisper/test_whisper_e2e.py::test_model_e2e[whisper-tiny-fp16]" \
    -v --e2e-model whisper-tiny-fp16 --engine-dir ... \
    --trtmc-binary ./build-sm89/trtmc --model-plugin-dir ./build-sm89/models \
    --rebuild-engines
tests/e2e/models/whisper/test_whisper_e2e.py::test_model_e2e[whisper-tiny-fp16] PASSED
1 passed in 286.65s (0:04:46)
```

Repository gates:

```
$ PYTHONPATH=python:. python3.12 tools/model_ci.py validate
exit 0

$ PYTHONPATH=python:. python3.12 tools/test_impact.py --validate
Validation passed. 225 models, 12 core, 85 families.

$ PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q
160 passed

$ git diff --check
(no output)

$ pre-commit run
all hooks Passed
```

### Hardware, Environment, and Revisions

- Branch head under test: `b5a7147f913db4ab18f3e4c1e7619cb22913a855`, branched from `upstream/main` at `2a264a67`.
- Model: `openai/whisper-tiny`. The reproduction audio is the LibriSpeech
  fixture already in the repository at
  `tests/e2e/models/whisper/data/librispeech-test-clean-6930-75918-0003.wav`.
- GPU: NVIDIA L4 (SM 89, 24 GB), GCP `g2-standard-16`, Ubuntu 22.04, host
  driver 580.173.02; the container runs CUDA 13.3 in forward-compatibility mode.
- Built from `Dockerfile.dev.x86` with `-DCMAKE_CUDA_ARCHITECTURES=89-real`,
  TensorRT 11.1.0.106.
- The E2E run needed `scipy` installed into the development image; the whisper
  HF reference imports it and the image does not ship it. That is an
  environment observation, not part of this change.

### Not Run / Remaining Gaps

- The debug-runner path (`whisper/debug_runner.py`) has the same exposure and is
  fixed by the same change, but it was not exercised; only the C++ pipeline was
  run.
- Only `whisper-tiny` was exercised. `whisper-small-fp16`,
  `whisper-large-v3-turbo`, and the TP profiles were not rebuilt; all of them
  either pin `fp32_layers: [0]` or build at FP32, so none of them changes
  shape under this fix, but none of them was re-run either.
- No BF16 build was tested. The same cast path applies, but it was not measured.
- No performance measurement. The added cast is on a sub-megabyte input once per
  transcription request, but no timing was recorded.
- `Dockerfile.dev.aarch64` was not built and no aarch64 run was performed.

## Notes For Future Readers

The underlying sharp edge is that the runtime's host-to-device path is untyped:
`TrtModuleImpl::forward_async` copies raw bytes and truncates to the smaller of
the two sizes, so a dtype disagreement between a bound host tensor and an engine
input is silent. Any family that binds a host tensor whose dtype is not
guaranteed to match its engine input has the same exposure; keeping such edges
at a fixed precision, as this change does, removes the class of failure rather
than one instance of it.

`fp32_layers: [0]` remains meaningful after this change. It still forces the
whole encoder body to FP32, which is a coarser and more expensive knob than the
input edge this change pins.

No third-party material is added. No artifact rebuild is required beyond
rebuilding FP16 whisper bundles, which were producing wrong output before.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Eight lines in one builder function. It widens one graph edge from half to FP32
and inserts a cast, which cannot change any configuration that was already FP32
there, and the one configuration it does change was producing garbage.
