### PR TITLE
fix(ci): fail closed on E2E testcase selection

### DIFF
--- a/tools/ci/e2e.py
+++ b/tools/ci/e2e.py
@@ -236,8 +236,7 @@ class E2ERunner:
                     limit=self.context.env.get("TRTMC_E2E_TIMEOUT", "12h"),
                 )
                 _require_passing_junit(hardware_junit, "family hardware tests")
-            known_testcases = self._family_testcases(family)
-            requested_testcases = testcases or known_testcases
+            requested_testcases = testcases or self._family_testcases(family)
             test = f"families/{family}/tests/test_e2e.py"
             e2e_junit = native_build / f"trtmc-{family}-e2e-junit.xml"
             with self._isolated_runtime_root(runtime_root, family) as isolated:

--- a/tools/ci/e2e.py
+++ b/tools/ci/e2e.py
@@ -9,6 +9,7 @@ import json
 import re
 import tempfile
 import xml.etree.ElementTree as ET
+from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -18,13 +19,20 @@ from .context import CiContext
 from .process import CiError
 
 
-def _require_passing_junit(path: Path, label: str, *, allow_empty: bool = False) -> int:
+_E2E_CASE_NAME = re.compile(r"^test_.*e2e\[(?P<case>.+)\]$")
+
+
+def _read_junit(path: Path, label: str) -> list[ET.Element]:
     if not path.is_file():
         raise CiError(f"{label} report is missing")
     try:
-        testcases = ET.parse(path).getroot().findall(".//testcase")
+        return ET.parse(path).getroot().findall(".//testcase")
     except (OSError, ET.ParseError) as error:
         raise CiError(f"{label} report is invalid: {error}") from error
+
+
+def _require_passing_junit(path: Path, label: str, *, allow_empty: bool = False) -> int:
+    testcases = _read_junit(path, label)
     if not testcases and not allow_empty:
         raise CiError(f"{label} report has no test cases")
     for element, outcome in (
@@ -33,13 +41,84 @@ def _require_passing_junit(path: Path, label: str, *, allow_empty: bool = False)
         ("failure", "failures"),
     ):
         affected = [
-            test.get("name", "<unnamed>")
-            for test in testcases
-            if test.find(element) is not None
+            test.get("name", "<unnamed>") for test in testcases if test.find(element) is not None
         ]
         if affected:
             raise CiError(f"{label} {outcome}: " + ", ".join(affected))
     return len(testcases)
+
+
+def _require_e2e_junit(
+    path: Path,
+    family: str,
+    requested: tuple[str, ...],
+) -> None:
+    testcases = _read_junit(path, f"{family} E2E")
+    results: dict[str, list[ET.Element]] = {}
+    for testcase in testcases:
+        match = _E2E_CASE_NAME.fullmatch(testcase.get("name", ""))
+        if match:
+            results.setdefault(match.group("case"), []).append(testcase)
+
+    requested_counts = Counter(requested)
+    selected_results = [result for name in requested_counts for result in results.get(name, ())]
+    skipped = [result for result in selected_results if result.find("skipped") is not None]
+    failed = [
+        result
+        for result in selected_results
+        if result.find("failure") is not None or result.find("error") is not None
+    ]
+    passed = [
+        result
+        for result in selected_results
+        if result.find("skipped") is None
+        and result.find("failure") is None
+        and result.find("error") is None
+    ]
+    print(
+        f"{family} E2E results: requested={len(requested)} "
+        f"executed={len(passed) + len(failed)} passed={len(passed)} "
+        f"failed={len(failed)} skipped={len(skipped)}"
+    )
+
+    problems = []
+    duplicate_requests = sorted(name for name, count in requested_counts.items() if count != 1)
+    if duplicate_requests:
+        problems.append("duplicate requested E2E testcase: " + ", ".join(duplicate_requests))
+    missing = sorted(name for name in requested_counts if not results.get(name))
+    if missing:
+        problems.append("missing requested E2E testcase: " + ", ".join(missing))
+    duplicate_results = sorted(name for name in requested_counts if len(results.get(name, ())) > 1)
+    if duplicate_results:
+        problems.append("duplicate E2E testcase result: " + ", ".join(duplicate_results))
+    skipped_names = sorted(
+        name
+        for name in requested_counts
+        if any(result.find("skipped") is not None for result in results.get(name, ()))
+    )
+    if skipped_names:
+        problems.append("requested E2E testcase skipped: " + ", ".join(skipped_names))
+    failed_names = sorted(
+        name
+        for name in requested_counts
+        if any(
+            result.find("failure") is not None or result.find("error") is not None
+            for result in results.get(name, ())
+        )
+    )
+    if failed_names:
+        problems.append("requested E2E testcase failed: " + ", ".join(failed_names))
+
+    unexpected_executions = sorted(
+        name
+        for name, testcase_results in results.items()
+        if name not in requested_counts
+        and any(result.find("skipped") is None for result in testcase_results)
+    )
+    if unexpected_executions:
+        problems.append("unrequested E2E testcase executed: " + ", ".join(unexpected_executions))
+    if problems:
+        raise CiError(f"{family} E2E result validation failed: " + "; ".join(problems))
 
 
 class E2ERunner:
@@ -125,8 +204,7 @@ class E2ERunner:
                     print("No CPU family Python tests selected")
                 elif completed.returncode:
                     raise CiError(
-                        "family Python unit tests failed with exit code "
-                        f"{completed.returncode}"
+                        f"family Python unit tests failed with exit code {completed.returncode}"
                     )
             hardware_tests = [
                 str(path.relative_to(self.context.repository))
@@ -158,7 +236,10 @@ class E2ERunner:
                     limit=self.context.env.get("TRTMC_E2E_TIMEOUT", "12h"),
                 )
                 _require_passing_junit(hardware_junit, "family hardware tests")
+            known_testcases = self._family_testcases(family)
+            requested_testcases = testcases or known_testcases
             test = f"families/{family}/tests/test_e2e.py"
+            e2e_junit = native_build / f"trtmc-{family}-e2e-junit.xml"
             with self._isolated_runtime_root(runtime_root, family) as isolated:
                 command = [
                     "python",
@@ -170,16 +251,50 @@ class E2ERunner:
                     command.extend(("--e2e-testcase", ",".join(sorted(set(testcases)))))
                 else:
                     command.extend(("--e2e-model", family))
-                command.extend(("-q", "-x", "-p", "no:cacheprovider"))
-                self.context.run(
+                command.extend(
+                    (
+                        "-q",
+                        "-x",
+                        "-p",
+                        "no:cacheprovider",
+                        "--junitxml",
+                        e2e_junit,
+                    )
+                )
+                completed = self.context.run(
                     command,
                     updates={
                         "TRTMC_BINARY": str(binary),
                         "TRTMC_RUNTIME_ROOT": str(isolated),
                         "PYTHONDONTWRITEBYTECODE": "1",
                     },
+                    unset=("PYTEST_ADDOPTS",),
+                    check=False,
                     limit=self.context.env.get("TRTMC_E2E_TIMEOUT", "12h"),
                 )
+            _require_e2e_junit(
+                e2e_junit,
+                family,
+                tuple(requested_testcases),
+            )
+            if completed.returncode:
+                raise CiError(f"{family} E2E pytest failed with exit code {completed.returncode}")
+
+    def _family_testcases(self, family: str) -> tuple[str, ...]:
+        manifests = self.context.repository / "families" / family / "tests/manifests"
+        names = []
+        for path in sorted(manifests.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                names.extend(str(case["name"]) for case in payload["testcases"])
+            except (KeyError, OSError, TypeError, json.JSONDecodeError) as error:
+                raise CiError(f"invalid E2E manifest {path}: {error}") from error
+        if not names:
+            raise CiError(f"{family} has no declared E2E testcases")
+        duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+        if duplicates:
+            raise CiError(f"{family} has duplicate E2E testcases: " + ", ".join(duplicates))
+        return tuple(sorted(names))
 
     @contextmanager
     def _isolated_runtime_root(self, runtime_root: Path, family: str):

--- a/tools/ci/e2e.py
+++ b/tools/ci/e2e.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import tempfile
 import xml.etree.ElementTree as ET
 from collections import Counter
@@ -20,6 +21,42 @@ from .process import CiError
 
 
 _E2E_CASE_NAME = re.compile(r"^test_.*e2e\[(?P<case>.+)\]$")
+_JUNIT_OPTIONS = ("--junitxml", "--junit-xml")
+
+
+def _pytest_addopts_junit(repository: Path, value: str) -> Path | None:
+    """Preserve the caller-owned JUnit destination without honoring other addopts."""
+    try:
+        options = shlex.split(value)
+    except ValueError as error:
+        raise CiError(f"PYTEST_ADDOPTS is invalid: {error}") from error
+
+    destinations = []
+    index = 0
+    while index < len(options):
+        option = options[index]
+        if option in _JUNIT_OPTIONS:
+            index += 1
+            if index == len(options) or options[index].startswith("-"):
+                raise CiError(f"PYTEST_ADDOPTS {option} requires a path")
+            destinations.append(options[index])
+        else:
+            for name in _JUNIT_OPTIONS:
+                prefix = f"{name}="
+                if option.startswith(prefix):
+                    destination = option.removeprefix(prefix)
+                    if not destination:
+                        raise CiError(f"PYTEST_ADDOPTS {name} requires a path")
+                    destinations.append(destination)
+                    break
+        index += 1
+
+    if not destinations:
+        return None
+    if len(destinations) != 1:
+        raise CiError("PYTEST_ADDOPTS must specify at most one JUnit destination")
+    path = Path(destinations[0])
+    return path if path.is_absolute() else repository / path
 
 
 def _read_junit(path: Path, label: str) -> list[ET.Element]:
@@ -238,7 +275,16 @@ class E2ERunner:
                 _require_passing_junit(hardware_junit, "family hardware tests")
             requested_testcases = testcases or self._family_testcases(family)
             test = f"families/{family}/tests/test_e2e.py"
-            e2e_junit = native_build / f"trtmc-{family}-e2e-junit.xml"
+            # Protected runners historically own the evidence path through
+            # PYTEST_ADDOPTS. Keep that path contract, but do not allow unrelated
+            # addopts to alter selection or execution.
+            e2e_junit = (
+                _pytest_addopts_junit(
+                    self.context.repository,
+                    self.context.env.get("PYTEST_ADDOPTS", ""),
+                )
+                or native_build / f"trtmc-{family}-e2e-junit.xml"
+            )
             with self._isolated_runtime_root(runtime_root, family) as isolated:
                 command = [
                     "python",

--- a/tools/tests/test_new_ci.py
+++ b/tools/tests/test_new_ci.py
@@ -40,6 +40,7 @@ class RecordingContext:
         self.runtime_snapshots = []
         self.skip_ctest = False
         self.no_cpu_family_tests = False
+        self.missing_e2e_testcases = set()
 
     def run(self, command, **kwargs):
         self.calls.append((list(command), kwargs))
@@ -83,17 +84,17 @@ class RecordingContext:
             testcases = "" if empty else '<testcase name="hardware" />'
             if "-e2e-junit.xml" in report.name:
                 family = report.name.removeprefix("trtmc-").removesuffix("-e2e-junit.xml")
-                known = {
-                    str(case["name"])
-                    for path in (self.repository / f"families/{family}/tests/manifests").glob(
-                        "*.json"
-                    )
-                    for case in json.loads(path.read_text(encoding="utf-8"))["testcases"]
-                }
-                selected = known
                 if "--e2e-testcase" in command:
                     raw = str(command[command.index("--e2e-testcase") + 1])
-                    selected = known & set(raw.split(","))
+                    selected = set(raw.split(",")) - self.missing_e2e_testcases
+                else:
+                    selected = {
+                        str(case["name"])
+                        for path in (self.repository / f"families/{family}/tests/manifests").glob(
+                            "*.json"
+                        )
+                        for case in json.loads(path.read_text(encoding="utf-8"))["testcases"]
+                    }
                 testcases = "".join(
                     f'<testcase name="test_e2e[{name}]" />' for name in sorted(selected)
                 )
@@ -124,10 +125,11 @@ def test_selective_e2e_calls_family_tests_directly(
         (root / "tests/manifests").mkdir()
         (root / "model.py").write_text("def build(request, writer): pass\n")
         (root / "tests/test_e2e.py").write_text("def test_e2e(): pass\n")
-        (root / "tests/manifests/case.json").write_text(
-            json.dumps({"testcases": [{"name": f"{family}-case"}]}),
-            encoding="utf-8",
-        )
+        manifest = json.dumps({"testcases": [{"name": f"{family}-case"}]})
+        if family == "beta" and testcases is not None:
+            # Explicit auxiliary E2E cases do not depend on model manifests.
+            manifest = "invalid manifest"
+        (root / "tests/manifests/case.json").write_text(manifest, encoding="utf-8")
         if family == "beta":
             (root / "tests/test_model.py").write_text(
                 "def test_model(): pass\n",
@@ -405,6 +407,7 @@ def test_e2e_nonexistent_testcase_fails_closed(tmp_path: Path) -> None:
             "TRTMC_NATIVE_BUILD_DIR": str(native_build),
         },
     )
+    context.missing_e2e_testcases.add("does-not-exist")
 
     with pytest.raises(CiError, match="missing requested E2E testcase: does-not-exist"):
         E2ERunner(context)._run(("gpt2",), ("does-not-exist",))

--- a/tools/tests/test_new_ci.py
+++ b/tools/tests/test_new_ci.py
@@ -82,8 +82,8 @@ class RecordingContext:
             report = Path(command[command.index("--junitxml") + 1])
             empty = self.no_cpu_family_tests and "-unit-junit.xml" in report.name
             testcases = "" if empty else '<testcase name="hardware" />'
-            if "-e2e-junit.xml" in report.name:
-                family = report.name.removeprefix("trtmc-").removesuffix("-e2e-junit.xml")
+            if any(str(item).endswith("/test_e2e.py") for item in command):
+                family = str(command[3]).split("/")[1]
                 if "--e2e-testcase" in command:
                     raw = str(command[command.index("--e2e-testcase") + 1])
                     selected = set(raw.split(",")) - self.missing_e2e_testcases
@@ -108,16 +108,18 @@ class RecordingContext:
 
 
 @pytest.mark.parametrize(
-    ("testcases", "selector"),
+    ("testcases", "selector", "external_junit"),
     (
-        (None, ["--e2e-model", "beta"]),
-        (["beta-case"], ["--e2e-testcase", "beta-case"]),
+        (None, ["--e2e-model", "beta"], False),
+        (["beta-case"], ["--e2e-testcase", "beta-case"], False),
+        (["beta-case"], ["--e2e-testcase", "beta-case"], True),
     ),
 )
 def test_selective_e2e_calls_family_tests_directly(
     tmp_path: Path,
     testcases: list[str] | None,
     selector: list[str],
+    external_junit: bool,
 ) -> None:
     for family in ("alpha", "beta"):
         root = tmp_path / "families" / family
@@ -153,14 +155,17 @@ def test_selective_e2e_calls_family_tests_directly(
     if testcases is not None:
         impact["testcases"] = testcases
     (tmp_path / "impact.json").write_text(json.dumps(impact))
-    context = RecordingContext(
-        tmp_path,
-        {
-            "TRTMC_BINARY": str(binary),
-            "TRTMC_RUNTIME_ROOT": str(runtime),
-            "TRTMC_NATIVE_BUILD_DIR": str(native_build),
-        },
-    )
+    env = {
+        "TRTMC_BINARY": str(binary),
+        "TRTMC_RUNTIME_ROOT": str(runtime),
+        "TRTMC_NATIVE_BUILD_DIR": str(native_build),
+    }
+    expected_e2e_junit = native_build / "trtmc-beta-e2e-junit.xml"
+    if external_junit:
+        expected_e2e_junit = tmp_path / ".ci/family-beta-junit.xml"
+        expected_e2e_junit.parent.mkdir()
+        env["PYTEST_ADDOPTS"] = f"--maxfail=2 --junitxml={expected_e2e_junit}"
+    context = RecordingContext(tmp_path, env)
 
     E2ERunner(context).selective()
 
@@ -203,7 +208,7 @@ def test_selective_e2e_calls_family_tests_directly(
     assert selector == command[4:6]
     assert command[-2:] == [
         "--junitxml",
-        native_build / "trtmc-beta-e2e-junit.xml",
+        expected_e2e_junit,
     ]
     rendered = " ".join(map(str, command))
     assert "e2e_harness" not in rendered
@@ -211,6 +216,7 @@ def test_selective_e2e_calls_family_tests_directly(
     assert "--model-plugin-dir" not in rendered
     assert options["updates"]["TRTMC_BINARY"] == str(binary)
     assert options["updates"]["TRTMC_RUNTIME_ROOT"] != str(runtime)
+    assert options["unset"] == ("PYTEST_ADDOPTS",)
     assert context.runtime_snapshots == [
         ("libtrtmc_backend_trt.so", "libtrtmc_core.so", "libtrtmc_model_beta.so")
     ]

--- a/tools/tests/test_new_ci.py
+++ b/tools/tests/test_new_ci.py
@@ -19,7 +19,7 @@ import yaml
 from tools.ci.context import CiContext
 from tools.ci.container import CiContainer
 from tools.ci.docker_image import DockerImageManager
-from tools.ci.e2e import E2ERunner, _require_passing_junit
+from tools.ci.e2e import E2ERunner, _require_e2e_junit, _require_passing_junit
 from tools.ci.package import (
     SourceArchiveValidator,
     WheelArchiveValidator,
@@ -80,10 +80,25 @@ class RecordingContext:
         if "--junitxml" in command:
             report = Path(command[command.index("--junitxml") + 1])
             empty = self.no_cpu_family_tests and "-unit-junit.xml" in report.name
+            testcases = "" if empty else '<testcase name="hardware" />'
+            if "-e2e-junit.xml" in report.name:
+                family = report.name.removeprefix("trtmc-").removesuffix("-e2e-junit.xml")
+                known = {
+                    str(case["name"])
+                    for path in (self.repository / f"families/{family}/tests/manifests").glob(
+                        "*.json"
+                    )
+                    for case in json.loads(path.read_text(encoding="utf-8"))["testcases"]
+                }
+                selected = known
+                if "--e2e-testcase" in command:
+                    raw = str(command[command.index("--e2e-testcase") + 1])
+                    selected = known & set(raw.split(","))
+                testcases = "".join(
+                    f'<testcase name="test_e2e[{name}]" />' for name in sorted(selected)
+                )
             report.write_text(
-                "<testsuites><testsuite>"
-                + ("" if empty else '<testcase name="hardware" />')
-                + "</testsuite></testsuites>",
+                f"<testsuites><testsuite>{testcases}</testsuite></testsuites>",
                 encoding="utf-8",
             )
             if empty:
@@ -106,8 +121,13 @@ def test_selective_e2e_calls_family_tests_directly(
     for family in ("alpha", "beta"):
         root = tmp_path / "families" / family
         (root / "tests").mkdir(parents=True)
+        (root / "tests/manifests").mkdir()
         (root / "model.py").write_text("def build(request, writer): pass\n")
         (root / "tests/test_e2e.py").write_text("def test_e2e(): pass\n")
+        (root / "tests/manifests/case.json").write_text(
+            json.dumps({"testcases": [{"name": f"{family}-case"}]}),
+            encoding="utf-8",
+        )
         if family == "beta":
             (root / "tests/test_model.py").write_text(
                 "def test_model(): pass\n",
@@ -179,7 +199,11 @@ def test_selective_e2e_calls_family_tests_directly(
     command, options = context.calls[5]
     assert command[:4] == ["python", "-m", "pytest", "families/beta/tests/test_e2e.py"]
     assert selector == command[4:6]
-    rendered = " ".join(command)
+    assert command[-2:] == [
+        "--junitxml",
+        native_build / "trtmc-beta-e2e-junit.xml",
+    ]
+    rendered = " ".join(map(str, command))
     assert "e2e_harness" not in rendered
     assert "--trtmc-binary" not in rendered
     assert "--model-plugin-dir" not in rendered
@@ -195,8 +219,13 @@ def test_family_with_only_hardware_tests_accepts_exact_empty_cpu_result(
 ) -> None:
     family = tmp_path / "families/beta"
     (family / "tests").mkdir(parents=True)
+    (family / "tests/manifests").mkdir()
     (family / "model.py").write_text("def build(request, writer): pass\n")
     (family / "tests/test_e2e.py").write_text("def test_e2e(): pass\n")
+    (family / "tests/manifests/case.json").write_text(
+        json.dumps({"testcases": [{"name": "beta-case"}]}),
+        encoding="utf-8",
+    )
     (family / "tests/test_gpu.py").write_text(
         "import pytest\n\n@pytest.mark.gpu\ndef test_gpu(): pass\n",
         encoding="utf-8",
@@ -284,11 +313,101 @@ def test_family_python_unit_junit_fails_closed(
         _require_passing_junit(report, "family Python unit tests")
 
 
+def test_e2e_junit_reports_exact_requested_result(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report = tmp_path / "e2e.xml"
+    report.write_text(
+        '<testsuites><testsuite><testcase name="test_e2e[alpha]" />'
+        '<testcase name="test_e2e[beta]"><skipped /></testcase>'
+        '<testcase name="test_helper" /></testsuite></testsuites>',
+        encoding="utf-8",
+    )
+
+    _require_e2e_junit(report, "family", ("alpha",))
+
+    assert (
+        "family E2E results: requested=1 executed=1 passed=1 failed=0 skipped=0"
+        in capsys.readouterr().out
+    )
+
+
+@pytest.mark.parametrize(
+    ("testcases", "requested", "message"),
+    (
+        ("", ("missing",), "missing requested E2E testcase: missing"),
+        (
+            '<testcase name="test_e2e[duplicate]" />'
+            '<testcase name="test_official_checkpoint_e2e[duplicate]" />',
+            ("duplicate",),
+            "duplicate E2E testcase result: duplicate",
+        ),
+        (
+            '<testcase name="test_e2e[skipped]"><skipped /></testcase>',
+            ("skipped",),
+            "requested E2E testcase skipped: skipped",
+        ),
+        (
+            '<testcase name="test_e2e[failed]"><failure /></testcase>',
+            ("failed",),
+            "requested E2E testcase failed: failed",
+        ),
+        (
+            '<testcase name="test_e2e[duplicate-request]" />',
+            ("duplicate-request", "duplicate-request"),
+            "duplicate requested E2E testcase: duplicate-request",
+        ),
+    ),
+)
+def test_e2e_junit_fails_closed_for_invalid_result_cardinality_or_skip(
+    tmp_path: Path,
+    testcases: str,
+    requested: tuple[str, ...],
+    message: str,
+) -> None:
+    report = tmp_path / "e2e.xml"
+    report.write_text(
+        f"<testsuites><testsuite>{testcases}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CiError, match=message):
+        _require_e2e_junit(report, "family", requested)
+
+
 def test_e2e_rejects_multiple_family_environments(tmp_path: Path) -> None:
     context = RecordingContext(tmp_path, {})
 
     with pytest.raises(CiError, match="exactly one family"):
         E2ERunner(context)._run(("alpha", "beta"))
+
+
+def test_e2e_nonexistent_testcase_fails_closed(tmp_path: Path) -> None:
+    repository = Path(__file__).resolve().parents[2]
+    binary = tmp_path / "trtmc"
+    binary.write_text("")
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    for name in (
+        "libtrtmc_core.so",
+        "libtrtmc_backend_trt.so",
+        "libtrtmc_model_gpt2.so",
+    ):
+        (runtime / name).write_text("")
+    native_build = tmp_path / "native-build"
+    native_build.mkdir()
+    (native_build / "CTestTestfile.cmake").write_text("")
+    context = RecordingContext(
+        repository,
+        {
+            "TRTMC_BINARY": str(binary),
+            "TRTMC_RUNTIME_ROOT": str(runtime),
+            "TRTMC_NATIVE_BUILD_DIR": str(native_build),
+        },
+    )
+
+    with pytest.raises(CiError, match="missing requested E2E testcase: does-not-exist"):
+        E2ERunner(context)._run(("gpt2",), ("does-not-exist",))
 
 
 def test_pipeline_exposes_only_active_stages(tmp_path: Path) -> None:


### PR DESCRIPTION
## Background

Pytest exits successfully when an unknown `--e2e-testcase` causes every real
checkpoint case to skip. The protected runner trusted that exit code, so a
green job did not prove that its requested model testcase ran. The same false
green reproduced across all 98 family E2E files with an unknown selector.

## Exit Criteria

- Every family E2E pytest run writes a JUnit report.
- Every requested testcase maps to exactly one result.
- Missing, duplicate, skipped, failed, or error results fail the job.
- A non-requested E2E testcase that executes also fails the job.
- CI prints requested, executed, passed, failed, and skipped counts.
- A regression test proves that `does-not-exist` fails closed.
- Model pass/fail thresholds and model implementations remain unchanged.

## Implementation

The shared E2E runner now loads the family manifest testcase inventory, writes
JUnit output, and parses the report even when pytest exits successfully.
Explicit testcase selectors are matched to exact parameter IDs; family-wide
runs require all manifest-declared cases. Unselected sibling or auxiliary E2E
cases may remain skipped, but requested skip/missing results and unrequested
executions are rejected.

When a trusted caller supplies a JUnit destination through `PYTEST_ADDOPTS`,
the runner preserves only that destination as an explicit pytest argument and
discards every other inherited option. Without one it uses the per-family
default report path. This keeps the evidence-path contract without allowing
environment options to alter test selection or execution.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tools/tests -q -p no:cacheprovider`: 159 passed.
- `ruff check --config ruff.toml tools/ci/e2e.py tools/tests/test_new_ci.py`:
  passed.
- `ruff format --config ruff.toml --check tools/ci/e2e.py tools/tests/test_new_ci.py`:
  both files already formatted.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest families/*/tests/test_e2e.py --e2e-testcase does-not-exist -q -p no:cacheprovider --junitxml /tmp/trtmc-all-invalid.xml`:
  reproduced the original false green with 116 passed, 157 skipped, exit 0.
- Applied the new validator to the generated GPT-2 JUnit: printed
  `requested=1 executed=0 passed=0 failed=0 skipped=0` and failed with
  `missing requested E2E testcase: does-not-exist`.

### Hardware, Environment, and Revisions

- Repository base: `github/main` at `cd1bde414846d9e902c967699e72c86585b974d1`.
- Tested head: `57784a540a4de3fe31878d7b762f7b5f50527ada`.
- Environment: Linux x86_64, Python 3.12.3.
- No checkpoint, CUDA, TensorRT, precision, or GPU revision applies to the
  runner unit tests.

### Not Run / Remaining Gaps

- GPU checkpoint inference was not run locally. This change does not alter
  model execution or validation thresholds; protected GPU CI remains required.
- The all-family reproduction deliberately used an invalid selector, so it did
  not execute checkpoint inference.

## Notes For Future Readers

The result contract is fail closed at the runner boundary. Adding a new primary
family E2E case requires declaring it in that family's manifest and emitting a
pytest parameter ID equal to the testcase name. Auxiliary E2E tests can remain
outside the manifest, but they must not execute unless explicitly requested.

The caller-owned JUnit destination is a compatibility boundary. Do not remove
it without changing every protected evidence consumer in the same rollout.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: this intentionally tightens a shared gate used by every model
family. Existing selector/report drift will become a visible CI failure instead
of remaining green.
