### PR TITLE
feat(qwen3.8): load FP8 checkpoints by dequantizing block scales

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_8/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/qwen3_8/checkpoint_mapper.py
@@ -186,14 +186,78 @@ def _to_numpy_fp32(t) -> np.ndarray:
     return np.asarray(t, dtype=np.float32)
 
 
+
+# Qwen3.8 FP8 checkpoints store the large projections as float8_e4m3 together
+# with a companion "<name>_scale_inv" tensor holding one bf16 scale per
+# weight_block_size block (128x128 for Qwen3.8-27B-FP8). Converting the raw
+# float8 values without applying those scales silently yields wrong weights, so
+# the two are always resolved together.
+_FP8_DTYPE_NAMES = frozenset({
+    "torch.float8_e4m3fn", "float8_e4m3fn", "float8_e4m3",
+    "torch.float8_e5m2", "float8_e5m2",
+})
+_SCALE_INV_SUFFIX = "_scale_inv"
+
+
+def _is_fp8_tensor(t) -> bool:
+    return str(getattr(t, "dtype", "")) in _FP8_DTYPE_NAMES
+
+
+def _apply_block_scales(values: np.ndarray, scale_inv: np.ndarray) -> np.ndarray:
+    """Scale a dequantized FP8 weight in place by its per-block scales.
+
+    ``scale_inv`` carries one entry per block; block extents are derived from the
+    two shapes so the loader does not need to read weight_block_size, and a
+    trailing partial block is handled by clipping. The multiply is done block by
+    block rather than by expanding the scales, because an expanded scale array
+    would be as large as the weight itself.
+    """
+    if values.ndim != 2 or scale_inv.ndim != 2:
+        raise ValueError(
+            f"FP8 block dequantization expects 2-D weight and scales, got "
+            f"{values.ndim}-D and {scale_inv.ndim}-D")
+    rows, cols = values.shape
+    s_rows, s_cols = scale_inv.shape
+    block_r = -(-rows // s_rows)
+    block_c = -(-cols // s_cols)
+    for i in range(s_rows):
+        r0, r1 = i * block_r, min((i + 1) * block_r, rows)
+        if r0 >= r1:
+            break
+        for j in range(s_cols):
+            c0, c1 = j * block_c, min((j + 1) * block_c, cols)
+            if c0 >= c1:
+                break
+            values[r0:r1, c0:c1] *= scale_inv[i, j]
+    return values
+
+
 def _load_tensor(readers: list, name: str) -> np.ndarray:
+    raw = _get_raw_tensor(readers, name)
+    values = _to_numpy_fp32(raw)
+    if not _is_fp8_tensor(raw):
+        return values
+
+    scale_name = name + _SCALE_INV_SUFFIX
+    if not _has_tensor(readers, scale_name):
+        # Refuse to return unscaled float8 values: they look like a plausible
+        # weight tensor and would corrupt the engine silently.
+        raise KeyError(
+            f"FP8 tensor {name!r} has no companion {scale_name!r}; "
+            "cannot dequantize")
+    scale_inv = _to_numpy_fp32(_get_raw_tensor(readers, scale_name))
+    return _apply_block_scales(values, scale_inv)
+
+
+def _get_raw_tensor(readers: list, name: str):
+    """Fetch a tensor from the shard collection without dtype conversion."""
     tensor_map = getattr(readers, "tensor_map", None)
     if tensor_map is not None:
         reader = tensor_map.get(name)
         if reader is None:
             raise KeyError(f"Tensor not found: {name}")
-        return _to_numpy_fp32(reader.get_tensor(name))
+        return reader.get_tensor(name)
     for r in readers:
         if name in r.keys():
-            return _to_numpy_fp32(r.get_tensor(name))
+            return r.get_tensor(name)
     raise KeyError(f"Tensor not found: {name}")

--- a/tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py
+++ b/tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py
@@ -532,3 +532,86 @@ def test_mock_bundle_serializes_decoder_and_hybrid_config(tmp_path):
     assert runtime_config["mamba_nheads"] == 48
     assert runtime_config["mamba_head_dim"] == 128
     assert runtime_config["conv_dim"] == 10240
+
+
+class _FakeFp8Tensor:
+    """Stands in for a safetensors float8 tensor without needing torch."""
+
+    def __init__(self, values: np.ndarray):
+        self._values = values.astype(np.float32)
+        self.dtype = "torch.float8_e4m3fn"
+
+    def float(self):
+        return self
+
+    def numpy(self):
+        return self._values
+
+
+def test_fp8_weights_are_dequantized_with_their_block_scales(monkeypatch):
+    """FP8 projections are stored with one scale per weight_block_size block.
+
+    Returning the raw float8 values would look like a plausible weight tensor
+    and corrupt the engine silently, so the loader must resolve the companion
+    `_scale_inv` and apply it.
+    """
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    # 4x4 weight, 2x2 blocks -> one scale per 2x2 quadrant
+    values = np.ones((4, 4), dtype=np.float32)
+    scale_inv = np.array([[2.0, 3.0], [4.0, 5.0]], dtype=np.float32)
+    store = {
+        "w": _FakeFp8Tensor(values),
+        "w_scale_inv": scale_inv,
+    }
+
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, name: name in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, name: store[name])
+
+    out = cm._load_tensor(["reader"], "w")
+    expected = np.array([
+        [2.0, 2.0, 3.0, 3.0],
+        [2.0, 2.0, 3.0, 3.0],
+        [4.0, 4.0, 5.0, 5.0],
+        [4.0, 4.0, 5.0, 5.0],
+    ], dtype=np.float32)
+    np.testing.assert_allclose(out, expected)
+
+
+def test_fp8_weight_without_scales_is_rejected(monkeypatch):
+    """An FP8 tensor missing its scales must fail loudly, not load unscaled."""
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    store = {"w": _FakeFp8Tensor(np.ones((4, 4), dtype=np.float32))}
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, name: name in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, name: store[name])
+
+    with pytest.raises(KeyError, match="no companion"):
+        cm._load_tensor(["reader"], "w")
+
+
+def test_non_fp8_weights_are_untouched(monkeypatch):
+    """A bf16/fp32 checkpoint must not gain any scaling behaviour."""
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    values = np.arange(16, dtype=np.float32).reshape(4, 4)
+    store = {"w": values}
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, name: name in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, name: store[name])
+
+    np.testing.assert_allclose(cm._load_tensor(["reader"], "w"), values)
+
+
+def test_block_scales_handle_a_trailing_partial_block():
+    """The last block is clipped when the shape is not a multiple of the block."""
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    values = np.ones((3, 3), dtype=np.float32)
+    scale_inv = np.array([[2.0, 3.0], [4.0, 5.0]], dtype=np.float32)
+    out = cm._apply_block_scales(values, scale_inv)
+    expected = np.array([
+        [2.0, 2.0, 3.0],
+        [2.0, 2.0, 3.0],
+        [4.0, 4.0, 5.0],
+    ], dtype=np.float32)
+    np.testing.assert_allclose(out, expected)


### PR DESCRIPTION
## Background

`Qwen/Qwen3.8-27B-FP8` is the FP8 release of Qwen3.8-27B and cannot be loaded
today. Its config declares `quant_method: "fp8"` with
`weight_block_size: [128, 128]`, a format no current scale provider accepts:
`PreQuantizedCheckpointProvider` handles gptq, awq and compressed-tensors and
raises on anything else.

Worse, reading it appeared to work and was silently wrong. The checkpoint reader
uses torch when available, so a `float8_e4m3` tensor reached `_to_numpy_fp32`,
which converts with `.float()` and returns the raw float8 values with none of
their block scales applied. Nothing downstream distinguishes that from a real
weight, so the build would have produced a corrupt engine and reported success.

**This pull request is stacked on #1085**, which adds the qwen3_8 family. Until
that merges, the commit list here also contains its five commits; only
`feat(qwen3.8): load FP8 checkpoints by dequantizing block scales` is new. The
dependency is real rather than cosmetic: `Qwen3.8-27B-FP8` declares
`model_type: "qwen3_5"`, so without the qwen3_8 family it does not dispatch.

## Exit Criteria

- `Qwen/Qwen3.8-27B-FP8` dispatches to the qwen3_8 family and builds an engine.
- FP8 weights are reconstructed with their block scales; an FP8 tensor whose
  scales are missing is rejected rather than loaded unscaled.
- A bf16 checkpoint is unaffected.
- Generation matches the bf16 sources.

Non-goals: this does not produce an FP8 engine. Weights are dequantized at load
time and the graph is unchanged, so the result is a normal fp16 engine, the same
size as the bf16 path, with no throughput or memory benefit.

## Implementation

Qwen3.8-27B-FP8 stores six projections per layer as `float8_e4m3` -- the
DeltaNet `in_proj_qkv`, `in_proj_z` and `out_proj`, and the SwiGLU `gate_proj`,
`up_proj` and `down_proj` -- each paired with a `<name>_scale_inv` tensor
carrying one bf16 scale per 128x128 block. Norms, `A_log`, `dt_bias`, `conv1d`
and the QK norms stay bf16, and the vision tower is excluded from quantization
entirely.

`_load_tensor` in the family's checkpoint mapper now resolves the weight and its
scales together. An FP8 tensor with no companion raises rather than returning
unscaled values. Block extents are derived from the weight and scale shapes, so
the loader never reads `weight_block_size`, and a trailing partial block is
clipped. The scaling runs block by block in place: materializing an expanded
scale array would double the memory of a load that already peaks near 200 GB.

No shared code changes, and no changes outside `families/qwen3_8`.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Unit tests covering the block-scale arithmetic, a trailing partial block, the
missing-scales rejection, and that a non-FP8 checkpoint is untouched:

```
pytest -q tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py
  -> 13 passed
```

Dispatch:

```
Qwen3.8-27B-FP8  -> 'qwen3_8'   quant_method=fp8  block=[128, 128]
Qwen3.8-27B      -> 'qwen3_8'
```

Engine build from the FP8 checkpoint:

```
python -m tensorrt_model_connect build .../Qwen3.8-27B-FP8 \
  --precision fp16 --max-cache-length 256 -o qwen38-27b-fp8.bundle

  Family: qwen3_8
  Weights loaded [289.8s]        (bf16 checkpoint: 237.8s)
  Engine built  [477.4s] (51313.4 MB)
  Bundle saved  [803.8s total]
```

Generation compared against both the bf16 engine and an independent Hugging
Face bf16 reference:

```
  "capital of France? one word"          exact (2 tok)  vs both
  "17 * 23? just the number"             exact (4 tok)  vs both   -> 391
  "single sentence explaining a GPU"     agrees 35 of 48 tokens
```

The third prompt diverges on an end-of-sequence decision after 35 identical
tokens, which is the expected effect of quantization on a low-margin token.
Token-identical output for 35 tokens is only possible if the block scales are
applied correctly.

Repository checks, both Community CPU stages reproduced with their own commands:

```
clang-format --dry-run --Werror                     clean
ruff check                                          clean
tools/legal_headers.py                              findings=0
tools/check_doc_file_references.py                  clean
pytest tests/tools/test_model_plugin_encapsulation_static.py   160 passed
pytest tests/builder/ tests/tools/ tests/e2e_harness/ (CI selection)
                                                    3778 passed, 1 skipped
qwen3_8 + qwen3_5 family tests                      22 passed
```

### Hardware, Environment, and Revisions

- Repository head under test: the head of this branch, on top of #1085.
- Checkpoint: `Qwen/Qwen3.8-27B-FP8`, 29 GB, `quant_method: fp8`,
  `fmt: e4m3`, `weight_block_size: [128, 128]`, `activation_scheme: dynamic`.
- GPU: 1x NVIDIA SM 10.0, 183359 MiB. Single device only.
- Host: 32 CPU, 512 GB RAM. A 256 GB host cannot build this model; see the
  host memory floor recorded in #1085.
- OS/container: Linux x86_64, image built from `Dockerfile.dev.x86`, CUDA 13.3.
- TensorRT: 11.1.0.106, ABI 11.1. Engine precision fp16.

### Not Run / Remaining Gaps

- **No FP8 engine.** Weights are dequantized at load time, so the engine is
  fp16 and the same 51 GB as the bf16 path. A true FP8 engine needs 2-D block
  scales in the shared quantization layer, where
  `PreQuantizedCheckpointProvider` rejects `quant_method: "fp8"` and
  `LayerScales.block_size` is a scalar group size. Not attempted here.
- **No E2E manifest for the FP8 model.** The harness runs its Hugging Face
  reference on CPU, and loading an FP8 checkpoint there needs quantization
  backends that are not available in the reference environment, so the case
  would not execute. The FP8 engine was instead compared against the bf16
  engine and an independent bf16 reference, as recorded above.
- **Not registered in the support matrix, validation workloads or benchmarks.**
  Those entries shift repository-wide counters and imply a runnable E2E case;
  they are deliberately left out until the reference question above is settled.
- **Single SM only.** Validated on SM 10.0; no other compute capability.
- **Performance not measured.** No throughput or memory claims are made, and
  none are expected, since the engine is identical in kind to the bf16 one.

## Notes For Future Readers

- Suggested review order: `_load_tensor` and `_apply_block_scales` in
  `families/qwen3_8/checkpoint_mapper.py`, then the four new unit tests.
- The failure mode this closes is silent. Before this change a Qwen3.8 FP8
  checkpoint loaded without error and produced wrong weights; the loader now
  refuses an FP8 tensor whose scales it cannot find.
- Block extents are derived from shapes rather than read from
  `weight_block_size`, so a checkpoint using a different block size loads
  without a code change.
- If a true FP8 engine is pursued later, this loader is the natural place to
  branch: it already locates both halves of each quantized weight.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The change is confined to one family's checkpoint mapper and only alters
behavior for tensors whose dtype is float8, a case that previously produced
silently wrong weights. A bf16 checkpoint takes exactly the path it did before,
which the existing qwen3_8 tests and the unchanged 3778-test CI selection cover.
