### PR TITLE
docs(runtime): document forward output contract

### DIFF
--- a/include/trtmc/runtime/trt_module.h
+++ b/include/trtmc/runtime/trt_module.h
@@ -31,8 +31,15 @@ class ITrtModule {
   public:
     virtual ~ITrtModule() = default;
 
-    // Forward passes
+    // Synchronous host forward pass. Each returned Tensor::data points to
+    // module-owned staging storage that is reused by the next forward() call on
+    // this module. Copy output data before calling forward() again when it must
+    // remain valid. Output tensors retain the engine output dtype, which may be
+    // a half-width type rather than float32.
     virtual TensorMap forward(const TensorMap& inputs) = 0;
+
+    // Device and asynchronous forward passes do not use the host staging
+    // storage described above.
     virtual DeviceTensorMap forward_device(const DeviceTensorMap& inputs) = 0;
     virtual void forward_device_async(const DeviceTensorMap& inputs) = 0;
     virtual void forward_async(const TensorMap& inputs) = 0;


### PR DESCRIPTION
## Background

`ITrtModule::forward()` did not document its output lifetime or dtype contract. Closes #1126.

## Exit Criteria

Document host-output lifetime and dtype without changing device-path behavior.

## Implementation

Added comments stating that `forward()` outputs use reusable module-owned staging storage and retain the engine output dtype. No API, ABI, runtime, dependency, or artifact changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `clang-format --dry-run --Werror include/trtmc/runtime/trt_module.h`: passed.
- `git diff --check`: passed.
- `python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 160 passed.

### Hardware, Environment, and Revisions

Head `e6f9c855467ecf11ecab0369b656702aada03d3b`; Windows, Python 3.14. Hardware and model revisions are not applicable.

### Not Run / Remaining Gaps

GPU and runtime execution were not run because executable behavior is unchanged.

## Notes For Future Readers

The documented lifetime applies only to synchronous host outputs.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Comments only; executable code is unchanged.