### PR TITLE
feat(cli): restore batch text generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,16 +339,18 @@ if(TRTMC_BUILD_TESTS)
   target_compile_options(test_task_api PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME task_api COMMAND test_task_api)
 
+  set(_trtmc_test_runtime_root "${CMAKE_BINARY_DIR}/tests/runtime")
+
   add_executable(test_cli apps/cli/tests/test_cli.cpp)
   target_include_directories(test_cli PRIVATE
     ${PROJECT_SOURCE_DIR}/core/runtime/include
+    ${PROJECT_SOURCE_DIR}/core
     ${PROJECT_SOURCE_DIR}/apps
   )
-  target_link_libraries(test_cli PRIVATE trtmc_cli)
+  target_link_libraries(test_cli PRIVATE trtmc_cli nlohmann_json::nlohmann_json)
   target_compile_options(test_cli PRIVATE -Wall -Wextra -Wpedantic)
-  add_test(NAME cli COMMAND test_cli)
+  add_test(NAME cli COMMAND test_cli "${_trtmc_test_runtime_root}")
 
-  set(_trtmc_test_runtime_root "${CMAKE_BINARY_DIR}/tests/runtime")
   add_library(trtmc_test_backend_fake SHARED core/runtime/tests/fake_backend.cpp)
   target_include_directories(trtmc_test_backend_fake PRIVATE ${PROJECT_SOURCE_DIR}/core/runtime/include)
   target_link_libraries(trtmc_test_backend_fake PRIVATE CUDA::cudart)
@@ -365,6 +367,18 @@ if(TRTMC_BUILD_TESTS)
     LIBRARY_OUTPUT_DIRECTORY "${_trtmc_test_runtime_root}"
     BUILD_RPATH "\$ORIGIN/../.."
   )
+
+  add_library(trtmc_test_family_cli_text_fake SHARED apps/cli/tests/fake_text_family.cpp)
+  target_include_directories(trtmc_test_family_cli_text_fake PRIVATE
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(trtmc_test_family_cli_text_fake PRIVATE trtmc_core)
+  set_target_properties(trtmc_test_family_cli_text_fake PROPERTIES
+    OUTPUT_NAME trtmc_model_cli_text_fake
+    LIBRARY_OUTPUT_DIRECTORY "${_trtmc_test_runtime_root}"
+    BUILD_RPATH "\$ORIGIN/../.."
+  )
+  add_dependencies(test_cli trtmc_test_backend_fake trtmc_test_family_cli_text_fake)
 
   add_executable(test_family_loader core/runtime/tests/test_family_loader.cpp)
   target_include_directories(test_family_loader PRIVATE

--- a/apps/cli/cli.cpp
+++ b/apps/cli/cli.cpp
@@ -46,6 +46,9 @@ const std::unordered_map<std::string, CommandSpec>& command_specs() {
         {"run",
          {CommandKind::kRun,
           {"--prompt",
+           "--prompts-file",
+           "--num-samples",
+           "--output",
            "--image",
            "--max-new-tokens",
            "--source-language-token-id",
@@ -312,6 +315,25 @@ std::vector<std::string> read_nonempty_lines(const std::string& path) {
     return lines;
 }
 
+std::vector<std::string> read_prompt_lines(const std::string& path) {
+    std::ifstream input(path);
+    if (!input)
+        throw std::runtime_error("unable to open prompts file: " + path);
+    std::vector<std::string> prompts;
+    for (std::string prompt; std::getline(input, prompt);) {
+        if (!prompt.empty() && prompt.back() == '\r')
+            prompt.pop_back();
+        prompts.push_back(std::move(prompt));
+    }
+    if (input.bad())
+        throw std::runtime_error("failed to read prompts file: " + path);
+    while (!prompts.empty() && prompts.back().empty())
+        prompts.pop_back();
+    if (prompts.empty())
+        throw std::runtime_error("prompts file has no prompts: " + path);
+    return prompts;
+}
+
 std::vector<std::uint32_t> parse_seeds(const std::string& text) {
     std::vector<std::uint32_t> seeds;
     std::istringstream input(text);
@@ -394,6 +416,14 @@ nlohmann::json text_json(const TextResult& result) {
         }
     }
     return value;
+}
+
+nlohmann::json text_sample_json(std::int32_t id, const std::string& prompt,
+                                const TextResult& result) {
+    return {{"id", id},
+            {"prompt", prompt},
+            {"generated", result.text},
+            {"token_ids", result.token_ids}};
 }
 
 nlohmann::json stream_result_json(const TranscriptionStreamResult& result) {
@@ -573,8 +603,10 @@ const char* event_kind_name(SpeechSessionEventKind kind) {
 }
 
 int dispatch_run(const Command& command, ITask& task, std::ostream& output) {
-    if (!has_option(command, "--prompt") && !has_option(command, "--initial-latents-raw")) {
-        throw std::invalid_argument("run requires --prompt or --initial-latents-raw");
+    if (!has_option(command, "--prompt") && !has_option(command, "--prompts-file") &&
+        !has_option(command, "--initial-latents-raw")) {
+        throw std::invalid_argument(
+            "run requires --prompt, --prompts-file, or --initial-latents-raw");
     }
     const std::string prompt =
         has_option(command, "--prompt") ? command.options.at("--prompt") : std::string{};
@@ -641,7 +673,64 @@ int dispatch_run(const Command& command, ITask& task, std::ostream& output) {
         auto& interface = require_interface<ITextGeneration>(task);
         config.max_new_tokens =
             int_option(command, "--max-new-tokens", interface.default_max_new_tokens(), 1);
-        write_json(output, text_json(interface.generate(prompt, config)));
+        const std::int32_t samples_per_prompt = int_option(command, "--num-samples", 1, 1);
+        const bool batch_requested = has_option(command, "--prompts-file") ||
+                                     samples_per_prompt > 1 || has_option(command, "--output");
+        if (!batch_requested) {
+            write_json(output, text_json(interface.generate(prompt, config)));
+            return EXIT_SUCCESS;
+        }
+
+        const std::vector<std::string> prompts =
+            has_option(command, "--prompts-file")
+                ? read_prompt_lines(command.options.at("--prompts-file"))
+                : std::vector<std::string>{prompt};
+        if (prompts.size() > static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() /
+                                                      samples_per_prompt)) {
+            throw std::invalid_argument("text batch has too many samples");
+        }
+        const std::int32_t total_samples =
+            static_cast<std::int32_t>(prompts.size()) * samples_per_prompt;
+        if (!config.initial_latents.empty() && total_samples > 1) {
+            throw std::invalid_argument(
+                "--initial-latents-raw can only be used with one text sample");
+        }
+        if (config.seed >= 0 &&
+            total_samples - 1 > std::numeric_limits<std::int32_t>::max() - config.seed) {
+            throw std::invalid_argument("--seed plus the text sample index is outside its valid "
+                                        "integer range");
+        }
+
+        std::ofstream output_file;
+        std::ostream* jsonl_output = &output;
+        if (has_option(command, "--output")) {
+            const fs::path output_path(command.options.at("--output"));
+            const fs::path parent = output_path.parent_path();
+            if (!parent.empty())
+                fs::create_directories(parent);
+            output_file.open(output_path, std::ios::out | std::ios::trunc);
+            if (!output_file)
+                throw std::runtime_error("failed to create output: " + output_path.string());
+            jsonl_output = &output_file;
+        }
+
+        std::int32_t sample_id = 0;
+        for (const auto& text_prompt : prompts) {
+            for (std::int32_t sample = 0; sample < samples_per_prompt; ++sample, ++sample_id) {
+                TextGenerationConfig sample_config = config;
+                if (config.seed >= 0)
+                    sample_config.seed = config.seed + sample_id;
+                write_json(*jsonl_output,
+                           text_sample_json(sample_id, text_prompt,
+                                            interface.generate(text_prompt, sample_config)));
+            }
+        }
+        if (!*jsonl_output)
+            throw std::runtime_error("failed to write text batch output");
+        if (output_file.is_open()) {
+            output << "Saved " << command.options.at("--output") << " (" << total_samples
+                   << " samples)\n";
+        }
         return EXIT_SUCCESS;
     }
     const io::LoadedImage image = read_image(require_option(command, "--image"));
@@ -729,6 +818,18 @@ Command parse_args(int argc, char** argv) {
     if (byok_option_count != 0 && byok_option_count != 3) {
         throw std::invalid_argument(
             "--byok-library, --byok-function, and --byok-name must be used together");
+    }
+    if (command.kind == CommandKind::kRun) {
+        if (has_option(command, "--prompt") && has_option(command, "--prompts-file"))
+            throw std::invalid_argument("--prompt and --prompts-file are mutually exclusive");
+        if (has_option(command, "--num-samples"))
+            (void)parse_int32(command.options.at("--num-samples"), "--num-samples", 1);
+        if (has_option(command, "--image") &&
+            (has_option(command, "--prompts-file") || has_option(command, "--num-samples") ||
+             has_option(command, "--output"))) {
+            throw std::invalid_argument(
+                "--prompts-file, --num-samples, and --output are text-only run options");
+        }
     }
     return command;
 }
@@ -1221,7 +1322,8 @@ void print_usage(std::ostream& output) {
               "  [--sde-noise-raw PATH] [--num-steps N] [--guidance-scale S]\n"
               "  [--cfg-scale S] [--sde-gamma S]\n\n"
               "Text generation options:\n"
-              "  [--source-language-token-id N] [--forced-bos-token-id N]\n\n"
+              "  [--source-language-token-id N] [--forced-bos-token-id N]\n"
+              "  [--prompts-file PATH] [--num-samples N] [--output PATH]\n\n"
               "Offline transcription options:\n"
               "  [--beam-size N] [--length-penalty F] [--punctuation true|false]\n"
               "  [--max-input-seconds F] [--segment-length-seconds F]\n"

--- a/apps/cli/tests/fake_text_family.cpp
+++ b/apps/cli/tests/fake_text_family.cpp
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/runtime/family_factory.h"
+#include "trtmc/runtime/trt_backend.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::int32_t factory_calls = 0;
+
+class FakeBatchText final : public trtmc::ITextGeneration {
+  public:
+    std::int32_t default_max_new_tokens() const override { return 8; }
+
+    trtmc::TextResult generate(const std::string& prompt,
+                               const trtmc::TextGenerationConfig& config) override {
+        return {prompt + ":" + std::to_string(config.seed), {generation_calls_++}};
+    }
+
+  private:
+    std::int32_t generation_calls_{0};
+};
+
+} // namespace
+
+extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
+    // The CLI integration emits several samples. Refusing a second factory call makes a
+    // successful batch prove that one loaded task handled every prompt and sample.
+    ++factory_calls;
+    if (factory_calls != 1)
+        return nullptr;
+    if (context.reader.info().family != "cli_text_fake")
+        throw std::runtime_error("unexpected family");
+    if (context.backend.name() == nullptr || std::string(context.backend.name()) != "fake")
+        throw std::runtime_error("unexpected backend");
+    const auto plan = context.reader.read_section("engine.plan");
+    if (std::string(plan.begin(), plan.end()) != "PLAN")
+        throw std::runtime_error("unexpected engine plan");
+    return new FakeBatchText();
+}

--- a/apps/cli/tests/test_cli.cpp
+++ b/apps/cli/tests/test_cli.cpp
@@ -5,12 +5,14 @@
 
 #include "cli/cli.h"
 #include "cli/io.h"
+#include "runtime/bundle/bundle_format.h"
 
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -43,6 +45,38 @@ bool parse_throws(std::vector<std::string> arguments) {
     } catch (const std::invalid_argument&) {
         return true;
     }
+}
+
+int invoke_cli(std::vector<std::string> arguments, std::ostream& output, std::ostream& error) {
+    std::vector<char*> argv;
+    argv.reserve(arguments.size());
+    for (auto& argument : arguments)
+        argv.push_back(argument.data());
+    return trtmc::cli::run(static_cast<int>(argv.size()), argv.data(), output, error);
+}
+
+void write_text_bundle(const std::filesystem::path& path) {
+    const std::string header =
+        "{\"format\":1,\"family\":\"cli_text_fake\",\"task\":\"text_generation\","
+        "\"backend\":\"fake\",\"sections\":{\"runtime.json\":{\"offset\":0,\"length\":2},"
+        "\"engine.plan\":{\"offset\":2,\"length\":4}}}";
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char*>(trtmc::kBundleMagic), 8);
+    const std::uint64_t header_length = header.size();
+    for (int shift = 0; shift < 64; shift += 8)
+        output.put(static_cast<char>((header_length >> shift) & 0xffU));
+    output.write(header.data(), static_cast<std::streamsize>(header.size()));
+    output.write("{}PLAN", 6);
+}
+
+std::vector<nlohmann::json> read_jsonl(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input)
+        throw std::runtime_error("unable to read JSONL test output");
+    std::vector<nlohmann::json> records;
+    for (std::string line; std::getline(input, line);)
+        records.push_back(nlohmann::json::parse(line));
+    return records;
 }
 
 class FakeText final : public trtmc::ITextGeneration,
@@ -254,7 +288,12 @@ bool dispatch_throws(const trtmc::cli::Command& command, trtmc::ITask& task) {
 
 } // namespace
 
-int main() {
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "usage: test_cli RUNTIME_ROOT\n";
+        return 2;
+    }
+    const std::filesystem::path runtime_root(argv[1]);
     const std::vector<std::string> execution_commands{
         "run",
         "encode",
@@ -322,6 +361,25 @@ int main() {
     check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
                         "--prompt", "b"}),
           "duplicate command option rejected");
+    const auto text_batch =
+        parse({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompts-file",
+               "prompts.txt", "--num-samples", "2", "--output", "samples.jsonl"});
+    check(text_batch.options.at("--prompts-file") == "prompts.txt" &&
+              text_batch.options.at("--num-samples") == "2" &&
+              text_batch.options.at("--output") == "samples.jsonl",
+          "text batch options are retained");
+    check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
+                        "--prompts-file", "prompts.txt"}),
+          "prompt and prompts file are mutually exclusive");
+    check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
+                        "--num-samples", "0"}),
+          "zero text sample count is rejected");
+    check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
+                        "--num-samples", "many"}),
+          "non-integer text sample count is rejected");
+    check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
+                        "--image", "image.png", "--num-samples", "2"}),
+          "text batch options cannot be combined with an image");
     check(parse_throws({"trtmc", "run", "model.bundle", "--runtime-root", "lib", "--prompt", "a",
                         "--generation-mode"}),
           "generation mode requires a value");
@@ -500,6 +558,73 @@ int main() {
               text.seen.text_generation_mode == "auto" && text.seen.block_length == 0 &&
               text.seen.confidence_threshold == -1.0F && text.seen.temperature == 1.0F,
           "text diffusion options preserve Task API defaults");
+
+    auto one_sample_run = default_run;
+    one_sample_run.options.emplace("--num-samples", "1");
+    one_sample_run.options.emplace("--seed", "17");
+    std::ostringstream one_sample_output;
+    check(trtmc::cli::dispatch(one_sample_run, text, one_sample_output) == 0 &&
+              text.seen.seed == 17 &&
+              one_sample_output.str().find("\"text\"") != std::string::npos &&
+              one_sample_output.str().find("\"generated\"") == std::string::npos,
+          "one prompt and one sample preserve the existing result and seed semantics");
+
+    const auto empty_prompts_path = runtime_root / "cli-text-empty-prompts.txt";
+    {
+        std::ofstream empty_prompts(empty_prompts_path, std::ios::trunc);
+    }
+    trtmc::cli::Command empty_batch;
+    empty_batch.kind = trtmc::cli::CommandKind::kRun;
+    empty_batch.name = "run";
+    empty_batch.options.emplace("--prompts-file", empty_prompts_path.string());
+    check(dispatch_throws(empty_batch, text), "empty prompts file is rejected");
+    std::filesystem::remove(empty_prompts_path);
+
+    const auto prompts_path = runtime_root / "cli-text-prompts.txt";
+    const auto bundle_path = runtime_root / "cli-text.bundle";
+    const auto output_path = runtime_root / "cli-text-samples.jsonl";
+    {
+        std::ofstream prompts(prompts_path, std::ios::binary | std::ios::trunc);
+        prompts << "first\r\n\r\nthird\r\n\r\n";
+    }
+    write_text_bundle(bundle_path);
+    std::ostringstream batch_output;
+    std::ostringstream batch_error;
+    const int batch_status =
+        invoke_cli({"trtmc", "run", bundle_path.string(), "--runtime-root", runtime_root.string(),
+                    "--prompts-file", prompts_path.string(), "--num-samples", "2", "--seed", "40",
+                    "--output", output_path.string()},
+                   batch_output, batch_error);
+    check(batch_status == 0 && batch_error.str().empty(),
+          "batch run loads the fake text family once");
+    std::vector<nlohmann::json> records;
+    try {
+        records = read_jsonl(output_path);
+    } catch (const std::exception& exception) {
+        std::cerr << "FAIL: text batch output is valid JSONL: " << exception.what() << '\n';
+        ++failures;
+    }
+    check(records.size() == 6, "text batch writes one JSONL record per prompt and sample");
+    const std::vector<std::string> expected_prompts{"first", "first", "", "", "third", "third"};
+    for (std::size_t index = 0; index < records.size() && index < expected_prompts.size();
+         ++index) {
+        const auto& record = records[index];
+        const auto expected_id = static_cast<std::int32_t>(index);
+        const auto expected_seed = 40 + expected_id;
+        check(record.value("id", -1) == expected_id &&
+                  record.value("prompt", std::string{"missing"}) == expected_prompts[index] &&
+                  record.value("generated", std::string{}) ==
+                      expected_prompts[index] + ":" + std::to_string(expected_seed) &&
+                  record.value("token_ids", std::vector<std::int32_t>{}) ==
+                      std::vector<std::int32_t>{expected_id},
+              "text batch preserves prompt order and derives deterministic seeds");
+    }
+    check(batch_output.str().find("6 samples") != std::string::npos,
+          "text batch reports the output sample count");
+    std::filesystem::remove(prompts_path);
+    std::filesystem::remove(bundle_path);
+    std::filesystem::remove(output_path);
+
     const std::filesystem::path unsupported_image_path = "/tmp/trtmc-cli-unsupported.ppm";
     {
         std::ofstream image_file(unsupported_image_path, std::ios::binary);

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -64,6 +64,23 @@ trtmc run gpt2.bundle \
   --max-new-tokens 32
 ```
 
+For ordered batch text generation, put one prompt on each line and reuse the
+same loaded task for every sample:
+
+```bash
+trtmc run gpt2.bundle \
+  --runtime-root /opt/trtmc/lib \
+  --prompts-file prompts.txt \
+  --num-samples 2 \
+  --seed 100 \
+  --output samples.jsonl
+```
+
+`--prompt` and `--prompts-file` are mutually exclusive. Batch records are
+written in prompt order, with one JSONL object per prompt and sample. Interior
+blank lines are empty prompts; blank lines at the end of the file are ignored.
+Without `--output`, the JSONL records are written to standard output.
+
 The shell variable above is only a convenient explicit argument. The CLI never
 searches environment variables, the current directory, or an installed
 fallback runtime.


### PR DESCRIPTION
## Background

PR #1093 preserved single-prompt text generation but removed the existing ordered batch CLI path. Users can no longer load one text bundle once, read prompts from a file, generate multiple deterministic samples, and write JSONL output.

## Exit Criteria

- `trtmc run` accepts either `--prompt` or `--prompts-file`, never both.
- One loaded `ITextGeneration` instance serves every prompt and sample.
- Prompt-major, sample-inner ordering and deterministic seed derivation are preserved.
- Interior blank prompts are preserved, trailing blank lines are ignored, and an empty file fails.
- The existing single-prompt command and JSON result remain unchanged.
- No new Task API, pool, registry, or configuration layer is introduced.

## Implementation

- Added `--prompts-file`, `--num-samples`, and `--output` to the existing text `run` command.
- Reused the existing line reader and Task dispatch, with one narrow prompt-file reader for the historical blank-line contract.
- Emits one JSONL object per prompt/sample with `id`, `prompt`, `generated`, and `token_ids`.
- Derives each non-negative seed as `base_seed + global_sample_id` and rejects overflow.
- Added a fake family whose second factory call fails, proving the full batch uses one loaded task.
- Documented the batch command in Quick Start.

### Change categories

- [ ] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `clang-format --dry-run --Werror apps/cli/cli.cpp apps/cli/tests/test_cli.cpp apps/cli/tests/fake_text_family.cpp` — passed.
- `git diff --check` — passed.
- In the local project development container: `cmake -S /tmp/trtmc-text-batch-batch-audit -B /tmp/trtmc-text-batch-batch-audit/build -DTRTMC_ENABLE_BYOK=OFF -DTRTMC_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release` — configured successfully.
- `cmake --build /tmp/trtmc-text-batch-batch-audit/build --target trtmc test_cli -j16` — passed.
- `ctest --test-dir /tmp/trtmc-text-batch-batch-audit/build --output-on-failure -R "^cli$"` — 1/1 passed.

### Hardware, Environment, and Revisions

- Repository head: `45953fd31676ca3c263ed291bbd1ba8a9c190dd7`.
- Base: `cd1bde414846d9e902c967699e72c86585b974d1`.
- Linux aarch64 project development environment.
- No model, checkpoint, dataset, GPU, precision, or TensorRT runtime execution was required for the fake-family CLI contract.

### Not Run / Remaining Gaps

- No real checkpoint build or model E2E was run.
- No GPU or Multi-Device test was run.
- The branch is independent of the separate first-run-defaults PR and may require a small mechanical rebase after that PR merges.

## Notes For Future Readers

This is application behavior over the existing `ITextGeneration` interface. The library contract remains single-request; batching, ordering, file I/O, seed derivation, and JSONL belong entirely to `apps/cli`.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: the implementation is CLI-local and covered by an end-to-end fake-family test, but it adds public command options and file-output semantics.
