### PR TITLE
feat(timm_resnet): register the resnet18 and resnext50 checkpoints

### DIFF
--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -1138,6 +1138,10 @@ additional_profiles:
     inherit: qwen.generate
   - model: qwen3-moe-tiny-random
     inherit: qwen_moe.generate
+  - model: resnet18-a1-in1k
+    inherit: timm_resnet.classify
+  - model: resnext50-32x4d-a1h-in1k
+    inherit: timm_resnet.classify
   - model: riva-translate-4b
     inherit: mistral.generate
   - model: roberta-base

--- a/tests/e2e/models/timm_resnet/MODEL.toml
+++ b/tests/e2e/models/timm_resnet/MODEL.toml
@@ -4,7 +4,9 @@
 id = "timm_resnet"
 plugin = "timm_resnet"
 test_manifests = [
+  "manifests/resnet18-a1-in1k.json",
   "manifests/resnet50-a1-in1k.json",
+  "manifests/resnext50-32x4d-a1h-in1k.json",
 ]
 
 [e2e_defaults.image_classification]

--- a/tests/e2e/models/timm_resnet/manifests/resnet18-a1-in1k.json
+++ b/tests/e2e/models/timm_resnet/manifests/resnet18-a1-in1k.json
@@ -1,0 +1,47 @@
+{
+  "name": "resnet18-a1-in1k",
+  "hf_id": "timm/resnet18.a1_in1k",
+  "bundle": "resnet18-a1-in1k.bundle",
+  "family": "timm_resnet",
+  "runtime_strategy": "timm_resnet_image_classification",
+  "task_strategy": "image_classification",
+  "max_cache_length": 1,
+  "precision": "fp16",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "resnet18-a1-in1k",
+      "trace_id": "IT-E2E-TIMM-RESNET-02",
+      "reference_family": "image_classification",
+      "user_contract": "image_classification",
+      "test_type": "image_classification",
+      "prompt": "",
+      "max_new_tokens": 0,
+      "reference_precision": "fp32",
+      "test_image": "data/test_img.jpeg",
+      "preflight_requirements": [
+        {
+          "kind": "binary_exists",
+          "args": {},
+          "gating": true
+        },
+        {
+          "kind": "asset_exists",
+          "args": {
+            "path": "data/test_img.jpeg"
+          },
+          "gating": true
+        },
+        {
+          "kind": "python_module_available",
+          "args": {
+            "module": "timm",
+            "phase": "reference"
+          },
+          "gating": true
+        }
+      ],
+      "core": true
+    }
+  ]
+}

--- a/tests/e2e/models/timm_resnet/manifests/resnext50-32x4d-a1h-in1k.json
+++ b/tests/e2e/models/timm_resnet/manifests/resnext50-32x4d-a1h-in1k.json
@@ -1,0 +1,47 @@
+{
+  "name": "resnext50-32x4d-a1h-in1k",
+  "hf_id": "timm/resnext50_32x4d.a1h_in1k",
+  "bundle": "resnext50-32x4d-a1h-in1k.bundle",
+  "family": "timm_resnet",
+  "runtime_strategy": "timm_resnet_image_classification",
+  "task_strategy": "image_classification",
+  "max_cache_length": 1,
+  "precision": "fp16",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "resnext50-32x4d-a1h-in1k",
+      "trace_id": "IT-E2E-TIMM-RESNET-03",
+      "reference_family": "image_classification",
+      "user_contract": "image_classification",
+      "test_type": "image_classification",
+      "prompt": "",
+      "max_new_tokens": 0,
+      "reference_precision": "fp32",
+      "test_image": "data/test_img.jpeg",
+      "preflight_requirements": [
+        {
+          "kind": "binary_exists",
+          "args": {},
+          "gating": true
+        },
+        {
+          "kind": "asset_exists",
+          "args": {
+            "path": "data/test_img.jpeg"
+          },
+          "gating": true
+        },
+        {
+          "kind": "python_module_available",
+          "args": {
+            "module": "timm",
+            "phase": "reference"
+          },
+          "gating": true
+        }
+      ],
+      "core": true
+    }
+  ]
+}

--- a/tests/e2e/models/timm_resnet/thresholds/resnet18-a1-in1k.json
+++ b/tests/e2e/models/timm_resnet/thresholds/resnet18-a1-in1k.json
@@ -1,0 +1,3 @@
+{
+  "threshold_overrides": {}
+}

--- a/tests/e2e/models/timm_resnet/thresholds/resnext50-32x4d-a1h-in1k.json
+++ b/tests/e2e/models/timm_resnet/thresholds/resnext50-32x4d-a1h-in1k.json
@@ -1,0 +1,3 @@
+{
+  "threshold_overrides": {}
+}

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -267,7 +267,11 @@ models:
     workloads: [mmlu_five_shot_mcq]
   qwen38-27b:
     workloads: [mmlu_five_shot_mcq]
+  resnet18-a1-in1k:
+    workloads: [imagenette_image_classification]
   resnet50-a1-in1k:
+    workloads: [imagenette_image_classification]
+  resnext50-32x4d-a1h-in1k:
     workloads: [imagenette_image_classification]
   riva-translate-4b:
     workloads: [flores200_en_fr_riva_translation_parity]

--- a/website/data/hf-model-metadata.json
+++ b/website/data/hf-model-metadata.json
@@ -1334,6 +1334,17 @@
       "architecture_source": "config.architecture"
     },
     {
+      "hf_id": "timm/resnet18.a1_in1k",
+      "revision": "491b427b45c94c7fb0e78b5474cc919aff584bbf",
+      "revision_source": "resolved",
+      "metadata_file": "config.json",
+      "model_type": null,
+      "architectures": [
+        "resnet18"
+      ],
+      "architecture_source": "config.architecture"
+    },
+    {
       "hf_id": "timm/resnet50.a1_in1k",
       "revision": "767268603ca0cb0bfe326fa87277f19c419566ef",
       "revision_source": "resolved",
@@ -1341,6 +1352,17 @@
       "model_type": null,
       "architectures": [
         "resnet50"
+      ],
+      "architecture_source": "config.architecture"
+    },
+    {
+      "hf_id": "timm/resnext50_32x4d.a1h_in1k",
+      "revision": "cc736cb0940158d05966023116d90fca4c38dae3",
+      "revision_source": "resolved",
+      "metadata_file": "config.json",
+      "model_type": null,
+      "architectures": [
+        "resnext50_32x4d"
       ],
       "architecture_source": "config.architecture"
     },

--- a/website/data/model-support-matrix.md
+++ b/website/data/model-support-matrix.md
@@ -105,7 +105,9 @@ SPDX-License-Identifier: Apache-2.0
 | `google-t5/t5-small` | `t5-small` | `FP16` | None | — | 🟢 Green |
 | `google/timesfm-2.0-500m-pytorch` | `timesfm-2.0-500m-official` | `FP32` | None | — | 🟢 Green |
 | `timm/mobilenetv3_large_100.ra_in1k` | `mobilenetv3-large-100-ra-in1k` | `FP16` | None | — | 🟢 Green |
+| `timm/resnet18.a1_in1k` | `resnet18-a1-in1k` | `FP16` | None | — | 🟢 Green |
 | `timm/resnet50.a1_in1k` | `resnet50-a1-in1k` | `FP16` | None | — | 🟢 Green |
+| `timm/resnext50_32x4d.a1h_in1k` | `resnext50-32x4d-a1h-in1k` | `FP16` | None | — | 🟢 Green |
 | `timm/vgg16.tv_in1k` | `vgg16-tv-in1k` | `FP16` | None | — | 🟢 Green |
 | `timm/vit_base_patch16_224.augreg_in21k_ft_in1k` | `timm-vit-base-p16-224-augreg-in21k-ft-in1k` | `FP16` | None | — | 🟢 Green |
 | `TinyLlama/TinyLlama-1.1B-Chat-v1.0` | `tinyllama-1.1b` | `FP16` | None | — | 🟢 Green |


### PR DESCRIPTION
> **Stacked on #1121.** That pull request adds the `timm_resnet` family; this
> one only registers two further checkpoints. The diff below includes #1121
> until it merges, after which this branch will be rebased.

## Background

#1121 adds the `timm_resnet` family with `timm/resnet50.a1_in1k` as its only
registered checkpoint. The builder recovers the stage layout from the
checkpoint rather than from a depth table, so the basic-block and
grouped-convolution variants already build correctly and were verified during
that work, but neither is registered as a supported model.

## Exit Criteria

- `timm/resnet18.a1_in1k` and `timm/resnext50_32x4d.a1h_in1k` are registered
  checkpoints with E2E manifests, validation workloads, and performance
  coverage.
- No builder change is required.

Non-goal: `resnet34`, `resnet101`, `resnet152`, and `wide_resnet` also match the
family prefixes but are not registered here.

## Implementation

Registration only. Adds E2E manifests and thresholds for both checkpoints,
registers them in the support matrix, HF metadata, and validation workloads,
and adds them to the release performance suite as `additional_profiles`
inheriting `timm_resnet.classify`. Repository counters are updated to match.

No source change to the family: `python/tensorrt_model_connect/families/timm_resnet`
and `src/runtime/models/timm_resnet` are untouched by this pull request.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

```
python -m pytest tests/builder/ tests/tools/ tests/e2e_harness/ -q -n 8 \
  --dist=worksteal --import-mode=importlib -p no:cacheprovider
=> 3948 passed, 8 skipped

python -m ruff check tests/e2e/models/timm_resnet   => All checks passed
python tools/legal_headers.py                       => findings=0
```

Numerical parity, measured when the family landed. Engine logits compared
against an independent PyTorch reference that applies batch norm unfolded:

| Checkpoint | Layout discovered | Correlation | argmax | top-5 |
| --- | --- | --- | --- | --- |
| `timm/resnet18.a1_in1k` | `[2,2,2,2]` basic | 0.99999826 | match | 5/5 |
| `timm/resnext50_32x4d.a1h_in1k` | `[3,4,6,3]` grouped | 0.99999678 | match | 5/5 |

### Hardware, Environment, and Revisions

- GPU: NVIDIA A100-SXM4-80GB, compute capability 8.0.
- Container: `Dockerfile.dev.x86` dev image, Ubuntu 24.04, Python 3.12.
- TensorRT 11.1.0.106, CUDA architecture `80-real`, Release build.
- Parity measured at fp32; both checkpoints are registered for `FP16` builds.
- Checkpoint revisions at time of testing:
  - `timm/resnet18.a1_in1k` @ `491b427b45c94c7fb0e78b5474cc919aff584bbf`
  - `timm/resnext50_32x4d.a1h_in1k` @ `cc736cb0940158d05966023116d90fca4c38dae3`

  The manifests intentionally do not pin `hf_revision`: the timm reference
  resolves `hf-hub:<id>` at `main`, so a pin would disagree with the cache the
  warm step populates and fail the offline reference run. See #1121.

### Not Run / Remaining Gaps

- No E2E harness run for either new checkpoint. Both are registered and will be
  exercised by the model proof; the parity evidence above comes from a direct
  engine-versus-PyTorch comparison rather than the harness.
- No performance numbers. The profiles are registered but were not run.
- `resnet34`, `resnet101`, `resnet152`, and `wide_resnet` remain unregistered
  and unverified.

## Notes For Future Readers

Adding a further ResNet depth should need only a manifest, the shared
registration entries, and a counter bump. The builder is layout-driven, so no
graph code changes.

Note that `tools/model_ci.py` reads manifests from the committed tree via
`git ls-tree`, so a new manifest must be committed before
`test_nightly_inventory_exactly_matches_every_model_proof_selection` will agree
with filesystem-based test selection.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Registration only, no source change to the family, and the full CPU suite
passes.
