### PR TITLE
fix(alerts): notify on actionable PR readiness

### DIFF
--- a/.github/workflows/community-activity-slack-alert.yml
+++ b/.github/workflows/community-activity-slack-alert.yml
@@ -12,19 +12,186 @@ on:
     types: [created]
   discussion_comment:
     types: [created]
-  pull_request_target:
-    branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["Community CPU"]
+    types: [completed]
 
-# General pull-request comments arrive through issue_comment. Review and diff
-# comment events are intentionally excluded because fork-triggered merge-ref
-# workflows do not receive Actions secrets.
+# Community CPU completion is a trusted, default-branch event. The readiness
+# job consumes only GitHub metadata and never downloads artifacts, checks out a
+# pull-request head, or executes contributor-controlled code.
+# General pull-request comments arrive through issue_comment. Maintainer
+# mentions and Internal CI requests receive a higher-priority Slack heading.
+# Review and diff comment events are intentionally excluded because
+# fork-triggered merge-ref workflows do not receive Actions secrets.
 # These trusted events read GitHub metadata only. They never check out or
 # execute contributor-controlled code.
 permissions: {}
 
 jobs:
-  notify:
+  notify-ready-pr:
+    if: >-
+      github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 7
+    permissions:
+      actions: read
+      checks: read
+      pull-requests: read
+    steps:
+      - name: Post ready external PR alert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_ACTIVITY_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.display_title }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::Missing SLACK_COMMUNITY_ACTIVITY_WEBHOOK_URL repository or organization secret."
+            exit 1
+          fi
+
+          run_name_pattern='^PR #([1-9][0-9]*) · public CPU · merge [0-9a-f]{40}$'
+          if [[ ! "$WORKFLOW_RUN_NAME" =~ $run_name_pattern ]]; then
+            echo "::error::Unexpected Community CPU run name: $WORKFLOW_RUN_NAME"
+            exit 1
+          fi
+          pr_number="${BASH_REMATCH[1]}"
+
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$pr_number")"
+          current_head_sha="$(jq -r ".head.sha" <<<"$pr_json")"
+          if [ "$current_head_sha" != "$HEAD_SHA" ]; then
+            echo "::notice::PR #$pr_number advanced beyond $HEAD_SHA; skipping the stale readiness alert."
+            exit 0
+          fi
+          if [ "$(jq -r ".state" <<<"$pr_json")" != "open" ]; then
+            echo "::notice::PR #$pr_number is no longer open; skipping the readiness alert."
+            exit 0
+          fi
+          if [ "$(jq -r ".draft" <<<"$pr_json")" = "true" ]; then
+            echo "::notice::PR #$pr_number is still a draft; skipping the readiness alert."
+            exit 0
+          fi
+          if [ "$(jq -r ".base.ref" <<<"$pr_json")" != "main" ]; then
+            echo "::notice::PR #$pr_number does not target main; skipping the readiness alert."
+            exit 0
+          fi
+
+          author_association="$(jq -r ".author_association" <<<"$pr_json")"
+          case "$author_association" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "::notice::PR #$pr_number is authored by a repository collaborator; skipping the community alert."
+              exit 0
+              ;;
+          esac
+
+          required_checks=(
+            "Community CPU / Required"
+            "PR Metadata / Required"
+            "DCO"
+          )
+          checks_ready=false
+          for attempt in {1..30}; do
+            pr_json="$(gh api "repos/$REPOSITORY/pulls/$pr_number")"
+            current_head_sha="$(jq -r ".head.sha" <<<"$pr_json")"
+            if [ "$current_head_sha" != "$HEAD_SHA" ]; then
+              echo "::notice::PR #$pr_number advanced while checking readiness; skipping the stale alert."
+              exit 0
+            fi
+
+            checks_json="$(gh api -H "Accept: application/vnd.github+json" "repos/$REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100")"
+            checks_ready=true
+            for required_check in "${required_checks[@]}"; do
+              conclusion="$(
+                jq -r --arg name "$required_check" \
+                  '[.check_runs[] | select(.name == $name)]
+                   | sort_by(.started_at) | last | .conclusion // ""' \
+                  <<<"$checks_json"
+              )"
+              if [ "$conclusion" != "success" ]; then
+                checks_ready=false
+                echo "Waiting for $required_check on $HEAD_SHA (latest conclusion: ${conclusion:-missing})."
+              fi
+            done
+
+            if [ "$checks_ready" = "true" ]; then
+              break
+            fi
+            if [ "$attempt" -lt 30 ]; then
+              sleep 10
+            fi
+          done
+
+          if [ "$checks_ready" != "true" ]; then
+            echo "::notice::PR #$pr_number did not satisfy all alert gates; no Slack notification was sent."
+            exit 0
+          fi
+
+          item_author="$(jq -r ".user.login" <<<"$pr_json")"
+          item_title="$(jq -r ".title" <<<"$pr_json")"
+          item_url="$(jq -r ".html_url" <<<"$pr_json")"
+          head_display="${HEAD_SHA:0:12}"
+
+          payload="$(jq -cn \
+            --arg author "$item_author" \
+            --arg association "$author_association" \
+            --arg number "$pr_number" \
+            --arg title "$item_title" \
+            --arg url "$item_url" \
+            --arg head "$head_display" \
+            'def slack_escape:
+              gsub("&"; "&amp;") |
+              gsub("<"; "&lt;") |
+              gsub(">"; "&gt;");
+             ($title | slack_escape) as $safe_title |
+             {
+               text: ("✅ 🔀 External PR ready for maintainer\n" +
+                 "Pull request #" + $number + " · required checks passed\n" +
+                 $author + " (" + $association + ")"),
+               blocks: [
+                 {
+                   type: "header",
+                   text: {
+                     type: "plain_text",
+                     text: "✅ 🔀 External PR ready for maintainer",
+                     emoji: true
+                   }
+                 },
+                 {
+                   type: "section",
+                   fields: [
+                     {type: "mrkdwn", text: "*Event:*\nPull request · required checks passed"},
+                     {type: "mrkdwn", text: ("*Author:*\n" + $author + " (" + $association + ")")}
+                   ]
+                 },
+                 {
+                   type: "section",
+                   fields: [
+                     {type: "mrkdwn", text: "*Checks:*\nCommunity CPU · DCO · PR Metadata"},
+                     {type: "mrkdwn", text: ("*Head:*\n" + $head)}
+                   ]
+                 },
+                 {
+                   type: "section",
+                   text: {
+                     type: "mrkdwn",
+                     text: ("*Pull request #" + $number + "*\n" +
+                       "<" + $url + "|" + $safe_title + ">")
+                   }
+                 }
+               ]
+             }')"
+
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"
+
+  notify-activity:
     if: >-
       github.repository == 'NVIDIA/TensorRT-Model-Connect' &&
       github.event.sender.type != 'Bot' &&
@@ -52,12 +219,6 @@ jobs:
           github.event.comment.author_association != 'OWNER' &&
           github.event.comment.author_association != 'MEMBER' &&
           github.event.comment.author_association != 'COLLABORATOR'
-        ) ||
-        (
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.author_association != 'OWNER' &&
-          github.event.pull_request.author_association != 'MEMBER' &&
-          github.event.pull_request.author_association != 'COLLABORATOR'
         )
       )
     runs-on: ubuntu-24.04
@@ -69,12 +230,14 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_ACTIVITY_WEBHOOK_URL }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          ITEM_AUTHOR: ${{ github.event.comment.user.login || github.event.pull_request.user.login || github.event.issue.user.login || github.event.discussion.user.login }}
-          ITEM_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || github.event.pull_request.author_association || github.event.issue.author_association || github.event.discussion.author_association }}
-          ITEM_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.discussion.number }}
-          ITEM_TITLE: ${{ github.event.pull_request.title || github.event.issue.title || github.event.discussion.title }}
-          ITEM_URL: ${{ github.event.comment.html_url || github.event.pull_request.html_url || github.event.issue.html_url || github.event.discussion.html_url }}
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request != null }}
+          ITEM_AUTHOR: ${{ github.event.comment.user.login || github.event.issue.user.login || github.event.discussion.user.login }}
+          ITEM_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || github.event.issue.author_association || github.event.discussion.author_association }}
+          ITEM_NUMBER: ${{ github.event.issue.number || github.event.discussion.number }}
+          ITEM_TITLE: ${{ github.event.issue.title || github.event.discussion.title }}
+          ITEM_URL: ${{ github.event.comment.html_url || github.event.issue.html_url || github.event.discussion.html_url }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          IS_PULL_REQUEST: ${{ github.event.issue.pull_request != null }}
+          IS_COMMENT: ${{ github.event_name == 'issue_comment' || github.event_name == 'discussion_comment' }}
         run: |
           set -euo pipefail
 
@@ -84,20 +247,49 @@ jobs:
           fi
 
           case "$EVENT_NAME" in
-            pull_request_target) item_kind="Pull request" ;;
             issue_comment)
               if [ "$IS_PULL_REQUEST" = "true" ]; then
                 item_kind="Pull request"
+                item_icon="🔀"
+                item_heading="External pull request activity"
               else
                 item_kind="Issue"
+                item_icon="🎫"
+                item_heading="External issue activity"
               fi
               ;;
-            issues) item_kind="Issue" ;;
-            discussion|discussion_comment) item_kind="Discussion" ;;
+            issues)
+              item_kind="Issue"
+              item_icon="🎫"
+              item_heading="External issue activity"
+              ;;
+            discussion|discussion_comment)
+              item_kind="Discussion"
+              item_icon="💬"
+              item_heading="External discussion activity"
+              ;;
             *) echo "::error::Unsupported community event: $EVENT_NAME"; exit 1 ;;
           esac
 
+          alert_heading="$item_heading"
+          alert_emoji="$item_icon"
+          comment_lower="$(printf '%s' "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')"
+          if [ "$IS_COMMENT" = "true" ] &&
+            {
+              [[ "$comment_lower" == *"@yifeif-nv"* ]] ||
+              [[ "$comment_lower" == *"@chaofengw-nv"* ]] ||
+              [[ "$comment_lower" == *"/request-internal-ci"* ]] ||
+              [[ "$comment_lower" == *"internal ci"* ]] ||
+              [[ "$comment_lower" == *"internal-ci"* ]] ||
+              [[ "$comment_lower" == *"trigger ci"* ]]
+            }; then
+            alert_heading="External maintainer request"
+            alert_emoji="🚨 $item_icon"
+          fi
+
           payload="$(jq -cn \
+            --arg heading "$alert_heading" \
+            --arg emoji "$alert_emoji" \
             --arg kind "$item_kind" \
             --arg action "$EVENT_ACTION" \
             --arg author "$ITEM_AUTHOR" \
@@ -111,7 +303,7 @@ jobs:
               gsub(">"; "&gt;");
              ($title | slack_escape) as $safe_title |
              {
-               text: (":bell: External community activity\n" +
+               text: ($emoji + " " + $heading + "\n" +
                  $kind + " #" + $number + " · " + $action + "\n" +
                  $author + " (" + $association + ")"),
                blocks: [
@@ -119,7 +311,7 @@ jobs:
                    type: "header",
                    text: {
                      type: "plain_text",
-                     text: "🔔 External community activity",
+                     text: ($emoji + " " + $heading),
                      emoji: true
                    }
                  },

--- a/.github/workflows/community-cpu.yml
+++ b/.github/workflows/community-cpu.yml
@@ -9,7 +9,7 @@ run-name: >-
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 

--- a/tests/tools/test_community_ci.py
+++ b/tests/tools/test_community_ci.py
@@ -162,7 +162,7 @@ def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:
     assert workflow["permissions"] == {}
     assert "pull_request:" in source
     assert "branches: [main]" in source
-    assert "types: [opened, synchronize, reopened]" in source
+    assert "types: [opened, synchronize, reopened, ready_for_review]" in source
     assert "issue_comment:" not in source
     assert "pull_request_target" not in source
     assert "workflow_dispatch:" not in source

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -201,6 +201,227 @@ else:
     )
 
 
+def _community_ready_alert_script() -> str:
+    workflow = yaml.safe_load(
+        (
+            REPO_ROOT
+            / ".github"
+            / "workflows"
+            / "community-activity-slack-alert.yml"
+        ).read_text(encoding="utf-8")
+    )
+    return workflow["jobs"]["notify-ready-pr"]["steps"][0]["run"]
+
+
+def _run_community_ready_alert(
+    tmp_path: Path,
+    *,
+    current_head_sha: str,
+    check_conclusions: dict[str, str],
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+
+endpoint = next(
+    (argument for argument in sys.argv[1:] if argument.startswith("repos/")),
+    "",
+)
+if "/pulls/" in endpoint:
+    print(os.environ["FAKE_PULL_JSON"])
+elif "/check-runs" in endpoint:
+    print(os.environ["FAKE_CHECKS_JSON"])
+else:
+    print(f"unexpected gh invocation: {sys.argv[1:]}", file=sys.stderr)
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    fake_jq = fake_bin / "jq"
+    fake_jq.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+
+arguments = sys.argv[1:]
+if "-cn" in arguments:
+    values = {}
+    index = 0
+    while index < len(arguments):
+        if arguments[index] == "--arg":
+            values[arguments[index + 1]] = arguments[index + 2]
+            index += 3
+        else:
+            index += 1
+    safe_title = (
+        values["title"]
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    print(
+        json.dumps(
+            {
+                "text": (
+                    "✅ 🔀 External PR ready for maintainer\\n"
+                    f"Pull request #{values['number']} · required checks passed\\n"
+                    f"{values['author']} ({values['association']})"
+                ),
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "✅ 🔀 External PR ready for maintainer",
+                            "emoji": True,
+                        },
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Event:*\\nPull request · required checks passed",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": (
+                                    f"*Author:*\\n{values['author']} "
+                                    f"({values['association']})"
+                                ),
+                            },
+                        ],
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Checks:*\\nCommunity CPU · DCO · PR Metadata",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Head:*\\n{values['head']}",
+                            },
+                        ],
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": (
+                                f"*Pull request #{values['number']}*\\n"
+                                f"<{values['url']}|{safe_title}>"
+                            ),
+                        },
+                    },
+                ],
+            }
+        )
+    )
+    raise SystemExit
+
+document = json.load(sys.stdin)
+expression = arguments[-1]
+if "--arg" in arguments:
+    name = arguments[arguments.index("--arg") + 2]
+    matching = [run for run in document["check_runs"] if run["name"] == name]
+    latest = max(matching, key=lambda run: run["started_at"], default={})
+    value = latest.get("conclusion", "")
+else:
+    paths = {
+        ".head.sha": ("head", "sha"),
+        ".state": ("state",),
+        ".draft": ("draft",),
+        ".base.ref": ("base", "ref"),
+        ".author_association": ("author_association",),
+        ".user.login": ("user", "login"),
+        ".title": ("title",),
+        ".html_url": ("html_url",),
+    }
+    value = document
+    for component in paths[expression]:
+        value = value[component]
+
+if isinstance(value, bool):
+    print(json.dumps(value))
+else:
+    print(value)
+""",
+        encoding="utf-8",
+    )
+    fake_jq.chmod(0o755)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+arguments = sys.argv[1:]
+payload = arguments[arguments.index("--data") + 1]
+Path(os.environ["FAKE_SLACK_PAYLOAD"]).write_text(payload, encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    fake_sleep = fake_bin / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sleep.chmod(0o755)
+
+    pull = {
+        "number": 1127,
+        "state": "open",
+        "draft": False,
+        "title": "External contribution",
+        "html_url": "https://github.com/NVIDIA/TensorRT-Model-Connect/pull/1127",
+        "author_association": "CONTRIBUTOR",
+        "user": {"login": "external-author"},
+        "base": {"ref": "main"},
+        "head": {"sha": current_head_sha},
+    }
+    checks = {
+        "check_runs": [
+            {
+                "name": name,
+                "started_at": f"2026-09-02T05:00:0{index}Z",
+                "conclusion": conclusion,
+            }
+            for index, (name, conclusion) in enumerate(check_conclusions.items())
+        ]
+    }
+    payload_path = tmp_path / "slack-payload.json"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "FAKE_CHECKS_JSON": json.dumps(checks),
+            "FAKE_PULL_JSON": json.dumps(pull),
+            "FAKE_SLACK_PAYLOAD": str(payload_path),
+            "GH_TOKEN": "test-token",
+            "HEAD_SHA": "a" * 40,
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "REPOSITORY": "NVIDIA/TensorRT-Model-Connect",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.test/community",
+            "WORKFLOW_RUN_NAME": f"PR #1127 · public CPU · merge {'b' * 40}",
+        }
+    )
+    process = subprocess.run(
+        ["bash", "-c", _community_ready_alert_script()],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return process, payload_path
+
+
 def _ci_source(*filenames: str) -> str:
     """Return the review surface for one or more class-based CI modules."""
     return "\n".join(
@@ -255,55 +476,68 @@ def test_community_activity_alert_only_posts_trusted_external_metadata() -> None
     path = REPO_ROOT / ".github" / "workflows" / "community-activity-slack-alert.yml"
     source = path.read_text(encoding="utf-8")
     workflow = yaml.safe_load(source)
-    job = workflow["jobs"]["notify"]
-    steps = job["steps"]
-    post = steps[0]
+    ready_job = workflow["jobs"]["notify-ready-pr"]
+    activity_job = workflow["jobs"]["notify-activity"]
+    activity_post = activity_job["steps"][0]
 
     assert "issues:" in source
     assert "issue_comment:" in source
     assert "discussion:" in source
     assert "discussion_comment:" in source
-    assert "pull_request_target:" in source
-    assert "branches: [main]" in source
-    assert "types: [opened, reopened, synchronize, ready_for_review]" in source
+    assert "workflow_run:" in source
+    assert 'workflows: ["Community CPU"]' in source
+    assert "types: [completed]" in source
+    assert "pull_request_target:" not in source
     assert source.count("types: [created]") == 3
     assert workflow["permissions"] == {}
-    assert job["permissions"] == {}
-    assert job["timeout-minutes"] == 5
-    assert "github.repository == 'NVIDIA/TensorRT-Model-Connect'" in job["if"]
-    assert "github.event.sender.type != 'Bot'" in job["if"]
+    assert ready_job["permissions"] == {
+        "actions": "read",
+        "checks": "read",
+        "pull-requests": "read",
+    }
+    assert activity_job["permissions"] == {}
+    assert ready_job["timeout-minutes"] == 7
+    assert activity_job["timeout-minutes"] == 5
+    assert "github.repository == 'NVIDIA/TensorRT-Model-Connect'" in ready_job["if"]
+    assert "github.event.workflow_run.conclusion == 'success'" in ready_job["if"]
+    assert "github.repository == 'NVIDIA/TensorRT-Model-Connect'" in activity_job["if"]
+    assert "github.event.sender.type != 'Bot'" in activity_job["if"]
     association_fields = {
         "issues": "github.event.issue.author_association",
         "issue_comment": "github.event.comment.author_association",
         "discussion": "github.event.discussion.author_association",
         "discussion_comment": "github.event.comment.author_association",
-        "pull_request_target": "github.event.pull_request.author_association",
     }
     for event_name, association in association_fields.items():
-        assert f"github.event_name == '{event_name}'" in job["if"]
+        assert f"github.event_name == '{event_name}'" in activity_job["if"]
         for trusted in ("OWNER", "MEMBER", "COLLABORATOR"):
-            assert f"{association} != '{trusted}'" in job["if"]
+            assert f"{association} != '{trusted}'" in activity_job["if"]
 
-    assert len(steps) == 1
-    assert all("uses" not in step for step in steps)
+    assert all(
+        "uses" not in step
+        for job in (ready_job, activity_job)
+        for step in job["steps"]
+    )
     assert "actions/checkout" not in source
-    assert "github.event.pull_request.head" not in source
     assert set(re.findall(r"secrets\.([A-Z][A-Z0-9_]*)", source)) == {
         "SLACK_COMMUNITY_ACTIVITY_WEBHOOK_URL"
     }
-    assert post["env"]["SLACK_WEBHOOK_URL"] == (
+    assert activity_post["env"]["SLACK_WEBHOOK_URL"] == (
         "${{ secrets.SLACK_COMMUNITY_ACTIVITY_WEBHOOK_URL }}"
     )
-    assert post["env"]["EVENT_NAME"] == "${{ github.event_name }}"
-    assert post["env"]["EVENT_ACTION"] == "${{ github.event.action }}"
-    assert post["env"]["ITEM_TITLE"] == (
-        "${{ github.event.pull_request.title || github.event.issue.title || "
-        "github.event.discussion.title }}"
+    assert activity_post["env"]["EVENT_NAME"] == "${{ github.event_name }}"
+    assert activity_post["env"]["EVENT_ACTION"] == "${{ github.event.action }}"
+    assert activity_post["env"]["ITEM_TITLE"] == (
+        "${{ github.event.issue.title || github.event.discussion.title }}"
     )
-    assert post["env"]["ITEM_URL"].startswith("${{ github.event.comment.html_url ||")
-    assert "github.event.issue.pull_request != null" in post["env"]["IS_PULL_REQUEST"]
+    assert activity_post["env"]["ITEM_URL"].startswith(
+        "${{ github.event.comment.html_url ||"
+    )
+    assert "github.event.issue.pull_request != null" in activity_post["env"][
+        "IS_PULL_REQUEST"
+    ]
 
-    script = post["run"]
+    script = activity_post["run"]
     assert "${{" not in script
     assert 'if [ -z "$SLACK_WEBHOOK_URL" ]; then' in script
     for kind in ("Pull request", "Issue", "Discussion"):
@@ -313,28 +547,155 @@ def test_community_activity_alert_only_posts_trusted_external_metadata() -> None
     assert 'gsub(">"; "&gt;")' in script
     assert "($title | slack_escape)" in script
     assert '" + $title +' not in script
-    assert "External community activity" in script
+    for icon, heading in (
+        ("🔀", "External pull request activity"),
+        ("🎫", "External issue activity"),
+        ("💬", "External discussion activity"),
+    ):
+        assert f'item_icon="{icon}"' in script
+        assert f'item_heading="{heading}"' in script
     assert '"*Event:*\\n" + $kind + " · " + $action' in script
     assert "curl --fail-with-body --silent --show-error" in script
     assert '--data "$payload"' in script
     assert '"$SLACK_WEBHOOK_URL"' in script
 
 
+def test_community_pr_alerts_wait_for_required_checks_and_keep_requests() -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "community-activity-slack-alert.yml"
+    source = path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(source)
+    ready_job = workflow["jobs"]["notify-ready-pr"]
+    activity_job = workflow["jobs"]["notify-activity"]
+    activity_condition = activity_job["if"]
+    ready_post = ready_job["steps"][0]
+    activity_post = activity_job["steps"][0]
+
+    assert "synchronize" not in source
+    assert "github.event.comment.body" not in activity_condition
+    assert activity_post["env"]["COMMENT_BODY"] == (
+        "${{ github.event.comment.body || '' }}"
+    )
+    activity_script = activity_post["run"]
+    for icon, heading in (
+        ("🔀", "External pull request activity"),
+        ("🎫", "External issue activity"),
+        ("💬", "External discussion activity"),
+    ):
+        assert f'item_icon="{icon}"' in activity_script
+        assert f'item_heading="{heading}"' in activity_script
+    for activity_signal in (
+        "@yifeif-nv",
+        "@chaofengw-nv",
+        "/request-internal-ci",
+        "internal ci",
+        "internal-ci",
+        "trigger ci",
+    ):
+        assert activity_signal in activity_script
+
+    assert activity_post["env"]["IS_COMMENT"] == (
+        "${{ github.event_name == 'issue_comment' || "
+        "github.event_name == 'discussion_comment' }}"
+    )
+    assert 'alert_heading="External maintainer request"' in activity_script
+    assert 'alert_emoji="🚨 $item_icon"' in activity_script
+
+    assert ready_post["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert ready_post["env"]["HEAD_SHA"] == (
+        "${{ github.event.workflow_run.head_sha }}"
+    )
+    assert ready_post["env"]["WORKFLOW_RUN_NAME"] == (
+        "${{ github.event.workflow_run.display_title }}"
+    )
+    ready_script = ready_post["run"]
+    assert "repos/$REPOSITORY/pulls/$pr_number" in ready_script
+    assert 'current_head_sha="$(jq -r ".head.sha"' in ready_script
+    assert '[ "$(jq -r ".draft"' in ready_script
+    assert "for attempt in {1..30}; do" in ready_script
+    assert "sleep 10" in ready_script
+    for required_check in (
+        "Community CPU / Required",
+        "PR Metadata / Required",
+        "DCO",
+    ):
+        assert required_check in ready_script
+    assert "sort_by(.started_at) | last" in ready_script
+    assert "✅ 🔀 External PR ready for maintainer" in ready_script
+
+
+def test_community_ready_alert_posts_only_after_all_required_checks(
+    tmp_path: Path,
+) -> None:
+    process, payload_path = _run_community_ready_alert(
+        tmp_path,
+        current_head_sha="a" * 40,
+        check_conclusions={
+            "Community CPU / Required": "success",
+            "PR Metadata / Required": "success",
+            "DCO": "success",
+        },
+    )
+
+    assert process.returncode == 0, process.stderr
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    assert payload["text"].startswith("✅ 🔀 External PR ready for maintainer")
+    assert payload["blocks"][0]["text"]["text"] == (
+        "✅ 🔀 External PR ready for maintainer"
+    )
+    assert "Community CPU · DCO · PR Metadata" in json.dumps(
+        payload, ensure_ascii=False
+    )
+
+
+def test_community_ready_alert_skips_a_stale_pr_head(tmp_path: Path) -> None:
+    process, payload_path = _run_community_ready_alert(
+        tmp_path,
+        current_head_sha="c" * 40,
+        check_conclusions={
+            "Community CPU / Required": "success",
+            "PR Metadata / Required": "success",
+            "DCO": "success",
+        },
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert "advanced beyond" in process.stdout
+    assert not payload_path.exists()
+
+
+def test_community_ready_alert_skips_when_a_required_check_is_not_green(
+    tmp_path: Path,
+) -> None:
+    process, payload_path = _run_community_ready_alert(
+        tmp_path,
+        current_head_sha="a" * 40,
+        check_conclusions={
+            "Community CPU / Required": "success",
+            "PR Metadata / Required": "success",
+            "DCO": "failure",
+        },
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert "did not satisfy all alert gates" in process.stdout
+    assert not payload_path.exists()
+
+
 def test_community_activity_alert_uses_structured_slack_blocks() -> None:
     path = REPO_ROOT / ".github" / "workflows" / "community-activity-slack-alert.yml"
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
-    script = workflow["jobs"]["notify"]["steps"][0]["run"]
+    scripts = [job["steps"][0]["run"] for job in workflow["jobs"].values()]
 
-    assert r"\\n" not in script
-    assert 'type: "header"' in script
-    assert 'type: "plain_text"' in script
-    assert 'type: "section"' in script
-    assert 'fields: [' in script
-    for label in ("Event", "Author"):
-        assert f'"*{label}:*\\n"' in script
-    assert '"*Repository:*\\n"' not in script
-    assert '"*Association:*\\n"' not in script
-    assert "$repository" not in script
+    for script in scripts:
+        assert r"\\n" not in script
+        assert 'type: "header"' in script
+        assert 'type: "plain_text"' in script
+        assert 'type: "section"' in script
+        assert 'fields: [' in script
+        for label in ("Event", "Author"):
+            assert f'"*{label}:*\\n' in script
+        assert '"*Repository:*\\n"' not in script
+        assert '"*Association:*\\n"' not in script
 
 
 def test_only_pages_workflow_creates_deployment_objects() -> None:


### PR DESCRIPTION
## Background

The community activity workflow currently posts a Slack message for every
external PR `synchronize` event. Contributors who push several revisions can
therefore generate repeated alerts before the PR is actionable, while
maintainers still need a reliable signal when the exact current head is ready
for protected Internal CI.

## Exit Criteria

- An external, non-draft PR targeting `main` alerts only after its current head
  passes `Community CPU / Required`, `DCO`, and `PR Metadata / Required`.
- Routine PR pushes no longer alert directly; a later head can alert again only
  after it independently reaches the complete public gate.
- All external issues, discussions, discussion comments, issue comments, and
  top-level PR conversation comments retain Slack coverage.
- Direct maintainer mentions and Internal CI request phrases receive a
  high-priority heading without suppressing ordinary comments.
- PR, Issue, and Discussion messages are visually distinguishable at a glance.

## Implementation

- Replaced direct PR event alerts with a trusted `Community CPU` `workflow_run`
  completion handler. It resolves the PR from the repository-controlled run
  name, verifies the exact current head, and polls the latest check runs for all
  three required successes before posting.
- Kept the readiness job metadata-only: it does not check out contributor code,
  download artifacts, or execute PR-controlled content.
- Added `ready_for_review` to Community CPU so a draft-to-ready transition can
  produce a fresh completion event.
- Preserved all external issue, discussion, and top-level conversation-comment
  events. Known maintainer mentions and Internal CI request phrases are marked
  as high priority.
- Added `🔀` for Pull Requests, `🎫` for Issues, and `💬` for Discussions;
  maintainer requests additionally receive `🚨`, and green PR readiness uses
  `✅ 🔀`.
- No public API, ABI, dependency, artifact-format, model-runtime, compatibility,
  migration, or rollout behavior changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_community_ci.py -q`: passed, 90 tests.
- `python -m ruff check tests/tools/test_github_actions_ci.py tests/tools/test_community_ci.py`: passed.
- PyYAML extraction followed by `bash -n` for both embedded alert scripts: passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Repository head: `52d5c120adaca8d2afab88b59b361e42271f7416`.
- CPU-only workflow/static validation on Linux `6.8.0-138-generic` x86_64
  with Python `3.12.3`.
- GPU, CUDA, TensorRT, model, checkpoint, dataset, and precision revisions are
  not applicable to this workflow-only change.

### Not Run / Remaining Gaps

- `actionlint` was not run because it is not installed locally; repository
  PyYAML parsing, static contract tests, shell syntax checks, and simulated
  GitHub/Slack execution paths passed.
- No live Slack webhook was invoked, to avoid test noise in the production
  channel.
- The new `workflow_run` handler can only execute from the default branch, so
  its real GitHub event delivery will begin after merge; exact-head green,
  stale-head, and failed-gate paths were exercised locally with fake GitHub and
  Slack endpoints.
- Inline review-thread comments and submitted reviews remain outside this
  secret-backed workflow. Top-level PR conversation comments are covered by
  `issue_comment`.

## Notes For Future Readers

- The Community CPU `run-name` format is now a routing contract for resolving
  fork PRs because GitHub's `workflow_run.pull_requests` can be empty for them.
- The readiness handler selects the latest check run with each required name;
  this handles a failed PR Metadata run followed by a successful rerun.
- The known maintainer handles and stable `/request-internal-ci` marker are the
  high-priority routing contract. Update the workflow if maintainership changes.
- Review the alert workflow first, then Community CPU's trigger and the
  static/execution tests. Rollback requires only restoring the prior event
  routing; there is no data or artifact migration.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this changes notification timing and depends on the Community
CPU run-name contract plus required check names. A contract drift could delay a
Slack alert, while the underlying GitHub activity and checks remain visible and
unchanged.
