### PR TITLE
test(tools): replace brittle inventory counts

### DIFF
--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -399,16 +399,16 @@ def test_inventory_report_is_deterministic_and_serializable(tmp_path: Path) -> N
     assert first["schema_version"] == specialization.SCHEMA_VERSION
 
 
-def test_repository_registers_all_current_families() -> None:
+def test_repository_family_packages_match_e2e_owners() -> None:
     repo_root = Path(__file__).resolve().parents[2]
 
-    families = specialization.family_dirs(repo_root, ())
+    family_names = {
+        family.name for family in specialization.family_dirs(repo_root, ())
+    }
+    e2e_owner_names = {
+        owner.name
+        for owner in (repo_root / "tests/e2e/models").iterdir()
+        if (owner / "MODEL.toml").is_file()
+    }
 
-    assert len(families) == 89
-    assert any(family.name == "cosmos3" for family in families)
-    assert any(family.name == "dinov3" for family in families)
-    assert any(family.name == "fast_foundation_stereo" for family in families)
-    assert any(family.name == "lfm2" for family in families)
-    assert any(family.name == "minimax_h3" for family in families)
-    assert any(family.name == "nemotron_voicechat" for family in families)
-    assert any(family.name == "sam2" for family in families)
+    assert family_names == e2e_owner_names

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -399,7 +399,7 @@ def test_inventory_report_is_deterministic_and_serializable(tmp_path: Path) -> N
     assert first["schema_version"] == specialization.SCHEMA_VERSION
 
 
-def test_repository_family_packages_match_e2e_owners() -> None:
+def test_repository_registers_all_current_families() -> None:
     repo_root = Path(__file__).resolve().parents[2]
 
     family_names = {

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 import yaml
 
+from benchmarks.performance.baselines.timing_contracts import MODEL_CALL_FAMILIES
 from tools import perf_matrix
 from tools.performance import catalog as performance_catalog
 
@@ -271,9 +272,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
 
     performance_catalog.validate_release_coverage(cases, excluded_profiles)
 
-    assert len(cases) == 112
-    assert len(raw_entries) == 82
-    assert len(raw_additional) == 30
+    assert len(cases) == len(raw_entries) + len(raw_additional)
     assert excluded_profiles == {
         "lfm2-1.2b": LFM2_EXCLUSION_REASON,
         "lfm2-2.6b": LFM2_EXCLUSION_REASON,
@@ -290,16 +289,23 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert not any("priority" in entry for entry in raw_entries)
     assert {case["model"] for case in cases} == ready_profiles - set(excluded_profiles)
     assert not any(performance_catalog.is_l0_profile(case["model"]) for case in cases)
-    assert len({(case["family"], case["operation"]) for case in cases}) == 82
-    assert len({case["family"] for case in cases}) == 80
-    assert [case["operation"] for case in cases if case["family"] == "eagle_vlm"] == [
-        "embed",
-        "rerank",
-    ]
-    assert Counter(perf_matrix._candidate_timing_scope(case) for case in cases) == {
-        "model_call_wall": 26,
-        "public_pipeline_call_wall": 86,
+    assert len({(case["family"], case["operation"]) for case in cases}) == len(raw_entries)
+    operations_by_family: dict[str, set[str]] = {}
+    for case in cases:
+        operations_by_family.setdefault(case["family"], set()).add(case["operation"])
+    assert {
+        family: operations
+        for family, operations in operations_by_family.items()
+        if len(operations) > 1
+    } == {
+        "bert": {"embed", "encode"},
+        "eagle_vlm": {"embed", "rerank"},
     }
+    assert {
+        case["family"]
+        for case in cases
+        if perf_matrix._candidate_timing_scope(case) == "model_call_wall"
+    } == MODEL_CALL_FAMILIES & set(operations_by_family)
     assert {case["id"] for case in cases if case["baseline"]["asset_loading_included"]} == {
         "canary.transcribe",
         "deepseek_ocr.generate",
@@ -2192,7 +2198,9 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert not scratch_root.exists()
     results = json.loads((output / "results.json").read_text(encoding="utf-8"))
     rows = {row["id"]: row for row in results["cases"]}
-    assert len(rows) == 112
+    assert set(rows) == {
+        case["id"] for case in performance_catalog.load_suite(SUITE).cases
+    }
     assert results["environment_config"]["name"] == "test-gb300"
     assert results["environment_config"]["execution"]["minimum_gpu_free_fraction"] == 0.0
     assert results["environment_config"]["source"] == str(environment.resolve())

--- a/tests/tools/test_performance_catalog.py
+++ b/tests/tools/test_performance_catalog.py
@@ -18,7 +18,6 @@ def test_release_suite_loads_and_selects_models_in_request_order() -> None:
     selected = suite.select(models=["distilgpt2", "gpt2-125m"])
 
     assert [case["model"] for case in selected] == ["distilgpt2", "gpt2-125m"]
-    assert len(suite.cases) == 112
 
 
 def test_release_suite_includes_fast_foundation_stereo() -> None:

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -3222,14 +3222,6 @@ class TestAggregation:
         assert not result.cap_applied
         assert sorted(result.e2e_models) == ["decoder-large", "decoder-small"]
 
-    def test_cap_applied_when_over(self, imap):
-        """Cap applied when affected models > cap."""
-        result = test_impact.analyze_impact(
-            ["python/tensorrt_model_connect/checkpoint_mapper.py"], imap, cap=5
-        )
-        assert result.cap_applied
-        assert sorted(result.e2e_models) == sorted(imap.core_models)
-
     def test_no_changed_files(self, imap):
         """No files -> no impact."""
         result = test_impact.analyze_impact([], imap)
@@ -3461,16 +3453,6 @@ class TestValidation:
         imap = test_impact.build_impact_map(real_root)
         errors = test_impact.validate_map(imap, real_root)
         assert errors == [], f"Validation errors: {errors}"
-
-    def test_real_repo_has_core_models(self):
-        """Real repo has at least 5 core models."""
-        real_root = REPO_ROOT
-        if not (real_root / "tests" / "e2e" / "models").is_dir():
-            pytest.skip("Not in the project repo")
-        imap = test_impact.build_impact_map(real_root)
-        assert len(imap.core_models) >= 5, (
-            f"Expected at least 5 core models, got {len(imap.core_models)}"
-        )
 
     def test_flux_runtime_selects_batch2_detector(self):
         """FLUX runtime changes must execute the real-bundle batch contract."""

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -45,7 +45,6 @@ def test_model_workload_catalog_covers_every_ready_model():
         task_models=task_models,
     )
 
-    assert len(catalog["models"]) == len(ready_models) == 121
     assert sum("not_compared_reason" in spec for spec in catalog["models"].values()) == 0
     assert all("e2e" not in spec.get("workloads", []) for spec in catalog["models"].values())
     assert "reference_cache_identity" not in catalog["models"]["personaplex-7b"]
@@ -64,7 +63,7 @@ def test_model_workload_catalog_covers_every_ready_model():
     }
     assert len(qwen_identities) == 1
     bindings = trtmc_validate.resolve_bindings(catalog, catalog["models"])
-    assert len(bindings) == 122
+    assert {binding.model for binding in bindings} == set(catalog["models"])
     assert {
         binding.model for binding in bindings if binding.workload == "mmlu_continuation_parity"
     } >= {
@@ -266,7 +265,6 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 121
 
 
 def test_shadow_gate_metrics_include_plugin_task_accuracy() -> None:


### PR DESCRIPTION
## Background

Several tools tests pin repository-wide model, family, binding, and performance-case totals. Legitimate catalog additions therefore require synchronized number changes without identifying which contract changed or whether the new entry is wired correctly.

## Exit Criteria

- Catalog growth does not require unrelated expected-total updates.
- Tests still detect missing or extra family owners, dropped performance cases, models without validation bindings, duplicate family operations, and timing-contract coverage gaps.
- Exact duplicate tests and assertions without an independent policy source are removed.

## Implementation

- Replace absolute performance and validation totals with set equality and relationships derived from the declarative inputs.
- Compare Python family packages directly with E2E model owners instead of checking a family count and a small sample.
- Remove one duplicate impact-cap test and the arbitrary `core_models >= 5` repository floor.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python -m ruff check tests/tools/test_performance_catalog.py tests/tools/test_perf_matrix.py tests/tools/test_trtmc_validate.py tests/tools/test_family_specialization.py tests/tools/test_test_impact.py`: passed.
- Changed tools files plus the importing builder contract: 626 passed.
- Full `tests/tools` run: 3008 passed, 2 failed. Both failures are unchanged Hugging Face cache isolation cases whose required `cp --reflink=always` operation is unsupported by the local workspace filesystem.
- `python tools/legal_headers.py`: `findings=0`.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Tested head: `8819abf64b681e2beff24a3efb6ab207db914da3`.
- Python 3.12.3 on the local Linux CPU environment. No GPU, CUDA, TensorRT, model checkpoint, or dataset was exercised because the diff changes tests only.

### Not Run / Remaining Gaps

- The full tools suite was not locally green because the workspace filesystem does not support the two unchanged reflink-required cache-isolation cases recorded above.
- No model build, inference, parity, performance, or hardware qualification was run; none is affected by this test-only diff.

## Notes For Future Readers

- Review the release-suite assertions first: they now describe one-to-one expansion, multi-operation families, timing-contract coverage, and exact output case IDs.
- This is test-only cleanup. It changes no model implementation, catalog data, or validation threshold.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The change is limited to CPU test assertions and removes no product behavior coverage.
