### PR TITLE
fix(model-checks): harden target recovery

### DIFF
--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -37,6 +37,24 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py check \
   --model distilgpt2
 ```
 
+Before consuming GPU time, validate the selected target's exact native build
+and Accuracy datasets. This is read-only and returns machine-readable blockers:
+
+```bash
+$TRTMC_CHECK_PYTHON tools/model_checks.py check \
+  --platform gb300 \
+  --environment gb300 \
+  --model distilgpt2 \
+  --revision <40-character-sha> \
+  --target-preflight \
+  --json
+```
+
+The JSON includes `resolved_revision` and `target_preflight`. A missing dataset,
+native executable, TensorRT backend, model-plugin directory, worker metadata,
+or matching embedded worker SHA makes the command fail before profile or bundle
+preparation.
+
 Select exact Accuracy suites per model:
 
 ```bash
@@ -89,8 +107,9 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
   --run-id gb300-distilgpt2-debug
 ```
 
-The controller creates missing Python profiles, pinned reference-source
-checkouts, and Perf bundles before measurement. Measurement then runs with
+The controller first writes `native-build-identity.json`, then creates missing
+Python profiles, pinned reference-source checkouts, and Perf bundles before
+measurement. Measurement then runs with
 dependency creation and Perf bundle builds disabled. Qualification also rejects
 a dirty worktree, imports outside the active worktree, and a requested revision
 different from HEAD. It rechecks that identity after preparation and before and
@@ -149,6 +168,13 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
   --run-id gb300-accuracy-all \
   --resume
 ```
+
+Resume is task-aware. Accuracy uses `--resume-existing` only when its own
+`accuracy/run.json` exists; an Accuracy task that never initialized starts
+normally in the existing campaign. Perf follows the same rule using its own run
+metadata. A failed combined campaign retains `task_source_identity` for each
+independently successful task so downstream supervision can reuse valid task
+evidence without treating the whole campaign as passed.
 
 After changing code that affects one model, invalidate that model as a unit so
 all of its selected Accuracy and Perf evidence is regenerated on the current

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -919,6 +919,105 @@ def test_checked_in_platform_resolves_complete_task_matrices(platform):
     assert model_checks.main(["check", "--platform", platform, "--all", "--json"]) == 0
 
 
+def test_check_target_preflight_reports_missing_dataset(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    revision = "a" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(tmp_path / "storage"))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision)
+    monkeypatch.setattr(
+        model_checks,
+        "_validate_native_build",
+        lambda *_args: {"source_revision": revision},
+    )
+
+    assert (
+        model_checks.main(
+            [
+                "check",
+                "--platform",
+                "gb300",
+                "--model",
+                "distilgpt2",
+                "--environment",
+                "gb300",
+                "--target-preflight",
+                "--json",
+            ]
+        )
+        == 2
+    )
+
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["resolved_revision"] == revision
+    assert plan["target_preflight"]["status"] == "blocked"
+    assert plan["target_preflight"]["native_build"]["status"] == "ready"
+    assert plan["target_preflight"]["blockers"][0]["category"] == "dataset_missing"
+
+
+def test_check_target_preflight_accepts_ready_dataset_and_native_build(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    revision = "b" * 40
+    data_root = tmp_path / "data"
+    suites = {
+        suite["id"]: suite
+        for suite in model_checks.validation_catalog.load_suites(
+            model_checks.trtmc_validate.DEFAULT_SUITES
+        )
+    }
+    dataset = model_checks.trtmc_validate.dataset_path(
+        suites["wikitext103_distilgpt2_continuation_parity"],
+        data_root,
+    )
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text("fixture", encoding="utf-8")
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(tmp_path / "storage"))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(data_root))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision)
+    monkeypatch.setattr(
+        model_checks,
+        "_validate_native_build",
+        lambda *_args: {"source_revision": revision},
+    )
+
+    assert (
+        model_checks.main(
+            [
+                "check",
+                "--platform",
+                "gb300",
+                "--model",
+                "distilgpt2",
+                "--environment",
+                "gb300",
+                "--target-preflight",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["target_preflight"]["status"] == "ready"
+    assert plan["target_preflight"]["datasets"] == [
+        {
+            "workload": "wikitext103_distilgpt2_continuation_parity",
+            "path": str(dataset.resolve()),
+            "status": "ready",
+        }
+    ]
+
+
 def test_e2e_only_profile_keeps_accuracy_and_excludes_perf() -> None:
     arguments = model_checks.build_parser().parse_args(
         ["check", "--platform", "gb300", "--model", "nemotron-voicechat-11b"]
@@ -1141,6 +1240,7 @@ def test_shard_resume_reuses_the_same_member_directory(tmp_path, monkeypatch):
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
     monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     selection = [
         "run",
         "--platform",
@@ -1155,6 +1255,12 @@ def test_shard_resume_reuses_the_same_member_directory(tmp_path, monkeypatch):
         "0/1",
     ]
     assert model_checks.main([*selection, "--dry-run"]) == 0
+    accuracy_root = (
+        storage
+        / "results/shard-resume-unit/shards/000-of-001/accuracy"
+    )
+    accuracy_root.mkdir(parents=True)
+    (accuracy_root / "run.json").write_text("{}", encoding="utf-8")
     commands = []
 
     def run(command, **_kwargs):
@@ -1263,6 +1369,83 @@ def test_run_default_output_is_concise_and_ends_with_task_summary(
     assert "tools/perf_matrix.py run" not in output
 
 
+def test_failed_qualification_preserves_successful_task_source_identity(
+    tmp_path,
+    monkeypatch,
+):
+    storage = tmp_path / "storage"
+    revision = "a" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_qualification_dependencies",
+        lambda *_args, **_kwargs: {},
+    )
+    identity_calls = []
+
+    def source_identity(_root, tasks):
+        selected = tuple(tasks)
+        identity_calls.append(selected)
+        return {
+            "consistent": True,
+            "models": {
+                "distilgpt2": {
+                    "status": "consistent",
+                    "source_revision": revision,
+                    "tasks": list(selected),
+                }
+            },
+        }
+
+    monkeypatch.setattr(model_checks, "_model_source_identity", source_identity)
+    returncodes = iter((1, 0))
+    monkeypatch.setattr(
+        model_checks.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=next(returncodes)),
+    )
+
+    assert (
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--model",
+                "distilgpt2",
+                "--run-id",
+                "partial-task-evidence",
+            ]
+        )
+        == 1
+    )
+
+    result = json.loads(
+        (storage / "results/partial-task-evidence/result.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert result["status"] == "failed"
+    assert result["task_source_identity"] == {
+        "perf": {
+            "consistent": True,
+            "models": {
+                "distilgpt2": {
+                    "status": "consistent",
+                    "source_revision": revision,
+                    "tasks": ["perf"],
+                }
+            },
+        }
+    }
+    assert identity_calls == [("perf",)]
+
+
 def test_run_verbose_prints_and_forwards_detailed_commands(tmp_path, monkeypatch, capsys):
     storage = tmp_path / "storage"
     monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
@@ -1271,6 +1454,7 @@ def test_run_verbose_prints_and_forwards_detailed_commands(tmp_path, monkeypatch
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
     monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     commands = []
 
     def run(command, **_kwargs):
@@ -1311,6 +1495,7 @@ def test_run_forwards_exact_source_revision_to_accuracy_and_perf(tmp_path, monke
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision.lower())
     monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     child_environments = []
     identity_checks = []
 
@@ -1393,6 +1578,7 @@ def test_run_defaults_to_qualification_and_uses_only_prepared_dependencies(tmp_p
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda value: revision)
     monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     events = []
 
     def prepare(*_args, **_kwargs):
@@ -1441,6 +1627,7 @@ def test_qualification_rechecks_source_identity_after_preparation(tmp_path, monk
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _value: revision)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     calls = 0
 
     def source_identity(_revision, *, require_clean=False):
@@ -1604,6 +1791,7 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
     monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
     monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
     selection = [
         "run",
         "--platform",
@@ -1616,6 +1804,9 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
         "resume-unit",
     ]
     assert model_checks.main([*selection, "--dry-run"]) == 0
+    accuracy_root = storage / "results/resume-unit/accuracy"
+    accuracy_root.mkdir(parents=True)
+    (accuracy_root / "run.json").write_text("{}", encoding="utf-8")
 
     commands = []
 
@@ -1656,6 +1847,92 @@ def test_run_resume_verifies_request_and_resumes_accuracy(tmp_path, monkeypatch)
     ]
     result = json.loads((storage / "results/resume-unit/result.json").read_text(encoding="utf-8"))
     assert result["resumed"] is True
+
+
+def test_run_resume_starts_accuracy_when_task_was_never_initialized(
+    tmp_path,
+    monkeypatch,
+):
+    storage = tmp_path / "storage"
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(model_checks, "_model_source_identity", _consistent_source_identity)
+    monkeypatch.setattr(model_checks, "_validate_native_build", lambda *_args: {})
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_qualification_dependencies",
+        lambda *_args, **_kwargs: {},
+    )
+    selection = [
+        "run",
+        "--platform",
+        "gb300",
+        "--task",
+        "accuracy",
+        "--model",
+        "distilgpt2",
+        "--run-id",
+        "uninitialized-accuracy-resume",
+    ]
+    assert model_checks.main([*selection, "--dry-run"]) == 0
+    accuracy_root = storage / "results/uninitialized-accuracy-resume/accuracy"
+    accuracy_root.mkdir(parents=True)
+    (accuracy_root / "build-identity.json").write_text("{}", encoding="utf-8")
+    commands = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(model_checks.subprocess, "run", run)
+
+    assert model_checks.main([*selection, "--resume"]) == 0
+    assert len(commands) == 1
+    assert "--resume-existing" not in commands[0]
+
+
+def test_qualification_checks_native_build_before_dependency_preparation(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    storage = tmp_path / "storage"
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(storage))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    build = tmp_path / "missing-native-build"
+    (build / "models").mkdir(parents=True)
+    for name in ("trtmc", "trtmc_dataset_benchmark", "libtrtmc_backend_trt.so"):
+        (build / name).write_text("fixture", encoding="utf-8")
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(build))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: "a" * 40)
+    monkeypatch.setattr(
+        model_checks,
+        "_prepare_qualification_dependencies",
+        lambda *_args, **_kwargs: pytest.fail(
+            "dependency preparation must not start before native preflight"
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        model_checks.main(
+            [
+                "run",
+                "--platform",
+                "gb300",
+                "--task",
+                "perf",
+                "--model",
+                "distilgpt2",
+                "--run-id",
+                "missing-native-preflight",
+            ]
+        )
+
+    assert "benchmark worker is missing for build identity preflight" in capsys.readouterr().err
 
 
 def test_unsharded_resume_rejects_request_without_the_frozen_revision(tmp_path):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -4733,6 +4733,19 @@ def test_build_identity_preflight_rejects_missing_worker(monkeypatch, tmp_path):
         trtmc_validate._validate_build_identity(arguments)
 
 
+def test_build_identity_preflight_rejects_non_executable_worker(monkeypatch, tmp_path):
+    arguments = _build_identity_arguments(tmp_path)
+    worker = arguments.benchmark_binary.parent / "trtmc_benchmark_worker"
+    worker.chmod(0o644)
+    monkeypatch.setattr(trtmc_validate, "_source_revision", lambda: "tested-revision")
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="benchmark worker is not executable",
+    ):
+        trtmc_validate._validate_build_identity(arguments)
+
+
 def test_build_identity_preflight_rejects_mixed_plugin_directory(
     monkeypatch,
     tmp_path,

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -104,6 +104,15 @@ def build_parser() -> argparse.ArgumentParser:
     check = commands.add_parser("check", help="show task bindings without running them")
     _add_selection_arguments(check)
     check.add_argument("--json", action="store_true", help="print the resolved JSON")
+    check.add_argument(
+        "--environment",
+        help="execution environment ID or YAML; defaults to the platform ID",
+    )
+    check.add_argument(
+        "--target-preflight",
+        action="store_true",
+        help="verify selected datasets and native build on this execution target",
+    )
     run = commands.add_parser("run", help="run resolved task bindings locally")
     _add_selection_arguments(run)
     run.add_argument(
@@ -878,10 +887,81 @@ def _resolve_request(
     return plan, platform
 
 
+def _target_preflight(
+    plan: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    try:
+        native_identity = _validate_native_build(environment, arguments.revision)
+        native_build: dict[str, Any] = {
+            "status": "ready",
+            "identity": native_identity,
+        }
+    except (ModelCheckError, trtmc_validate.ValidationError) as error:
+        native_build = {"status": "blocked", "detail": str(error)}
+        blockers.append({"category": "native_build_unavailable", "detail": str(error)})
+
+    suites = {
+        suite["id"]: suite
+        for suite in validation_catalog.load_suites(arguments.suites)
+    }
+    dataset_root = Path(
+        str(environment["tasks"]["accuracy"]["options"]["dataset-root"])
+    )
+    datasets: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for binding in _task_bindings(plan, "accuracy"):
+        workload = str(binding["workload"])
+        suite = suites[workload]
+        path = trtmc_validate.dataset_path(suite, dataset_root).resolve()
+        key = (workload, str(path))
+        if key in seen:
+            continue
+        seen.add(key)
+        exists = path.is_file()
+        record = {
+            "workload": workload,
+            "path": str(path),
+            "status": "ready" if exists else "missing",
+        }
+        datasets.append(record)
+        if not exists:
+            blockers.append(
+                {
+                    "category": "dataset_missing",
+                    "workload": workload,
+                    "detail": f"dataset is missing: {path}",
+                }
+            )
+    return {
+        "status": "ready" if not blockers else "blocked",
+        "environment": environment["id"],
+        "environment_source": environment["source"],
+        "revision": arguments.revision,
+        "native_build": native_build,
+        "datasets": datasets,
+        "blockers": blockers,
+    }
+
+
 def _check(arguments: argparse.Namespace) -> int:
-    plan, _ = _resolve_request(arguments)
+    arguments.revision = _resolved_revision(arguments.revision)
+    plan, platform = _resolve_request(arguments)
+    plan["resolved_revision"] = arguments.revision
+    if arguments.target_preflight:
+        environment = load_execution_environment(
+            arguments.environment or str(platform["id"]),
+            platform_id=str(platform["id"]),
+        )
+        plan["target_preflight"] = _target_preflight(plan, environment, arguments)
     print(json.dumps(plan, indent=2) if arguments.json else _render(plan))
-    return 2 if plan["summary"]["blocker_count"] else 0
+    preflight_blocked = (
+        arguments.target_preflight
+        and plan["target_preflight"]["status"] != "ready"
+    )
+    return 2 if plan["summary"]["blocker_count"] or preflight_blocked else 0
 
 
 def _default_run_id(platform_id: str) -> str:
@@ -1194,6 +1274,32 @@ def _resolved_perf_environment(
     raw = _expand_environment(raw, "performance environment")
     destination.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     return destination
+
+
+def _validate_native_build(
+    environment: Mapping[str, Any],
+    revision: str,
+) -> dict[str, Any]:
+    options = environment["tasks"]["accuracy"].get("options", {})
+    required = (
+        "trtmc-binary",
+        "benchmark-binary",
+        "backend-dir",
+        "model-plugin-dir",
+    )
+    missing = [name for name in required if not str(options.get(name, "") or "").strip()]
+    if missing:
+        raise ModelCheckError(
+            "model-check environment is missing native build paths: "
+            + ", ".join(missing)
+        )
+    return trtmc_validate.validate_build_identity(
+        trtmc_binary=Path(str(options["trtmc-binary"])),
+        benchmark_binary=Path(str(options["benchmark-binary"])),
+        backend_dir=Path(str(options["backend-dir"])),
+        model_plugin_dir=Path(str(options["model-plugin-dir"])),
+        expected_revision=revision,
+    )
 
 
 def _perf_command(
@@ -2027,11 +2133,17 @@ def _run(arguments: argparse.Namespace) -> int:
             if command is None:
                 execution_commands.append((task, None))
             elif task == "accuracy":
-                resumed = [*command, "--resume-existing"]
-                task_models = {str(binding["model"]) for binding in task_bindings[task]}
-                for model in sorted(invalidated_models & task_models):
-                    resumed.extend(["--invalidate-model", model])
-                execution_commands.append((task, resumed))
+                run_metadata = execution_root / "accuracy" / "run.json"
+                if run_metadata.is_file():
+                    resumed = [*command, "--resume-existing"]
+                    task_models = {
+                        str(binding["model"]) for binding in task_bindings[task]
+                    }
+                    for model in sorted(invalidated_models & task_models):
+                        resumed.extend(["--invalidate-model", model])
+                    execution_commands.append((task, resumed))
+                else:
+                    execution_commands.append((task, command))
             else:
                 resume_command = _perf_resume_command(
                     environment,
@@ -2069,6 +2181,16 @@ def _run(arguments: argparse.Namespace) -> int:
 
     if arguments.dry_run:
         return 0
+
+    if arguments.intent == "qualification":
+        native_build_identity = _validate_native_build(
+            environment,
+            arguments.revision,
+        )
+        _write_request(
+            execution_root / "native-build-identity.json",
+            native_build_identity,
+        )
 
     if shard is not None:
         _write_request(
@@ -2161,6 +2283,15 @@ def _run(arguments: argparse.Namespace) -> int:
         status = "PASSED" if completed.returncode == 0 else "FAILED"
         print(f"[{index}/{len(runnable)}] {label}: {status}", flush=True)
     tasks_passed = all(code == 0 for code in task_results.values())
+    task_source_identity = (
+        {
+            task: _model_source_identity(execution_root, (task,))
+            for task, returncode in task_results.items()
+            if returncode == 0
+        }
+        if arguments.intent == "qualification"
+        else {}
+    )
     model_source_identity = (
         _model_source_identity(execution_root, task_results)
         if tasks_passed and task_results
@@ -2175,6 +2306,7 @@ def _run(arguments: argparse.Namespace) -> int:
         "resumed": bool(arguments.resume),
         "execution_revision": arguments.revision,
         "task_exit_codes": task_results,
+        "task_source_identity": task_source_identity,
         "model_source_identity": model_source_identity,
         "status": "passed" if tasks_passed and identity_passed else "failed",
     }

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -738,7 +738,7 @@ def ensure_reference_sources(
     return ReferenceSourceSelection(environment=environment)
 
 
-def _dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
+def dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
     raw = str(suite.get("dataset", {}).get("default_path", "") or "")
     if not raw:
         raise ValidationError(f"workload {suite.get('id')} has no default dataset path")
@@ -752,6 +752,10 @@ def _dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
     except ValueError:
         relative = Path(path.name)
     return dataset_root / relative
+
+
+def _dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
+    return dataset_path(suite, dataset_root)
 
 
 def _run_subprocess(command: Sequence[str], log_path: Path, env: Mapping[str, str]) -> int:
@@ -1971,23 +1975,29 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _validate_build_identity(arguments: argparse.Namespace) -> dict[str, Any]:
-    """Fail before GPU work when source and native build provenance differ."""
-    expected_revision = _source_revision()
+def validate_build_identity(
+    *,
+    trtmc_binary: Path,
+    benchmark_binary: Path,
+    backend_dir: Path | None,
+    model_plugin_dir: Path | None,
+    expected_revision: str,
+) -> dict[str, Any]:
+    """Validate one native build before dependency preparation or GPU work."""
     if not expected_revision:
         raise ValidationError(
             "cannot determine the validation source revision for build identity preflight"
         )
 
-    benchmark_binary = arguments.benchmark_binary.expanduser().resolve()
+    benchmark_binary = benchmark_binary.expanduser().resolve()
     build_root = benchmark_binary.parent
-    trtmc_binary = arguments.trtmc_binary.expanduser().resolve()
+    trtmc_binary = trtmc_binary.expanduser().resolve()
     backend_dir = (
-        arguments.backend_dir.expanduser().resolve() if arguments.backend_dir else build_root
+        backend_dir.expanduser().resolve() if backend_dir else build_root
     )
     model_plugin_dir = (
-        arguments.model_plugin_dir.expanduser().resolve()
-        if arguments.model_plugin_dir
+        model_plugin_dir.expanduser().resolve()
+        if model_plugin_dir
         else build_root / "models"
     )
     worker = build_root / "trtmc_benchmark_worker"
@@ -2021,6 +2031,12 @@ def _validate_build_identity(arguments: argparse.Namespace) -> dict[str, Any]:
     for label, path in required_files.items():
         if not path.is_file():
             raise ValidationError(f"{label} is missing for build identity preflight: {path}")
+    for label in ("trtmc binary", "dataset benchmark", "benchmark worker"):
+        path = required_files[label]
+        if not os.access(path, os.X_OK):
+            raise ValidationError(
+                f"{label} is not executable for build identity preflight: {path}"
+            )
     if not model_plugin_dir.is_dir():
         raise ValidationError(
             f"model plugin directory is missing for build identity preflight: {model_plugin_dir}"
@@ -2060,6 +2076,17 @@ def _validate_build_identity(arguments: argparse.Namespace) -> dict[str, Any]:
         "model_plugin_dir": str(model_plugin_dir),
         "artifacts": artifacts,
     }
+
+
+def _validate_build_identity(arguments: argparse.Namespace) -> dict[str, Any]:
+    """Fail before GPU work when source and native build provenance differ."""
+    return validate_build_identity(
+        trtmc_binary=arguments.trtmc_binary,
+        benchmark_binary=arguments.benchmark_binary,
+        backend_dir=arguments.backend_dir,
+        model_plugin_dir=arguments.model_plugin_dir,
+        expected_revision=_source_revision(),
+    )
 
 
 def _write_build_identity(


### PR DESCRIPTION
## Background

A bounded GB300 supervisor pilot exposed three recovery gaps in formal model checks:

- a combined campaign always passed `--resume-existing` to Accuracy even when that task had never initialized;
- missing target datasets or an unusable native build were discovered only after dependency preparation;
- a combined failure discarded valid task-level evidence, forcing already successful work to be rerun.

## Exit Criteria

- Start an uninitialized task and resume only a task with existing run state.
- Reject missing target datasets and native artifacts that do not match the exact source SHA before dependency preparation.
- Preserve independently valid Accuracy or Performance evidence when the other task fails.
- Keep all existing Accuracy and Performance pass criteria unchanged.

## Implementation

- Add environment-aware target preflight to `model_checks.py check`.
- Validate and record native build identity before formal preparation.
- Make combined qualification resume task-aware.
- Emit task-level source identity and retain it for successful tasks on partial failure.
- Expose reusable dataset and native-build validation helpers.
- Add regression coverage and update the model-check documentation.

There are no public API, ABI, bundle-format, dependency, migration, or rollout changes. The affected surface is model-check developer tooling and its JSON evidence contract.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest -q tests/tools/test_model_checks.py tests/tools/test_trtmc_validate.py tests/tools/test_perf_matrix.py`
  - 376 passed
- `python3 -m ruff check tools/model_checks.py tools/trtmc_validate.py tests/tools/test_model_checks.py tests/tools/test_trtmc_validate.py`
  - passed
- `git diff --check`
  - passed before commit
- `python3 tools/model_checks.py check --platform gb300 --model distilgpt2 --revision 7163242cd5088f1058888ef9864c5414c96a9ea8 --json`
  - resolved the exact requested SHA and reported two configured bindings

### Hardware, Environment, and Revisions

- Repository head under review: `ce7f964c65e86a7212be6a25c5a837ee88d3826e`.
- Unit, lint, and CLI checks ran in the local CPU development environment against Python 3.
- The CLI smoke check used platform `gb300`, model `distilgpt2`, and exact requested source revision `7163242cd5088f1058888ef9864c5414c96a9ea8`; it exercised static configuration resolution only and did not execute GPU inference.
- No model checkpoint, dataset payload, CUDA, TensorRT, precision, or GPU result is claimed by these local checks.

### Not Run / Remaining Gaps

- The earlier GB300 pilot motivated these changes, but it predates this commit and is not GPU qualification evidence for this head.
- A post-fix GB300 Accuracy/Performance campaign has not been run for `ce7f964c65e86a7212be6a25c5a837ee88d3826e`.
- Bare-metal target-probe integration remains unvalidated; the bounded pilot covered the container path.

## Notes For Future Readers

- Review `tools/model_checks.py` first, followed by `tools/trtmc_validate.py` and their tests.
- The local-only `trtmc-agents` supervisor integration is intentionally not part of this PR.
- Existing pass thresholds are unchanged. The main compatibility consideration is that formal qualification now fails early when target native-build identity or required datasets are invalid.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Medium risk: the change affects qualification recovery and machine-readable evidence semantics, with focused regression coverage but no post-fix GPU campaign yet.
