### PR TITLE
fix(stablelm): let a submodule import resolve without loading the plugin

### DIFF
--- a/python/tensorrt_model_connect/families/stablelm/__init__.py
+++ b/python/tensorrt_model_connect/families/stablelm/__init__.py
@@ -26,6 +26,19 @@ def _load_plugin_module():
 def __getattr__(name: str) -> Any:
     if name.startswith("__"):
         raise AttributeError(name)
+    if name != "plugin":
+        # ``from . import <submodule>`` consults this hook before the import
+        # system falls back to importing the submodule itself. Answering it by
+        # loading the plugin makes a submodule's own import re-enter that
+        # submodule through the plugin, which fails while it is half-built.
+        # A real submodule therefore has to resolve as itself first.
+        try:
+            return importlib.import_module(f"{__name__}.{name}")
+        except ModuleNotFoundError as exc:
+            # Only "there is no such submodule" falls through to the plugin; a
+            # failure raised from inside an existing submodule is a real error.
+            if exc.name != f"{__name__}.{name}":
+                raise
     plugin_module = _load_plugin_module()
     if name == "plugin":
         return getattr(plugin_module, "plugin")

--- a/tests/e2e/models/stablelm/test_stablelm_submodule_import.py
+++ b/tests/e2e/models/stablelm/test_stablelm_submodule_import.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Importing a stablelm submodule first must not go through the plugin.
+
+The family package resolves unknown attributes by importing ``.plugin``. That
+hook also runs for ``from . import <submodule>``, so a submodule that imports a
+sibling during its own import used to be answered by loading the plugin, which
+imports that submodule back while it is still half-built.
+
+Each case runs in a fresh interpreter because the failure only appears when the
+submodule is the first thing to touch the package; once anything else has
+imported the plugin, the attribute is already set and the hook never runs.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+_PACKAGE = "tensorrt_model_connect.families.stablelm"
+
+
+def _run(statement: str) -> subprocess.CompletedProcess:
+    """Run one statement in a fresh interpreter that sees the same packages.
+
+    The subprocess inherits this interpreter's search path so it imports the
+    checkout under test rather than whatever happens to be installed.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", statement],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)},
+    )
+
+
+@pytest.mark.parametrize(
+    "submodule",
+    ["default_decoder", "standard_decoder_builder", "default_dual_profile_decoder"],
+)
+def test_submodule_imports_first_without_the_plugin(submodule: str) -> None:
+    result = _run(
+        f"import importlib; importlib.import_module('{_PACKAGE}.{submodule}')")
+    assert result.returncode == 0, (
+        f"importing {submodule} before anything else touches the package failed:\n"
+        f"{result.stderr}"
+    )
+
+
+def test_plugin_attribute_is_the_plugin_not_the_module() -> None:
+    """The submodule shortcut must not shadow the ``plugin`` attribute.
+
+    ``stablelm.plugin`` is both a module name and the public FamilyPlugin
+    instance; the package deliberately exposes the instance.
+    """
+    result = _run(
+        f"import importlib, types;"
+        f" m = importlib.import_module('{_PACKAGE}');"
+        f" assert not isinstance(m.plugin, types.ModuleType), type(m.plugin)")
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Background

Importing any `stablelm` submodule before anything else has touched the family
package raises an `ImportError`. On `main`, at `92db1113`:

```
python -c "import importlib; importlib.import_module(
    'tensorrt_model_connect.families.stablelm.default_decoder')"

ImportError: cannot import name '_apply_norm' from partially initialized module
'tensorrt_model_connect.families.stablelm.default_decoder'
(most likely due to a circular import)
```

The chain is:

1. `default_decoder` starts importing and runs `from . import graph_ops`.
2. `from . import <name>` consults the package's `__getattr__` **before** the
   import system falls back to importing the submodule.
3. That hook answers by loading `.plugin`, which imports
   `standard_decoder_builder`, which imports `default_decoder` — still half
   built, so `_apply_norm` does not exist yet.

This is why `Community CPU / Unit` has been failing intermittently. The unit
stage runs `tests/e2e/models/` under `-n 8 --dist=worksteal`, and
`test_stablelm_precision_contract.py` reaches these submodules through
`importlib.import_module`. Whether the failure appears depends only on which
module a worker happens to import first, and the stage runs with `-x`, so one
occurrence fails the whole job. It is currently failing consistently.

## Exit Criteria

- Importing a `stablelm` submodule first succeeds.
- `stablelm.plugin` still resolves to the `FamilyPlugin` instance, not to the
  `plugin` module.
- An import error raised from *inside* an existing submodule still propagates
  instead of being swallowed.
- The unit stage's own command passes.

## Implementation

`__getattr__` in `families/stablelm/__init__.py` now resolves a real submodule
as itself before falling back to loading the plugin. `plugin` is excluded from
that shortcut, because the package deliberately exposes the `FamilyPlugin`
instance under a name that is also a module.

The `ModuleNotFoundError` handler re-raises unless the missing module is
exactly the attribute being looked up, so a genuine failure inside an existing
submodule is not turned into a silent fallback.

Scope: only `stablelm` is changed. 34 other families carry a byte-identical
`__init__.py` and share the latent pattern, but none of them currently has a
submodule that both imports a sibling during its own import and is imported
directly by a test, so none of them reproduces. I have not touched them here to
keep this reviewable and to avoid a 35-family diff; happy to follow up if you
would rather have it fixed everywhere at once.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

The unit stage's own command, which is the one failing on `main`:

```
python -m pytest tests/e2e/models/ tests/test_e2e_selection.py -q -n 8 \
  --dist=worksteal --import-mode=importlib -p no:cacheprovider \
  -m "not gpu and not trt and not e2e and not model_proof_allocator" \
  --ignore-glob="*_e2e.py"
2583 passed, 21 skipped in 32.90s
```

New regression test, with the fix:

```
python -m pytest tests/e2e/models/stablelm/test_stablelm_submodule_import.py -q
4 passed in 1.00s
```

The same test with `__init__.py` reverted to `main`, confirming it actually
covers the defect rather than merely passing:

```
3 failed, 1 passed in 0.94s
```

The one case that passes without the fix is `default_dual_profile_decoder`,
which does not import a sibling that reaches back through the plugin.

Full stablelm directory:

```
python -m pytest tests/e2e/models/stablelm/ -q
1 failed, 41 passed in 39.58s
```

The remaining failure is `test_stablelm_e2e.py::test_model_e2e[stablelm2-1.6b]`,
which needs a checkpoint this machine does not have. It fails identically on an
unmodified `main` checkout, so it is not related to this change.

### Hardware, Environment, and Revisions

| Item | Value |
| --- | --- |
| Repository head | `92db1113` |
| Container | project `Dockerfile.dev.x86`, Ubuntu 24.04, Python 3.12 |
| Python | 3.12.3 |

### Not Run / Remaining Gaps

- The GPU and TRT-marked tests were not run; this change only affects module
  import order and touches no build path.
- The other 34 families sharing this `__init__.py` were not changed and have no
  regression test for the same pattern.

## Notes For Future Readers

The failure is invisible once anything has imported the family plugin, because
the submodule attribute is then already set and `__getattr__` never runs. That
is why the regression test spawns a fresh interpreter per case, and why the CI
failure looked like a flake for so long.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The change adds a lookup ahead of an existing fallback and does not remove any
path. The `plugin` attribute is explicitly excluded so the package's public
surface is unchanged, and that is covered by a test.
