### PR TITLE
test(lance): cover runtime JSON contract

### DIFF
--- a/families/lance/runtime/CMakeLists.txt
+++ b/families/lance/runtime/CMakeLists.txt
@@ -73,4 +73,27 @@ if(TRTMC_BUILD_TESTS)
     LABELS gpu
     SKIP_RETURN_CODE 77
   )
+
+  add_executable(test_lance_runtime_config_contract
+    ${PROJECT_SOURCE_DIR}/families/lance/tests/cpp/test_lance_runtime_config_contract.cpp
+    ${PROJECT_SOURCE_DIR}/families/lance/runtime/image_preprocessor.cpp
+  )
+  target_include_directories(test_lance_runtime_config_contract PRIVATE
+    ${PROJECT_SOURCE_DIR}
+  )
+  target_include_directories(test_lance_runtime_config_contract SYSTEM PRIVATE
+    ${PROJECT_SOURCE_DIR}/third_party/stb
+  )
+  target_link_libraries(test_lance_runtime_config_contract PRIVATE
+    nlohmann_json::nlohmann_json
+  )
+  target_compile_options(test_lance_runtime_config_contract PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME test_lance_runtime_config_contract
+    COMMAND test_lance_runtime_config_contract
+  )
+  set_tests_properties(test_lance_runtime_config_contract PROPERTIES
+    LABELS cpu
+  )
 endif()

--- a/families/lance/tests/cpp/test_lance_runtime_config_contract.cpp
+++ b/families/lance/tests/cpp/test_lance_runtime_config_contract.cpp
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/lance/runtime/image_preprocessor.h"
+
+#include <cmath>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void rejects(const std::string& text, const std::string& message) {
+    try {
+        (void)trtmc::lance_parse_preprocess_config(text);
+        check(false, message);
+    } catch (const std::exception&) {
+    }
+}
+
+const std::string valid_runtime = R"JSON({
+    "vision_config": {
+      "preprocessor_type": "decoy",
+      "image_token_id": 7,
+      "fixed_image_size": 32,
+      "patch_size": 8,
+      "merge_size": 1,
+      "temporal_patch_size": 1,
+      "num_image_pad_tokens": 3,
+      "vision_output_dim": 64,
+      "vl_prompt_template": "decoy {prompt}",
+      "image_token_str": "<decoy>",
+      "interpolation": "bicubic",
+      "image_mean": [9.0, 9.0, 9.0],
+      "image_std": [8.0, 8.0, 8.0]
+    },
+    "preprocessor_type": "pad_center_chw",
+    "image_token_id": 31415,
+    "fixed_image_size": 448,
+    "patch_size": 16,
+    "merge_size": 3,
+    "temporal_patch_size": 4,
+    "num_image_pad_tokens": 42,
+    "vision_output_dim": 2048,
+    "vl_prompt_template": "prefix\n\"quoted\"\\ {image_pads} :: {prompt}",
+    "image_token_str": "<image>",
+    "interpolation": "nearest",
+    "image_mean": [0.1, 0.2, 0.3],
+    "image_std": [1.1, 1.2, 1.3]
+  })JSON";
+
+} // namespace
+
+int main() {
+    const auto document = nlohmann::json::parse(valid_runtime);
+    const auto config = trtmc::lance_parse_preprocess_config(valid_runtime);
+
+    check(config.preprocessor_type == "pad_center_chw", "top-level preprocessor type");
+    check(config.image_token_id == 31415, "top-level image token ID");
+    check(config.fixed_image_size == 448, "fixed image size");
+    check(config.patch_size == 16, "patch size");
+    check(config.merge_size == 3, "merge size");
+    check(config.temporal_patch_size == 4, "temporal patch size");
+    check(config.num_image_pad_tokens == 42, "top-level image pad token count");
+    check(config.vision_output_dim == 2048, "top-level vision output dimension");
+    check(config.vl_prompt_template == "prefix\n\"quoted\"\\ {image_pads} :: {prompt}",
+          "escaped template is decoded");
+    check(config.image_token_str == "<image>", "image token string");
+    check(config.interpolation == "nearest", "interpolation");
+    const float mean[] = {0.1F, 0.2F, 0.3F};
+    const float stddev[] = {1.1F, 1.2F, 1.3F};
+    for (int index = 0; index < 3; ++index) {
+        check(std::fabs(config.image_mean[index] - mean[index]) < 1e-6F, "image mean component");
+        check(std::fabs(config.image_std[index] - stddev[index]) < 1e-6F, "image std component");
+    }
+
+    auto format_config = config;
+    format_config.num_image_pad_tokens = 2;
+    check(trtmc::lance_format_prompt("go", format_config) ==
+              "prefix\n\"quoted\"\\ <image><image> :: go",
+          "escaped template formatting");
+
+    // Every promoted preprocessing field is required at the runtime.json top level.
+    for (const auto& item : document.items()) {
+        if (item.key() == "vision_config")
+            continue;
+        auto missing = document;
+        missing.erase(item.key());
+        rejects(missing.dump(), "missing " + item.key());
+        auto null_value = document;
+        null_value[item.key()] = nullptr;
+        rejects(null_value.dump(), "null " + item.key());
+    }
+
+    for (const auto* key : {"image_token_id", "fixed_image_size", "patch_size", "merge_size",
+                            "temporal_patch_size", "num_image_pad_tokens", "vision_output_dim"}) {
+        for (const auto& value :
+             {nlohmann::json(1.5), nlohmann::json("16"), nlohmann::json(true)}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("non-integer ") + key);
+        }
+    }
+    for (const auto* key :
+         {"preprocessor_type", "vl_prompt_template", "image_token_str", "interpolation"}) {
+        for (const auto& value : {nlohmann::json(1), nlohmann::json(true),
+                                  nlohmann::json::array({"not", "a", "string"})}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("non-string ") + key);
+        }
+    }
+    for (const auto* key : {"image_mean", "image_std"}) {
+        for (const auto& value :
+             {nlohmann::json::array({0.1, 0.2}), nlohmann::json::array({0.1, 0.2, 0.3, 0.4}),
+              nlohmann::json::array({0.1, "0.2", 0.3})}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("invalid triplet ") + key);
+        }
+    }
+
+    for (const auto* key : {"fixed_image_size", "patch_size", "merge_size", "temporal_patch_size",
+                            "vision_output_dim"}) {
+        for (const int value : {0, -1}) {
+            auto invalid = document;
+            invalid[key] = value;
+            rejects(invalid.dump(), std::string("non-positive ") + key);
+        }
+    }
+
+    for (const auto* mode : {"nearest", "bilinear", "bicubic"}) {
+        auto accepted = document;
+        accepted["interpolation"] = mode;
+        const auto parsed = trtmc::lance_parse_preprocess_config(accepted.dump());
+        check(parsed.interpolation == mode, std::string("accepted interpolation ") + mode);
+    }
+    auto invalid_interpolation = document;
+    invalid_interpolation["interpolation"] = "lanczos";
+    rejects(invalid_interpolation.dump(), "unsupported interpolation");
+    rejects("{", "malformed JSON");
+    rejects("[]", "non-object JSON");
+
+    if (failures == 0)
+        std::cout << "PASS: Lance runtime preprocessing config contract\n";
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

Migrate this test PR to the family-owned architecture requested in discussion #1183. The current consumer reads explicit preprocessing fields from `runtime.json`; the retired two-section config precedence, numeric resample fallback and `MODEL.toml` registration no longer describe this boundary.

## Exit Criteria

- Exercise `lance_parse_preprocess_config()`, the production plugin's preprocessing consumer, through a CPU CTest.
- Pin top-level field binding, newline/quote/backslash template escapes and formatting, required types, geometry and interpolation validation.
- Keep all changes inside `families/lance/`.

## Implementation

Add a family-local C++ test and register it in `runtime/CMakeLists.txt` with the `cpu` label. The executable compiles `image_preprocessor.cpp` directly and uses the existing nlohmann/STB dependencies, without linking the family DSO.

The fixture places nested decoys before explicit top-level preprocessing fields and uses sentinel values to expose ignored inputs. Checks remain active in Release builds. Missing/null fields, non-integer dimensions, malformed triplets, non-positive geometry, unsupported interpolation and invalid JSON are rejected; all three supported interpolation modes are preserved.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

Direct source-only build and run passed (set `JSON_INCLUDE` to the installed nlohmann include directory):

```sh
g++ -std=c++17 -O2 -I. -Ithird_party/stb -I"$JSON_INCLUDE" \
  families/lance/tests/cpp/test_lance_runtime_config_contract.cpp \
  families/lance/runtime/image_preprocessor.cpp \
  -o /tmp/test_lance_runtime_config_contract
/tmp/test_lance_runtime_config_contract
# PASS: Lance runtime preprocessing config contract
```

- Family-only CMake harness loading the actual `runtime/CMakeLists.txt`, followed by `cmake --build <build> --target test_lance_runtime_config_contract` and `ctest --test-dir <build> -R '^test_lance_runtime_config_contract$' --output-on-failure --no-tests=error`: 1/1 passed, CPU-labelled. The harness supplies the repository root and existing nlohmann include target; it does not configure the full project or use SDK stubs.
- Three independent production-source mutations (hardcode vision width, remove geometry guard, remove interpolation guard): each compiled and made the test exit 1. Mutations were confined to disposable copies.
- `python3 -m tools.model_ci validate`: passed.
- `python3 tools/test_impact.py --validate`: passed.
- `python3 -m pytest tools/tests/test_architecture.py tools/tests/test_family_impact.py tools/tests/test_community_ci.py tools/tests/test_public_source_hygiene.py tools/tests/test_new_ci.py tools/tests/test_pr_metadata.py -q -p no:cacheprovider`: 125 passed.
- `clang-format --dry-run --Werror families/lance/tests/cpp/test_lance_runtime_config_contract.cpp` and `git diff --check`: passed.

### Hardware, Environment, and Revisions

- Base: `40523401ae65735056f85ae73028c04025aa1c50`.
- Head: `3554e482c18007db72cec32e4ca4b8220090e3ac`.
- Local Linux x86_64, GCC 11.4, C++17, Release build. Inline synthetic JSON; no checkpoint or GPU needed for this test.

### Not Run / Remaining Gaps

Full root configure (`cmake -S . -B <build> -G Ninja -DTRTMC_BUILD_TESTS=ON -DTRTMC_ENABLE_BYOK=OFF`) stopped because `NvInferRuntime.h` is unavailable locally. Full project integration and protected premerge remain for exact-head CI. Decoder loading, image processing, audio and inference are outside this preprocessing-config unit.

## Contributor Self-Review

Reviewed against the post-#1093 boundary before marking this ready.

- Diff boundary: the change is confined to `families/lance/**` (the family's own runtime `CMakeLists.txt` and its own `tests/cpp/`). No `core/**`, no shared build list, no sibling family, no application code.
- Ownership: the test and its CMake registration are owned by the family that owns the contract under test. No sibling family is imported, included, linked, or read.
- Behavior: the coverage targets `lance_parse_preprocess_config()`, the entry point `plugin.cpp` actually calls. All thirteen promoted preprocessing fields resolve through `require_preprocess_*`, so omission is a contract violation for every one of them and rejection is the expected parsed outcome.
- Base: `families/lance/**` is unchanged between this PR's base and current `main`, so the pinned behavior still holds and the branch merges clean without a rebase.
- Scope: test-only. No production source is modified.

- [x] I have completed a self-review of this change.

## Notes For Future Readers

This replaces the pre-cutover implementation and its validation record. Review the family CMake registration, then the fixture and rejection checks. Production parser behavior is unchanged; keep runtime.json coverage here rather than restoring old checkpoint-config fallback expectations.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Test-only, one family; existing production and GPU targets are unchanged.

