### PR TITLE
docs: route agents to the repo skills and the pre-merge gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,25 @@
   `.agents/plugins/marketplace.json`.
 - The `trtmc-agent-skills` plugin is marked `INSTALLED_BY_DEFAULT` and exposes
   repo-local skills from `plugins/trtmc-agent-skills/skills/`.
-- Use `$write-git-messages` when drafting or reviewing commit messages, PR
-  titles, PR descriptions, squash merge messages, or rebase message text.
-- If `$write-git-messages` is not listed in the active runtime skills, load
-  `plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md` directly and
-  follow it.
+- **If a skill below is not listed in the active runtime skills, load
+  `plugins/trtmc-agent-skills/skills/<name>/SKILL.md` directly and follow it.**
+  Registration is through the Codex plugin path, so other agent runtimes do not
+  list these; an empty runtime skill list is not evidence that no skill covers
+  the task.
+- Consult the skill that matches the task before starting it:
+
+| Task | Skill |
+| --- | --- |
+| Onboard a Hugging Face model, or extend a family, to produce a bundle | `transform-model` |
+| TensorRT output disagrees with the reference, or validation fails numerically | `debug-trt-mismatch` |
+| FP16/BF16 dtype threading and explicit FP32 boundaries | `fp16-trt-network` |
+| Evaluate a precision or quantization format for a model | `optimize-model-precision` |
+| Diagnose runtime cost, or produce performance evidence | `profile-model` |
+| Prepare a build or validation environment on an unfamiliar host | `setup-trtmc-environment` |
+| Publish a change as a pull request | `submit-github-pr` |
+| Monitor PR CI, diagnose failed checks, rebase onto `github/main` | `pr-babysitter` |
+| Turn a finding into a GitHub issue | `submit-github-bug-issue` |
+| Draft or review commit messages, PR titles, PR descriptions, merge messages | `write-git-messages` |
+| Keep the website, skills, commands, and architecture docs aligned | `doc-sync` |
 
 <!-- Collaborative review anchor: batch 2. -->

--- a/website/docs/agent-guide.md
+++ b/website/docs/agent-guide.md
@@ -24,6 +24,20 @@ Before changing or running anything, an agent must:
    publication evidence in its report; and
 5. state which meaningful validations were not run.
 
+## Repository skills
+
+The repository ships task-specific skills under
+`plugins/trtmc-agent-skills/skills/`. They are registered through the Codex
+plugin path, so another agent runtime will not list them: read
+`plugins/trtmc-agent-skills/skills/<name>/SKILL.md` directly. An empty runtime
+skill list is not evidence that no skill covers the task.
+
+Start from the routing table in
+[`AGENTS.md`](https://github.com/NVIDIA/TensorRT-Model-Connect/blob/main/AGENTS.md).
+The two that cover the most common contributions are `transform-model`, for
+onboarding a Hugging Face model or extending a family, and
+`debug-trt-mismatch`, for output that disagrees with the reference.
+
 ## Safety boundaries
 
 An agent must not:

--- a/website/docs/extend/add-model-family.md
+++ b/website/docs/extend/add-model-family.md
@@ -105,6 +105,47 @@ The expected diff boundary for a normal family contribution is
 `families/my_family/**`. Examples, benchmarks, and BYOK are optional consumers
 of public APIs; neither a family nor core may import their implementation.
 
+## Reproduce the pre-merge gates before you push
+
+`.github/workflows/community-cpu.yml` runs four jobs on every pull request, and
+`Community CPU / Required` fails unless all four pass. Each has a local
+equivalent, so a failure does not have to cost a push and a CI round trip.
+
+The source-quality gate invokes `python`, `lizard`, `ruff`, and `clang-format`
+by name. Create and activate its environment before running the commands:
+
+```bash
+python3 -m venv .venv-ci
+source .venv-ci/bin/activate
+python3 -m pip install --requirement requirements/community-ci.txt
+export RUNNER_TEMP="${RUNNER_TEMP:-$(mktemp -d)}"
+```
+
+Then run from the repository root, with `<base-ref>` as the commit you branched
+from (`upstream/main` or `github/main`):
+
+| Pre-merge job | Run locally | Covers |
+| --- | --- | --- |
+| `Community CPU / Source quality` | `python3 -m tools.community_ci source-quality --base <base-ref>` | the `core/runtime` complexity ceiling across the whole tree; `ruff` and `clang-format` on changed files; model architecture contracts |
+| `Community CPU / Ownership and impact` | `python3 -m tools.community_ci impact --base <base-ref>` | ownership resolution and the CPU test scope your change selects |
+| `Community CPU / Unit / C++ and Python` | `python3 -m tools.community_ci unit` | compiles the shared runtime and runs the source-only C++ and Python unit tests in the CI container |
+| `Community CPU / Docs` | `cd website && npm ci && npm run test:model-support && npm run build` | the generated model support inventory and the production documentation build |
+
+The unit command builds and runs the CI container, so it needs a working Docker
+daemon. Its image follows the Docker host architecture unless
+`DOCKER_DEFAULT_PLATFORM` overrides it; pre-merge runs on `linux/amd64`. Before
+chasing a platform-specific failure, check whether it also fails on the base
+branch.
+
+Two failure modes worth knowing, because both look like success:
+
+- A **skipped** test is not a passing test. `pytest` skips whatever its
+  `importorskip` guards cannot import, so a virtual environment without
+  `numpy`, `torch`, or `safetensors` silently drops that coverage. Run with
+  `-rs` and read which tests skipped, not only the count.
+- The **complexity ceiling for `core/runtime` is 10**, and it is checked against
+  the whole tree rather than only your diff.
+
 An E2E manifest may declare an exact `hf_id` (and, when available,
 `hf_revision`) or omit `hf_id` for a prepared local checkpoint supplied through
 the family-specific model-directory environment variable. Do not invent an HF


### PR DESCRIPTION
## Background

The repository ships eleven task-specific agent skills, but its documented
entry points routed only `write-git-messages`. Contributors and non-Codex
agents could therefore miss the end-to-end model onboarding and mismatch
debugging workflows unless they already knew to inspect the plugin directory.

Issue: #1125. A maintainer asked for both the routing update and a clear mapping
between local validation and the public pre-merge jobs.

## Exit Criteria

- Agents can select the applicable repository skill from `AGENTS.md`.
- Runtimes that do not load the Codex plugin have a direct-path fallback.
- The agent and add-a-family guides expose the skill entry point and the exact
  local equivalents of the four Community CPU jobs.

This PR does not change skill content, source code, tests, workflows, or model
behavior.

## Implementation

- Add a task-to-skill routing table for all eleven repository skills and
  generalize the direct-path loading fallback.
- Point the AI & Agent Guide to the table and the two end-to-end contributor
  skills.
- Document the post-#1093 Community CPU commands in the add-a-family guide,
  including environment activation, Docker architecture behavior, skipped-test
  interpretation, and the `core/runtime` complexity boundary.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$PWD:/repo" -w /repo/website node:20 bash -lc 'npm ci && npm run test:model-support && npm run build'`: 7 inventory tests passed and the production documentation build completed successfully.
- `python3 -m tools.community_ci impact --base github/main`: passed; the three changed paths resolve to the `docs` scope with no family owners.
- `SOURCE_QUALITY_TIMEOUT= python3 -m tools.community_ci source-quality --base github/main`: model inventory, complexity, formatting, and 127 architecture tests passed; one native unresolved-symbol fixture failed on macOS and fails identically on unmodified `github/main`.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

- Head: `0f6cdd2366651d2f8545bfa060dc45834c06270c`
- Base: `54d6d566f1e1fba7aa476857c4fe9cb38bb24b59`
- macOS host, Python 3.12.10; documentation validation used the `node:20`
  container. No GPU is involved.

### Not Run / Remaining Gaps

The complete Community CPU container suite was not run locally. The development
host is macOS, while public CI runs the required suite on Ubuntu `linux/amd64`.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

- This branch was rebased onto the family-isolation layout from #1093. Removed
  central inventory paths and the retired `unit --scope all` interface were not
  carried forward.
- The routing table must remain synchronized when a repository skill is added,
  removed, or renamed. Automating that check would be an appropriate follow-up.

Closes #1125

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Documentation only; all changes are additive except for generalizing the
existing direct-path fallback.
