### PR TITLE
feat(k2-horizon-uno): add native linear Psi-Spec family

### DIFF
--- a/apps/benchmark/performance/release.yaml
+++ b/apps/benchmark/performance/release.yaml
@@ -34,6 +34,11 @@ excluded_profiles:
     reason: >-
       Pinned BF16 build and Hugging Face parity qualification are present, but
       no matching release-performance workload or receipt has been collected.
+  - model: k2-horizon-7b-uno
+    reason: >-
+      Pinned BF16 build and exact linear Psi-Spec parity qualification are
+      present, but the algorithmic committed-token receipt is not a matched
+      wall-clock release-performance workload.
   - model: minimax-h3-768p
     reason: >-
       The pinned Diffusers reference for MiniMax-H3 has not yet been integrated

--- a/families/k2_horizon_uno/__init__.py
+++ b/families/k2_horizon_uno/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""K2-Horizon-Uno model family."""

--- a/families/k2_horizon_uno/checkpoint_mapper.py
+++ b/families/k2_horizon_uno/checkpoint_mapper.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint and conditional-LoRA loader for pinned K2-Horizon-7B-Uno."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from safetensors import safe_open
+
+try:
+    import ml_dtypes
+except ImportError:  # pragma: no cover - selected family requirements provide it
+    ml_dtypes = None
+
+from .config import (
+    ADAPTER_FILENAME,
+    K2HorizonUnoConfig,
+)
+
+
+WeightDict = dict[str, np.ndarray]
+_PROJECTIONS = (
+    ("self_attn", "q_proj", "w_q"),
+    ("self_attn", "k_proj", "w_k"),
+    ("self_attn", "v_proj", "w_v"),
+    ("self_attn", "o_proj", "w_o"),
+    ("mlp", "gate_proj", "w_gate"),
+    ("mlp", "up_proj", "w_up"),
+    ("mlp", "down_proj", "w_down"),
+)
+
+
+def _layer_key(layer_index: int, suffix: str) -> str:
+    return f"model.layers.{layer_index}.{suffix}"
+
+
+def _base_tensor_names(num_layers: int) -> set[str]:
+    names = {"model.embed_tokens.weight", "model.norm.weight", "lm_head.weight"}
+    for layer_index in range(num_layers):
+        names.add(_layer_key(layer_index, "input_layernorm.weight"))
+        names.add(_layer_key(layer_index, "post_attention_layernorm.weight"))
+        names.update(
+            _layer_key(layer_index, f"{scope}.{projection}.weight")
+            for scope, projection, _logical in _PROJECTIONS
+        )
+    return names
+
+
+def _adapter_tensor_names(num_layers: int) -> set[str]:
+    return {
+        f"{_layer_key(layer_index, f'{scope}.{projection}')}.{suffix}"
+        for layer_index in range(num_layers)
+        for scope, projection, _logical in _PROJECTIONS
+        for suffix in ("lora_A.weight", "lora_B.weight")
+    }
+
+
+def _open_base_readers(model_dir: Path) -> dict[str, object]:
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(
+            f"Uno staged base is missing model.safetensors.index.json: {model_dir}"
+        )
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError("Uno base safetensors index has no weight_map")
+    shards = sorted(set(weight_map.values()))
+    if any(not isinstance(name, str) or not name for name in shards):
+        raise ValueError("Uno base safetensors index contains an invalid shard name")
+    readers_by_file = {name: safe_open(str(model_dir / name), framework="numpy") for name in shards}
+    return {name: readers_by_file[shard] for name, shard in weight_map.items()}
+
+
+def _open_adapter_reader(model_dir: Path):
+    return safe_open(str(model_dir / ADAPTER_FILENAME), framework="numpy")
+
+
+def _validate_inventory(actual: set[str], expected: set[str], label: str) -> None:
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append("missing=" + ", ".join(missing[:8]))
+        if unexpected:
+            details.append("unexpected=" + ", ".join(unexpected[:8]))
+        raise ValueError(f"K2-Horizon-Uno {label} tensor inventory mismatch: " + "; ".join(details))
+
+
+def _get_tensor(readers, name: str):
+    if isinstance(readers, dict):
+        reader = readers.get(name)
+        if reader is None:
+            raise KeyError(f"Tensor not found: {name}")
+        return reader.get_tensor(name)
+    if name not in readers.keys():
+        raise KeyError(f"Tensor not found: {name}")
+    return readers.get_tensor(name)
+
+
+def _to_fp32(tensor) -> np.ndarray:
+    source = np.asarray(tensor)
+    if source.dtype == np.uint16:
+        if ml_dtypes is not None:
+            return source.view(ml_dtypes.bfloat16).astype(np.float32)
+        return (source.astype(np.uint32) << np.uint32(16)).view(np.float32)
+    return np.asarray(source, dtype=np.float32)
+
+
+def _to_bf16_bits(tensor, *, transpose: bool = False) -> np.ndarray:
+    source = np.asarray(tensor)
+    if transpose:
+        if source.ndim != 2:
+            raise ValueError("Uno projection tensors must be rank two")
+        source = source.T
+    if source.dtype == np.uint16:
+        return np.array(source, dtype=np.uint16, order="C", copy=True)
+    if ml_dtypes is None:
+        source_fp32 = np.ascontiguousarray(source, dtype=np.float32)
+        source_bits = source_fp32.view(np.uint32)
+        rounding_bias = np.uint32(0x7FFF) + ((source_bits >> np.uint32(16)) & np.uint32(1))
+        rounded = source_bits + rounding_bias
+        return np.ascontiguousarray((rounded >> np.uint32(16)).astype(np.uint16))
+    bf16 = np.asarray(source, dtype=ml_dtypes.bfloat16)
+    return np.array(bf16.view(np.uint16), dtype=np.uint16, order="C", copy=True)
+
+
+def _load_bf16(readers, name: str, *, transpose: bool = False) -> np.ndarray:
+    return _to_bf16_bits(_get_tensor(readers, name), transpose=transpose)
+
+
+def _load_norm(readers, name: str) -> np.ndarray:
+    return np.array(_to_fp32(_get_tensor(readers, name)), dtype=np.float32, copy=True)
+
+
+def _expected_projection_shapes(cfg: K2HorizonUnoConfig) -> dict[str, tuple[int, int]]:
+    return {
+        "q_proj": (cfg.hidden_size, cfg.attention_size),
+        "k_proj": (cfg.hidden_size, cfg.kv_attention_size),
+        "v_proj": (cfg.hidden_size, cfg.kv_attention_size),
+        "o_proj": (cfg.attention_size, cfg.hidden_size),
+        "gate_proj": (cfg.hidden_size, cfg.intermediate_size),
+        "up_proj": (cfg.hidden_size, cfg.intermediate_size),
+        "down_proj": (cfg.intermediate_size, cfg.hidden_size),
+    }
+
+
+def load_standard_weights(
+    base_dir: str | Path,
+    adapter_dir: str | Path,
+    cfg: K2HorizonUnoConfig,
+) -> WeightDict:
+    """Load base BF16 weights plus the exact per-projection Uno LoRA tensors."""
+
+    base_path = Path(base_dir)
+    adapter_path = Path(adapter_dir)
+    base = _open_base_readers(base_path)
+    adapter = _open_adapter_reader(adapter_path)
+    _validate_inventory(set(base), _base_tensor_names(cfg.num_hidden_layers), "base")
+    _validate_inventory(
+        set(adapter.keys()), _adapter_tensor_names(cfg.num_hidden_layers), "adapter"
+    )
+
+    weights = WeightDict()
+    weights["embedding"] = _load_bf16(base, "model.embed_tokens.weight")
+    if weights["embedding"].shape != (cfg.vocab_size, cfg.hidden_size):
+        raise ValueError("K2-Horizon-Uno embedding shape does not match config")
+
+    projection_shapes = _expected_projection_shapes(cfg)
+
+    def load_layer(layer_index: int) -> WeightDict:
+        layer = WeightDict()
+        logical_prefix = f"layer.{layer_index}"
+        for logical, source in (
+            ("input_norm", "input_layernorm.weight"),
+            ("post_attn_norm", "post_attention_layernorm.weight"),
+        ):
+            value = _load_norm(base, _layer_key(layer_index, source))
+            if value.shape != (cfg.hidden_size,):
+                raise ValueError(f"K2-Horizon-Uno layer {layer_index} {logical} shape mismatch")
+            layer[f"{logical_prefix}.{logical}"] = value
+
+        for scope, projection, logical in _PROJECTIONS:
+            source_prefix = _layer_key(layer_index, f"{scope}.{projection}")
+            expected = projection_shapes[projection]
+            base_weight = _load_bf16(base, f"{source_prefix}.weight", transpose=True)
+            lora_a = _load_bf16(adapter, f"{source_prefix}.lora_A.weight", transpose=True)
+            lora_b = _load_bf16(adapter, f"{source_prefix}.lora_B.weight", transpose=True)
+            if base_weight.shape != expected:
+                raise ValueError(
+                    f"K2-Horizon-Uno {source_prefix} base shape must be {expected}, "
+                    f"got {base_weight.shape}"
+                )
+            if lora_a.shape != (expected[0], cfg.lora_rank):
+                raise ValueError(
+                    f"K2-Horizon-Uno {source_prefix} LoRA A shape mismatch: {lora_a.shape}"
+                )
+            if lora_b.shape != (cfg.lora_rank, expected[1]):
+                raise ValueError(
+                    f"K2-Horizon-Uno {source_prefix} LoRA B shape mismatch: {lora_b.shape}"
+                )
+            layer[f"{logical_prefix}.{logical}"] = base_weight
+            layer[f"{logical_prefix}.{logical}_lora_a"] = lora_a
+            layer[f"{logical_prefix}.{logical}_lora_b"] = lora_b
+        return layer
+
+    for layer_index in range(cfg.num_hidden_layers):
+        weights.update(load_layer(layer_index))
+
+    weights["final_norm"] = _load_norm(base, "model.norm.weight")
+    weights["w_out"] = _load_bf16(base, "lm_head.weight", transpose=True)
+    if weights["final_norm"].shape != (cfg.hidden_size,):
+        raise ValueError("K2-Horizon-Uno final norm shape does not match config")
+    if weights["w_out"].shape != (cfg.hidden_size, cfg.vocab_size):
+        raise ValueError("K2-Horizon-Uno LM head shape does not match config")
+    return weights

--- a/families/k2_horizon_uno/config.py
+++ b/families/k2_horizon_uno/config.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the qualified K2-Horizon-7B-Uno checkpoint recipe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+
+
+BASE_ARCHITECTURE = "K2HorizonForCausalLM"
+BASE_MODEL_ID = "IFM/K2-Horizon-7B"
+BASE_REVISION = "586b03f0fd1fbbf2f13eeafc33749e95ae34dd10"
+ADAPTER_FILENAME = "adapter_model.safetensors"
+LORA_RANK = 128
+LORA_ALPHA = 8192.0
+LORA_SCALE = 64.0
+LORA_TARGET_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "down_proj",
+    "up_proj",
+)
+DEFAULT_MAX_BLOCK_SIZE = 8
+
+
+@dataclass(frozen=True)
+class K2HorizonUnoConfig:
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    rope_theta: float
+    layernorm_num_groups: int
+    lora_rank: int = LORA_RANK
+    lora_scale: float = LORA_SCALE
+    max_block_size: int = DEFAULT_MAX_BLOCK_SIZE
+
+    @property
+    def attention_size(self) -> int:
+        return self.num_attention_heads * self.head_dim
+
+    @property
+    def kv_attention_size(self) -> int:
+        return self.num_key_value_heads * self.head_dim
+
+
+_EXACT_INTS = {
+    "vocab_size": 250_624,
+    "hidden_size": 4096,
+    "intermediate_size": 12_288,
+    "num_hidden_layers": 36,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "max_position_embeddings": 524_288,
+    "layernorm_num_groups": 4,
+}
+
+
+def _raw(config: object) -> dict:
+    value = getattr(config, "raw", {})
+    return value if isinstance(value, dict) else {}
+
+
+def _enabled(value: object) -> bool:
+    return value not in (None, False, 0, "", (), [], {})
+
+
+def _exact_positive_float(value: object, expected: float, name: str) -> float:
+    try:
+        resolved = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f"K2-Horizon-Uno {name} must be {expected}") from error
+    if not math.isfinite(resolved) or resolved != expected:
+        raise ValueError(f"K2-Horizon-Uno {name} must be {expected}")
+    return resolved
+
+
+def load_and_validate_adapter_config(path: str | Path) -> dict:
+    """Return the exact public PEFT recipe or fail closed."""
+
+    config_path = Path(path)
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid Uno adapter config: {config_path}") from error
+    if not isinstance(raw, dict):
+        raise ValueError("Uno adapter_config.json must contain a JSON object")
+
+    expected = {
+        "base_model_name_or_path": BASE_MODEL_ID,
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": True,
+        "init_lora_weights": True,
+        "layers_pattern": None,
+        "layers_to_transform": None,
+        "loftq_config": {},
+        "lora_alpha": LORA_ALPHA,
+        "lora_dropout": 0.05,
+        "modules_to_save": None,
+        "peft_type": "LORA",
+        "r": LORA_RANK,
+        "revision": None,
+        "target_modules": list(LORA_TARGET_MODULES),
+        "task_type": "CAUSAL_LM",
+    }
+    if raw != expected:
+        changed = sorted(
+            key for key in set(raw) | set(expected) if raw.get(key) != expected.get(key)
+        )
+        raise ValueError(
+            "Uno adapter_config.json does not match the qualified recipe; changed fields: "
+            + ", ".join(changed)
+        )
+    return raw
+
+
+def validate_config(config: object) -> K2HorizonUnoConfig:
+    """Accept only the dense BF16 K2-Horizon-7B base graph."""
+
+    raw = _raw(config)
+    if str(getattr(config, "model_type", "")).lower() != "k2_horizon":
+        raise ValueError("K2-Horizon-Uno base requires model_type='k2_horizon'")
+    if tuple(getattr(config, "architectures", ()) or ()) != (BASE_ARCHITECTURE,):
+        raise ValueError(
+            f"K2-Horizon-Uno base architectures must contain exactly {BASE_ARCHITECTURE}"
+        )
+
+    resolved_ints: dict[str, int] = {}
+    for name, expected in _EXACT_INTS.items():
+        value = raw.get(name, getattr(config, name, None))
+        if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+            raise ValueError(f"K2-Horizon-Uno {name} must be {expected}")
+        resolved_ints[name] = value
+
+    unsupported: list[str] = []
+    if str(raw.get("dtype", "")).lower() != "bfloat16":
+        unsupported.append("dtype")
+    if str(raw.get("hidden_act", getattr(config, "hidden_act", ""))).lower() != "silu":
+        unsupported.append("hidden_act")
+    for name in (
+        "attention_bias",
+        "mlp_bias",
+        "query_key_norm",
+        "attention_gate_func",
+        "use_sliding_window",
+        "sliding_window",
+        "dynamic_kv_cache",
+        "quantization_config",
+        "is_encoder_decoder",
+        "num_experts",
+        "num_local_experts",
+        "mova_num_experts",
+        "mova_num_experts_per_tok",
+        "num_experts_per_tok",
+        "moe_intermediate_size",
+        "rope_interleaved",
+        "interleaved_rope",
+    ):
+        if _enabled(raw.get(name)):
+            unsupported.append(name)
+    if bool(raw.get("tie_word_embeddings", getattr(config, "tie_word_embeddings", False))):
+        unsupported.append("tie_word_embeddings")
+    if raw.get("rope_head_dim", resolved_ints["head_dim"]) != resolved_ints["head_dim"]:
+        unsupported.append("rope_head_dim")
+    rope = raw.get("rope_parameters")
+    if not isinstance(rope, dict) or rope != {
+        "rope_theta": 10_000_000.0,
+        "rope_type": "default",
+    }:
+        unsupported.append("rope_parameters")
+    if raw.get("rope_scaling") is not None:
+        unsupported.append("rope_scaling")
+    if unsupported:
+        raise ValueError(
+            "K2-Horizon-Uno supports only the dense BF16 full-RoPE base graph; "
+            "unsupported fields: " + ", ".join(sorted(set(unsupported)))
+        )
+
+    rope_theta = getattr(config, "rope_theta", None)
+    if rope_theta is None:
+        rope_theta = rope.get("rope_theta") if isinstance(rope, dict) else None
+    return K2HorizonUnoConfig(
+        **resolved_ints,
+        rms_norm_eps=_exact_positive_float(
+            getattr(config, "rms_norm_eps", raw.get("rms_norm_eps")),
+            1e-6,
+            "rms_norm_eps",
+        ),
+        rope_theta=_exact_positive_float(rope_theta, 10_000_000.0, "rope_theta"),
+    )

--- a/families/k2_horizon_uno/model.py
+++ b/families/k2_horizon_uno/model.py
@@ -1,0 +1,720 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamic-block TensorRT graph for conditional-LoRA K2-Horizon Uno."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import numpy as np
+import tensorrt as trt
+
+from .native_kv_attention_builder import (
+    NativeKvMasks,
+    add_active_prefix_causal_masks,
+    add_explicit_masked_grouped_query_attention,
+)
+
+from .checkpoint_mapper import WeightDict, load_standard_weights
+from .config import (
+    ADAPTER_FILENAME,
+    BASE_MODEL_ID,
+    BASE_REVISION,
+    K2HorizonUnoConfig,
+    load_and_validate_adapter_config,
+    validate_config,
+)
+
+
+if TYPE_CHECKING:
+    from tensorrt_model_connect.build import BuildRequest
+    from tensorrt_model_connect.bundle_writer import BundleWriter
+
+
+def layer_tensor_name(stem: str, layer: int) -> str:
+    return f"{stem}_{layer}"
+
+
+def _cast(network, tensor, dtype):
+    if tensor.dtype == dtype:
+        return tensor
+    layer = network.add_cast(tensor, dtype)
+    if layer is None:
+        raise RuntimeError("TensorRT failed to add a K2-Horizon-Uno cast")
+    return layer.get_output(0)
+
+
+def _constant(
+    network,
+    shape: tuple[int, ...],
+    values: np.ndarray,
+    keepalive: list[np.ndarray],
+    *,
+    dtype: np.dtype = np.dtype(np.float32),
+):
+    array = np.ascontiguousarray(values, dtype=dtype).reshape(shape)
+    keepalive.append(array)
+    layer = network.add_constant(shape, trt.Weights(array))
+    if layer is None:
+        raise RuntimeError("TensorRT failed to create a K2-Horizon-Uno constant")
+    return layer.get_output(0)
+
+
+def _work_constant(
+    network,
+    shape: tuple[int, ...],
+    values: np.ndarray,
+    *,
+    work_dtype,
+    constant_keepalive: list[np.ndarray],
+):
+    if work_dtype != trt.bfloat16:
+        raise ValueError("K2-Horizon-Uno weight constants require BF16")
+    array = np.asarray(values)
+    if array.dtype != np.uint16 or not array.flags.c_contiguous:
+        raise ValueError("K2-Horizon-Uno BF16 weights must be contiguous uint16 bit patterns")
+    if tuple(array.shape) != shape:
+        raise ValueError(f"K2-Horizon-Uno BF16 constant must have shape {shape}, got {array.shape}")
+    constant_keepalive.append(array)
+    weights = trt.Weights(trt.bfloat16, int(array.ctypes.data), int(array.size))
+    layer = network.add_constant(shape, weights)
+    if layer is None:
+        raise RuntimeError("TensorRT failed to create a K2-Horizon-Uno BF16 constant")
+    return layer.get_output(0)
+
+
+def _matmul(
+    network,
+    lhs,
+    rhs: np.ndarray,
+    *,
+    lhs_width: int,
+    rhs_width: int,
+    work_dtype,
+    constant_keepalive: list[np.ndarray],
+    name: str,
+):
+    expected = (lhs_width, rhs_width)
+    if tuple(np.asarray(rhs).shape) != expected:
+        raise ValueError(
+            f"mapped Uno weight {name} must have shape {expected}, got {np.asarray(rhs).shape}"
+        )
+    rhs_tensor = _work_constant(
+        network,
+        expected,
+        rhs,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+    )
+    layer = network.add_matrix_multiply(
+        lhs, trt.MatrixOperation.NONE, rhs_tensor, trt.MatrixOperation.NONE
+    )
+    if layer is None:
+        raise RuntimeError(f"TensorRT failed to add K2-Horizon-Uno matmul {name}")
+    layer.name = name
+    return layer.get_output(0)
+
+
+def _conditional_projection(
+    network,
+    lhs,
+    base_weight: np.ndarray,
+    lora_a: np.ndarray,
+    lora_b: np.ndarray,
+    lora_mask,
+    *,
+    lhs_width: int,
+    rhs_width: int,
+    rank: int,
+    scale: float,
+    work_dtype,
+    constant_keepalive: list[np.ndarray],
+    name: str,
+):
+    """Compute ``xW + mask * scale * (xA)B`` for every active token row."""
+
+    base = _matmul(
+        network,
+        lhs,
+        base_weight,
+        lhs_width=lhs_width,
+        rhs_width=rhs_width,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+        name=name + ".base",
+    )
+    low_rank = _matmul(
+        network,
+        lhs,
+        lora_a,
+        lhs_width=lhs_width,
+        rhs_width=rank,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+        name=name + ".lora_A",
+    )
+    delta = _matmul(
+        network,
+        low_rank,
+        lora_b,
+        lhs_width=rank,
+        rhs_width=rhs_width,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+        name=name + ".lora_B",
+    )
+    scale_tensor = _constant(
+        network,
+        (1, 1),
+        np.array([[scale]], dtype=np.float32),
+        constant_keepalive,
+    )
+    scale_tensor = _cast(network, scale_tensor, work_dtype)
+    scaled = network.add_elementwise(delta, scale_tensor, trt.ElementWiseOperation.PROD)
+    if scaled is None:
+        raise RuntimeError(f"TensorRT failed to scale conditional LoRA for {name}")
+    mask_rows = network.add_shuffle(lora_mask)
+    mask_rows.reshape_dims = (-1, 1)
+    mask_work = _cast(network, mask_rows.get_output(0), work_dtype)
+    selected = network.add_elementwise(
+        scaled.get_output(0), mask_work, trt.ElementWiseOperation.PROD
+    )
+    if selected is None:
+        raise RuntimeError(f"TensorRT failed to mask conditional LoRA for {name}")
+    result = network.add_elementwise(base, selected.get_output(0), trt.ElementWiseOperation.SUM)
+    if result is None:
+        raise RuntimeError(f"TensorRT failed to apply conditional LoRA for {name}")
+    result.name = name
+    return result.get_output(0)
+
+
+def _grouped_rms_norm(
+    network,
+    tensor,
+    gamma: np.ndarray,
+    *,
+    hidden_size: int,
+    num_groups: int,
+    epsilon: float,
+    work_dtype,
+    constant_keepalive: list[np.ndarray],
+):
+    if tuple(np.asarray(gamma).shape) != (hidden_size,):
+        raise ValueError("mapped Uno grouped RMSNorm weight has the wrong shape")
+    group_width = hidden_size // num_groups
+    fp32 = _cast(network, tensor, trt.float32)
+    shaped = network.add_shuffle(fp32)
+    shaped.reshape_dims = (-1, num_groups, group_width)
+    grouped = shaped.get_output(0)
+    squared = network.add_elementwise(grouped, grouped, trt.ElementWiseOperation.PROD).get_output(0)
+    mean = network.add_reduce(squared, trt.ReduceOperation.AVG, 1 << 2, True).get_output(0)
+    eps = _constant(
+        network,
+        (1, 1, 1),
+        np.array([epsilon], dtype=np.float32),
+        constant_keepalive,
+    )
+    variance = network.add_elementwise(mean, eps, trt.ElementWiseOperation.SUM).get_output(0)
+    root = network.add_unary(variance, trt.UnaryOperation.SQRT).get_output(0)
+    reciprocal = network.add_unary(root, trt.UnaryOperation.RECIP).get_output(0)
+    normalized = network.add_elementwise(
+        grouped, reciprocal, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    flattened = network.add_shuffle(normalized)
+    flattened.reshape_dims = (-1, hidden_size)
+    gamma_tensor = _constant(
+        network,
+        (1, hidden_size),
+        gamma,
+        constant_keepalive,
+        dtype=np.dtype(np.float32),
+    )
+    scaled = network.add_elementwise(
+        flattened.get_output(0), gamma_tensor, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    return _cast(network, scaled, work_dtype)
+
+
+def _silu(network, tensor):
+    sigmoid = network.add_activation(tensor, trt.ActivationType.SIGMOID)
+    return network.add_elementwise(
+        tensor, sigmoid.get_output(0), trt.ElementWiseOperation.PROD
+    ).get_output(0)
+
+
+def _active_rope_cache(
+    network,
+    position_id,
+    *,
+    head_dim: int,
+    rope_theta: float,
+    work_dtype,
+    constant_keepalive: list[np.ndarray],
+):
+    inverse_frequency = 1.0 / (
+        float(rope_theta) ** (np.arange(0, head_dim, 2, dtype=np.float32) / float(head_dim))
+    )
+    position = _cast(network, position_id, trt.float32)
+    position_column = network.add_shuffle(position)
+    position_column.reshape_dims = (-1, 1)
+    inverse = _constant(
+        network,
+        (1, head_dim // 2),
+        inverse_frequency.reshape(1, -1),
+        constant_keepalive,
+    )
+    angles = network.add_elementwise(
+        position_column.get_output(0), inverse, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    cos = network.add_unary(angles, trt.UnaryOperation.COS).get_output(0)
+    sin = network.add_unary(angles, trt.UnaryOperation.SIN).get_output(0)
+    cos_3d = network.add_shuffle(cos)
+    cos_3d.reshape_dims = (1, -1, head_dim // 2)
+    sin_3d = network.add_shuffle(sin)
+    sin_3d.reshape_dims = (1, -1, head_dim // 2)
+    return (
+        _cast(network, cos_3d.get_output(0), work_dtype),
+        _cast(network, sin_3d.get_output(0), work_dtype),
+    )
+
+
+def _reshape_rows_to_heads(network, tensor, *, num_heads: int, head_dim: int):
+    rows = network.add_shuffle(tensor)
+    rows.reshape_dims = (-1, num_heads, head_dim)
+    rows.second_transpose = trt.Permutation([1, 0, 2])
+    shaped = network.add_shuffle(rows.get_output(0))
+    shaped.reshape_dims = (1, num_heads, -1, head_dim)
+    return shaped.get_output(0)
+
+
+def _reshape_heads_to_rows(network, tensor, *, width: int):
+    rows = network.add_shuffle(tensor)
+    rows.first_transpose = trt.Permutation([0, 2, 1, 3])
+    rows.reshape_dims = (-1, width)
+    return rows.get_output(0)
+
+
+def _apply_rope(
+    network,
+    tensor,
+    cos_cache,
+    sin_cache,
+    *,
+    num_heads: int,
+    head_dim: int,
+):
+    heads = _reshape_rows_to_heads(network, tensor, num_heads=num_heads, head_dim=head_dim)
+    rope = network.add_rotary_embedding(heads, cos_cache, sin_cache, False, head_dim)
+    if rope is None:
+        raise RuntimeError("TensorRT failed to create K2-Horizon-Uno rotary embedding")
+    return _reshape_heads_to_rows(network, rope.get_output(0), width=num_heads * head_dim)
+
+
+def _native_attention(
+    network,
+    q,
+    k,
+    v,
+    cache_k,
+    cache_v,
+    cache_write_indices,
+    attention_masks: NativeKvMasks,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    constant_keepalive: list[np.ndarray],
+    tag: str,
+):
+    k_4d = _reshape_rows_to_heads(network, k, num_heads=num_kv_heads, head_dim=head_dim)
+    v_4d = _reshape_rows_to_heads(network, v, num_heads=num_kv_heads, head_dim=head_dim)
+    update_k = network.add_kv_cache_update(
+        cache_k, k_4d, cache_write_indices, trt.KVCacheMode.LINEAR
+    )
+    update_v = network.add_kv_cache_update(
+        cache_v, v_4d, cache_write_indices, trt.KVCacheMode.LINEAR
+    )
+    if update_k is None or update_v is None:
+        raise RuntimeError("TensorRT failed to create K2-Horizon-Uno KV updates")
+    update_k.name = tag + ".cache_k_update"
+    update_v.name = tag + ".cache_v_update"
+    present_k = update_k.get_output(0)
+    present_v = update_v.get_output(0)
+    q_4d = _reshape_rows_to_heads(network, q, num_heads=num_heads, head_dim=head_dim)
+    context_4d = add_explicit_masked_grouped_query_attention(
+        network,
+        q_4d,
+        present_k,
+        present_v,
+        attention_masks,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        constant_keepalive=constant_keepalive,
+        scale=float(1.0 / np.sqrt(head_dim)),
+        tag=tag,
+    )
+    return {
+        "context": _reshape_heads_to_rows(network, context_4d, width=num_heads * head_dim),
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def build_engine(
+    cfg: K2HorizonUnoConfig,
+    weights: WeightDict,
+    max_cache_length: int,
+    *,
+    verbose: bool = False,
+) -> bytes:
+    """Build one dynamic ``S=1..8`` BF16 engine with conditional Uno LoRA."""
+
+    if isinstance(max_cache_length, bool) or not isinstance(max_cache_length, int):
+        raise ValueError("K2-Horizon-Uno max_cache_length must be an integer")
+    if max_cache_length < cfg.max_block_size or max_cache_length > cfg.max_position_embeddings:
+        raise ValueError(
+            "K2-Horizon-Uno max_cache_length must be at least max_block_size and no "
+            f"greater than {cfg.max_position_embeddings}"
+        )
+    work_dtype = trt.bfloat16
+    constant_keepalive: list[np.ndarray] = []
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    network = builder.create_network(flags)
+    builder_config = builder.create_builder_config()
+    builder_config.builder_optimization_level = 1
+    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 16 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    cache_write_indices = network.add_input("cache_write_indices", trt.int32, (1,))
+    key_value_lengths = network.add_input("key_value_lengths", trt.int32, (1,))
+    lora_mask = network.add_input("lora_mask", trt.float32, (-1,))
+    if any(
+        value is None
+        for value in (token_id, position_id, cache_write_indices, key_value_lengths, lora_mask)
+    ):
+        raise RuntimeError("TensorRT failed to create K2-Horizon-Uno engine inputs")
+
+    profile = builder.create_optimization_profile()
+    optimum = cfg.max_block_size
+    for name in ("token_id", "position_id", "lora_mask"):
+        # TensorRT 11.1 mutates the profile in place and returns ``None`` from
+        # this Python binding.  Registration below is the authoritative
+        # validation boundary.
+        profile.set_shape(name, (1,), (optimum,), (cfg.max_block_size,))
+    if builder_config.add_optimization_profile(profile) < 0:
+        raise RuntimeError("TensorRT rejected the K2-Horizon-Uno optimization profile")
+
+    attention_masks = add_active_prefix_causal_masks(
+        network,
+        token_id,
+        cache_write_indices,
+        key_value_lengths,
+        max_cache_length,
+        constant_keepalive=constant_keepalive,
+    )
+    cache_shape = (1, cfg.num_key_value_heads, max_cache_length, cfg.head_dim)
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_index in range(cfg.num_hidden_layers):
+        cache_k_inputs.append(
+            network.add_input(layer_tensor_name("cache_k", layer_index), work_dtype, cache_shape)
+        )
+        cache_v_inputs.append(
+            network.add_input(layer_tensor_name("cache_v", layer_index), work_dtype, cache_shape)
+        )
+
+    embedding = _work_constant(
+        network,
+        (cfg.vocab_size, cfg.hidden_size),
+        weights["embedding"],
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+    )
+    hidden_state = _cast(
+        network, network.add_gather(embedding, token_id, 0).get_output(0), work_dtype
+    )
+    cos_cache, sin_cache = _active_rope_cache(
+        network,
+        position_id,
+        head_dim=cfg.head_dim,
+        rope_theta=cfg.rope_theta,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+    )
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_index in range(cfg.num_hidden_layers):
+        prefix = f"layer.{layer_index}"
+
+        def projection(lhs, logical: str, lhs_width: int, rhs_width: int, graph_name: str):
+            return _conditional_projection(
+                network,
+                lhs,
+                weights[f"{prefix}.{logical}"],
+                weights[f"{prefix}.{logical}_lora_a"],
+                weights[f"{prefix}.{logical}_lora_b"],
+                lora_mask,
+                lhs_width=lhs_width,
+                rhs_width=rhs_width,
+                rank=cfg.lora_rank,
+                scale=cfg.lora_scale,
+                work_dtype=work_dtype,
+                constant_keepalive=constant_keepalive,
+                name=f"{prefix}.{graph_name}",
+            )
+
+        normed = _grouped_rms_norm(
+            network,
+            hidden_state,
+            weights[f"{prefix}.input_norm"],
+            hidden_size=cfg.hidden_size,
+            num_groups=cfg.layernorm_num_groups,
+            epsilon=cfg.rms_norm_eps,
+            work_dtype=work_dtype,
+            constant_keepalive=constant_keepalive,
+        )
+        q = projection(normed, "w_q", cfg.hidden_size, cfg.attention_size, "self_attn.q_proj")
+        k = projection(normed, "w_k", cfg.hidden_size, cfg.kv_attention_size, "self_attn.k_proj")
+        v = projection(normed, "w_v", cfg.hidden_size, cfg.kv_attention_size, "self_attn.v_proj")
+        q = _apply_rope(
+            network,
+            q,
+            cos_cache,
+            sin_cache,
+            num_heads=cfg.num_attention_heads,
+            head_dim=cfg.head_dim,
+        )
+        k = _apply_rope(
+            network,
+            k,
+            cos_cache,
+            sin_cache,
+            num_heads=cfg.num_key_value_heads,
+            head_dim=cfg.head_dim,
+        )
+        attention = _native_attention(
+            network,
+            q,
+            k,
+            v,
+            cache_k_inputs[layer_index],
+            cache_v_inputs[layer_index],
+            cache_write_indices,
+            attention_masks,
+            num_heads=cfg.num_attention_heads,
+            num_kv_heads=cfg.num_key_value_heads,
+            head_dim=cfg.head_dim,
+            constant_keepalive=constant_keepalive,
+            tag=f"{prefix}.self_attn",
+        )
+        attn_out = projection(
+            attention["context"],
+            "w_o",
+            cfg.attention_size,
+            cfg.hidden_size,
+            "self_attn.o_proj",
+        )
+        hidden_state = network.add_elementwise(
+            hidden_state, attn_out, trt.ElementWiseOperation.SUM
+        ).get_output(0)
+        mlp_input = _grouped_rms_norm(
+            network,
+            hidden_state,
+            weights[f"{prefix}.post_attn_norm"],
+            hidden_size=cfg.hidden_size,
+            num_groups=cfg.layernorm_num_groups,
+            epsilon=cfg.rms_norm_eps,
+            work_dtype=work_dtype,
+            constant_keepalive=constant_keepalive,
+        )
+        gate = projection(
+            mlp_input,
+            "w_gate",
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            "mlp.gate_proj",
+        )
+        up = projection(
+            mlp_input,
+            "w_up",
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            "mlp.up_proj",
+        )
+        gated = network.add_elementwise(
+            _silu(network, gate), up, trt.ElementWiseOperation.PROD
+        ).get_output(0)
+        mlp_out = projection(
+            gated,
+            "w_down",
+            cfg.intermediate_size,
+            cfg.hidden_size,
+            "mlp.down_proj",
+        )
+        hidden_state = network.add_elementwise(
+            hidden_state, mlp_out, trt.ElementWiseOperation.SUM
+        ).get_output(0)
+        present_k_outputs.append(attention["present_k"])
+        present_v_outputs.append(attention["present_v"])
+
+    hidden_state = _grouped_rms_norm(
+        network,
+        hidden_state,
+        weights["final_norm"],
+        hidden_size=cfg.hidden_size,
+        num_groups=cfg.layernorm_num_groups,
+        epsilon=cfg.rms_norm_eps,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+    )
+    logits = _matmul(
+        network,
+        hidden_state,
+        weights["w_out"],
+        lhs_width=cfg.hidden_size,
+        rhs_width=cfg.vocab_size,
+        work_dtype=work_dtype,
+        constant_keepalive=constant_keepalive,
+        name="lm_head",
+    )
+    logits = _cast(network, logits, trt.float32)
+    logits.name = "logits"
+    network.mark_output(logits)
+    for layer_index, tensor in enumerate(present_k_outputs):
+        tensor.name = layer_tensor_name("present_k", layer_index)
+        network.mark_output(tensor)
+    for layer_index, tensor in enumerate(present_v_outputs):
+        tensor.name = layer_tensor_name("present_v", layer_index)
+        network.mark_output(tensor)
+
+    if verbose:
+        print(
+            "[trtmc build] Building K2-Horizon-Uno BF16 dynamic-block engine "
+            f"(layers={cfg.num_hidden_layers}, cache={max_cache_length}, "
+            f"block=1..{cfg.max_block_size}, rank={cfg.lora_rank}) ...",
+            file=sys.stderr,
+        )
+    try:
+        plan = builder.build_serialized_network(network, builder_config)
+    finally:
+        constant_keepalive.clear()
+    if plan is None:
+        raise RuntimeError("TensorRT failed to build the K2-Horizon-Uno engine")
+    return bytes(plan)
+
+
+_BASE_ALLOW_PATTERNS = (
+    "config.json",
+    "model.safetensors.index.json",
+    "pytorch_model-*.safetensors",
+    "tokenizer.json",
+    "chat_template.jinja",
+)
+_BUNDLE_FILES = ("tokenizer.json", "chat_template.jinja")
+
+
+def _load_config(model_dir: Path) -> SimpleNamespace:
+    path = model_dir / "config.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid K2-Horizon-Uno base config: {path}") from error
+    if not isinstance(raw, dict):
+        raise ValueError("K2-Horizon-Uno base config.json must contain one object")
+    return SimpleNamespace(raw=raw, **raw)
+
+
+def _resolve_base_model() -> Path:
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            repo_id=BASE_MODEL_ID,
+            revision=BASE_REVISION,
+            allow_patterns=_BASE_ALLOW_PATTERNS,
+        )
+    )
+
+
+def build(request: "BuildRequest", writer: "BundleWriter") -> None:
+    """Build the qualified BF16 dynamic-block K2-Horizon-7B-Uno bundle."""
+
+    if request.dynamic_kv_cache:
+        raise NotImplementedError("k2_horizon_uno does not support dynamic_kv_cache")
+    if request.image_height is not None or request.image_width is not None:
+        raise NotImplementedError("K2-Horizon-Uno does not support image dimensions")
+    if request.video_num_frames is not None:
+        raise NotImplementedError("K2-Horizon-Uno does not support video inputs")
+    if request.max_batch_size != 1:
+        raise NotImplementedError("K2-Horizon-Uno supports only max_batch_size=1")
+    if request.tensor_parallel_size != 1:
+        raise NotImplementedError("K2-Horizon-Uno does not support tensor parallelism")
+    if request.context_parallel_size != 1:
+        raise NotImplementedError("K2-Horizon-Uno does not support context parallelism")
+    if request.task != "text_generation":
+        raise ValueError("K2-Horizon-Uno supports only task=text_generation")
+    if str(request.precision).lower() != "bf16":
+        raise ValueError("K2-Horizon-Uno currently supports only BF16 builds")
+    if request.backend != "trt":
+        raise NotImplementedError("K2-Horizon-Uno currently supports only backend=trt")
+    if request.quantization not in {None, "none"}:
+        raise NotImplementedError("K2-Horizon-Uno does not support quantized builds")
+    if request.fp32_layers:
+        raise NotImplementedError("K2-Horizon-Uno does not support mixed-FP32 layers")
+
+    adapter_dir = Path(request.model_dir)
+    load_and_validate_adapter_config(adapter_dir / "adapter_config.json")
+    if not (adapter_dir / ADAPTER_FILENAME).is_file():
+        raise FileNotFoundError(f"K2-Horizon-Uno adapter is missing {ADAPTER_FILENAME}")
+    base_dir = _resolve_base_model()
+    source_config = _load_config(base_dir)
+    config = validate_config(source_config)
+    max_cache_length = (
+        min(256, config.max_position_embeddings)
+        if request.max_sequence_length is None
+        else request.max_sequence_length
+    )
+    if (
+        max_cache_length < config.max_block_size
+        or max_cache_length > config.max_position_embeddings
+    ):
+        raise ValueError(
+            "K2-Horizon-Uno max_sequence_length must cover block length 8 and stay "
+            "within checkpoint capacity"
+        )
+    weights = load_standard_weights(
+        base_dir,
+        adapter_dir,
+        config,
+    )
+    plan = build_engine(
+        config,
+        weights,
+        max_cache_length,
+        verbose=bool(request.verbose),
+    )
+
+    tokenizer = base_dir / "tokenizer.json"
+    chat_template = base_dir / "chat_template.jinja"
+    if not tokenizer.is_file() or not chat_template.is_file():
+        raise FileNotFoundError(
+            "K2-Horizon-Uno base must contain tokenizer.json and chat_template.jinja"
+        )
+    writer.set_header(family="k2_horizon_uno", task=request.task, backend=request.backend)
+    writer.add_bytes("engine.plan", plan)
+    writer.add_json("runtime.json", {"max_cache_length": max_cache_length})
+    for filename in _BUNDLE_FILES:
+        path = base_dir / filename
+        if path.is_file():
+            writer.add_bytes(filename, path.read_bytes())

--- a/families/k2_horizon_uno/native_kv_attention_builder.py
+++ b/families/k2_horizon_uno/native_kv_attention_builder.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""K2-Horizon-Uno-owned fixed linear KV-cache attention graph primitives."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+import tensorrt as trt
+
+
+class NativeKvMasks(NamedTuple):
+    """Masks shared by every attention layer in one decoder engine."""
+
+    attention: trt.ITensor
+    active_prefix: trt.ITensor
+
+
+def _constant(
+    network: trt.INetworkDefinition,
+    shape: tuple[int, ...],
+    values: np.ndarray,
+    *,
+    keepalive: list[np.ndarray],
+    dtype: np.dtype = np.dtype(np.float32),
+) -> trt.ITensor:
+    array = np.ascontiguousarray(values, dtype=dtype)
+    keepalive.append(array)
+    layer = network.add_constant(shape, trt.Weights(array))
+    if layer is None:
+        raise RuntimeError("TensorRT failed to create a native KV constant")
+    return layer.get_output(0)
+
+
+def _cast(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    dtype: trt.DataType,
+) -> trt.ITensor:
+    if tensor.dtype == dtype:
+        return tensor
+    return network.add_cast(tensor, dtype).get_output(0)
+
+
+def add_active_prefix_causal_masks(
+    network: trt.INetworkDefinition,
+    query_rows: trt.ITensor,
+    cache_write_indices: trt.ITensor,
+    key_value_lengths: trt.ITensor,
+    cache_capacity: int,
+    *,
+    constant_keepalive: list[np.ndarray],
+) -> NativeKvMasks:
+    """Build BOOL attention and active-prefix masks for a cache append."""
+
+    if cache_capacity <= 0:
+        raise ValueError("native KV cache capacity must be positive")
+
+    query_shape = network.add_shape(query_rows).get_output(0)
+    query_length = network.add_slice(query_shape, start=(0,), shape=(1,), stride=(1,)).get_output(0)
+    zero_i32 = _constant(
+        network,
+        (),
+        np.array(0, dtype=np.int32),
+        keepalive=constant_keepalive,
+        dtype=np.dtype(np.int32),
+    )
+    one_i32 = _constant(
+        network,
+        (1,),
+        np.array([1], dtype=np.int32),
+        keepalive=constant_keepalive,
+        dtype=np.dtype(np.int32),
+    )
+    query_iota = network.add_fill((1,), trt.FillOperation.LINSPACE, trt.int32)
+    query_iota.set_input(0, query_length)
+    query_iota.set_input(1, zero_i32)
+    query_iota.set_input(2, one_i32)
+    query_positions = network.add_elementwise(
+        query_iota.get_output(0),
+        cache_write_indices,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+    query_limits = network.add_elementwise(
+        query_positions,
+        one_i32,
+        trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+
+    one_i64 = _constant(
+        network,
+        (1,),
+        np.array([1], dtype=np.int64),
+        keepalive=constant_keepalive,
+        dtype=np.dtype(np.int64),
+    )
+    query_limit_shape = network.add_concatenation([query_length, one_i64])
+    query_limit_shape.axis = 0
+    query_limits_2d = network.add_shuffle(query_limits)
+    query_limits_2d.set_input(1, query_limit_shape.get_output(0))
+
+    key_positions = _constant(
+        network,
+        (1, cache_capacity),
+        np.arange(cache_capacity, dtype=np.int32).reshape(1, cache_capacity),
+        keepalive=constant_keepalive,
+        dtype=np.dtype(np.int32),
+    )
+    active_length_2d = network.add_shuffle(key_value_lengths)
+    active_length_2d.reshape_dims = (1, 1)
+    causal = network.add_elementwise(
+        key_positions,
+        query_limits_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    active = network.add_elementwise(
+        key_positions,
+        active_length_2d.get_output(0),
+        trt.ElementWiseOperation.LESS,
+    ).get_output(0)
+    valid = network.add_elementwise(
+        causal,
+        active,
+        trt.ElementWiseOperation.AND,
+    ).get_output(0)
+
+    mask_shape = network.add_shape(valid).get_output(0)
+    leading_ones = _constant(
+        network,
+        (2,),
+        np.array([1, 1], dtype=np.int64),
+        keepalive=constant_keepalive,
+        dtype=np.dtype(np.int64),
+    )
+    target_shape = network.add_concatenation([leading_ones, mask_shape])
+    target_shape.axis = 0
+    mask_4d = network.add_shuffle(valid)
+    mask_4d.set_input(1, target_shape.get_output(0))
+
+    active_4d = network.add_shuffle(active)
+    active_4d.reshape_dims = (1, 1, 1, cache_capacity)
+    return NativeKvMasks(
+        attention=mask_4d.get_output(0),
+        active_prefix=active_4d.get_output(0),
+    )
+
+
+def _blocked_score(
+    network: trt.INetworkDefinition,
+    dtype: trt.DataType,
+    *,
+    constant_keepalive: list[np.ndarray],
+) -> trt.ITensor:
+    if dtype == trt.float16:
+        return _constant(
+            network,
+            (1, 1, 1, 1, 1),
+            np.array([-1.0e4], dtype=np.float16),
+            keepalive=constant_keepalive,
+            dtype=np.dtype(np.float16),
+        )
+    blocked = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([-1.0e30], dtype=np.float32),
+        keepalive=constant_keepalive,
+    )
+    return _cast(network, blocked, dtype)
+
+
+def add_explicit_masked_grouped_query_attention(
+    network: trt.INetworkDefinition,
+    query: trt.ITensor,
+    key: trt.ITensor,
+    value: trt.ITensor,
+    masks: NativeKvMasks,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    constant_keepalive: list[np.ndarray],
+    scale: float | None = None,
+    tag: str | None = None,
+) -> trt.ITensor:
+    """Compute explicitly masked grouped-query attention."""
+
+    if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+        raise ValueError(f"num_heads={num_heads} must be divisible by num_kv_heads={num_kv_heads}")
+    if head_dim <= 0:
+        raise ValueError("native KV attention head_dim must be positive")
+    if query.dtype not in {trt.float16, trt.bfloat16, trt.float32}:
+        raise ValueError("native KV attention requires FP16, BF16, or FP32")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("native KV query, key, and value dtypes must match")
+    if masks.attention.dtype != trt.bool or masks.active_prefix.dtype != trt.bool:
+        raise ValueError("native KV attention requires BOOL explicit masks")
+
+    groups = num_heads // num_kv_heads
+    query_grouped = network.add_shuffle(query)
+    query_grouped.reshape_dims = (
+        1,
+        num_kv_heads,
+        groups,
+        -1,
+        head_dim,
+    )
+    key_grouped = network.add_shuffle(key)
+    key_grouped.reshape_dims = (1, num_kv_heads, 1, -1, head_dim)
+    value_grouped = network.add_shuffle(value)
+    value_grouped.reshape_dims = (1, num_kv_heads, 1, -1, head_dim)
+    mask_grouped = network.add_shuffle(masks.attention)
+    mask_grouped.reshape_dims = (1, 1, 1, -1, int(key.shape[-2]))
+    active_grouped = network.add_shuffle(masks.active_prefix)
+    active_grouped.reshape_dims = (1, 1, 1, int(key.shape[-2]), 1)
+
+    zero = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([0.0], dtype=np.float32),
+        keepalive=constant_keepalive,
+    )
+    zero = _cast(network, zero, query.dtype)
+    safe_key = network.add_select(
+        active_grouped.get_output(0),
+        key_grouped.get_output(0),
+        zero,
+    )
+    safe_value = network.add_select(
+        active_grouped.get_output(0),
+        value_grouped.get_output(0),
+        zero,
+    )
+    if safe_key is None or safe_value is None:
+        raise RuntimeError("TensorRT failed to sanitize inactive native KV rows")
+
+    if scale is None:
+        scale = float(1.0 / np.sqrt(head_dim))
+    query_fp32 = network.add_cast(query_grouped.get_output(0), trt.float32).get_output(0)
+    scale_tensor = _constant(
+        network,
+        (1, 1, 1, 1, 1),
+        np.array([scale], dtype=np.float32),
+        keepalive=constant_keepalive,
+    )
+    scaled_query = network.add_elementwise(
+        query_fp32,
+        scale_tensor,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    scaled_query = _cast(network, scaled_query, query.dtype)
+
+    scores = network.add_matrix_multiply(
+        scaled_query,
+        trt.MatrixOperation.NONE,
+        safe_key.get_output(0),
+        trt.MatrixOperation.TRANSPOSE,
+    )
+    if scores is None:
+        raise RuntimeError("TensorRT failed to create native KV score matmul")
+    if tag:
+        scores.name = tag + ".scores"
+    masked_scores = network.add_select(
+        mask_grouped.get_output(0),
+        scores.get_output(0),
+        _blocked_score(
+            network,
+            query.dtype,
+            constant_keepalive=constant_keepalive,
+        ),
+    )
+    if masked_scores is None:
+        raise RuntimeError("TensorRT failed to apply native KV attention mask")
+    if tag:
+        masked_scores.name = tag + ".mask"
+
+    probabilities = network.add_softmax(masked_scores.get_output(0))
+    if probabilities is None:
+        raise RuntimeError("TensorRT failed to create native KV softmax")
+    probabilities.axes = 1 << 4
+    if tag:
+        probabilities.name = tag + ".softmax"
+    context_grouped = network.add_matrix_multiply(
+        probabilities.get_output(0),
+        trt.MatrixOperation.NONE,
+        safe_value.get_output(0),
+        trt.MatrixOperation.NONE,
+    )
+    if context_grouped is None:
+        raise RuntimeError("TensorRT failed to create native KV context matmul")
+    if tag:
+        context_grouped.name = tag + ".context"
+
+    context = network.add_shuffle(context_grouped.get_output(0))
+    context.reshape_dims = (1, num_heads, -1, head_dim)
+    return context.get_output(0)

--- a/families/k2_horizon_uno/requirements.txt
+++ b/families/k2_horizon_uno/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+transformers==5.15.0
+safetensors==0.8.0

--- a/families/k2_horizon_uno/runtime/CMakeLists.txt
+++ b/families/k2_horizon_uno/runtime/CMakeLists.txt
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(trtmc_model_k2_horizon_uno SHARED
+  algorithm.cpp
+  bpe_tokenizer.cpp
+  chat_template.cpp
+  kv_cache.cpp
+  pipeline.cpp
+  plugin.cpp
+)
+
+target_include_directories(trtmc_model_k2_horizon_uno
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+)
+target_include_directories(trtmc_model_k2_horizon_uno SYSTEM PRIVATE
+  ${TRTMC_CUDA_INCLUDE_DIR}
+)
+target_link_libraries(trtmc_model_k2_horizon_uno PRIVATE
+  trtmc_core
+  nlohmann_json::nlohmann_json
+  ${TRTMC_CUDART_LIBRARY}
+)
+target_compile_options(trtmc_model_k2_horizon_uno PRIVATE -Wall -Wextra -Wpedantic)
+set_target_properties(trtmc_model_k2_horizon_uno PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  BUILD_RPATH "\$ORIGIN"
+  INSTALL_RPATH "\$ORIGIN"
+)
+install(TARGETS trtmc_model_k2_horizon_uno
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+if(TRTMC_BUILD_TESTS)
+  foreach(test_name IN ITEMS
+      test_k2_horizon_uno_algorithm
+      test_k2_horizon_uno_chat_template
+      test_k2_horizon_uno_runtime_config
+  )
+    add_executable(${test_name}
+      ${PROJECT_SOURCE_DIR}/families/k2_horizon_uno/tests/cpp/${test_name}.cpp
+    )
+    target_include_directories(${test_name} PRIVATE
+      ${PROJECT_SOURCE_DIR}
+      ${PROJECT_SOURCE_DIR}/core/runtime/include
+    )
+    target_link_libraries(${test_name} PRIVATE
+      trtmc_model_k2_horizon_uno
+      trtmc_core
+      ${TRTMC_CUDART_LIBRARY}
+    )
+    target_compile_options(${test_name} PRIVATE -Wall -Wextra -Wpedantic)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+  endforeach()
+endif()

--- a/families/k2_horizon_uno/runtime/algorithm.cpp
+++ b/families/k2_horizon_uno/runtime/algorithm.cpp
@@ -1,0 +1,402 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/algorithm.h"
+
+#include "trtmc/task.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+namespace trtmc {
+namespace {
+
+constexpr std::uint64_t kPromptSeed = UINT64_C(0xD6E8FEB86659FD93);
+constexpr std::uint64_t kPromptMultiplier = UINT64_C(0x9E3779B185EBCA87);
+constexpr std::uint64_t kNoiseSaltMultiplier = UINT64_C(0xD1B54A32D192ED03);
+constexpr std::uint64_t kCompletionMultiplier = UINT64_C(0xC2B2AE3D27D4EB4F);
+constexpr std::uint64_t kSeedTokenMultiplier = UINT64_C(0x165667B19E3779F9);
+constexpr std::uint64_t kSequenceLengthMultiplier = UINT64_C(0x85EBCA77C2B2AE63);
+constexpr std::uint64_t kSlotMultiplier = UINT64_C(0x27D4EB2F165667C5);
+
+std::uint64_t mix_u64(std::uint64_t value) {
+    value = (value ^ (value >> 30U)) * UINT64_C(0xBF58476D1CE4E5B9);
+    value = (value ^ (value >> 27U)) * UINT64_C(0x94D049BB133111EB);
+    return value ^ (value >> 31U);
+}
+
+bool supported_noise_mode(const std::string& mode) {
+    return mode == "deterministic_uniform";
+}
+
+std::string normalize_mode(std::string mode) {
+    std::transform(mode.begin(), mode.end(), mode.begin(),
+                   [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+    std::replace(mode.begin(), mode.end(), '-', '_');
+    return mode.empty() ? "auto" : mode;
+}
+
+bool uses_greedy_sampling(const TextGenerationConfig& config) {
+    return config.temperature == 0.0F || config.top_p == 0.0F ||
+           (config.top_k == 1 && config.top_p == 1.0F);
+}
+
+bool has_diffusion_scalar_controls(const TextGenerationConfig& config) {
+    return config.guidance_scale >= 0.0F || config.cfg_scale >= 0.0F || config.num_steps >= 0 ||
+           config.sde_gamma >= 0.0F || config.confidence_threshold >= 0.0F;
+}
+
+bool has_conditioning_inputs(const TextGenerationConfig& config) {
+    return !config.initial_latents.empty() || !config.condition_latents.empty() ||
+           !config.condition_mask.empty() || !config.sampling_steps.empty() ||
+           !config.sde_noises.empty();
+}
+
+bool has_diffusion_controls(const TextGenerationConfig& config) {
+    return has_diffusion_scalar_controls(config) || has_conditioning_inputs(config);
+}
+
+void validate_decoder_request_shape(const TextGenerationConfig& config) {
+    if (config.max_new_tokens < 0)
+        throw std::invalid_argument("K2-Horizon-Uno max_new_tokens must be non-negative");
+    if (config.source_language_token_id >= 0)
+        throw std::invalid_argument("K2-Horizon-Uno supports one decoder-only sample");
+    if (config.forced_bos_token_id >= 0)
+        throw std::invalid_argument("K2-Horizon-Uno supports one decoder-only sample");
+}
+
+void validate_finite_sampling_controls(const TextGenerationConfig& config) {
+    if (!std::isfinite(config.temperature))
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (!std::isfinite(config.top_p))
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (!std::isfinite(config.min_p))
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (!std::isfinite(config.repetition_penalty))
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+}
+
+void validate_sampling_ranges(const TextGenerationConfig& config) {
+    if (config.temperature < 0.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (config.top_p < 0.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (config.top_p > 1.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (config.min_p < 0.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (config.min_p > 1.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+    if (config.repetition_penalty <= 0.0F)
+        throw std::invalid_argument("K2-Horizon-Uno sampling controls are outside their range");
+}
+
+void validate_greedy_sampling_contract(const TextGenerationConfig& config) {
+    if (!uses_greedy_sampling(config)) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno currently supports deterministic greedy generation only");
+    }
+    if (config.min_p != 0.0F)
+        throw std::invalid_argument("K2-Horizon-Uno does not support min-p or repetition penalty");
+    if (config.repetition_penalty != 1.0F)
+        throw std::invalid_argument("K2-Horizon-Uno does not support min-p or repetition penalty");
+    if (config.seed != -1) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise does not accept a seed override");
+    }
+}
+
+void validate_optional_request_controls(const TextGenerationConfig& config) {
+    if (config.use_chat_template && !config.enable_thinking) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno chat supports only publisher high-reasoning mode");
+    }
+    if (config.stop_on_boxed_answer)
+        throw std::invalid_argument("K2-Horizon-Uno does not support answer-stop parsing");
+    if (!config.lora_adapter_id.empty()) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno uses its pinned bundled adapter and rejects external LoRA IDs");
+    }
+    if (has_diffusion_controls(config)) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno received controls outside its linear Psi-Spec contract");
+    }
+}
+
+void validate_common_controls(const TextGenerationConfig& config) {
+    validate_decoder_request_shape(config);
+    validate_finite_sampling_controls(config);
+    validate_sampling_ranges(config);
+    validate_greedy_sampling_contract(config);
+    validate_optional_request_controls(config);
+}
+
+void validate_block_bounds(int32_t default_block_length, int32_t maximum_block_length) {
+    if (default_block_length <= 0)
+        throw std::invalid_argument("K2-Horizon-Uno bundle block-length bounds are invalid");
+    if (maximum_block_length <= 0)
+        throw std::invalid_argument("K2-Horizon-Uno bundle block-length bounds are invalid");
+    if (default_block_length > maximum_block_length)
+        throw std::invalid_argument("K2-Horizon-Uno bundle block-length bounds are invalid");
+}
+
+bool is_uno_mode(const std::string& mode) {
+    static const std::vector<std::string> modes{"auto", "uno", "linear_psi_spec",
+                                                "linear_spec_lora"};
+    return std::find(modes.begin(), modes.end(), mode) != modes.end();
+}
+
+bool is_ar_mode(const std::string& mode) {
+    static const std::vector<std::string> modes{"ar", "autoregressive"};
+    return std::find(modes.begin(), modes.end(), mode) != modes.end();
+}
+
+int32_t resolve_uno_block_length(const TextGenerationConfig& config, int32_t default_block_length,
+                                 int32_t maximum_block_length) {
+    const int32_t block_length =
+        config.block_length == 0 ? default_block_length : config.block_length;
+    if (block_length <= 0 || block_length > maximum_block_length) {
+        throw std::invalid_argument("K2-Horizon-Uno block_length must be in [1, " +
+                                    std::to_string(maximum_block_length) + "]");
+    }
+    return block_length;
+}
+
+void validate_ar_block_length(int32_t block_length) {
+    if (block_length == 0)
+        return;
+    if (block_length == 1)
+        return;
+    throw std::invalid_argument("K2-Horizon-Uno autoregressive mode requires block_length 0 or 1");
+}
+
+void validate_deterministic_noise_scalars(int32_t completion_token_count, int32_t seed_token,
+                                          int32_t total_sequence_length, int32_t count,
+                                          int32_t vocab_size) {
+    if (vocab_size <= 1)
+        throw std::invalid_argument("K2-Horizon-Uno noise range requires vocab_size > 1");
+    if (completion_token_count < 0)
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise counts must be non-negative");
+    if (total_sequence_length < 0)
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise counts must be non-negative");
+    if (count < 0)
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise counts must be non-negative");
+    if (seed_token < 0 || seed_token >= vocab_size)
+        throw std::invalid_argument("K2-Horizon-Uno deterministic noise seed is out of range");
+}
+
+void validate_sequence_accounting(const std::vector<int32_t>& prompt_token_ids,
+                                  int32_t completion_token_count, int32_t total_sequence_length) {
+    if (prompt_token_ids.size() > static_cast<std::size_t>(std::numeric_limits<int32_t>::max()))
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise sequence length is inconsistent");
+    const auto expected =
+        static_cast<std::int64_t>(prompt_token_ids.size()) + completion_token_count;
+    if (expected > std::numeric_limits<int32_t>::max())
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise sequence length is inconsistent");
+    if (total_sequence_length != expected)
+        throw std::invalid_argument(
+            "K2-Horizon-Uno deterministic noise sequence length is inconsistent");
+}
+
+std::uint64_t prompt_noise_seed(const std::vector<int32_t>& prompt_token_ids, int32_t vocab_size) {
+    std::uint64_t seed = kPromptSeed;
+    for (int32_t token : prompt_token_ids) {
+        if (token < 0 || token >= vocab_size)
+            throw std::invalid_argument(
+                "K2-Horizon-Uno deterministic noise prompt token is out of range");
+        seed = mix_u64(seed ^ static_cast<std::uint64_t>(token));
+    }
+    return seed;
+}
+
+std::uint64_t deterministic_noise_base(std::uint64_t sequence_seed, int32_t completion_token_count,
+                                       int32_t seed_token, int32_t total_sequence_length) {
+    // B=1 fixes noise_salt/sequence id to zero.
+    return sequence_seed * kPromptMultiplier + UINT64_C(0) * kNoiseSaltMultiplier +
+           static_cast<std::uint64_t>(completion_token_count) * kCompletionMultiplier +
+           static_cast<std::uint64_t>(seed_token) * kSeedTokenMultiplier +
+           static_cast<std::uint64_t>(total_sequence_length) * kSequenceLengthMultiplier;
+}
+
+} // namespace
+
+K2HorizonUnoResolvedGenerateConfig
+k2_horizon_uno_resolve_generate_config(const TextGenerationConfig& config,
+                                       int32_t default_block_length, int32_t maximum_block_length) {
+    validate_common_controls(config);
+    validate_block_bounds(default_block_length, maximum_block_length);
+
+    const std::string mode = normalize_mode(config.text_generation_mode);
+    K2HorizonUnoResolvedGenerateConfig resolved;
+    if (is_uno_mode(mode)) {
+        resolved.mode = K2HorizonUnoGenerationMode::kLinearPsiSpec;
+        resolved.block_length =
+            resolve_uno_block_length(config, default_block_length, maximum_block_length);
+        return resolved;
+    }
+    if (is_ar_mode(mode)) {
+        validate_ar_block_length(config.block_length);
+        resolved.mode = K2HorizonUnoGenerationMode::kAutoregressive;
+        resolved.block_length = 1;
+        return resolved;
+    }
+    throw std::invalid_argument("Unsupported K2-Horizon-Uno generation mode: " + mode);
+}
+
+std::vector<int32_t> k2_horizon_uno_argmax_rows(const float* logits, int32_t rows,
+                                                int32_t vocab_size) {
+    if (logits == nullptr || rows <= 0 || vocab_size <= 1)
+        throw std::invalid_argument("K2-Horizon-Uno argmax requires nonempty row logits");
+    if (static_cast<std::uint64_t>(rows) * static_cast<std::uint64_t>(vocab_size) >
+        static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        throw std::overflow_error("K2-Horizon-Uno logits element count overflows size_t");
+    }
+
+    std::vector<int32_t> result;
+    result.reserve(static_cast<std::size_t>(rows));
+    for (int32_t row = 0; row < rows; ++row) {
+        const float* row_logits =
+            logits + static_cast<std::size_t>(row) * static_cast<std::size_t>(vocab_size);
+        if (!std::isfinite(row_logits[0]))
+            throw std::runtime_error("K2-Horizon-Uno received non-finite logits");
+        int32_t best = 0;
+        for (int32_t token = 1; token < vocab_size; ++token) {
+            if (!std::isfinite(row_logits[token]))
+                throw std::runtime_error("K2-Horizon-Uno received non-finite logits");
+            if (row_logits[token] > row_logits[best])
+                best = token;
+        }
+        result.push_back(best);
+    }
+    return result;
+}
+
+std::vector<int32_t> k2_horizon_uno_deterministic_uniform_noise(
+    const std::vector<int32_t>& prompt_token_ids, int32_t completion_token_count,
+    int32_t seed_token, int32_t total_sequence_length, int32_t count, int32_t vocab_size) {
+    validate_deterministic_noise_scalars(completion_token_count, seed_token, total_sequence_length,
+                                         count, vocab_size);
+    validate_sequence_accounting(prompt_token_ids, completion_token_count, total_sequence_length);
+    const std::uint64_t sequence_seed = prompt_noise_seed(prompt_token_ids, vocab_size);
+
+    // Unsigned arithmetic intentionally wraps modulo 2^64, matching Python's
+    // explicit masking in ifm-ai/uno.
+    const std::uint64_t base = deterministic_noise_base(sequence_seed, completion_token_count,
+                                                        seed_token, total_sequence_length);
+    const std::uint64_t span = static_cast<std::uint64_t>(vocab_size - 1);
+    std::vector<int32_t> noise;
+    noise.reserve(static_cast<std::size_t>(count));
+    for (int32_t slot = 0; slot < count; ++slot) {
+        const std::uint64_t mixed =
+            mix_u64(base + static_cast<std::uint64_t>(slot) * kSlotMultiplier);
+        noise.push_back(1 + static_cast<int32_t>(mixed % span));
+    }
+    return noise;
+}
+
+std::vector<float> k2_horizon_uno_draft_lora_mask(int32_t block_length) {
+    if (block_length <= 0)
+        throw std::invalid_argument("K2-Horizon-Uno LoRA mask must be nonempty");
+    std::vector<float> mask(static_cast<std::size_t>(block_length), 1.0F);
+    mask.front() = 0.0F;
+    return mask;
+}
+
+K2HorizonUnoCommitDecision
+k2_horizon_uno_decide_greedy_commit(const std::vector<int32_t>& proposal_tokens,
+                                    const std::vector<int32_t>& verifier_next_tokens) {
+    if (proposal_tokens.empty() || proposal_tokens.size() != verifier_next_tokens.size()) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno verification requires equal nonempty proposal and verifier rows");
+    }
+
+    K2HorizonUnoCommitDecision decision;
+    const std::size_t future_count = proposal_tokens.size() - 1;
+    for (std::size_t index = 0; index < future_count; ++index) {
+        if (verifier_next_tokens[index] == proposal_tokens[index + 1]) {
+            ++decision.accepted_draft_tokens;
+            continue;
+        }
+
+        decision.tokens.insert(decision.tokens.end(), proposal_tokens.begin(),
+                               proposal_tokens.begin() + static_cast<std::ptrdiff_t>(index + 1));
+        decision.tokens.push_back(verifier_next_tokens[index]);
+        return decision;
+    }
+
+    decision.all_draft_tokens_accepted = true;
+    decision.tokens = proposal_tokens;
+    decision.tokens.push_back(verifier_next_tokens.back());
+    return decision;
+}
+
+bool k2_horizon_uno_is_eos(const std::vector<int32_t>& eos_token_ids, int32_t token_id) {
+    return std::find(eos_token_ids.begin(), eos_token_ids.end(), token_id) != eos_token_ids.end();
+}
+
+void k2_horizon_uno_validate_eos_token_ids(const std::vector<int32_t>& eos_token_ids,
+                                           int32_t vocab_size) {
+    if (vocab_size <= 1 || eos_token_ids.empty())
+        throw std::invalid_argument("K2-Horizon-Uno requires a nonempty in-range EOS set");
+    std::vector<int32_t> seen;
+    seen.reserve(eos_token_ids.size());
+    for (int32_t token : eos_token_ids) {
+        if (token < 0 || token >= vocab_size)
+            throw std::invalid_argument("K2-Horizon-Uno EOS token is outside vocabulary");
+        if (std::find(seen.begin(), seen.end(), token) != seen.end())
+            throw std::invalid_argument("K2-Horizon-Uno EOS token set contains duplicates");
+        seen.push_back(token);
+    }
+}
+
+void k2_horizon_uno_truncate_commit(std::vector<int32_t>& tokens, std::size_t maximum_tokens,
+                                    const std::vector<int32_t>& eos_token_ids) {
+    if (tokens.size() > maximum_tokens)
+        tokens.resize(maximum_tokens);
+    const auto eos = std::find_if(tokens.begin(), tokens.end(), [&](int32_t token) {
+        return k2_horizon_uno_is_eos(eos_token_ids, token);
+    });
+    if (eos != tokens.end())
+        tokens.erase(eos + 1, tokens.end());
+}
+
+int32_t k2_horizon_uno_retained_kv_position(int32_t cycle_start, std::size_t committed_tokens) {
+    if (cycle_start < 0 || committed_tokens == 0)
+        throw std::invalid_argument(
+            "K2-Horizon-Uno retained KV position requires a nonempty commit");
+    if (committed_tokens >
+        static_cast<std::size_t>(std::numeric_limits<int32_t>::max() - cycle_start)) {
+        throw std::overflow_error("K2-Horizon-Uno retained KV position overflows int32");
+    }
+    return cycle_start + static_cast<int32_t>(committed_tokens);
+}
+
+std::string k2_horizon_uno_format_decode_receipt(K2HorizonUnoGenerationMode mode,
+                                                 int32_t block_length,
+                                                 const std::string& noise_mode, int32_t forwards,
+                                                 int32_t committed_tokens, int32_t lookaheads) {
+    if (block_length <= 0 || forwards < 0 || committed_tokens < 0 || lookaheads < 0)
+        throw std::invalid_argument("K2-Horizon-Uno decode receipt counters are invalid");
+    if (!supported_noise_mode(noise_mode))
+        throw std::invalid_argument("K2-Horizon-Uno decode receipt noise mode is invalid");
+    std::ostringstream receipt;
+    receipt << "[trtmc.k2_horizon_uno.decode] mode="
+            << (mode == K2HorizonUnoGenerationMode::kLinearPsiSpec ? "linear_spec_lora" : "ar")
+            << " block_length=" << block_length << " noise_mode=" << noise_mode
+            << " forwards=" << forwards << " committed_tokens=" << committed_tokens
+            << " lookaheads=" << lookaheads;
+    return receipt.str();
+}
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/algorithm.h
+++ b/families/k2_horizon_uno/runtime/algorithm.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+struct TextGenerationConfig;
+
+enum class K2HorizonUnoGenerationMode {
+    kAutoregressive,
+    kLinearPsiSpec,
+};
+
+struct K2HorizonUnoResolvedGenerateConfig {
+    K2HorizonUnoGenerationMode mode{K2HorizonUnoGenerationMode::kLinearPsiSpec};
+    int32_t block_length{8};
+};
+
+struct K2HorizonUnoCommitDecision {
+    // Tokens to publish after the currently uncached seed token.
+    std::vector<int32_t> tokens;
+    // Number of future-position draft tokens accepted before a rejection.
+    int32_t accepted_draft_tokens{0};
+    bool all_draft_tokens_accepted{false};
+};
+
+// Validate the deliberately narrow public request surface. The initial runtime
+// supports batch-one greedy AR and greedy linear Psi-Spec only.
+K2HorizonUnoResolvedGenerateConfig
+k2_horizon_uno_resolve_generate_config(const TextGenerationConfig& config,
+                                       int32_t default_block_length = 8,
+                                       int32_t maximum_block_length = 8);
+
+// Deterministic lowest-index argmax over row-major [rows, vocab_size] logits.
+std::vector<int32_t> k2_horizon_uno_argmax_rows(const float* logits, int32_t rows,
+                                                int32_t vocab_size);
+
+// Exact B=1 implementation of ifm-ai/uno's deterministic_uniform noise. The
+// sequence id/noise salt is fixed to zero. total_sequence_length must equal the
+// prompt length plus completion_token_count.
+std::vector<int32_t> k2_horizon_uno_deterministic_uniform_noise(
+    const std::vector<int32_t>& prompt_token_ids, int32_t completion_token_count,
+    int32_t seed_token, int32_t total_sequence_length, int32_t count, int32_t vocab_size);
+
+// Conditional LoRA is disabled for the causal seed and enabled only for noise
+// rows: [0, 1, ..., 1].
+std::vector<float> k2_horizon_uno_draft_lora_mask(int32_t block_length);
+
+// Greedy Psi-Spec verification. proposal_tokens is [clean, spec_1, ...].
+// verifier_next_tokens contains the base-AR next token predicted after each
+// corresponding proposal row. A rejection commits the verified correction;
+// full acceptance commits the final verifier lookahead.
+K2HorizonUnoCommitDecision
+k2_horizon_uno_decide_greedy_commit(const std::vector<int32_t>& proposal_tokens,
+                                    const std::vector<int32_t>& verifier_next_tokens);
+
+bool k2_horizon_uno_is_eos(const std::vector<int32_t>& eos_token_ids, int32_t token_id);
+void k2_horizon_uno_validate_eos_token_ids(const std::vector<int32_t>& eos_token_ids,
+                                           int32_t vocab_size);
+
+// Limit a commit to the caller's remaining budget and stop after the first EOS,
+// retaining EOS itself.
+void k2_horizon_uno_truncate_commit(std::vector<int32_t>& tokens, std::size_t maximum_tokens,
+                                    const std::vector<int32_t>& eos_token_ids);
+
+// With an uncached seed before the cycle, committing N new tokens leaves that
+// seed plus the first N-1 committed tokens in KV. Therefore the new logical KV
+// frontier is cycle_start + N.
+int32_t k2_horizon_uno_retained_kv_position(int32_t cycle_start, std::size_t committed_tokens);
+
+std::string k2_horizon_uno_format_decode_receipt(K2HorizonUnoGenerationMode mode,
+                                                 int32_t block_length,
+                                                 const std::string& noise_mode, int32_t forwards,
+                                                 int32_t committed_tokens, int32_t lookaheads);
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/bpe_tokenizer.cpp
+++ b/families/k2_horizon_uno/runtime/bpe_tokenizer.cpp
@@ -1,0 +1,704 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/tokenizer.h"
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+namespace {
+
+constexpr std::int32_t kBaseVocabSize = 250000;
+constexpr std::int32_t kFullVocabSize = 250624;
+constexpr std::size_t kMergeCount = 249742;
+constexpr std::size_t kAddedTokenCount = 626;
+constexpr std::size_t kSpecialTokenCount = 606;
+constexpr std::int32_t kBosId = 0;
+
+constexpr std::string_view kPretokenizerPattern =
+    R"regex((?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?(?:\p{L}|\p{M}|\u200C|\u200D)+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+)regex";
+
+[[noreturn]] void schema_error(const std::string& detail) {
+    throw std::runtime_error("K2-Horizon-Uno tokenizer.json " + detail);
+}
+
+void require_schema(bool condition, const std::string& detail) {
+    if (!condition)
+        schema_error(detail);
+}
+
+std::string codepoint_to_utf8(char32_t codepoint) {
+    std::string result;
+    if (codepoint <= 0x7F) {
+        result.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7FF) {
+        result.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+        result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    } else {
+        result.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+        result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+        result.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    return result;
+}
+
+char32_t next_codepoint(std::string_view text, std::size_t& position) {
+    const auto first = static_cast<unsigned char>(text[position++]);
+    if (first < 0x80)
+        return first;
+
+    int continuation_count = 0;
+    char32_t codepoint = 0;
+    if ((first & 0xE0) == 0xC0) {
+        continuation_count = 1;
+        codepoint = first & 0x1F;
+    } else if ((first & 0xF0) == 0xE0) {
+        continuation_count = 2;
+        codepoint = first & 0x0F;
+    } else if ((first & 0xF8) == 0xF0) {
+        continuation_count = 3;
+        codepoint = first & 0x07;
+    } else {
+        schema_error("contains an invalid byte-level vocabulary token");
+    }
+
+    if (position + static_cast<std::size_t>(continuation_count) > text.size())
+        schema_error("contains a truncated byte-level vocabulary token");
+    for (int index = 0; index < continuation_count; ++index) {
+        const auto next = static_cast<unsigned char>(text[position++]);
+        if ((next & 0xC0) != 0x80)
+            schema_error("contains an invalid byte-level vocabulary token");
+        codepoint = (codepoint << 6) | (next & 0x3F);
+    }
+    return codepoint;
+}
+
+struct ByteEncoderTables {
+    std::array<std::string, 256> byte_to_token;
+    std::unordered_map<char32_t, std::uint8_t> token_to_byte;
+
+    ByteEncoderTables() {
+        std::array<bool, 256> direct{};
+        for (int byte = 33; byte <= 126; ++byte)
+            direct[static_cast<std::size_t>(byte)] = true;
+        for (int byte = 161; byte <= 172; ++byte)
+            direct[static_cast<std::size_t>(byte)] = true;
+        for (int byte = 174; byte <= 255; ++byte)
+            direct[static_cast<std::size_t>(byte)] = true;
+
+        int displaced = 0;
+        for (int byte = 0; byte < 256; ++byte) {
+            const char32_t codepoint = direct[static_cast<std::size_t>(byte)]
+                                           ? static_cast<char32_t>(byte)
+                                           : static_cast<char32_t>(256 + displaced++);
+            byte_to_token[static_cast<std::size_t>(byte)] = codepoint_to_utf8(codepoint);
+            token_to_byte.emplace(codepoint, static_cast<std::uint8_t>(byte));
+        }
+    }
+};
+
+const ByteEncoderTables& byte_tables() {
+    static const ByteEncoderTables tables;
+    return tables;
+}
+
+std::string utf8_lossy(std::string_view bytes) {
+    constexpr std::string_view replacement = "\xEF\xBF\xBD";
+    const auto continuation = [](unsigned char byte) { return (byte & 0xC0U) == 0x80U; };
+    std::string result;
+    result.reserve(bytes.size());
+
+    std::size_t position = 0;
+    while (position < bytes.size()) {
+        const auto first = static_cast<unsigned char>(bytes[position]);
+        if (first < 0x80U) {
+            result.push_back(bytes[position++]);
+            continue;
+        }
+
+        std::size_t length = 0;
+        if (first >= 0xC2U && first <= 0xDFU) {
+            length = 2;
+        } else if (first >= 0xE0U && first <= 0xEFU) {
+            length = 3;
+        } else if (first >= 0xF0U && first <= 0xF4U) {
+            length = 4;
+        } else {
+            result += replacement;
+            ++position;
+            continue;
+        }
+
+        if (position + 1 >= bytes.size()) {
+            result += replacement;
+            break;
+        }
+        const auto second = static_cast<unsigned char>(bytes[position + 1]);
+        const bool second_valid = continuation(second) && !(first == 0xE0U && second < 0xA0U) &&
+                                  !(first == 0xEDU && second >= 0xA0U) &&
+                                  !(first == 0xF0U && second < 0x90U) &&
+                                  !(first == 0xF4U && second >= 0x90U);
+        if (!second_valid) {
+            result += replacement;
+            ++position;
+            continue;
+        }
+
+        if (length >= 3) {
+            if (position + 2 >= bytes.size()) {
+                result += replacement;
+                break;
+            }
+            if (!continuation(static_cast<unsigned char>(bytes[position + 2]))) {
+                result += replacement;
+                position += 2;
+                continue;
+            }
+        }
+        if (length == 4) {
+            if (position + 3 >= bytes.size()) {
+                result += replacement;
+                break;
+            }
+            if (!continuation(static_cast<unsigned char>(bytes[position + 3]))) {
+                result += replacement;
+                position += 3;
+                continue;
+            }
+        }
+
+        result.append(bytes.substr(position, length));
+        position += length;
+    }
+    return result;
+}
+
+bool is_letter(char value) {
+    return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
+}
+
+bool is_digit(char value) {
+    return value >= '0' && value <= '9';
+}
+
+bool is_line_break(char value) {
+    return value == '\r' || value == '\n';
+}
+
+bool is_whitespace(char value) {
+    return value == ' ' || value == '\t' || value == '\r' || value == '\n' || value == '\v' ||
+           value == '\f';
+}
+
+bool is_punctuation(char value) {
+    return !is_whitespace(value) && !is_letter(value) && !is_digit(value);
+}
+
+char ascii_lower(char value) {
+    return value >= 'A' && value <= 'Z' ? static_cast<char>(value - 'A' + 'a') : value;
+}
+
+std::size_t contraction_length(std::string_view text, std::size_t position) {
+    if (position >= text.size())
+        return 0;
+    const char first = ascii_lower(text[position]);
+    if (first == 's' || first == 't' || first == 'm' || first == 'd')
+        return 1;
+    if (position + 1 >= text.size())
+        return 0;
+    const char second = ascii_lower(text[position + 1]);
+    return ((first == 'r' || first == 'v') && second == 'e') || (first == 'l' && second == 'l') ? 2
+                                                                                                : 0;
+}
+
+std::vector<std::string> pre_tokenize_ascii(std::string_view text) {
+    std::vector<std::string> result;
+    std::size_t position = 0;
+    while (position < text.size()) {
+        const std::size_t start = position;
+        const char first = text[position];
+
+        if (first == '\'') {
+            const std::size_t suffix = contraction_length(text, position + 1);
+            if (suffix != 0) {
+                position += suffix + 1;
+                result.emplace_back(text.substr(start, position - start));
+                continue;
+            }
+        }
+
+        if (is_letter(first)) {
+            while (++position < text.size() && is_letter(text[position])) {
+            }
+            result.emplace_back(text.substr(start, position - start));
+            continue;
+        }
+
+        if (!is_line_break(first) && !is_letter(first) && !is_digit(first) &&
+            position + 1 < text.size() && is_letter(text[position + 1])) {
+            position += 2;
+            while (position < text.size() && is_letter(text[position]))
+                ++position;
+            result.emplace_back(text.substr(start, position - start));
+            continue;
+        }
+
+        if (is_digit(first)) {
+            ++position;
+            while (position < text.size() && position - start < 3 && is_digit(text[position]))
+                ++position;
+            result.emplace_back(text.substr(start, position - start));
+            continue;
+        }
+
+        std::size_t punctuation = position;
+        if (first == ' ' && position + 1 < text.size() && is_punctuation(text[position + 1]))
+            ++punctuation;
+        if (punctuation < text.size() && is_punctuation(text[punctuation])) {
+            position = punctuation + 1;
+            while (position < text.size() && is_punctuation(text[position]))
+                ++position;
+            while (position < text.size() && is_line_break(text[position]))
+                ++position;
+            result.emplace_back(text.substr(start, position - start));
+            continue;
+        }
+
+        if (is_whitespace(first)) {
+            std::size_t run_end = position + 1;
+            std::size_t last_line_break = is_line_break(first) ? position : std::string_view::npos;
+            while (run_end < text.size() && is_whitespace(text[run_end])) {
+                if (is_line_break(text[run_end]))
+                    last_line_break = run_end;
+                ++run_end;
+            }
+            if (last_line_break != std::string_view::npos) {
+                position = last_line_break + 1;
+            } else if (run_end == text.size() || run_end - position == 1) {
+                position = run_end;
+            } else {
+                position = run_end - 1;
+            }
+            result.emplace_back(text.substr(start, position - start));
+            continue;
+        }
+
+        schema_error("ASCII pre-tokenizer reached an unsupported byte");
+    }
+    return result;
+}
+
+struct PairHash {
+    std::size_t operator()(const std::pair<std::string, std::string>& pair) const {
+        const std::size_t first = std::hash<std::string>{}(pair.first);
+        const std::size_t second = std::hash<std::string>{}(pair.second);
+        return first ^ (second + 0x9e3779b9U + (first << 6U) + (first >> 2U));
+    }
+};
+
+class BpeTokenizer final : public ITokenizer {
+  public:
+    static std::unique_ptr<BpeTokenizer> create(const char* data, std::size_t size,
+                                                bool add_special_tokens) {
+        if (data == nullptr || size == 0)
+            schema_error("is empty");
+        auto tokenizer = std::unique_ptr<BpeTokenizer>(new BpeTokenizer(add_special_tokens));
+        tokenizer->parse(data, size);
+        return tokenizer;
+    }
+
+    std::vector<std::int32_t> encode(const std::string& text) const override {
+        k2_horizon_uno_require_ascii_tokenizer_input(text);
+        std::vector<std::int32_t> result;
+        if (add_special_tokens_)
+            result.push_back(kBosId);
+        for (const auto& segment : split_added_tokens(text)) {
+            if (segment.added_id >= 0) {
+                result.push_back(segment.added_id);
+            } else {
+                encode_text(segment.text, result);
+            }
+        }
+        return result;
+    }
+
+    std::string decode(const std::vector<std::int32_t>& ids) const override {
+        std::string encoded;
+        for (const std::int32_t id : ids) {
+            if (id < 0 || id >= static_cast<std::int32_t>(vocabulary_.size()))
+                throw std::invalid_argument("K2-Horizon-Uno token ID is outside the vocabulary");
+            if (special_ids_.count(id) == 0)
+                encoded += vocabulary_[static_cast<std::size_t>(id)];
+        }
+
+        std::string bytes;
+        std::size_t position = 0;
+        const auto& reverse = byte_tables().token_to_byte;
+        while (position < encoded.size()) {
+            const std::size_t start = position;
+            const char32_t codepoint = next_codepoint(encoded, position);
+            const auto found = reverse.find(codepoint);
+            if (found != reverse.end()) {
+                bytes.push_back(static_cast<char>(found->second));
+            } else {
+                bytes.append(encoded, start, position - start);
+            }
+        }
+        // Hugging Face tokenizers use Rust's String::from_utf8_lossy after
+        // byte-level decode. Match its replacement grouping so JSON output is
+        // always valid UTF-8, including for incomplete generated byte tokens.
+        return utf8_lossy(bytes);
+    }
+
+    std::int32_t id_for_token(std::string_view token) const override {
+        const auto found = token_to_id_.find(std::string(token));
+        return found == token_to_id_.end() ? -1 : found->second;
+    }
+
+    std::string token_for_id(std::int32_t id) const override {
+        return id >= 0 && id < static_cast<std::int32_t>(vocabulary_.size())
+                   ? vocabulary_[static_cast<std::size_t>(id)]
+                   : std::string{};
+    }
+
+  private:
+    struct Segment {
+        std::string text;
+        std::int32_t added_id{-1};
+    };
+
+    struct MergeCandidate {
+        int rank{INT_MAX};
+        std::string first;
+        std::string second;
+    };
+
+    explicit BpeTokenizer(bool add_special_tokens) : add_special_tokens_(add_special_tokens) {}
+
+    static const nlohmann::json& one_entry(const nlohmann::json& value, const char* key) {
+        require_schema(value.is_object() && value.size() == 1 && value.contains(key),
+                       std::string("has invalid post_processor.") + key);
+        return value.at(key);
+    }
+
+    static void validate_template_entry(const nlohmann::json& entry, const char* kind,
+                                        const char* id) {
+        const auto& value = one_entry(entry, kind);
+        require_schema(value.is_object() && value.size() == 2 && value.at("id") == id &&
+                           value.at("type_id") == 0,
+                       "has an unsupported post_processor template");
+    }
+
+    static void validate_special_definition(const nlohmann::json& definitions, const char* token,
+                                            std::int32_t expected_id) {
+        require_schema(definitions.contains(token), "is missing a post_processor special token");
+        const auto& value = definitions.at(token);
+        require_schema(value.is_object() && value.size() == 3 && value.at("id") == token,
+                       "has an invalid post_processor special token");
+        require_schema(value.at("ids") == nlohmann::json::array({expected_id}) &&
+                           value.at("tokens") == nlohmann::json::array({token}),
+                       "has an invalid post_processor special-token ID");
+    }
+
+    static void validate_schema(const nlohmann::json& root) {
+        require_schema(root.is_object() && root.size() == 9, "has an unexpected top-level shape");
+        require_schema(root.at("version") == "1.0" && root.at("truncation").is_null() &&
+                           root.at("padding").is_null(),
+                       "uses unsupported version, truncation, or padding");
+
+        const auto& normalizer = root.at("normalizer");
+        require_schema(normalizer.is_object() && normalizer.size() == 1 &&
+                           normalizer.at("type") == "NFC",
+                       "must use the pinned NFC normalizer");
+
+        const auto& pre = root.at("pre_tokenizer");
+        require_schema(pre.is_object() && pre.size() == 2 && pre.at("type") == "Sequence",
+                       "must use the pinned Sequence pre-tokenizer");
+        const auto& stages = pre.at("pretokenizers");
+        require_schema(stages.is_array() && stages.size() == 2,
+                       "must contain the pinned Split and ByteLevel stages");
+        const auto& split = stages.at(0);
+        require_schema(split.is_object() && split.size() == 4 && split.at("type") == "Split" &&
+                           split.at("behavior") == "Isolated" && split.at("invert") == false &&
+                           split.at("pattern").is_object() && split.at("pattern").size() == 1 &&
+                           split.at("pattern").at("Regex") == kPretokenizerPattern,
+                       "does not match the pinned Qwen ASCII-compatible Split contract");
+        const auto& byte_level = stages.at(1);
+        require_schema(byte_level.is_object() && byte_level.size() == 4 &&
+                           byte_level.at("type") == "ByteLevel" &&
+                           byte_level.at("add_prefix_space") == false &&
+                           byte_level.at("trim_offsets") == true &&
+                           byte_level.at("use_regex") == false,
+                       "does not match the pinned ByteLevel pre-tokenizer contract");
+
+        const auto& decoder = root.at("decoder");
+        require_schema(decoder.is_object() && decoder.size() == 4 &&
+                           decoder.at("type") == "ByteLevel" &&
+                           decoder.at("add_prefix_space") == true &&
+                           decoder.at("trim_offsets") == true && decoder.at("use_regex") == true,
+                       "must use the pinned ByteLevel decoder");
+
+        const auto& model = root.at("model");
+        require_schema(model.is_object() && model.size() == 10 && model.at("type") == "BPE" &&
+                           model.at("dropout").is_null() && model.at("unk_token").is_null() &&
+                           model.at("continuing_subword_prefix") == "" &&
+                           model.at("end_of_word_suffix") == "" && model.at("fuse_unk") == false &&
+                           model.at("byte_fallback") == false && model.at("ignore_merges") == false,
+                       "must use the pinned byte-level BPE model");
+        require_schema(
+            model.at("vocab").is_object() && model.at("vocab").size() == kBaseVocabSize &&
+                model.at("merges").is_array() && model.at("merges").size() == kMergeCount,
+            "has an unexpected BPE vocabulary or merge count");
+
+        const auto& post = root.at("post_processor");
+        require_schema(post.is_object() && post.size() == 4 &&
+                           post.at("type") == "TemplateProcessing",
+                       "must use the pinned TemplateProcessing post-processor");
+        const auto& single = post.at("single");
+        require_schema(single.is_array() && single.size() == 2,
+                       "has an unsupported single-sequence template");
+        validate_template_entry(single.at(0), "SpecialToken", "<|ifm|begin_of_text|>");
+        validate_template_entry(single.at(1), "Sequence", "A");
+        const auto& pair = post.at("pair");
+        require_schema(pair.is_array() && pair.size() == 4,
+                       "has an unsupported pair-sequence template");
+        validate_template_entry(pair.at(0), "SpecialToken", "<|ifm|begin_of_text|>");
+        validate_template_entry(pair.at(1), "Sequence", "A");
+        validate_template_entry(pair.at(2), "SpecialToken", "<|ifm|endoftext|>");
+        validate_template_entry(pair.at(3), "Sequence", "B");
+        const auto& definitions = post.at("special_tokens");
+        require_schema(definitions.is_object() && definitions.size() == 2,
+                       "has an unexpected post_processor special-token set");
+        validate_special_definition(definitions, "<|ifm|begin_of_text|>", 0);
+        validate_special_definition(definitions, "<|ifm|endoftext|>", 1);
+    }
+
+    void parse(const char* data, std::size_t size) {
+        nlohmann::json root;
+        try {
+            root = nlohmann::json::parse(data, data + size);
+            validate_schema(root);
+            parse_vocabulary(root.at("model").at("vocab"));
+            parse_added_tokens(root.at("added_tokens"));
+            parse_merges(root.at("model").at("merges"));
+            validate_protocol_tokens();
+        } catch (const nlohmann::json::exception& error) {
+            schema_error(std::string("is invalid: ") + error.what());
+        }
+    }
+
+    void parse_vocabulary(const nlohmann::json& values) {
+        vocabulary_.resize(kFullVocabSize);
+        token_to_id_.reserve(kFullVocabSize);
+        std::vector<bool> seen(kBaseVocabSize);
+        for (const auto& [token, value] : values.items()) {
+            require_schema(value.is_number_integer(), "contains a non-integer vocabulary ID");
+            const auto id = value.get<std::int32_t>();
+            require_schema(id >= 0 && id < kBaseVocabSize,
+                           "contains an out-of-range vocabulary ID");
+            require_schema(!seen[static_cast<std::size_t>(id)],
+                           "contains a duplicate vocabulary ID");
+            seen[static_cast<std::size_t>(id)] = true;
+            vocabulary_[static_cast<std::size_t>(id)] = token;
+            token_to_id_.emplace(token, id);
+        }
+        require_schema(std::all_of(seen.begin(), seen.end(), [](bool value) { return value; }),
+                       "base vocabulary is not dense");
+        for (const auto& token : byte_tables().byte_to_token)
+            require_schema(token_to_id_.count(token) == 1,
+                           "base vocabulary is missing a byte-level token");
+    }
+
+    void parse_added_tokens(const nlohmann::json& values) {
+        require_schema(values.is_array() && values.size() == kAddedTokenCount,
+                       "has an unexpected added-token count");
+        std::size_t special_count = 0;
+        added_tokens_.reserve(values.size());
+        for (std::size_t index = 0; index < values.size(); ++index) {
+            const auto& value = values.at(index);
+            require_schema(value.is_object() && value.size() == 7,
+                           "contains an invalid added-token entry");
+            const std::int32_t id = value.at("id").get<std::int32_t>();
+            const std::int32_t expected_id =
+                index < 2 ? static_cast<std::int32_t>(index)
+                          : kBaseVocabSize + static_cast<std::int32_t>(index - 2);
+            const std::string content = value.at("content").get<std::string>();
+            require_schema(id == expected_id && !content.empty() &&
+                               value.at("single_word") == false && value.at("lstrip") == false &&
+                               value.at("rstrip") == false && value.at("normalized") == false,
+                           "contains an unsupported added-token contract");
+            require_schema(std::all_of(content.begin(), content.end(),
+                                       [](unsigned char byte) { return byte < 0x80U; }),
+                           "contains a non-ASCII added token");
+
+            if (id < kBaseVocabSize) {
+                require_schema(vocabulary_[static_cast<std::size_t>(id)] == content,
+                               "base and added-token vocabularies disagree");
+            } else {
+                require_schema(vocabulary_[static_cast<std::size_t>(id)].empty(),
+                               "contains a duplicate added-token ID");
+                vocabulary_[static_cast<std::size_t>(id)] = content;
+                require_schema(token_to_id_.emplace(content, id).second,
+                               "contains duplicate added-token content");
+            }
+
+            const bool special = value.at("special").get<bool>();
+            if (special) {
+                special_ids_.insert(id);
+                ++special_count;
+            }
+            added_tokens_.emplace_back(content, id);
+        }
+        require_schema(special_count == kSpecialTokenCount,
+                       "has an unexpected special-token count");
+        std::sort(added_tokens_.begin(), added_tokens_.end(),
+                  [](const auto& left, const auto& right) {
+                      return left.first.size() > right.first.size();
+                  });
+    }
+
+    void parse_merges(const nlohmann::json& values) {
+        merge_rank_.reserve(values.size());
+        for (std::size_t index = 0; index < values.size(); ++index) {
+            const auto& value = values.at(index);
+            require_schema(value.is_array() && value.size() == 2 && value.at(0).is_string() &&
+                               value.at(1).is_string(),
+                           "contains an invalid BPE merge");
+            auto pair =
+                std::make_pair(value.at(0).get<std::string>(), value.at(1).get<std::string>());
+            require_schema(merge_rank_.emplace(std::move(pair), static_cast<int>(index)).second,
+                           "contains a duplicate BPE merge");
+        }
+    }
+
+    void validate_protocol_tokens() const {
+        const auto require_token = [&](std::string_view token, std::int32_t id, bool special) {
+            const auto found = token_to_id_.find(std::string(token));
+            require_schema(found != token_to_id_.end() && found->second == id &&
+                               (special_ids_.count(id) != 0) == special,
+                           "does not match the pinned publisher protocol token set");
+        };
+        require_token("<|ifm|begin_of_text|>", 0, true);
+        require_token("<|ifm|endoftext|>", 1, true);
+        require_token("<|ifm|im_start|>", 250018, true);
+        require_token("<|ifm|im_end|>", 250019, true);
+        require_token("<ifm|think>", 250029, false);
+        require_token("</ifm|think>", 250030, false);
+    }
+
+    std::vector<Segment> split_added_tokens(std::string_view text) const {
+        std::vector<Segment> result;
+        std::size_t position = 0;
+        while (position < text.size()) {
+            const auto found =
+                std::find_if(added_tokens_.begin(), added_tokens_.end(), [&](const auto& token) {
+                    return token.first.size() <= text.size() - position &&
+                           text.compare(position, token.first.size(), token.first) == 0;
+                });
+            if (found != added_tokens_.end()) {
+                result.push_back({found->first, found->second});
+                position += found->first.size();
+                continue;
+            }
+            if (result.empty() || result.back().added_id >= 0)
+                result.push_back({});
+            result.back().text.push_back(text[position++]);
+        }
+        return result;
+    }
+
+    static std::vector<std::string> byte_encode(std::string_view text) {
+        std::vector<std::string> result;
+        result.reserve(text.size());
+        for (const unsigned char byte : text)
+            result.push_back(byte_tables().byte_to_token[byte]);
+        return result;
+    }
+
+    MergeCandidate best_merge(const std::vector<std::string>& tokens) const {
+        MergeCandidate best;
+        for (std::size_t index = 0; index + 1 < tokens.size(); ++index) {
+            const auto found = merge_rank_.find({tokens[index], tokens[index + 1]});
+            if (found != merge_rank_.end() && found->second < best.rank)
+                best = {found->second, tokens[index], tokens[index + 1]};
+        }
+        return best;
+    }
+
+    static std::vector<std::string> merge_pair(std::vector<std::string> tokens,
+                                               const MergeCandidate& merge) {
+        std::vector<std::string> result;
+        result.reserve(tokens.size());
+        for (std::size_t index = 0; index < tokens.size(); ++index) {
+            if (index + 1 < tokens.size() && tokens[index] == merge.first &&
+                tokens[index + 1] == merge.second) {
+                result.push_back(merge.first + merge.second);
+                ++index;
+            } else {
+                result.push_back(std::move(tokens[index]));
+            }
+        }
+        return result;
+    }
+
+    std::vector<std::string> apply_merges(std::vector<std::string> tokens) const {
+        while (tokens.size() > 1) {
+            const auto merge = best_merge(tokens);
+            if (merge.rank == INT_MAX)
+                break;
+            tokens = merge_pair(std::move(tokens), merge);
+        }
+        return tokens;
+    }
+
+    void encode_text(std::string_view text, std::vector<std::int32_t>& result) const {
+        for (const auto& word : pre_tokenize_ascii(text)) {
+            for (const auto& token : apply_merges(byte_encode(word))) {
+                const auto found = token_to_id_.find(token);
+                if (found == token_to_id_.end())
+                    schema_error("cannot encode a byte-level BPE token");
+                result.push_back(found->second);
+            }
+        }
+    }
+
+    std::vector<std::string> vocabulary_;
+    std::unordered_map<std::string, std::int32_t> token_to_id_;
+    std::unordered_map<std::pair<std::string, std::string>, int, PairHash> merge_rank_;
+    std::unordered_set<std::int32_t> special_ids_;
+    std::vector<std::pair<std::string, std::int32_t>> added_tokens_;
+    bool add_special_tokens_{false};
+};
+
+} // namespace
+
+std::string k2_horizon_uno_utf8_lossy(std::string_view bytes) {
+    return utf8_lossy(bytes);
+}
+
+void k2_horizon_uno_require_ascii_tokenizer_input(std::string_view text) {
+    if (std::any_of(text.begin(), text.end(), [](unsigned char byte) { return byte >= 0x80U; })) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno native tokenizer currently supports ASCII prompt text only");
+    }
+}
+
+std::unique_ptr<ITokenizer> CreateK2HorizonUnoBpeTokenizer(const char* tokenizer_json_data,
+                                                           std::size_t tokenizer_json_size,
+                                                           bool add_special_tokens) {
+    return BpeTokenizer::create(tokenizer_json_data, tokenizer_json_size, add_special_tokens);
+}
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/chat_template.cpp
+++ b/families/k2_horizon_uno/runtime/chat_template.cpp
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/chat_template.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace trtmc {
+
+std::string k2_horizon_uno_apply_chat_template(const std::string& format, const std::string& prompt,
+                                               const std::string& reasoning_effort) {
+    if (format != kK2HorizonUnoPublisherChatTemplateFormat) {
+        throw std::invalid_argument("Unsupported K2-Horizon-Uno chat template format: " + format);
+    }
+    if (reasoning_effort != "high") {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno native chat supports only reasoning_effort='high'");
+    }
+    if (prompt.find("<|ifm|") != std::string::npos || prompt.find("<ifm|") != std::string::npos ||
+        prompt.find("</ifm|") != std::string::npos) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno chat prompts must not contain publisher protocol markers");
+    }
+
+    // The tokenizer owns BOS insertion, so this renderer deliberately omits it.
+    return "<|ifm|im_start|>user\n" + prompt +
+           "<|ifm|im_end|><|ifm|im_start|>assistant\n<ifm|think>\n";
+}
+
+void k2_horizon_uno_validate_chat_eos_token_ids(const std::vector<int32_t>& eos_token_ids) {
+    constexpr int32_t end_of_text_id = 1;
+    constexpr int32_t end_of_message_id = 250019;
+    if (eos_token_ids.size() != 2 ||
+        std::find(eos_token_ids.begin(), eos_token_ids.end(), end_of_text_id) ==
+            eos_token_ids.end() ||
+        std::find(eos_token_ids.begin(), eos_token_ids.end(), end_of_message_id) ==
+            eos_token_ids.end()) {
+        throw std::invalid_argument("K2-Horizon-Uno requires publisher EOS token IDs {1, 250019}");
+    }
+}
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/chat_template.h
+++ b/families/k2_horizon_uno/runtime/chat_template.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+inline constexpr char kK2HorizonUnoPublisherChatTemplateFormat[] = "k2_horizon_uno_publisher_v1";
+
+std::string k2_horizon_uno_apply_chat_template(const std::string& format, const std::string& prompt,
+                                               const std::string& reasoning_effort);
+void k2_horizon_uno_validate_chat_eos_token_ids(const std::vector<int32_t>& eos_token_ids);
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/kv_cache.cpp
+++ b/families/k2_horizon_uno/runtime/kv_cache.cpp
@@ -1,0 +1,184 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/kv_cache.h"
+
+#include "trtmc/runtime/trt_module.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+namespace {
+
+constexpr int32_t kHeadDim = 128;
+constexpr int32_t kMaximumBlockLength = 8;
+constexpr int32_t kNumKvHeads = 8;
+constexpr int32_t kNumLayers = 36;
+
+void require_dynamic_input(ITrtModule& module, const std::string& name, DType dtype) {
+    if (!module.has_input(name) || module.tensor_dtype(name) != dtype ||
+        !module.input_is_dynamic(name)) {
+        throw std::runtime_error("K2-Horizon-Uno KV input contract mismatch for '" + name + "'");
+    }
+}
+
+void require_static_input(ITrtModule& module, const std::string& name, DType dtype,
+                          const std::vector<int64_t>& shape) {
+    if (!module.has_input(name) || module.tensor_dtype(name) != dtype ||
+        module.tensor_shape(name) != shape || module.input_is_dynamic(name)) {
+        throw std::runtime_error("K2-Horizon-Uno KV input contract mismatch for '" + name + "'");
+    }
+}
+
+void validate_cache_pair(ITrtModule& module, const std::string& cache_name,
+                         const std::string& present_name,
+                         const std::vector<int64_t>& expected_shape) {
+    if (!module.has_input(cache_name) || !module.has_output(present_name) ||
+        module.tensor_shape(cache_name) != expected_shape ||
+        module.tensor_shape(present_name) != expected_shape ||
+        module.tensor_dtype(cache_name) != DType::kBFloat16 ||
+        module.tensor_dtype(present_name) != DType::kBFloat16) {
+        throw std::runtime_error(
+            "K2-Horizon-Uno cache/present tensors must be aliased BF16 [1,Hkv,K,128]");
+    }
+}
+
+bool all_tensors_ok(const std::vector<DeviceTensor>& tensors) {
+    return std::all_of(tensors.begin(), tensors.end(),
+                       [](const DeviceTensor& tensor) { return tensor.ok(); });
+}
+
+void validate_cache_names(const K2HorizonUnoKvCacheNames& names) {
+    constexpr auto expected = static_cast<std::size_t>(kNumLayers);
+    if (names.cache_k.size() != expected || names.cache_v.size() != expected ||
+        names.present_k.size() != expected || names.present_v.size() != expected) {
+        throw std::invalid_argument("K2-Horizon-Uno per-layer KV name count mismatch");
+    }
+}
+
+bool allocate_cache_tensors(std::vector<DeviceTensor>& cache_k, std::vector<DeviceTensor>& cache_v,
+                            const std::vector<int64_t>& shape, cudaStream_t stream) {
+    cache_k.reserve(kNumLayers);
+    cache_v.reserve(kNumLayers);
+    for (int32_t layer = 0; layer < kNumLayers; ++layer) {
+        cache_k.emplace_back(shape, DType::kBFloat16, stream);
+        if (!cache_k.back().ok())
+            return false;
+        cache_v.emplace_back(shape, DType::kBFloat16, stream);
+        if (!cache_v.back().ok())
+            return false;
+    }
+    return true;
+}
+
+} // namespace
+
+K2HorizonUnoCacheCursor::K2HorizonUnoCacheCursor(int32_t capacity) : capacity_(capacity) {
+    if (capacity_ <= 0)
+        throw std::invalid_argument("K2-Horizon-Uno KV capacity must be positive");
+}
+
+void K2HorizonUnoCacheCursor::validate_block(int32_t sequence_length) const {
+    if (sequence_length <= 0 || sequence_length > kMaximumBlockLength) {
+        throw std::invalid_argument("K2-Horizon-Uno block length must be in [1, 8]");
+    }
+    if (position_ > capacity_ - sequence_length)
+        throw std::runtime_error("K2-Horizon-Uno sequence exceeds fixed KV capacity");
+}
+
+void K2HorizonUnoCacheCursor::advance(int32_t sequence_length) {
+    validate_block(sequence_length);
+    position_ += sequence_length;
+}
+
+void K2HorizonUnoCacheCursor::rollback(int32_t position) {
+    if (position < 0 || position > position_)
+        throw std::invalid_argument("K2-Horizon-Uno rollback must stay within committed KV");
+    position_ = position;
+}
+
+K2HorizonUnoKvCache::K2HorizonUnoKvCache(int32_t max_length, cudaStream_t stream,
+                                         K2HorizonUnoKvCacheNames names)
+    : cursor_(max_length), names_(std::move(names)) {
+    validate_cache_names(names_);
+    const std::vector<int64_t> shape{1, kNumKvHeads, max_length, kHeadDim};
+    (void)allocate_cache_tensors(cache_k_, cache_v_, shape, stream);
+}
+
+void K2HorizonUnoKvCache::validate_engine_contract(ITrtModule& module) const {
+    require_dynamic_input(module, names_.position_id, DType::kInt32);
+    require_static_input(module, names_.cache_write_indices, DType::kInt32, {1});
+    require_static_input(module, names_.key_value_lengths, DType::kInt32, {1});
+    const std::vector<int64_t> shape{1, kNumKvHeads, max_length(), kHeadDim};
+    for (int32_t layer = 0; layer < kNumLayers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        validate_cache_pair(module, names_.cache_k[index], names_.present_k[index], shape);
+        validate_cache_pair(module, names_.cache_v[index], names_.present_v[index], shape);
+    }
+}
+
+void K2HorizonUnoKvCache::bind_cache_aliases(ITrtModule& module) {
+    for (int32_t layer = 0; layer < kNumLayers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        module.bind_external(names_.cache_k[index], cache_k_[index].data());
+        module.bind_external(names_.cache_v[index], cache_v_[index].data());
+        if (module.device_ptr(names_.cache_k[index]) != cache_k_[index].data() ||
+            module.device_ptr(names_.present_k[index]) != cache_k_[index].data() ||
+            module.device_ptr(names_.cache_v[index]) != cache_v_[index].data() ||
+            module.device_ptr(names_.present_v[index]) != cache_v_[index].data()) {
+            throw std::runtime_error(
+                "K2-Horizon-Uno engine did not preserve cache/present aliasing");
+        }
+    }
+}
+
+void K2HorizonUnoKvCache::bind_to(ITrtModule& module) {
+    if (!ok())
+        throw std::runtime_error("K2-Horizon-Uno KV allocation is incomplete");
+    validate_engine_contract(module);
+    bind_cache_aliases(module);
+    bound_ = true;
+}
+
+void K2HorizonUnoKvCache::prepare_block(TensorMap& inputs, int32_t sequence_length) {
+    if (!bound_)
+        throw std::runtime_error("K2-Horizon-Uno KV cache must be bound before inference");
+    cursor_.validate_block(sequence_length);
+
+    position_ids_.resize(static_cast<std::size_t>(sequence_length));
+    for (int32_t row = 0; row < sequence_length; ++row)
+        position_ids_[static_cast<std::size_t>(row)] = cursor_.position() + row;
+    cache_write_index_ = cursor_.position();
+    key_value_length_ = cursor_.position() + sequence_length;
+    inputs[names_.position_id] =
+        Tensor{position_ids_.data(), {static_cast<int64_t>(sequence_length)}, DType::kInt32};
+    inputs[names_.cache_write_indices] = Tensor{&cache_write_index_, {1}, DType::kInt32};
+    inputs[names_.key_value_lengths] = Tensor{&key_value_length_, {1}, DType::kInt32};
+}
+
+void K2HorizonUnoKvCache::advance(int32_t sequence_length) {
+    cursor_.advance(sequence_length);
+}
+
+void K2HorizonUnoKvCache::rollback(int32_t position) {
+    cursor_.rollback(position);
+}
+
+void K2HorizonUnoKvCache::reset() {
+    cursor_.reset();
+    position_ids_.clear();
+    cache_write_index_ = 0;
+    key_value_length_ = 0;
+}
+
+bool K2HorizonUnoKvCache::ok() const {
+    constexpr auto expected = static_cast<std::size_t>(kNumLayers);
+    return cache_k_.size() == expected && cache_v_.size() == expected && all_tensors_ok(cache_k_) &&
+           all_tensors_ok(cache_v_);
+}
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/kv_cache.h
+++ b/families/k2_horizon_uno/runtime/kv_cache.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/device_tensor.h"
+#include "trtmc/runtime/tensor.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class ITrtModule;
+
+struct K2HorizonUnoKvCacheNames {
+    std::vector<std::string> cache_k;
+    std::vector<std::string> cache_v;
+    std::vector<std::string> present_k;
+    std::vector<std::string> present_v;
+    std::string cache_write_indices{"cache_write_indices"};
+    std::string key_value_lengths{"key_value_lengths"};
+    std::string position_id{"position_id"};
+};
+
+// Pure logical state used by the device-owning cache and focused CPU tests.
+class K2HorizonUnoCacheCursor {
+  public:
+    explicit K2HorizonUnoCacheCursor(int32_t capacity);
+
+    void validate_block(int32_t sequence_length) const;
+    void advance(int32_t sequence_length);
+    void rollback(int32_t position);
+    void reset() { position_ = 0; }
+
+    int32_t position() const { return position_; }
+    int32_t capacity() const { return capacity_; }
+
+  private:
+    int32_t capacity_{0};
+    int32_t position_{0};
+};
+
+// Fixed-capacity BF16 native KV cache. TensorRT updates each layer cache in
+// place; present outputs must alias their cache inputs. Logical rollback hides
+// temporary draft/verify suffixes, which later enqueues overwrite.
+class K2HorizonUnoKvCache {
+  public:
+    K2HorizonUnoKvCache(int32_t max_length, cudaStream_t stream, K2HorizonUnoKvCacheNames names);
+
+    void reset();
+    void bind_to(ITrtModule& module);
+    void prepare_block(TensorMap& inputs, int32_t sequence_length);
+    void advance(int32_t sequence_length);
+    void rollback(int32_t position);
+
+    int32_t position() const { return cursor_.position(); }
+    int32_t max_length() const { return cursor_.capacity(); }
+    bool ok() const;
+
+  private:
+    void validate_engine_contract(ITrtModule& module) const;
+    void bind_cache_aliases(ITrtModule& module);
+
+    std::vector<DeviceTensor> cache_k_;
+    std::vector<DeviceTensor> cache_v_;
+    K2HorizonUnoCacheCursor cursor_;
+    std::vector<int32_t> position_ids_;
+    int32_t cache_write_index_{0};
+    int32_t key_value_length_{0};
+    K2HorizonUnoKvCacheNames names_;
+    bool bound_{false};
+};
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/pipeline.cpp
+++ b/families/k2_horizon_uno/runtime/pipeline.cpp
@@ -1,0 +1,277 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/pipeline.h"
+
+#include "families/k2_horizon_uno/runtime/chat_template.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+namespace {
+
+constexpr int32_t kMaximumBlockLength = 8;
+constexpr int32_t kVocabSize = 250624;
+
+int32_t checked_size_to_int32(std::size_t value, const char* label) {
+    if (value > static_cast<std::size_t>(std::numeric_limits<int32_t>::max()))
+        throw std::overflow_error(std::string("K2-Horizon-Uno ") + label + " exceeds int32");
+    return static_cast<int32_t>(value);
+}
+
+void validate_pipeline_components(const std::unique_ptr<ITrtModule>& decoder,
+                                  const std::unique_ptr<K2HorizonUnoKvCache>& cache) {
+    if (!decoder || !decoder->ok())
+        throw std::runtime_error("K2HorizonUnoTextGenerationPipeline: invalid decoder module");
+    if (!cache || !cache->ok())
+        throw std::runtime_error("K2HorizonUnoTextGenerationPipeline: invalid native KV cache");
+}
+
+void validate_generation_inputs(const std::vector<int32_t>& token_ids, int32_t max_new_tokens) {
+    if (max_new_tokens > 0 && token_ids.empty())
+        throw std::invalid_argument("K2-Horizon-Uno generation requires a nonempty prompt");
+    for (int32_t token : token_ids) {
+        if (token < 0 || token >= kVocabSize)
+            throw std::invalid_argument("K2-Horizon-Uno token is outside the vocabulary");
+    }
+}
+
+} // namespace
+
+K2HorizonUnoTextGenerationPipeline::K2HorizonUnoTextGenerationPipeline(
+    std::unique_ptr<ITrtModule> decoder, std::unique_ptr<K2HorizonUnoKvCache> cache,
+    std::shared_ptr<ITokenizer> tokenizer)
+    : decoder_(std::move(decoder)), cache_(std::move(cache)), tokenizer_(std::move(tokenizer)) {
+    validate_pipeline_components(decoder_, cache_);
+}
+
+TextResult K2HorizonUnoTextGenerationPipeline::generate(const std::string& prompt,
+                                                        const TextGenerationConfig& cfg) {
+    (void)k2_horizon_uno_resolve_generate_config(cfg);
+    if (!tokenizer_)
+        throw std::runtime_error("K2HorizonUnoTextGenerationPipeline: no tokenizer configured");
+    if (cfg.use_chat_template && cfg.eos_token_id >= 0) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno chat requires the publisher EOS set from the bundle");
+    }
+
+    const std::string effective_prompt =
+        cfg.use_chat_template ? k2_horizon_uno_apply_chat_template(
+                                    kK2HorizonUnoPublisherChatTemplateFormat, prompt, "high")
+                              : prompt;
+    const auto input_ids = tokenizer_->encode(effective_prompt);
+
+    last_setup_ms_ = 0.0;
+    auto generated = generate_from_ids(input_ids, cfg);
+    std::vector<int32_t> new_tokens(generated.token_ids.begin() +
+                                        static_cast<std::ptrdiff_t>(input_ids.size()),
+                                    generated.token_ids.end());
+    TextResult result{tokenizer_->decode(new_tokens), std::move(new_tokens), generated.prefill_ms,
+                      generated.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    log_decode_receipt(generated.stats);
+    return result;
+}
+
+K2HorizonUnoTextGenerationPipeline::TimedGenResult
+K2HorizonUnoTextGenerationPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
+                                                      const TextGenerationConfig& cfg) {
+    const auto resolved = k2_horizon_uno_resolve_generate_config(cfg);
+    validate_generation_inputs(input_ids, cfg.max_new_tokens);
+    // Validate request overrides before resetting state or executing the engine.
+    (void)effective_eos_ids(cfg);
+    // The current seed is not cached, so linear verification reaches at most
+    // prompt_tokens + max_new_tokens, including its transient lookahead row.
+    if (input_ids.size() > static_cast<std::size_t>(cache_->max_length()) ||
+        static_cast<std::size_t>(cfg.max_new_tokens) >
+            static_cast<std::size_t>(cache_->max_length()) - input_ids.size()) {
+        throw std::invalid_argument(
+            "K2-Horizon-Uno prompt and generation exceed fixed KV capacity");
+    }
+
+    if (cfg.max_new_tokens == 0) {
+        TimedGenResult result;
+        result.token_ids = input_ids;
+        result.stats.mode = resolved.mode;
+        result.stats.block_length = resolved.block_length;
+        return result;
+    }
+    if (resolved.mode == K2HorizonUnoGenerationMode::kAutoregressive)
+        return generate_ar(input_ids, cfg, resolved);
+    return generate_linear_psi_spec(input_ids, cfg, resolved);
+}
+
+K2HorizonUnoTextGenerationPipeline::TimedGenResult K2HorizonUnoTextGenerationPipeline::generate_ar(
+    const std::vector<int32_t>& input_ids, const TextGenerationConfig& cfg,
+    const K2HorizonUnoResolvedGenerateConfig& resolved) {
+    using Clock = std::chrono::steady_clock;
+    reset_generation_context();
+    std::vector<float> logits;
+    const auto prefill_start = Clock::now();
+    run_prefill(input_ids, logits);
+    const auto prefill_end = Clock::now();
+
+    const auto eos_ids = effective_eos_ids(cfg);
+    std::vector<int32_t> output = input_ids;
+    DecodeStats stats;
+    stats.mode = resolved.mode;
+    stats.block_length = 1;
+    const auto decode_start = Clock::now();
+    for (int32_t generated = 0; generated < cfg.max_new_tokens; ++generated) {
+        const int32_t token = k2_horizon_uno_argmax_rows(logits.data(), 1, kVocabSize).front();
+        output.push_back(token);
+        ++stats.committed_tokens;
+        if (k2_horizon_uno_is_eos(eos_ids, token))
+            break;
+        if (generated + 1 < cfg.max_new_tokens) {
+            run_block({token}, {0.0F}, logits);
+            ++stats.forwards;
+        }
+    }
+    const auto decode_end = Clock::now();
+    return TimedGenResult{
+        std::move(output),
+        std::chrono::duration<double, std::milli>(prefill_end - prefill_start).count(),
+        std::chrono::duration<double, std::milli>(decode_end - decode_start).count(), stats};
+}
+
+K2HorizonUnoTextGenerationPipeline::TimedGenResult
+K2HorizonUnoTextGenerationPipeline::generate_linear_psi_spec(
+    const std::vector<int32_t>& input_ids, const TextGenerationConfig& cfg,
+    const K2HorizonUnoResolvedGenerateConfig& resolved) {
+    using Clock = std::chrono::steady_clock;
+    reset_generation_context();
+    std::vector<float> logits;
+    const auto prefill_start = Clock::now();
+    run_prefill(input_ids, logits);
+    const auto prefill_end = Clock::now();
+
+    const auto eos_ids = effective_eos_ids(cfg);
+    std::vector<int32_t> output = input_ids;
+    DecodeStats stats;
+    stats.mode = resolved.mode;
+    stats.block_length = resolved.block_length;
+    const auto decode_start = Clock::now();
+    int32_t seed_token = k2_horizon_uno_argmax_rows(logits.data(), 1, kVocabSize).front();
+    output.push_back(seed_token);
+    ++stats.committed_tokens;
+    int32_t generated_tokens = 1;
+
+    while (generated_tokens < cfg.max_new_tokens && !k2_horizon_uno_is_eos(eos_ids, seed_token)) {
+        const int32_t remaining = cfg.max_new_tokens - generated_tokens;
+        const int32_t block_length = std::min(resolved.block_length, remaining);
+        const int32_t cycle_start = cache_->position();
+
+        std::vector<int32_t> draft{seed_token};
+        auto noise = k2_horizon_uno_deterministic_uniform_noise(
+            input_ids, generated_tokens, seed_token,
+            checked_size_to_int32(output.size(), "sequence length"), block_length - 1, kVocabSize);
+        draft.insert(draft.end(), noise.begin(), noise.end());
+        run_block(draft, k2_horizon_uno_draft_lora_mask(block_length), logits);
+        ++stats.forwards;
+        auto proposals = k2_horizon_uno_argmax_rows(logits.data(), block_length, kVocabSize);
+
+        // Draft K/V for the seed is valid base-model state; noise suffix rows
+        // are temporary and become invisible before verification.
+        cache_->rollback(cycle_start + 1);
+        run_block(proposals, std::vector<float>(static_cast<std::size_t>(block_length), 0.0F),
+                  logits);
+        ++stats.forwards;
+        const auto verifier = k2_horizon_uno_argmax_rows(logits.data(), block_length, kVocabSize);
+
+        auto decision = k2_horizon_uno_decide_greedy_commit(proposals, verifier);
+        if (decision.all_draft_tokens_accepted && block_length > 1)
+            ++stats.lookaheads;
+        k2_horizon_uno_truncate_commit(decision.tokens, static_cast<std::size_t>(remaining),
+                                       eos_ids);
+        if (decision.tokens.empty())
+            throw std::runtime_error("K2-Horizon-Uno produced an empty verified commit");
+
+        cache_->rollback(k2_horizon_uno_retained_kv_position(cycle_start, decision.tokens.size()));
+        generated_tokens += checked_size_to_int32(decision.tokens.size(), "commit length");
+        stats.committed_tokens += checked_size_to_int32(decision.tokens.size(), "commit length");
+        output.insert(output.end(), decision.tokens.begin(), decision.tokens.end());
+        seed_token = decision.tokens.back();
+    }
+
+    const auto decode_end = Clock::now();
+    return TimedGenResult{
+        std::move(output),
+        std::chrono::duration<double, std::milli>(prefill_end - prefill_start).count(),
+        std::chrono::duration<double, std::milli>(decode_end - decode_start).count(), stats};
+}
+
+void K2HorizonUnoTextGenerationPipeline::reset_generation_context() {
+    const auto start = std::chrono::steady_clock::now();
+    cache_->reset();
+    decoder_->reset_execution_context();
+    cache_->bind_to(*decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+}
+
+void K2HorizonUnoTextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
+                                                     std::vector<float>& logits) {
+    const std::size_t chunk = kMaximumBlockLength;
+    std::size_t offset = 0;
+    while (input_ids.size() - offset > 1) {
+        const std::size_t rows = std::min(chunk, input_ids.size() - offset - 1);
+        const auto begin = input_ids.begin() + static_cast<std::ptrdiff_t>(offset);
+        const std::vector<int32_t> tokens(begin, begin + static_cast<std::ptrdiff_t>(rows));
+        run_block(tokens, std::vector<float>(rows, 0.0F), logits);
+        offset += rows;
+    }
+    // Keep the final row isolated because seed selection consumes logits row zero.
+    run_block({input_ids[offset]}, {0.0F}, logits);
+}
+
+void K2HorizonUnoTextGenerationPipeline::run_block(const std::vector<int32_t>& token_ids,
+                                                   const std::vector<float>& lora_mask,
+                                                   std::vector<float>& logits) {
+    if (token_ids.empty() || token_ids.size() != lora_mask.size() ||
+        token_ids.size() > static_cast<std::size_t>(kMaximumBlockLength)) {
+        throw std::invalid_argument("K2-Horizon-Uno block input contract is invalid");
+    }
+    const int32_t rows = checked_size_to_int32(token_ids.size(), "block length");
+    TensorMap inputs;
+    inputs["token_id"] = Tensor{const_cast<int32_t*>(token_ids.data()), {rows}, DType::kInt32};
+    inputs["lora_mask"] = Tensor{const_cast<float*>(lora_mask.data()), {rows}, DType::kFloat32};
+    cache_->prepare_block(inputs, rows);
+
+    const TensorMap outputs = decoder_->forward(inputs);
+    const auto found = outputs.find("logits");
+    if (found == outputs.end() || found->second.dtype != DType::kFloat32 ||
+        found->second.shape != std::vector<int64_t>{rows, kVocabSize}) {
+        throw std::runtime_error(
+            "K2-Horizon-Uno engine must return float32 full logits [S,vocab_size]");
+    }
+    const auto count = static_cast<std::size_t>(rows) * static_cast<std::size_t>(kVocabSize);
+    logits.resize(count);
+    std::memcpy(logits.data(), found->second.data, count * sizeof(float));
+    cache_->advance(rows);
+}
+
+std::vector<int32_t>
+K2HorizonUnoTextGenerationPipeline::effective_eos_ids(const TextGenerationConfig& cfg) const {
+    std::vector<int32_t> result = cfg.eos_token_id >= 0 ? std::vector<int32_t>{cfg.eos_token_id}
+                                                        : std::vector<int32_t>{1, 250019};
+    k2_horizon_uno_validate_eos_token_ids(result, kVocabSize);
+    return result;
+}
+
+void K2HorizonUnoTextGenerationPipeline::log_decode_receipt(const DecodeStats& stats) const {
+    std::cerr << k2_horizon_uno_format_decode_receipt(stats.mode, stats.block_length,
+                                                      "deterministic_uniform", stats.forwards,
+                                                      stats.committed_tokens, stats.lookaheads)
+              << '\n';
+}
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/pipeline.h
+++ b/families/k2_horizon_uno/runtime/pipeline.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "families/k2_horizon_uno/runtime/algorithm.h"
+#include "families/k2_horizon_uno/runtime/kv_cache.h"
+#include "families/k2_horizon_uno/runtime/tokenizer.h"
+#include "trtmc/runtime/trt_module.h"
+#include "trtmc/task.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class K2HorizonUnoTextGenerationPipeline final : public ITextGeneration {
+  public:
+    K2HorizonUnoTextGenerationPipeline(std::unique_ptr<ITrtModule> decoder,
+                                       std::unique_ptr<K2HorizonUnoKvCache> cache,
+                                       std::shared_ptr<ITokenizer> tokenizer = nullptr);
+
+    TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
+    int32_t default_max_new_tokens() const override { return 128; }
+
+  private:
+    struct DecodeStats {
+        K2HorizonUnoGenerationMode mode{K2HorizonUnoGenerationMode::kLinearPsiSpec};
+        int32_t block_length{1};
+        int32_t forwards{0};
+        int32_t committed_tokens{0};
+        int32_t lookaheads{0};
+    };
+
+    struct TimedGenResult {
+        std::vector<int32_t> token_ids;
+        double prefill_ms{0.0};
+        double decode_ms{0.0};
+        DecodeStats stats;
+    };
+
+    TimedGenResult generate_from_ids(const std::vector<int32_t>& input_ids,
+                                     const TextGenerationConfig& cfg);
+    TimedGenResult generate_ar(const std::vector<int32_t>& input_ids,
+                               const TextGenerationConfig& cfg,
+                               const K2HorizonUnoResolvedGenerateConfig& resolved);
+    TimedGenResult generate_linear_psi_spec(const std::vector<int32_t>& input_ids,
+                                            const TextGenerationConfig& cfg,
+                                            const K2HorizonUnoResolvedGenerateConfig& resolved);
+
+    void reset_generation_context();
+    void run_prefill(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    void run_block(const std::vector<int32_t>& token_ids, const std::vector<float>& lora_mask,
+                   std::vector<float>& logits);
+    std::vector<int32_t> effective_eos_ids(const TextGenerationConfig& cfg) const;
+    void log_decode_receipt(const DecodeStats& stats) const;
+
+    std::unique_ptr<ITrtModule> decoder_;
+    std::unique_ptr<K2HorizonUnoKvCache> cache_;
+    std::shared_ptr<ITokenizer> tokenizer_;
+    double last_setup_ms_{0.0};
+};
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/runtime/plugin.cpp
+++ b/families/k2_horizon_uno/runtime/plugin.cpp
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/chat_template.h"
+#include "families/k2_horizon_uno/runtime/kv_cache.h"
+#include "families/k2_horizon_uno/runtime/pipeline.h"
+#include "families/k2_horizon_uno/runtime/runtime_config.h"
+#include "families/k2_horizon_uno/runtime/tokenizer.h"
+#include "trtmc/bundle.h"
+#include "trtmc/runtime/family_factory.h"
+#include "trtmc/runtime/trt_backend.h"
+
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace trtmc::k2_horizon_uno {
+namespace {
+
+constexpr std::int32_t kMaximumBlockLength = 8;
+constexpr std::int32_t kVocabSize = 250624;
+constexpr std::int32_t kNumLayers = 36;
+constexpr std::int32_t kMaxPositionEmbeddings = 524288;
+
+std::vector<char> require_section(const BundleReader& bundle, std::string_view name) {
+    const auto* section = bundle.find_section(name);
+    if (section == nullptr || section->length == 0)
+        throw std::runtime_error("K2-Horizon-Uno bundle section is missing or empty: " +
+                                 std::string(name));
+    return bundle.read_section(name);
+}
+
+std::string require_text_section(const BundleReader& bundle, std::string_view name) {
+    const auto data = require_section(bundle, name);
+    return {data.begin(), data.end()};
+}
+
+std::unique_ptr<ITrtModule> load_engine(IBackend& backend, const std::vector<char>& plan) {
+    const auto start = std::chrono::steady_clock::now();
+    auto module = backend.create_module(plan.data(), plan.size(), {});
+    const auto elapsed =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+    std::ostringstream receipt;
+    receipt << std::fixed << std::setprecision(6)
+            << "[trtmc.load_timing] label=\"k2_horizon_uno.engine.plan\" load_deserialize_ms="
+            << elapsed << " plan_bytes=" << plan.size() << '\n';
+    std::cerr << receipt.str();
+    if (module == nullptr || !module->ok())
+        throw std::runtime_error("K2-Horizon-Uno failed to load engine.plan");
+    module->set_timing_label("k2_horizon_uno.engine.plan");
+    return module;
+}
+
+std::shared_ptr<ITokenizer> create_tokenizer(const BundleReader& bundle) {
+    const auto data = require_section(bundle, "tokenizer.json");
+    auto tokenizer = CreateK2HorizonUnoBpeTokenizer(data.data(), data.size(), true);
+    if (tokenizer == nullptr)
+        throw std::runtime_error("K2-Horizon-Uno native BPE tokenizer construction failed");
+    return std::shared_ptr<ITokenizer>(std::move(tokenizer));
+}
+
+std::int32_t parse_max_cache_length(std::string_view text) {
+    nlohmann::json json;
+    try {
+        json = nlohmann::json::parse(text);
+    } catch (const nlohmann::json::exception& error) {
+        throw std::runtime_error("K2-Horizon-Uno invalid runtime.json: " +
+                                 std::string(error.what()));
+    }
+    if (!json.is_object() || json.size() != 1)
+        throw std::runtime_error("K2-Horizon-Uno runtime.json must contain only max_cache_length");
+    std::int64_t max_cache_length;
+    try {
+        const auto& value = json.at("max_cache_length");
+        if (!value.is_number_integer())
+            throw std::runtime_error("K2-Horizon-Uno runtime.json has invalid max_cache_length");
+        max_cache_length = value.get<std::int64_t>();
+    } catch (const nlohmann::json::exception&) {
+        throw std::runtime_error("K2-Horizon-Uno runtime.json has invalid max_cache_length");
+    }
+    if (max_cache_length < kMaximumBlockLength || max_cache_length > kMaxPositionEmbeddings)
+        throw std::runtime_error("K2-Horizon-Uno runtime.json has invalid max_cache_length");
+    return static_cast<std::int32_t>(max_cache_length);
+}
+
+K2HorizonUnoKvCacheNames make_cache_names() {
+    K2HorizonUnoKvCacheNames names;
+    for (std::int32_t layer = 0; layer < kNumLayers; ++layer) {
+        const auto suffix = std::to_string(layer);
+        names.cache_k.push_back("cache_k_" + suffix);
+        names.cache_v.push_back("cache_v_" + suffix);
+        names.present_k.push_back("present_k_" + suffix);
+        names.present_v.push_back("present_v_" + suffix);
+    }
+    return names;
+}
+
+void require_dynamic_vector_input(const ITrtModule& module, const std::string& name, DType dtype) {
+    if (!module.has_input(name) || module.tensor_dtype(name) != dtype ||
+        !module.input_is_dynamic(name) ||
+        module.input_profile_shape(name, 0, ProfileShapeSelector::kMin) !=
+            std::vector<std::int64_t>{1} ||
+        module.input_profile_shape(name, 0, ProfileShapeSelector::kMax) !=
+            std::vector<std::int64_t>{kMaximumBlockLength}) {
+        throw std::runtime_error("K2-Horizon-Uno dynamic input contract mismatch for '" + name +
+                                 "'");
+    }
+    const auto optimum = module.input_profile_shape(name, 0, ProfileShapeSelector::kOpt);
+    if (optimum.size() != 1 || optimum.front() < 1 || optimum.front() > kMaximumBlockLength) {
+        throw std::runtime_error("K2-Horizon-Uno input profile optimum is invalid for '" + name +
+                                 "'");
+    }
+}
+
+std::set<std::string> tensor_names(const std::vector<TensorInfo>& tensors) {
+    std::set<std::string> result;
+    for (const auto& tensor : tensors)
+        result.insert(tensor.name);
+    return result;
+}
+
+void validate_engine(const ITrtModule& module, const K2HorizonUnoKvCacheNames& cache_names) {
+    if (module.optimization_profile_count() != 1)
+        throw std::runtime_error("K2-Horizon-Uno requires exactly one optimization profile");
+    require_dynamic_vector_input(module, "token_id", DType::kInt32);
+    require_dynamic_vector_input(module, "position_id", DType::kInt32);
+    require_dynamic_vector_input(module, "lora_mask", DType::kFloat32);
+    if (!module.has_output("logits") || module.tensor_dtype("logits") != DType::kFloat32 ||
+        module.tensor_shape("logits") !=
+            std::vector<std::int64_t>{kMaximumBlockLength, kVocabSize}) {
+        throw std::runtime_error("K2-Horizon-Uno logits must be dynamic float32 [S,vocab_size]");
+    }
+
+    std::set<std::string> expected_inputs{"token_id", "position_id", "cache_write_indices",
+                                          "key_value_lengths", "lora_mask"};
+    expected_inputs.insert(cache_names.cache_k.begin(), cache_names.cache_k.end());
+    expected_inputs.insert(cache_names.cache_v.begin(), cache_names.cache_v.end());
+    std::set<std::string> expected_outputs{"logits"};
+    expected_outputs.insert(cache_names.present_k.begin(), cache_names.present_k.end());
+    expected_outputs.insert(cache_names.present_v.begin(), cache_names.present_v.end());
+    if (tensor_names(module.input_info()) != expected_inputs ||
+        tensor_names(module.output_info()) != expected_outputs) {
+        throw std::runtime_error("K2-Horizon-Uno engine I/O inventory is not exact");
+    }
+}
+
+void validate_chat_tokenizer(const ITokenizer& tokenizer) {
+    constexpr std::int32_t im_start = 250018;
+    constexpr std::int32_t im_end = 250019;
+    constexpr std::int32_t think = 250029;
+    if (tokenizer.id_for_token("<|ifm|begin_of_text|>") != 0 ||
+        tokenizer.id_for_token("<|ifm|im_start|>") != im_start ||
+        tokenizer.id_for_token("<|ifm|im_end|>") != im_end ||
+        tokenizer.id_for_token("<ifm|think>") != think) {
+        throw std::runtime_error("K2-Horizon-Uno chat protocol token IDs are inconsistent");
+    }
+    const auto probe = tokenizer.encode(
+        k2_horizon_uno_apply_chat_template(kK2HorizonUnoPublisherChatTemplateFormat, "", "high"));
+    const std::vector<std::int32_t> expected{0,        im_start, 2672, 200,   im_end,
+                                             im_start, 142036,   200,  think, 200};
+    if (probe != expected)
+        throw std::runtime_error("K2-Horizon-Uno tokenizer chat framing is inconsistent");
+
+    const std::vector<std::pair<std::string, std::vector<std::int32_t>>> ascii_probes{
+        {"IT'S", {0, 1938, 17456}},
+        {"'z", {0, 180302}},
+        {"\t.A", {0, 199, 6197}},
+    };
+    for (const auto& [text, token_ids] : ascii_probes) {
+        if (tokenizer.encode(text) != token_ids) {
+            throw std::runtime_error(
+                "K2-Horizon-Uno tokenizer ASCII pre-tokenization is inconsistent");
+        }
+    }
+}
+
+} // namespace
+
+void validate_runtime_config_json(std::string_view json) {
+    (void)parse_max_cache_length(json);
+}
+
+ITask* create(const FamilyContext& context) {
+    const char* backend_name = context.backend.name();
+    if (backend_name == nullptr || std::string(backend_name) != "trt")
+        throw std::runtime_error("K2-Horizon-Uno requires the TensorRT backend");
+
+    const auto max_cache_length =
+        parse_max_cache_length(require_text_section(context.reader, "runtime.json"));
+    (void)require_section(context.reader, "chat_template.jinja");
+    auto tokenizer = create_tokenizer(context.reader);
+    validate_chat_tokenizer(*tokenizer);
+
+    auto decoder = load_engine(context.backend, require_section(context.reader, "engine.plan"));
+    auto cache_names = make_cache_names();
+    validate_engine(*decoder, cache_names);
+    auto cache = std::make_unique<K2HorizonUnoKvCache>(max_cache_length, decoder->stream(),
+                                                       std::move(cache_names));
+    if (!cache->ok())
+        throw std::runtime_error("K2-Horizon-Uno KV allocation failed");
+    cache->bind_to(*decoder);
+
+    return new K2HorizonUnoTextGenerationPipeline(std::move(decoder), std::move(cache),
+                                                  std::move(tokenizer));
+}
+
+} // namespace trtmc::k2_horizon_uno
+
+extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
+    if (context.kv_cache_size_bytes != 0)
+        throw std::invalid_argument("k2_horizon_uno does not support --kv-cache-size");
+    return trtmc::k2_horizon_uno::create(context);
+}

--- a/families/k2_horizon_uno/runtime/runtime_config.h
+++ b/families/k2_horizon_uno/runtime/runtime_config.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace trtmc::k2_horizon_uno {
+
+// Testable boundary for the bundle-owned KV capacity.
+void validate_runtime_config_json(std::string_view json);
+
+} // namespace trtmc::k2_horizon_uno

--- a/families/k2_horizon_uno/runtime/tokenizer.h
+++ b/families/k2_horizon_uno/runtime/tokenizer.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc {
+
+class ITokenizer {
+  public:
+    virtual ~ITokenizer() = default;
+    virtual std::vector<std::int32_t> encode(const std::string& text) const = 0;
+    virtual std::string decode(const std::vector<std::int32_t>& ids) const = 0;
+    virtual std::int32_t id_for_token(std::string_view token) const = 0;
+    virtual std::string token_for_id(std::int32_t id) const = 0;
+};
+
+void k2_horizon_uno_require_ascii_tokenizer_input(std::string_view text);
+std::string k2_horizon_uno_utf8_lossy(std::string_view bytes);
+
+std::unique_ptr<ITokenizer> CreateK2HorizonUnoBpeTokenizer(const char* tokenizer_json_data,
+                                                           std::size_t tokenizer_json_size,
+                                                           bool add_special_tokens = false);
+
+} // namespace trtmc

--- a/families/k2_horizon_uno/support.py
+++ b/families/k2_horizon_uno/support.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned model and task support for K2-Horizon-Uno."""
+
+from tensorrt_model_connect.model_support import FamilySupport, ModelMetadata
+
+
+_SUPPORT = FamilySupport(tasks=("text_generation",), default_task="text_generation")
+_FILES = ("adapter_config.json", "adapter_model.safetensors")
+
+
+def describe(metadata: ModelMetadata) -> FamilySupport | None:
+    """Select the two-file adapter snapshot; build validates its exact recipe."""
+
+    return _SUPPORT if metadata.files == _FILES else None

--- a/families/k2_horizon_uno/tests/__init__.py
+++ b/families/k2_horizon_uno/tests/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""K2-Horizon-Uno family tests and checkpoint evidence."""

--- a/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_algorithm.cpp
+++ b/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_algorithm.cpp
@@ -1,0 +1,269 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/algorithm.h"
+#include "families/k2_horizon_uno/runtime/kv_cache.h"
+#include "trtmc/task.h"
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+template <typename Callable>
+bool rejects(Callable&& callable) {
+    try {
+        callable();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+template <typename Callable>
+bool accepts(Callable&& callable) {
+    try {
+        callable();
+    } catch (const std::exception&) {
+        return false;
+    }
+    return true;
+}
+
+void test_generation_modes_and_bounds() {
+    trtmc::TextGenerationConfig config;
+    trtmc::K2HorizonUnoResolvedGenerateConfig resolved;
+    check(accepts([&] { resolved = trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "default generation config is accepted");
+    check(resolved.mode == trtmc::K2HorizonUnoGenerationMode::kLinearPsiSpec,
+          "auto selects linear Psi-Spec");
+    check(resolved.block_length == 8, "auto uses publisher block length eight");
+
+    for (const std::string mode :
+         {"uno", "linear_psi_spec", "linear-psi-spec", "linear_spec_lora"}) {
+        config.text_generation_mode = mode;
+        config.block_length = 4;
+        check(accepts([&] { resolved = trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+              "Uno generation aliases are accepted");
+        check(resolved.mode == trtmc::K2HorizonUnoGenerationMode::kLinearPsiSpec,
+              "Uno mode alias resolves to Psi-Spec");
+        check(resolved.block_length == 4, "explicit block length is retained");
+    }
+
+    config = {};
+    config.text_generation_mode = "ar";
+    check(accepts([&] { resolved = trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "AR generation config is accepted");
+    check(resolved.mode == trtmc::K2HorizonUnoGenerationMode::kAutoregressive,
+          "AR control resolves independently");
+    check(resolved.block_length == 1, "AR always uses one row");
+
+    config = {};
+    config.block_length = 9;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "block length above engine profile is rejected");
+    config.text_generation_mode = "ar";
+    config.block_length = 2;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "AR rejects multi-row block request");
+    config = {};
+    config.text_generation_mode = "diffusion";
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "unrelated diffusion mode is rejected");
+}
+
+void test_request_surface_fails_closed() {
+    trtmc::TextGenerationConfig config;
+    config.top_k = 2;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "stochastic sampling is rejected");
+
+    config = {};
+    config.top_p = 0.9F;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "active nucleus sampling overrides the default top-k one");
+
+    config = {};
+    config.top_k = 1;
+    config.top_p = 1.0F;
+    check(accepts([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "default top-k one is accepted");
+
+    config = {};
+    config.temperature = 0.0F;
+    config.top_k = 50;
+    config.top_p = 0.9F;
+    check(accepts([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "temperature-zero greedy config is accepted");
+
+    config = {};
+    config.top_k = 50;
+    config.top_p = 0.0F;
+    check(accepts([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "top-p-zero greedy config is accepted");
+
+    config = {};
+    config.lora_adapter_id = "external";
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "external LoRA selection is rejected");
+    config = {};
+    config.seed = 0;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "deterministic noise rejects a silent seed override");
+    config = {};
+    config.confidence_threshold = 0.9F;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "confidence-transfer decoding is rejected");
+    config = {};
+    config.use_chat_template = true;
+    config.enable_thinking = false;
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_resolve_generate_config(config); }),
+          "non-high chat reasoning is rejected");
+}
+
+void test_row_gate_is_exact() {
+    const auto mask = trtmc::k2_horizon_uno_draft_lora_mask(8);
+    check(mask.size() == 8 && mask.front() == 0.0F, "causal seed has LoRA disabled");
+    bool noise_enabled = true;
+    for (std::size_t index = 1; index < mask.size(); ++index)
+        noise_enabled = noise_enabled && mask[index] == 1.0F;
+    check(noise_enabled, "all noise rows have LoRA enabled");
+}
+
+void test_official_deterministic_uniform_golden() {
+    // Golden values were computed independently with BigInt arithmetic from
+    // ifm-ai/uno noise.py's explicit modulo-2^64 formula.
+    const std::vector<int32_t> prompt{0, 250018, 2672, 200, 3749};
+    const auto noise = trtmc::k2_horizon_uno_deterministic_uniform_noise(
+        prompt, /*completion_token_count=*/5, /*seed_token=*/12345,
+        /*total_sequence_length=*/10, /*count=*/7, /*vocab_size=*/250624);
+    check(noise == std::vector<int32_t>({92094, 225933, 112692, 93512, 180152, 155240, 168818}),
+          "deterministic_uniform matches the independent official-formula golden");
+
+    const auto small = trtmc::k2_horizon_uno_deterministic_uniform_noise(
+        {1, 2, 3}, /*completion_token_count=*/1, /*seed_token=*/7,
+        /*total_sequence_length=*/4, /*count=*/3, /*vocab_size=*/32);
+    check(small == std::vector<int32_t>({29, 20, 29}),
+          "deterministic_uniform preserves modulo arithmetic at small vocabulary");
+    check(rejects([] {
+              (void)trtmc::k2_horizon_uno_deterministic_uniform_noise(
+                  {1, 2, 3}, 1, 7, /*inconsistent total=*/5, 3, 32);
+          }),
+          "deterministic_uniform rejects inconsistent sequence accounting");
+}
+
+void test_greedy_verification_commits_correction_or_lookahead() {
+    auto decision = trtmc::k2_horizon_uno_decide_greedy_commit({10, 20, 30}, {21, 31, 41});
+    check(decision.tokens == std::vector<int32_t>({10, 21}),
+          "first rejection commits clean plus correction");
+    check(decision.accepted_draft_tokens == 0 && !decision.all_draft_tokens_accepted,
+          "first rejection reports zero accepted future drafts");
+
+    decision = trtmc::k2_horizon_uno_decide_greedy_commit({10, 20, 30}, {20, 31, 41});
+    check(decision.tokens == std::vector<int32_t>({10, 20, 31}),
+          "accepted prefix precedes verified correction");
+    check(decision.accepted_draft_tokens == 1 && !decision.all_draft_tokens_accepted,
+          "one accepted future draft is counted");
+
+    decision = trtmc::k2_horizon_uno_decide_greedy_commit({10, 20, 30}, {20, 30, 40});
+    check(decision.tokens == std::vector<int32_t>({10, 20, 30, 40}),
+          "full acceptance appends verifier lookahead");
+    check(decision.accepted_draft_tokens == 2 && decision.all_draft_tokens_accepted,
+          "full future draft acceptance is reported");
+}
+
+void test_commit_truncation_and_retained_kv_frontier() {
+    std::vector<int32_t> tokens{10, 20, 1, 40};
+    trtmc::k2_horizon_uno_truncate_commit(tokens, 4, {1, 250019});
+    check(tokens == std::vector<int32_t>({10, 20, 1}), "EOS is retained and terminates commit");
+    check(trtmc::k2_horizon_uno_retained_kv_position(12, tokens.size()) == 15,
+          "KV retains prior seed and all committed tokens except the last");
+
+    tokens = {10, 20, 30};
+    trtmc::k2_horizon_uno_truncate_commit(tokens, 2, {});
+    check(tokens == std::vector<int32_t>({10, 20}), "remaining generation budget truncates commit");
+}
+
+void test_eos_set_validation() {
+    trtmc::k2_horizon_uno_validate_eos_token_ids({1, 31}, 32);
+    check(rejects([] { trtmc::k2_horizon_uno_validate_eos_token_ids({}, 32); }),
+          "empty EOS set is rejected");
+    check(rejects([] { trtmc::k2_horizon_uno_validate_eos_token_ids({32}, 32); }),
+          "request EOS at vocabulary upper bound is rejected");
+    check(rejects([] { trtmc::k2_horizon_uno_validate_eos_token_ids({1, 1}, 32); }),
+          "duplicate EOS IDs are rejected");
+}
+
+void test_cache_cursor_rollback_contract() {
+    trtmc::K2HorizonUnoCacheCursor cursor(32);
+    cursor.advance(8);
+    check(cursor.position() == 8, "draft block advances cursor");
+    cursor.rollback(1);
+    check(cursor.position() == 1, "draft noise rollback retains seed row");
+    cursor.advance(3);
+    check(cursor.position() == 4, "verify block advances from retained seed");
+    cursor.rollback(3);
+    check(cursor.position() == 3, "commit rollback leaves final token uncached");
+    check(rejects([&] { cursor.rollback(4); }), "rollback cannot move frontier forward");
+    cursor.reset();
+    check(cursor.position() == 0, "cursor reset clears logical state");
+    check(rejects([&] { cursor.advance(9); }), "cursor rejects blocks above engine maximum");
+
+    // Three prompt rows plus five completion tokens fill capacity exactly.
+    // The first completion seed remains uncached: draft reaches 7, then
+    // retaining its seed and verifying four rows reaches 8, not 9.
+    trtmc::K2HorizonUnoCacheCursor boundary(8);
+    boundary.advance(3);
+    boundary.advance(4);
+    boundary.rollback(4);
+    boundary.advance(4);
+    check(boundary.position() == 8, "linear verify can reach exact KV capacity");
+}
+
+void test_argmax_and_receipt_contract() {
+    const float logits[] = {0.0F, 2.0F, 2.0F, 1.0F, -1.0F, 0.0F, 4.0F, 3.0F};
+    check(trtmc::k2_horizon_uno_argmax_rows(logits, 2, 4) == std::vector<int32_t>({1, 2}),
+          "row argmax uses lowest-index ties");
+    const float invalid[] = {0.0F, std::numeric_limits<float>::quiet_NaN()};
+    check(rejects([&] { (void)trtmc::k2_horizon_uno_argmax_rows(invalid, 1, 2); }),
+          "non-finite logits fail closed");
+
+    check(trtmc::k2_horizon_uno_format_decode_receipt(
+              trtmc::K2HorizonUnoGenerationMode::kLinearPsiSpec, 8, "deterministic_uniform", 6, 13,
+              2) == "[trtmc.k2_horizon_uno.decode] mode=linear_spec_lora block_length=8 "
+                    "noise_mode=deterministic_uniform forwards=6 committed_tokens=13 lookaheads=2",
+          "decode receipt has one stable aggregate-only format");
+}
+
+} // namespace
+
+int main() {
+    test_generation_modes_and_bounds();
+    test_request_surface_fails_closed();
+    test_row_gate_is_exact();
+    test_official_deterministic_uniform_golden();
+    test_greedy_verification_commits_correction_or_lookahead();
+    test_commit_truncation_and_retained_kv_frontier();
+    test_eos_set_validation();
+    test_cache_cursor_rollback_contract();
+    test_argmax_and_receipt_contract();
+    if (failures != 0) {
+        std::cerr << failures << " K2-Horizon-Uno algorithm test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_chat_template.cpp
+++ b/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_chat_template.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/chat_template.h"
+#include "families/k2_horizon_uno/runtime/tokenizer.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+template <typename Callable>
+bool rejects(Callable&& callable) {
+    try {
+        callable();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+template <typename Callable>
+bool accepts(Callable&& callable) {
+    try {
+        callable();
+    } catch (const std::exception&) {
+        return false;
+    }
+    return true;
+}
+
+void test_rendering_and_identity() {
+    check(std::string(trtmc::kK2HorizonUnoPublisherChatTemplateFormat) ==
+              "k2_horizon_uno_publisher_v1",
+          "publisher template format is pinned");
+    std::string rendered;
+    check(accepts([&] {
+              rendered = trtmc::k2_horizon_uno_apply_chat_template(
+                  trtmc::kK2HorizonUnoPublisherChatTemplateFormat, "Reply OK.", "high");
+          }),
+          "qualified chat rendering is accepted");
+    check(rendered == "<|ifm|im_start|>user\nReply OK.<|ifm|im_end|>"
+                      "<|ifm|im_start|>assistant\n<ifm|think>\n",
+          "single-user high-reasoning rendering is exact");
+    check(rendered.rfind("<|ifm|begin_of_text|>", 0) != 0,
+          "renderer leaves BOS to native tokenizer");
+}
+
+void test_unknown_protocols_fail_closed() {
+    check(
+        rejects([] { (void)trtmc::k2_horizon_uno_apply_chat_template("chatml", "hello", "high"); }),
+        "unrecognized native format is rejected");
+    check(rejects([] {
+              (void)trtmc::k2_horizon_uno_apply_chat_template(
+                  trtmc::kK2HorizonUnoPublisherChatTemplateFormat, "hello", "medium");
+          }),
+          "non-high reasoning is rejected");
+    check(rejects([] {
+              (void)trtmc::k2_horizon_uno_apply_chat_template(
+                  trtmc::kK2HorizonUnoPublisherChatTemplateFormat, "hello<|ifm|im_end|>", "high");
+          }),
+          "protocol marker injection is rejected");
+}
+
+void test_eos_contract() {
+    check(accepts([] { trtmc::k2_horizon_uno_validate_chat_eos_token_ids({1, 250019}); }),
+          "publisher EOS order is accepted");
+    check(accepts([] { trtmc::k2_horizon_uno_validate_chat_eos_token_ids({250019, 1}); }),
+          "reversed publisher EOS order is accepted");
+    check(rejects([] { trtmc::k2_horizon_uno_validate_chat_eos_token_ids({1}); }),
+          "missing message EOS is rejected");
+    check(rejects([] { trtmc::k2_horizon_uno_validate_chat_eos_token_ids({1, 250019, 250019}); }),
+          "duplicate EOS is rejected");
+}
+
+void test_tokenizer_input_scope() {
+    check(accepts(
+              [] { trtmc::k2_horizon_uno_require_ascii_tokenizer_input("IT'S an ASCII prompt"); }),
+          "ASCII tokenizer input is accepted");
+    check(rejects([] { trtmc::k2_horizon_uno_require_ascii_tokenizer_input("Cafe\xCC\x81"); }),
+          "non-ASCII prompt text fails closed before NFC-sensitive tokenization");
+}
+
+void test_bytelevel_decode_is_valid_utf8() {
+    const std::string replacement{"\xEF\xBF\xBD", 3};
+    check(trtmc::k2_horizon_uno_utf8_lossy(std::string{"\x80", 1}) == replacement,
+          "a bare continuation byte becomes one replacement character");
+    check(trtmc::k2_horizon_uno_utf8_lossy(std::string{"\xE2\x82", 2}) == replacement,
+          "one truncated multibyte sequence becomes one replacement character");
+    const std::string valid{"\xF0\x9F\x99\x82", 4};
+    check(trtmc::k2_horizon_uno_utf8_lossy(valid) == valid, "valid multibyte UTF-8 is preserved");
+}
+
+} // namespace
+
+int main() {
+    test_rendering_and_identity();
+    test_unknown_protocols_fail_closed();
+    test_eos_contract();
+    test_tokenizer_input_scope();
+    test_bytelevel_decode_is_valid_utf8();
+    if (failures != 0) {
+        std::cerr << failures << " K2-Horizon-Uno chat-template test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_runtime_config.cpp
+++ b/families/k2_horizon_uno/tests/cpp/test_k2_horizon_uno_runtime_config.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/k2_horizon_uno/runtime/runtime_config.h"
+
+#include <iostream>
+#include <string_view>
+
+namespace {
+
+int failures = 0;
+
+bool accepts(std::string_view json) {
+    try {
+        trtmc::k2_horizon_uno::validate_runtime_config_json(json);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    check(accepts(R"({"max_cache_length":256})"), "valid cache length is accepted");
+    check(!accepts(R"({})"), "missing cache length is rejected");
+    check(!accepts(R"({"max_cache_length":"256"})"), "wrong type is rejected");
+    check(!accepts(R"({"max_cache_length":256.9})"), "fractional cache length is rejected");
+    check(!accepts(R"({"max_cache_length":7})"), "cache shorter than one block is rejected");
+    check(!accepts(R"({"max_cache_length":524289})"), "model position limit is enforced");
+    check(!accepts(R"({"max_cache_length":256,"extra":true})"), "extra fields are rejected");
+    check(!accepts("{"), "invalid JSON is rejected");
+    return failures == 0 ? 0 : 1;
+}

--- a/families/k2_horizon_uno/tests/manifests/k2-horizon-7b-uno.json
+++ b/families/k2_horizon_uno/tests/manifests/k2-horizon-7b-uno.json
@@ -1,0 +1,70 @@
+{
+  "name": "k2-horizon-7b-uno",
+  "hf_id": "IFM/K2-Horizon-7B-Uno",
+  "hf_revision": "ec92bbd768f4a404319625204544782e3377bcd7",
+  "hf_dependencies": [
+    {
+      "repo_id": "IFM/K2-Horizon-7B",
+      "revision": "586b03f0fd1fbbf2f13eeafc33749e95ae34dd10"
+    }
+  ],
+  "bundle": "k2-horizon-7b-uno.bundle",
+  "family": "k2_horizon_uno",
+  "task": "text_generation",
+  "precision": "bf16",
+  "max_sequence_length": 256,
+  "tensor_parallel_size": 1,
+  "base_reference_trust_remote_code": true,
+  "testcases": [
+    {
+      "name": "k2-horizon-7b-uno-linear-psi-spec-l0",
+      "premerge": true,
+      "prompt": "Reply with the word OK.",
+      "max_new_tokens": 26,
+      "temperature": 0.0,
+      "top_k": 1,
+      "generation_mode": "linear_spec_lora",
+      "block_length": 8,
+      "use_chat_template": true,
+      "enable_thinking": true,
+      "expected_prompt_token_ids": [
+        0, 250018, 2672, 200, 42035, 458, 293, 5512, 19677, 15, 250019, 250018,
+        142036, 200, 250029, 200
+      ],
+      "expected_continuation_token_ids": [
+        864, 3318, 4943, 27, 322, 42035, 458, 293, 5512, 19677, 2818, 2953, 627,
+        1767, 9359, 458, 322, 8228, 2338, 2515, 4791, 3343, 15, 250030, 8228, 250019
+      ],
+      "expected_continuation_text": "The user says: \"Reply with the word OK.\" So we should respond with \"OK\". No extra text.</ifm|think>OK",
+      "expected_decode_mode": "linear_spec_lora",
+      "expected_forwards": 18,
+      "expected_committed_tokens": 26,
+      "expected_lookaheads": 1
+    },
+    {
+      "name": "k2-horizon-7b-uno-ar-control",
+      "premerge": false,
+      "prompt": "Reply with the word OK.",
+      "max_new_tokens": 26,
+      "temperature": 0.0,
+      "top_k": 1,
+      "generation_mode": "ar",
+      "block_length": 1,
+      "use_chat_template": true,
+      "enable_thinking": true,
+      "expected_prompt_token_ids": [
+        0, 250018, 2672, 200, 42035, 458, 293, 5512, 19677, 15, 250019, 250018,
+        142036, 200, 250029, 200
+      ],
+      "expected_continuation_token_ids": [
+        864, 3318, 4943, 27, 322, 42035, 458, 293, 5512, 19677, 2818, 2953, 627,
+        1767, 9359, 458, 322, 8228, 2338, 2515, 4791, 3343, 15, 250030, 8228, 250019
+      ],
+      "expected_continuation_text": "The user says: \"Reply with the word OK.\" So we should respond with \"OK\". No extra text.</ifm|think>OK",
+      "expected_decode_mode": "ar",
+      "expected_forwards": 25,
+      "expected_committed_tokens": 26,
+      "expected_lookaheads": 0
+    }
+  ]
+}

--- a/families/k2_horizon_uno/tests/test_e2e.py
+++ b/families/k2_horizon_uno/tests/test_e2e.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned checkpoint-to-native-runtime proof for K2-Horizon-Uno."""
+
+from __future__ import annotations
+
+import gc
+from importlib.metadata import version
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect import BuildRequest, build
+
+
+_TEST_DIR = Path(__file__).resolve().parent
+_FAMILY = _TEST_DIR.parent.name
+_DECODE_RECEIPT = re.compile(
+    r"^\[trtmc\.k2_horizon_uno\.decode\] "
+    r"mode=(ar|linear_spec_lora) block_length=([0-9]+) "
+    r"noise_mode=(deterministic_uniform) forwards=([0-9]+) "
+    r"committed_tokens=([0-9]+) lookaheads=([0-9]+)$"
+)
+
+
+def _load_cases() -> dict[str, tuple[dict, dict]]:
+    cases: dict[str, tuple[dict, dict]] = {}
+    for path in sorted((_TEST_DIR / "manifests").glob("*.json")):
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        assert manifest["family"] == _FAMILY, path
+        assert manifest["task"] == "text_generation", path
+        assert manifest["precision"] == "bf16", path
+        assert isinstance(manifest["max_sequence_length"], int), path
+        assert manifest["tensor_parallel_size"] == 1, path
+        assert isinstance(manifest["hf_dependencies"], list), path
+        for case in manifest["testcases"]:
+            name = case["name"]
+            assert name not in cases, name
+            cases[name] = (manifest, case)
+    assert cases, f"{_FAMILY} has no E2E cases"
+    return cases
+
+
+_CASES = _load_cases()
+
+
+def parse_decode_receipt(stderr: str) -> dict[str, int | str]:
+    matches = [
+        match
+        for line in stderr.splitlines()
+        if (match := _DECODE_RECEIPT.fullmatch(line.strip())) is not None
+    ]
+    if len(matches) != 1:
+        return {}
+    mode, block_length, noise_mode, forwards, committed_tokens, lookaheads = matches[0].groups()
+    return {
+        "mode": mode,
+        "block_length": int(block_length),
+        "noise_mode": noise_mode,
+        "forwards": int(forwards),
+        "committed_tokens": int(committed_tokens),
+        "lookaheads": int(lookaheads),
+    }
+
+
+def _csv_values(values: list[str]) -> set[str]:
+    return {item.strip() for value in values for item in str(value).split(",") if item.strip()}
+
+
+def _selection(config) -> set[str]:
+    selected = _csv_values(config.getoption("--e2e-model", default=[]) or [])
+    selected |= _csv_values(config.getoption("--e2e-testcase", default=[]) or [])
+    models_file = config.getoption("--e2e-models-file", default=None)
+    if models_file:
+        path = Path(models_file)
+        assert path.is_file(), f"E2E models file does not exist: {path}"
+        selected |= {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+    return selected
+
+
+def _require_selected(case_name: str, manifest: dict, config) -> None:
+    selected = _selection(config)
+    enabled = os.environ.get("TRTMC_E2E") == "1"
+    if not enabled and not selected:
+        pytest.skip("real family E2E requires TRTMC_E2E=1 or an explicit E2E selection")
+    if selected and not ({_FAMILY, manifest["name"], case_name} & selected):
+        pytest.skip(f"{case_name} was not selected")
+
+
+def _required_environment():
+    binary_value = os.environ.get("TRTMC_BINARY")
+    runtime_value = os.environ.get("TRTMC_RUNTIME_ROOT")
+    assert binary_value, "selected E2E requires TRTMC_BINARY"
+    assert runtime_value, "selected E2E requires TRTMC_RUNTIME_ROOT"
+    binary = Path(binary_value)
+    runtime_root = Path(runtime_value)
+    assert binary.is_file() and os.access(binary, os.X_OK), binary
+    assert runtime_root.is_dir(), runtime_root
+    assert (runtime_root / "libtrtmc_backend_trt.so").is_file(), runtime_root
+    assert (runtime_root / f"libtrtmc_model_{_FAMILY}.so").is_file(), runtime_root
+
+    import torch
+
+    assert torch.cuda.is_available(), "selected E2E requires CUDA"
+    return binary, runtime_root, torch
+
+
+def _snapshot(repo_id: str, revision: str) -> Path:
+    from huggingface_hub import snapshot_download
+
+    assert isinstance(revision, str) and len(revision) == 40
+    return Path(snapshot_download(repo_id=repo_id, revision=revision))
+
+
+def _checkpoints(manifest: dict) -> tuple[Path, Path]:
+    adapter = _snapshot(manifest["hf_id"], manifest["hf_revision"])
+    dependencies = manifest["hf_dependencies"]
+    assert len(dependencies) == 1
+    dependency = dependencies[0]
+    assert set(dependency) == {"repo_id", "revision"}
+    base = _snapshot(dependency["repo_id"], dependency["revision"])
+    assert (adapter / "adapter_config.json").is_file(), adapter
+    assert (adapter / "adapter_model.safetensors").is_file(), adapter
+    assert (base / "config.json").is_file(), base
+    return adapter, base
+
+
+def _build_bundle(manifest: dict, adapter: Path, bundle: Path) -> None:
+    build(
+        BuildRequest(
+            model_dir=adapter,
+            output_path=bundle,
+            family=_FAMILY,
+            task=manifest["task"],
+            precision=manifest["precision"],
+            max_sequence_length=manifest["max_sequence_length"],
+            tensor_parallel_size=manifest["tensor_parallel_size"],
+        )
+    )
+    assert bundle.is_file() and bundle.stat().st_size > 0, bundle
+
+
+def _native_arguments(bundle: Path, runtime_root: Path, case: dict) -> list[str]:
+    arguments = [
+        "run",
+        str(bundle),
+        "--runtime-root",
+        str(runtime_root),
+        "--prompt",
+        str(case["prompt"]),
+        "--max-new-tokens",
+        str(case["max_new_tokens"]),
+        "--temperature",
+        str(case["temperature"]),
+        "--top-k",
+        str(case["top_k"]),
+        "--generation-mode",
+        str(case["generation_mode"]),
+        "--block-length",
+        str(case["block_length"]),
+        "--use-chat-template",
+        "true" if case["use_chat_template"] else "false",
+        "--enable-thinking",
+        "true" if case["enable_thinking"] else "false",
+    ]
+    return arguments
+
+
+def _run_native(binary: Path, runtime_root: Path, bundle: Path, case: dict, tmp_path: Path):
+    command = [str(binary), *_native_arguments(bundle, runtime_root, case)]
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+    except subprocess.TimeoutExpired as error:
+        stderr = error.stderr or ""
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        log = tmp_path / "native-timeout.stderr.log"
+        log.write_text(str(stderr), encoding="utf-8")
+        raise RuntimeError(f"Uno native generation timed out; full stderr: {log}") from error
+    payload = json.loads(completed.stdout)
+    assert isinstance(payload, dict)
+    return payload, completed.stderr
+
+
+def _render_prompt(tokenizer, case: dict):
+    if not case["use_chat_template"]:
+        return tokenizer(case["prompt"], return_tensors="pt")
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": case["prompt"]}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=case["enable_thinking"],
+    )
+    return tokenizer(rendered, return_tensors="pt", add_special_tokens=False)
+
+
+def _base_reference(base: Path, manifest: dict, case: dict, torch):
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    trust_remote_code = manifest["base_reference_trust_remote_code"]
+    assert trust_remote_code is True
+    tokenizer = AutoTokenizer.from_pretrained(
+        base,
+        trust_remote_code=trust_remote_code,
+        local_files_only=True,
+    )
+    model = (
+        AutoModelForCausalLM.from_pretrained(
+            base,
+            dtype=torch.bfloat16,
+            trust_remote_code=trust_remote_code,
+            local_files_only=True,
+        )
+        .eval()
+        .to("cuda")
+    )
+    inputs = _render_prompt(tokenizer, case).to(model.device)
+    prompt_ids = [int(token) for token in inputs["input_ids"][0].tolist()]
+    assert prompt_ids == case["expected_prompt_token_ids"]
+    with torch.inference_mode():
+        generated = model.generate(
+            **inputs,
+            max_new_tokens=int(case["max_new_tokens"]),
+            do_sample=False,
+        )
+    continuation = [int(token) for token in generated[0, inputs["input_ids"].shape[1] :].tolist()]
+    text = tokenizer.decode(continuation, skip_special_tokens=True).strip()
+    del model
+    gc.collect()
+    torch.cuda.empty_cache()
+    return prompt_ids, continuation, text
+
+
+@pytest.mark.parametrize("case_name", sorted(_CASES))
+def test_e2e(case_name: str, request, tmp_path: Path) -> None:
+    manifest, case = _CASES[case_name]
+    _require_selected(case_name, manifest, request.config)
+    binary, runtime_root, torch = _required_environment()
+    assert version("transformers") == "5.15.0"
+    assert version("safetensors") == "0.8.0"
+    adapter, base = _checkpoints(manifest)
+    bundle = tmp_path / manifest["bundle"]
+    _build_bundle(manifest, adapter, bundle)
+
+    payload, stderr = _run_native(binary, runtime_root, bundle, case, tmp_path)
+    prompt_ids, reference_ids, reference_text = _base_reference(base, manifest, case, torch)
+    actual_ids = payload["token_ids"]
+    actual_text = str(payload["text"]).strip()
+
+    assert prompt_ids == case["expected_prompt_token_ids"]
+    assert actual_ids == reference_ids == case["expected_continuation_token_ids"]
+    assert actual_text == reference_text == case["expected_continuation_text"]
+    assert "[trtmc.k2_horizon_uno.prompt]" not in stderr
+    assert case["prompt"] not in stderr
+
+    stats = parse_decode_receipt(stderr)
+    assert stats == {
+        "mode": case["expected_decode_mode"],
+        "block_length": case["block_length"],
+        "noise_mode": "deterministic_uniform",
+        "forwards": case["expected_forwards"],
+        "committed_tokens": case["expected_committed_tokens"],
+        "lookaheads": case["expected_lookaheads"],
+    }
+    if case["generation_mode"] == "linear_spec_lora":
+        assert stats["committed_tokens"] > stats["forwards"]

--- a/families/k2_horizon_uno/tests/test_model.py
+++ b/families/k2_horizon_uno/tests/test_model.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect import BuildRequest
+from tensorrt_model_connect.model_support import ModelMetadata
+
+from families.k2_horizon_uno.checkpoint_mapper import (
+    _adapter_tensor_names,
+    _base_tensor_names,
+    _to_bf16_bits,
+    _validate_inventory,
+)
+from families.k2_horizon_uno.config import (
+    BASE_MODEL_ID,
+    LORA_TARGET_MODULES,
+    load_and_validate_adapter_config,
+    validate_config,
+)
+from families.k2_horizon_uno.support import describe
+
+
+def _adapter_recipe() -> dict:
+    return {
+        "base_model_name_or_path": BASE_MODEL_ID,
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": True,
+        "init_lora_weights": True,
+        "layers_pattern": None,
+        "layers_to_transform": None,
+        "loftq_config": {},
+        "lora_alpha": 8192.0,
+        "lora_dropout": 0.05,
+        "modules_to_save": None,
+        "peft_type": "LORA",
+        "r": 128,
+        "revision": None,
+        "target_modules": list(LORA_TARGET_MODULES),
+        "task_type": "CAUSAL_LM",
+    }
+
+
+def _base_config(**overrides) -> SimpleNamespace:
+    raw = {
+        "model_type": "k2_horizon",
+        "architectures": ["K2HorizonForCausalLM"],
+        "vocab_size": 250624,
+        "hidden_size": 4096,
+        "intermediate_size": 12288,
+        "num_hidden_layers": 36,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "rms_norm_eps": 1e-6,
+        "rope_parameters": {"rope_theta": 10_000_000.0, "rope_type": "default"},
+        "max_position_embeddings": 524288,
+        "hidden_act": "silu",
+        "dtype": "bfloat16",
+        "layernorm_num_groups": 4,
+    }
+    raw.update(overrides)
+    return SimpleNamespace(raw=raw, **raw)
+
+
+def _prepare_tracked_reimport(monkeypatch, module_name: str) -> None:
+    marker = ModuleType(f"{module_name}.__test_restore_marker__")
+    monkeypatch.setitem(sys.modules, module_name, marker)
+    monkeypatch.delitem(sys.modules, module_name)
+
+
+def _model_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "tensorrt", ModuleType("tensorrt"))
+    _prepare_tracked_reimport(monkeypatch, "families.k2_horizon_uno.native_kv_attention_builder")
+    _prepare_tracked_reimport(monkeypatch, "families.k2_horizon_uno.model")
+    return importlib.import_module("families.k2_horizon_uno.model")
+
+
+def test_support_matches_only_the_adapter_identity() -> None:
+    adapter = ModelMetadata({}, {}, ("adapter_config.json", "adapter_model.safetensors"))
+    assert describe(adapter).tasks == ("text_generation",)
+    assert describe(ModelMetadata({}, {}, ("adapter_config.json",))) is None
+    assert describe(ModelMetadata({}, {}, (*adapter.files, "README.md"))) is None
+
+
+def test_exact_base_config_and_adapter_recipe(tmp_path: Path) -> None:
+    resolved = validate_config(_base_config())
+    assert resolved.hidden_size == 4096
+    assert resolved.attention_size == 4096
+    assert resolved.kv_attention_size == 1024
+    assert resolved.lora_rank == 128
+    assert resolved.lora_scale == 64.0
+    assert resolved.max_block_size == 8
+
+    for field, value in (
+        ("model_type", "qwen"),
+        ("architectures", ["QwenForCausalLM"]),
+        ("hidden_size", 512),
+        ("num_hidden_layers", 35),
+        ("dtype", "float16"),
+        ("layernorm_num_groups", 1),
+    ):
+        with pytest.raises(ValueError):
+            validate_config(_base_config(**{field: value}))
+
+    adapter_config = tmp_path / "adapter_config.json"
+    adapter_config.write_text(json.dumps(_adapter_recipe()), encoding="utf-8")
+    assert load_and_validate_adapter_config(adapter_config)["target_modules"] == list(
+        LORA_TARGET_MODULES
+    )
+    changed = _adapter_recipe()
+    changed["r"] = 64
+    adapter_config.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="changed fields: r"):
+        load_and_validate_adapter_config(adapter_config)
+
+
+def test_checkpoint_tensor_inventories_are_closed() -> None:
+    assert len(_base_tensor_names(36)) == 327
+    adapter_names = _adapter_tensor_names(36)
+    assert len(adapter_names) == 504
+    assert "model.layers.0.self_attn.q_proj.lora_A.weight" in adapter_names
+    assert "model.layers.35.mlp.down_proj.lora_B.weight" in adapter_names
+    with pytest.raises(ValueError, match="unexpected=drift.weight"):
+        _validate_inventory(adapter_names | {"drift.weight"}, adapter_names, "adapter")
+
+
+def test_bf16_adapter_conversion_rounds_and_transposes() -> None:
+    source = np.array(
+        [[1.0 / 3.0, 1.0, -1.0 / 3.0], [2.0 / 3.0, 2.0, -2.0 / 3.0]],
+        dtype=np.float32,
+    )
+    bits = _to_bf16_bits(source, transpose=True)
+    expected = np.array(
+        [[0x3EAB, 0x3F2B], [0x3F80, 0x4000], [0xBEAB, 0xBF2B]],
+        dtype=np.uint16,
+    )
+    assert bits.dtype == np.uint16
+    assert bits.flags.c_contiguous
+    np.testing.assert_array_equal(bits, expected)
+
+
+def test_native_kv_constants_keep_the_exact_trt_buffer_alive(monkeypatch) -> None:
+    fake_trt = ModuleType("tensorrt")
+    fake_trt.Weights = lambda array: SimpleNamespace(array=array)
+    monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+    _prepare_tracked_reimport(monkeypatch, "families.k2_horizon_uno.native_kv_attention_builder")
+    helper = importlib.import_module("families.k2_horizon_uno.native_kv_attention_builder")
+
+    class Layer:
+        def get_output(self, index):
+            assert index == 0
+            return "constant"
+
+    class Network:
+        def add_constant(self, shape, weights):
+            assert shape == (2,)
+            self.weights = weights
+            return Layer()
+
+    network = Network()
+    keepalive = []
+    assert (
+        helper._constant(
+            network,
+            (2,),
+            np.array([1, 2], dtype=np.int64),
+            keepalive=keepalive,
+            dtype=np.dtype(np.int32),
+        )
+        == "constant"
+    )
+    assert len(keepalive) == 1
+    assert keepalive[0].dtype == np.int32
+    assert keepalive[0].flags.c_contiguous
+    assert network.weights.array is keepalive[0]
+
+
+def _build_request(adapter: Path, output: Path, **overrides) -> BuildRequest:
+    request = BuildRequest(
+        model_dir=adapter,
+        output_path=output,
+        family="k2_horizon_uno",
+        task="text_generation",
+        precision="bf16",
+        max_sequence_length=256,
+    )
+    return replace(request, **overrides)
+
+
+def test_build_resolves_separate_base_and_adapter_and_writes_exact_sections(
+    tmp_path: Path, monkeypatch
+) -> None:
+    model = _model_module(monkeypatch)
+    adapter = tmp_path / "adapter"
+    base = tmp_path / "base"
+    adapter.mkdir()
+    base.mkdir()
+    (adapter / "adapter_config.json").write_text(json.dumps(_adapter_recipe()), encoding="utf-8")
+    (adapter / "adapter_model.safetensors").write_bytes(b"adapter")
+    (base / "config.json").write_text(json.dumps(_base_config().raw), encoding="utf-8")
+    (base / "tokenizer.json").write_text("{}", encoding="utf-8")
+    (base / "chat_template.jinja").write_text("publisher template", encoding="utf-8")
+    captured = {}
+
+    def fake_weights(base_dir, adapter_dir, config):
+        captured.update(
+            base_dir=Path(base_dir),
+            adapter_dir=Path(adapter_dir),
+            config=config,
+        )
+        return {}
+
+    monkeypatch.setattr(model, "_resolve_base_model", lambda: base)
+    monkeypatch.setattr(model, "load_standard_weights", fake_weights)
+    monkeypatch.setattr(model, "build_engine", lambda *_args, **_kwargs: b"plan")
+
+    class Writer:
+        def __init__(self):
+            self.header = None
+            self.sections = {}
+
+        def set_header(self, **value):
+            self.header = value
+
+        def add_bytes(self, name, value):
+            self.sections[name] = value
+
+        def add_json(self, name, value):
+            self.sections[name] = value
+
+    writer = Writer()
+    model.build(_build_request(adapter, tmp_path / "model.bundle"), writer)
+
+    assert captured["base_dir"] == base
+    assert captured["adapter_dir"] == adapter
+    assert writer.header == {
+        "family": "k2_horizon_uno",
+        "task": "text_generation",
+        "backend": "trt",
+    }
+    assert {"engine.plan", "runtime.json", "tokenizer.json", "chat_template.jinja"} <= set(
+        writer.sections
+    )
+    runtime = writer.sections["runtime.json"]
+    assert runtime == {"max_cache_length": 256}
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("dynamic_kv_cache", True),
+        ("max_batch_size", 2),
+        ("tensor_parallel_size", 2),
+        ("context_parallel_size", 2),
+        ("backend", "trt_rtx"),
+        ("quantization", "fp8"),
+        ("fp32_layers", (0,)),
+    ],
+)
+def test_build_rejects_unsupported_request_fields(
+    tmp_path: Path, monkeypatch, field: str, value: object
+) -> None:
+    model = _model_module(monkeypatch)
+    adapter = tmp_path / "adapter"
+    adapter.mkdir()
+    request = _build_request(adapter, tmp_path / "model.bundle", **{field: value})
+    with pytest.raises((ValueError, NotImplementedError)):
+        model.build(request, SimpleNamespace())

--- a/website/docs/features/model-families.md
+++ b/website/docs/features/model-families.md
@@ -27,6 +27,45 @@ calls its plain `build(request, writer)` function. The family owns config and
 weight interpretation, TensorRT graph topology, precision/quantization policy,
 engine construction, and bundle-section semantics.
 
+### K2-Horizon-Uno task contract
+
+`IFM/K2-Horizon-7B-Uno` is an adapter-only checkpoint. The independent
+`k2_horizon_uno` family resolves its pinned `IFM/K2-Horizon-7B` base and
+compiles the rank-128 conditional LoRA into one BF16 TensorRT engine. Build it
+directly from the adapter ID:
+
+```bash
+python -m tensorrt_model_connect build IFM/K2-Horizon-7B-Uno \
+  --revision ec92bbd768f4a404319625204544782e3377bcd7 \
+  --precision bf16 \
+  -o k2-horizon-7b-uno.bundle
+```
+
+Run the qualified high-reasoning chat path with the family-owned linear mode:
+
+```bash
+trtmc run k2-horizon-7b-uno.bundle \
+  --runtime-root /opt/trtmc/lib \
+  --prompt "Reply with the word OK." \
+  --max-new-tokens 26 \
+  --temperature 0 \
+  --top-k 1 \
+  --generation-mode linear_spec_lora \
+  --block-length 8 \
+  --use-chat-template true \
+  --enable-thinking true
+```
+
+The initial runtime supports batch-one deterministic greedy generation with
+linear Psi-Spec and block lengths from 1 through 8. Block 8 is the qualified
+default. It also supports the pinned single-user, high-reasoning chat template
+and an autoregressive control mode. String prompts are currently limited to
+ASCII and fail closed before tokenization otherwise. Stochastic sampling, tree
+verification, batching, tensor parallelism, quantization, the 0.9B adapter, and
+long-context qualification remain outside this contract. The
+committed-token-per-forward receipt is an algorithmic diagnostic, not a
+wall-clock speedup claim.
+
 ## Runtime and validation
 
 The directory name is also the runtime DSO identity:


### PR DESCRIPTION
## Background

`IFM/K2-Horizon-7B-Uno` is an adapter-only conditional-LoRA checkpoint on
`IFM/K2-Horizon-7B`. Its row-gated LoRA and linear Psi-Spec decode contract do
not belong in the dense K2 family. After #1093, the integration belongs in one
independent physical family.

## Exit Criteria

- Add Uno without changing builder/runtime core or depending on another family.
- Build the pinned 7B base and rank-128 adapter into one BF16 TensorRT engine.
- Support deterministic batch-one linear Psi-Spec, an AR control, and the
  publisher high-reasoning chat framing.
- Match the pinned base-model greedy continuation exactly and never log prompt
  text or prompt token IDs.
- Fail closed for unsupported recipes, checkpoints, inputs, and build/runtime
  options. Do not present token/forward counts as wall-clock speedup evidence.

## Implementation

- Adds the self-contained `families/k2_horizon_uno` slice: support discovery,
  checkpoint validation, TensorRT graph build, native runtime, tokenizer, tests,
  and exact manifests.
- Uses the existing #1093 `ModelMetadata.files` contract; builder and runtime
  core are unchanged. Discovery matches the pinned two-file adapter snapshot,
  then the family validates the complete PEFT recipe before resolving the base.
- Pins the public base revision, validates the closed 327-base/504-adapter
  tensor inventories and every projection shape, and compiles all seven LoRA
  targets behind the row mask.
- Uses the existing `FamilyContext`, `BundleReader`, `ITrtModule`, and
  `ITextGeneration` contracts. Runtime metadata contains only KV capacity;
  fixed model properties remain family-owned constants.
- Specializes the native tokenizer to the pinned NFC + Qwen-regex + ByteLevel
  BPE schema. ASCII prompts are supported; non-ASCII prompts fail before
  tokenization. Decode follows Rust/Hugging Face lossy UTF-8 semantics so every
  generated token sequence remains valid JSON text.
- Bundles the pinned tokenizer and chat-template source, and provides separate
  linear Psi-Spec and AR paths with aggregate, prompt-free decode receipts.

There is no public API, core runtime ABI, or bundle-format change. Preview
bundles from earlier revisions of this unmerged PR must be rebuilt because the
new family-owned `runtime.json` is intentionally minimal.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=core/builder:. python3 -m tools.community_ci source-quality --base github/main`
  - Passed: 128 source/architecture tests.
- `PYTHONPATH=core/builder:. python3 -m tools.community_ci unit`
  - Passed from an exact-commit standalone clone: 327 Python/source tests and
    126 CPU CTests; five GPU-only CTests skipped as designed.
- `PYTHONPATH=core/builder:. python3 -m tools.model_ci validate`
  - Passed; `k2_horizon_uno` is in the physical family inventory.
- `PYTHONPATH=core/builder:. python3 -m tools.test_impact --validate`
  - Passed.
- Clean CMake/Ninja build of `trtmc`, `trtmc_backend_trt`, the Uno DSO, and all
  three Uno test targets passed; focused CTest passed 3/3, including the exact
  full-capacity draft/verify KV cursor boundary.
- Offline differential against the pinned Hugging Face tokenizer passed for
  51,371 ASCII encode/decode cases, 10,006 no-BOS encodes, all 250,624
  single-token decodes, 17,661 valid/invalid/truncated byte sequences, and
  20,001 random generated-ID sequences. Seven schema mutations and non-ASCII
  prompt input were rejected.
- A fresh 18.7 GB bundle built on GB300. The full linear E2E passed exact prompt
  IDs, continuation IDs, text, HF base-reference parity, and privacy checks.
  Final-DSO direct runs produced the same 26-token continuation in both modes:
  linear `forwards=18 committed_tokens=26 lookaheads=1`; AR
  `forwards=25 committed_tokens=26 lookaheads=0`.
- `python3 tools/legal_headers.py --check`
  - Passed with zero findings. Public-source, secret, host-path, artifact, and
    sibling-family isolation audits were clean.

### Hardware, Environment, and Revisions

- Repository head: `bde27ff06aabe0b44a0c373f25fdd14a860ab30c`
- Base/main: `54d6d566f1e1fba7aa476857c4fe9cb38bb24b59`
- Adapter: `IFM/K2-Horizon-7B-Uno@ec92bbd768f4a404319625204544782e3377bcd7`
- Base: `IFM/K2-Horizon-7B@586b03f0fd1fbbf2f13eeafc33749e95ae34dd10`
- NVIDIA GB300, Linux aarch64, CUDA 13.3, TensorRT 11.1.0.106, BF16
- Transformers 5.15.0 and safetensors 0.8.0 for build/reference qualification

### Not Run / Remaining Gaps

- Non-ASCII string prompts, stochastic sampling, tree verification, batching,
  tensor parallelism, quantization, the 0.9B adapter, and contexts above 256
  tokens are not qualified; unsupported paths fail closed.
- No matched wall-clock release benchmark was run. The committed-token receipt
  is an algorithmic diagnostic only.
- The isolated reference loads the pinned base with repository code because the
  upstream architecture requires it. Production build/runtime do not execute
  repository code.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Three independent reviews covered Python build/discovery, C++ runtime/KV and
tokenization, and public-information/isolation boundaries. All blocking
findings were fixed before final validation.

## Notes For Future Readers

Review `support.py` and `model.py` first, then the algorithm/KV lifecycle, then
the tokenizer and manifest-driven E2E. The current public adapter revision has
exactly `adapter_config.json` and `adapter_model.safetensors`; another snapshot
with the identical two-file shape would be routed here and rejected by the full
recipe check. Exact discovery without a core hook requires an upstream unique
marker. The model revision pin is the trust boundary for full vocab/merge
contents. Keep this family isolated from `k2_horizon`, Qwen, and diffusion
families.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The family is isolated and fail-closed, but it adds a large BF16 engine, custom
byte-level tokenization, and two-pass KV accounting. Exact HF parity, exhaustive
tokenizer differential, an AR control, focused C++ tests, and full CPU CI bound
that risk.
