### PR TITLE
fix(perf): align BERT reference timing scope

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -1196,12 +1196,21 @@ def _load_embedding(
         .eval()
         .to(device)
     )
-    inputs = _to_device(
-        tokenizer(str(request.get("prompt", "")), return_tensors="pt", truncation=True),
-        device,
-    )
+    prompt = str(request.get("prompt", ""))
+    declared_timing = timing_contract(runner="task-reference", family=arguments.family)
+
+    def prepare_inputs() -> Mapping[str, Any]:
+        return _to_device(
+            tokenizer(prompt, return_tensors="pt", truncation=True),
+            device,
+        )
+
+    prepared_inputs = None
+    if not declared_timing["input_preparation_included"]:
+        prepared_inputs = prepare_inputs()
 
     def invoke() -> Mapping[str, Any]:
+        inputs = prepare_inputs() if prepared_inputs is None else prepared_inputs
         with torch.inference_mode():
             outputs = model(**inputs, output_hidden_states=True)
         hidden = getattr(outputs, "last_hidden_state", None)
@@ -1221,7 +1230,14 @@ def _load_embedding(
         )
         return summary
 
-    return Session(invoke, _resolved_revision(arguments, model), "transformers")
+    return Session(
+        invoke,
+        _resolved_revision(arguments, model),
+        "transformers",
+        timing_scope=str(declared_timing["timing_scope"]),
+        input_preparation_included=bool(declared_timing["input_preparation_included"]),
+        asset_loading_included=bool(declared_timing["asset_loading_included"]),
+    )
 
 
 def _load_reranking(

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -3308,6 +3308,138 @@ def test_task_reference_runner_measures_loaded_public_operation(
     }
 
 
+@pytest.mark.parametrize(
+    (
+        "family",
+        "expected_scope",
+        "input_preparation_included",
+        "calls_after_load",
+        "calls_after_invoke",
+    ),
+    [
+        (
+            "bert",
+            "task-pipeline-call-wall",
+            True,
+            [],
+            ["tokenize", "model"],
+        ),
+        (
+            "eagle_vlm",
+            "task-model-call-wall",
+            False,
+            ["tokenize"],
+            ["tokenize", "model"],
+        ),
+    ],
+)
+def test_embedding_task_reference_measures_the_family_timing_contract(
+    monkeypatch,
+    family,
+    expected_scope,
+    input_preparation_included,
+    calls_after_load,
+    calls_after_invoke,
+) -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    calls: list[str] = []
+
+    class FakeTensor:
+        shape = (1, 2)
+        dtype = "fp32"
+
+        def to(self, *_args, **_kwargs):
+            return self
+
+        def unsqueeze(self, _dimension):
+            return self
+
+        def sum(self, **_kwargs):
+            return self
+
+        def clamp(self, **_kwargs):
+            return self
+
+        def numel(self):
+            return 2
+
+        def isfinite(self):
+            return self
+
+        def all(self):
+            return self
+
+        def item(self):
+            return True
+
+        def __mul__(self, _other):
+            return self
+
+        def __truediv__(self, _other):
+            return self
+
+    class FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            return cls()
+
+        def __call__(self, *_args, **_kwargs):
+            calls.append("tokenize")
+            return {"input_ids": FakeTensor(), "attention_mask": FakeTensor()}
+
+    class FakeModel:
+        config = Namespace(_commit_hash="model-revision")
+
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            return cls()
+
+        def eval(self):
+            return self
+
+        def to(self, *_args, **_kwargs):
+            return self
+
+        def __call__(self, **_kwargs):
+            calls.append("model")
+            return Namespace(last_hidden_state=FakeTensor())
+
+    fake_torch = ModuleType("torch")
+    fake_torch.device = lambda value: value
+    fake_torch.float16 = "fp16"
+    fake_torch.float32 = "fp32"
+    fake_torch.bfloat16 = "bf16"
+    fake_torch.inference_mode = nullcontext
+    fake_torch.ones = lambda *_args, **_kwargs: FakeTensor()
+    fake_torch.nn = Namespace(functional=Namespace(normalize=lambda value, **_kwargs: value))
+    fake_transformers = ModuleType("transformers")
+    fake_transformers.AutoModel = FakeModel
+    fake_transformers.AutoTokenizer = FakeTokenizer
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    arguments = Namespace(
+        family=family,
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        precision="fp32",
+        revision="model-revision",
+        trust_remote_code=False,
+        local_files_only=True,
+    )
+
+    session = runner["LOADERS"]["hf-transformers-embedding"](
+        arguments,
+        {"prompt": "The quick brown fox"},
+        {},
+    )
+
+    assert calls == calls_after_load
+    assert session.timing_scope == expected_scope
+    assert session.input_preparation_included is input_preparation_included
+    assert session.asset_loading_included is False
+    assert session.invoke()["embedding_vectors"] == 1
+    assert calls == calls_after_invoke
+
+
 def test_nemotron35_perf_reference_uses_archive_compatible_loader(monkeypatch) -> None:
     runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
     from tools.reference import speech


### PR DESCRIPTION
## Background

The BERT embedding task reference prepared tokenizer inputs before its timed
operation while the release suite declared end-to-end pipeline timing. The
runtime timing guard therefore rejected `bert.embed` before collecting a valid
baseline or candidate comparison.

The same `hf-transformers-embedding` adapter is also used by Eagle VLM, whose
declared boundary intentionally excludes input preparation. The fix must
preserve both family contracts.

## Exit Criteria

- BERT embedding reference timing includes tokenization and device input
  preparation and matches the declared pipeline contract.
- Eagle VLM embedding continues to prepare inputs outside its model-call timing
  boundary.
- Model loading and warmup remain excluded from reported latency.
- A regression test covers both family contracts and their invocation
  boundaries.

## Implementation

- Resolve the authoritative task-reference timing contract for the selected
  model family inside the shared embedding adapter.
- Prepare inputs lazily inside each BERT invocation when the contract includes
  input preparation; otherwise prepare them once outside the timed invocation.
- Populate the session timing metadata from that same contract.
- Add CPU-safe regression coverage using fake external framework boundaries.

There are no public API, ABI, artifact format, dependency, compatibility,
migration, or rollout changes.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `env PYTHONPATH=/tmp/trtmc-bert-perf-timing/python python3 -m pytest -q tests/tools/test_perf_matrix.py tests/e2e/models/bert/test_bert_embedding_runner.py`: 149 passed.
- `python3 -m ruff check benchmarks/performance/baselines/task_reference.py tests/tools/test_perf_matrix.py`: passed.
- `git diff --check`: passed.
- Claude SDK/DevToolkit GB300 campaign for `all-minilm-l6-v2`: container
  environment ready, native build succeeded, and `check`, `hf_preflight`,
  `preview`, and `formal` all passed without retries or recoveries. The single
  `bert.embed` case was green.

### Hardware, Environment, and Revisions

- Repository head: `6ca45e757bdda1302902b4677e61c9a95d540fba`.
- GPU: NVIDIA GB300; Linux aarch64; container image digest
  `sha256:2ec7d8b70819c36d290225d5c56a4b3d6c9ff250d0f4115c32b674a14fe84fd6`.
- CUDA 13.0; TensorRT 11.0.0.114; PyTorch 2.12.0+cu130; Transformers 5.2.0.
- Model: `sentence-transformers/all-MiniLM-L6-v2`, resolved revision
  `1110a243fdf4706b3f48f1d95db1a4f5529b4d41`.
- Reference FP32 and candidate FP16, 3 warmups and 10 measured samples each.
  Reference recorded `task-pipeline-call-wall` with input preparation included;
  candidate recorded `public_pipeline_call_wall` with input preparation
  included. Both sample sets were stable. P50 latency was 3.4004 ms reference
  and 0.3420 ms candidate.

### Not Run / Remaining Gaps

- Eagle VLM was not run on GPU for this change. Its existing model-only timing
  behavior is preserved and covered by the focused CPU regression test.
- Other GPU platforms and embedding models were not run because the change is
  limited to the shared reference timing boundary and the GB300 BERT case
  exercises the corrected path.

## Notes For Future Readers

- This does not change the release YAML, timing contracts, performance
  thresholds, model selection, or comparison criteria.
- The GB300 model engine was a cache hit; DevToolkit still produced a native
  worker from the exact repository head above.
- Review the family-aware input preparation boundary first, then the
  parameterized regression test.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The change is isolated to reference timing for one shared adapter, derives its
behavior from the existing contract source, and is covered for both consumers.
