### PR TITLE
feat(smollm3): add native SmolLM3 model family

### DIFF
--- a/families/smollm3/__init__.py
+++ b/families/smollm3/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dense SmolLM3 model family."""

--- a/families/smollm3/build_routing.py
+++ b/families/smollm3/build_routing.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Routing contract for dense SmolLM3 models using TensorRT native KV cache."""
+
+from __future__ import annotations
+
+import math
+import operator
+
+from .config import resolve_rope_layer_schedule
+
+_INT32_MAX = (1 << 31) - 1
+_UINT64_MAX = (1 << 64) - 1
+
+
+class NativeKvCapability:
+    """Small, loader-safe capability result (no dataclass dependency)."""
+
+    __slots__ = ("applicable", "eligible", "reason")
+
+    def __init__(
+        self,
+        applicable: bool,
+        eligible: bool,
+        reason: str,
+    ) -> None:
+        self.applicable = applicable
+        self.eligible = eligible
+        self.reason = reason
+
+
+def _result(
+    *,
+    applicable: bool = True,
+    reasons: list[str] | tuple[str, ...] = (),
+) -> NativeKvCapability:
+    return NativeKvCapability(
+        applicable,
+        applicable and not reasons,
+        "; ".join(reasons) or "supported",
+    )
+
+
+def _raw(config: object) -> dict:
+    value = getattr(config, "raw", {})
+    return value if isinstance(value, dict) else {}
+
+
+def _integer(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(operator.index(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _positive(config: object, name: str) -> int:
+    value = _integer(getattr(config, name, None), name)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    if value > _INT32_MAX:
+        raise ValueError(f"{name} exceeds TensorRT's int32 dimension limit")
+    return value
+
+
+def resolved_head_dim(config: object) -> int:
+    """Return the explicit HF head width, or derive it when absent."""
+
+    raw = _raw(config)
+    explicit = raw.get("head_dim", getattr(config, "_head_dim", 0))
+    if "head_dim" in raw or explicit not in (None, 0):
+        head_dim = _integer(explicit, "head_dim")
+    else:
+        hidden = _positive(config, "hidden_size")
+        heads = _positive(config, "num_attention_heads")
+        if hidden % heads:
+            raise ValueError(
+                "hidden_size must be divisible by num_attention_heads when head_dim is absent"
+            )
+        head_dim = hidden // heads
+    if not 0 < head_dim <= _INT32_MAX:
+        raise ValueError("head_dim must be a positive TensorRT dimension")
+    return head_dim
+
+
+def _checked_product(label: str, *values: int) -> int:
+    product = 1
+    for value in values:
+        if value <= 0 or product > _UINT64_MAX // value:
+            raise ValueError(f"native SmolLM3 KV {label} exceeds uint64")
+        product *= value
+    return product
+
+
+def native_kv_cache_geometry(
+    config: object,
+    capacity: int,
+    *,
+    element_bytes: int = 2,
+) -> tuple[int, int]:
+    """Return runtime byte geometry for the required full-context cache."""
+
+    capacity = _integer(capacity, "max_cache_length")
+    context = _positive(config, "max_position_embeddings")
+    if capacity != context:
+        raise ValueError(
+            "native SmolLM3 KV requires max_cache_length == "
+            f"max_position_embeddings ({context}), got {capacity}"
+        )
+    row_bytes = _checked_product(
+        "row size",
+        2,
+        _positive(config, "num_hidden_layers"),
+        _positive(config, "num_key_value_heads"),
+        resolved_head_dim(config),
+        _integer(element_bytes, "element_bytes"),
+    )
+    return row_bytes, _checked_product("cache size", capacity, row_bytes)
+
+
+def _enabled(value: object) -> bool:
+    return value not in (None, False, 0, "", (), [], {})
+
+
+def _validate_rope(raw: dict, reasons: list[str]) -> None:
+    parameters = raw.get("rope_parameters")
+    scaling = raw.get("rope_scaling")
+    if parameters is not None and scaling is not None:
+        reasons.append("RoPE configuration is ambiguous")
+        return
+    rope = parameters if parameters is not None else scaling
+    if rope is None:
+        return
+    if not isinstance(rope, dict):
+        reasons.append("RoPE configuration must be an object")
+        return
+    rope_type = str(rope.get("rope_type", rope.get("type", "default"))).lower()
+    if rope_type in ("", "default"):
+        if any(
+            key in rope
+            for key in (
+                "factor",
+                "low_freq_factor",
+                "high_freq_factor",
+                "original_max_position_embeddings",
+            )
+        ):
+            reasons.append("default RoPE must not contain scaling parameters")
+        return
+    if rope_type != "llama3":
+        # The family still builds these: they route to the standard decoder,
+        # which applies the scaling through an indexed cos/sin table. Only the
+        # native KV graph is limited to unscaled and llama3 RoPE.
+        reasons.append(
+            f"native SmolLM3 KV does not support rope_type={rope_type!r}")
+        return
+    required = (
+        "factor",
+        "low_freq_factor",
+        "high_freq_factor",
+        "original_max_position_embeddings",
+    )
+    if any(name not in rope for name in required):
+        reasons.append("llama3 RoPE is missing required scaling parameters")
+        return
+    try:
+        factor = float(rope["factor"])
+        low = float(rope["low_freq_factor"])
+        high = float(rope["high_freq_factor"])
+        original = _integer(
+            rope["original_max_position_embeddings"],
+            "original_max_position_embeddings",
+        )
+    except (TypeError, ValueError, OverflowError):
+        reasons.append("llama3 RoPE scaling parameters must be numeric")
+        return
+    if (
+        not all(math.isfinite(value) for value in (factor, low, high))
+        or factor < 1.0
+        or low <= 0.0
+        or high <= low
+        or original <= 0
+    ):
+        reasons.append("llama3 RoPE scaling parameters are invalid")
+
+
+def _validate_rope_layer_schedule(
+    config: object,
+    raw: dict,
+    reasons: list[str],
+) -> None:
+    """Reject a malformed NoPE schedule at routing time.
+
+    SmolLM3 marks NoPE layers through ``no_rope_layers`` (1 = the layer applies
+    RoPE, 0 = NoPE) or, when that list is absent, ``no_rope_layer_interval``.
+    Resolving it here keeps a bad schedule from surfacing as an exception deep
+    in the graph builder.
+    """
+    if raw.get("no_rope_layers") is None and raw.get(
+        "no_rope_layer_interval"
+    ) is None:
+        return
+    try:
+        schedule = resolve_rope_layer_schedule(config)
+    except (TypeError, ValueError) as exc:
+        reasons.append(str(exc))
+        return
+    num_layers = int(getattr(config, "num_hidden_layers", 0) or 0)
+    if len(schedule) != num_layers:
+        reasons.append(
+            "NoPE schedule must cover every layer: got "
+            f"{len(schedule)} entries for {num_layers} layers"
+        )
+
+
+def native_kv_architecture_capability(
+    config: object,
+) -> NativeKvCapability:
+    """Accept any model size that retains the dense SmolLM3 graph contract."""
+
+    model_type = str(getattr(config, "model_type", "")).lower()
+    if not model_type.startswith("smollm3"):
+        return _result(applicable=False)
+    if model_type != "smollm3":
+        return _result(reasons=["model_type must be exactly 'smollm3'"])
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if tuple(getattr(config, "architectures", ()) or ()) != ("SmolLM3ForCausalLM",):
+        reasons.append("architectures must contain exactly SmolLM3ForCausalLM")
+
+    try:
+        dimensions = {
+            name: _positive(config, name)
+            for name in (
+                "vocab_size",
+                "hidden_size",
+                "intermediate_size",
+                "num_hidden_layers",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "max_position_embeddings",
+            )
+        }
+        head_dim = resolved_head_dim(config)
+        if dimensions["num_attention_heads"] % dimensions["num_key_value_heads"]:
+            reasons.append("num_attention_heads must be divisible by num_key_value_heads")
+        if head_dim != 128:
+            reasons.append("native SmolLM3 attention requires head_dim=128")
+    except ValueError as exc:
+        reasons.append(str(exc))
+
+    if str(getattr(config, "hidden_act", "")).lower() != "silu":
+        reasons.append("native SmolLM3 requires hidden_act='silu'")
+    for name in ("rms_norm_eps", "rope_theta"):
+        try:
+            value = float(getattr(config, name))
+        except (TypeError, ValueError, OverflowError):
+            value = 0.0
+        if not math.isfinite(value) or value <= 0:
+            reasons.append(f"{name} must be finite and positive")
+
+    unsupported_flags = (
+        "attention_bias",
+        "mlp_bias",
+        "is_encoder_decoder",
+        "use_sliding_window",
+        "sliding_window",
+        "rope_interleaved",
+        "interleaved_rope",
+        "num_experts",
+        "num_local_experts",
+        "num_experts_per_tok",
+    )
+    enabled = [name for name in unsupported_flags if _enabled(raw.get(name))]
+    if enabled:
+        reasons.append("unsupported SmolLM3 fields: " + ", ".join(enabled))
+    # pretraining_tp is deliberately not gated. SmolLM3ForCausalLM neither
+    # defines nor reads it -- the field is absent from both the upstream
+    # configuration class and the modeling code -- so it describes nothing
+    # about the graph this family builds. The published checkpoint still
+    # carries pretraining_tp=2 from the Llama-derived template it started
+    # from, and rejecting that would route the only checkpoint this family
+    # targets away from the path its manifest declares. Llama gates it
+    # because Llama's own implementation reads it.
+    try:
+        if float(raw.get("partial_rotary_factor", 1.0)) != 1.0:
+            reasons.append("native SmolLM3 requires full rotary embeddings")
+    except (TypeError, ValueError, OverflowError):
+        reasons.append("partial_rotary_factor must be numeric")
+    layer_types = raw.get("layer_types")
+    if layer_types is not None and (
+        not isinstance(layer_types, (list, tuple))
+        or any(str(value).lower() != "full_attention" for value in layer_types)
+    ):
+        reasons.append("native SmolLM3 does not support hybrid layer types")
+    _validate_rope(raw, reasons)
+    _validate_rope_layer_schedule(config, raw, reasons)
+    return _result(reasons=reasons)
+
+
+def native_kv_build_capability(
+    config: object,
+    *,
+    precision: str = "bf16",
+    max_cache_length: int | None = None,
+    parallel_enabled: bool | None = None,
+    quantized: bool | None = None,
+    debug_layer_outputs: bool = False,
+) -> NativeKvCapability:
+    """Apply deployment constraints once, after architecture routing."""
+
+    architecture = native_kv_architecture_capability(config)
+    if not architecture.eligible:
+        return architecture
+
+    raw = _raw(config)
+    reasons: list[str] = []
+    if str(precision).lower() != "bf16":
+        reasons.append("native SmolLM3 requires BF16")
+    if str(raw.get("_decoder_engine_layout", "split")) != "split":
+        reasons.append("native SmolLM3 requires split prefill/decode engines")
+    if parallel_enabled or raw.get("_parallel_build_enabled"):
+        reasons.append("native SmolLM3 does not support tensor parallel builds")
+    if quantized or raw.get("quantization_config") or raw.get("_quantized_build_requested"):
+        reasons.append("native SmolLM3 does not support quantized builds")
+    if raw.get("_fp32_layers"):
+        reasons.append("native SmolLM3 does not support FP32 layer overrides")
+    if debug_layer_outputs:
+        reasons.append("native SmolLM3 does not support debug layer outputs")
+    try:
+        native_kv_cache_geometry(
+            config,
+            (
+                int(getattr(config, "max_position_embeddings"))
+                if max_cache_length is None
+                else max_cache_length
+            ),
+        )
+    except ValueError as exc:
+        reasons.append(str(exc))
+    return _result(reasons=reasons)

--- a/families/smollm3/checkpoint_mapper.py
+++ b/families/smollm3/checkpoint_mapper.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""1:1 port of standard_checkpoint_mapper.cpp + tensor_math.cpp to Python.
+
+Loads HF safetensors and maps keys to the flat weight dict expected by
+standard_decoder_builder.py. All projections are transposed from HF
+[out, in] layout to [in, out] for TRT matmul.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import numpy as np
+
+# Register NumPy bfloat16 support required by safetensors.
+import ml_dtypes  # noqa: F401
+
+from safetensors import safe_open
+
+from .config import ModelConfig
+
+
+def _target_np_dtype(precision: str) -> np.dtype:
+    """Map precision string to numpy dtype for weight storage."""
+    if precision in ("fp16", "bf16"):
+        return np.float16
+    return np.float32
+
+
+def _layer_key(layer_idx: int, suffix: str, model_prefix: str = "model") -> str:
+    return f"{model_prefix}.layers.{layer_idx}.{suffix}"
+
+
+def _transpose_2d(arr: np.ndarray, name: str, precision: str = "fp32") -> np.ndarray:
+    """Transpose [rows, cols] -> [cols, rows] in C-contiguous target dtype."""
+    if arr.ndim != 2:
+        raise ValueError(f"Expected rank-2 tensor for transpose: {name}")
+    return np.ascontiguousarray(arr.T, dtype=_target_np_dtype(precision))
+
+
+def _repeat_head_norm(norm: np.ndarray, num_heads: int) -> np.ndarray:
+    """Repeat per-head norm [head_dim] -> [num_heads * head_dim]."""
+    return np.tile(norm, num_heads).astype(np.float32)
+
+
+class WeightDict(dict):
+    """A dict mapping logical weight names to flat float32 arrays.
+
+    Keys follow the convention used by standard_decoder_builder.py:
+      - embedding: [vocab, hidden]
+      - layer.{i}.input_norm: [hidden]
+      - layer.{i}.w_q: [hidden, attention_size]
+      - layer.{i}.w_k: [hidden, kv_attention_size]
+      - layer.{i}.w_v: [hidden, kv_attention_size]
+      - layer.{i}.q_bias: [attention_size]       (optional)
+      - layer.{i}.k_bias: [kv_attention_size]    (optional)
+      - layer.{i}.v_bias: [kv_attention_size]    (optional)
+      - layer.{i}.q_norm: [attention_size]        (optional)
+      - layer.{i}.k_norm: [kv_attention_size]     (optional)
+      - layer.{i}.w_o: [attention_size, hidden]
+      - layer.{i}.post_attn_norm: [hidden]
+      - layer.{i}.w_gate: [hidden, mlp_size]
+      - layer.{i}.w_up: [hidden, mlp_size]
+      - layer.{i}.w_down: [mlp_size, hidden]
+      - final_norm: [hidden]
+      - w_out: [hidden, vocab]
+    """
+
+
+def load_standard_weights(
+    model_dir: str | Path,
+    config: ModelConfig,
+    *,
+    precision: str = "fp32",
+    fp32_layers: tuple[int, ...] = (),
+    model_prefix: str = "model",
+    embedding_key: str | None = None,
+    final_norm_key: str | None = None,
+    lm_head_key: str = "lm_head.weight",
+) -> WeightDict:
+    """Load HF safetensors and map to standard weight dict."""
+    model_dir = Path(model_dir)
+    readers = _open_safetensors(model_dir)
+
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads
+    num_kv_heads = config.num_key_value_heads
+    target_dtype = _target_np_dtype(precision)
+    selected_fp32_layers = frozenset(int(layer) for layer in fp32_layers)
+    invalid_fp32_layers = sorted(
+        layer for layer in selected_fp32_layers if layer < 0 or layer >= num_layers
+    )
+    if invalid_fp32_layers:
+        raise ValueError(f"fp32_layers contains out-of-range indices: {invalid_fp32_layers}")
+    if precision == "fp32":
+        selected_fp32_layers = frozenset()
+
+    weights = WeightDict()
+
+    # Embedding
+    if embedding_key is None:
+        embedding_key = f"{model_prefix}.embed_tokens.weight"
+    embedding = _load_tensor(readers, embedding_key)
+    assert embedding.shape == (vocab, hidden), (
+        f"Embedding shape {embedding.shape} != ({vocab}, {hidden})"
+    )
+    weights["embedding"] = embedding.astype(target_dtype)
+
+    def _load_layer(layer_idx: int) -> tuple[int, WeightDict, int, int]:
+        prefix = f"layer.{layer_idx}"
+        layer = WeightDict()
+        layer_precision = "fp32" if layer_idx in selected_fp32_layers else precision
+        layer_target_dtype = _target_np_dtype(layer_precision)
+
+        # Norms
+        input_norm = _load_tensor(
+            readers, _layer_key(layer_idx, "input_layernorm.weight", model_prefix)
+        )
+        post_norm = _load_tensor(
+            readers, _layer_key(layer_idx, "post_attention_layernorm.weight", model_prefix)
+        )
+        layer[f"{prefix}.input_norm"] = input_norm.astype(np.float32)
+        layer[f"{prefix}.post_attn_norm"] = post_norm.astype(np.float32)
+
+        # Q/K/V/O projections
+        q_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "self_attn.q_proj.weight", model_prefix)
+        )
+        k_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "self_attn.k_proj.weight", model_prefix)
+        )
+        v_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "self_attn.v_proj.weight", model_prefix)
+        )
+        o_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "self_attn.o_proj.weight", model_prefix)
+        )
+
+        q_hidden = q_raw.shape[0]
+        gate_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "mlp.gate_proj.weight", model_prefix)
+        )
+        layer_mlp_size = gate_raw.shape[0]
+
+        # Transpose all projections [out, in] -> [in, out]
+        q_t = _transpose_2d(q_raw, "q_proj", precision=layer_precision)
+        k_t = _transpose_2d(k_raw, "k_proj", precision=layer_precision)
+        v_t = _transpose_2d(v_raw, "v_proj", precision=layer_precision)
+        o_t = _transpose_2d(o_raw, "o_proj", precision=layer_precision)
+
+        layer[f"{prefix}.w_q"] = q_t
+        layer[f"{prefix}.w_k"] = k_t
+        layer[f"{prefix}.w_v"] = v_t
+        layer[f"{prefix}.w_o"] = o_t
+
+        # Optional QKV biases (Qwen2 style)
+        q_bias_key = _layer_key(layer_idx, "self_attn.q_proj.bias", model_prefix)
+        k_bias_key = _layer_key(layer_idx, "self_attn.k_proj.bias", model_prefix)
+        v_bias_key = _layer_key(layer_idx, "self_attn.v_proj.bias", model_prefix)
+        if _has_tensor(readers, q_bias_key):
+            layer[f"{prefix}.q_bias"] = _load_tensor(readers, q_bias_key).astype(layer_target_dtype)
+        if _has_tensor(readers, k_bias_key):
+            layer[f"{prefix}.k_bias"] = _load_tensor(readers, k_bias_key).astype(layer_target_dtype)
+        if _has_tensor(readers, v_bias_key):
+            layer[f"{prefix}.v_bias"] = _load_tensor(readers, v_bias_key).astype(layer_target_dtype)
+
+        # Optional per-head q/k norm (Qwen3 style)
+        q_norm_key = _layer_key(layer_idx, "self_attn.q_norm.weight", model_prefix)
+        k_norm_key = _layer_key(layer_idx, "self_attn.k_norm.weight", model_prefix)
+        if _has_tensor(readers, q_norm_key):
+            layer[f"{prefix}.q_norm"] = _repeat_head_norm(
+                _load_tensor(readers, q_norm_key).astype(np.float32), num_heads
+            )
+        if _has_tensor(readers, k_norm_key):
+            layer[f"{prefix}.k_norm"] = _repeat_head_norm(
+                _load_tensor(readers, k_norm_key).astype(np.float32), num_kv_heads
+            )
+
+        # MLP projections
+        up_raw = _load_tensor(readers, _layer_key(layer_idx, "mlp.up_proj.weight", model_prefix))
+        down_raw = _load_tensor(
+            readers, _layer_key(layer_idx, "mlp.down_proj.weight", model_prefix)
+        )
+
+        layer[f"{prefix}.w_gate"] = _transpose_2d(gate_raw, "gate_proj", precision=layer_precision)
+        layer[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up_proj", precision=layer_precision)
+        layer[f"{prefix}.w_down"] = _transpose_2d(down_raw, "down_proj", precision=layer_precision)
+
+        return layer_idx, layer, q_hidden, layer_mlp_size
+
+    layer_results: list[tuple[int, WeightDict, int, int] | None] = [None] * num_layers
+    max_workers = min(8, max(1, os.cpu_count() or 1))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(_load_layer, i) for i in range(num_layers)]
+        for future in as_completed(futures):
+            layer_idx, layer, attention_size, mlp_size = future.result()
+            layer_results[layer_idx] = (layer_idx, layer, attention_size, mlp_size)
+
+    attention_size = 0
+    kv_attention_size = 0
+    mlp_size = 0
+    for result in layer_results:
+        if result is None:
+            continue
+        _layer_idx, layer, layer_attention_size, layer_mlp_size = result
+        weights.update(layer)
+        if attention_size == 0:
+            attention_size = layer_attention_size
+            first_k = layer[f"layer.{_layer_idx}.w_k"]
+            kv_attention_size = int(first_k.shape[1])
+        if mlp_size == 0:
+            mlp_size = layer_mlp_size
+
+    # Final norm
+    if final_norm_key is None:
+        final_norm_key = f"{model_prefix}.norm.weight"
+    if _has_tensor(readers, final_norm_key):
+        weights["final_norm"] = _load_tensor(readers, final_norm_key).astype(np.float32)
+    else:
+        weights["final_norm"] = np.ones(hidden, dtype=np.float32)
+
+    # LM head
+    if _has_tensor(readers, lm_head_key):
+        weights["w_out"] = _transpose_2d(
+            _load_tensor(readers, lm_head_key), "lm_head", precision=precision
+        )
+    else:
+        # Tied embeddings
+        weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied", precision=precision)
+
+    weights["_attention_size"] = attention_size  # type: ignore[assignment]
+    weights["_kv_attention_size"] = kv_attention_size  # type: ignore[assignment]
+    weights["_mlp_size"] = mlp_size  # type: ignore[assignment]
+
+    return weights
+
+
+# ---------------------------------------------------------------------------
+# Safetensors I/O helpers
+# ---------------------------------------------------------------------------
+class _ReaderCollection(list):
+    """Checkpoint readers with one exact tensor-to-reader index."""
+
+    def __init__(self, readers: list, *, tensor_map: dict[str, object] | None = None):
+        super().__init__(readers)
+        if tensor_map is None:
+            tensor_map = {name: reader for reader in readers for name in reader.keys()}
+        self.tensor_map = tensor_map
+
+
+def _open_safetensors(model_dir: Path) -> _ReaderCollection:
+    """Open the checkpoint's required NumPy safetensors readers."""
+    import json
+
+    single = model_dir / "model.safetensors"
+    if single.is_file():
+        return _ReaderCollection([safe_open(str(single), framework="numpy")])
+
+    index_path = model_dir / "model.safetensors.index.json"
+    if index_path.is_file():
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise ValueError("model.safetensors.index.json has no weight_map")
+        shard_files = sorted(set(str(value) for value in weight_map.values()))
+        readers_by_file = {
+            shard: safe_open(str(model_dir / shard), framework="numpy") for shard in shard_files
+        }
+        return _ReaderCollection(
+            [readers_by_file[shard] for shard in shard_files],
+            tensor_map={
+                str(name): readers_by_file[str(shard)] for name, shard in weight_map.items()
+            },
+        )
+
+    diff_single = model_dir / "diffusion_pytorch_model.safetensors"
+    if diff_single.is_file():
+        return _ReaderCollection([safe_open(str(diff_single), framework="numpy")])
+
+    diff_index = model_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if diff_index.is_file():
+        index = json.loads(diff_index.read_text(encoding="utf-8"))
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise ValueError("diffusion safetensors index has no weight_map")
+        shard_files = sorted(set(str(value) for value in weight_map.values()))
+        readers_by_file = {
+            shard: safe_open(str(model_dir / shard), framework="numpy") for shard in shard_files
+        }
+        return _ReaderCollection(
+            [readers_by_file[shard] for shard in shard_files],
+            tensor_map={
+                str(name): readers_by_file[str(shard)] for name, shard in weight_map.items()
+            },
+        )
+
+    raise FileNotFoundError(f"No supported safetensors checkpoint in {model_dir}")
+
+
+def _has_tensor(readers: _ReaderCollection, name: str) -> bool:
+    return name in readers.tensor_map
+
+
+def _to_numpy_fp32(tensor) -> np.ndarray:
+    """Copy a NumPy or ml_dtypes checkpoint tensor to float32."""
+    return np.asarray(tensor, dtype=np.float32)
+
+
+def _load_tensor(readers: _ReaderCollection, name: str) -> np.ndarray:
+    reader = readers.tensor_map.get(name)
+    if reader is None:
+        raise KeyError(f"Tensor not found: {name}")
+    return _to_numpy_fp32(reader.get_tensor(name))

--- a/families/smollm3/checkpoint_mapper.py
+++ b/families/smollm3/checkpoint_mapper.py
@@ -107,9 +107,8 @@ def load_standard_weights(
     if embedding_key is None:
         embedding_key = f"{model_prefix}.embed_tokens.weight"
     embedding = _load_tensor(readers, embedding_key)
-    assert embedding.shape == (vocab, hidden), (
-        f"Embedding shape {embedding.shape} != ({vocab}, {hidden})"
-    )
+    if embedding.shape != (vocab, hidden):
+        raise ValueError(f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
     weights["embedding"] = embedding.astype(target_dtype)
 
     def _load_layer(layer_idx: int) -> tuple[int, WeightDict, int, int]:

--- a/families/smollm3/config.py
+++ b/families/smollm3/config.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModelConfig — parse HF config.json into a typed dataclass."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _raw_config(config: object) -> dict:
+    """Return a config object's raw HF mapping.
+
+    Accepts any config the build path may carry. ``engine_builder`` constructs
+    the shared ``tensorrt_model_connect.config.ModelConfig``, not this module's
+    dataclass, so anything the builders need from the checkpoint has to be
+    resolved from ``raw`` rather than from a family-local method.
+    """
+    raw = getattr(config, "raw", None)
+    if not isinstance(raw, dict):
+        raise ValueError("SmolLM3 config.raw must be a JSON object")
+    return raw
+
+
+def resolve_rope_layer_schedule(config: object) -> tuple[bool, ...]:
+    """Per-layer RoPE flags: ``True`` where the layer applies RoPE.
+
+    SmolLM3 interleaves NoPE layers (no positional encoding) among regular RoPE
+    layers. The checkpoint publishes this as ``no_rope_layers``, whose entries
+    are ``1`` where the layer *uses* RoPE and ``0`` where it is a NoPE layer.
+    When the list is absent it is derived from ``no_rope_layer_interval``: layer
+    ``i`` is NoPE when ``(i + 1) % interval == 0``, matching the upstream
+    default of one NoPE layer every four layers.
+    """
+    raw = _raw_config(config)
+    num_layers = int(getattr(config, "num_hidden_layers", 0) or 0)
+    if num_layers <= 0:
+        num_layers = int(raw.get("num_hidden_layers", 0) or 0)
+    published = raw.get("no_rope_layers")
+    if published is not None:
+        if (not isinstance(published, (list, tuple))
+                or len(published) < num_layers):
+            raise ValueError(
+                "no_rope_layers must be a sequence with at least "
+                f"num_hidden_layers ({num_layers}) entries, got "
+                f"{published!r}")
+        return tuple(bool(int(flag)) for flag in published[:num_layers])
+
+    interval = raw.get("no_rope_layer_interval")
+    if interval is None:
+        return (True,) * num_layers
+    interval = int(interval)
+    if interval <= 0:
+        raise ValueError(
+            f"no_rope_layer_interval must be positive, got {interval}")
+    return tuple((idx + 1) % interval != 0 for idx in range(num_layers))
+
+
+@dataclass
+class ModelConfig:
+    """Parsed model architecture from HF config.json."""
+
+    model_type: str = ""
+    architectures: list[str] = field(default_factory=list)
+    vocab_size: int = 0
+    hidden_size: int = 0
+    intermediate_size: int = 0
+    num_hidden_layers: int = 0
+    num_attention_heads: int = 1
+    num_key_value_heads: int = 1
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 10000.0
+    bos_token_id: int = -1
+    eos_token_id: int = -1
+    pad_token_id: int = -1
+    tie_word_embeddings: bool = False
+    max_position_embeddings: int = 8192
+    hidden_act: str = ""
+
+    # Explicit head_dim from config.json (0 = not set, fall back to computed).
+    _head_dim: int = 0
+
+    # Raw JSON dict for family-specific fields
+    raw: dict = field(default_factory=dict, repr=False)
+
+    @property
+    def head_dim(self) -> int:
+        if self._head_dim > 0:
+            return self._head_dim
+        if self.num_attention_heads <= 0:
+            return 0
+        return self.hidden_size // self.num_attention_heads
+
+    @property
+    def attention_size(self) -> int:
+        return self.num_attention_heads * self.head_dim
+
+    def rope_layer_schedule(self) -> tuple[bool, ...]:
+        """Per-layer RoPE flags for this config.
+
+        Delegates to :func:`resolve_rope_layer_schedule`, which is what the
+        builders call: they receive the shared ``ModelConfig``, which does not
+        carry this method.
+        """
+        return resolve_rope_layer_schedule(self)
+
+    @staticmethod
+    def from_json(text: str) -> ModelConfig:
+        d = json.loads(text)
+
+        # Some multimodal configs nest decoder fields under "text_config".
+        # Merge text_config into top level so standard key lookup works.
+        # Preserve top-level model_type and architectures (these identify the
+        # top-level model, not the nested decoder).
+        original_raw = d
+        text_config = d.get("text_config")
+        if text_config and isinstance(text_config, dict):
+            top_model_type = d.get("model_type")
+            top_architectures = d.get("architectures")
+            merged = {**d, **text_config}
+            if top_model_type:
+                merged["model_type"] = top_model_type
+            if top_architectures:
+                merged["architectures"] = top_architectures
+            d = merged
+
+        # Some multimodal configs nest the language decoder config under
+        # "language_config".  Merge into top level like text_config.
+        if not d.get("hidden_size"):
+            lang_config = d.get("language_config")
+            if isinstance(lang_config, dict):
+                top_model_type = d.get("model_type")
+                top_architectures = d.get("architectures")
+                top_vision_config = d.get("vision_config")
+                merged = {**d, **lang_config}
+                if top_model_type:
+                    merged["model_type"] = top_model_type
+                if top_architectures:
+                    merged["architectures"] = top_architectures
+                if top_vision_config:
+                    merged["vision_config"] = top_vision_config
+                d = merged
+
+        # Some multimodal configs nest LLM config under "llm_config".
+        # Merge into top level like text_config, preserving top-level
+        # model_type, architectures, and vision_config.
+        if not d.get("hidden_size"):
+            llm_config = d.get("llm_config")
+            if isinstance(llm_config, dict):
+                top_model_type = d.get("model_type")
+                top_architectures = d.get("architectures")
+                top_vision_config = d.get("vision_config")
+                merged = {**d, **llm_config}
+                if top_model_type:
+                    merged["model_type"] = top_model_type
+                if top_architectures:
+                    merged["architectures"] = top_architectures
+                if top_vision_config:
+                    merged["vision_config"] = top_vision_config
+                d = merged
+
+        # Some multimodal audio/text configs nest the primary decoder config
+        # under thinker_config.text_config. If top-level hidden_size is
+        # still missing after the text_config merge above, look there.
+        if not d.get("hidden_size"):
+            thinker_cfg = d.get("thinker_config")
+            if isinstance(thinker_cfg, dict):
+                thinker_text = thinker_cfg.get("text_config")
+                if isinstance(thinker_text, dict):
+                    top_model_type = d.get("model_type")
+                    top_architectures = d.get("architectures")
+                    merged = {**d, **thinker_text}
+                    if top_model_type:
+                        merged["model_type"] = top_model_type
+                    if top_architectures:
+                        merged["architectures"] = top_architectures
+                    # Also propagate vision_config from thinker_config
+                    # so VL pipelines can find it.
+                    if "vision_config" not in merged and "vision_config" in thinker_cfg:
+                        merged["vision_config"] = thinker_cfg["vision_config"]
+                    d = merged
+
+        # Handle non-standard config key names:
+        #   GPT-2: n_embd, n_head, n_layer, n_inner
+        #   XGLM/Bloom: d_model, attention_heads, num_layers, ffn_dim
+        #   DistilBERT: dim, n_heads, n_layers, hidden_dim
+        hidden_size = (d.get("hidden_size", 0) or d.get("n_embd", 0)
+                       or d.get("d_model", 0) or d.get("n_embed", 0)
+                       or d.get("dim", 0))
+        num_heads = (d.get("num_attention_heads", 0) or d.get("n_head", 0)
+                     or d.get("attention_heads", 0) or d.get("num_heads", 0)
+                     or d.get("n_heads", 0) or d.get("decoder_attention_heads", 0) or 1)
+        num_layers = (d.get("num_hidden_layers", 0) or d.get("n_layer", 0)
+                      or d.get("num_layers", 0) or d.get("n_layers", 0))
+        intermediate = (d.get("intermediate_size", 0)
+                        or d.get("n_inner", 0)
+                        or d.get("ffn_dim", 0)
+                        or d.get("hidden_dim", 0)
+                        or hidden_size * 4)
+
+        # Norm epsilon: try rms_norm_eps, then layer_norm_epsilon, then
+        # layer_norm_eps, then norm_epsilon, then norm_eps.
+        eps = (d.get("rms_norm_eps")
+               or d.get("layer_norm_epsilon")
+               or d.get("layer_norm_eps")
+               or d.get("norm_epsilon")
+               or d.get("norm_eps")
+               or 1e-5)
+
+        # rope_theta: check top-level first, then rope_parameters dict
+        # (some model configs store it there),
+        # then rope_scaling dict.
+        rope_theta = d.get("rope_theta", None)
+        if rope_theta is None:
+            rope_params = d.get("rope_parameters")
+            if isinstance(rope_params, dict):
+                rope_theta = rope_params.get("rope_theta", 10000.0)
+            else:
+                rope_scaling = d.get("rope_scaling")
+                if isinstance(rope_scaling, dict):
+                    rope_theta = rope_scaling.get("rope_theta", 10000.0)
+                else:
+                    rope_theta = 10000.0
+        rope_theta = float(rope_theta)
+
+        architecture = d.get("architecture", "")
+        architectures = d.get("architectures", [])
+        if not architectures and architecture:
+            architectures = [architecture]
+
+        return ModelConfig(
+            model_type=d.get("model_type", "") or architecture,
+            architectures=architectures,
+            vocab_size=d.get("vocab_size", 0),
+            hidden_size=hidden_size or d.get("num_features", 0),
+            intermediate_size=intermediate,
+            num_hidden_layers=num_layers,
+            num_attention_heads=num_heads,
+            num_key_value_heads=d.get("num_key_value_heads", num_heads),
+            rms_norm_eps=eps,
+            rope_theta=rope_theta,
+            bos_token_id=d.get("bos_token_id", -1) or -1,
+            eos_token_id=d.get("eos_token_id", -1) or -1,
+            pad_token_id=d.get("pad_token_id", -1) or -1,
+            tie_word_embeddings=d.get("tie_word_embeddings", False),
+            max_position_embeddings=d.get("max_position_embeddings",
+                                          d.get("n_positions", 8192)),
+            hidden_act=d.get("hidden_act", "") or d.get("activation_function", ""),
+            _head_dim=d.get("head_dim", 0),
+            raw=original_raw,
+        )
+
+    @classmethod
+    def create_tiny(cls, model_type: str, **overrides) -> "ModelConfig":
+        """Create a minimal ModelConfig for testing (2 layers, hidden=16, vocab=32)."""
+        defaults = {
+            "model_type": model_type,
+            "vocab_size": 32, "hidden_size": 16, "intermediate_size": 32,
+            "num_hidden_layers": 2, "num_attention_heads": 4,
+            "num_key_value_heads": 4, "rms_norm_eps": 1e-6,
+            "rope_theta": 10000.0, "max_position_embeddings": 128,
+        }
+        defaults.update(overrides)
+        return cls.from_json(json.dumps(defaults))
+
+    @staticmethod
+    def from_dir(model_dir: str | Path) -> ModelConfig:
+        model_path = Path(model_dir)
+        config_path = model_path / "config.json"
+        if config_path.exists():
+            return ModelConfig.from_json(config_path.read_text())
+        return ModelConfig.from_json(config_path.read_text())

--- a/families/smollm3/config.py
+++ b/families/smollm3/config.py
@@ -269,6 +269,4 @@ class ModelConfig:
     def from_dir(model_dir: str | Path) -> ModelConfig:
         model_path = Path(model_dir)
         config_path = model_path / "config.json"
-        if config_path.exists():
-            return ModelConfig.from_json(config_path.read_text())
         return ModelConfig.from_json(config_path.read_text())

--- a/families/smollm3/dual_profile_decoder_builder.py
+++ b/families/smollm3/dual_profile_decoder_builder.py
@@ -1,46 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dual-profile decoder engine builder — single engine, two optimization profiles.
+"""SmolLM3 prefill/decode graphs with dynamic sequence profiles.
 
-Produces one TensorRT engine that handles both prefill (multi-token) and
-decode (single-token) phases by switching between two optimization profiles
-at runtime:
-  * Profile 0 (prefill): Sq ranges over [1, opt=opt_prefill_length, max=max_prefill_length].
-    TensorRT picks batched MHA kernels (e.g. ``_gemm_mha_v2``) at opt Sq.
-  * Profile 1 (decode): Sq fixed to 1. TensorRT picks the GEMV fast-path
-    (``_gemv_mha_v1``).
-
-Both profiles use the same graph and weights — only the optimization
-profile differs, so the engine's weights live once in GPU memory and the
-C++ runtime creates two ``IExecutionContext``s (one per profile) that
-share the engine.
-
-Scope: covers the same architectural variants the explicit
-``standard_decoder_builder`` supports — RMSNorm or LayerNorm; SwiGLU or
-GeluFC MLP; RoPE (full / partial / interleaved), learned absolute, or
-ALiBi position; sequential or parallel residual; optional q/k_norm,
-QKV/output/MLP biases, and a Bloom-style embedding LayerNorm. Quantized
-builds (fp8 / int8 ``quant_ctx``) thread Q/DQ insertion through every
-projection matmul via ``QuantContext.maybe_quantized_matmul``. Per-layer
-debug outputs, hidden-state outputs, and the VL ``embed_input`` path stay
-on ``standard_decoder_builder`` for now and are dispatched there from
-inside ``build_standard_decoder_engine``.
-
-Tensor contract for the TensorRT native KV-cache path:
-  Inputs (Sq varies by profile; cache capacity is static)
-    token_id        int32   (-1,)
-    position_id     int32   (-1,)
-    cache_write_indices int32 (1,)                   # update start offset
-    key_value_lengths   int32 (1,)                   # active length after update
-    cache_k_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
-    cache_v_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
-  Outputs
-    logits          float32 (1, vocab)               # last-row sliced inside the engine
-    present_k_i     bf16 (1, Hkv, capacity, D)       # aliases cache_k_i
-    present_v_i     bf16 (1, Hkv, capacity, D)       # aliases cache_v_i
-
-The dense-mask path covers SmolLM3 checkpoints outside the native-KV contract.
+The native path uses BF16 caches shaped [1, Hkv, capacity, D], write indices,
+and active lengths. The portable path uses explicit masks. Both emit the
+last token's logits as float32 [1, vocab].
 """
 
 from __future__ import annotations
@@ -60,120 +25,11 @@ from . import graph_blocks
 # Runtime import: the schedule is resolved while the graph is built, so this
 # cannot live under TYPE_CHECKING the way the annotation-only names do.
 from .config import resolve_rope_layer_schedule
+from .utils import const_in_work_dtype
 
 if TYPE_CHECKING:
     from .config import ModelConfig
     from .checkpoint_mapper import WeightDict
-
-
-def _const_in_work_dtype(
-    network: trt.INetworkDefinition,
-    shape: tuple,
-    values: np.ndarray,
-    work_np_dtype: np.dtype,
-    work_trt_dtype: trt.DataType,
-) -> trt.ITensor:
-    """Create a constant in work_np_dtype storage and cast it to work_trt_dtype.
-
-    Needed for bf16 builds: the dual-profile builder stores bf16 weights
-    on disk as fp16 (work_np_dtype = np.float16), but the runtime tensor
-    must be bfloat16 to match the rest of the graph. ``add_constant``
-    alone produces an fp16 constant — we need an explicit cast to
-    bfloat16 so layers like IRotaryEmbeddingLayer (which require all
-    inputs to share a dtype) accept it. fp16 / fp32 builds are no-ops
-    because work_np_dtype maps directly to work_trt_dtype.
-    """
-    const = graph_ops.add_constant(network, shape, values, dtype=work_np_dtype)
-    if const.dtype != work_trt_dtype:
-        const = network.add_cast(const, work_trt_dtype).get_output(0)
-    return const
-
-
-def _make_matmul_fn(
-    network: trt.INetworkDefinition,
-    dtype: np.dtype,
-):
-    """Create the SmolLM3 projection matmul callable."""
-
-    def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
-        del weight_name
-        return graph_ops.add_matmul_rhs_constant(
-            network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype
-        )
-
-    return matmul
-
-
-def _norm_multi(
-    network: trt.INetworkDefinition,
-    inp: trt.ITensor,
-    hidden: int,
-    gamma: np.ndarray,
-    beta: np.ndarray | None,
-    eps_tensor: trt.ITensor,
-    norm_type: str,
-    dtype: np.dtype,
-) -> trt.ITensor:
-    if norm_type == "layernorm":
-        if beta is None:
-            beta = np.zeros(hidden, dtype=np.float32)
-        return graph_ops.add_layer_norm(network, inp, hidden, gamma, beta, eps_tensor, dtype=dtype)
-    return graph_ops.add_rms_norm(network, inp, hidden, gamma, eps_tensor, dtype=dtype)
-
-
-# ---------------------------------------------------------------------------
-# MLP helpers.
-# ---------------------------------------------------------------------------
-
-
-def _swiglu_mlp(
-    network: trt.INetworkDefinition,
-    inp: trt.ITensor,
-    *,
-    matmul,
-    weights: "WeightDict",
-    prefix: str,
-    hidden: int,
-    mlp_size: int,
-) -> trt.ITensor:
-    gate = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
-    up = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_up"], f"{prefix}.w_up")
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
-    gated = network.add_elementwise(swish.get_output(0), up, trt.ElementWiseOperation.PROD)
-    mlp_out = matmul(
-        gated.get_output(0), mlp_size, hidden, weights[f"{prefix}.w_down"], f"{prefix}.w_down"
-    )
-    return mlp_out
-
-
-def _gelu_fc_mlp(
-    network: trt.INetworkDefinition,
-    inp: trt.ITensor,
-    *,
-    matmul,
-    weights: "WeightDict",
-    prefix: str,
-    hidden: int,
-    mlp_size: int,
-    activation: str,
-    work_np_dtype: np.dtype,
-) -> trt.ITensor:
-    fc1 = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_fc1"], f"{prefix}.w_fc1")
-    fc1_bias = weights.get(f"{prefix}.fc1_bias")
-    if fc1_bias is not None:
-        fc1 = graph_ops.add_bias_sum(network, fc1, mlp_size, fc1_bias, dtype=work_np_dtype)
-    activated = graph_ops.add_activation(network, fc1, activation, dtype=work_np_dtype)
-    fc2 = matmul(activated, mlp_size, hidden, weights[f"{prefix}.w_fc2"], f"{prefix}.w_fc2")
-    fc2_bias = weights.get(f"{prefix}.fc2_bias")
-    if fc2_bias is not None:
-        fc2 = graph_ops.add_bias_sum(network, fc2, hidden, fc2_bias, dtype=work_np_dtype)
-    return fc2
-
-
-# ---------------------------------------------------------------------------
-# Config guard.
-# ---------------------------------------------------------------------------
 
 
 def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
@@ -380,7 +236,7 @@ def build_dual_profile_decoder_engine(
         _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
-    embedding_table = _const_in_work_dtype(
+    embedding_table = const_in_work_dtype(
         network, (vocab, hidden), weights["embedding"], work_np_dtype, work_trt_dtype
     )
 
@@ -425,10 +281,10 @@ def build_dual_profile_decoder_engine(
             # BF16 must round directly from the FP32 indexed table. Routing
             # through FP16 storage would introduce FP16 -> BF16 double rounding.
             rope_np_dtype = np.float32 if work_trt_dtype == trt.bfloat16 else work_np_dtype
-            cos_half_table = _const_in_work_dtype(
+            cos_half_table = const_in_work_dtype(
                 network, cos_half_np.shape, cos_half_np, rope_np_dtype, work_trt_dtype
             )
-            sin_half_table = _const_in_work_dtype(
+            sin_half_table = const_in_work_dtype(
                 network, sin_half_np.shape, sin_half_np, rope_np_dtype, work_trt_dtype
             )
 
@@ -436,7 +292,7 @@ def build_dual_profile_decoder_engine(
     position_embed_table: trt.ITensor | None = None
     if position_type == "learned":
         pos_embed_np = weights["position_embedding"]
-        position_embed_table = _const_in_work_dtype(
+        position_embed_table = const_in_work_dtype(
             network, pos_embed_np.shape, pos_embed_np, work_np_dtype, work_trt_dtype
         )
 
@@ -472,7 +328,7 @@ def build_dual_profile_decoder_engine(
     # Attention scale.
     attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
 
-    matmul = _make_matmul_fn(network, work_np_dtype)
+    matmul = graph_blocks.make_matmul_fn(network, work_np_dtype)
 
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
@@ -494,7 +350,7 @@ def build_dual_profile_decoder_engine(
     embed_norm = weights.get("embedding_norm")
     if embed_norm is not None:
         embed_norm_beta = weights.get("embedding_norm_beta", np.zeros(hidden, dtype=np.float32))
-        hidden_state = _norm_multi(
+        hidden_state = graph_blocks.apply_norm(
             network,
             hidden_state,
             hidden,
@@ -547,7 +403,7 @@ def build_dual_profile_decoder_engine(
         prefix = f"layer.{layer_idx}"
 
         # Pre-attention norm.
-        normed = _norm_multi(
+        normed = graph_blocks.apply_norm(
             network,
             hidden_state,
             hidden,
@@ -690,7 +546,7 @@ def build_dual_profile_decoder_engine(
         if parallel_residual:
             post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
             if post_attn_norm_w is not None:
-                norm2 = _norm_multi(
+                norm2 = graph_blocks.apply_norm(
                     network,
                     hidden_state,
                     hidden,
@@ -706,7 +562,7 @@ def build_dual_profile_decoder_engine(
             residual1 = network.add_elementwise(
                 hidden_state, attn_out, trt.ElementWiseOperation.SUM
             )
-            norm2 = _norm_multi(
+            norm2 = graph_blocks.apply_norm(
                 network,
                 residual1.get_output(0),
                 hidden,
@@ -719,26 +575,25 @@ def build_dual_profile_decoder_engine(
 
         # MLP — SwiGLU (Llama-style) or GeluFC (GPT-2-style).
         if mlp_type == "gelu_fc":
-            mlp_out = _gelu_fc_mlp(
+            mlp_out = graph_blocks.add_gelu_fc_mlp(
                 network,
                 norm2,
-                matmul=matmul,
                 weights=weights,
                 prefix=prefix,
-                hidden=hidden,
+                hidden_size=hidden,
                 mlp_size=mlp_size,
                 activation=activation,
-                work_np_dtype=work_np_dtype,
+                dtype=work_np_dtype,
             )
         else:
-            mlp_out = _swiglu_mlp(
+            mlp_out = graph_blocks.add_swiglu_mlp(
                 network,
                 norm2,
-                matmul=matmul,
                 weights=weights,
                 prefix=prefix,
-                hidden=hidden,
+                hidden_size=hidden,
                 mlp_size=mlp_size,
+                dtype=work_np_dtype,
             )
 
         # Final residual.
@@ -756,7 +611,7 @@ def build_dual_profile_decoder_engine(
     # ---- Final norm + LM head -------------------------------------------
     final_norm = weights.get("final_norm")
     if final_norm is not None and len(final_norm) > 0:
-        hidden_state = _norm_multi(
+        hidden_state = graph_blocks.apply_norm(
             network,
             hidden_state,
             hidden,

--- a/families/smollm3/dual_profile_decoder_builder.py
+++ b/families/smollm3/dual_profile_decoder_builder.py
@@ -403,6 +403,7 @@ def build_dual_profile_decoder_engine(
             rope_position_id = None
         else:
             kmax = max_cache_length + max_prefill_length
+            rope_scaling = graph_ops.resolve_rope_scaling(config.raw)
             cos_half_np = graph_ops.make_rope_table_half_dim(
                 kmax,
                 head_dim,
@@ -410,7 +411,7 @@ def build_dual_profile_decoder_engine(
                 True,
                 partial_rotary_factor,
                 interleaved=interleaved_rope,
-                rope_scaling=config.raw.get("rope_scaling"),
+                rope_scaling=rope_scaling,
             )
             sin_half_np = graph_ops.make_rope_table_half_dim(
                 kmax,
@@ -419,7 +420,7 @@ def build_dual_profile_decoder_engine(
                 False,
                 partial_rotary_factor,
                 interleaved=interleaved_rope,
-                rope_scaling=config.raw.get("rope_scaling"),
+                rope_scaling=rope_scaling,
             )
             # BF16 must round directly from the FP32 indexed table. Routing
             # through FP16 storage would introduce FP16 -> BF16 double rounding.

--- a/families/smollm3/dual_profile_decoder_builder.py
+++ b/families/smollm3/dual_profile_decoder_builder.py
@@ -1,0 +1,828 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dual-profile decoder engine builder — single engine, two optimization profiles.
+
+Produces one TensorRT engine that handles both prefill (multi-token) and
+decode (single-token) phases by switching between two optimization profiles
+at runtime:
+  * Profile 0 (prefill): Sq ranges over [1, opt=opt_prefill_length, max=max_prefill_length].
+    TensorRT picks batched MHA kernels (e.g. ``_gemm_mha_v2``) at opt Sq.
+  * Profile 1 (decode): Sq fixed to 1. TensorRT picks the GEMV fast-path
+    (``_gemv_mha_v1``).
+
+Both profiles use the same graph and weights — only the optimization
+profile differs, so the engine's weights live once in GPU memory and the
+C++ runtime creates two ``IExecutionContext``s (one per profile) that
+share the engine.
+
+Scope: covers the same architectural variants the explicit
+``standard_decoder_builder`` supports — RMSNorm or LayerNorm; SwiGLU or
+GeluFC MLP; RoPE (full / partial / interleaved), learned absolute, or
+ALiBi position; sequential or parallel residual; optional q/k_norm,
+QKV/output/MLP biases, and a Bloom-style embedding LayerNorm. Quantized
+builds (fp8 / int8 ``quant_ctx``) thread Q/DQ insertion through every
+projection matmul via ``QuantContext.maybe_quantized_matmul``. Per-layer
+debug outputs, hidden-state outputs, and the VL ``embed_input`` path stay
+on ``standard_decoder_builder`` for now and are dispatched there from
+inside ``build_standard_decoder_engine``.
+
+Tensor contract for the TensorRT native KV-cache path:
+  Inputs (Sq varies by profile; cache capacity is static)
+    token_id        int32   (-1,)
+    position_id     int32   (-1,)
+    cache_write_indices int32 (1,)                   # update start offset
+    key_value_lengths   int32 (1,)                   # active length after update
+    cache_k_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
+    cache_v_i       bf16 (1, Hkv, capacity, D)       # user-owned static buffer
+  Outputs
+    logits          float32 (1, vocab)               # last-row sliced inside the engine
+    present_k_i     bf16 (1, Hkv, capacity, D)       # aliases cache_k_i
+    present_v_i     bf16 (1, Hkv, capacity, D)       # aliases cache_v_i
+
+The dense-mask path covers SmolLM3 checkpoints outside the native-KV contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+import tensorrt as trt
+from .native_kv_attention_builder import (
+    EXPLICIT_ATTENTION_PREFILL_CHUNK_TOKENS,
+    add_active_prefix_causal_masks,
+)
+
+from . import graph_ops
+from . import graph_blocks
+# Runtime import: the schedule is resolved while the graph is built, so this
+# cannot live under TYPE_CHECKING the way the annotation-only names do.
+from .config import resolve_rope_layer_schedule
+
+if TYPE_CHECKING:
+    from .config import ModelConfig
+    from .checkpoint_mapper import WeightDict
+
+
+def _const_in_work_dtype(
+    network: trt.INetworkDefinition,
+    shape: tuple,
+    values: np.ndarray,
+    work_np_dtype: np.dtype,
+    work_trt_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Create a constant in work_np_dtype storage and cast it to work_trt_dtype.
+
+    Needed for bf16 builds: the dual-profile builder stores bf16 weights
+    on disk as fp16 (work_np_dtype = np.float16), but the runtime tensor
+    must be bfloat16 to match the rest of the graph. ``add_constant``
+    alone produces an fp16 constant — we need an explicit cast to
+    bfloat16 so layers like IRotaryEmbeddingLayer (which require all
+    inputs to share a dtype) accept it. fp16 / fp32 builds are no-ops
+    because work_np_dtype maps directly to work_trt_dtype.
+    """
+    const = graph_ops.add_constant(network, shape, values, dtype=work_np_dtype)
+    if const.dtype != work_trt_dtype:
+        const = network.add_cast(const, work_trt_dtype).get_output(0)
+    return const
+
+
+def _make_matmul_fn(
+    network: trt.INetworkDefinition,
+    dtype: np.dtype,
+):
+    """Create the SmolLM3 projection matmul callable."""
+
+    def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
+        del weight_name
+        return graph_ops.add_matmul_rhs_constant(
+            network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype
+        )
+
+    return matmul
+
+
+def _norm_multi(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    if norm_type == "layernorm":
+        if beta is None:
+            beta = np.zeros(hidden, dtype=np.float32)
+        return graph_ops.add_layer_norm(network, inp, hidden, gamma, beta, eps_tensor, dtype=dtype)
+    return graph_ops.add_rms_norm(network, inp, hidden, gamma, eps_tensor, dtype=dtype)
+
+
+# ---------------------------------------------------------------------------
+# MLP helpers.
+# ---------------------------------------------------------------------------
+
+
+def _swiglu_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    matmul,
+    weights: "WeightDict",
+    prefix: str,
+    hidden: int,
+    mlp_size: int,
+) -> trt.ITensor:
+    gate = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
+    up = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_up"], f"{prefix}.w_up")
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    mlp_out = matmul(
+        gated.get_output(0), mlp_size, hidden, weights[f"{prefix}.w_down"], f"{prefix}.w_down"
+    )
+    return mlp_out
+
+
+def _gelu_fc_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    matmul,
+    weights: "WeightDict",
+    prefix: str,
+    hidden: int,
+    mlp_size: int,
+    activation: str,
+    work_np_dtype: np.dtype,
+) -> trt.ITensor:
+    fc1 = matmul(inp, hidden, mlp_size, weights[f"{prefix}.w_fc1"], f"{prefix}.w_fc1")
+    fc1_bias = weights.get(f"{prefix}.fc1_bias")
+    if fc1_bias is not None:
+        fc1 = graph_ops.add_bias_sum(network, fc1, mlp_size, fc1_bias, dtype=work_np_dtype)
+    activated = graph_ops.add_activation(network, fc1, activation, dtype=work_np_dtype)
+    fc2 = matmul(activated, mlp_size, hidden, weights[f"{prefix}.w_fc2"], f"{prefix}.w_fc2")
+    fc2_bias = weights.get(f"{prefix}.fc2_bias")
+    if fc2_bias is not None:
+        fc2 = graph_ops.add_bias_sum(network, fc2, hidden, fc2_bias, dtype=work_np_dtype)
+    return fc2
+
+
+# ---------------------------------------------------------------------------
+# Config guard.
+# ---------------------------------------------------------------------------
+
+
+def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
+    """Reject configs the dual-profile builder cannot handle."""
+    model_type = getattr(config, "model_type", "").lower()
+    if "moe" in model_type or "mamba" in model_type or "rwkv" in model_type:
+        raise NotImplementedError(
+            f"dual_profile_decoder_builder does not support model_type={model_type!r}"
+        )
+    if "embedding" not in weights:
+        raise NotImplementedError("missing embedding weight")
+    if "final_norm" not in weights:
+        raise NotImplementedError("missing final_norm weight")
+
+
+# ---------------------------------------------------------------------------
+# Main builder.
+# ---------------------------------------------------------------------------
+
+
+def build_dual_profile_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp16",
+    opt_prefill_length: int = 64,
+    max_prefill_length: int | None = None,
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    activation: str = "silu",
+    partial_rotary_factor: float = 1.0,
+    interleaved_rope: bool = False,
+    parallel_residual: bool = False,
+    scale_attn_weights: bool = True,
+    alibi_bias_scale: float = 1.0,
+    verbose: bool = False,
+    profile_mode: str = "dual_profile",
+    native_kv_cache: bool = False,
+    runtime_sized_kv_cache: bool = False,
+) -> bytes:
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
+
+    ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
+    ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
+    ``scale_attn_weights`` mirror the same parameters on
+    ``build_standard_decoder_engine``.
+    ``alibi_bias_scale`` is multiplied into ALiBi slopes before they are added
+    through the native attention mask.
+
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one decode profile.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+    * ``"decode"``: one fixed-Sq=1 profile only. This is the decode half of a
+      split-engine bundle.
+
+
+    ``native_kv_cache`` selects TensorRT's ``IKVCacheUpdateLayer`` and a
+    primitive attention graph with an explicit active-prefix causal mask.
+    SmolLM3 enables it internally by default; it is not exposed as a user build
+    flag.
+
+    ``runtime_sized_kv_cache`` makes the standard cache row dimension dynamic
+    from one row through the bundle capacity.
+    """
+    _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill", "decode"):
+        raise ValueError(
+            f"profile_mode must be 'dual_profile', 'prefill', or 'decode', got {profile_mode!r}"
+        )
+
+    if max_prefill_length is None:
+        max_prefill_length = max_cache_length
+    if native_kv_cache or runtime_sized_kv_cache:
+        # Physical KV capacity and one TensorRT enqueue's query length are
+        # separate limits. Keep the complete model context in the cache while
+        # bounding the explicit score matrix; the runtime transparently
+        # advances through multiple chunks. Clamp explicit caller overrides as
+        # well as the default so they cannot bypass this safety bound.
+        max_prefill_length = min(max_prefill_length, EXPLICIT_ATTENTION_PREFILL_CHUNK_TOKENS)
+    max_prefill_length = max(1, min(max_prefill_length, max_cache_length))
+    opt_prefill_length = max(1, min(opt_prefill_length, max_prefill_length))
+
+    if native_kv_cache and position_type == "alibi":
+        raise NotImplementedError("TensorRT native KV cache prototype does not support ALiBi")
+    if native_kv_cache and runtime_sized_kv_cache:
+        raise ValueError("native SmolLM3 KV cache has one fixed physical capacity")
+
+    attention_size = weights.get("_attention_size", config.attention_size)
+    mlp_size = weights.get("_mlp_size", config.intermediate_size)
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads
+    num_kv_heads = config.num_key_value_heads
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim
+    )
+    rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    native_rope_inv_freq: np.ndarray | None = None
+    if native_kv_cache and position_type == "rope":
+        rope_scaling = config.raw.get("rope_parameters") or config.raw.get("rope_scaling")
+        native_rope_inv_freq = graph_ops.make_native_active_rope_inv_freq(
+            head_dim,
+            config.rope_theta,
+            partial_rotary_factor,
+            rope_scaling=rope_scaling,
+        )
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.builder_optimization_level = 1
+    # Native full-context SmolLM3 builds can require substantial tactic workspace
+    # while TensorRT compiles the primitive attention graph. This is build-time
+    # scratch only (it is not serialized as runtime KV memory), and the limit
+    # does not allocate the bytes eagerly. Other paths keep TensorRT's device
+    # default instead of imposing the former 1 GiB cap.
+    if native_kv_cache:
+        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 16 << 30)
+
+    if precision == "fp16":
+        work_np_dtype, work_trt_dtype = np.float16, trt.float16
+    elif precision == "bf16":
+        work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
+    else:
+        work_np_dtype, work_trt_dtype = np.float32, trt.float32
+
+    # ---- Inputs (dynamic Sq) ---------------------------------------------
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    attention_mask: trt.ITensor | None = None
+    cache_write_indices: trt.ITensor | None = None
+    key_value_lengths: trt.ITensor | None = None
+    if native_kv_cache:
+        cache_write_indices = network.add_input("cache_write_indices", trt.int32, (1,))
+        key_value_lengths = network.add_input("key_value_lengths", trt.int32, (1,))
+    else:
+        attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+
+    cache_shape: tuple[int, ...]
+    if native_kv_cache:
+        cache_shape = (1, num_kv_heads, max_cache_length, head_dim)
+    elif runtime_sized_kv_cache:
+        cache_shape = (-1, kv_attention_size)
+    else:
+        cache_shape = (max_cache_length, kv_attention_size)
+    cache_k_inputs: list[trt.ITensor] = []
+    cache_v_inputs: list[trt.ITensor] = []
+    for i in range(num_layers):
+        ck = network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i), work_trt_dtype, cache_shape
+        )
+        cv = network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i), work_trt_dtype, cache_shape
+        )
+        cache_k_inputs.append(ck)
+        cache_v_inputs.append(cv)
+
+    # Cast the dense mask to compute dtype for elementwise broadcast.
+    attention_mask_work: trt.ITensor | None = attention_mask
+    if attention_mask is not None and work_trt_dtype != trt.float32:
+        attention_mask_work = network.add_cast(attention_mask, work_trt_dtype).get_output(0)
+
+    # Prefill/decode optimization profiles — same graph, different Sq / cache.
+    def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False):
+        prof = builder.create_optimization_profile()
+        min_sq = opt_sq if fixed else 1
+        opt_cache_rows = max_cache_length
+        prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+        prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        if not native_kv_cache:
+            prof.set_shape(
+                "attention_mask",
+                (min_sq, (1 if runtime_sized_kv_cache else max_cache_length) + min_sq),
+                (
+                    opt_sq,
+                    (opt_cache_rows if runtime_sized_kv_cache else max_cache_length) + opt_sq,
+                ),
+                (max_sq, max_cache_length + max_sq),
+            )
+        if runtime_sized_kv_cache:
+            for i in range(num_layers):
+                for prefix in ("cache_k", "cache_v"):
+                    prof.set_shape(
+                        graph_ops.layer_tensor_name(prefix, i),
+                        (1, kv_attention_size),
+                        (opt_cache_rows, kv_attention_size),
+                        (max_cache_length, kv_attention_size),
+                    )
+        trt_config.add_optimization_profile(prof)
+
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False)
+    elif profile_mode == "decode":
+        _add_profile(1, 1, fixed=True)
+    else:
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False)
+        _add_profile(1, 1, fixed=True)
+
+    # ---- Shared constants ------------------------------------------------
+    embedding_table = _const_in_work_dtype(
+        network, (vocab, hidden), weights["embedding"], work_np_dtype, work_trt_dtype
+    )
+
+    # Native KV derives RoPE only for runtime-active positions, so the engine
+    # stores a small [D/2] inverse-frequency constant instead of serializing an
+    # O(context_capacity) table. The dense-mask graph uses its indexed table.
+    cos_half_table: trt.ITensor | None = None
+    sin_half_table: trt.ITensor | None = None
+    rope_position_id: trt.ITensor | None = position_id
+    if position_type == "rope":
+        graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        if native_kv_cache:
+            assert native_rope_inv_freq is not None
+            cos_half_table, sin_half_table = graph_ops.add_active_rope_cache(
+                network,
+                position_id,
+                native_rope_inv_freq,
+                work_trt_dtype,
+            )
+            rope_position_id = None
+        else:
+            kmax = max_cache_length + max_prefill_length
+            cos_half_np = graph_ops.make_rope_table_half_dim(
+                kmax,
+                head_dim,
+                config.rope_theta,
+                True,
+                partial_rotary_factor,
+                interleaved=interleaved_rope,
+                rope_scaling=config.raw.get("rope_scaling"),
+            )
+            sin_half_np = graph_ops.make_rope_table_half_dim(
+                kmax,
+                head_dim,
+                config.rope_theta,
+                False,
+                partial_rotary_factor,
+                interleaved=interleaved_rope,
+                rope_scaling=config.raw.get("rope_scaling"),
+            )
+            # BF16 must round directly from the FP32 indexed table. Routing
+            # through FP16 storage would introduce FP16 -> BF16 double rounding.
+            rope_np_dtype = np.float32 if work_trt_dtype == trt.bfloat16 else work_np_dtype
+            cos_half_table = _const_in_work_dtype(
+                network, cos_half_np.shape, cos_half_np, rope_np_dtype, work_trt_dtype
+            )
+            sin_half_table = _const_in_work_dtype(
+                network, sin_half_np.shape, sin_half_np, rope_np_dtype, work_trt_dtype
+            )
+
+    # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
+    position_embed_table: trt.ITensor | None = None
+    if position_type == "learned":
+        pos_embed_np = weights["position_embedding"]
+        position_embed_table = _const_in_work_dtype(
+            network, pos_embed_np.shape, pos_embed_np, work_np_dtype, work_trt_dtype
+        )
+
+    # ALiBi slopes + cache-slot positions for multi-row mask augmentation.
+    alibi_slopes_tensor: trt.ITensor | None = None
+    alibi_cache_positions_fp32: trt.ITensor | None = None
+    if position_type == "alibi":
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
+        # Slopes live as fp32 so the (key_pos - q_pos) math stays in fp32;
+        # add_alibi_mask_4d casts the final bias to work_trt_dtype before adding
+        # to the additive mask.
+        alibi_slopes_tensor = graph_ops.add_constant(
+            network, (num_heads, 1, 1), alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32
+        )
+        # Cache slot k (for k in [0, max_cache_length)) holds the K/V at
+        # position k. The current step's K/V live in slots
+        # [max_cache_length, max_cache_length + Sq) and their positions come
+        # from position_id at runtime, so we only pre-build the cache half.
+        alibi_cache_positions_fp32 = graph_ops.add_constant(
+            network,
+            (max_cache_length,),
+            np.arange(max_cache_length, dtype=np.float32),
+            dtype=np.float32,
+        )
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([[config.rms_norm_eps]], dtype=np.float32), dtype=np.float32
+    )
+    eps_tensor_per_head = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([[[config.rms_norm_eps]]], dtype=np.float32), dtype=np.float32
+    )
+
+    # Attention scale.
+    attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+
+    matmul = _make_matmul_fn(network, work_np_dtype)
+
+    # ---- Embedding -------------------------------------------------------
+    emb = network.add_gather(embedding_table, token_id, 0)
+    hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if position_type == "learned" and position_embed_table is not None:
+        pos_gather = network.add_gather(position_embed_table, position_id, 0)
+        pos_add = network.add_elementwise(
+            hidden_state, pos_gather.get_output(0), trt.ElementWiseOperation.SUM
+        )
+        hidden_state = pos_add.get_output(0)
+
+    # Make sure the main hidden stream is in the requested runtime dtype
+    # before entering the layer stack (BF16 mode stores fp16 constants).
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+
+    # Optional embedding LayerNorm (Bloom).
+    embed_norm = weights.get("embedding_norm")
+    if embed_norm is not None:
+        embed_norm_beta = weights.get("embedding_norm_beta", np.zeros(hidden, dtype=np.float32))
+        hidden_state = _norm_multi(
+            network,
+            hidden_state,
+            hidden,
+            embed_norm,
+            embed_norm_beta,
+            eps_tensor,
+            "layernorm",
+            work_np_dtype,
+        )
+
+    # The native cache path shares one explicit BOOL mask across every layer.
+    # The dense-mask path uses an additive-mask graph.
+    mask_4d: trt.ITensor | None
+    if native_kv_cache:
+        mask_4d = None
+    elif position_type == "alibi":
+        assert attention_mask_work is not None
+        mask_4d = graph_ops.add_alibi_mask_4d(
+            network,
+            attention_mask_work,
+            position_id,
+            alibi_slopes_tensor,
+            alibi_cache_positions_fp32,
+            num_heads,
+            target_dtype=work_trt_dtype,
+        )
+    else:
+        assert attention_mask_work is not None
+        mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
+
+    native_attention_masks = None
+    if native_kv_cache:
+        assert cache_write_indices is not None
+        assert key_value_lengths is not None
+        native_attention_masks = add_active_prefix_causal_masks(
+            network,
+            token_id,
+            cache_write_indices,
+            key_value_lengths,
+            max_cache_length,
+        )
+
+    present_k_outs: list[trt.ITensor] = []
+    present_v_outs: list[trt.ITensor] = []
+
+    # SmolLM3 interleaves NoPE layers; layers flagged False here skip RoPE.
+    rope_schedule = resolve_rope_layer_schedule(config)
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        # Pre-attention norm.
+        normed = _norm_multi(
+            network,
+            hidden_state,
+            hidden,
+            weights[f"{prefix}.input_norm"],
+            weights.get(f"{prefix}.input_norm_beta"),
+            eps_tensor,
+            norm_type,
+            work_np_dtype,
+        )
+
+        # Q / K / V projections.
+        q = matmul(normed, hidden, attention_size, weights[f"{prefix}.w_q"], f"{prefix}.w_q")
+        k = matmul(normed, hidden, kv_attention_size, weights[f"{prefix}.w_k"], f"{prefix}.w_k")
+        v = matmul(normed, hidden, kv_attention_size, weights[f"{prefix}.w_v"], f"{prefix}.w_v")
+
+        # Optional QKV biases (Qwen2 / GPT-2 / OPT / Bloom / Falcon / etc.).
+        q_bias = weights.get(f"{prefix}.q_bias")
+        if q_bias is not None:
+            q = graph_ops.add_bias_sum(network, q, attention_size, q_bias, dtype=work_np_dtype)
+        k_bias = weights.get(f"{prefix}.k_bias")
+        if k_bias is not None:
+            k = graph_ops.add_bias_sum(network, k, kv_attention_size, k_bias, dtype=work_np_dtype)
+        v_bias = weights.get(f"{prefix}.v_bias")
+        if v_bias is not None:
+            v = graph_ops.add_bias_sum(network, v, kv_attention_size, v_bias, dtype=work_np_dtype)
+
+        # Optional per-head q/k norm (Qwen3).
+        q_norm = weights.get(f"{prefix}.q_norm")
+        if q_norm is not None:
+            q = graph_ops.add_rms_norm_per_head(
+                network,
+                q,
+                num_heads,
+                head_dim,
+                q_norm,
+                eps_tensor_per_head,
+                dtype=work_np_dtype,
+                sequence_length=None,
+            )
+        k_norm = weights.get(f"{prefix}.k_norm")
+        if k_norm is not None:
+            k = graph_ops.add_rms_norm_per_head(
+                network,
+                k,
+                num_kv_heads,
+                head_dim,
+                k_norm,
+                eps_tensor_per_head,
+                dtype=work_np_dtype,
+                sequence_length=None,
+            )
+
+        # Position embedding (RoPE only; learned was applied above and ALiBi
+        # is added into the attention mask).
+        # NoPE layers carry no positional encoding: q/k stay unrotated.
+        if position_type == "rope" and rope_schedule[layer_idx]:
+            q = graph_ops.add_apply_rope_native(
+                network,
+                q,
+                num_heads,
+                head_dim,
+                cos_half_table,
+                sin_half_table,
+                rope_position_id,
+                rotary_embedding_dim,
+                interleaved_rope,
+                sequence_length=None,
+            )
+            k = graph_ops.add_apply_rope_native(
+                network,
+                k,
+                num_kv_heads,
+                head_dim,
+                cos_half_table,
+                sin_half_table,
+                rope_position_id,
+                rotary_embedding_dim,
+                interleaved_rope,
+                sequence_length=None,
+            )
+
+        if native_kv_cache:
+            assert cache_write_indices is not None
+            assert native_attention_masks is not None
+            native_attention = graph_ops.add_native_kv_cache_attention_from_rows(
+                network,
+                q,
+                k,
+                v,
+                cache_k_inputs[layer_idx],
+                cache_v_inputs[layer_idx],
+                cache_write_indices,
+                native_attention_masks,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                q_seq=None,
+                scale=attn_scale,
+                tag=f"{prefix}.attn",
+            )
+            context = native_attention["context"]
+            present_k_outs.append(native_attention["present_k"])
+            present_v_outs.append(native_attention["present_v"])
+        else:
+            # Fixed-Sq contract: export only this step's raw K/V and materialize
+            # cache + update with concatenation for attention.
+            present_k_outs.append(k)
+            present_v_outs.append(v)
+            all_k_cat = network.add_concatenation([cache_k_inputs[layer_idx], k])
+            all_k_cat.axis = 0
+            all_v_cat = network.add_concatenation([cache_v_inputs[layer_idx], v])
+            all_v_cat.axis = 0
+            context = graph_ops.add_attention_from_rows(
+                network,
+                q,
+                all_k_cat.get_output(0),
+                all_v_cat.get_output(0),
+                num_heads=num_heads,
+                head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                q_seq=None,
+                kv_seq=None,
+                causal=False,
+                mask=mask_4d,
+                scale=attn_scale,
+                tag=f"{prefix}.attn",
+            )
+
+        attn_out = matmul(
+            context, attention_size, hidden, weights[f"{prefix}.w_o"], f"{prefix}.w_o"
+        )
+        o_bias = weights.get(f"{prefix}.o_bias")
+        if o_bias is not None:
+            attn_out = graph_ops.add_bias_sum(
+                network, attn_out, hidden, o_bias, dtype=work_np_dtype
+            )
+
+        # Residual structure: parallel (GPT-NeoX / CodeGen / Falcon-3) vs
+        # sequential (everything else).
+        if parallel_residual:
+            post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
+            if post_attn_norm_w is not None:
+                norm2 = _norm_multi(
+                    network,
+                    hidden_state,
+                    hidden,
+                    post_attn_norm_w,
+                    weights.get(f"{prefix}.post_attn_norm_beta"),
+                    eps_tensor,
+                    norm_type,
+                    work_np_dtype,
+                )
+            else:
+                norm2 = normed
+        else:
+            residual1 = network.add_elementwise(
+                hidden_state, attn_out, trt.ElementWiseOperation.SUM
+            )
+            norm2 = _norm_multi(
+                network,
+                residual1.get_output(0),
+                hidden,
+                weights[f"{prefix}.post_attn_norm"],
+                weights.get(f"{prefix}.post_attn_norm_beta"),
+                eps_tensor,
+                norm_type,
+                work_np_dtype,
+            )
+
+        # MLP — SwiGLU (Llama-style) or GeluFC (GPT-2-style).
+        if mlp_type == "gelu_fc":
+            mlp_out = _gelu_fc_mlp(
+                network,
+                norm2,
+                matmul=matmul,
+                weights=weights,
+                prefix=prefix,
+                hidden=hidden,
+                mlp_size=mlp_size,
+                activation=activation,
+                work_np_dtype=work_np_dtype,
+            )
+        else:
+            mlp_out = _swiglu_mlp(
+                network,
+                norm2,
+                matmul=matmul,
+                weights=weights,
+                prefix=prefix,
+                hidden=hidden,
+                mlp_size=mlp_size,
+            )
+
+        # Final residual.
+        if parallel_residual:
+            sum_attn = network.add_elementwise(hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+            residual2 = network.add_elementwise(
+                sum_attn.get_output(0), mlp_out, trt.ElementWiseOperation.SUM
+            )
+        else:
+            residual2 = network.add_elementwise(
+                residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM
+            )
+        hidden_state = residual2.get_output(0)
+
+    # ---- Final norm + LM head -------------------------------------------
+    final_norm = weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _norm_multi(
+            network,
+            hidden_state,
+            hidden,
+            final_norm,
+            weights.get("final_norm_beta"),
+            eps_tensor,
+            norm_type,
+            work_np_dtype,
+        )
+
+    # Only the LAST prompt token's logits matter for the next-token sample,
+    # so slice hidden_state from (Sq, hidden) to (1, hidden) before the LM
+    # head. This keeps the output contract identical to the single-token
+    # engine (logits shape = (1, vocab)) under both profiles and avoids
+    # computing (Sq - 1) redundant vocab-sized matmul rows during prefill.
+    shape_t = network.add_shape(hidden_state).get_output(0)  # [2] int64
+    one_hidden = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64
+    )
+    start_sub = network.add_elementwise(shape_t, one_hidden, trt.ElementWiseOperation.SUB)
+    start_t = start_sub.get_output(0)  # [Sq - 1, 0]
+    size_t = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64
+    )
+    slicer = network.add_slice(hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+    slicer.set_input(1, start_t)
+    slicer.set_input(2, size_t)
+    last_hidden = slicer.get_output(0)
+
+    out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, last_hidden, hidden, out_vocab, weights["w_out"], dtype=work_np_dtype
+    )
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is not None:
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+    else:
+        zero_bias = np.zeros(out_vocab, dtype=work_np_dtype)
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, zero_bias, dtype=work_np_dtype)
+
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(num_layers):
+        pk = present_k_outs[i]
+        pv = present_v_outs[i]
+        pk.name = graph_ops.layer_tensor_name("present_k", i)
+        pv.name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(pk)
+        network.mark_output(pv)
+
+    if verbose:
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(
+            f"[trtmc build] Building {mode_label} engine "
+            f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
+            f"kv={kv_attention_size}, "
+            f"mlp={mlp_size}, cache={max_cache_length}, "
+            f"opt_prefill={opt_prefill_length}, max_prefill={max_prefill_length}, "
+            f"norm={norm_type}, mlp_type={mlp_type}, pos={position_type}, "
+            f"precision={precision}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("dual-profile decoder engine build failed")
+    return bytes(plan)

--- a/families/smollm3/graph_blocks.py
+++ b/families/smollm3/graph_blocks.py
@@ -1,23 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Composable architectural building blocks for TRT engine construction.
+"""Family-owned attention, normalization, and MLP blocks.
 
-Layer 2 in the three-layer builder stack:
-
-    graph_ops.py        Layer 1: Atomic TRT operations (tensor-in/tensor-out)
-        |
-    graph_blocks.py     Layer 2: Composable blocks (weight-aware)  <- THIS FILE
-        |
-    builders / plugins  Layer 3: Full engine assembly
-
-Each block composes multiple graph_ops into a reusable sub-structure
-(full attention block, SwiGLU MLP, GELU MLP, norm dispatch). Functions
-accept a ``weights`` dict + ``prefix`` string to resolve weight names.
-
-Blocks do NOT apply residual connections. Callers compose the residual
-pattern, which is what varies across architectures (sequential vs parallel
-residual, DeepStack injection, MoE routing, etc.).
+Builders own residual connections; blocks resolve weights and compose graph_ops.
 """
 
 from __future__ import annotations
@@ -39,7 +25,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 def make_matmul_fn(network, dtype):
-    """Create the GPT-2 projection matmul callable."""
+    """Create the SmolLM3 projection matmul callable."""
 
     def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
         del weight_name
@@ -47,9 +33,6 @@ def make_matmul_fn(network, dtype):
             network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype)
 
     return matmul
-
-
-_make_matmul_fn = make_matmul_fn
 
 
 def infer_kv_attention_size(
@@ -146,7 +129,7 @@ def add_attention_block(
     ALiBi is represented as a per-head additive attention mask and still uses
     native IAttention.
     """
-    matmul = _make_matmul_fn(network, dtype)
+    matmul = make_matmul_fn(network, dtype)
     attention_window = max_cache_length + 1
     if num_kv_heads is None:
         num_kv_heads = num_heads
@@ -296,7 +279,7 @@ def add_swiglu_mlp(
     layer_prefix: str = "",
 ) -> trt.ITensor:
     """Gate/up/down SwiGLU MLP. Returns output tensor."""
-    matmul = _make_matmul_fn(network, dtype)
+    matmul = make_matmul_fn(network, dtype)
     _lp = layer_prefix or prefix
 
     gate = matmul(inp, hidden_size, mlp_size,
@@ -328,7 +311,7 @@ def add_gelu_fc_mlp(
     layer_prefix: str = "",
 ) -> trt.ITensor:
     """fc1 -> activation -> fc2 MLP. Returns output tensor."""
-    matmul = _make_matmul_fn(network, dtype)
+    matmul = make_matmul_fn(network, dtype)
     _lp = layer_prefix or prefix
 
     fc1 = matmul(inp, hidden_size, mlp_size,

--- a/families/smollm3/graph_blocks.py
+++ b/families/smollm3/graph_blocks.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable architectural building blocks for TRT engine construction.
+
+Layer 2 in the three-layer builder stack:
+
+    graph_ops.py        Layer 1: Atomic TRT operations (tensor-in/tensor-out)
+        |
+    graph_blocks.py     Layer 2: Composable blocks (weight-aware)  <- THIS FILE
+        |
+    builders / plugins  Layer 3: Full engine assembly
+
+Each block composes multiple graph_ops into a reusable sub-structure
+(full attention block, SwiGLU MLP, GELU MLP, norm dispatch). Functions
+accept a ``weights`` dict + ``prefix`` string to resolve weight names.
+
+Blocks do NOT apply residual connections. Callers compose the residual
+pattern, which is what varies across architectures (sequential vs parallel
+residual, DeepStack injection, MoE routing, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import tensorrt as trt
+
+from . import graph_ops
+
+if TYPE_CHECKING:
+    from .checkpoint_mapper import WeightDict
+
+
+# ---------------------------------------------------------------------------
+# Precision boundary helpers (used by standard_decoder_builder, not inside
+# blocks themselves).
+# ---------------------------------------------------------------------------
+
+def make_matmul_fn(network, dtype):
+    """Create the GPT-2 projection matmul callable."""
+
+    def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
+        del weight_name
+        return graph_ops.add_matmul_rhs_constant(
+            network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype)
+
+    return matmul
+
+
+_make_matmul_fn = make_matmul_fn
+
+
+def infer_kv_attention_size(
+    weights: dict,
+    *,
+    prefix: str = "layer.0",
+    num_kv_heads: int,
+    head_dim: int,
+) -> int:
+    """Validate and return the compact K/V row width."""
+    expected = int(num_kv_heads * head_dim)
+    explicit = weights.get("_kv_attention_size")
+    if explicit is not None and int(explicit) != expected:
+        raise ValueError(
+            f"Compact K/V cache width must be num_kv_heads * head_dim "
+            f"({expected}), got _kv_attention_size={int(explicit)}")
+    w_k = weights.get(f"{prefix}.w_k")
+    if isinstance(w_k, np.ndarray) and w_k.ndim == 2:
+        actual = int(w_k.shape[1])
+        if actual != expected:
+            raise ValueError(
+                f"{prefix}.w_k must use compact K/V width {expected}, "
+                f"got {actual}")
+    return expected
+
+
+def apply_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype = np.float32,
+    eps: float | None = None,
+) -> trt.ITensor:
+    """Dispatch to RMSNorm or LayerNorm based on norm_type."""
+    if norm_type == "layernorm":
+        if beta is None:
+            beta = np.zeros(hidden_size, dtype=np.float32)
+        if eps is not None:
+            return graph_ops.add_layer_norm_native(
+                network, inp, hidden_size, gamma, beta, eps, dtype=dtype)
+        # An epsilon tensor requires the explicit LayerNorm graph.
+        return graph_ops.add_layer_norm(
+            network, inp, hidden_size, gamma, beta, eps_tensor, dtype=dtype)
+    else:
+        return graph_ops.add_rms_norm(
+            network, inp, hidden_size, gamma, eps_tensor, dtype=dtype)
+
+
+def add_attention_block(
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    *,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    num_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    eps_tensor: trt.ITensor,
+    kv_attention_size: int | None = None,
+    num_kv_heads: int | None = None,
+    attention_scale: float | None = None,
+    eps: float | None = None,
+    norm_type: str = "rmsnorm",
+    position_type: str = "rope",
+    apply_rope: bool = True,
+    alibi_slopes_tensor: trt.ITensor | None = None,
+    alibi_indices_tensor: trt.ITensor | None = None,
+    dtype: np.dtype = np.float32,
+    layer_prefix: str = "",
+    # TRT 10 native API tensors.
+    cos_half_tensor: trt.ITensor | None = None,
+    sin_half_tensor: trt.ITensor | None = None,
+    rotary_embedding_dim: int = 0,
+    interleaved_rope: bool = False,
+) -> dict[str, trt.ITensor]:
+    """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
+
+    Returns {"normed": ..., "attn_out": ..., "present_k": ..., "present_v": ...}.
+    Does NOT apply residual -- callers compose the residual pattern.
+
+    This function uses TRT 10 native APIs for the basic transformer primitives:
+      - IRotaryEmbeddingLayer for RoPE
+      - IAttention for scaled dot-product attention
+    ALiBi is represented as a per-head additive attention mask and still uses
+    native IAttention.
+    """
+    matmul = _make_matmul_fn(network, dtype)
+    attention_window = max_cache_length + 1
+    if num_kv_heads is None:
+        num_kv_heads = num_heads
+    if kv_attention_size is None:
+        kv_attention_size = num_kv_heads * head_dim
+
+    # Weight name for quant scale lookup — use layer_prefix if provided,
+    # otherwise fall back to the weights-dict prefix.
+    _lp = layer_prefix or prefix
+
+    # Pre-attention norm
+    normed = apply_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"],
+        weights.get(f"{prefix}.input_norm_beta"),
+        eps_tensor, norm_type, dtype=dtype, eps=eps)
+
+    # QKV projections
+    q = matmul(normed, hidden_size, attention_size,
+               weights[f"{prefix}.w_q"], f"{_lp}.w_q")
+    k = matmul(normed, hidden_size, kv_attention_size,
+               weights[f"{prefix}.w_k"], f"{_lp}.w_k")
+    v = matmul(normed, hidden_size, kv_attention_size,
+               weights[f"{prefix}.w_v"], f"{_lp}.w_v")
+
+    # Optional QKV biases
+    q_bias = weights.get(f"{prefix}.q_bias")
+    if q_bias is not None:
+        q = graph_ops.add_bias_sum(network, q, attention_size, q_bias, dtype=dtype)
+    k_bias = weights.get(f"{prefix}.k_bias")
+    if k_bias is not None:
+        k = graph_ops.add_bias_sum(network, k, kv_attention_size, k_bias, dtype=dtype)
+    v_bias = weights.get(f"{prefix}.v_bias")
+    if v_bias is not None:
+        v = graph_ops.add_bias_sum(network, v, kv_attention_size, v_bias, dtype=dtype)
+
+    # Optional per-head q/k norm
+    q_norm = weights.get(f"{prefix}.q_norm")
+    if q_norm is not None:
+        q = graph_ops.add_rms_norm_per_head(
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+    k_norm = weights.get(f"{prefix}.k_norm")
+    if k_norm is not None:
+        k = graph_ops.add_rms_norm_per_head(
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+
+    # ------------------------------------------------------------------ #
+    # RoPE via native IRotaryEmbeddingLayer                              #
+    # ------------------------------------------------------------------ #
+
+    # ``apply_rope`` is False on NoPE layers, which carry no positional
+    # encoding at all: q/k reach attention unrotated.
+    if position_type == "rope" and apply_rope:
+        if cos_half_tensor is None or sin_half_tensor is None:
+            raise ValueError(
+                "RoPE attention requires half-dimension cos/sin tensors for "
+                "TRT native IRotaryEmbeddingLayer")
+        rope_dim = rotary_embedding_dim or head_dim
+        rope_dim = graph_ops.validate_native_rope_dim(rope_dim)
+        q = graph_ops.add_apply_rope_native(
+            network, q, num_heads, head_dim,
+            cos_half_tensor, sin_half_tensor, position_id,
+            rope_dim, interleaved_rope)
+        k = graph_ops.add_apply_rope_native(
+            network, k, num_kv_heads, head_dim,
+            cos_half_tensor, sin_half_tensor, position_id,
+            rope_dim, interleaved_rope)
+
+    # Save present K/V (before concatenation, this is the raw projection output)
+    present_k = k
+    present_v = v
+
+    # Reshape current K, V for concatenation
+    k_reshape = network.add_shuffle(k)
+    k_reshape.reshape_dims = (1, kv_attention_size)
+    v_reshape = network.add_shuffle(v)
+    v_reshape.reshape_dims = (1, kv_attention_size)
+
+    # Concatenate with cache
+    all_k = network.add_concatenation(
+        [cache_k, k_reshape.get_output(0)])
+    all_k.axis = 0
+    all_v = network.add_concatenation(
+        [cache_v, v_reshape.get_output(0)])
+    all_v.axis = 0
+
+    # ------------------------------------------------------------------ #
+    # Attention core — native IAttention                                  #
+    # ------------------------------------------------------------------ #
+    kv_seq = attention_window
+    if alibi_slopes_tensor is not None:
+        if alibi_indices_tensor is None:
+            raise ValueError("ALiBi attention requires cache position indices")
+        mask_4d = graph_ops.add_alibi_mask_4d(
+            network,
+            attention_mask,
+            position_id,
+            alibi_slopes_tensor,
+            alibi_indices_tensor,
+            num_heads,
+        )
+    else:
+        mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+
+    context = graph_ops.add_attention_from_rows(
+        network,
+        q,
+        all_k.get_output(0),
+        all_v.get_output(0),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        num_kv_heads=num_kv_heads,
+        q_seq=1,
+        kv_seq=kv_seq,
+        causal=False,
+        mask=mask_4d,
+        scale=attention_scale,
+    )
+
+    # Output projection
+    attn_out = matmul(context,
+                      attention_size, hidden_size,
+                      weights[f"{prefix}.w_o"], f"{_lp}.w_o")
+
+    # Optional output projection bias
+    o_bias = weights.get(f"{prefix}.o_bias")
+    if o_bias is not None:
+        attn_out = graph_ops.add_bias_sum(network, attn_out, hidden_size, o_bias, dtype=dtype)
+
+    return {
+        "normed": normed,
+        "attn_out": attn_out,
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def add_swiglu_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    mlp_size: int,
+    dtype: np.dtype = np.float32,
+    layer_prefix: str = "",
+) -> trt.ITensor:
+    """Gate/up/down SwiGLU MLP. Returns output tensor."""
+    matmul = _make_matmul_fn(network, dtype)
+    _lp = layer_prefix or prefix
+
+    gate = matmul(inp, hidden_size, mlp_size,
+                  weights[f"{prefix}.w_gate"], f"{_lp}.w_gate")
+    up = matmul(inp, hidden_size, mlp_size,
+                weights[f"{prefix}.w_up"], f"{_lp}.w_up")
+
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+
+    mlp_out = matmul(gated.get_output(0), mlp_size, hidden_size,
+                     weights[f"{prefix}.w_down"], f"{_lp}.w_down")
+    return mlp_out
+
+
+def add_gelu_fc_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    mlp_size: int,
+    activation: str = "gelu_new",
+    dtype: np.dtype = np.float32,
+    layer_prefix: str = "",
+) -> trt.ITensor:
+    """fc1 -> activation -> fc2 MLP. Returns output tensor."""
+    matmul = _make_matmul_fn(network, dtype)
+    _lp = layer_prefix or prefix
+
+    fc1 = matmul(inp, hidden_size, mlp_size,
+                 weights[f"{prefix}.w_fc1"], f"{_lp}.w_fc1")
+    fc1_bias = weights.get(f"{prefix}.fc1_bias")
+    if fc1_bias is not None:
+        fc1 = graph_ops.add_bias_sum(network, fc1, mlp_size, fc1_bias, dtype=dtype)
+
+    activated = graph_ops.add_activation(network, fc1, activation, dtype=dtype)
+
+    fc2 = matmul(activated, mlp_size, hidden_size,
+                 weights[f"{prefix}.w_fc2"], f"{_lp}.w_fc2")
+    fc2_bias = weights.get(f"{prefix}.fc2_bias")
+    if fc2_bias is not None:
+        fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size, fc2_bias, dtype=dtype)
+
+    return fc2

--- a/families/smollm3/graph_ops.py
+++ b/families/smollm3/graph_ops.py
@@ -1,0 +1,1381 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned TensorRT graph operations for Python engine builds.
+
+Tensor names and shapes must stay compatible with the C++ bundle runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import math
+from typing import Any
+
+import numpy as np
+import tensorrt as trt
+from .native_kv_attention_builder import (
+    NativeKvMasks,
+    add_explicit_masked_grouped_query_attention,
+)
+
+
+def _cast_back_to_trt_dtype(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    target_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Cast a tensor back to the original TRT runtime dtype after FP32 compute."""
+    if tensor.dtype == target_dtype:
+        return tensor
+    return network.add_cast(tensor, target_dtype).get_output(0)
+
+
+def _add_matrix_multiply_with_fp32_accumulation(
+    network: trt.INetworkDefinition,
+    lhs: trt.ITensor,
+    lhs_op: trt.MatrixOperation,
+    rhs: trt.ITensor,
+    rhs_op: trt.MatrixOperation,
+) -> trt.ITensor:
+    """Request TensorRT's fused FP16 GEMM with FP32 accumulation."""
+    output_dtype = lhs.dtype
+    if lhs.dtype == trt.float16 and rhs.dtype == trt.float16:
+        lhs = network.add_cast(lhs, trt.float32).get_output(0)
+        rhs = network.add_cast(rhs, trt.float32).get_output(0)
+    output = network.add_matrix_multiply(lhs, lhs_op, rhs, rhs_op).get_output(0)
+    return _cast_back_to_trt_dtype(network, output, output_dtype)
+
+def layer_tensor_name(stem: str, layer: int) -> str:
+    return f"{stem}_{layer}"
+
+
+def add_constant(
+    network: trt.INetworkDefinition,
+    shape: tuple[int, ...],
+    values: np.ndarray,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Add a constant tensor in the given *dtype* (default float32)."""
+    weights = trt.Weights(np.ascontiguousarray(values, dtype=dtype))
+    layer = network.add_constant(shape, weights)
+    return layer.get_output(0)
+
+
+def add_matmul_rhs_constant(
+    network: trt.INetworkDefinition,
+    lhs: trt.ITensor,
+    lhs_width: int,
+    rhs_width: int,
+    rhs_weights: np.ndarray,
+    dtype: np.dtype = np.float32,
+    fp32_accumulation: bool = True,
+) -> trt.ITensor:
+    """Matrix multiply: lhs @ rhs_constant.  rhs is [lhs_width, rhs_width]."""
+    rank = len(tuple(lhs.shape))
+    rhs_shape = (
+        (lhs_width, rhs_width)
+        if rank <= 2
+        else (1,) * (rank - 2) + (lhs_width, rhs_width)
+    )
+    rhs = add_constant(
+        network,
+        rhs_shape,
+        np.asarray(rhs_weights).reshape(rhs_shape),
+        dtype=dtype,
+    )
+    rhs = _cast_back_to_trt_dtype(network, rhs, lhs.dtype)
+    if fp32_accumulation:
+        return _add_matrix_multiply_with_fp32_accumulation(
+            network,
+            lhs, trt.MatrixOperation.NONE,
+            rhs, trt.MatrixOperation.NONE,
+        )
+    mm = network.add_matrix_multiply(
+        lhs, trt.MatrixOperation.NONE,
+        rhs, trt.MatrixOperation.NONE,
+    )
+    return _cast_back_to_trt_dtype(network, mm.get_output(0), lhs.dtype)
+
+
+def add_bias_sum(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    width: int,
+    bias: np.ndarray,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Element-wise add a bias broadcast over all non-feature axes."""
+    rank = len(tuple(inp.shape))
+    bias_shape = (width,) if rank <= 1 else (1,) * (rank - 1) + (width,)
+    bias_t = add_constant(
+        network, bias_shape, np.asarray(bias).reshape(bias_shape), dtype=dtype)
+    bias_t = _cast_back_to_trt_dtype(network, bias_t, inp.dtype)
+    s = network.add_elementwise(inp, bias_t, trt.ElementWiseOperation.SUM)
+    return _cast_back_to_trt_dtype(network, s.get_output(0), inp.dtype)
+
+
+def add_rms_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """RMSNorm: gamma * (x / sqrt(mean(x^2) + eps)).
+
+    FP32 precision boundary: when dtype != float32, casts to FP32 before
+    norm computation for numerical stability, then casts back.
+
+    TRT's native normalization API implements mean-centered LayerNorm, not
+    RMSNorm, so this remains a manual shared implementation.
+    """
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+    if need_cast:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+    sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        inp, recip.get_output(0), trt.ElementWiseOperation.PROD)
+    gamma_t = add_constant(network, (1, hidden_size), gamma, dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    return result
+
+
+def add_rms_norm_per_head(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+    sequence_length: int | None = 1,
+) -> trt.ITensor:
+    """Per-head RMSNorm for [Sq, num_heads * head_dim] tensors.
+
+    FP32 precision boundary: when dtype != float32, casts to FP32 before
+    norm computation for numerical stability, then casts back.
+    ``sequence_length=None`` means runtime-dynamic Sq.
+    ``gamma`` may be [num_heads * head_dim] or [head_dim] broadcast to heads.
+    """
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+    seq_dim = -1 if sequence_length is None else sequence_length
+    reshape_in = network.add_shuffle(inp)
+    reshape_in.reshape_dims = (seq_dim, num_heads, head_dim)
+
+    reshaped = reshape_in.get_output(0)
+    if need_cast:
+        reshaped = network.add_cast(reshaped, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+    eps_3d = network.add_shuffle(eps_tensor)
+    eps_3d.reshape_dims = (1, 1, 1)
+    sq = network.add_elementwise(reshaped, reshaped, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 2, keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_3d.get_output(0), trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        reshaped, recip.get_output(0), trt.ElementWiseOperation.PROD)
+    gamma_arr = np.asarray(gamma, dtype=np.float32)
+    if gamma_arr.size == head_dim:
+        gamma_t = add_constant(
+            network, (1, 1, head_dim), gamma_arr.reshape(1, 1, head_dim),
+            dtype=np.float32)
+    else:
+        gamma_t = add_constant(
+            network, (1, num_heads, head_dim),
+            gamma_arr.reshape(num_heads, head_dim), dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    reshape_out = network.add_shuffle(result)
+    reshape_out.reshape_dims = (seq_dim, num_heads * head_dim)
+    return reshape_out.get_output(0)
+
+
+def add_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """LayerNorm: gamma * ((x - mean) / sqrt(var + eps)) + beta.
+
+    FP32 precision boundary: when dtype != float32, casts to FP32 before
+    norm computation for numerical stability, then casts back.
+    """
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+    if need_cast:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+    # mean = reduce_mean(x)
+    mean = network.add_reduce(
+        inp, trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    # x - mean
+    centered = network.add_elementwise(
+        inp, mean.get_output(0), trt.ElementWiseOperation.SUB)
+    # variance = mean((x - mean)^2)
+    sq = network.add_elementwise(
+        centered.get_output(0), centered.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    var = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    # sqrt(var + eps)
+    denom_in = network.add_elementwise(
+        var.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    # normalized = (x - mean) / sqrt(var + eps)
+    normalized = network.add_elementwise(
+        centered.get_output(0), recip.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    # gamma * normalized + beta
+    gamma_t = add_constant(network, (1, hidden_size), gamma, dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+    beta_t = add_constant(network, (1, hidden_size), beta, dtype=np.float32)
+    result = network.add_elementwise(
+        scaled.get_output(0), beta_t, trt.ElementWiseOperation.SUM)
+    result = result.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    return result
+
+
+def add_gelu_new(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """GELU (tanh approximation): 0.5*x*(1+tanh(sqrt(2/pi)*(x+0.044715*x^3))).
+
+    Constants are cast to ``inp.dtype`` so the elementwise ops are valid in
+    a STRONGLY_TYPED network when ``inp`` is bf16 (storage np_dtype is
+    fp16, runtime trt_dtype is bfloat16) or any other non-matching combo.
+    """
+    target_dtype = inp.dtype
+    const_shape = (1,) * max(1, len(tuple(inp.shape)))
+
+    def _const(name, value):
+        c = add_constant(
+            network, const_shape, np.array([value], dtype=np.float32), dtype=dtype)
+        return _cast_back_to_trt_dtype(network, c, target_dtype)
+
+    # x^3
+    x_sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
+    x_cu = network.add_elementwise(
+        x_sq.get_output(0), inp, trt.ElementWiseOperation.PROD)
+    # 0.044715 * x^3
+    coeff = _const("coeff", 0.044715)
+    scaled_cube = network.add_elementwise(
+        x_cu.get_output(0), coeff, trt.ElementWiseOperation.PROD)
+    # x + 0.044715 * x^3
+    inner_sum = network.add_elementwise(
+        inp, scaled_cube.get_output(0), trt.ElementWiseOperation.SUM)
+    # sqrt(2/pi) * (x + 0.044715 * x^3)
+    sqrt_2_over_pi = _const("sqrt_2_over_pi", np.sqrt(2.0 / np.pi))
+    tanh_arg = network.add_elementwise(
+        sqrt_2_over_pi, inner_sum.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    # tanh(...)
+    tanh_l = network.add_activation(
+        tanh_arg.get_output(0), trt.ActivationType.TANH)
+    # 1 + tanh(...)
+    one = _const("one", 1.0)
+    one_plus_tanh = network.add_elementwise(
+        one, tanh_l.get_output(0), trt.ElementWiseOperation.SUM)
+    # 0.5 * x
+    half = _const("half", 0.5)
+    half_x = network.add_elementwise(
+        half, inp, trt.ElementWiseOperation.PROD)
+    # 0.5 * x * (1 + tanh(...))
+    result = network.add_elementwise(
+        half_x.get_output(0), one_plus_tanh.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    return result.get_output(0)
+
+
+def add_activation(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    activation_type: str,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Dispatch activation by name: 'silu', 'gelu_new', 'gelu', 'relu', 'relu2'/'squared_relu'."""
+    if activation_type in ("gelu_new", "gelu"):
+        return add_gelu_new(network, inp, dtype=dtype)
+    elif activation_type == "relu":
+        act = network.add_activation(inp, trt.ActivationType.RELU)
+        return act.get_output(0)
+    elif activation_type in ("relu2", "squared_relu"):
+        relu = network.add_activation(inp, trt.ActivationType.RELU)
+        sq = network.add_elementwise(
+            relu.get_output(0), relu.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        return sq.get_output(0)
+    elif activation_type == "silu":
+        sigmoid = network.add_activation(inp, trt.ActivationType.SIGMOID)
+        swish = network.add_elementwise(
+            inp, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+        return swish.get_output(0)
+    else:
+        raise ValueError(f"Unsupported activation: {activation_type}")
+
+
+def compute_alibi_slopes(num_heads: int) -> np.ndarray:
+    """Compute ALiBi slopes for each attention head (from the ALiBi paper).
+
+    For power-of-2 num_heads: geometric sequence 2^(-8/n * i), i in 1..n.
+    For non-power-of-2: interleave two geometric sequences.
+
+    Returns: [num_heads] float32 array.
+    """
+    def _get_slopes_power_of_2(n: int) -> list[float]:
+        start = 2 ** (-(2 ** -(np.log2(n) - 3)))
+        return [start * (start ** i) for i in range(n)]
+
+    if num_heads > 0 and (num_heads & (num_heads - 1)) == 0:
+        # Power of 2
+        return np.array(_get_slopes_power_of_2(num_heads), dtype=np.float32)
+    else:
+        closest_power_of_2 = 2 ** int(np.floor(np.log2(num_heads)))
+        slopes_a = _get_slopes_power_of_2(closest_power_of_2)
+        slopes_b = _get_slopes_power_of_2(2 * closest_power_of_2)
+        slopes_b = slopes_b[0::2][: num_heads - closest_power_of_2]
+        return np.array(slopes_a + slopes_b, dtype=np.float32)
+
+
+
+# ---------------------------------------------------------------------------
+# TRT 10 native attention APIs (TRT 10.x)
+#
+# Three primitives replace manual primitive chains:
+#   add_layer_norm_native  → INormalizationLayer  (replaces add_layer_norm)
+#   add_apply_rope_native  → IRotaryEmbeddingLayer
+#   add_attention_core     → IAttention           (replaces score+softmax+V)
+# ---------------------------------------------------------------------------
+
+def add_layer_norm_native(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """LayerNorm via TRT native INormalizationLayer (add_normalization_v2).
+
+    Replaces the manual reduce/elementwise chain in add_layer_norm with a
+    single fused layer that TRT can optimize end-to-end. In strongly typed
+    networks, input/scale/bias must have identical tensor types; compute
+    precision is set to FP32 for numerical stability when the TensorRT Python
+    layer exposes that control.
+
+    Note: INormalizationLayer computes (x - mean) / sqrt(var + eps) * gamma + beta.
+    This is LayerNorm, NOT RMSNorm.  Use add_rms_norm for RMSNorm models.
+
+    Args:
+        inp:         Input tensor [*, hidden_size].
+        hidden_size: Size of the normalized dimension (last axis).
+        gamma:       Scale weights [hidden_size].
+        beta:        Bias weights [hidden_size].
+        eps:         Numerical stability epsilon (scalar, not a tensor).
+        dtype:       Storage dtype for gamma/beta constants before TRT cast.
+    """
+    inp_shape = getattr(inp, "shape", None)
+    rank = len(tuple(inp_shape)) if inp_shape is not None else 2
+    param_shape = (
+        (hidden_size,) if rank <= 1 else (1,) * (rank - 1) + (hidden_size,)
+    )
+    gamma_t = add_constant(
+        network, param_shape, np.asarray(gamma).reshape(param_shape), dtype=dtype)
+    beta_t = add_constant(
+        network, param_shape, np.asarray(beta).reshape(param_shape), dtype=dtype)
+    gamma_t = _cast_back_to_trt_dtype(network, gamma_t, inp.dtype)
+    beta_t = _cast_back_to_trt_dtype(network, beta_t, inp.dtype)
+    # axesMask bit i selects axis i as a reduction axis. The normalized
+    # hidden dimension is always the last axis for [*, hidden_size] tensors.
+    norm = network.add_normalization_v2(inp, gamma_t, beta_t, 1 << (rank - 1))
+    norm.epsilon = eps
+    return norm.get_output(0)
+
+
+def validate_native_rope_dim(
+    rotary_embedding_dim: int,
+    *,
+    field_name: str = "rotary_embedding_dim",
+) -> int:
+    """Validate the dimension contract required by TRT native RoPE."""
+    rotary_embedding_dim = int(rotary_embedding_dim)
+    if rotary_embedding_dim < 2 or rotary_embedding_dim % 2 != 0:
+        raise ValueError(
+            f"TRT native RoPE requires {field_name} to be an even value >= 2; "
+            f"got {rotary_embedding_dim}")
+    return rotary_embedding_dim
+
+
+def make_native_active_rope_inv_freq(
+    head_dim: int,
+    rope_theta: float,
+    partial_rotary_factor: float = 1.0,
+    *,
+    rope_scaling: Mapping[str, Any] | None = None,
+) -> np.ndarray:
+    """Return HF/Torch-exact frequencies for native active-position RoPE.
+
+    Hugging Face initializes Llama inverse frequencies on CPU with Torch before
+    moving the model to the inference device. NumPy ``power`` can differ from
+    that operation by one ULP at long positions. The indexed-table
+    helper below is intentionally unchanged.
+    """
+    rotary_ndims = validate_native_rope_dim(
+        int(head_dim * partial_rotary_factor))
+    rope_theta = float(rope_theta)
+    if not np.isfinite(rope_theta) or rope_theta <= 0.0:
+        raise ValueError(
+            "TRT native RoPE requires rope_theta to be finite and positive; "
+            f"got {rope_theta}")
+    try:
+        import torch
+    except (ImportError, OSError) as exc:
+        raise RuntimeError(
+            "TensorRT native SmolLM3 KV build requires PyTorch in the Model "
+            "Connect build environment to generate Hugging Face-exact RoPE "
+            "frequencies"
+        ) from exc
+
+    with torch.no_grad():
+        exponents = torch.arange(
+            0,
+            rotary_ndims,
+            2,
+            dtype=torch.int64,
+            device="cpu",
+        ).to(dtype=torch.float32) / rotary_ndims
+        inv_freq = 1.0 / (rope_theta ** exponents)
+        if rope_scaling:
+            rope_type = str(
+                rope_scaling.get("rope_type")
+                or rope_scaling.get("type")
+                or ""
+            ).lower()
+            if rope_type in ("", "default"):
+                rope_scaling = None
+            elif rope_type != "llama3":
+                raise ValueError(
+                    "native active-position RoPE supports only llama3 scaling"
+                )
+        if rope_scaling:
+            factor = float(rope_scaling["factor"])
+            low = float(rope_scaling["low_freq_factor"])
+            high = float(rope_scaling["high_freq_factor"])
+            original = int(
+                rope_scaling["original_max_position_embeddings"]
+            )
+            wavelength = 2 * math.pi / inv_freq
+            low_wavelength = original / low
+            high_wavelength = original / high
+            scaled = torch.where(
+                wavelength > low_wavelength,
+                inv_freq / factor,
+                inv_freq,
+            )
+            smooth = (
+                original / wavelength - low
+            ) / (high - low)
+            interpolated = (
+                (1 - smooth) * scaled / factor + smooth * scaled
+            )
+            medium = (
+                ~(wavelength < high_wavelength)
+                * ~(wavelength > low_wavelength)
+            )
+            inv_freq = torch.where(medium, interpolated, scaled)
+    return np.asarray(
+        inv_freq.detach().cpu().contiguous().numpy(),
+        dtype=np.float32,
+    ).copy()
+
+
+def add_active_rope_cache(
+    network: trt.INetworkDefinition,
+    position_id: trt.ITensor,
+    inv_freq: np.ndarray,
+    output_dtype: trt.DataType,
+) -> tuple[trt.ITensor, trt.ITensor]:
+    """Build ``[1, Sq, D/2]`` cos/sin tensors for active positions only."""
+    inv_freq = np.asarray(inv_freq, dtype=np.float32)
+    if inv_freq.ndim != 1 or inv_freq.size == 0:
+        raise ValueError(
+            "active RoPE inverse frequencies must be a non-empty rank-1 array")
+
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    pos_col = network.add_shuffle(pos_float)
+    pos_col.reshape_dims = (-1, 1)
+    inv_freq_tensor = add_constant(
+        network,
+        (1, int(inv_freq.size)),
+        inv_freq.reshape(1, -1),
+        dtype=np.float32,
+    )
+    angles = network.add_elementwise(
+        pos_col.get_output(0),
+        inv_freq_tensor,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    cos_2d = network.add_unary(
+        angles, trt.UnaryOperation.COS).get_output(0)
+    sin_2d = network.add_unary(
+        angles, trt.UnaryOperation.SIN).get_output(0)
+
+    cos_3d = network.add_shuffle(cos_2d)
+    cos_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    sin_3d = network.add_shuffle(sin_2d)
+    sin_3d.reshape_dims = (1, -1, int(inv_freq.size))
+    cos_cache = cos_3d.get_output(0)
+    sin_cache = sin_3d.get_output(0)
+    if cos_cache.dtype != output_dtype:
+        cos_cache = network.add_cast(
+            cos_cache, output_dtype).get_output(0)
+        sin_cache = network.add_cast(
+            sin_cache, output_dtype).get_output(0)
+    return cos_cache, sin_cache
+
+
+def _yarn_inverse_frequencies(
+    inverse_frequencies: np.ndarray,
+    rotary_ndims: int,
+    rope_theta: float,
+    rope_scaling: Mapping[str, Any],
+) -> tuple[np.ndarray, float]:
+    """YaRN-scaled inverse frequencies and the attention scale that goes with them.
+
+    Mirrors Hugging Face's ``_compute_yarn_parameters``. Frequencies below the
+    ``beta_fast`` correction dimension keep their extrapolated value, those above
+    ``beta_slow`` are interpolated by ``factor``, and the band between the two is
+    ramped linearly. Upstream folds ``attention_factor`` into cos/sin rather than
+    into the attention scores, so it is returned here and applied to the table.
+    """
+    factor = float(rope_scaling["factor"])
+    original_context = float(rope_scaling["original_max_position_embeddings"])
+    beta_fast = float(rope_scaling.get("beta_fast") or 32.0)
+    beta_slow = float(rope_scaling.get("beta_slow") or 1.0)
+    if (
+        factor <= 0.0
+        or original_context <= 0.0
+        or beta_fast <= 0.0
+        or beta_slow <= 0.0
+        or beta_slow >= beta_fast
+    ):
+        raise ValueError(f"Invalid YaRN RoPE scaling: {dict(rope_scaling)}")
+
+    def correction_dim(rotations: float) -> float:
+        return (
+            rotary_ndims
+            * np.log(original_context / (rotations * 2.0 * np.pi))
+            / (2.0 * np.log(rope_theta))
+        )
+
+    half = rotary_ndims // 2
+    low = max(int(np.floor(correction_dim(beta_fast))), 0)
+    high = min(int(np.ceil(correction_dim(beta_slow))), half - 1)
+    ramp = np.clip(
+        (np.arange(half, dtype=np.float64) - low) / max(high - low, 1),
+        0.0,
+        1.0,
+    )
+    scaled = (
+        inverse_frequencies / factor * ramp
+        + inverse_frequencies * (1.0 - ramp)
+    )
+    attention_factor = rope_scaling.get("attention_factor")
+    if attention_factor is None:
+        attention_factor = 0.1 * np.log(factor) + 1.0
+    return scaled, float(attention_factor)
+
+
+def make_rope_table_half_dim(
+    max_cache_length: int,
+    head_dim: int,
+    rope_theta: float,
+    cosine: bool,
+    partial_rotary_factor: float = 1.0,
+    interleaved: bool = False,
+    rope_scaling: Mapping[str, Any] | None = None,
+) -> np.ndarray:
+    """Build a RoPE cos/sin table of shape [max_cache_length, rotary_ndims // 2].
+
+    IRotaryEmbeddingLayer expects the cos/sin cache with only the *half*
+    rotary dimension (it internally handles both halves).  This is different
+    from make_rope_table which produces [max_cache_length, hidden_size] by
+    repeating the per-head values across all heads.
+
+    Args:
+        max_cache_length: Number of positions (rows in the table).
+        head_dim:         Full head dimension (D).
+        rope_theta:       Base frequency for inverse-frequency computation.
+        cosine:           True → cos table, False → sin table.
+        partial_rotary_factor: Fraction of head dims that rotate (default 1.0).
+        interleaved:      If True, adjacent-pair frequencies (CodeGen/GPT-J).
+                          If False, half-split frequencies (LLaMA/Qwen).
+        rope_scaling:     Optional Hugging Face RoPE scaling configuration.
+
+    Returns:
+        Float32 array [max_cache_length, rotary_ndims // 2].
+    """
+    rotary_ndims = int(head_dim * partial_rotary_factor)
+    rotary_ndims = validate_native_rope_dim(rotary_ndims)
+    half = rotary_ndims // 2
+    default = 1.0 if cosine else 0.0
+    if max_cache_length <= 0 or rope_theta <= 0.0:
+        return np.full((max(max_cache_length, 1), max(half, 1)),
+                       default, dtype=np.float32)
+    if not rope_scaling:
+        table = np.full(
+            (max_cache_length, half),
+            default,
+            dtype=np.float32,
+        )
+        for pos in range(max_cache_length):
+            for dimension in range(half):
+                exponent = (2.0 * dimension) / rotary_ndims
+                inverse_frequency = rope_theta ** (-exponent)
+                angle = pos * inverse_frequency
+                table[pos, dimension] = (
+                    np.cos(angle) if cosine else np.sin(angle)
+                )
+        return table
+
+    exponents = np.arange(0, rotary_ndims, 2, dtype=np.float64) / rotary_ndims
+    inverse_frequencies = np.power(float(rope_theta), -exponents)
+    rope_type = str(
+        rope_scaling.get("rope_type")
+        or rope_scaling.get("type")
+        or ""
+    ).lower()
+    attention_scaling = 1.0
+    if rope_type == "yarn":
+        inverse_frequencies, attention_scaling = _yarn_inverse_frequencies(
+            inverse_frequencies, rotary_ndims, float(rope_theta), rope_scaling
+        )
+        angles = np.outer(
+            np.arange(max_cache_length, dtype=np.float64),
+            inverse_frequencies,
+        )
+        values = np.cos(angles) if cosine else np.sin(angles)
+        return (values * attention_scaling).astype(np.float32)
+
+    if rope_type != "llama3":
+        raise NotImplementedError(
+            f"Unsupported SmolLM3 RoPE scaling type: {rope_type or '<missing>'}"
+        )
+    factor = float(rope_scaling["factor"])
+    low_freq_factor = float(rope_scaling["low_freq_factor"])
+    high_freq_factor = float(rope_scaling["high_freq_factor"])
+    original_context = float(
+        rope_scaling["original_max_position_embeddings"]
+    )
+    if (
+        factor <= 0.0
+        or low_freq_factor <= 0.0
+        or high_freq_factor <= low_freq_factor
+        or original_context <= 0.0
+    ):
+        raise ValueError(f"Invalid Llama-3 RoPE scaling: {dict(rope_scaling)}")
+
+    wavelengths = 2.0 * np.pi / inverse_frequencies
+    low_freq_wavelength = original_context / low_freq_factor
+    high_freq_wavelength = original_context / high_freq_factor
+    scaled = np.where(
+        wavelengths > low_freq_wavelength,
+        inverse_frequencies / factor,
+        inverse_frequencies,
+    )
+    smooth = (
+        original_context / wavelengths - low_freq_factor
+    ) / (high_freq_factor - low_freq_factor)
+    interpolated = (1.0 - smooth) * scaled / factor + smooth * scaled
+    medium = (
+        (wavelengths >= high_freq_wavelength)
+        & (wavelengths <= low_freq_wavelength)
+    )
+    inverse_frequencies = np.where(medium, interpolated, scaled)
+
+    angles = np.outer(
+        np.arange(max_cache_length, dtype=np.float64),
+        inverse_frequencies,
+    )
+    values = np.cos(angles) if cosine else np.sin(angles)
+    return values.astype(np.float32)
+
+
+def reshape_rows_to_heads_4d(
+    network: trt.INetworkDefinition,
+    x: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    sequence_length: int | None = None,
+    tag: str | None = None,
+) -> trt.ITensor:
+    """Reshape [S, H * D] rows into [1, H, S, D].
+
+    The transpose is required for S > 1 because each input row contains all
+    heads for one token. ``sequence_length=None`` means runtime-dynamic S.
+    """
+    seq_dim = -1 if sequence_length is None else sequence_length
+    r1 = network.add_shuffle(x)
+    if tag:
+        r1.name = tag + "_s_h_d"
+    r1.reshape_dims = (seq_dim, num_heads, head_dim)
+    r1.second_transpose = trt.Permutation([1, 0, 2])
+
+    r2 = network.add_shuffle(r1.get_output(0))
+    if tag:
+        r2.name = tag + "_1_h_s_d"
+    r2.reshape_dims = (1, num_heads, seq_dim, head_dim)
+    return r2.get_output(0)
+
+
+def reshape_heads_4d_to_rows(
+    network: trt.INetworkDefinition,
+    x_4d: trt.ITensor,
+    attention_size: int,
+    sequence_length: int | None = None,
+    tag: str | None = None,
+) -> trt.ITensor:
+    """Reshape [1, H, S, D] back to [S, H * D]."""
+    seq_dim = -1 if sequence_length is None else sequence_length
+    out = network.add_shuffle(x_4d)
+    if tag:
+        out.name = tag + "_s_h_d"
+    out.first_transpose = trt.Permutation([0, 2, 1, 3])
+    out.reshape_dims = (seq_dim, attention_size)
+    return out.get_output(0)
+
+
+def add_2d_mask_to_4d(
+    network: trt.INetworkDefinition,
+    mask_2d: trt.ITensor,
+) -> trt.ITensor:
+    """Reshape additive attention mask [Sq, K] to [1, 1, Sq, K]."""
+    mask_shape = network.add_shape(mask_2d).get_output(0)
+    ones = add_constant(
+        network, (2,), np.array([1, 1], dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([ones, mask_shape])
+    target.axis = 0
+    mask_4d = network.add_shuffle(mask_2d)
+    mask_4d.set_input(1, target.get_output(0))
+    return mask_4d.get_output(0)
+
+
+def add_alibi_mask_4d(
+    network: trt.INetworkDefinition,
+    mask_2d: trt.ITensor,
+    position_id: trt.ITensor,
+    alibi_slopes_tensor: trt.ITensor,
+    cache_position_indices: trt.ITensor,
+    num_heads: int,
+    target_dtype: trt.DataType | None = None,
+) -> trt.ITensor:
+    """Build a per-head ALiBi additive mask for native IAttention.
+
+    Args:
+        mask_2d: [Sq, K] additive mask.
+        position_id: [Sq] query positions.
+        alibi_slopes_tensor: [H, 1, 1] per-head slopes.
+        cache_position_indices: [cache_rows] key positions for cached rows.
+        target_dtype: Optional dtype for the returned mask. Defaults to
+            ``mask_2d.dtype``.
+
+    Returns:
+        [1, H, Sq, K] additive mask containing both ``mask_2d`` and
+        ``slope[h] * (key_pos[k] - query_pos[q])``.
+    """
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    cache_positions = cache_position_indices
+    if cache_positions.dtype != trt.float32:
+        cache_positions = network.add_cast(cache_positions, trt.float32).get_output(0)
+
+    key_pos = network.add_concatenation([cache_positions, pos_float])
+    key_pos.axis = 0
+
+    mask_shape = network.add_shape(mask_2d).get_output(0)
+    one_const = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
+    sq_size = network.add_slice(mask_shape, start=(0,), shape=(1,), stride=(1,))
+    k_size = network.add_slice(mask_shape, start=(1,), shape=(1,), stride=(1,))
+    sq_size_t = sq_size.get_output(0)
+    k_size_t = k_size.get_output(0)
+
+    key_pos_shape = network.add_concatenation([one_const, k_size_t])
+    key_pos_shape.axis = 0
+    key_pos_2d = network.add_shuffle(key_pos.get_output(0))
+    key_pos_2d.set_input(1, key_pos_shape.get_output(0))
+
+    query_pos_shape = network.add_concatenation([sq_size_t, one_const])
+    query_pos_shape.axis = 0
+    query_pos_2d = network.add_shuffle(pos_float)
+    query_pos_2d.set_input(1, query_pos_shape.get_output(0))
+
+    rel_pos = network.add_elementwise(
+        key_pos_2d.get_output(0), query_pos_2d.get_output(0),
+        trt.ElementWiseOperation.SUB)
+
+    one_const2 = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
+    rel_shape = network.add_concatenation([one_const, one_const2, sq_size_t, k_size_t])
+    rel_shape.axis = 0
+    rel_4d = network.add_shuffle(rel_pos.get_output(0))
+    rel_4d.set_input(1, rel_shape.get_output(0))
+
+    slopes = alibi_slopes_tensor
+    if slopes.dtype != trt.float32:
+        slopes = network.add_cast(slopes, trt.float32).get_output(0)
+    slopes_4d = network.add_shuffle(slopes)
+    slopes_4d.reshape_dims = (1, num_heads, 1, 1)
+
+    alibi_bias = network.add_elementwise(
+        slopes_4d.get_output(0), rel_4d.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    alibi_bias_t = alibi_bias.get_output(0)
+
+    mask_4d = add_2d_mask_to_4d(network, mask_2d)
+    out_dtype = target_dtype or mask_4d.dtype
+    if alibi_bias_t.dtype != out_dtype:
+        alibi_bias_t = network.add_cast(alibi_bias_t, out_dtype).get_output(0)
+
+    combined = network.add_elementwise(
+        mask_4d, alibi_bias_t, trt.ElementWiseOperation.SUM)
+    return combined.get_output(0)
+
+
+def add_apply_rope_native(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    position_id: trt.ITensor | None,
+    rotary_embedding_dim: int,
+    interleaved: bool = False,
+    sequence_length: int | None = 1,
+) -> trt.ITensor:
+    """Apply RoPE via TRT native IRotaryEmbeddingLayer.
+
+    Handles both single-token decoder steps and dynamic-Sq prefill/decode
+    graphs without a manual rotate-half matmul chain.
+
+    Shape contract with indexed, full-capacity caches:
+      input:           [1, num_heads, Sq, head_dim]  (reshaped internally)
+      cos_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
+      sin_cache_2d:    [max_S, rotary_embedding_dim // 2]  (2-D constant)
+      position_id:     [Sq] int32, reshaped to [1, Sq] internally
+
+    Shape contract with active-position caches:
+      input:           [1, num_heads, Sq, head_dim]
+      cos_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      sin_cache_2d:    [1, Sq, rotary_embedding_dim // 2]
+      position_id:     None; the caches already correspond to active positions
+      interleaved:     False → rotate-half (LLaMA/Qwen)
+                       True  → adjacent-pair (CodeGen/GPT-J)
+
+    Args:
+        inp:                  [Sq, num_heads * head_dim].
+        num_heads:            Number of attention heads.
+        head_dim:             Per-head dimension.
+        cos_cache_2d:         Pre-built 2-D cos table constant.
+        sin_cache_2d:         Pre-built 2-D sin table constant.
+        position_id:          Runtime position indices, shape [Sq] int32, or
+                              ``None`` for active-position rank-3 caches.
+        rotary_embedding_dim: Number of head dims that participate in RoPE.
+        interleaved:          Frequency layout (see above).
+        sequence_length:      Static Sq, or None for runtime-dynamic Sq.
+
+    Returns:
+        [Sq, num_heads * head_dim] with RoPE applied.
+    """
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    attention_size = num_heads * head_dim
+
+    inp_4d = reshape_rows_to_heads_4d(
+        network, inp, num_heads, head_dim, sequence_length)
+
+    rope = network.add_rotary_embedding(
+        inp_4d,
+        cos_cache_2d,
+        sin_cache_2d,
+        interleaved,
+        rotary_embedding_dim,
+    )
+    if position_id is not None:
+        # Reshape position_id [Sq] -> [1, Sq] (batch=1).
+        seq_dim = -1 if sequence_length is None else sequence_length
+        pos_2d = network.add_shuffle(position_id)
+        pos_2d.reshape_dims = (1, seq_dim)
+        rope.set_input(3, pos_2d.get_output(0))
+
+    return reshape_heads_4d_to_rows(
+        network, rope.get_output(0), attention_size, sequence_length)
+
+
+def add_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    causal: bool = False,
+    mask: trt.ITensor | None = None,
+    scale: float | None = None,
+    fp32_accumulation: bool = False,
+) -> trt.ITensor:
+    """Scaled dot-product attention via TRT native IAttention layer.
+
+    Replaces the manual Q@K^T → scale → softmax → @V chain.  TRT 10 fuses
+    this into a single kernel when available; ``decomposable=True`` permits
+    TensorRT to lower the same operation into primitives.
+
+    NOTE: TRT IAttention computes raw BMM1 = Q @ K^T without any built-in
+    1/sqrt(D) scaling.  We pre-scale Q by 1/sqrt(D) so that the fused kernel
+    computes the standard scaled dot-product attention formula.
+
+    Args:
+        q_4d:    Query  [B, H, q_seq, D].
+        k_4d:    Key    [B, H, kv_seq, D].
+        v_4d:    Value  [B, H, kv_seq, D].
+        causal:  Apply causal (autoregressive) mask.  Mutually exclusive
+                 with ``mask``.
+        mask:    Optional additive float mask [B, H, q_seq, kv_seq] added
+                 to scaled logits before softmax.  Cannot be used with
+                 causal=True.
+        scale:   Optional Q pre-scale factor.  Defaults to 1/sqrt(D).
+        fp32_accumulation:
+                 Cast Q/K/V to FP32 before IAttention, then cast the context
+                 back to the original Q dtype.  TRT may still select a
+                 Half-input fused MHA tactic after optimizing the casts, while
+                 keeping the IAttention accumulation/output boundary in FP32.
+
+    Returns:
+        Context tensor [B, H, q_seq, D].
+    """
+    output_dtype = q_4d.dtype
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    # Pre-scale Q: TRT IAttention does not apply score scaling itself.
+    # Match the scale constant's dtype to Q's dtype: in strongly-typed networks
+    # a FP32 constant mixed with a FP16/BF16 Q causes add_elementwise to emit
+    # a type-mismatch error and produce a tensor with corrupted dimensions,
+    # which makes add_attention return None.
+    if scale is None:
+        head_dim = q_4d.shape[-1]
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    # Use FP16 weights directly for FP16; BF16 has no numpy native type so
+    # create as FP32 and cast; FP32 falls through to the default.
+    scale_np_dtype = np.float16 if q_4d.dtype == trt.float16 else np.float32
+    scale_t = add_constant(network, (1, 1, 1, 1), np.array([[[[scale]]]]), dtype=scale_np_dtype)
+    if q_4d.dtype == trt.bfloat16:
+        scale_t = network.add_cast(scale_t, trt.bfloat16).get_output(0)
+    q_scaled = network.add_elementwise(q_4d, scale_t, trt.ElementWiseOperation.PROD)
+
+    attn = network.add_attention(
+        q_scaled.get_output(0), k_4d, v_4d,
+        trt.AttentionNormalizationOp.SOFTMAX,
+        causal,
+    )
+    # Allow TRT to decompose into primitive ops when no fused kernel is
+    # available (e.g. unsupported head-dim or dtype).  This guarantees
+    # correctness on any configuration at the cost of potential performance.
+    attn.decomposable = True
+    if mask is not None and not causal:
+        attn.mask = mask
+    return _cast_back_to_trt_dtype(network, attn.get_output(0), output_dtype)
+
+
+def add_native_kv_cache_attention_from_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k_update: trt.ITensor,
+    v_update: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    attention_masks: NativeKvMasks,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    q_seq: int | None,
+    scale: float | None = None,
+    tag: str | None = None,
+) -> dict[str, trt.ITensor]:
+    """Update a user-owned KV cache and attend over its active prefix.
+
+    ``IKVCacheUpdateLayer`` writes this step's K/V rows into the static,
+    full-capacity cache in place. Attention uses a shared explicit
+    active-prefix causal mask and a primitive grouped-query graph, avoiding
+    correctness and kernel-coverage dependence on
+    ``IAttention.key_value_lengths``.
+
+    Cache inputs and outputs have shape ``[1, Hkv, capacity, D]``. The runtime
+    must bind each output to the same device address as its corresponding
+    input, as required by TensorRT's KV-cache aliasing contract.
+    """
+    k_update_4d = reshape_rows_to_heads_4d(
+        network,
+        k_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".k_update",
+    )
+    v_update_4d = reshape_rows_to_heads_4d(
+        network,
+        v_update,
+        num_kv_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".v_update",
+    )
+
+    update_k = network.add_kv_cache_update(
+        cache_k,
+        k_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    update_v = network.add_kv_cache_update(
+        cache_v,
+        v_update_4d,
+        cache_write_indices,
+        trt.KVCacheMode.LINEAR,
+    )
+    if update_k is None or update_v is None:
+        raise RuntimeError("TensorRT failed to create SmolLM3 KV-cache update layers")
+    if tag:
+        update_k.name = tag + ".cache_k_update"
+        update_v.name = tag + ".cache_v_update"
+    updated_k = update_k.get_output(0)
+    updated_v = update_v.get_output(0)
+
+    q_4d = reshape_rows_to_heads_4d(
+        network,
+        q,
+        num_heads,
+        head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".q",
+    )
+    if q_4d.dtype != trt.bfloat16:
+        raise ValueError("SmolLM3 native KV attention requires BF16 queries")
+    context_4d = add_explicit_masked_grouped_query_attention(
+        network,
+        q_4d,
+        updated_k,
+        updated_v,
+        attention_masks,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        scale=scale,
+        tag=tag,
+    )
+    context = reshape_heads_4d_to_rows(
+        network,
+        context_4d,
+        num_heads * head_dim,
+        sequence_length=q_seq,
+        tag=None if tag is None else tag + ".ctx",
+    )
+    return {
+        "context": context,
+        "present_k": updated_k,
+        "present_v": updated_v,
+    }
+
+
+def _scalar_constant_for_trt_dtype(
+    network: trt.INetworkDefinition,
+    shape: tuple[int, ...],
+    value: float,
+    dtype: trt.DataType,
+) -> trt.ITensor:
+    np_dtype = np.float16 if dtype == trt.float16 else np.float32
+    const = add_constant(
+        network, shape, np.full(shape, value, dtype=np_dtype),
+        dtype=np_dtype)
+    if dtype == trt.bfloat16:
+        const = network.add_cast(const, trt.bfloat16).get_output(0)
+    return const
+
+
+def add_tanh_softcap(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    cap: float,
+    *,
+    scalar_shape: tuple[int, ...],
+) -> trt.ITensor:
+    """Apply ``tanh(tensor / cap) * cap`` using scalar broadcasting."""
+    cap_t = _scalar_constant_for_trt_dtype(
+        network, scalar_shape, float(cap), tensor.dtype)
+    scaled = network.add_elementwise(
+        tensor, cap_t, trt.ElementWiseOperation.DIV).get_output(0)
+    capped = network.add_activation(
+        scaled, trt.ActivationType.TANH).get_output(0)
+    return network.add_elementwise(
+        capped, cap_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _repeat_kv_heads_4d(
+    network: trt.INetworkDefinition,
+    x_4d: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> trt.ITensor:
+    if num_kv_heads == num_heads:
+        return x_4d
+    if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_heads={num_heads} must be divisible by "
+            f"num_kv_heads={num_kv_heads}")
+
+    repeat = num_heads // num_kv_heads
+    if num_kv_heads == 1:
+        concat = network.add_concatenation([x_4d] * repeat)
+        concat.axis = 1
+        return concat.get_output(0)
+
+    x_shape = network.add_shape(x_4d).get_output(0)
+    one = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
+    seq = network.add_slice(x_shape, start=(2,), shape=(1,), stride=(1,))
+    dim = add_constant(
+        network, (1,), np.array([head_dim], dtype=np.int64), dtype=np.int64)
+    slice_shape = network.add_concatenation([one, one, seq.get_output(0), dim])
+    slice_shape.axis = 0
+
+    repeated = []
+    for head_idx in range(num_kv_heads):
+        head_slice = network.add_slice(
+            x_4d, start=(0, head_idx, 0, 0),
+            shape=(1, 1, 1, head_dim), stride=(1, 1, 1, 1))
+        head_slice.set_input(2, slice_shape.get_output(0))
+        repeated.extend([head_slice.get_output(0)] * repeat)
+
+    concat = network.add_concatenation(repeated)
+    concat.axis = 1
+    return concat.get_output(0)
+
+
+def _add_explicit_masked_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    mask: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    scale: float,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Lower masked attention to primitives instead of TRT's Myelin wrapper."""
+
+    output_dtype = q_4d.dtype
+    k_4d = _repeat_kv_heads_4d(
+        network,
+        k_4d,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+    )
+    v_4d = _repeat_kv_heads_4d(
+        network,
+        v_4d,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+    )
+    score_q = q_4d
+    score_k = k_4d
+    score_mask = mask
+    if fp32_accumulation and output_dtype != trt.float32:
+        score_q = network.add_cast(score_q, trt.float32).get_output(0)
+        score_k = network.add_cast(score_k, trt.float32).get_output(0)
+        score_mask = network.add_cast(score_mask, trt.float32).get_output(0)
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, score_q.dtype)
+    score_q = network.add_elementwise(
+        score_q, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    scores = network.add_matrix_multiply(
+        score_q, trt.MatrixOperation.NONE,
+        score_k, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if score_mask.dtype != scores.dtype:
+        score_mask = network.add_cast(score_mask, scores.dtype).get_output(0)
+    scores = network.add_elementwise(
+        scores, score_mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probabilities = network.add_softmax(scores)
+    probabilities.axes = 1 << 3
+    probability_tensor = probabilities.get_output(0)
+    if probability_tensor.dtype != v_4d.dtype:
+        probability_tensor = network.add_cast(probability_tensor, v_4d.dtype).get_output(0)
+    context = network.add_matrix_multiply(
+        probability_tensor, trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
+def _add_attention_core_with_logit_softcap(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    mask: trt.ITensor | None,
+    scale: float,
+    logit_softcap: float,
+) -> trt.ITensor:
+    output_dtype = q_4d.dtype
+    k_4d = _repeat_kv_heads_4d(
+        network, k_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+    v_4d = _repeat_kv_heads_4d(
+        network, v_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+
+    score_q = q_4d
+    score_k = k_4d
+    score_mask = mask
+    if output_dtype != trt.float32:
+        score_q = network.add_cast(score_q, trt.float32).get_output(0)
+        score_k = network.add_cast(score_k, trt.float32).get_output(0)
+        if score_mask is not None and score_mask.dtype != trt.float32:
+            score_mask = network.add_cast(score_mask, trt.float32).get_output(0)
+
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, score_q.dtype)
+    scores = network.add_matrix_multiply(
+        score_q, trt.MatrixOperation.NONE,
+        score_k, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    scores = network.add_elementwise(
+        scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+    scores = add_tanh_softcap(
+        network, scores, logit_softcap, scalar_shape=(1, 1, 1, 1))
+
+    if score_mask is not None:
+        scores = network.add_elementwise(
+            scores, score_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    probs_t = probs.get_output(0)
+    if probs_t.dtype != output_dtype:
+        probs_t = network.add_cast(probs_t, output_dtype).get_output(0)
+
+    context = network.add_matrix_multiply(
+        probs_t, trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
+def add_attention_from_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k: trt.ITensor,
+    v: trt.ITensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+    num_kv_heads: int | None = None,
+    q_seq: int | None,
+    kv_seq: int | None,
+    causal: bool = False,
+    mask: trt.ITensor | None = None,
+    scale: float | None = None,
+    logit_softcap: float | None = None,
+    fp32_accumulation: bool = False,
+    tag: str | None = None,
+) -> trt.ITensor:
+    """Native IAttention for row-major [S, H * D] Q/K/V tensors.
+
+    ``num_kv_heads`` can be smaller than ``num_heads`` for GQA/MQA. TRT
+    native IAttention supports this directly, so callers should not expand K/V
+    heads unless the model semantics require per-query-head K/V values.
+    """
+    attention_size = num_heads * head_dim
+    kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+    q_4d = reshape_rows_to_heads_4d(
+        network, q, num_heads, head_dim, sequence_length=q_seq,
+        tag=None if tag is None else tag + ".q")
+    k_4d = reshape_rows_to_heads_4d(
+        network, k, kv_heads, head_dim, sequence_length=kv_seq,
+        tag=None if tag is None else tag + ".k")
+    v_4d = reshape_rows_to_heads_4d(
+        network, v, kv_heads, head_dim, sequence_length=kv_seq,
+        tag=None if tag is None else tag + ".v")
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    if logit_softcap is not None and float(logit_softcap) > 0.0:
+        if causal:
+            raise NotImplementedError(
+                "logit_softcap attention requires an explicit additive mask")
+        ctx_4d = _add_attention_core_with_logit_softcap(
+            network, q_4d, k_4d, v_4d,
+            num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
+            mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif mask is not None and not causal:
+        ctx_4d = _add_explicit_masked_attention_core(
+            network,
+            q_4d,
+            k_4d,
+            v_4d,
+            mask,
+            num_heads=num_heads,
+            num_kv_heads=kv_heads,
+            head_dim=head_dim,
+            scale=scale,
+            fp32_accumulation=fp32_accumulation,
+        )
+    else:
+        ctx_4d = add_attention_core(
+            network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
+    return reshape_heads_4d_to_rows(
+        network, ctx_4d, attention_size, sequence_length=q_seq,
+        tag=None if tag is None else tag + ".ctx")

--- a/families/smollm3/graph_ops.py
+++ b/families/smollm3/graph_ops.py
@@ -20,6 +20,14 @@ from .native_kv_attention_builder import (
 )
 
 
+def resolve_rope_scaling(raw_config: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the Hugging Face RoPE block across old and new config keys."""
+    parameters = raw_config.get("rope_parameters")
+    if parameters is not None:
+        return parameters
+    return raw_config.get("rope_scaling")
+
+
 def _cast_back_to_trt_dtype(
     network: trt.INetworkDefinition,
     tensor: trt.ITensor,
@@ -38,9 +46,10 @@ def _add_matrix_multiply_with_fp32_accumulation(
     rhs: trt.ITensor,
     rhs_op: trt.MatrixOperation,
 ) -> trt.ITensor:
-    """Request TensorRT's fused FP16 GEMM with FP32 accumulation."""
+    """Request TensorRT's fused low-precision GEMM with FP32 accumulation."""
     output_dtype = lhs.dtype
-    if lhs.dtype == trt.float16 and rhs.dtype == trt.float16:
+    low_precision = {trt.float16, trt.bfloat16}
+    if lhs.dtype in low_precision and rhs.dtype in low_precision:
         lhs = network.add_cast(lhs, trt.float32).get_output(0)
         rhs = network.add_cast(rhs, trt.float32).get_output(0)
     output = network.add_matrix_multiply(lhs, lhs_op, rhs, rhs_op).get_output(0)

--- a/families/smollm3/model.py
+++ b/families/smollm3/model.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Complete dense SmolLM3 checkpoint-to-bundle build path."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .build_routing import native_kv_architecture_capability, native_kv_build_capability
+from .checkpoint_mapper import WeightDict, load_standard_weights
+from .config import ModelConfig
+from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
+from .native_kv_contract import validate_native_kv_weights
+from .standard_decoder_builder import build_standard_decoder_engine
+
+
+if TYPE_CHECKING:
+    from tensorrt_model_connect.build import BuildRequest
+    from tensorrt_model_connect.bundle_writer import BundleWriter
+
+
+_BUNDLE_FILES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "chat_template.jinja",
+    "vocab.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "tokenizer.model",
+)
+
+
+def _positive_int(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f"{name} must be a positive integer") from error
+    if result < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
+def _build_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_sequence_length: int,
+    *,
+    precision: str,
+    verbose: bool,
+) -> bytes:
+    capability = native_kv_build_capability(
+        config,
+        precision=precision,
+        max_cache_length=max_sequence_length,
+        quantized=False,
+        debug_layer_outputs=False,
+    )
+    if capability.eligible:
+        validate_native_kv_weights(config, weights)
+        config.raw["_native_kv_cache_metadata"] = {
+            "native_kv_contract_version": 1,
+            "native_kv_cache": True,
+        }
+        role = str(config.raw.get("_decoder_engine_role", ""))
+        if role not in {"prefill", "decode"}:
+            raise ValueError("native SmolLM3 build requires an explicit prefill or decode role")
+        return build_dual_profile_decoder_engine(
+            config,
+            weights,
+            max_sequence_length,
+            precision="bf16",
+            verbose=verbose,
+            profile_mode=role,
+            native_kv_cache=True,
+        )
+
+    config.raw.pop("_native_kv_cache_metadata", None)
+    return build_standard_decoder_engine(
+        config,
+        weights,
+        max_sequence_length,
+        precision=precision,
+        verbose=verbose,
+    )
+
+
+def _runtime_config(model_dir: Path, config: ModelConfig, **updates) -> dict:
+    runtime = {
+        "vocab_size": config.vocab_size,
+        "hidden_size": config.hidden_size,
+        "num_hidden_layers": config.num_hidden_layers,
+        "num_attention_heads": config.num_attention_heads,
+        "num_key_value_heads": config.num_key_value_heads,
+        "head_dim": config.head_dim,
+        "bos_token_id": config.bos_token_id,
+        "eos_token_id": config.eos_token_id,
+        "pad_token_id": config.pad_token_id,
+    }
+    runtime.update(config.raw.get("_native_kv_cache_metadata", {}))
+    generation_path = model_dir / "generation_config.json"
+    if generation_path.is_file():
+        generation = json.loads(generation_path.read_text(encoding="utf-8"))
+        if not isinstance(generation, dict):
+            raise ValueError("generation_config.json must contain one JSON object")
+        if "eos_token_id" in generation:
+            runtime["eos_token_id"] = generation["eos_token_id"]
+    runtime.update(updates)
+    return runtime
+
+
+def build(request: "BuildRequest", writer: "BundleWriter") -> None:
+    """Build one dense SmolLM3 bundle through family-owned code only."""
+    if request.dynamic_kv_cache:
+        raise NotImplementedError("smollm3 does not support dynamic_kv_cache")
+
+    if request.image_height is not None:
+        raise NotImplementedError("smollm3 does not support image_height")
+
+    if request.image_width is not None:
+        raise NotImplementedError("smollm3 does not support image_width")
+
+    if request.video_num_frames is not None:
+        raise NotImplementedError("smollm3 does not support video_num_frames")
+
+    if request.max_batch_size != 1:
+        raise NotImplementedError("smollm3 does not support max_batch_size")
+
+    if request.context_parallel_size != 1:
+        raise ValueError("this family does not support context parallelism")
+
+    if request.task != "text_generation":
+        raise ValueError("smollm3 supports only task=text_generation")
+
+    model_dir = Path(request.model_dir)
+    config = ModelConfig.from_dir(model_dir)
+    if str(config.model_type).lower() != "smollm3":
+        raise ValueError(f"SmolLM3 does not support model_type={config.model_type!r}")
+    precision = str(request.precision).lower()
+    if precision not in {"fp32", "fp16", "bf16"}:
+        raise ValueError("SmolLM3 precision must be fp32, fp16, or bf16")
+    architecture = native_kv_architecture_capability(config)
+    default_length = (
+        config.max_position_embeddings
+        if architecture.eligible
+        else min(config.max_position_embeddings, 256)
+    )
+    max_sequence_length = _positive_int(
+        request.max_sequence_length or default_length,
+        "max_sequence_length",
+    )
+    if max_sequence_length > config.max_position_embeddings:
+        raise ValueError("SmolLM3 max_sequence_length exceeds checkpoint context capacity")
+    if request.tensor_parallel_size != 1:
+        raise NotImplementedError("SmolLM3 does not expose a tensor-parallel builder")
+    if request.quantization not in {None, "none"}:
+        raise NotImplementedError("SmolLM3 has no qualified family-owned quantized build")
+
+    config.raw["_model_dir"] = str(model_dir)
+    config.raw["_fp32_layers"] = list(request.fp32_layers)
+    config.raw["_resolved_build_precision"] = precision
+    weights = load_standard_weights(
+        str(model_dir),
+        config,
+        precision=precision,
+        fp32_layers=request.fp32_layers,
+    )
+
+    writer.set_header(family="smollm3", task=request.task, backend=request.backend)
+    if request.fp32_layers:
+        config.raw["_decoder_engine_role"] = "dual_profile"
+        plan = _build_engine(
+            config,
+            weights,
+            max_sequence_length,
+            precision=precision,
+            verbose=bool(request.verbose),
+        )
+        writer.add_bytes("engine.plan", plan)
+        layout = "dual_profile"
+    else:
+        config.raw["_decoder_engine_role"] = "prefill"
+        prefill = _build_engine(
+            config,
+            weights,
+            max_sequence_length,
+            precision=precision,
+            verbose=bool(request.verbose),
+        )
+        config.raw["_decoder_engine_role"] = "decode"
+        decode = _build_engine(
+            config,
+            weights,
+            max_sequence_length,
+            precision=precision,
+            verbose=bool(request.verbose),
+        )
+        writer.add_bytes("engine.plan", decode)
+        writer.add_bytes("prefill.plan", prefill)
+        layout = "split"
+    config.raw.pop("_decoder_engine_role", None)
+
+    runtime_config = _runtime_config(
+        model_dir,
+        config,
+        precision=precision,
+        max_cache_length=max_sequence_length,
+        decoder_engine_layout=layout,
+    )
+    writer.add_json("runtime.json", runtime_config)
+    for filename in _BUNDLE_FILES:
+        path = model_dir / filename
+        if path.is_file():
+            writer.add_bytes(filename, path.read_bytes())

--- a/families/smollm3/native_kv_attention_builder.py
+++ b/families/smollm3/native_kv_attention_builder.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SmolLM3-owned fixed linear KV-cache attention graph primitives."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+import tensorrt as trt
+
+EXPLICIT_ATTENTION_PREFILL_CHUNK_TOKENS = 64
+
+
+class NativeKvMasks(NamedTuple):
+    """Masks shared by every attention layer in one decoder engine."""
+
+    attention: trt.ITensor
+    active_prefix: trt.ITensor
+
+
+def _constant(
+    network: trt.INetworkDefinition,
+    shape: tuple[int, ...],
+    values: np.ndarray,
+    *,
+    dtype: np.dtype = np.dtype(np.float32),
+) -> trt.ITensor:
+    weights = trt.Weights(np.ascontiguousarray(values, dtype=dtype))
+    return network.add_constant(shape, weights).get_output(0)
+
+
+def _cast(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    dtype: trt.DataType,
+) -> trt.ITensor:
+    if tensor.dtype == dtype:
+        return tensor
+    return network.add_cast(tensor, dtype).get_output(0)
+
+
+def add_active_prefix_causal_masks(
+    network: trt.INetworkDefinition,
+    query_rows: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    cache_capacity: int,
+) -> NativeKvMasks:
+    """Build BOOL attention and active-prefix masks for a cache append."""
+
+    if cache_capacity <= 0:
+        raise ValueError("native KV cache capacity must be positive")
+
+    query_shape = network.add_shape(query_rows).get_output(0)
+    query_length = network.add_slice(
+        query_shape, start=(0,), shape=(1,), stride=(1,)
+    ).get_output(0)
+    zero_i32 = _constant(
+        network, (), np.array(0, dtype=np.int32), dtype=np.dtype(np.int32)
+    )
+    one_i32 = _constant(
+        network,
+        (1,),
+        np.array([1], dtype=np.int32),
+        dtype=np.dtype(np.int32),
+    )
+    query_iota = network.add_fill((1,), trt.FillOperation.LINSPACE, trt.int32)
+    query_iota.set_input(0, query_length)
+    query_iota.set_input(1, zero_i32)
+    query_iota.set_input(2, one_i32)
+    query_positions = network.add_elementwise(
+        query_iota.get_output(0),
+        cache_write_indices,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+    query_limits = network.add_elementwise(
+        query_positions,
+        one_i32,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+
+    one_i64 = _constant(
+        network,
+        (1,),
+        np.array([1], dtype=np.int64),
+        dtype=np.dtype(np.int64),
+    )
+    query_limit_shape = network.add_concatenation([query_length, one_i64])
+    query_limit_shape.axis = 0
+    query_limits_2d = network.add_shuffle(query_limits)
+    query_limits_2d.set_input(1, query_limit_shape.get_output(0))
+
+    key_positions = _constant(
+        network,
+        (1, cache_capacity),
+        np.arange(cache_capacity, dtype=np.int32).reshape(1, cache_capacity),
+        dtype=np.dtype(np.int32),
+    )
+    active_length_2d = network.add_shuffle(key_value_lengths)
+    active_length_2d.reshape_dims = (1, 1)
+    causal = network.add_elementwise(
+        key_positions,
+        query_limits_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    active = network.add_elementwise(
+        key_positions,
+        active_length_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    valid = network.add_elementwise(
+        causal,
+        active,
+        trt.ElementWiseOperation.AND,
+    ).get_output(0)
+
+    mask_shape = network.add_shape(valid).get_output(0)
+    leading_ones = _constant(
+        network,
+        (2,),
+        np.array([1, 1], dtype=np.int64),
+        dtype=np.dtype(np.int64),
+    )
+    target_shape = network.add_concatenation([leading_ones, mask_shape])
+    target_shape.axis = 0
+    mask_4d = network.add_shuffle(valid)
+    mask_4d.set_input(1, target_shape.get_output(0))
+
+    active_4d = network.add_shuffle(active)
+    active_4d.reshape_dims = (1, 1, 1, cache_capacity)
+    return NativeKvMasks(
+        attention=mask_4d.get_output(0),
+        active_prefix=active_4d.get_output(0),
+    )
+
+
+def _blocked_score(
+    network: trt.INetworkDefinition,
+    dtype: trt.DataType,
+) -> trt.ITensor:
+    if dtype == trt.float16:
+        return _constant(
+            network,
+            (1, 1, 1, 1, 1),
+            np.array([-1.0e4], dtype=np.float16),
+            dtype=np.dtype(np.float16),
+        )
+    blocked = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([-1.0e30], dtype=np.float32),
+    )
+    return _cast(network, blocked, dtype)
+
+
+def add_explicit_masked_grouped_query_attention(
+    network: trt.INetworkDefinition,
+    query: trt.ITensor,
+    key: trt.ITensor,
+    value: trt.ITensor,
+    masks: NativeKvMasks,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    scale: float | None = None,
+    tag: str | None = None,
+) -> trt.ITensor:
+    """Compute explicitly masked grouped-query attention."""
+
+    if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_heads={num_heads} must be divisible by "
+            f"num_kv_heads={num_kv_heads}"
+        )
+    if head_dim <= 0:
+        raise ValueError("native KV attention head_dim must be positive")
+    if query.dtype not in {trt.float16, trt.bfloat16, trt.float32}:
+        raise ValueError("native KV attention requires FP16, BF16, or FP32")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("native KV query, key, and value dtypes must match")
+    if masks.attention.dtype != trt.bool or masks.active_prefix.dtype != trt.bool:
+        raise ValueError("native KV attention requires BOOL explicit masks")
+
+    groups = num_heads // num_kv_heads
+    query_grouped = network.add_shuffle(query)
+    query_grouped.reshape_dims = (
+        1,
+        num_kv_heads,
+        groups,
+        -1,
+        head_dim,
+    )
+    key_grouped = network.add_shuffle(key)
+    key_grouped.reshape_dims = (1, num_kv_heads, 1, -1, head_dim)
+    value_grouped = network.add_shuffle(value)
+    value_grouped.reshape_dims = (1, num_kv_heads, 1, -1, head_dim)
+    mask_grouped = network.add_shuffle(masks.attention)
+    mask_grouped.reshape_dims = (1, 1, 1, -1, int(key.shape[-2]))
+    active_grouped = network.add_shuffle(masks.active_prefix)
+    active_grouped.reshape_dims = (1, 1, 1, int(key.shape[-2]), 1)
+
+    zero = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([0.0], dtype=np.float32),
+    )
+    zero = _cast(network, zero, query.dtype)
+    safe_key = network.add_select(
+        active_grouped.get_output(0),
+        key_grouped.get_output(0),
+        zero,
+    )
+    safe_value = network.add_select(
+        active_grouped.get_output(0),
+        value_grouped.get_output(0),
+        zero,
+    )
+    if safe_key is None or safe_value is None:
+        raise RuntimeError("TensorRT failed to sanitize inactive native KV rows")
+
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim))
+    query_fp32 = network.add_cast(
+        query_grouped.get_output(0), trt.float32
+    ).get_output(0)
+    scale_tensor = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([scale], dtype=np.float32),
+    )
+    scaled_query = network.add_elementwise(
+        query_fp32,
+        scale_tensor,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    scaled_query = _cast(network, scaled_query, query.dtype)
+
+    scores = network.add_matrix_multiply(
+        scaled_query,
+        trt.MatrixOperation.NONE,
+        safe_key.get_output(0),
+        trt.MatrixOperation.TRANSPOSE,
+    )
+    if scores is None:
+        raise RuntimeError("TensorRT failed to create native KV score matmul")
+    if tag:
+        scores.name = tag + ".scores"
+    masked_scores = network.add_select(
+        mask_grouped.get_output(0),
+        scores.get_output(0),
+        _blocked_score(network, query.dtype),
+    )
+    if masked_scores is None:
+        raise RuntimeError("TensorRT failed to apply native KV attention mask")
+    if tag:
+        masked_scores.name = tag + ".mask"
+
+    probabilities = network.add_softmax(masked_scores.get_output(0))
+    if probabilities is None:
+        raise RuntimeError("TensorRT failed to create native KV softmax")
+    probabilities.axes = 1 << 4
+    if tag:
+        probabilities.name = tag + ".softmax"
+    context_grouped = network.add_matrix_multiply(
+        probabilities.get_output(0),
+        trt.MatrixOperation.NONE,
+        safe_value.get_output(0),
+        trt.MatrixOperation.NONE,
+    )
+    if context_grouped is None:
+        raise RuntimeError("TensorRT failed to create native KV context matmul")
+    if tag:
+        context_grouped.name = tag + ".context"
+
+    context = network.add_shuffle(context_grouped.get_output(0))
+    context.reshape_dims = (1, num_heads, -1, head_dim)
+    return context.get_output(0)

--- a/families/smollm3/native_kv_contract.py
+++ b/families/smollm3/native_kv_contract.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mapped-weight contract for SmolLM3's TensorRT native KV graph."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from .build_routing import resolved_head_dim
+
+_LAYER_KEY = re.compile(r"^layer\.(\d+)\.")
+_BIAS_SUFFIXES = (
+    "input_norm_beta",
+    "q_bias",
+    "k_bias",
+    "v_bias",
+    "o_bias",
+    "post_attn_norm_beta",
+    "gate_bias",
+    "up_bias",
+    "down_bias",
+)
+
+
+def _shape(value: object, name: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(dim) for dim in value.shape)
+    except (AttributeError, TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"native SmolLM3 weight {name} has an invalid shape"
+        ) from exc
+
+
+def _require(
+    weights: Mapping[str, object],
+    name: str,
+    expected: tuple[int, ...],
+) -> None:
+    if name not in weights:
+        raise ValueError(f"missing native SmolLM3 weight {name}")
+    actual = _shape(weights[name], name)
+    if actual != expected:
+        raise ValueError(
+            f"native SmolLM3 weight {name} must have shape "
+            f"{expected}, got {actual}"
+        )
+
+
+def validate_native_kv_weights(
+    config: object,
+    weights: Mapping[str, object],
+) -> None:
+    """Validate mapped tensors once, before TensorRT graph construction."""
+
+    if not isinstance(weights, Mapping):
+        raise ValueError("native SmolLM3 weights must be a mapping")
+
+    hidden = int(getattr(config, "hidden_size"))
+    vocab = int(getattr(config, "vocab_size"))
+    mlp = int(getattr(config, "intermediate_size"))
+    layers = int(getattr(config, "num_hidden_layers"))
+    heads = int(getattr(config, "num_attention_heads"))
+    kv_heads = int(getattr(config, "num_key_value_heads"))
+    head_dim = resolved_head_dim(config)
+    attention = heads * head_dim
+    kv_attention = kv_heads * head_dim
+
+    layer_indices: set[int] = set()
+    malformed: list[str] = []
+    for name in weights:
+        if not isinstance(name, str) or not name.startswith("layer."):
+            continue
+        match = _LAYER_KEY.match(name)
+        if match is None:
+            malformed.append(name)
+        else:
+            layer_indices.add(int(match.group(1)))
+    if malformed or layer_indices != set(range(layers)):
+        raise ValueError(
+            "native SmolLM3 weights require continuous layer indices; "
+            f"malformed={sorted(malformed)}, found={sorted(layer_indices)}"
+        )
+
+    for name, expected in (
+        ("_attention_size", attention),
+        ("_kv_attention_size", kv_attention),
+        ("_mlp_size", mlp),
+    ):
+        if name in weights and int(weights[name]) != expected:
+            raise ValueError(
+                f"native SmolLM3 metadata {name} must be {expected}"
+            )
+
+    _require(weights, "embedding", (vocab, hidden))
+    _require(weights, "final_norm", (hidden,))
+    _require(weights, "w_out", (hidden, vocab))
+    forbidden = [
+        name
+        for name in ("final_norm_beta", "lm_head_bias")
+        if name in weights
+    ]
+
+    for layer in range(layers):
+        prefix = f"layer.{layer}"
+        for suffix, expected in (
+            ("input_norm", (hidden,)),
+            ("w_q", (hidden, attention)),
+            ("w_k", (hidden, kv_attention)),
+            ("w_v", (hidden, kv_attention)),
+            ("w_o", (attention, hidden)),
+            ("post_attn_norm", (hidden,)),
+            ("w_gate", (hidden, mlp)),
+            ("w_up", (hidden, mlp)),
+            ("w_down", (mlp, hidden)),
+        ):
+            _require(weights, f"{prefix}.{suffix}", expected)
+        for suffix, expected in (
+            ("q_norm", (attention,)),
+            ("k_norm", (kv_attention,)),
+        ):
+            name = f"{prefix}.{suffix}"
+            if name in weights:
+                _require(weights, name, expected)
+        forbidden.extend(
+            f"{prefix}.{suffix}"
+            for suffix in _BIAS_SUFFIXES
+            if f"{prefix}.{suffix}" in weights
+        )
+
+    if forbidden:
+        raise ValueError(
+            "native dense SmolLM3 does not support bias weights: "
+            + ", ".join(sorted(forbidden))
+        )

--- a/families/smollm3/runtime/CMakeLists.txt
+++ b/families/smollm3/runtime/CMakeLists.txt
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(trtmc_model_smollm3 SHARED
+  bpe_tokenizer.cpp
+  chat_templates.cpp
+  kv_cache.cpp
+  pipeline.cpp
+  plugin.cpp
+  plugin_helpers.cpp
+  sampler.cpp
+)
+
+target_include_directories(trtmc_model_smollm3
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+)
+target_include_directories(trtmc_model_smollm3 SYSTEM PRIVATE
+  ${TRTMC_CUDA_INCLUDE_DIR}
+)
+target_link_libraries(trtmc_model_smollm3 PRIVATE
+  trtmc_core
+  nlohmann_json::nlohmann_json
+  ${TRTMC_CUDART_LIBRARY}
+)
+target_compile_options(trtmc_model_smollm3 PRIVATE -Wall -Wextra -Wpedantic)
+set_target_properties(trtmc_model_smollm3 PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  BUILD_RPATH "\$ORIGIN"
+  INSTALL_RPATH "\$ORIGIN"
+)
+install(TARGETS trtmc_model_smollm3
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+if(TRTMC_BUILD_TESTS)
+  foreach(test_name IN ITEMS test_smollm3_chat_template test_smollm3_native_kv_cache)
+    add_executable(${test_name}
+      ${PROJECT_SOURCE_DIR}/families/smollm3/tests/cpp/${test_name}.cpp
+    )
+    target_include_directories(${test_name} PRIVATE
+      ${PROJECT_SOURCE_DIR}
+      ${PROJECT_SOURCE_DIR}/core/runtime/include
+    )
+    target_link_libraries(${test_name} PRIVATE
+      trtmc_model_smollm3
+      trtmc_core
+      ${TRTMC_CUDART_LIBRARY}
+    )
+    add_test(NAME ${test_name} COMMAND ${test_name})
+  endforeach()
+  set_tests_properties(test_smollm3_native_kv_cache PROPERTIES SKIP_RETURN_CODE 77)
+
+  add_executable(test_smollm3_plugin_helpers
+    ${PROJECT_SOURCE_DIR}/families/smollm3/tests/cpp/test_smollm3_plugin_helpers.cpp
+  )
+  target_include_directories(test_smollm3_plugin_helpers PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(test_smollm3_plugin_helpers PRIVATE
+    trtmc_model_smollm3
+    trtmc_core
+  )
+  target_compile_options(test_smollm3_plugin_helpers PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME test_smollm3_plugin_helpers COMMAND test_smollm3_plugin_helpers)
+
+  add_executable(test_smollm3_pipeline
+    ${PROJECT_SOURCE_DIR}/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
+  )
+  target_include_directories(test_smollm3_pipeline PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_include_directories(test_smollm3_pipeline SYSTEM PRIVATE
+    ${TRTMC_TRT_INCLUDE_DIR}
+    ${TRTMC_CUDA_INCLUDE_DIR}
+  )
+  target_link_libraries(test_smollm3_pipeline PRIVATE
+    trtmc_model_smollm3
+    trtmc_backend_trt
+    trtmc_core
+    ${TRTMC_TRT_LIBRARY}
+    ${TRTMC_CUDART_LIBRARY}
+  )
+  target_compile_options(test_smollm3_pipeline PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME test_smollm3_pipeline COMMAND test_smollm3_pipeline)
+  set_tests_properties(test_smollm3_pipeline PROPERTIES
+    LABELS gpu
+    SKIP_RETURN_CODE 77
+  )
+endif()

--- a/families/smollm3/runtime/bpe_tokenizer.cpp
+++ b/families/smollm3/runtime/bpe_tokenizer.cpp
@@ -1,0 +1,1565 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/tokenizer.h"
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cstdio>
+#include <cstring>
+#include <list>
+#include <nlohmann/json.hpp>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+namespace {
+
+// ─── UTF-8 helpers ───
+
+// Decode one UTF-8 codepoint from s starting at pos, advance pos.
+inline char32_t utf8_to_char32(const std::string& s, size_t& pos) {
+    unsigned char c = static_cast<unsigned char>(s[pos]);
+    if (c < 0x80) {
+        ++pos;
+        return static_cast<char32_t>(c);
+    }
+    if ((c & 0xE0) == 0xC0 && pos + 1 < s.size()) {
+        char32_t cp = (static_cast<char32_t>(c & 0x1F) << 6) |
+                      static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F);
+        pos += 2;
+        return cp;
+    }
+    if ((c & 0xF0) == 0xE0 && pos + 2 < s.size()) {
+        char32_t cp = (static_cast<char32_t>(c & 0x0F) << 12) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F) << 6) |
+                      static_cast<char32_t>(static_cast<unsigned char>(s[pos + 2]) & 0x3F);
+        pos += 3;
+        return cp;
+    }
+    if ((c & 0xF8) == 0xF0 && pos + 3 < s.size()) {
+        char32_t cp = (static_cast<char32_t>(c & 0x07) << 18) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F) << 12) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 2]) & 0x3F) << 6) |
+                      static_cast<char32_t>(static_cast<unsigned char>(s[pos + 3]) & 0x3F);
+        pos += 4;
+        return cp;
+    }
+    ++pos;
+    return 0xFFFD;
+}
+
+inline std::string utf32_to_utf8(char32_t cp) {
+    std::string r;
+    if (cp <= 0x7F) {
+        r.push_back(static_cast<char>(cp));
+    } else if (cp <= 0x7FF) {
+        r.push_back(static_cast<char>(0xC0 | ((cp >> 6) & 0x1F)));
+        r.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp <= 0xFFFF) {
+        r.push_back(static_cast<char>(0xE0 | ((cp >> 12) & 0x0F)));
+        r.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        r.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp <= 0x10FFFF) {
+        r.push_back(static_cast<char>(0xF0 | ((cp >> 18) & 0x07)));
+        r.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        r.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        r.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    return r;
+}
+
+// Read one UTF-8 codepoint from raw bytes, advance ptr. Returns 0xFFFD on error.
+inline char32_t read_utf8(const char*& p, const char* end) {
+    if (p >= end)
+        return 0xFFFD;
+    unsigned char c = static_cast<unsigned char>(*p);
+    if (c < 0x80) {
+        ++p;
+        return c;
+    }
+    if ((c & 0xE0) == 0xC0 && p + 1 < end) {
+        char32_t cp =
+            (static_cast<char32_t>(c & 0x1F) << 6) | (static_cast<unsigned char>(p[1]) & 0x3F);
+        p += 2;
+        return cp;
+    }
+    if ((c & 0xF0) == 0xE0 && p + 2 < end) {
+        char32_t cp = (static_cast<char32_t>(c & 0x0F) << 12) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(p[1]) & 0x3F) << 6) |
+                      (static_cast<unsigned char>(p[2]) & 0x3F);
+        p += 3;
+        return cp;
+    }
+    if ((c & 0xF8) == 0xF0 && p + 3 < end) {
+        char32_t cp = (static_cast<char32_t>(c & 0x07) << 18) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(p[1]) & 0x3F) << 12) |
+                      (static_cast<char32_t>(static_cast<unsigned char>(p[2]) & 0x3F) << 6) |
+                      (static_cast<unsigned char>(p[3]) & 0x3F);
+        p += 4;
+        return cp;
+    }
+    ++p;
+    return 0xFFFD;
+}
+
+// ─── GPT-2 byte encoder: byte value <-> Unicode codepoint ───
+
+struct ByteEncoderTables {
+    // byte -> UTF-8 encoded string (precomputed for speed)
+    std::string byte_to_utf8[256];
+    // Unicode codepoint -> byte value
+    std::unordered_map<char32_t, uint8_t> cp_to_byte;
+
+    ByteEncoderTables() {
+        // GPT-2 byte encoder: printable bytes map to themselves,
+        // others map to 256+ to avoid control chars.
+        bool direct[256] = {};
+        for (int b = 33; b <= 126; ++b)
+            direct[b] = true; // !"#$...~
+        for (int b = 161; b <= 172; ++b)
+            direct[b] = true; // non-breaking space area
+        for (int b = 174; b <= 255; ++b)
+            direct[b] = true; // extended latin
+
+        int n = 0;
+        for (int b = 0; b < 256; ++b) {
+            char32_t cp = direct[b] ? static_cast<char32_t>(b) : static_cast<char32_t>(256 + n++);
+            byte_to_utf8[b] = utf32_to_utf8(cp);
+            cp_to_byte[cp] = static_cast<uint8_t>(b);
+        }
+    }
+};
+
+static const ByteEncoderTables& byte_tables() {
+    static ByteEncoderTables tables;
+    return tables;
+}
+
+// ─── Hand-written BPE pre-tokenizer ───
+//
+// Supports two regex variants:
+//
+// GPT-2 (used by GPT-2, Falcon, OPT):
+//   'contractions| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
+//
+// Qwen3 (used by Qwen3, LLaMA-3, Mistral, Phi):
+//   (?i:contractions)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}|
+//   ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+
+//
+// Key differences: Qwen3 allows any non-CR/LF/letter/digit as optional prefix before
+// letters, matches single digits, and has explicit newline handling.
+
+namespace pretok {
+
+enum class Variant { kSmolLM3, kQwen3, kBloom, kDeepSeek, kClip };
+
+// ── Character classification ──
+
+struct UnicodeRange {
+    char32_t lo, hi;
+};
+
+constexpr UnicodeRange kLetterRanges[] = {
+    {'A', 'Z'},         {'a', 'z'},       {0xB5, 0xB5},   // µ (micro sign, treated as letter)
+    {0xC0, 0xD6},       {0xD8, 0xF6},     {0xF8, 0x1BA},  // Latin-1 + Extended A/B
+    {0x1BC, 0x1BF},     {0x1C4, 0x293},   {0x295, 0x2AF}, // Latin Extended B cont.
+    {0x370, 0x373},     {0x376, 0x377},   {0x37B, 0x37D},   {0x37F, 0x37F}, // Greek
+    {0x386, 0x386},     {0x388, 0x38A},   {0x38C, 0x38C},   {0x38E, 0x3A1},
+    {0x3A3, 0x3F5},     {0x3F7, 0x481},   {0x48A, 0x52F},   // Greek + Cyrillic
+    {0x531, 0x556},     {0x559, 0x559},                     // Armenian
+    {0x560, 0x588},                                         // Armenian lowercase
+    {0x600, 0x6FF},                                         // Arabic
+    {0x900, 0x97F},                                         // Devanagari
+    {0xE00, 0xE7F},                                         // Thai
+    {0x10A0, 0x10C5},                                       // Georgian
+    {0x13A0, 0x13F5},                                       // Cherokee
+    {0x1C90, 0x1CBA},   {0x1CBD, 0x1CBF},                   // Georgian Extended
+    {0x1D00, 0x1D2B},   {0x1D6B, 0x1D77}, {0x1D79, 0x1D9A}, // Phonetic Extensions
+    {0x1E00, 0x1F15},   {0x1F18, 0x1F1D}, {0x1F20, 0x1F45}, // Latin Ext. Additional + Greek Ext.
+    {0x2C00, 0x2C5F},                                       // Glagolitic
+    {0x3040, 0x309F},                                       // Hiragana
+    {0x30A0, 0x30FF},                                       // Katakana
+    {0x3400, 0x4DBF},                                       // CJK Extension A
+    {0x4E00, 0x9FFF},                                       // CJK Unified Ideographs
+    {0xAC00, 0xD7AF},                                       // Hangul Syllables
+    {0xFB00, 0xFDFF},   // Alphabetic Presentation Forms + Arabic Forms
+    {0x10000, 0x1007F}, // Linear B Syllabary
+};
+
+inline bool is_letter(char32_t cp) {
+    for (const auto& r : kLetterRanges) {
+        if (cp >= r.lo && cp <= r.hi)
+            return true;
+    }
+    return false;
+}
+
+inline bool is_digit(char32_t cp) {
+    return (cp >= '0' && cp <= '9');
+}
+
+inline bool is_whitespace(char32_t cp) {
+    return cp == ' ' || cp == '\t' || cp == '\n' || cp == '\r' || cp == 0x0B || cp == 0x0C // VT, FF
+           || cp == 0xA0                   // non-breaking space
+           || cp == 0x2000 || cp == 0x200A // en space through hair space
+           || cp == 0x3000;                // ideographic space
+}
+
+// BLOOM punctuation set: .,!?...
+constexpr char32_t kBloomPunct[] = {
+    '.',    ',', '!', '?',
+    0x2026, // ellipsis
+    0x3002, // ideographic full stop
+    0xFF0C, // fullwidth comma
+    0x3001, // ideographic comma
+    0x0964, // Devanagari danda
+    0x06D4, // Arabic full stop
+    0x060C, // Arabic comma
+};
+
+inline bool is_bloom_punct(char32_t cp) {
+    for (auto c : kBloomPunct) {
+        if (cp == c)
+            return true;
+    }
+    return false;
+}
+
+inline bool is_newline(char32_t cp) {
+    return cp == '\n' || cp == '\r';
+}
+
+// Is this char a valid optional prefix before a word?
+// GPT-2/BLOOM: only space (0x20)
+// Qwen3: any char except CR, LF, letter, digit
+// DeepSeek: any whitespace (\s?)
+inline bool is_prefix(char32_t cp, Variant v) {
+    if (v == Variant::kClip) {
+        return false;
+    }
+    if (v == Variant::kQwen3) {
+        return !is_newline(cp) && !is_letter(cp) && !is_digit(cp);
+    }
+    if (v == Variant::kDeepSeek) {
+        return is_whitespace(cp);
+    }
+    return cp == ' ';
+}
+
+// BLOOM word char: not whitespace and not BLOOM punctuation
+inline bool is_bloom_word_char(char32_t cp) {
+    // The serialized regex is `[^(\s|[.,!?…。，、।۔،])]`. Parentheses and
+    // the pipe are literal members of that negated character class.
+    return !is_whitespace(cp) && !is_bloom_punct(cp) && cp != '(' && cp != ')' && cp != '|';
+}
+
+// ── Scanning helpers (advance pointer past matching chars) ──
+
+inline void scan_letters(const char*& p, const char* end) {
+    while (p < end) {
+        const char* peek = p;
+        if (!is_letter(read_utf8(peek, end)))
+            break;
+        p = peek;
+    }
+}
+
+inline void scan_digits(const char*& p, const char* end, int max_group = 0) {
+    int count = 0;
+    while (p < end) {
+        if (max_group > 0 && count >= max_group)
+            break;
+        const char* peek = p;
+        if (!is_digit(read_utf8(peek, end)))
+            break;
+        p = peek;
+        ++count;
+    }
+}
+
+inline void scan_others(const char*& p, const char* end) {
+    while (p < end) {
+        const char* peek = p;
+        char32_t nc = read_utf8(peek, end);
+        if (is_whitespace(nc) || is_letter(nc) || is_digit(nc))
+            break;
+        p = peek;
+    }
+}
+
+inline void scan_newlines(const char*& p, const char* end) {
+    while (p < end) {
+        const char* peek = p;
+        if (!is_newline(read_utf8(peek, end)))
+            break;
+        p = peek;
+    }
+}
+
+inline void scan_all_whitespace(const char*& p, const char* end) {
+    while (p < end) {
+        const char* peek = p;
+        if (!is_whitespace(read_utf8(peek, end)))
+            break;
+        p = peek;
+    }
+}
+
+// Qwen3 regex branch: \s*[\r\n]+
+// Consume any leading whitespace up to the first newline, then consume the
+// contiguous newline run itself, but stop before whitespace that follows the
+// last newline.
+inline void scan_qwen3_newline_chunk(char32_t first_cp, const char*& p, const char* end) {
+    bool saw_newline = is_newline(first_cp);
+    while (p < end) {
+        const char* peek = p;
+        char32_t nc = read_utf8(peek, end);
+        if (!saw_newline) {
+            if (is_newline(nc)) {
+                saw_newline = true;
+                p = peek;
+                continue;
+            }
+            if (is_whitespace(nc)) {
+                p = peek;
+                continue;
+            }
+            break;
+        }
+        if (!is_newline(nc))
+            break;
+        p = peek;
+    }
+}
+
+inline void scan_bloom_words(const char*& p, const char* end) {
+    while (p < end) {
+        const char* peek = p;
+        if (!is_bloom_word_char(read_utf8(peek, end)))
+            break;
+        p = peek;
+    }
+}
+
+// Emit whitespace run, leaving last ws char for next token's optional prefix
+inline void emit_whitespace_leave_last(const char*& p, const char* end, const char* start,
+                                       std::vector<std::string>& result) {
+    const char* last_ws_start = start;
+    while (p < end) {
+        const char* peek = p;
+        char32_t nc = read_utf8(peek, end);
+        if (!is_whitespace(nc))
+            break;
+        last_ws_start = p;
+        p = peek;
+    }
+    if (p < end && last_ws_start > start) {
+        p = last_ws_start;
+    }
+    result.emplace_back(start, p);
+}
+
+// ── Contraction matching ──
+
+inline bool is_two_char_contraction(char c1, char c2) {
+    return (c1 == 'r' && c2 == 'e') || (c1 == 'v' && c2 == 'e') || (c1 == 'l' && c2 == 'l');
+}
+
+// Returns length of contraction suffix after apostrophe ('s 't 'm 'd 're 've 'll)
+inline int match_contraction_suffix(const char* p, const char* end) {
+    if (p >= end)
+        return 0;
+    char c = *p;
+    if (c == 's' || c == 't' || c == 'm' || c == 'd')
+        return 1;
+    if (p + 1 < end && is_two_char_contraction(c, p[1]))
+        return 2;
+    return 0;
+}
+
+// ── GPT-2/Qwen3 pre-tokenize dispatch helpers ──
+
+// Handle apostrophe: either contraction or "other" chars run
+inline bool try_contraction(char32_t cp, const char*& p, const char* end, const char* start,
+                            std::vector<std::string>& result) {
+    if (cp != '\'')
+        return false;
+    int suffix = match_contraction_suffix(p, end);
+    if (suffix > 0) {
+        p += suffix;
+    } else {
+        scan_others(p, end);
+    }
+    result.emplace_back(start, p);
+    return true;
+}
+
+// Handle optional prefix + letter/digit/other run
+inline bool try_prefix_run(char32_t cp, const char*& p, const char* end, const char* start,
+                           Variant variant, std::vector<std::string>& result) {
+    if (!is_prefix(cp, variant) || p >= end)
+        return false;
+    const char* after_prefix = p;
+    char32_t next_cp = read_utf8(p, end);
+
+    if (is_letter(next_cp)) {
+        scan_letters(p, end);
+        result.emplace_back(start, p);
+        return true;
+    }
+    if (is_digit(next_cp)) {
+        // The regex prefix [^\r\n\p{L}\p{N}]? only applies before \p{L}+ (letters).
+        // Digits are matched by standalone \p{N} — no prefix. Back up so the
+        // digit is handled by try_simple_run instead.
+        if (variant == Variant::kQwen3) {
+            p = after_prefix;
+            return false;
+        }
+        scan_digits(p, end);
+        result.emplace_back(start, p);
+        return true;
+    }
+    if (!is_whitespace(next_cp)) {
+        scan_others(p, end);
+        if (variant == Variant::kQwen3)
+            scan_newlines(p, end);
+        result.emplace_back(start, p);
+        return true;
+    }
+    // Prefix followed by whitespace — back up, let whitespace handler deal with it
+    p = after_prefix;
+    return false;
+}
+
+// Check if a whitespace run contains any newline character
+inline bool has_newline_in_ws(char32_t first_cp, const char* p, const char* end) {
+    if (is_newline(first_cp))
+        return true;
+    const char* scan = p;
+    while (scan < end) {
+        const char* peek = scan;
+        char32_t nc = read_utf8(peek, end);
+        if (!is_whitespace(nc))
+            break;
+        if (is_newline(nc))
+            return true;
+        scan = peek;
+    }
+    return false;
+}
+
+// Handle whitespace (Qwen3 newline sequences + general whitespace)
+inline bool try_whitespace_run(char32_t cp, const char*& p, const char* end, const char* start,
+                               Variant variant, std::vector<std::string>& result) {
+    if (!is_whitespace(cp))
+        return false;
+
+    // kClip is selected only for CLIP's Removed + inverted Split contract,
+    // which retains regex matches and removes the gaps. Whitespace therefore
+    // never reaches ByteLevel.
+    if (variant == Variant::kClip) {
+        scan_all_whitespace(p, end);
+        return true;
+    }
+
+    // Qwen3: \s*[\r\n]+ — newline sequences take priority
+    if (variant == Variant::kQwen3 && has_newline_in_ws(cp, p, end)) {
+        scan_qwen3_newline_chunk(cp, p, end);
+        result.emplace_back(start, p);
+        return true;
+    }
+
+    // General whitespace: leave last ws char for next token's prefix
+    emit_whitespace_leave_last(p, end, start, result);
+    return true;
+}
+
+// Handle letter or digit run (no prefix)
+inline bool try_simple_run(char32_t cp, const char*& p, const char* end, const char* start,
+                           Variant variant, std::vector<std::string>& result, int digit_group = 0) {
+    if (is_letter(cp)) {
+        scan_letters(p, end);
+        result.emplace_back(start, p);
+        return true;
+    }
+    if (is_digit(cp)) {
+        if (variant == Variant::kQwen3) {
+            if (digit_group > 1)
+                scan_digits(p, end, digit_group - 1);
+        } else if (variant != Variant::kClip) {
+            scan_digits(p, end);
+        }
+        result.emplace_back(start, p);
+        return true;
+    }
+    return false;
+}
+
+// ── Main pre-tokenize functions ──
+
+std::vector<std::string> pre_tokenize(const std::string& text, Variant variant,
+                                      int digit_group = 0) {
+    std::vector<std::string> result;
+    if (text.empty())
+        return result;
+
+    const char* p = text.data();
+    const char* end = p + text.size();
+
+    while (p < end) {
+        const char* start = p;
+        char32_t cp = read_utf8(p, end);
+
+        if (try_contraction(cp, p, end, start, result))
+            continue;
+        if (try_prefix_run(cp, p, end, start, variant, result))
+            continue;
+        if (try_whitespace_run(cp, p, end, start, variant, result))
+            continue;
+        if (try_simple_run(cp, p, end, start, variant, result, digit_group))
+            continue;
+
+        // Other chars (punctuation/symbols)
+        scan_others(p, end);
+        if (variant == pretok::Variant::kQwen3) {
+            // Qwen3's ` ?[^\s\p{L}\p{N}]+[\r\n]*` keeps trailing newlines
+            // attached to punctuation/symbol runs even without an optional prefix.
+            scan_newlines(p, end);
+        }
+        result.emplace_back(start, p);
+    }
+
+    return result;
+}
+
+// Return the end of a BLOOM Split-regex match beginning at `start`.
+// The regex is " ?[^(\s|[.,!?...])]+": an optional ASCII space followed by
+// one or more non-whitespace, non-punctuation characters.
+const char* bloom_match_end(const char* start, const char* end) {
+    const char* p = start;
+    char32_t cp = read_utf8(p, end);
+    if (cp == ' ') {
+        if (p >= end)
+            return nullptr;
+        cp = read_utf8(p, end);
+        if (!is_bloom_word_char(cp))
+            return nullptr;
+    } else if (!is_bloom_word_char(cp)) {
+        return nullptr;
+    }
+    scan_bloom_words(p, end);
+    return p;
+}
+
+// BLOOM uses Split(..., behavior="Isolated", invert=false) followed by
+// ByteLevel(use_regex=false). Regex matches are isolated, while every
+// contiguous unmatched span remains a single pre-token. In particular,
+// punctuation and adjacent newlines must stay together so BPE can merge
+// strings such as ".\n\n".
+std::vector<std::string> bloom_pre_tokenize(const std::string& text) {
+    std::vector<std::string> result;
+    if (text.empty())
+        return result;
+
+    const char* p = text.data();
+    const char* end = p + text.size();
+
+    while (p < end) {
+        const char* start = p;
+        if (const char* match_end = bloom_match_end(start, end)) {
+            result.emplace_back(start, match_end);
+            p = match_end;
+            continue;
+        }
+
+        // Preserve one contiguous unmatched span until the next regex match.
+        read_utf8(p, end);
+        while (p < end && bloom_match_end(p, end) == nullptr)
+            read_utf8(p, end);
+        result.emplace_back(start, p);
+    }
+
+    return result;
+}
+
+} // namespace pretok
+
+// ─── BpeTokenizer implementation ───
+
+class BpeTokenizer final : public ITokenizer {
+  public:
+    static std::unique_ptr<BpeTokenizer> Create(const char* tokenizer_json_data,
+                                                std::size_t tokenizer_json_size,
+                                                bool add_special_tokens = false) {
+        auto tokenizer = std::unique_ptr<BpeTokenizer>(new BpeTokenizer());
+        tokenizer->mAddSpecialTokens = add_special_tokens;
+        tokenizer->parse_tokenizer_json(tokenizer_json_data, tokenizer_json_size);
+        return tokenizer;
+    }
+
+    void encode_segment(const std::string& text, std::vector<int32_t>& result) const {
+        const auto normalized = normalize_text(text);
+        if (mIsSentencePiece) {
+            encode_sentencepiece(normalized, result);
+        } else if (mIsMetaspace) {
+            encode_metaspace(normalized, result);
+        } else {
+            encode_bytelevel(normalized, result);
+        }
+    }
+
+    std::vector<int32_t> encode(const std::string& text) const override {
+        std::vector<int32_t> result;
+        if (text.empty())
+            return result;
+
+        if (mAddSpecialTokens) {
+            for (int32_t bos_id : mPostBosIds)
+                result.push_back(bos_id);
+        }
+
+        auto segments = split_added_tokens(text);
+        for (const auto& seg : segments) {
+            if (seg.added_id >= 0)
+                result.push_back(seg.added_id);
+            else
+                encode_segment(seg.text, result);
+        }
+
+        if (mAddSpecialTokens) {
+            for (int32_t eos_id : mPostEosIds)
+                result.push_back(eos_id);
+        }
+
+        return result;
+    }
+
+    std::string decode(const std::vector<int32_t>& ids) const override {
+        std::string joined = join_vocab_tokens(ids);
+        switch (mDecoderType) {
+        case DecoderType::kByteLevel:
+            return byte_decode(joined);
+        case DecoderType::kMetaspace:
+            return decode_metaspace(joined);
+        case DecoderType::kSequence:
+            return decode_sequence(joined);
+        }
+        return byte_decode(joined);
+    }
+
+    int32_t id_for_token(std::string_view token) const override {
+        auto it = mTokenToId.find(std::string(token));
+        return it != mTokenToId.end() ? it->second : -1;
+    }
+
+    std::string token_for_id(int32_t id) const override {
+        if (id >= 0 && static_cast<size_t>(id) < mVocab.size()) {
+            return mVocab[id];
+        }
+        return "";
+    }
+
+  private:
+    BpeTokenizer() = default;
+
+    enum class DecoderType { kByteLevel, kMetaspace, kSequence };
+
+    std::string normalize_text(const std::string& text) const {
+        if (!mNormalizeLowercase && !mNormalizeWhitespace) {
+            return text;
+        }
+
+        std::string normalized;
+        normalized.reserve(text.size());
+        const char* cursor = text.data();
+        const char* end = cursor + text.size();
+        bool previous_was_whitespace = false;
+        while (cursor < end) {
+            const char* char_start = cursor;
+            const char32_t cp = read_utf8(cursor, end);
+            if (mNormalizeWhitespace && pretok::is_whitespace(cp)) {
+                if (!previous_was_whitespace) {
+                    normalized.push_back(' ');
+                }
+                previous_was_whitespace = true;
+                continue;
+            }
+            previous_was_whitespace = false;
+            if (mNormalizeLowercase && cp >= 'A' && cp <= 'Z') {
+                normalized.push_back(static_cast<char>(cp - 'A' + 'a'));
+            } else {
+                normalized.append(char_start, cursor);
+            }
+        }
+        return normalized;
+    }
+
+    // ─── Added token segmentation ───
+
+    struct Segment {
+        std::string text;
+        int32_t added_id; /* -1 = normal */
+    };
+
+    std::pair<int32_t, size_t> find_longest_added_token(const std::string& text, size_t pos) const {
+        int32_t best_id = -1;
+        size_t best_len = 0;
+        for (const auto& [content, id] : mAddedTokenPatterns) {
+            if (pos + content.size() <= text.size() && content.size() > best_len &&
+                text.compare(pos, content.size(), content) == 0) {
+                best_id = id;
+                best_len = content.size();
+            }
+        }
+        return {best_id, best_len};
+    }
+
+    std::vector<Segment> split_added_tokens(const std::string& text) const {
+        std::vector<Segment> segments;
+        if (mAddedTokenPatterns.empty()) {
+            segments.push_back({text, -1});
+            return segments;
+        }
+        size_t pos = 0;
+        while (pos < text.size()) {
+            auto [best_id, best_len] = find_longest_added_token(text, pos);
+            if (best_id >= 0) {
+                segments.push_back({text.substr(pos, best_len), best_id});
+                pos += best_len;
+            } else {
+                if (segments.empty() || segments.back().added_id >= 0) {
+                    segments.push_back({"", -1});
+                }
+                segments.back().text.push_back(text[pos]);
+                ++pos;
+            }
+        }
+        return segments;
+    }
+
+    // ─── Encoding helpers ───
+
+    // Metaspace encode (DeepSeek style): raw UTF-8 char split, BPE merge.
+    // Spaces are dropped (not in vocab), Ġ (U+0120) used as separator.
+    void encode_metaspace(const std::string& text, std::vector<int32_t>& result) const {
+        std::vector<std::string> chars;
+        const char* cp = text.data();
+        const char* ce = cp + text.size();
+        while (cp < ce) {
+            const char* cs = cp;
+            read_utf8(cp, ce);
+            std::string ch(cs, cp);
+            if (mTokenToId.count(ch)) {
+                chars.push_back(std::move(ch));
+            }
+        }
+        auto tokens = apply_merges(std::move(chars));
+        for (const auto& token : tokens) {
+            auto it = mTokenToId.find(token);
+            if (it != mTokenToId.end()) {
+                result.push_back(it->second);
+            }
+        }
+    }
+
+    // SentencePiece-style encode: replace spaces with ▁, split to chars, BPE merge.
+    // Used for Metaspace pre-tokenizer and Sequence decoder models (LLaMA, Mistral, Phi-3).
+    // Normalize text for SentencePiece: replace spaces with ▁, handle prepend
+    std::string normalize_sentencepiece(const std::string& text) const {
+        static const std::string sp = "\xe2\x96\x81"; // U+2581
+        std::string out;
+        if (mSentencePiecePrependAlways) {
+            out = sp;
+        }
+        for (char c : text) {
+            out += (c == ' ') ? sp : std::string(1, c);
+        }
+        // Metaspace prepend_scheme=first: prepend if not already starting with ▁
+        if (!mSentencePiecePrependAlways && mSentencePiecePrependIfMissing &&
+            (out.empty() || out.compare(0, sp.size(), sp) != 0)) {
+            out = sp + out;
+        }
+        return out;
+    }
+
+    void encode_sentencepiece(const std::string& text, std::vector<int32_t>& result) const {
+        std::string normalized = normalize_sentencepiece(text);
+
+        // Split into UTF-8 characters
+        std::vector<std::string> chars;
+        const char* cp = normalized.data();
+        const char* ce = cp + normalized.size();
+        while (cp < ce) {
+            const char* cs = cp;
+            read_utf8(cp, ce);
+            chars.emplace_back(cs, cp);
+        }
+
+        // byte_fallback: replace unknown chars with <0xXX>
+        if (mByteFallback) {
+            chars = apply_byte_fallback_encode(std::move(chars));
+        }
+
+        // BPE merge and lookup
+        auto tokens = apply_merges(std::move(chars));
+        for (const auto& token : tokens) {
+            auto it = mTokenToId.find(token);
+            if (it != mTokenToId.end()) {
+                result.push_back(it->second);
+            }
+        }
+    }
+
+    // For byte_fallback: replace chars not in vocab with <0xXX> byte tokens
+    std::vector<std::string> apply_byte_fallback_encode(std::vector<std::string> chars) const {
+        std::vector<std::string> result;
+        for (auto& ch : chars) {
+            if (mTokenToId.count(ch)) {
+                result.push_back(std::move(ch));
+            } else {
+                // Split into individual bytes as <0xXX>
+                for (unsigned char byte : ch) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "<0x%02X>", byte);
+                    result.push_back(std::string(buf));
+                }
+            }
+        }
+        return result;
+    }
+
+    void encode_bytelevel(const std::string& text, std::vector<int32_t>& result) const {
+        std::vector<std::string> words;
+        if (!mUsePreTokenizer) {
+            words = fallback_pre_tokenize(text);
+        } else if (mPreTokenizerVariant == pretok::Variant::kBloom) {
+            words = pretok::bloom_pre_tokenize(text);
+        } else {
+            words = pretok::pre_tokenize(text, mPreTokenizerVariant, mPreTokenizerDigitGroup);
+        }
+
+        for (const auto& word : words) {
+            auto chars = byte_encode(word);
+            if (!chars.empty() && !mEndOfWordSuffix.empty()) {
+                chars.back() += mEndOfWordSuffix;
+            }
+            auto tokens = apply_merges(std::move(chars));
+            for (const auto& token : tokens) {
+                auto it = mTokenToId.find(token);
+                if (it != mTokenToId.end()) {
+                    result.push_back(it->second);
+                }
+            }
+        }
+    }
+
+    // ─── Decoding helpers ───
+
+    std::string join_vocab_tokens(const std::vector<int32_t>& ids) const {
+        std::string joined;
+        for (int32_t id : ids) {
+            if (mSpecialIds.count(id))
+                continue;
+            if (id >= 0 && static_cast<size_t>(id) < mVocab.size()) {
+                joined += mVocab[id];
+            }
+        }
+        return joined;
+    }
+
+    std::string decode_metaspace(const std::string& joined) const {
+        std::string result;
+        const std::string g_char = utf32_to_utf8(0x0120);
+        const std::string spiece_char = "\xe2\x96\x81"; // U+2581
+        size_t pos = 0;
+        while (pos < joined.size()) {
+            if (pos + g_char.size() <= joined.size() &&
+                joined.compare(pos, g_char.size(), g_char) == 0) {
+                result.push_back(' ');
+                pos += g_char.size();
+            } else if (pos + spiece_char.size() <= joined.size() &&
+                       joined.compare(pos, spiece_char.size(), spiece_char) == 0) {
+                result.push_back(' ');
+                pos += spiece_char.size();
+            } else {
+                result.push_back(joined[pos]);
+                ++pos;
+            }
+        }
+        if (!result.empty() && result[0] == ' ') {
+            result.erase(0, 1);
+        }
+        return result;
+    }
+
+    // ─── Sequence decoder (SentencePiece BPE models: LLaMA, Mistral, Phi-3) ───
+
+    std::string decode_sequence(const std::string& joined) const {
+        std::string text = joined;
+        // Step 1: Apply Replace operations (e.g. ▁ → space)
+        for (const auto& rep : mSeqDecoderReplaces) {
+            text = string_replace_all(text, rep.pattern, rep.content);
+        }
+        // Step 2: ByteFallback — convert <0xXX> tokens to raw bytes
+        if (mSeqDecoderByteFallback) {
+            text = apply_byte_fallback(text);
+        }
+        // Step 3: Fuse is implicit (tokens already joined)
+        // Step 4: Strip leading space
+        if (mSeqDecoderStripLeft && !text.empty() && text[0] == ' ') {
+            text.erase(0, 1);
+        }
+        return text;
+    }
+
+    static std::string string_replace_all(const std::string& input, const std::string& from,
+                                          const std::string& to) {
+        if (from.empty())
+            return input;
+        std::string result;
+        result.reserve(input.size());
+        size_t pos = 0;
+        while (pos < input.size()) {
+            if (pos + from.size() <= input.size() && input.compare(pos, from.size(), from) == 0) {
+                result += to;
+                pos += from.size();
+            } else {
+                result.push_back(input[pos]);
+                ++pos;
+            }
+        }
+        return result;
+    }
+
+    static int hex_char_value(char c) {
+        if (c >= '0' && c <= '9')
+            return c - '0';
+        if (c >= 'a' && c <= 'f')
+            return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F')
+            return c - 'A' + 10;
+        return -1;
+    }
+
+    // Try to parse <0xXX> at position pos. Returns parsed byte or -1.
+    static int try_parse_byte_token(const std::string& text, size_t pos) {
+        if (pos + 6 > text.size())
+            return -1;
+        if (text[pos] != '<' || text[pos + 1] != '0' || text[pos + 2] != 'x' ||
+            text[pos + 5] != '>')
+            return -1;
+        int h = hex_char_value(text[pos + 3]);
+        int l = hex_char_value(text[pos + 4]);
+        if (h < 0 || l < 0)
+            return -1;
+        return (h << 4) | l;
+    }
+
+    static std::string apply_byte_fallback(const std::string& text) {
+        std::string result;
+        result.reserve(text.size());
+        size_t pos = 0;
+        while (pos < text.size()) {
+            int byte_val = try_parse_byte_token(text, pos);
+            if (byte_val >= 0) {
+                result.push_back(static_cast<char>(byte_val));
+                pos += 6;
+            } else {
+                result.push_back(text[pos]);
+                ++pos;
+            }
+        }
+        return result;
+    }
+
+    // ─── Byte-level encoding ───
+
+    static std::vector<std::string> byte_encode(const std::string& text) {
+        const auto& tables = byte_tables();
+        std::vector<std::string> result;
+        result.reserve(text.size());
+        for (unsigned char byte : text) {
+            result.push_back(tables.byte_to_utf8[byte]);
+        }
+        return result;
+    }
+
+    static std::string byte_decode(const std::string& text) {
+        const auto& tables = byte_tables();
+        std::string result;
+        result.reserve(text.size());
+        size_t pos = 0;
+        while (pos < text.size()) {
+            size_t start = pos;
+            char32_t cp = utf8_to_char32(text, pos);
+            auto it = tables.cp_to_byte.find(cp);
+            if (it != tables.cp_to_byte.end()) {
+                result.push_back(static_cast<char>(it->second));
+            } else {
+                // Not a GPT-2 byte-encoded codepoint — pass through raw UTF-8
+                result.append(text, start, pos - start);
+            }
+        }
+        return result;
+    }
+
+    // Generic pre-tokenizer used when no GPT-2 pattern is declared.
+
+    static std::vector<std::string> fallback_pre_tokenize(const std::string& text) {
+        std::vector<std::string> result;
+        if (text.empty())
+            return result;
+        result.push_back(text);
+        return result;
+    }
+
+    // ─── BPE merge algorithm ───
+
+    struct MergeCandidate {
+        int rank;
+        std::string first;
+        std::string second;
+    };
+
+    MergeCandidate find_best_merge(const std::vector<std::string>& tokens) const {
+        MergeCandidate best{INT_MAX, "", ""};
+        for (size_t i = 0; i + 1 < tokens.size(); ++i) {
+            auto it =
+                mMergeRank.find(std::make_pair(std::cref(tokens[i]), std::cref(tokens[i + 1])));
+            if (it != mMergeRank.end() && it->second < best.rank) {
+                best = {it->second, tokens[i], tokens[i + 1]};
+            }
+        }
+        return best;
+    }
+
+    static std::vector<std::string> merge_all_pairs(std::vector<std::string> tokens,
+                                                    const std::string& first,
+                                                    const std::string& second) {
+        std::string merged = first + second;
+        std::vector<std::string> result;
+        result.reserve(tokens.size());
+        for (size_t i = 0; i < tokens.size(); ++i) {
+            if (i + 1 < tokens.size() && tokens[i] == first && tokens[i + 1] == second) {
+                result.push_back(merged);
+                ++i; // skip next
+            } else {
+                result.push_back(std::move(tokens[i]));
+            }
+        }
+        return result;
+    }
+
+    // Optimized: merge ALL occurrences of the best pair per pass.
+    std::vector<std::string> apply_merges(std::vector<std::string> tokens) const {
+        if (tokens.size() <= 1)
+            return tokens;
+
+        while (true) {
+            auto best = find_best_merge(tokens);
+            if (best.rank == INT_MAX)
+                break;
+            tokens = merge_all_pairs(std::move(tokens), best.first, best.second);
+            if (tokens.size() <= 1)
+                break;
+        }
+
+        return tokens;
+    }
+
+    // ─── JSON parsing helpers ───
+
+    static bool is_eos_content(const std::string& s) {
+        return s == "<|endoftext|>" || s == "</s>" || s == "<|end_of_text|>";
+    }
+
+    void parse_vocab(const nlohmann::json& j) {
+        auto& vocab_obj = j["model"]["vocab"];
+        size_t vocab_size = vocab_obj.size();
+        mVocab.resize(vocab_size);
+
+        for (auto& [token, id] : vocab_obj.items()) {
+            int32_t token_id = id.get<int32_t>();
+            if (token_id >= 0 && token_id < static_cast<int32_t>(vocab_size)) {
+                mVocab[token_id] = token;
+                mTokenToId[token] = token_id;
+            }
+        }
+    }
+
+    void parse_merges(const nlohmann::json& j) {
+        if (!j["model"].contains("merges"))
+            throw std::runtime_error("Invalid tokenizer.json: missing model.merges");
+
+        auto& merges_arr = j["model"]["merges"];
+        mMergeRank.reserve(merges_arr.size());
+
+        for (size_t i = 0; i < merges_arr.size(); ++i) {
+            std::string first, second;
+
+            if (merges_arr[i].is_array()) {
+                auto arr = merges_arr[i].get<std::vector<std::string>>();
+                if (arr.size() != 2)
+                    continue;
+                first = std::move(arr[0]);
+                second = std::move(arr[1]);
+            } else if (merges_arr[i].is_string()) {
+                std::string merge_str = merges_arr[i].get<std::string>();
+                auto space_pos = merge_str.find(' ');
+                if (space_pos == std::string::npos)
+                    continue;
+                first = merge_str.substr(0, space_pos);
+                second = merge_str.substr(space_pos + 1);
+            } else {
+                continue;
+            }
+
+            auto pair = std::make_pair(std::move(first), std::move(second));
+            mMergeRank[pair] = static_cast<int>(i);
+        }
+    }
+
+    void parse_added_tokens(const nlohmann::json& j) {
+        if (!j.contains("added_tokens"))
+            return;
+        for (auto& tok : j["added_tokens"]) {
+            std::string content = tok["content"].get<std::string>();
+            int32_t id = tok["id"].get<int32_t>();
+
+            if (id >= 0 && static_cast<size_t>(id) >= mVocab.size()) {
+                mVocab.resize(static_cast<size_t>(id) + 1);
+            }
+            if (id >= 0) {
+                mVocab[id] = content;
+                mTokenToId[content] = id;
+            }
+
+            if (tok.value("special", false)) {
+                mSpecialTokens[content] = id;
+                mSpecialIds.insert(id);
+                if (is_eos_content(content))
+                    mEosId = id;
+            }
+            // All added tokens (special and non-special) participate in pre-split
+            // matching during encode, matching HuggingFace's AddedToken behavior.
+            // The special flag only controls decode filtering (mSpecialIds) and
+            // post_processor BOS/EOS insertion.
+            mAddedTokenPatterns.push_back({content, id});
+        }
+        // Sort by length descending for longest-match-first
+        std::sort(mAddedTokenPatterns.begin(), mAddedTokenPatterns.end(),
+                  [](const auto& a, const auto& b) { return a.first.size() > b.first.size(); });
+    }
+
+    // Parse digit group size from regex pattern like \p{N}{1,3} → 3.
+    // Returns 0 if no digit grouping found (single digit or unlimited).
+    static int parse_digit_group(const std::string& regex) {
+        // Search for "\p{N}{" — the standalone grouped variant, not [^\p{N}]
+        auto pos = regex.find("\\p{N}{");
+        if (pos == std::string::npos)
+            return 0;
+        auto open = pos + 6; // after "\\p{N}{"
+        auto close = regex.find('}', open);
+        if (close == std::string::npos)
+            return 0;
+        auto comma = regex.find(',', open);
+        if (comma == std::string::npos || comma >= close)
+            return 0;
+        return std::stoi(regex.substr(comma + 1, close - comma - 1));
+    }
+
+    static bool is_clip_split_regex(const std::string& regex) {
+        const bool has_boundary_token = regex.find("startoftext") != std::string::npos ||
+                                        regex.find("endoftext") != std::string::npos;
+        return has_boundary_token && regex.find("\\p{L}") != std::string::npos &&
+               regex.find("\\p{N}") != std::string::npos;
+    }
+
+    static pretok::Variant classify_clip_split(const nlohmann::json& split) {
+        const auto behavior = split.value("behavior", "");
+        const bool invert = split.value("invert", false);
+        if (behavior == "Removed" && invert)
+            return pretok::Variant::kClip;
+        if (behavior == "Isolated" && invert)
+            return pretok::Variant::kSmolLM3;
+        throw std::runtime_error("Unsupported CLIP Split contract: behavior=" + behavior +
+                                 ", invert=" + (invert ? "true" : "false"));
+    }
+
+    static bool is_qwen3_split_regex(const std::string& regex) {
+        return regex.find("[^\r\n") != std::string::npos ||
+               regex.find("[^\\r\\n") != std::string::npos;
+    }
+
+    static bool is_bloom_split_regex(const std::string& regex) {
+        return regex.find("[^(\\s") != std::string::npos ||
+               regex.find("[^(\\\\s") != std::string::npos;
+    }
+
+    // Classify one Split pre-tokenizer from both its pattern and contract.
+    static pretok::Variant classify_split(const nlohmann::json& split, int& digit_group_out) {
+        const auto regex = split["pattern"]["Regex"].get<std::string>();
+        if (is_clip_split_regex(regex))
+            return classify_clip_split(split);
+        if (is_qwen3_split_regex(regex)) {
+            digit_group_out = parse_digit_group(regex);
+            return pretok::Variant::kQwen3;
+        }
+        if (is_bloom_split_regex(regex)) {
+            return pretok::Variant::kBloom;
+        }
+        if (regex.find("\\s?[A-Za-z") != std::string::npos) {
+            return pretok::Variant::kDeepSeek;
+        }
+        return pretok::Variant::kSmolLM3;
+    }
+
+    // Detect variant from the Split inside a Sequence pre_tokenizer.
+    static pretok::Variant detect_split_variant(const nlohmann::json& pt, int& digit_group_out) {
+        digit_group_out = 0;
+        if (!pt.contains("pretokenizers"))
+            return pretok::Variant::kSmolLM3;
+        for (auto& sub : pt["pretokenizers"]) {
+            if (sub.value("type", "") != "Split")
+                continue;
+            if (!sub.contains("pattern") || !sub["pattern"].contains("Regex"))
+                continue;
+            return classify_split(sub, digit_group_out);
+        }
+        return pretok::Variant::kSmolLM3;
+    }
+
+    static bool is_space_split_pre_tokenizer(const nlohmann::json& pt, const std::string& pt_type) {
+        if (pt_type != "Split")
+            return false;
+        if (!pt.contains("pattern") || !pt["pattern"].contains("String"))
+            return false;
+        return pt["pattern"]["String"].get<std::string>() == " ";
+    }
+
+    void detect_pre_tokenizer(const nlohmann::json& j) {
+        mUsePreTokenizer = true;
+        mPreTokenizerVariant = pretok::Variant::kSmolLM3;
+
+        if (!j.contains("pre_tokenizer") || j["pre_tokenizer"].is_null())
+            return;
+        auto& pt = j["pre_tokenizer"];
+        std::string pt_type = pt.value("type", "");
+
+        if (pt_type == "ByteLevel") {
+            mPreTokenizerVariant = pretok::Variant::kSmolLM3;
+        } else if (pt_type == "Sequence") {
+            int digit_group = 0;
+            mPreTokenizerVariant = detect_split_variant(pt, digit_group);
+            mPreTokenizerDigitGroup = digit_group;
+        } else if (is_space_split_pre_tokenizer(pt, pt_type)) {
+            // Gemma SentencePiece-BPE tokenizers use a direct Split(" ")
+            // pre-tokenizer with spaces already normalized to U+2581.
+            mUsePreTokenizer = false;
+        } else if (pt_type == "Metaspace") {
+            mIsMetaspace = true;
+            mUsePreTokenizer = false;
+        } else if (pt_type.empty()) {
+            mUsePreTokenizer = false;
+        } else {
+            throw std::runtime_error("Unsupported pre_tokenizer type: " + pt_type);
+        }
+    }
+
+    DecoderType classify_decoder_type(const nlohmann::json& j) const {
+        if (!j.contains("decoder") || j["decoder"].is_null()) {
+            return mIsMetaspace ? DecoderType::kMetaspace : DecoderType::kByteLevel;
+        }
+        std::string dt = j["decoder"].value("type", "");
+        if (dt == "ByteLevel")
+            return DecoderType::kByteLevel;
+        if (dt == "Metaspace")
+            return DecoderType::kMetaspace;
+        if (dt == "Sequence")
+            return DecoderType::kSequence;
+        return mIsMetaspace ? DecoderType::kMetaspace : DecoderType::kByteLevel;
+    }
+
+    void detect_decoder(const nlohmann::json& j) {
+        mDecoderType = classify_decoder_type(j);
+        if (mDecoderType == DecoderType::kSequence) {
+            parse_sequence_decoder(j["decoder"]);
+        }
+        // SentencePiece encode: vocab uses ▁ (U+2581) for spaces.
+        // Detect by: (1) ▁ in vocabulary, or (2) normalizer prepends ▁.
+        static const std::string spiece_marker = "\xe2\x96\x81"; // U+2581
+        mIsSentencePiece = mTokenToId.count(spiece_marker) > 0 || mSentencePiecePrependAlways;
+    }
+
+    void parse_seq_decoder_replace(const nlohmann::json& sub) {
+        SeqDecoderReplace rep;
+        if (sub.contains("pattern") && sub["pattern"].contains("String")) {
+            rep.pattern = sub["pattern"]["String"].get<std::string>();
+        }
+        rep.content = sub.value("content", "");
+        if (!rep.pattern.empty()) {
+            mSeqDecoderReplaces.push_back(std::move(rep));
+        }
+    }
+
+    void parse_sequence_decoder(const nlohmann::json& dec) {
+        if (!dec.contains("decoders"))
+            return;
+        for (auto& sub : dec["decoders"]) {
+            std::string sub_type = sub.value("type", "");
+            if (sub_type == "Replace") {
+                parse_seq_decoder_replace(sub);
+            } else if (sub_type == "ByteFallback") {
+                mSeqDecoderByteFallback = true;
+            } else if (sub_type == "Strip") {
+                if (sub.value("content", " ") == " " && sub.value("start", 0) > 0) {
+                    mSeqDecoderStripLeft = true;
+                }
+            }
+            // Fuse is implicit (tokens already joined)
+        }
+    }
+
+    static std::string optional_model_string(const nlohmann::json& model, const char* key) {
+        auto it = model.find(key);
+        if (it != model.end() && it->is_string())
+            return it->get<std::string>();
+        return {};
+    }
+
+    void parse_tokenizer_json(const char* json_data, std::size_t json_size) {
+        nlohmann::json j;
+        try {
+            j = nlohmann::json::parse(json_data, json_data + json_size);
+        } catch (const std::exception& e) {
+            throw std::runtime_error(std::string("Failed to parse tokenizer.json: ") + e.what());
+        }
+
+        if (!j.contains("model"))
+            throw std::runtime_error("Invalid tokenizer.json: missing model");
+        auto& model = j["model"];
+        if (!model.contains("vocab") || !model["vocab"].is_object())
+            throw std::runtime_error("Invalid tokenizer.json: model.vocab must be an object");
+        if (!model.contains("merges") || !model["merges"].is_array())
+            throw std::runtime_error("Invalid tokenizer.json: model.merges must be an array");
+
+        mByteFallback = model.value("byte_fallback", false);
+        mEndOfWordSuffix = optional_model_string(model, "end_of_word_suffix");
+        parse_vocab(j);
+        parse_merges(j);
+        parse_added_tokens(j);
+        parse_post_processor(j);
+        detect_normalizer(j);
+        detect_pre_tokenizer(j);
+        detect_decoder(j);
+    }
+
+    // Detect normalizer: check for Prepend (always prepend ▁) vs none
+    static bool normalizer_sequence_prepends(const nlohmann::json& norm,
+                                             const std::string& norm_type) {
+        if (norm_type != "Sequence" || !norm.contains("normalizers"))
+            return false;
+        for (auto& sub : norm["normalizers"]) {
+            if (sub.value("type", "") == "Prepend")
+                return true;
+        }
+        return false;
+    }
+
+    static bool normalizer_replaces_space_with_sentence_piece(const nlohmann::json& norm,
+                                                              const std::string& norm_type) {
+        if (norm_type == "Sequence" && norm.contains("normalizers")) {
+            for (const auto& sub : norm["normalizers"]) {
+                if (normalizer_replaces_space_with_sentence_piece(sub, sub.value("type", ""))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (norm_type != "Replace")
+            return false;
+        if (!norm.contains("pattern") || !norm["pattern"].contains("String"))
+            return false;
+        if (norm["pattern"]["String"].get<std::string>() != " ")
+            return false;
+        return norm.value("content", "") == "\xe2\x96\x81";
+    }
+
+    void detect_normalizer(const nlohmann::json& j) {
+        if (!j.contains("normalizer") || j["normalizer"].is_null())
+            return;
+        auto& norm = j["normalizer"];
+        std::string norm_type = norm.value("type", "");
+        detect_text_normalizers(norm);
+        if (normalizer_sequence_prepends(norm, norm_type)) {
+            mSentencePiecePrependAlways = true;
+        } else if (normalizer_replaces_space_with_sentence_piece(norm, norm_type)) {
+            // Gemma replaces spaces with ▁ but does not prepend ▁ to the
+            // first token. Preserve the old prepend-if-missing behavior for
+            // Metaspace-style SentencePiece models.
+            mSentencePiecePrependIfMissing = false;
+        }
+    }
+
+    void detect_text_normalizers(const nlohmann::json& normalizer) {
+        const std::string type = normalizer.value("type", "");
+        if (type == "Sequence" && normalizer.contains("normalizers")) {
+            for (const auto& child : normalizer["normalizers"]) {
+                detect_text_normalizers(child);
+            }
+            return;
+        }
+        if (type == "Lowercase") {
+            mNormalizeLowercase = true;
+            return;
+        }
+        if (type == "Replace" && normalizer.contains("pattern") &&
+            normalizer["pattern"].contains("Regex") &&
+            normalizer["pattern"]["Regex"].get<std::string>() == "\\s+" &&
+            normalizer.value("content", "") == " ") {
+            mNormalizeWhitespace = true;
+        }
+    }
+
+    // Parse post_processor to extract BOS/EOS tokens for add_special_tokens
+    void parse_post_processor(const nlohmann::json& j) {
+        if (!j.contains("post_processor") || j["post_processor"].is_null())
+            return;
+        auto& pp = j["post_processor"];
+        std::string pp_type = pp.value("type", "");
+
+        if (pp_type == "TemplateProcessing") {
+            parse_template_post_processor(pp);
+        } else if (pp_type == "Sequence") {
+            parse_sequence_post_processor(pp);
+        } else if (pp_type == "RobertaProcessing") {
+            parse_roberta_post_processor(pp);
+        }
+        // ByteLevel post_processor doesn't add tokens, nothing to do
+    }
+
+    // Iterate Sequence post_processor's processors array to find TemplateProcessing
+    void parse_sequence_post_processor(const nlohmann::json& pp) {
+        if (!pp.contains("processors"))
+            return;
+        for (auto& sub : pp["processors"]) {
+            if (sub.value("type", "") == "TemplateProcessing") {
+                parse_template_post_processor(sub);
+                return; // first TemplateProcessing wins
+            }
+        }
+    }
+
+    // RobertaProcessing: {"type":"RobertaProcessing","cls":["<s>",0],"sep":["</s>",2],...}
+    void parse_roberta_post_processor(const nlohmann::json& pp) {
+        if (pp.contains("cls") && pp["cls"].is_array() && pp["cls"].size() >= 2) {
+            int32_t cls_id = pp["cls"][1].get<int32_t>();
+            mPostBosIds.push_back(cls_id);
+        }
+        if (pp.contains("sep") && pp["sep"].is_array() && pp["sep"].size() >= 2) {
+            int32_t sep_id = pp["sep"][1].get<int32_t>();
+            mPostEosIds.push_back(sep_id);
+        }
+    }
+
+    int32_t resolve_special_token_id(const nlohmann::json& entry) const {
+        if (!entry.contains("SpecialToken"))
+            return -1;
+        std::string token_id = entry["SpecialToken"].value("id", "");
+        if (token_id.empty())
+            return -1;
+        auto it = mSpecialTokens.find(token_id);
+        return it != mSpecialTokens.end() ? it->second : -1;
+    }
+
+    void parse_template_post_processor(const nlohmann::json& pp) {
+        if (!pp.contains("single"))
+            return;
+        bool seen_sequence = false;
+        for (auto& entry : pp["single"]) {
+            if (entry.contains("Sequence")) {
+                seen_sequence = true;
+                continue;
+            }
+            int32_t id = resolve_special_token_id(entry);
+            if (id < 0)
+                continue;
+            if (seen_sequence) {
+                mPostEosIds.push_back(id);
+            } else {
+                mPostBosIds.push_back(id);
+            }
+        }
+    }
+
+    // ─── Data members ───
+
+    std::vector<std::string> mVocab;
+    std::unordered_map<std::string, int32_t> mTokenToId;
+
+    struct PairHash {
+        size_t operator()(const std::pair<std::string, std::string>& p) const {
+            size_t h1 = std::hash<std::string>{}(p.first);
+            size_t h2 = std::hash<std::string>{}(p.second);
+            return h1 ^ (h2 * 0x9e3779b97f4a7c15ULL + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+        }
+    };
+
+    std::unordered_map<std::pair<std::string, std::string>, int, PairHash> mMergeRank;
+
+    std::unordered_map<std::string, int32_t> mSpecialTokens;
+    std::unordered_set<int32_t> mSpecialIds; // O(1) lookup in decode()
+    int32_t mEosId = -1;
+
+    // Non-special added tokens: matched before pre-tokenization (longest first)
+    std::vector<std::pair<std::string, int32_t>> mAddedTokenPatterns;
+
+    bool mAddSpecialTokens = false;
+    bool mUsePreTokenizer = true;
+    bool mIsMetaspace = false; // Set by detect_pre_tokenizer.
+    bool mIsSentencePiece = false;
+    bool mSentencePiecePrependAlways =
+        false; // true for Normalizer Prepend, false for Metaspace first
+    bool mSentencePiecePrependIfMissing = true;
+    bool mByteFallback = false;
+    bool mNormalizeLowercase = false;
+    bool mNormalizeWhitespace = false;
+    std::string mEndOfWordSuffix;
+
+    // Post-processor: BOS/EOS token IDs to add when add_special_tokens=true
+    // Vectors to support multiple BOS/EOS tokens (e.g. GLM-4: [gMASK] + <sop>)
+    std::vector<int32_t> mPostBosIds;
+    std::vector<int32_t> mPostEosIds;
+    pretok::Variant mPreTokenizerVariant = pretok::Variant::kSmolLM3;
+    int mPreTokenizerDigitGroup = 0; // 0=unlimited, 3=\p{N}{1,3} (LLaMA 3.1/GLM-4)
+
+    DecoderType mDecoderType = DecoderType::kByteLevel;
+
+    // Sequence decoder config (parsed from tokenizer.json decoder field)
+    struct SeqDecoderReplace {
+        std::string pattern;
+        std::string content;
+    };
+    std::vector<SeqDecoderReplace> mSeqDecoderReplaces;
+    bool mSeqDecoderByteFallback = false;
+    bool mSeqDecoderStripLeft = false;
+};
+
+} // namespace
+
+std::unique_ptr<ITokenizer> CreateBpeTokenizer(const char* tokenizer_json_data,
+                                               std::size_t tokenizer_json_size,
+                                               bool add_special_tokens) {
+    return BpeTokenizer::Create(tokenizer_json_data, tokenizer_json_size, add_special_tokens);
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/bpe_tokenizer.cpp
+++ b/families/smollm3/runtime/bpe_tokenizer.cpp
@@ -209,9 +209,13 @@ inline bool is_digit(char32_t cp) {
 
 inline bool is_whitespace(char32_t cp) {
     return cp == ' ' || cp == '\t' || cp == '\n' || cp == '\r' || cp == 0x0B || cp == 0x0C // VT, FF
-           || cp == 0xA0                   // non-breaking space
-           || cp == 0x2000 || cp == 0x200A // en space through hair space
-           || cp == 0x3000;                // ideographic space
+           || cp == 0x85                     // next line
+           || cp == 0xA0                     // non-breaking space
+           || cp == 0x1680                   // Ogham space mark
+           || (cp >= 0x2000 && cp <= 0x200A) // en quad through hair space
+           || cp == 0x2028 || cp == 0x2029   // line/paragraph separator
+           || cp == 0x202F || cp == 0x205F   // narrow/medium mathematical space
+           || cp == 0x3000;                  // ideographic space
 }
 
 // BLOOM punctuation set: .,!?...

--- a/families/smollm3/runtime/chat_templates.cpp
+++ b/families/smollm3/runtime/chat_templates.cpp
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/chat_templates.h"
+
+#include <cstdio>
+#include <ctime>
+#include <string>
+
+namespace trtmc {
+namespace {
+
+std::string apply_chatml(const std::string& prompt, bool enable_thinking) {
+    std::string r = "<|im_start|>user\n" + prompt + "<|im_end|>\n<|im_start|>assistant\n";
+    if (!enable_thinking)
+        r += "<think>\n\n</think>\n\n";
+    return r;
+}
+
+std::string apply_mistral(const std::string& prompt, bool /*enable_thinking*/) {
+    return "[INST] " + prompt + " [/INST]";
+}
+
+std::string apply_phi(const std::string& prompt, bool /*enable_thinking*/) {
+    return "<|user|>\n" + prompt + "<|end|>\n<|assistant|>\n";
+}
+
+std::string apply_gemma(const std::string& prompt, bool /*enable_thinking*/) {
+    return "<start_of_turn>user\n" + prompt + "<end_of_turn>\n<start_of_turn>model\n";
+}
+
+std::string apply_llama3(const std::string& prompt, bool enable_thinking) {
+    std::string r = "<|begin_of_text|>";
+    if (!enable_thinking)
+        r += "<|start_header_id|>system<|end_header_id|>\n\ndetailed thinking off<|eot_id|>";
+    r += "<|start_header_id|>user<|end_header_id|>\n\n" + prompt +
+         "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n";
+    return r;
+}
+
+std::string apply_nemotron(const std::string& prompt, bool /*enable_thinking*/) {
+    return "<extra_id_0>System\n\n<extra_id_1>User\n" + prompt + "\n<extra_id_1>Assistant\n";
+}
+
+std::string apply_nemotron_h(const std::string& prompt, bool enable_thinking) {
+    std::string r =
+        "<SPECIAL_10>System\n\n<SPECIAL_11>User\n" + prompt + "\n<SPECIAL_11>Assistant\n";
+    r += enable_thinking ? "<think>\n" : "<think></think>";
+    return r;
+}
+
+// SmolLM3 always emits a system block, even when the caller supplies no system
+// message. The two Custom Instruction bodies below are the upstream defaults for
+// the two reasoning modes; reproducing them verbatim is what keeps the served
+// prompt identical to the Hugging Face chat template.
+constexpr char kSmollm3ThinkInstructions[] =
+    "You are a helpful AI assistant named SmolLM, trained by Hugging Face. Your role as an "
+    "assistant involves thoroughly exploring questions through a systematic thinking process "
+    "before providing the final precise and accurate solutions. This requires engaging in a "
+    "comprehensive cycle of analysis, summarizing, exploration, reassessment, reflection, "
+    "backtracking, and iteration to develop well-considered thinking process. Please structure "
+    "your response into two main sections: Thought and Solution using the specified format: "
+    "<think> Thought section </think> Solution section. In the Thought section, detail your "
+    "reasoning process in steps. Each step should include detailed considerations such as "
+    "analysing questions, summarizing relevant findings, brainstorming new ideas, verifying the "
+    "accuracy of the current steps, refining any errors, and revisiting previous steps. In the "
+    "Solution section, based on various attempts, explorations, and reflections from the Thought "
+    "section, systematically present the final solution that you deem correct. The Solution "
+    "section should be logical, accurate, and concise and detail necessary steps needed to reach "
+    "the conclusion.";
+constexpr char kSmollm3NoThinkInstructions[] =
+    "You are a helpful AI assistant named SmolLM, trained by Hugging Face.";
+
+std::string smollm3_today() {
+    return smollm3_format_date(std::time(nullptr));
+}
+
+std::string apply_smollm3(const std::string& prompt, bool enable_thinking,
+                          const std::string& today) {
+    const std::string mode = enable_thinking ? "/think" : "/no_think";
+    std::string r = "<|im_start|>system\n";
+    r += "## Metadata\n\n";
+    r += "Knowledge Cutoff Date: June 2025\n";
+    r += "Today Date: " + (today.empty() ? smollm3_today() : today) + "\n";
+    r += "Reasoning Mode: " + mode + "\n\n";
+    r += "## Custom Instructions\n\n";
+    r += enable_thinking ? kSmollm3ThinkInstructions : kSmollm3NoThinkInstructions;
+    r += "\n\n";
+    // Upstream does NOT close the system block with <|im_end|>: the instructions
+    // run straight into the user turn. Verified against apply_chat_template.
+    r += "<|im_start|>user\n" + prompt + "<|im_end|>\n";
+    r += "<|im_start|>assistant\n";
+    if (!enable_thinking)
+        r += "<think>\n\n</think>\n";
+    return r;
+}
+
+} // namespace
+
+std::string smollm3_format_date(std::time_t when) {
+    // Upstream renders strftime_now("%d %B %Y"), e.g. "04 September 2026". The
+    // month name comes from this table rather than from strftime's %B, which
+    // follows LC_TIME and yields a translated name under a non-English locale.
+    // The served prompt would then stop matching the reference for those users.
+    static constexpr const char* kMonths[] = {"January",   "February", "March",    "April",
+                                              "May",       "June",     "July",     "August",
+                                              "September", "October",  "November", "December"};
+
+    std::tm tm_utc{};
+#if defined(_WIN32)
+    gmtime_s(&tm_utc, &when);
+#else
+    gmtime_r(&when, &tm_utc);
+#endif
+    if (tm_utc.tm_mon < 0 || tm_utc.tm_mon > 11)
+        return {};
+
+    char buf[32];
+    const int written = std::snprintf(buf, sizeof(buf), "%02d %s %d", tm_utc.tm_mday,
+                                      kMonths[tm_utc.tm_mon], tm_utc.tm_year + 1900);
+    if (written <= 0 || static_cast<std::size_t>(written) >= sizeof(buf))
+        return {};
+    return std::string(buf);
+}
+
+std::string smollm3_detect_chat_template_format(const std::string& jinja_template) {
+    // Ordered marker table: the first row whose markers are all present wins.
+    // SmolLM3's template is ChatML-framed, so it is matched on its mandatory
+    // system block before the generic ChatML row below. A row's second marker
+    // is either an additional requirement (`require_both`) or an alternative.
+    struct Rule {
+        const char* first;
+        const char* second;
+        bool require_both;
+        const char* format;
+    };
+    static constexpr Rule kRules[] = {
+        {"<|im_start|>", "Reasoning Mode:", true, "smollm3"},
+        {"<|im_start|>", nullptr, false, "chatml"},
+        {"[INST]", nullptr, false, "mistral"},
+        {"<|user|>", "<|assistant|>", false, "phi"},
+        {"<start_of_turn>", nullptr, false, "gemma"},
+        {"<|start_header_id|>", nullptr, false, "llama3"},
+        {"<extra_id_0>", nullptr, false, "nemotron"},
+        {"<SPECIAL_10>", nullptr, false, "nemotron_h"},
+    };
+
+    for (const Rule& rule : kRules) {
+        const bool has_first = jinja_template.find(rule.first) != std::string::npos;
+        const bool has_second =
+            rule.second != nullptr && jinja_template.find(rule.second) != std::string::npos;
+        const bool matched =
+            rule.require_both ? (has_first && has_second) : (has_first || has_second);
+        if (matched)
+            return rule.format;
+    }
+    return {};
+}
+
+std::string smollm3_apply_chat_template(const std::string& format, const std::string& prompt,
+                                        bool enable_thinking, const std::string& today) {
+    if (format.empty())
+        return prompt;
+    if (format == "smollm3")
+        return apply_smollm3(prompt, enable_thinking, today);
+    if (format == "chatml")
+        return apply_chatml(prompt, enable_thinking);
+    if (format == "mistral")
+        return apply_mistral(prompt, enable_thinking);
+    if (format == "phi")
+        return apply_phi(prompt, enable_thinking);
+    if (format == "gemma")
+        return apply_gemma(prompt, enable_thinking);
+    if (format == "llama3")
+        return apply_llama3(prompt, enable_thinking);
+    if (format == "nemotron")
+        return apply_nemotron(prompt, enable_thinking);
+    if (format == "nemotron_h")
+        return apply_nemotron_h(prompt, enable_thinking);
+    return prompt;
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/chat_templates.h
+++ b/families/smollm3/runtime/chat_templates.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <ctime>
+#include <string>
+
+namespace trtmc {
+
+// Renders "%d <English month> %Y" for a UTC timestamp. The month name is not
+// taken from strftime's %B, which follows LC_TIME; taking the parameter keeps
+// the formatting testable on any calendar day.
+std::string smollm3_format_date(std::time_t when);
+std::string smollm3_detect_chat_template_format(const std::string& jinja_template);
+std::string smollm3_apply_chat_template(const std::string& format, const std::string& prompt,
+                                        bool enable_thinking = true, const std::string& today = {});
+
+} // namespace trtmc

--- a/families/smollm3/runtime/inference_state.h
+++ b/families/smollm3/runtime/inference_state.h
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// SmolLM3InferenceState: unified interface for autoregressive inference state.
+//
+// Both KV-cache attention state and recurrent state implementations expose
+// this interface. Pipelines and plugins program against it — never against
+// concrete state classes.
+//
+// The interface captures the lifecycle of per-sequence inference state:
+//   1. reset()        — prepare for a new sequence
+//   2. bind_to()      — bind state tensors to TRT engine I/O
+//   3. prepare_step() — write state-related inputs (mask, position) into TensorMap
+//   4. advance()      — update state after each decode step
+//   5. position()     — current sequence position
+//
+// Implementations:
+//   SmolLM3KvCache          — dense append-only (current default)
+//   Family-owned recurrent state — recurrent tensor state
+//   Family-owned hybrid state — SmolLM3KvCache + family-owned recurrent state composed
+//   (future: RingKvCache, PagedKvCache, MlaCache, SlidingWindowCache)
+
+#include "trtmc/runtime/tensor.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace trtmc {
+
+class ITrtModule;
+
+class SmolLM3InferenceState {
+  public:
+    virtual ~SmolLM3InferenceState() = default;
+
+    // --- Lifecycle ---
+
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
+    virtual void reset() = 0;
+
+    // Bind all state tensors to the given TRT module.
+    // Called once per sequence after reset(). The module reads/writes
+    // state tensors via the bound device pointers.
+    virtual void bind_to(ITrtModule& module) = 0;
+
+    // Write state-related inputs (mask, position, block table, etc.) into
+    // the TensorMap before engine.forward(). The state owns its buffers —
+    // Tensor.data pointers remain valid until the next prepare_step() call.
+    // Pipelines call this instead of manually constructing mask/position tensors.
+    virtual void prepare_step(TensorMap& inputs, int32_t seq_len = 1) = 0;
+
+    // Update state after one decode step. Copies "present" outputs
+    // into "cache" inputs, advances position.
+    // n_tokens: number of tokens processed in this step (default 1).
+    //           >1 for batched prefill / multi-token steps.
+    virtual void advance(int32_t n_tokens = 1) = 0;
+
+    // Provide the total prompt length before prefill starts.
+    // Cache policies that distinguish prompt and decode tokens can use this
+    // to protect prompt tokens even if compression triggers during prefill.
+    virtual void set_prompt_length(int32_t prompt_length) { (void)prompt_length; }
+
+    // Mark the transition from prompt prefill to autoregressive decoding.
+    // State types that do not distinguish the phases can ignore this.
+    virtual void mark_prefill_complete() {}
+
+    // --- Queries ---
+
+    // Current sequence position (0 = empty, increments with advance()).
+    virtual int32_t position() const = 0;
+
+    // Maximum sequence length this state can hold.
+    // -1 for unbounded (recurrent models with no cache length limit).
+    virtual int32_t max_length() const = 0;
+
+    // Number of transformer/SSM layers.
+    virtual int32_t num_layers() const = 0;
+
+    // Whether this state type needs an attention mask.
+    // SmolLM3KvCache -> true. Family-owned recurrent state -> false.
+    virtual bool needs_attention_mask() const = 0;
+
+    // Total device memory consumed by this state (bytes).
+    virtual std::size_t device_memory_bytes() const = 0;
+
+    // Human-readable state type for diagnostics.
+    virtual const char* state_type() const = 0;
+
+    // Whether all allocations succeeded.
+    virtual bool ok() const = 0;
+};
+
+} // namespace trtmc

--- a/families/smollm3/runtime/kv_cache.cpp
+++ b/families/smollm3/runtime/kv_cache.cpp
@@ -1,0 +1,529 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/kv_cache.h"
+
+#include "trtmc/runtime/trt_module.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+
+namespace trtmc {
+
+namespace {
+
+void validate_native_scalar_input(ITrtModule& module, const std::string& name) {
+    if (module.tensor_dtype(name) != DType::kInt32 ||
+        module.tensor_shape(name) != std::vector<int64_t>{1}) {
+        throw std::runtime_error("SmolLM3 native KV input '" + name + "' must be int32 [1]");
+    }
+}
+
+bool valid_native_cache_shape(const std::vector<int64_t>& shape, int32_t max_length,
+                              int32_t kv_dim) {
+    if (shape.size() != 4)
+        return false;
+    if (shape[0] != 1 || shape[2] != static_cast<int64_t>(max_length))
+        return false;
+    if (shape[1] <= 0 || shape[3] <= 0)
+        return false;
+    return shape[1] * shape[3] == kv_dim;
+}
+
+void validate_native_cache_pair(ITrtModule& module, const std::string& cache_name,
+                                const std::string& present_name, int32_t max_length, int32_t kv_dim,
+                                DType cache_dtype) {
+    if (!module.has_input(cache_name) || !module.has_output(present_name)) {
+        throw std::runtime_error("SmolLM3 native KV engine is missing cache/present pair '" +
+                                 cache_name + "'/'" + present_name + "'");
+    }
+    const auto cache_shape = module.tensor_shape(cache_name);
+    const auto present_shape = module.tensor_shape(present_name);
+    if (!valid_native_cache_shape(cache_shape, max_length, kv_dim) ||
+        present_shape != cache_shape) {
+        throw std::runtime_error("SmolLM3 native KV cache/present tensors must share static "
+                                 "[1,Hkv,max_length,D] shape");
+    }
+    if (module.tensor_dtype(cache_name) != cache_dtype ||
+        module.tensor_dtype(present_name) != cache_dtype) {
+        throw std::runtime_error("SmolLM3 native KV cache dtype does not match model precision");
+    }
+}
+
+bool all_tensors_ok(const std::vector<DeviceTensor>& tensors) {
+    for (const auto& tensor : tensors) {
+        if (!tensor.ok())
+            return false;
+    }
+    return true;
+}
+
+} // namespace
+
+SmolLM3KvCache::SmolLM3KvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim,
+                               cudaStream_t stream, DType cache_dtype, SmolLM3KvCacheNames names)
+    : num_layers_(num_layers), max_length_(max_length), kv_dim_(kv_dim), stream_(stream),
+      cache_dtype_(cache_dtype), cache_element_size_(dtype_size(cache_dtype)),
+      names_(std::move(names)) {
+
+    // If names were not supplied, generate standard defaults.
+    if (names_.cache_k.empty()) {
+        names_.cache_k.reserve(static_cast<std::size_t>(num_layers));
+        names_.cache_v.reserve(static_cast<std::size_t>(num_layers));
+        names_.present_k.reserve(static_cast<std::size_t>(num_layers));
+        names_.present_v.reserve(static_cast<std::size_t>(num_layers));
+        for (int32_t i = 0; i < num_layers; ++i) {
+            std::string suffix = "_" + std::to_string(i);
+            names_.cache_k.push_back("cache_k" + suffix);
+            names_.cache_v.push_back("cache_v" + suffix);
+            names_.present_k.push_back("present_k" + suffix);
+            names_.present_v.push_back("present_v" + suffix);
+        }
+    }
+    const auto expected_names = static_cast<std::size_t>(num_layers);
+    if (names_.cache_k.size() != expected_names || names_.cache_v.size() != expected_names ||
+        names_.present_k.size() != expected_names || names_.present_v.size() != expected_names) {
+        throw std::invalid_argument("SmolLM3KvCache: per-layer tensor name count mismatch");
+    }
+
+    cache_k_.reserve(static_cast<std::size_t>(num_layers));
+    cache_v_.reserve(static_cast<std::size_t>(num_layers));
+    present_k_.reserve(static_cast<std::size_t>(num_layers));
+    present_v_.reserve(static_cast<std::size_t>(num_layers));
+
+    for (int32_t i = 0; i < num_layers; ++i) {
+        cache_k_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
+        if (!cache_k_.back().ok())
+            return;
+        cache_v_.emplace_back(std::vector<int64_t>{max_length, kv_dim}, cache_dtype_, stream);
+        if (!cache_v_.back().ok())
+            return;
+    }
+
+    // Pre-allocate mask buffer: [max_length + 1] for dense causal mask.
+    mask_buf_.resize(static_cast<std::size_t>(max_length) + 1);
+
+    reset();
+}
+
+bool SmolLM3KvCache::configure_binding_mode(ITrtModule& module) {
+    const bool has_write_indices = module.has_input(names_.cache_write_indices);
+    const bool has_kv_lengths = module.has_input(names_.key_value_lengths);
+    if (has_write_indices != has_kv_lengths) {
+        throw std::runtime_error(
+            "SmolLM3 native KV engine must expose both cache_write_indices and "
+            "key_value_lengths");
+    }
+
+    const bool native_mode = has_write_indices && has_kv_lengths;
+    if (binding_mode_initialized_ && native_mode != native_kv_update_enabled_) {
+        throw std::runtime_error(
+            "SmolLM3 prefill and decode engines use incompatible KV cache contracts");
+    }
+    binding_mode_initialized_ = true;
+    native_kv_update_enabled_ = native_mode;
+    if (native_mode)
+        validate_native_kv_contract(module);
+    return native_mode;
+}
+
+void SmolLM3KvCache::validate_native_kv_contract(ITrtModule& module) const {
+    validate_native_scalar_input(module, names_.cache_write_indices);
+    validate_native_scalar_input(module, names_.key_value_lengths);
+
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        validate_native_cache_pair(module, names_.cache_k[li], names_.present_k[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+        validate_native_cache_pair(module, names_.cache_v[li], names_.present_v[li], max_length_,
+                                   kv_dim_, cache_dtype_);
+    }
+}
+
+void SmolLM3KvCache::ensure_standard_present_buffers() {
+    if (!present_k_.empty())
+        return;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        present_k_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        present_v_.emplace_back(std::vector<int64_t>{1, kv_dim_}, cache_dtype_, stream_);
+        if (!present_k_.back().ok() || !present_v_.back().ok()) {
+            throw std::runtime_error("SmolLM3 standard KV present-buffer allocation failed");
+        }
+    }
+}
+
+void SmolLM3KvCache::bind_native_cache(ITrtModule& module) {
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        module.bind_external(names_.cache_k[li], cache_k_[li].data());
+        module.bind_external(names_.cache_v[li], cache_v_[li].data());
+        if (module.device_ptr(names_.cache_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.present_k[li]) != cache_k_[li].data() ||
+            module.device_ptr(names_.cache_v[li]) != cache_v_[li].data() ||
+            module.device_ptr(names_.present_v[li]) != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "SmolLM3 native KV engine did not preserve cache/present aliasing");
+        }
+    }
+}
+
+void SmolLM3KvCache::validate_native_aliases(const std::vector<const void*>& present_k,
+                                             const std::vector<const void*>& present_v) const {
+    if (static_cast<int32_t>(present_k.size()) != num_layers_ ||
+        static_cast<int32_t>(present_v.size()) != num_layers_) {
+        throw std::runtime_error("SmolLM3 native KV per-layer pointer count mismatch");
+    }
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto li = static_cast<std::size_t>(i);
+        if (present_k[li] != cache_k_[li].data() || present_v[li] != cache_v_[li].data()) {
+            throw std::runtime_error(
+                "SmolLM3 native prefill present tensors must alias the KV cache");
+        }
+    }
+}
+
+void SmolLM3KvCache::write_native_kv_inputs(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len > max_length_ - position_) {
+        throw std::runtime_error("SmolLM3 sequence exceeds the model's fixed KV cache capacity");
+    }
+    cache_write_index_ = position_;
+    key_value_length_ = position_ + seq_len;
+    inputs[names_.cache_write_indices] = Tensor{&cache_write_index_, {1}, DType::kInt32};
+    inputs[names_.key_value_lengths] = Tensor{&key_value_length_, {1}, DType::kInt32};
+}
+
+// Masked score constant is model-local.
+static constexpr float kMaskedScore = -1.0e4F;
+
+void SmolLM3KvCache::write_position_input(TensorMap& inputs, int32_t seq_len) {
+    if (!has_position_input_)
+        return;
+    pos_buf_vec_.resize(static_cast<std::size_t>(seq_len));
+    for (int32_t i = 0; i < seq_len; ++i)
+        pos_buf_vec_[static_cast<std::size_t>(i)] = position_ + i;
+    Tensor pos_t;
+    pos_t.data = pos_buf_vec_.data();
+    pos_t.shape = {static_cast<int64_t>(seq_len)};
+    pos_t.dtype = DType::kInt32;
+    inputs[names_.position_id] = pos_t;
+}
+
+void SmolLM3KvCache::write_batched_mask(TensorMap& inputs, int32_t seq_len) {
+    // Batched prefill mask: (seq_len, max_length + seq_len). Columns
+    // [0, valid) are visible cache, [valid, max_length) are stale slots,
+    // [max_length, max_length+seq_len) are the new tokens — causal so
+    // token i sees tokens 0..i.
+    const int32_t valid = std::max(0, std::min(position_, max_length_));
+    const int32_t kv_len = max_length_ + seq_len;
+    const std::size_t total = static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(kv_len);
+    mask_buf_.assign(total, kMaskedScore);
+    for (int32_t i = 0; i < seq_len; ++i) {
+        const std::size_t row = static_cast<std::size_t>(i) * static_cast<std::size_t>(kv_len);
+        for (int32_t j = 0; j < valid; ++j)
+            mask_buf_[row + static_cast<std::size_t>(j)] = 0.0f;
+        for (int32_t j = 0; j <= i; ++j)
+            mask_buf_[row + static_cast<std::size_t>(max_length_) + static_cast<std::size_t>(j)] =
+                0.0f;
+    }
+    Tensor mask_t;
+    mask_t.data = mask_buf_.data();
+    mask_t.shape = {static_cast<int64_t>(seq_len), static_cast<int64_t>(kv_len)};
+    mask_t.dtype = DType::kFloat32;
+    inputs[names_.attention_mask] = mask_t;
+}
+
+void SmolLM3KvCache::write_bidirectional_mask(TensorMap& inputs, int32_t seq_len) {
+    // Diffusion block mask: all valid prefix cache rows are visible, stale cache
+    // rows are hidden, and every token in the current block can see every other
+    // token in the current block.
+    const int32_t valid = std::max(0, std::min(position_, max_length_));
+    const int32_t kv_len = max_length_ + seq_len;
+    const std::size_t total = static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(kv_len);
+    mask_buf_.assign(total, kMaskedScore);
+    for (int32_t i = 0; i < seq_len; ++i) {
+        const std::size_t row = static_cast<std::size_t>(i) * static_cast<std::size_t>(kv_len);
+        for (int32_t j = 0; j < valid; ++j)
+            mask_buf_[row + static_cast<std::size_t>(j)] = 0.0f;
+        for (int32_t j = 0; j < seq_len; ++j)
+            mask_buf_[row + static_cast<std::size_t>(max_length_) + static_cast<std::size_t>(j)] =
+                0.0f;
+    }
+    Tensor mask_t;
+    mask_t.data = mask_buf_.data();
+    mask_t.shape = {static_cast<int64_t>(seq_len), static_cast<int64_t>(kv_len)};
+    mask_t.dtype = DType::kFloat32;
+    inputs[names_.attention_mask] = mask_t;
+}
+
+void SmolLM3KvCache::write_decode_mask(TensorMap& inputs) {
+    if (bound_module_ == nullptr ||
+        (!dynamic_binding_enabled_ && bound_module_->tensor_shape(names_.attention_mask) !=
+                                          std::vector<int64_t>{1, max_length_ + 1})) {
+        throw std::runtime_error("SmolLM3 standard decoder has an invalid attention-mask contract");
+    }
+
+    const int32_t valid = std::max(0, std::min(position_, max_length_));
+    const int32_t mask_width = max_length_ + 1;
+    if (mask_buf_.size() != static_cast<std::size_t>(mask_width))
+        mask_buf_.resize(static_cast<std::size_t>(mask_width));
+    std::fill(mask_buf_.begin(), mask_buf_.end(), kMaskedScore);
+    for (int32_t i = 0; i < valid; ++i)
+        mask_buf_[static_cast<std::size_t>(i)] = 0.0F;
+    mask_buf_.back() = 0.0F;
+
+    Tensor mask_t;
+    mask_t.data = mask_buf_.data();
+    mask_t.shape = {1, mask_width};
+    mask_t.dtype = DType::kFloat32;
+    inputs[names_.attention_mask] = mask_t;
+}
+
+void SmolLM3KvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len <= 0)
+        seq_len = 1;
+    write_position_input(inputs, seq_len);
+    if (native_kv_update_enabled_) {
+        write_native_kv_inputs(inputs, seq_len);
+        return;
+    }
+    if (seq_len > 1)
+        write_batched_mask(inputs, seq_len);
+    else
+        write_decode_mask(inputs);
+}
+
+void SmolLM3KvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len <= 0)
+        seq_len = 1;
+    if (native_kv_update_enabled_) {
+        throw std::runtime_error("SmolLM3 native TensorRT KV cache supports causal attention only; "
+                                 "bidirectional block decoding is unsupported");
+    }
+    write_position_input(inputs, seq_len);
+    write_bidirectional_mask(inputs, seq_len);
+}
+
+void SmolLM3KvCache::bind_to(ITrtModule& module) {
+    bound_module_ = &module;
+    has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bind_native_cache(module);
+        return;
+    }
+
+    ensure_standard_present_buffers();
+    dynamic_binding_enabled_ = module.input_is_dynamic(names_.cache_k.front());
+    if (dynamic_binding_enabled_ && !module.input_is_dynamic(names_.attention_mask)) {
+        throw std::runtime_error(
+            "SmolLM3 runtime-sized KV engine must make cache and attention mask dynamic");
+    }
+    if (!dynamic_binding_enabled_ &&
+        module.tensor_shape(names_.attention_mask) != std::vector<int64_t>{1, max_length_ + 1}) {
+        throw std::runtime_error("SmolLM3 standard decoder has an invalid attention-mask contract");
+    }
+    const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
+    const std::vector<int64_t> present_shape{1, kv_dim_};
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto layer = static_cast<std::size_t>(i);
+        if (!module.has_input(names_.cache_k[layer]) || !module.has_input(names_.cache_v[layer]) ||
+            !module.has_output(names_.present_k[layer]) ||
+            !module.has_output(names_.present_v[layer]) ||
+            (!dynamic_binding_enabled_ &&
+             (module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
+              module.tensor_shape(names_.cache_v[layer]) != cache_shape)) ||
+            module.tensor_shape(names_.present_k[layer]) != present_shape ||
+            module.tensor_shape(names_.present_v[layer]) != present_shape) {
+            throw std::runtime_error("SmolLM3 standard decoder has an invalid KV contract");
+        }
+        if (dynamic_binding_enabled_) {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data(), cache_shape);
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data(), cache_shape);
+        } else {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        }
+        module.bind_external(names_.present_k[layer], present_k_[layer].data());
+        module.bind_external(names_.present_v[layer], present_v_[layer].data());
+    }
+}
+
+void SmolLM3KvCache::bind_cache_inputs(ITrtModule& module) {
+    bound_module_ = &module;
+    has_position_input_ = module.has_input(names_.position_id);
+    if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
+        bind_native_cache(module);
+        return;
+    }
+
+    dynamic_binding_enabled_ = module.input_is_dynamic(names_.cache_k.front());
+    if (dynamic_binding_enabled_ && !module.input_is_dynamic(names_.attention_mask)) {
+        throw std::runtime_error(
+            "SmolLM3 runtime-sized KV engine must make cache and attention mask dynamic");
+    }
+    const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        const auto layer = static_cast<std::size_t>(i);
+        if (!module.has_input(names_.cache_k[layer]) || !module.has_input(names_.cache_v[layer]) ||
+            (!dynamic_binding_enabled_ &&
+             (module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
+              module.tensor_shape(names_.cache_v[layer]) != cache_shape))) {
+            throw std::runtime_error("SmolLM3 standard prefill has an invalid KV contract");
+        }
+        if (dynamic_binding_enabled_) {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data(), cache_shape);
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data(), cache_shape);
+        } else {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        }
+    }
+}
+
+void SmolLM3KvCache::write_prefill_kv(const std::vector<const void*>& prefill_k,
+                                      const std::vector<const void*>& prefill_v, int32_t seq_len) {
+    if (seq_len <= 0)
+        return;
+    if (seq_len > max_length_)
+        throw std::runtime_error("SmolLM3KvCache::write_prefill_kv: seq_len exceeds max_length");
+    if (static_cast<int32_t>(prefill_k.size()) != num_layers_ ||
+        static_cast<int32_t>(prefill_v.size()) != num_layers_) {
+        throw std::runtime_error(
+            "SmolLM3KvCache::write_prefill_kv: per-layer pointer count mismatch");
+    }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ = seq_len;
+        return;
+    }
+    const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
+    const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        auto li = static_cast<std::size_t>(i);
+        cudaMemcpyAsync(cache_k_[li].data(), prefill_k[li], block_bytes, cudaMemcpyDeviceToDevice,
+                        stream_);
+        cudaMemcpyAsync(cache_v_[li].data(), prefill_v[li], block_bytes, cudaMemcpyDeviceToDevice,
+                        stream_);
+    }
+    position_ = seq_len;
+}
+
+void SmolLM3KvCache::append_prefill_kv(const std::vector<const void*>& prefill_k,
+                                       const std::vector<const void*>& prefill_v, int32_t seq_len) {
+    if (seq_len <= 0)
+        return;
+    if (position_ + seq_len > max_length_)
+        throw std::runtime_error("SmolLM3KvCache::append_prefill_kv: append exceeds max_length");
+    if (static_cast<int32_t>(prefill_k.size()) != num_layers_ ||
+        static_cast<int32_t>(prefill_v.size()) != num_layers_) {
+        throw std::runtime_error(
+            "SmolLM3KvCache::append_prefill_kv: per-layer pointer count mismatch");
+    }
+    if (native_kv_update_enabled_) {
+        validate_native_aliases(prefill_k, prefill_v);
+        position_ += seq_len;
+        return;
+    }
+    const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
+    const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
+    const auto offset = static_cast<std::size_t>(position_) * row_bytes;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        auto li = static_cast<std::size_t>(i);
+        cudaMemcpyAsync(static_cast<uint8_t*>(cache_k_[li].data()) + offset, prefill_k[li],
+                        block_bytes, cudaMemcpyDeviceToDevice, stream_);
+        cudaMemcpyAsync(static_cast<uint8_t*>(cache_v_[li].data()) + offset, prefill_v[li],
+                        block_bytes, cudaMemcpyDeviceToDevice, stream_);
+    }
+    position_ += seq_len;
+}
+
+void SmolLM3KvCache::set_position(int32_t position) {
+    position_ = std::max(0, std::min(position, max_length_));
+}
+
+void SmolLM3KvCache::advance(int32_t n_tokens) {
+    // For now, only single-token advance is supported.
+    // n_tokens > 1 reserved for future batched prefill (TASK-10).
+    assert(n_tokens == 1 && "SmolLM3KvCache::advance: only n_tokens==1 supported");
+    (void)n_tokens;
+
+    if (native_kv_update_enabled_) {
+        if (position_ >= max_length_) {
+            throw std::runtime_error(
+                "SmolLM3 sequence exceeds the model's fixed KV cache capacity");
+        }
+        ++position_;
+        return;
+    }
+
+    // Copy present K/V (single row) into cache at current position.
+    // present_k_[layer] is [1, kv_dim] → copy to cache_k_[layer][position_, :]
+    auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
+
+    if (position_ < max_length_) {
+        // Normal append: write to position_ slot
+        auto offset = static_cast<std::size_t>(position_) * row_bytes;
+        for (int32_t i = 0; i < num_layers_; ++i) {
+            auto li = static_cast<std::size_t>(i);
+            cudaMemcpyAsync(static_cast<uint8_t*>(cache_k_[li].data()) + offset,
+                            present_k_[li].data(), row_bytes, cudaMemcpyDeviceToDevice, stream_);
+            cudaMemcpyAsync(static_cast<uint8_t*>(cache_v_[li].data()) + offset,
+                            present_v_[li].data(), row_bytes, cudaMemcpyDeviceToDevice, stream_);
+        }
+        ++position_;
+    } else {
+        // Cache full: shift [1..max) → [0..max-1), then write at tail
+        auto shift_bytes = static_cast<std::size_t>(max_length_ - 1) * row_bytes;
+        auto tail_offset = shift_bytes;
+        for (int32_t i = 0; i < num_layers_; ++i) {
+            auto li = static_cast<std::size_t>(i);
+            auto* ck = static_cast<uint8_t*>(cache_k_[li].data());
+            auto* cv = static_cast<uint8_t*>(cache_v_[li].data());
+            cudaMemcpyAsync(ck, ck + row_bytes, shift_bytes, cudaMemcpyDeviceToDevice, stream_);
+            cudaMemcpyAsync(cv, cv + row_bytes, shift_bytes, cudaMemcpyDeviceToDevice, stream_);
+            cudaMemcpyAsync(ck + tail_offset, present_k_[li].data(), row_bytes,
+                            cudaMemcpyDeviceToDevice, stream_);
+            cudaMemcpyAsync(cv + tail_offset, present_v_[li].data(), row_bytes,
+                            cudaMemcpyDeviceToDevice, stream_);
+        }
+        // position_ stays at max_length_ (cache is full, all slots visible)
+    }
+}
+
+void SmolLM3KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
+    position_ = 0;
+    cache_write_index_ = 0;
+    key_value_length_ = 0;
+}
+
+std::size_t SmolLM3KvCache::device_memory_bytes() const {
+    std::size_t total = 0;
+    for (const auto& t : cache_k_)
+        total += t.nbytes();
+    for (const auto& t : cache_v_)
+        total += t.nbytes();
+    for (const auto& t : present_k_)
+        total += t.nbytes();
+    for (const auto& t : present_v_)
+        total += t.nbytes();
+    return total;
+}
+
+bool SmolLM3KvCache::ok() const {
+    const auto expected_layers = static_cast<std::size_t>(num_layers_);
+    if (cache_k_.size() != expected_layers)
+        return false;
+    if (cache_v_.size() != expected_layers)
+        return false;
+    return all_tensors_ok(cache_k_) && all_tensors_ok(cache_v_) && all_tensors_ok(present_k_) &&
+           all_tensors_ok(present_v_);
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/kv_cache.cpp
+++ b/families/smollm3/runtime/kv_cache.cpp
@@ -484,8 +484,15 @@ void SmolLM3KvCache::advance(int32_t n_tokens) {
             auto li = static_cast<std::size_t>(i);
             auto* ck = static_cast<uint8_t*>(cache_k_[li].data());
             auto* cv = static_cast<uint8_t*>(cache_v_[li].data());
-            cudaMemcpyAsync(ck, ck + row_bytes, shift_bytes, cudaMemcpyDeviceToDevice, stream_);
-            cudaMemcpyAsync(cv, cv + row_bytes, shift_bytes, cudaMemcpyDeviceToDevice, stream_);
+            // CUDA memcpy does not permit overlapping ranges. Shift toward the
+            // front one row at a time so every individual copy is disjoint;
+            // stream ordering preserves the original source rows.
+            for (int32_t row = 0; row + 1 < max_length_; ++row) {
+                const auto dst = static_cast<std::size_t>(row) * row_bytes;
+                const auto src = dst + row_bytes;
+                cudaMemcpyAsync(ck + dst, ck + src, row_bytes, cudaMemcpyDeviceToDevice, stream_);
+                cudaMemcpyAsync(cv + dst, cv + src, row_bytes, cudaMemcpyDeviceToDevice, stream_);
+            }
             cudaMemcpyAsync(ck + tail_offset, present_k_[li].data(), row_bytes,
                             cudaMemcpyDeviceToDevice, stream_);
             cudaMemcpyAsync(cv + tail_offset, present_v_[li].data(), row_bytes,

--- a/families/smollm3/runtime/kv_cache.h
+++ b/families/smollm3/runtime/kv_cache.h
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// SmolLM3KvCache: autoregressive KV cache state manager.
+// HF equivalent: DynamicCache / past_key_values.
+//
+// Manages per-layer K/V device tensors and position tracking. Native TensorRT
+// KV engines update these buffers in place; standard engines use present rows
+// plus an attention mask.
+
+#include "families/smollm3/runtime/inference_state.h"
+#include "trtmc/runtime/device_tensor.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class ITrtModule;
+
+// Explicit tensor names for KV cache I/O binding.
+// Per-layer vectors hold expanded names; scalar names are for single inputs.
+struct SmolLM3KvCacheNames {
+    std::vector<std::string> cache_k;
+    std::vector<std::string> cache_v;
+    std::vector<std::string> present_k;
+    std::vector<std::string> present_v;
+    std::string cache_write_indices{"cache_write_indices"};
+    std::string key_value_lengths{"key_value_lengths"};
+    std::string position_id{"position_id"};
+    std::string attention_mask{"attention_mask"};
+};
+
+class SmolLM3KvCache : public SmolLM3InferenceState {
+  public:
+    // Allocate cache buffers for the given configuration.
+    // kv_dim = num_kv_heads * head_dim (size of one K or V row per layer).
+    // cache_dtype controls the element type for K/V cache buffers (default FP32).
+    // names provides explicit tensor names for engine I/O binding.
+    SmolLM3KvCache(int32_t num_layers, int32_t max_length, int32_t kv_dim, cudaStream_t stream,
+                   DType cache_dtype = DType::kFloat32, SmolLM3KvCacheNames names = {});
+
+    // --- SmolLM3InferenceState overrides ---
+    void reset() override;
+    void bind_to(ITrtModule& module) override;
+    void prepare_step(TensorMap& inputs, int32_t seq_len = 1) override;
+    void advance(int32_t n_tokens = 1) override;
+    int32_t position() const override { return position_; }
+    int32_t max_length() const override { return max_length_; }
+    int32_t num_layers() const override { return num_layers_; }
+    bool needs_attention_mask() const override { return !native_kv_update_enabled_; }
+    std::size_t device_memory_bytes() const override;
+    const char* state_type() const override { return "dense_kv_cache"; }
+    bool ok() const override;
+
+    // --- SmolLM3KvCache-specific methods (not on the interface) ---
+
+    // Direct access for advanced use (cross-attention, VL embedding).
+    DeviceTensor& cache_k(int32_t layer) { return cache_k_[static_cast<std::size_t>(layer)]; }
+    DeviceTensor& cache_v(int32_t layer) { return cache_v_[static_cast<std::size_t>(layer)]; }
+
+    // Complete a batched prefill and advance position_ to seq_len. Native
+    // TensorRT KV engines have already updated the aliased cache in place;
+    // standard engines copy their per-layer outputs into the cache.
+    void write_prefill_kv(const std::vector<const void*>& prefill_k,
+                          const std::vector<const void*>& prefill_v, int32_t seq_len);
+
+    // Prepare a multi-token block whose new tokens may attend bidirectionally
+    // to one another while still seeing the valid prefix cache.
+    void prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len);
+
+    // Append batched present K/V at the current position. Used after causal
+    // block verification in diffusion-style text decoders.
+    void append_prefill_kv(const std::vector<const void*>& prefill_k,
+                           const std::vector<const void*>& prefill_v, int32_t seq_len);
+
+    // Move the logical cache length without touching device memory. Stale rows
+    // remain masked out by subsequent prepare_step calls.
+    void set_position(int32_t position);
+
+    // Bind prefill KV tensors. Native TensorRT engines bind cache and present
+    // to the same full-capacity storage; standard engines bind cache inputs only.
+    void bind_cache_inputs(ITrtModule& module);
+
+  private:
+    bool configure_binding_mode(ITrtModule& module);
+    void validate_native_kv_contract(ITrtModule& module) const;
+    void validate_native_aliases(const std::vector<const void*>& present_k,
+                                 const std::vector<const void*>& present_v) const;
+    void ensure_standard_present_buffers();
+    void bind_native_cache(ITrtModule& module);
+    void write_native_kv_inputs(TensorMap& inputs, int32_t seq_len);
+    void write_position_input(TensorMap& inputs, int32_t seq_len);
+    void write_batched_mask(TensorMap& inputs, int32_t seq_len);
+    void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
+    void write_decode_mask(TensorMap& inputs);
+
+    std::vector<DeviceTensor> cache_k_; // [num_layers], shape [max_length, kv_dim]
+    std::vector<DeviceTensor> cache_v_; // [num_layers]
+    // Standard-only single-step outputs, allocated lazily when a standard engine is bound.
+    std::vector<DeviceTensor> present_k_;
+    std::vector<DeviceTensor> present_v_;
+    int32_t num_layers_{0};
+    int32_t max_length_{0};
+    int32_t kv_dim_{0};
+    int32_t position_{0};
+    cudaStream_t stream_{nullptr};
+    // Buffers owned by this object — Tensor.data in prepare_step() points here.
+    std::vector<float> mask_buf_;
+    std::vector<int32_t> pos_buf_vec_;
+    int32_t cache_write_index_{0};
+    int32_t key_value_length_{0};
+    bool has_position_input_{false};
+    bool binding_mode_initialized_{false};
+    bool native_kv_update_enabled_{false};
+    bool dynamic_binding_enabled_{false};
+    DType cache_dtype_{DType::kFloat32};
+    std::size_t cache_element_size_{sizeof(float)};
+    SmolLM3KvCacheNames names_;
+    ITrtModule* bound_module_{nullptr};
+};
+
+} // namespace trtmc

--- a/families/smollm3/runtime/pipeline.cpp
+++ b/families/smollm3/runtime/pipeline.cpp
@@ -1,0 +1,405 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/pipeline.h"
+
+#include "families/smollm3/runtime/chat_templates.h"
+#include "families/smollm3/runtime/kv_cache.h"
+#include "families/smollm3/runtime/tensor_names.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc {
+
+namespace {
+
+bool contains_boxed_answer(const std::string& text) {
+    const std::string marker = "\\boxed{";
+    const auto start = text.find(marker);
+    if (start == std::string::npos)
+        return false;
+    return text.find('}', start + marker.size()) != std::string::npos;
+}
+
+bool contains_final_answer(const std::string& text) {
+    const std::string marker = "Final answer:";
+    const auto start = text.find(marker);
+    if (start == std::string::npos)
+        return false;
+    for (std::size_t i = start + marker.size(); i < text.size(); ++i) {
+        if (!std::isspace(static_cast<unsigned char>(text[i])))
+            return true;
+    }
+    return false;
+}
+
+SmolLM3TextGenConfig normalize_eos_token_ids(SmolLM3TextGenConfig config) {
+    if (config.id_eos_ids.empty() && config.id_eos >= 0)
+        config.id_eos_ids.push_back(config.id_eos);
+    if (!config.id_eos_ids.empty())
+        config.id_eos = config.id_eos_ids.front();
+    return config;
+}
+
+std::string normalize_generation_mode(std::string mode) {
+    std::transform(mode.begin(), mode.end(), mode.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    std::replace(mode.begin(), mode.end(), '-', '_');
+    return mode;
+}
+
+} // namespace
+
+SmolLM3TextGenerationPipeline::SmolLM3TextGenerationPipeline(
+    std::unique_ptr<ITrtModule> decoder, std::unique_ptr<SmolLM3InferenceState> state,
+    SmolLM3TextGenConfig config, std::shared_ptr<ITokenizer> tokenizer,
+    std::unique_ptr<ITrtModule> prefill, std::shared_ptr<void> distributed_owner)
+    : distributed_owner_(std::move(distributed_owner)), decoder_(std::move(decoder)),
+      prefill_(std::move(prefill)), state_(std::move(state)),
+      config_(normalize_eos_token_ids(std::move(config))), tokenizer_(std::move(tokenizer)),
+      logits_output_name_(config_.logits_output_name) {
+    if (!decoder_ || !decoder_->ok())
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid decoder module");
+    if (!prefill_ || !prefill_->ok())
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid prefill module");
+    if (!tokenizer_)
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid tokenizer");
+    if (!state_ || !state_->ok()) {
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid inference state");
+    }
+
+    decoder_->enable_cuda_graph();
+}
+
+// Encode a prompt, optionally applying a chat template first.
+// Deduplicates the leading BOS token that chat templates embed but
+// the tokenizer's add_special_tokens may also prepend.
+static std::vector<int32_t> encode_prompt(const ITokenizer& tokenizer,
+                                          const SmolLM3TextGenConfig& config,
+                                          const std::string& prompt,
+                                          const TextGenerationConfig& cfg) {
+    std::string effective = prompt;
+    bool templated = false;
+    if (cfg.use_chat_template && !config.chat_template_format.empty()) {
+        effective =
+            smollm3_apply_chat_template(config.chat_template_format, prompt, cfg.enable_thinking);
+        templated = true;
+    }
+    auto ids = tokenizer.encode(effective);
+    if (templated && ids.size() >= 2 && config.id_bos >= 0 && ids[0] == config.id_bos &&
+        ids[1] == config.id_bos) {
+        ids.erase(ids.begin());
+    }
+    return ids;
+}
+
+TextResult SmolLM3TextGenerationPipeline::generate(const std::string& prompt,
+                                                   const TextGenerationConfig& cfg) {
+
+    auto input_ids = encode_prompt(*tokenizer_, config_, prompt, cfg);
+    int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
+    auto sp = smollm3_sampling_params_from_config(cfg, config_.id_eos_ids);
+    last_setup_ms_ = 0.0;
+    auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
+
+    // Decode only the NEW tokens (skip input)
+    std::vector<int32_t> new_tokens(timed.token_ids.begin() +
+                                        static_cast<std::ptrdiff_t>(input_ids.size()),
+                                    timed.token_ids.end());
+    std::string text = tokenizer_->decode(new_tokens);
+
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
+}
+
+SmolLM3TextGenerationPipeline::GenerationResult
+SmolLM3TextGenerationPipeline::generate_ids(const std::vector<int32_t>& input_ids,
+                                            const TextGenerationConfig& cfg) {
+    int32_t max_new = cfg.max_new_tokens; // honour exact value (0 = no generation)
+    auto sp = smollm3_sampling_params_from_config(cfg, config_.id_eos_ids);
+    return GenerationResult{generate_from_ids(input_ids, max_new, sp, cfg).token_ids};
+}
+
+namespace {
+
+void require_prefill_kv_pointers(ITrtModule& prefill, const SmolLM3TextGenConfig& cfg,
+                                 std::vector<const void*>& pk, std::vector<const void*>& pv) {
+    pk.resize(static_cast<std::size_t>(cfg.num_layers));
+    pv.resize(static_cast<std::size_t>(cfg.num_layers));
+    for (int32_t layer = 0; layer < cfg.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        pk[index] = prefill.device_ptr(smollm3_expand_layer_name(cfg.present_k_pattern, layer));
+        pv[index] = prefill.device_ptr(smollm3_expand_layer_name(cfg.present_v_pattern, layer));
+        if (pk[index] == nullptr || pv[index] == nullptr) {
+            throw std::runtime_error(
+                "SmolLM3TextGenerationPipeline: prefill module is missing K/V output for layer " +
+                std::to_string(layer));
+        }
+    }
+}
+
+void require_batched_prefill_contract(ITrtModule& prefill, const SmolLM3TextGenConfig& cfg,
+                                      int32_t sq, SmolLM3InferenceState* state) {
+    if (!prefill.ok())
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid prefill module");
+    if (sq <= 0)
+        throw std::runtime_error(
+            "SmolLM3TextGenerationPipeline: prefill requires a non-empty prompt");
+    if (cfg.prefill_max_length <= 0 || cfg.num_layers <= 0 || cfg.vocab_size <= 0)
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: invalid prefill configuration");
+    auto* kv = dynamic_cast<SmolLM3KvCache*>(state);
+    if (kv == nullptr)
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: prefill requires SmolLM3KvCache");
+}
+
+int32_t resolve_prefill_chunk_limit(const SmolLM3TextGenConfig& cfg) {
+    if (cfg.prefill_max_length <= 0)
+        throw std::runtime_error("SmolLM3 prefill engine has no valid profile capacity");
+    return cfg.prefill_max_length;
+}
+
+void validate_generation_capacity(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+                                  SmolLM3InferenceState* state) {
+    const auto* kv = dynamic_cast<const SmolLM3KvCache*>(state);
+    if (kv == nullptr)
+        throw std::runtime_error("SmolLM3 generation requires SmolLM3KvCache");
+
+    const auto capacity = static_cast<std::size_t>(kv->max_length());
+    if (input_ids.size() > capacity ||
+        (max_new_tokens > 0 &&
+         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size())) {
+        throw std::runtime_error(
+            "SmolLM3 requested prompt and generation exceed the model's fixed KV cache capacity");
+    }
+}
+} // namespace
+
+void SmolLM3TextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& input_ids,
+                                                        std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    require_batched_prefill_contract(*prefill_, config_, sq, state_.get());
+    auto* kv = static_cast<SmolLM3KvCache*>(state_.get());
+
+    // The prefill module shares the same external KV cache buffers as the
+    // decode module(s), so we rebind the cache_k/cache_v inputs onto the
+    // prefill execution context before running.
+    kv->bind_cache_inputs(*prefill_);
+    if (sq > kv->max_length()) {
+        throw std::runtime_error("SmolLM3 sequence exceeds the model's fixed KV cache capacity");
+    }
+
+    std::vector<const void*> pk, pv;
+    require_prefill_kv_pointers(*prefill_, config_, pk, pv);
+
+    const int32_t chunk_limit = resolve_prefill_chunk_limit(config_);
+    int32_t launches = 0;
+    int32_t max_chunk = 0;
+    for (int32_t start = 0; start < sq;) {
+        const int32_t chunk_size = std::min(chunk_limit, sq - start);
+        run_prefill_chunk(input_ids.data() + start, chunk_size, pk, pv, *kv, logits);
+        ++launches;
+        max_chunk = std::max(max_chunk, chunk_size);
+        start += chunk_size;
+    }
+    std::cerr << "[trtmc.prefill] tokens=" << sq << " launches=" << launches
+              << " max_chunk=" << max_chunk << '\n';
+}
+
+void SmolLM3TextGenerationPipeline::run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                                                      const std::vector<const void*>& present_k,
+                                                      const std::vector<const void*>& present_v,
+                                                      SmolLM3KvCache& kv,
+                                                      std::vector<float>& logits) {
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = const_cast<int32_t*>(token_ids);
+    token_tensor.shape = {static_cast<int64_t>(chunk_size)};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+    state_->prepare_step(inputs, chunk_size);
+
+    TensorMap outputs = prefill_->forward(inputs);
+    const auto logits_it = outputs.find(config_.logits_output_name);
+    if (logits_it == outputs.end()) {
+        throw std::runtime_error(
+            "SmolLM3TextGenerationPipeline: prefill module has no logits output");
+    }
+
+    const auto& logits_tensor = logits_it->second;
+    const auto vocab = static_cast<std::size_t>(config_.vocab_size);
+    if (static_cast<std::size_t>(logits_tensor.numel()) < vocab) {
+        throw std::runtime_error(
+            "SmolLM3TextGenerationPipeline: prefill logits are smaller than vocabulary");
+    }
+
+    logits.resize(vocab);
+    const auto logits_offset = static_cast<std::size_t>(logits_tensor.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(logits_tensor.data) + logits_offset,
+                vocab * sizeof(float));
+    kv.append_prefill_kv(present_k, present_v, chunk_size);
+}
+
+void SmolLM3TextGenerationPipeline::prime_decoder_after_batched_prefill(
+    const std::vector<int32_t>& input_ids) {
+    if (input_ids.empty())
+        return;
+
+    ITrtModule& decoder = bind_decoder_for_step();
+    if (!decoder.cuda_graph_active())
+        return;
+
+    int32_t token_id = input_ids.back();
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = &token_id;
+    token_tensor.shape = {1};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+
+    state_->prepare_step(inputs);
+    decoder.forward_async(inputs);
+    decoder.sync();
+}
+
+void SmolLM3TextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
+                                                std::vector<float>& logits) {
+    run_prefill_batched(input_ids, logits);
+    prime_decoder_after_batched_prefill(input_ids);
+    state_->mark_prefill_complete();
+}
+
+std::string
+SmolLM3TextGenerationPipeline::resolve_generation_mode(const TextGenerationConfig& cfg) const {
+    std::string mode = normalize_generation_mode(cfg.text_generation_mode);
+    if (mode.empty() || mode == "auto" || mode == "autoregressive")
+        return "ar";
+    return mode;
+}
+
+void SmolLM3TextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
+    state_->reset();
+    state_bound_ = false;
+    decoder_->reset_execution_context();
+    prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+}
+
+SmolLM3TextGenerationPipeline::TimedGenResult SmolLM3TextGenerationPipeline::generate_from_ids(
+    const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+    const SmolLM3SamplingParams& params, const TextGenerationConfig& cfg) {
+    using Clock = std::chrono::steady_clock;
+    if (max_new_tokens == 0 || input_ids.empty())
+        return TimedGenResult{input_ids, 0.0, 0.0};
+    validate_generation_capacity(input_ids, max_new_tokens, state_.get());
+
+    const std::string mode = resolve_generation_mode(cfg);
+    if (mode != "ar")
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: unsupported generation mode '" +
+                                 mode + "'");
+    auto active_sampler = create_smollm3_sampler(params);
+    active_sampler->reset();
+
+    reset_generation_context();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+
+    std::vector<float> logits;
+    const auto t0 = Clock::now();
+    run_prefill(input_ids, logits);
+    const auto t1 = Clock::now();
+
+    std::vector<int32_t> output = input_ids;
+    run_decode_loop(active_sampler.get(), params, output, logits, max_new_tokens, cfg,
+                    static_cast<int32_t>(input_ids.size()));
+    const auto t2 = Clock::now();
+
+    const double prefill_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    const double decode_ms = std::chrono::duration<double, std::milli>(t2 - t1).count();
+    return TimedGenResult{std::move(output), prefill_ms, decode_ms};
+}
+
+bool SmolLM3TextGenerationPipeline::should_stop_on_answer(const std::vector<int32_t>& output,
+                                                          int32_t prompt_token_count,
+                                                          const TextGenerationConfig& cfg,
+                                                          int32_t steps, int32_t stop_interval,
+                                                          bool is_eos) const {
+    if (!cfg.stop_on_boxed_answer || !tokenizer_)
+        return false;
+    if ((steps % stop_interval) != 0 && !is_eos)
+        return false;
+    std::vector<int32_t> new_tokens(output.begin() + prompt_token_count, output.end());
+    const std::string decoded = tokenizer_->decode(new_tokens);
+    return contains_boxed_answer(decoded) || contains_final_answer(decoded);
+}
+
+int32_t SmolLM3TextGenerationPipeline::run_decode_loop(
+    SmolLM3ISampler* sampler, const SmolLM3SamplingParams& params, std::vector<int32_t>& output,
+    std::vector<float>& logits, int32_t max_new_tokens, const TextGenerationConfig& cfg,
+    int32_t prompt_token_count) {
+    const int32_t vocab_size = static_cast<int32_t>(logits.size());
+    const int32_t stop_interval = std::max(cfg.stop_check_interval, 1);
+    int32_t steps = 0;
+    for (int32_t step = 0; step < max_new_tokens; ++step) {
+        const SmolLM3SampleResult result = sampler->sample(logits.data(), vocab_size, params);
+        const bool is_eos = result.is_eos || smollm3_is_eos_token(params, result.token_id);
+        output.push_back(result.token_id);
+        ++steps;
+        if (should_stop_on_answer(output, prompt_token_count, cfg, steps, stop_interval, is_eos))
+            break;
+        if (is_eos)
+            break;
+        run_step(result.token_id, logits);
+    }
+    return steps;
+}
+
+ITrtModule& SmolLM3TextGenerationPipeline::bind_decoder_for_step() {
+    if (!state_bound_) {
+        state_->bind_to(*decoder_);
+        state_bound_ = true;
+    }
+    return *decoder_;
+}
+
+void SmolLM3TextGenerationPipeline::run_step(int32_t token_id, std::vector<float>& logits) {
+    TensorMap inputs;
+
+    Tensor token_tensor;
+    token_tensor.data = &token_id;
+    token_tensor.shape = {1};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+
+    ITrtModule& decoder = bind_decoder_for_step();
+    state_->prepare_step(inputs);
+
+    TensorMap outputs = decoder.forward(inputs);
+
+    auto it = outputs.find(logits_output_name_);
+    if (it == outputs.end()) {
+        throw std::runtime_error("SmolLM3TextGenerationPipeline: no '" + logits_output_name_ +
+                                 "' output");
+    }
+
+    const auto& logits_tensor = it->second;
+    auto num_logits = logits_tensor.numel();
+    logits.resize(static_cast<std::size_t>(num_logits));
+    std::memcpy(logits.data(), logits_tensor.data, num_logits * sizeof(float));
+
+    state_->advance();
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/pipeline.cpp
+++ b/families/smollm3/runtime/pipeline.cpp
@@ -396,12 +396,12 @@ void SmolLM3TextGenerationPipeline::run_step(int32_t token_id, std::vector<float
 
     const auto& logits_tensor = it->second;
     auto num_logits = logits_tensor.numel();
-    if (num_logits < config_.vocab_size) {
+    if (num_logits != config_.vocab_size) {
         throw std::runtime_error(
-            "SmolLM3TextGenerationPipeline: decoder logits are smaller than vocabulary");
+            "SmolLM3TextGenerationPipeline: decoder logits do not match vocabulary size");
     }
-    logits.resize(static_cast<std::size_t>(num_logits));
-    std::memcpy(logits.data(), logits_tensor.data, num_logits * sizeof(float));
+    logits.resize(static_cast<std::size_t>(config_.vocab_size));
+    std::memcpy(logits.data(), logits_tensor.data, logits.size() * sizeof(float));
 
     state_->advance();
 }

--- a/families/smollm3/runtime/pipeline.cpp
+++ b/families/smollm3/runtime/pipeline.cpp
@@ -396,6 +396,10 @@ void SmolLM3TextGenerationPipeline::run_step(int32_t token_id, std::vector<float
 
     const auto& logits_tensor = it->second;
     auto num_logits = logits_tensor.numel();
+    if (num_logits < config_.vocab_size) {
+        throw std::runtime_error(
+            "SmolLM3TextGenerationPipeline: decoder logits are smaller than vocabulary");
+    }
     logits.resize(static_cast<std::size_t>(num_logits));
     std::memcpy(logits.data(), logits_tensor.data, num_logits * sizeof(float));
 

--- a/families/smollm3/runtime/pipeline.h
+++ b/families/smollm3/runtime/pipeline.h
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// Model-owned decoder text pipeline.
+//
+// Composes: ITrtModule (decoder) + SmolLM3KvCache + ITokenizer for this runtime
+// plugin. Architecture-specific behavior remains in this model directory and
+// in the TRT engine emitted by the matching family builder.
+
+#include "families/smollm3/runtime/inference_state.h"
+#include "families/smollm3/runtime/sampler.h"
+#include "families/smollm3/runtime/tokenizer.h"
+#include "trtmc/runtime/trt_module.h"
+#include "trtmc/task.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class SmolLM3KvCache;
+
+struct SmolLM3TextGenConfig {
+    int32_t vocab_size{0};
+    int32_t id_bos{0};
+    int32_t id_eos{0};
+    std::vector<int32_t> id_eos_ids;
+    std::string chat_template_format{};
+    std::string token_id_name{"token_id"};
+    std::string logits_output_name{"logits"};
+    // Required family-owned chunked prefill contract.
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
+    int32_t prefill_max_length{0};
+    int32_t num_layers{0};
+};
+
+class SmolLM3TextGenerationPipeline final : public ITextGeneration {
+  public:
+    SmolLM3TextGenerationPipeline(std::unique_ptr<ITrtModule> decoder,
+                                  std::unique_ptr<SmolLM3InferenceState> state,
+                                  SmolLM3TextGenConfig config,
+                                  std::shared_ptr<ITokenizer> tokenizer,
+                                  std::unique_ptr<ITrtModule> prefill,
+                                  std::shared_ptr<void> distributed_owner = nullptr);
+
+    // Public API: takes raw text, returns typed result.
+    TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
+    int32_t default_max_new_tokens() const override { return 128; }
+
+    // Token-ID-based generation (for unit tests and internal callers).
+    struct GenerationResult {
+        std::vector<int32_t> token_ids;
+    };
+    GenerationResult generate_ids(const std::vector<int32_t>& input_ids,
+                                  const TextGenerationConfig& cfg);
+
+  private:
+    // Kept before TRT modules so TP communicators outlive contexts/engines.
+    std::shared_ptr<void> distributed_owner_;
+    std::unique_ptr<ITrtModule> decoder_;
+    std::unique_ptr<ITrtModule> prefill_;
+    std::unique_ptr<SmolLM3InferenceState> state_;
+    SmolLM3TextGenConfig config_;
+    std::shared_ptr<ITokenizer> tokenizer_;
+    std::string logits_output_name_;
+    bool state_bound_{false};
+    double last_setup_ms_{0.0};
+
+    // Internal: generate from token IDs with sampling parameters and timing.
+    struct TimedGenResult {
+        std::vector<int32_t> token_ids;
+        double prefill_ms{0.0};
+        double decode_ms{0.0};
+    };
+    TimedGenResult generate_from_ids(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
+                                     const SmolLM3SamplingParams& params,
+                                     const TextGenerationConfig& cfg);
+    std::string resolve_generation_mode(const TextGenerationConfig& cfg) const;
+    void reset_generation_context();
+
+    // Run one decoder step: token_id → logits (D2H to host). Updates cache.
+    void run_step(int32_t token_id, std::vector<float>& logits);
+
+    // Decode loop (extracted for CCN).
+    int32_t run_decode_loop(SmolLM3ISampler* sampler, const SmolLM3SamplingParams& params,
+                            std::vector<int32_t>& output, std::vector<float>& logits,
+                            int32_t max_new_tokens, const TextGenerationConfig& cfg,
+                            int32_t prompt_token_count);
+    ITrtModule& bind_decoder_for_step();
+    void run_prefill(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    // Execute the required family-owned batched prefill engine.
+    void run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    void run_prefill_chunk(const int32_t* token_ids, int32_t chunk_size,
+                           const std::vector<const void*>& present_k,
+                           const std::vector<const void*>& present_v, SmolLM3KvCache& kv,
+                           std::vector<float>& logits);
+    void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
+    bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
+                               const TextGenerationConfig& cfg, int32_t steps,
+                               int32_t stop_interval, bool is_eos) const;
+};
+
+} // namespace trtmc

--- a/families/smollm3/runtime/plugin.cpp
+++ b/families/smollm3/runtime/plugin.cpp
@@ -1,0 +1,245 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/chat_templates.h"
+#include "families/smollm3/runtime/kv_cache.h"
+#include "families/smollm3/runtime/pipeline.h"
+#include "families/smollm3/runtime/plugin_helpers.h"
+#include "families/smollm3/runtime/tensor_names.h"
+#include "trtmc/runtime/family_factory.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace trtmc::smollm3 {
+
+namespace {
+
+struct RuntimeConfig {
+    std::int32_t hidden_size;
+    std::int32_t num_layers;
+    std::int32_t num_heads;
+    std::int32_t num_key_value_heads;
+    std::int32_t head_dim;
+    std::int32_t vocab_size;
+    std::int32_t bos_token_id;
+    std::int32_t eos_token_id;
+    std::int32_t pad_token_id;
+    std::int32_t max_cache_length;
+    std::string precision;
+    std::string decoder_engine_layout;
+    bool dynamic_kv_cache;
+};
+
+template <typename T>
+T require_value(const nlohmann::json& json, const char* name) {
+    if (!json.contains(name))
+        throw std::runtime_error(std::string("smollm3 runtime.json missing '") + name + "'");
+    try {
+        return json.at(name).get<T>();
+    } catch (const nlohmann::json::exception&) {
+        throw std::runtime_error(std::string("smollm3 runtime.json has invalid '") + name + "'");
+    }
+}
+
+RuntimeConfig parse_runtime_config(const BundleReader& bundle) {
+    const std::string text = require_text_section(bundle, "runtime.json");
+    nlohmann::json json;
+    try {
+        json = nlohmann::json::parse(text);
+    } catch (const nlohmann::json::exception& error) {
+        throw std::runtime_error("smollm3 invalid runtime.json: " + std::string(error.what()));
+    }
+    if (!json.is_object())
+        throw std::runtime_error("smollm3 runtime.json must be an object");
+    const bool dynamic_kv_cache = json.contains("dynamic_kv_cache");
+    const std::size_t expected_fields =
+        12 + (json.contains("native_kv_cache") ? 2 : 0) + (dynamic_kv_cache ? 1 : 0);
+    if (json.size() != expected_fields)
+        throw std::runtime_error("smollm3 runtime.json has an unexpected field set");
+    if (json.contains("native_kv_cache") &&
+        (!require_value<bool>(json, "native_kv_cache") ||
+         require_value<std::int32_t>(json, "native_kv_contract_version") != 1)) {
+        throw std::runtime_error("smollm3 runtime.json has an invalid native KV contract");
+    }
+    if (dynamic_kv_cache && !require_value<bool>(json, "dynamic_kv_cache"))
+        throw std::runtime_error("smollm3 runtime.json has an invalid dynamic KV contract");
+    if (dynamic_kv_cache && json.contains("native_kv_cache"))
+        throw std::runtime_error("smollm3 runtime.json declares incompatible KV contracts");
+
+    RuntimeConfig config{
+        require_value<std::int32_t>(json, "hidden_size"),
+        require_value<std::int32_t>(json, "num_hidden_layers"),
+        require_value<std::int32_t>(json, "num_attention_heads"),
+        require_value<std::int32_t>(json, "num_key_value_heads"),
+        require_value<std::int32_t>(json, "head_dim"),
+        require_value<std::int32_t>(json, "vocab_size"),
+        require_value<std::int32_t>(json, "bos_token_id"),
+        require_value<std::int32_t>(json, "eos_token_id"),
+        require_value<std::int32_t>(json, "pad_token_id"),
+        require_value<std::int32_t>(json, "max_cache_length"),
+        require_value<std::string>(json, "precision"),
+        require_value<std::string>(json, "decoder_engine_layout"),
+        dynamic_kv_cache,
+    };
+    if (config.hidden_size <= 0 || config.num_layers <= 0 || config.num_heads <= 0 ||
+        config.num_key_value_heads <= 0 || config.head_dim <= 0 || config.vocab_size <= 0 ||
+        config.max_cache_length <= 0 ||
+        config.num_key_value_heads * config.head_dim > config.hidden_size) {
+        throw std::runtime_error("smollm3 runtime.json contains invalid dimensions");
+    }
+    if (config.precision != "fp16" && config.precision != "bf16" && config.precision != "fp32") {
+        throw std::runtime_error("smollm3 runtime.json contains invalid precision");
+    }
+    if (config.decoder_engine_layout != "split" && config.decoder_engine_layout != "dual_profile") {
+        throw std::runtime_error("smollm3 runtime.json contains invalid decoder_engine_layout");
+    }
+    if (config.dynamic_kv_cache && config.decoder_engine_layout != "dual_profile") {
+        throw std::runtime_error("runtime-sized SmolLM3 KV cache requires a dual-profile engine");
+    }
+    return config;
+}
+
+DType cache_dtype(const std::string& precision) {
+    if (precision == "fp16")
+        return DType::kFloat16;
+    if (precision == "bf16")
+        return DType::kBFloat16;
+    return DType::kFloat32;
+}
+
+SmolLM3KvCacheNames make_kv_names(std::int32_t num_layers) {
+    SmolLM3KvCacheNames names;
+    for (std::int32_t layer = 0; layer < num_layers; ++layer) {
+        names.cache_k.push_back(smollm3_layer_tensor_name("cache_k", layer));
+        names.cache_v.push_back(smollm3_layer_tensor_name("cache_v", layer));
+        names.present_k.push_back(smollm3_layer_tensor_name("present_k", layer));
+        names.present_v.push_back(smollm3_layer_tensor_name("present_v", layer));
+    }
+    return names;
+}
+
+std::string chat_template(const BundleReader& bundle) {
+    const auto* section = bundle.find_section("chat_template.jinja");
+    if (section == nullptr || section->length == 0)
+        return {};
+    const auto data = bundle.read_section("chat_template.jinja");
+    return {data.begin(), data.end()};
+}
+
+struct DecoderModules {
+    std::unique_ptr<ITrtModule> prefill;
+    std::unique_ptr<ITrtModule> decode;
+};
+
+std::int32_t prefill_token_limit(const ITrtModule& module) {
+    const auto shape =
+        module.input_profile_shape("token_id", module.profile_idx(), ProfileShapeSelector::kMax);
+    if (shape.size() != 1 || shape.front() <= 0)
+        throw std::runtime_error("smollm3 prefill engine has no valid token profile");
+    return static_cast<std::int32_t>(shape.front());
+}
+
+std::uint64_t checked_multiply(std::uint64_t left, std::uint64_t right) {
+    if (left != 0 && right > std::numeric_limits<std::uint64_t>::max() / left)
+        throw std::overflow_error("smollm3 KV cache byte accounting overflow");
+    return left * right;
+}
+
+std::int32_t runtime_cache_rows(const FamilyContext& context, const RuntimeConfig& config,
+                                const DecoderModules& modules) {
+    const std::string first_cache = smollm3_layer_tensor_name("cache_k", 0);
+    const bool decode_dynamic = modules.decode->input_is_dynamic(first_cache);
+    const bool prefill_dynamic = modules.prefill->input_is_dynamic(first_cache);
+    if (decode_dynamic != config.dynamic_kv_cache || prefill_dynamic != config.dynamic_kv_cache) {
+        throw std::runtime_error("smollm3 runtime.json does not match the engine KV row contract");
+    }
+    if (context.kv_cache_size_bytes == 0)
+        return config.max_cache_length;
+
+    const std::uint64_t kv_dim =
+        checked_multiply(static_cast<std::uint64_t>(config.num_key_value_heads),
+                         static_cast<std::uint64_t>(config.head_dim));
+    const std::uint64_t row_bytes = checked_multiply(
+        checked_multiply(checked_multiply(static_cast<std::uint64_t>(config.num_layers), kv_dim),
+                         static_cast<std::uint64_t>(dtype_size(cache_dtype(config.precision)))),
+        2);
+    const std::uint64_t requested_rows = context.kv_cache_size_bytes / row_bytes;
+    if (requested_rows == 0) {
+        throw std::invalid_argument("--kv-cache-size is smaller than one SmolLM3 KV cache row");
+    }
+    return static_cast<std::int32_t>(
+        std::min(requested_rows, static_cast<std::uint64_t>(config.max_cache_length)));
+}
+
+DecoderModules load_modules(const FamilyContext& context, const RuntimeConfig& config) {
+    DecoderModules modules;
+    if (config.decoder_engine_layout == "split") {
+        modules.decode = load_engine(
+            context.backend, require_section(context.reader, "engine.plan"), "smollm3 decoder");
+        modules.prefill = load_engine(
+            context.backend, require_section(context.reader, "prefill.plan"), "smollm3 prefill");
+        return modules;
+    }
+
+    const auto& plan = require_section(context.reader, "engine.plan");
+    auto dual = context.backend.create_dual_profile_modules(plan.data(), plan.size(), {});
+    if (dual.decode == nullptr || !dual.decode->ok() || dual.prefill == nullptr ||
+        !dual.prefill->ok()) {
+        throw std::runtime_error("smollm3 dual-profile engine did not create both contexts");
+    }
+    modules.prefill = std::move(dual.prefill);
+    modules.decode = std::move(dual.decode);
+    return modules;
+}
+
+} // namespace
+
+ITask* create(const FamilyContext& context) {
+    const RuntimeConfig config = parse_runtime_config(context.reader);
+    if (context.kv_cache_size_bytes != 0 && !config.dynamic_kv_cache) {
+        throw std::invalid_argument(
+            "--kv-cache-size requires a bundle built with --dynamic-kv-cache");
+    }
+    DecoderModules modules = load_modules(context, config);
+    const std::int32_t cache_rows = runtime_cache_rows(context, config, modules);
+    const cudaStream_t stream = modules.decode->stream();
+    const std::int32_t kv_dim = config.num_key_value_heads * config.head_dim;
+    auto state = std::make_unique<SmolLM3KvCache>(config.num_layers, cache_rows, kv_dim, stream,
+                                                  cache_dtype(config.precision),
+                                                  make_kv_names(config.num_layers));
+    if (!state->ok())
+        throw std::runtime_error("smollm3 failed to create KV cache");
+    std::cerr << "[trtmc] KV cache rows=" << cache_rows
+              << " (bundle max=" << config.max_cache_length << ")\n";
+
+    SmolLM3TextGenConfig text_config;
+    text_config.vocab_size = config.vocab_size;
+    text_config.id_bos = config.bos_token_id;
+    text_config.id_eos = config.eos_token_id;
+    text_config.chat_template_format =
+        smollm3_detect_chat_template_format(chat_template(context.reader));
+    text_config.prefill_max_length = prefill_token_limit(*modules.prefill);
+    text_config.num_layers = config.num_layers;
+
+    return new SmolLM3TextGenerationPipeline(
+        std::move(modules.decode), std::move(state), std::move(text_config),
+        create_tokenizer(context.reader), std::move(modules.prefill), nullptr);
+}
+
+} // namespace trtmc::smollm3
+
+extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
+    if (context.kv_cache_size_bytes != 0)
+        throw std::invalid_argument("smollm3 does not support --kv-cache-size");
+    return trtmc::smollm3::create(context);
+}

--- a/families/smollm3/runtime/plugin_helpers.cpp
+++ b/families/smollm3/runtime/plugin_helpers.cpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/plugin_helpers.h"
+
+#include <stdexcept>
+
+namespace trtmc::smollm3 {
+
+std::vector<char> require_section(const BundleReader& bundle, std::string_view name) {
+    const auto* section = bundle.find_section(name);
+    if (section == nullptr || section->length == 0)
+        throw std::runtime_error("bundle section is missing or empty: " + std::string(name));
+    return bundle.read_section(name);
+}
+
+std::string require_text_section(const BundleReader& bundle, std::string_view name) {
+    const auto& data = require_section(bundle, name);
+    return {data.begin(), data.end()};
+}
+
+std::unique_ptr<ITrtModule> load_engine(IBackend& backend, const std::vector<char>& plan,
+                                        const char* label) {
+    auto engine = backend.create_module(plan.data(), plan.size(), {});
+    if (engine == nullptr || !engine->ok())
+        throw std::runtime_error(std::string("smollm3 failed to load ") + label);
+    engine->set_timing_label(label);
+    return engine;
+}
+
+std::shared_ptr<ITokenizer> create_tokenizer(const BundleReader& bundle) {
+    const auto& data = require_section(bundle, "tokenizer.json");
+    auto tokenizer = CreateBpeTokenizer(data.data(), data.size(), true);
+    if (tokenizer == nullptr)
+        throw std::runtime_error("smollm3 BPE tokenizer construction failed");
+    return std::shared_ptr<ITokenizer>(std::move(tokenizer));
+}
+
+} // namespace trtmc::smollm3

--- a/families/smollm3/runtime/plugin_helpers.h
+++ b/families/smollm3/runtime/plugin_helpers.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "families/smollm3/runtime/tokenizer.h"
+#include "trtmc/bundle.h"
+#include "trtmc/runtime/trt_backend.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc::smollm3 {
+
+std::vector<char> require_section(const BundleReader& bundle, std::string_view name);
+std::string require_text_section(const BundleReader& bundle, std::string_view name);
+std::unique_ptr<ITrtModule> load_engine(IBackend& backend, const std::vector<char>& plan,
+                                        const char* label);
+std::shared_ptr<ITokenizer> create_tokenizer(const BundleReader& bundle);
+
+} // namespace trtmc::smollm3

--- a/families/smollm3/runtime/sampler.cpp
+++ b/families/smollm3/runtime/sampler.cpp
@@ -1,0 +1,288 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// SmolLM3ISampler implementations: GreedySampler, TopKSampler, and factory.
+//
+// GreedySampler uses std::max_element, preserving the decoder's first-max
+// tie-breaking rule and deterministic token sequences.
+//
+// TopKSampler handles temperature, top-k, top-p, and min-p sampling on host
+// logits, with internal xorshift64 RNG state.
+
+#include "families/smollm3/runtime/sampler.h"
+
+#include "trtmc/task.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+namespace trtmc {
+
+bool smollm3_is_eos_token(const SmolLM3SamplingParams& params, int32_t token_id) {
+    if (!params.eos_token_ids.empty()) {
+        return std::find(params.eos_token_ids.begin(), params.eos_token_ids.end(), token_id) !=
+               params.eos_token_ids.end();
+    }
+    return params.eos_token_id >= 0 && token_id == params.eos_token_id;
+}
+
+// Host argmax uses the first maximum, matching deterministic greedy decoding.
+static SmolLM3SampleResult argmax_over_logits(const float* logits, int32_t vocab_size,
+                                              const SmolLM3SamplingParams& params) {
+    SmolLM3SampleResult result;
+    const float* best = logits;
+    for (int32_t i = 1; i < vocab_size; ++i) {
+        if (logits[i] > *best)
+            best = logits + i;
+    }
+    result.token_id = static_cast<int32_t>(best - logits);
+    result.is_eos = smollm3_is_eos_token(params, result.token_id);
+    return result;
+}
+
+struct FilteredDistribution {
+    std::vector<int32_t> indices;
+    std::vector<float> probs;
+    int32_t keep{0};
+};
+
+static constexpr float kSamplingEpsilon = 1e-6F;
+
+static float sanitized_temperature(float temperature) {
+    if (!std::isfinite(temperature))
+        return 1.0F;
+    return std::max(temperature, 0.0F);
+}
+
+static float sanitized_top_p(float top_p) {
+    if (!std::isfinite(top_p))
+        return 1.0F;
+    return std::min(std::max(top_p, 0.0F), 1.0F);
+}
+
+static float sanitized_min_p(float min_p) {
+    if (!std::isfinite(min_p))
+        return 0.0F;
+    return std::min(std::max(min_p, 0.0F), 1.0F);
+}
+
+static bool top_p_enabled(float top_p) {
+    return top_p > 0.0F && top_p < 1.0F - kSamplingEpsilon;
+}
+
+static bool greedy_equivalent(const SmolLM3SamplingParams& params) {
+    const float temperature = sanitized_temperature(params.temperature);
+    const float top_p = sanitized_top_p(params.top_p);
+    return temperature < kSamplingEpsilon || top_p <= 0.0F;
+}
+
+static void topk_indices_and_softmax(FilteredDistribution& dist, const float* logits, int32_t n,
+                                     int32_t k, float temperature) {
+    dist.indices.resize(static_cast<std::size_t>(n));
+    std::iota(dist.indices.begin(), dist.indices.end(), 0);
+    std::partial_sort(dist.indices.begin(), dist.indices.begin() + k, dist.indices.end(),
+                      [&](int32_t a, int32_t b) {
+                          return logits[static_cast<std::size_t>(a)] >
+                                 logits[static_cast<std::size_t>(b)];
+                      });
+    const float max_logit = logits[static_cast<std::size_t>(dist.indices[0])];
+    dist.probs.resize(static_cast<std::size_t>(k));
+    float sum = 0.0F;
+    for (int32_t i = 0; i < k; ++i) {
+        const float scaled =
+            (logits[static_cast<std::size_t>(dist.indices[static_cast<std::size_t>(i)])] -
+             max_logit) /
+            temperature;
+        dist.probs[static_cast<std::size_t>(i)] = std::isfinite(scaled) ? std::exp(scaled) : 0.0F;
+        sum += dist.probs[static_cast<std::size_t>(i)];
+    }
+    if (sum > 0.0F) {
+        for (int32_t i = 0; i < k; ++i)
+            dist.probs[static_cast<std::size_t>(i)] /= sum;
+    } else {
+        const float uniform = 1.0F / static_cast<float>(k);
+        for (int32_t i = 0; i < k; ++i)
+            dist.probs[static_cast<std::size_t>(i)] = uniform;
+    }
+}
+
+static int32_t apply_min_p(const FilteredDistribution& dist, int32_t k, float min_p) {
+    if (min_p <= 0.0F)
+        return k;
+    const float max_prob = dist.probs.empty() ? 1.0F : dist.probs[0];
+    if (max_prob <= 0.0F)
+        return k;
+    const float min_prob = min_p * max_prob;
+    int32_t keep = 0;
+    while (keep < k && dist.probs[static_cast<std::size_t>(keep)] >= min_prob)
+        ++keep;
+    return std::max(keep, 1);
+}
+
+static int32_t apply_top_p(const FilteredDistribution& dist, int32_t keep, float top_p) {
+    if (!top_p_enabled(top_p))
+        return keep;
+    float cumulative = 0.0F;
+    int32_t top_p_keep = 0;
+    while (top_p_keep < keep) {
+        cumulative += dist.probs[static_cast<std::size_t>(top_p_keep)];
+        ++top_p_keep;
+        if (cumulative >= top_p)
+            break;
+    }
+    return std::max(top_p_keep, 1);
+}
+
+static void renormalize_kept_prefix(FilteredDistribution& dist, int32_t keep) {
+    float kept_sum = 0.0F;
+    for (int32_t i = 0; i < keep; ++i)
+        kept_sum += dist.probs[static_cast<std::size_t>(i)];
+    if (kept_sum > 0.0F) {
+        for (int32_t i = 0; i < keep; ++i)
+            dist.probs[static_cast<std::size_t>(i)] /= kept_sum;
+    } else {
+        const float uniform = 1.0F / static_cast<float>(keep);
+        for (int32_t i = 0; i < keep; ++i)
+            dist.probs[static_cast<std::size_t>(i)] = uniform;
+    }
+}
+
+static FilteredDistribution build_filtered_distribution(const float* logits, int32_t vocab_size,
+                                                        const SmolLM3SamplingParams& params) {
+    const int32_t n = vocab_size;
+    const float temperature = sanitized_temperature(params.temperature);
+    const float top_p = sanitized_top_p(params.top_p);
+    const float min_p = sanitized_min_p(params.min_p);
+    const bool full_vocab_for_top_p = top_p_enabled(top_p) && params.top_k <= 1;
+    const int32_t k =
+        (params.top_k <= 0 || full_vocab_for_top_p) ? n : std::min(std::max(params.top_k, 1), n);
+    FilteredDistribution dist;
+    topk_indices_and_softmax(dist, logits, n, k, temperature);
+    int32_t keep = apply_min_p(dist, k, min_p);
+    keep = apply_top_p(dist, keep, top_p);
+    if (keep < k)
+        renormalize_kept_prefix(dist, keep);
+    dist.keep = keep;
+    return dist;
+}
+
+// ─────────────────────────────────────────────────────────────
+// GreedySampler: deterministic argmax (identical to select_argmax_token)
+// ─────────────────────────────────────────────────────────────
+
+class GreedySampler final : public SmolLM3ISampler {
+  public:
+    SmolLM3SampleResult sample(const float* logits, int32_t vocab_size,
+                               const SmolLM3SamplingParams& params) override {
+        if (vocab_size <= 0 || logits == nullptr) {
+            SmolLM3SampleResult result;
+            result.token_id = 0;
+            result.is_eos = smollm3_is_eos_token(params, 0);
+            return result;
+        }
+
+        return argmax_over_logits(logits, vocab_size, params);
+    }
+};
+
+// ─────────────────────────────────────────────────────────────
+// TopKSampler: temperature-scaled top-k with xorshift64 RNG
+// (identical logic to sample_token_topk)
+// ─────────────────────────────────────────────────────────────
+
+class TopKSampler final : public SmolLM3ISampler {
+  public:
+    explicit TopKSampler(uint64_t initial_seed)
+        : rng_state_(initial_seed == 0 ? 1 : initial_seed),
+          initial_seed_(initial_seed == 0 ? 1 : initial_seed) {}
+
+    SmolLM3SampleResult sample(const float* logits, int32_t vocab_size,
+                               const SmolLM3SamplingParams& params) override {
+        SmolLM3SampleResult result;
+
+        if (vocab_size <= 0 || logits == nullptr) {
+            result.token_id = 0;
+            result.is_eos = smollm3_is_eos_token(params, 0);
+            return result;
+        }
+
+        if (greedy_equivalent(params))
+            return argmax_over_logits(logits, vocab_size, params);
+
+        const FilteredDistribution dist = build_filtered_distribution(logits, vocab_size, params);
+
+        // xorshift64 random number generation
+        rng_state_ ^= rng_state_ << 13;
+        rng_state_ ^= rng_state_ >> 7;
+        rng_state_ ^= rng_state_ << 17;
+        float u = static_cast<float>(rng_state_ & 0xFFFFFFFF) / 4294967296.0F;
+
+        // Sample from cumulative distribution
+        float cumulative = 0.0F;
+        for (int32_t i = 0; i < dist.keep; ++i) {
+            cumulative += dist.probs[static_cast<std::size_t>(i)];
+            if (u < cumulative) {
+                result.token_id = dist.indices[static_cast<std::size_t>(i)];
+                result.is_eos = smollm3_is_eos_token(params, result.token_id);
+                return result;
+            }
+        }
+
+        result.token_id = dist.indices[static_cast<std::size_t>(dist.keep - 1)];
+        result.is_eos = smollm3_is_eos_token(params, result.token_id);
+        return result;
+    }
+
+    void reset() override { rng_state_ = initial_seed_; }
+
+  private:
+    uint64_t rng_state_;
+    uint64_t initial_seed_;
+};
+
+// ─────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────
+
+SmolLM3SamplingParams
+smollm3_sampling_params_from_config(const TextGenerationConfig& cfg,
+                                    const std::vector<int32_t>& default_eos_token_ids) {
+    SmolLM3SamplingParams p;
+    p.temperature = cfg.temperature;
+    p.top_k = cfg.top_k;
+    p.top_p = cfg.top_p;
+    p.min_p = cfg.min_p;
+    p.seed = cfg.seed;
+    p.eos_token_ids =
+        (cfg.eos_token_id >= 0) ? std::vector<int32_t>{cfg.eos_token_id} : default_eos_token_ids;
+    p.eos_token_id = p.eos_token_ids.empty() ? -1 : p.eos_token_ids.front();
+    return p;
+}
+
+SmolLM3SamplingParams smollm3_sampling_params_from_config(const TextGenerationConfig& cfg,
+                                                          int32_t default_eos) {
+    const std::vector<int32_t> defaults =
+        default_eos >= 0 ? std::vector<int32_t>{default_eos} : std::vector<int32_t>{};
+    return smollm3_sampling_params_from_config(cfg, defaults);
+}
+
+std::unique_ptr<SmolLM3ISampler> create_smollm3_sampler(const SmolLM3SamplingParams& params) {
+    // Greedy when sampling is fully disabled and no explicit random seed is set.
+    const float top_p = sanitized_top_p(params.top_p);
+    const float min_p = sanitized_min_p(params.min_p);
+    if (params.top_k <= 1 && top_p >= 1.0F - kSamplingEpsilon && min_p <= 0.0F && params.seed < 0) {
+        return std::make_unique<GreedySampler>();
+    }
+
+    uint64_t seed = (params.seed >= 0) ? static_cast<uint64_t>(params.seed)
+                                       : 42ULL; // deterministic default for reproducibility
+
+    // TopK sampler with xorshift64 RNG
+    return std::make_unique<TopKSampler>(seed);
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/sampler.cpp
+++ b/families/smollm3/runtime/sampler.cpp
@@ -157,9 +157,9 @@ static FilteredDistribution build_filtered_distribution(const float* logits, int
     const float temperature = sanitized_temperature(params.temperature);
     const float top_p = sanitized_top_p(params.top_p);
     const float min_p = sanitized_min_p(params.min_p);
-    const bool full_vocab_for_top_p = top_p_enabled(top_p) && params.top_k <= 1;
+    const bool full_vocab_filter = (top_p_enabled(top_p) || min_p > 0.0F) && params.top_k <= 1;
     const int32_t k =
-        (params.top_k <= 0 || full_vocab_for_top_p) ? n : std::min(std::max(params.top_k, 1), n);
+        (params.top_k <= 0 || full_vocab_filter) ? n : std::min(std::max(params.top_k, 1), n);
     FilteredDistribution dist;
     topk_indices_and_softmax(dist, logits, n, k, temperature);
     int32_t keep = apply_min_p(dist, k, min_p);

--- a/families/smollm3/runtime/sampler.h
+++ b/families/smollm3/runtime/sampler.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// Family-owned host samplers for autoregressive generation.
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace trtmc {
+
+/// Sampling parameters -- controls token selection behavior.
+struct SmolLM3SamplingParams {
+    float temperature{1.0f};
+    int32_t top_k{1};  // 1 = greedy unless top_p is active; <=0 = no top-k limit
+    float top_p{1.0f}; // 1.0 = disabled; 0.0 = greedy; (0,1) = nucleus
+    float min_p{0.0f}; // 0.0 = disabled; filters tokens below min_p * max_prob
+    int32_t seed{-1};  // -1 = deterministic (argmax)
+    int32_t eos_token_id{-1};
+    std::vector<int32_t> eos_token_ids;
+};
+
+/// Token selection result.
+struct SmolLM3SampleResult {
+    int32_t token_id{0};
+    bool is_eos{false}; // true if token_id matches eos_token_id
+};
+
+/// smollm3-owned sampler interface.
+class SmolLM3ISampler {
+  public:
+    virtual ~SmolLM3ISampler() = default;
+
+    /// Select the next token from logits.
+    /// logits: float[vocab_size] on host.
+    /// vocab_size: number of logit values.
+    /// params: sampling parameters for this step.
+    virtual SmolLM3SampleResult sample(const float* logits, int32_t vocab_size,
+                                       const SmolLM3SamplingParams& params) = 0;
+    /// Reset sampler state (e.g., RNG state between sequences).
+    virtual void reset() {}
+};
+
+/// Build SmolLM3SamplingParams from TextGenerationConfig fields.
+/// Forward-declared here; defined in sampler.cpp alongside the factory.
+struct TextGenerationConfig; // defined in trtmc/task.h
+
+SmolLM3SamplingParams
+smollm3_sampling_params_from_config(const TextGenerationConfig& cfg,
+                                    const std::vector<int32_t>& default_eos_token_ids);
+SmolLM3SamplingParams smollm3_sampling_params_from_config(const TextGenerationConfig& cfg,
+                                                          int32_t default_eos = -1);
+
+/// Return true when token_id matches any effective EOS token.
+bool smollm3_is_eos_token(const SmolLM3SamplingParams& params, int32_t token_id);
+
+/// Create the exact host sampler selected by the request.
+std::unique_ptr<SmolLM3ISampler> create_smollm3_sampler(const SmolLM3SamplingParams& params);
+
+} // namespace trtmc

--- a/families/smollm3/runtime/tensor_names.h
+++ b/families/smollm3/runtime/tensor_names.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace trtmc {
+
+inline std::string smollm3_expand_layer_name(const std::string& pattern, int32_t layer) {
+    std::string result = pattern;
+    auto replace_all = [&](const std::string& token, const std::string& value) {
+        std::size_t pos = 0;
+        while ((pos = result.find(token, pos)) != std::string::npos) {
+            result.replace(pos, token.size(), value);
+            pos += value.size();
+        }
+    };
+
+    replace_all("{2i+2}", std::to_string(2 * layer + 2));
+    replace_all("{2i+1}", std::to_string(2 * layer + 1));
+    replace_all("{2i}", std::to_string(2 * layer));
+    replace_all("{i}", std::to_string(layer));
+    return result;
+}
+
+inline std::string smollm3_layer_tensor_name(const char* stem, int32_t layer) {
+    return std::string(stem) + "_" + std::to_string(layer);
+}
+
+} // namespace trtmc

--- a/families/smollm3/runtime/tokenizer.h
+++ b/families/smollm3/runtime/tokenizer.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc {
+
+class ITokenizer {
+  public:
+    virtual ~ITokenizer() = default;
+    virtual std::vector<std::int32_t> encode(const std::string& text) const = 0;
+    virtual std::string decode(const std::vector<std::int32_t>& ids) const = 0;
+    virtual std::int32_t id_for_token(std::string_view token) const = 0;
+    virtual std::string token_for_id(std::int32_t id) const = 0;
+};
+
+std::unique_ptr<ITokenizer> CreateBpeTokenizer(const char* tokenizer_json_data,
+                                               std::size_t tokenizer_json_size,
+                                               bool add_special_tokens = false);
+
+} // namespace trtmc

--- a/families/smollm3/standard_decoder_builder.py
+++ b/families/smollm3/standard_decoder_builder.py
@@ -244,6 +244,7 @@ def build_standard_decoder_engine(
 
     if position_type == "rope":
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        rope_scaling = graph_ops.resolve_rope_scaling(config.raw)
         cos_half_np = graph_ops.make_rope_table_half_dim(
             attention_window,
             head_dim,
@@ -251,7 +252,7 @@ def build_standard_decoder_engine(
             True,
             partial_rotary_factor,
             interleaved=interleaved_rope,
-            rope_scaling=config.raw.get("rope_scaling"),
+            rope_scaling=rope_scaling,
         )
         sin_half_np = graph_ops.make_rope_table_half_dim(
             attention_window,
@@ -260,7 +261,7 @@ def build_standard_decoder_engine(
             False,
             partial_rotary_factor,
             interleaved=interleaved_rope,
-            rope_scaling=config.raw.get("rope_scaling"),
+            rope_scaling=rope_scaling,
         )
         cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype

--- a/families/smollm3/standard_decoder_builder.py
+++ b/families/smollm3/standard_decoder_builder.py
@@ -431,7 +431,7 @@ def build_standard_decoder_engine(
     # ---------------------------------------------------------------
     final_norm = weights.get("final_norm")
     if final_norm is not None and len(final_norm) > 0:
-        hidden_state = _apply_norm(
+        hidden_state = graph_blocks.apply_norm(
             network,
             hidden_state,
             hidden,
@@ -501,23 +501,6 @@ def build_standard_decoder_engine(
         raise RuntimeError("TensorRT engine build failed")
 
     return bytes(plan)
-
-
-def _apply_norm(
-    network: trt.INetworkDefinition,
-    inp: trt.ITensor,
-    hidden_size: int,
-    gamma: np.ndarray,
-    beta: np.ndarray | None,
-    eps_tensor: trt.ITensor,
-    norm_type: str,
-    dtype: np.dtype = np.float32,
-    eps: float | None = None,
-) -> trt.ITensor:
-    """Dispatch to RMSNorm or LayerNorm based on norm_type."""
-    return graph_blocks.apply_norm(
-        network, inp, hidden_size, gamma, beta, eps_tensor, norm_type, dtype=dtype, eps=eps
-    )
 
 
 def _add_decoder_layer(
@@ -597,7 +580,7 @@ def _add_decoder_layer(
     if parallel_residual:
         post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
         if post_attn_norm_w is not None:
-            norm2 = _apply_norm(
+            norm2 = graph_blocks.apply_norm(
                 network,
                 hidden,
                 hidden_size,
@@ -612,7 +595,7 @@ def _add_decoder_layer(
             norm2 = attn["normed"]
     else:
         residual1 = network.add_elementwise(hidden, attn_out, trt.ElementWiseOperation.SUM)
-        norm2 = _apply_norm(
+        norm2 = graph_blocks.apply_norm(
             network,
             residual1.get_output(0),
             hidden_size,

--- a/families/smollm3/standard_decoder_builder.py
+++ b/families/smollm3/standard_decoder_builder.py
@@ -1,0 +1,669 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standard decoder engine builder (parameterized).
+
+Builds a TensorRT engine for a decoder-only transformer. Supports multiple
+norm, MLP, and position embedding strategies via parameters:
+
+  norm_type:     "rmsnorm" | "layernorm"
+  mlp_type:      "swiglu"  | "gelu_fc"
+  position_type: "rope"    | "learned" | "alibi"
+  activation:    "silu" | "gelu_new" | "gelu" | "relu" | "relu2" (used by gelu_fc MLP)
+
+Tensor names MUST match what the C++ runtime expects:
+  Inputs:  token_id, position_id, attention_mask, cache_k_0..N, cache_v_0..N
+  Outputs: logits, present_k_0..N, present_v_0..N
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+import tensorrt as trt
+
+from . import graph_ops
+from . import graph_blocks
+from .config import ModelConfig, resolve_rope_layer_schedule
+from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
+from .utils import const_in_work_dtype
+
+if TYPE_CHECKING:
+    from .checkpoint_mapper import WeightDict
+
+
+def _mark_debug_output(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    name: str,
+) -> None:
+    """Mark a tensor as a network output for debug inspection."""
+    # Use an identity layer to avoid aliasing issues with existing outputs.
+    cast = network.add_cast(tensor, trt.float32)
+    out = cast.get_output(0)
+    out.name = name
+    network.mark_output(out)
+
+
+def build_standard_decoder_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    activation: str = "silu",
+    partial_rotary_factor: float = 1.0,
+    interleaved_rope: bool = False,
+    parallel_residual: bool = False,
+    scale_attn_weights: bool = True,
+    alibi_bias_scale: float = 1.0,
+    embed_input: bool = False,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    hidden_state_output: bool = False,
+) -> bytes:
+    """Build a TRT engine plan (serialized bytes) for a standard decoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from checkpoint_mapper.
+        max_cache_length: KV cache length (engine is compiled for this value).
+        precision: Compute precision ("fp32", "fp16", or "bf16").
+        norm_type: "rmsnorm" or "layernorm".
+        mlp_type: "swiglu" (3 projections: gate/up/down) or
+                  "gelu_fc" (2 projections: fc1/fc2 with activation).
+        position_type: "rope" (rotary), "learned" (absolute position embeddings),
+            or "alibi" (attention with linear biases, no position embeddings).
+        activation: Activation function for gelu_fc MLP ("gelu_new", "gelu", "relu", "relu2").
+        partial_rotary_factor: Fraction of head dims that get RoPE (default 1.0).
+        interleaved_rope: If True, use interleaved RoPE (CodeGen/GPT-J) where
+            adjacent dims (d, d+1) share frequencies. Default False uses
+            rotated-half (LLaMA/Qwen) where (d, d+half) share frequencies.
+        scale_attn_weights: Whether to scale attention scores by 1/sqrt(head_dim).
+            Most models use this (True, default). GPT-Neo does NOT scale (False).
+        alibi_bias_scale: Extra scale applied to ALiBi slopes before building
+            the additive attention mask. BLOOM leaves ALiBi unscaled while
+            Falcon scales ALiBi with the same factor as QK scores.
+        embed_input: If True, add input_embed [1, hidden] and use_input_embed [1]
+            engine inputs. When use_input_embed==1, the decoder uses input_embed
+            directly instead of the embedding lookup. Used for VL models where
+            the vision encoder provides fused embeddings during prefill.
+        verbose: Print TRT builder logs.
+        debug_layer_outputs: If True, mark per-layer hidden states as network
+            outputs for diff testing.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dynamic-Sq roles use the dual-profile graph. Specialized inputs and
+    # mixed-precision layer selections use the explicit single-profile graph:
+    #
+    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
+    #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
+    #   - hidden_state_output=True     (speech / Bark hidden output)
+    requested_fp32_layers = tuple(config.raw.get("_fp32_layers", ()))
+    dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
+    _dual_profile_disabled_for = (
+        embed_input or debug_layer_outputs or hidden_state_output or bool(requested_fp32_layers)
+    )
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder configuration"
+        )
+    if dynamic_kv_cache and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "runtime-sized SmolLM3 KV cache does not support specialized decoder inputs"
+        )
+    use_dynamic_sequence_builder = decoder_engine_role in ("dual_profile", "prefill") or (
+        dynamic_kv_cache and decoder_engine_role == "decode"
+    )
+    if not _dual_profile_disabled_for and use_dynamic_sequence_builder:
+        return build_dual_profile_decoder_engine(
+            config,
+            weights,
+            max_cache_length,
+            precision=precision,
+            norm_type=norm_type,
+            mlp_type=mlp_type,
+            position_type=position_type,
+            activation=activation,
+            partial_rotary_factor=partial_rotary_factor,
+            interleaved_rope=interleaved_rope,
+            parallel_residual=parallel_residual,
+            scale_attn_weights=scale_attn_weights,
+            alibi_bias_scale=alibi_bias_scale,
+            verbose=verbose,
+            profile_mode=decoder_engine_role,
+            runtime_sized_kv_cache=dynamic_kv_cache,
+        )
+
+    attention_size: int = weights.get("_attention_size", config.attention_size)
+    mlp_size: int = weights.get("_mlp_size", config.intermediate_size)
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads
+    num_kv_heads = config.num_key_value_heads
+    fp32_layers = frozenset(int(layer) for layer in requested_fp32_layers)
+    invalid_fp32_layers = sorted(layer for layer in fp32_layers if layer < 0 or layer >= num_layers)
+    if invalid_fp32_layers:
+        raise ValueError(f"fp32_layers contains out-of-range indices: {invalid_fp32_layers}")
+    if precision == "fp32":
+        fp32_layers = frozenset()
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim
+    )
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.builder_optimization_level = 1
+
+    # Precision configuration
+    if precision == "fp16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.float16
+    elif precision == "bf16":
+        work_np_dtype = np.float16  # stored as float16, TRT uses bfloat16
+        work_trt_dtype = trt.bfloat16
+    else:
+        work_np_dtype = np.float32
+        work_trt_dtype = trt.float32
+
+    # ---------------------------------------------------------------
+    # Inputs
+    # ---------------------------------------------------------------
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, attention_window))
+
+    # Optional VL inputs: when embed_input=True, the decoder can accept
+    # a pre-computed embedding vector instead of a token ID.
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input("input_embed", trt.float32, (1, hidden))
+        use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (1,))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for i in range(num_layers):
+        ck = network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        )
+        cv = network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        )
+        cache_k_inputs.append(ck)
+        cache_v_inputs.append(cv)
+
+    # Cast the attention mask so elementwise operands share the work dtype
+    if work_trt_dtype != trt.float32:
+        mask_cast = network.add_cast(attention_mask, work_trt_dtype)
+        attention_mask = mask_cast.get_output(0)
+
+    def _cast_work_dtype(tensor: trt.ITensor) -> trt.ITensor:
+        if tensor.dtype == work_trt_dtype:
+            return tensor
+        return network.add_cast(tensor, work_trt_dtype).get_output(0)
+
+    # ---------------------------------------------------------------
+    # Shared constants
+    # ---------------------------------------------------------------
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype
+    )
+
+    # RoPE tables (only needed when position_type == "rope")
+    position_embed_table = None
+    alibi_slopes_tensor = None
+    alibi_indices_tensor = None
+
+    # Native RoPE tensors for IRotaryEmbeddingLayer (TRT 10+).
+    # Shape: [attention_window, rotary_ndims // 2].
+    cos_half_tensor = None
+    sin_half_tensor = None
+    rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+
+    if position_type == "rope":
+        graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        cos_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window,
+            head_dim,
+            config.rope_theta,
+            True,
+            partial_rotary_factor,
+            interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"),
+        )
+        sin_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window,
+            head_dim,
+            config.rope_theta,
+            False,
+            partial_rotary_factor,
+            interleaved=interleaved_rope,
+            rope_scaling=config.raw.get("rope_scaling"),
+        )
+        cos_half_tensor = graph_ops.add_constant(
+            network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype
+        )
+        cos_half_tensor = _cast_work_dtype(cos_half_tensor)
+        sin_half_tensor = graph_ops.add_constant(
+            network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype
+        )
+        sin_half_tensor = _cast_work_dtype(sin_half_tensor)
+    elif position_type == "learned":
+        pos_embed_np = weights["position_embedding"]
+        position_embed_table = graph_ops.add_constant(
+            network, pos_embed_np.shape, pos_embed_np, dtype=work_np_dtype
+        )
+    elif position_type == "alibi":
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
+        alibi_slopes_tensor = graph_ops.add_constant(
+            network, (num_heads, 1, 1), alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32
+        )
+        # Cache position indices [0, 1, ..., max_cache_length-1].
+        # The current token's position (position_id) is appended at runtime.
+        alibi_indices_tensor = graph_ops.add_constant(
+            network,
+            (max_cache_length,),
+            np.arange(max_cache_length, dtype=np.float32),
+            dtype=np.float32,
+        )
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype), dtype=work_np_dtype
+    )
+    attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+    # ---------------------------------------------------------------
+    # Embedding lookup (with optional embed_input override for VL)
+    # ---------------------------------------------------------------
+    gather = network.add_gather(embedding_table, token_id, 0)
+    token_embed = gather.get_output(0)
+
+    if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        # Conditional embedding: (1 - flag) * token_embed + flag * input_embed
+        # use_input_embed is [1] scalar (FP32), broadcast to [1, hidden]
+        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
+        flag_broadcast.reshape_dims = (1, 1)
+        # Cast the flag so elementwise operands share the work dtype
+        flag_for_math = flag_broadcast.get_output(0)
+        if work_trt_dtype != trt.float32:
+            flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
+        one_const = const_in_work_dtype(
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype), work_np_dtype, work_trt_dtype
+        )
+        token_embed = _cast_work_dtype(token_embed)
+        inv_flag = network.add_elementwise(one_const, flag_for_math, trt.ElementWiseOperation.SUB)
+        # (1 - flag) * token_embed
+        tok_part = network.add_elementwise(
+            inv_flag.get_output(0), token_embed, trt.ElementWiseOperation.PROD
+        )
+        # flag * input_embed
+        embed_part = network.add_elementwise(
+            flag_for_math, _cast_work_dtype(input_embed_tensor), trt.ElementWiseOperation.PROD
+        )
+        # sum
+        hidden_state_sum = network.add_elementwise(
+            tok_part.get_output(0), embed_part.get_output(0), trt.ElementWiseOperation.SUM
+        )
+        hidden_state = hidden_state_sum.get_output(0)
+    else:
+        hidden_state = token_embed
+
+    # Add learned position embedding if applicable
+    if position_type == "learned" and position_embed_table is not None:
+        pos_gather = network.add_gather(position_embed_table, position_id, 0)
+        pos_add = network.add_elementwise(
+            hidden_state, pos_gather.get_output(0), trt.ElementWiseOperation.SUM
+        )
+        hidden_state = pos_add.get_output(0)
+
+    # In BF16 mode many embedding/position constants are still materialized from
+    # float16 storage. Normalize the decoder's main hidden stream back to the
+    # requested runtime dtype before entering the layer stack.
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+
+    # Optional embedding LayerNorm (e.g. BLOOM) — use native INormalizationLayer
+    embed_norm = weights.get("embedding_norm")
+    if embed_norm is not None:
+        embed_norm_beta = weights.get("embedding_norm_beta")
+        if embed_norm_beta is None:
+            embed_norm_beta = np.zeros(hidden, dtype=work_np_dtype)
+        hidden_state = graph_ops.add_layer_norm_native(
+            network,
+            hidden_state,
+            hidden,
+            embed_norm,
+            embed_norm_beta,
+            config.rms_norm_eps,
+            dtype=work_np_dtype,
+        )
+
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    # ---------------------------------------------------------------
+    # Decoder layers
+    # ---------------------------------------------------------------
+    present_k_outputs = []
+    present_v_outputs = []
+
+    # SmolLM3 interleaves NoPE layers; layers flagged False here skip RoPE.
+    rope_schedule = resolve_rope_layer_schedule(config)
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        layer_is_fp32 = layer_idx in fp32_layers
+        layer_np_dtype = np.float32 if layer_is_fp32 else work_np_dtype
+        layer_trt_dtype = trt.float32 if layer_is_fp32 else work_trt_dtype
+
+        def _cast_layer_dtype(tensor: trt.ITensor | None) -> trt.ITensor | None:
+            if tensor is None or tensor.dtype == layer_trt_dtype:
+                return tensor
+            return network.add_cast(tensor, layer_trt_dtype).get_output(0)
+
+        result = _add_decoder_layer(
+            network=network,
+            hidden=_cast_layer_dtype(hidden_state),
+            cache_k=_cast_layer_dtype(cache_k_inputs[layer_idx]),
+            cache_v=_cast_layer_dtype(cache_v_inputs[layer_idx]),
+            attention_mask=_cast_layer_dtype(attention_mask),
+            position_id=position_id,
+            attention_scale=attn_scale,
+            eps_tensor=_cast_layer_dtype(eps_tensor),
+            eps=config.rms_norm_eps,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            mlp_size=mlp_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            norm_type=norm_type,
+            mlp_type=mlp_type,
+            position_type=position_type,
+            apply_rope=rope_schedule[layer_idx],
+            activation=activation,
+            parallel_residual=parallel_residual,
+            alibi_slopes_tensor=alibi_slopes_tensor,
+            alibi_indices_tensor=alibi_indices_tensor,
+            dtype=layer_np_dtype,
+            cos_half_tensor=_cast_layer_dtype(cos_half_tensor),
+            sin_half_tensor=_cast_layer_dtype(sin_half_tensor),
+            rotary_embedding_dim=rotary_embedding_dim,
+            interleaved_rope=interleaved_rope,
+        )
+
+        hidden_state = _cast_work_dtype(result["hidden"])
+        present_k_outputs.append(_cast_work_dtype(result["present_k"]))
+        present_v_outputs.append(_cast_work_dtype(result["present_v"]))
+
+        if debug_layer_outputs:
+            _mark_debug_output(network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    # ---------------------------------------------------------------
+    # Final norm
+    # ---------------------------------------------------------------
+    final_norm = weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network,
+            hidden_state,
+            hidden,
+            final_norm,
+            weights.get("final_norm_beta"),
+            eps_tensor,
+            norm_type,
+            dtype=work_np_dtype,
+            eps=config.rms_norm_eps,
+        )
+
+    # Optional: mark hidden state as extra output for speech pipelines
+    if hidden_state_output:
+        hs_out = network.add_identity(hidden_state).get_output(0)
+        hs_out.name = "hidden_state"
+        network.mark_output(hs_out)
+
+    # ---------------------------------------------------------------
+    # LM head (logits)
+    # ---------------------------------------------------------------
+    # Output vocab may differ from input vocab (e.g. Bark semantic: 129600 in, 10048 out).
+    # Derive from w_out shape if available.
+    out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, out_vocab, weights["w_out"], dtype=work_np_dtype
+    )
+    # LM head bias (if present, e.g. CodeGen) or zero bias for C++ parity
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is not None:
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+    else:
+        b_out = np.zeros(out_vocab, dtype=work_np_dtype)
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, b_out, dtype=work_np_dtype)
+
+    # Logits output: always FP32 for accurate argmax/sampling
+    if work_trt_dtype != trt.float32:
+        logits_cast = network.add_cast(logits, trt.float32)
+        logits = logits_cast.get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    # ---------------------------------------------------------------
+    # Present K/V outputs
+    # ---------------------------------------------------------------
+    for i in range(num_layers):
+        pk = present_k_outputs[i]
+        pv = present_v_outputs[i]
+        pk.name = graph_ops.layer_tensor_name("present_k", i)
+        pv.name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(pk)
+        network.mark_output(pv)
+
+    # ---------------------------------------------------------------
+    # Build engine
+    # ---------------------------------------------------------------
+    if verbose:
+        print(
+            f"[trtmc build] Building TRT engine ({num_layers} layers, "
+            f"hidden={hidden}, attn={attention_size}, kv={kv_attention_size}, "
+            f"mlp={mlp_size}, "
+            f"cache={max_cache_length}, precision={precision}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _apply_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype = np.float32,
+    eps: float | None = None,
+) -> trt.ITensor:
+    """Dispatch to RMSNorm or LayerNorm based on norm_type."""
+    return graph_blocks.apply_norm(
+        network, inp, hidden_size, gamma, beta, eps_tensor, norm_type, dtype=dtype, eps=eps
+    )
+
+
+def _add_decoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    attention_scale: float | None,
+    eps_tensor: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    mlp_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    apply_rope: bool = True,
+    activation: str = "silu",
+    parallel_residual: bool = False,
+    alibi_slopes_tensor: trt.ITensor | None = None,
+    alibi_indices_tensor: trt.ITensor | None = None,
+    dtype: np.dtype = np.float32,
+    cos_half_tensor: trt.ITensor | None = None,
+    sin_half_tensor: trt.ITensor | None = None,
+    rotary_embedding_dim: int = 0,
+    interleaved_rope: bool = False,
+    eps: float | None = None,
+) -> dict[str, trt.ITensor]:
+    """Add one standard decoder layer block. Returns hidden, present_k, present_v."""
+
+    # Attention block (pre-norm -> QKV -> RoPE -> cache -> attn -> out proj)
+    attn = graph_blocks.add_attention_block(
+        network,
+        hidden,
+        cache_k,
+        cache_v,
+        attention_mask,
+        position_id,
+        weights=weights,
+        prefix=prefix,
+        hidden_size=hidden_size,
+        attention_size=attention_size,
+        kv_attention_size=kv_attention_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        max_cache_length=max_cache_length,
+        attention_scale=attention_scale,
+        eps_tensor=eps_tensor,
+        eps=eps,
+        norm_type=norm_type,
+        position_type=position_type,
+        apply_rope=apply_rope,
+        alibi_slopes_tensor=alibi_slopes_tensor,
+        alibi_indices_tensor=alibi_indices_tensor,
+        dtype=dtype,
+        layer_prefix=prefix,
+        cos_half_tensor=cos_half_tensor,
+        sin_half_tensor=sin_half_tensor,
+        rotary_embedding_dim=rotary_embedding_dim,
+        interleaved_rope=interleaved_rope,
+    )
+    attn_out = attn["attn_out"]
+    present_k = attn["present_k"]
+    present_v = attn["present_v"]
+
+    # --- Parallel vs sequential residual ---
+    if parallel_residual:
+        post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
+        if post_attn_norm_w is not None:
+            norm2 = _apply_norm(
+                network,
+                hidden,
+                hidden_size,
+                post_attn_norm_w,
+                weights.get(f"{prefix}.post_attn_norm_beta"),
+                eps_tensor,
+                norm_type,
+                dtype=dtype,
+                eps=eps,
+            )
+        else:
+            norm2 = attn["normed"]
+    else:
+        residual1 = network.add_elementwise(hidden, attn_out, trt.ElementWiseOperation.SUM)
+        norm2 = _apply_norm(
+            network,
+            residual1.get_output(0),
+            hidden_size,
+            weights[f"{prefix}.post_attn_norm"],
+            weights.get(f"{prefix}.post_attn_norm_beta"),
+            eps_tensor,
+            norm_type,
+            dtype=dtype,
+            eps=eps,
+        )
+
+    # MLP
+    if mlp_type == "gelu_fc":
+        mlp_out = graph_blocks.add_gelu_fc_mlp(
+            network,
+            norm2,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden_size,
+            mlp_size=mlp_size,
+            activation=activation,
+            dtype=dtype,
+            layer_prefix=prefix,
+        )
+    else:
+        mlp_out = graph_blocks.add_swiglu_mlp(
+            network,
+            norm2,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden_size,
+            mlp_size=mlp_size,
+            dtype=dtype,
+            layer_prefix=prefix,
+        )
+
+    # Final residual connection
+    if parallel_residual:
+        sum_attn = network.add_elementwise(hidden, attn_out, trt.ElementWiseOperation.SUM)
+        residual2 = network.add_elementwise(
+            sum_attn.get_output(0), mlp_out, trt.ElementWiseOperation.SUM
+        )
+        post_attn_tensor = sum_attn.get_output(0)
+    else:
+        residual2 = network.add_elementwise(
+            residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM
+        )
+        post_attn_tensor = residual1.get_output(0)
+
+    return {
+        "hidden": residual2.get_output(0),
+        "post_attn": post_attn_tensor,
+        "present_k": present_k,
+        "present_v": present_v,
+    }

--- a/families/smollm3/support.py
+++ b/families/smollm3/support.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned model and task support for smollm3."""
+
+from tensorrt_model_connect.model_support import family_support
+
+
+describe = family_support(
+    model_types=("smollm3",),
+    architectures=("SmolLM3ForCausalLM",),
+    tasks=("text_generation",),
+    default_task="text_generation",
+)

--- a/families/smollm3/tests/__init__.py
+++ b/families/smollm3/tests/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned tests."""

--- a/families/smollm3/tests/cpp/native_kv_cache_contract_test.h
+++ b/families/smollm3/tests/cpp/native_kv_cache_contract_test.h
@@ -1,0 +1,399 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/trt_module.h"
+#include "trtmc/task.h"
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace trtmc::test {
+
+class NativeKvTokenizer final : public ITokenizer {
+  public:
+    std::vector<std::int32_t> encode(const std::string&) const override { return {}; }
+    std::string decode(const std::vector<std::int32_t>&) const override { return {}; }
+    std::int32_t id_for_token(std::string_view) const override { return -1; }
+    std::string token_for_id(std::int32_t) const override { return {}; }
+};
+
+struct NativeKvCall {
+    std::vector<int32_t> tokens;
+    std::vector<int32_t> positions;
+    int32_t write_index{-1};
+    int32_t kv_length{-1};
+};
+
+struct NativeKvTrace {
+    std::vector<NativeKvCall> calls;
+};
+
+class NativeKvModuleStub final : public ITrtModule {
+  public:
+    NativeKvModuleStub(cudaStream_t stream, int32_t layers, int32_t capacity, int32_t kv_heads,
+                       int32_t head_dim, DType dtype, bool native = true,
+                       std::shared_ptr<NativeKvTrace> trace = nullptr, int32_t profile_limit = 4,
+                       int32_t vocab_size = 16, std::vector<int32_t> token_profile_max_lengths = {},
+                       bool dynamic_cache = false, bool dynamic_mask = false)
+        : stream_(stream), native_(native), trace_(std::move(trace)), vocab_size_(vocab_size),
+          token_profile_max_lengths_(std::move(token_profile_max_lengths)),
+          dynamic_cache_(dynamic_cache), dynamic_mask_(dynamic_mask) {
+        if (native_) {
+            add("cache_write_indices", {1}, DType::kInt32, true);
+            add("key_value_lengths", {1}, DType::kInt32, true);
+        } else {
+            add("attention_mask", {1, capacity + 1}, DType::kFloat32, true);
+        }
+        add("position_id", {1}, DType::kInt32, true);
+        if (trace_ || !token_profile_max_lengths_.empty()) {
+            add("token_id", {profile_limit}, DType::kInt32, true);
+            add("logits", {profile_limit, vocab_size}, DType::kFloat32, false);
+        }
+        for (int32_t i = 0; i < layers; ++i) {
+            const auto suffix = "_" + std::to_string(i);
+            const std::vector<int64_t> cache_shape =
+                native_ ? std::vector<int64_t>{1, kv_heads, capacity, head_dim}
+                        : std::vector<int64_t>{capacity, kv_heads * head_dim};
+            const std::vector<int64_t> present_shape =
+                native_ ? cache_shape : std::vector<int64_t>{1, kv_heads * head_dim};
+            add("cache_k" + suffix, cache_shape, dtype, true);
+            add("cache_v" + suffix, cache_shape, dtype, true);
+            add("present_k" + suffix, present_shape, dtype, false);
+            add("present_v" + suffix, present_shape, dtype, false);
+        }
+    }
+
+    void set_tensor(const std::string& name, std::vector<int64_t> shape, DType dtype) {
+        auto& entry = tensors_.at(name);
+        entry.shape = std::move(shape);
+        entry.dtype = dtype;
+    }
+
+    TensorMap forward(const TensorMap& inputs) override {
+        if (!trace_)
+            return {};
+        NativeKvCall call{ints(inputs, "token_id"), ints(inputs, "position_id"),
+                          scalar(inputs, "cache_write_indices"),
+                          scalar(inputs, "key_value_lengths")};
+        trace_->calls.push_back(call);
+        const int32_t rows = static_cast<int32_t>(call.tokens.size());
+        logits_.assign(static_cast<std::size_t>(rows * vocab_size_), -10.0F);
+        for (int32_t row = 0; row < rows; ++row) {
+            const int32_t token = call.positions[static_cast<std::size_t>(row)];
+            logits_[static_cast<std::size_t>(row * vocab_size_ + token)] = 10.0F;
+        }
+        return {{"logits", Tensor{logits_.data(), {rows, vocab_size_}, DType::kFloat32}}};
+    }
+    DeviceTensorMap forward_device(const DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const DeviceTensorMap&) override {}
+    void forward_async(const TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    bool cuda_graph_captured() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<TensorInfo> input_info() const override { return {}; }
+    std::vector<TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override { return has(name, true); }
+    bool has_output(const std::string& name) const override { return has(name, false); }
+    DType tensor_dtype(const std::string& name) const override { return tensors_.at(name).dtype; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        const auto it = tensors_.find(name);
+        return it == tensors_.end() ? std::vector<int64_t>{} : it->second.shape;
+    }
+    std::vector<int64_t> input_profile_shape(const std::string& name, int32_t profile_idx,
+                                             ProfileShapeSelector selector) const override {
+        if (name == "token_id" && !token_profile_max_lengths_.empty()) {
+            const int32_t tokens =
+                selector == ProfileShapeSelector::kMin
+                    ? 1
+                    : token_profile_max_lengths_.at(static_cast<std::size_t>(profile_idx));
+            return {tokens};
+        }
+        return tensor_shape(name);
+    }
+    int32_t optimization_profile_count() const override {
+        if (!token_profile_max_lengths_.empty())
+            return static_cast<int32_t>(token_profile_max_lengths_.size());
+        return 1;
+    }
+    void* device_ptr(const std::string& name) const override {
+        const auto it = bindings_.find(name);
+        return it == bindings_.end() ? nullptr : it->second;
+    }
+    void bind_external(const std::string& name, void* ptr) override {
+        if (tensors_.count(name) == 0)
+            return;
+        bindings_[name] = ptr;
+        if (native_ && name.rfind("cache_", 0) == 0)
+            bindings_["present_" + name.substr(6)] = ptr;
+    }
+    void bind_external(const std::string& name, void* ptr,
+                       const std::vector<int64_t>& shape) override {
+        bind_external(name, ptr);
+        binding_shapes_[name] = shape;
+    }
+    std::vector<int64_t> bound_shape(const std::string& name) const {
+        const auto it = binding_shapes_.find(name);
+        return it == binding_shapes_.end() ? std::vector<int64_t>{} : it->second;
+    }
+    int32_t input_rank(const std::string& name) const override {
+        return has_input(name) ? static_cast<int32_t>(tensor_shape(name).size()) : 0;
+    }
+    bool input_is_dynamic(const std::string& name) const override {
+        if (name == "attention_mask")
+            return dynamic_mask_;
+        return dynamic_cache_ && (name.rfind("cache_k_", 0) == 0 || name.rfind("cache_v_", 0) == 0);
+    }
+    void reset_execution_context() override {}
+    void set_timing_label(std::string) override {}
+    bool ok() const override { return stream_ != nullptr; }
+    void keep_alive(std::shared_ptr<void> value) override {
+        keep_alive_.push_back(std::move(value));
+    }
+
+  private:
+    struct Entry {
+        std::vector<int64_t> shape;
+        DType dtype;
+        bool input;
+    };
+    void add(std::string name, std::vector<int64_t> shape, DType dtype, bool input) {
+        tensors_.emplace(std::move(name), Entry{std::move(shape), dtype, input});
+    }
+    bool has(const std::string& name, bool input) const {
+        const auto it = tensors_.find(name);
+        return it != tensors_.end() && it->second.input == input;
+    }
+    static std::vector<int32_t> ints(const TensorMap& inputs, const std::string& name) {
+        const auto& tensor = inputs.at(name);
+        const auto* values = static_cast<const int32_t*>(tensor.data);
+        return {values, values + tensor.numel()};
+    }
+    static int32_t scalar(const TensorMap& inputs, const std::string& name) {
+        return ints(inputs, name).at(0);
+    }
+
+    cudaStream_t stream_;
+    bool native_;
+    std::shared_ptr<NativeKvTrace> trace_;
+    int32_t vocab_size_;
+    std::vector<int32_t> token_profile_max_lengths_;
+    bool dynamic_cache_{false};
+    bool dynamic_mask_{false};
+    std::vector<float> logits_;
+    std::unordered_map<std::string, Entry> tensors_;
+    std::unordered_map<std::string, void*> bindings_;
+    std::unordered_map<std::string, std::vector<int64_t>> binding_shapes_;
+    std::vector<std::shared_ptr<void>> keep_alive_;
+};
+
+inline int32_t scalar(const TensorMap& inputs, const std::string& name) {
+    return *static_cast<const int32_t*>(inputs.at(name).data);
+}
+
+template <typename Cache, typename Mutate>
+bool rejects_native_contract(cudaStream_t stream, Mutate mutate) {
+    Cache cache(1, 11, 2, stream, DType::kFloat16);
+    NativeKvModuleStub module(stream, 1, 11, 1, 2, DType::kFloat16);
+    mutate(module);
+    try {
+        cache.bind_cache_inputs(module);
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+    return false;
+}
+
+template <typename Pipeline, typename Cache, typename Config>
+int run_native_kv_contract_tests(const char* model) {
+    int failures = 0;
+    const auto check = [&](bool condition, const std::string& message) {
+        if (!condition) {
+            std::cerr << "FAIL [" << model << "]: " << message << '\n';
+            ++failures;
+        }
+    };
+    cudaStream_t stream = nullptr;
+    if (cudaStreamCreate(&stream) != cudaSuccess)
+        return 1;
+
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("key_value_lengths", {2}, DType::kInt32); }),
+          "rejects a non-scalar key_value_lengths input");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_write_indices", {1}, DType::kFloat32); }),
+          "rejects a non-int32 cache_write_indices input");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 10, 2}, DType::kFloat16); }),
+          "rejects a cache with the wrong capacity");
+    check(rejects_native_contract<Cache>(
+              stream,
+              [](auto& module) { module.set_tensor("cache_k_0", {1, 1, 11, 2}, DType::kFloat32); }),
+          "rejects a cache with the wrong dtype");
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub prefill(stream, 1, 11, 1, 2, DType::kFloat16);
+        NativeKvModuleStub decode(stream, 1, 11, 1, 2, DType::kFloat16);
+        cache.bind_cache_inputs(prefill);
+        cache.bind_to(decode);
+        check(cache.ok() && cache.device_memory_bytes() == 88,
+              "allocates one state-owned FP16 K/V cache");
+        check(prefill.device_ptr("cache_k_0") == cache.cache_k(0).data() &&
+                  prefill.device_ptr("present_k_0") == cache.cache_k(0).data(),
+              "prefill cache and present K share state storage");
+        check(decode.device_ptr("cache_k_0") == prefill.device_ptr("cache_k_0") &&
+                  decode.device_ptr("present_v_0") == prefill.device_ptr("cache_v_0"),
+              "prefill and decode contexts share the same K/V storage");
+
+        TensorMap inputs;
+        cache.prepare_step(inputs, 4);
+        check(inputs.count("attention_mask") == 0 && scalar(inputs, "cache_write_indices") == 0 &&
+                  scalar(inputs, "key_value_lengths") == 4,
+              "native metadata describes the current write without a dense mask");
+
+        cache.set_position(10);
+        inputs.clear();
+        cache.prepare_step(inputs);
+        check(scalar(inputs, "cache_write_indices") == 10 &&
+                  scalar(inputs, "key_value_lengths") == 11,
+              "the final cache row is usable");
+        cache.advance();
+        bool overflow = false;
+        try {
+            cache.prepare_step(inputs);
+        } catch (const std::runtime_error&) {
+            overflow = true;
+        }
+        check(overflow && cache.position() == 11,
+              "an over-capacity write is rejected without logical progression");
+    }
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub standard(stream, 1, 11, 1, 2, DType::kFloat16, false);
+        cache.bind_to(standard);
+        TensorMap inputs;
+        cache.prepare_step(inputs);
+        cache.advance();
+        check(cache.needs_attention_mask() && inputs.count("attention_mask") == 1 &&
+                  inputs.count("cache_write_indices") == 0 && cache.position() == 1,
+              "standard attention-mask cache path still advances normally");
+    }
+
+    {
+        Cache cache(1, 7, 2, stream, DType::kFloat16);
+        NativeKvModuleStub dynamic(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16, {},
+                                   true, true);
+        cache.bind_to(dynamic);
+        TensorMap inputs;
+        cache.prepare_step(inputs);
+        check(dynamic.bound_shape("cache_k_0") == std::vector<int64_t>({7, 2}) &&
+                  inputs.at("attention_mask").shape == std::vector<int64_t>({1, 8}),
+              "runtime-sized cache binds its allocation and mask directly");
+    }
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub prefill(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16, {},
+                                   false, true);
+        cache.bind_cache_inputs(prefill);
+        check(prefill.device_ptr("cache_k_0") == cache.cache_k(0).data() &&
+                  prefill.bound_shape("cache_k_0").empty(),
+              "static cache accepts the dynamic batched-prefill mask contract");
+    }
+
+    const auto make_config = [] {
+        Config config;
+        config.vocab_size = 16;
+        config.id_eos = 9;
+        config.prefill_max_length = 4;
+        config.num_layers = 1;
+        return config;
+    };
+    const auto make_request = [](int32_t max_new_tokens) {
+        TextGenerationConfig request;
+        request.max_new_tokens = max_new_tokens;
+        request.temperature = 0.0F;
+        request.top_k = 1;
+        request.seed = -1;
+        return request;
+    };
+    const std::vector<int32_t> prompt{10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+
+    {
+        auto prefill_trace = std::make_shared<NativeKvTrace>();
+        auto decode_trace = std::make_shared<NativeKvTrace>();
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, 11, 2, stream, DType::kFloat16);
+        Cache* cache_ptr = cache.get();
+        Pipeline pipeline(std::move(decoder), std::move(cache), make_config(),
+                          std::make_shared<NativeKvTokenizer>(), std::move(prefill));
+        const auto result = pipeline.generate_ids(prompt, make_request(1));
+
+        check(prefill_trace->calls.size() == 3, "split prefill runs 4/4/2 chunks");
+        const int32_t starts[] = {0, 4, 8};
+        const int32_t sizes[] = {4, 4, 2};
+        if (prefill_trace->calls.size() == 3) {
+            for (int32_t i = 0; i < 3; ++i) {
+                const auto& call = prefill_trace->calls[static_cast<std::size_t>(i)];
+                check(static_cast<int32_t>(call.tokens.size()) == sizes[i] &&
+                          call.write_index == starts[i] && call.kv_length == starts[i] + sizes[i],
+                      "chunk " + std::to_string(i) + " has correct size and KV range");
+                for (int32_t j = 0; j < sizes[i]; ++j)
+                    check(call.tokens[static_cast<std::size_t>(j)] == 10 + starts[i] + j &&
+                              call.positions[static_cast<std::size_t>(j)] == starts[i] + j,
+                          "chunk token and absolute position progress together");
+            }
+        }
+        check(result.token_ids.size() == 11 && result.token_ids.back() == 9 &&
+                  cache_ptr->position() == 10 && decode_trace->calls.empty(),
+              "final prefill row supplies EOS without an extra decode");
+    }
+
+    {
+        auto prefill_trace = std::make_shared<NativeKvTrace>();
+        auto decode_trace = std::make_shared<NativeKvTrace>();
+        auto prefill = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, prefill_trace);
+        auto decoder = std::make_unique<NativeKvModuleStub>(stream, 1, 11, 1, 2, DType::kFloat16,
+                                                            true, decode_trace);
+        auto cache = std::make_unique<Cache>(1, 11, 2, stream, DType::kFloat16);
+        Cache* cache_ptr = cache.get();
+        Pipeline pipeline(std::move(decoder), std::move(cache), make_config(),
+                          std::make_shared<NativeKvTokenizer>(), std::move(prefill));
+        bool overflow = false;
+        try {
+            (void)pipeline.generate_ids(prompt, make_request(2));
+        } catch (const std::runtime_error&) {
+            overflow = true;
+        }
+        check(overflow && prefill_trace->calls.empty() && decode_trace->calls.empty() &&
+                  cache_ptr->position() == 0,
+              "request over capacity is rejected before any runtime progression");
+    }
+
+    cudaStreamDestroy(stream);
+    return failures;
+}
+
+} // namespace trtmc::test

--- a/families/smollm3/tests/cpp/test_smollm3_chat_template.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_chat_template.cpp
@@ -1,0 +1,266 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Model-owned chat-template coverage for smollm3 decoder formats.
+
+#include "families/smollm3/runtime/chat_templates.h"
+
+#include <clocale>
+#include <ctime>
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static void test_detect_nemotron_h() {
+    std::string tpl = "{% if add_generation_prompt %}<SPECIAL_10>System\n"
+                      "<SPECIAL_11>User\n{{ message.content }}\n"
+                      "<SPECIAL_11>Assistant\n<think>{% endif %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "nemotron_h", "nemotron-h detection");
+}
+
+static void test_detect_chatml() {
+    std::string tpl = "{% for message in messages %}<|im_start|>{{ message.role }}\n{{ "
+                      "message.content }}<|im_end|>\n{% endfor %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "chatml", "chatml detection");
+}
+
+static void test_detect_mistral() {
+    std::string tpl = "{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' "
+                      "%}[INST] {{ message['content'] }} [/INST]{% endif %}{% endfor %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "mistral", "mistral detection");
+}
+
+static void test_detect_phi() {
+    std::string tpl = "{% for message in messages %}<|user|>\n{{ message.content "
+                      "}}<|end|>\n<|assistant|>\n{% endfor %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "phi", "phi detection");
+}
+
+static void test_detect_gemma() {
+    std::string tpl = "{% for message in messages %}<start_of_turn>{{ message.role }}\n{{ "
+                      "message.content }}<end_of_turn>\n{% endfor %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "gemma", "gemma detection");
+}
+
+static void test_detect_llama3() {
+    std::string tpl = "{% for message in messages %}<|start_header_id|>{{ message.role "
+                      "}}<|end_header_id|>\n{{ message.content }}<|eot_id|>{% endfor %}";
+    auto fmt = trtmc::smollm3_detect_chat_template_format(tpl);
+    check(fmt == "llama3", "llama3 detection");
+}
+
+static void test_apply_nemotron_h_no_thinking() {
+    auto result = trtmc::smollm3_apply_chat_template("nemotron_h", "hello", false);
+    check(result == "<SPECIAL_10>System\n\n<SPECIAL_11>User\nhello\n"
+                    "<SPECIAL_11>Assistant\n<think></think>",
+          "nemotron-h no-thinking application");
+}
+
+static void test_apply_chatml_no_thinking() {
+    auto result = trtmc::smollm3_apply_chat_template("chatml", "What is 2+2?", false);
+    check(result == "<|im_start|>user\nWhat is "
+                    "2+2?<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+          "chatml no-thinking application");
+}
+
+static void test_apply_mistral_no_thinking_ignored() {
+    auto result = trtmc::smollm3_apply_chat_template("mistral", "hello", false);
+    check(result == "[INST] hello [/INST]", "mistral no-thinking ignored");
+}
+
+static void test_apply_phi() {
+    auto result = trtmc::smollm3_apply_chat_template("phi", "hello");
+    check(result == "<|user|>\nhello<|end|>\n<|assistant|>\n", "phi application");
+}
+
+static void test_apply_gemma() {
+    auto result = trtmc::smollm3_apply_chat_template("gemma", "hello");
+    check(result == "<start_of_turn>user\nhello<end_of_turn>\n<start_of_turn>model\n",
+          "gemma application");
+}
+
+static void test_apply_llama3() {
+    auto result = trtmc::smollm3_apply_chat_template("llama3", "hello");
+    check(result == "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nhello<|eot_id|><|"
+                    "start_header_id|>assistant<|end_header_id|>\n\n",
+          "llama3 application");
+}
+
+// ── SmolLM3's own chat template ─────────────────────────────────────────────
+// The expected strings below are the verbatim output of the upstream
+// tokenizer's apply_chat_template() for HuggingFaceTB/SmolLM3-3B at revision
+// a07cc9a0, captured with the date pinned. Asserting against the real
+// rendering, rather than a reading of the Jinja source, is what makes this a
+// contract: SmolLM3 always emits a system block, and it does *not* close that
+// block with <|im_end|> before the user turn.
+
+static const char* kSmollm3Date = "04 September 2026";
+
+static void test_detect_smollm3_over_chatml() {
+    // SmolLM3's template is ChatML-framed, so generic ChatML detection must not
+    // claim it -- the SmolLM3 branch carries the mandatory system block.
+    std::string tpl = "{%- if enable_thinking %}{%- set reasoning_mode = \"/think\" %}{%- endif %}"
+                      "{{- \"<|im_start|>system\\n\" -}}"
+                      "{{- \"Reasoning Mode: \" + reasoning_mode + \"\\n\\n\" -}}";
+    check(trtmc::smollm3_detect_chat_template_format(tpl) == "smollm3",
+          "smollm3 detection wins over chatml");
+}
+
+static void test_apply_smollm3_no_thinking() {
+    const std::string expected =
+        "<|im_start|>system\n"
+        "## Metadata\n"
+        "\n"
+        "Knowledge Cutoff Date: June 2025\n"
+        "Today Date: 04 September 2026\n"
+        "Reasoning Mode: /no_think\n"
+        "\n"
+        "## Custom Instructions\n"
+        "\n"
+        "You are a helpful AI assistant named SmolLM, trained by Hugging Face.\n"
+        "\n"
+        "<|im_start|>user\n"
+        "What is 2+2?<|im_end|>\n"
+        "<|im_start|>assistant\n"
+        "<think>\n"
+        "\n"
+        "</think>\n";
+    auto result =
+        trtmc::smollm3_apply_chat_template("smollm3", "What is 2+2?", false, kSmollm3Date);
+    check(result == expected, "smollm3 /no_think matches upstream byte for byte");
+    check(result.size() == 297, "smollm3 /no_think length matches upstream (297)");
+}
+
+static void test_apply_smollm3_thinking() {
+    const std::string expected =
+        "<|im_start|>system\n"
+        "## Metadata\n"
+        "\n"
+        "Knowledge Cutoff Date: June 2025\n"
+        "Today Date: 04 September 2026\n"
+        "Reasoning Mode: /think\n"
+        "\n"
+        "## Custom Instructions\n"
+        "\n"
+        "You are a helpful AI assistant named SmolLM, trained by Hugging Face. Your role as an "
+        "assistant involves thoroughly exploring questions through a systematic thinking process "
+        "before providing the final precise and accurate solutions. This requires engaging in a "
+        "comprehensive cycle of analysis, summarizing, exploration, reassessment, reflection, "
+        "backtracking, and iteration to develop well-considered thinking process. Please structure "
+        "your response into two main sections: Thought and Solution using the specified format: "
+        "<think> Thought section </think> Solution section. In the Thought section, detail your "
+        "reasoning process in steps. Each step should include detailed considerations such as "
+        "analysing questions, summarizing relevant findings, brainstorming new ideas, verifying "
+        "the accuracy of the current steps, refining any errors, and revisiting previous steps. In "
+        "the Solution section, based on various attempts, explorations, and reflections from the "
+        "Thought section, systematically present the final solution that you deem correct. The "
+        "Solution section should be logical, accurate, and concise and detail necessary steps "
+        "needed to reach the conclusion.\n"
+        "\n"
+        "<|im_start|>user\n"
+        "What is 2+2?<|im_end|>\n"
+        "<|im_start|>assistant\n";
+    auto result = trtmc::smollm3_apply_chat_template("smollm3", "What is 2+2?", true, kSmollm3Date);
+    check(result == expected, "smollm3 /think matches upstream byte for byte");
+    check(result.size() == 1369, "smollm3 /think length matches upstream (1369)");
+}
+
+// The rendered date must not follow LC_TIME. strftime's %B returns the locale's
+// translated month name where the reference says the English one, which would
+// desynchronise the served prompt from the reference for every user outside an
+// English locale. Fixed timestamps are used so this does not depend on which
+// month the suite happens to run in.
+static void test_date_is_locale_independent() {
+    // 15th of each month in 2026, UTC.
+    struct Case {
+        std::time_t when;
+        const char* expected;
+    };
+    static const Case kCases[] = {
+        {1768435200, "15 January 2026"},   {1771113600, "15 February 2026"},
+        {1773532800, "15 March 2026"},     {1776211200, "15 April 2026"},
+        {1778803200, "15 May 2026"},       {1781481600, "15 June 2026"},
+        {1784073600, "15 July 2026"},      {1786752000, "15 August 2026"},
+        {1789430400, "15 September 2026"}, {1792022400, "15 October 2026"},
+        {1794700800, "15 November 2026"},  {1797292800, "15 December 2026"},
+    };
+
+    // The formatter is a pure function of the timestamp, so these hold under
+    // whatever locale the suite was started in. This part never skips.
+    for (const Case& one : kCases)
+        check(trtmc::smollm3_format_date(one.when) == one.expected,
+              "date renders the English month name");
+
+    // Now the LC_TIME independence itself. setlocale succeeding proves nothing:
+    // a locale only demonstrates the property where it actually renders the date
+    // differently, so count the cases the replaced strftime("%d %B %Y") would
+    // have got wrong rather than trusting that a locale name resolved.
+    const char* const locales[] = {
+        "de_DE.UTF-8", "de_DE.utf8", "fr_FR.UTF-8", "fr_FR.utf8", "es_ES.UTF-8", "C.UTF-8", "C"};
+    int translating = 0;
+    for (const char* name : locales) {
+        if (std::setlocale(LC_TIME, name) == nullptr)
+            continue; // not installed on this host
+        for (const Case& one : kCases) {
+            const std::tm* tm_utc = std::gmtime(&one.when);
+            char native[64];
+            if (tm_utc != nullptr &&
+                std::strftime(native, sizeof(native), "%d %B %Y", tm_utc) != 0 &&
+                std::string(native) != one.expected)
+                ++translating;
+            check(trtmc::smollm3_format_date(one.when) == one.expected, "date ignores LC_TIME");
+        }
+    }
+    std::setlocale(LC_TIME, "C");
+
+    // A silent pass on a host with only English locales would be a tautology,
+    // so say which of the two happened rather than reporting a bare green.
+    if (translating == 0)
+        std::cerr << "NOTE: no locale on this host renders the date differently; the "
+                     "LC_TIME check could not exercise the property\n";
+    else
+        std::cout << "  LC_TIME check covered " << translating
+                  << " date(s) this host would otherwise render differently\n";
+}
+
+int main() {
+
+    test_detect_smollm3_over_chatml();
+    test_detect_chatml();
+    test_detect_mistral();
+    test_detect_phi();
+    test_detect_gemma();
+    test_detect_llama3();
+    test_detect_nemotron_h();
+    test_apply_smollm3_no_thinking();
+    test_apply_smollm3_thinking();
+    test_apply_chatml_no_thinking();
+    test_apply_mistral_no_thinking_ignored();
+    test_apply_phi();
+    test_apply_gemma();
+    test_apply_llama3();
+    test_apply_nemotron_h_no_thinking();
+    test_date_is_locale_independent();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All smollm3 chat_template tests passed.\n";
+    return 0;
+}

--- a/families/smollm3/tests/cpp/test_smollm3_native_kv_cache.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_native_kv_cache.cpp
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/kv_cache.h"
+#include "families/smollm3/runtime/pipeline.h"
+#include "families/smollm3/tests/cpp/native_kv_cache_contract_test.h"
+
+#include <filesystem>
+#include <iostream>
+
+int main() {
+    if (!std::filesystem::exists("/dev/nvidiactl")) {
+        std::cout << "SKIP: CUDA device is unavailable\n";
+        return 77;
+    }
+    return trtmc::test::run_native_kv_contract_tests<
+        trtmc::SmolLM3TextGenerationPipeline, trtmc::SmolLM3KvCache, trtmc::SmolLM3TextGenConfig>(
+        "SmolLM3");
+}

--- a/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
@@ -1,0 +1,417 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "core/runtime/primitives/trt_common.h"
+#include "core/runtime/tensorrt/trt_module_impl.h"
+#include "families/smollm3/runtime/kv_cache.h"
+#include "families/smollm3/runtime/pipeline.h"
+#include "families/smollm3/runtime/tokenizer.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <NvInfer.h>
+#include <algorithm>
+#include <cstdint>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+
+class TrtModuleImplTestPeer {
+  public:
+    static void set_execution_context_name(TrtModuleImpl& module, const char* name) {
+        module.ctx_->setName(name);
+    }
+
+    static std::string execution_context_name(const TrtModuleImpl& module) {
+        return module.ctx_->getName();
+    }
+};
+
+} // namespace trtmc
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+class StreamFixture {
+  public:
+    StreamFixture() { cudaStreamCreate(&stream); }
+    ~StreamFixture() { cudaStreamDestroy(stream); }
+    cudaStream_t stream{nullptr};
+};
+
+class MockTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<std::int32_t> encode(const std::string&) const override { return {9}; }
+
+    std::string decode(const std::vector<std::int32_t>& ids) const override {
+        std::string text;
+        for (const std::int32_t id : ids)
+            text += token_for_id(id);
+        return text;
+    }
+
+    std::int32_t id_for_token(std::string_view token) const override {
+        if (token == "\\boxed{")
+            return 1;
+        if (token == "70")
+            return 2;
+        if (token == "}")
+            return 3;
+        if (token == " extra")
+            return 4;
+        return 0;
+    }
+
+    std::string token_for_id(std::int32_t id) const override {
+        switch (id) {
+        case 1:
+            return "\\boxed{";
+        case 2:
+            return "70";
+        case 3:
+            return "}";
+        case 4:
+            return " extra";
+        default:
+            return "";
+        }
+    }
+};
+
+class FixedSmolLM3Module final : public trtmc::ITrtModule {
+  public:
+    FixedSmolLM3Module(cudaStream_t stream, bool prefill, std::vector<std::int32_t> output_tokens,
+                       std::int32_t capacity = 16)
+        : stream_(stream), prefill_(prefill), output_tokens_(std::move(output_tokens)),
+          capacity_(capacity), present_k_(std::vector<std::int64_t>{prefill ? capacity : 1, 4},
+                                          trtmc::DType::kFloat32, stream),
+          present_v_(std::vector<std::int64_t>{prefill ? capacity : 1, 4}, trtmc::DType::kFloat32,
+                     stream) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        const auto rows = static_cast<std::int32_t>(inputs.at("token_id").numel());
+        const auto index = std::min(cursor_, output_tokens_.size() - 1);
+        const std::int32_t token = output_tokens_[index];
+        if (cursor_ < output_tokens_.size())
+            ++cursor_;
+        logits_.assign(static_cast<std::size_t>(rows) * 4, -10.0F);
+        for (std::int32_t row = 0; row < rows; ++row)
+            logits_[static_cast<std::size_t>(row) * 4 + token] = 10.0F;
+        return {{"logits", trtmc::Tensor{logits_.data(), {rows, 4}, trtmc::DType::kFloat32}}};
+    }
+
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    bool cuda_graph_captured() const override { return false; }
+    std::int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "attention_mask" || name == "cache_k_0" ||
+               name == "cache_v_0";
+    }
+
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        return name == "token_id" ? trtmc::DType::kInt32 : trtmc::DType::kFloat32;
+    }
+
+    std::vector<std::int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {capacity_, 4};
+        if (name == "present_k_0" || name == "present_v_0")
+            return {prefill_ ? capacity_ : 1, 4};
+        if (name == "attention_mask")
+            return {1, capacity_ + 1};
+        return {};
+    }
+
+    std::vector<std::int64_t>
+    input_profile_shape(const std::string& name, std::int32_t,
+                        trtmc::ProfileShapeSelector selector) const override {
+        if (name == "token_id")
+            return {selector == trtmc::ProfileShapeSelector::kMin ? 1 : capacity_};
+        return tensor_shape(name);
+    }
+
+    std::int32_t optimization_profile_count() const override { return 1; }
+
+    void* device_ptr(const std::string& name) const override {
+        const auto binding = bindings_.find(name);
+        if (binding != bindings_.end())
+            return binding->second;
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+
+    void bind_external(const std::string& name, void* pointer) override {
+        bindings_[name] = pointer;
+    }
+
+    void bind_external(const std::string& name, void* pointer,
+                       const std::vector<std::int64_t>&) override {
+        bind_external(name, pointer);
+    }
+
+    std::int32_t input_rank(const std::string& name) const override {
+        return static_cast<std::int32_t>(tensor_shape(name).size());
+    }
+
+    bool input_is_dynamic(const std::string&) const override { return false; }
+    void reset_execution_context() override { cursor_ = 0; }
+    void set_timing_label(std::string) override {}
+    bool ok() const override {
+        return !output_tokens_.empty() && present_k_.ok() && present_v_.ok();
+    }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    cudaStream_t stream_{nullptr};
+    bool prefill_{false};
+    std::vector<std::int32_t> output_tokens_;
+    std::size_t cursor_{0};
+    std::int32_t capacity_{0};
+    mutable std::unordered_map<std::string, void*> bindings_;
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_;
+};
+
+trtmc::SmolLM3TextGenConfig make_config() {
+    trtmc::SmolLM3TextGenConfig config;
+    config.vocab_size = 4;
+    config.id_bos = 0;
+    config.id_eos = 2;
+    config.prefill_max_length = 16;
+    config.num_layers = 1;
+    return config;
+}
+
+std::unique_ptr<trtmc::SmolLM3TextGenerationPipeline>
+make_pipeline(cudaStream_t stream, trtmc::SmolLM3TextGenConfig config,
+              std::vector<std::int32_t> prefill_tokens = {2},
+              std::vector<std::int32_t> decode_tokens = {2},
+              std::shared_ptr<trtmc::ITokenizer> tokenizer = std::make_shared<MockTokenizer>()) {
+    auto decoder =
+        std::make_unique<FixedSmolLM3Module>(stream, false, std::move(decode_tokens), 16);
+    auto prefill =
+        std::make_unique<FixedSmolLM3Module>(stream, true, std::move(prefill_tokens), 16);
+    auto cache = std::make_unique<trtmc::SmolLM3KvCache>(1, 16, 4, stream);
+    return std::make_unique<trtmc::SmolLM3TextGenerationPipeline>(
+        std::move(decoder), std::move(cache), std::move(config), std::move(tokenizer),
+        std::move(prefill));
+}
+
+void test_pipeline_construction() {
+    StreamFixture fixture;
+    auto pipeline = make_pipeline(fixture.stream, make_config());
+    check(std::string(pipeline->task()) == trtmc::ITextGeneration::kTask,
+          "pipeline exposes text-generation Task API");
+    check(pipeline->default_max_new_tokens() == 128, "pipeline default token limit");
+}
+
+void test_generate_stops_at_eos() {
+    StreamFixture fixture;
+    auto pipeline = make_pipeline(fixture.stream, make_config());
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 10;
+    const auto result = pipeline->generate_ids({1}, request);
+    check(result.token_ids == std::vector<std::int32_t>({1, 2}),
+          "generation stops at configured EOS");
+}
+
+void test_generate_stops_at_any_default_eos() {
+    StreamFixture fixture;
+    auto config = make_config();
+    config.id_eos = 1;
+    config.id_eos_ids = {1, 2};
+    auto pipeline = make_pipeline(fixture.stream, config);
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 10;
+    check(pipeline->generate_ids({1}, request).token_ids == std::vector<std::int32_t>({1, 2}),
+          "generation stops at any default EOS");
+}
+
+void test_explicit_eos_override_replaces_default_set() {
+    StreamFixture fixture;
+    auto config = make_config();
+    config.id_eos = 1;
+    config.id_eos_ids = {1, 2};
+    auto pipeline = make_pipeline(fixture.stream, config);
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 3;
+    request.eos_token_id = 3;
+    check(pipeline->generate_ids({1}, request).token_ids == std::vector<std::int32_t>({1, 2, 2, 2}),
+          "explicit EOS replaces the default set");
+}
+
+void test_generate_max_tokens() {
+    StreamFixture fixture;
+    auto config = make_config();
+    config.id_eos = 99;
+    auto pipeline = make_pipeline(fixture.stream, config);
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 3;
+    check(pipeline->generate_ids({1}, request).token_ids == std::vector<std::int32_t>({1, 2, 2, 2}),
+          "generation respects max_new_tokens");
+}
+
+void test_argmax() {
+    trtmc::SmolLM3SamplingParams params;
+    auto sampler = trtmc::create_smollm3_sampler(params);
+    const std::vector<float> logits = {0.1F, 0.5F, 0.3F, 0.8F, 0.2F};
+    check(
+        sampler->sample(logits.data(), static_cast<std::int32_t>(logits.size()), params).token_id ==
+            3,
+        "argmax selects the largest logit");
+    const std::vector<float> single = {42.0F};
+    check(sampler->sample(single.data(), 1, params).token_id == 0, "argmax selects the only token");
+    check(sampler->sample(nullptr, 0, params).token_id == 0, "empty argmax returns token zero");
+}
+
+void test_zero_max_tokens() {
+    StreamFixture fixture;
+    auto pipeline = make_pipeline(fixture.stream, make_config());
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 0;
+    check(pipeline->generate_ids({1, 2, 3}, request).token_ids ==
+              std::vector<std::int32_t>({1, 2, 3}),
+          "zero max_new_tokens returns the prompt unchanged");
+}
+
+void test_kv_reset_is_logical_and_masks_stale_rows() {
+    StreamFixture fixture;
+    FixedSmolLM3Module decoder(fixture.stream, false, {2}, 8);
+    trtmc::SmolLM3KvCache cache(1, 8, 4, fixture.stream);
+    cache.bind_to(decoder);
+    std::vector<float> stale_k(32, 3.25F);
+    std::vector<float> stale_v(32, -7.5F);
+    check(cache.cache_k(0).copy_from_host(stale_k.data()), "upload stale K rows");
+    check(cache.cache_v(0).copy_from_host(stale_v.data()), "upload stale V rows");
+    cache.set_position(5);
+    cache.reset();
+
+    std::vector<float> actual_k(stale_k.size());
+    std::vector<float> actual_v(stale_v.size());
+    check(cache.cache_k(0).copy_to_host(actual_k.data()), "download stale K rows");
+    check(cache.cache_v(0).copy_to_host(actual_v.data()), "download stale V rows");
+    check(actual_k == stale_k && actual_v == stale_v,
+          "logical reset preserves allocated KV storage");
+    check(cache.position() == 0, "logical reset clears visible cache length");
+
+    trtmc::TensorMap inputs;
+    cache.prepare_step(inputs);
+    const auto& mask = inputs.at("attention_mask");
+    check(mask.shape == std::vector<std::int64_t>({1, 9}),
+          "logical reset mask matches current rank-two decoder contract");
+    const auto* values = static_cast<const float*>(mask.data);
+    check(std::all_of(values, values + 8, [](float value) { return value < -1000.0F; }),
+          "logical reset masks stale cache rows");
+    check(values[8] == 0.0F, "logical reset keeps the current token visible");
+}
+
+trtmc::TrtLogger logger;
+
+trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_context_engine() {
+    auto builder = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(logger));
+    auto network = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(builder->createNetworkV2(0));
+    auto config = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
+    config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 20);
+    auto* token = network->addInput("token_id", nvinfer1::DataType::kINT32, nvinfer1::Dims{1, {1}});
+    auto* mask =
+        network->addInput("attention_mask", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{1, {8}});
+    const float values[4] = {0.1F, 0.2F, 0.9F, 0.3F};
+    auto* logits = network->addConstant(nvinfer1::Dims{1, {4}},
+                                        nvinfer1::Weights{nvinfer1::DataType::kFLOAT, values, 4});
+    logits->getOutput(0)->setName("logits");
+    network->markOutput(*logits->getOutput(0));
+    network->addIdentity(*token)->getOutput(0)->setName("_token");
+    network->addIdentity(*mask)->getOutput(0)->setName("_mask");
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(
+        builder->buildSerializedNetwork(*network, *config));
+    if (!plan)
+        return nullptr;
+    auto runtime = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(logger));
+    return trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        runtime->deserializeCudaEngine(plan->data(), plan->size()));
+}
+
+void test_generation_reset_reuses_execution_context() {
+    StreamFixture fixture;
+    auto engine = build_context_engine();
+    check(engine != nullptr, "build context-reset engine");
+    if (!engine)
+        return;
+    trtmc::TrtModuleImpl module(engine.get(), engine->createExecutionContext(), fixture.stream);
+    trtmc::TrtModuleImplTestPeer::set_execution_context_name(module, "generation-context");
+    module.reset_execution_context();
+    check(trtmc::TrtModuleImplTestPeer::execution_context_name(module) == "generation-context",
+          "generation reset reuses the loaded execution context");
+
+    std::int32_t token_id = 7;
+    std::vector<float> attention_mask(8, 0.0F);
+    trtmc::TensorMap inputs;
+    inputs["token_id"] = trtmc::Tensor{&token_id, {1}, trtmc::DType::kInt32};
+    inputs["attention_mask"] = trtmc::Tensor{attention_mask.data(), {8}, trtmc::DType::kFloat32};
+    check(module.forward(inputs).count("logits") == 1,
+          "reused execution context remains executable");
+}
+
+void test_stop_on_boxed_answer() {
+    StreamFixture fixture;
+    auto config = make_config();
+    config.id_eos = 99;
+    auto pipeline = make_pipeline(fixture.stream, config, {1}, {2, 3, 4});
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 10;
+    request.stop_on_boxed_answer = true;
+    request.stop_check_interval = 1;
+    check(pipeline->generate_ids({9}, request).token_ids == std::vector<std::int32_t>({9, 1, 2, 3}),
+          "boxed-answer stop truncates after the closing brace");
+}
+
+} // namespace
+
+int main() {
+    test_argmax();
+    test_pipeline_construction();
+    test_generate_stops_at_eos();
+    test_generate_stops_at_any_default_eos();
+    test_explicit_eos_override_replaces_default_set();
+    test_generate_max_tokens();
+    test_zero_max_tokens();
+    test_kv_reset_is_logical_and_masks_stale_rows();
+    test_generation_reset_reuses_execution_context();
+    test_stop_on_boxed_answer();
+    if (failures != 0)
+        std::cerr << failures << " SmolLM3 pipeline test(s) failed\n";
+    return failures;
+}

--- a/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
@@ -284,6 +284,23 @@ void test_generate_max_tokens() {
           "generation respects max_new_tokens");
 }
 
+void test_decode_rejects_logits_wider_than_the_vocabulary() {
+    StreamFixture fixture;
+    auto config = make_config();
+    config.vocab_size = 3;
+    config.id_eos = 99;
+    auto pipeline = make_pipeline(fixture.stream, config, {2}, {2});
+    trtmc::TextGenerationConfig request;
+    request.max_new_tokens = 2;
+    bool rejected = false;
+    try {
+        (void)pipeline->generate_ids({1}, request);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    check(rejected, "decode rejects logits wider than the configured vocabulary");
+}
+
 void test_argmax() {
     trtmc::SmolLM3SamplingParams params;
     auto sampler = trtmc::create_smollm3_sampler(params);
@@ -420,6 +437,7 @@ int main() {
     test_generate_stops_at_any_default_eos();
     test_explicit_eos_override_replaces_default_set();
     test_generate_max_tokens();
+    test_decode_rejects_logits_wider_than_the_vocabulary();
     test_zero_max_tokens();
     test_kv_reset_is_logical_and_masks_stale_rows();
     test_generation_reset_reuses_execution_context();

--- a/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_pipeline.cpp
@@ -297,6 +297,18 @@ void test_argmax() {
     check(sampler->sample(nullptr, 0, params).token_id == 0, "empty argmax returns token zero");
 }
 
+void test_min_p_uses_the_full_distribution_without_top_k() {
+    trtmc::SmolLM3SamplingParams params;
+    params.min_p = 0.5F;
+    params.seed = 2;
+    const std::vector<float> logits = {1.0F, 0.9F, 0.8F};
+    auto sampler = trtmc::create_smollm3_sampler(params);
+    check(
+        sampler->sample(logits.data(), static_cast<std::int32_t>(logits.size()), params).token_id ==
+            1,
+        "min-p with default top-k samples beyond the argmax");
+}
+
 void test_zero_max_tokens() {
     StreamFixture fixture;
     auto pipeline = make_pipeline(fixture.stream, make_config());
@@ -402,6 +414,7 @@ void test_stop_on_boxed_answer() {
 
 int main() {
     test_argmax();
+    test_min_p_uses_the_full_distribution_without_top_k();
     test_pipeline_construction();
     test_generate_stops_at_eos();
     test_generate_stops_at_any_default_eos();

--- a/families/smollm3/tests/cpp/test_smollm3_plugin_helpers.cpp
+++ b/families/smollm3/tests/cpp/test_smollm3_plugin_helpers.cpp
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/smollm3/runtime/plugin_helpers.h"
+#include "families/smollm3/runtime/tokenizer.h"
+#include "trtmc/bundle.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+void check_ids(const std::vector<std::int32_t>& actual, const std::vector<std::int32_t>& expected,
+               const char* name) {
+    check(actual == expected, name);
+}
+
+std::string tokenizer_json() {
+    return R"({
+      "model": {
+        "type": "BPE",
+        "unk_token": "<unk>",
+        "vocab": {"<unk>": 0, "<s>": 1, "</s>": 2, "\u2581": 3, "h": 4, "e": 5},
+        "merges": []
+      },
+      "added_tokens": [
+        {"id": 1, "content": "<s>", "special": true},
+        {"id": 2, "content": "</s>", "special": true}
+      ],
+      "pre_tokenizer": {
+        "type": "Metaspace", "replacement": "\u2581", "add_prefix_space": true
+      },
+      "post_processor": {
+        "type": "TemplateProcessing",
+        "single": [
+          {"SpecialToken": {"id": "<s>", "type_id": 0}},
+          {"Sequence": {"id": "A", "type_id": 0}}
+        ]
+      }
+    })";
+}
+
+std::filesystem::path write_tokenizer_bundle(std::string_view tokenizer) {
+    char path[] = "/tmp/trtmc_smollm3_plugin_helpers_XXXXXX";
+    const int descriptor = mkstemp(path);
+    if (descriptor < 0)
+        throw std::runtime_error("mkstemp failed");
+    close(descriptor);
+    const std::string header =
+        R"({"format":1,"family":"smollm3","task":"text_generation","backend":"trt","sections":{"tokenizer.json":{"offset":0,"length":)" +
+        std::to_string(tokenizer.size()) + "}}}";
+    static constexpr unsigned char magic[8] = {'B', 'U', 'N', 'D', 'L', 'E', '\x01', '\0'};
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char*>(magic), sizeof(magic));
+    const auto header_size = static_cast<std::uint64_t>(header.size());
+    for (int shift = 0; shift < 64; shift += 8)
+        output.put(static_cast<char>((header_size >> shift) & 0xffU));
+    output.write(header.data(), static_cast<std::streamsize>(header.size()));
+    output.write(tokenizer.data(), static_cast<std::streamsize>(tokenizer.size()));
+    output.close();
+    return path;
+}
+
+void test_exact_special_frame_uses_bundle_tokenizer() {
+    const std::string json = tokenizer_json();
+    const auto path = write_tokenizer_bundle(json);
+    try {
+        const trtmc::BundleReader bundle(path.string());
+        const auto tokenizer = trtmc::smollm3::create_tokenizer(bundle);
+        check(tokenizer != nullptr, "create tokenizer from current file-backed bundle");
+        check_ids(tokenizer->encode("he"), {1, 3, 4, 5},
+                  "exact post-processor frame adds BOS without fallback EOS");
+    } catch (...) {
+        std::filesystem::remove(path);
+        throw;
+    }
+    std::filesystem::remove(path);
+}
+
+void test_exact_special_frame_respects_add_special_false() {
+    const std::string json = tokenizer_json();
+    const auto tokenizer = trtmc::CreateBpeTokenizer(json.data(), json.size(), false);
+    check(tokenizer != nullptr, "create tokenizer with special frame disabled");
+    check_ids(tokenizer->encode("he"), {3, 4, 5},
+              "exact post-processor frame respects add_special_tokens=false");
+}
+
+} // namespace
+
+int main() {
+    test_exact_special_frame_uses_bundle_tokenizer();
+    test_exact_special_frame_respects_add_special_false();
+    if (failures != 0)
+        std::cerr << failures << " SmolLM3 plugin-helper test(s) failed\n";
+    return failures;
+}

--- a/families/smollm3/tests/manifests/smollm3-3b-l0.json
+++ b/families/smollm3/tests/manifests/smollm3-3b-l0.json
@@ -1,0 +1,23 @@
+{
+  "name": "smollm3-3b-l0",
+  "hf_id": "HuggingFaceTB/SmolLM3-3B",
+  "hf_revision": "a07cc9a04f16550a088caea529712d1d335b0ac1",
+  "bundle": "smollm3-3b-l0.bundle",
+  "family": "smollm3",
+  "task": "text_generation",
+  "precision": "bf16",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "smollm3-3b-l0",
+      "premerge": true,
+      "reference_precision": "fp32",
+      "prompt": "What is the capital of France? Answer in one word.",
+      "max_new_tokens": 10,
+      "use_chat_template": true,
+      "enable_thinking": false
+    }
+  ],
+  "max_sequence_length": 256,
+  "tensor_parallel_size": 1
+}

--- a/families/smollm3/tests/manifests/smollm3-3b-l0.json
+++ b/families/smollm3/tests/manifests/smollm3-3b-l0.json
@@ -14,6 +14,11 @@
       "reference_precision": "fp32",
       "prompt": "What is the capital of France? Answer in one word.",
       "max_new_tokens": 10,
+      "expected_prompt_tokens": 12,
+      "expected_runtime_prefill_tokens": 80,
+      "expected_kv_cache_rows": 256,
+      "expected_prefill_chunks": 2,
+      "expected_prefill_chunk_limit": 64,
       "use_chat_template": true,
       "enable_thinking": false
     }

--- a/families/smollm3/tests/manifests/smollm3-3b-l0.json
+++ b/families/smollm3/tests/manifests/smollm3-3b-l0.json
@@ -16,13 +16,13 @@
       "max_new_tokens": 10,
       "expected_prompt_tokens": 12,
       "expected_runtime_prefill_tokens": 80,
-      "expected_kv_cache_rows": 256,
+      "expected_kv_cache_rows": 65536,
       "expected_prefill_chunks": 2,
       "expected_prefill_chunk_limit": 64,
       "use_chat_template": true,
       "enable_thinking": false
     }
   ],
-  "max_sequence_length": 256,
+  "max_sequence_length": 65536,
   "tensor_parallel_size": 1
 }

--- a/families/smollm3/tests/runtime_receipt.py
+++ b/families/smollm3/tests/runtime_receipt.py
@@ -24,7 +24,9 @@ def prefill_observations(stderr: str) -> tuple[tuple[int, int, int], ...]:
     return tuple(values)
 
 
-def assert_native_kv_receipt(payload: dict, case: dict, prompt_tokens: int) -> None:
+def assert_native_kv_receipt(
+    payload: dict, case: dict, prompt_tokens: int, *, eos_token_ids: tuple[int, ...] = ()
+) -> None:
     stderr = str(payload["runtime_stderr"])
     expected_rows = int(case["expected_kv_cache_rows"])
     expected_launches = int(case["expected_prefill_chunks"])
@@ -42,5 +44,10 @@ def assert_native_kv_receipt(payload: dict, case: dict, prompt_tokens: int) -> N
     assert 0 < observed_max_chunk <= expected_limit
     assert f"KV cache rows={expected_rows} (bundle max={expected_rows})" in stderr
     assert not _RUNTIME_ERROR.search(stderr)
-    assert len(payload["token_ids"]) == int(case["max_new_tokens"])
+    token_ids = payload["token_ids"]
+    limit = int(case["max_new_tokens"])
+    assert 0 < len(token_ids) <= limit
+    assert not any(token in eos_token_ids for token in token_ids[:-1]), "tokens follow EOS"
+    if len(token_ids) < limit:
+        assert token_ids[-1] in eos_token_ids, "generation stopped before its limit without EOS"
     assert float(payload["decode_ms"]) > 0.0

--- a/families/smollm3/tests/runtime_receipt.py
+++ b/families/smollm3/tests/runtime_receipt.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SmolLM3 native-KV runtime receipt checks used by family E2E."""
+
+from __future__ import annotations
+
+import re
+
+_PREFILL = re.compile(r"^\[trtmc\.prefill\] tokens=(\d+) launches=(\d+) max_chunk=(\d+)$")
+_RUNTIME_ERROR = re.compile(
+    r"\[trt\]\s+ERROR:|IExecutionContext::enqueueV3:\s+Error Code|"
+    r"Internal Error:|Cuda Runtime|illegal memory access",
+    re.IGNORECASE,
+)
+
+
+def prefill_observations(stderr: str) -> tuple[tuple[int, int, int], ...]:
+    values = []
+    for line in stderr.splitlines():
+        match = _PREFILL.fullmatch(line.strip())
+        if match:
+            values.append(tuple(int(value) for value in match.groups()))
+    return tuple(values)
+
+
+def assert_native_kv_receipt(payload: dict, case: dict, prompt_tokens: int) -> None:
+    stderr = str(payload["runtime_stderr"])
+    expected_rows = int(case["expected_kv_cache_rows"])
+    expected_launches = int(case["expected_prefill_chunks"])
+    expected_limit = int(case["expected_prefill_chunk_limit"])
+    expected_prompt = int(case["expected_prompt_tokens"])
+    runtime_tokens = int(case["expected_runtime_prefill_tokens"])
+    assert prompt_tokens == expected_prompt
+    observations = prefill_observations(stderr)
+    observed_tokens = sum(value[0] for value in observations)
+    observed_launches = sum(value[1] for value in observations)
+    observed_max_chunk = max((value[2] for value in observations), default=0)
+    assert expected_launches == (runtime_tokens + expected_limit - 1) // expected_limit
+    assert observed_tokens == runtime_tokens
+    assert observed_launches == expected_launches
+    assert 0 < observed_max_chunk <= expected_limit
+    assert f"KV cache rows={expected_rows} (bundle max={expected_rows}" in stderr
+    assert not _RUNTIME_ERROR.search(stderr)
+    assert len(payload["token_ids"]) == int(case["max_new_tokens"])
+    assert float(payload["decode_ms"]) > 0.0

--- a/families/smollm3/tests/runtime_receipt.py
+++ b/families/smollm3/tests/runtime_receipt.py
@@ -40,7 +40,7 @@ def assert_native_kv_receipt(payload: dict, case: dict, prompt_tokens: int) -> N
     assert observed_tokens == runtime_tokens
     assert observed_launches == expected_launches
     assert 0 < observed_max_chunk <= expected_limit
-    assert f"KV cache rows={expected_rows} (bundle max={expected_rows}" in stderr
+    assert f"KV cache rows={expected_rows} (bundle max={expected_rows})" in stderr
     assert not _RUNTIME_ERROR.search(stderr)
     assert len(payload["token_ids"]) == int(case["max_new_tokens"])
     assert float(payload["decode_ms"]) > 0.0

--- a/families/smollm3/tests/test_builder_variants.py
+++ b/families/smollm3/tests/test_builder_variants.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Current single-GPU SmolLM3 standard-decoder builder variants."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+trt = pytest.importorskip("tensorrt")
+
+from ..checkpoint_mapper import WeightDict  # noqa: E402
+from ..config import ModelConfig  # noqa: E402
+from ..standard_decoder_builder import build_standard_decoder_engine  # noqa: E402
+
+
+pytestmark = [pytest.mark.gpu, pytest.mark.trt]
+
+
+def _make_weights(
+    hidden: int,
+    vocab: int,
+    num_layers: int,
+    attention_size: int,
+    mlp_size: int,
+    *,
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+) -> WeightDict:
+    rng = np.random.RandomState(42)
+    weights = WeightDict()
+    weights["embedding"] = rng.randn(vocab, hidden).astype(np.float32)
+    for layer in range(num_layers):
+        prefix = f"layer.{layer}"
+        weights[f"{prefix}.input_norm"] = rng.randn(hidden).astype(np.float32)
+        weights[f"{prefix}.post_attn_norm"] = rng.randn(hidden).astype(np.float32)
+        weights[f"{prefix}.w_q"] = rng.randn(hidden, attention_size).astype(np.float32)
+        weights[f"{prefix}.w_k"] = rng.randn(hidden, attention_size).astype(np.float32)
+        weights[f"{prefix}.w_v"] = rng.randn(hidden, attention_size).astype(np.float32)
+        weights[f"{prefix}.w_o"] = rng.randn(attention_size, hidden).astype(np.float32)
+        if mlp_type == "swiglu":
+            weights[f"{prefix}.w_gate"] = rng.randn(hidden, mlp_size).astype(np.float32)
+            weights[f"{prefix}.w_up"] = rng.randn(hidden, mlp_size).astype(np.float32)
+            weights[f"{prefix}.w_down"] = rng.randn(mlp_size, hidden).astype(np.float32)
+        else:
+            weights[f"{prefix}.w_fc1"] = rng.randn(hidden, mlp_size).astype(np.float32)
+            weights[f"{prefix}.w_fc2"] = rng.randn(mlp_size, hidden).astype(np.float32)
+    weights["final_norm"] = rng.randn(hidden).astype(np.float32)
+    weights["w_out"] = rng.randn(hidden, vocab).astype(np.float32)
+    weights["_attention_size"] = attention_size
+    weights["_mlp_size"] = mlp_size
+    if position_type == "learned":
+        weights["position_embedding"] = rng.randn(64, hidden).astype(np.float32)
+    return weights
+
+
+def _build_engine(**kwargs) -> bytes:
+    hidden, vocab, num_layers = 16, 32, 2
+    config = ModelConfig(
+        model_type="smollm3",
+        hidden_size=hidden,
+        vocab_size=vocab,
+        intermediate_size=32,
+        num_hidden_layers=num_layers,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+        max_position_embeddings=64,
+    )
+    mlp_type = kwargs.get("mlp_type", "swiglu")
+    position_type = kwargs.get("position_type", "rope")
+    weights = _make_weights(
+        hidden,
+        vocab,
+        num_layers,
+        hidden,
+        32,
+        mlp_type=mlp_type,
+        position_type=position_type,
+    )
+    return build_standard_decoder_engine(config, weights, 4, **kwargs)
+
+
+def _deserialize(plan: bytes):
+    return trt.Runtime(trt.Logger(trt.Logger.WARNING)).deserialize_cuda_engine(plan)
+
+
+def _io_names(plan: bytes) -> tuple[set[str], set[str]]:
+    engine = _deserialize(plan)
+    assert engine is not None
+    inputs: set[str] = set()
+    outputs: set[str] = set()
+    for index in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(index)
+        target = inputs if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT else outputs
+        target.add(name)
+    return inputs, outputs
+
+
+def test_default_rope_swiglu() -> None:
+    plan = _build_engine()
+    inputs, outputs = _io_names(plan)
+
+    assert {
+        "token_id",
+        "position_id",
+        "attention_mask",
+        "cache_k_0",
+        "cache_k_1",
+        "cache_v_0",
+        "cache_v_1",
+    } <= inputs
+    assert {"logits", "present_k_0", "present_k_1", "present_v_0", "present_v_1"} <= outputs
+    engine = _deserialize(plan)
+    assert engine is not None
+    assert engine.get_tensor_profile_shape("attention_mask", 0) == [(1, 5), (4, 8), (4, 8)]
+    assert engine.get_tensor_profile_shape("attention_mask", 1) == [(1, 5), (1, 5), (1, 5)]
+
+
+def test_layernorm_gelu_fc() -> None:
+    inputs, outputs = _io_names(
+        _build_engine(norm_type="layernorm", mlp_type="gelu_fc", activation="gelu_new")
+    )
+    assert "token_id" in inputs
+    assert {"logits", "present_k_0"} <= outputs
+
+
+def test_learned_positions() -> None:
+    inputs, outputs = _io_names(_build_engine(position_type="learned"))
+    assert {"token_id", "position_id"} <= inputs
+    assert "logits" in outputs
+
+
+def test_alibi_positions() -> None:
+    inputs, outputs = _io_names(_build_engine(position_type="alibi"))
+    assert {"token_id", "position_id"} <= inputs
+    assert "logits" in outputs
+
+
+def test_embed_input() -> None:
+    inputs, outputs = _io_names(_build_engine(embed_input=True))
+    assert {"input_embed", "use_input_embed", "token_id"} <= inputs
+    assert "logits" in outputs

--- a/families/smollm3/tests/test_checkpoint_mapper.py
+++ b/families/smollm3/tests/test_checkpoint_mapper.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from families.smollm3 import checkpoint_mapper
+from families.smollm3.config import ModelConfig
+
+
+class _Reader:
+    def get_tensor(self, _name: str) -> np.ndarray:
+        return np.zeros((3, 4), dtype=np.float32)
+
+
+def test_checkpoint_embedding_shape_validation_is_always_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    reader = _Reader()
+    readers = SimpleNamespace(tensor_map={"model.embed_tokens.weight": reader})
+    monkeypatch.setattr(checkpoint_mapper, "_open_safetensors", lambda _path: readers)
+    config = ModelConfig.create_tiny(
+        "smollm3",
+        hidden_size=4,
+        vocab_size=5,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        max_position_embeddings=16,
+    )
+
+    with pytest.raises(ValueError, match=r"Embedding shape \(3, 4\) != \(5, 4\)"):
+        checkpoint_mapper.load_standard_weights(tmp_path, config)

--- a/families/smollm3/tests/test_e2e.py
+++ b/families/smollm3/tests/test_e2e.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned checkpoint-to-native-runtime proof."""
+
+from __future__ import annotations
+
+import gc
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect import BuildRequest, build
+
+
+_TEST_DIR = Path(__file__).resolve().parent
+_FAMILY = _TEST_DIR.parent.name
+_MPI_RANK_ZERO = re.compile(r"^\[[^,]+,0\]<stdout>:(.*)$")
+_NATIVE_KV_FIELDS = frozenset(
+    {
+        "expected_prompt_tokens",
+        "expected_runtime_prefill_tokens",
+        "expected_kv_cache_rows",
+        "expected_prefill_chunks",
+        "expected_prefill_chunk_limit",
+    }
+)
+
+
+def _load_cases() -> dict[str, tuple[dict, dict]]:
+    cases: dict[str, tuple[dict, dict]] = {}
+    for path in sorted((_TEST_DIR / "manifests").glob("*.json")):
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        assert manifest["family"] == _FAMILY, path
+        assert manifest["task"] == "text_generation", path
+        assert isinstance(manifest["precision"], str), path
+        assert isinstance(manifest["max_sequence_length"], int), path
+        assert isinstance(manifest["tensor_parallel_size"], int), path
+        for case in manifest["testcases"]:
+            name = case["name"]
+            assert name not in cases, name
+            cases[name] = (manifest, case)
+    assert cases, f"{_FAMILY} has no E2E cases"
+    return cases
+
+
+_CASES = _load_cases()
+
+
+def _csv_values(values: list[str]) -> set[str]:
+    return {item.strip() for value in values for item in str(value).split(",") if item.strip()}
+
+
+def _selection(config) -> set[str]:
+    selected = _csv_values(config.getoption("--e2e-model", default=[]) or [])
+    selected |= _csv_values(config.getoption("--e2e-testcase", default=[]) or [])
+    models_file = config.getoption("--e2e-models-file", default=None)
+    if models_file:
+        path = Path(models_file)
+        assert path.is_file(), f"E2E models file does not exist: {path}"
+        selected |= {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+    return selected
+
+
+def _require_selected(case_name: str, manifest: dict, config) -> None:
+    selected = _selection(config)
+    enabled = os.environ.get("TRTMC_E2E") == "1"
+    if not enabled and not selected:
+        pytest.skip("real family E2E requires TRTMC_E2E=1 or an explicit E2E selection")
+    if selected and not ({_FAMILY, manifest["name"], case_name} & selected):
+        pytest.skip(f"{case_name} was not selected")
+
+
+def _required_environment(tp_size: int):
+    binary_value = os.environ.get("TRTMC_BINARY")
+    runtime_value = os.environ.get("TRTMC_RUNTIME_ROOT")
+    assert binary_value, "selected E2E requires TRTMC_BINARY"
+    assert runtime_value, "selected E2E requires TRTMC_RUNTIME_ROOT"
+
+    binary = Path(binary_value)
+    runtime_root = Path(runtime_value)
+    assert binary.is_file() and os.access(binary, os.X_OK), binary
+    assert runtime_root.is_dir(), runtime_root
+    assert (runtime_root / "libtrtmc_backend_trt.so").is_file(), runtime_root
+    assert (runtime_root / f"libtrtmc_model_{_FAMILY}.so").is_file(), runtime_root
+
+    import torch
+
+    assert torch.cuda.is_available(), "selected E2E requires CUDA"
+    assert torch.cuda.device_count() >= tp_size, (
+        f"{_FAMILY} TP{tp_size} requires {tp_size} visible GPUs; found {torch.cuda.device_count()}"
+    )
+    if tp_size > 1:
+        assert shutil.which("mpirun"), "selected TP E2E requires mpirun"
+    return binary, runtime_root, torch
+
+
+def _checkpoint(manifest: dict) -> Path:
+    from huggingface_hub import snapshot_download
+
+    path = Path(
+        snapshot_download(
+            repo_id=manifest["hf_id"],
+            revision=manifest.get("hf_revision"),
+        )
+    )
+    assert (path / "config.json").is_file(), path
+    return path
+
+
+def _prompt(case: dict) -> str:
+    if "prompt" in case:
+        prompt = case["prompt"]
+        assert isinstance(prompt, str) and prompt, case["name"]
+        return prompt
+    repeated = case["prompt_repeat"]
+    count = int(repeated["count"])
+    assert count > 0
+    return str(repeated["separator"]).join([str(repeated["text"])] * count) + str(
+        repeated.get("suffix", "")
+    )
+
+
+def _thresholds(case_name: str) -> dict[str, float]:
+    path = _TEST_DIR / "thresholds" / f"{case_name}.json"
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    thresholds = payload["threshold_overrides"]
+    assert isinstance(thresholds, dict) and thresholds, path
+    return thresholds
+
+
+def _build_bundle(manifest: dict, model_dir: Path, bundle: Path) -> None:
+    quantization = manifest.get("quantization")
+    assert quantization is None or isinstance(quantization, str)
+    fp32_layers = tuple(manifest.get("fp32_layers", ()))
+    build(
+        BuildRequest(
+            model_dir=model_dir,
+            output_path=bundle,
+            family=_FAMILY,
+            task="text_generation",
+            precision=manifest["precision"],
+            max_sequence_length=manifest["max_sequence_length"],
+            tensor_parallel_size=manifest["tensor_parallel_size"],
+            quantization=quantization,
+            fp32_layers=fp32_layers,
+            dynamic_kv_cache=bool(manifest.get("dynamic_kv_cache", False)),
+        )
+    )
+    assert bundle.is_file() and bundle.stat().st_size > 0, bundle
+
+
+def _assert_rank_sections(binary: Path, bundle: Path, tp_size: int) -> None:
+    inspected = subprocess.run(
+        [str(binary), "inspect", str(bundle)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    payload = json.loads(inspected.stdout)
+    assert payload["family"] == _FAMILY
+    assert payload["task"] == "text_generation"
+    if tp_size > 1:
+        rank_sections = {
+            name
+            for name in payload["sections"]
+            if name.startswith("engine.rank") and name.endswith(".plan")
+        }
+        assert rank_sections == {f"engine.rank{rank}.plan" for rank in range(tp_size)}
+
+
+def _native_arguments(bundle: Path, runtime_root: Path, prompt: str, case: dict) -> list[str]:
+    arguments = [
+        "run",
+        str(bundle),
+        "--runtime-root",
+        str(runtime_root),
+        "--prompt",
+        prompt,
+        "--max-new-tokens",
+        str(case["max_new_tokens"]),
+    ]
+    options = {
+        "temperature": "--temperature",
+        "top_k": "--top-k",
+        "top_p": "--top-p",
+        "min_p": "--min-p",
+        "seed": "--seed",
+        "repetition_penalty": "--repetition-penalty",
+        "use_chat_template": "--use-chat-template",
+        "enable_thinking": "--enable-thinking",
+    }
+    for field, option in options.items():
+        if field not in case:
+            continue
+        value = case[field]
+        if isinstance(value, bool):
+            value = "true" if value else "false"
+        arguments.extend([option, str(value)])
+    if "kv_cache_size" in case:
+        arguments.extend(["--kv-cache-size", str(case["kv_cache_size"])])
+    return arguments
+
+
+def _run_native(
+    binary: Path,
+    runtime_root: Path,
+    bundle: Path,
+    prompt: str,
+    case: dict,
+    tp_size: int,
+    tmp_path: Path,
+) -> dict:
+    command = [str(binary), *_native_arguments(bundle, runtime_root, prompt, case)]
+    environment = dict(os.environ)
+    if tp_size > 1:
+        environment["TRTMC_NCCL_RENDEZVOUS"] = str(tmp_path / "nccl.rendezvous")
+        prefix = ["mpirun", "--tag-output", "-np", str(tp_size)]
+        for name in ("LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES", "TRTMC_NCCL_RENDEZVOUS"):
+            if name in environment:
+                prefix.extend(["-x", name])
+        command = [*prefix, *command]
+
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=environment,
+    )
+    if tp_size == 1:
+        payload = json.loads(completed.stdout)
+        payload["runtime_stderr"] = completed.stderr
+        return payload
+
+    rank_zero_payloads = []
+    for line in completed.stdout.splitlines():
+        match = _MPI_RANK_ZERO.fullmatch(line)
+        if match and match.group(1).lstrip().startswith("{"):
+            rank_zero_payloads.append(match.group(1))
+    assert len(rank_zero_payloads) == 1, completed.stdout
+    payload = json.loads(rank_zero_payloads[0])
+    payload["runtime_stderr"] = completed.stderr
+    return payload
+
+
+def _raw_prompt_token_count(model_dir: Path, manifest: dict, prompt: str) -> int:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_dir,
+        local_files_only=True,
+        trust_remote_code=bool(manifest.get("trust_remote_code", False)),
+    )
+    return len(tokenizer.encode(prompt, add_special_tokens=False))
+
+
+def _render_prompt(tokenizer, prompt: str, case: dict):
+    if not case.get("use_chat_template", False):
+        return tokenizer(prompt, return_tensors="pt")
+    options = {"tokenize": False, "add_generation_prompt": True}
+    if "enable_thinking" in case:
+        options["enable_thinking"] = case["enable_thinking"]
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        **options,
+    )
+    return tokenizer(rendered, return_tensors="pt", add_special_tokens=False)
+
+
+def _is_sampling(case: dict) -> bool:
+    return bool(
+        case.get("do_sample", False)
+        or float(case.get("temperature", 1.0)) not in {0.0, 1.0}
+        or int(case.get("top_k", 1)) > 1
+        or float(case.get("top_p", 1.0)) < 1.0
+        or float(case.get("min_p", 0.0)) > 0.0
+    )
+
+
+def _apply_repetition_penalty(logits, token_ids: list[int], penalty: float):
+    if penalty == 1.0:
+        return logits
+    logits = logits.clone()
+    for token_id in set(token_ids):
+        logits[token_id] = (
+            logits[token_id] * penalty if logits[token_id] < 0 else logits[token_id] / penalty
+        )
+    return logits
+
+
+def _allowed_tokens(torch, logits, case: dict, history: list[int]):
+    penalty = float(case.get("repetition_penalty", 1.0))
+    logits = _apply_repetition_penalty(logits.float(), history, penalty)
+    temperature = float(case.get("temperature", 1.0))
+    if temperature > 0.0:
+        logits = logits / temperature
+    probabilities = torch.softmax(logits, dim=-1)
+    allowed = torch.ones_like(probabilities, dtype=torch.bool)
+
+    top_k = int(case.get("top_k", 0))
+    if top_k > 0 and top_k < probabilities.numel():
+        top_indices = torch.topk(probabilities, top_k).indices
+        top_mask = torch.zeros_like(allowed)
+        top_mask[top_indices] = True
+        allowed &= top_mask
+
+    top_p = float(case.get("top_p", 1.0))
+    if top_p < 1.0:
+        sorted_probabilities, sorted_indices = torch.sort(probabilities, descending=True)
+        keep = torch.cumsum(sorted_probabilities, dim=-1) - sorted_probabilities < top_p
+        top_p_mask = torch.zeros_like(allowed)
+        top_p_mask[sorted_indices[keep]] = True
+        allowed &= top_p_mask
+
+    min_p = float(case.get("min_p", 0.0))
+    if min_p > 0.0:
+        allowed &= probabilities >= probabilities.max() * min_p
+    return allowed
+
+
+def _hf_reference(
+    model_dir: Path,
+    manifest: dict,
+    case: dict,
+    prompt: str,
+    actual_ids: list[int],
+    torch,
+) -> tuple[list[int], str, float | None, str]:
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    trust_remote_code = bool(manifest.get("trust_remote_code", False))
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_dir,
+        local_files_only=True,
+        trust_remote_code=trust_remote_code,
+    )
+    reference_precision = case.get(
+        "reference_precision",
+        manifest.get("reference_precision", manifest["precision"]),
+    )
+    dtypes = {
+        "fp32": torch.float32,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }
+    assert reference_precision in dtypes, reference_precision
+    model = (
+        AutoModelForCausalLM.from_pretrained(
+            model_dir,
+            local_files_only=True,
+            trust_remote_code=trust_remote_code,
+            dtype=dtypes[reference_precision],
+        )
+        .eval()
+        .to("cuda")
+    )
+    inputs = _render_prompt(tokenizer, prompt, case).to(model.device)
+    prompt_ids = inputs["input_ids"][0].tolist()
+    if "expected_prompt_token_ids" in case:
+        assert prompt_ids == case["expected_prompt_token_ids"]
+
+    sampling_support = None
+    reference_ids: list[int] = []
+    reference_text = ""
+    with torch.inference_mode():
+        if _is_sampling(case):
+            output = model(**inputs, use_cache=True)
+            past = output.past_key_values
+            history = list(prompt_ids)
+            attention_mask = inputs.get("attention_mask")
+            accepted = 0
+            for token_id in actual_ids:
+                allowed = _allowed_tokens(torch, output.logits[0, -1], case, history)
+                accepted += int(0 <= token_id < allowed.numel() and allowed[token_id].item())
+                history.append(token_id)
+                next_id = torch.tensor([[token_id]], dtype=torch.long, device=model.device)
+                next_inputs = {
+                    "input_ids": next_id,
+                    "past_key_values": past,
+                    "use_cache": True,
+                }
+                if attention_mask is not None:
+                    attention_mask = torch.cat(
+                        [
+                            attention_mask,
+                            torch.ones(
+                                (1, 1),
+                                dtype=attention_mask.dtype,
+                                device=model.device,
+                            ),
+                        ],
+                        dim=1,
+                    )
+                    next_inputs["attention_mask"] = attention_mask
+                output = model(**next_inputs)
+                past = output.past_key_values
+            sampling_support = accepted / len(actual_ids)
+        else:
+            generate_options = {
+                "max_new_tokens": int(case["max_new_tokens"]),
+                "do_sample": False,
+            }
+            if "repetition_penalty" in case:
+                generate_options["repetition_penalty"] = float(case["repetition_penalty"])
+            generated = model.generate(**inputs, **generate_options)
+            reference_ids = generated[0, inputs["input_ids"].shape[1] :].tolist()
+            reference_text = tokenizer.decode(reference_ids, skip_special_tokens=True).strip()
+
+    actual_decoded = tokenizer.decode(actual_ids, skip_special_tokens=True).strip()
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return reference_ids, reference_text, sampling_support, actual_decoded
+
+
+def _normalized_edit_distance(left: str, right: str) -> float:
+    left = " ".join(left.casefold().split())
+    right = " ".join(right.casefold().split())
+    if not left and not right:
+        return 0.0
+    previous = list(range(len(right) + 1))
+    for left_index, left_character in enumerate(left, start=1):
+        current = [left_index]
+        for right_index, right_character in enumerate(right, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[right_index] + 1,
+                    previous[right_index - 1] + (left_character != right_character),
+                )
+            )
+        previous = current
+    return previous[-1] / max(len(left), len(right))
+
+
+def _text_threshold(case: dict, thresholds: dict[str, float]) -> float:
+    default = 0.15 if case.get("use_chat_template") else 0.25
+    return float(thresholds.get("contract_ned_threshold", default))
+
+
+def _assert_correctness(
+    payload: dict,
+    case: dict,
+    thresholds: dict[str, float],
+    reference_ids: list[int],
+    reference_text: str,
+    sampling_support: float | None,
+    actual_decoded: str,
+) -> None:
+    actual_ids = payload["token_ids"]
+    assert isinstance(actual_ids, list) and actual_ids
+    assert all(isinstance(token_id, int) for token_id in actual_ids)
+    assert len(actual_ids) <= int(case["max_new_tokens"]), (
+        "Task API token_ids must contain generated tokens only"
+    )
+    actual_text = str(payload["text"]).strip()
+    if case.get("enable_thinking") is False:
+        assert "<think>" not in actual_text.casefold()
+    if "expected_continuation_token_ids" in case:
+        assert actual_ids == case["expected_continuation_token_ids"]
+    if "expected_continuation_text" in case:
+        assert case["expected_continuation_text"].casefold() in actual_decoded.casefold()
+    expected_answers = case.get("expected_answers", ())
+    if expected_answers:
+        assert any(answer.casefold() in actual_decoded.casefold() for answer in expected_answers)
+
+    del sampling_support
+    assert actual_text
+    assert _normalized_edit_distance(actual_text, reference_text) <= _text_threshold(
+        case, thresholds
+    )
+
+
+@pytest.mark.parametrize("case_name", sorted(_CASES))
+def test_e2e(case_name: str, request, tmp_path: Path) -> None:
+    manifest, case = _CASES[case_name]
+    _require_selected(case_name, manifest, request.config)
+    tp_size = manifest["tensor_parallel_size"]
+    binary, runtime_root, torch = _required_environment(tp_size)
+    model_dir = _checkpoint(manifest)
+    prompt = _prompt(case)
+    bundle = tmp_path / manifest["bundle"]
+
+    _build_bundle(manifest, model_dir, bundle)
+    _assert_rank_sections(binary, bundle, tp_size)
+    payload = _run_native(
+        binary,
+        runtime_root,
+        bundle,
+        prompt,
+        case,
+        tp_size,
+        tmp_path,
+    )
+    reruns = int(case.get("determinism_reruns", 0))
+    for _ in range(reruns):
+        repeated = _run_native(
+            binary,
+            runtime_root,
+            bundle,
+            prompt,
+            case,
+            tp_size,
+            tmp_path,
+        )
+        assert repeated["token_ids"] == payload["token_ids"]
+        assert repeated["text"] == payload["text"]
+
+    if "expected_kv_cache_rows" in case:
+        assert (
+            f"[trtmc] KV cache rows={case['expected_kv_cache_rows']} "
+            f"(bundle max={manifest['max_sequence_length']})" in payload["runtime_stderr"]
+        )
+
+    if _NATIVE_KV_FIELDS <= case.keys():
+        from families.smollm3.tests.runtime_receipt import assert_native_kv_receipt
+
+        prompt_tokens = _raw_prompt_token_count(model_dir, manifest, prompt)
+        assert_native_kv_receipt(payload, case, prompt_tokens)
+        return
+
+    reference = _hf_reference(
+        model_dir,
+        manifest,
+        case,
+        prompt,
+        payload["token_ids"],
+        torch,
+    )
+    _assert_correctness(payload, case, _thresholds(case_name), *reference)

--- a/families/smollm3/tests/test_e2e.py
+++ b/families/smollm3/tests/test_e2e.py
@@ -479,11 +479,23 @@ def _assert_correctness(
     if expected_answers:
         assert any(answer.casefold() in actual_decoded.casefold() for answer in expected_answers)
 
-    del sampling_support
     assert actual_text
+    if sampling_support is not None:
+        assert sampling_support >= float(thresholds.get("unstable_topk_hit_rate", 0.8))
+        return
     assert _normalized_edit_distance(actual_text, reference_text) <= _text_threshold(
         case, thresholds
     )
+
+
+def test_sampling_correctness_uses_support_instead_of_empty_reference() -> None:
+    payload = {"token_ids": [7, 8], "text": "sampled text"}
+    case = {"max_new_tokens": 2, "temperature": 0.7}
+
+    _assert_correctness(payload, case, {"unstable_topk_hit_rate": 0.8}, [], "", 1.0, "")
+
+    with pytest.raises(AssertionError):
+        _assert_correctness(payload, case, {"unstable_topk_hit_rate": 0.8}, [], "", 0.5, "")
 
 
 @pytest.mark.parametrize("case_name", sorted(_CASES))
@@ -532,7 +544,6 @@ def test_e2e(case_name: str, request, tmp_path: Path) -> None:
 
         prompt_tokens = _raw_prompt_token_count(model_dir, manifest, prompt)
         assert_native_kv_receipt(payload, case, prompt_tokens)
-        return
 
     reference = _hf_reference(
         model_dir,

--- a/families/smollm3/tests/test_e2e.py
+++ b/families/smollm3/tests/test_e2e.py
@@ -540,10 +540,14 @@ def test_e2e(case_name: str, request, tmp_path: Path) -> None:
         )
 
     if _NATIVE_KV_FIELDS <= case.keys():
+        from transformers import GenerationConfig
+
         from families.smollm3.tests.runtime_receipt import assert_native_kv_receipt
 
         prompt_tokens = _raw_prompt_token_count(model_dir, manifest, prompt)
-        assert_native_kv_receipt(payload, case, prompt_tokens)
+        eos = GenerationConfig.from_pretrained(model_dir, local_files_only=True).eos_token_id
+        eos_token_ids = () if eos is None else tuple(eos if isinstance(eos, list) else [eos])
+        assert_native_kv_receipt(payload, case, prompt_tokens, eos_token_ids=eos_token_ids)
 
     reference = _hf_reference(
         model_dir,

--- a/families/smollm3/tests/test_model.py
+++ b/families/smollm3/tests/test_model.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned tests for the plain SmolLM3 build entry point."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tensorrt")
+
+from families.smollm3 import model  # noqa: E402
+from tensorrt_model_connect import BuildRequest  # noqa: E402
+
+
+class RecordingWriter:
+    def __init__(self) -> None:
+        self.header: dict[str, object] | None = None
+        self.sections: dict[str, bytes] = {}
+        self.json_sections: dict[str, object] = {}
+
+    def set_header(self, **header: object) -> None:
+        self.header = header
+
+    def add_bytes(self, name: str, value: bytes) -> None:
+        assert name not in self.sections
+        self.sections[name] = value
+
+    def add_json(self, name: str, value: object) -> None:
+        assert name not in self.json_sections
+        self.json_sections[name] = value
+
+
+def _checkpoint(root: Path) -> Path:
+    root.mkdir()
+    config = {
+        "model_type": "smollm3",
+        "architectures": ["SmolLM3ForCausalLM"],
+        "vocab_size": 128256,
+        "hidden_size": 2048,
+        "intermediate_size": 11008,
+        "num_hidden_layers": 36,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 5_000_000.0,
+        "bos_token_id": 128000,
+        "eos_token_id": 128012,
+        "pad_token_id": 128004,
+        "tie_word_embeddings": True,
+        "max_position_embeddings": 65536,
+        "hidden_act": "silu",
+        "no_rope_layer_interval": 4,
+        "no_rope_layers": [int((index + 1) % 4 != 0) for index in range(36)],
+        "pretraining_tp": 2,
+    }
+    (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (root / "tokenizer.json").write_bytes(b"tokenizer")
+    return root
+
+
+def _request(model_dir: Path, **changes: object) -> BuildRequest:
+    request = BuildRequest(
+        model_dir=model_dir,
+        output_path=model_dir.parent / "smollm3.bundle",
+        family="smollm3",
+        task="text_generation",
+        precision="bf16",
+        max_sequence_length=256,
+    )
+    return replace(request, **changes)
+
+
+def test_build_emits_the_family_owned_split_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    checkpoint = _checkpoint(tmp_path / "checkpoint")
+    calls: list[tuple[str, int, str]] = []
+    monkeypatch.setattr(model, "load_standard_weights", lambda *args, **kwargs: {})
+
+    def build_engine(config, weights, length: int, *, precision: str, verbose: bool) -> bytes:
+        role = str(config.raw["_decoder_engine_role"])
+        calls.append((role, length, precision))
+        return role.encode()
+
+    monkeypatch.setattr(model, "_build_engine", build_engine)
+    writer = RecordingWriter()
+
+    model.build(_request(checkpoint), writer)
+
+    assert writer.header == {
+        "family": "smollm3",
+        "task": "text_generation",
+        "backend": "trt",
+    }
+    assert writer.sections == {
+        "prefill.plan": b"prefill",
+        "engine.plan": b"decode",
+        "tokenizer.json": b"tokenizer",
+    }
+    assert calls == [("prefill", 256, "bf16"), ("decode", 256, "bf16")]
+    runtime = writer.json_sections["runtime.json"]
+    assert isinstance(runtime, dict)
+    assert runtime["decoder_engine_layout"] == "split"
+    assert runtime["max_cache_length"] == 256
+    assert runtime["precision"] == "bf16"
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"task": "classification"}, "task=text_generation"),
+        ({"dynamic_kv_cache": True}, "dynamic_kv_cache"),
+        ({"precision": "fp8"}, "fp32, fp16, or bf16"),
+        ({"max_batch_size": 2}, "max_batch_size"),
+        ({"tensor_parallel_size": 2}, "tensor-parallel"),
+        ({"context_parallel_size": 2}, "context parallelism"),
+        ({"quantization": "fp8"}, "quantized"),
+        ({"image_height": 256}, "image_height"),
+        ({"image_width": 256}, "image_width"),
+        ({"video_num_frames": 8}, "video_num_frames"),
+    ],
+)
+def test_build_rejects_unsupported_profiles(
+    tmp_path: Path, changes: dict[str, object], message: str
+) -> None:
+    checkpoint = _checkpoint(tmp_path / "checkpoint")
+    with pytest.raises((ValueError, NotImplementedError), match=message):
+        model.build(_request(checkpoint, **changes), RecordingWriter())

--- a/families/smollm3/tests/test_native_kv_routing.py
+++ b/families/smollm3/tests/test_native_kv_routing.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU routing and NoPE contracts for the published SmolLM3 family."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from families.smollm3.build_routing import (
+    native_kv_architecture_capability,
+    native_kv_build_capability,
+    native_kv_cache_geometry,
+)
+from families.smollm3.config import ModelConfig, resolve_rope_layer_schedule
+
+
+def _published_checkpoint_config(**raw_updates: object) -> ModelConfig:
+    """Return config.json fields from the revision pinned by the manifest."""
+    raw = {
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "layer_types": ["full_attention"] * 36,
+        "max_window_layers": 28,
+        "mlp_bias": False,
+        "no_rope_layer_interval": 4,
+        "no_rope_layers": [int((index + 1) % 4 != 0) for index in range(36)],
+        "pretraining_tp": 2,
+        "rope_scaling": None,
+        "sliding_window": None,
+        "torch_dtype": "bfloat16",
+        "use_cache": False,
+        "use_sliding_window": False,
+    }
+    raw.update(raw_updates)
+    return ModelConfig(
+        model_type="smollm3",
+        architectures=["SmolLM3ForCausalLM"],
+        vocab_size=128256,
+        hidden_size=2048,
+        intermediate_size=11008,
+        num_hidden_layers=36,
+        num_attention_heads=16,
+        num_key_value_heads=4,
+        rms_norm_eps=1e-6,
+        rope_theta=5_000_000.0,
+        bos_token_id=128000,
+        eos_token_id=128012,
+        pad_token_id=128004,
+        tie_word_embeddings=True,
+        max_position_embeddings=65536,
+        hidden_act="silu",
+        raw=raw,
+    )
+
+
+def test_published_checkpoint_reaches_native_kv_despite_training_metadata() -> None:
+    config = _published_checkpoint_config()
+
+    architecture = native_kv_architecture_capability(config)
+    build = native_kv_build_capability(
+        config,
+        precision="bf16",
+        max_cache_length=config.max_position_embeddings,
+    )
+
+    assert config.raw["pretraining_tp"] == 2
+    assert architecture.eligible, architecture.reason
+    assert build.eligible, build.reason
+
+
+def test_native_kv_requires_the_full_checkpoint_window() -> None:
+    config = _published_checkpoint_config()
+
+    decision = native_kv_build_capability(
+        config,
+        precision="bf16",
+        max_cache_length=256,
+    )
+
+    assert not decision.eligible
+    assert "max_position_embeddings (65536)" in decision.reason
+    row_bytes, total_bytes = native_kv_cache_geometry(config, 65536)
+    assert row_bytes == 2 * 36 * 4 * 128 * 2
+    assert total_bytes == 65536 * row_bytes
+
+
+def test_nope_schedule_matches_the_published_every_fourth_layer_pattern() -> None:
+    schedule = resolve_rope_layer_schedule(_published_checkpoint_config())
+
+    assert len(schedule) == 36
+    assert [index for index, uses_rope in enumerate(schedule) if not uses_rope] == [
+        3,
+        7,
+        11,
+        15,
+        19,
+        23,
+        27,
+        31,
+        35,
+    ]
+
+
+def test_published_schedule_overrides_the_interval() -> None:
+    published = [1] * 36
+    published[5] = 0
+    schedule = resolve_rope_layer_schedule(
+        _published_checkpoint_config(no_rope_layers=published)
+    )
+
+    assert [index for index, uses_rope in enumerate(schedule) if not uses_rope] == [5]
+
+
+@pytest.mark.parametrize(
+    ("raw_updates", "fragment"),
+    [
+        ({"no_rope_layers": None, "no_rope_layer_interval": 0}, "must be positive"),
+        ({"no_rope_layers": [1, 1, 1]}, "at least num_hidden_layers"),
+        ({"no_rope_layers": [1, None] + [1] * 34}, "int()"),
+        ({"no_rope_layers": ["x"] * 36}, "invalid literal"),
+    ],
+)
+def test_malformed_nope_schedule_fails_closed(
+    raw_updates: dict[str, object], fragment: str
+) -> None:
+    decision = native_kv_architecture_capability(
+        _published_checkpoint_config(**raw_updates)
+    )
+
+    assert not decision.eligible
+    assert fragment in decision.reason
+
+
+def test_both_builders_index_the_schedule_with_the_layer_loop_variable() -> None:
+    family = Path(__file__).resolve().parents[1]
+    for name in ("standard_decoder_builder.py", "dual_profile_decoder_builder.py"):
+        tree = ast.parse((family / name).read_text(encoding="utf-8"))
+        indices = {
+            node.slice.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "rope_schedule"
+            and isinstance(node.slice, ast.Name)
+        }
+        assert indices == {"layer_idx"}, name
+
+
+def test_standard_builder_forwards_the_resolved_nope_flag() -> None:
+    tree = ast.parse(
+        (Path(__file__).resolve().parents[1] / "standard_decoder_builder.py").read_text(
+            encoding="utf-8"
+        )
+    )
+    forwarded = [
+        keyword.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "apply_rope"
+    ]
+    assert any(
+        isinstance(value, ast.Subscript)
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "rope_schedule"
+        for value in forwarded
+    )
+
+
+class _FakeTensor:
+    def __init__(self, name: str = "tensor", shape: tuple[int, ...] = (1, 1, 64)) -> None:
+        self.name = name
+        self.shape = shape
+        self.dtype = None
+
+    def __getattr__(self, _name: str):
+        return None
+
+
+class _FakeLayer:
+    def get_output(self, _index: int) -> _FakeTensor:
+        return _FakeTensor("out")
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+    def __setattr__(self, _name: str, _value: object) -> None:
+        pass
+
+
+class _FakeNetwork:
+    def __getattr__(self, name: str):
+        if name.startswith("add_"):
+            return lambda *args, **kwargs: _FakeLayer()
+        raise AttributeError(name)
+
+
+def _rope_insertions(monkeypatch: pytest.MonkeyPatch, *, apply_rope: bool) -> int:
+    pytest.importorskip("tensorrt")
+    import numpy as np
+
+    from families.smollm3 import graph_blocks, graph_ops
+
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        graph_ops,
+        "add_apply_rope_native",
+        lambda *args, **kwargs: calls.append(args) or _FakeTensor("roped"),
+    )
+    hidden = attention = 64
+    prefix = "layer.0"
+    weights = {
+        f"{prefix}.input_norm": np.ones(hidden, dtype=np.float32),
+        f"{prefix}.w_q": np.zeros((hidden, attention), dtype=np.float32),
+        f"{prefix}.w_k": np.zeros((hidden, attention), dtype=np.float32),
+        f"{prefix}.w_v": np.zeros((hidden, attention), dtype=np.float32),
+        f"{prefix}.w_o": np.zeros((attention, hidden), dtype=np.float32),
+    }
+    graph_blocks.add_attention_block(
+        _FakeNetwork(),
+        _FakeTensor("hidden"),
+        _FakeTensor("cache_k"),
+        _FakeTensor("cache_v"),
+        _FakeTensor("mask"),
+        _FakeTensor("position"),
+        weights=weights,
+        prefix=prefix,
+        hidden_size=hidden,
+        attention_size=attention,
+        kv_attention_size=attention,
+        num_heads=2,
+        num_kv_heads=2,
+        head_dim=32,
+        max_cache_length=16,
+        eps_tensor=_FakeTensor("eps"),
+        apply_rope=apply_rope,
+        cos_half_tensor=_FakeTensor("cos"),
+        sin_half_tensor=_FakeTensor("sin"),
+    )
+    return len(calls)
+
+
+def test_rope_gate_controls_real_graph_insertion(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _rope_insertions(monkeypatch, apply_rope=True) == 2
+    assert _rope_insertions(monkeypatch, apply_rope=False) == 0

--- a/families/smollm3/tests/test_rope_scaling.py
+++ b/families/smollm3/tests/test_rope_scaling.py
@@ -22,6 +22,59 @@ import pytest
 from families.smollm3 import graph_ops
 
 
+def test_resolve_rope_scaling_accepts_the_transformers_rope_parameters_key() -> None:
+    parameters = {"rope_type": "yarn", "factor": 2.0}
+    assert graph_ops.resolve_rope_scaling({"rope_parameters": parameters}) is parameters
+
+
+def test_resolve_rope_scaling_keeps_the_legacy_rope_scaling_key() -> None:
+    scaling = {"rope_type": "llama3", "factor": 8.0}
+    assert graph_ops.resolve_rope_scaling({"rope_scaling": scaling}) is scaling
+
+
+def test_bf16_gemm_casts_operands_to_fp32_for_accumulation() -> None:
+    class Tensor:
+        def __init__(self, dtype) -> None:
+            self.dtype = dtype
+
+    class Layer:
+        def __init__(self, output) -> None:
+            self.output = output
+
+        def get_output(self, _index: int):
+            return self.output
+
+    class Network:
+        def __init__(self) -> None:
+            self.cast_targets = []
+            self.matmul_dtypes = None
+
+        def add_cast(self, _tensor, target):
+            self.cast_targets.append(target)
+            return Layer(Tensor(target))
+
+        def add_matrix_multiply(self, lhs, _lhs_op, rhs, _rhs_op):
+            self.matmul_dtypes = (lhs.dtype, rhs.dtype)
+            return Layer(Tensor(graph_ops.trt.float32))
+
+    network = Network()
+    output = graph_ops._add_matrix_multiply_with_fp32_accumulation(
+        network,
+        Tensor(graph_ops.trt.bfloat16),
+        None,
+        Tensor(graph_ops.trt.bfloat16),
+        None,
+    )
+
+    assert network.matmul_dtypes == (graph_ops.trt.float32, graph_ops.trt.float32)
+    assert network.cast_targets == [
+        graph_ops.trt.float32,
+        graph_ops.trt.float32,
+        graph_ops.trt.bfloat16,
+    ]
+    assert output.dtype == graph_ops.trt.bfloat16
+
+
 YARN_SCALING = {
     "rope_type": "yarn",
     "factor": 2.0,

--- a/families/smollm3/tests/test_rope_scaling.py
+++ b/families/smollm3/tests/test_rope_scaling.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SmolLM3 YaRN RoPE scaling tests.
+
+SmolLM3-3B ships with ``rope_scaling: null`` and a 65536-token window. The
+model card extends that to 128k by setting ``max_position_embeddings`` to
+131072 and adding a YaRN block, which is the configuration these tests pin.
+
+The reference below is the exact float64 form of Hugging Face's
+``_compute_yarn_parameters``. One detail is easy to miss and is asserted
+separately: upstream folds ``attention_factor`` (``0.1 * ln(factor) + 1``) into
+cos/sin inside the rotary embedding rather than applying it to attention
+scores, so a table built without it is uniformly off by that factor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from families.smollm3 import graph_ops
+
+
+YARN_SCALING = {
+    "rope_type": "yarn",
+    "factor": 2.0,
+    "original_max_position_embeddings": 65536,
+}
+HEAD_DIM = 128
+ROPE_THETA = 5000000.0
+
+
+def _yarn_reference(head_dim: int, rope_theta: float, factor: float,
+                    original_context: float) -> tuple[np.ndarray, float]:
+    """Exact float64 YaRN inverse frequencies and attention factor."""
+    extrapolation = rope_theta ** (
+        -np.arange(0, head_dim, 2, dtype=np.float64) / head_dim
+    )
+    half = head_dim // 2
+
+    def correction_dim(rotations: float) -> float:
+        return (
+            head_dim
+            * np.log(original_context / (rotations * 2.0 * np.pi))
+            / (2.0 * np.log(rope_theta))
+        )
+
+    low = max(int(np.floor(correction_dim(32.0))), 0)
+    high = min(int(np.ceil(correction_dim(1.0))), half - 1)
+    ramp = np.clip(
+        (np.arange(half, dtype=np.float64) - low) / max(high - low, 1), 0.0, 1.0
+    )
+    inverse = extrapolation / factor * ramp + extrapolation * (1.0 - ramp)
+    return inverse, 0.1 * np.log(factor) + 1.0
+
+
+def test_half_dim_table_matches_yarn_reference_formula() -> None:
+    positions = 32
+    inverse, attention_factor = _yarn_reference(
+        HEAD_DIM, ROPE_THETA, 2.0, 65536.0
+    )
+    angles = np.outer(np.arange(positions, dtype=np.float64), inverse)
+
+    cosine = graph_ops.make_rope_table_half_dim(
+        positions, HEAD_DIM, ROPE_THETA, True, rope_scaling=YARN_SCALING
+    )
+    sine = graph_ops.make_rope_table_half_dim(
+        positions, HEAD_DIM, ROPE_THETA, False, rope_scaling=YARN_SCALING
+    )
+
+    np.testing.assert_allclose(
+        cosine, np.cos(angles) * attention_factor, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        sine, np.sin(angles) * attention_factor, atol=1e-7
+    )
+
+
+def test_attention_factor_is_folded_into_the_table() -> None:
+    # Omitting it leaves every entry short by ~6.9% for factor=2.0, which is
+    # four orders of magnitude above float32 noise.
+    inverse, attention_factor = _yarn_reference(
+        HEAD_DIM, ROPE_THETA, 2.0, 65536.0
+    )
+    assert attention_factor == pytest.approx(1.0693147180559945)
+
+    cosine = graph_ops.make_rope_table_half_dim(
+        8, HEAD_DIM, ROPE_THETA, True, rope_scaling=YARN_SCALING
+    )
+    unscaled = np.cos(np.outer(np.arange(8, dtype=np.float64), inverse))
+    assert np.abs(cosine - unscaled).max() > 1e-3
+    np.testing.assert_allclose(cosine, unscaled * attention_factor, atol=1e-7)
+
+
+def test_explicit_attention_factor_overrides_the_derived_one() -> None:
+    scaling = dict(YARN_SCALING, attention_factor=1.0)
+    inverse, _ = _yarn_reference(HEAD_DIM, ROPE_THETA, 2.0, 65536.0)
+    cosine = graph_ops.make_rope_table_half_dim(
+        8, HEAD_DIM, ROPE_THETA, True, rope_scaling=scaling
+    )
+    expected = np.cos(np.outer(np.arange(8, dtype=np.float64), inverse))
+    np.testing.assert_allclose(cosine, expected, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"factor": 0.0},
+        {"original_max_position_embeddings": 0},
+        {"beta_fast": 1.0, "beta_slow": 32.0},
+    ],
+)
+def test_malformed_yarn_scaling_is_rejected(override) -> None:
+    with pytest.raises(ValueError):
+        graph_ops.make_rope_table_half_dim(
+            8, HEAD_DIM, ROPE_THETA, True,
+            rope_scaling=dict(YARN_SCALING, **override),
+        )
+
+
+def test_unscaled_rope_is_unaffected_by_yarn_support() -> None:
+    positions = 16
+    inverse = ROPE_THETA ** (
+        -np.arange(0, HEAD_DIM, 2, dtype=np.float64) / HEAD_DIM
+    )
+    angles = np.outer(np.arange(positions, dtype=np.float64), inverse)
+    cosine = graph_ops.make_rope_table_half_dim(
+        positions, HEAD_DIM, ROPE_THETA, True
+    )
+    np.testing.assert_allclose(cosine, np.cos(angles), atol=1e-7)

--- a/families/smollm3/tests/test_runtime_receipt.py
+++ b/families/smollm3/tests/test_runtime_receipt.py
@@ -69,3 +69,14 @@ def test_receipt_rejects_missing_decode_step() -> None:
     payload["decode_ms"] = 0.0
     with pytest.raises(AssertionError):
         assert_native_kv_receipt(payload, _case(), 65)
+
+
+def test_receipt_rejects_a_bundle_max_numeric_prefix() -> None:
+    stderr = "\n".join(
+        [
+            "[trtmc] KV cache rows=256 (bundle max=2560)",
+            "[trtmc.prefill] tokens=66 launches=2 max_chunk=64",
+        ]
+    )
+    with pytest.raises(AssertionError):
+        assert_native_kv_receipt(_payload(stderr), _case(), 65)

--- a/families/smollm3/tests/test_runtime_receipt.py
+++ b/families/smollm3/tests/test_runtime_receipt.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from families.smollm3.build_routing import native_kv_build_capability
@@ -26,6 +29,7 @@ def _payload(stderr: str) -> dict:
 
 
 def test_long_prefill_manifest_selects_the_native_bf16_route() -> None:
+    manifest = json.loads((Path(__file__).parent / "manifests" / "smollm3-3b-l0.json").read_text())
     config = ModelConfig.create_tiny(
         "smollm3",
         architectures=["SmolLM3ForCausalLM"],
@@ -41,11 +45,14 @@ def test_long_prefill_manifest_selects_the_native_bf16_route() -> None:
 
     capability = native_kv_build_capability(
         config,
-        precision="bf16",
-        max_cache_length=65536,
+        precision=manifest["precision"],
+        max_cache_length=manifest["max_sequence_length"],
     )
 
     assert capability.eligible, capability.reason
+    for case in manifest["testcases"]:
+        assert case["expected_kv_cache_rows"] == manifest["max_sequence_length"]
+        assert case["expected_runtime_prefill_tokens"] > case["expected_prefill_chunk_limit"]
 
 
 def test_receipt_distinguishes_raw_prompt_from_runtime_bos() -> None:
@@ -80,3 +87,31 @@ def test_receipt_rejects_a_bundle_max_numeric_prefix() -> None:
     )
     with pytest.raises(AssertionError):
         assert_native_kv_receipt(_payload(stderr), _case(), 65)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "eos_ids", "valid"),
+    [
+        ([1, 2], (), True),
+        ([1, 99], (99,), True),
+        ([99], (98, 99), True),
+        ([1], (99,), False),
+        ([99], (), False),
+        ([98], (99,), False),
+        ([], (99,), False),
+        ([1, 2, 99], (99,), False),
+        ([99, 1], (99,), False),
+    ],
+)
+def test_receipt_accepts_only_budget_or_eos_termination(tokens, eos_ids, valid) -> None:
+    stderr = (
+        "[trtmc] KV cache rows=256 (bundle max=256)\n"
+        "[trtmc.prefill] tokens=66 launches=2 max_chunk=64"
+    )
+    payload = _payload(stderr)
+    payload["token_ids"] = tokens
+    if valid:
+        assert_native_kv_receipt(payload, _case(), 65, eos_token_ids=eos_ids)
+    else:
+        with pytest.raises(AssertionError):
+            assert_native_kv_receipt(payload, _case(), 65, eos_token_ids=eos_ids)

--- a/families/smollm3/tests/test_runtime_receipt.py
+++ b/families/smollm3/tests/test_runtime_receipt.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from families.smollm3.build_routing import native_kv_build_capability
+from families.smollm3.config import ModelConfig
+from families.smollm3.tests.runtime_receipt import assert_native_kv_receipt
+
+
+def _case() -> dict:
+    return {
+        "expected_prompt_tokens": 65,
+        "expected_runtime_prefill_tokens": 66,
+        "expected_kv_cache_rows": 256,
+        "expected_prefill_chunks": 2,
+        "expected_prefill_chunk_limit": 64,
+        "max_new_tokens": 2,
+    }
+
+
+def _payload(stderr: str) -> dict:
+    return {"runtime_stderr": stderr, "token_ids": [1, 2], "decode_ms": 1.0}
+
+
+def test_long_prefill_manifest_selects_the_native_bf16_route() -> None:
+    config = ModelConfig.create_tiny(
+        "smollm3",
+        architectures=["SmolLM3ForCausalLM"],
+        hidden_size=128,
+        intermediate_size=256,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=128,
+        max_position_embeddings=65536,
+        hidden_act="silu",
+    )
+    config.raw["no_rope_layer_interval"] = 4
+
+    capability = native_kv_build_capability(
+        config,
+        precision="bf16",
+        max_cache_length=65536,
+    )
+
+    assert capability.eligible, capability.reason
+
+
+def test_receipt_distinguishes_raw_prompt_from_runtime_bos() -> None:
+    stderr = "\n".join(
+        [
+            "[trtmc] KV cache rows=256 (bundle max=256)",
+            "[trtmc.prefill] tokens=66 launches=2 max_chunk=64",
+        ]
+    )
+    assert_native_kv_receipt(_payload(stderr), _case(), 65)
+
+
+def test_receipt_rejects_missing_decode_step() -> None:
+    stderr = "\n".join(
+        [
+            "[trtmc] KV cache rows=256 (bundle max=256)",
+            "[trtmc.prefill] tokens=66 launches=2 max_chunk=64",
+        ]
+    )
+    payload = _payload(stderr)
+    payload["decode_ms"] = 0.0
+    with pytest.raises(AssertionError):
+        assert_native_kv_receipt(payload, _case(), 65)

--- a/families/smollm3/utils.py
+++ b/families/smollm3/utils.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-agnostic helpers for TensorRT engine builders."""
+
+from __future__ import annotations
+
+
+import numpy as np
+import tensorrt as trt
+
+from . import graph_ops
+
+
+def const_in_work_dtype(
+    network: trt.INetworkDefinition,
+    shape: tuple,
+    values: np.ndarray,
+    work_np_dtype: np.dtype,
+    work_trt_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Create a constant in storage dtype and cast it to runtime dtype."""
+    const = graph_ops.add_constant(network, shape, values, dtype=work_np_dtype)
+    if const.dtype != work_trt_dtype:
+        const = network.add_cast(const, work_trt_dtype).get_output(0)
+    return const


### PR DESCRIPTION
## Background

`HuggingFaceTB/SmolLM3-3B` is not resolved by an existing family: its published configuration declares `model_type: "smollm3"` and `SmolLM3ForCausalLM`. Its main topology difference from the dense Llama contract is a checkpoint-defined per-layer NoPE schedule. The published model applies RoPE on 27 layers and leaves layers 3, 7, 11, ..., 35 unrotated.

This PR supersedes its pre-cutover implementation and follows the family-isolated architecture announced in #1183. The complete change is now owned by `families/smollm3/**`; it does not edit a central registry, central CMake list, shared model helper, or sibling family.

Closes #1146.

## Exit Criteria

- The pinned SmolLM3-3B checkpoint is detected without `trust_remote_code` and builds through a plain family-owned `build(request, writer)` entry point.
- Both decoder builders apply RoPE exactly where the checkpoint schedule requires it and leave NoPE layers unrotated.
- The native runtime implements the shared text-generation Task contract and reproduces the checkpoint chat template, including reasoning mode and locale-independent dates.
- The published default BF16/full-window profile reaches native KV; the 256-token qualification profile remains on the portable path.
- The family owns its build, runtime, manifest, and tests without importing, including, or linking another family.

## Implementation

- `support.py` owns exact model/task detection; `model.py` owns bundle construction through the new plain build API. Unsupported dynamic KV, tensor parallel, quantized, multimodal, and multi-batch profiles fail explicitly rather than falling through to an unqualified path.
- The graph resolves `no_rope_layers` or `no_rope_layer_interval` once per checkpoint. Both the standard and native-KV builders index that schedule with their current layer and forward the result to the actual rotary insertion gate.
- The published `pretraining_tp: 2` field is not used as a routing gate. Upstream SmolLM3 neither defines nor reads it, so it does not describe the graph being built.
- YaRN table generation follows the model-card 128k recipe and folds the upstream attention factor into cosine/sine values. Scaled RoPE routes to the standard decoder; the native-KV graph remains limited to its qualified RoPE contract.
- `runtime/**` owns the tokenizer, SmolLM3 chat rendering, fixed/native KV state, sampling, pipeline, plugin, and four C++ tests behind the abstract Task interface.
- `smollm3-3b-l0` is a BF16, TP1, 256-token chat-instruct premerge case pinned to checkpoint revision `a07cc9a04f16550a088caea529712d1d335b0ac1`. The L0 qualification name keeps a functional premerge case out of the release-performance matrix until a performance receipt exists.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [x] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

Current head: `0fc6464d7e7b86f9d56d60aea9a00aa4691dd7e3`.

- `python -m tools.model_ci validate` and `python tools/test_impact.py --validate`: passed; `smollm3` is discovered and the family-only impact is valid.
- `pytest tools/tests/test_architecture.py tools/tests/test_family_impact.py`: 65 passed.
- Community CPU Python scope excluding two macOS-incompatible upstream test groups: 284 passed. The excluded DevToolkit architecture tests (`arm64` versus Linux `aarch64`) and unresolved-symbol linker test fail identically on a clean `origin/main` checkout; they are not SmolLM3 regressions.
- Family CPU contracts with an import-only TensorRT stub: 31 passed, 1 skipped, 6 hardware-marked/deselected. The exercised tests cover published-checkpoint routing, malformed NoPE schedules, both builder wiring sites, YaRN math, runtime receipts, and the plain build contract. This is not TensorRT execution evidence.
- Standalone C++ chat-template build: passed byte-exact reasoning/non-reasoning fixtures and 32 locale-sensitive fixed-date checks.
- `pre-commit run --files <all family files>`: trailing whitespace, EOF, Ruff, and clang-format checks passed.

### Hardware, Environment, and Revisions

- Repository head: `0fc6464d7e7b86f9d56d60aea9a00aa4691dd7e3`, based directly on `origin/main` at `cd1bde414846d9e902c967699e72c86585b974d1`.
- Checkpoint: `HuggingFaceTB/SmolLM3-3B` at `a07cc9a04f16550a088caea529712d1d335b0ac1`.
- Local static/CPU validation: macOS arm64, Python 3.13. No CUDA or TensorRT runtime was available for the post-cutover checks recorded above.

### Not Run / Remaining Gaps

The previous H100 build, parity, harness E2E, and CTest results were produced before the breaking architecture cutover and do **not** validate this head. TensorRT build/run, the new chat-instruct E2E, CTest, long-context YaRN qualification, and protected premerge CI must be rerun on `0fc6464d` before this PR is considered fully qualified.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Agent-assisted review covered the family changes, E2E configuration, EOS termination checks, and public test results. Protected internal CI remains unverified.

## Notes For Future Readers

- Review `config.py::resolve_rope_layer_schedule()` and its three consumers first; the per-layer RoPE gate is the principal topology delta.
- Review `model.py` next for the native-versus-portable route and the explicit unsupported-profile boundary, then `runtime/plugin.cpp` and `runtime/pipeline.cpp` for Task creation.
- Existing serialized bundles from the pre-cutover implementation are intentionally not compatible with the new contracts and must be rebuilt.
- YaRN code is covered by CPU numerical tests, but the 128k standard-decoder path is not yet qualified on this head. Do not infer long-context GPU support from the table tests alone.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The change is a large native build/runtime slice and still needs exact-head GPU qualification, but its ownership and rollback boundary is limited to the new `smollm3` family directory.

Thanks to @iamziyuzhao for helping run experiments and simplify the code.

Co-authored-by: Moviw <xvzimo@gmail.com>
Co-authored-by: Ziyu Zhao <144565088+iamziyuzhao@users.noreply.github.com>

