### PR TITLE
feat(k2-horizon): add native chat template

### DIFF
--- a/src/runtime/models/k2_horizon/MODEL.toml
+++ b/src/runtime/models/k2_horizon/MODEL.toml
@@ -4,8 +4,11 @@
 id = "k2_horizon"
 runtime_library = "libtrtmc_model_k2_horizon.so"
 runtime_plugins = ["plugin.cpp|register_k2_horizon_plugin"]
+runtime_config_schemas = ["config_schema.cpp|register_k2_horizon_schema"]
 runtime_strategies = ["k2_horizon_decoder_kv_cache"]
 runtime_tests = [
+  "test_k2_horizon_chat_template|test_k2_horizon_chat_template.cpp|trtmc_model_k2_horizon|_|_",
+  "test_k2_horizon_config_schema|test_k2_horizon_config_schema.cpp|trtmc_model_k2_horizon|_|_",
   "test_k2_horizon_sampler|test_k2_horizon_sampler.cpp|trtmc_model_k2_horizon|_|_",
 ]
 [validation_profiles]

--- a/src/runtime/models/k2_horizon/chat_template.cpp
+++ b/src/runtime/models/k2_horizon/chat_template.cpp
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/k2_horizon/chat_template.h"
+
+#include "utils/sha256.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+namespace trtmc {
+
+std::string k2_horizon_detect_chat_template_format(const std::string& jinja_template) {
+    if (jinja_template.empty())
+        throw std::invalid_argument("K2-Horizon chat template must not be empty");
+
+    internal::Sha256 hash;
+    hash.update(jinja_template);
+    if (hash.hex_digest() != kK2HorizonPublisherChatTemplateSha256) {
+        throw std::invalid_argument(
+            "K2-Horizon supports only the pinned publisher chat template contract");
+    }
+    return kK2HorizonPublisherChatTemplateFormat;
+}
+
+std::string k2_horizon_apply_chat_template(const std::string& format, const std::string& prompt,
+                                           const std::string& reasoning_effort) {
+    if (format.empty())
+        throw std::invalid_argument("K2-Horizon chat template format must not be empty");
+    if (format != kK2HorizonPublisherChatTemplateFormat) {
+        throw std::invalid_argument("Unsupported K2-Horizon chat template format: " + format);
+    }
+    if (reasoning_effort != "high") {
+        throw std::invalid_argument(
+            "K2-Horizon native chat currently supports only reasoning_effort='high'");
+    }
+    if (prompt.find("<|ifm|") != std::string::npos || prompt.find("<ifm|") != std::string::npos ||
+        prompt.find("</ifm|") != std::string::npos) {
+        throw std::invalid_argument(
+            "K2-Horizon chat prompts must not contain publisher protocol markers");
+    }
+
+    // The tokenizer owns BOS insertion, so the native renderer deliberately omits bos_token.
+    return "<|ifm|im_start|>user\n" + prompt +
+           "<|ifm|im_end|><|ifm|im_start|>assistant\n<ifm|think>\n";
+}
+
+void k2_horizon_validate_chat_eos_token_ids(const std::vector<int32_t>& eos_token_ids) {
+    constexpr int32_t end_of_text_id = 1;
+    constexpr int32_t end_of_message_id = 250019;
+    if (eos_token_ids.size() != 2 ||
+        std::find(eos_token_ids.begin(), eos_token_ids.end(), end_of_text_id) ==
+            eos_token_ids.end() ||
+        std::find(eos_token_ids.begin(), eos_token_ids.end(), end_of_message_id) ==
+            eos_token_ids.end()) {
+        throw std::invalid_argument("K2-Horizon requires publisher EOS token IDs {1, 250019}");
+    }
+}
+
+} // namespace trtmc

--- a/src/runtime/models/k2_horizon/chat_template.h
+++ b/src/runtime/models/k2_horizon/chat_template.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+inline constexpr char kK2HorizonPublisherChatTemplateFormat[] = "k2_horizon_publisher_v1";
+inline constexpr char kK2HorizonPublisherChatTemplateSha256[] =
+    "a892cd0b0195599f283a8c706787520d9a6747640efb2f4dec4144b0abb62590";
+
+// Validate the exact bundled publisher Jinja contract and return its native format identifier.
+// The runtime never evaluates Jinja; unknown template bytes are rejected fail-closed.
+std::string k2_horizon_detect_chat_template_format(const std::string& jinja_template);
+
+// Render the qualified single-user, add-generation-prompt form. The initial native contract
+// intentionally supports only the publisher's high reasoning mode.
+std::string k2_horizon_apply_chat_template(const std::string& format, const std::string& prompt,
+                                           const std::string& reasoning_effort);
+
+// Preserve both publisher stop conditions for native chat generation.
+void k2_horizon_validate_chat_eos_token_ids(const std::vector<int32_t>& eos_token_ids);
+
+} // namespace trtmc

--- a/src/runtime/models/k2_horizon/config_schema.cpp
+++ b/src/runtime/models/k2_horizon/config_schema.cpp
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/k2_horizon/config_schema.h"
+
+#include <any>
+#include <set>
+
+namespace trtmc::config::schemas {
+
+Schema make_k2_horizon_schema() {
+    const std::set<Layer> session_only = {Layer::SessionRequest};
+    return Schema{
+        "k2_horizon",
+        {
+            ConfigField{"emit_prompt_token_ids", "bool", std::any{false}, session_only, nullptr},
+        },
+    };
+}
+
+REGISTER_CONFIG_SCHEMA_FACTORY_WITH_MANIFEST(register_k2_horizon_schema, make_k2_horizon_schema);
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/k2_horizon/config_schema.h
+++ b/src/runtime/models/k2_horizon/config_schema.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/config/schema_registry.h"
+
+namespace trtmc::config::schemas {
+
+Schema make_k2_horizon_schema();
+
+} // namespace trtmc::config::schemas

--- a/src/runtime/models/k2_horizon/pipeline.cpp
+++ b/src/runtime/models/k2_horizon/pipeline.cpp
@@ -5,6 +5,8 @@
 
 #include "runtime/models/k2_horizon/pipeline.h"
 
+#include "runtime/models/k2_horizon/chat_template.h"
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -48,6 +50,17 @@ bool has_non_text_inputs(const GenerateConfig& cfg) {
            has_conditioning_inputs(cfg) || has_media_controls(cfg);
 }
 
+void validate_reasoning_and_chat_controls(const GenerateConfig& cfg) {
+    if (cfg.use_chat_template && !cfg.enable_thinking) {
+        throw std::invalid_argument(
+            "K2-Horizon does not support disabling its high-reasoning mode");
+    }
+    if (cfg.use_chat_template && cfg.eos_token_id >= 0) {
+        throw std::invalid_argument(
+            "K2-Horizon chat requires the publisher EOS token set from the bundle");
+    }
+}
+
 } // namespace
 
 void k2_horizon_validate_generate_config(const GenerateConfig& cfg) {
@@ -57,10 +70,7 @@ void k2_horizon_validate_generate_config(const GenerateConfig& cfg) {
     if (mode != "auto" && mode != "ar" && mode != "autoregressive") {
         throw std::invalid_argument("K2-Horizon currently supports autoregressive generation only");
     }
-    if (cfg.use_chat_template) {
-        throw std::invalid_argument(
-            "K2-Horizon currently supports plain completion only; chat templates are disabled");
-    }
+    validate_reasoning_and_chat_controls(cfg);
     if (cfg.stop_on_boxed_answer) {
         throw std::invalid_argument(
             "K2-Horizon does not support reasoning-specific answer-stop parsing");
@@ -69,7 +79,15 @@ void k2_horizon_validate_generate_config(const GenerateConfig& cfg) {
         throw std::invalid_argument("K2-Horizon does not support LoRA adapters");
     if (has_non_text_inputs(cfg)) {
         throw std::invalid_argument(
-            "K2-Horizon received generation controls outside its plain-completion contract");
+            "K2-Horizon received generation controls outside its text-generation contract");
+    }
+}
+
+void k2_horizon_validate_generate_ids_config(const GenerateConfig& cfg) {
+    k2_horizon_validate_generate_config(cfg);
+    if (cfg.use_chat_template) {
+        throw std::invalid_argument(
+            "K2-Horizon cannot apply a chat template to pre-tokenized input IDs");
     }
 }
 
@@ -106,7 +124,11 @@ TextResult K2HorizonTextGenerationPipeline::generate(const std::string& prompt,
     if (!tokenizer_)
         throw std::runtime_error("K2HorizonTextGenerationPipeline: no tokenizer configured");
 
-    const auto input_ids = tokenizer_->encode(prompt);
+    const std::string effective_prompt =
+        cfg.use_chat_template
+            ? k2_horizon_apply_chat_template(config_.chat_template_format, prompt, "high")
+            : prompt;
+    const auto input_ids = tokenizer_->encode(effective_prompt);
     const int32_t max_new_tokens = cfg.max_new_tokens;
     const auto params = k2_horizon_sampling_params_from_config(cfg, config_.eos_token_ids);
 
@@ -126,7 +148,7 @@ TextResult K2HorizonTextGenerationPipeline::generate(const std::string& prompt,
 K2HorizonTextGenerationPipeline::GenerationResult
 K2HorizonTextGenerationPipeline::generate_ids(const std::vector<int32_t>& input_ids,
                                               const GenerateConfig& cfg) {
-    k2_horizon_validate_generate_config(cfg);
+    k2_horizon_validate_generate_ids_config(cfg);
     const auto params = k2_horizon_sampling_params_from_config(cfg, config_.eos_token_ids);
     return GenerationResult{
         generate_from_ids(input_ids, cfg.max_new_tokens, params, cfg).token_ids};
@@ -148,9 +170,13 @@ K2HorizonTextGenerationPipeline::TimedGenResult K2HorizonTextGenerationPipeline:
     const auto capacity = static_cast<std::size_t>(cache_->max_length());
     if (input_ids.size() > capacity ||
         static_cast<std::size_t>(max_new_tokens) > capacity - input_ids.size()) {
-        throw std::invalid_argument(
-            "K2-Horizon prompt and generation exceed the fixed KV cache capacity");
+        throw std::invalid_argument("K2-Horizon prompt tokens (" +
+                                    std::to_string(input_ids.size()) + ") plus max_new_tokens (" +
+                                    std::to_string(max_new_tokens) + ") exceed KV capacity (" +
+                                    std::to_string(capacity) + ")");
     }
+    if (cfg.use_chat_template)
+        log_prompt_token_ids(input_ids);
 
     reset_generation_context();
     std::vector<float> logits;
@@ -221,6 +247,19 @@ int32_t K2HorizonTextGenerationPipeline::run_decode_loop(K2HorizonISampler& samp
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
     log_decode_summary(steps, elapsed);
     return steps;
+}
+
+void K2HorizonTextGenerationPipeline::log_prompt_token_ids(
+    const std::vector<int32_t>& token_ids) const {
+    if (!config_.emit_prompt_token_ids)
+        return;
+    std::cerr << "[trtmc.k2_horizon.prompt] token_ids=[";
+    for (std::size_t index = 0; index < token_ids.size(); ++index) {
+        if (index != 0)
+            std::cerr << ',';
+        std::cerr << token_ids[index];
+    }
+    std::cerr << "]\n";
 }
 
 void K2HorizonTextGenerationPipeline::log_decode_summary(int32_t steps, double milliseconds) const {

--- a/src/runtime/models/k2_horizon/pipeline.h
+++ b/src/runtime/models/k2_horizon/pipeline.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-// K2-Horizon-owned plain-completion pipeline. The initial family contract is
-// intentionally narrow: one native fixed-KV decoder and host greedy sampling.
+// K2-Horizon-owned text pipeline. The initial family contract is intentionally
+// narrow: plain completion plus pinned single-user chat on one native fixed-KV
+// decoder with host greedy sampling.
 
 #include "runtime/models/k2_horizon/kv_cache.h"
 #include "runtime/models/k2_horizon/sampler.h"
@@ -26,12 +27,15 @@ struct K2HorizonTextGenConfig {
     std::vector<int32_t> eos_token_ids;
     std::string token_id_name{"token_id"};
     std::string logits_output_name{"logits"};
+    std::string chat_template_format;
     bool enable_cuda_graph{false};
     bool log_runtime_stats{false};
+    bool emit_prompt_token_ids{false};
 };
 
 // Validate the family-owned request boundary before any engine execution.
 void k2_horizon_validate_generate_config(const GenerateConfig& config);
+void k2_horizon_validate_generate_ids_config(const GenerateConfig& config);
 void k2_horizon_validate_generation_inputs(const std::vector<int32_t>& token_ids,
                                            int32_t max_new_tokens, int32_t vocab_size);
 
@@ -68,6 +72,7 @@ class K2HorizonTextGenerationPipeline final : public IPipeline {
     int32_t run_decode_loop(K2HorizonISampler& sampler, const K2HorizonSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,
                             int32_t max_new_tokens);
+    void log_prompt_token_ids(const std::vector<int32_t>& token_ids) const;
     void log_decode_summary(int32_t steps, double milliseconds) const;
 
     std::unique_ptr<TrtModule> decoder_;

--- a/src/runtime/models/k2_horizon/plugin.cpp
+++ b/src/runtime/models/k2_horizon/plugin.cpp
@@ -7,6 +7,7 @@
 // BF16, single-engine, fixed native-KV contract is accepted.
 
 #include "plugin_helpers.h"
+#include "runtime/models/k2_horizon/chat_template.h"
 #include "runtime/models/k2_horizon/kv_cache.h"
 #include "runtime/models/k2_horizon/pipeline.h"
 #include "runtime/models/k2_horizon/tensor_names.h"
@@ -218,12 +219,61 @@ std::vector<int32_t> normalized_eos_token_ids(std::vector<int32_t> token_ids,
     return normalized;
 }
 
+std::string load_chat_template_format(const PipelineContext& ctx) {
+    const auto* section = find_section(ctx.bundle, "chat_template.jinja");
+    if (section == nullptr || section->empty()) {
+        throw std::invalid_argument(
+            "K2-Horizon bundle is missing the required publisher chat template");
+    }
+    if (!ctx.config.tokenizer_add_special_tokens_present ||
+        !ctx.config.tokenizer_add_special_tokens) {
+        throw std::invalid_argument("K2-Horizon chat requires tokenizer_add_special_tokens=1");
+    }
+    return k2_horizon_detect_chat_template_format(std::string(section->begin(), section->end()));
+}
+
+void validate_chat_tokenizer_contract(const PipelineContext& ctx, const ITokenizer& tokenizer,
+                                      const std::string& chat_template_format) {
+    constexpr int32_t bos_id = 0;
+    constexpr int32_t im_start_id = 250018;
+    constexpr int32_t im_end_id = 250019;
+    constexpr int32_t think_id = 250029;
+    if (ctx.config.id_bos != bos_id || tokenizer.id_for_token("<|ifm|begin_of_text|>") != bos_id) {
+        throw std::invalid_argument("K2-Horizon chat BOS token metadata is inconsistent");
+    }
+    if (tokenizer.id_for_token("<|ifm|im_start|>") != im_start_id ||
+        tokenizer.id_for_token("<|ifm|im_end|>") != im_end_id ||
+        tokenizer.id_for_token("<ifm|think>") != think_id) {
+        throw std::invalid_argument("K2-Horizon chat protocol token IDs are inconsistent");
+    }
+    const auto framed_probe =
+        tokenizer.encode(k2_horizon_apply_chat_template(chat_template_format, "", "high"));
+    const std::vector<int32_t> expected_probe{bos_id,      im_start_id, 2672, 200,      im_end_id,
+                                              im_start_id, 142036,      200,  think_id, 200};
+    if (std::any_of(expected_probe.begin(), expected_probe.end(), [&](int32_t token_id) {
+            return token_id < 0 || token_id >= ctx.config.vocab_size;
+        })) {
+        throw std::invalid_argument(
+            "K2-Horizon chat framing token is outside the model vocabulary");
+    }
+    if (framed_probe != expected_probe) {
+        throw std::invalid_argument(
+            "K2-Horizon native tokenizer does not reproduce the pinned chat framing");
+    }
+}
+
 } // namespace
 
 class K2HorizonDecoderPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         reject_unqualified_bundle(ctx);
+        auto eos_token_ids = normalized_eos_token_ids(ctx.config.id_eos_ids, ctx.config.id_eos,
+                                                      ctx.config.vocab_size);
+        k2_horizon_validate_chat_eos_token_ids(eos_token_ids);
+        const std::string chat_template_format = load_chat_template_format(ctx);
+        auto tokenizer = create_k2_horizon_bpe_tokenizer(ctx.bundle);
+        validate_chat_tokenizer_contract(ctx, *tokenizer, chat_template_format);
 
         const bool prefer_gpu_greedy =
             runtime_flag(ctx.runtime_config, "runtime", "prefer_gpu_greedy", false);
@@ -252,15 +302,16 @@ class K2HorizonDecoderPlugin final : public IPipelinePlugin {
 
         K2HorizonTextGenConfig generation;
         generation.vocab_size = ctx.config.vocab_size;
-        generation.eos_token_ids = normalized_eos_token_ids(
-            ctx.config.id_eos_ids, ctx.config.id_eos, ctx.config.vocab_size);
+        generation.eos_token_ids = std::move(eos_token_ids);
         generation.token_id_name = ctx.config.io_map.token_id;
         generation.logits_output_name = ctx.config.io_map.logits;
+        generation.chat_template_format = chat_template_format;
         generation.enable_cuda_graph = enable_cuda_graph;
         generation.log_runtime_stats =
             runtime_flag(ctx.runtime_config, "platform", "trt_log_stderr", false);
+        generation.emit_prompt_token_ids =
+            runtime_flag(ctx.runtime_config, "k2_horizon", "emit_prompt_token_ids", false);
 
-        auto tokenizer = create_k2_horizon_bpe_tokenizer(ctx.bundle);
         return std::make_unique<K2HorizonTextGenerationPipeline>(
             std::move(decoder), std::move(cache), std::move(generation), std::move(tokenizer),
             ctx.bundle.info.model_id);

--- a/tests/cpp/models/k2_horizon/test_k2_horizon_chat_template.cpp
+++ b/tests/cpp/models/k2_horizon/test_k2_horizon_chat_template.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/k2_horizon/chat_template.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+template <typename Function>
+bool rejects(Function&& function) {
+    try {
+        function();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+void test_pinned_publisher_contract_identity_is_explicit() {
+    check(std::string(trtmc::kK2HorizonPublisherChatTemplateSha256) ==
+              "a892cd0b0195599f283a8c706787520d9a6747640efb2f4dec4144b0abb62590",
+          "pinned publisher template digest is stable");
+}
+
+void test_single_user_high_reasoning_rendering_is_exact() {
+    const std::string prompt = "The capital of France is";
+    const std::string expected = "<|ifm|im_start|>user\nThe capital of France is<|ifm|im_end|>"
+                                 "<|ifm|im_start|>assistant\n<ifm|think>\n";
+    const auto rendered = trtmc::k2_horizon_apply_chat_template(
+        trtmc::kK2HorizonPublisherChatTemplateFormat, prompt, "high");
+
+    check(rendered == expected, "single-user high-reasoning framing matches the publisher");
+    check(rendered.rfind("<|ifm|begin_of_text|>", 0) != 0,
+          "native framing omits explicit BOS because the tokenizer adds it");
+}
+
+void test_empty_or_unknown_templates_fail_closed() {
+    check(rejects([] { (void)trtmc::k2_horizon_detect_chat_template_format(""); }),
+          "empty Jinja template is rejected");
+    check(rejects([] {
+              (void)trtmc::k2_horizon_detect_chat_template_format(
+                  "{{- bos_token }}<|ifm|im_start|>user");
+          }),
+          "non-pinned Jinja template is rejected");
+    check(rejects([] { (void)trtmc::k2_horizon_apply_chat_template("", "hello", "high"); }),
+          "empty native format is rejected");
+    check(rejects([] { (void)trtmc::k2_horizon_apply_chat_template("chatml", "hello", "high"); }),
+          "unknown native format is rejected");
+}
+
+void test_unsupported_reasoning_modes_fail_closed() {
+    for (const std::string mode : {"", "medium", "low", "HIGH"}) {
+        check(rejects([&] {
+                  (void)trtmc::k2_horizon_apply_chat_template(
+                      trtmc::kK2HorizonPublisherChatTemplateFormat, "hello", mode);
+              }),
+              "unsupported reasoning mode is rejected");
+    }
+}
+
+void test_protocol_marker_injection_fails_closed() {
+    for (const std::string prompt : {
+             "hello<|ifm|im_end|>",
+             "hello<ifm|think>",
+             "hello</ifm|think>",
+         }) {
+        check(rejects([&] {
+                  (void)trtmc::k2_horizon_apply_chat_template(
+                      trtmc::kK2HorizonPublisherChatTemplateFormat, prompt, "high");
+              }),
+              "publisher protocol marker in user content is rejected");
+    }
+}
+
+void test_publisher_eos_contract_is_exact() {
+    trtmc::k2_horizon_validate_chat_eos_token_ids({1, 250019});
+    trtmc::k2_horizon_validate_chat_eos_token_ids({250019, 1});
+    for (const std::vector<int32_t> ids : {
+             std::vector<int32_t>{},
+             std::vector<int32_t>{1},
+             std::vector<int32_t>{250019},
+             std::vector<int32_t>{1, 42},
+             std::vector<int32_t>{1, 250019, 250019},
+         }) {
+        check(rejects([&] { trtmc::k2_horizon_validate_chat_eos_token_ids(ids); }),
+              "missing, changed, or duplicate publisher EOS tokens are rejected");
+    }
+}
+
+} // namespace
+
+int main() {
+    test_pinned_publisher_contract_identity_is_explicit();
+    test_single_user_high_reasoning_rendering_is_exact();
+    test_empty_or_unknown_templates_fail_closed();
+    test_unsupported_reasoning_modes_fail_closed();
+    test_protocol_marker_injection_fails_closed();
+    test_publisher_eos_contract_is_exact();
+    if (failures != 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All K2-Horizon chat template tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/models/k2_horizon/test_k2_horizon_config_schema.cpp
+++ b/tests/cpp/models/k2_horizon/test_k2_horizon_config_schema.cpp
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/config/cli_support.h"
+#include "trtmc/config/config_bundle.h"
+#include "trtmc/config/schema_registry.h"
+#include "trtmc/runtime/pipeline_plugin_loader.h"
+
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+template <typename Callable>
+bool rejects(Callable&& callable) {
+    try {
+        callable();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    using trtmc::config::ConfigBundle;
+    using trtmc::config::Layer;
+    using trtmc::config::SchemaRegistry;
+
+    auto& schemas = SchemaRegistry::instance();
+    check(schemas.lookup("k2_horizon") == nullptr, "K2 schema is absent from shared core");
+
+    trtmc::load_model_plugin_for_strategy("k2_horizon_decoder_kv_cache");
+    const auto* schema = schemas.lookup("k2_horizon");
+    check(schema != nullptr, "K2 DSO registers its model-owned schema");
+    check(schema != nullptr && schema->fields.size() == 1, "K2 schema field count is exact");
+
+    const ConfigBundle defaults = ConfigBundle::build({}, schemas);
+    check(defaults.source_of("k2_horizon", "emit_prompt_token_ids") == Layer::SchemaDefault,
+          "prompt receipt is schema-defaulted");
+    check(!defaults.get<bool>("k2_horizon", "emit_prompt_token_ids"),
+          "prompt receipt defaults off");
+
+    const ConfigBundle enabled = trtmc::config::resolve_cli_config(
+        "", {"k2_horizon.emit_prompt_token_ids=true"}, {}, schemas);
+    check(enabled.source_of("k2_horizon", "emit_prompt_token_ids") == Layer::SessionRequest,
+          "prompt receipt requires an explicit session request");
+    check(enabled.get<bool>("k2_horizon", "emit_prompt_token_ids"),
+          "explicit session request enables prompt receipt");
+
+    check(rejects([&] {
+              (void)trtmc::config::resolve_cli_config("", {"emit_prompt_token_ids=true"}, {},
+                                                      schemas);
+          }),
+          "unqualified prompt receipt option is rejected");
+    check(rejects([&] {
+              (void)trtmc::config::resolve_cli_config(
+                  "", {"k2_horizon.emit_prompt_token_ids=maybe"}, {}, schemas);
+          }),
+          "invalid Boolean prompt receipt option is rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " K2-Horizon config schema test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/k2_horizon/test_k2_horizon_sampler.cpp
+++ b/tests/cpp/models/k2_horizon/test_k2_horizon_sampler.cpp
@@ -137,7 +137,29 @@ void test_unsupported_generation_controls_fail_closed() {
 
     config = valid;
     config.use_chat_template = true;
-    check(request_is_rejected(config), "chat template request is rejected");
+    check(!request_is_rejected(config), "single-user high-reasoning chat is accepted");
+
+    config.enable_thinking = false;
+    check(request_is_rejected(config), "chat without high reasoning is rejected");
+
+    config = valid;
+    config.enable_thinking = false;
+    check(!request_is_rejected(config), "plain completion preserves its no-thinking no-op");
+
+    config = valid;
+    config.use_chat_template = true;
+    config.eos_token_id = 1;
+    check(request_is_rejected(config), "chat EOS override is rejected");
+
+    config = valid;
+    config.use_chat_template = true;
+    bool tokenized_chat_rejected = false;
+    try {
+        trtmc::k2_horizon_validate_generate_ids_config(config);
+    } catch (const std::invalid_argument&) {
+        tokenized_chat_rejected = true;
+    }
+    check(tokenized_chat_rejected, "chat over pre-tokenized input is rejected");
 
     config = valid;
     config.lora_adapter_id = "adapter";

--- a/tests/e2e/models/k2_horizon/e2e_plugins/comparators/text.py
+++ b/tests/e2e/models/k2_horizon/e2e_plugins/comparators/text.py
@@ -424,6 +424,7 @@ class TextComparator:
         # --- Metric 6: normalized_text_edit_distance ---
         trt_text = (trt.text or "").strip()
         ref_text = (ref.text or "").strip()
+        texts_match_exactly = bool(trt_text) and trt_text == ref_text
 
         prompt = (trt.data or {}).get("prompt", "")
         # Prompt echo handling is TRT-side only. HF reference text is decoded
@@ -450,6 +451,11 @@ class TextComparator:
 
         if trt_text_for_ned and ref_text_for_ned:
             ned = normalized_edit_distance(trt_text_for_ned, ref_text_for_ned)
+            # A reasoning trace can quote the user prompt naturally. Generic
+            # prompt-echo cleanup is asymmetric (TRT-only), so it must never
+            # turn byte-identical continuations into a text-parity failure.
+            if texts_match_exactly:
+                ned = 0.0
             # Some TRT CLI paths stop decoding early on EOS while the debug/HF
             # text path keeps fixed-length continuation tokens. If token/logit
             # metrics already agree, compare on the common prefix to avoid

--- a/tests/e2e/models/k2_horizon/e2e_plugins/contract.py
+++ b/tests/e2e/models/k2_horizon/e2e_plugins/contract.py
@@ -36,6 +36,20 @@ def _contract_config(case: E2ECase) -> dict:
     return dict(config) if isinstance(config, dict) else {}
 
 
+def _cpp_command(output: StageOutput) -> list[str]:
+    return [str(item) for item in (output.metadata or {}).get("cpp", {}).get("command", [])]
+
+
+def _prompt_tokens(output: StageOutput) -> list[int]:
+    return [int(token) for token in (output.data or {}).get("prompt_token_ids", [])]
+
+
+def _command_has_pair(command: list[str], flag: str, value: str) -> bool:
+    return any(
+        command[index] == flag and command[index + 1] == value for index in range(len(command) - 1)
+    )
+
+
 class K2HorizonGreedyContinuationPlugin:
     reference_families = ["k2_horizon_greedy_continuation"]
     user_contract = "continuation_parity"
@@ -102,4 +116,123 @@ class K2HorizonGreedyContinuationPlugin:
         )
 
 
-plugin = K2HorizonGreedyContinuationPlugin()
+class K2HorizonHighReasoningChatPlugin(K2HorizonGreedyContinuationPlugin):
+    """Verify the pinned publisher prefix and deterministic high-reasoning reply."""
+
+    reference_families = ["k2_horizon_high_reasoning_chat"]
+    user_contract = "chat_prefix_parity"
+
+    def verify(
+        self,
+        trt_output: StageOutput,
+        ref_output: StageOutput,
+        case: E2ECase,
+        threshold: ThresholdProfile,
+    ) -> CompareResult:
+        base = super().verify(trt_output, ref_output, case, threshold)
+        config = _contract_config(case)
+        command = _cpp_command(trt_output)
+        production_prompt = _prompt_tokens(trt_output)
+        reference_prompt = _prompt_tokens(ref_output)
+        debug_prompt = [
+            int(token)
+            for token in (trt_output.metadata or {})
+            .get("debug_runner", {})
+            .get("prompt_token_ids", [])
+        ]
+        expected_prompt_raw = case.metadata.get("expected_prompt_token_ids")
+        expected_prompt = (
+            [int(token) for token in expected_prompt_raw]
+            if isinstance(expected_prompt_raw, list)
+            else []
+        )
+        expected_text = str(case.metadata.get("expected_continuation_text", ""))
+        trt_text = trt_output.text or ""
+        reference_text = ref_output.text or ""
+        generation = (ref_output.data or {}).get("generation", {})
+
+        checks = {
+            "base_numeric_and_golden_contract": (
+                base.status == StageStatus.PASSED.value,
+                base.message,
+            ),
+            "chat_contract_config_exact": (
+                config == {"use_chat_template": True, "reasoning_effort": "high"},
+                f"config={config}",
+            ),
+            "chat_template_flag_forwarded": (
+                "--chat-template" in command,
+                f"command={command}",
+            ),
+            "prompt_token_receipt_requested": (
+                _command_has_pair(
+                    command,
+                    "--set",
+                    "k2_horizon.emit_prompt_token_ids=true",
+                ),
+                f"command={command}",
+            ),
+            "expected_chat_prompt_declared": (
+                bool(expected_prompt),
+                f"expected={expected_prompt}",
+            ),
+            "production_prompt_matches_expected": (
+                bool(expected_prompt) and production_prompt == expected_prompt,
+                f"expected={expected_prompt}, C++={production_prompt}",
+            ),
+            "reference_prompt_matches_expected": (
+                bool(expected_prompt) and reference_prompt == expected_prompt,
+                f"expected={expected_prompt}, HF={reference_prompt}",
+            ),
+            "debug_prompt_matches_expected": (
+                bool(expected_prompt) and debug_prompt == expected_prompt,
+                f"expected={expected_prompt}, debug={debug_prompt}",
+            ),
+            "reference_and_debug_prompt_match": (
+                bool(reference_prompt) and reference_prompt == debug_prompt,
+                f"HF={reference_prompt}, debug={debug_prompt}",
+            ),
+            "production_reference_and_debug_prompt_match": (
+                bool(production_prompt)
+                and production_prompt == reference_prompt
+                and production_prompt == debug_prompt,
+                f"C++={production_prompt}, HF={reference_prompt}, debug={debug_prompt}",
+            ),
+            "expected_decoded_continuation": (
+                bool(expected_text)
+                and trt_text == expected_text
+                and reference_text == expected_text,
+                f"expected={expected_text!r}, TRT={trt_text!r}, HF={reference_text!r}",
+            ),
+            "reference_reasoning_effort_forwarded": (
+                isinstance(generation, dict) and generation.get("reasoning_effort") == "high",
+                f"generation={generation}",
+            ),
+        }
+        chat_metrics = {name: _metric(passed, note) for name, (passed, note) in checks.items()}
+        metrics = {**base.metrics, **chat_metrics}
+        passed = all(passed for passed, _note in checks.values())
+        failed = [name for name, (ok, _note) in checks.items() if not ok]
+        status = (
+            StageStatus.ERROR.value
+            if base.status == StageStatus.ERROR.value
+            else StageStatus.PASSED.value
+            if passed
+            else StageStatus.FAILED.value
+        )
+        message = "Pinned K2-Horizon high-reasoning chat parity"
+        if failed:
+            message += " failed: " + ", ".join(failed)
+        return CompareResult(
+            stage_name=trt_output.stage_name,
+            status=status,
+            metrics=metrics,
+            composite_rule=f"({base.composite_rule}) AND " + " AND ".join(checks),
+            message=message,
+        )
+
+
+plugin = [
+    K2HorizonGreedyContinuationPlugin(),
+    K2HorizonHighReasoningChatPlugin(),
+]

--- a/tests/e2e/models/k2_horizon/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/k2_horizon/e2e_plugins/references/hf_transformers.py
@@ -30,6 +30,18 @@ def _reference_dtype(case: E2ECase) -> str:
     return _TORCH_DTYPE.get(precision, "torch.bfloat16")
 
 
+def _chat_reasoning_effort(case: E2ECase) -> str:
+    contract_config = case.metadata.get("contract_config", {})
+    if not isinstance(contract_config, dict) or not contract_config.get("use_chat_template", False):
+        return ""
+    reasoning_effort = contract_config.get("reasoning_effort")
+    if reasoning_effort != "high":
+        raise ValueError(
+            "K2-Horizon chat reference supports only contract_config.reasoning_effort='high'"
+        )
+    return reasoning_effort
+
+
 class K2HorizonHfTransformersReference:
     """Run the exact checkpoint revision with native Transformers K2-Horizon code."""
 
@@ -63,6 +75,7 @@ class K2HorizonHfTransformersReference:
         use_chat_template = bool(
             isinstance(contract_config, dict) and contract_config.get("use_chat_template", False)
         )
+        reasoning_effort = _chat_reasoning_effort(case)
         trust_remote_code = bool(case.metadata.get("trust_remote_code", False))
 
         script = textwrap.dedent(
@@ -84,6 +97,7 @@ class K2HorizonHfTransformersReference:
             repetition_penalty = {repetition_penalty!r}
             seed = {seed!r}
             use_chat_template = {use_chat_template!r}
+            reasoning_effort = {reasoning_effort!r}
             trust_remote_code = {trust_remote_code!r}
             logits_path = {str(logits_path)!r}
 
@@ -111,6 +125,7 @@ class K2HorizonHfTransformersReference:
                     tokenize=True,
                     return_dict=True,
                     return_tensors="pt",
+                    reasoning_effort=reasoning_effort,
                 )
             else:
                 inputs = tokenizer(prompt, return_tensors="pt")
@@ -164,6 +179,7 @@ class K2HorizonHfTransformersReference:
                     "seed": seed,
                     "max_new_tokens": max_new_tokens,
                     "use_chat_template": use_chat_template,
+                    "reasoning_effort": reasoning_effort,
                 }},
             }}))
             """

--- a/tests/e2e/models/k2_horizon/e2e_plugins/runners/text_generation.py
+++ b/tests/e2e/models/k2_horizon/e2e_plugins/runners/text_generation.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -20,6 +21,12 @@ from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
 from ..runtime_config import runtime_config_set_tokens
 
 logger = logging.getLogger(__name__)
+
+_CPP_PROMPT_TOKEN_RECEIPT = re.compile(
+    r"^\[trtmc\.k2_horizon\.prompt\] token_ids=(.*)$",
+    re.MULTILINE,
+)
+_STRICT_TOKEN_ID_LIST = re.compile(r"\[([0-9]+(?:,[0-9]+)*)\]")
 
 
 def _read_first_jsonl(path: Path) -> dict:
@@ -39,6 +46,29 @@ def _read_first_jsonl(path: Path) -> dict:
     return {}
 
 
+def _chat_reasoning_effort(case: E2ECase) -> str:
+    contract_config = case.metadata.get("contract_config", {})
+    if not isinstance(contract_config, dict) or not contract_config.get("use_chat_template", False):
+        return ""
+    reasoning_effort = contract_config.get("reasoning_effort")
+    if reasoning_effort != "high":
+        raise ValueError(
+            "K2-Horizon chat E2E supports only contract_config.reasoning_effort='high'"
+        )
+    return reasoning_effort
+
+
+def _parse_cpp_prompt_token_ids(stderr: str) -> list[int]:
+    """Parse the opt-in K2 production-tokenizer receipt from C++ stderr."""
+    receipts = _CPP_PROMPT_TOKEN_RECEIPT.findall(stderr)
+    if len(receipts) != 1:
+        return []
+    match = _STRICT_TOKEN_ID_LIST.fullmatch(receipts[0])
+    if match is None:
+        return []
+    return [int(token) for token in match.group(1).split(",")]
+
+
 class TextGenerationCausalRunner:
     """Execute K2-Horizon generation and retain exact token/flag evidence."""
 
@@ -53,6 +83,7 @@ class TextGenerationCausalRunner:
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
         prompt = str(case.inputs.get("prompt", ""))
         max_new_tokens = int(case.inputs.get("max_new_tokens", 30))
+        _chat_reasoning_effort(case)
         cpp_text, cpp_time, cpp_meta = self._run_cpp_binary(
             ctx,
             case,
@@ -190,6 +221,9 @@ class TextGenerationCausalRunner:
             "stdout": result.stdout,
             "stderr": result.stderr,
         }
+        prompt_token_ids = _parse_cpp_prompt_token_ids(result.stderr)
+        if prompt_token_ids:
+            metadata["prompt_token_ids"] = prompt_token_ids
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
                 result.stderr,
@@ -233,6 +267,7 @@ class TextGenerationCausalRunner:
         use_chat_template = bool(
             isinstance(contract_config, dict) and contract_config.get("use_chat_template", False)
         )
+        reasoning_effort = _chat_reasoning_effort(case)
         trust_remote_code = bool(case.metadata.get("trust_remote_code", False))
 
         script = textwrap.dedent(
@@ -252,6 +287,7 @@ class TextGenerationCausalRunner:
             prompt = {prompt!r}
             max_new_tokens = {max_new_tokens}
             use_chat_template = {use_chat_template!r}
+            reasoning_effort = {reasoning_effort!r}
             trust_remote_code = {trust_remote_code!r}
             logits_path = {str(logits_path)!r}
 
@@ -276,6 +312,7 @@ class TextGenerationCausalRunner:
                     tokenize=True,
                     return_dict=True,
                     return_tensors="pt",
+                    reasoning_effort=reasoning_effort,
                 )
                 input_ids = [int(token) for token in encoded["input_ids"][0].tolist()]
             else:
@@ -288,10 +325,16 @@ class TextGenerationCausalRunner:
             # that same window rather than comparing prompt-prefill rows.
             start = max(len(input_ids) - 1, 0)
             generation_results = results[start:start + max_new_tokens]
-            logits = [
-                np.asarray(result["logits"]).reshape(-1)
-                for result in generation_results
-            ]
+            raw_eos = config.get("eos_token_id", [])
+            eos_token_ids = {{int(raw_eos)}} if isinstance(raw_eos, int) else {{
+                int(token) for token in raw_eos
+            }}
+            logits = []
+            for result in generation_results:
+                step_logits = np.asarray(result["logits"]).reshape(-1)
+                logits.append(step_logits)
+                if int(np.argmax(step_logits)) in eos_token_ids:
+                    break
             if logits:
                 np.save(logits_path, np.stack(logits, axis=0).astype(np.float32))
             else:
@@ -299,6 +342,7 @@ class TextGenerationCausalRunner:
             print(json.dumps({{
                 "steps": len(logits),
                 "prompt_token_ids": input_ids,
+                "reasoning_effort": reasoning_effort,
             }}))
             """
         )

--- a/tests/e2e/models/k2_horizon/manifests/k2-horizon-7b.json
+++ b/tests/e2e/models/k2_horizon/manifests/k2-horizon-7b.json
@@ -31,7 +31,42 @@
       "contract_config": {
         "use_chat_template": false
       },
-      "notes": "Pinned BF16 plain-completion parity for the publisher-documented Transformers path. Native chat, sampling, reasoning/tool parsing, and the full 524288-token context are outside this minimal checkpoint contract."
+      "notes": "Pinned BF16 plain-completion parity for the publisher-documented Transformers path. Sampling, reasoning/tool parsing, and the full 524288-token context are outside this minimal checkpoint contract."
+    },
+    {
+      "name": "k2-horizon-7b-chat-high",
+      "trace_id": "IT-E2E-K2H7B-02",
+      "reference_backend": "hf_transformers",
+      "oracle_level": "L1_external_reference",
+      "reference_family": "k2_horizon_high_reasoning_chat",
+      "reference_precision": "bf16",
+      "user_contract": "chat_prefix_parity",
+      "prompt": "Reply with the word OK.",
+      "max_new_tokens": 48,
+      "temperature": 0.0,
+      "top_k": 1,
+      "inputs": {
+        "do_sample": false
+      },
+      "expected_prompt_token_ids": [
+        0, 250018, 2672, 200, 42035, 458, 293, 5512, 19677, 15, 250019, 250018,
+        142036, 200, 250029, 200
+      ],
+      "expected_continuation_token_ids": [
+        864, 3318, 4943, 27, 322, 42035, 458, 293, 5512, 19677, 2818, 2953, 627,
+        1767, 9359, 458, 322, 8228, 2338, 2515, 4791, 3343, 15, 250030, 8228, 250019
+      ],
+      "expected_continuation_text": "The user says: \"Reply with the word OK.\" So we should respond with \"OK\". No extra text.</ifm|think>OK",
+      "contract_config": {
+        "use_chat_template": true,
+        "reasoning_effort": "high"
+      },
+      "runtime_config": {
+        "k2_horizon": {
+          "emit_prompt_token_ids": true
+        }
+      },
+      "notes": "Pinned single-user, high-reasoning chat-template parity within the qualified 256-token deterministic smoke. System messages, history, tools, alternate reasoning levels, and sampling are not supported."
     }
   ]
 }

--- a/tests/e2e/models/k2_horizon/test_k2_horizon_manifest_contract.py
+++ b/tests/e2e/models/k2_horizon/test_k2_horizon_manifest_contract.py
@@ -13,17 +13,74 @@ import pytest
 from tests.e2e.models.k2_horizon.e2e_plugins.comparators.text import TextComparator
 from tests.e2e.models.k2_horizon.e2e_plugins.contract import (
     K2HorizonGreedyContinuationPlugin,
+    K2HorizonHighReasoningChatPlugin,
+)
+from tests.e2e.models.k2_horizon.e2e_plugins.references import (
+    hf_transformers as hf_transformers_reference,
 )
 from tests.e2e.models.k2_horizon.e2e_plugins.runners import (
     text_generation as text_generation_runner,
 )
 from tests.e2e_harness.contracts import StageOutput, StageSpec, ThresholdProfile
-from tests.e2e_harness.manifest_loader import load_manifest
+from tests.e2e_harness.manifest_loader import load_manifest, load_model_manifest
+
+
+_MANIFEST_PATH = Path(__file__).with_name("manifests") / "k2-horizon-7b.json"
+_CHAT_PROMPT_TOKENS = [
+    0,
+    250018,
+    2672,
+    200,
+    42035,
+    458,
+    293,
+    5512,
+    19677,
+    15,
+    250019,
+    250018,
+    142036,
+    200,
+    250029,
+    200,
+]
+_CHAT_CONTINUATION_TOKENS = [
+    864,
+    3318,
+    4943,
+    27,
+    322,
+    42035,
+    458,
+    293,
+    5512,
+    19677,
+    2818,
+    2953,
+    627,
+    1767,
+    9359,
+    458,
+    322,
+    8228,
+    2338,
+    2515,
+    4791,
+    3343,
+    15,
+    250030,
+    8228,
+    250019,
+]
+_CHAT_CONTINUATION_TEXT = (
+    'The user says: "Reply with the word OK." So we should respond with "OK". '
+    "No extra text.</ifm|think>OK"
+)
 
 
 def test_manifest_pins_the_independent_native_family() -> None:
-    manifest_path = Path(__file__).with_name("manifests") / "k2-horizon-7b.json"
-    case = load_manifest(manifest_path)
+    model = load_model_manifest(_MANIFEST_PATH)
+    case = model.build_case
 
     assert case.hf_id == "IFM/K2-Horizon-7B"
     assert case.hf_revision == "586b03f0fd1fbbf2f13eeafc33749e95ae34dd10"
@@ -38,6 +95,31 @@ def test_manifest_pins_the_independent_native_family() -> None:
     assert case.execution_profiles["reference"] == "k2_horizon_reference"
     assert case.metadata["contract_config"] == {"use_chat_template": False}
     assert case.metadata["expected_continuation_token_ids"] == [11511, 15, 589, 7169]
+
+    assert [child.name for child in model.testcases] == [
+        "k2-horizon-7b",
+        "k2-horizon-7b-chat-high",
+    ]
+    chat = model.testcases[1]
+    assert chat.reference_family == "k2_horizon_high_reasoning_chat"
+    assert chat.user_contract == "chat_prefix_parity"
+    assert chat.inputs == {
+        "do_sample": False,
+        "prompt": "Reply with the word OK.",
+        "max_new_tokens": 48,
+        "max_cache_length": 256,
+        "temperature": 0.0,
+        "top_k": 1,
+    }
+    assert chat.metadata["contract_config"] == {
+        "use_chat_template": True,
+        "reasoning_effort": "high",
+    }
+    assert chat.metadata["runtime_config"] == {"k2_horizon": {"emit_prompt_token_ids": True}}
+    assert chat.metadata["expected_prompt_token_ids"] == _CHAT_PROMPT_TOKENS
+    assert chat.metadata["expected_continuation_token_ids"] == _CHAT_CONTINUATION_TOKENS
+    assert chat.metadata["expected_continuation_text"] == _CHAT_CONTINUATION_TEXT
+    assert (Path(__file__).with_name("thresholds") / "k2-horizon-7b-chat-high.json").is_file()
 
 
 def test_e2e_code_uses_only_k2_horizon_owners() -> None:
@@ -242,6 +324,184 @@ def test_combined_contract_rejects_logit_drift_even_when_tokens_match() -> None:
     assert result.status == "failed"
     assert not result.metrics["token_agreement_rate"].passed
     assert "logit_cosine_p5" in result.metrics
+
+
+def _chat_contract_result(
+    *,
+    config: dict | None = None,
+    command: list[str] | None = None,
+    reference_prompt: list[int] | None = None,
+    debug_prompt: list[int] | None = None,
+    production_prompt: list[int] | None = None,
+    trt_text: str = _CHAT_CONTINUATION_TEXT,
+    reference_text: str = _CHAT_CONTINUATION_TEXT,
+    reference_reasoning_effort: str = "high",
+):
+    case = load_model_manifest(_MANIFEST_PATH).testcases[1]
+    if config is not None:
+        case.metadata["contract_config"] = config
+    logits = np.array([[0.0, 3.0, -1.0]], dtype=np.float32)
+    return K2HorizonHighReasoningChatPlugin().verify(
+        trt_output=StageOutput(
+            stage_name="full_generation",
+            data={
+                "cpp_returncode": 0,
+                "token_ids": _CHAT_CONTINUATION_TOKENS,
+                "prompt": "Reply with the word OK.",
+                "prompt_token_ids": production_prompt
+                if production_prompt is not None
+                else _CHAT_PROMPT_TOKENS,
+            },
+            text=trt_text,
+            logits=logits,
+            metadata={
+                "cpp": {
+                    "command": command
+                    if command is not None
+                    else [
+                        "trtmc",
+                        "run",
+                        "bundle",
+                        "--chat-template",
+                        "--set",
+                        "k2_horizon.emit_prompt_token_ids=true",
+                    ]
+                },
+                "debug_runner": {
+                    "prompt_token_ids": debug_prompt
+                    if debug_prompt is not None
+                    else _CHAT_PROMPT_TOKENS
+                },
+            },
+        ),
+        ref_output=StageOutput(
+            stage_name="full_generation",
+            data={
+                "token_ids": _CHAT_CONTINUATION_TOKENS,
+                "prompt_token_ids": reference_prompt
+                if reference_prompt is not None
+                else _CHAT_PROMPT_TOKENS,
+                "model_revision": case.hf_revision,
+                "generation": {"reasoning_effort": reference_reasoning_effort},
+            },
+            text=reference_text,
+            logits=logits,
+        ),
+        case=case,
+        threshold=ThresholdProfile(
+            task_strategy="text_generation_causal",
+            profile_name="k2-horizon-chat-test",
+            metrics={
+                "logit_cosine_p5": 0.99,
+                "logit_rel_l2_p95": 0.05,
+                "stable_top1_match_rate": 0.9,
+                "unstable_topk_hit_rate": 0.8,
+                "token_agreement_rate": 0.8,
+                "normalized_text_edit_distance": 0.2,
+            },
+        ),
+    )
+
+
+def test_chat_contract_requires_numeric_golden_prefix_and_high_reasoning() -> None:
+    result = _chat_contract_result()
+
+    assert result.status == "passed"
+    for metric in (
+        "logit_cosine_p5",
+        "exact_token_parity",
+        "expected_golden_continuation",
+        "chat_contract_config_exact",
+        "chat_template_flag_forwarded",
+        "prompt_token_receipt_requested",
+        "production_prompt_matches_expected",
+        "reference_prompt_matches_expected",
+        "debug_prompt_matches_expected",
+        "production_reference_and_debug_prompt_match",
+        "expected_decoded_continuation",
+        "reference_reasoning_effort_forwarded",
+    ):
+        assert result.metrics[metric].passed, metric
+
+
+def test_chat_contract_fails_closed_on_prefix_flag_text_or_reasoning_drift() -> None:
+    result = _chat_contract_result(
+        config={"use_chat_template": True, "reasoning_effort": "medium"},
+        command=["trtmc", "run", "bundle"],
+        production_prompt=_CHAT_PROMPT_TOKENS[:-1],
+        reference_prompt=_CHAT_PROMPT_TOKENS[:-1],
+        debug_prompt=_CHAT_PROMPT_TOKENS[1:],
+        trt_text="4",
+        reference_reasoning_effort="medium",
+    )
+
+    assert result.status == "failed"
+    for metric in (
+        "chat_contract_config_exact",
+        "chat_template_flag_forwarded",
+        "prompt_token_receipt_requested",
+        "production_prompt_matches_expected",
+        "reference_prompt_matches_expected",
+        "debug_prompt_matches_expected",
+        "production_reference_and_debug_prompt_match",
+        "expected_decoded_continuation",
+        "reference_reasoning_effort_forwarded",
+    ):
+        assert not result.metrics[metric].passed, metric
+
+
+@pytest.mark.parametrize(
+    "module",
+    [text_generation_runner, hf_transformers_reference],
+)
+def test_chat_execution_paths_accept_only_explicit_high_reasoning(module) -> None:
+    chat = load_model_manifest(_MANIFEST_PATH).testcases[1]
+    assert module._chat_reasoning_effort(chat) == "high"
+
+    chat.metadata["contract_config"] = {
+        "use_chat_template": True,
+        "reasoning_effort": "medium",
+    }
+    with pytest.raises(ValueError, match="only.*reasoning_effort='high'"):
+        module._chat_reasoning_effort(chat)
+
+
+def test_cpp_prompt_token_receipt_parser_is_exact_and_fail_closed() -> None:
+    receipt = (
+        "load diagnostics\n"
+        "[trtmc.k2_horizon.prompt] token_ids=[0,250018,2672,200]\n"
+        "timing diagnostics\n"
+    )
+    assert text_generation_runner._parse_cpp_prompt_token_ids(receipt) == [
+        0,
+        250018,
+        2672,
+        200,
+    ]
+    assert (
+        text_generation_runner._parse_cpp_prompt_token_ids(
+            "[trtmc.k2_horizon.prompt] token_ids=[0,-1]\n"
+        )
+        == []
+    )
+    assert (
+        text_generation_runner._parse_cpp_prompt_token_ids(
+            "[trtmc.k2_horizon.prompt] token_ids=[0,]\n"
+        )
+        == []
+    )
+    assert (
+        text_generation_runner._parse_cpp_prompt_token_ids(
+            "[trtmc.k2_horizon.prompt] token_ids=[0,,1]\n"
+        )
+        == []
+    )
+    assert (
+        text_generation_runner._parse_cpp_prompt_token_ids(
+            "[trtmc.k2_horizon.prompt] token_ids=[0,1]\n[trtmc.k2_horizon.prompt] token_ids=[0,1]\n"
+        )
+        == []
+    )
 
 
 def test_debug_timeout_preserves_diagnostics(tmp_path, monkeypatch) -> None:

--- a/tests/e2e/models/k2_horizon/thresholds/k2-horizon-7b-chat-high.json
+++ b/tests/e2e/models/k2_horizon/thresholds/k2-horizon-7b-chat-high.json
@@ -1,0 +1,13 @@
+{
+  "threshold_overrides": {
+    "layer_atol": 0.05,
+    "logit_atol": 0.001,
+    "logit_cosine_p5": 0.99,
+    "logit_rel_l2_p95": 0.05,
+    "normalized_text_edit_distance": 0.2,
+    "stable_margin": 0.1,
+    "stable_top1_match_rate": 0.9,
+    "token_agreement_rate": 0.8,
+    "unstable_topk_hit_rate": 0.8
+  }
+}

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -749,7 +749,8 @@ def test_k2_horizon_nightly_is_owned_by_its_family(tmp_path: Path) -> None:
 
     assert selection["suite"] == "nightly"
     assert [case["name"] for case in selection["e2e_cases"]] == [
-        "k2-horizon-7b"
+        "k2-horizon-7b",
+        "k2-horizon-7b-chat-high",
     ]
 
 


### PR DESCRIPTION
## Background

PR #1157 added K2-Horizon as an independent model family, but its native runtime still rejects `--chat-template` even though the pinned checkpoint bundle contains the publisher template. This change adds the smallest model-owned native chat path that can be qualified without coupling K2 to another family or adding a general Jinja runtime.

## Exit Criteria

- Render the pinned publisher template for one user message with an assistant generation prompt and high reasoning, using only K2-owned runtime code.
- Match the pinned publisher tokenizer framing exactly, including one BOS token, the IFM role delimiters, the high-reasoning prefix, and both publisher EOS IDs.
- Pass production C++ generation plus exact production prompt-token, continuation-token, decoded-text, and logit parity against the pinned Transformers implementation.
- Fail closed for unknown template bytes, out-of-range framing IDs, protocol markers in user content, disabled thinking in chat, request-level chat EOS overrides, and attempts to apply chat framing to pre-tokenized IDs.
- Preserve plain-completion behavior, including the existing no-op handling of its chat-only thinking flag.
- Keep system messages, conversation history, tools, alternate reasoning levels, sampling, and long-context reasoning outside this change.

## Implementation

- Add a K2-owned renderer for the single-user/high-reasoning path. The runtime does not execute Jinja: it accepts only the exact 51,034-byte publisher template identified by SHA-256 `a892cd0b0195599f283a8c706787520d9a6747640efb2f4dec4144b0abb62590`.
- Validate the pinned tokenizer contract before engine deserialization: `tokenizer_add_special_tokens=1`, BOS ID `0`, in-range IFM delimiter IDs, the native framing probe, and publisher EOS IDs `{1, 250019}`. The renderer omits an explicit BOS because the native tokenizer owns that insertion.
- Route `GenerateConfig::use_chat_template` through this renderer while preserving plain completion. Reject unsupported chat request shapes and IFM protocol-marker injection before engine execution.
- Add the model-scoped `k2_horizon.emit_prompt_token_ids` diagnostic receipt. It is default-off, session-request-only, and emitted after input/capacity validation but before inference; ordinary runtime logging never records prompt tokens.
- Add a second testcase to the existing K2 manifest, with a separate high-reasoning chat contract and threshold sidecar. The contract requires both the exact receipt-enabling CLI setting and one strict production receipt, then gates C++/HF/debug prompt-token agreement, numeric parity, exact continuation tokens, the pinned model revision, the C++ `--chat-template` flag, and the decoded golden output.
- Stop the debug-logit trace at the first publisher EOS so its rows align exactly with Transformers generation scores. Preserve byte-identical decoded continuations before prompt-echo normalization.
- Update the model-proof inventory so K2 nightly selection requires both the existing plain case and the new chat case.

There is no C++ API, ABI, bundle-format, dependency, or sibling-family change. The only additive configuration surface is the K2-scoped diagnostic receipt described above.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

All results below are for `11033321ee6c9c54ccb21cf9579cb220fbd32fd7` against base `b962f968fc244a9c95ee8d289c148ed3b6bc4860`.

### Commands and Results

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python:. python -m tools.community_ci source-quality --base github/main`: passed; maximum CCN was `10`, changed-file lint and formatting passed, and all `160` architecture-contract tests passed.
- `cmake --build "$BUILD_DIR" --target trtmc_cpu_cpp_tests -j4 && ctest --test-dir "$BUILD_DIR" --output-on-failure -L cpu`: passed, `151/151` CTests.
- `PYTHONPATH=python:. python -m pytest tests/e2e/models/k2_horizon/test_k2_horizon_family.py tests/e2e/models/k2_horizon/test_k2_horizon_manifest_contract.py tests/tools/test_model_plugin_encapsulation_static.py tests/builder/test_manifest_validation.py -q`: passed, `255 passed`.
- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_model_proof_runner.py -p no:cacheprovider`: passed, `173 passed`, including exact K2 nightly ownership of both cases.
- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_public_source_hygiene.py -p no:cacheprovider`: passed, `3 passed`; no private or host-specific source fingerprints were found.
- `PYTHONPATH=python:. python tools/family_specialization.py audit --family k2_horizon`: passed with zero violations and zero sibling-family imports. `python tools/model_ci.py validate`, `python tools/legal_headers.py --check`, Ruff, and `git diff --check` also passed.
- `trtmc build IFM/K2-Horizon-7B --model-revision 586b03f0fd1fbbf2f13eeafc33749e95ae34dd10 --max-cache-length 256 --precision bf16 --trust-remote-code -o "$ENGINE_DIR/k2-horizon-7b.bundle"`: passed offline from the pinned cache. The 17,166.5 MiB engine compiled in 216.2 seconds; total build time was 229.6 seconds. Bundle size: 18,021,057,724 bytes. Bundle SHA-256: `311d349238b4aa1cb9d428f138ae4523e9c5677ba88bc3ac3ecb458c143dfd30`.
- `python -m pytest tests/e2e/models/k2_horizon/test_k2_horizon_e2e.py -v --engine-dir "$ENGINE_DIR" --trtmc-binary "$TRTMC_BINARY" --hf-python "$HF_PYTHON" --model-plugin-dir "$PLUGIN_DIR" --e2e-artifacts-dir "$ARTIFACT_DIR"`: passed with both child cases using the exact-head bundle and K2 DSO.
  - Plain completion retained exact token/golden/revision agreement and stable top-1 rate `1.0`; text NED `0.0`; logit cosine p5 `0.999908`; relative L2 p95 `0.013601`.
  - High-reasoning chat used the exact 16-token publisher prompt prefix and produced the same 26 continuation tokens in production C++, native debug execution, and Transformers, including EOS. Receipt setting, production/HF/debug prompt agreement, exact token/golden agreement, and stable top-1 rate were `1.0`; text NED `0.0`; logit cosine p5 `0.999066`; relative L2 p95 `0.042660`.
  - Prompt: `Reply with the word OK.`
  - Decoded output: `The user says: "Reply with the word OK." So we should respond with "OK". No extra text.</ifm|think>OK`

### Hardware, Environment, and Revisions

- Repository head: `11033321ee6c9c54ccb21cf9579cb220fbd32fd7`; base: `b962f968fc244a9c95ee8d289c148ed3b6bc4860`.
- Model: `IFM/K2-Horizon-7B` at immutable revision `586b03f0fd1fbbf2f13eeafc33749e95ae34dd10`.
- GPU proof: one NVIDIA GB300, Linux/aarch64, CUDA 13.3, TensorRT 11.1.0.106, BF16, fixed cache capacity 256.

### Not Run / Remaining Gaps

- System messages, multi-turn history, tool definitions or calls, medium/low reasoning modes, disabled thinking in chat, non-greedy sampling, and a parsed answer-only response are unsupported and fail closed or remain outside the API surface.
- The publisher's long-context reasoning regime, the full 524,288-token model context, alternate precisions, tensor parallelism, quantization, RTX, dynamic KV cache, other GPU architectures, and performance qualification were not run and are not claimed.

## Notes For Future Readers

- Review `src/runtime/models/k2_horizon/chat_template.cpp` first, then the K2 pipeline/plugin changes and finally the second manifest testcase and contract.
- The exact template hash and tokenizer IDs belong to the pinned checkpoint contract. A checkpoint/template revision must add new evidence rather than silently reuse this format identifier.
- Native output intentionally remains the publisher's raw reasoning-plus-answer text, including `</ifm|think>`; this PR does not add a reasoning parser or Chat Completions response schema.
- Prompt-token receipts can reveal request content. They are disabled by default and should be enabled only for explicit single-request diagnostics or parity qualification.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: this changes native generation input framing, but only behind the existing chat flag; the accepted template and tokenizer contract are exact, unsupported variants fail closed, the diagnostic receipt is explicit and default-off, plain completion remains unchanged, and both CPU regression and exact native/HF GPU parity passed.
