### PR TITLE
ci(governance): protect repository control files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,7 @@
 # Default owner for the public repository. Replace this entry with project
 # teams once those teams are created in the NVIDIA GitHub organization.
 * @yifeif-nv
+
+# Keep the repository control plane under explicit ownership. When code-owner
+# review is required, this directory rule also covers CODEOWNERS itself.
+/.github/ @yifeif-nv

--- a/.github/workflows/internal-ci-bridge.yml
+++ b/.github/workflows/internal-ci-bridge.yml
@@ -51,8 +51,8 @@ jobs:
       policy_sha: ${{ steps.snapshot.outputs.policy_sha }}
 
     steps:
-      # This trusted workflow reads PR metadata only. It never checks out or
-      # executes the pull-request head.
+      # This trusted workflow reads PR metadata and changed-file names only. It
+      # never checks out or executes the pull-request head.
       - name: Capture the exact pull-request snapshot
         id: snapshot
         env:
@@ -90,6 +90,7 @@ jobs:
           base_ref="$(jq -er '.base.ref' <<<"$pull")"
           base_sha="$(jq -er '.base.sha' <<<"$pull")"
           head_sha="$(jq -er '.head.sha' <<<"$pull")"
+          author_association="$(jq -er '.author_association' <<<"$pull")"
 
           test "$state" = "open"
           test "$base_repo" = "$GITHUB_REPOSITORY"
@@ -101,6 +102,39 @@ jobs:
             echo "::error::The CI trigger was superseded by a newer PR head."
             exit 1
           fi
+
+          case "$author_association" in
+            OWNER|MEMBER) ;;
+            *)
+              protected_path_count=0
+              protected_page_counts="$(
+                gh api --paginate --method GET \
+                  "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+                  --jq '[.[] | (.filename, .previous_filename?)
+                    | select(type == "string")
+                    | select(. == "CODEOWNERS" or . == ".github" or startswith(".github/"))]
+                    | length'
+              )"
+              while IFS= read -r page_count; do
+                [[ "$page_count" =~ ^[0-9]+$ ]]
+                ((protected_path_count += page_count)) || true
+              done <<<"$protected_page_counts"
+              scanned_head_sha="$(
+                gh api --method GET \
+                  "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+                  --jq '.head.sha'
+              )"
+              [[ "$scanned_head_sha" =~ ^[0-9a-f]{40}$ ]]
+              if [ "$scanned_head_sha" != "$head_sha" ]; then
+                echo "::error::The PR head changed while protected paths were inspected."
+                exit 1
+              fi
+              if [ "$protected_path_count" -ne 0 ]; then
+                echo "::error::External pull requests cannot modify .github/** or CODEOWNERS. Open an issue for a repository maintainer instead."
+                exit 1
+              fi
+              ;;
+          esac
 
           community_cpu_run="$(
             gh api --method GET \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,13 @@ Compilation, unit tests, inference, model parity, target-hardware execution,
 performance, and release qualification are separate evidence levels. Claim only
 what the recorded validation proves.
 
+Repository workflows and ownership policy form a trusted control plane.
+Pull requests authored outside the NVIDIA GitHub organization cannot modify
+`.github/**` or `CODEOWNERS`; open an issue describing the requested change so
+a repository maintainer can evaluate and land it from an organization-owned
+branch. This restriction applies even when the rest of the contribution is
+valid.
+
 ### 8. Run contributor-visible public CPU validation
 
 Opening a pull request or pushing a new commit automatically starts Community

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -117,6 +117,9 @@ def _run_internal_ci_snapshot(
     pr_head_sha: str,
     event_name: str = "pull_request_target",
     actor_role: str = "maintain",
+    pr_author_association: str = "CONTRIBUTOR",
+    changed_files: list[dict[str, str]] | None = None,
+    pr_head_sha_after_scan: str | None = None,
     community_conclusion: str = "success",
     community_head_sha: str | None = None,
     community_merge_sha: str | None = None,
@@ -140,8 +143,22 @@ endpoint = next(
 )
 if "/collaborators/" in endpoint:
     print(os.environ["FAKE_ACTOR_ROLE"])
+elif "/files?" in endpoint:
+    changes = json.loads(os.environ["FAKE_CHANGED_FILES"])
+    protected = []
+    for change in changes:
+        for key in ("filename", "previous_filename"):
+            path = change.get(key)
+            if isinstance(path, str) and (
+                path in {"CODEOWNERS", ".github"} or path.startswith(".github/")
+            ):
+                protected.append(path)
+    print(len(protected))
 elif "/pulls/" in endpoint:
-    print(os.environ["FAKE_PULL_JSON"])
+    if "--jq" in arguments and arguments[arguments.index("--jq") + 1] == ".head.sha":
+        print(os.environ["FAKE_CURRENT_HEAD_SHA"])
+    else:
+        print(os.environ["FAKE_PULL_JSON"])
 elif "/actions/workflows/community-cpu.yml/runs" in endpoint:
     query = arguments[arguments.index("--jq") + 1]
     old_merge = os.environ["FAKE_COMMUNITY_MERGE_SHA"]
@@ -170,6 +187,7 @@ else:
             "repo": {"full_name": "NVIDIA/TensorRT-Model-Connect"},
         },
         "head": {"sha": pr_head_sha},
+        "author_association": pr_author_association,
         "merge_commit_sha": "a" * 40,
     }
     environment = os.environ.copy()
@@ -182,6 +200,8 @@ else:
             "FAKE_COMMUNITY_CONCLUSION": community_conclusion,
             "FAKE_COMMUNITY_HEAD_SHA": community_head_sha or pr_head_sha,
             "FAKE_COMMUNITY_MERGE_SHA": community_merge_sha or "",
+            "FAKE_CHANGED_FILES": json.dumps(changed_files or []),
+            "FAKE_CURRENT_HEAD_SHA": pr_head_sha_after_scan or pr_head_sha,
             "FAKE_PULL_JSON": json.dumps(pull),
             "GH_TOKEN": "test-token",
             "GITHUB_OUTPUT": str(output),
@@ -802,6 +822,12 @@ def test_internal_ci_bridge_only_dispatches_an_exact_trusted_head() -> None:
     assert "head_repo" not in authorize
     assert "head_ref" not in authorize
     assert '[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]' in authorize
+    assert "author_association" in authorize
+    assert '"/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100"' in authorize
+    assert ".previous_filename?" in authorize
+    assert 'startswith(".github/")' in authorize
+    assert "The PR head changed while protected paths were inspected" in authorize
+    assert "External pull requests cannot modify .github/** or CODEOWNERS" in authorize
     assert "Community CPU / Required" in authorize
     assert (
         "/actions/workflows/community-cpu.yml/runs?event=pull_request&head_sha=$head_sha"
@@ -936,6 +962,80 @@ def test_internal_ci_bridge_uses_upstream_pr_metadata_without_fork_access(
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "changed_files",
+    (
+        [{"filename": ".github/workflows/untrusted.yml"}],
+        [{"filename": "moved.yml", "previous_filename": ".github/workflows/secure.yml"}],
+        [{"filename": "CODEOWNERS"}],
+    ),
+)
+def test_internal_ci_bridge_rejects_external_repository_control_changes(
+    tmp_path: Path,
+    changed_files: list[dict[str, str]],
+) -> None:
+    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
+
+    result = _run_internal_ci_snapshot(
+        tmp_path,
+        event_head_sha=head_sha,
+        pr_head_sha=head_sha,
+        changed_files=changed_files,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "External pull requests cannot modify .github/** or CODEOWNERS"
+        in result.stdout + result.stderr
+    )
+
+
+@pytest.mark.parametrize("association", ("OWNER", "MEMBER"))
+def test_internal_ci_bridge_allows_organization_repository_control_changes(
+    tmp_path: Path,
+    association: str,
+) -> None:
+    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
+
+    result = _run_internal_ci_snapshot(
+        tmp_path,
+        event_head_sha=head_sha,
+        pr_head_sha=head_sha,
+        pr_author_association=association,
+        changed_files=[{"filename": ".github/workflows/trusted.yml"}],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_internal_ci_bridge_rejects_a_head_change_during_protected_path_scan(
+    tmp_path: Path,
+) -> None:
+    head_sha = "c8844445a1c630aef586b45daf7dfb31d4168c5a"
+
+    result = _run_internal_ci_snapshot(
+        tmp_path,
+        event_head_sha=head_sha,
+        pr_head_sha=head_sha,
+        pr_head_sha_after_scan="f7b48712c82318ded4e41c0dd7003379e1790198",
+    )
+
+    assert result.returncode != 0
+    assert "The PR head changed while protected paths were inspected" in (
+        result.stdout + result.stderr
+    )
+
+
+def test_codeowners_self_protects_the_repository_control_plane() -> None:
+    codeowners = REPO_ROOT / ".github" / "CODEOWNERS"
+
+    assert codeowners.is_file()
+    assert not (REPO_ROOT / "CODEOWNERS").exists()
+    source = codeowners.read_text(encoding="utf-8")
+    assert "* @yifeif-nv" in source
+    assert "/.github/ @yifeif-nv" in source
 
 
 def test_internal_ci_bridge_accepts_a_green_head_after_the_base_moves(

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -146,6 +146,13 @@ the repository's DCO check.
 Compilation, source tests, model parity, target-hardware execution,
 performance, and release qualification are different evidence tiers.
 
+Repository workflows and ownership policy form a trusted control plane.
+Pull requests authored outside the NVIDIA GitHub organization cannot modify
+`.github/**` or `CODEOWNERS`; open an issue describing the requested change so
+a repository maintainer can evaluate and land it from an organization-owned
+branch. This restriction applies even when the rest of the contribution is
+valid.
+
 ## 6. Run public CPU validation
 
 Opening the pull request or pushing a new commit automatically starts


### PR DESCRIPTION
## Background

The public repository accepts pull requests from forks, but repository workflows and
ownership configuration are part of the trusted control plane. External contributors
could currently include changes to those paths and still request the required protected
CI result.

## Exit Criteria

- Pull requests authored outside the NVIDIA GitHub organization cannot obtain protected
  CI approval while changing `.github/**` or root `CODEOWNERS`.
- Organization owners and members can continue changing those paths through normal PRs.
- Renames out of protected paths and PR-head changes during inspection fail closed.
- The guard does not check out or execute pull-request code.
- Preventing edits inside a contributor's own fork is not a goal; this change protects
  what can be accepted into upstream `main`.

## Implementation

- Extend the trusted `pull_request_target` bridge to inspect paginated PR file metadata
  before dispatch. Both current and previous filenames are checked, and the head SHA is
  revalidated after the scan to close the update race.
- Move `CODEOWNERS` to `.github/CODEOWNERS` and explicitly own the `.github` control
  plane so code-owner review can cover the ownership file itself.
- Document the protected-path contribution boundary in both contributor guides.
- Add regression coverage for external rejection, rename detection, owner/member access,
  head-change rejection, and CODEOWNERS placement.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest -q tests/tools/test_github_actions_ci.py`: passed, 85 tests.
- `python3 -m tools.legal_headers --check --repo-root .`: passed, 6,375 tracked files,
  5,454 managed files, and zero findings.
- `ruff check tests/tools/test_github_actions_ci.py`: passed.
- `git diff --cached --check`: passed before commit.
- Parsed `.github/workflows/internal-ci-bridge.yml` with `yaml.safe_load` and asserted
  the existing job permission boundary: passed.
- Evaluated the protected-path `jq` selector against modified and renamed sample paths:
  returned the expected count of two.

### Hardware, Environment, and Revisions

Validated head `4dea3bac1c6a846258c48840ae6a1667a3f9684c` against base
`3ee90b6e11d8929849271aaf067ade6bd627e416` on Linux 6.8.0 x86_64 with
Python 3.12.3. This is CPU-only workflow-policy validation; no GPU, CUDA, TensorRT,
model, checkpoint, dataset, ABI, or artifact revision applies.

### Not Run / Remaining Gaps

The live `pull_request_target` path cannot exercise the new base-branch policy until the
change is merged. No protected/Internal CI pass is claimed; remote checks on this exact
head remain authoritative.

## Notes For Future Readers

Review the bridge guard first, then its simulated workflow tests, and finally the
CODEOWNERS move and contributor documentation. The guard deliberately treats only
GitHub `OWNER` and `MEMBER` associations as trusted; outside collaborators must ask an
organization member to land control-plane changes. It reuses the existing required
`TRTMC Internal CI / Automated premerge gate` and does not require a new ruleset check.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

This changes protected-CI authorization and can intentionally block external PRs that
touch repository-control files. Reverting the commit restores the previous behavior.
