### PR TITLE
docs(readme): restore community landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,127 +2,194 @@
 
 <h1>TensorRT-Model-Connect</h1>
 
-<p><strong>Self-contained model families that build TensorRT bundles and implement native C++ task APIs.</strong></p>
+<p><strong>Deploy supported Hugging Face models for end-to-end TensorRT inference in just two commands.</strong></p>
 
-[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;|&nbsp;&nbsp;[Supported Models](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;|&nbsp;&nbsp;[Architecture](https://nvidia.github.io/TensorRT-Model-Connect/architecture/ai-native-horizontal-scaling)
+[Documentation](https://nvidia.github.io/TensorRT-Model-Connect/)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Model Support](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[API Reference](https://nvidia.github.io/TensorRT-Model-Connect/api/python-builder)
 
 </div>
 
-## Architecture
+> **Public Preview** — TensorRT-Model-Connect is evolving rapidly and is
+> intended for evaluation and feedback. APIs, scope, and direction may change.
+> See [Project status](#project-status).
 
-Every model family is one complete vertical slice:
+<a id="news-and-updates"></a>
 
-```text
-families/<family>/
-├── support.py        # checkpoint ownership + supported/default tasks
-├── model.py          # plain build(request, writer); inheritance forbidden
-├── requirements.txt  # optional family-owned build/reference/test dependencies
-├── runtime/          # one libtrtmc_model_<family>.so
-└── tests/            # family-owned manifests and validation
-```
+## 📰 News and Updates
 
-The shared core is intentionally narrow. Python reads standard Hugging Face
-metadata, asks every lightweight family `support.py`, requires exactly one
-owner, and imports only that family's `model.py`. C++ reads the bundle header,
-loads exactly the named backend and family DSO, and returns an abstract
-interface from `trtmc/task.h`. Family implementations depend on those
-interfaces; they do not depend on each other.
+<!-- Newest first. Keep no more than the three most recent entries. -->
 
-There is no central model registry, runtime-strategy switch, builder base
-class, compatibility layer, or fallback path.
+- **2026-08-23 · Blog** — [AI-Native by Design: What We Learned Building
+  TensorRT-Model-Connect](https://nvidia.github.io/TensorRT-Model-Connect/blog/ai-native-by-design)
+- **2026-08-18 · Announcement** — [TensorRT-Model-Connect enters public
+  preview](https://x.com/NVIDIAAI/status/2089750360869233059)
 
-GPU build/reference/E2E environments use one pinned base image. A family may
-add a plain `requirements.txt` in its own directory; changing it does not
-publish another image digest or modify a central dependency registry.
+<a id="example-code"></a>
 
-## Build a bundle
+## 💻 Example Code
 
 ```bash
-python -m tensorrt_model_connect build openai-community/gpt2 \
-  --precision fp16 \
-  --output gpt2.bundle
+python -m tensorrt_model_connect build Qwen/Qwen3-0.6B \
+  --max-sequence-length 16384 \
+  --output qwen3-0.6b.bundle
+trtmc run ./qwen3-0.6b.bundle \
+  --runtime-root /opt/trtmc/lib \
+  --prompt "What is the capital of France? Answer in one word." \
+  --use-chat-template true \
+  --enable-thinking false
+# Generated text: Paris
 ```
 
-The positional model may be a Hugging Face model ID or local snapshot. The
-matching family owns its model identities, supported tasks, meaningful default
-task, TensorRT graph, weights, section names, and runtime configuration. Use
-`--task` only to override the family default. The bundle container stores only
-`format`, `family`, `task`, `backend`, and section offsets and lengths.
-
-Two existing opt-in paths remain direct rather than becoming configuration
-systems:
-
-```bash
-# Llama runtime-sized KV cache
-python -m tensorrt_model_connect build MODEL -o model.bundle --dynamic-kv-cache
-trtmc run model.bundle --runtime-root /opt/trtmc/lib \
-  --kv-cache-size 1GiB --prompt "Hello"
-
-# TensorRT-RTX, when its Python package and optional backend DSO are installed
-python -m tensorrt_model_connect build MODEL -o model.bundle --backend trt_rtx
-trtmc run model.bundle --runtime-root /opt/trtmc/lib \
-  --runtime-cache kernels.cache --cuda-graphs --prompt "Hello"
-```
-
-## Load from C++
+The same bundle works from
+[C++](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api):
 
 ```cpp
+#include <iostream>
+#include <stdexcept>
+
 #include <trtmc/runtime/family_loader.h>
 #include <trtmc/task.h>
 
-auto task = trtmc::load_task("gpt2.bundle", "/opt/trtmc/lib");
+auto task = trtmc::load_task("./qwen3-0.6b.bundle", "/opt/trtmc/lib");
 auto* text = dynamic_cast<trtmc::ITextGeneration*>(task.get());
 if (text == nullptr) throw std::runtime_error("unexpected task");
-auto result = text->generate("What is TensorRT?");
+std::cout << text->generate("What is the capital of France? Answer in one word.").text << '\n';
 ```
 
-The runtime directory must contain the native core, runtime loader, requested
-backend, and exact family DSO produced by the same build.
+<a id="get-started-and-stay-tuned"></a>
 
-## Applications and tools
+## 🌟 Get Started & Stay Tuned
 
-Applications depend one way on public ModelConnect APIs; core and model
-families never depend on application code.
+<div align="center">
 
-- [Bring your own kernel](examples/byok/README.md) connects an explicit
-  TVM-FFI kernel DSO to a family-owned TensorRT graph, either directly in the
-  family or through the optional pre-serialization graph transform.
-- [Persistent audio streaming](examples/audio_streaming/README.md) loads one
-  bundle once and serves one prompt per input line through the public Task API.
-- [Cosmos3 dual Spark](examples/models/cosmos3/dual_spark/README.md) runs the
-  CP=2 video pipeline across two DGX Sparks.
-- [Nemotron VoiceChat full duplex](examples/models/nemotron_voicechat/full_duplex/README.md)
-  provides the live ALSA microphone/speaker application.
-- `trtmc-bench` and [the performance matrix](apps/benchmark/performance/README.md)
-  measure the public Task APIs without adding behavior to core.
+<img width="960" height="540" alt="Animated TensorRT-Model-Connect project hero" src="TRTMCHERO-small.gif" />
 
-## Add a family
+</div>
 
-Adding a family means adding one directory, including its own `support.py`. It
-must not require editing core source lists, registries, or sibling families.
-Similar code is copied until a real shared contract—not code similarity—proves
-a shared boundary is needed.
+Ready to try TensorRT-Model-Connect? Follow the
+[Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start)
+to build and run your first supported model.
 
-If the family needs packages beyond the base environment, install them with
-`python -m pip install -r families/<family>/requirements.txt` before its build
-or reference test. Native bundle deployment never reads this file or launches
-Python.
+We're glad you're here. [Star the repository](https://github.com/NVIDIA/TensorRT-Model-Connect)
+to keep TensorRT-Model-Connect on your radar as we share new model integrations,
+releases, examples, and community updates. Ideas and feedback are always
+welcome through the [issue chooser](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new/choose).
 
-See [Add a Model Family](website/docs/extend/add-model-family.md) and the
-[full architecture](website/docs/architecture/ai-native-horizontal-scaling.md).
+<a id="what-is-tensorrt-model-connect"></a>
 
-## Validate
+## 🔎 What is TensorRT-Model-Connect?
+**TensorRT Model Connect is an extensive collection of AI Model reference implementations in C++, on top of NVIDIA TensorRT**. Model Connect is powered by an agentic workflow that continuously adds support for upcoming models, drastically reducing integration effort on user side and time until new models become compatible.
+<img width="1318" height="1088" alt="MC-what-it-is" src="website/static/img/readme/model-connect-overview.png" />
 
-```bash
-PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.model_ci validate
-PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest -q
-git diff --check
+<a id="choose-the-right-tensorrt-path"></a>
+
+## 🧭 Choose the right abstraction layer
+
+- Use TensorRT-Model-Connect to explore models quickly and evaluate broad
+  model coverage.
+- For production LLM/VLM deployment on NVIDIA edge platforms where performance
+  is the priority, start directly with
+  [TensorRT Edge-LLM](https://github.com/NVIDIA/TensorRT-Edge-LLM).
+
+<img width="1606" height="979" alt="TensorRT abstraction layers from Model Connect through Edge-LLM to TensorRT" src="website/static/img/readme/tensorrt-stack.png" />
+
+<a id="why-tensorrt-model-connect"></a>
+
+## 💡 Why TensorRT-Model-Connect?
+
+- Start from a supported Hugging Face or local checkpoint and build TensorRT
+  engines without an intermediate ONNX export step.
+- Hand a versioned `.bundle` artifact from the Python-first build environment
+  to native C++ task APIs such as text generation, transcription, image and
+  video generation, segmentation, embedding, and forecasting.
+- Use model-family-owned builders, runtime pipelines, helper kernels, and
+  validation contracts as concrete blueprints for modification and
+  customization.
+- Keep native TensorRT and optional TensorRT-RTX execution behind the same
+  task-oriented application boundary.
+
+Read the [Architecture Overview](https://nvidia.github.io/TensorRT-Model-Connect/architecture/ai-native-horizontal-scaling)
+for the architecture boundary, intended users, and comparison with other
+TensorRT integration paths.
+
+TensorRT-Model-Connect is a reference implementation. Users are responsible
+for trusting the checkpoints, bundles, native libraries, and local environment
+they provide when building or running models.
+
+<a id="getting-started"></a>
+
+## 🚀 Getting Started
+
+**Recommended Quick Start: AI-Native**
+
+Give an AI coding agent with terminal, Docker, and NVIDIA GPU access this
+prompt:
+
+```text
+/goal Use the current TensorRT-Model-Connect checkout, or clone
+https://github.com/NVIDIA/TensorRT-Model-Connect.git if none is provided. Read
+AGENTS.md, then follow website/docs/getting-started/source-build.md and
+website/docs/getting-started/quick-start.md exactly. Do not modify source,
+tests, Dockerfiles, git history, or remote state. Report the selected GPU,
+exact commands, bundle path, inference output, and any deviation from the
+documentation.
 ```
 
-Then build and run the affected family's native target and real E2E recipe.
-Do not weaken a correctness threshold to make CI pass.
+Want to know more? See the
+[Quick Start documentation](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start).
 
-## Contributing and license
+<a id="explore-the-documentation"></a>
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md). Contributions require DCO sign-off.
-TensorRT-Model-Connect is licensed under [Apache-2.0](LICENSE).
+## 📚 Explore the documentation
+
+| Goal | Start here |
+| --- | --- |
+| Complete the first Qwen inference | [Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
+| Select and install an environment | [Quick Start](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/quick-start) |
+| Compile the CLI, backends, and model DSOs | [Build from Source](https://nvidia.github.io/TensorRT-Model-Connect/getting-started/source-build) |
+| Find an exact checkpoint or model recipe | [Models & Recipes](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview) |
+| Look up task and runtime contracts | [C++ Task API](https://nvidia.github.io/TensorRT-Model-Connect/api/cpp-api) |
+| Understand the bundle contract | [Bundle Format](https://nvidia.github.io/TensorRT-Model-Connect/architecture/bundle-format) |
+| Understand the source layout | [Source Layout](https://nvidia.github.io/TensorRT-Model-Connect/reference/source-layout) |
+| Add an isolated model family | [Add a Model Family](https://nvidia.github.io/TensorRT-Model-Connect/extend/add-model-family) |
+| Understand the dependency boundaries | [Architecture](https://nvidia.github.io/TensorRT-Model-Connect/architecture/ai-native-horizontal-scaling) |
+| Contribute to the project | [Contributing](https://nvidia.github.io/TensorRT-Model-Connect/extend/contributing) |
+
+<a id="supported-models"></a>
+
+## 🧩 Supported models
+
+The [Supported Models](https://nvidia.github.io/TensorRT-Model-Connect/models-recipes/overview)
+page is the single source of truth for exact checkpoints, Hugging Face
+architectures, family-owned tasks, precision, quantization, topology, and
+validation evidence.
+
+<a id="get-help-and-file-an-issue"></a>
+
+## 🛟 Get help and file an issue
+
+Collect the model, environment, command, and log details maintainers need, then
+use the [issue chooser](https://github.com/NVIDIA/TensorRT-Model-Connect/issues/new/choose)
+for usage questions, reproducible bugs, feature or model requests, and
+documentation corrections.
+
+Do not disclose suspected security vulnerabilities in a public issue. Follow
+[SECURITY.md](SECURITY.md) to report them privately to NVIDIA PSIRT.
+
+<a id="project-status"></a>
+
+## 🧪 Project status
+
+TensorRT-Model-Connect is an experimental project. Its APIs, scope, and
+direction may evolve as we learn from users. This preview is intended to inform
+future decisions and does not establish a specific product roadmap or release
+timeline.
+
+<a id="contributing"></a>
+
+## 🤝 Contributing
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing source or model
+  integration changes.
+- TensorRT-Model-Connect is licensed under the terms in [LICENSE](LICENSE).
+
+<!-- Collaborative review anchor: batch 2. -->


### PR DESCRIPTION
## Background

PR #1093 replaced the repository landing page with an architecture-first README. Restore the previous community-facing presentation, including the existing animated hero, project overview, and TensorRT stack visuals, without reverting the new repository architecture.

## Exit Criteria

- Restore the previous README sections and visual presentation.
- Keep every README command, API example, and documentation route valid for the current `core/`, `families/`, and `apps/` layout.
- Keep the change scoped to `README.md`; do not restore website content or legacy source structure in this PR.

## Implementation

- Restored the community landing-page structure from the immediate pre-#1093 revision.
- Reused the three existing, already-licensed repository assets; no binary files were copied or changed.
- Updated bundle build and run commands for the current Python builder and explicit runtime-root contract.
- Updated the C++ example to use `load_task()` and the abstract `ITextGeneration` interface.
- Pointed navigation at routes that exist in the current documentation site.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `git diff --check` — passed.
- Verified all three local README image targets exist — passed.
- Verified every local documentation route referenced by the restored README has a source page — passed.
- `python3 -m pytest tools/tests/test_public_source_hygiene.py tools/tests/test_family_impact.py -q` — 25 passed.
- `npm run test:model-support` — 1 passed.
- `npm run build` — production documentation build succeeded.

### Hardware, Environment, and Revisions

- Repository head: `335dba3d0f0dffd35028f7c856201bd9f87fabda`.
- Base: `c19a3e6d8d112cd1b2c3d02f6c39c408ac8e83e8`.
- Local validation: Linux aarch64, Python 3.12.3, Node.js 25.6.1, npm 11.9.0.
- GPU, CUDA, TensorRT, model, checkpoint, precision, and dataset revisions are not applicable to this README-only change.

### Not Run / Remaining Gaps

- Model builds, runtime inference, GPU tests, parity, and performance tests were not run because no executable source or model-family behavior changed.
- The broader restoration and adaptation of the previous website content is intentionally deferred to a separate PR.

## Notes For Future Readers

The previous README presentation is restored while its commands and links remain aligned with the post-#1093 repository. The website content restoration is separate so this PR stays small and reviewable.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: the diff is limited to the root README, reuses unchanged licensed assets, and does not change code, dependencies, APIs, ABI, or bundle artifacts.
