### PR TITLE
test(phi4-multimodal): cover runtime JSON contract

### DIFF
--- a/families/phi4_multimodal/runtime/CMakeLists.txt
+++ b/families/phi4_multimodal/runtime/CMakeLists.txt
@@ -44,3 +44,26 @@ set_target_properties(trtmc_model_phi4_multimodal PROPERTIES
 install(TARGETS trtmc_model_phi4_multimodal
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(TRTMC_BUILD_TESTS)
+  add_executable(test_phi4_multimodal_runtime_config_contract
+    ${PROJECT_SOURCE_DIR}/families/phi4_multimodal/tests/cpp/test_phi4_multimodal_runtime_config_contract.cpp
+    image_preprocessor.cpp
+  )
+  target_include_directories(test_phi4_multimodal_runtime_config_contract PRIVATE
+    ${PROJECT_SOURCE_DIR}
+  )
+  target_include_directories(test_phi4_multimodal_runtime_config_contract SYSTEM PRIVATE
+    ${PROJECT_SOURCE_DIR}/third_party/stb
+  )
+  target_link_libraries(test_phi4_multimodal_runtime_config_contract PRIVATE
+    nlohmann_json::nlohmann_json
+  )
+  target_compile_options(test_phi4_multimodal_runtime_config_contract PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME test_phi4_multimodal_runtime_config_contract
+    COMMAND test_phi4_multimodal_runtime_config_contract
+  )
+  set_tests_properties(test_phi4_multimodal_runtime_config_contract PROPERTIES LABELS cpu)
+endif()

--- a/families/phi4_multimodal/tests/cpp/test_phi4_multimodal_runtime_config_contract.cpp
+++ b/families/phi4_multimodal/tests/cpp/test_phi4_multimodal_runtime_config_contract.cpp
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/phi4_multimodal/runtime/image_preprocessor.h"
+
+#include <cmath>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace {
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void rejects(const std::string& text, const std::string& message) {
+    try {
+        (void)trtmc::phi4_multimodal_parse_preprocess_config(text);
+        check(false, message);
+    } catch (const nlohmann::json::exception&) {
+    } catch (const std::runtime_error&) {
+    }
+}
+} // namespace
+
+int main() {
+    // runtime.json contains the promoted preprocessing fields, not the HF decoder config.
+    // Keep nested decoys first to catch a first-occurrence scan of the JSON text.
+    const std::string text = R"({
+        "img_processor": {"image_token_id": 7, "vision_output_dim": 64,
+                          "num_image_pad_tokens": 3},
+        "preprocessor_type": "phi4_hd_chw",
+        "image_token_id": 200010,
+        "fixed_image_size": 336,
+        "patch_size": 16,
+        "merge_size": 3,
+        "temporal_patch_size": 1,
+        "num_image_pad_tokens": 721,
+        "vision_output_dim": 3072,
+        "vl_prompt_template": "<|user|>\n{image_pads}{prompt}\n<|end|><|assistant|>",
+        "image_token_str": "<|endoftext10|>",
+        "interpolation": "bilinear",
+        "image_mean": [0.1, 0.2, 0.3],
+        "image_std": [0.6, 0.7, 0.8]
+    })";
+    const auto cfg = trtmc::phi4_multimodal_parse_preprocess_config(text);
+    check(cfg.preprocessor_type == "phi4_hd_chw", "preprocessor type");
+    check(cfg.image_token_id == 200010, "top-level image token ID");
+    check(cfg.fixed_image_size == 336, "fixed image size");
+    check(cfg.patch_size == 16, "patch size");
+    check(cfg.merge_size == 3, "merge size");
+    check(cfg.temporal_patch_size == 1, "temporal patch size");
+    check(cfg.num_image_pad_tokens == 721, "top-level image pad token count");
+    check(cfg.vision_output_dim == 3072, "top-level vision output dimension");
+    check(cfg.vl_prompt_template == "<|user|>\n{image_pads}{prompt}\n<|end|><|assistant|>",
+          "template newlines are decoded");
+    check(cfg.image_token_str == "<|endoftext10|>", "image token string");
+    check(cfg.interpolation == "bilinear", "interpolation");
+    const float mean[] = {0.1F, 0.2F, 0.3F};
+    const float std[] = {0.6F, 0.7F, 0.8F};
+    for (int i = 0; i < 3; ++i) {
+        check(std::fabs(cfg.image_mean[i] - mean[i]) < 1e-6F, "image mean component");
+        check(std::fabs(cfg.image_std[i] - std[i]) < 1e-6F, "image std component");
+    }
+
+    const auto document = nlohmann::json::parse(text);
+    for (const auto& item : document.items()) {
+        if (item.key() == "img_processor")
+            continue;
+        auto missing = document;
+        missing.erase(item.key());
+        rejects(missing.dump(), "missing " + item.key());
+        auto wrong_type = document;
+        wrong_type[item.key()] = nullptr;
+        rejects(wrong_type.dump(), "null " + item.key());
+    }
+    for (const auto* key : {"image_token_id", "fixed_image_size", "patch_size", "merge_size",
+                            "temporal_patch_size", "num_image_pad_tokens", "vision_output_dim"}) {
+        for (const auto& value :
+             {nlohmann::json(1.5), nlohmann::json("16"), nlohmann::json(true)}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("non-integer ") + key);
+        }
+    }
+    for (const auto* key : {"fixed_image_size", "patch_size", "merge_size", "temporal_patch_size",
+                            "vision_output_dim"}) {
+        for (int value : {0, -1}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("non-positive ") + key);
+        }
+    }
+    for (const auto* key : {"image_mean", "image_std"}) {
+        for (const auto& value :
+             {nlohmann::json::array({0.1, 0.2}), nlohmann::json::array({0.1, 0.2, 0.3, 0.4}),
+              nlohmann::json::array({0.1, "0.2", 0.3})}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("invalid triplet ") + key);
+        }
+    }
+    for (const auto* mode : {"nearest", "bilinear", "bicubic"}) {
+        auto valid = document;
+        valid["interpolation"] = mode;
+        check(trtmc::phi4_multimodal_parse_preprocess_config(valid.dump()).interpolation == mode,
+              std::string("accepted interpolation ") + mode);
+    }
+    auto invalid = document;
+    invalid["interpolation"] = "lanczos";
+    rejects(invalid.dump(), "unsupported interpolation");
+    rejects("{", "malformed JSON");
+    rejects("[]", "non-object JSON");
+    if (failures == 0)
+        std::cout << "PASS: Phi4 runtime preprocessing config contract\n";
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

Migrate this test PR to the family-owned architecture requested in discussion #1183. The current consumer reads explicit preprocessing fields from `runtime.json`; the retired `parse_base_config()` and `MODEL.toml` registration no longer describe this boundary.

## Exit Criteria

- Exercise `phi4_multimodal_parse_preprocess_config()`, the production plugin's preprocessing consumer, through a CPU CTest.
- Pin top-level field binding, template escapes, required types, geometry and interpolation validation.
- Keep all changes inside `families/phi4_multimodal/`.

## Implementation

Add a family-local C++ test and register it in `runtime/CMakeLists.txt` with the `cpu` label. The executable compiles `image_preprocessor.cpp` directly and uses the existing nlohmann/STB dependencies, without linking the family DSO.

The fixture places nested decoys before explicit top-level preprocessing fields and uses sentinel values to expose ignored inputs. Checks remain active in Release builds. Missing/null fields, non-integer dimensions, malformed triplets, non-positive geometry, unsupported interpolation and invalid JSON are rejected; all three supported interpolation modes are preserved.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

Direct source-only build and run passed (set `JSON_INCLUDE` to the installed nlohmann include directory):

```sh
g++ -std=c++17 -O2 -I. -Ithird_party/stb -I"$JSON_INCLUDE" \
  families/phi4_multimodal/tests/cpp/test_phi4_multimodal_runtime_config_contract.cpp \
  families/phi4_multimodal/runtime/image_preprocessor.cpp \
  -o /tmp/test_phi4_multimodal_runtime_config_contract
/tmp/test_phi4_multimodal_runtime_config_contract
# PASS: Phi4 runtime preprocessing config contract
```

- Family-only CMake harness loading the actual `runtime/CMakeLists.txt`, followed by `cmake --build <build> --target test_phi4_multimodal_runtime_config_contract` and `ctest --test-dir <build> -R '^test_phi4_multimodal_runtime_config_contract$' --output-on-failure --no-tests=error`: 1/1 passed, CPU-labelled. The harness supplies the repository root and existing nlohmann include target; it does not configure the full project or use SDK stubs.
- Three independent production-source mutations (hardcode vision width, remove geometry guard, remove interpolation guard): each compiled and made the test exit 1. Mutations were confined to disposable copies.
- `python3 -m tools.model_ci validate`: passed.
- `python3 tools/test_impact.py --validate`: passed.
- `python3 -m pytest tools/tests/test_architecture.py tools/tests/test_family_impact.py tools/tests/test_community_ci.py tools/tests/test_public_source_hygiene.py tools/tests/test_new_ci.py tools/tests/test_pr_metadata.py -q -p no:cacheprovider`: 125 passed.
- `clang-format --dry-run --Werror families/phi4_multimodal/tests/cpp/test_phi4_multimodal_runtime_config_contract.cpp` and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Base: `40523401ae65735056f85ae73028c04025aa1c50`.
- Head: `4be682035a0af4582a938402b3c3aa6e0e99ab6e`.
- Local Linux x86_64, GCC 11.4, C++17, Release build. Inline synthetic JSON; no checkpoint or GPU needed for this test.

### Not Run / Remaining Gaps

Full root configure (`cmake -S . -B <build> -G Ninja -DTRTMC_BUILD_TESTS=ON -DTRTMC_ENABLE_BYOK=OFF`) stopped because `NvInferRuntime.h` is unavailable locally. Full project integration and protected premerge remain for exact-head CI. Decoder loading, image processing, audio and inference are outside this preprocessing-config unit.

## Notes For Future Readers

This replaces the pre-cutover implementation and its validation record. Review the family CMake registration, then the fixture and rejection checks. Production parser behavior is unchanged; keep runtime.json coverage here rather than restoring old checkpoint-config fallback expectations.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Test-only, one family; existing production and GPU targets are unchanged.
