### PR TITLE
fix(model-checks): run perf cases sequentially

### DIFF
--- a/tests/model_checks/README.md
+++ b/tests/model_checks/README.md
@@ -76,11 +76,12 @@ model in `tests/validation/model_workloads.yaml`.
 ## Run
 
 By default, `run` is a formal qualification run. Each execution attempt freezes source identity,
-prepares missing dependencies, runs preflight, and then switches measurement to
-prebuilt-only mode. During development, add `--debug` to allow a dirty worktree
-and on-demand dependency creation. Every run still resolves the active worktree
-HEAD to a 40-character commit SHA and places the current repository Python paths
-first in each child process.
+prepares missing Python profiles and reference sources, and runs preflight. Perf
+then builds, measures, records, and cleans up one case before moving to the next.
+During development, add `--debug` to allow a dirty worktree and on-demand
+dependency creation. Every run still resolves the active worktree HEAD to a
+40-character commit SHA and places the current repository Python paths first in
+each child process.
 
 Run one model through formal Accuracy and then Perf qualification:
 
@@ -111,13 +112,15 @@ $TRTMC_CHECK_PYTHON tools/model_checks.py run \
 ```
 
 The controller first writes `native-build-identity.json`, then creates missing
-Python profiles, pinned reference-source checkouts, and Perf bundles before
-measurement. Measurement then runs with
-dependency creation and Perf bundle builds disabled. Qualification also rejects
-a dirty worktree, imports outside the active worktree, and a requested revision
-different from HEAD. It rechecks that identity after preparation and before and
-after every task, so evidence from an attempt cannot silently cross a mid-run
-edit. Accuracy and Perf receipts record the exact SHA tested; native workers and
+Python profiles and pinned reference-source checkouts before measurement. It
+does not eagerly materialize the full Perf bundle matrix: each Perf case builds
+its source-bound bundle on demand, measures it, records the durable result, and
+applies the configured bundle cleanup policy before the next case. Qualification
+also rejects a dirty worktree, imports outside the active worktree, and a
+requested revision different from HEAD. It rechecks that identity after
+preparation and before and after every task, so evidence from an attempt cannot
+silently cross a mid-run edit. Accuracy and Perf receipts record the exact SHA
+tested; native workers and
 bundles must report that SHA. A campaign may be resumed on a later commit, but
 all final Accuracy and Perf receipts for one model must agree on one SHA. Other
 models may complete on different SHAs.

--- a/tests/tools/test_model_checks.py
+++ b/tests/tools/test_model_checks.py
@@ -1769,7 +1769,7 @@ def test_qualification_rechecks_source_identity_after_preparation(tmp_path, monk
     assert calls == 2
 
 
-def test_qualification_prepare_phase_runs_accuracy_and_perf_bundle_preparation(
+def test_qualification_prepare_phase_checks_perf_without_building_bundles(
     tmp_path, monkeypatch
 ):
     events = []
@@ -1809,12 +1809,14 @@ def test_qualification_prepare_phase_runs_accuracy_and_perf_bundle_preparation(
     )
     monkeypatch.setattr(
         model_checks,
-        "_perf_prepare_command",
-        lambda *_args, **_kwargs: [sys.executable, "perf_matrix.py", "prepare"],
+        "_perf_check_command",
+        lambda *_args, **_kwargs: [sys.executable, "perf_matrix.py", "check"],
     )
 
-    def run(*_args, **_kwargs):
-        events.append("perf-prepare")
+    def run(command, **_kwargs):
+        assert "prepare" not in command
+        assert "--prepare-only" not in command
+        events.append("perf-check")
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(model_checks.subprocess, "run", run)
@@ -1825,15 +1827,14 @@ def test_qualification_prepare_phase_runs_accuracy_and_perf_bundle_preparation(
         arguments,
         task_bindings=task_bindings,
         perf_environment=tmp_path / "perf-environment.yaml",
-        perf_preparation_receipt=tmp_path / "perf-preparation.json",
         model_reference_cache_root=tmp_path / "references",
     )
 
     assert result == {}
-    assert events == ["accuracy", "references", "perf-prepare"]
+    assert events == ["accuracy", "references", "perf-check"]
 
 
-def test_qualification_perf_commands_require_prebuilt_bundles(tmp_path):
+def test_qualification_perf_commands_build_each_case_on_demand(tmp_path):
     plan = {"models": []}
     environment = {"tasks": {"perf": {"runner_python": sys.executable, "suite": tmp_path}}}
     run = tmp_path / "results" / "run-a"
@@ -1845,16 +1846,14 @@ def test_qualification_perf_commands_require_prebuilt_bundles(tmp_path):
         environment,
         tmp_path / "environment.yaml",
         bindings=[{"entry": "entry-a"}],
-        require_prebuilt=True,
     )
     resume = model_checks._perf_resume_command(
         environment,
         tmp_path / "results",
-        require_prebuilt=True,
     )
 
-    assert command is not None and "--no-build" in command
-    assert resume is not None and "--no-build" in resume
+    assert command is not None and "--no-build" not in command
+    assert resume is not None and "--no-build" not in resume
 
 
 def test_source_identity_rejects_import_from_another_checkout(monkeypatch):

--- a/tools/model_checks.py
+++ b/tools/model_checks.py
@@ -1396,7 +1396,6 @@ def _perf_command(
     resolved_environment: Path,
     *,
     bindings: Sequence[Mapping[str, Any]] | None = None,
-    require_prebuilt: bool = False,
 ) -> list[str] | None:
     bindings = list(bindings) if bindings is not None else _task_bindings(plan, "perf")
     if not bindings:
@@ -1412,16 +1411,13 @@ def _perf_command(
     ]
     for binding in bindings:
         command.extend(["--entry", str(binding["entry"])])
-    if require_prebuilt:
-        command.append("--no-build")
     return command
 
 
-def _perf_prepare_command(
+def _perf_check_command(
     plan: Mapping[str, Any],
     environment: Mapping[str, Any],
     resolved_environment: Path,
-    receipt: Path,
     *,
     bindings: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[str] | None:
@@ -1432,12 +1428,10 @@ def _perf_prepare_command(
     command = [
         str(config["runner_python"]),
         str(REPOSITORY / "tools" / "perf_matrix.py"),
-        "prepare",
+        "check",
         str(config["suite"]),
         "--environment",
         str(resolved_environment),
-        "--output",
-        str(receipt),
     ]
     for binding in bindings:
         command.extend(["--entry", str(binding["entry"])])
@@ -1447,8 +1441,6 @@ def _perf_prepare_command(
 def _perf_resume_command(
     environment: Mapping[str, Any],
     results_root: Path,
-    *,
-    require_prebuilt: bool = False,
 ) -> list[str] | None:
     if not results_root.is_dir():
         return None
@@ -1468,8 +1460,6 @@ def _perf_resume_command(
         "resume",
         str(candidates[0]),
     ]
-    if require_prebuilt:
-        command.append("--no-build")
     return command
 
 
@@ -1959,7 +1949,6 @@ def _prepare_qualification_dependencies(
     *,
     task_bindings: Mapping[str, Sequence[Mapping[str, Any]]],
     perf_environment: Path | None,
-    perf_preparation_receipt: Path | None,
     model_reference_cache_root: Path,
 ) -> dict[str, str]:
     print("\nPreparing qualification dependencies", flush=True)
@@ -1978,12 +1967,11 @@ def _prepare_qualification_dependencies(
         contracts,
         model_reference_cache_root,
     )
-    if perf_environment is not None and perf_preparation_receipt is not None:
-        command = _perf_prepare_command(
+    if perf_environment is not None:
+        command = _perf_check_command(
             plan,
             environment,
             perf_environment,
-            perf_preparation_receipt,
             bindings=task_bindings.get("perf", ()),
         )
         if command is not None:
@@ -1998,8 +1986,11 @@ def _prepare_qualification_dependencies(
                 ),
             )
             if completed.returncode:
-                raise ModelCheckError("Perf bundle preparation failed")
-    print("Qualification dependencies prepared; starting frozen measurement", flush=True)
+                raise ModelCheckError("Perf dependency preflight failed")
+    print(
+        "Qualification dependencies prepared; starting per-case build and measurement",
+        flush=True,
+    )
     return reference_environment
 
 
@@ -2143,9 +2134,6 @@ def _run(arguments: argparse.Namespace) -> int:
             scratch_root=execution_root / "work" / "perf",
             bundle_cache=(execution_root / "cache" / "perf" if shard else None),
         )
-    perf_preparation_receipt = (
-        execution_root / "perf-bundle-preparation.json" if perf_environment is not None else None
-    )
     commands: list[tuple[str, list[str] | None]] = []
     for task in plan["execution"]["task_order"]:
         if task == "accuracy":
@@ -2163,7 +2151,6 @@ def _run(arguments: argparse.Namespace) -> int:
                     environment,
                     perf_environment,
                     bindings=task_bindings[task],
-                    require_prebuilt=arguments.intent == "qualification",
                 )
                 if perf_environment is not None
                 else None
@@ -2236,7 +2223,6 @@ def _run(arguments: argparse.Namespace) -> int:
                 resume_command = _perf_resume_command(
                     environment,
                     execution_root / "perf" / "results",
-                    require_prebuilt=arguments.intent == "qualification",
                 )
                 resumed = resume_command or command
                 if resume_command is not None:
@@ -2307,7 +2293,6 @@ def _run(arguments: argparse.Namespace) -> int:
             arguments,
             task_bindings=preparation_bindings,
             perf_environment=perf_environment,
-            perf_preparation_receipt=perf_preparation_receipt,
             model_reference_cache_root=model_reference_cache_root,
         )
         _revalidate_qualification_source(arguments.revision, source_identity)
@@ -2350,23 +2335,6 @@ def _run(arguments: argparse.Namespace) -> int:
         )
         if arguments.intent == "qualification":
             _revalidate_qualification_source(arguments.revision, source_identity)
-        if (
-            task == "perf"
-            and completed.returncode == 0
-            and preparation_bindings.get("perf")
-            and perf_preparation_receipt is not None
-            and perf_preparation_receipt.is_file()
-        ):
-            perf_output = _perf_shard_output(execution_root)
-            if perf_output is None:
-                raise ModelCheckError("cannot locate completed Perf output")
-            try:
-                perf_matrix.write_report(
-                    perf_output,
-                    preparation_receipt=perf_preparation_receipt,
-                )
-            except perf_matrix.PerfMatrixError as error:
-                raise ModelCheckError(str(error)) from error
         task_results[task] = completed.returncode
         status = "PASSED" if completed.returncode == 0 else "FAILED"
         print(f"[{index}/{len(runnable)}] {label}: {status}", flush=True)


### PR DESCRIPTION
## Background

Formal model checks currently prepare every selected Performance bundle before measuring any case. A gated model reached later in the matrix can therefore fail after earlier bundles have consumed substantial time and disk, while none of those earlier cases has a durable Performance result.

## Exit Criteria

- Formal Performance qualification builds, measures, records, and cleans one case before moving to the next.
- Exact source, worker, bundle, and case provenance checks remain enforced.
- Resume keeps completed terminal cases and retries only eligible work.

## Implementation

- Replace eager `perf_matrix prepare` with the existing lightweight `perf_matrix check` dependency preflight.
- Let formal `perf_matrix run` and `resume` build bundles on demand instead of forcing `--no-build`.
- Remove the task-level preparation receipt path; per-case execution now records the actual bundle source directly.
- Update model-check documentation and regression coverage for sequential execution.

## Validation

- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m pytest -q tests/tools/test_model_checks.py`: 79 passed.
- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m pytest -q tests/tools/test_perf_matrix.py`: 145 passed.
- `/home/chaofengw/workspace/TensorRT-Model-Connect/.venv-trtmc/bin/python -m ruff check tools/model_checks.py tests/tools/test_model_checks.py`: passed.

## Notes For Future Readers

- Review `tools/model_checks.py` first. The underlying `perf_matrix` per-case loop and retention behavior are unchanged.
- The standalone `perf_matrix prepare` command remains available for explicitly prebuilt workflows; unified formal model checks no longer use it.
- No target-hardware qualification was run for this commit; GB300 validation should follow after merge so the formal checkout remains clean and revision-bound.
