### PR TITLE
fix(e2e): remove stale eagle VL waives

### DIFF
--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -1,6 +1,3 @@
 # Waived E2E tests — centralized skip/xfail tracking.
 # Format: model-name  SKIP|XFAIL  (reason)
 # Platform-specific: GB300/model-name  XFAIL  (reason)
-
-eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
-eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)

--- a/tests/tools/test_e2e_waives.py
+++ b/tests/tools/test_e2e_waives.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from tests import test_e2e
+from tests.e2e_harness.manifest_loader import get_case_names
 
 
 def test_load_waives_filters_with_explicit_platform(monkeypatch, tmp_path) -> None:
@@ -45,3 +48,46 @@ def test_load_waives_without_platform_ignores_prefixed_entries(monkeypatch, tmp_
     waives = test_e2e._load_waives()
 
     assert waives == {"model-shared": ("XFAIL", "shared waive")}
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WAIVES_FILE = _REPO_ROOT / "tests" / "e2e" / "waives.txt"
+
+
+def _declared_case_names() -> set[str]:
+    return set(get_case_names())
+
+
+def test_every_waive_names_a_declared_case() -> None:
+    """A waive for a name no E2E testcase declares is silently inert.
+
+    The runtime resolves a waive against ``case.name``, so the namespace to
+    check against is the child testcase names, not the top-level manifest
+    names -- 50 of the former are not the latter. ``_load_waives`` skips any
+    line it cannot parse and reports nothing when a name stops matching, so
+    such an entry quietly stops doing anything. If the name is ever reused,
+    the waive springs back and skips a case no one intended to waive.
+    """
+    declared = _declared_case_names()
+    assert declared, "no E2E testcases were discovered"
+
+    # Platform-prefixed waives are only visible when that platform is
+    # selected, so collect across every platform the file mentions.
+    platforms = {""}
+    for line in _WAIVES_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name_part = line.split(None, 1)[0]
+        if "/" in name_part:
+            platforms.add(name_part.split("/", 1)[0])
+
+    waived: set[str] = set()
+    for platform in platforms:
+        waived.update(test_e2e._load_waives(platform))
+
+    orphans = sorted(waived - declared)
+    assert not orphans, (
+        "waives.txt names cases that no E2E testcase declares, so these waives "
+        f"are silently inert: {orphans}"
+    )


### PR DESCRIPTION
## Background

`tests/e2e/waives.txt` skipped two models for a 404 Hugging Face repo:

```
eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
```

No manifest declares either name. The `eagle_vlm` manifests are
`nemotron-embed-vl-1b-v2` and `nemotron-rerank-vl-1b-v2` (plus their `-tp4`
variants), pointing at `nvidia/llama-nemotron-embed-vl-1b-v2` and
`nvidia/llama-nemotron-rerank-vl-1b-v2`. Both are listed 🟢 Green in
`website/data/model-support-matrix.md`. The repo is reachable and the waived
names are gone, so both the subjects and the reason are stale.

`_load_waives` matches purely by model name and skips any line it cannot
parse, so these entries have been silently inert rather than failing — which is
exactly why they rotted unnoticed. If either name were ever reused, the waive
would spring back and skip a Green model with no one asking for it.

Precedent: `19316ed9 fix(e2e): remove stale Qwen TorchTRT waive`.

No originating issue; found while surveying `eagle_vlm` coverage.

## Exit Criteria

- `tests/e2e/waives.txt` contains no entry naming a model with no declared
  manifest.
- A CPU test reports the next such entry instead of letting it rot.
- Existing `_load_waives` platform-selection coverage is unchanged.

Non-goals: no change to `_load_waives` itself, to the per-family
`waives.txt` files, or to any manifest.

## Implementation

Remove the two stale entries. Add
`test_every_waive_names_a_declared_manifest` to the existing
`tests/tools/test_e2e_waives.py`: every waived name must resolve to a manifest
declared through the E2E harness's own `iter_manifest_paths()`, collected
across every platform prefix the file mentions so platform-scoped waives are
also checked.

The guard reuses the harness loader rather than globbing, so it follows the
same indexed/flat/nested manifest layouts the harness supports.

Affected components: `tests/e2e/waives.txt`, `tests/tools/test_e2e_waives.py`.
No public API, ABI, bundle-format, or dependency change.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

Test-first. With the guard added and `tests/e2e/waives.txt` still at
`upstream/main`, it reproduces exactly the two stale names:

```
$ git checkout upstream/main -- tests/e2e/waives.txt
$ PYTHONPATH=python:. pytest tests/tools/test_e2e_waives.py -q
E   assert not ['eagle-embed-vl-1b-v2', 'eagle-rerank-vl-1b-v2']
FAILED tests/tools/test_e2e_waives.py::test_every_waive_names_a_declared_manifest
1 failed, 2 passed
```

After removing the two entries:

```
$ PYTHONPATH=python:. pytest tests/tools/test_e2e_waives.py -v
tests/tools/test_e2e_waives.py::test_load_waives_filters_with_explicit_platform PASSED
tests/tools/test_e2e_waives.py::test_load_waives_without_platform_ignores_prefixed_entries PASSED
tests/tools/test_e2e_waives.py::test_every_waive_names_a_declared_manifest PASSED
3 passed
```

The two pre-existing tests in this file are unchanged; the diff on it is
purely additive (0 deleted lines).

Full CPU `tests/tools`, on this branch and on `upstream/main`, using the same
marker set and the same deselect the workflow applies for filesystems without
reflink support:

```
$ PYTHONPATH=python:. pytest tests/tools -q \
    -m "not gpu and not trt and not e2e and not model_proof_allocator" \
    --deselect tests/tools/test_model_proof_runner.py::test_distinct_explicit_hf_cache_paths_reach_both_containers

upstream/main:  2986 passed, 22 deselected
this branch:    2987 passed, 22 deselected
```

The single extra pass is the new guard. No failures on either side.

The two public gates that run without a GPU:

```
$ python3 -m tools.community_ci source-quality --base upstream/main
[ccm] PASS
All checks passed!            # ruff on tests/tools/test_e2e_waives.py
160 passed in 18.72s          # model architecture contracts
exit 0

$ python3 -m tools.community_ci impact --base upstream/main
{
  "changed_paths": ["tests/e2e/waives.txt", "tests/tools/test_e2e_waives.py"],
  "classifications": ["platform", "unit_tests"],
  "run_unit_tests": true,
  "unit_scope": "all"
}
exit 0
```

Evidence for the staleness claim:

```
$ ls tests/e2e/models/eagle_vlm/manifests/
nemotron-embed-vl-1b-v2-tp4.json   nemotron-embed-vl-1b-v2.json
nemotron-rerank-vl-1b-v2-tp4.json  nemotron-rerank-vl-1b-v2.json
$ grep -i "nemotron-embed-vl\|nemotron-rerank-vl" website/data/model-support-matrix.md
| `nvidia/llama-nemotron-embed-vl-1b-v2`  | `nemotron-embed-vl-1b-v2`  | `FP16` | None | — | 🟢 Green |
| `nvidia/llama-nemotron-rerank-vl-1b-v2` | `nemotron-rerank-vl-1b-v2` | `FP16` | None | — | 🟢 Green |
```

Consistency checks:

```
$ PYTHONPATH=python:. python3 tools/test_impact.py --validate
Validation passed. 229 models, 13 core, 89 families.
$ PYTHONPATH=python:. python3 tools/legal_headers.py
legal headers: tracked=6226 managed=5321 excepted=4 ignored=901 changed=0 findings=0
$ git diff --check
```

Unit evidence only. No inference, parity, performance, or qualification claim.

### Hardware, Environment, and Revisions

- Repository head: `e9f45793` (`upstream/main`), branch rebased onto it.
- Host: Ubuntu 22.04.5, Python 3.13.9, pytest 8.4.2 and ruff 0.16.4 from
  `requirements/community-ci.txt`, plus numpy, PyYAML, torch 2.5.1+cu121,
  safetensors, transformers, tensorrt 11.2.1.2 and cuda-python so the full
  `tests/tools` set collects.
- No GPU execution: this change is data and a Python test.

### Not Run / Remaining Gaps

- No E2E run: removing a waive for a name nothing declares cannot change E2E
  selection, since `_load_waives` never matched it.
- The `Community CPU / Docs` job was not run locally; this change touches
  nothing under `website/`.
- The unit stage was not run through `tools.community_ci unit --scope all`,
  which requires Docker; Docker on this host needs privileges the contributor
  account does not have. The same test set was run directly instead, as
  recorded above.
- The guard covers the repo-wide `tests/e2e/waives.txt` only. The five
  per-family `waives.txt` files are loaded by each family's own `runner.py`
  and are currently header-only; extending the guard to them is model-owned
  work and is left to those owners.

## Notes For Future Readers

The silent-`continue` behavior in every waive loader is the root of this: a
waive that stops matching stops doing anything, and nothing reports it. The
guard turns the next occurrence into a CPU failure instead of a slow rot.

Promoting the loader itself to reject unparseable lines would be a stronger
fix, but it changes `_load_waives` behavior for all callers and belongs in a
separate change.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Deletes two entries that provably matched nothing, and adds one test. No
production code touched.
