### PR TITLE
fix(alerts): structure Slack notifications

### DIFF
--- a/.github/workflows/community-activity-slack-alert.yml
+++ b/.github/workflows/community-activity-slack-alert.yml
@@ -75,7 +75,6 @@ jobs:
           ITEM_TITLE: ${{ github.event.pull_request.title || github.event.issue.title || github.event.discussion.title }}
           ITEM_URL: ${{ github.event.comment.html_url || github.event.pull_request.html_url || github.event.issue.html_url || github.event.discussion.html_url }}
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request != null }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -99,7 +98,6 @@ jobs:
           esac
 
           payload="$(jq -cn \
-            --arg repository "$REPOSITORY" \
             --arg kind "$item_kind" \
             --arg action "$EVENT_ACTION" \
             --arg author "$ITEM_AUTHOR" \
@@ -115,7 +113,6 @@ jobs:
              {
                text: (":bell: External community activity\n" +
                  $kind + " #" + $number + " · " + $action + "\n" +
-                 $repository + "\n" +
                  $author + " (" + $association + ")"),
                blocks: [
                  {
@@ -129,10 +126,8 @@ jobs:
                  {
                    type: "section",
                    fields: [
-                     {type: "mrkdwn", text: ("*Repository:*\n" + $repository)},
                      {type: "mrkdwn", text: ("*Event:*\n" + $kind + " · " + $action)},
-                     {type: "mrkdwn", text: ("*Author:*\n" + $author)},
-                     {type: "mrkdwn", text: ("*Association:*\n" + $association)}
+                     {type: "mrkdwn", text: ("*Author:*\n" + $author + " (" + $association + ")")}
                    ]
                  },
                  {

--- a/.github/workflows/community-activity-slack-alert.yml
+++ b/.github/workflows/community-activity-slack-alert.yml
@@ -111,11 +111,40 @@ jobs:
               gsub("&"; "&amp;") |
               gsub("<"; "&lt;") |
               gsub(">"; "&gt;");
-             {text: (":bell: *External community activity*\\n" +
-              "*Repository:* " + $repository + "\\n" +
-              "*Event:* " + $kind + " · " + $action + "\\n" +
-              "*Item:* <" + $url + "|#" + $number + " — " + ($title | slack_escape) + ">\\n" +
-              "*Author:* " + $author + " (" + $association + ")")}')"
+             ($title | slack_escape) as $safe_title |
+             {
+               text: (":bell: External community activity\n" +
+                 $kind + " #" + $number + " · " + $action + "\n" +
+                 $repository + "\n" +
+                 $author + " (" + $association + ")"),
+               blocks: [
+                 {
+                   type: "header",
+                   text: {
+                     type: "plain_text",
+                     text: "🔔 External community activity",
+                     emoji: true
+                   }
+                 },
+                 {
+                   type: "section",
+                   fields: [
+                     {type: "mrkdwn", text: ("*Repository:*\n" + $repository)},
+                     {type: "mrkdwn", text: ("*Event:*\n" + $kind + " · " + $action)},
+                     {type: "mrkdwn", text: ("*Author:*\n" + $author)},
+                     {type: "mrkdwn", text: ("*Association:*\n" + $association)}
+                   ]
+                 },
+                 {
+                   type: "section",
+                   text: {
+                     type: "mrkdwn",
+                     text: ("*" + $kind + " #" + $number + "*\n" +
+                       "<" + $url + "|" + $safe_title + ">")
+                   }
+                 }
+               ]
+             }')"
 
           curl --fail-with-body --silent --show-error \
             --request POST \

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -313,11 +313,25 @@ def test_community_activity_alert_only_posts_trusted_external_metadata() -> None
     assert 'gsub(">"; "&gt;")' in script
     assert "($title | slack_escape)" in script
     assert '" + $title +' not in script
-    assert "*External community activity*" in script
-    assert '"*Event:* " + $kind + " · " + $action' in script
+    assert "External community activity" in script
+    assert '"*Event:*\\n" + $kind + " · " + $action' in script
     assert "curl --fail-with-body --silent --show-error" in script
     assert '--data "$payload"' in script
     assert '"$SLACK_WEBHOOK_URL"' in script
+
+
+def test_community_activity_alert_uses_structured_slack_blocks() -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "community-activity-slack-alert.yml"
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    script = workflow["jobs"]["notify"]["steps"][0]["run"]
+
+    assert r"\\n" not in script
+    assert 'type: "header"' in script
+    assert 'type: "plain_text"' in script
+    assert 'type: "section"' in script
+    assert 'fields: [' in script
+    for label in ("Repository", "Event", "Author", "Association"):
+        assert f'"*{label}:*\\n"' in script
 
 
 def test_only_pages_workflow_creates_deployment_objects() -> None:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -330,8 +330,11 @@ def test_community_activity_alert_uses_structured_slack_blocks() -> None:
     assert 'type: "plain_text"' in script
     assert 'type: "section"' in script
     assert 'fields: [' in script
-    for label in ("Repository", "Event", "Author", "Association"):
+    for label in ("Event", "Author"):
         assert f'"*{label}:*\\n"' in script
+    assert '"*Repository:*\\n"' not in script
+    assert '"*Association:*\\n"' not in script
+    assert "$repository" not in script
 
 
 def test_only_pages_workflow_creates_deployment_objects() -> None:


### PR DESCRIPTION
## Background

Community activity alerts currently render the literal characters `\n` in Slack, leaving repository, event, item, and author metadata on one unstructured line. The jq program double-escapes its newline sequences before sending the Incoming Webhook payload.

## Exit Criteria

- Slack renders community activity metadata as structured fields with real line breaks.
- The linked PR, issue, or discussion remains prominent and clickable.
- Existing external-author filtering, secret handling, and contributor-title escaping remain unchanged.

## Implementation

- Build the Incoming Webhook payload with Slack Block Kit header, field, and item sections.
- Keep a concise fallback `text` value with correctly escaped JSON newlines.
- Add a regression contract that rejects double-escaped newline sequences and requires the structured blocks.
- No public API, ABI, artifact, dependency, compatibility, migration, or rollout changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tests/tools/test_github_actions_ci.py -q -k 'community_activity_alert_uses_structured_slack_blocks'` — passed after reproducing the test failure against the old payload.
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q` — 74 passed.
- `pre-commit run --files .github/workflows/community-activity-slack-alert.yml tests/tools/test_github_actions_ci.py` — all applicable hooks passed.
- `git diff --check` — passed.
- A representative jq payload was generated locally and parsed successfully with real newline characters, structured `blocks`, and escaped Slack control characters in the item title.

### Hardware, Environment, and Revisions

- Repository head: `950828194cf0db864840aa2aea7737c72bd28b1a`
- Linux 6.8.0-138-generic; Python 3.12.3; jq 1.7.
- CPU-only workflow and payload validation; GPU, CUDA, TensorRT, model, checkpoint, dataset, and precision are not applicable.

### Not Run / Remaining Gaps

- A live Slack delivery is not run from the feature branch because repository secrets are only available to the trusted workflow after merge. GitHub Actions CI will validate the submitted branch before merge.

## Notes For Future Readers

The webhook secret name and delivery path are unchanged. The workflow still reads trusted GitHub metadata only and does not check out or execute contributor-controlled code.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: this only changes the Slack JSON presentation and adds a regression test; event selection and security boundaries are unchanged.
