### PR TITLE
feat(qwen3.8): load ModelOpt NVFP4 checkpoints (RadixArk/Qwen3.8-27B-NVFP4)

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_8/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/qwen3_8/checkpoint_mapper.py
@@ -232,21 +232,115 @@ def _apply_block_scales(values: np.ndarray, scale_inv: np.ndarray) -> np.ndarray
     return values
 
 
+
+# ModelOpt MIXED_PRECISION checkpoints (RadixArk/Qwen3.8-27B-NVFP4) carry two
+# schemes side by side, described by quantization_config.config_groups:
+#
+#   FP8   attention and DeltaNet projections: float8_e4m3 weights with a single
+#         per-tensor "<name>.weight_scale".
+#   NVFP4 MLP projections and lm_head: 4-bit E2M1 values packed two per uint8,
+#         a per-16-element "<name>.weight_scale" stored as float8_e4m3, and a
+#         global "<name>.weight_scale_2".
+#
+# "<name>.input_scale" describes activations and is unused here: the graph runs
+# in fp16 and quantizes nothing at runtime.
+_PER_TENSOR_SCALE_SUFFIX = ".weight_scale"
+_GLOBAL_SCALE_SUFFIX = ".weight_scale_2"
+
+# E2M1: one sign bit, two exponent bits, one mantissa bit, exponent bias 1.
+# Subnormals give 0 and 0.5; the normals are 1, 1.5, 2, 3, 4, 6.
+_E2M1_MAGNITUDES = np.array(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+
+
+def _scale_key(name: str, suffix: str) -> str:
+    """Map "<...>.weight" to its sibling scale tensor name."""
+    base = name[: -len(".weight")] if name.endswith(".weight") else name
+    return base + suffix
+
+
+def _decode_e2m1(nibbles: np.ndarray) -> np.ndarray:
+    magnitudes = _E2M1_MAGNITUDES[nibbles & 0x07]
+    return np.where(nibbles & 0x08, -magnitudes, magnitudes)
+
+
+def _unpack_nvfp4(packed: np.ndarray) -> np.ndarray:
+    """Expand uint8 pairs of E2M1 values into a float32 array of twice the width.
+
+    The low nibble holds the even column and the high nibble the odd one, which
+    is the packing ModelOpt emits.
+    """
+    if packed.ndim != 2:
+        raise ValueError(f"NVFP4 weights must be 2-D, got {packed.ndim}-D")
+    packed = packed.astype(np.uint8, copy=False)
+    rows, packed_cols = packed.shape
+    out = np.empty((rows, packed_cols * 2), dtype=np.float32)
+    out[:, 0::2] = _decode_e2m1(packed & 0x0F)
+    out[:, 1::2] = _decode_e2m1(packed >> 4)
+    return out
+
+
+def _apply_group_scales(values: np.ndarray, group_scale: np.ndarray,
+                        global_scale: float) -> np.ndarray:
+    """Scale unpacked NVFP4 values by their per-group and global scales.
+
+    Reshaping to (rows, groups, group_size) lets the per-group multiply happen in
+    place; expanding the scales to the weight's own size would cost as much
+    memory again, and lm_head alone is 248320 x 5120.
+    """
+    rows, cols = values.shape
+    s_rows, s_cols = group_scale.shape
+    if s_rows != rows or cols % s_cols:
+        raise ValueError(
+            f"NVFP4 scale shape {group_scale.shape} does not tile weight shape "
+            f"{values.shape}")
+    group_size = cols // s_cols
+    view = values.reshape(rows, s_cols, group_size)
+    view *= group_scale.astype(np.float32).reshape(rows, s_cols, 1)
+    return (values * np.float32(global_scale)) if global_scale != 1.0 else values
+
+
 def _load_tensor(readers: list, name: str) -> np.ndarray:
     raw = _get_raw_tensor(readers, name)
+
+    # NVFP4: 4-bit values packed two per uint8, identified by the global scale
+    # that only this scheme carries. Checked before the dtype tests because the
+    # payload arrives as plain uint8.
+    global_key = _scale_key(name, _GLOBAL_SCALE_SUFFIX)
+    if _has_tensor(readers, global_key):
+        group_key = _scale_key(name, _PER_TENSOR_SCALE_SUFFIX)
+        if not _has_tensor(readers, group_key):
+            raise KeyError(
+                f"NVFP4 tensor {name!r} has {global_key!r} but no {group_key!r}; "
+                "cannot dequantize")
+        packed = np.asarray(raw.numpy() if hasattr(raw, "numpy") else raw)
+        group_scale = _to_numpy_fp32(_get_raw_tensor(readers, group_key))
+        global_scale = float(
+            _to_numpy_fp32(_get_raw_tensor(readers, global_key)).reshape(-1)[0])
+        return _apply_group_scales(_unpack_nvfp4(packed), group_scale, global_scale)
+
     values = _to_numpy_fp32(raw)
     if not _is_fp8_tensor(raw):
         return values
 
-    scale_name = name + _SCALE_INV_SUFFIX
-    if not _has_tensor(readers, scale_name):
-        # Refuse to return unscaled float8 values: they look like a plausible
-        # weight tensor and would corrupt the engine silently.
-        raise KeyError(
-            f"FP8 tensor {name!r} has no companion {scale_name!r}; "
-            "cannot dequantize")
-    scale_inv = _to_numpy_fp32(_get_raw_tensor(readers, scale_name))
-    return _apply_block_scales(values, scale_inv)
+    # Qwen native FP8: one scale per weight_block_size block.
+    block_key = name + _SCALE_INV_SUFFIX
+    if _has_tensor(readers, block_key):
+        block_scale = _to_numpy_fp32(_get_raw_tensor(readers, block_key))
+        return _apply_block_scales(values, block_scale)
+
+    # ModelOpt FP8: a single per-tensor scale.
+    tensor_key = _scale_key(name, _PER_TENSOR_SCALE_SUFFIX)
+    if _has_tensor(readers, tensor_key):
+        scale = _to_numpy_fp32(_get_raw_tensor(readers, tensor_key)).reshape(-1)[0]
+        values *= np.float32(scale)
+        return values
+
+    # Refuse to return unscaled float8 values: they look like a plausible weight
+    # tensor and would corrupt the engine silently.
+    raise KeyError(
+        f"FP8 tensor {name!r} has no companion {block_key!r} or {tensor_key!r}; "
+        "cannot dequantize")
 
 
 def _get_raw_tensor(readers: list, name: str):

--- a/tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py
+++ b/tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py
@@ -615,3 +615,93 @@ def test_block_scales_handle_a_trailing_partial_block():
         [4.0, 4.0, 5.0],
     ], dtype=np.float32)
     np.testing.assert_allclose(out, expected)
+
+
+class _FakeTensor:
+    """Reader stand-in returning a fixed payload for any requested name."""
+
+    def __init__(self, values, dtype: str = ""):
+        self._values = values
+        self.dtype = dtype
+
+    def float(self):
+        return self
+
+    def numpy(self):
+        return self._values
+
+
+def _nvfp4_store(name, packed, group_scale, global_scale):
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+    return {
+        name: _FakeTensor(packed),
+        cm._scale_key(name, ".weight_scale"): group_scale,
+        cm._scale_key(name, ".weight_scale_2"): np.array([global_scale], dtype=np.float32),
+    }
+
+
+def test_nvfp4_weights_are_unpacked_and_double_scaled(monkeypatch):
+    """NVFP4 packs two E2M1 values per byte, low nibble first.
+
+    A wrong nibble order or magnitude table still yields plausible numbers, so
+    the expected values are spelled out rather than recomputed.
+    """
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    # Low nibble is the even column: 0x10 -> (0x0, 0x1) = (0.0, 0.5),
+    # 0x32 -> (0x2, 0x3) = (1.0, 1.5), 0x9E -> (0xE, 0x9) = (-4.0, -0.5).
+    packed = np.array([[0x10, 0x32], [0x9E, 0x00]], dtype=np.uint8)
+    group_scale = np.array([[2.0], [10.0]], dtype=np.float32)  # one group of 4
+    store = _nvfp4_store("m.weight", packed, group_scale, 3.0)
+
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, n: n in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, n: store[n])
+
+    out = cm._load_tensor(["r"], "m.weight")
+    expected = np.array([
+        [0.0, 0.5, 1.0, 1.5],
+        [-4.0, -0.5, 0.0, 0.0],
+    ], dtype=np.float32) * np.array([[2.0], [10.0]], dtype=np.float32) * 3.0
+    np.testing.assert_allclose(out, expected, rtol=1e-6)
+
+
+def test_nvfp4_without_group_scale_is_rejected(monkeypatch):
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    name = "m.weight"
+    store = {
+        name: _FakeTensor(np.zeros((2, 2), dtype=np.uint8)),
+        cm._scale_key(name, ".weight_scale_2"): np.array([1.0], dtype=np.float32),
+    }
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, n: n in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, n: store[n])
+
+    with pytest.raises(KeyError, match="no .*weight_scale"):
+        cm._load_tensor(["r"], name)
+
+
+def test_modelopt_per_tensor_fp8_scale_is_applied(monkeypatch):
+    """ModelOpt FP8 uses one scalar scale, unlike Qwen's per-block scale_inv."""
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    name = "m.weight"
+    store = {
+        name: _FakeFp8Tensor(np.full((2, 2), 3.0, dtype=np.float32)),
+        cm._scale_key(name, ".weight_scale"): np.array([0.5], dtype=np.float32),
+    }
+    monkeypatch.setattr(cm, "_has_tensor", lambda _r, n: n in store)
+    monkeypatch.setattr(cm, "_get_raw_tensor", lambda _r, n: store[n])
+
+    np.testing.assert_allclose(
+        cm._load_tensor(["r"], name), np.full((2, 2), 1.5, dtype=np.float32))
+
+
+def test_e2m1_magnitudes_match_the_format():
+    """0 and 0.5 are subnormal; 1, 1.5, 2, 3, 4, 6 are the normals."""
+    from tensorrt_model_connect.families.qwen3_8 import checkpoint_mapper as cm
+
+    nibbles = np.arange(16, dtype=np.uint8)
+    decoded = cm._decode_e2m1(nibbles)
+    expected = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+    np.testing.assert_allclose(decoded[:8], expected)
+    np.testing.assert_allclose(decoded[8:], -expected)


### PR DESCRIPTION
## Background

`RadixArk/Qwen3.8-27B-NVFP4` is a ModelOpt export of Qwen3.8-27B and cannot be
loaded today. It is a `MIXED_PRECISION` checkpoint carrying two schemes at once,
described by `quantization_config.config_groups`:

- **FP8** for the attention and DeltaNet projections (`q/k/v/o_proj`,
  `in_proj_qkv`, `in_proj_z`, `out_proj`): `float8_e4m3` weights with a single
  per-tensor `weight_scale`.
- **NVFP4** for the MLP projections and `lm_head`: 4-bit E2M1 values packed two
  per `uint8`, a per-16-element `weight_scale` stored as `float8_e4m3`, and a
  global `weight_scale_2`.

**This pull request is stacked on #1115**, which adds Qwen's own FP8 release, and
through it on #1085, which adds the qwen3_8 family. Until those merge the commit
list here also contains theirs; only
`feat(qwen3.8): load ModelOpt NVFP4 checkpoints` is new. The dependency is real:
this checkpoint declares `model_type: "qwen3_5"`, so without the qwen3_8 family
it does not dispatch.

## Exit Criteria

- `RadixArk/Qwen3.8-27B-NVFP4` dispatches to qwen3_8 and builds an engine.
- Both schemes are reconstructed with their scales; a quantized weight whose
  scales cannot be found is rejected rather than loaded unscaled.
- bf16 and the existing FP8 paths are unaffected.
- Reconstructed weights match the bf16 release within quantization error.

Non-goals: this does not produce an NVFP4 engine. Weights are dequantized at
load time and the graph is unchanged, so the engine is fp16 and the same size as
the bf16 path, with no throughput or memory benefit.

## Implementation

`_load_tensor` in the family checkpoint mapper selects the scheme from the
companion tensors rather than from config, because the NVFP4 payload arrives as
plain `uint8` and is otherwise indistinguishable from an ordinary tensor:

- `weight_scale_2` present -> NVFP4: unpack nibbles, apply the per-group scale
  and then the global scale.
- `float8` weight with `weight_scale_inv` -> Qwen's block-scaled FP8 (#1115).
- `float8` weight with `weight_scale` -> ModelOpt per-tensor FP8.
- otherwise raise, rather than return unscaled values.

E2M1 is decoded through an explicit magnitude table (0, 0.5, 1, 1.5, 2, 3, 4, 6,
with a separate sign bit); the low nibble is the even column, which is the
packing ModelOpt emits. Group scales are applied through a
`(rows, groups, group_size)` view so the multiply happens in place; expanding
them to the weight's own size would cost as much memory again, and `lm_head`
alone is 248320 x 5120.

`input_scale` is ignored because the graph runs in fp16 and quantizes nothing at
runtime, and `kv_cache_quant_algo` because the runtime allocates its own KV
cache.

No shared code changes, and no changes outside `families/qwen3_8`.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Reconstruction against the bf16 release of the same model. A wrong nibble order
or magnitude table still produces plausible numbers, so real tensors were
dequantized and compared with `Qwen/Qwen3.8-27B`:

```
NVFP4           mlp.gate_proj.weight          mean|rel err|=0.0896  corr=0.99545
NVFP4           mlp.down_proj.weight          mean|rel err|=0.0897  corr=0.99548
FP8 per-tensor  self_attn.q_proj.weight       mean|rel err|=0.0226  corr=0.99964
FP8 per-tensor  linear_attn.out_proj.weight   mean|rel err|=0.0227  corr=0.99964
```

Those are the error magnitudes expected from 4-bit and 8-bit quantization; a
wrong unpacking gives correlation near zero.

Unit tests covering the packing order, the E2M1 table over all sixteen nibbles,
the per-tensor FP8 scale, and the missing-scale rejection:

```
pytest -q tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py   -> 17 passed
```

Engine build:

```
python -m tensorrt_model_connect build .../Qwen3.8-27B-NVFP4 \
  --precision fp16 --max-cache-length 256 -o qwen38-27b-nvfp4.bundle

  Family: qwen3_8
  Weights loaded [363.4s]
  Engine built  [417.5s] (51313.5 MB)
  Bundle saved  [818.5s total]
```

Generation is coherent and correct, including `17 * 23` -> `391` and
"capital of Japan" -> "Tokyo".

Repository checks, both Community CPU stages reproduced with their own commands:

```
clang-format --dry-run --Werror                     clean
ruff check                                          clean
tools/legal_headers.py                              findings=0
tools/check_doc_file_references.py                  clean
test_model_plugin_encapsulation_static              160 passed
pytest tests/builder/ tests/tools/ tests/e2e_harness/ (CI selection)
                                                    3778 passed, 1 skipped
qwen3_8 + qwen3_5 family tests                      26 passed
```

### Hardware, Environment, and Revisions

- Checkpoint: `RadixArk/Qwen3.8-27B-NVFP4`, 21.9 GB, `quant_method: modelopt`,
  `quant_algo: MIXED_PRECISION`, producer modelopt 0.47.0.dev0.
- Reference for the reconstruction check: `Qwen/Qwen3.8-27B` at
  `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`.
- GPU: 1x NVIDIA SM 10.0, 183359 MiB. Single device only.
- Host: 32 CPU, 512 GB RAM. A 256 GB host cannot build this model.
- OS/container: Linux x86_64, `Dockerfile.dev.x86`, CUDA 13.3.
- TensorRT: 11.1.0.106, ABI 11.1. Engine precision fp16.

### Not Run / Remaining Gaps

- **No NVFP4 engine.** Weights are dequantized at load time, so the engine is
  fp16 and the same 51 GB as the bf16 path. A true low-precision engine needs
  block-scaled Q/DQ in the shared quantization layer and is not attempted here.
- **This checkpoint ships no `chat_template.jinja`.** `trtmc run
  --chat-template` therefore has no template to apply and the raw prompt is
  used, which shows up as a leading newline and trailing special tokens in
  generated text. That is a property of the published checkpoint, not of this
  change, and it is why generation was assessed on content rather than on
  token-exact agreement with the bf16 engine.
- **No E2E manifest, support-matrix row, or workload entries.** The harness
  reference runs on CPU and cannot load this checkpoint, so the case would not
  execute; registering it would also shift repository-wide counters.
- **Single SM only.** Validated on SM 10.0.
- **Performance not measured.** None is expected: the engine is identical in
  kind to the bf16 one.
- **`input_scale` and `kv_cache_quant_algo` are ignored**, which is correct for
  an fp16 graph with a runtime-allocated KV cache but means the checkpoint's
  activation and KV calibration are unused.

## Notes For Future Readers

- Suggested review order: the scheme selection in `_load_tensor`, then
  `_unpack_nvfp4` and `_decode_e2m1`, then `_apply_group_scales`, then the
  four new unit tests.
- Scheme detection is by companion tensor, not by config. That keeps the loader
  working for a checkpoint whose `config_groups` name layers this build does not
  know about, at the cost of relying on ModelOpt's naming.
- The reconstruction check in the validation section is the meaningful test of
  the packing order; the unit tests pin the behavior once it is known correct.
- Group sizes are derived from the weight and scale shapes, so a checkpoint
  using a group size other than 16 loads without a code change.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Confined to one family's checkpoint mapper. It only alters behavior for tensors
carrying ModelOpt scale companions, which cannot load correctly today; bf16 and
the FP8 path from #1115 take exactly the routes they did before, covered by the
existing qwen3_8 tests and the unchanged 3778-test CI selection.
