### PR TITLE
fix(perf): propagate and verify backend path

### DIFF
--- a/python/tensorrt_model_connect/benchmark/builder.py
+++ b/python/tensorrt_model_connect/benchmark/builder.py
@@ -91,9 +91,18 @@ class _BuildPlan:
 class BundleBuilder:
     """Materialize missing benchmark bundles through the public builder CLI."""
 
-    def __init__(self, cache_root: Path | None = None, *, backend_abi: str | None = None) -> None:
+    def __init__(
+        self,
+        cache_root: Path | None = None,
+        *,
+        backend_abi: str | None = None,
+        native_bin_dir: Path | None = None,
+    ) -> None:
         self.cache_root = (cache_root or default_bundle_cache()).expanduser().resolve()
         self.backend_abi = backend_abi
+        self.native_bin_dir = (
+            native_bin_dir.expanduser().resolve() if native_bin_dir is not None else None
+        )
 
     def provisional_path(self, model: ModelDescriptor) -> Path:
         """Return a non-materialized path used while cases are being resolved."""
@@ -198,7 +207,9 @@ class BundleBuilder:
     def _plan(self, model: ModelDescriptor, cases: Sequence[ResolvedCase]) -> _BuildPlan:
         options = _build_options(model, cases)
         runtime = _resolve_builder_runtime(self.backend_abi)
-        environment = _build_environment(model, runtime)
+        environment = _build_environment(
+            model, runtime, native_bin_dir=self.native_bin_dir
+        )
         identity_options = dict(options)
         if "fp8_scales" in identity_options:
             identity_options["fp8_scales"] = model.build_settings["fp8_scales"]
@@ -659,8 +670,15 @@ _REQUIRED_BUILD_ENVIRONMENT_INPUTS = frozenset(
 )
 
 
-def _build_environment(model: ModelDescriptor, runtime: _BuilderRuntime) -> dict[str, str]:
+def _build_environment(
+    model: ModelDescriptor,
+    runtime: _BuilderRuntime,
+    *,
+    native_bin_dir: Path | None = None,
+) -> dict[str, str]:
     environment = os.environ.copy()
+    if native_bin_dir is not None:
+        environment["_TRTMC_INTERNAL_NATIVE_BIN_DIR"] = str(native_bin_dir)
     if runtime.python_root is not None:
         environment["TRTMC_BENCH_TRT_PYTHON_ROOT"] = str(runtime.python_root)
     if runtime.block_libs_wheel:

--- a/python/tensorrt_model_connect/benchmark/cli.py
+++ b/python/tensorrt_model_connect/benchmark/cli.py
@@ -189,7 +189,11 @@ def _run(arguments: argparse.Namespace) -> int:
         except BenchmarkError:
             pass
     backend_abi = worker_backend_abi(worker) if worker is not None else None
-    builder = BundleBuilder(arguments.bundle_cache, backend_abi=backend_abi)
+    builder = BundleBuilder(
+        arguments.bundle_cache,
+        backend_abi=backend_abi,
+        native_bin_dir=worker.parent if worker is not None else None,
+    )
     cases = _resolve_cases(arguments, spec, catalog, builder)
     cases, bundle_preparation = builder.prepare(
         cases,

--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -53,7 +53,10 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py check \
 The JSON includes `resolved_revision` and `target_preflight`. A missing dataset,
 native executable, TensorRT backend, model-plugin directory, worker metadata,
 or matching embedded worker SHA makes the command fail before profile or bundle
-preparation.
+preparation. When Perf is selected, preflight also loads the packaged TensorRT
+backend through the declared Perf runner Python. The command fails if that
+loader smoke test cannot resolve or load the backend and records the result in
+`target_preflight.perf_backend_loader`.
 
 Select exact Accuracy suites per model:
 

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -935,6 +935,11 @@ def test_check_target_preflight_reports_missing_dataset(
         "_validate_native_build",
         lambda *_args: {"source_revision": revision},
     )
+    monkeypatch.setattr(
+        model_checks,
+        "_probe_perf_backend_loader",
+        lambda *_args: {"status": "ready"},
+    )
 
     assert (
         model_checks.main(
@@ -989,6 +994,11 @@ def test_check_target_preflight_accepts_ready_dataset_and_native_build(
         "_validate_native_build",
         lambda *_args: {"source_revision": revision},
     )
+    monkeypatch.setattr(
+        model_checks,
+        "_probe_perf_backend_loader",
+        lambda *_args: {"status": "ready"},
+    )
 
     assert (
         model_checks.main(
@@ -1009,11 +1019,108 @@ def test_check_target_preflight_accepts_ready_dataset_and_native_build(
 
     plan = json.loads(capsys.readouterr().out)
     assert plan["target_preflight"]["status"] == "ready"
+    assert plan["target_preflight"]["perf_backend_loader"] == {"status": "ready"}
     assert plan["target_preflight"]["datasets"] == [
         {
             "workload": "wikitext103_distilgpt2_continuation_parity",
             "path": str(dataset.resolve()),
             "status": "ready",
+        }
+    ]
+
+
+def test_perf_backend_loader_preflight_uses_declared_runner_and_native_dir(
+    tmp_path,
+    monkeypatch,
+):
+    native_dir = tmp_path / "runtime"
+    native_dir.mkdir()
+    backend = native_dir / "libtrtmc_backend_trt.so"
+    backend.touch()
+    runner = tmp_path / "python"
+    runner.touch(mode=0o755)
+    environment = {
+        "tasks": {
+            "accuracy": {"options": {"backend-dir": str(native_dir)}},
+            "perf": {"runner_python": str(runner)},
+        }
+    }
+
+    def fake_run(command, **options):
+        assert command[0] == str(runner.resolve())
+        assert command[1] == "-c"
+        assert options["cwd"] == model_checks.REPOSITORY
+        assert options["env"]["_TRTMC_INTERNAL_NATIVE_BIN_DIR"] == str(
+            native_dir.resolve()
+        )
+        return model_checks.subprocess.CompletedProcess(
+            command, 0, '{"status": "loaded"}\n', ""
+        )
+
+    monkeypatch.setattr(model_checks.subprocess, "run", fake_run)
+
+    assert model_checks._probe_perf_backend_loader(environment) == {
+        "status": "ready",
+        "python": str(runner.resolve()),
+        "native_dir": str(native_dir.resolve()),
+        "backend": str(backend.resolve()),
+    }
+
+
+def test_check_target_preflight_blocks_when_perf_backend_cannot_load(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    revision = "c" * 40
+    monkeypatch.setenv("TRTMC_CHECK_STORAGE_ROOT", str(tmp_path / "storage"))
+    monkeypatch.setenv("TRTMC_CHECK_DATASET_ROOT", str(tmp_path / "data"))
+    monkeypatch.setenv("TRTMC_CHECK_BUILD_DIR", str(tmp_path / "runtime"))
+    monkeypatch.setenv("TRTMC_CHECK_PYTHON", sys.executable)
+    monkeypatch.setattr(model_checks, "_resolved_revision", lambda _revision: revision)
+    monkeypatch.setattr(
+        model_checks,
+        "_validate_native_build",
+        lambda *_args: {"source_revision": revision},
+    )
+
+    def reject_backend(*_args):
+        raise model_checks.ModelCheckError("backend loader could not find its DSO")
+
+    monkeypatch.setattr(
+        model_checks,
+        "_probe_perf_backend_loader",
+        reject_backend,
+        raising=False,
+    )
+
+    assert (
+        model_checks.main(
+            [
+                "check",
+                "--platform",
+                "gb300",
+                "--task",
+                "perf",
+                "--model",
+                "distilgpt2",
+                "--environment",
+                "gb300",
+                "--target-preflight",
+                "--json",
+            ]
+        )
+        == 2
+    )
+
+    plan = json.loads(capsys.readouterr().out)
+    preflight = plan["target_preflight"]
+    assert preflight["status"] == "blocked"
+    assert preflight["perf_backend_loader"]["status"] == "blocked"
+    assert preflight["blockers"] == [
+        {
+            "category": "perf_backend_loader_unavailable",
+            "detail": "backend loader could not find its DSO",
         }
     ]
 

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -920,6 +920,46 @@ def test_prepare_only_builds_bundle_without_starting_measurement(
     assert receipt["bundles"][0]["source_revision"] == revision
 
 
+def test_prepare_only_exposes_worker_native_plugins_to_bundle_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    revision = "a" * 40
+    worker = _worker(tmp_path)
+    (tmp_path / "libtrtmc_backend_trt.so").touch()
+    assert worker_backend_abi(worker) is None
+
+    def fake_build(command, environment, _timeout_s):
+        assert environment["_TRTMC_INTERNAL_NATIVE_BIN_DIR"] == str(tmp_path.resolve())
+        output = Path(command[command.index("-o") + 1])
+        write_bundle(
+            output,
+            BundleInfo(),
+            [BundleSection("config.json", json.dumps({"source_revision": revision}).encode())],
+        )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.delenv("_TRTMC_INTERNAL_NATIVE_BIN_DIR", raising=False)
+    monkeypatch.setenv("TRTMC_ENGINE_BUILD_REVISION", revision)
+    monkeypatch.setenv("TRTMC_BENCH_BUILD_PLATFORM", "test-sm80")
+    monkeypatch.setattr(BundleBuilder, "_execute", staticmethod(fake_build))
+
+    assert (
+        main(
+            [
+                "run",
+                "--model",
+                "distilgpt2",
+                "--bundle-cache",
+                str(tmp_path / "cache"),
+                "--worker",
+                str(worker),
+                "--prepare-only",
+            ]
+        )
+        == 0
+    )
+
+
 def test_image_rate_and_seconds_per_image_account_for_batch_size() -> None:
     metrics = reduce_metrics(
         "generate_image",

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -887,6 +887,74 @@ def _resolve_request(
     return plan, platform
 
 
+def _probe_perf_backend_loader(environment: Mapping[str, Any]) -> dict[str, Any]:
+    accuracy_options = environment["tasks"]["accuracy"].get("options", {})
+    native_dir_value = str(accuracy_options.get("backend-dir", "") or "").strip()
+    if not native_dir_value:
+        raise ModelCheckError(
+            "model-check environment accuracy.options.backend-dir is required "
+            "for the Perf backend loader preflight"
+        )
+    native_dir = Path(native_dir_value).expanduser().resolve()
+    backend = native_dir / "libtrtmc_backend_trt.so"
+    if not backend.is_file():
+        raise ModelCheckError(f"Perf backend DSO is missing: {backend}")
+
+    python_value = str(environment["tasks"]["perf"].get("runner_python", "") or "").strip()
+    if not python_value:
+        raise ModelCheckError(
+            "model-check environment perf.runner_python is required for "
+            "the backend loader preflight"
+        )
+    python = Path(python_value).expanduser().resolve()
+    if not python.is_file() or not os.access(python, os.X_OK):
+        raise ModelCheckError(f"Perf runner Python is unavailable: {python}")
+
+    child = os.environ.copy()
+    python_paths = [str(REPOSITORY / "python")]
+    inherited_python_path = child.get("PYTHONPATH", "")
+    if inherited_python_path:
+        python_paths.append(inherited_python_path)
+    child["PYTHONPATH"] = os.pathsep.join(python_paths)
+    child["_TRTMC_INTERNAL_NATIVE_BIN_DIR"] = str(native_dir)
+    probe = (
+        "import json; "
+        "from tensorrt_model_connect import trt_compat; "
+        "trt_compat.load_native_backend_plugins(); "
+        "print(json.dumps({'status': 'loaded'}))"
+    )
+    try:
+        completed = subprocess.run(
+            [str(python), "-c", probe],
+            cwd=REPOSITORY,
+            env=child,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ModelCheckError(f"cannot execute Perf backend loader preflight: {error}") from error
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise ModelCheckError(
+            "Perf backend loader preflight failed: "
+            + (detail or f"exit code {completed.returncode}")
+        )
+    try:
+        receipt = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ModelCheckError("Perf backend loader preflight returned invalid JSON") from error
+    if not isinstance(receipt, Mapping) or receipt.get("status") != "loaded":
+        raise ModelCheckError("Perf backend loader preflight did not confirm loading")
+    return {
+        "status": "ready",
+        "python": str(python),
+        "native_dir": str(native_dir),
+        "backend": str(backend),
+    }
+
+
 def _target_preflight(
     plan: Mapping[str, Any],
     environment: Mapping[str, Any],
@@ -902,6 +970,25 @@ def _target_preflight(
     except (ModelCheckError, trtmc_validate.ValidationError) as error:
         native_build = {"status": "blocked", "detail": str(error)}
         blockers.append({"category": "native_build_unavailable", "detail": str(error)})
+
+    perf_backend_loader: dict[str, Any] = {"status": "not_required"}
+    if _task_bindings(plan, "perf"):
+        if native_build["status"] != "ready":
+            perf_backend_loader = {
+                "status": "blocked",
+                "detail": "native build must pass before probing the Perf backend loader",
+            }
+        else:
+            try:
+                perf_backend_loader = _probe_perf_backend_loader(environment)
+            except ModelCheckError as error:
+                perf_backend_loader = {"status": "blocked", "detail": str(error)}
+                blockers.append(
+                    {
+                        "category": "perf_backend_loader_unavailable",
+                        "detail": str(error),
+                    }
+                )
 
     suites = {
         suite["id"]: suite
@@ -941,6 +1028,7 @@ def _target_preflight(
         "environment_source": environment["source"],
         "revision": arguments.revision,
         "native_build": native_build,
+        "perf_backend_loader": perf_backend_loader,
         "datasets": datasets,
         "blockers": blockers,
     }


### PR DESCRIPTION
## Background

A GB300 Perf qualification failed during bundle preparation because the builder child process could not discover `libtrtmc_backend_trt.so`, even though the DSO existed beside the selected benchmark worker. The target preflight only validated native build identity and therefore allowed this failure to reach the GPU execution flow.

## Exit Criteria

- Bundle preparation receives the native directory associated with the selected worker.
- Perf target preflight proves that the packaged backend can be loaded through the declared runner Python and blocks before preview/formal work otherwise.
- Public CLI and preflight behavior have regression coverage.
- Non-goal: this change does not alter the backend ABI or bundle format.

## Implementation

- Propagate the selected worker's parent directory through `BundleBuilder` as `_TRTMC_INTERNAL_NATIVE_BIN_DIR` for builder subprocesses.
- Add a target-local backend loader smoke test to model-check preflight and emit machine-readable `perf_backend_loader` evidence.
- Document the new preflight contract and cover the success and blocker paths.
- Compatibility: Accuracy-only preflight reports the loader check as not required; there are no dependency, migration, public API, ABI, or artifact-format changes.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_trtmc_bench.py tests/tools/test_model_checks.py`: 157 passed.
- `ruff check python/tensorrt_model_connect/benchmark/builder.py python/tensorrt_model_connect/benchmark/cli.py tools/model_checks.py tests/tools/test_trtmc_bench.py tests/tools/test_model_checks.py`: passed.
- `git diff --check`: passed before commit.

### Hardware, Environment, and Revisions

- Tested repository head: `93035425efbb39f9506d0dbd9e8d9180afc4419c`.
- Local CPU-only Python test environment; no GPU, CUDA, or TensorRT runtime was used by these tests.
- The CLI regression uses the checked-in `distilgpt2` profile with temporary worker/backend fixtures; no external model checkpoint or dataset revision is involved.

### Not Run / Remaining Gaps

- GB300 qualification was not rerun. It should be restarted only after this change is deployed to the target revision.
- Target TensorRT DSO loading is not claimed from the CPU tests; target preflight now makes that proof a required machine-readable gate.

## Notes For Future Readers

- Review the worker-to-builder path propagation first, then the model-check preflight receipt and its tests.
- Existing consumers that validate target-preflight JSON should tolerate the additive `perf_backend_loader` field.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The path propagation is narrow and covered by CPU tests, but the original failure occurred on GB300 and has not yet been rerun there.
