### PR TITLE
fix(runtime): retain configured backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,19 @@ if(TRTMC_BUILD_TESTS)
     LIBRARY_OUTPUT_DIRECTORY "${_trtmc_test_runtime_root}"
   )
 
+  add_library(trtmc_test_backend_fake_rtx SHARED core/runtime/tests/fake_backend.cpp)
+  target_include_directories(trtmc_test_backend_fake_rtx PRIVATE
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(trtmc_test_backend_fake_rtx PRIVATE CUDA::cudart)
+  target_compile_definitions(trtmc_test_backend_fake_rtx PRIVATE
+    TRTMC_FAKE_BACKEND_NAME="trt_rtx"
+  )
+  set_target_properties(trtmc_test_backend_fake_rtx PROPERTIES
+    OUTPUT_NAME trtmc_backend_trt_rtx
+    LIBRARY_OUTPUT_DIRECTORY "${_trtmc_test_runtime_root}"
+  )
+
   add_library(trtmc_test_family_fake SHARED core/runtime/tests/fake_family.cpp)
   target_include_directories(trtmc_test_family_fake PRIVATE ${PROJECT_SOURCE_DIR}/core/runtime/include)
   target_link_libraries(trtmc_test_family_fake PRIVATE trtmc_core)
@@ -373,7 +386,11 @@ if(TRTMC_BUILD_TESTS)
   )
   target_link_libraries(test_family_loader PRIVATE trtmc_runtime)
   target_compile_options(test_family_loader PRIVATE -Wall -Wextra -Wpedantic)
-  add_dependencies(test_family_loader trtmc_test_backend_fake trtmc_test_family_fake)
+  add_dependencies(test_family_loader
+    trtmc_test_backend_fake
+    trtmc_test_backend_fake_rtx
+    trtmc_test_family_fake
+  )
   add_test(NAME family_loader COMMAND test_family_loader "${_trtmc_test_runtime_root}")
 
   add_executable(test_trt_module_dynamic_input

--- a/core/runtime/include/trtmc/runtime/family_loader.h
+++ b/core/runtime/include/trtmc/runtime/family_loader.h
@@ -15,8 +15,9 @@ namespace trtmc {
 
 // Load exactly the family and backend named in bundle_path from runtime_root.
 // No environment, installed-package, current-directory, alias, or fallback
-// search is performed. Loaded DSOs and backend instances stay resident for the
-// process lifetime, so the returned task needs no task-specific ownership proxy.
+// search is performed. Loaded DSOs, backend instances, and immutable backend
+// option adapters stay resident for the process lifetime so family tasks may
+// safely defer module creation.
 std::unique_ptr<ITask> load_task(const std::string& bundle_path, const std::string& runtime_root,
                                  std::uint64_t kv_cache_size_bytes = 0,
                                  const std::string& runtime_cache_path = {},

--- a/core/runtime/loader/family_loader.cpp
+++ b/core/runtime/loader/family_loader.cpp
@@ -11,6 +11,7 @@
 
 #include <dlfcn.h>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -150,9 +151,9 @@ class FamilyLibrary {
 
 class RuntimeOptionsBackend final : public IBackend {
   public:
-    RuntimeOptionsBackend(IBackend& backend, const std::string& runtime_cache_path,
-                          bool cuda_graphs)
-        : backend_(backend), runtime_cache_path_(runtime_cache_path), cuda_graphs_(cuda_graphs) {}
+    RuntimeOptionsBackend(IBackend& backend, std::string runtime_cache_path, bool cuda_graphs)
+        : backend_(backend), runtime_cache_path_(std::move(runtime_cache_path)),
+          cuda_graphs_(cuda_graphs) {}
 
     std::unique_ptr<ITrtModule> create_module(const void* plan_data, size_t plan_size,
                                               const ModuleCreateOptions& options) override {
@@ -184,20 +185,44 @@ class RuntimeOptionsBackend final : public IBackend {
     }
 
     IBackend& backend_;
-    const std::string& runtime_cache_path_;
+    std::string runtime_cache_path_;
     bool cuda_graphs_;
+};
+
+struct ConfiguredBackendKey {
+    IBackend* backend{nullptr};
+    std::string runtime_cache_path;
+    bool cuda_graphs{false};
+
+    bool operator==(const ConfiguredBackendKey& other) const noexcept {
+        return backend == other.backend && runtime_cache_path == other.runtime_cache_path &&
+               cuda_graphs == other.cuda_graphs;
+    }
+};
+
+struct ConfiguredBackendKeyHash {
+    std::size_t operator()(const ConfiguredBackendKey& key) const noexcept {
+        std::size_t value = std::hash<IBackend*>{}(key.backend);
+        value ^= std::hash<std::string>{}(key.runtime_cache_path) + 0x9e3779b9U + (value << 6U) +
+                 (value >> 2U);
+        value ^= std::hash<bool>{}(key.cuda_graphs) + 0x9e3779b9U + (value << 6U) + (value >> 2U);
+        return value;
+    }
 };
 
 struct RuntimeLibraryCache {
     std::mutex mutex;
     std::unordered_map<std::string, std::unique_ptr<BackendLibrary>> backends;
     std::unordered_map<std::string, std::unique_ptr<FamilyLibrary>> families;
+    std::unordered_map<ConfiguredBackendKey, std::unique_ptr<RuntimeOptionsBackend>,
+                       ConfiguredBackendKeyHash>
+        configured_backends;
 };
 
 RuntimeLibraryCache& runtime_library_cache() {
-    // The cache deliberately lives until process exit. Task objects can be
-    // destroyed without a task-specific proxy because their code and backend
-    // are never unloaded underneath them.
+    // The cache deliberately lives until process exit. Family tasks may defer
+    // module creation, so their code, backend, and immutable runtime-options
+    // adapter must never be unloaded underneath them.
     static RuntimeLibraryCache* cache = new RuntimeLibraryCache();
     return *cache;
 }
@@ -214,6 +239,22 @@ IBackend& cached_backend(const fs::path& runtime_root, const std::string& backen
     IBackend& backend = library->get();
     cache.backends.emplace(path, std::move(library));
     return backend;
+}
+
+IBackend& cached_configured_backend(IBackend& backend, const std::string& runtime_cache_path,
+                                    bool cuda_graphs) {
+    ConfiguredBackendKey key{&backend, runtime_cache_path, cuda_graphs};
+    auto& cache = runtime_library_cache();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    const auto found = cache.configured_backends.find(key);
+    if (found != cache.configured_backends.end())
+        return *found->second;
+
+    auto configured =
+        std::make_unique<RuntimeOptionsBackend>(backend, runtime_cache_path, cuda_graphs);
+    IBackend& result = *configured;
+    cache.configured_backends.emplace(std::move(key), std::move(configured));
+    return result;
 }
 
 FamilyLibrary& cached_family(const fs::path& runtime_root, const std::string& family_id) {
@@ -258,7 +299,8 @@ std::unique_ptr<ITask> load_task(const std::string& bundle_path, const std::stri
     const fs::path root = explicit_runtime_root(runtime_root);
     IBackend& backend = cached_backend(root, info.backend);
     FamilyLibrary& family = cached_family(root, info.family);
-    RuntimeOptionsBackend configured_backend(backend, runtime_cache_path, cuda_graphs);
+    IBackend& configured_backend =
+        cached_configured_backend(backend, runtime_cache_path, cuda_graphs);
     FamilyContext context{reader, configured_backend, kv_cache_size_bytes};
     std::unique_ptr<ITask> task(family.create(context));
     if (task == nullptr)

--- a/core/runtime/tests/fake_backend.cpp
+++ b/core/runtime/tests/fake_backend.cpp
@@ -6,16 +6,27 @@
 #include "trtmc/runtime/trt_backend.h"
 
 #include <memory>
+#include <string>
 #include <vector>
+
+#ifndef TRTMC_FAKE_BACKEND_NAME
+#define TRTMC_FAKE_BACKEND_NAME "fake"
+#endif
 
 namespace {
 
 int create_count = 0;
+std::string last_runtime_cache_path;
+bool last_cuda_graphs = false;
 
 class FakeBackend final : public trtmc::IBackend {
   public:
-    std::unique_ptr<trtmc::ITrtModule> create_module(const void*, std::size_t,
-                                                     const trtmc::ModuleCreateOptions&) override {
+    std::unique_ptr<trtmc::ITrtModule>
+    create_module(const void*, std::size_t, const trtmc::ModuleCreateOptions& options) override {
+        last_runtime_cache_path = options.runtime_cache_path != nullptr
+                                      ? std::string(options.runtime_cache_path)
+                                      : std::string();
+        last_cuda_graphs = options.cuda_graphs;
         return nullptr;
     }
 
@@ -31,7 +42,7 @@ class FakeBackend final : public trtmc::IBackend {
         return {};
     }
 
-    const char* name() const override { return "fake"; }
+    const char* name() const override { return TRTMC_FAKE_BACKEND_NAME; }
 };
 
 } // namespace
@@ -45,4 +56,12 @@ extern "C" trtmc::IBackend* trtmc_create_backend() {
 
 extern "C" void trtmc_destroy_backend(trtmc::IBackend* backend) {
     delete backend;
+}
+
+extern "C" const char* trtmc_test_backend_last_runtime_cache_path() {
+    return last_runtime_cache_path.c_str();
+}
+
+extern "C" bool trtmc_test_backend_last_cuda_graphs() {
+    return last_cuda_graphs;
 }

--- a/core/runtime/tests/fake_family.cpp
+++ b/core/runtime/tests/fake_family.cpp
@@ -12,10 +12,17 @@ namespace {
 
 class FakeForecast final : public trtmc::ITimeSeriesForecast {
   public:
-    explicit FakeForecast(std::uint64_t kv_cache_size_bytes)
-        : kv_cache_size_bytes_(kv_cache_size_bytes) {}
+    FakeForecast(trtmc::IBackend& backend, std::uint64_t kv_cache_size_bytes)
+        : backend_(backend), kv_cache_size_bytes_(kv_cache_size_bytes) {}
 
     trtmc::ForecastResult forecast(const trtmc::ForecastRequest& request) override {
+        const char* backend_name = backend_.name();
+        if (backend_name == nullptr ||
+            (std::string(backend_name) != "fake" && std::string(backend_name) != "trt_rtx")) {
+            throw std::runtime_error("backend lifetime did not extend to task execution");
+        }
+        if (std::string(backend_name) == "trt_rtx")
+            (void)backend_.create_module(nullptr, 0, {});
         if (!request.observed_mask.empty() &&
             request.observed_mask.size() != request.past_values.size()) {
             throw std::invalid_argument("observed_mask length must match past_values");
@@ -31,6 +38,7 @@ class FakeForecast final : public trtmc::ITimeSeriesForecast {
     }
 
   private:
+    trtmc::IBackend& backend_;
     std::uint64_t kv_cache_size_bytes_;
 };
 
@@ -39,10 +47,13 @@ class FakeForecast final : public trtmc::ITimeSeriesForecast {
 extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
     if (context.reader.info().family != "fake")
         throw std::runtime_error("unexpected family");
-    if (context.backend.name() == nullptr || std::string(context.backend.name()) != "fake")
+    const char* backend_name = context.backend.name();
+    if (backend_name == nullptr ||
+        (std::string(backend_name) != "fake" && std::string(backend_name) != "trt_rtx")) {
         throw std::runtime_error("unexpected backend");
+    }
     const auto plan = context.reader.read_section("engine.plan");
     if (std::string(plan.begin(), plan.end()) != "PLAN")
         throw std::runtime_error("unexpected engine plan");
-    return new FakeForecast(context.kv_cache_size_bytes);
+    return new FakeForecast(context.backend, context.kv_cache_size_bytes);
 }

--- a/core/runtime/tests/test_family_loader.cpp
+++ b/core/runtime/tests/test_family_loader.cpp
@@ -7,6 +7,7 @@
 #include "trtmc/runtime/family_loader.h"
 
 #include <cstdint>
+#include <dlfcn.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -25,9 +26,11 @@ void check(bool condition, const char* name) {
 }
 
 void write_bundle(const std::filesystem::path& path, const std::string& family,
-                  const std::string& task = "time_series_forecast") {
+                  const std::string& task = "time_series_forecast",
+                  const std::string& backend = "fake") {
     const std::string header = "{\"format\":1,\"family\":\"" + family + "\",\"task\":\"" + task +
-                               "\",\"backend\":\"fake\","
+                               "\",\"backend\":\"" + backend +
+                               "\","
                                "\"sections\":{\"runtime.json\":{\"offset\":0,\"length\":2},"
                                "\"engine.plan\":{\"offset\":2,\"length\":4}}}";
     std::ofstream output(path, std::ios::binary);
@@ -55,6 +58,30 @@ bool rtx_options_throw(const std::filesystem::path& bundle, const std::string& r
     } catch (const std::invalid_argument&) {
         return true;
     }
+}
+
+void check_rtx_options(const std::filesystem::path& runtime_root,
+                       const std::string& expected_cache_path, bool expected_cuda_graphs) {
+    const auto library_path = runtime_root / "libtrtmc_backend_trt_rtx.so";
+    void* handle = dlopen(library_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    check(handle != nullptr, "fake RTX backend remains loaded");
+    if (handle == nullptr)
+        return;
+
+    using CachePathFn = const char* (*)();
+    using CudaGraphsFn = bool (*)();
+    const auto cache_path =
+        reinterpret_cast<CachePathFn>(dlsym(handle, "trtmc_test_backend_last_runtime_cache_path"));
+    const auto cuda_graphs =
+        reinterpret_cast<CudaGraphsFn>(dlsym(handle, "trtmc_test_backend_last_cuda_graphs"));
+    check(cache_path != nullptr, "fake RTX cache-path probe is exported");
+    check(cuda_graphs != nullptr, "fake RTX CUDA-graphs probe is exported");
+    if (cache_path != nullptr)
+        check(expected_cache_path == cache_path(), "runtime cache path remains owned by value");
+    if (cuda_graphs != nullptr)
+        check(cuda_graphs() == expected_cuda_graphs,
+              "CUDA-graphs option reaches delayed module creation");
+    dlclose(handle);
 }
 
 } // namespace
@@ -89,6 +116,33 @@ int main(int argc, char** argv) {
     check(rtx_options_throw(bundle_path, runtime_root.string()),
           "TensorRT-RTX options reject a non-RTX bundle");
 
+    const auto rtx_bundle = runtime_root / "fake-rtx.bundle";
+    write_bundle(rtx_bundle, "fake", "time_series_forecast", "trt_rtx");
+    const std::string expected_cache_path = (runtime_root / std::string(256, 'r')).string();
+    std::unique_ptr<trtmc::ITask> rtx_task;
+    {
+        std::string caller_owned_cache_path = expected_cache_path;
+        rtx_task = trtmc::load_task(rtx_bundle.string(), runtime_root.string(), 0,
+                                    caller_owned_cache_path, true);
+    }
+    auto* rtx_forecast = dynamic_cast<trtmc::ITimeSeriesForecast*>(rtx_task.get());
+    check(rtx_forecast != nullptr, "RTX load returns forecast interface");
+    if (rtx_forecast != nullptr)
+        (void)rtx_forecast->forecast({values, mask});
+    check_rtx_options(runtime_root, expected_cache_path, true);
+
+    const std::string second_cache_path = (runtime_root / std::string(256, 's')).string();
+    auto second_rtx_task =
+        trtmc::load_task(rtx_bundle.string(), runtime_root.string(), 0, second_cache_path, false);
+    auto* second_rtx_forecast = dynamic_cast<trtmc::ITimeSeriesForecast*>(second_rtx_task.get());
+    check(second_rtx_forecast != nullptr, "second RTX load returns forecast interface");
+    if (second_rtx_forecast != nullptr)
+        (void)second_rtx_forecast->forecast({values, mask});
+    check_rtx_options(runtime_root, second_cache_path, false);
+    if (rtx_forecast != nullptr)
+        (void)rtx_forecast->forecast({values, mask});
+    check_rtx_options(runtime_root, expected_cache_path, true);
+
     check(load_throws(bundle_path, ""), "empty runtime root rejected");
     check(load_throws(bundle_path, (runtime_root / "missing").string()),
           "loader does not search outside explicit root");
@@ -105,6 +159,7 @@ int main(int argc, char** argv) {
     std::filesystem::remove(bundle_path);
     std::filesystem::remove(unsafe_bundle);
     std::filesystem::remove(mismatch_bundle);
+    std::filesystem::remove(rtx_bundle);
     std::cerr << (failures == 0 ? "ALL PASSED\n" : "SOME FAILED\n");
     return failures;
 }

--- a/tools/tests/test_architecture.py
+++ b/tools/tests/test_architecture.py
@@ -1171,7 +1171,6 @@ def test_family_factory_receives_only_direct_runtime_inputs() -> None:
     loader = (REPO / "core/runtime/loader/family_loader.cpp").read_text(encoding="utf-8")
     load_task = loader.split("std::unique_ptr<ITask> load_task", 1)[1]
     assert "const BundleReader reader(bundle_path);" in load_task
-    assert "RuntimeOptionsBackend configured_backend" in load_task
     assert "FamilyContext context{reader, configured_backend, kv_cache_size_bytes};" in load_task
     assert "BundleFile" not in load_task
     assert "ReadBundleFile" not in load_task


### PR DESCRIPTION
## Background

PR #1093 made `load_task()` pass a stack-local `RuntimeOptionsBackend` into each family factory. Cosmos3, MiniMax-H3, Wan2.2 TI2V, and Nemotron speech streaming retain that backend for delayed module creation, so their first task call can dereference the adapter after `load_task()` has returned. An ASan reproduction confirmed `stack-use-after-return` in the loader frame.

The adapter also retained `runtime_cache_path` by reference, which would leave the TensorRT-RTX delayed path dangling even if only the adapter lifetime were extended.

## Exit Criteria

- A family task can call its backend after `load_task()` returns without using expired stack state.
- TensorRT-RTX cache path and CUDA-graphs settings remain valid and isolated across distinct task configurations.
- The public `load_task()` return type and family factory context remain unchanged.

## Implementation

- Cache immutable runtime-options backend adapters for the process lifetime alongside the already process-resident family and backend DSOs.
- Key adapters by the underlying backend, runtime cache path, and CUDA-graphs setting so concurrent task configurations do not overwrite one another.
- Store the runtime cache path by value inside the adapter.
- Extend the fake family/backend test seam to defer backend access until task execution and to exercise distinct TensorRT-RTX option sets.
- Remove the architecture assertion that required a stack-local adapter; the runtime regression now owns this implementation-specific coverage.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- ASan reproduction before the fix: failed with `stack-use-after-return` at the fake task's delayed backend call, identifying `configured_backend` in `load_task()` as the expired stack object.
- `ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 /build/test_family_loader /build/tests/runtime`: passed after the fix, including caller cache-path destruction and two distinct TensorRT-RTX configurations.
- `ctest --test-dir /build --output-on-failure -R "^family_loader$"`: passed in a Release build.
- `CI_BASE_REF=github/main python -m tools.ci pipeline source-quality`: passed; 117 tests passed.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

- Tested head: `87b8b117344c8ae87042c3edec3e8fafd9633064`.
- Local build/test environment: x86_64 Ubuntu 24.04, CUDA 13.3 compiler/runtime, TensorRT 10.15.2 headers and library, Debug ASan and Release configurations.
- Model/checkpoint/dataset/precision: not applicable to the fake-DSO loader lifetime regression; no model graph or numerical path changed.

### Not Run / Remaining Gaps

- Model checkpoint E2E and GPU inference were not run locally because this fix changes shared loader ownership rather than family graph or inference behavior.
- `TRTMC Internal CI / Automated premerge gate` has not yet passed on this exact head; protected CI remains required before merge.

## Notes For Future Readers

- Review `core/runtime/loader/family_loader.cpp` first, then the delayed fake-family and fake TensorRT-RTX coverage in `core/runtime/tests/`.
- Runtime option adapters are intentionally immutable and process-resident, matching the existing DSO/backend cache lifetime. Do not move them back to `load_task()` stack storage while families can defer module creation.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: this is a small, API-compatible patch, but it changes the shared runtime loader used by every model family and fixes a confirmed use-after-lifetime in production paths.
