### PR TITLE
feat(foundationpose): add native refinement and scoring

### DIFF
--- a/ASSET_LICENSES.md
+++ b/ASSET_LICENSES.md
@@ -192,4 +192,15 @@ parquet and video paths and their SHA-256 digests.
 - `recorded_observation.json`; SHA-256
   `aecd4e0c5123d2e7fb632b32772c60c4175fa37e6425393f182b53e76bd1278f`
 
+## FoundationPose external model artifacts
+
+FoundationPose qualification downloads no model artifact into this repository.
+The model-proof cache fetches the official `refine_model.onnx` and
+`score_model.onnx` files from NVIDIA NGC model
+`nvidia/isaac/foundationpose:1.0.1_onnx`, verifies their exact sizes and
+SHA-256 digests, and exposes only private ephemeral copies to the offline proof
+container. Users remain responsible for the license terms presented by NGC.
+The deterministic RGB+XYZ qualification crops are generated locally by
+project-owned Apache-2.0 code and are not derived from the upstream demo data.
+
 <!-- Collaborative review anchor: batch 2. -->

--- a/examples/models/foundationpose/preprocessed_refinement/CMakeLists.txt
+++ b/examples/models/foundationpose/preprocessed_refinement/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+project(trtmc_foundationpose_preprocessed LANGUAGES CXX)
+
+get_filename_component(_trtmc_default_source_dir "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)
+set(TRTMC_SOURCE_DIR "${_trtmc_default_source_dir}" CACHE PATH "TensorRT-Model-Connect source directory")
+if(NOT EXISTS "${TRTMC_SOURCE_DIR}/include/trtmc/pipeline.h")
+  message(FATAL_ERROR "TRTMC_SOURCE_DIR is not a TensorRT-Model-Connect source tree")
+endif()
+
+set(TRTMC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL OFF CACHE BOOL "" FORCE)
+set(TRTMC_ENABLE_TVM_FFI OFF CACHE BOOL "" FORCE)
+set(TRTMC_BUILD_BACKEND_TRT ON CACHE BOOL "" FORCE)
+add_subdirectory("${TRTMC_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/trtmc")
+
+add_executable(trtmc_foundationpose_preprocessed main.cpp)
+target_compile_features(trtmc_foundationpose_preprocessed PRIVATE cxx_std_17)
+target_compile_options(trtmc_foundationpose_preprocessed PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(trtmc_foundationpose_preprocessed PRIVATE trtmc_core)
+add_dependencies(trtmc_foundationpose_preprocessed trtmc_model_foundationpose trtmc_backend_trt)
+set_target_properties(trtmc_foundationpose_preprocessed PROPERTIES
+  BUILD_RPATH "\$ORIGIN;\$ORIGIN/trtmc"
+  BUILD_RPATH_USE_ORIGIN TRUE
+)

--- a/examples/models/foundationpose/preprocessed_refinement/README.md
+++ b/examples/models/foundationpose/preprocessed_refinement/README.md
@@ -1,57 +1,52 @@
 # FoundationPose preprocessed refinement
 
-This native example loads the pinned official FoundationPose refiner and scorer
-from one TensorRT Model Connect bundle, refines three object-to-camera pose
-hypotheses twice, ranks them, and writes row-major 4x4 transforms.
+This example refines and ranks three object-to-camera pose hypotheses with the
+FoundationPose refiner and scorer in one TensorRT Model Connect bundle. It takes
+preprocessed RGB+XYZ crops and writes row-major 4x4 transforms.
 
-The integration boundary starts after segmentation and CAD rendering. Each
-network input is NHWC `[N,160,160,6]` float32: RGB in `[0,1]`, followed by XYZ
-relative to the current candidate translation and divided by half the mesh
-diameter. Invalid/background XYZ samples are zero. A production crop callback
-must render again from the current poses for every refinement iteration. The
-deterministic example reuses static preprocessed crops solely for reproducible
-neural inference qualification.
+## Build and run
 
-## Pinned artifacts
+Run these commands from the repository root. The `trtmc` command must be
+installed and available on `PATH`.
 
-- Source: `NVlabs/FoundationPose` commit
-  `a1b694b83e633c2cb6115b9063d940a687759392`.
-- NGC model: `nvidia/isaac/foundationpose:1.0.1_onnx`.
-- `refine_model.onnx`: SHA-256
-  `dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7`.
-- `score_model.onnx`: SHA-256
-  `0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503`.
-
-Place both ONNX files in one directory and build the FP32 bundle:
+Set `MODEL_DIR` to the pinned `nvidia/isaac/foundationpose:1.0.1_onnx` weight
+directory. It contains `refine_model.onnx` and `score_model.onnx`; their exact
+digests are in the family
+[`MODEL.toml`](../../../../python/tensorrt_model_connect/families/foundationpose/MODEL.toml).
+The native builder reads only their initializer tensors—it does not parse or
+execute either ONNX graph. A different weight format is not currently supported.
 
 ```bash
-trtmc build /path/to/foundationpose-onnx \
-  --precision fp32 -o /tmp/foundationpose.bundle
-python3 examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py \
-  /tmp/foundationpose-inputs
-cmake -S examples/models/foundationpose/preprocessed_refinement \
-  -B /tmp/foundationpose-example
-cmake --build /tmp/foundationpose-example \
-  --target trtmc_foundationpose_preprocessed -j
-/tmp/foundationpose-example/trtmc_foundationpose_preprocessed \
-  /tmp/foundationpose.bundle /tmp/foundationpose-inputs /tmp/refined-poses.f32
+MODEL_DIR=/path/to/foundationpose-weights
+BUNDLE=/tmp/foundationpose.bundle
+INPUTS=/tmp/foundationpose-inputs
+EXAMPLE_BUILD=/tmp/foundationpose-example
+
+trtmc build "$MODEL_DIR" --precision fp32 -o "$BUNDLE"
+python3 examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py "$INPUTS"
+
+cmake -S examples/models/foundationpose/preprocessed_refinement -B "$EXAMPLE_BUILD"
+cmake --build "$EXAMPLE_BUILD" --target trtmc_foundationpose_preprocessed -j
+
+"$EXAMPLE_BUILD"/trtmc_foundationpose_preprocessed \
+  "$BUNDLE" "$INPUTS" /tmp/refined-poses.f32
 ```
 
-The initial bundle supports FP32, 1-42 hypotheses per refiner invocation,
-up to 252 hypotheses overall (refinement is chunked), 1-10 refinement
-iterations, and joint scoring of up to 252 hypotheses. `reset()` clears the
-tracked best pose while preserving both TensorRT execution contexts.
+The executable prints the best hypothesis, its score, and whether every output
+pose is rigid. All refined poses are written to `/tmp/refined-poses.f32` as
+FP32 matrices.
 
-## Qualification and limitations
+## Input contract
 
-The E2E test compares all refined poses, score logits, and the complete stable
-hypothesis ordering with ONNX Runtime, checks rigid-transform invariants, rejects bad
-shapes/non-finite values/non-rigid inputs, exercises dynamic batches and reset,
-and gates single-hypothesis tracking at at least 10 Hz. The recorded GB300,
-TensorRT 11.1 qualification is under `qualification/`.
+Inputs are FP32 NHWC `[N,160,160,6]`: RGB in `[0,1]`, followed by XYZ relative
+to the candidate translation and normalized by half the mesh diameter.
+Invalid/background XYZ values are zero. The bundle supports 1-252 hypotheses,
+1-10 refinement iterations, and FP32 only.
 
-This example does not perform object segmentation, mesh loading, CAD rendering,
-camera calibration, collision checking, motion planning, or actuator control.
-Its pose output is not a physical-robot safety guarantee. Applications must
-validate calibration, units, coordinate frames, workspace limits, and failure
-handling before consuming a pose in a control system.
+## Scope
+
+The example uses fixed synthetic crops for reproducibility. A production
+application must regenerate rendered crops from the current pose after every
+refinement iteration. Segmentation, mesh loading, CAD rendering, calibration,
+collision checking, motion planning, and robot-safety validation are outside
+this example.

--- a/examples/models/foundationpose/preprocessed_refinement/README.md
+++ b/examples/models/foundationpose/preprocessed_refinement/README.md
@@ -22,7 +22,7 @@ BUNDLE=/tmp/foundationpose.bundle
 INPUTS=/tmp/foundationpose-inputs
 EXAMPLE_BUILD=/tmp/foundationpose-example
 
-trtmc build "$MODEL_DIR" --precision fp32 -o "$BUNDLE"
+trtmc build "$MODEL_DIR" -o "$BUNDLE"
 python3 examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py "$INPUTS"
 
 cmake -S examples/models/foundationpose/preprocessed_refinement -B "$EXAMPLE_BUILD"
@@ -40,8 +40,10 @@ FP32 matrices.
 
 Inputs are FP32 NHWC `[N,160,160,6]`: RGB in `[0,1]`, followed by XYZ relative
 to the candidate translation and normalized by half the mesh diameter.
-Invalid/background XYZ values are zero. The bundle supports 1-252 hypotheses,
-1-10 refinement iterations, and FP32 only.
+Invalid/background XYZ values are zero. The bundle supports 1-252 hypotheses
+and 1-10 refinement iterations. The default mixed-FP16 build keeps the
+numerically sensitive scorer cross-attention in FP32. Pass `--precision fp32`
+to build the entire model in FP32 instead.
 
 ## Scope
 

--- a/examples/models/foundationpose/preprocessed_refinement/README.md
+++ b/examples/models/foundationpose/preprocessed_refinement/README.md
@@ -1,0 +1,57 @@
+# FoundationPose preprocessed refinement
+
+This native example loads the pinned official FoundationPose refiner and scorer
+from one TensorRT Model Connect bundle, refines three object-to-camera pose
+hypotheses twice, ranks them, and writes row-major 4x4 transforms.
+
+The integration boundary starts after segmentation and CAD rendering. Each
+network input is NHWC `[N,160,160,6]` float32: RGB in `[0,1]`, followed by XYZ
+relative to the current candidate translation and divided by half the mesh
+diameter. Invalid/background XYZ samples are zero. A production crop callback
+must render again from the current poses for every refinement iteration. The
+deterministic example reuses static preprocessed crops solely for reproducible
+neural inference qualification.
+
+## Pinned artifacts
+
+- Source: `NVlabs/FoundationPose` commit
+  `a1b694b83e633c2cb6115b9063d940a687759392`.
+- NGC model: `nvidia/isaac/foundationpose:1.0.1_onnx`.
+- `refine_model.onnx`: SHA-256
+  `dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7`.
+- `score_model.onnx`: SHA-256
+  `0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503`.
+
+Place both ONNX files in one directory and build the FP32 bundle:
+
+```bash
+trtmc build /path/to/foundationpose-onnx \
+  --precision fp32 -o /tmp/foundationpose.bundle
+python3 examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py \
+  /tmp/foundationpose-inputs
+cmake -S examples/models/foundationpose/preprocessed_refinement \
+  -B /tmp/foundationpose-example
+cmake --build /tmp/foundationpose-example \
+  --target trtmc_foundationpose_preprocessed -j
+/tmp/foundationpose-example/trtmc_foundationpose_preprocessed \
+  /tmp/foundationpose.bundle /tmp/foundationpose-inputs /tmp/refined-poses.f32
+```
+
+The initial bundle supports FP32, 1-42 hypotheses per refiner invocation,
+up to 252 hypotheses overall (refinement is chunked), 1-10 refinement
+iterations, and joint scoring of up to 252 hypotheses. `reset()` clears the
+tracked best pose while preserving both TensorRT execution contexts.
+
+## Qualification and limitations
+
+The E2E test compares all refined poses, score logits, and the complete stable
+hypothesis ordering with ONNX Runtime, checks rigid-transform invariants, rejects bad
+shapes/non-finite values/non-rigid inputs, exercises dynamic batches and reset,
+and gates single-hypothesis tracking at at least 10 Hz. The recorded GB300,
+TensorRT 11.1 qualification is under `qualification/`.
+
+This example does not perform object segmentation, mesh loading, CAD rendering,
+camera calibration, collision checking, motion planning, or actuator control.
+Its pose output is not a physical-robot safety guarantee. Applications must
+validate calibration, units, coordinate frames, workspace limits, and failure
+handling before consuming a pose in a control system.

--- a/examples/models/foundationpose/preprocessed_refinement/main.cpp
+++ b/examples/models/foundationpose/preprocessed_refinement/main.cpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/pipeline.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<float> read_floats(const std::filesystem::path& path, std::size_t expected) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input || input.tellg() != static_cast<std::streamoff>(expected * sizeof(float)))
+        throw std::runtime_error(path.string() + " has an unexpected size");
+    std::vector<float> values(expected);
+    input.seekg(0);
+    input.read(reinterpret_cast<char*>(values.data()),
+               static_cast<std::streamsize>(expected * sizeof(float)));
+    if (!input)
+        throw std::runtime_error("failed to read " + path.string());
+    return values;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        if (argc != 4) {
+            std::cerr << "Usage: " << argv[0] << " MODEL.bundle INPUT_DIR OUTPUT_POSES.f32\n";
+            return 2;
+        }
+        constexpr int32_t hypotheses = 3;
+        constexpr std::size_t crop_values = hypotheses * 160U * 160U * 6U;
+        const std::filesystem::path input_dir = argv[2];
+        auto poses = read_floats(input_dir / "candidate_poses.f32", hypotheses * 16U);
+        auto rendered = read_floats(input_dir / "rendered_features.f32", crop_values);
+        auto observed = read_floats(input_dir / "observed_features.f32", crop_values);
+
+        auto pipeline = trtmc::load(argv[1]);
+        trtmc::PoseEstimationRequest request;
+        request.candidate_poses = poses;
+        request.num_hypotheses = hypotheses;
+        request.mesh_diameter = 0.18F;
+        request.refinement_iterations = 2;
+        request.crop_provider = [&](const std::vector<float>&, trtmc::PoseCropStage, int32_t) {
+            return trtmc::PoseCropBatch{rendered, observed, hypotheses, 160, 160, 6};
+        };
+        const auto result = pipeline->estimate_pose_hypotheses(request);
+        std::ofstream output(argv[3], std::ios::binary | std::ios::trunc);
+        output.write(reinterpret_cast<const char*>(result.refined_poses.data()),
+                     static_cast<std::streamsize>(result.refined_poses.size() * sizeof(float)));
+        if (!output)
+            throw std::runtime_error("failed to write refined poses");
+        std::cout << "best_index=" << result.best_index
+                  << " score=" << result.scores.at(result.best_index) << " rigid=" << std::boolalpha
+                  << result.all_poses_rigid << '\n';
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py
+++ b/examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create deterministic preprocessed RGB+XYZ crop inputs for the example."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    count = 3
+    rendered = np.zeros((count, 160, 160, 6), dtype=np.float32)
+    observed = np.zeros_like(rendered)
+    y, x = np.mgrid[:160, :160].astype(np.float32)
+    xn, yn = (x - 79.5) / 80.0, (y - 79.5) / 80.0
+    mask = xn * xn + yn * yn <= 0.72
+    for index in range(count):
+        rendered[index, ..., 0][mask] = (0.08 * (index + 1) + 0.4 * (x / 159.0))[mask]
+        rendered[index, ..., 1][mask] = (0.5 * (y / 159.0))[mask]
+        rendered[index, ..., 2][mask] = 0.35
+        rendered[index, ..., 3][mask] = (0.2 * xn)[mask]
+        rendered[index, ..., 4][mask] = (0.2 * yn)[mask]
+        rendered[index, ..., 5][mask] = 0.10 + 0.01 * index
+        observed[index, ..., 0][mask] = (0.25 + 0.4 * (x / 159.0))[mask]
+        observed[index, ..., 1][mask] = (0.10 + 0.5 * (y / 159.0))[mask]
+        observed[index, ..., 2][mask] = 0.40
+        observed[index, ..., 3][mask] = (0.2 * xn + 0.02 * index)[mask]
+        observed[index, ..., 4][mask] = (0.2 * yn)[mask]
+        observed[index, ..., 5][mask] = 0.11
+    poses = np.repeat(np.eye(4, dtype=np.float32)[None], count, axis=0)
+    poses[:, 0, 3] = (-0.02, 0.01, 0.02)
+    poses.tofile(args.output / "candidate_poses.f32")
+    rendered.tofile(args.output / "rendered_features.f32")
+    observed.tofile(args.output / "observed_features.f32")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/foundationpose/preprocessed_refinement/qualification/gb300-trt11.1-fp16.json
+++ b/examples/models/foundationpose/preprocessed_refinement/qualification/gb300-trt11.1-fp16.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "status": "passed",
+  "qualified_at": "2026-09-03",
+  "target": {
+    "gpu": "NVIDIA GB300",
+    "gpu_count_used": 1,
+    "gpu_memory_total_mib": 283136.0,
+    "driver": "580.105.08",
+    "cuda_toolkit": "13.3.0",
+    "tensorrt": "11.1.0.106",
+    "container": "trtmc-ci:trt11.1",
+    "precision": "fp16",
+    "precision_notes": "FP16 graph with FP32 normalization accumulation, external I/O, scorer cross-hypothesis attention, and score projection."
+  },
+  "pins": {
+    "source_repository": "https://github.com/NVlabs/FoundationPose.git",
+    "source_revision": "a1b694b83e633c2cb6115b9063d940a687759392",
+    "ngc_model": "nvidia/isaac/foundationpose",
+    "ngc_version": "1.0.1_onnx",
+    "refiner_sha256": "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7",
+    "scorer_sha256": "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503"
+  },
+  "build": {
+    "total_seconds": 189.6,
+    "refiner_seconds": 97.7,
+    "scorer_seconds": 88.2,
+    "bundle_size_mib": 66.44,
+    "bundle_sha256": "a6e11bca226a8c532c6db60c6c6c8fb3e997e191a248f61b08c9dfc407568579"
+  },
+  "native_runtime": {
+    "registration_hypotheses": 3,
+    "registration_refinement_iterations": 2,
+    "tracking_hypotheses": 1,
+    "tracking_refinement_iterations": 1,
+    "warmup_runs": 20,
+    "timed_runs": 200,
+    "repeated_trials": 5,
+    "startup_ms": 409.942144,
+    "tracking_latency_p50_ms": 2.950846,
+    "tracking_latency_p95_ms": 2.990735,
+    "tracking_jitter_ms": 1.551768,
+    "tracking_throughput_hz": 338.885865,
+    "gpu_memory_delta_mib": 1209.8125,
+    "registration_refinement_ms": 16.967594,
+    "registration_scoring_ms": 7.893051,
+    "all_poses_rigid": true
+  },
+  "external_reference_parity": {
+    "backend": "onnxruntime-1.29.0-cpu",
+    "pose_max_abs_error": 0.0003729574382305145,
+    "score_max_abs_error": 0.02972412109375,
+    "ranking_agreement": 1.0,
+    "rigid_pose_fraction": 1.0
+  },
+  "qualification_limits": {
+    "pose_max_abs_error": 0.005,
+    "score_max_abs_error": 0.05,
+    "ranking_agreement": 1.0,
+    "rigid_pose_fraction": 1.0,
+    "tracking_throughput_hz_min": 10.0,
+    "tracking_latency_p95_ms": 100.0,
+    "tracking_jitter_ms": 25.0,
+    "startup_ms": 10000.0,
+    "gpu_memory_delta_mib": 4096.0
+  },
+  "includes_segmentation": false,
+  "includes_cad_rendering": false,
+  "robotics_safety_validated": false
+}

--- a/examples/models/foundationpose/preprocessed_refinement/qualification/gb300-trt11.1-fp32.json
+++ b/examples/models/foundationpose/preprocessed_refinement/qualification/gb300-trt11.1-fp32.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "status": "passed",
+  "qualified_at": "2026-09-02",
+  "target": {
+    "gpu": "NVIDIA GB300",
+    "gpu_count_used": 1,
+    "gpu_memory_total_mib": 283136.0,
+    "driver": "580.105.08",
+    "cuda_toolkit": "13.3.0",
+    "tensorrt": "11.1.0.106",
+    "container": "trtmc-dev-gb300:manylinux_2_39-8fe55b901b36",
+    "precision": "fp32"
+  },
+  "pins": {
+    "source_repository": "https://github.com/NVlabs/FoundationPose.git",
+    "source_revision": "a1b694b83e633c2cb6115b9063d940a687759392",
+    "ngc_model": "nvidia/isaac/foundationpose",
+    "ngc_version": "1.0.1_onnx",
+    "refiner_sha256": "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7",
+    "scorer_sha256": "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503"
+  },
+  "build": {
+    "total_seconds": 244.9,
+    "refiner_seconds": 127.2,
+    "scorer_seconds": 112.3,
+    "bundle_size_mib": 127.75,
+    "bundle_sha256": "e148ba55e515175cfeaf1103c89d8001c96f027177c3b9d831a9ac6e02a2f4fe"
+  },
+  "native_runtime": {
+    "registration_hypotheses": 3,
+    "registration_refinement_iterations": 2,
+    "tracking_hypotheses": 1,
+    "tracking_refinement_iterations": 1,
+    "warmup_runs": 3,
+    "timed_runs": 20,
+    "startup_ms": 858.285462,
+    "tracking_latency_p50_ms": 3.3793315,
+    "tracking_latency_p95_ms": 3.69105225,
+    "tracking_jitter_ms": 0.568008,
+    "tracking_throughput_hz": 295.916515,
+    "gpu_memory_delta_mib": 3234.0,
+    "registration_refinement_ms": 9.67394,
+    "registration_scoring_ms": 3.885308,
+    "all_poses_rigid": true
+  },
+  "external_reference_parity": {
+    "backend": "onnxruntime-1.29.0-cpu",
+    "pose_max_abs_error": 0.00004853680729866028,
+    "score_max_abs_error": 0.0050563812255859375,
+    "ranking_agreement": 1.0,
+    "rigid_pose_fraction": 1.0
+  },
+  "qualification_limits": {
+    "pose_max_abs_error": 0.005,
+    "score_max_abs_error": 0.05,
+    "ranking_agreement": 1.0,
+    "rigid_pose_fraction": 1.0,
+    "tracking_throughput_hz_min": 10.0,
+    "tracking_latency_p95_ms": 100.0,
+    "tracking_jitter_ms": 25.0,
+    "startup_ms": 10000.0,
+    "gpu_memory_delta_mib": 4096.0
+  },
+  "includes_segmentation": false,
+  "includes_cad_rendering": false,
+  "robotics_safety_validated": false
+}

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -213,6 +213,50 @@ struct RobotAction {
     double inference_ms{0.0};
 };
 
+// A model-based pose refiner can request caller-produced rendered/observed
+// feature crops. Layout and feature semantics are owned by the model bundle;
+// rendering and segmentation remain outside this model-agnostic contract.
+enum class PoseCropStage {
+    kRefinement,
+    kScoring,
+};
+
+struct PoseCropBatch {
+    std::vector<float> rendered_features;
+    std::vector<float> observed_features;
+    int32_t num_hypotheses{0};
+    int32_t height{0};
+    int32_t width{0};
+    int32_t channels{0};
+};
+
+using PoseCropProvider =
+    std::function<PoseCropBatch(const std::vector<float>& current_object_to_camera_poses,
+                                PoseCropStage stage, int32_t refinement_iteration)>;
+
+struct PoseEstimationRequest {
+    // Row-major [num_hypotheses, 4, 4] object-to-camera rigid transforms.
+    // Leave empty with use_tracked_pose=true to refine the last selected pose.
+    std::vector<float> candidate_poses;
+    int32_t num_hypotheses{0};
+    float mesh_diameter{0.0F};
+    int32_t refinement_iterations{1};
+    bool score_hypotheses{true};
+    bool use_tracked_pose{false};
+    bool update_tracking_state{true};
+    PoseCropProvider crop_provider;
+};
+
+struct PoseEstimationResult {
+    std::vector<float> refined_poses; // row-major [num_hypotheses, 4, 4]
+    std::vector<float> scores;        // one confidence logit per hypothesis
+    int32_t num_hypotheses{0};
+    int32_t best_index{-1};
+    bool all_poses_rigid{false};
+    double refinement_ms{0.0};
+    double scoring_ms{0.0};
+};
+
 struct TextEmbedding {
     std::vector<float> data;
     std::vector<int64_t> shape;
@@ -750,6 +794,14 @@ class IPipeline {
     // Clear model-owned request/episode state while retaining reusable engine
     // allocations. Stateless pipelines may keep the default no-op.
     virtual void reset() {}
+
+    // -- Model-based object pose refinement and scoring --
+    // Added after all pre-existing virtuals to retain their ABI slots.
+    virtual PoseEstimationResult estimate_pose_hypotheses(const PoseEstimationRequest& request) {
+        (void)request;
+        throw std::runtime_error(std::string(pipeline_type()) +
+                                 " does not support estimate_pose_hypotheses()");
+    }
 };
 
 // --- Factory ---

--- a/python/tensorrt_model_connect/families/foundationpose/MODEL.toml
+++ b/python/tensorrt_model_connect/families/foundationpose/MODEL.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "foundationpose"
+plugin = "foundationpose"
+module = "plugin"
+python_profile_specs = [
+  "foundationpose_reference|families/foundationpose/python_profile_requirements/foundationpose_reference.lock.txt|families/foundationpose/python_profile_verify.py|true",
+]
+default_execution_profiles = [
+  "reference|foundationpose_reference",
+]
+config_adapter = "plugin.py|config_from_dir"
+aliases = ["foundationpose", "foundation-pose", "FoundationPose"]
+prefixes = ["foundationpose"]

--- a/python/tensorrt_model_connect/families/foundationpose/__init__.py
+++ b/python/tensorrt_model_connect/families/foundationpose/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FoundationPose family integration."""
+
+from .plugin import FoundationPosePlugin, plugin
+
+__all__ = ["FoundationPosePlugin", "plugin"]

--- a/python/tensorrt_model_connect/families/foundationpose/builder.py
+++ b/python/tensorrt_model_connect/families/foundationpose/builder.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT builders for the official FoundationPose NGC ONNX pair."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _parser_errors(parser: Any) -> str:
+    return "\n".join(str(parser.get_error(index)) for index in range(parser.num_errors))
+
+
+def build_onnx_engine(
+    path: str,
+    *,
+    kind: str,
+    max_batch: int,
+    precision: str,
+    verbose: bool = False,
+) -> bytes:
+    if precision != "fp32":
+        raise ValueError("FoundationPose ONNX engines currently support fp32 builds only")
+    if kind not in {"refiner", "scorer"}:
+        raise ValueError(f"Unsupported FoundationPose engine kind: {kind!r}")
+    if max_batch <= 0:
+        raise ValueError("FoundationPose max_batch must be positive")
+
+    from tensorrt_model_connect import trt_compat
+
+    trt = trt_compat.get_trt()
+    logger = trt.Logger(trt.Logger.INFO if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        trt_compat.network_creation_flags(explicit_batch=True, strongly_typed=True)
+    )
+    parser = trt.OnnxParser(network, logger)
+    model_path = Path(path)
+    if not parser.parse(model_path.read_bytes()):
+        raise RuntimeError(
+            f"TensorRT could not parse FoundationPose {kind} ONNX {model_path}:\n"
+            f"{_parser_errors(parser)}"
+        )
+    expected_outputs = {"output1", "output2"} if kind == "refiner" else {"output1"}
+    inputs = {network.get_input(index).name: network.get_input(index) for index in range(network.num_inputs)}
+    outputs = {network.get_output(index).name for index in range(network.num_outputs)}
+    if set(inputs) != {"input1", "input2"} or outputs != expected_outputs:
+        raise RuntimeError(
+            f"FoundationPose {kind} ONNX contract mismatch: inputs={sorted(inputs)}, "
+            f"outputs={sorted(outputs)}"
+        )
+    for name, tensor in inputs.items():
+        if tuple(int(value) for value in tensor.shape)[1:] != (160, 160, 6):
+            raise RuntimeError(
+                f"FoundationPose {kind} input {name} has unsupported shape {tuple(tensor.shape)}"
+            )
+
+    profile = builder.create_optimization_profile()
+    opt_batch = min(8, max_batch)
+    for name in ("input1", "input2"):
+        profile.set_shape(name, (1, 160, 160, 6), (opt_batch, 160, 160, 6),
+                          (max_batch, 160, 160, 6))
+    config = builder.create_builder_config()
+    config.add_optimization_profile(profile)
+    workspace_gib = int(os.environ.get("TRTMC_FOUNDATIONPOSE_WORKSPACE_GIB", "8"))
+    if workspace_gib <= 0 or workspace_gib > 64:
+        raise ValueError("TRTMC_FOUNDATIONPOSE_WORKSPACE_GIB must be between 1 and 64")
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_gib << 30)
+    if hasattr(config, "builder_optimization_level"):
+        config.builder_optimization_level = int(
+            os.environ.get("TRTMC_FOUNDATIONPOSE_OPT_LEVEL", "4")
+        )
+    if hasattr(config, "max_aux_streams"):
+        config.max_aux_streams = 0
+    if verbose:
+        print(
+            f"[trtmc build] Building FoundationPose {kind} engine "
+            f"(batch=1..{max_batch}, input=160x160x6, precision=fp32) ...",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError(f"TensorRT failed to build the FoundationPose {kind} engine")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/foundationpose/builder.py
+++ b/python/tensorrt_model_connect/families/foundationpose/builder.py
@@ -98,11 +98,19 @@ class _OnnxWeightArchive:
 
 
 class _FoundationPoseGraph:
-    def __init__(self, trt: Any, network: Any, archive: _OnnxWeightArchive, kind: str) -> None:
+    def __init__(
+        self,
+        trt: Any,
+        network: Any,
+        archive: _OnnxWeightArchive,
+        kind: str,
+        work_np_dtype: type[np.float16] | type[np.float32],
+    ) -> None:
         self.trt = trt
         self.network = network
         self.archive = archive
         self.kind = kind
+        self.work_np_dtype = work_np_dtype
         self._host_weights: list[np.ndarray] = []
 
     def layer(self, value: Any, kind: str, name: str) -> Any:
@@ -111,12 +119,25 @@ class _FoundationPoseGraph:
         value.name = name
         return value
 
-    def constant(self, value: np.ndarray | float, name: str) -> Any:
-        array = np.ascontiguousarray(value, dtype=np.float32)
+    def constant(
+        self,
+        value: np.ndarray | float,
+        name: str,
+        dtype: type[np.float16] | type[np.float32] | None = None,
+    ) -> Any:
+        array = np.ascontiguousarray(value, dtype=dtype or self.work_np_dtype)
         self._host_weights.append(array)
         return self.layer(
             self.network.add_constant(array.shape, self.trt.Weights(array)), "constant", name
         ).get_output(0)
+
+    def cast(self, tensor: Any, dtype: Any, name: str) -> Any:
+        if tensor.dtype == dtype:
+            return tensor
+        return self.layer(self.network.add_cast(tensor, dtype), "cast", name).get_output(0)
+
+    def numpy_dtype(self, tensor: Any) -> type[np.float16] | type[np.float32]:
+        return np.float32 if tensor.dtype == self.trt.float32 else np.float16
 
     def add(self, left: Any, right: Any, name: str) -> Any:
         return self.layer(
@@ -171,6 +192,9 @@ class _FoundationPoseGraph:
             node_name, 1, self._conv_shape(node_name), operation="Conv"
         )
         bias = self.archive.node_parameter(node_name, 2, (int(weight.shape[0]),), operation="Conv")
+        dtype = self.numpy_dtype(tensor)
+        weight = np.ascontiguousarray(weight, dtype=dtype)
+        bias = np.ascontiguousarray(bias, dtype=dtype)
         self._host_weights.extend((weight, bias))
         convolution = self.layer(
             self.network.add_convolution_nd(
@@ -253,14 +277,15 @@ class _FoundationPoseGraph:
         bias: np.ndarray | None,
         name: str,
     ) -> Any:
-        weight = np.ascontiguousarray(weight, dtype=np.float32)
+        dtype = self.numpy_dtype(tensor)
+        weight = np.ascontiguousarray(weight, dtype=dtype)
         self._host_weights.append(weight)
         weight_shape = (1,) * (len(tuple(tensor.shape)) - 2) + tuple(weight.shape)
         output = self.layer(
             self.network.add_matrix_multiply(
                 tensor,
                 self.trt.MatrixOperation.NONE,
-                self.constant(weight.reshape(weight_shape), f"{name}.weight"),
+                self.constant(weight.reshape(weight_shape), f"{name}.weight", dtype),
                 self.trt.MatrixOperation.NONE,
             ),
             "matrix multiply",
@@ -269,7 +294,9 @@ class _FoundationPoseGraph:
         if bias is None:
             return output
         bias_shape = (1,) * (len(tuple(output.shape)) - 1) + (int(bias.shape[0]),)
-        return self.add(output, self.constant(bias.reshape(bias_shape), f"{name}.bias"), name)
+        return self.add(
+            output, self.constant(bias.reshape(bias_shape), f"{name}.bias", dtype), name
+        )
 
     def linear_torch(
         self,
@@ -278,14 +305,15 @@ class _FoundationPoseGraph:
         bias: np.ndarray | None,
         name: str,
     ) -> Any:
-        weight = np.ascontiguousarray(weight, dtype=np.float32)
+        dtype = self.numpy_dtype(tensor)
+        weight = np.ascontiguousarray(weight, dtype=dtype)
         self._host_weights.append(weight)
         weight_shape = (1,) * (len(tuple(tensor.shape)) - 2) + tuple(weight.shape)
         output = self.layer(
             self.network.add_matrix_multiply(
                 tensor,
                 self.trt.MatrixOperation.NONE,
-                self.constant(weight.reshape(weight_shape), f"{name}.weight"),
+                self.constant(weight.reshape(weight_shape), f"{name}.weight", dtype),
                 self.trt.MatrixOperation.TRANSPOSE,
             ),
             "matrix multiply",
@@ -294,9 +322,22 @@ class _FoundationPoseGraph:
         if bias is None:
             return output
         bias_shape = (1,) * (len(tuple(output.shape)) - 1) + (int(bias.shape[0]),)
-        return self.add(output, self.constant(bias.reshape(bias_shape), f"{name}.bias"), name)
+        return self.add(
+            output, self.constant(bias.reshape(bias_shape), f"{name}.bias", dtype), name
+        )
 
-    def attention(self, tensor: Any, prefix: str, name: str, *, dynamic_tokens: bool) -> Any:
+    def attention(
+        self,
+        tensor: Any,
+        prefix: str,
+        name: str,
+        *,
+        dynamic_tokens: bool,
+        force_fp32: bool = False,
+    ) -> Any:
+        if force_fp32:
+            tensor = self.cast(tensor, self.trt.float32, f"{name}.to_fp32")
+        dtype = self.numpy_dtype(tensor)
         root = prefix.split(".", maxsplit=1)[0]
         if prefix.endswith(".self_attn"):
             module, operation = prefix.rsplit(".", maxsplit=1)
@@ -339,15 +380,21 @@ class _FoundationPoseGraph:
         if self.kind == "refiner":
             split_scale = np.array([[[[float(_HEAD_DIM) ** -0.25]]]], dtype=np.float32)
             query = self.multiply(
-                query, self.constant(split_scale, f"{name}.query_scale"), f"{name}.scaled_query"
+                query,
+                self.constant(split_scale, f"{name}.query_scale", dtype),
+                f"{name}.scaled_query",
             )
             key = self.multiply(
-                key, self.constant(split_scale, f"{name}.key_scale"), f"{name}.scaled_key"
+                key,
+                self.constant(split_scale, f"{name}.key_scale", dtype),
+                f"{name}.scaled_key",
             )
         else:
             scale = np.array([[[[math.sqrt(_HEAD_DIM)]]]], dtype=np.float32)
             query = self.divide(
-                query, self.constant(scale, f"{name}.scale"), f"{name}.scaled_query"
+                query,
+                self.constant(scale, f"{name}.scale", dtype),
+                f"{name}.scaled_query",
             )
         scores = self.layer(
             self.network.add_matrix_multiply(
@@ -458,8 +505,14 @@ class _FoundationPoseGraph:
             "candidate_attention.mean",
         ).get_output(0)
         candidates = self.reshape(pooled, (1, -1, _HIDDEN), "candidates.to_sequence")
+        # Cross-hypothesis attention directly controls the score ordering and is
+        # more numerically sensitive than the per-candidate feature extractor.
         candidates = self.attention(
-            candidates, "att_cross", "candidate_cross_attention", dynamic_tokens=True
+            candidates,
+            "att_cross",
+            "candidate_cross_attention",
+            dynamic_tokens=True,
+            force_fp32=self.work_np_dtype is np.float16,
         )
         logits = self.linear_onnx(
             candidates,
@@ -479,8 +532,8 @@ def build_foundationpose_engine(
     verbose: bool = False,
 ) -> bytes:
     """Build a FoundationPose engine from family-owned TensorRT layers."""
-    if precision != "fp32":
-        raise ValueError("FoundationPose engines currently support fp32 builds only")
+    if precision not in {"fp16", "fp32"}:
+        raise ValueError("FoundationPose engines support fp16 or fp32 builds")
     if kind not in {"refiner", "scorer"}:
         raise ValueError(f"Unsupported FoundationPose engine kind: {kind!r}")
     if max_batch <= 0:
@@ -489,26 +542,33 @@ def build_foundationpose_engine(
     from tensorrt_model_connect import trt_compat
 
     trt = trt_compat.get_trt()
+    work_np_dtype = np.float16 if precision == "fp16" else np.float32
+    work_trt_dtype = trt.float16 if precision == "fp16" else trt.float32
     logger = trt.Logger(trt.Logger.INFO if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(
         trt_compat.network_creation_flags(explicit_batch=True, strongly_typed=True)
     )
     archive = _OnnxWeightArchive(path, kind)
-    graph = _FoundationPoseGraph(trt, network, archive, kind)
+    graph = _FoundationPoseGraph(trt, network, archive, kind, work_np_dtype)
     input_shape = (-1, _INPUT_HEIGHT, _INPUT_WIDTH, _INPUT_CHANNELS)
     input1 = network.add_input("input1", trt.float32, input_shape)
     input2 = network.add_input("input2", trt.float32, input_shape)
     if input1 is None or input2 is None:
         raise RuntimeError("TensorRT rejected the FoundationPose input contract")
+    input1 = graph.cast(input1, work_trt_dtype, "input1.to_working_precision")
+    input2 = graph.cast(input2, work_trt_dtype, "input2.to_working_precision")
     if kind == "refiner":
         translation, rotation = graph.build_refiner(input1, input2)
+        translation = graph.cast(translation, trt.float32, "output1.to_fp32")
+        rotation = graph.cast(rotation, trt.float32, "output2.to_fp32")
         translation.name = "output1"
         rotation.name = "output2"
         network.mark_output(translation)
         network.mark_output(rotation)
     else:
         score = graph.build_scorer(input1, input2)
+        score = graph.cast(score, trt.float32, "output1.to_fp32")
         score.name = "output1"
         network.mark_output(score)
 
@@ -536,7 +596,7 @@ def build_foundationpose_engine(
     if verbose:
         print(
             f"[trtmc build] Building native FoundationPose {kind} graph "
-            f"(batch=1..{max_batch}, input=160x160x6, precision=fp32) ...",
+            f"(batch=1..{max_batch}, input=160x160x6, precision={precision}) ...",
             file=sys.stderr,
         )
     plan = builder.build_serialized_network(network, config)

--- a/python/tensorrt_model_connect/families/foundationpose/builder.py
+++ b/python/tensorrt_model_connect/families/foundationpose/builder.py
@@ -1,21 +1,476 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""TensorRT builders for the official FoundationPose NGC ONNX pair."""
+"""Family-owned TensorRT Python graphs for FoundationPose.
+
+The pinned NGC ONNX files are used only as immutable weight containers.  The
+TensorRT networks below are authored explicitly with the TensorRT Python API;
+they never pass the ONNX computation graph to TensorRT.
+"""
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
+
+import numpy as np
 
 
-def _parser_errors(parser: Any) -> str:
-    return "\n".join(str(parser.get_error(index)) for index in range(parser.num_errors))
+_INPUT_HEIGHT = 160
+_INPUT_WIDTH = 160
+_INPUT_CHANNELS = 6
+_FEATURE_HEIGHT = 20
+_FEATURE_WIDTH = 20
+_TOKENS = _FEATURE_HEIGHT * _FEATURE_WIDTH
+_HIDDEN = 512
+_HEADS = 4
+_HEAD_DIM = _HIDDEN // _HEADS
+_LAYER_NORM_EPS = 1.0e-5
 
 
-def build_onnx_engine(
+class _OnnxWeightArchive:
+    """Read tensors from the pinned artifact without importing its graph into TRT."""
+
+    def __init__(self, path: str | Path, kind: str) -> None:
+        import onnx
+        from onnx import numpy_helper
+
+        self.path = Path(path)
+        model = onnx.load(self.path, load_external_data=True)
+        expected_outputs = {"output1", "output2"} if kind == "refiner" else {"output1"}
+        inputs = {value.name for value in model.graph.input}
+        outputs = {value.name for value in model.graph.output}
+        if inputs != {"input1", "input2"} or outputs != expected_outputs:
+            raise ValueError(
+                f"FoundationPose {kind} weight artifact contract mismatch: "
+                f"inputs={sorted(inputs)}, outputs={sorted(outputs)}"
+            )
+        self.nodes = {node.name: node for node in model.graph.node}
+        if len(self.nodes) != len(model.graph.node):
+            raise ValueError(f"FoundationPose {kind} weight artifact has duplicate node names")
+        self.arrays = {
+            value.name: np.ascontiguousarray(numpy_helper.to_array(value), dtype=np.float32)
+            for value in model.graph.initializer
+        }
+
+    def named(self, name: str, expected: tuple[int, ...]) -> np.ndarray:
+        try:
+            value = self.arrays[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"FoundationPose weight artifact {self.path} is missing tensor {name!r}"
+            ) from exc
+        if tuple(value.shape) != expected:
+            raise ValueError(
+                f"FoundationPose tensor {name!r} has shape {tuple(value.shape)}, "
+                f"expected {expected}"
+            )
+        return value
+
+    def node_parameter(
+        self,
+        node_name: str,
+        input_index: int,
+        expected: tuple[int, ...],
+        *,
+        operation: str,
+    ) -> np.ndarray:
+        try:
+            node = self.nodes[node_name]
+        except KeyError as exc:
+            raise KeyError(
+                f"FoundationPose weight artifact {self.path} is missing node {node_name!r}"
+            ) from exc
+        if node.op_type != operation:
+            raise ValueError(
+                f"FoundationPose node {node_name!r} is {node.op_type}, expected {operation}"
+            )
+        try:
+            tensor_name = node.input[input_index]
+        except IndexError as exc:
+            raise ValueError(
+                f"FoundationPose node {node_name!r} has no input {input_index}"
+            ) from exc
+        return self.named(tensor_name, expected)
+
+
+class _FoundationPoseGraph:
+    def __init__(self, trt: Any, network: Any, archive: _OnnxWeightArchive, kind: str) -> None:
+        self.trt = trt
+        self.network = network
+        self.archive = archive
+        self.kind = kind
+        self._host_weights: list[np.ndarray] = []
+
+    def layer(self, value: Any, kind: str, name: str) -> Any:
+        if value is None:
+            raise RuntimeError(f"TensorRT rejected FoundationPose {kind} layer {name!r}")
+        value.name = name
+        return value
+
+    def constant(self, value: np.ndarray | float, name: str) -> Any:
+        array = np.ascontiguousarray(value, dtype=np.float32)
+        self._host_weights.append(array)
+        return self.layer(
+            self.network.add_constant(array.shape, self.trt.Weights(array)), "constant", name
+        ).get_output(0)
+
+    def add(self, left: Any, right: Any, name: str) -> Any:
+        return self.layer(
+            self.network.add_elementwise(left, right, self.trt.ElementWiseOperation.SUM),
+            "sum",
+            name,
+        ).get_output(0)
+
+    def multiply(self, left: Any, right: Any, name: str) -> Any:
+        return self.layer(
+            self.network.add_elementwise(left, right, self.trt.ElementWiseOperation.PROD),
+            "product",
+            name,
+        ).get_output(0)
+
+    def divide(self, left: Any, right: Any, name: str) -> Any:
+        return self.layer(
+            self.network.add_elementwise(left, right, self.trt.ElementWiseOperation.DIV),
+            "division",
+            name,
+        ).get_output(0)
+
+    def reshape(
+        self,
+        tensor: Any,
+        shape: tuple[int, ...],
+        name: str,
+        *,
+        first_transpose: tuple[int, ...] | None = None,
+        second_transpose: tuple[int, ...] | None = None,
+    ) -> Any:
+        shuffle = self.layer(self.network.add_shuffle(tensor), "shuffle", name)
+        if first_transpose is not None:
+            shuffle.first_transpose = first_transpose
+        shuffle.reshape_dims = shape
+        if second_transpose is not None:
+            shuffle.second_transpose = second_transpose
+        return shuffle.get_output(0)
+
+    def concatenate(self, tensors: Sequence[Any], axis: int, name: str) -> Any:
+        concat = self.layer(self.network.add_concatenation(list(tensors)), "concatenation", name)
+        concat.axis = axis
+        return concat.get_output(0)
+
+    def relu(self, tensor: Any, name: str) -> Any:
+        return self.layer(
+            self.network.add_activation(tensor, self.trt.ActivationType.RELU), "ReLU", name
+        ).get_output(0)
+
+    def convolution(self, tensor: Any, node_name: str, name: str) -> Any:
+        weight = self.archive.node_parameter(
+            node_name, 1, self._conv_shape(node_name), operation="Conv"
+        )
+        bias = self.archive.node_parameter(node_name, 2, (int(weight.shape[0]),), operation="Conv")
+        self._host_weights.extend((weight, bias))
+        convolution = self.layer(
+            self.network.add_convolution_nd(
+                tensor,
+                int(weight.shape[0]),
+                tuple(int(value) for value in weight.shape[2:]),
+                self.trt.Weights(weight),
+                self.trt.Weights(bias),
+            ),
+            "convolution",
+            name,
+        )
+        stride = (
+            2
+            if node_name.endswith((".0/net/net.0/Conv", ".1/net/net.0/Conv", ".2/net/net.0/Conv"))
+            else 1
+        )
+        kernel = int(weight.shape[2])
+        convolution.stride_nd = (stride, stride)
+        convolution.padding_nd = (kernel // 2, kernel // 2)
+        return convolution.get_output(0)
+
+    def _conv_shape(self, node_name: str) -> tuple[int, ...]:
+        if "/encodeAB/" in node_name or "/encoderAB/" in node_name:
+            if node_name.endswith(".2/net/net.0/Conv"):
+                return (512, 256, 3, 3)
+            if ".0/" in node_name or ".1/" in node_name:
+                return (256, 256, 3, 3)
+            return (512, 512, 3, 3)
+        if node_name.endswith(".0/net/net.0/Conv"):
+            return (64, 6, 7, 7)
+        if node_name.endswith(".1/net/net.0/Conv"):
+            return (128, 64, 3, 3)
+        return (128, 128, 3, 3)
+
+    def residual_block(self, tensor: Any, prefix: str, name: str) -> Any:
+        hidden = self.convolution(tensor, f"/{prefix}/conv1/Conv", f"{name}.conv1")
+        hidden = self.relu(hidden, f"{name}.relu1")
+        hidden = self.convolution(hidden, f"/{prefix}/conv2/Conv", f"{name}.conv2")
+        return self.relu(self.add(hidden, tensor, f"{name}.residual"), f"{name}.relu2")
+
+    def image_encoder(self, tensor: Any, name: str) -> Any:
+        prefix = "encodeA" if self.kind == "refiner" else "encoderA"
+        tensor = self.reshape(
+            tensor, (-1, 6, 160, 160), f"{name}.to_nchw", first_transpose=(0, 3, 1, 2)
+        )
+        tensor = self.convolution(tensor, f"/{prefix}/{prefix}.0/net/net.0/Conv", f"{name}.conv0")
+        tensor = self.relu(tensor, f"{name}.relu0")
+        tensor = self.convolution(tensor, f"/{prefix}/{prefix}.1/net/net.0/Conv", f"{name}.conv1")
+        tensor = self.relu(tensor, f"{name}.relu1")
+        tensor = self.residual_block(tensor, f"{prefix}/{prefix}.2", f"{name}.block0")
+        return self.residual_block(tensor, f"{prefix}/{prefix}.3", f"{name}.block1")
+
+    def paired_features(self, input1: Any, input2: Any) -> Any:
+        first = self.image_encoder(input1, "input1_encoder")
+        second = self.image_encoder(input2, "input2_encoder")
+        tensor = self.concatenate((first, second), 1, "paired_features")
+        prefix = "encodeAB" if self.kind == "refiner" else "encoderAB"
+        tensor = self.residual_block(tensor, f"{prefix}/{prefix}.0", "paired.block0")
+        tensor = self.residual_block(tensor, f"{prefix}/{prefix}.1", "paired.block1")
+        tensor = self.convolution(
+            tensor, f"/{prefix}/{prefix}.2/net/net.0/Conv", "paired.downsample"
+        )
+        tensor = self.relu(tensor, "paired.downsample_relu")
+        tensor = self.residual_block(tensor, f"{prefix}/{prefix}.3", "paired.block2")
+        tensor = self.residual_block(tensor, f"{prefix}/{prefix}.4", "paired.block3")
+        tensor = self.reshape(tensor, (-1, _HIDDEN, _TOKENS), "features.flatten")
+        position = self.archive.named("/pos_embed/Slice_output_0", (1, _HIDDEN, _TOKENS))
+        tensor = self.add(
+            tensor, self.constant(position, "position_embedding"), "features.positioned"
+        )
+        return self.reshape(
+            tensor, (-1, _HIDDEN, _TOKENS), "features.tokens", second_transpose=(0, 2, 1)
+        )
+
+    def linear_onnx(
+        self,
+        tensor: Any,
+        weight: np.ndarray,
+        bias: np.ndarray | None,
+        name: str,
+    ) -> Any:
+        weight = np.ascontiguousarray(weight, dtype=np.float32)
+        self._host_weights.append(weight)
+        weight_shape = (1,) * (len(tuple(tensor.shape)) - 2) + tuple(weight.shape)
+        output = self.layer(
+            self.network.add_matrix_multiply(
+                tensor,
+                self.trt.MatrixOperation.NONE,
+                self.constant(weight.reshape(weight_shape), f"{name}.weight"),
+                self.trt.MatrixOperation.NONE,
+            ),
+            "matrix multiply",
+            f"{name}.matmul",
+        ).get_output(0)
+        if bias is None:
+            return output
+        bias_shape = (1,) * (len(tuple(output.shape)) - 1) + (int(bias.shape[0]),)
+        return self.add(output, self.constant(bias.reshape(bias_shape), f"{name}.bias"), name)
+
+    def linear_torch(
+        self,
+        tensor: Any,
+        weight: np.ndarray,
+        bias: np.ndarray | None,
+        name: str,
+    ) -> Any:
+        weight = np.ascontiguousarray(weight, dtype=np.float32)
+        self._host_weights.append(weight)
+        weight_shape = (1,) * (len(tuple(tensor.shape)) - 2) + tuple(weight.shape)
+        output = self.layer(
+            self.network.add_matrix_multiply(
+                tensor,
+                self.trt.MatrixOperation.NONE,
+                self.constant(weight.reshape(weight_shape), f"{name}.weight"),
+                self.trt.MatrixOperation.TRANSPOSE,
+            ),
+            "matrix multiply",
+            f"{name}.matmul",
+        ).get_output(0)
+        if bias is None:
+            return output
+        bias_shape = (1,) * (len(tuple(output.shape)) - 1) + (int(bias.shape[0]),)
+        return self.add(output, self.constant(bias.reshape(bias_shape), f"{name}.bias"), name)
+
+    def attention(self, tensor: Any, prefix: str, name: str, *, dynamic_tokens: bool) -> Any:
+        root = prefix.split(".", maxsplit=1)[0]
+        if prefix.endswith(".self_attn"):
+            module, operation = prefix.rsplit(".", maxsplit=1)
+            node_name = f"/{root}/{module}/{operation}/MatMul"
+        else:
+            node_name = f"/{prefix}/MatMul"
+        projection = self.archive.node_parameter(
+            node_name, 1, (_HIDDEN, 3 * _HIDDEN), operation="MatMul"
+        )
+        bias = self.archive.named(f"{prefix.replace('/', '.')}.in_proj_bias", (3 * _HIDDEN,))
+        query = self.linear_onnx(tensor, projection[:, :_HIDDEN], bias[:_HIDDEN], f"{name}.query")
+        key = self.linear_onnx(
+            tensor,
+            projection[:, _HIDDEN : 2 * _HIDDEN],
+            bias[_HIDDEN : 2 * _HIDDEN],
+            f"{name}.key",
+        )
+        value = self.linear_onnx(
+            tensor, projection[:, 2 * _HIDDEN :], bias[2 * _HIDDEN :], f"{name}.value"
+        )
+        token_dim = 0 if dynamic_tokens else _TOKENS
+        query = self.reshape(
+            query,
+            (-1, token_dim, _HEADS, _HEAD_DIM),
+            f"{name}.query_heads",
+            second_transpose=(0, 2, 1, 3),
+        )
+        key = self.reshape(
+            key,
+            (-1, token_dim, _HEADS, _HEAD_DIM),
+            f"{name}.key_heads",
+            second_transpose=(0, 2, 3, 1),
+        )
+        value = self.reshape(
+            value,
+            (-1, token_dim, _HEADS, _HEAD_DIM),
+            f"{name}.value_heads",
+            second_transpose=(0, 2, 1, 3),
+        )
+        if self.kind == "refiner":
+            split_scale = np.array([[[[float(_HEAD_DIM) ** -0.25]]]], dtype=np.float32)
+            query = self.multiply(
+                query, self.constant(split_scale, f"{name}.query_scale"), f"{name}.scaled_query"
+            )
+            key = self.multiply(
+                key, self.constant(split_scale, f"{name}.key_scale"), f"{name}.scaled_key"
+            )
+        else:
+            scale = np.array([[[[math.sqrt(_HEAD_DIM)]]]], dtype=np.float32)
+            query = self.divide(
+                query, self.constant(scale, f"{name}.scale"), f"{name}.scaled_query"
+            )
+        scores = self.layer(
+            self.network.add_matrix_multiply(
+                query,
+                self.trt.MatrixOperation.NONE,
+                key,
+                self.trt.MatrixOperation.NONE,
+            ),
+            "attention scores",
+            f"{name}.scores",
+        ).get_output(0)
+        softmax = self.layer(self.network.add_softmax(scores), "softmax", f"{name}.softmax")
+        softmax.axes = 1 << 3
+        context = self.layer(
+            self.network.add_matrix_multiply(
+                softmax.get_output(0),
+                self.trt.MatrixOperation.NONE,
+                value,
+                self.trt.MatrixOperation.NONE,
+            ),
+            "attention context",
+            f"{name}.context_heads",
+        ).get_output(0)
+        context = self.reshape(
+            context,
+            (-1, token_dim, _HIDDEN),
+            f"{name}.context",
+            first_transpose=(0, 2, 1, 3),
+        )
+        out_weight = self.archive.named(
+            f"{prefix.replace('/', '.')}.out_proj.weight", (_HIDDEN, _HIDDEN)
+        )
+        out_bias = self.archive.named(f"{prefix.replace('/', '.')}.out_proj.bias", (_HIDDEN,))
+        return self.linear_torch(context, out_weight, out_bias, f"{name}.output")
+
+    def layer_norm(self, tensor: Any, prefix: str, name: str) -> Any:
+        scale = self.archive.named(f"{prefix}.weight", (_HIDDEN,)).reshape(1, 1, _HIDDEN)
+        bias = self.archive.named(f"{prefix}.bias", (_HIDDEN,)).reshape(1, 1, _HIDDEN)
+        normalization = self.layer(
+            self.network.add_normalization_v2(
+                tensor,
+                self.constant(scale, f"{name}.scale"),
+                self.constant(bias, f"{name}.bias"),
+                1 << 2,
+            ),
+            "layer normalization",
+            name,
+        )
+        normalization.epsilon = _LAYER_NORM_EPS
+        if hasattr(normalization, "compute_precision"):
+            normalization.compute_precision = self.trt.float32
+        return normalization.get_output(0)
+
+    def transformer_head(self, tokens: Any, prefix: str, name: str) -> Any:
+        attention = self.attention(
+            tokens, f"{prefix}.0.self_attn", f"{name}.attention", dynamic_tokens=False
+        )
+        hidden = self.layer_norm(
+            self.add(tokens, attention, f"{name}.attention_residual"),
+            f"{prefix}.0.norm1",
+            f"{name}.norm1",
+        )
+        linear1_node = f"/{prefix.replace('.', '/')}/{prefix.split('.')[0]}.0/linear1/MatMul"
+        linear2_node = f"/{prefix.replace('.', '/')}/{prefix.split('.')[0]}.0/linear2/MatMul"
+        head_node = f"/{prefix.replace('.', '/')}/{prefix.split('.')[0]}.1/MatMul"
+        feed_forward = self.linear_onnx(
+            hidden,
+            self.archive.node_parameter(linear1_node, 1, (_HIDDEN, _HIDDEN), operation="MatMul"),
+            self.archive.named(f"{prefix}.0.linear1.bias", (_HIDDEN,)),
+            f"{name}.linear1",
+        )
+        feed_forward = self.relu(feed_forward, f"{name}.relu")
+        feed_forward = self.linear_onnx(
+            feed_forward,
+            self.archive.node_parameter(linear2_node, 1, (_HIDDEN, _HIDDEN), operation="MatMul"),
+            self.archive.named(f"{prefix}.0.linear2.bias", (_HIDDEN,)),
+            f"{name}.linear2",
+        )
+        hidden = self.layer_norm(
+            self.add(hidden, feed_forward, f"{name}.feed_forward_residual"),
+            f"{prefix}.0.norm2",
+            f"{name}.norm2",
+        )
+        output = self.linear_onnx(
+            hidden,
+            self.archive.node_parameter(head_node, 1, (_HIDDEN, 3), operation="MatMul"),
+            self.archive.named(f"{prefix}.1.bias", (3,)),
+            f"{name}.output",
+        )
+        return self.layer(
+            self.network.add_reduce(output, self.trt.ReduceOperation.AVG, 1 << 1, keep_dims=False),
+            "token mean",
+            f"{name}.mean",
+        ).get_output(0)
+
+    def build_refiner(self, input1: Any, input2: Any) -> tuple[Any, Any]:
+        tokens = self.paired_features(input1, input2)
+        translation = self.transformer_head(tokens, "trans_head", "translation_head")
+        rotation = self.transformer_head(tokens, "rot_head", "rotation_head")
+        return translation, rotation
+
+    def build_scorer(self, input1: Any, input2: Any) -> Any:
+        tokens = self.paired_features(input1, input2)
+        tokens = self.attention(tokens, "att", "candidate_attention", dynamic_tokens=False)
+        pooled = self.layer(
+            self.network.add_reduce(tokens, self.trt.ReduceOperation.AVG, 1 << 1, keep_dims=False),
+            "token mean",
+            "candidate_attention.mean",
+        ).get_output(0)
+        candidates = self.reshape(pooled, (1, -1, _HIDDEN), "candidates.to_sequence")
+        candidates = self.attention(
+            candidates, "att_cross", "candidate_cross_attention", dynamic_tokens=True
+        )
+        logits = self.linear_onnx(
+            candidates,
+            self.archive.node_parameter("/linear/MatMul", 1, (_HIDDEN, 1), operation="MatMul"),
+            self.archive.named("linear.bias", (1,)),
+            "score",
+        )
+        return self.reshape(logits, (1, -1), "score.output")
+
+
+def build_foundationpose_engine(
     path: str,
     *,
     kind: str,
@@ -23,8 +478,9 @@ def build_onnx_engine(
     precision: str,
     verbose: bool = False,
 ) -> bytes:
+    """Build a FoundationPose engine from family-owned TensorRT layers."""
     if precision != "fp32":
-        raise ValueError("FoundationPose ONNX engines currently support fp32 builds only")
+        raise ValueError("FoundationPose engines currently support fp32 builds only")
     if kind not in {"refiner", "scorer"}:
         raise ValueError(f"Unsupported FoundationPose engine kind: {kind!r}")
     if max_batch <= 0:
@@ -38,32 +494,33 @@ def build_onnx_engine(
     network = builder.create_network(
         trt_compat.network_creation_flags(explicit_batch=True, strongly_typed=True)
     )
-    parser = trt.OnnxParser(network, logger)
-    model_path = Path(path)
-    if not parser.parse(model_path.read_bytes()):
-        raise RuntimeError(
-            f"TensorRT could not parse FoundationPose {kind} ONNX {model_path}:\n"
-            f"{_parser_errors(parser)}"
-        )
-    expected_outputs = {"output1", "output2"} if kind == "refiner" else {"output1"}
-    inputs = {network.get_input(index).name: network.get_input(index) for index in range(network.num_inputs)}
-    outputs = {network.get_output(index).name for index in range(network.num_outputs)}
-    if set(inputs) != {"input1", "input2"} or outputs != expected_outputs:
-        raise RuntimeError(
-            f"FoundationPose {kind} ONNX contract mismatch: inputs={sorted(inputs)}, "
-            f"outputs={sorted(outputs)}"
-        )
-    for name, tensor in inputs.items():
-        if tuple(int(value) for value in tensor.shape)[1:] != (160, 160, 6):
-            raise RuntimeError(
-                f"FoundationPose {kind} input {name} has unsupported shape {tuple(tensor.shape)}"
-            )
+    archive = _OnnxWeightArchive(path, kind)
+    graph = _FoundationPoseGraph(trt, network, archive, kind)
+    input_shape = (-1, _INPUT_HEIGHT, _INPUT_WIDTH, _INPUT_CHANNELS)
+    input1 = network.add_input("input1", trt.float32, input_shape)
+    input2 = network.add_input("input2", trt.float32, input_shape)
+    if input1 is None or input2 is None:
+        raise RuntimeError("TensorRT rejected the FoundationPose input contract")
+    if kind == "refiner":
+        translation, rotation = graph.build_refiner(input1, input2)
+        translation.name = "output1"
+        rotation.name = "output2"
+        network.mark_output(translation)
+        network.mark_output(rotation)
+    else:
+        score = graph.build_scorer(input1, input2)
+        score.name = "output1"
+        network.mark_output(score)
 
     profile = builder.create_optimization_profile()
     opt_batch = min(8, max_batch)
     for name in ("input1", "input2"):
-        profile.set_shape(name, (1, 160, 160, 6), (opt_batch, 160, 160, 6),
-                          (max_batch, 160, 160, 6))
+        profile.set_shape(
+            name,
+            (1, _INPUT_HEIGHT, _INPUT_WIDTH, _INPUT_CHANNELS),
+            (opt_batch, _INPUT_HEIGHT, _INPUT_WIDTH, _INPUT_CHANNELS),
+            (max_batch, _INPUT_HEIGHT, _INPUT_WIDTH, _INPUT_CHANNELS),
+        )
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
     workspace_gib = int(os.environ.get("TRTMC_FOUNDATIONPOSE_WORKSPACE_GIB", "8"))
@@ -78,7 +535,7 @@ def build_onnx_engine(
         config.max_aux_streams = 0
     if verbose:
         print(
-            f"[trtmc build] Building FoundationPose {kind} engine "
+            f"[trtmc build] Building native FoundationPose {kind} graph "
             f"(batch=1..{max_batch}, input=160x160x6, precision=fp32) ...",
             file=sys.stderr,
         )

--- a/python/tensorrt_model_connect/families/foundationpose/plugin.py
+++ b/python/tensorrt_model_connect/families/foundationpose/plugin.py
@@ -74,7 +74,7 @@ class FoundationPosePlugin:
     name = "foundationpose"
     runtime_strategy = "foundationpose_pose_refinement"
     requires_tokenizer = False
-    default_build_precision = "fp32"
+    default_build_precision = "fp16"
 
     def matches(self, model_type: str) -> bool:
         return (model_type or "").lower().replace("-", "_") == "foundationpose"
@@ -87,10 +87,10 @@ class FoundationPosePlugin:
         model_dir: str,
         config: ModelConfig,
         *,
-        precision: str = "fp32",
+        precision: str = "fp16",
     ) -> dict[str, str]:
-        if precision != "fp32":
-            raise ValueError("The pinned FoundationPose accuracy contract supports fp32 only")
+        if precision not in {"fp16", "fp32"}:
+            raise ValueError("FoundationPose supports fp16 or fp32 builds")
         refiner, scorer = _validate_models(model_dir)
         config.raw["_foundationpose_model_dir"] = str(Path(model_dir).resolve())
         return {"refiner": str(refiner), "scorer": str(scorer)}
@@ -101,7 +101,7 @@ class FoundationPosePlugin:
         weights: dict[str, str],
         max_cache_length: int,
         *,
-        precision: str = "fp32",
+        precision: str = "fp16",
         quant_ctx=None,
         verbose: bool = False,
     ) -> bytes:
@@ -120,7 +120,7 @@ class FoundationPosePlugin:
         weights: dict[str, str],
         max_cache_length: int,
         *,
-        precision: str = "fp32",
+        precision: str = "fp16",
         quant_ctx=None,
         verbose: bool = False,
     ) -> dict[str, bytes]:

--- a/python/tensorrt_model_connect/families/foundationpose/plugin.py
+++ b/python/tensorrt_model_connect/families/foundationpose/plugin.py
@@ -108,11 +108,10 @@ class FoundationPosePlugin:
         del config, max_cache_length
         if quant_ctx is not None:
             raise ValueError("FoundationPose does not support quantized builds")
-        from .builder import build_onnx_engine
+        from .builder import build_foundationpose_engine
 
-        return build_onnx_engine(
-            weights["refiner"], kind="refiner", max_batch=42,
-            precision=precision, verbose=verbose
+        return build_foundationpose_engine(
+            weights["refiner"], kind="refiner", max_batch=42, precision=precision, verbose=verbose
         )
 
     def build_extra_engines(
@@ -128,12 +127,15 @@ class FoundationPosePlugin:
         del config, max_cache_length
         if quant_ctx is not None:
             raise ValueError("FoundationPose does not support quantized builds")
-        from .builder import build_onnx_engine
+        from .builder import build_foundationpose_engine
 
         return {
-            SCORE_SECTION: build_onnx_engine(
-                weights["scorer"], kind="scorer", max_batch=252,
-                precision=precision, verbose=verbose
+            SCORE_SECTION: build_foundationpose_engine(
+                weights["scorer"],
+                kind="scorer",
+                max_batch=252,
+                precision=precision,
+                verbose=verbose,
             )
         }
 
@@ -146,6 +148,7 @@ class FoundationPosePlugin:
             "foundationpose_ngc_version": NGC_VERSION,
             "foundationpose_refiner_sha256": REFINER_SHA256,
             "foundationpose_scorer_sha256": SCORER_SHA256,
+            "foundationpose_engine_builder": "tensorrt_python_api",
             "pose_crop_layout": "NHWC",
             "pose_crop_height": 160,
             "pose_crop_width": 160,

--- a/python/tensorrt_model_connect/families/foundationpose/plugin.py
+++ b/python/tensorrt_model_connect/families/foundationpose/plugin.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pinned FoundationPose refiner/scorer family plugin."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Protocol
+
+
+SOURCE_REPOSITORY = "https://github.com/NVlabs/FoundationPose.git"
+SOURCE_REVISION = "a1b694b83e633c2cb6115b9063d940a687759392"
+NGC_MODEL = "nvidia/isaac/foundationpose"
+NGC_VERSION = "1.0.1_onnx"
+REFINER_FILE = "refine_model.onnx"
+SCORER_FILE = "score_model.onnx"
+REFINER_SHA256 = "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7"
+SCORER_SHA256 = "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503"
+SCORE_SECTION = "foundationpose_score_engine_plan"
+
+
+class ModelConfig(Protocol):
+    raw: dict[str, Any]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_models(model_dir: str | Path) -> tuple[Path, Path]:
+    root = Path(model_dir).resolve()
+    refiner = root / REFINER_FILE
+    scorer = root / SCORER_FILE
+    expected = ((refiner, REFINER_SHA256), (scorer, SCORER_SHA256))
+    for path, digest in expected:
+        if not path.is_file():
+            raise FileNotFoundError(f"FoundationPose requires {path.name} under {root}")
+        actual = _sha256(path)
+        if actual != digest:
+            raise ValueError(
+                f"FoundationPose {path.name} digest mismatch: expected {digest}, found {actual}"
+            )
+    return refiner, scorer
+
+
+def config_from_dir(model_dir: str | Path) -> dict[str, Any] | None:
+    root = Path(model_dir)
+    if not (root / REFINER_FILE).is_file() or not (root / SCORER_FILE).is_file():
+        return None
+    _validate_models(root)
+    return {
+        "model_type": "foundationpose",
+        "architectures": ["FoundationPoseRefinerScorer"],
+        "runtime_strategy": "foundationpose_pose_refinement",
+        "vocab_size": 0,
+        "hidden_size": 0,
+        "intermediate_size": 0,
+        "num_hidden_layers": 0,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 1,
+        "requires_tokenizer": False,
+        "_foundationpose_model_dir": str(root.resolve()),
+    }
+
+
+class FoundationPosePlugin:
+    name = "foundationpose"
+    runtime_strategy = "foundationpose_pose_refinement"
+    requires_tokenizer = False
+    default_build_precision = "fp32"
+
+    def matches(self, model_type: str) -> bool:
+        return (model_type or "").lower().replace("-", "_") == "foundationpose"
+
+    def matches_config(self, config: Any) -> bool:
+        return self.matches(str(getattr(config, "model_type", "")))
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> dict[str, str]:
+        if precision != "fp32":
+            raise ValueError("The pinned FoundationPose accuracy contract supports fp32 only")
+        refiner, scorer = _validate_models(model_dir)
+        config.raw["_foundationpose_model_dir"] = str(Path(model_dir).resolve())
+        return {"refiner": str(refiner), "scorer": str(scorer)}
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: dict[str, str],
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        del config, max_cache_length
+        if quant_ctx is not None:
+            raise ValueError("FoundationPose does not support quantized builds")
+        from .builder import build_onnx_engine
+
+        return build_onnx_engine(
+            weights["refiner"], kind="refiner", max_batch=42,
+            precision=precision, verbose=verbose
+        )
+
+    def build_extra_engines(
+        self,
+        config: ModelConfig,
+        weights: dict[str, str],
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> dict[str, bytes]:
+        del config, max_cache_length
+        if quant_ctx is not None:
+            raise ValueError("FoundationPose does not support quantized builds")
+        from .builder import build_onnx_engine
+
+        return {
+            SCORE_SECTION: build_onnx_engine(
+                weights["scorer"], kind="scorer", max_batch=252,
+                precision=precision, verbose=verbose
+            )
+        }
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict[str, Any]:
+        del config
+        return {
+            "foundationpose_source_repository": SOURCE_REPOSITORY,
+            "foundationpose_source_revision": SOURCE_REVISION,
+            "foundationpose_ngc_model": NGC_MODEL,
+            "foundationpose_ngc_version": NGC_VERSION,
+            "foundationpose_refiner_sha256": REFINER_SHA256,
+            "foundationpose_scorer_sha256": SCORER_SHA256,
+            "pose_crop_layout": "NHWC",
+            "pose_crop_height": 160,
+            "pose_crop_width": 160,
+            "pose_crop_channels": 6,
+            "pose_crop_features": "rgb_0_1_xyz_mesh_radius_normalized",
+            "pose_transform_convention": "row_major_object_to_camera",
+            "pose_rotation_representation": "axis_angle",
+            "pose_rotation_normalizer": 0.3490658503988659,
+            "pose_refiner_max_batch": 42,
+            "pose_max_hypotheses": 252,
+            "pose_max_refinement_iterations": 10,
+            "includes_segmentation": False,
+            "includes_cad_rendering": False,
+            "robotics_safety_validated": False,
+        }
+
+
+plugin = FoundationPosePlugin()

--- a/python/tensorrt_model_connect/families/foundationpose/python_profile_requirements/foundationpose_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/foundationpose/python_profile_requirements/foundationpose_reference.lock.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+onnxruntime==1.29.0
+flatbuffers==24.3.25
+numpy==1.26.4
+packaging==24.2
+protobuf==5.29.5

--- a/python/tensorrt_model_connect/families/foundationpose/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/foundationpose/python_profile_verify.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import onnxruntime
+
+if onnxruntime.__version__ != "1.29.0":
+    raise RuntimeError(
+        f"FoundationPose reference requires onnxruntime 1.29.0, got {onnxruntime.__version__}"
+    )

--- a/python/tensorrt_model_connect/families/foundationpose/tests/__init__.py
+++ b/python/tensorrt_model_connect/families/foundationpose/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
+++ b/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
@@ -12,6 +12,7 @@ family = importlib.import_module("tensorrt_model_connect.families.foundationpose
 
 
 def test_bundle_contract_is_pinned_and_explicit():
+    assert family.plugin.default_build_precision == "fp16"
     metadata = family.plugin.get_bundle_config_overrides(SimpleNamespace(raw={}))
     assert metadata["foundationpose_source_revision"] == family.SOURCE_REVISION
     assert metadata["foundationpose_ngc_version"] == "1.0.1_onnx"
@@ -47,10 +48,22 @@ def test_digest_mismatch_fails_closed(monkeypatch, tmp_path: Path):
         family.config_from_dir(tmp_path)
 
 
-def test_only_fp32_and_unquantized_builds_are_admitted(tmp_path: Path):
+def test_fp16_and_fp32_unquantized_builds_are_admitted(monkeypatch, tmp_path: Path):
+    for name in (family.REFINER_FILE, family.SCORER_FILE):
+        (tmp_path / name).write_bytes(b"weights")
+    digests = {
+        family.REFINER_FILE: family.REFINER_SHA256,
+        family.SCORER_FILE: family.SCORER_SHA256,
+    }
+    monkeypatch.setattr(family, "_sha256", lambda path: digests[path.name])
     config = SimpleNamespace(raw={})
-    with pytest.raises(ValueError, match="fp32"):
-        family.plugin.load_weights(str(tmp_path), config, precision="fp16")
+
+    for precision in ("fp16", "fp32"):
+        weights = family.plugin.load_weights(str(tmp_path), config, precision=precision)
+        assert set(weights) == {"refiner", "scorer"}
+
+    with pytest.raises(ValueError, match="fp16 or fp32"):
+        family.plugin.load_weights(str(tmp_path), config, precision="bf16")
     with pytest.raises(ValueError, match="quantized"):
         family.plugin.build_engine(
             config,

--- a/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
+++ b/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 family = importlib.import_module("tensorrt_model_connect.families.foundationpose.plugin")
+builder = importlib.import_module("tensorrt_model_connect.families.foundationpose.builder")
 
 
 def test_bundle_contract_is_pinned_and_explicit():
@@ -18,6 +19,7 @@ def test_bundle_contract_is_pinned_and_explicit():
     assert metadata["pose_refiner_max_batch"] == 42
     assert metadata["pose_max_hypotheses"] == 252
     assert metadata["pose_crop_layout"] == "NHWC"
+    assert metadata["foundationpose_engine_builder"] == "tensorrt_python_api"
     assert metadata["includes_segmentation"] is False
     assert metadata["includes_cad_rendering"] is False
     assert metadata["robotics_safety_validated"] is False
@@ -66,3 +68,23 @@ def test_reference_profile_version_check_survives_python_optimization():
 
     assert "raise RuntimeError" in source
     assert not [node for node in ast.walk(tree) if isinstance(node, ast.Assert)]
+
+
+def test_builder_authors_the_network_with_tensorrt_python_apis():
+    source = Path(builder.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    assert "OnnxParser" not in source
+    assert ".parse(" not in source
+    calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert {
+        "add_convolution_nd",
+        "add_matrix_multiply",
+        "add_normalization_v2",
+        "add_reduce",
+        "add_softmax",
+    } <= calls

--- a/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
+++ b/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 import pytest
 
 family = importlib.import_module("tensorrt_model_connect.families.foundationpose.plugin")
-builder = importlib.import_module("tensorrt_model_connect.families.foundationpose.builder")
 
 
 def test_bundle_contract_is_pinned_and_explicit():
@@ -68,23 +67,3 @@ def test_reference_profile_version_check_survives_python_optimization():
 
     assert "raise RuntimeError" in source
     assert not [node for node in ast.walk(tree) if isinstance(node, ast.Assert)]
-
-
-def test_builder_authors_the_network_with_tensorrt_python_apis():
-    source = Path(builder.__file__).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    assert "OnnxParser" not in source
-    assert ".parse(" not in source
-    calls = {
-        node.func.attr
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-    }
-    assert {
-        "add_convolution_nd",
-        "add_matrix_multiply",
-        "add_normalization_v2",
-        "add_reduce",
-        "add_softmax",
-    } <= calls

--- a/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
+++ b/python/tensorrt_model_connect/families/foundationpose/tests/test_foundationpose.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+family = importlib.import_module("tensorrt_model_connect.families.foundationpose.plugin")
+
+
+def test_bundle_contract_is_pinned_and_explicit():
+    metadata = family.plugin.get_bundle_config_overrides(SimpleNamespace(raw={}))
+    assert metadata["foundationpose_source_revision"] == family.SOURCE_REVISION
+    assert metadata["foundationpose_ngc_version"] == "1.0.1_onnx"
+    assert metadata["pose_refiner_max_batch"] == 42
+    assert metadata["pose_max_hypotheses"] == 252
+    assert metadata["pose_crop_layout"] == "NHWC"
+    assert metadata["includes_segmentation"] is False
+    assert metadata["includes_cad_rendering"] is False
+    assert metadata["robotics_safety_validated"] is False
+
+
+def test_config_requires_both_pinned_artifacts(monkeypatch, tmp_path: Path):
+    (tmp_path / family.REFINER_FILE).write_bytes(b"refiner")
+    assert family.config_from_dir(tmp_path) is None
+    (tmp_path / family.SCORER_FILE).write_bytes(b"scorer")
+    digests = {
+        family.REFINER_FILE: family.REFINER_SHA256,
+        family.SCORER_FILE: family.SCORER_SHA256,
+    }
+    monkeypatch.setattr(family, "_sha256", lambda path: digests[path.name])
+    config = family.config_from_dir(tmp_path)
+    assert config is not None
+    assert config["model_type"] == "foundationpose"
+    assert config["runtime_strategy"] == "foundationpose_pose_refinement"
+
+
+def test_digest_mismatch_fails_closed(monkeypatch, tmp_path: Path):
+    for name in (family.REFINER_FILE, family.SCORER_FILE):
+        (tmp_path / name).write_bytes(b"wrong")
+    monkeypatch.setattr(family, "_sha256", lambda path: "0" * 64)
+    with pytest.raises(ValueError, match="digest mismatch"):
+        family.config_from_dir(tmp_path)
+
+
+def test_only_fp32_and_unquantized_builds_are_admitted(tmp_path: Path):
+    config = SimpleNamespace(raw={})
+    with pytest.raises(ValueError, match="fp32"):
+        family.plugin.load_weights(str(tmp_path), config, precision="fp16")
+    with pytest.raises(ValueError, match="quantized"):
+        family.plugin.build_engine(
+            config,
+            {"refiner": "unused"},
+            1,
+            quant_ctx=object(),
+        )
+
+
+def test_reference_profile_version_check_survives_python_optimization():
+    path = Path(family.__file__).with_name("python_profile_verify.py")
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    assert "raise RuntimeError" in source
+    assert not [node for node in ast.walk(tree) if isinstance(node, ast.Assert)]

--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -103,6 +103,7 @@ _TASK_STRATEGY_TO_MODALITY = {
     "embedding": "numeric",
     "reranking": "reranking",
     "robot_action_chunk": "numeric",
+    "pose_hypothesis_refinement": "numeric",
     "neural_operator": "neural_operator",
     "omni_multimodal": "omni",
     # Kept explicit for forward-compatible manifests.  Unknown strategies
@@ -3822,6 +3823,31 @@ def validate_evidence(
                     and reference_path.stat().st_size > 0,
                     "missing reference geometry artifact",
                 )
+        elif strategy == "pose_hypothesis_refinement":
+            art_dir = Path(result.get("_artifact_dir") or ".")
+            count = inputs.get("num_hypotheses")
+            count_valid = type(count) is int and 1 <= count <= 252
+            require(count_valid, "missing valid hypothesis count")
+            for filename, values_per_hypothesis in (
+                ("candidate_poses.f32", 16),
+                ("trt_refined_poses.f32", 16),
+                ("trt_scores.f32", 1),
+            ):
+                path = _path_within(art_dir / "native" / filename, art_dir)
+                require(
+                    path is not None
+                    and path.name == filename
+                    and count_valid
+                    and path.stat().st_size == count * values_per_hypothesis * 4,
+                    f"missing or malformed TRT/base {filename}",
+                )
+            reference_index = _first_stage_data(result, "ref").get("best_index")
+            require(
+                type(reference_index) is int
+                and count_valid
+                and 0 <= reference_index < count,
+                "missing or invalid reference best_index",
+            )
         elif strategy == "reranking":
             require(bool(_first_stage_value(result, "trt", ("scores",))),
                     "missing TRT/base reranking scores")

--- a/scripts/warm_hf_cache.py
+++ b/scripts/warm_hf_cache.py
@@ -264,11 +264,18 @@ parser.add_argument(
     help="Stop after the first failed item. Requires --strict or "
          "--emit-cache-repos so the early stop cannot report success.",
 )
+parser.add_argument(
+    "--allow-empty-cache-repos",
+    action="store_true",
+    help="Allow empty --emit-cache-repos evidence for a separately verified non-Hub artifact model.",
+)
 args = parser.parse_args()
 if args.attempt_timeout_seconds <= 0:
     parser.error("--attempt-timeout-seconds must be greater than zero")
 if args.fail_fast and not (args.strict or args.emit_cache_repos):
     parser.error("--fail-fast requires --strict or --emit-cache-repos")
+if args.allow_empty_cache_repos and not args.emit_cache_repos:
+    parser.error("--allow-empty-cache-repos requires --emit-cache-repos")
 
 models_dir = ROOT / "tests" / "e2e" / "models"
 manifests = sorted({
@@ -310,6 +317,10 @@ for m in manifests:
     if not d.get("hf_id"):
         continue
     if filter_names is not None and name not in filter_names:
+        continue
+    # Digest-pinned non-Hub model artifacts are provisioned by the model proof
+    # host into this private absolute path. They must never be sent to the Hub.
+    if str(d["hf_id"]).startswith("/work/model-artifacts/"):
         continue
     entries.append(
         (
@@ -710,6 +721,7 @@ def _cache_repository_manifest(
     repo_ids: list[str],
     *,
     hub_cache: pathlib.Path,
+    allow_empty: bool = False,
 ) -> dict[str, object]:
     """Return a fail-closed manifest for selected repositories in one HF cache."""
     try:
@@ -759,7 +771,7 @@ def _cache_repository_manifest(
             }
         )
 
-    if not repositories:
+    if not repositories and not allow_empty:
         raise RuntimeError("no selected Hugging Face repositories were resolved")
     return {
         "schema_version": 1,
@@ -771,10 +783,13 @@ def _cache_repository_manifest(
 def _write_cache_repository_manifest(
     output: pathlib.Path,
     repo_ids: list[str],
+    *,
+    allow_empty: bool = False,
 ) -> None:
     payload = _cache_repository_manifest(
         repo_ids,
         hub_cache=pathlib.Path(hf_constants.HF_HUB_CACHE),
+        allow_empty=allow_empty,
     )
     output.parent.mkdir(parents=True, exist_ok=True)
     temporary = output.with_name(f".{output.name}.tmp-{os.getpid()}")
@@ -897,6 +912,7 @@ if args.emit_cache_repos and not warned:
         _write_cache_repository_manifest(
             pathlib.Path(args.emit_cache_repos),
             selected_repo_ids,
+            allow_empty=args.allow_empty_cache_repos,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: could not emit selected cache repositories: {exc}", file=sys.stderr)

--- a/src/runtime/models/foundationpose/MODEL.toml
+++ b/src/runtime/models/foundationpose/MODEL.toml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "foundationpose"
+runtime_library = "libtrtmc_model_foundationpose.so"
+runtime_plugins = ["plugin.cpp|register_foundationpose_plugin"]
+runtime_strategies = ["foundationpose_pose_refinement"]
+runtime_tests = [
+  "test_foundationpose_pipeline|test_foundationpose_pipeline.cpp|trtmc_model_foundationpose|_|_",
+]
+task_strategy = "pose_hypothesis_refinement"

--- a/src/runtime/models/foundationpose/pipeline.cpp
+++ b/src/runtime/models/foundationpose/pipeline.cpp
@@ -1,0 +1,283 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/foundationpose/pipeline.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+namespace {
+
+constexpr float kRotationNormalizer = 0.3490658503988659F;
+constexpr float kRigidTolerance = 2.0e-3F;
+
+void validate_module(const ITrtModule* module, const char* label,
+                     const char* second_output = nullptr) {
+    if (module == nullptr || !module->ok())
+        throw std::runtime_error(std::string("FoundationPose: invalid ") + label + " module");
+    if (!module->has_input("input1") || !module->has_input("input2") ||
+        !module->has_output("output1") ||
+        (second_output != nullptr && !module->has_output(second_output)))
+        throw std::runtime_error(std::string("FoundationPose: ") + label +
+                                 " engine tensor contract mismatch");
+}
+
+bool finite_values(const std::vector<float>& values) {
+    return std::all_of(values.begin(), values.end(),
+                       [](float value) { return std::isfinite(value); });
+}
+
+void require_argument(bool condition, const char* message) {
+    if (!condition)
+        throw std::invalid_argument(message);
+}
+
+void require_runtime(bool condition, const char* message) {
+    if (!condition)
+        throw std::runtime_error(message);
+}
+
+float determinant(const float* pose) {
+    return pose[0] * (pose[5] * pose[10] - pose[6] * pose[9]) -
+           pose[1] * (pose[4] * pose[10] - pose[6] * pose[8]) +
+           pose[2] * (pose[4] * pose[9] - pose[5] * pose[8]);
+}
+
+bool valid_homogeneous_row(const float* pose) {
+    return std::abs(pose[12]) <= kRigidTolerance && std::abs(pose[13]) <= kRigidTolerance &&
+           std::abs(pose[14]) <= kRigidTolerance && std::abs(pose[15] - 1.0F) <= kRigidTolerance;
+}
+
+bool orthonormal_rotation(const float* pose) {
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            float dot = 0.0F;
+            for (int axis = 0; axis < 3; ++axis)
+                dot += pose[row * 4 + axis] * pose[col * 4 + axis];
+            const float expected = row == col ? 1.0F : 0.0F;
+            if (std::abs(dot - expected) > kRigidTolerance)
+                return false;
+        }
+    }
+    return true;
+}
+
+bool rigid_pose(const float* pose) {
+    return std::all_of(pose, pose + 16, [](float value) { return std::isfinite(value); }) &&
+           valid_homogeneous_row(pose) && orthonormal_rotation(pose) &&
+           std::abs(determinant(pose) - 1.0F) <= 3.0F * kRigidTolerance;
+}
+
+void apply_delta(float* pose, const float* translation, const float* rotation,
+                 float mesh_diameter) {
+    const float x = std::tanh(rotation[0]) * kRotationNormalizer;
+    const float y = std::tanh(rotation[1]) * kRotationNormalizer;
+    const float z = std::tanh(rotation[2]) * kRotationNormalizer;
+    const float theta = std::sqrt(x * x + y * y + z * z);
+    float a = 1.0F;
+    float b = 0.5F;
+    if (theta > 1.0e-7F) {
+        a = std::sin(theta) / theta;
+        b = (1.0F - std::cos(theta)) / (theta * theta);
+    }
+    // Transpose of the conventional Rodrigues exponential, matching the
+    // pinned FoundationPose decoder's so3_exp_map(...).permute(0, 2, 1).
+    const float r[9] = {
+        1.0F - b * (y * y + z * z), b * x * y + a * z,          b * x * z - a * y,
+        b * x * y - a * z,          1.0F - b * (x * x + z * z), b * y * z + a * x,
+        b * x * z + a * y,          b * y * z - a * x,          1.0F - b * (x * x + y * y),
+    };
+    float old[9];
+    for (int row = 0; row < 3; ++row)
+        for (int col = 0; col < 3; ++col)
+            old[row * 3 + col] = pose[row * 4 + col];
+    for (int row = 0; row < 3; ++row)
+        for (int col = 0; col < 3; ++col) {
+            float value = 0.0F;
+            for (int axis = 0; axis < 3; ++axis)
+                value += r[row * 3 + axis] * old[axis * 3 + col];
+            pose[row * 4 + col] = value;
+        }
+    const float scale = mesh_diameter * 0.5F;
+    pose[3] += translation[0] * scale;
+    pose[7] += translation[1] * scale;
+    pose[11] += translation[2] * scale;
+}
+
+const Tensor& require_output(const TensorMap& outputs, const char* name, std::size_t values) {
+    const auto it = outputs.find(name);
+    if (it == outputs.end() || it->second.data == nullptr || it->second.dtype != DType::kFloat32 ||
+        it->second.numel() != values)
+        throw std::runtime_error(std::string("FoundationPose engine returned invalid ") + name);
+    return it->second;
+}
+
+} // namespace
+
+FoundationPosePipeline::FoundationPosePipeline(std::unique_ptr<ITrtModule> refiner,
+                                               std::unique_ptr<ITrtModule> scorer,
+                                               int32_t crop_height, int32_t crop_width,
+                                               int32_t channels, int32_t max_refiner_batch,
+                                               int32_t max_hypotheses, std::string model_id)
+    : refiner_(std::move(refiner)), scorer_(std::move(scorer)), crop_height_(crop_height),
+      crop_width_(crop_width), channels_(channels), max_refiner_batch_(max_refiner_batch),
+      max_hypotheses_(max_hypotheses), model_id_(std::move(model_id)) {
+    validate_module(refiner_.get(), "refiner", "output2");
+    validate_module(scorer_.get(), "scorer");
+    if (crop_height_ <= 0 || crop_width_ <= 0 || channels_ != 6 || max_refiner_batch_ <= 0 ||
+        max_hypotheses_ < max_refiner_batch_)
+        throw std::runtime_error("FoundationPose: invalid bundle contract dimensions");
+}
+
+PoseCropBatch FoundationPosePipeline::request_crops(const PoseEstimationRequest& request,
+                                                    const std::vector<float>& poses,
+                                                    PoseCropStage stage, int32_t iteration) const {
+    if (!request.crop_provider)
+        throw std::invalid_argument("FoundationPose crop provider is required");
+    auto crops = request.crop_provider(poses, stage, iteration);
+    const auto count =
+        static_cast<std::size_t>(request.num_hypotheses) * crop_height_ * crop_width_ * channels_;
+    if (crops.num_hypotheses != request.num_hypotheses || crops.height != crop_height_ ||
+        crops.width != crop_width_ || crops.channels != channels_ ||
+        crops.rendered_features.size() != count || crops.observed_features.size() != count)
+        throw std::invalid_argument("FoundationPose crop provider returned an invalid shape");
+    if (!finite_values(crops.rendered_features) || !finite_values(crops.observed_features))
+        throw std::invalid_argument("FoundationPose crop features must be finite");
+    return crops;
+}
+
+PoseEstimationResult
+FoundationPosePipeline::estimate_pose_hypotheses(const PoseEstimationRequest& request) {
+    auto poses = initial_poses(request);
+    validate_request(request, poses);
+    PoseEstimationResult result;
+    result.num_hypotheses = request.num_hypotheses;
+    result.refinement_ms = refine_poses(request, poses);
+    if (request.score_hypotheses)
+        score_poses(request, poses, result);
+    else
+        result.best_index = 0;
+    result.refined_poses = std::move(poses);
+    validate_result(result);
+    result.all_poses_rigid = true;
+    if (request.update_tracking_state) {
+        const auto begin = result.refined_poses.begin() + result.best_index * 16;
+        tracked_pose_.assign(begin, begin + 16);
+    }
+    return result;
+}
+
+std::vector<float>
+FoundationPosePipeline::initial_poses(const PoseEstimationRequest& request) const {
+    if (request.use_tracked_pose) {
+        require_argument(request.num_hypotheses == 1,
+                         "FoundationPose tracked refinement requires one hypothesis");
+        require_argument(request.candidate_poses.empty(),
+                         "FoundationPose tracked refinement does not accept candidates");
+        require_argument(!tracked_pose_.empty(), "FoundationPose tracking state is empty");
+        return tracked_pose_;
+    }
+    return request.candidate_poses;
+}
+
+void FoundationPosePipeline::validate_request(const PoseEstimationRequest& request,
+                                              const std::vector<float>& poses) const {
+    require_argument(request.num_hypotheses > 0,
+                     "FoundationPose hypothesis count must be positive");
+    require_argument(request.num_hypotheses <= max_hypotheses_,
+                     "FoundationPose hypothesis count exceeds the bundle limit");
+    require_argument(poses.size() == static_cast<std::size_t>(request.num_hypotheses) * 16,
+                     "FoundationPose candidate pose shape is invalid");
+    require_argument(std::isfinite(request.mesh_diameter),
+                     "FoundationPose mesh diameter must be finite");
+    require_argument(request.mesh_diameter > 0.0F, "FoundationPose mesh diameter must be positive");
+    require_argument(request.refinement_iterations > 0,
+                     "FoundationPose refinement iterations must be positive");
+    require_argument(request.refinement_iterations <= 10,
+                     "FoundationPose refinement iterations exceed the bundle limit");
+    for (int32_t index = 0; index < request.num_hypotheses; ++index)
+        require_argument(rigid_pose(poses.data() + static_cast<std::size_t>(index) * 16),
+                         "FoundationPose candidates must be rigid transforms");
+    require_argument(request.score_hypotheses || request.num_hypotheses == 1,
+                     "FoundationPose multi-hypothesis requests require scoring");
+}
+
+double FoundationPosePipeline::refine_poses(const PoseEstimationRequest& request,
+                                            std::vector<float>& poses) {
+    double elapsed_ms = 0.0;
+    for (int32_t iteration = 0; iteration < request.refinement_iterations; ++iteration) {
+        auto crops = request_crops(request, poses, PoseCropStage::kRefinement, iteration);
+        const auto begin = std::chrono::steady_clock::now();
+        const auto values_per_crop =
+            static_cast<std::size_t>(crop_height_) * crop_width_ * channels_;
+        for (int32_t offset = 0; offset < request.num_hypotheses; offset += max_refiner_batch_) {
+            const int32_t batch = std::min(max_refiner_batch_, request.num_hypotheses - offset);
+            const auto value_offset = static_cast<std::size_t>(offset) * values_per_crop;
+            Tensor rendered{crops.rendered_features.data() + value_offset,
+                            {batch, crop_height_, crop_width_, channels_},
+                            DType::kFloat32};
+            Tensor observed{crops.observed_features.data() + value_offset,
+                            {batch, crop_height_, crop_width_, channels_},
+                            DType::kFloat32};
+            const auto outputs = refiner_->forward({{"input1", rendered}, {"input2", observed}});
+            const auto& translation = require_output(outputs, "output1", batch * 3U);
+            const auto& rotation = require_output(outputs, "output2", batch * 3U);
+            const auto* translations = static_cast<const float*>(translation.data);
+            const auto* rotations = static_cast<const float*>(rotation.data);
+            for (int32_t local = 0; local < batch; ++local)
+                apply_delta(poses.data() + static_cast<std::size_t>(offset + local) * 16,
+                            translations + local * 3, rotations + local * 3, request.mesh_diameter);
+        }
+        elapsed_ms +=
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - begin)
+                .count();
+    }
+    return elapsed_ms;
+}
+
+void FoundationPosePipeline::score_poses(const PoseEstimationRequest& request,
+                                         const std::vector<float>& poses,
+                                         PoseEstimationResult& result) {
+    auto crops =
+        request_crops(request, poses, PoseCropStage::kScoring, request.refinement_iterations);
+    Tensor rendered{crops.rendered_features.data(),
+                    {request.num_hypotheses, crop_height_, crop_width_, channels_},
+                    DType::kFloat32};
+    Tensor observed{crops.observed_features.data(),
+                    {request.num_hypotheses, crop_height_, crop_width_, channels_},
+                    DType::kFloat32};
+    const auto begin = std::chrono::steady_clock::now();
+    const auto outputs = scorer_->forward({{"input1", rendered}, {"input2", observed}});
+    result.scoring_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - begin).count();
+    const auto& scores = require_output(outputs, "output1", request.num_hypotheses);
+    const auto* score_values = static_cast<const float*>(scores.data);
+    result.scores.assign(score_values, score_values + request.num_hypotheses);
+    require_runtime(finite_values(result.scores),
+                    "FoundationPose scorer returned non-finite logits");
+    result.best_index = static_cast<int32_t>(std::distance(
+        result.scores.begin(), std::max_element(result.scores.begin(), result.scores.end())));
+}
+
+void FoundationPosePipeline::validate_result(const PoseEstimationResult& result) const {
+    for (int32_t index = 0; index < result.num_hypotheses; ++index)
+        require_runtime(
+            rigid_pose(result.refined_poses.data() + static_cast<std::size_t>(index) * 16),
+            "FoundationPose decoder produced a non-rigid transform");
+}
+
+void FoundationPosePipeline::reset() {
+    tracked_pose_.clear();
+    refiner_->reset_execution_context();
+    scorer_->reset_execution_context();
+}
+
+} // namespace trtmc

--- a/src/runtime/models/foundationpose/pipeline.h
+++ b/src/runtime/models/foundationpose/pipeline.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class FoundationPosePipeline final : public IPipeline {
+  public:
+    FoundationPosePipeline(std::unique_ptr<ITrtModule> refiner, std::unique_ptr<ITrtModule> scorer,
+                           int32_t crop_height = 160, int32_t crop_width = 160,
+                           int32_t channels = 6, int32_t max_refiner_batch = 42,
+                           int32_t max_hypotheses = 252, std::string model_id = "");
+
+    PoseEstimationResult estimate_pose_hypotheses(const PoseEstimationRequest& request) override;
+    void reset() override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "FoundationPosePipeline"; }
+
+  private:
+    PoseCropBatch request_crops(const PoseEstimationRequest& request,
+                                const std::vector<float>& poses, PoseCropStage stage,
+                                int32_t iteration) const;
+    std::vector<float> initial_poses(const PoseEstimationRequest& request) const;
+    void validate_request(const PoseEstimationRequest& request,
+                          const std::vector<float>& poses) const;
+    double refine_poses(const PoseEstimationRequest& request, std::vector<float>& poses);
+    void score_poses(const PoseEstimationRequest& request, const std::vector<float>& poses,
+                     PoseEstimationResult& result);
+    void validate_result(const PoseEstimationResult& result) const;
+
+    std::unique_ptr<ITrtModule> refiner_;
+    std::unique_ptr<ITrtModule> scorer_;
+    int32_t crop_height_{0};
+    int32_t crop_width_{0};
+    int32_t channels_{0};
+    int32_t max_refiner_batch_{0};
+    int32_t max_hypotheses_{0};
+    std::string model_id_;
+    std::vector<float> tracked_pose_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/foundationpose/plugin.cpp
+++ b/src/runtime/models/foundationpose/plugin.cpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bundle/bundle_view.h"
+#include "runtime/models/foundationpose/pipeline.h"
+#include "trtmc/runtime/pipeline_registry.h"
+#include "trtmc/runtime/trt_backend.h"
+#include "utils/json_helpers.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc {
+namespace {
+
+std::unique_ptr<ITrtModule> load_module(const PipelineContext& context, const char* section,
+                                        const char* label, cudaStream_t stream) {
+    const auto* plan = find_section(context.bundle, section);
+    if (plan == nullptr || plan->empty())
+        throw std::runtime_error(std::string("FoundationPose bundle is missing ") + section);
+    if (context.backend == nullptr)
+        throw std::runtime_error("FoundationPose runtime has no TensorRT backend");
+    ModuleCreateOptions options;
+    options.runtime_cache_path = context.runtime_cache_path.c_str();
+    options.cuda_graphs = context.cuda_graphs;
+    options.stream = stream;
+    auto module = context.backend->create_module(plan->data(), plan->size(), options);
+    if (!module || !module->ok())
+        throw std::runtime_error(std::string("FoundationPose failed to load ") + section);
+    module->set_timing_label(label);
+    return module;
+}
+
+class FoundationPosePlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& context) override {
+        auto refiner = load_module(context, "engine_plan", "FoundationPose refiner", nullptr);
+        auto scorer = load_module(context, "foundationpose_score_engine_plan",
+                                  "FoundationPose scorer", refiner->stream());
+        if (scorer->stream() != refiner->stream())
+            throw std::runtime_error("FoundationPose engines must share one CUDA stream");
+        return std::make_unique<FoundationPosePipeline>(
+            std::move(refiner), std::move(scorer),
+            extract_json_int(context.config_json, "pose_crop_height", 160),
+            extract_json_int(context.config_json, "pose_crop_width", 160),
+            extract_json_int(context.config_json, "pose_crop_channels", 6),
+            extract_json_int(context.config_json, "pose_refiner_max_batch", 42),
+            extract_json_int(context.config_json, "pose_max_hypotheses", 252),
+            context.bundle.info.model_id);
+    }
+};
+
+} // namespace
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_foundationpose_plugin, FoundationPosePlugin,
+                                       "foundationpose_pose_refinement");
+
+} // namespace trtmc

--- a/tests/cpp/models/foundationpose/test_foundationpose_pipeline.cpp
+++ b/tests/cpp/models/foundationpose/test_foundationpose_pipeline.cpp
@@ -1,0 +1,439 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/foundationpose/pipeline.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+class FakeModule final : public trtmc::ITrtModule {
+  public:
+    explicit FakeModule(bool scorer) : scorer_(scorer) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++forward_calls;
+        const auto batch = static_cast<int32_t>(inputs.at("input1").shape.at(0));
+        batches.push_back(batch);
+        if (scorer_) {
+            values_.resize(batch);
+            for (int32_t index = 0; index < batch; ++index)
+                values_[index] = static_cast<float>(index) - 1.0F;
+            return {{"output1", {values_.data(), {1, batch}, trtmc::DType::kFloat32}}};
+        }
+        translation_.assign(static_cast<std::size_t>(batch) * 3, 0.0F);
+        rotation_.assign(static_cast<std::size_t>(batch) * 3, 0.0F);
+        for (int32_t index = 0; index < batch; ++index) {
+            translation_[static_cast<std::size_t>(index) * 3] = 0.1F;
+            rotation_[static_cast<std::size_t>(index) * 3 + 2] = 0.2F;
+        }
+        return {
+            {"output1", {translation_.data(), {batch, 3}, trtmc::DType::kFloat32}},
+            {"output2", {rotation_.data(), {batch, 3}, trtmc::DType::kFloat32}},
+        };
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "input1" || name == "input2";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "output1" || (!scorer_ && name == "output2");
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    void reset_execution_context() override { ++reset_calls; }
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+    bool scorer_{false};
+    int forward_calls{0};
+    int reset_calls{0};
+    std::vector<int32_t> batches;
+    std::vector<float> translation_;
+    std::vector<float> rotation_;
+    std::vector<float> values_;
+};
+
+std::vector<float> identity_poses(int32_t count) {
+    std::vector<float> poses(static_cast<std::size_t>(count) * 16, 0.0F);
+    for (int32_t index = 0; index < count; ++index) {
+        auto* pose = poses.data() + static_cast<std::size_t>(index) * 16;
+        pose[0] = pose[5] = pose[10] = pose[15] = 1.0F;
+    }
+    return poses;
+}
+
+trtmc::PoseCropProvider crops(int32_t expected_count, int* calls = nullptr) {
+    return [=](const std::vector<float>& poses, trtmc::PoseCropStage, int32_t) mutable {
+        if (calls != nullptr)
+            ++*calls;
+        const auto values = static_cast<std::size_t>(expected_count) * 2 * 2 * 6;
+        trtmc::PoseCropBatch result;
+        result.rendered_features.assign(values, poses.at(3));
+        result.observed_features.assign(values, 0.25F);
+        result.num_hypotheses = expected_count;
+        result.height = 2;
+        result.width = 2;
+        result.channels = 6;
+        return result;
+    };
+}
+
+void test_refinement_scoring_and_chunking() {
+    auto refiner = std::make_unique<FakeModule>(false);
+    auto scorer = std::make_unique<FakeModule>(true);
+    auto* refiner_ptr = refiner.get();
+    auto* scorer_ptr = scorer.get();
+    trtmc::FoundationPosePipeline pipeline(std::move(refiner), std::move(scorer), 2, 2, 6, 2, 5,
+                                           "foundationpose-test");
+    int crop_calls = 0;
+    trtmc::PoseEstimationRequest request;
+    request.candidate_poses = identity_poses(5);
+    request.num_hypotheses = 5;
+    request.mesh_diameter = 2.0F;
+    request.refinement_iterations = 2;
+    request.crop_provider = crops(5, &crop_calls);
+    const auto result = pipeline.estimate_pose_hypotheses(request);
+
+    check(result.num_hypotheses == 5 && result.refined_poses.size() == 80,
+          "FoundationPose result shape");
+    check(result.scores == std::vector<float>({-1.0F, 0.0F, 1.0F, 2.0F, 3.0F}),
+          "FoundationPose score logits");
+    check(result.best_index == 4, "FoundationPose best hypothesis selection");
+    check(result.all_poses_rigid, "FoundationPose decoded transforms remain rigid");
+    check(std::abs(result.refined_poses[3] - 0.2F) < 1.0e-6F,
+          "FoundationPose iterative metric translation decoding");
+    check(refiner_ptr->batches == std::vector<int32_t>({2, 2, 1, 2, 2, 1}),
+          "FoundationPose chunks refiner batches at the profile limit");
+    check(scorer_ptr->batches == std::vector<int32_t>({5}),
+          "FoundationPose scores all hypotheses jointly");
+    check(crop_calls == 3, "FoundationPose asks for rerendered crops each iteration and scoring");
+}
+
+void test_tracking_and_reset() {
+    auto refiner = std::make_unique<FakeModule>(false);
+    auto scorer = std::make_unique<FakeModule>(true);
+    auto* refiner_ptr = refiner.get();
+    auto* scorer_ptr = scorer.get();
+    trtmc::FoundationPosePipeline pipeline(std::move(refiner), std::move(scorer), 2, 2, 6, 2, 5);
+    trtmc::PoseEstimationRequest request;
+    request.candidate_poses = identity_poses(1);
+    request.num_hypotheses = 1;
+    request.mesh_diameter = 1.0F;
+    request.score_hypotheses = false;
+    request.crop_provider = crops(1);
+    const auto first = pipeline.estimate_pose_hypotheses(request);
+    request.candidate_poses.clear();
+    request.use_tracked_pose = true;
+    const auto tracked = pipeline.estimate_pose_hypotheses(request);
+    check(tracked.refined_poses[3] > first.refined_poses[3],
+          "FoundationPose tracking refines the selected prior pose");
+    pipeline.reset();
+    bool rejected = false;
+    try {
+        (void)pipeline.estimate_pose_hypotheses(request);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    check(rejected, "FoundationPose reset clears tracking state");
+    check(refiner_ptr->reset_calls == 1 && scorer_ptr->reset_calls == 1,
+          "FoundationPose reset reuses both engine contexts");
+}
+
+void test_invalid_contracts() {
+    trtmc::FoundationPosePipeline pipeline(std::make_unique<FakeModule>(false),
+                                           std::make_unique<FakeModule>(true), 2, 2, 6, 2, 5);
+    auto valid = trtmc::PoseEstimationRequest{};
+    valid.candidate_poses = identity_poses(1);
+    valid.num_hypotheses = 1;
+    valid.mesh_diameter = 1.0F;
+    valid.score_hypotheses = false;
+    valid.crop_provider = crops(1);
+    auto rejects = [&](const trtmc::PoseEstimationRequest& request) {
+        try {
+            (void)pipeline.estimate_pose_hypotheses(request);
+            return false;
+        } catch (const std::invalid_argument&) {
+            return true;
+        }
+    };
+    auto value = valid;
+    value.candidate_poses[15] = 0.0F;
+    check(rejects(value), "FoundationPose rejects non-rigid candidates");
+    value = valid;
+    value.mesh_diameter = std::numeric_limits<float>::quiet_NaN();
+    check(rejects(value), "FoundationPose rejects invalid mesh scale");
+    value = valid;
+    value.num_hypotheses = 6;
+    value.candidate_poses = identity_poses(6);
+    value.crop_provider = crops(6);
+    check(rejects(value), "FoundationPose rejects batches above the bundle limit");
+    value = valid;
+    value.crop_provider = [](const std::vector<float>&, trtmc::PoseCropStage, int32_t) {
+        return trtmc::PoseCropBatch{{0.0F}, {0.0F}, 1, 2, 2, 6};
+    };
+    check(rejects(value), "FoundationPose rejects malformed crop tensors");
+    value = valid;
+    value.crop_provider = [](const std::vector<float>&, trtmc::PoseCropStage, int32_t) {
+        trtmc::PoseCropBatch result;
+        result.rendered_features.assign(24, 0.0F);
+        result.observed_features.assign(24, 0.0F);
+        result.observed_features[3] = std::numeric_limits<float>::infinity();
+        result.num_hypotheses = 1;
+        result.height = result.width = 2;
+        result.channels = 6;
+        return result;
+    };
+    check(rejects(value), "FoundationPose rejects non-finite crop features");
+}
+
+double percentile(std::vector<double> values, double fraction) {
+    std::sort(values.begin(), values.end());
+    const double position = fraction * static_cast<double>(values.size() - 1);
+    const auto lower = static_cast<std::size_t>(std::floor(position));
+    const auto upper = static_cast<std::size_t>(std::ceil(position));
+    const double weight = position - static_cast<double>(lower);
+    return values[lower] * (1.0 - weight) + values[upper] * weight;
+}
+
+void write_floats(const std::filesystem::path& path, const std::vector<float>& values) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char*>(values.data()),
+                 static_cast<std::streamsize>(values.size() * sizeof(float)));
+    if (!output)
+        throw std::runtime_error("failed to write " + path.string());
+}
+
+trtmc::PoseCropBatch synthetic_crops(int32_t count, const std::vector<float>* poses = nullptr) {
+    constexpr int32_t height = 160;
+    constexpr int32_t width = 160;
+    constexpr int32_t channels = 6;
+    trtmc::PoseCropBatch result;
+    result.num_hypotheses = count;
+    result.height = height;
+    result.width = width;
+    result.channels = channels;
+    const auto values = static_cast<std::size_t>(count) * height * width * channels;
+    result.rendered_features.assign(values, 0.0F);
+    result.observed_features.assign(values, 0.0F);
+    for (int32_t hypothesis = 0; hypothesis < count; ++hypothesis) {
+        const float pose_x =
+            poses == nullptr ? 0.0F : poses->at(static_cast<std::size_t>(hypothesis) * 16 + 3);
+        for (int32_t y = 0; y < height; ++y) {
+            for (int32_t x = 0; x < width; ++x) {
+                const float xn = (static_cast<float>(x) - 79.5F) / 80.0F;
+                const float yn = (static_cast<float>(y) - 79.5F) / 80.0F;
+                if (xn * xn + yn * yn > 0.72F)
+                    continue;
+                const auto base =
+                    ((static_cast<std::size_t>(hypothesis) * height + y) * width + x) * channels;
+                result.rendered_features[base] = 0.08F * (hypothesis + 1) + 0.4F * (x / 159.0F);
+                result.rendered_features[base + 1] = 0.5F * (y / 159.0F);
+                result.rendered_features[base + 2] = 0.35F;
+                result.rendered_features[base + 3] = 0.2F * xn + pose_x;
+                result.rendered_features[base + 4] = 0.2F * yn;
+                result.rendered_features[base + 5] = 0.10F + 0.01F * hypothesis;
+                result.observed_features[base] = 0.25F + 0.4F * (x / 159.0F);
+                result.observed_features[base + 1] = 0.10F + 0.5F * (y / 159.0F);
+                result.observed_features[base + 2] = 0.40F;
+                result.observed_features[base + 3] = 0.2F * xn + 0.02F * hypothesis;
+                result.observed_features[base + 4] = 0.2F * yn;
+                result.observed_features[base + 5] = 0.11F;
+            }
+        }
+    }
+    return result;
+}
+
+int run_qualification(int argc, char** argv) {
+    std::string bundle;
+    std::string output_dir;
+    std::string backend_dir;
+    std::string plugin_dir;
+    int benchmark_runs = 20;
+    int warmup_runs = 3;
+    int32_t num_hypotheses = 3;
+    int32_t refinement_iterations = 2;
+    float mesh_diameter = 0.18F;
+    for (int index = 2; index < argc; ++index) {
+        const std::string option = argv[index];
+        if (++index >= argc)
+            throw std::invalid_argument(option + " requires a value");
+        const std::string value = argv[index];
+        if (option == "--bundle")
+            bundle = value;
+        else if (option == "--output-dir")
+            output_dir = value;
+        else if (option == "--backend-dir")
+            backend_dir = value;
+        else if (option == "--model-plugin-dir")
+            plugin_dir = value;
+        else if (option == "--benchmark")
+            benchmark_runs = std::stoi(value);
+        else if (option == "--warmup")
+            warmup_runs = std::stoi(value);
+        else if (option == "--num-hypotheses")
+            num_hypotheses = std::stoi(value);
+        else if (option == "--refinement-iterations")
+            refinement_iterations = std::stoi(value);
+        else if (option == "--mesh-diameter")
+            mesh_diameter = std::stof(value);
+        else
+            throw std::invalid_argument("unknown qualification option: " + option);
+    }
+    if (bundle.empty() || output_dir.empty() || benchmark_runs < 1 || warmup_runs < 0 ||
+        num_hypotheses < 1 || num_hypotheses > 252 || refinement_iterations < 1 ||
+        refinement_iterations > 10 || !std::isfinite(mesh_diameter) || mesh_diameter <= 0.0F)
+        throw std::invalid_argument(
+            "qualification requires bundle, output-dir, and valid inference parameters");
+    std::filesystem::create_directories(output_dir);
+
+    std::size_t free_before = 0;
+    std::size_t total_memory = 0;
+    if (cudaMemGetInfo(&free_before, &total_memory) != cudaSuccess)
+        throw std::runtime_error("cudaMemGetInfo failed before pipeline load");
+    trtmc::LoadOptions options;
+    if (!backend_dir.empty())
+        options.backend_search_paths.push_back(backend_dir);
+    if (!plugin_dir.empty())
+        options.model_plugin_search_paths.push_back(plugin_dir);
+    const auto load_begin = std::chrono::steady_clock::now();
+    auto pipeline = trtmc::load(bundle, options);
+    const double startup_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - load_begin)
+            .count();
+    std::size_t free_after = 0;
+    if (cudaMemGetInfo(&free_after, &total_memory) != cudaSuccess)
+        throw std::runtime_error("cudaMemGetInfo failed after pipeline load");
+
+    trtmc::PoseEstimationRequest registration;
+    registration.candidate_poses = identity_poses(num_hypotheses);
+    for (int32_t hypothesis = 0; hypothesis < num_hypotheses; ++hypothesis) {
+        registration.candidate_poses[static_cast<std::size_t>(hypothesis) * 16 + 3] =
+            (static_cast<float>(hypothesis) - 0.5F * (num_hypotheses - 1)) * 0.02F;
+    }
+    registration.num_hypotheses = num_hypotheses;
+    registration.mesh_diameter = mesh_diameter;
+    registration.refinement_iterations = refinement_iterations;
+    registration.crop_provider = [&](const std::vector<float>& poses, trtmc::PoseCropStage stage,
+                                     int32_t iteration) {
+        auto batch = synthetic_crops(num_hypotheses, &poses);
+        const std::string suffix =
+            (stage == trtmc::PoseCropStage::kRefinement ? "refinement-" : "scoring-") +
+            std::to_string(iteration) + ".f32";
+        write_floats(std::filesystem::path(output_dir) / ("rendered_features." + suffix),
+                     batch.rendered_features);
+        write_floats(std::filesystem::path(output_dir) / ("observed_features." + suffix),
+                     batch.observed_features);
+        return batch;
+    };
+    const auto result = pipeline->estimate_pose_hypotheses(registration);
+    if (!result.all_poses_rigid || result.best_index < 0)
+        throw std::runtime_error("FoundationPose qualification produced invalid poses");
+
+    write_floats(std::filesystem::path(output_dir) / "candidate_poses.f32",
+                 registration.candidate_poses);
+    write_floats(std::filesystem::path(output_dir) / "trt_refined_poses.f32", result.refined_poses);
+    write_floats(std::filesystem::path(output_dir) / "trt_scores.f32", result.scores);
+
+    trtmc::PoseCropBatch tracking_crops = synthetic_crops(1);
+    trtmc::PoseEstimationRequest tracking;
+    tracking.candidate_poses = identity_poses(1);
+    tracking.num_hypotheses = 1;
+    tracking.mesh_diameter = registration.mesh_diameter;
+    tracking.refinement_iterations = 1;
+    tracking.score_hypotheses = false;
+    tracking.update_tracking_state = false;
+    tracking.crop_provider = [&](const std::vector<float>&, trtmc::PoseCropStage, int32_t) {
+        return tracking_crops;
+    };
+    for (int index = 0; index < warmup_runs; ++index)
+        (void)pipeline->estimate_pose_hypotheses(tracking);
+    std::vector<double> timings;
+    for (int index = 0; index < benchmark_runs; ++index) {
+        const auto begin = std::chrono::steady_clock::now();
+        (void)pipeline->estimate_pose_hypotheses(tracking);
+        timings.push_back(
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - begin)
+                .count());
+    }
+    const double p50 = percentile(timings, 0.50);
+    const double p95 = percentile(timings, 0.95);
+    const double minimum = *std::min_element(timings.begin(), timings.end());
+    const double maximum = *std::max_element(timings.begin(), timings.end());
+    const double jitter = maximum - minimum;
+    const double gpu_delta_mib =
+        free_before > free_after ? static_cast<double>(free_before - free_after) / (1 << 20) : 0.0;
+    std::cout << std::setprecision(9) << "{\"num_hypotheses\":" << result.num_hypotheses
+              << ",\"best_index\":" << result.best_index << ",\"all_poses_rigid\":true"
+              << ",\"tracking_latency_p50_ms\":" << p50 << ",\"tracking_latency_p95_ms\":" << p95
+              << ",\"tracking_jitter_ms\":" << jitter
+              << ",\"tracking_throughput_hz\":" << (p50 > 0.0 ? 1000.0 / p50 : 0.0)
+              << ",\"startup_ms\":" << startup_ms << ",\"gpu_memory_delta_mib\":" << gpu_delta_mib
+              << ",\"gpu_memory_total_mib\":" << static_cast<double>(total_memory) / (1 << 20)
+              << ",\"refinement_ms\":" << result.refinement_ms
+              << ",\"scoring_ms\":" << result.scoring_ms << "}\n";
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc > 1 && std::string(argv[1]) == "--qualify") {
+        try {
+            return run_qualification(argc, argv);
+        } catch (const std::exception& error) {
+            std::cerr << "FoundationPose qualification failed: " << error.what() << '\n';
+            return 2;
+        }
+    }
+    test_refinement_scoring_and_chunking();
+    test_tracking_and_reset();
+    test_invalid_contracts();
+    if (failures != 0) {
+        std::cerr << failures << " FoundationPose pipeline test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/e2e/models/foundationpose/MODEL.toml
+++ b/tests/e2e/models/foundationpose/MODEL.toml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "foundationpose"
+plugin = "foundationpose"
+test_manifests = ["manifests/foundationpose-ngc-1.0.1.json"]
+
+[model_reference_cache]
+repository = "https://github.com/NVlabs/FoundationPose.git"
+revision = "a1b694b83e633c2cb6115b9063d940a687759392"
+relative_path = "foundationpose/reference/FoundationPose-a1b694b83e63"
+entrypoint = "estimater.py"
+environment_variable = "TRTMC_FOUNDATIONPOSE_SOURCE_DIR"
+
+[model_artifact_cache]
+relative_path = "foundationpose/ngc-1.0.1"
+environment_variable = "TRTMC_FOUNDATIONPOSE_MODEL_DIR"
+files = [
+  { path = "refine_model.onnx", url = "https://api.ngc.nvidia.com/v2/models/nvidia/isaac/foundationpose/versions/1.0.1_onnx/files/refine_model.onnx", sha256 = "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7", size = 68161611 },
+  { path = "score_model.onnx", url = "https://api.ngc.nvidia.com/v2/models/nvidia/isaac/foundationpose/versions/1.0.1_onnx/files/score_model.onnx", sha256 = "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503", size = 63907741 },
+]
+
+[e2e_defaults.pose_hypothesis_refinement]
+reference_backend = "foundationpose_onnxruntime"
+oracle_level = "L1_external_reference"
+stages = [{ name = "synthetic_crop_pose_refinement", required = true }]
+input_fields = [
+  { input = "num_hypotheses", manifest = "num_hypotheses" },
+  { input = "refinement_iterations", manifest = "refinement_iterations" },
+  { input = "mesh_diameter", manifest = "mesh_diameter" },
+]
+preflight_requirements = [
+  { kind = "python_module_available", args = { module = "onnxruntime", phase = "reference" }, gating = true },
+]

--- a/tests/e2e/models/foundationpose/data/validation.json
+++ b/tests/e2e/models/foundationpose/data/validation.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "trtmc.model-plugin-validation/v1",
+  "dataset": "FoundationPose deterministic preprocessed RGB+XYZ pose qualification",
+  "version": "1",
+  "requests": [
+    {
+      "sample_id": "foundationpose-ngc-1.0.1-synthetic-crops",
+      "testcase": "foundationpose-ngc-1.0.1-synthetic-crops",
+      "stage": "synthetic_crop_pose_refinement",
+      "category": "deterministic-preprocessed-pose-refinement",
+      "inputs": {
+        "num_hypotheses": 3,
+        "refinement_iterations": 2,
+        "mesh_diameter": 0.18
+      }
+    }
+  ]
+}

--- a/tests/e2e/models/foundationpose/e2e_plugins/__init__.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/e2e/models/foundationpose/e2e_plugins/comparator.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/comparator.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pose parity, ranking, rigidity, and tracking-rate qualification gates."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tests.e2e_harness.contracts import CompareResult, MetricResult, StageOutput, StageSpec, StageStatus, ThresholdProfile
+
+_OPERATORS = {
+    "pose_max_abs_error": "<=", "score_max_abs_error": "<=",
+    "ranking_agreement": ">=", "rigid_pose_fraction": ">=",
+    "tracking_throughput_hz": ">=", "tracking_latency_p95_ms": "<=",
+    "tracking_jitter_ms": "<=", "startup_ms": "<=", "gpu_memory_delta_mib": "<=",
+}
+
+
+def _rigid_fraction(poses: np.ndarray) -> float:
+    valid = []
+    for pose in poses:
+        rotation = pose[:3, :3].astype(np.float64)
+        valid.append(
+            np.isfinite(pose).all()
+            and np.max(np.abs(rotation @ rotation.T - np.eye(3))) <= 2.0e-3
+            and abs(np.linalg.det(rotation) - 1.0) <= 6.0e-3
+            and np.max(np.abs(pose[3] - np.array([0, 0, 0, 1], dtype=np.float32))) <= 2.0e-3
+        )
+    return float(np.mean(valid))
+
+
+def _ranking_agreement(scores: np.ndarray, reference_scores: np.ndarray) -> float:
+    candidate_order = np.argsort(-scores, kind="stable")
+    reference_order = np.argsort(-reference_scores, kind="stable")
+    return float(int(np.array_equal(candidate_order, reference_order)))
+
+
+class FoundationPoseComparator:
+    @property
+    def task_strategy(self) -> str:
+        return "pose_hypothesis_refinement"
+
+    def compare(self, trt: StageOutput, ref: StageOutput, threshold: ThresholdProfile,
+                stage: StageSpec) -> CompareResult:
+        try:
+            poses = np.asarray(trt.data["refined_poses"], dtype=np.float32)
+            reference_poses = np.asarray(ref.data["refined_poses"], dtype=np.float32)
+            scores = np.asarray(trt.data["scores"], dtype=np.float32)
+            reference_scores = np.asarray(ref.data["scores"], dtype=np.float32)
+            summary = trt.data["summary"]
+            count = summary["num_hypotheses"]
+            if type(count) is not int or not 1 <= count <= 252:
+                raise ValueError("qualified hypothesis count must be in [1, 252]")
+            if poses.shape != (count, 4, 4) or reference_poses.shape != poses.shape:
+                raise ValueError(f"qualified pose arrays must have shape ({count}, 4, 4)")
+            if scores.shape != (count,) or reference_scores.shape != scores.shape:
+                raise ValueError(f"qualified score arrays must have shape ({count},)")
+            if not all(name in threshold.metrics for name in _OPERATORS):
+                raise ValueError("FoundationPose threshold profile is incomplete")
+            numeric = {
+                "pose_max_abs_error": float(np.max(np.abs(poses - reference_poses))),
+                "score_max_abs_error": float(np.max(np.abs(scores - reference_scores))),
+                "ranking_agreement": _ranking_agreement(scores, reference_scores),
+                "rigid_pose_fraction": _rigid_fraction(poses),
+                **{name: float(summary[name]) for name in (
+                    "tracking_throughput_hz", "tracking_latency_p95_ms", "tracking_jitter_ms",
+                    "startup_ms", "gpu_memory_delta_mib")},
+            }
+        except (KeyError, TypeError, ValueError) as error:
+            return CompareResult(stage_name=stage.name, status=StageStatus.ERROR.value,
+                                 message=f"Invalid FoundationPose result contract: {error}")
+        metrics = {}
+        for name, operator in _OPERATORS.items():
+            value = numeric[name]
+            limit = float(threshold.metrics[name])
+            passed = np.isfinite(value) and (value <= limit if operator == "<=" else value >= limit)
+            metrics[name] = MetricResult(value=value, threshold=limit, operator=operator, passed=bool(passed))
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule="all pose parity, score, ranking, rigidity, and 10 Hz tracking gates must pass",
+            message="FoundationPose qualification passed" if passed else "FoundationPose qualification failed",
+        )
+
+
+comparator = FoundationPoseComparator()

--- a/tests/e2e/models/foundationpose/e2e_plugins/comparators/__init__.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/comparators/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FoundationPose comparator implementations."""

--- a/tests/e2e/models/foundationpose/e2e_plugins/reference.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/reference.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Official NGC ONNX Runtime reference for FoundationPose."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+import time
+
+import numpy as np
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+class FoundationPoseOnnxRuntimeReference:
+    @property
+    def backend_name(self) -> str:
+        return "foundationpose_onnxruntime"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name != "synthetic_crop_pose_refinement":
+            raise ValueError(f"Unsupported FoundationPose reference stage: {stage.name!r}")
+        root = Path(os.environ.get("TRTMC_FOUNDATIONPOSE_MODEL_DIR", ""))
+        refiner_path = root / "refine_model.onnx"
+        scorer_path = root / "score_model.onnx"
+        if not refiner_path.is_file() or not scorer_path.is_file():
+            raise FileNotFoundError(
+                "TRTMC_FOUNDATIONPOSE_MODEL_DIR must contain the pinned NGC pair"
+            )
+        fixture = Path(ctx.artifacts_dir or "/tmp") / case.name / "native"
+        output_path = fixture.parent / "onnxruntime_reference.npz"
+        output_path.unlink(missing_ok=True)
+        script = Path(__file__).resolve().parents[1] / "official_reference.py"
+        command = [
+            ctx.reference_python_path() or sys.executable,
+            str(script),
+            "--model-dir",
+            str(root),
+            "--fixture-dir",
+            str(fixture),
+            "--output",
+            str(output_path),
+            "--num-hypotheses",
+            str(case.inputs["num_hypotheses"]),
+            "--refinement-iterations",
+            str(case.inputs["refinement_iterations"]),
+            "--mesh-diameter",
+            str(case.inputs["mesh_diameter"]),
+        ]
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        started = time.monotonic()
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=300, env=env)
+        elapsed = time.monotonic() - started
+        data: dict = {
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+        if completed.returncode == 0 and output_path.is_file():
+            with np.load(output_path, allow_pickle=False) as payload:
+                data.update(
+                    refined_poses=np.array(payload["refined_poses"], copy=True),
+                    scores=np.array(payload["scores"], copy=True),
+                    best_index=int(payload["best_index"]),
+                    output_path=str(output_path),
+                )
+        elif completed.returncode == 0:
+            data["output_error"] = f"reference exited 0 but did not create {output_path}"
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            timing_s=elapsed,
+            metadata={
+                "backend": self.backend_name,
+                "command": command,
+                "returncode": completed.returncode,
+                "ngc_version": "1.0.1_onnx",
+            },
+        )
+
+
+reference = FoundationPoseOnnxRuntimeReference()

--- a/tests/e2e/models/foundationpose/e2e_plugins/references/__init__.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/references/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FoundationPose reference implementations."""

--- a/tests/e2e/models/foundationpose/e2e_plugins/report.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/report.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned report evidence for FoundationPose refinement and scoring."""
+
+from __future__ import annotations
+
+import html
+import math
+from pathlib import Path
+import struct
+from typing import Any
+
+_MAX_HYPOTHESES = 252
+
+_STYLE = """
+<style>
+.fp-report{border:1px solid #cbd5e1;border-radius:12px;padding:16px;background:#f8fafc}.fp-heading{display:flex;justify-content:space-between;gap:16px;align-items:start}.fp-heading h4{margin:2px 0 6px}.fp-heading p{margin:0;color:#475569;max-width:820px}.fp-status{padding:7px 12px;border-radius:999px;font-weight:700;color:#fff;background:#b91c1c}.fp-status.pass{background:#15803d}.fp-summary{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin:14px 0}.fp-card{padding:9px;border:1px solid #cbd5e1;border-radius:8px;background:#fff}.fp-card span{display:block;color:#64748b;font-size:.75em}.fp-card strong{font:700 .9em monospace}.fp-table{width:100%;border-collapse:collapse;background:#fff}.fp-table th,.fp-table td{padding:7px;border:1px solid #cbd5e1;text-align:right;font-family:monospace}.fp-table th:first-child,.fp-table td:first-child{text-align:center}.fp-table tr.best{background:#dcfce7}.fp-help{margin-top:12px;color:#475569;font-size:.82em}.fp-metric-fail{color:#991b1b}.fp-metric-pass{color:#166534}@media(max-width:760px){.fp-summary{grid-template-columns:repeat(2,minmax(0,1fr))}.fp-heading{display:block}.fp-status{display:inline-block;margin-top:8px}.fp-table{font-size:.78em}}
+</style>
+"""
+
+
+def _esc(value: Any) -> str:
+    return html.escape(str(value))
+
+
+def _artifact_file(root: Path, name: str) -> Path:
+    path = (root / name).resolve(strict=True)
+    try:
+        path.relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"{name} escapes the artifact directory") from error
+    if not path.is_file():
+        raise ValueError(f"{name} is not a regular file")
+    return path
+
+
+def _f32(path: Path, count: int) -> tuple[float, ...]:
+    payload = path.read_bytes()
+    expected = count * 4
+    if len(payload) != expected:
+        raise ValueError(f"{path.name} must contain exactly {count} float32 values")
+    values = struct.unpack(f"<{count}f", payload)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"{path.name} contains non-finite values")
+    return values
+
+
+def _metric(result: dict[str, Any], name: str) -> tuple[str, str]:
+    metric = (
+        ((result.get("stages") or {}).get("synthetic_crop_pose_refinement") or {})
+        .get("metrics", {})
+        .get(name, {})
+    )
+    if not isinstance(metric, dict) or not isinstance(metric.get("value"), (int, float)):
+        return "unavailable", ""
+    css = "fp-metric-pass" if metric.get("passed") is True else "fp-metric-fail"
+    return f"{float(metric['value']):.6g}", css
+
+
+def _card(label: str, value: str, css: str = "") -> str:
+    return (
+        '<div class="fp-card">'
+        f'<span>{_esc(label)}</span><strong class="{_esc(css)}">{_esc(value)}</strong></div>'
+    )
+
+
+def render(result: dict[str, Any], *, project_dir: Path) -> str:
+    """Render bounded pose/ranking evidence from the native output artifacts."""
+    del project_dir
+    try:
+        artifact_ref = result.get("_artifact_dir")
+        if not isinstance(artifact_ref, str) or not artifact_ref:
+            raise ValueError("artifact directory is missing")
+        artifact_dir = Path(artifact_ref).resolve(strict=True)
+        native_dir = (artifact_dir / "native").resolve(strict=True)
+        native_dir.relative_to(artifact_dir)
+        if not native_dir.is_dir():
+            raise ValueError("native artifact directory is not a directory")
+        inputs = (result.get("case_config") or {}).get("inputs") or {}
+        count = inputs.get("num_hypotheses")
+        if type(count) is not int or not 1 <= count <= _MAX_HYPOTHESES:
+            raise ValueError("num_hypotheses must be an integer in [1, 252]")
+        candidates = _f32(_artifact_file(native_dir, "candidate_poses.f32"), count * 16)
+        refined = _f32(_artifact_file(native_dir, "trt_refined_poses.f32"), count * 16)
+        scores = _f32(_artifact_file(native_dir, "trt_scores.f32"), count)
+        best = max(range(count), key=scores.__getitem__)
+        reference = (
+            ((result.get("stage_outputs") or {}).get("ref_synthetic_crop_pose_refinement") or {})
+            .get("data", {})
+            .get("best_index")
+        )
+        if type(reference) is not int or not 0 <= reference < count:
+            raise ValueError("reference best_index is missing or invalid")
+    except (FileNotFoundError, OSError, TypeError, ValueError) as error:
+        return f'<p class="missing">FoundationPose evidence unavailable: {_esc(error)}</p>'
+
+    rows = []
+    for index, score in enumerate(scores):
+        offset = index * 16
+        source_xyz = candidates[offset + 3], candidates[offset + 7], candidates[offset + 11]
+        refined_xyz = refined[offset + 3], refined[offset + 7], refined[offset + 11]
+        shift = math.sqrt(sum((right - left) ** 2 for left, right in zip(source_xyz, refined_xyz)))
+        row_class = ' class="best"' if index == best else ""
+        rows.append(
+            f"<tr{row_class}><td>{index}{' ★' if index == best else ''}</td>"
+            f"<td>{score:.6f}</td>"
+            f"<td>{source_xyz[0]:.5f}, {source_xyz[1]:.5f}, {source_xyz[2]:.5f}</td>"
+            f"<td>{refined_xyz[0]:.5f}, {refined_xyz[1]:.5f}, {refined_xyz[2]:.5f}</td>"
+            f"<td>{shift:.6f}</td></tr>"
+        )
+
+    pose_error, pose_css = _metric(result, "pose_max_abs_error")
+    score_error, score_css = _metric(result, "score_max_abs_error")
+    throughput, throughput_css = _metric(result, "tracking_throughput_hz")
+    latency, latency_css = _metric(result, "tracking_latency_p95_ms")
+    status = str(result.get("status") or "error")
+    status_class = " pass" if status == "pass" else ""
+    agreement = "yes" if best == reference else "no"
+    return (
+        _STYLE + '<section class="fp-report"><header class="fp-heading"><div>'
+        "<h4>FoundationPose refinement and ranking</h4><p>Deterministic preprocessed "
+        "RGB+XYZ crop pairs exercise iterative pose refinement and joint scoring. "
+        "Highlighted output is the TensorRT best hypothesis.</p></div>"
+        f'<span class="fp-status{status_class}">{_esc(status.upper())}</span></header>'
+        '<div class="fp-summary">'
+        + _card("Pose max |error|", pose_error, pose_css)
+        + _card("Score max |error|", score_error, score_css)
+        + _card("Tracking throughput (Hz)", throughput, throughput_css)
+        + _card("Tracking p95 (ms)", latency, latency_css)
+        + '</div><table class="fp-table"><thead><tr><th>Hypothesis</th><th>Score</th>'
+        "<th>Candidate translation (m)</th><th>Refined translation (m)</th>"
+        "<th>Translation update (m)</th></tr></thead><tbody>"
+        + "".join(rows)
+        + '</tbody></table><p class="fp-help">TensorRT best index: '
+        f"<strong>{best}</strong>; ONNX Runtime best index: <strong>{reference}</strong>; "
+        f"best-hypothesis agreement: <strong>{agreement}</strong>. Numerical gates also require "
+        "every emitted transform to remain rigid.</p></section>"
+    )

--- a/tests/e2e/models/foundationpose/e2e_plugins/runner.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/runner.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native FoundationPose qualification runner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+import numpy as np
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+
+class FoundationPoseRunner:
+    @property
+    def strategy_name(self) -> str:
+        return "pose_hypothesis_refinement"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name != "synthetic_crop_pose_refinement":
+            raise ValueError(f"Unsupported FoundationPose runtime stage: {stage.name!r}")
+        directory = Path(ctx.artifacts_dir or "/tmp") / case.name / "native"
+        directory.mkdir(parents=True, exist_ok=True)
+        executable = Path(ctx.binary_path).with_name("test_foundationpose_pipeline")
+        bundle = Path(case.bundle)
+        if not bundle.is_absolute():
+            bundle = Path(ctx.engine_dir) / bundle
+        command = [
+            str(executable), "--qualify", "--bundle", str(bundle),
+            "--output-dir", str(directory), "--backend-dir", str(Path(ctx.binary_path).parent),
+            "--benchmark", "20", "--warmup", "3",
+            "--num-hypotheses", str(case.inputs["num_hypotheses"]),
+            "--refinement-iterations", str(case.inputs["refinement_iterations"]),
+            "--mesh-diameter", str(case.inputs["mesh_diameter"]),
+        ]
+        if ctx.model_plugin_dir:
+            command.extend(("--model-plugin-dir", ctx.model_plugin_dir))
+        environment = dict(os.environ)
+        if ctx.ld_library_path:
+            environment["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        started = time.monotonic()
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=1800, env=environment)
+        elapsed = time.monotonic() - started
+        data: dict = {
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+        if completed.returncode == 0:
+            try:
+                data.update(
+                    summary=json.loads(completed.stdout),
+                    refined_poses=np.fromfile(
+                        directory / "trt_refined_poses.f32", dtype="<f4"
+                    ).reshape(int(case.inputs["num_hypotheses"]), 4, 4),
+                    scores=np.fromfile(directory / "trt_scores.f32", dtype="<f4"),
+                    fixture_dir=str(directory),
+                )
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                data["output_error"] = str(error)
+        return StageOutput(stage_name=stage.name, data=data, timing_s=elapsed,
+                           metadata={"command": command, "returncode": completed.returncode})
+
+
+runner = FoundationPoseRunner()

--- a/tests/e2e/models/foundationpose/e2e_plugins/runners/__init__.py
+++ b/tests/e2e/models/foundationpose/e2e_plugins/runners/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FoundationPose runner implementations."""

--- a/tests/e2e/models/foundationpose/manifests/foundationpose-ngc-1.0.1.json
+++ b/tests/e2e/models/foundationpose/manifests/foundationpose-ngc-1.0.1.json
@@ -1,0 +1,43 @@
+{
+  "name": "foundationpose-ngc-1.0.1",
+  "hf_id": "/work/model-artifacts/foundationpose/ngc-1.0.1",
+  "model_source": {
+    "kind": "ngc",
+    "id": "nvidia/isaac/foundationpose",
+    "revision": "1.0.1_onnx"
+  },
+  "bundle": "foundationpose-ngc-1.0.1.bundle",
+  "benchmark_exclusion_reason": "FoundationPose qualification benchmarks its stateful one-hypothesis pose-refinement contract rather than a generic catalog workload.",
+  "family": "foundationpose",
+  "runtime_strategy": "foundationpose_pose_refinement",
+  "task_strategy": "pose_hypothesis_refinement",
+  "precision": "fp32",
+  "trust_remote_code": false,
+  "execution_profiles": {
+    "build": "base",
+    "runtime": "base",
+    "reference": "foundationpose_reference"
+  },
+  "e2e_parallel_resource": "exclusive_gpu",
+  "e2e_min_free_gpu_memory_mib": 8192,
+  "build_timeout_s": 3600,
+  "testcases": [
+    {
+      "name": "foundationpose-ngc-1.0.1-synthetic-crops",
+      "trace_id": "IT-E2E-FOUNDATIONPOSE-01",
+      "test_type": "pose_hypothesis_refinement",
+      "reference_family": "pose_hypothesis_refinement",
+      "reference_precision": "fp32",
+      "user_contract": "ranked_rigid_object_to_camera_poses",
+      "ci_tier": "default",
+      "num_hypotheses": 3,
+      "refinement_iterations": 2,
+      "mesh_diameter": 0.18,
+      "source_revision": "a1b694b83e633c2cb6115b9063d940a687759392",
+      "ngc_version": "1.0.1_onnx",
+      "refiner_sha256": "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7",
+      "scorer_sha256": "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503",
+      "notes": "Runs two refinement iterations and joint scoring on deterministic preprocessed RGB+XYZ crop pairs, compares to the official NGC ONNX pair, validates rigid transforms and ranking, and measures single-hypothesis tracking capacity. Segmentation, CAD rendering, collision safety, and physical robot safety are outside this qualification."
+    }
+  ]
+}

--- a/tests/e2e/models/foundationpose/manifests/foundationpose-ngc-1.0.1.json
+++ b/tests/e2e/models/foundationpose/manifests/foundationpose-ngc-1.0.1.json
@@ -11,7 +11,11 @@
   "family": "foundationpose",
   "runtime_strategy": "foundationpose_pose_refinement",
   "task_strategy": "pose_hypothesis_refinement",
-  "precision": "fp32",
+  "precision": "fp16",
+  "task_eval": {
+    "reference_precision": "fp32",
+    "allow_reference_precision_mismatch": true
+  },
   "trust_remote_code": false,
   "execution_profiles": {
     "build": "base",
@@ -37,7 +41,7 @@
       "ngc_version": "1.0.1_onnx",
       "refiner_sha256": "dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7",
       "scorer_sha256": "0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503",
-      "notes": "Runs two refinement iterations and joint scoring on deterministic preprocessed RGB+XYZ crop pairs, compares to the official NGC ONNX pair, validates rigid transforms and ranking, and measures single-hypothesis tracking capacity. Segmentation, CAD rendering, collision safety, and physical robot safety are outside this qualification."
+      "notes": "Runs the default mixed-FP16 build for two refinement iterations and joint scoring on deterministic preprocessed RGB+XYZ crop pairs, compares to the official NGC ONNX pair in FP32, validates rigid transforms and ranking, and measures single-hypothesis tracking capacity. The scorer cross-hypothesis attention and score projection remain FP32 for numerical stability. Segmentation, CAD rendering, collision safety, and physical robot safety are outside this qualification."
     }
   ]
 }

--- a/tests/e2e/models/foundationpose/official_reference.py
+++ b/tests/e2e/models/foundationpose/official_reference.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the pinned FoundationPose ONNX models in the isolated reference profile."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+
+
+def _feeds(fixture_dir: Path, count: int, stage: str, iteration: int) -> dict[str, np.ndarray]:
+    suffix = f"{stage}-{iteration}.f32"
+    shape = (count, 160, 160, 6)
+    rendered = np.fromfile(
+        fixture_dir / f"rendered_features.{suffix}", dtype="<f4"
+    ).reshape(shape)
+    observed = np.fromfile(
+        fixture_dir / f"observed_features.{suffix}", dtype="<f4"
+    ).reshape(shape)
+    return {"input1": rendered, "input2": observed}
+
+
+def _apply_delta(
+    poses: np.ndarray,
+    translation: np.ndarray,
+    rotation: np.ndarray,
+    mesh_diameter: float,
+) -> np.ndarray:
+    result = poses.copy()
+    vectors = np.tanh(rotation.astype(np.float64)) * 0.3490658503988659
+    for index, vector in enumerate(vectors):
+        x, y, z = vector
+        theta = float(np.linalg.norm(vector))
+        if theta > 1.0e-7:
+            a = np.sin(theta) / theta
+            b = (1.0 - np.cos(theta)) / (theta * theta)
+        else:
+            a, b = 1.0, 0.5
+        matrix = np.array(
+            [
+                [1 - b * (y * y + z * z), b * x * y + a * z, b * x * z - a * y],
+                [b * x * y - a * z, 1 - b * (x * x + z * z), b * y * z + a * x],
+                [b * x * z + a * y, b * y * z - a * x, 1 - b * (x * x + y * y)],
+            ],
+            dtype=np.float64,
+        )
+        result[index, :3, :3] = (matrix @ result[index, :3, :3]).astype(np.float32)
+        result[index, :3, 3] += translation[index] * np.float32(mesh_diameter * 0.5)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--fixture-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--num-hypotheses", type=int, required=True)
+    parser.add_argument("--refinement-iterations", type=int, required=True)
+    parser.add_argument("--mesh-diameter", type=float, required=True)
+    args = parser.parse_args()
+
+    refiner_path = args.model_dir / "refine_model.onnx"
+    scorer_path = args.model_dir / "score_model.onnx"
+    if not refiner_path.is_file() or not scorer_path.is_file():
+        raise FileNotFoundError("model directory must contain the pinned NGC ONNX pair")
+
+    count = args.num_hypotheses
+    poses = np.fromfile(args.fixture_dir / "candidate_poses.f32", dtype="<f4").reshape(count, 4, 4)
+
+    options = ort.SessionOptions()
+    options.intra_op_num_threads = 1
+    refiner = ort.InferenceSession(str(refiner_path), options, providers=["CPUExecutionProvider"])
+    scorer = ort.InferenceSession(str(scorer_path), options, providers=["CPUExecutionProvider"])
+    for iteration in range(args.refinement_iterations):
+        feeds = _feeds(args.fixture_dir, count, "refinement", iteration)
+        translation, rotation = refiner.run(["output1", "output2"], feeds)
+        poses = _apply_delta(poses, translation, rotation, args.mesh_diameter)
+    feeds = _feeds(args.fixture_dir, count, "scoring", args.refinement_iterations)
+    scores = np.asarray(scorer.run(["output1"], feeds)[0], dtype=np.float32).reshape(-1)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        args.output,
+        refined_poses=poses,
+        scores=scores,
+        best_index=np.asarray(int(np.argmax(scores)), dtype=np.int64),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/models/foundationpose/runner.py
+++ b/tests/e2e/models/foundationpose/runner.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E entrypoint support for FoundationPose."""
+
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from tests.e2e_harness.model_runner import model_names_for_dir, run_model_e2e as run_manifest
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_PROJECT_DIR = _MODEL_DIR.parents[3]
+
+
+def _resolve_binary(config) -> str:
+    configured = config.getoption("--trtmc-binary", default=None)
+    candidate = Path(configured) if configured else _PROJECT_DIR / "build" / "trtmc"
+    return str(candidate.absolute()) if candidate.is_file() else ""
+
+
+def _resolve_hf_python(config) -> str:
+    configured = config.getoption("--hf-python", default=None)
+    return str(Path(configured).absolute()) if configured else sys.executable
+
+
+def _resolve_engine_dir(config) -> str:
+    configured = config.getoption("--engine-dir", default=None)
+    directory = Path(configured) if configured else Path("/tmp/foundationpose-engines")
+    directory.mkdir(parents=True, exist_ok=True)
+    return str(directory)
+
+
+def _resolve_model_plugin_dir(config) -> str:
+    configured = config.getoption("--model-plugin-dir", default=None)
+    return str(Path(configured).absolute()) if configured else ""
+
+
+def _resolve_artifacts_dir(config) -> str:
+    configured = config.getoption("--e2e-artifacts-dir", default=None)
+    return str(Path(configured)) if configured else "/tmp/e2e_artifacts/foundationpose"
+
+
+@contextmanager
+def _model_plugin_dir_env(path: str):
+    previous = os.environ.get("TRTMC_MODEL_PLUGIN_DIR")
+    if path:
+        os.environ["TRTMC_MODEL_PLUGIN_DIR"] = path
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TRTMC_MODEL_PLUGIN_DIR", None)
+        else:
+            os.environ["TRTMC_MODEL_PLUGIN_DIR"] = previous
+
+
+def _resolve_ld_library_path() -> str:
+    return ":".join(value for value in ("/usr/local/cuda/lib64", os.environ.get("LD_LIBRARY_PATH", "")) if value)
+
+
+def _case_matches(case, filters: set[str]) -> bool:
+    return not filters or bool(filters & {case.name, case.family, case.runtime_strategy, case.task_strategy})
+
+
+def model_case_names(config=None) -> list[str]:
+    return model_names_for_dir(config=config, model_dir=_MODEL_DIR,
+                               case_matches_model=_case_matches,
+                               is_multi_device_case=lambda case: False)
+
+
+def run_model_e2e(case_name: str, request) -> None:
+    run_manifest(
+        model_name=case_name, request=request, model_dir=_MODEL_DIR,
+        load_waives=lambda platform="": {}, case_matches_model=_case_matches,
+        is_multi_device_case=lambda case: False, resolve_hf_python=_resolve_hf_python,
+        resolve_artifacts_dir=_resolve_artifacts_dir, resolve_binary=_resolve_binary,
+        resolve_ld_library_path=_resolve_ld_library_path, resolve_engine_dir=_resolve_engine_dir,
+        resolve_model_plugin_dir=_resolve_model_plugin_dir,
+        model_plugin_dir_env=_model_plugin_dir_env,
+    )

--- a/tests/e2e/models/foundationpose/test_foundationpose_e2e.py
+++ b/tests/e2e/models/foundationpose/test_foundationpose_e2e.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location("foundationpose_e2e_runner", Path(__file__).with_name("runner.py"))
+assert _SPEC is not None and _SPEC.loader is not None
+_runner = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_runner)
+
+
+def pytest_generate_tests(metafunc):
+    if "case_name" in metafunc.fixturenames:
+        cases = _runner.model_case_names(metafunc.config)
+        if not cases:
+            pytest.skip("No FoundationPose manifests selected", allow_module_level=True)
+        metafunc.parametrize("case_name", cases)
+
+
+def test_model_e2e(case_name: str, request) -> None:
+    _runner.run_model_e2e(case_name, request)

--- a/tests/e2e/models/foundationpose/test_foundationpose_report.py
+++ b/tests/e2e/models/foundationpose/test_foundationpose_report.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import struct
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+
+from tests.e2e.models.foundationpose.e2e_plugins import comparator, runner
+from tests.e2e.models.foundationpose.e2e_plugins import report
+from tests.e2e_harness.contracts import StageSpec
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _generator_module():
+    path = _REPO_ROOT / "scripts" / "generate_e2e_report.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("foundationpose_report_generator_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_f32(path: Path, values: list[float]) -> None:
+    path.write_bytes(struct.pack(f"<{len(values)}f", *values))
+
+
+def _pose(x: float, y: float, z: float) -> list[float]:
+    return [1, 0, 0, x, 0, 1, 0, y, 0, 0, 1, z, 0, 0, 0, 1]
+
+
+def _result(artifact_dir: Path) -> dict:
+    native = artifact_dir / "native"
+    native.mkdir(parents=True)
+    _write_f32(native / "candidate_poses.f32", _pose(0, 0, 0.5) + _pose(0.1, 0, 0.5))
+    _write_f32(native / "trt_refined_poses.f32", _pose(0.01, 0, 0.5) + _pose(0.12, 0, 0.5))
+    _write_f32(native / "trt_scores.f32", [0.2, 0.8])
+    return {
+        "_artifact_dir": str(artifact_dir),
+        "case_name": "foundationpose-report-test",
+        "status": "pass",
+        "oracle_level": "L1_external_reference",
+        "case_config": {
+            "family": "foundationpose",
+            "task_strategy": "pose_hypothesis_refinement",
+            "reference_backend": "foundationpose_onnxruntime",
+            "inputs": {"num_hypotheses": 2},
+        },
+        "stages": {
+            "synthetic_crop_pose_refinement": {
+                "metrics": {
+                    "pose_max_abs_error": {"value": 0.000058, "passed": True},
+                    "score_max_abs_error": {"value": 0.00765, "passed": True},
+                    "tracking_throughput_hz": {"value": 313.5, "passed": True},
+                    "tracking_latency_p95_ms": {"value": 3.22, "passed": True},
+                }
+            }
+        },
+        "stage_outputs": {
+            "trt_synthetic_crop_pose_refinement": {"data": {"best_index": 1}},
+            "ref_synthetic_crop_pose_refinement": {"data": {"best_index": 1}},
+        },
+    }
+
+
+def test_report_renders_pose_ranking_and_performance_evidence(tmp_path: Path) -> None:
+    result = _result(tmp_path / "case")
+
+    rendered = report.render(result, project_dir=_REPO_ROOT)
+
+    assert "FoundationPose refinement and ranking" in rendered
+    assert "Pose max |error|" in rendered
+    assert "5.8e-05" in rendered
+    assert "313.5" in rendered
+    assert "1 ★" in rendered
+    assert "best-hypothesis agreement: <strong>yes</strong>" in rendered
+    assert "0.010000" in rendered
+
+
+def test_shared_report_recognizes_strategy_and_loads_owned_renderer(tmp_path: Path) -> None:
+    result = _result(tmp_path / "case")
+    generator = _generator_module()
+
+    rendered = generator.render_model_section(result, _REPO_ROOT)
+
+    assert generator.classify_modality(result) == "numeric"
+    assert generator.validate_evidence([result], _REPO_ROOT) == []
+    assert rendered.index("FoundationPose refinement and ranking") < rendered.index(
+        "Numerical evidence"
+    )
+
+
+def test_strict_evidence_rejects_missing_pose_artifacts_and_reference_index(
+    tmp_path: Path,
+) -> None:
+    generator = _generator_module()
+    missing_artifact = _result(tmp_path / "missing-artifact")
+    (Path(missing_artifact["_artifact_dir"]) / "native" / "candidate_poses.f32").unlink()
+
+    issues = generator.validate_evidence([missing_artifact], _REPO_ROOT)
+
+    assert any("candidate_poses.f32" in issue for issue in issues)
+
+    missing_reference = _result(tmp_path / "missing-reference")
+    missing_reference["stage_outputs"]["ref_synthetic_crop_pose_refinement"]["data"].pop(
+        "best_index"
+    )
+
+    issues = generator.validate_evidence([missing_reference], _REPO_ROOT)
+
+    assert any("reference best_index" in issue for issue in issues)
+
+
+def test_report_fails_closed_for_missing_and_escaping_artifacts(tmp_path: Path) -> None:
+    missing = report.render({"_artifact_dir": str(tmp_path / "missing")}, project_dir=_REPO_ROOT)
+    assert "FoundationPose evidence unavailable" in missing
+
+    result = _result(tmp_path / "case")
+    native = Path(result["_artifact_dir"]) / "native"
+    outside = tmp_path / "outside.f32"
+    outside.write_bytes((native / "trt_scores.f32").read_bytes())
+    (native / "trt_scores.f32").unlink()
+    (native / "trt_scores.f32").symlink_to(outside)
+
+    escaped = report.render(result, project_dir=_REPO_ROOT)
+
+    assert "escapes the artifact directory" in escaped
+    assert "FoundationPose refinement and ranking" not in escaped
+
+
+def test_report_escapes_status_and_rejects_nonfinite_values(tmp_path: Path) -> None:
+    result = _result(tmp_path / "case")
+    result["status"] = '<script>alert("status")</script>'
+    rendered = report.render(result, project_dir=_REPO_ROOT)
+    assert '<script>alert("status")</script>' not in rendered
+    assert "&lt;SCRIPT&gt;" in rendered
+
+    native = Path(result["_artifact_dir"]) / "native"
+    _write_f32(native / "trt_scores.f32", [0.2, float("nan")])
+    rejected = report.render(result, project_dir=_REPO_ROOT)
+    assert "contains non-finite values" in rejected
+
+
+def test_ranking_agreement_requires_the_complete_order() -> None:
+    reference_scores = np.asarray([0.9, 0.6, 0.2], dtype=np.float32)
+
+    assert comparator._ranking_agreement(reference_scores, reference_scores) == 1.0
+    assert (
+        comparator._ranking_agreement(
+            np.asarray([0.9, 0.2, 0.6], dtype=np.float32), reference_scores
+        )
+        == 0.0
+    )
+
+
+def test_native_runner_forwards_manifest_pose_parameters(monkeypatch, tmp_path: Path) -> None:
+    captured = []
+
+    def run(command, **_kwargs):
+        captured.extend(command)
+        output_dir = Path(command[command.index("--output-dir") + 1])
+        _write_f32(output_dir / "trt_refined_poses.f32", _pose(0, 0, 0) * 2)
+        _write_f32(output_dir / "trt_scores.f32", [0.1, 0.2])
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"num_hypotheses": 2, "best_index": 1}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", run)
+    case = SimpleNamespace(
+        name="foundationpose-runner-test",
+        bundle="fixture.bundle",
+        inputs={
+            "num_hypotheses": 2,
+            "refinement_iterations": 4,
+            "mesh_diameter": 0.25,
+        },
+    )
+    context = SimpleNamespace(
+        artifacts_dir=str(tmp_path),
+        binary_path=str(tmp_path / "build" / "trtmc"),
+        engine_dir=str(tmp_path / "engines"),
+        model_plugin_dir="",
+        ld_library_path="",
+    )
+
+    output = runner.FoundationPoseRunner().run_stage(
+        case, StageSpec(name="synthetic_crop_pose_refinement"), context
+    )
+
+    assert captured[captured.index("--num-hypotheses") + 1] == "2"
+    assert captured[captured.index("--refinement-iterations") + 1] == "4"
+    assert captured[captured.index("--mesh-diameter") + 1] == "0.25"
+    assert output.data["refined_poses"].shape == (2, 4, 4)

--- a/tests/e2e/models/foundationpose/thresholds/foundationpose-ngc-1.0.1-synthetic-crops.json
+++ b/tests/e2e/models/foundationpose/thresholds/foundationpose-ngc-1.0.1-synthetic-crops.json
@@ -1,0 +1,13 @@
+{
+  "threshold_overrides": {
+    "pose_max_abs_error": 0.005,
+    "score_max_abs_error": 0.05,
+    "ranking_agreement": 1.0,
+    "rigid_pose_fraction": 1.0,
+    "tracking_throughput_hz": 10.0,
+    "tracking_latency_p95_ms": 100.0,
+    "tracking_jitter_ms": 25.0,
+    "startup_ms": 10000.0,
+    "gpu_memory_delta_mib": 4096.0
+  }
+}

--- a/tests/tools/test_model_artifact_cache.py
+++ b/tests/tools/test_model_artifact_cache.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.ci.context import CiContext
+from tools.ci.model_artifact_cache import (
+    ModelArtifactCache,
+    ModelArtifactCacheWarmer,
+    ModelArtifactContract,
+    ModelArtifactFile,
+    parse_model_artifact_contract,
+)
+from tools.ci.process import CiError
+
+
+def _owner(url: str = "https://api.ngc.nvidia.com/v2/models/example") -> dict:
+    content = b"pinned model"
+    return {
+        "model_artifact_cache": {
+            "relative_path": "example/ngc-1",
+            "environment_variable": "TRTMC_EXAMPLE_MODEL_DIR",
+            "files": [{
+                "path": "model.onnx",
+                "url": url,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+            }],
+        }
+    }
+
+
+def test_parse_model_artifact_contract():
+    contract = parse_model_artifact_contract(_owner(), "example", Path("MODEL.toml"), "premerge")
+    assert contract is not None
+    assert contract.relative_path == "example/ngc-1"
+    assert contract.files[0].path == "model.onnx"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://api.ngc.nvidia.com/model",
+        "https://example.com/model",
+        "https://user@api.ngc.nvidia.com/model",
+        "https://user:secret@api.ngc.nvidia.com/model",
+        "https://api.ngc.nvidia.com/model#fragment",
+    ],
+)
+def test_parse_rejects_non_ngc_origins(url: str):
+    with pytest.raises(CiError, match="allowed HTTPS URL"):
+        parse_model_artifact_contract(_owner(url), "example", Path("MODEL.toml"), "premerge")
+
+
+def test_prepare_copies_only_verified_cached_files(tmp_path: Path):
+    content = b"pinned model"
+    item = ModelArtifactFile(
+        "model.onnx",
+        "https://api.ngc.nvidia.com/v2/models/example",
+        hashlib.sha256(content).hexdigest(),
+        len(content),
+    )
+    contract = ModelArtifactContract(
+        "example", "example/ngc-1", "TRTMC_EXAMPLE_MODEL_DIR", (item,)
+    )
+    cache = tmp_path / "cache"
+    cached_file = cache / "model-artifacts/example/ngc-1/model.onnx"
+    cached_file.parent.mkdir(parents=True)
+    cached_file.write_bytes(content)
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    context = CiContext(repository, {"TRTMC_MODEL_ARTIFACT_CACHE_ROOT": str(cache)})
+    assert ModelArtifactCacheWarmer(context).warm_contract(contract) == cached_file.parent
+
+    work = tmp_path / "work"
+    artifacts = tmp_path / "artifacts"
+    work.mkdir()
+    artifacts.mkdir()
+    ModelArtifactCache(context, "example").prepare(contract.as_payload(), work, artifacts)
+    assert (work / "model-artifacts/example/ngc-1/model.onnx").read_bytes() == content
+    evidence = json.loads((artifacts / "model-artifact-cache.json").read_text())
+    assert evidence["isolation"] == "selected-digest-private"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "relative_path": "example/ngc-1",
+            "environment_variable": "TRTMC_EXAMPLE_MODEL_DIR",
+            "files": [None],
+        },
+        {
+            "relative_path": "example/ngc-1",
+            "environment_variable": "TRTMC_EXAMPLE_MODEL_DIR",
+            "files": [{"path": "model.onnx"}],
+        },
+    ],
+)
+def test_prepare_rejects_malformed_payload_as_ci_error(tmp_path: Path, payload: dict):
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    context = CiContext(repository, {})
+
+    with pytest.raises(CiError):
+        ModelArtifactCache(context, "example").prepare(
+            payload, tmp_path / "work", tmp_path / "artifacts"
+        )
+
+
+def test_cached_digest_mismatch_fails_closed(tmp_path: Path):
+    contract = parse_model_artifact_contract(_owner(), "example", Path("MODEL.toml"), "premerge")
+    assert contract is not None
+    cache = tmp_path / "cache"
+    cached_file = cache / "model-artifacts/example/ngc-1/model.onnx"
+    cached_file.parent.mkdir(parents=True)
+    cached_file.write_bytes(b"broken model")
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    context = CiContext(repository, {"TRTMC_MODEL_ARTIFACT_CACHE_ROOT": str(cache)})
+    with pytest.raises(CiError, match="pinned size/digest"):
+        ModelArtifactCacheWarmer(context).warm_contract(contract)
+
+
+def test_cache_root_must_not_be_inside_repository(tmp_path: Path):
+    contract = parse_model_artifact_contract(_owner(), "example", Path("MODEL.toml"), "premerge")
+    assert contract is not None
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    cache = repository / ".model-artifact-cache"
+    context = CiContext(repository, {
+        "TRTMC_MODEL_ARTIFACT_CACHE_ROOT": str(cache)
+    })
+
+    with pytest.raises(CiError, match="cache root is invalid"):
+        ModelArtifactCacheWarmer(context).warm_contract(contract)
+    assert not cache.exists()

--- a/tests/tools/test_selected_wheel_runtime.py
+++ b/tests/tools/test_selected_wheel_runtime.py
@@ -230,7 +230,7 @@ def test_model_proof_mounts_selected_wheels_read_only_and_forwards_contract(
         tmp_path / "work",
         tmp_path / "hf",
         "fixture-image",
-        SimpleNamespace(reference_cache=None),
+        SimpleNamespace(reference_cache=None, artifact_cache=None),
         None,
         python_profiles,
     )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -294,6 +294,13 @@ class TorchReference:
             "hf_id": "example/lerobot-act-case",
         },
         {
+            "name": "foundationpose-case",
+            "family": "foundationpose",
+            "runtime_strategy": "foundationpose_pose_refinement",
+            "task_strategy": "pose_hypothesis_refinement",
+            "hf_id": "example/foundationpose-case",
+        },
+        {
             "name": "media-core",
             "family": "media_family",
             "runtime_strategy": "diffusion_media_primary",
@@ -2031,6 +2038,30 @@ class TestUnitTiers:
 
         assert match.rule == "lerobot_act_recorded_control_example"
         assert match.models == ["lerobot-act-case"]
+        assert match.unit_tiers == ["cpp", "tools"]
+        assert match.rebuild_cpp is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "examples/models/foundationpose/preprocessed_refinement/CMakeLists.txt",
+            "examples/models/foundationpose/preprocessed_refinement/README.md",
+            "examples/models/foundationpose/preprocessed_refinement/main.cpp",
+            "examples/models/foundationpose/preprocessed_refinement/prepare_synthetic_inputs.py",
+            (
+                "examples/models/foundationpose/preprocessed_refinement/"
+                "qualification/gb300-trt11.1-fp32.json"
+            ),
+        ],
+    )
+    def test_foundationpose_preprocessed_refinement_example_is_model_owned(
+        self, imap, path
+    ):
+        """The preprocessed-pose example runs FoundationPose C++ and tools checks."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "foundationpose_preprocessed_refinement_example"
+        assert match.models == ["foundationpose-case"]
         assert match.unit_tiers == ["cpp", "tools"]
         assert match.rebuild_cpp is True
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -52,6 +52,9 @@ def test_model_workload_catalog_covers_every_ready_model():
         catalog["models"]["flux-2-dev"]["reference_cache_identity"]
         == catalog["models"]["flux-2-dev-fp8"]["reference_cache_identity"]
     )
+    assert catalog["models"]["foundationpose-ngc-1.0.1"]["workloads"] == [
+        "foundationpose_preprocessed_pose_refinement_fp32_parity"
+    ]
     assert catalog["models"]["flux-2-dev"]["reference_cache_identity"] == "flux-2-dev-dpg-v2"
     qwen_identities = {
         catalog["models"][name]["reference_cache_identity"]
@@ -225,6 +228,7 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     assert {workload for workload, limit in catalog["sample_limits"].items() if limit == 1} == {
         "dinov3_image_feature_extraction_parity",
         "fast_foundation_stereo_synthetic_parity",
+        "foundationpose_preprocessed_pose_refinement_fp32_parity",
         "lfm2_model_card_sampling_parity",
         "lerobot_act_recorded_control_fp32_parity",
         "minimax_h3_official_profile_parity",

--- a/tests/tools/test_validation_engine.py
+++ b/tests/tools/test_validation_engine.py
@@ -875,6 +875,23 @@ def test_default_suites_include_model_aligned_vision_tasks() -> None:
     assert robotics["scoring"] == {"scorer": "model_plugin_parity"}
     assert robotics["gates"] == {"min_sample_pass_rate": 1.0}
 
+    pose = validation_engine.suite_by_id(
+        suites, "foundationpose_preprocessed_pose_refinement_fp32_parity"
+    )
+    assert pose["dataset"] == {
+        "kind": "model_plugin_json",
+        "default_path": "tests/e2e/models/foundationpose/data/validation.json",
+    }
+    assert pose["selectors"] == {
+        "model_names": ["foundationpose-ngc-1.0.1"],
+        "task_strategies": ["pose_hypothesis_refinement"],
+        "runtime_strategies": ["foundationpose_pose_refinement"],
+        "user_contracts": ["ranked_rigid_object_to_camera_poses"],
+        "families": ["foundationpose"],
+    }
+    assert pose["scoring"] == {"scorer": "model_plugin_parity"}
+    assert pose["gates"] == {"min_sample_pass_rate": 1.0}
+
     classification = validation_engine.suite_by_id(suites, "imagenette_image_classification")
     assert classification["dataset"]["kind"] == "image_classification_json"
     assert classification["scoring"]["task_metric"] == "top1_accuracy"

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -17,6 +17,7 @@ sample_limits:
   etth1_time_series_parity: 10
   fast_foundation_stereo_synthetic_parity: 1
   fast_foundation_stereo_middlebury_q_task_accuracy: 15
+  foundationpose_preprocessed_pose_refinement_fp32_parity: 1
   flores200_en_fr_riva_translation_parity: 10
   gedit_bench_image_edit: 5
   humaneval_code_continuation_parity: 10
@@ -123,6 +124,8 @@ models:
     workloads:
       - fast_foundation_stereo_synthetic_parity
       - fast_foundation_stereo_middlebury_q_task_accuracy
+  foundationpose-ngc-1.0.1:
+    workloads: [foundationpose_preprocessed_pose_refinement_fp32_parity]
   flux-2-dev:
     workloads: [dpg_bench_diffusion_image]
     reference_cache_identity: flux-2-dev-dpg-v2

--- a/tests/validation/workloads.yaml
+++ b/tests/validation/workloads.yaml
@@ -1236,6 +1236,39 @@ suites:
         Numeric and systems thresholds remain owned by the LeRobot ACT
         comparator and are not overridden by this suite.
 
+  - id: foundationpose_preprocessed_pose_refinement_fp32_parity
+    description: >
+      Native FP32 FoundationPose qualification on three deterministic,
+      preprocessed RGB+XYZ crop pairs and rigid candidate poses. The pinned
+      official NGC refiner and scorer ONNX models and TRTMC runtime consume the
+      same tensors, perform two refinement iterations, and gate all refined
+      poses, scorer logits, and final ranking through the model-owned comparator.
+      Segmentation, CAD rendering, and physical robot safety are outside this
+      preprocessed inference contract.
+    user_contract: ranked_rigid_object_to_camera_poses
+    task_type: Preprocessed RGB+XYZ Crops + Candidate Poses → Ranked Rigid Poses
+    default_model_names: [foundationpose-ngc-1.0.1]
+    dataset:
+      kind: model_plugin_json
+      default_path: tests/e2e/models/foundationpose/data/validation.json
+    selectors:
+      model_names: [foundationpose-ngc-1.0.1]
+      task_strategies: [pose_hypothesis_refinement]
+      runtime_strategies: [foundationpose_pose_refinement]
+      user_contracts: [ranked_rigid_object_to_camera_poses]
+      families: [foundationpose]
+    scoring:
+      scorer: model_plugin_parity
+    gates:
+      min_sample_pass_rate: 1.0
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        GB300-only pinned-NGC FP32 parity and stateful tracking-capacity
+        qualification. Numeric, rigidity, ranking, latency, jitter, startup,
+        and memory thresholds remain model-owned and are not overridden here.
+
   - id: imagenette_image_classification
     description: >
       HF-to-TRTMC image-classification parity on Imagenette validation, a

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -619,11 +619,28 @@ the producing class remains the source of truth for optional evidence fields.
   network. Bulk nightly warming and selected premerge first-use warming share
   the same validation and atomic publication path.
 
+### `model_artifact_cache.py`
+
+- **Functionality / units:** validates a suite-selected
+  `[model_artifact_cache]`, downloads each declared public NGC file once, and
+  admits it only when its exact byte size and SHA-256 digest match.
+- **Inputs:** a family-owned relative destination, an environment-variable
+  name, and one to eight HTTPS file declarations under the allowlisted NGC API
+  origin. The host cache uses `TRTMC_MODEL_ARTIFACT_CACHE_ROOT`, falling back to
+  `TRTMC_MODEL_REFERENCE_CACHE_ROOT` for existing model-proof deployments.
+- **Outputs:** verified host-cache files and a private
+  `/work/model-artifacts/<family>/...` copy plus
+  `model-artifact-cache.json` evidence for the selected proof.
+- **Boundary:** only the trusted host phase has network access. The proof
+  container receives no shared cache paths or undeclared files and rechecks
+  every size and digest before build and inference.
+
 ### `model_proof_selection.py`
 
 - **Functionality / units:** `ModelProofSelector` validates a positive
   one-model projection and resolves runtime/Python/E2E owners, tests, reference
-  cache contract, and required GPU resource class.
+  source-reference and binary-artifact cache contracts, and required GPU
+  resource class.
 - **Inputs:** `model`, `suite`, pinned `revision`, projected source path
   containing `.trtmc-model-projection.json` and one owner manifest per layer,
   plus optional lease evidence.

--- a/tools/ci/model_artifact_cache.py
+++ b/tools/ci/model_artifact_cache.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Digest-verified public model artifacts for network-disabled model proofs.
+
+Boundary: artifact retrieval, digest validation, and isolated cache projection only;
+model-specific artifact selection and semantics remain family-owned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import tempfile
+import urllib.parse
+import urllib.request
+
+from .context import CiContext
+from .process import CiError
+
+_MAX_FILE_BYTES = 512 << 20
+_ALLOWED_ORIGINS = {"api.ngc.nvidia.com"}
+
+
+@dataclass(frozen=True)
+class ModelArtifactFile:
+    path: str
+    url: str
+    sha256: str
+    size: int
+
+    def as_payload(self) -> dict[str, object]:
+        return {"path": self.path, "url": self.url, "sha256": self.sha256, "size": self.size}
+
+
+@dataclass(frozen=True)
+class ModelArtifactContract:
+    family: str
+    relative_path: str
+    environment_variable: str
+    files: tuple[ModelArtifactFile, ...]
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "relative_path": self.relative_path,
+            "environment_variable": self.environment_variable,
+            "files": [item.as_payload() for item in self.files],
+        }
+
+
+def _relative(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise CiError(f"{field} must be a non-empty POSIX path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value or any(
+        part in {"", ".", ".."} for part in path.parts
+    ):
+        raise CiError(f"{field} must be a canonical relative path")
+    return value
+
+
+def parse_model_artifact_contract(
+    owner: dict[str, object], family: str, manifest: Path, suite: str | None
+) -> ModelArtifactContract | None:
+    raw = owner.get("model_artifact_cache")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise CiError(f"model_artifact_cache must be a table in {manifest}")
+    suites = raw.get("suites")
+    if suites is not None and (
+        not isinstance(suites, list)
+        or not suites
+        or any(item not in {"premerge", "nightly"} for item in suites)
+        or len(suites) != len(set(suites))
+    ):
+        raise CiError("model_artifact_cache.suites must select premerge and/or nightly")
+    if suites is not None and suite is not None and suite not in suites:
+        return None
+    relative_path = _relative(raw.get("relative_path"), "model_artifact_cache.relative_path")
+    if PurePosixPath(relative_path).parts[0] != family:
+        raise CiError("model_artifact_cache.relative_path must be owned by its E2E family")
+    environment = raw.get("environment_variable")
+    if not isinstance(environment, str) or not re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*", environment
+    ):
+        raise CiError("model_artifact_cache.environment_variable is invalid")
+    file_values = raw.get("files")
+    if not isinstance(file_values, list) or not file_values or len(file_values) > 8:
+        raise CiError("model_artifact_cache.files must contain between one and eight files")
+    files: list[ModelArtifactFile] = []
+    seen: set[str] = set()
+    for index, value in enumerate(file_values):
+        if not isinstance(value, dict):
+            raise CiError(f"model_artifact_cache.files[{index}] must be a table")
+        path = _relative(value.get("path"), f"model_artifact_cache.files[{index}].path")
+        if len(PurePosixPath(path).parts) != 1:
+            raise CiError(f"model_artifact_cache.files[{index}].path must be a filename")
+        url = value.get("url")
+        parsed = urllib.parse.urlsplit(url) if isinstance(url, str) else None
+        if (
+            parsed is None
+            or parsed.scheme != "https"
+            or parsed.hostname not in _ALLOWED_ORIGINS
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+        ):
+            raise CiError(f"model_artifact_cache.files[{index}].url is not an allowed HTTPS URL")
+        digest = value.get("sha256")
+        size = value.get("size")
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise CiError(f"model_artifact_cache.files[{index}].sha256 is invalid")
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0 or size > _MAX_FILE_BYTES:
+            raise CiError(f"model_artifact_cache.files[{index}].size is invalid")
+        if path in seen:
+            raise CiError(f"duplicate model artifact path: {path}")
+        seen.add(path)
+        files.append(ModelArtifactFile(path, url, digest, size))
+    if sum(item.size for item in files) > _MAX_FILE_BYTES:
+        raise CiError("model_artifact_cache exceeds the 512 MiB total limit")
+    return ModelArtifactContract(family, relative_path, environment, tuple(files))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def validate_artifact(path: Path, contract: ModelArtifactFile) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise CiError(f"model artifact is not a regular file: {path}")
+    if path.stat().st_size != contract.size or _sha256(path) != contract.sha256:
+        raise CiError(f"model artifact does not match its pinned size/digest: {path}")
+
+
+class ModelArtifactCacheWarmer:
+    def __init__(self, context: CiContext):
+        self.context = context
+
+    def warm_contract(self, contract: ModelArtifactContract) -> Path:
+        configured = self.context.env.get("TRTMC_MODEL_ARTIFACT_CACHE_ROOT") or self.context.env.get(
+            "TRTMC_MODEL_REFERENCE_CACHE_ROOT", ""
+        )
+        if not configured:
+            raise CiError("TRTMC_MODEL_ARTIFACT_CACHE_ROOT is required")
+        repository = self.context.repository.resolve(strict=True)
+        requested = Path(configured)
+        unresolved_root = requested.resolve(strict=False)
+        if (
+            unresolved_root == Path("/")
+            or unresolved_root == repository
+            or unresolved_root.is_relative_to(repository)
+        ):
+            raise CiError("model artifact cache root is invalid")
+        requested.mkdir(parents=True, exist_ok=True)
+        root = requested.resolve(strict=True)
+        if root == Path("/") or root == repository or root.is_relative_to(repository):
+            raise CiError("model artifact cache root is invalid")
+        destination = root / "model-artifacts" / contract.relative_path
+        lock_dir = root / ".artifact-locks"
+        if lock_dir.is_symlink():
+            raise CiError("model artifact cache lock directory must not be a symlink")
+        lock_dir.mkdir(exist_ok=True)
+        lock_path = lock_dir / (hashlib.sha256(contract.relative_path.encode()).hexdigest() + ".lock")
+        with lock_path.open("a+", encoding="utf-8") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            destination.mkdir(parents=True, exist_ok=True)
+            if destination.is_symlink() or not destination.resolve().is_relative_to(root):
+                raise CiError("model artifact cache destination is unsafe")
+            for item in contract.files:
+                target = destination.joinpath(*PurePosixPath(item.path).parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists():
+                    validate_artifact(target, item)
+                    continue
+                handle, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+                os.close(handle)
+                temporary = Path(temporary_name)
+                try:
+                    digest = hashlib.sha256()
+                    size = 0
+                    request = urllib.request.Request(item.url, headers={"User-Agent": "trtmc-model-proof/1"})
+                    with urllib.request.urlopen(request, timeout=60) as response, temporary.open("wb") as output:
+                        while block := response.read(1 << 20):
+                            size += len(block)
+                            if size > item.size:
+                                raise CiError(f"model artifact exceeds its declared size: {item.path}")
+                            digest.update(block)
+                            output.write(block)
+                    if size != item.size or digest.hexdigest() != item.sha256:
+                        raise CiError(f"downloaded model artifact failed verification: {item.path}")
+                    os.replace(temporary, target)
+                finally:
+                    temporary.unlink(missing_ok=True)
+                validate_artifact(target, item)
+        return destination
+
+
+class ModelArtifactCache:
+    def __init__(self, context: CiContext, model: str):
+        self.context = context
+        self.model = model
+
+    def prepare(self, payload: dict[str, object] | None, work: Path, artifacts: Path) -> None:
+        if payload is None:
+            return
+        contract = parse_model_artifact_contract(
+            {"model_artifact_cache": payload},
+            self.model,
+            Path("model proof selection"),
+            suite=None,
+        )
+        if contract is None:  # Defensive: a non-null payload always selects a contract.
+            raise CiError("model artifact cache payload did not select a contract")
+        files = contract.files
+        source = ModelArtifactCacheWarmer(self.context).warm_contract(contract)
+        destination = work / "model-artifacts" / contract.relative_path
+        if destination.exists():
+            raise CiError("proof-private model artifact destination already exists")
+        destination.mkdir(parents=True)
+        for item in files:
+            source_file = source.joinpath(*PurePosixPath(item.path).parts)
+            validate_artifact(source_file, item)
+            target = destination.joinpath(*PurePosixPath(item.path).parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_file, target)
+            validate_artifact(target, item)
+        evidence = {
+            "schema_version": 1,
+            "model": self.model,
+            "isolation": "selected-digest-private",
+            "relative_path": contract.relative_path,
+            "container_storage_root": "/work/model-artifacts",
+            "files": [item.as_payload() for item in files],
+        }
+        (artifacts / "model-artifact-cache.json").write_text(
+            json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+        )

--- a/tools/ci/model_proof.py
+++ b/tools/ci/model_proof.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
 from .context import CiContext
 from .gpu_lease import GpuLease
 from .model_reference_cache import ModelReferenceCacheWarmer, ModelReferenceContract
+from .model_artifact_cache import ModelArtifactCache
 from .model_proof_selection import ModelProofSelection, ModelProofSelector
 from .process import CiError
 from .selected_wheel import (
@@ -315,6 +316,9 @@ class ModelProofRunner:
         ModelReferenceCache(self.context, self.request).prepare(
             selection.reference_cache, work, self.artifacts_dir
         )
+        ModelArtifactCache(self.context, self.request.model).prepare(
+            selection.artifact_cache, work, self.artifacts_dir
+        )
         expected = self.context.env.get("TRTMC_MODEL_PROOF_EXPECTED_RESOURCE_CLASS", "")
         if expected and expected not in {"shared", "exclusive_gpu"}:
             raise CiError(
@@ -354,7 +358,13 @@ class ModelProofRunner:
             validation_container,
             self._job_labels(),
         ).prepare()
-        private_hub = self._prepare_hf_cache(projection, work, image, models_file)
+        private_hub = self._prepare_hf_cache(
+            projection,
+            work,
+            image,
+            models_file,
+            allow_empty=bool(selection.artifact_cache),
+        )
         (self.artifacts_dir / "gpu-lease-requested.txt").write_text(
             selection.resource_class + "\n", encoding="utf-8"
         )
@@ -795,7 +805,13 @@ class ModelProofRunner:
         return value.replace("_", "-")
 
     def _prepare_hf_cache(
-        self, projection: Path, work: Path, image: str, models_file: Path
+        self,
+        projection: Path,
+        work: Path,
+        image: str,
+        models_file: Path,
+        *,
+        allow_empty: bool = False,
     ) -> Path:
         assert self.artifacts_dir is not None
         root = self.context.env.get(
@@ -872,6 +888,7 @@ class ModelProofRunner:
             "--strict",
             "--emit-cache-repos",
             "/artifacts/hf-cache-repos.json",
+            *(["--allow-empty-cache-repos"] if allow_empty else []),
         ]
         result = self._run_logged(command, self.artifacts_dir / "cache-check.log")
         if result:
@@ -964,8 +981,8 @@ class ModelProofRunner:
         if payload.get("schema_version") != 1 or payload.get("hub_cache") != "/hf-cache/hub":
             raise CiError("selected Hugging Face cache evidence has an unsupported schema")
         repositories = payload.get("repositories")
-        if not isinstance(repositories, list) or not repositories:
-            raise CiError("selected HF cache evidence contains no repositories")
+        if not isinstance(repositories, list):
+            raise CiError("selected HF cache evidence repositories must be a list")
         result = []
         seen = set()
         resolved_hub = hub.resolve(strict=True)
@@ -1076,7 +1093,9 @@ class ModelProofRunner:
             "/src",
             "--tmpfs",
             "/tmp:rw,exec,nosuid,nodev,size=4g",
-            *self._proof_environment(slots, selection.reference_cache, selected_wheel),
+            *self._proof_environment(
+                slots, selection.reference_cache, selection.artifact_cache, selected_wheel
+            ),
             image,
             "python3",
             "-m",
@@ -1100,6 +1119,7 @@ class ModelProofRunner:
         self,
         slots: str,
         reference: dict[str, str] | None,
+        artifact: dict[str, object] | None = None,
         selected_wheel: SelectedWheelContract | None = None,
     ) -> list[str]:
         assert self.lease and self.lease.gpu_id is not None
@@ -1142,6 +1162,11 @@ class ModelProofRunner:
                 values[environment_variable] = (
                     f"/work/reference-private/{reference['relative_path']}"
                 )
+        if artifact:
+            environment_variable = str(artifact["environment_variable"])
+            values[environment_variable] = (
+                f"/work/model-artifacts/{artifact['relative_path']}"
+            )
         if selected_wheel is not None:
             values.update(
                 {

--- a/tools/ci/model_proof_inner.py
+++ b/tools/ci/model_proof_inner.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from .context import CiContext
 from .model_proof import ModelProofRequest
+from .model_artifact_cache import ModelArtifactFile, validate_artifact
 from .model_proof_selection import ModelProofSelection, ModelProofSelector
 from .process import CiError
 from .selected_wheel import SelectedWheelRuntime
@@ -59,6 +60,7 @@ class ProofStatus:
     STEPS = {
         "hf_cache_isolation": "hf-cache-repos.json",
         "model_reference_isolation": "selection.json",
+        "model_artifact_isolation": "model-artifact-cache.json",
         "projection_validation": "source-projection.json, selection.json",
         "configure": "configure.log",
         "scratch_build": "build.log",
@@ -163,7 +165,10 @@ class ModelProofInnerPipeline:
             )
             count = self._validate_hf_cache()
             self.status.step("hf_cache_isolation", "passed")
-            self.status.fact("hf_cache_isolation", "selected-repositories-only")
+            self.status.fact(
+                "hf_cache_isolation",
+                "selected-repositories-only" if count else "not-required",
+            )
             self.status.fact("hf_cache_repository_count", count)
             shutil.copy2(
                 self.source / ".trtmc-model-projection.json",
@@ -173,6 +178,7 @@ class ModelProofInnerPipeline:
                 self.request.model, self.request.suite, self.request.revision, self.source
             ).select(self.artifacts / "selection.json", lease)
             self._validate_reference_cache()
+            self._validate_artifact_cache()
             self.status.step("projection_validation", "passed")
             self._build_and_test()
             print(f"PASS: isolated model proof completed for {self.request.model}")
@@ -389,8 +395,8 @@ class ModelProofInnerPipeline:
         if payload.get("schema_version") != 1 or payload.get("hub_cache") != "/hf-cache/hub":
             raise CiError("selected HF cache evidence has an unsupported schema")
         repositories = payload.get("repositories")
-        if not isinstance(repositories, list) or not repositories:
-            raise CiError("selected HF cache evidence contains no repositories")
+        if not isinstance(repositories, list):
+            raise CiError("selected HF cache evidence repositories must be a list")
         expected_folders = set()
         for entry in repositories:
             repo_id = entry.get("repo_id") if isinstance(entry, dict) else None
@@ -419,6 +425,48 @@ class ModelProofInnerPipeline:
                 f"selected HF cache view mismatch: {sorted(actual)} != {sorted(expected_folders)}"
             )
         return len(repositories)
+
+    def _validate_artifact_cache(self) -> None:
+        assert self.status and self.selection
+        contract = self.selection.artifact_cache
+        evidence_path = self.artifacts / "model-artifact-cache.json"
+        if not contract:
+            if evidence_path.exists():
+                raise CiError("model artifact cache exposed for a model that declares none")
+            self.status.step(
+                "model_artifact_isolation", "passed",
+                "selection.json (no external binary artifact required)"
+            )
+            self.status.fact("model_artifact_isolation", "not-required")
+            return
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        for key, value in {
+            "schema_version": 1,
+            "model": self.request.model,
+            "relative_path": contract["relative_path"],
+            "container_storage_root": "/work/model-artifacts",
+        }.items():
+            if evidence.get(key) != value:
+                raise CiError(f"model artifact evidence mismatch for {key}")
+        if evidence.get("files") != contract["files"]:
+            raise CiError("model artifact evidence file contract mismatch")
+        root = Path("/work/model-artifacts") / str(contract["relative_path"])
+        if root.is_symlink() or not root.is_dir():
+            raise CiError("proof-private model artifact directory is unavailable")
+        expected: set[Path] = set()
+        for raw in contract["files"]:
+            item = ModelArtifactFile(**raw)
+            path = root.joinpath(*Path(item.path).parts)
+            validate_artifact(path, item)
+            expected.add(path.relative_to(root))
+        actual = {path.relative_to(root) for path in root.rglob("*") if path.is_file()}
+        if actual != expected or any(path.is_symlink() for path in root.rglob("*")):
+            raise CiError("proof-private model artifact view contains undeclared files")
+        environment = str(contract["environment_variable"])
+        if self.context.env.get(environment) != str(root):
+            raise CiError(f"{environment} must select the proof-private model artifacts")
+        self.status.step("model_artifact_isolation", "passed", "model-artifact-cache.json")
+        self.status.fact("model_artifact_isolation", "selected-digest-private")
 
     def _validate_reference_cache(self) -> None:
         assert self.status and self.selection
@@ -556,7 +604,11 @@ class ModelProofInnerPipeline:
             "model_dso_count": 1,
             "network": "disabled",
             "plugin_search": "strict",
-            "hf_cache_isolation": "selected-repositories-only",
+            "hf_cache_isolation": (
+                "selected-repositories-only"
+                if json.loads((self.artifacts / "hf-cache-repos.json").read_text())["repositories"]
+                else "not-required"
+            ),
             "hf_cache_repository_count": len(
                 json.loads((self.artifacts / "hf-cache-repos.json").read_text())["repositories"]
             ),
@@ -564,12 +616,17 @@ class ModelProofInnerPipeline:
             "model_reference_isolation": (
                 "selected-pinned-private" if self.selection.reference_cache else "not-required"
             ),
+            "model_artifact_isolation": (
+                "selected-digest-private" if self.selection.artifact_cache else "not-required"
+            ),
         }
         if self.selection.min_free_gpu_memory_mib:
             proof["gpu_memory_admission"] = payload["gpu_memory_admission"]
         if self.selection.reference_cache:
             proof["model_reference_revision"] = self.selection.reference_cache["revision"]
             proof["model_reference_evidence"] = "model-reference-cache.json"
+        if self.selection.artifact_cache:
+            proof["model_artifact_evidence"] = "model-artifact-cache.json"
         proof.update(self._selected_wheel_proof())
         (self.artifacts / "proof.json").write_text(
             json.dumps(proof, indent=2) + "\n", encoding="utf-8"

--- a/tools/ci/model_proof_selection.py
+++ b/tools/ci/model_proof_selection.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .model_reference_cache import parse_model_reference_contract
+from .model_artifact_cache import parse_model_artifact_contract
 from .process import CiError
 
 
@@ -45,6 +46,11 @@ class ModelProofSelection:
         value = self.payload.get("model_reference_cache")
         return dict(value) if isinstance(value, dict) else None
 
+    @property
+    def artifact_cache(self) -> dict[str, object] | None:
+        value = self.payload.get("model_artifact_cache")
+        return dict(value) if isinstance(value, dict) else None
+
 
 class ModelProofSelector:
     """Turn allowlisted projected metadata into one deterministic proof selection."""
@@ -70,6 +76,9 @@ class ModelProofSelector:
         owner_data = tomllib.loads((e2e_dir / "MODEL.toml").read_text(encoding="utf-8"))
         reference_cache = self._reference_cache(
             owner_data, str(owners["e2e"]), e2e_dir / "MODEL.toml"
+        )
+        artifact_contract = parse_model_artifact_contract(
+            owner_data, str(owners["e2e"]), e2e_dir / "MODEL.toml", self.suite
         )
         cases = self._cases(e2e_dir)
         selected_cases = self._select_cases(cases, str(owners["e2e"]))
@@ -119,6 +128,8 @@ class ModelProofSelector:
         }
         if reference_cache:
             payload["model_reference_cache"] = reference_cache
+        if artifact_contract:
+            payload["model_artifact_cache"] = artifact_contract.as_payload()
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         return ModelProofSelection(payload)

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1884,6 +1884,20 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestUnitTiers.test_lerobot_act_recorded_control_example_is_model_owned",),
         ),
         ClassificationRule(
+            priority=452,
+            name="foundationpose_preprocessed_refinement_example",
+            matcher=_regex_rule(r"examples/models/(foundationpose)/preprocessed_refinement/.+$"),
+            resolver=_match_result(
+                "foundationpose_preprocessed_refinement_example",
+                _family_models,
+                ["cpp", "tools"],
+                True,
+            ),
+            covered_by=(
+                "TestUnitTiers.test_foundationpose_preprocessed_refinement_example_is_model_owned",
+            ),
+        ),
+        ClassificationRule(
             priority=456,
             name="cpp_example_tool",
             matcher=_regex_rule(r"examples/.+\.cpp$"),

--- a/website/plugins/model-support-inventory/index.js
+++ b/website/plugins/model-support-inventory/index.js
@@ -159,6 +159,7 @@ const CLI_COMMANDS_BY_TASK_STRATEGY = {
   neural_operator: ['solve'],
   omni_multimodal: ['generate-audio'],
   prompted_segmentation: ['segment-prompted'],
+  pose_hypothesis_refinement: [],
   reranking: ['rerank'],
   robot_action_chunk: ['act'],
   segmentation: ['segment'],
@@ -238,6 +239,37 @@ function hfMetadataFields(metadata) {
     hfMetadataRevision: metadata.revision,
     hfMetadataRevisionSource: metadata.revision_source,
     hfMetadataFile: metadata.metadata_file || 'not declared',
+  };
+}
+
+function externalModelSource(manifest, manifestPath) {
+  const source = manifest.model_source;
+  if (source === undefined) return null;
+  if (
+    !source ||
+    typeof source !== 'object' ||
+    Array.isArray(source) ||
+    source.kind !== 'ngc' ||
+    typeof source.id !== 'string' ||
+    !source.id ||
+    typeof source.revision !== 'string' ||
+    !source.revision ||
+    !path.isAbsolute(manifest.hf_id) ||
+    Object.hasOwn(manifest, 'hf_revision')
+  ) {
+    throw new Error(`Malformed external model_source in ${manifestPath}`);
+  }
+  return {
+    hfId: source.id,
+    revision: source.revision,
+    sourceKind: source.kind,
+    buildInput: manifest.hf_id,
+    hfModelType: 'not applicable',
+    hfArchitectures: [],
+    hfArchitectureSource: 'not applicable',
+    hfMetadataRevision: source.revision,
+    hfMetadataRevisionSource: source.kind,
+    hfMetadataFile: 'not applicable',
   };
 }
 
@@ -342,6 +374,8 @@ function hfTasksForManifest(manifest) {
     case 'neural_operator':
       return ['time-series-forecasting'];
     case 'robot_action_chunk':
+      return ['robotics'];
+    case 'pose_hypothesis_refinement':
       return ['robotics'];
     case 'diffusion_media_generation': {
       const tasks = new Set();
@@ -952,6 +986,7 @@ function typedConfigOptions(implementedFields, definitions, requirement = 'Optio
 }
 
 function commandContractForProfile(profile, capability) {
+  if (profile.cliCommands.length === 0) return null;
   const evidence = [
     'src/cli/main.cpp',
     'include/trtmc/pipeline.h',
@@ -1266,6 +1301,7 @@ function collectFamilyCommandContracts(repoRoot, profiles, runtimeOwnersByStrate
     });
     const merged = mergeRuntimeCapabilities(capabilities);
     const contract = commandContractForProfile(profile, merged);
+    if (contract === null) continue;
     const key = JSON.stringify({
       command: contract.command,
       purpose: contract.purpose,
@@ -1454,11 +1490,15 @@ function collectModelSupportInventory(repoRoot) {
       if (!manifest.name || !manifest.hf_id || !manifest.family || !manifest.task_strategy) {
         return null;
       }
+      const externalSource = externalModelSource(manifest, manifestPath);
       const hfMetadata = hfMetadataById.get(manifest.hf_id);
-      if (!hfMetadata) {
+      if (!hfMetadata && !externalSource) {
         throw new Error(
           `Missing Hugging Face model metadata for ${manifest.hf_id} (${manifestPath})`
         );
+      }
+      if (hfMetadata && externalSource) {
+        throw new Error(`Manifest cannot declare both Hugging Face and external metadata (${manifestPath})`);
       }
       if (manifest.hf_revision && manifest.hf_revision !== hfMetadata.revision) {
         throw new Error(
@@ -1469,8 +1509,8 @@ function collectModelSupportInventory(repoRoot) {
       const hfTasks = hfTasksForManifest(manifest);
       return {
         profile: manifest.name,
-        hfId: manifest.hf_id,
-        revision: manifest.hf_revision || 'not pinned',
+        hfId: externalSource?.hfId || manifest.hf_id,
+        revision: externalSource?.revision || manifest.hf_revision || 'not pinned',
         bundle: manifest.bundle || `${manifest.name}.bundle`,
         family: manifest.family,
         runtimeStrategy: manifest.runtime_strategy || 'not declared',
@@ -1482,7 +1522,7 @@ function collectModelSupportInventory(repoRoot) {
           : [],
         fp32Layers: Array.isArray(manifest.fp32_layers) ? manifest.fp32_layers : [],
         sourcePath: path.relative(repoRoot, manifestPath).replace(/\\/g, '/'),
-        ...hfMetadataFields(hfMetadata),
+        ...(externalSource || hfMetadataFields(hfMetadata)),
         ...manifestBuildConfiguration(manifest),
       };
     })
@@ -1547,7 +1587,9 @@ function collectModelSupportInventory(repoRoot) {
     };
   });
   const referencedHfIds = new Set([
-    ...modelProfiles.map((profile) => profile.hfId),
+    ...modelProfiles
+      .filter((profile) => !profile.sourceKind)
+      .map((profile) => profile.hfId),
     ...performanceSnapshot.map((row) => row.hfId),
   ]);
   const staleMetadata = [...hfMetadataById.keys()].filter(
@@ -1617,3 +1659,4 @@ function modelSupportInventoryPlugin(context) {
 module.exports = modelSupportInventoryPlugin;
 module.exports.collectModelSupportInventory = collectModelSupportInventory;
 module.exports.collectRuntimeCapabilities = collectRuntimeCapabilities;
+module.exports.externalModelSource = externalModelSource;

--- a/website/plugins/model-support-inventory/index.test.js
+++ b/website/plugins/model-support-inventory/index.test.js
@@ -12,7 +12,27 @@ const test = require('node:test');
 const {
   collectModelSupportInventory,
   collectRuntimeCapabilities,
+  externalModelSource,
 } = require('./index');
+
+test('rejects hf_revision for external model sources regardless of its value', () => {
+  const manifest = {
+    hf_id: '/work/model-artifacts/foundationpose/ngc-1.0.1',
+    model_source: {
+      kind: 'ngc',
+      id: 'nvidia/isaac/foundationpose',
+      revision: '1.0.1_onnx',
+    },
+  };
+
+  assert.equal(externalModelSource(manifest, 'manifest.json').sourceKind, 'ngc');
+  for (const hfRevision of ['', null]) {
+    assert.throws(
+      () => externalModelSource({...manifest, hf_revision: hfRevision}, 'manifest.json'),
+      /Malformed external model_source/
+    );
+  }
+});
 
 function writeFixture(repoRoot, relativePath, content = '') {
   const fixturePath = path.join(repoRoot, relativePath);
@@ -491,4 +511,27 @@ test('publishes LFM2 and MoGe profiles in model recipes and the website sidebar'
     href: '/models-recipes/model-recipes/families/lfm2',
     autoAddBaseUrl: true,
   });
+});
+
+test('publishes the external NGC FoundationPose recipe without HF metadata', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const inventory = collectModelSupportInventory(repoRoot);
+  const profile = inventory.modelProfiles.find(
+    (candidate) => candidate.profile === 'foundationpose-ngc-1.0.1'
+  );
+
+  assert.ok(profile, 'missing FoundationPose NGC profile');
+  assert.equal(profile.hfId, 'nvidia/isaac/foundationpose');
+  assert.equal(profile.revision, '1.0.1_onnx');
+  assert.equal(profile.sourceKind, 'ngc');
+  assert.equal(profile.buildInput, '/work/model-artifacts/foundationpose/ngc-1.0.1');
+  assert.deepEqual(profile.hfTasks, ['robotics']);
+  assert.deepEqual(profile.cliCommands, []);
+  assert.equal(profile.hfModelType, 'not applicable');
+  assert.deepEqual(profile.hfArchitectures, []);
+  assert.deepEqual(
+    inventory.familyRecipes.find((candidate) => candidate.family === 'foundationpose')
+      ?.commandContracts,
+    []
+  );
 });

--- a/website/src/components/ModelRecipes/FamilyPage.js
+++ b/website/src/components/ModelRecipes/FamilyPage.js
@@ -12,7 +12,7 @@ import RecipePageLayout from './RecipePageLayout';
 const BUNDLE_CLI_REFERENCE = {
   build: {
     purpose: 'Build one exact checkpoint into a TensorRT-Model-Connect bundle.',
-    syntax: 'trtmc build <hf-id> --output <bundle.bundle>',
+    syntax: 'trtmc build <model-id-or-path> --output <bundle.bundle>',
   },
   inspect: {
     purpose: 'Inspect bundle metadata, runtime identity, and packaged sections.',
@@ -34,7 +34,10 @@ function parallelLabel(profile) {
 
 function ArchitectureNames({profile}) {
   if (profile.hfArchitectures.length === 0) {
-    return <><span>—</span><br /><small>Not declared by checkpoint metadata</small></>;
+    const emptyReason = profile.sourceKind
+      ? 'Not applicable to this external artifact source'
+      : 'Not declared by checkpoint metadata';
+    return <><span>—</span><br /><small>{emptyReason}</small></>;
   }
   return (
     <>
@@ -189,8 +192,9 @@ export default function ModelFamilyRecipePage({familySlug}) {
 
         <h2>Supported architectures and task heads</h2>
         <p>
-          The Hugging Face values below are copied from checkpoint metadata at
-          the recorded revision. The TRTMC task contract comes from the exact
+          Hugging Face values, where applicable, are copied from checkpoint metadata
+          at the recorded revision. External artifact recipes identify their source
+          and revision explicitly. The TRTMC task contract comes from the exact
           E2E recipe. Architecture identity selects or describes a source graph;
           it does not imply that TRTMC reproduces every Hugging Face head with
           the same <code>model_type</code>. For example, an encoder recipe may
@@ -234,7 +238,7 @@ export default function ModelFamilyRecipePage({familySlug}) {
           <thead>
             <tr>
               <th>Recipe</th>
-              <th>Exact Hugging Face checkpoint</th>
+              <th>Exact model source</th>
               <th>Task</th>
               <th>Build configuration</th>
               <th>Declared E2E cases</th>
@@ -248,6 +252,7 @@ export default function ModelFamilyRecipePage({familySlug}) {
                 <td>
                   <code>{profile.hfId}</code>
                   {profile.revision !== 'not pinned' && <><br /><small>Revision: <code>{profile.revision}</code></small></>}
+                  {profile.buildInput && <><br /><small>Build from: <code>{profile.buildInput}</code></small></>}
                 </td>
                 <td>
                   {profile.hfTasks.map((taskSlug) => (

--- a/website/src/components/ModelSupportInventory/index.js
+++ b/website/src/components/ModelSupportInventory/index.js
@@ -17,6 +17,7 @@ const TASK_LABELS = {
   monocular_geometry: 'Monocular geometry',
   neural_operator: 'Time-series / neural operator',
   omni_multimodal: 'Omni multimodal',
+  pose_hypothesis_refinement: 'Pose hypothesis refinement',
   prompted_segmentation: 'Prompted segmentation',
   reranking: 'Reranking',
   segmentation: 'Segmentation',
@@ -63,7 +64,7 @@ function ModelProfileTable({profiles, taskGroup}) {
         <table>
           <thead>
             <tr>
-              <th>Hugging Face checkpoint</th>
+              <th>Model source / build input</th>
               <th>Manifest profile</th>
               <th>Task</th>
               <th>Family / runtime</th>
@@ -78,6 +79,7 @@ function ModelProfileTable({profiles, taskGroup}) {
                   <code>{profile.hfId}</code>
                   <br />
                   <small>Revision: {profile.revision}</small>
+                  {profile.buildInput && <><br /><small>Local build input: <code>{profile.buildInput}</code></small></>}
                 </td>
                 <td>
                   <code>{profile.profile}</code>


### PR DESCRIPTION
## Background

Issue #939 requests native FoundationPose support. The repository did not have a family-owned way to package or execute the official refiner/scorer pair, decode iterative pose deltas, rank hypotheses, or qualify the result against an external reference.

Closes #939.

## Exit Criteria

- The pinned FoundationPose refiner and scorer topologies are authored with TensorRT Python network APIs, build into one Model Connect bundle, and execute through a native family plugin without invoking the TensorRT ONNX parser.
- The default mixed-FP16 build produces rigid refined poses and rankings matching the pinned FP32 ONNX Runtime reference within the unchanged declared tolerances.
- Dynamic hypotheses, invalid inputs, iterative rerendering, best-pose selection, reset behavior, and at least 10 Hz single-hypothesis tracking are covered.
- Object segmentation, CAD rendering, collision checking, and physical robot safety remain explicit non-goals.

## Implementation

- Pins NVlabs/FoundationPose source revision `a1b694b83e633c2cb6115b9063d940a687759392` and NGC `nvidia/isaac/foundationpose:1.0.1_onnx` refiner/scorer SHA-256 digests.
- Adds family-owned, strongly typed TensorRT Python graphs for the convolutional/residual backbone, positional features, four-head attention, transformer heads, candidate cross-attention, and output reductions. The NGC ONNX artifacts are immutable weight containers; their computation graphs are never passed to TensorRT.
- Makes mixed FP16 the default build: model weights and most graph computation use FP16, while external I/O, normalization accumulation, scorer cross-hypothesis attention, and the score projection remain FP32. Explicit `--precision fp32` builds remain supported.
- Adds a two-engine bundle and family-owned C++ pipeline with bounded dynamic batches, exact iterative SE(3) delta decoding, rigid-transform validation, joint scoring, tracking state, and reset.
- Adds model-agnostic pose crop/request/result contracts to the public pipeline interface. The new virtual entry point is appended to the existing interface; existing bundle wire format is unchanged.
- Adds a native preprocessed-input example, deterministic synthetic qualification fixtures, a pinned isolated ONNX Runtime reference profile, model-owned E2E comparison/reporting, and GB300 FP32 and mixed-FP16 performance evidence.
- Registers the model in the validation catalog with an FP16 candidate and explicit FP32 reference-precision contract. Numeric, rigidity, ranking, and systems thresholds remain unchanged.
- Adds a declarative, digest-verified NGC model-artifact cache path to model proof. Artifacts stay outside the repository and are copied only into the proof-private work directory.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [x] ABI
- [x] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m tools.ci model-proof --model foundationpose --suite premerge --revision HEAD ...` — passed at `b8a6bb0e04589d450bbdd8cc5f2b07e1304eba3f`: cache/source isolation, scratch compilation, DSO isolation, C++/Python tests, fresh native-API FP32 engine builds, E2E reference parity, engine-build verification, result verification, and strict HTML reporting.
- Final mixed-FP16 build at `53f6a73e2` — passed with TensorRT 11.1.0.106 on GB300; 189.6 s total and a 66.44 MiB bundle.
- Final mixed-FP16 TensorRT/ONNX Runtime E2E — passed: pose max absolute error `0.000373` (limit `0.005`), score max absolute error `0.029724` (limit `0.05`), complete ranking agreement `1.0`, and rigid-pose fraction `1.0`.
- Five alternating 200-run GB300 tracking trials — mixed FP16 median p50 `2.951 ms`, p95 `2.991 ms`, and `338.9 Hz`, versus FP32 p50 `3.235 ms`, p95 `3.265 ms`, and `309.2 Hz`. Runtime GPU-memory delta fell from `3003.8 MiB` to `1209.8 MiB` and bundle size fell from `127.38 MiB` to `66.44 MiB`.
- `python3 -m pytest -q python/tensorrt_model_connect/families/foundationpose/tests tests/e2e/models/foundationpose/test_foundationpose_e2e.py tests/e2e/models/foundationpose/test_foundationpose_report.py` — 12 passed, 1 environment-dependent E2E selection skipped.
- Ruff lint/format, Python compilation, JSON parsing, and `git diff --check` — passed.
- GitHub Community CPU run `33818327745` and Internal CI Bridge run `33819468944` — passed for `53f6a73e2`, including `TRTMC Internal CI / Automated premerge gate`.

### Hardware, Environment, and Revisions

- Current implementation head: `53f6a73e2`.
- Hardware: NVIDIA GB300, compute capability 10.3; driver 580.105.08.
- Container: `trtmc-ci:trt11.1`; CUDA 13.3; TensorRT 11.1.0.106; mixed FP16 with the stated FP32 safeguards.
- FoundationPose source: `a1b694b83e633c2cb6115b9063d940a687759392`.
- NGC models: `1.0.1_onnx`; refiner SHA-256 `dcc695a19c4bcfe5e1d909a22d8f652d8ec8bab1e19bd1544c6b45f2d3595cf7`; scorer SHA-256 `0bf1026c0db7320ebf9a548ecf0d3c810c8dbd377948630bd3e5af1d49440503`.
- Reference dependency: ONNX Runtime 1.29.0 in an isolated exact-pinned profile.

### Not Run / Remaining Gaps

- Live camera input, object segmentation, CAD mesh rendering, and physical robot execution were not run because they are outside this model-stage integration and its safety boundary.
- Hardware other than GB300 was not qualified.
- The deterministic synthetic workload proves numerical parity and system behavior, not real-dataset ADD/ADD-S pose-estimation accuracy.

## Notes For Future Readers

The upstream NGC ONNX files are downloaded from the declared public NGC endpoints into a digest-keyed host cache and are never committed or published as CI artifacts. `builder.py` extracts only their pinned initializer tensors and authors the TensorRT topology itself. Crop generation/rerendering remains application-owned through a callback so model topology and orchestration stay within the FoundationPose family while generic public types contain no family semantics.

Review the family-native Python builder first, then the public pose contract and family runtime, followed by model-proof artifact isolation and E2E evidence. Pure FP16 was rejected because its score max error was `0.051239`, above the unchanged `0.05` limit; retaining only scorer cross-hypothesis attention and score projection in FP32 restored margin without the memory cost of a broader FP32 scorer.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this adds a public virtual API entry point, a new GPU model family with two external artifacts, and generic proof-cache mechanics. The implementation is family-isolated, fail-closed on shapes/digests/rigidity, and covered by fresh-engine parity and performance qualification.
