### PR TITLE
feat(cli): streamline first-run defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@
 ## 💻 Example Code
 
 ```bash
-python -m tensorrt_model_connect build Qwen/Qwen3-0.6B \
+trtmc build Qwen/Qwen3-0.6B \
   --max-sequence-length 16384 \
   --output qwen3-0.6b.bundle
 trtmc run ./qwen3-0.6b.bundle \
-  --runtime-root /opt/trtmc/lib \
   --prompt "What is the capital of France? Answer in one word." \
-  --use-chat-template true \
   --enable-thinking false
 # Generated text: Paris
 ```
@@ -52,7 +50,10 @@ The same bundle works from
 auto task = trtmc::load_task("./qwen3-0.6b.bundle", "/opt/trtmc/lib");
 auto* text = dynamic_cast<trtmc::ITextGeneration*>(task.get());
 if (text == nullptr) throw std::runtime_error("unexpected task");
-std::cout << text->generate("What is the capital of France? Answer in one word.").text << '\n';
+trtmc::TextGenerationConfig config;
+config.use_chat_template = text->default_use_chat_template();
+config.enable_thinking = false;
+std::cout << text->generate("What is the capital of France? Answer in one word.", config).text << '\n';
 ```
 
 <a id="get-started-and-stay-tuned"></a>

--- a/apps/cli/cli.cpp
+++ b/apps/cli/cli.cpp
@@ -9,6 +9,7 @@
 #include "trtmc/runtime/family_loader.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -35,6 +36,36 @@ namespace trtmc::cli {
 namespace {
 
 namespace fs = std::filesystem;
+
+bool is_safe_id(const std::string& value) {
+    if (value.empty() || value.front() < 'a' || value.front() > 'z')
+        return false;
+    return std::all_of(value.begin(), value.end(), [](const unsigned char character) {
+        return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') ||
+               character == '_';
+    });
+}
+
+bool has_complete_runtime(const fs::path& root, const BundleInfo& bundle) {
+    if (root.empty())
+        return false;
+    const std::array<std::string, 4> files{
+        "libtrtmc_core.so",
+        "libtrtmc_runtime.so",
+        "libtrtmc_backend_" + bundle.backend + ".so",
+        "libtrtmc_model_" + bundle.family + ".so",
+    };
+    return std::all_of(files.begin(), files.end(), [&](const std::string& file) {
+        std::error_code error;
+        return fs::is_regular_file(root / file, error) && !error;
+    });
+}
+
+fs::path current_executable_path() {
+    std::error_code error;
+    const fs::path executable = fs::read_symlink("/proc/self/exe", error);
+    return error ? fs::path{} : executable;
+}
 
 struct CommandSpec {
     CommandKind kind;
@@ -639,6 +670,8 @@ int dispatch_run(const Command& command, ITask& task, std::ostream& output) {
     }
     if (!has_option(command, "--image")) {
         auto& interface = require_interface<ITextGeneration>(task);
+        if (!has_option(command, "--use-chat-template"))
+            config.use_chat_template = interface.default_use_chat_template();
         config.max_new_tokens =
             int_option(command, "--max-new-tokens", interface.default_max_new_tokens(), 1);
         write_json(output, text_json(interface.generate(prompt, config)));
@@ -653,6 +686,23 @@ int dispatch_run(const Command& command, ITask& task, std::ostream& output) {
 }
 
 } // namespace
+
+std::string resolve_runtime_root(const Command& command, const BundleInfo& bundle,
+                                 const fs::path& current_directory, const fs::path& executable) {
+    if (!command.runtime_root.empty())
+        return command.runtime_root;
+    if (!is_safe_id(bundle.family) || !is_safe_id(bundle.backend))
+        throw std::invalid_argument("bundle family and backend must match [a-z][a-z0-9_]*");
+
+    if (has_complete_runtime(current_directory, bundle))
+        return current_directory.string();
+    const fs::path executable_directory = executable.parent_path();
+    if (has_complete_runtime(executable_directory, bundle))
+        return executable_directory.string();
+
+    throw std::invalid_argument(
+        "no complete runtime found in the current or executable directory; pass --runtime-root");
+}
 
 Command parse_args(int argc, char** argv) {
     if (argc < 2)
@@ -721,8 +771,6 @@ Command parse_args(int argc, char** argv) {
             throw std::invalid_argument(option + " may be specified only once");
         command.options.emplace(option, take_value(argc, argv, index, option));
     }
-    if (command.runtime_root.empty())
-        throw std::invalid_argument("--runtime-root is required for " + name);
     const int byok_option_count = static_cast<int>(command.options.count("--byok-library") +
                                                    command.options.count("--byok-function") +
                                                    command.options.count("--byok-name"));
@@ -1206,7 +1254,7 @@ void print_usage(std::ostream& output) {
     output << "Usage:\n"
               "  trtmc version\n"
               "  trtmc inspect BUNDLE\n"
-              "  trtmc COMMAND BUNDLE --runtime-root DIR [OPTIONS]\n\n"
+              "  trtmc COMMAND BUNDLE [--runtime-root DIR] [OPTIONS]\n\n"
               "Execution commands:\n"
               "  run, encode, embed, rerank, classify, extract-features, disparity, geometry,\n"
               "  segment,\n"
@@ -1233,12 +1281,13 @@ void print_usage(std::ostream& output) {
               "  [--kv-cache-size BYTES|GB|GiB]\n\n"
               "TensorRT-RTX runtime options:\n"
               "  [--runtime-cache PATH] [--cuda-graphs]\n\n"
-              "Execution never searches for runtimes; --runtime-root is always required.\n";
+              "Without --runtime-root, execution checks the current directory, then the\n"
+              "directory containing the running trtmc executable.\n";
 }
 
 int run(int argc, char** argv, std::ostream& output, std::ostream& error) {
     try {
-        const Command command = parse_args(argc, argv);
+        Command command = parse_args(argc, argv);
         if (command.kind == CommandKind::kHelp) {
             print_usage(output);
             return EXIT_SUCCESS;
@@ -1259,6 +1308,8 @@ int run(int argc, char** argv, std::ostream& output, std::ostream& error) {
                                 {"sections", std::move(sections)}});
             return EXIT_SUCCESS;
         }
+        command.runtime_root = resolve_runtime_root(command, InspectBundle(command.bundle),
+                                                    fs::current_path(), current_executable_path());
         const bool has_byok_library = has_option(command, "--byok-library");
         const bool has_byok_function = has_option(command, "--byok-function");
         const bool has_byok_name = has_option(command, "--byok-name");

--- a/apps/cli/cli.h
+++ b/apps/cli/cli.h
@@ -9,6 +9,7 @@
 #include "trtmc/task.h"
 
 #include <cstdint>
+#include <filesystem>
 #include <iosfwd>
 #include <string>
 #include <unordered_map>
@@ -60,6 +61,9 @@ struct Command {
 };
 
 Command parse_args(int argc, char** argv);
+std::string resolve_runtime_root(const Command& command, const BundleInfo& bundle,
+                                 const std::filesystem::path& current_directory,
+                                 const std::filesystem::path& executable);
 int dispatch(const Command& command, ITask& task, std::ostream& output);
 void print_usage(std::ostream& output);
 int run(int argc, char** argv, std::ostream& output, std::ostream& error);

--- a/apps/cli/tests/test_cli.cpp
+++ b/apps/cli/tests/test_cli.cpp
@@ -45,6 +45,66 @@ bool parse_throws(std::vector<std::string> arguments) {
     }
 }
 
+bool runtime_root_throws(const trtmc::cli::Command& command, const trtmc::BundleInfo& bundle,
+                         const std::filesystem::path& current_directory,
+                         const std::filesystem::path& executable) {
+    try {
+        (void)trtmc::cli::resolve_runtime_root(command, bundle, current_directory, executable);
+        return false;
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+}
+
+void add_runtime_files(const std::filesystem::path& root, const trtmc::BundleInfo& bundle) {
+    std::filesystem::create_directories(root);
+    for (const auto& name : {std::string("libtrtmc_core.so"), std::string("libtrtmc_runtime.so"),
+                             "libtrtmc_backend_" + bundle.backend + ".so",
+                             "libtrtmc_model_" + bundle.family + ".so"}) {
+        std::ofstream(root / name).put('\0');
+    }
+}
+
+void test_runtime_root_resolution() {
+    const auto root = std::filesystem::temp_directory_path() / "trtmc-cli-runtime-root";
+    std::filesystem::remove_all(root);
+    const auto current_directory = root / "current";
+    const auto executable_directory = root / "executable";
+    const auto executable = executable_directory / "trtmc";
+
+    trtmc::BundleInfo bundle;
+    bundle.family = "fake";
+    bundle.task = "text_generation";
+    bundle.backend = "fake";
+
+    trtmc::cli::Command command;
+    command.runtime_root = (root / "explicit").string();
+    check(trtmc::cli::resolve_runtime_root(command, bundle, current_directory, executable) ==
+              command.runtime_root,
+          "explicit runtime root wins without discovery");
+
+    command.runtime_root.clear();
+    add_runtime_files(current_directory, bundle);
+    add_runtime_files(executable_directory, bundle);
+    check(trtmc::cli::resolve_runtime_root(command, bundle, current_directory, executable) ==
+              current_directory.string(),
+          "complete current directory wins before executable directory");
+
+    std::filesystem::remove(current_directory / "libtrtmc_model_fake.so");
+    check(trtmc::cli::resolve_runtime_root(command, bundle, current_directory, executable) ==
+              executable_directory.string(),
+          "complete executable directory is the second default");
+
+    std::filesystem::remove(executable_directory / "libtrtmc_backend_fake.so");
+    check(runtime_root_throws(command, bundle, current_directory, executable),
+          "missing exact runtime files require an explicit root");
+
+    bundle.family = "../fake";
+    check(runtime_root_throws(command, bundle, current_directory, executable),
+          "unsafe bundle identity is rejected before path construction");
+    std::filesystem::remove_all(root);
+}
+
 class FakeText final : public trtmc::ITextGeneration,
                        public trtmc::IEmbedding,
                        public trtmc::ILoraAdapterManager {
@@ -54,6 +114,7 @@ class FakeText final : public trtmc::ITextGeneration,
     std::string loaded_adapter_path;
     const char* task() const noexcept override { return trtmc::ITextGeneration::kTask; }
     std::int32_t default_max_new_tokens() const override { return 7; }
+    bool default_use_chat_template() const noexcept override { return true; }
 
     trtmc::TextResult generate(const std::string& prompt,
                                const trtmc::TextGenerationConfig& config) override {
@@ -255,6 +316,8 @@ bool dispatch_throws(const trtmc::cli::Command& command, trtmc::ITask& task) {
 } // namespace
 
 int main() {
+    test_runtime_root_resolution();
+
     const std::vector<std::string> execution_commands{
         "run",
         "encode",
@@ -287,8 +350,8 @@ int main() {
         check(command.runtime_root == "lib", "runtime root is retained");
     }
 
-    check(parse_throws({"trtmc", "run", "model.bundle"}),
-          "execution command requires runtime root");
+    check(parse({"trtmc", "run", "model.bundle"}).runtime_root.empty(),
+          "execution command may defer runtime root resolution");
     check(parse_throws(
               {"trtmc", "run", "model.bundle", "--runtime-root", "a", "--runtime-root", "b"}),
           "duplicate runtime root rejected");
@@ -498,8 +561,12 @@ int main() {
     default_run.options.emplace("--prompt", "hello");
     check(trtmc::cli::dispatch(default_run, text, output) == 0 &&
               text.seen.text_generation_mode == "auto" && text.seen.block_length == 0 &&
-              text.seen.confidence_threshold == -1.0F && text.seen.temperature == 1.0F,
-          "text diffusion options preserve Task API defaults");
+              text.seen.confidence_threshold == -1.0F && text.seen.temperature == 1.0F &&
+              text.seen.use_chat_template,
+          "text request uses the family-owned chat template default");
+    default_run.options.emplace("--use-chat-template", "false");
+    check(trtmc::cli::dispatch(default_run, text, output) == 0 && !text.seen.use_chat_template,
+          "explicit false overrides the family-owned chat template default");
     const std::filesystem::path unsupported_image_path = "/tmp/trtmc-cli-unsupported.ppm";
     {
         std::ofstream image_file(unsupported_image_path, std::ios::binary);

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,19 +75,16 @@ class TensorRTModelConnectConan(ConanFile):
         build = Path(self.build_folder)
         package = Path(self.package_folder)
         module_bin = package / "tensorrt_model_connect" / "bin"
-        script_bin = package / f"{self.name.replace('-', '_')}-{self.version}.data" / "scripts"
 
         copy(self, "trtmc", src=str(build), dst=str(module_bin), keep_path=False)
-        copy(self, "trtmc", src=str(build), dst=str(script_bin), keep_path=False)
-        for destination in (module_bin, script_bin):
-            for library in ("libtrtmc_core.so", "libtrtmc_runtime.so"):
-                copy(
-                    self,
-                    library,
-                    src=str(build),
-                    dst=str(destination),
-                    keep_path=False,
-                )
+        for library in ("libtrtmc_core.so", "libtrtmc_runtime.so"):
+            copy(
+                self,
+                library,
+                src=str(build),
+                dst=str(module_bin),
+                keep_path=False,
+            )
         copy(
             self,
             "libtrtmc_backend_trt*.so",
@@ -146,11 +143,8 @@ class TensorRTModelConnectConan(ConanFile):
             )
 
         native = module_bin / "trtmc"
-        installed = script_bin / "trtmc"
         shared_runtime = [
-            destination / library
-            for destination in (module_bin, script_bin)
-            for library in ("libtrtmc_core.so", "libtrtmc_runtime.so")
+            module_bin / library for library in ("libtrtmc_core.so", "libtrtmc_runtime.so")
         ]
         backend = module_bin / "libtrtmc_backend_trt.so"
         backends = sorted(module_bin.glob("libtrtmc_backend_trt*.so"))
@@ -159,7 +153,6 @@ class TensorRTModelConnectConan(ConanFile):
         dataset_benchmark = module_bin / "trtmc_dataset_benchmark"
         if (
             not native.is_file()
-            or not installed.is_file()
             or not all(library.is_file() for library in shared_runtime)
             or not backend.is_file()
             or not byok.is_file()
@@ -168,7 +161,7 @@ class TensorRTModelConnectConan(ConanFile):
         ):
             raise ConanException("native runtime package is incomplete")
 
-        for executable in (native, installed, benchmark_worker, dataset_benchmark):
+        for executable in (native, benchmark_worker, dataset_benchmark):
             _make_executable(executable)
             _set_runpath(executable, "$ORIGIN")
         for library in shared_runtime:

--- a/core/builder/tensorrt_model_connect/__main__.py
+++ b/core/builder/tensorrt_model_connect/__main__.py
@@ -1,8 +1,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run the family-owned bundle build CLI."""
+"""Run the installed build command or packaged native CLI."""
 
-from .build_cli import main
+from __future__ import annotations
 
-raise SystemExit(main())
+import os
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from . import build_cli
+
+
+def _native_executable() -> Path:
+    return Path(__file__).resolve().parent / "bin" / "trtmc"
+
+
+def main(argv: Sequence[str] | None = None) -> int | None:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments and arguments[0] == "build":
+        return build_cli.main(arguments)
+
+    executable = _native_executable()
+    if not executable.is_file():
+        raise FileNotFoundError(f"packaged native trtmc does not exist: {executable}")
+    os.execv(str(executable), [str(executable), *arguments])
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/builder/tests/test_build_cli.py
+++ b/core/builder/tests/test_build_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,41 @@ from types import SimpleNamespace
 import pytest
 
 from tensorrt_model_connect import build_cli
+
+
+def test_module_entry_routes_build_to_the_existing_builder(monkeypatch) -> None:
+    entry = importlib.import_module("tensorrt_model_connect.__main__")
+    calls = []
+    monkeypatch.setattr(entry.build_cli, "main", lambda arguments: calls.append(arguments) or 7)
+
+    assert entry.main(["build", "model", "--output", "model.bundle"]) == 7
+    assert calls == [["build", "model", "--output", "model.bundle"]]
+
+
+def test_module_entry_executes_the_packaged_native_cli(monkeypatch, tmp_path: Path) -> None:
+    entry = importlib.import_module("tensorrt_model_connect.__main__")
+    executable = tmp_path / "trtmc"
+    executable.write_text("native", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(entry, "_native_executable", lambda: executable)
+    monkeypatch.setattr(entry.os, "execv", lambda path, arguments: calls.append((path, arguments)))
+
+    assert entry.main(["run", "model.bundle", "--prompt", "hello"]) is None
+    assert calls == [
+        (
+            str(executable),
+            [str(executable), "run", "model.bundle", "--prompt", "hello"],
+        )
+    ]
+
+
+def test_module_entry_rejects_a_missing_native_cli(monkeypatch, tmp_path: Path) -> None:
+    entry = importlib.import_module("tensorrt_model_connect.__main__")
+    missing = tmp_path / "missing-trtmc"
+    monkeypatch.setattr(entry, "_native_executable", lambda: missing)
+
+    with pytest.raises(FileNotFoundError, match="packaged native trtmc does not exist"):
+        entry.main(["version"])
 
 
 def test_build_command_forwards_only_direct_inputs(monkeypatch, tmp_path: Path) -> None:

--- a/core/runtime/include/trtmc/task.h
+++ b/core/runtime/include/trtmc/task.h
@@ -446,6 +446,7 @@ class ITextGeneration : public virtual ITask {
     static constexpr const char* kTask = "text_generation";
     const char* task() const noexcept override { return kTask; }
     virtual std::int32_t default_max_new_tokens() const = 0;
+    virtual bool default_use_chat_template() const noexcept { return false; }
     virtual TextResult generate(const std::string& prompt,
                                 const TextGenerationConfig& config = {}) = 0;
 };

--- a/core/runtime/tests/test_task_api.cpp
+++ b/core/runtime/tests/test_task_api.cpp
@@ -96,6 +96,8 @@ int main() {
     auto* embedding = dynamic_cast<trtmc::IEmbedding*>(task.get());
     if (text == nullptr || embedding == nullptr)
         return 1;
+    if (text->default_use_chat_template())
+        return 1;
     if (text->generate("hello").text != "hello")
         return 1;
     if (embedding->embed("abc").data != std::vector<float>{3.0F})

--- a/families/bloom/runtime/pipeline.h
+++ b/families/bloom/runtime/pipeline.h
@@ -51,6 +51,9 @@ class BloomTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/bloom/tests/manifests/bloom-560m-tp4.json
+++ b/families/bloom/tests/manifests/bloom-560m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "bloom-560m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/bloom/tests/manifests/bloom-560m.json
+++ b/families/bloom/tests/manifests/bloom-560m.json
@@ -11,7 +11,8 @@
       "name": "bloom-560m",
       "premerge": true,
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/codegen/runtime/pipeline.h
+++ b/families/codegen/runtime/pipeline.h
@@ -52,6 +52,9 @@ class CodegenTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/codegen/tests/manifests/codegen-350m-tp4.json
+++ b/families/codegen/tests/manifests/codegen-350m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "codegen-350m-tp4",
       "prompt": "def fibonacci(n):",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/codegen/tests/manifests/codegen-350m.json
+++ b/families/codegen/tests/manifests/codegen-350m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "def fibonacci(n):",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/deepseek_v2/runtime/pipeline.h
+++ b/families/deepseek_v2/runtime/pipeline.h
@@ -52,6 +52,9 @@ class DeepseekV2TextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/deepseek_v2/tests/manifests/deepseek-v2-lite-tp4.json
+++ b/families/deepseek_v2/tests/manifests/deepseek-v2-lite-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "deepseek-v2-lite-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/deepseek_v2/tests/manifests/deepseek-v2-lite.json
+++ b/families/deepseek_v2/tests/manifests/deepseek-v2-lite.json
@@ -11,7 +11,8 @@
       "name": "deepseek-v2-lite",
       "reference_precision": "fp16",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 128,

--- a/families/deepseek_v2/tests/manifests/deepseek-v2-tiny-tp2.json
+++ b/families/deepseek_v2/tests/manifests/deepseek-v2-tiny-tp2.json
@@ -11,7 +11,8 @@
       "name": "deepseek-v2-tiny-tp2",
       "reference_experts_implementation": "batched_mm",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/deepseek_v2/tests/manifests/deepseek-v2-tiny.json
+++ b/families/deepseek_v2/tests/manifests/deepseek-v2-tiny.json
@@ -14,7 +14,8 @@
       "reference_precision": "fp16",
       "reference_experts_implementation": "batched_mm",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 64,

--- a/families/falcon/runtime/pipeline.h
+++ b/families/falcon/runtime/pipeline.h
@@ -51,6 +51,9 @@ class FalconTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/falcon/tests/manifests/falcon-rw-1b-tp4.json
+++ b/families/falcon/tests/manifests/falcon-rw-1b-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "falcon-rw-1b-tp4",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/falcon/tests/manifests/falcon-rw-1b.json
+++ b/families/falcon/tests/manifests/falcon-rw-1b.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/gemma/runtime/pipeline.h
+++ b/families/gemma/runtime/pipeline.h
@@ -52,6 +52,9 @@ class GemmaTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/glm/runtime/pipeline.h
+++ b/families/glm/runtime/pipeline.h
@@ -51,6 +51,9 @@ class GlmTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/glm/tests/manifests/glm-4-9b-l0-tp2.json
+++ b/families/glm/tests/manifests/glm-4-9b-l0-tp2.json
@@ -9,7 +9,8 @@
     {
       "name": "glm-4-9b-l0-tp2",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 8
+      "max_new_tokens": 8,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/glm/tests/manifests/glm-4-9b-l0.json
+++ b/families/glm/tests/manifests/glm-4-9b-l0.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 8
+      "max_new_tokens": 8,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/glm/tests/manifests/glm-4-9b.json
+++ b/families/glm/tests/manifests/glm-4-9b.json
@@ -11,7 +11,8 @@
       "name": "glm-4-9b",
       "reference_precision": "fp32",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/gpt2/runtime/pipeline.h
+++ b/families/gpt2/runtime/pipeline.h
@@ -51,6 +51,9 @@ class Gpt2TextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/gpt2/tests/manifests/distilgpt2.json
+++ b/families/gpt2/tests/manifests/distilgpt2.json
@@ -11,7 +11,8 @@
       "name": "distilgpt2",
       "reference_precision": "fp32",
       "prompt": "Hello, I'm a language model",
-      "max_new_tokens": 12
+      "max_new_tokens": 12,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/gpt2/tests/manifests/gpt2-125m-tp4.json
+++ b/families/gpt2/tests/manifests/gpt2-125m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "gpt2-125m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/gpt2/tests/manifests/gpt2-125m.json
+++ b/families/gpt2/tests/manifests/gpt2-125m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/gpt_neo/runtime/pipeline.h
+++ b/families/gpt_neo/runtime/pipeline.h
@@ -51,6 +51,9 @@ class GptNeoTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/gpt_neo/tests/manifests/gpt-neo-125m-tp4.json
+++ b/families/gpt_neo/tests/manifests/gpt-neo-125m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "gpt-neo-125m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/gpt_neo/tests/manifests/gpt-neo-125m.json
+++ b/families/gpt_neo/tests/manifests/gpt-neo-125m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/gpt_neox/runtime/pipeline.h
+++ b/families/gpt_neox/runtime/pipeline.h
@@ -52,6 +52,9 @@ class GptNeoxTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/gpt_neox/tests/manifests/pythia-70m-tp4.json
+++ b/families/gpt_neox/tests/manifests/pythia-70m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "pythia-70m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/gpt_neox/tests/manifests/pythia-70m.json
+++ b/families/gpt_neox/tests/manifests/pythia-70m.json
@@ -11,7 +11,8 @@
       "name": "pythia-70m",
       "premerge": true,
       "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nStatement 1 | A factor group of a non-Abelian group is non-Abelian. Statement 2 | If K is a normal subgroup of H and H is a normal subgroup of G, then K is a normal subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer:",
-      "max_new_tokens": 32
+      "max_new_tokens": 32,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 400,

--- a/families/gpt_oss/runtime/pipeline.h
+++ b/families/gpt_oss/runtime/pipeline.h
@@ -51,6 +51,9 @@ class GptOssTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/granite/runtime/pipeline.h
+++ b/families/granite/runtime/pipeline.h
@@ -52,6 +52,9 @@ class GraniteTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/granite/tests/manifests/granite-3.1-2b-tp4.json
+++ b/families/granite/tests/manifests/granite-3.1-2b-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "granite-3.1-2b-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/granite/tests/manifests/granite-3.1-2b.json
+++ b/families/granite/tests/manifests/granite-3.1-2b.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/internlm/runtime/pipeline.h
+++ b/families/internlm/runtime/pipeline.h
@@ -52,6 +52,9 @@ class InternlmTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/k2_horizon/runtime/pipeline.h
+++ b/families/k2_horizon/runtime/pipeline.h
@@ -44,6 +44,7 @@ class K2HorizonTextGenerationPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override { return false; }
 
     struct GenerationResult {
         std::vector<int32_t> token_ids;

--- a/families/lfm2/runtime/pipeline.h
+++ b/families/lfm2/runtime/pipeline.h
@@ -37,6 +37,9 @@ class Lfm2TextGenerationPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     struct GenerationResult {
         std::vector<int32_t> token_ids;

--- a/families/lfm2/tests/manifests/lfm2-1.2b.json
+++ b/families/lfm2/tests/manifests/lfm2-1.2b.json
@@ -13,6 +13,7 @@
       "reference_precision": "bf16",
       "prompt": "The capital of France is",
       "max_new_tokens": 8,
+      "use_chat_template": false,
       "do_sample": false
     }
   ],

--- a/families/lfm2/tests/manifests/lfm2-2.6b.json
+++ b/families/lfm2/tests/manifests/lfm2-2.6b.json
@@ -13,6 +13,7 @@
       "reference_precision": "bf16",
       "prompt": "The capital of France is",
       "max_new_tokens": 8,
+      "use_chat_template": false,
       "do_sample": false
     }
   ],

--- a/families/lfm2/tests/manifests/lfm2-700m.json
+++ b/families/lfm2/tests/manifests/lfm2-700m.json
@@ -13,6 +13,7 @@
       "reference_precision": "bf16",
       "prompt": "The capital of France is",
       "max_new_tokens": 8,
+      "use_chat_template": false,
       "do_sample": false
     }
   ],

--- a/families/llama/runtime/pipeline.h
+++ b/families/llama/runtime/pipeline.h
@@ -52,6 +52,9 @@ class LlamaTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/llama/tests/cpp/test_llama_pipeline.cpp
+++ b/families/llama/tests/cpp/test_llama_pipeline.cpp
@@ -230,10 +230,14 @@ make_pipeline(cudaStream_t stream, trtmc::LlamaTextGenConfig config,
 
 void test_pipeline_construction() {
     StreamFixture fixture;
-    auto pipeline = make_pipeline(fixture.stream, make_config());
+    auto config = make_config();
+    config.chat_template_format = "chatml";
+    auto pipeline = make_pipeline(fixture.stream, config);
     check(std::string(pipeline->task()) == trtmc::ITextGeneration::kTask,
           "pipeline exposes text-generation Task API");
     check(pipeline->default_max_new_tokens() == 128, "pipeline default token limit");
+    check(pipeline->default_use_chat_template(),
+          "pipeline defaults to its supported chat template");
 }
 
 void test_generate_stops_at_eos() {

--- a/families/llama/tests/manifests/falcon3-1b.json
+++ b/families/llama/tests/manifests/falcon3-1b.json
@@ -11,7 +11,8 @@
       "name": "falcon3-1b",
       "reference_precision": "fp32",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/llama/tests/manifests/minitron-4b-depth.json
+++ b/families/llama/tests/manifests/minitron-4b-depth.json
@@ -11,7 +11,8 @@
       "name": "minitron-4b-depth",
       "reference_precision": "fp32",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/llama/tests/manifests/minitron-4b-width-l0.json
+++ b/families/llama/tests/manifests/minitron-4b-width-l0.json
@@ -14,6 +14,7 @@
       "reference_precision": "fp16",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
       "max_new_tokens": 8,
+      "use_chat_template": false,
       "kv_cache_size": "16777216",
       "expected_kv_cache_rows": 128
     }

--- a/families/llama/tests/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
+++ b/families/llama/tests/manifests/minitron-4b-width-regression-native-kv-chunked-prefill.json
@@ -23,7 +23,8 @@
       "expected_prefill_chunk_limit": 64,
       "max_new_tokens": 2,
       "temperature": 0.0,
-      "top_k": 1
+      "top_k": 1,
+      "use_chat_template": false
     }
   ],
   "precision": "bf16",

--- a/families/llama/tests/manifests/minitron-4b-width.json
+++ b/families/llama/tests/manifests/minitron-4b-width.json
@@ -13,6 +13,7 @@
       "reference_precision": "fp16",
       "prompt": "The quick brown fox jumps over the lazy dog. Once upon a time",
       "max_new_tokens": 20,
+      "use_chat_template": false,
       "kv_cache_size": "1GiB",
       "expected_kv_cache_rows": 8192
     }

--- a/families/mamba/runtime/pipeline.h
+++ b/families/mamba/runtime/pipeline.h
@@ -40,6 +40,9 @@ class RecurrentPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/mamba/tests/manifests/mamba-130m-tp4.json
+++ b/families/mamba/tests/manifests/mamba-130m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "mamba-130m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/mamba/tests/manifests/mamba-130m.json
+++ b/families/mamba/tests/manifests/mamba-130m.json
@@ -11,7 +11,8 @@
       "name": "mamba-130m",
       "premerge": true,
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/mistral/runtime/pipeline.h
+++ b/families/mistral/runtime/pipeline.h
@@ -52,6 +52,9 @@ class MistralTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/mixtral/runtime/pipeline.h
+++ b/families/mixtral/runtime/pipeline.h
@@ -52,6 +52,9 @@ class MixtralTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/mixtral/tests/manifests/mixtral-stories-15m-tp2.json
+++ b/families/mixtral/tests/manifests/mixtral-stories-15m-tp2.json
@@ -9,7 +9,8 @@
     {
       "name": "mixtral-stories-15m-tp2",
       "prompt": "Once upon a time there was a little",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/mixtral/tests/manifests/mixtral-stories-15m.json
+++ b/families/mixtral/tests/manifests/mixtral-stories-15m.json
@@ -17,7 +17,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "Once upon a time there was a little",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/nemotron/runtime/pipeline.h
+++ b/families/nemotron/runtime/pipeline.h
@@ -52,6 +52,9 @@ class NemotronTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/nemotron/tests/manifests/nemotron-hindi-4b.json
+++ b/families/nemotron/tests/manifests/nemotron-hindi-4b.json
@@ -11,7 +11,8 @@
       "name": "nemotron-hindi-4b",
       "reference_precision": "bf16",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/nemotron_h/runtime/pipeline.h
+++ b/families/nemotron_h/runtime/pipeline.h
@@ -40,6 +40,9 @@ class RecurrentPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/nemotron_labs_diffusion/runtime/pipeline.h
+++ b/families/nemotron_labs_diffusion/runtime/pipeline.h
@@ -56,6 +56,9 @@ class NemotronLabsDiffusionTextGenerationPipeline final : public ITextGeneration
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/olmo/runtime/pipeline.h
+++ b/families/olmo/runtime/pipeline.h
@@ -51,6 +51,9 @@ class OlmoTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/olmo/tests/manifests/olmo-1b-tp4.json
+++ b/families/olmo/tests/manifests/olmo-1b-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "olmo-1b-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/olmo/tests/manifests/olmo-1b.json
+++ b/families/olmo/tests/manifests/olmo-1b.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/olmo2/runtime/pipeline.h
+++ b/families/olmo2/runtime/pipeline.h
@@ -51,6 +51,9 @@ class Olmo2TextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/olmo2/tests/manifests/olmo2-1b-tp4.json
+++ b/families/olmo2/tests/manifests/olmo2-1b-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "olmo2-1b-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/olmo2/tests/manifests/olmo2-1b.json
+++ b/families/olmo2/tests/manifests/olmo2-1b.json
@@ -13,7 +13,8 @@
       "premerge": true,
       "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nFind the degree for the given field extension Q(sqrt(2), sqrt(3), sqrt(18)) over Q.\nA. 0\nB. 4\nC. 2\nD. 6\nAnswer:",
       "max_new_tokens": 8,
-      "reference_precision": "fp32"
+      "reference_precision": "fp32",
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 352,

--- a/families/opt/runtime/pipeline.h
+++ b/families/opt/runtime/pipeline.h
@@ -51,6 +51,9 @@ class OptTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/opt/tests/manifests/opt-125m-tp4.json
+++ b/families/opt/tests/manifests/opt-125m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "opt-125m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/opt/tests/manifests/opt-125m.json
+++ b/families/opt/tests/manifests/opt-125m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/phi/runtime/pipeline.h
+++ b/families/phi/runtime/pipeline.h
@@ -51,6 +51,9 @@ class PhiTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/phi_moe/runtime/pipeline.h
+++ b/families/phi_moe/runtime/pipeline.h
@@ -51,6 +51,9 @@ class PhiMoeTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/qwen/runtime/pipeline.h
+++ b/families/qwen/runtime/pipeline.h
@@ -52,6 +52,9 @@ class QwenTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/qwen/tests/manifests/qwen3-0.6b-fp8-tp4.json
+++ b/families/qwen/tests/manifests/qwen3-0.6b-fp8-tp4.json
@@ -15,6 +15,7 @@
         "Paris"
       ],
       "max_new_tokens": 10,
+      "use_chat_template": false,
       "reference_precision": "bf16"
     }
   ],

--- a/families/qwen/tests/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
+++ b/families/qwen/tests/manifests/qwen3-0.6b-regression-native-kv-chunked-prefill.json
@@ -22,7 +22,8 @@
       "expected_prefill_chunk_limit": 64,
       "max_new_tokens": 2,
       "temperature": 0.0,
-      "top_k": 1
+      "top_k": 1,
+      "use_chat_template": false
     },
     {
       "name": "qwen3-0.6b-bf16-native-kv-two-chunk-parity",

--- a/families/qwen/tests/manifests/qwen3-0.6b-topp-tp4.json
+++ b/families/qwen/tests/manifests/qwen3-0.6b-topp-tp4.json
@@ -15,6 +15,7 @@
       "top_p": 0.9,
       "top_k": 50,
       "seed": 42,
+      "use_chat_template": false,
       "determinism_reruns": 1
     }
   ],

--- a/families/qwen/tests/manifests/qwen3-0.6b-topp.json
+++ b/families/qwen/tests/manifests/qwen3-0.6b-topp.json
@@ -15,6 +15,7 @@
       "top_p": 0.9,
       "top_k": 50,
       "seed": 42,
+      "use_chat_template": false,
       "determinism_reruns": 1
     }
   ],

--- a/families/qwen3_5/runtime/pipeline.h
+++ b/families/qwen3_5/runtime/pipeline.h
@@ -40,6 +40,9 @@ class RecurrentPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/qwen3_8/runtime/pipeline.h
+++ b/families/qwen3_8/runtime/pipeline.h
@@ -41,6 +41,9 @@ class RecurrentPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/qwen3_omni/runtime/pipeline.h
+++ b/families/qwen3_omni/runtime/pipeline.h
@@ -35,6 +35,7 @@ class Qwen3OmniTextPipeline final : public ITextGeneration {
                           Qwen3OmniRuntimeConfig config, std::shared_ptr<ITokenizer> tokenizer);
 
     std::int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override { return false; }
     TextResult generate(const std::string& prompt,
                         const TextGenerationConfig& config = {}) override;
 

--- a/families/qwen3_omni/tests/cpp/test_qwen3_omni_pipeline.cpp
+++ b/families/qwen3_omni/tests/cpp/test_qwen3_omni_pipeline.cpp
@@ -202,6 +202,8 @@ void test_pipeline_construction() {
           "Qwen3-Omni implements the text-generation Task API");
     check(pipeline->default_max_new_tokens() == 128,
           "Qwen3-Omni preserves its default text token limit");
+    check(!pipeline->default_use_chat_template(),
+          "Qwen3-Omni keeps its fixed internal prompt instead of the generic chat option");
 }
 
 void test_validates_thinker() {

--- a/families/qwen_moe/runtime/pipeline.h
+++ b/families/qwen_moe/runtime/pipeline.h
@@ -52,6 +52,9 @@ class QwenMoeTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/qwen_moe/tests/manifests/qwen3-moe-tiny-random.json
+++ b/families/qwen_moe/tests/manifests/qwen3-moe-tiny-random.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "What is the largest planet in our solar system? Answer in one word.",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 128,

--- a/families/rwkv/runtime/pipeline.h
+++ b/families/rwkv/runtime/pipeline.h
@@ -40,6 +40,9 @@ class RecurrentPipeline final : public ITextGeneration {
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/rwkv/tests/manifests/rwkv-169m-tp4.json
+++ b/families/rwkv/tests/manifests/rwkv-169m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "rwkv-169m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/rwkv/tests/manifests/rwkv-169m.json
+++ b/families/rwkv/tests/manifests/rwkv-169m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 10
+      "max_new_tokens": 10,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 32,

--- a/families/stablelm/runtime/pipeline.h
+++ b/families/stablelm/runtime/pipeline.h
@@ -52,6 +52,9 @@ class StablelmTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/stablelm/tests/manifests/stablelm2-1.6b-tp4.json
+++ b/families/stablelm/tests/manifests/stablelm2-1.6b-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "stablelm2-1.6b-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/stablelm/tests/manifests/stablelm2-1.6b.json
+++ b/families/stablelm/tests/manifests/stablelm2-1.6b.json
@@ -16,7 +16,8 @@
       "premerge": true,
       "reference_precision": "fp16",
       "prompt": "The following are multiple choice questions (with answers) about abstract algebra.\n\nFind all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.\nA. 0\nB. 1\nC. 2\nD. 3\nAnswer: B\n\nStatement 1 | If aH is an element of a factor group, then |aH| divides |a|. Statement 2 | If H and K are subgroups of G then HK is a subgroup of G.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: B\n\nStatement 1 | Every element of a group generates a cyclic subgroup of the group. Statement 2 | The symmetric group S_10 has 10 elements.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: C\n\nStatement 1| Every function from a finite set onto itself must be one to one. Statement 2 | Every subgroup of an abelian group is abelian.\nA. True, True\nB. False, False\nC. True, False\nD. False, True\nAnswer: A\n\nFind the characteristic of the ring 2Z.\nA. 0\nB. 3\nC. 12\nD. 30\nAnswer: A\n\nLet p = (1, 2, 5, 4)(2, 3) in S_5 . Find the index of <p> in S_5.\nA. 8\nB. 2\nC. 24\nD. 120\nAnswer:",
-      "max_new_tokens": 22
+      "max_new_tokens": 22,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 384,

--- a/families/starcoder2/runtime/pipeline.h
+++ b/families/starcoder2/runtime/pipeline.h
@@ -52,6 +52,9 @@ class Starcoder2TextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/starcoder2/tests/manifests/starcoder2-3b-tp2.json
+++ b/families/starcoder2/tests/manifests/starcoder2-3b-tp2.json
@@ -9,7 +9,8 @@
     {
       "name": "starcoder2-3b-tp2",
       "prompt": "def fibonacci(n):",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/starcoder2/tests/manifests/starcoder2-3b.json
+++ b/families/starcoder2/tests/manifests/starcoder2-3b.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "def f():\n    0.5",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/families/xglm/runtime/pipeline.h
+++ b/families/xglm/runtime/pipeline.h
@@ -51,6 +51,9 @@ class XglmTextGenerationPipeline final : public ITextGeneration {
     // Public API: takes raw text, returns typed result.
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 128; }
+    bool default_use_chat_template() const noexcept override {
+        return !config_.chat_template_format.empty();
+    }
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {

--- a/families/xglm/tests/manifests/xglm-564m-tp4.json
+++ b/families/xglm/tests/manifests/xglm-564m-tp4.json
@@ -9,7 +9,8 @@
     {
       "name": "xglm-564m-tp4",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "precision": "fp32",

--- a/families/xglm/tests/manifests/xglm-564m.json
+++ b/families/xglm/tests/manifests/xglm-564m.json
@@ -12,7 +12,8 @@
       "premerge": true,
       "reference_precision": "fp32",
       "prompt": "The capital of France is",
-      "max_new_tokens": 20
+      "max_new_tokens": 20,
+      "use_chat_template": false
     }
   ],
   "max_sequence_length": 256,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 ]
 
 [project.scripts]
+trtmc = "tensorrt_model_connect.__main__:main"
 trtmc-bench = "trtmc_benchmark.cli:main"
 
 [project.optional-dependencies]

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -262,20 +262,24 @@ class WheelArchiveValidator:
                 raise CiError(
                     f"{wheel}: expected only unaliased TensorRT backend DSOs, found {backend_dsos}"
                 )
-            scripts = [name for name in names if name.endswith(".data/scripts/trtmc")]
-            script_cores = [
-                name for name in names if name.endswith(".data/scripts/libtrtmc_core.so")
+            duplicate_native_scripts = [
+                name
+                for name in names
+                if ".data/scripts/" in name
+                and Path(name).name in {"trtmc", "libtrtmc_core.so", "libtrtmc_runtime.so"}
             ]
-            script_runtimes = [
-                name for name in names if name.endswith(".data/scripts/libtrtmc_runtime.so")
-            ]
-            if len(scripts) != 1 or len(script_cores) != 1 or len(script_runtimes) != 1:
-                raise CiError(f"{wheel}: installed CLI payload is incomplete")
+            if duplicate_native_scripts:
+                raise CiError(f"{wheel}: duplicate native CLI payload is forbidden")
             entry_points = [name for name in names if name.endswith(".dist-info/entry_points.txt")]
-            if len(entry_points) != 1 or "trtmc-bench" not in archive.read(entry_points[0]).decode(
-                "utf-8"
-            ):
-                raise CiError(f"{wheel}: trtmc-bench console entrypoint is missing")
+            if len(entry_points) != 1:
+                raise CiError(f"{wheel}: console entrypoints are missing")
+            entry_point_text = archive.read(entry_points[0]).decode("utf-8")
+            expected_entrypoints = (
+                "trtmc = tensorrt_model_connect.__main__:main",
+                "trtmc-bench = trtmc_benchmark.cli:main",
+            )
+            if any(entrypoint not in entry_point_text for entrypoint in expected_entrypoints):
+                raise CiError(f"{wheel}: required console entrypoints are missing")
         print(f"validated wheel={wheel} families={len(expected_families)}")
 
 
@@ -369,6 +373,16 @@ print(json.dumps({
         )
         if not version.stdout.startswith("trtmc "):
             raise CiError("installed trtmc CLI returned an invalid version")
+        build_help = subprocess.run(
+            [executable, "build", "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=Path("/tmp"),
+            env=environment,
+        )
+        if "usage: trtmc build" not in build_help.stdout:
+            raise CiError("installed trtmc build command returned invalid help")
         with tempfile.TemporaryDirectory(prefix="trtmc-installed-wheel-") as directory:
             bundle = Path(directory) / "inspect.bundle"
             subprocess.run(

--- a/tools/tests/test_new_ci.py
+++ b/tools/tests/test_new_ci.py
@@ -647,7 +647,9 @@ def test_wheel_validation_requires_exact_new_payload(tmp_path: Path) -> None:
         archive.writestr("tensorrt_model_connect/bin/libtrtmc_byok_tvm_ffi.so", "")
         archive.writestr(
             "package-0.1.dist-info/entry_points.txt",
-            "[console_scripts]\ntrtmc-bench = trtmc_benchmark.cli:main\n",
+            "[console_scripts]\n"
+            "trtmc = tensorrt_model_connect.__main__:main\n"
+            "trtmc-bench = trtmc_benchmark.cli:main\n",
         )
         archive.writestr(
             "package-0.1.dist-info/METADATA",
@@ -657,9 +659,6 @@ def test_wheel_validation_requires_exact_new_payload(tmp_path: Path) -> None:
             "Provides-Extra: cutedsl\n"
             "Provides-Extra: test\n",
         )
-        archive.writestr("package-0.1.data/scripts/trtmc", "")
-        archive.writestr("package-0.1.data/scripts/libtrtmc_core.so", "")
-        archive.writestr("package-0.1.data/scripts/libtrtmc_runtime.so", "")
         for family in family_names:
             archive.writestr(
                 f"families/{family}/model.py",
@@ -668,6 +667,14 @@ def test_wheel_validation_requires_exact_new_payload(tmp_path: Path) -> None:
             archive.writestr(f"tensorrt_model_connect/bin/libtrtmc_model_{family}.so", "")
 
     WheelArchiveValidator(CiContext(tmp_path, {})).validate([wheel])
+
+    duplicate_native = tmp_path / "duplicate-native.whl"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(duplicate_native, "w") as output:
+        for entry in source.infolist():
+            output.writestr(entry, source.read(entry.filename))
+        output.writestr("package-0.1.data/scripts/trtmc", "")
+    with pytest.raises(CiError, match="duplicate native CLI payload"):
+        WheelArchiveValidator(CiContext(tmp_path, {})).validate([duplicate_native])
 
     corrupt = tmp_path / "corrupt.whl"
     with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(corrupt, "w") as output:

--- a/website/docs/api/cpp-api.md
+++ b/website/docs/api/cpp-api.md
@@ -12,8 +12,14 @@ to that task interface, never to a family implementation:
 auto task = trtmc::load_task("gpt2.bundle", "/opt/trtmc/lib");
 auto* text = dynamic_cast<trtmc::ITextGeneration*>(task.get());
 if (text == nullptr) throw std::runtime_error("not a text-generation bundle");
-auto result = text->generate("Hello");
+trtmc::TextGenerationConfig config;
+config.use_chat_template = text->default_use_chat_template();
+auto result = text->generate("Hello", config);
 ```
+
+The chat-template default is selected by the loaded family and checkpoint. An
+application can set `config.use_chat_template` explicitly when it needs raw
+completion or a template regardless of that default.
 
 Each family DSO directly implements one or more interfaces from
 `trtmc/task.h`. The loader verifies that `ITask::task()` exactly matches the

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -26,44 +26,42 @@ python -m pip install -r "$FAMILY_REQUIREMENTS"
 There is no central family extra or dependency registry. A family without a
 `requirements.txt` needs only the pinned base environment and the wheel.
 
-Build a bundle directly from a Hugging Face model ID:
+After the wheel is installed, build and run a supported model in two commands:
 
 ```bash
-python -m tensorrt_model_connect build openai-community/gpt2 \
-  --precision fp16 \
-  --output gpt2.bundle
+trtmc build Qwen/Qwen3-0.6B \
+  --max-sequence-length 16384 \
+  --output qwen3-0.6b.bundle
+trtmc run qwen3-0.6b.bundle \
+  --prompt "What is the capital of France? Answer in one word." \
+  --enable-thinking false
 ```
 
 The CLI downloads the snapshot, reads `config.json` or `model_index.json`, and
 asks every dependency-free family `support.py`. Exactly one family must claim
 the checkpoint. That family supplies the default task; pass `--task` only when
 selecting another task supported by the same family. The build then imports
-only the selected `families.gpt2.model` and calls `build(request, writer)` once.
+only the selected `families.qwen.model` and calls `build(request, writer)` once.
 A prepared local snapshot can be passed in place of the model ID.
 
-For a wheel install, resolve its native runtime directory directly from the
-installed package:
-
-```bash
-TRTMC_RUNTIME_ROOT="$(python -c 'import pathlib, tensorrt_model_connect as m; print(pathlib.Path(m.__file__).parent / "bin")')"
-trtmc run gpt2.bundle \
-  --runtime-root "$TRTMC_RUNTIME_ROOT" \
-  --prompt "Hello" \
-  --max-new-tokens 32
-```
+The installed `trtmc` command routes `build` to the existing Python builder and
+executes the native CLI packaged beside the runtime DSOs for every other
+command. A text family that owns a supported chat template enables it by
+default; pass `--use-chat-template false` to request raw completion instead.
 
 For a native CMake install, point the loader at the directory containing the matching
 `libtrtmc_core.so`, `libtrtmc_runtime.so`, `libtrtmc_backend_trt.so`, and
-`libtrtmc_model_gpt2.so`. The loader reads the bundle header, loads exactly
+selected family DSO. The loader reads the bundle header, loads exactly
 those DSOs, and returns the abstract task interface declared by the bundle.
 
 ```bash
-trtmc run gpt2.bundle \
+trtmc run model.bundle \
   --runtime-root /opt/trtmc/lib \
-  --prompt "Hello" \
-  --max-new-tokens 32
+  --prompt "Hello"
 ```
 
-The shell variable above is only a convenient explicit argument. The CLI never
-searches environment variables, the current directory, or an installed
-fallback runtime.
+An explicit `--runtime-root` always wins. Without it, the native CLI accepts a
+directory only when the exact core, runtime, backend, and family files are all
+present. It checks the current directory first and the real executable
+directory second. It does not scan environment variables or other install
+locations.

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -120,6 +120,20 @@ cmake --build "$TRTMC_BUILD_DIR" --parallel "$(nproc)" --target \
 export PATH="$PWD/$TRTMC_BUILD_DIR:$PATH"
 ```
 
+The native executable and selected DSOs share the build directory, so runtime
+commands issued from the checkout or through this `PATH` entry do not need
+`--runtime-root`. Build the bundle through the installed Python module, then run
+it natively:
+
+```bash
+python -m tensorrt_model_connect build Qwen/Qwen3-0.6B \
+  --max-sequence-length 16384 \
+  --output qwen3-0.6b.bundle
+trtmc run qwen3-0.6b.bundle \
+  --prompt "What is the capital of France? Answer in one word." \
+  --enable-thinking false
+```
+
 TensorRT-RTX is an explicit optional build. When its SDK is installed, enable
 only its backend DSO with the exact include and library directories:
 


### PR DESCRIPTION
## Background

The post-#1093 Quick Start required users to invoke the builder as a Python module, discover a runtime directory, pass `--runtime-root`, and explicitly enable a chat template. The first successful model run should require as little repository-specific knowledge as possible.

## Exit Criteria

- An installed wheel supports `trtmc build MODEL -o model.bundle`.
- `trtmc run model.bundle --prompt "..."` finds a complete colocated runtime without a path argument.
- An explicit `--runtime-root` always wins.
- Automatic lookup is limited to a complete current directory, then the real native executable directory.
- Text families enable a chat template only when that family actually owns one; explicit `false` remains effective.
- Existing model E2E request semantics remain unchanged.
- The low-level C++ `load_task()` API remains explicit and fail-closed.

## Implementation

- Reused `tensorrt_model_connect.__main__` as the installed `trtmc` entrypoint: `build` calls the existing Python builder and every native command `execv`s the packaged binary.
- Removed the duplicate native executable and core/runtime libraries from the wheel's `.data/scripts` payload.
- Added a CLI-only runtime resolver with the precedence explicit root, complete current directory, then complete executable directory. A candidate must contain the exact core, runtime, backend, and family files required by the bundle.
- Added `ITextGeneration::default_use_chat_template()`. All 35 text-family consumers own their answer: 33 derive it from their non-empty family chat-template format; K2-Horizon and Qwen3-Omni return false.
- Added explicit `use_chat_template: false` to 54 existing raw-completion testcases. A structural audit verifies those are the only manifest value changes.
- Updated the README, Quick Start, source-build guide, and C++ API example.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [x] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest core/builder/tests tools/tests -q` — 225 passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.model_ci validate` — valid, 98 families.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 tools/test_impact.py --validate` — valid, 98 families.
- Inside the pinned project development image: `cmake -S . -B .ci/quickstart-ux -G Ninja -DTRTMC_ENABLE_BYOK=OFF -DTRTMC_BUILD_EXAMPLES=OFF -DTRTMC_BUILD_TESTS=ON && cmake --build .ci/quickstart-ux --parallel 8 --target test_cli test_task_api && ctest --test-dir .ci/quickstart-ux --output-on-failure -R "^(cli|task_api)$"` — 2/2 passed.
- Single-GPU: `ctest --test-dir .ci/quickstart-ux --output-on-failure -R "^(test_llama_pipeline|test_qwen3_omni_pipeline)$"` — 2/2 passed.
- Inside the pinned project development image: `python -m build --no-isolation --wheel --outdir dist .` — exact-tree aarch64 wheel built all 98 family targets and packaged 102 shared libraries.
- `WheelArchiveValidator(...).validate([wheel])` — passed for 98 families; both console entrypoints present and no duplicate native `.data/scripts` payload.
- `InstalledWheelValidator(...).validate(wheel)` — passed, including `trtmc-bench --help`, `trtmc version`, `trtmc build --help`, and `trtmc inspect`.
- Installed-wheel no-root smoke — reached the packaged GPT-2 family and failed only on the deliberately omitted `runtime.json`, proving runtime resolution completed.
- Static chat audit — 35 consumers, 35 family overrides, 0 missing, 0 extra.
- Manifest semantic audit — 54 files, 54 explicit-false additions, no other value changes.
- `npm --prefix website ci && npm --prefix website run test:model-support && npm --prefix website run build` — model inventory and production documentation build passed.
- Ruff, clang-format check mode, and `git diff --check` — passed.

### Hardware, Environment, and Revisions

- Repository head: `d51a274de963f58e1d73af6a44b1b6af4a9ffc73`.
- Base: `cd1bde414846d9e902c967699e72c86585b974d1`.
- Local host: Linux aarch64, Python 3.12.3, CMake 3.28.3.
- Native/wheel builds used the repository's pinned development environment and CUDA architecture 100.
- The Llama and Qwen3-Omni default-policy tests used one GPU.

### Not Run / Remaining Gaps

- No Hugging Face checkpoint was downloaded or built for a complete real-model two-command E2E.
- No Multi-Device or NVLink test was run.
- Exact affected-family model E2E remains for CI.

## Notes For Future Readers

The convenience behavior lives in the application and packaging layers. `load_task()` still rejects an empty runtime root, and no environment-variable, library-path, installation-prefix, registry, or fallback search was added. Family manifests explicitly preserve existing test requests while new CLI users receive the family-owned default.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: the change intentionally updates installed CLI behavior, wheel layout, a public virtual Task method, and defaults across 35 text families. The implementation is small at each boundary, but the affected surface requires exact package and family E2E review.
