### PR TITLE
fix(runtime): reject an input image the pipeline cannot consume

### DIFF
--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -430,12 +430,16 @@ class IPipeline {
     }
 
     // -- Text generation with image --
+    // A pipeline that cannot consume an image must reject one rather than
+    // answer from the prompt alone. Forwarding is reserved for the case where
+    // the caller supplied no image at all.
     virtual TextResult generate(const std::string& prompt, const float* image_pixels,
                                 int32_t image_height, int32_t image_width,
                                 const GenerateConfig& cfg = {}) {
-        (void)image_pixels;
-        (void)image_height;
-        (void)image_width;
+        if (image_pixels != nullptr || image_height > 0 || image_width > 0) {
+            throw std::runtime_error(std::string(pipeline_type()) +
+                                     " does not accept an input image");
+        }
         return generate(prompt, cfg);
     }
 
@@ -458,9 +462,10 @@ class IPipeline {
     virtual ImageResult generate_image(const std::string& prompt, const float* image_pixels,
                                        int32_t image_height, int32_t image_width,
                                        const GenerateConfig& cfg = {}) {
-        (void)image_pixels;
-        (void)image_height;
-        (void)image_width;
+        if (image_pixels != nullptr || image_height > 0 || image_width > 0) {
+            throw std::runtime_error(std::string(pipeline_type()) +
+                                     " does not accept an input image");
+        }
         return generate_image(prompt, cfg);
     }
 

--- a/tests/cpp/test_pipeline_api.cpp
+++ b/tests/cpp/test_pipeline_api.cpp
@@ -60,6 +60,30 @@ class DummyPipeline final : public trtmc::IPipeline {
     const char* pipeline_type() const override { return "DummyPipeline"; }
 };
 
+// A pipeline that supports text generation but not images. This is the shape
+// every text-only family has (llama, qwen, mistral, ...), and the shape that
+// DummyPipeline cannot exercise: because DummyPipeline supports nothing, the
+// image overloads appear to throw when they merely delegate to a throwing
+// text-only path.
+class TextOnlyPipeline final : public trtmc::IPipeline {
+  public:
+    const char* model_id() const override { return "text-only-model"; }
+    const char* pipeline_type() const override { return "TextOnlyPipeline"; }
+
+    trtmc::TextResult generate(const std::string& prompt,
+                               const trtmc::GenerateConfig& cfg = {}) override {
+        (void)cfg;
+        return {prompt, {}};
+    }
+
+    trtmc::ImageResult generate_image(const std::string& prompt,
+                                      const trtmc::GenerateConfig& cfg = {}) override {
+        (void)prompt;
+        (void)cfg;
+        return {};
+    }
+};
+
 class RecordingTranscriptionPipeline final : public trtmc::IPipeline {
   public:
     const char* model_id() const override { return "recording"; }
@@ -674,6 +698,49 @@ static void test_pipeline_pool_leases_and_adapter_maintenance() {
     check(pool.loaded_lora_adapters().empty(), "pipeline pool unloads adapter across lanes");
 }
 
+// A pipeline that cannot consume an image must reject one, not silently drop
+// it. Every other unsupported capability on IPipeline throws; these two
+// overloads used to discard the image and fall through to the no-image path,
+// so `trtmc run <text-only>.bundle --image cat.png` answered from the prompt
+// alone with no diagnostic.
+static void test_ipipeline_rejects_unconsumable_image() {
+    TextOnlyPipeline concrete;
+    // Call through the base interface, as the CLI does: it holds a
+    // std::unique_ptr<IPipeline>. Naming generate() in the derived class hides
+    // the base image overloads, so a concrete-typed call would not compile.
+    trtmc::IPipeline& pipeline = concrete;
+    const std::vector<float> pixels(2 * 2 * 3, 0.5F);
+
+    bool threw = false;
+    try {
+        pipeline.generate("describe this", pixels.data(), 2, 2);
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    check(threw, "text-only generate(string,image) rejects a supplied image");
+
+    // Passing no image must still reach the text-only path.
+    const trtmc::TextResult text = pipeline.generate("describe this", nullptr, 0, 0);
+    check(text.text == "describe this",
+          "generate(string,image) forwards when no image is supplied");
+
+    threw = false;
+    try {
+        pipeline.generate_image("make it night", pixels.data(), 2, 2);
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    check(threw, "text-to-image generate_image(string,image) rejects a supplied image");
+
+    bool image_threw = false;
+    try {
+        (void)pipeline.generate_image("make it night", nullptr, 0, 0);
+    } catch (const std::runtime_error&) {
+        image_threw = true;
+    }
+    check(!image_threw, "generate_image(string,image) forwards when no image is supplied");
+}
+
 int main() {
     test_null_input_returns_null();
     test_invalid_path_returns_null();
@@ -682,6 +749,7 @@ int main() {
     test_sizeof_ipipeline_is_vtable();
     test_delete_null_safe();
     test_ipipeline_default_virtuals();
+    test_ipipeline_rejects_unconsumable_image();
     test_speech_session_value_contract();
     test_speech_batch_session_optional_interface();
     test_speech_session_virtual_interface();


### PR DESCRIPTION
## Background

`IPipeline`'s two image-taking overloads discarded the image and delegated to
the no-image path:

- `include/trtmc/pipeline.h` `generate(prompt, image_pixels, h, w, cfg)`
- `include/trtmc/pipeline.h` `generate_image(prompt, image_pixels, h, w, cfg)`

Every other unsupported capability on the same interface throws
(`generate`, `generate_image`, `encode_text`, `generate_audio`). These two were
the only exceptions, so a pipeline that cannot see an image answered from the
prompt alone with no diagnostic.

This is reachable from the CLI. `src/cli/main.cpp` calls both overloads through
`std::unique_ptr<IPipeline>` after loading a non-empty image, so:

| Command | Current behavior |
| --- | --- |
| `trtmc run <text-only>.bundle --image cat.png --prompt "describe this"` | image dropped, description invented, no warning |
| `trtmc run <text-to-image>.bundle --image ref.png --prompt "..."` | reference image ignored, generated from scratch |

`examples/trtmc_benchmark_worker.cpp` reaches both overloads the same way,
each behind an `!input_image.empty()` guard, so an image-conditioned benchmark
against a pipeline that cannot consume images was silently measuring the
text-only path.

The repository has already made this call once at family scope:
`src/runtime/models/qwen_image/pipeline.cpp` hand-rolls
`validate_text_to_image_overload_call()`, which throws when a text-to-image
bundle is handed an input image. This change moves that decision to the
contract where it belongs, so every family gets it.

No originating issue; found while reading the VL runtime path.

## Exit Criteria

- A pipeline that cannot consume an input image rejects one instead of
  silently answering without it, for both the text and image-generation
  overloads.
- Callers that supply no image (`nullptr, 0, 0`) keep the existing
  pass-through behavior.
- No in-tree pipeline changes behavior: every VL pipeline already overrides
  both overloads.
- The default-virtual test no longer passes for the wrong reason.

Non-goals: no CLI change (`main()` already prints `Error: <what>` and returns
`EXIT_FAILURE`); no change to any family pipeline, including the
`qwen_image` validator that motivated this.

## Implementation

Both base overloads in `include/trtmc/pipeline.h` now throw
`std::runtime_error("<pipeline_type> does not accept an input image")` when an
image is actually supplied, and forward to the no-image path otherwise. The
"no image supplied" condition matches the one `qwen_image` already applies.

Affected components: `include/trtmc/pipeline.h` (public C++ header),
`tests/cpp/test_pipeline_api.cpp`.

Public API: behavioral change to two `IPipeline` default implementations. No
signature, ABI, bundle-format, or dependency change. An out-of-tree pipeline
that relied on the silent drop will now throw; that is the intended
correction.

Test change: `DummyPipeline` implements nothing, so its image overloads threw
only after delegating to a throwing text-only path — the existing assertions
passed for the wrong reason and would not have caught this. `TextOnlyPipeline`
implements `generate()` and `generate_image()` and therefore reproduces the
defect. The new assertions call through `IPipeline&` because naming
`generate()` in a derived class hides the base image overloads, which is also
why the defect only ever surfaced through the base pointer the CLI holds. The
existing `DummyPipeline` assertions are unchanged and still pass.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Test-first, through the project's own CTest target. With the new assertions in
place and `include/trtmc/pipeline.h` reverted to `upstream/main`, the real
`test_pipeline_api` target fails on exactly the two new checks:

```
$ git checkout upstream/main -- include/trtmc/pipeline.h
$ cmake --build build-cpu --parallel 24 --target test_pipeline_api
$ ctest --test-dir build-cpu -R '^test_pipeline_api$' --output-on-failure
    Start 25: test_pipeline_api
1/1 Test #25: test_pipeline_api ................***Failed    0.02 sec
FAIL: text-only generate(string,image) rejects a supplied image
FAIL: text-to-image generate_image(string,image) rejects a supplied image
2 test(s) FAILED

0% tests passed, 1 tests failed out of 1
```

With the header change restored, the same target passes:

```
$ git checkout HEAD -- include/trtmc/pipeline.h
$ cmake --build build-cpu --parallel 24 --target test_pipeline_api
$ ctest --test-dir build-cpu -R '^test_pipeline_api$'
1/1 Test #25: test_pipeline_api ................   Passed    0.02 sec
100% tests passed, 0 tests failed out of 1
```

The whole platform CPU suite also builds and passes with the change, which is
the tier a public-header change is most likely to disturb:

```
$ cmake --build build-cpu --parallel 24 --target trtmc_platform_cpp_tests
$ ctest --test-dir build-cpu -L platform -LE gpu
100% tests passed, 0 tests failed out of 39
```

The pre-existing `DummyPipeline` default-virtual assertions are in the same
binary and pass unchanged in both runs.

Configure and static checks:

```
$ cmake -S . -B build-cpu -G Ninja -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_CUDA_ARCHITECTURES=86-real \
    -DTRTMC_BUILD_BACKEND_TRT=OFF -DTRTMC_BUILD_BACKEND_RTX=OFF \
    -DTRTMC_BUILD_TESTS=ON -DTRTMC_BUILD_BENCHMARKS=OFF \
    -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF
$ clang-format --dry-run --Werror include/trtmc/pipeline.h tests/cpp/test_pipeline_api.cpp
$ PYTHONPATH=python:. python3 tools/test_impact.py --validate
Validation passed. 229 models, 13 core, 89 families.
$ PYTHONPATH=python:. python3 tools/legal_headers.py
legal headers: tracked=6236 managed=5330 excepted=4 ignored=902 changed=0 findings=0
$ git diff --check
```

Compilation and unit evidence only. No inference, parity, performance, or
qualification claim.

### Hardware, Environment, and Revisions

- Repository head: `c3c62317` (`upstream/main`), branch rebased onto it.
- Host: Ubuntu 22.04.5, g++ 11.4.0, CMake 4.3.2, Ninja 1.13.0, C++17.
- CUDA 12.1 headers and cudart; `TRTMC_HAS_TRT=0`.
- GPU present (RTX 3090) but unused: this change has no device code path.
- Dependencies unchanged.

### Not Run / Remaining Gaps

- No TensorRT SDK in this environment, so every `REQUIRES_TRT` test was
  skipped at configure time, including all VL pipeline tests. Those are the
  tests that would exercise the overriding implementations; the change does
  not touch them.
- The full `trtmc_cpu_cpp_tests` target does not link in this environment:
  `src/runtime/models/flux/gpu_matmul.cpp` fails on a local CUDA
  toolchain-version skew unrelated to this change. `test_pipeline_api` links
  only `trtmc_core`, which builds clean, so it was built and run directly.
- No GPU, inference, or E2E path was run.
- `tools/test_impact.py` selects 201 E2E models and `C++ rebuild needed: yes`
  for this diff, because the change touches a public header. That fan-out is
  the header's blast radius, not new coverage this change requires; every VL
  pipeline overrides both overloads and is unaffected.

## Notes For Future Readers

The name-hiding detail is the reason this survived: a derived class that
declares `generate(prompt, cfg)` hides the base image overloads, so the defect
is unreachable through a concrete type and only appears through the
`IPipeline` pointer the CLI holds. Any future test of these overloads must go
through the base interface.

`qwen_image`'s `validate_text_to_image_overload_call()` is now redundant for
the "no input image accepted" case, but is left in place: it is family-owned,
it carries a more specific message, and removing it is a separate change under
a different owner.

Suggested review order: `include/trtmc/pipeline.h`, then the new
`TextOnlyPipeline` and `test_ipipeline_rejects_unconsumable_image()` in
`tests/cpp/test_pipeline_api.cpp`.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Two default implementations in one header, changed only on a path that
previously produced a silently wrong answer. In-tree callers are two CLI sites
that already guarantee a non-empty image, and every VL pipeline overrides both
overloads.
