### PR TITLE
test(deepseek-ocr): cover the runtime config boundary

### DIFF
--- a/src/runtime/models/deepseek_ocr/MODEL.toml
+++ b/src/runtime/models/deepseek_ocr/MODEL.toml
@@ -6,5 +6,6 @@ runtime_library = "libtrtmc_model_deepseek_ocr.so"
 runtime_plugins = ["plugin.cpp|register_deepseek_ocr_plugin"]
 runtime_strategies = ["deepseek_ocr_vision_language"]
 runtime_tests = [
+  "test_deepseek_ocr_runtime_config_contract|test_deepseek_ocr_runtime_config_contract.cpp|_|image_preprocessor.cpp|EXTRA_INCLUDES,third_party/stb",
   "test_deepseek_ocr_vl_pipeline|test_deepseek_ocr_vl_pipeline.cpp|trtmc_model_deepseek_ocr,trtmc_backend_trt|_|REQUIRES_TRT,REQUIRES_GPU",
 ]

--- a/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_runtime_config_contract.cpp
+++ b/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_runtime_config_contract.cpp
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// CPU-only consumer contract for DeepSeek-OCR's serialized decoder config.
+//
+// DeepSeek-OCR nests its decoder geometry under "language_config", so the
+// family plugin promotes those fields to bundle scope via
+// get_bundle_config_overrides(). The nested block, and the vision tower's own
+// "vision_config" dimensions, remain in the bundle's config.json next to the
+// promoted values, so nothing pinned that the runtime reads the decoder
+// contract rather than either neighbour.
+//
+// This exercises parse_base_config(), the production parser whose BaseConfig
+// plugin.cpp consumes. The VL keys the plugin reads inline while building its
+// PipelineContext are not reachable without a bundle and engines, so they stay
+// with the REQUIRES_TRT,REQUIRES_GPU pipeline test rather than being restated
+// here as generic JSON lookups.
+
+#include "runtime/models/deepseek_ocr/image_preprocessor.h"
+#include "trtmc/runtime/pipeline_plugin.h"
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+int main() {
+    // Top-level values are the promoted decoder contract. The nested
+    // "language_config" and "vision_config" carry deliberately different
+    // values so a consumer that reached into either would fail these checks.
+    const std::string config = R"({
+        "model_type": "deepseek_vl_v2",
+        "language_config": {
+            "vocab_size": 1,
+            "hidden_size": 2,
+            "num_hidden_layers": 3,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 5
+        },
+        "vision_config": {
+            "hidden_size": 1024,
+            "num_attention_heads": 16,
+            "num_hidden_layers": 24,
+            "image_token_id": 999,
+            "vision_output_dim": 777,
+            "num_image_pad_tokens": 888
+        },
+        "vocab_size": 129280,
+        "hidden_size": 1280,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 10,
+        "num_key_value_heads": 10,
+        "head_dim": 128,
+        "bos_token_id": 0,
+        "eos_token_id": 1,
+        "max_position_embeddings": 4096,
+        "image_token_id": 128815,
+        "fixed_image_size": 768,
+        "num_image_pad_tokens": 145,
+        "vision_output_dim": 1280,
+        "preprocessor_type": "simple_chw",
+        "interpolation": "bicubic",
+        "temporal_patch_size": 1,
+        "image_token_str": "<image>",
+        "has_vision_engine": 1,
+        "runtime_strategy": "deepseek_ocr_vision_language"
+    })";
+
+    const auto parsed = trtmc::parse_base_config(config, 768);
+    bool ok = true;
+    const auto check = [&](bool condition, const char* name) {
+        if (!condition) {
+            std::cerr << "FAIL: " << name << '\n';
+            ok = false;
+        }
+    };
+
+    check(parsed.runtime_strategy == "deepseek_ocr_vision_language", "runtime strategy");
+    check(parsed.vocab_size == 129280, "vocabulary size");
+    check(parsed.hidden_size == 1280, "hidden size");
+    check(parsed.num_layers == 12, "layer count");
+    check(parsed.num_heads == 10, "attention head count");
+    check(parsed.num_kv_heads == 10, "KV head count");
+    check(parsed.head_dim == 128, "head dimension");
+    check(parsed.id_bos == 0, "BOS token");
+    check(parsed.id_eos == 1, "EOS token");
+    check(parsed.attention_size == 1280, "attention width");
+    check(parsed.max_cache_length == 768, "max cache length override");
+
+    // The VL contract, through the family's own consumer: plugin.cpp builds
+    // its DeepseekOcrPreprocessConfig with exactly this call, so a regression
+    // that stops reading a key, reads vision_config instead, or silently
+    // falls back to a default fails here.
+    const auto vl = trtmc::deepseek_ocr_parse_preprocess_config(config, "");
+    check(vl.image_token_id == 128815, "image token id reaches the VL config");
+    check(vl.vision_output_dim == 1280, "vision output dim reaches the VL config");
+    check(vl.num_image_pad_tokens == 145, "image pad token count");
+    check(vl.fixed_image_size == 768, "fixed image size");
+    check(vl.preprocessor_type == "simple_chw", "preprocessor strategy");
+    check(vl.interpolation == "bicubic", "interpolation");
+    check(vl.temporal_patch_size == 1, "temporal patch size");
+    check(vl.image_token_str == "<image>", "image placeholder token");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Background

`src/runtime/models/deepseek_ocr/MODEL.toml` declared a single runtime test,
tagged `REQUIRES_TRT,REQUIRES_GPU`. Nothing about DeepSeek-OCR's runtime config
boundary was covered in the public CPU tier.

The family nests its decoder geometry under `language_config` and promotes it
to bundle scope in `get_bundle_config_overrides()`. The bundle's `config.json`
is the checkpoint config plus injected keys, so the nested `language_config`
block and the vision tower's own `vision_config` dimensions sit right next to
the promoted values that `parse_base_config()` reads. Nothing pinned that the
runtime resolves the decoder contract rather than either neighbour, and
nothing would catch the producer silently dropping a promoted field.

`internvl`, `qwen_vl`, `qwen3_5` and `locateanything` already carry this CPU
contract (`eb88037d`, `ddb13786`, `4fadf73f`, `3ea6fd7d`). This applies the
same pattern to `deepseek_ocr`.

No originating issue; found while surveying VLM coverage in the public CPU
tier.

## Exit Criteria

- DeepSeek-OCR has at least one runtime test that runs in the public CPU tier.
- The test covers both halves through the production consumers: the decoder
  contract via `parse_base_config()`, and the VL contract via the
  family-owned `deepseek_ocr_parse_preprocess_config()` -- the same function
  `plugin.cpp` calls to build its `DeepseekOcrPreprocessConfig`.
- The test fails if the producer stops promoting the nested decoder fields.

Non-goals: no change to the family plugin, the runtime, or the existing
GPU test. This adds coverage only.

## Implementation

New CPU test `tests/cpp/models/deepseek_ocr/test_deepseek_ocr_runtime_config_contract.cpp`,
registered in `src/runtime/models/deepseek_ocr/MODEL.toml` as
`...|_|_|_` so it links no TensorRT target, compiles no extra runtime source,
and carries no GPU/TRT option — placing it in the `cpu` CTest label.

The fixture gives `language_config` and `vision_config` deliberately different
values from the promoted top-level ones, so a consumer that reached into
either would fail the checks.

The VL half runs the family's own consumer rather than restating the keys as
`extract_json_int` lookups. An earlier revision did the latter, which tests
the shared JSON helper instead of this family's consumption: a regression that
stopped reading a key, reached into `vision_config`, or fell back to a default
would still have passed. `image_preprocessor.cpp` is compiled into the test
through the manifest's `extra_sources` field, with `third_party/stb` supplied
via the `EXTRA_INCLUDES` option `trtmc_add_test` already accepts, so no shared
build plumbing changes.

`has_vision_engine` and `prefill_max_length` are still not asserted: the
plugin reads those inline while assembling its `PipelineContext`, which needs
a bundle and loaded engines, so they stay with the
`REQUIRES_TRT,REQUIRES_GPU` pipeline test.

Affected components: `deepseek_ocr` model root only. No public API, ABI,
bundle-format, or dependency change.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

Built and run through the project's own CMake/CTest path, which also proves
the `MODEL.toml` registration resolves:

```
$ cmake -S . -B build-cpu -G Ninja -DCMAKE_BUILD_TYPE=Release \\
    -DCMAKE_CUDA_ARCHITECTURES=86-real \\
    -DTRTMC_BUILD_BACKEND_TRT=OFF -DTRTMC_BUILD_BACKEND_RTX=OFF \\
    -DTRTMC_BUILD_TESTS=ON -DTRTMC_BUILD_BENCHMARKS=OFF \\
    -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF
$ cmake --build build-cpu --parallel 24 --target test_deepseek_ocr_runtime_config_contract
$ ctest --test-dir build-cpu -R '^test_deepseek_ocr_runtime_config_contract$' --output-on-failure
1/1 Test #33: test_deepseek_ocr_runtime_config_contract ...   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

Label Time Summary:
cpu      =   0.00 sec*proc (1 test)
```

The test carries the `cpu` and `model` labels and appears in
`ctest -N -L cpu`, so the public CPU tier picks it up.

Mutation check — with the promoted top-level `hidden_size` and `num_attention_heads` removed from the fixture, leaving only the nested ones, the test fails as intended:

```
FAIL: hidden size
FAIL: attention head count
FAIL: attention width
exit 1
```

And dropping the promoted top-level VL keys, leaving only the `vision_config`
decoys, fails the VL half:

```
FAIL: image token id reaches the VL config
FAIL: vision output dim reaches the VL config
FAIL: image pad token count
exit 1
```

Static and consistency checks:

```
$ clang-format --dry-run --Werror tests/cpp/models/deepseek_ocr/test_deepseek_ocr_runtime_config_contract.cpp
$ PYTHONPATH=python:. python3 tools/test_impact.py --validate
Validation passed. 229 models, 13 core, 89 families.
$ PYTHONPATH=python:. python3 tools/legal_headers.py
legal headers: tracked=6236 managed=5330 excepted=4 ignored=902 changed=0 findings=0
$ git diff --check
```

Compilation and unit evidence only. No inference, parity, performance, or
qualification claim.

### Hardware, Environment, and Revisions

- Repository head: `b5d720a5` (`upstream/main`), branch rebased onto it.
- Host: Ubuntu 22.04.5, g++ 11.4.0, CMake 4.3.2, Ninja 1.13.0, C++17.
- CUDA 12.1 headers and cudart; no TensorRT SDK, so `TRTMC_HAS_TRT=0`.
- GPU present (RTX 3090) but unused: the test has no device code path.
- Dependencies unchanged.

### Not Run / Remaining Gaps

- No TensorRT SDK in this environment, so the existing
  `REQUIRES_TRT,REQUIRES_GPU` pipeline test for this family was skipped at
  configure time and was not run.
- The full `trtmc_cpu_cpp_tests` target does not link here:
  `src/runtime/models/flux/gpu_matmul.cpp` fails on a local CUDA
  toolchain-version skew unrelated to this change. This test links only
  `trtmc_core`, which builds clean, so it was built and run directly.
- The unit stage was not run through `tools.community_ci unit --scope all`,
  which requires Docker; Docker on this host needs privileges the contributor
  account does not have.
- Fixture values follow the family's own documented dimensions
  (`hidden_size` 1280, `image_token_id` 128815, `prefill_max_length` 256 from
  `prefill_config.MAX_SEQUENCE_PREFILL_LENGTH`); they were not read back from
  a downloaded checkpoint.

## Notes For Future Readers

The fixture's decoy values are the point of the test. If the nested blocks are
ever changed to match the top level, the test still passes but stops proving
anything — keep them distinct.

A producer-side test (mocked-engine `build_bundle`, as `eb88037d` added for
internvl) would close the loop from the other end. Not included here to keep
this reviewable; happy to add it if preferred.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Test-only, single model root, no production code touched.
