### PR TITLE
feat(api): restore a pure C task API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,22 @@ set_target_properties(trtmc_runtime PROPERTIES
   INSTALL_RPATH "\$ORIGIN"
 )
 
+add_library(trtmc_c SHARED
+  core/runtime/c_api/trtmc_c.cpp
+)
+target_include_directories(trtmc_c
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/core/runtime/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(trtmc_c PRIVATE trtmc_runtime)
+target_compile_definitions(trtmc_c PRIVATE TRTMC_VERSION_STRING="${PROJECT_VERSION}")
+target_compile_options(trtmc_c PRIVATE -Wall -Wextra -Wpedantic)
+set_target_properties(trtmc_c PROPERTIES
+  BUILD_RPATH "\$ORIGIN"
+  INSTALL_RPATH "\$ORIGIN"
+)
+
 add_library(trtmc_backend_trt SHARED
   core/runtime/tensorrt/trt_backend.cpp
   core/runtime/tensorrt/trt_logger.cpp
@@ -244,6 +260,9 @@ endif()
 option(TRTMC_BUILD_TESTS "Build tests" ON)
 option(TRTMC_BUILD_EXAMPLES "Build examples" ON)
 if(TRTMC_BUILD_TESTS)
+  enable_language(C)
+  find_package(Threads REQUIRED)
+
   enable_testing()
 endif()
 
@@ -379,6 +398,17 @@ if(TRTMC_BUILD_TESTS)
     BUILD_RPATH "\$ORIGIN/../.."
   )
 
+  add_library(trtmc_test_family_fake_c SHARED core/runtime/tests/fake_c_family.cpp)
+  target_include_directories(trtmc_test_family_fake_c PRIVATE
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(trtmc_test_family_fake_c PRIVATE trtmc_core)
+  set_target_properties(trtmc_test_family_fake_c PROPERTIES
+    OUTPUT_NAME trtmc_model_fake_c
+    LIBRARY_OUTPUT_DIRECTORY "${_trtmc_test_runtime_root}"
+    BUILD_RPATH "\$ORIGIN/../.."
+  )
+
   add_executable(test_family_loader core/runtime/tests/test_family_loader.cpp)
   target_include_directories(test_family_loader PRIVATE
     ${PROJECT_SOURCE_DIR}/core/runtime/include
@@ -392,6 +422,17 @@ if(TRTMC_BUILD_TESTS)
     trtmc_test_family_fake
   )
   add_test(NAME family_loader COMMAND test_family_loader "${_trtmc_test_runtime_root}")
+
+  add_executable(test_c_api core/runtime/tests/test_c_api.c)
+  target_link_libraries(test_c_api PRIVATE trtmc_c Threads::Threads)
+  target_compile_options(test_c_api PRIVATE -Wall -Wextra -Wpedantic)
+  set_target_properties(test_c_api PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+  )
+  add_dependencies(test_c_api trtmc_test_backend_fake trtmc_test_family_fake_c)
+  add_test(NAME c_api COMMAND test_c_api "${_trtmc_test_runtime_root}")
 
   add_executable(test_trt_module_dynamic_input
     core/runtime/tests/test_trt_module_dynamic_input.cpp
@@ -506,7 +547,7 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-install(TARGETS trtmc_core trtmc_runtime
+install(TARGETS trtmc_core trtmc_runtime trtmc_c
   EXPORT trtmcTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -537,6 +578,7 @@ endif()
 install(FILES
   core/runtime/include/trtmc/byok.h
   core/runtime/include/trtmc/bundle.h
+  core/runtime/include/trtmc/c_api.h
   core/runtime/include/trtmc/task.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/trtmc
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -75,6 +75,7 @@ class TensorRTModelConnectConan(ConanFile):
         build = Path(self.build_folder)
         package = Path(self.package_folder)
         module_bin = package / "tensorrt_model_connect" / "bin"
+        module_include = package / "tensorrt_model_connect" / "include" / "trtmc"
         script_bin = package / f"{self.name.replace('-', '_')}-{self.version}.data" / "scripts"
 
         copy(self, "trtmc", src=str(build), dst=str(module_bin), keep_path=False)
@@ -88,6 +89,20 @@ class TensorRTModelConnectConan(ConanFile):
                     dst=str(destination),
                     keep_path=False,
                 )
+        copy(
+            self,
+            "libtrtmc_c.so",
+            src=str(build),
+            dst=str(module_bin),
+            keep_path=False,
+        )
+        copy(
+            self,
+            "c_api.h",
+            src=str(source / "core/runtime/include/trtmc"),
+            dst=str(module_include),
+            keep_path=False,
+        )
         copy(
             self,
             "libtrtmc_backend_trt*.so",
@@ -153,6 +168,8 @@ class TensorRTModelConnectConan(ConanFile):
             for library in ("libtrtmc_core.so", "libtrtmc_runtime.so")
         ]
         backend = module_bin / "libtrtmc_backend_trt.so"
+        c_api = module_bin / "libtrtmc_c.so"
+        c_header = module_include / "c_api.h"
         backends = sorted(module_bin.glob("libtrtmc_backend_trt*.so"))
         byok = module_bin / "libtrtmc_byok_tvm_ffi.so"
         benchmark_worker = module_bin / "trtmc_benchmark_worker"
@@ -161,6 +178,8 @@ class TensorRTModelConnectConan(ConanFile):
             not native.is_file()
             or not installed.is_file()
             or not all(library.is_file() for library in shared_runtime)
+            or not c_api.is_file()
+            or not c_header.is_file()
             or not backend.is_file()
             or not byok.is_file()
             or not benchmark_worker.is_file()
@@ -173,6 +192,7 @@ class TensorRTModelConnectConan(ConanFile):
             _set_runpath(executable, "$ORIGIN")
         for library in shared_runtime:
             _set_runpath(library, "$ORIGIN:/usr/local/cuda/lib64")
+        _set_runpath(c_api, "$ORIGIN")
         _set_runpath(
             byok,
             "$ORIGIN:$ORIGIN/../../tensorrt_libs:$ORIGIN/../../tvm_ffi/lib:/usr/local/cuda/lib64",

--- a/core/runtime/c_api/trtmc_c.cpp
+++ b/core/runtime/c_api/trtmc_c.cpp
@@ -1,0 +1,333 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/c_api.h"
+#include "trtmc/runtime/family_loader.h"
+#include "trtmc/task.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifndef TRTMC_VERSION_STRING
+#define TRTMC_VERSION_STRING "0.1.0"
+#endif
+
+struct trtmc_task {
+    std::unique_ptr<trtmc::ITask> value;
+};
+
+namespace {
+
+thread_local char g_last_error[1024] = {};
+
+void clear_error() noexcept {
+    g_last_error[0] = '\0';
+}
+
+void set_error(const char* message) noexcept {
+    std::snprintf(g_last_error, sizeof(g_last_error), "%s",
+                  message != nullptr ? message : "unknown error");
+}
+
+trtmc_status_t fail(trtmc_status_t status, const char* message) noexcept {
+    set_error(message);
+    return status;
+}
+
+template <typename Function>
+trtmc_status_t guarded(Function&& function) noexcept {
+    clear_error();
+    try {
+        return function();
+    } catch (const std::invalid_argument& error) {
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, error.what());
+    } catch (const std::bad_alloc&) {
+        return fail(TRTMC_STATUS_OUT_OF_MEMORY, "out of memory");
+    } catch (const std::exception& error) {
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, error.what());
+    } catch (...) {
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "unknown runtime error");
+    }
+}
+
+void zero_text_result(trtmc_text_result_t* result) noexcept {
+    *result = trtmc_text_result_t{};
+}
+
+void zero_image_result(trtmc_image_result_t* result) noexcept {
+    *result = trtmc_image_result_t{};
+}
+
+bool checked_product(size_t left, size_t right, size_t* result) noexcept {
+    if (right != 0 && left > std::numeric_limits<size_t>::max() / right)
+        return false;
+    *result = left * right;
+    return true;
+}
+
+trtmc_status_t copy_text_result(const trtmc::TextResult& source,
+                                trtmc_text_result_t* output) noexcept {
+    trtmc_text_result_t result{};
+    if (source.text.size() == std::numeric_limits<size_t>::max())
+        return fail(TRTMC_STATUS_OUT_OF_MEMORY, "text result is too large");
+    result.text = static_cast<char*>(std::malloc(source.text.size() + 1));
+    if (result.text == nullptr)
+        return fail(TRTMC_STATUS_OUT_OF_MEMORY, "unable to allocate text result");
+    std::memcpy(result.text, source.text.data(), source.text.size());
+    result.text[source.text.size()] = '\0';
+    result.text_length = source.text.size();
+
+    if (!source.token_ids.empty()) {
+        size_t bytes = 0;
+        if (!checked_product(source.token_ids.size(), sizeof(int32_t), &bytes)) {
+            std::free(result.text);
+            return fail(TRTMC_STATUS_OUT_OF_MEMORY, "token result is too large");
+        }
+        result.token_ids = static_cast<int32_t*>(std::malloc(bytes));
+        if (result.token_ids == nullptr) {
+            std::free(result.text);
+            return fail(TRTMC_STATUS_OUT_OF_MEMORY, "unable to allocate token result");
+        }
+        std::memcpy(result.token_ids, source.token_ids.data(), bytes);
+        result.token_count = source.token_ids.size();
+    }
+
+    result.setup_ms = source.setup_ms;
+    result.prefill_ms = source.prefill_ms;
+    result.decode_ms = source.decode_ms;
+    *output = result;
+    return TRTMC_STATUS_OK;
+}
+
+bool image_dimensions_are_positive(const trtmc::ImageResult& source) noexcept {
+    return source.height > 0 && source.width > 0 && source.channels > 0 && source.num_frames > 0;
+}
+
+trtmc_status_t image_element_count(const trtmc::ImageResult& source, size_t* count) noexcept {
+    if (!image_dimensions_are_positive(source))
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "image result has invalid dimensions");
+    *count = static_cast<size_t>(source.height);
+    if (!checked_product(*count, static_cast<size_t>(source.width), count))
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "image result dimensions overflow");
+    if (!checked_product(*count, static_cast<size_t>(source.channels), count))
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "image result dimensions overflow");
+    if (!checked_product(*count, static_cast<size_t>(source.num_frames), count))
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "image result dimensions overflow");
+    if (*count != source.pixels.size())
+        return fail(TRTMC_STATUS_RUNTIME_ERROR, "image result size does not match its dimensions");
+    return TRTMC_STATUS_OK;
+}
+
+trtmc_status_t copy_image_result(const trtmc::ImageResult& source,
+                                 trtmc_image_result_t* output) noexcept {
+    size_t expected = 0;
+    const trtmc_status_t count_status = image_element_count(source, &expected);
+    if (count_status != TRTMC_STATUS_OK)
+        return count_status;
+
+    size_t bytes = 0;
+    if (!checked_product(expected, sizeof(float), &bytes))
+        return fail(TRTMC_STATUS_OUT_OF_MEMORY, "image result is too large");
+    float* pixels = static_cast<float*>(std::malloc(bytes));
+    if (pixels == nullptr)
+        return fail(TRTMC_STATUS_OUT_OF_MEMORY, "unable to allocate image result");
+    std::memcpy(pixels, source.pixels.data(), bytes);
+
+    output->pixels = pixels;
+    output->pixel_count = expected;
+    output->height = source.height;
+    output->width = source.width;
+    output->channels = source.channels;
+    output->num_frames = source.num_frames;
+    return TRTMC_STATUS_OK;
+}
+
+trtmc_status_t prepare_image_outputs(trtmc_image_result_t* outputs, size_t count) noexcept {
+    if (outputs == nullptr)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "out_results must not be null");
+    if (count == 0)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "count is outside its valid range");
+    if (count > static_cast<size_t>(std::numeric_limits<int32_t>::max()))
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "count is outside its valid range");
+    for (size_t index = 0; index < count; ++index)
+        zero_image_result(&outputs[index]);
+    return TRTMC_STATUS_OK;
+}
+
+trtmc_status_t validate_image_config(const trtmc_task_t* task, int32_t num_steps,
+                                     float guidance_scale) noexcept {
+    if (task == nullptr || task->value == nullptr)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "task must not be null");
+    if (num_steps <= 0)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "num_steps must be positive");
+    if (!std::isfinite(guidance_scale))
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT,
+                    "guidance_scale must be finite and non-negative");
+    if (guidance_scale < 0.0F)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT,
+                    "guidance_scale must be finite and non-negative");
+    return TRTMC_STATUS_OK;
+}
+
+trtmc_status_t copy_prompts(const char* const* prompts, size_t count,
+                            std::vector<std::string>* output) {
+    if (prompts == nullptr)
+        return fail(TRTMC_STATUS_INVALID_ARGUMENT, "prompts must not be null");
+    output->reserve(count);
+    for (size_t index = 0; index < count; ++index) {
+        if (prompts[index] == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "every prompt must be non-null");
+        output->emplace_back(prompts[index]);
+    }
+    return TRTMC_STATUS_OK;
+}
+
+trtmc_status_t copy_image_results(const std::vector<trtmc::ImageResult>& source,
+                                  trtmc_image_result_t* output) noexcept {
+    for (size_t index = 0; index < source.size(); ++index) {
+        const trtmc_status_t status = copy_image_result(source[index], &output[index]);
+        if (status != TRTMC_STATUS_OK) {
+            for (size_t completed = 0; completed < index; ++completed)
+                trtmc_image_result_free(&output[completed]);
+            return status;
+        }
+    }
+    return TRTMC_STATUS_OK;
+}
+
+} // namespace
+
+extern "C" {
+
+const char* trtmc_version(void) {
+    return TRTMC_VERSION_STRING;
+}
+
+const char* trtmc_last_error(void) {
+    return g_last_error;
+}
+
+trtmc_status_t trtmc_task_load(const char* bundle_path, const char* runtime_root,
+                               trtmc_task_t** out_task) {
+    return guarded([&]() {
+        if (out_task == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "out_task must not be null");
+        *out_task = nullptr;
+        if (bundle_path == nullptr || bundle_path[0] == '\0')
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "bundle_path must not be null or empty");
+        if (runtime_root == nullptr || runtime_root[0] == '\0')
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "runtime_root must not be null or empty");
+
+        std::unique_ptr<trtmc::ITask> task = trtmc::load_task(bundle_path, runtime_root);
+        if (task == nullptr)
+            return fail(TRTMC_STATUS_RUNTIME_ERROR, "runtime returned a null task");
+        auto handle = std::make_unique<trtmc_task>();
+        handle->value = std::move(task);
+        *out_task = handle.release();
+        return TRTMC_STATUS_OK;
+    });
+}
+
+void trtmc_task_destroy(trtmc_task_t* task) {
+    delete task;
+}
+
+trtmc_status_t trtmc_task_name(const trtmc_task_t* task, const char** out_name) {
+    return guarded([&]() {
+        if (out_name == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "out_name must not be null");
+        *out_name = nullptr;
+        if (task == nullptr || task->value == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "task must not be null");
+        const char* name = task->value->task();
+        if (name == nullptr || name[0] == '\0')
+            return fail(TRTMC_STATUS_RUNTIME_ERROR, "loaded task has no name");
+        *out_name = name;
+        return TRTMC_STATUS_OK;
+    });
+}
+
+trtmc_status_t trtmc_text_generate(trtmc_task_t* task, const char* prompt, int32_t max_new_tokens,
+                                   trtmc_text_result_t* out_result) {
+    return guarded([&]() {
+        if (out_result == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "out_result must not be null");
+        zero_text_result(out_result);
+        if (task == nullptr || task->value == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "task must not be null");
+        if (prompt == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "prompt must not be null");
+        if (max_new_tokens <= 0)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "max_new_tokens must be positive");
+        auto* text = dynamic_cast<trtmc::ITextGeneration*>(task->value.get());
+        if (text == nullptr) {
+            return fail(TRTMC_STATUS_WRONG_TASK, "task does not implement text_generation");
+        }
+        trtmc::TextGenerationConfig config;
+        config.max_new_tokens = max_new_tokens;
+        return copy_text_result(text->generate(prompt, config), out_result);
+    });
+}
+
+void trtmc_text_result_free(trtmc_text_result_t* result) {
+    if (result == nullptr)
+        return;
+    std::free(result->text);
+    std::free(result->token_ids);
+    zero_text_result(result);
+}
+
+trtmc_status_t trtmc_image_generate_batch(trtmc_task_t* task, const char* const* prompts,
+                                          const uint32_t* seeds, size_t count, int32_t num_steps,
+                                          float guidance_scale, trtmc_image_result_t* out_results) {
+    return guarded([&]() {
+        const trtmc_status_t output_status = prepare_image_outputs(out_results, count);
+        if (output_status != TRTMC_STATUS_OK)
+            return output_status;
+        const trtmc_status_t config_status = validate_image_config(task, num_steps, guidance_scale);
+        if (config_status != TRTMC_STATUS_OK)
+            return config_status;
+        if (seeds == nullptr)
+            return fail(TRTMC_STATUS_INVALID_ARGUMENT, "seeds must not be null");
+
+        std::vector<std::string> prompt_values;
+        const trtmc_status_t prompt_status = copy_prompts(prompts, count, &prompt_values);
+        if (prompt_status != TRTMC_STATUS_OK)
+            return prompt_status;
+        std::vector<std::uint32_t> seed_values(seeds, seeds + count);
+        auto* image = dynamic_cast<trtmc::IImageBatchGeneration*>(task->value.get());
+        if (image == nullptr) {
+            return fail(TRTMC_STATUS_WRONG_TASK, "task does not implement image_generation_batch");
+        }
+
+        trtmc::ImageGenerationConfig config;
+        config.num_steps = num_steps;
+        config.guidance_scale = guidance_scale;
+        const auto results = image->generate_image_batch(prompt_values, seed_values, config);
+        if (results.size() != count)
+            return fail(TRTMC_STATUS_RUNTIME_ERROR, "image task returned the wrong result count");
+        return copy_image_results(results, out_results);
+    });
+}
+
+void trtmc_image_result_free(trtmc_image_result_t* result) {
+    if (result == nullptr)
+        return;
+    std::free(result->pixels);
+    zero_image_result(result);
+}
+
+} // extern "C"

--- a/core/runtime/include/trtmc/c_api.h
+++ b/core/runtime/include/trtmc/c_api.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TRTMC_C_API_H
+#define TRTMC_C_API_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct trtmc_task trtmc_task_t;
+
+typedef enum trtmc_status {
+    TRTMC_STATUS_OK = 0,
+    TRTMC_STATUS_INVALID_ARGUMENT = 1,
+    TRTMC_STATUS_WRONG_TASK = 2,
+    TRTMC_STATUS_RUNTIME_ERROR = 3,
+    TRTMC_STATUS_OUT_OF_MEMORY = 4
+} trtmc_status_t;
+
+typedef struct trtmc_text_result {
+    char* text;
+    size_t text_length;
+    int32_t* token_ids;
+    size_t token_count;
+    double setup_ms;
+    double prefill_ms;
+    double decode_ms;
+} trtmc_text_result_t;
+
+typedef struct trtmc_image_result {
+    float* pixels;
+    size_t pixel_count;
+    int32_t height;
+    int32_t width;
+    int32_t channels;
+    int32_t num_frames;
+} trtmc_image_result_t;
+
+/*
+ * Return the current library version. The returned process-lifetime string is
+ * owned by TensorRT-Model-Connect and must not be freed.
+ */
+const char* trtmc_version(void);
+
+/*
+ * Return the error for the most recent failed status-returning API call on this
+ * thread. A successful status-returning call clears it. The returned pointer is
+ * valid until the next such call on the same thread and must not be freed.
+ */
+const char* trtmc_last_error(void);
+
+/*
+ * Load exactly the family and backend named by bundle_path from runtime_root.
+ * Both paths and out_task must be non-null and non-empty where applicable.
+ * On success, *out_task is caller-owned and must be passed to
+ * trtmc_task_destroy. On failure, *out_task is NULL.
+ */
+trtmc_status_t trtmc_task_load(const char* bundle_path, const char* runtime_root,
+                               trtmc_task_t** out_task);
+
+/* Destroy a task handle. Passing NULL is allowed. */
+void trtmc_task_destroy(trtmc_task_t* task);
+
+/*
+ * Return the task identity declared by the loaded implementation. The borrowed
+ * string is valid until task is destroyed and must not be freed.
+ */
+trtmc_status_t trtmc_task_name(const trtmc_task_t* task, const char** out_name);
+
+/*
+ * Invoke an ITextGeneration task. prompt and out_result must be non-null and
+ * max_new_tokens must be positive. out_result must be zero-initialized or have
+ * been released already. On success its text and token_ids are caller-owned and
+ * must be released with trtmc_text_result_free. On failure it is zeroed.
+ */
+trtmc_status_t trtmc_text_generate(trtmc_task_t* task, const char* prompt, int32_t max_new_tokens,
+                                   trtmc_text_result_t* out_result);
+
+/* Release one text result and zero all of its fields. Passing NULL is allowed. */
+void trtmc_text_result_free(trtmc_text_result_t* result);
+
+/*
+ * Invoke an IImageBatchGeneration task. prompts, seeds, and out_results each
+ * contain count entries; every prompt must be non-null. count and num_steps must
+ * be positive, and guidance_scale must be finite and non-negative. Each output
+ * element must be zero-initialized or have been released already. On success
+ * every pixels buffer is caller-owned and must be released separately with
+ * trtmc_image_result_free. On failure every output element is zeroed.
+ */
+trtmc_status_t trtmc_image_generate_batch(trtmc_task_t* task, const char* const* prompts,
+                                          const uint32_t* seeds, size_t count, int32_t num_steps,
+                                          float guidance_scale, trtmc_image_result_t* out_results);
+
+/* Release one image result and zero all of its fields. Passing NULL is allowed. */
+void trtmc_image_result_free(trtmc_image_result_t* result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/core/runtime/tests/fake_c_family.cpp
+++ b/core/runtime/tests/fake_c_family.cpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/runtime/family_factory.h"
+#include "trtmc/runtime/trt_backend.h"
+#include "trtmc/task.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+class FakeText final : public trtmc::ITextGeneration {
+  public:
+    std::int32_t default_max_new_tokens() const override { return 7; }
+
+    trtmc::TextResult generate(const std::string& prompt,
+                               const trtmc::TextGenerationConfig& config) override {
+        return {prompt + ":" + std::to_string(config.max_new_tokens),
+                {1, 2, config.max_new_tokens}};
+    }
+};
+
+class FakeImageBatch final : public trtmc::IImageBatchGeneration {
+  public:
+    std::vector<trtmc::ImageResult>
+    generate_image_batch(const std::vector<std::string>& prompts,
+                         const std::vector<std::uint32_t>& seeds,
+                         const trtmc::ImageGenerationConfig& config) override {
+        if (prompts.size() != seeds.size())
+            throw std::invalid_argument("fake image batch size mismatch");
+        std::vector<trtmc::ImageResult> results;
+        results.reserve(prompts.size());
+        for (std::size_t index = 0; index < prompts.size(); ++index) {
+            trtmc::ImageResult result;
+            result.height = 1;
+            result.width = 4;
+            result.channels = 1;
+            result.num_frames = 1;
+            result.pixels = {
+                static_cast<float>(prompts[index].size()),
+                static_cast<float>(seeds[index]),
+                static_cast<float>(config.num_steps),
+                config.guidance_scale,
+            };
+            results.push_back(std::move(result));
+        }
+        return results;
+    }
+};
+
+} // namespace
+
+extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
+    if (context.reader.info().family != "fake_c")
+        throw std::runtime_error("unexpected C API test family");
+    if (context.backend.name() == nullptr || std::string(context.backend.name()) != "fake")
+        throw std::runtime_error("unexpected C API test backend");
+    if (context.reader.info().task == trtmc::ITextGeneration::kTask)
+        return new FakeText();
+    if (context.reader.info().task == trtmc::IImageBatchGeneration::kTask)
+        return new FakeImageBatch();
+    throw std::invalid_argument("unsupported C API test task");
+}

--- a/core/runtime/tests/test_c_api.c
+++ b/core/runtime/tests/test_c_api.c
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/c_api.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+static void check(int condition, const char* name) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", name);
+        ++failures;
+    }
+}
+
+static int write_bundle(const char* path, const char* task) {
+    static const unsigned char magic[8] = {'B', 'U', 'N', 'D', 'L', 'E', 1, 0};
+    char header[256];
+    const int header_size = snprintf(header, sizeof(header),
+                                     "{\"format\":1,\"family\":\"fake_c\",\"task\":\"%s\","
+                                     "\"backend\":\"fake\",\"sections\":{}}",
+                                     task);
+    if (header_size <= 0 || (size_t)header_size >= sizeof(header))
+        return 0;
+
+    FILE* output = fopen(path, "wb");
+    if (output == NULL)
+        return 0;
+    if (fwrite(magic, sizeof(magic), 1, output) != 1) {
+        fclose(output);
+        return 0;
+    }
+    const uint64_t length = (uint64_t)header_size;
+    for (int shift = 0; shift < 64; shift += 8)
+        fputc((int)((length >> shift) & 0xffU), output);
+    const int ok = fwrite(header, (size_t)header_size, 1, output) == 1;
+    return fclose(output) == 0 && ok;
+}
+
+struct thread_error {
+    trtmc_status_t status;
+    char message[128];
+};
+
+static void* set_thread_error(void* opaque) {
+    struct thread_error* result = (struct thread_error*)opaque;
+    const char* name = NULL;
+    result->status = trtmc_task_name(NULL, &name);
+    snprintf(result->message, sizeof(result->message), "%s", trtmc_last_error());
+    return NULL;
+}
+
+static void test_error_contract(const char* bundle, const char* runtime_root) {
+    trtmc_task_t* task = (trtmc_task_t*)(uintptr_t)1;
+    check(trtmc_task_load(NULL, runtime_root, &task) == TRTMC_STATUS_INVALID_ARGUMENT,
+          "null bundle path is rejected");
+    check(task == NULL, "failed load clears output handle");
+    check(strstr(trtmc_last_error(), "bundle_path") != NULL, "load failure sets last error");
+
+    char missing_root[1024];
+    snprintf(missing_root, sizeof(missing_root), "%s/missing", runtime_root);
+    task = (trtmc_task_t*)(uintptr_t)1;
+    check(trtmc_task_load(bundle, missing_root, &task) == TRTMC_STATUS_RUNTIME_ERROR,
+          "explicit missing runtime root fails closed");
+    check(task == NULL, "runtime load failure clears output handle");
+
+    char main_error[1024];
+    snprintf(main_error, sizeof(main_error), "%s", trtmc_last_error());
+    struct thread_error thread_result = {TRTMC_STATUS_OK, {0}};
+    pthread_t thread;
+    check(pthread_create(&thread, NULL, set_thread_error, &thread_result) == 0,
+          "error test thread starts");
+    check(pthread_join(thread, NULL) == 0, "error test thread joins");
+    check(thread_result.status == TRTMC_STATUS_INVALID_ARGUMENT,
+          "thread receives its own error status");
+    check(strstr(thread_result.message, "task") != NULL, "thread receives its own error text");
+    check(strcmp(trtmc_last_error(), main_error) == 0, "last error is thread local");
+}
+
+static void test_text(const char* bundle, const char* runtime_root) {
+    trtmc_task_t* task = NULL;
+    check(trtmc_task_load(bundle, runtime_root, &task) == TRTMC_STATUS_OK,
+          "text task loads through the runtime");
+    check(task != NULL, "text task handle is returned");
+    check(trtmc_last_error()[0] == '\0', "successful load clears last error");
+
+    const char* task_name = NULL;
+    check(trtmc_task_name(task, &task_name) == TRTMC_STATUS_OK, "text task name is available");
+    check(task_name != NULL && strcmp(task_name, "text_generation") == 0,
+          "text task name matches the bundle");
+
+    trtmc_text_result_t result = {0};
+    check(trtmc_text_generate(task, "hello", 5, &result) == TRTMC_STATUS_OK,
+          "text generation succeeds");
+    check(result.text != NULL && strcmp(result.text, "hello:5") == 0,
+          "text result is copied to C ownership");
+    check(result.text_length == 7, "text length excludes the null terminator");
+    check(result.token_count == 3 && result.token_ids != NULL && result.token_ids[2] == 5,
+          "token IDs are copied to C ownership");
+    trtmc_text_result_free(&result);
+    check(result.text == NULL && result.token_ids == NULL && result.text_length == 0 &&
+              result.token_count == 0,
+          "text result free is idempotent and clears ownership");
+    trtmc_text_result_free(&result);
+
+    const char* prompts[] = {"wrong task"};
+    const uint32_t seeds[] = {1};
+    trtmc_image_result_t image = {0};
+    check(trtmc_image_generate_batch(task, prompts, seeds, 1, 4, 7.5F, &image) ==
+              TRTMC_STATUS_WRONG_TASK,
+          "typed image call rejects a text task");
+    check(strstr(trtmc_last_error(), "image_generation_batch") != NULL,
+          "wrong-task failure is actionable");
+
+    trtmc_task_destroy(task);
+}
+
+static void test_image_batch(const char* bundle, const char* runtime_root) {
+    trtmc_task_t* task = NULL;
+    check(trtmc_task_load(bundle, runtime_root, &task) == TRTMC_STATUS_OK,
+          "image batch task loads through the runtime");
+
+    const char* prompts[] = {"cat", "puppy"};
+    const uint32_t seeds[] = {42, 7};
+    trtmc_image_result_t results[2] = {{0}};
+    check(trtmc_image_generate_batch(task, prompts, seeds, 2, 4, 7.5F, results) == TRTMC_STATUS_OK,
+          "image batch generation succeeds");
+    check(results[0].height == 1, "first image height is copied");
+    check(results[0].width == 4, "first image width is copied");
+    check(results[0].channels == 1, "first image channel count is copied");
+    check(results[0].num_frames == 1, "first image frame count is copied");
+    check(results[0].pixel_count == 4, "first image pixel count is copied");
+    check(results[1].pixel_count == 4, "second image pixel count is copied");
+    check(results[0].pixels[0] == 3.0F, "first prompt length is preserved");
+    check(results[0].pixels[1] == 42.0F, "first seed is preserved");
+    check(results[0].pixels[2] == 4.0F, "step count is preserved");
+    check(results[0].pixels[3] == 7.5F, "guidance scale is preserved");
+    check(results[1].pixels[0] == 5.0F, "second prompt length is preserved");
+    check(results[1].pixels[1] == 7.0F, "second seed is preserved");
+
+    trtmc_image_result_free(&results[0]);
+    trtmc_image_result_free(&results[1]);
+    check(results[0].pixels == NULL, "first image pixels are cleared");
+    check(results[0].pixel_count == 0, "first image size is cleared");
+    check(results[1].pixels == NULL, "second image pixels are cleared");
+    check(results[1].pixel_count == 0, "second image size is cleared");
+    trtmc_task_destroy(task);
+}
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        fprintf(stderr, "usage: test_c_api RUNTIME_ROOT\n");
+        return 2;
+    }
+    const char* runtime_root = argv[1];
+    char text_bundle[1024];
+    char image_bundle[1024];
+    snprintf(text_bundle, sizeof(text_bundle), "%s/fake-c-text.bundle", runtime_root);
+    snprintf(image_bundle, sizeof(image_bundle), "%s/fake-c-image.bundle", runtime_root);
+    check(write_bundle(text_bundle, "text_generation"), "text bundle is written");
+    check(write_bundle(image_bundle, "image_generation_batch"), "image bundle is written");
+
+    check(trtmc_version() != NULL && trtmc_version()[0] != '\0', "version is non-empty");
+    test_error_contract(text_bundle, runtime_root);
+    test_text(text_bundle, runtime_root);
+    test_image_batch(image_bundle, runtime_root);
+    trtmc_task_destroy(NULL);
+    trtmc_text_result_free(NULL);
+    trtmc_image_result_free(NULL);
+
+    remove(text_bundle);
+    remove(image_bundle);
+    fprintf(stderr, "%s\n", failures == 0 ? "ALL PASSED" : "SOME FAILED");
+    return failures;
+}

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -64,6 +64,7 @@ def load_native_libraries(bin_dir: Path, families: tuple[str, ...]) -> None:
     libraries = [
         bin_dir / "libtrtmc_core.so",
         bin_dir / "libtrtmc_runtime.so",
+        bin_dir / "libtrtmc_c.so",
         bin_dir / "libtrtmc_backend_trt.so",
         bin_dir / "libtrtmc_byok_tvm_ffi.so",
         *(bin_dir / f"libtrtmc_model_{family}.so" for family in families),
@@ -117,6 +118,8 @@ class WheelArchiveValidator:
                 raise CiError(f"{wheel}: generated Python cache files are packaged")
             if "tensorrt_model_connect/__init__.py" not in names:
                 raise CiError(f"{wheel}: Python core package is missing")
+            if "tensorrt_model_connect/include/trtmc/c_api.h" not in names:
+                raise CiError(f"{wheel}: public C header is missing")
             if "trtmc_benchmark/__init__.py" not in names:
                 raise CiError(f"{wheel}: Python benchmark application is missing")
             source_suffixes = {
@@ -234,6 +237,7 @@ class WheelArchiveValidator:
                 "trtmc",
                 "libtrtmc_core.so",
                 "libtrtmc_runtime.so",
+                "libtrtmc_c.so",
                 "libtrtmc_backend_trt.so",
                 "libtrtmc_byok_tvm_ffi.so",
                 "trtmc_benchmark_worker",
@@ -301,6 +305,7 @@ print(json.dumps({
         path.parent.name for path in Path(families.__file__).resolve().parent.glob("*/requirements.txt")
     ),
     "bin": str(Path(core.__file__).resolve().parent / "bin"),
+    "include": str(Path(core.__file__).resolve().parent / "include"),
     "scripts": sysconfig.get_path("scripts"),
 }))
 """
@@ -319,6 +324,7 @@ print(json.dumps({
         if any(path.is_relative_to(self.repository.resolve()) for path in imported):
             raise CiError("installed wheel validation imported the source checkout")
         bin_dir = Path(payload["bin"])
+        include_dir = Path(payload["include"])
         expected = set(family_ids(self.repository))
         expected_requirements = {
             path.parent.name for path in (self.repository / "families").glob("*/requirements.txt")
@@ -333,6 +339,7 @@ print(json.dumps({
             bin_dir / "trtmc",
             bin_dir / "libtrtmc_core.so",
             bin_dir / "libtrtmc_runtime.so",
+            bin_dir / "libtrtmc_c.so",
             bin_dir / "libtrtmc_backend_trt.so",
             bin_dir / "libtrtmc_byok_tvm_ffi.so",
             bin_dir / "trtmc_benchmark_worker",
@@ -340,6 +347,8 @@ print(json.dumps({
         )
         if not all(path.is_file() for path in required) or packaged != expected:
             raise CiError(f"installed wheel is incomplete: {wheel}")
+        if not (include_dir / "trtmc/c_api.h").is_file():
+            raise CiError(f"installed wheel has no public C header: {wheel}")
         load_native_libraries(bin_dir, tuple(sorted(expected)))
         executable = Path(payload["scripts"]) / "trtmc"
         if not executable.is_file() or not os.access(executable, os.X_OK):

--- a/tools/tests/test_architecture.py
+++ b/tools/tests/test_architecture.py
@@ -254,7 +254,7 @@ def test_core_languages_are_strictly_separated() -> None:
     assert [
         path.relative_to(REPO)
         for path in runtime_files
-        if path.suffix not in {".cc", ".cpp", ".cu", ".cuh", ".h", ".hpp"}
+        if path.suffix not in {".c", ".cc", ".cpp", ".cu", ".cuh", ".h", ".hpp"}
     ] == []
 
 
@@ -279,6 +279,7 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
     expected_native = {
         "core/runtime/bundle/bundle_format.cpp",
         "core/runtime/bundle/bundle_format.h",
+        "core/runtime/c_api/trtmc_c.cpp",
         "core/runtime/tensorrt/trt_backend.cpp",
         "core/runtime/tensorrt/trt_logger.cpp",
         "core/runtime/tensorrt/trt_logger.h",
@@ -299,6 +300,7 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
         "core/runtime/loader/family_loader.cpp",
         "core/runtime/include/trtmc/byok.h",
         "core/runtime/include/trtmc/bundle.h",
+        "core/runtime/include/trtmc/c_api.h",
         "core/runtime/include/trtmc/task.h",
         "core/runtime/include/trtmc/runtime/device_tensor.h",
         "core/runtime/include/trtmc/runtime/family_factory.h",
@@ -307,9 +309,11 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
         "core/runtime/include/trtmc/runtime/trt_backend.h",
         "core/runtime/include/trtmc/runtime/trt_module.h",
         "core/runtime/tests/fake_backend.cpp",
+        "core/runtime/tests/fake_c_family.cpp",
         "core/runtime/tests/fake_family.cpp",
         "core/runtime/tests/test_bundle_format_v1.cpp",
         "core/runtime/tests/test_byok_shape_spec.cpp",
+        "core/runtime/tests/test_c_api.c",
         "core/runtime/tests/test_family_loader.cpp",
         "core/runtime/tests/test_task_api.cpp",
         "core/runtime/tests/test_trt_module_dynamic_input.cpp",
@@ -1034,6 +1038,11 @@ def test_native_loader_and_preprocessing_stay_out_of_shared_core() -> None:
 
     runtime_sources = cmake.split("add_library(trtmc_runtime SHARED", 1)[1].split(")", 1)[0]
     assert "core/runtime/loader/family_loader.cpp" in runtime_sources
+    c_api_sources = cmake.split("add_library(trtmc_c SHARED", 1)[1].split(")", 1)[0]
+    assert "core/runtime/c_api/trtmc_c.cpp" in c_api_sources
+    c_api_links = cmake.split("target_link_libraries(trtmc_c PRIVATE", 1)[1].split(")", 1)[0]
+    assert "trtmc_runtime" in c_api_links
+    assert "families/" not in c_api_links
     cli_links = cmake.split("target_link_libraries(trtmc_cli", 1)[1].split(")", 1)[0]
     assert "trtmc_runtime" in cli_links
     assert "trtmc_core" in cli_links

--- a/tools/tests/test_new_ci.py
+++ b/tools/tests/test_new_ci.py
@@ -636,6 +636,7 @@ def test_wheel_validation_requires_exact_new_payload(tmp_path: Path) -> None:
     wheel = tmp_path / "package.whl"
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr("tensorrt_model_connect/__init__.py", "")
+        archive.writestr("tensorrt_model_connect/include/trtmc/c_api.h", "")
         archive.writestr("trtmc_benchmark/__init__.py", "")
         archive.writestr("families/__init__.py", "")
         archive.writestr("tensorrt_model_connect/bin/trtmc", "")
@@ -643,6 +644,7 @@ def test_wheel_validation_requires_exact_new_payload(tmp_path: Path) -> None:
         archive.writestr("tensorrt_model_connect/bin/trtmc_dataset_benchmark", "")
         archive.writestr("tensorrt_model_connect/bin/libtrtmc_core.so", "")
         archive.writestr("tensorrt_model_connect/bin/libtrtmc_runtime.so", "")
+        archive.writestr("tensorrt_model_connect/bin/libtrtmc_c.so", "")
         archive.writestr("tensorrt_model_connect/bin/libtrtmc_backend_trt.so", "")
         archive.writestr("tensorrt_model_connect/bin/libtrtmc_byok_tvm_ffi.so", "")
         archive.writestr(
@@ -720,6 +722,7 @@ def test_native_validation_rejects_unresolved_family_symbols(tmp_path: Path) -> 
 
     compile_library("libtrtmc_core.so", "void core_symbol(void) {}\n")
     compile_library("libtrtmc_runtime.so", "void runtime_symbol(void) {}\n")
+    compile_library("libtrtmc_c.so", "void c_api_symbol(void) {}\n")
     compile_library("libtrtmc_backend_trt.so", "void backend_symbol(void) {}\n")
     compile_library("libtrtmc_byok_tvm_ffi.so", "void byok_symbol(void) {}\n")
     compile_library("libtrtmc_model_alpha.so", "void alpha_symbol(void) {}\n")

--- a/website/docs/api/c-api.md
+++ b/website/docs/api/c-api.md
@@ -1,0 +1,92 @@
+---
+title: C Task API
+---
+
+`<trtmc/c_api.h>` is a C11-compatible wrapper over the current abstract Task
+interfaces. It exposes no C++ types. Link `libtrtmc_c.so`; the adapter delegates
+loading to `libtrtmc_runtime.so` and does not contain model behavior.
+
+```cmake
+find_package(trtmc 0.1.0 EXACT REQUIRED)
+target_link_libraries(my_c_app PRIVATE trtmc::trtmc_c)
+```
+
+## Status and errors
+
+Every operation that can fail returns one of these values:
+
+| Status | Meaning |
+| --- | --- |
+| `TRTMC_STATUS_OK` | The call completed and cleared this thread's last error. |
+| `TRTMC_STATUS_INVALID_ARGUMENT` | A required pointer, path, count, or numeric value is invalid. |
+| `TRTMC_STATUS_WRONG_TASK` | The loaded task does not implement the requested typed operation. |
+| `TRTMC_STATUS_RUNTIME_ERROR` | Loading or the family implementation failed. |
+| `TRTMC_STATUS_OUT_OF_MEMORY` | The adapter could not copy a caller-owned result. |
+
+`trtmc_last_error()` returns a borrowed thread-local string. It is valid until
+the next status-returning C API call on that thread and must not be freed.
+`trtmc_version()` returns a borrowed process-lifetime string.
+
+## Load and destroy
+
+```c
+#include <trtmc/c_api.h>
+#include <stdio.h>
+
+trtmc_task_t* task = NULL;
+trtmc_status_t status = trtmc_task_load(
+    "model.bundle", "/opt/trtmc/lib", &task);
+if (status != TRTMC_STATUS_OK) {
+    fprintf(stderr, "%s\n", trtmc_last_error());
+    return 1;
+}
+
+const char* name = NULL;
+status = trtmc_task_name(task, &name);
+/* name is borrowed until task is destroyed. */
+
+trtmc_task_destroy(task);
+```
+
+`runtime_root` is always explicit. The loader opens exactly the family and
+backend named by the bundle and does not try another implementation.
+
+## Text generation
+
+```c
+trtmc_text_result_t result = {0};
+status = trtmc_text_generate(task, "Hello", 32, &result);
+if (status == TRTMC_STATUS_OK) {
+    fwrite(result.text, 1, result.text_length, stdout);
+}
+trtmc_text_result_free(&result);
+```
+
+`max_new_tokens` must be positive. On success, `text` is null-terminated,
+`text_length` excludes that terminator, and both `text` and `token_ids` belong
+to the caller. Free the whole result only with `trtmc_text_result_free()`.
+
+## Batch image generation
+
+```c
+const char* prompts[] = {"A red fox", "A blue bird"};
+const uint32_t seeds[] = {42, 7};
+trtmc_image_result_t results[2] = {{0}};
+
+status = trtmc_image_generate_batch(
+    task, prompts, seeds, 2, 20, 7.5f, results);
+if (status == TRTMC_STATUS_OK) {
+    /* Each pixels buffer is contiguous float THWC/HWC data. */
+}
+trtmc_image_result_free(&results[0]);
+trtmc_image_result_free(&results[1]);
+```
+
+The task must implement `image_generation_batch`. Prompts and seeds have one
+shared positive count; `num_steps` is positive and `guidance_scale` is finite
+and non-negative. Each image result owns an independent pixel allocation and is
+freed independently.
+
+Result structs must be zero-initialized before first use or released before
+reuse. When a valid output object or array is supplied, failed typed operations
+leave its owned pointers and sizes zeroed.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -121,6 +121,7 @@ module.exports = {
         'api/cli-reference',
         'api/python-builder',
         'api/cpp-api',
+        'api/c-api',
         'architecture/bundle-format',
         'features/config-and-backends',
         'features/sampling',


### PR DESCRIPTION
## Background

PR #1093 removed the repository's user-facing C-linkage entrypoints while moving runtime behavior to typed `ITask` interfaces. C and FFI consumers currently have no supported way to load, invoke, and destroy a task without using C++.

## Exit Criteria

- Ship a header that compiles as strict C11 and exposes no C++ type.
- Provide an opaque task handle with explicit load, name, and destroy ownership.
- Provide thread-local error reporting and a version query.
- Restore typed text generation and image-batch invocation with explicit result ownership.
- Install and package the C header and shared library.
- Keep family code unchanged and preserve the current explicit `runtime_root` loader contract.
- Add no compatibility shim, registry, generic options bag, or fallback.

## Implementation

- Added the pure C `trtmc/c_api.h` contract and a thin `libtrtmc_c.so` adapter over `load_task()`.
- Added status codes, an opaque task handle, borrowed task-name/version strings, and thread-local last-error storage.
- Added C-owned text and image result buffers with explicit free functions.
- Added typed text generation and image-batch generation entrypoints; wrong task types fail explicitly.
- Added C-compiled fake-family integration tests covering load, invoke, copy, free, errors, and thread-local isolation.
- Installed the target/header through CMake and included both in the wheel payload and validators.
- Added a C API reference page.

### Change categories

- [ ] Model or runtime behavior
- [x] Public API
- [x] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `cc -std=c11 -Wall -Wextra -Wpedantic -Werror -Icore/runtime/include -fsyntax-only core/runtime/tests/test_c_api.c` — passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest core/builder/tests tools/tests -q` — 222 passed.
- In the pinned project development image: `cmake -S . -B .ci/c-api -G Ninja -DTRTMC_ENABLE_BYOK=OFF -DTRTMC_BUILD_EXAMPLES=OFF -DTRTMC_BUILD_TESTS=ON && cmake --build .ci/c-api --parallel 8 --target test_bundle_format_v1 test_task_api test_family_loader test_c_api` — passed.
- `ctest --test-dir .ci/c-api --output-on-failure -R "^(bundle_format_v1|task_api|family_loader|c_api)$"` — 4/4 passed.
- CMake install plus a `project(... LANGUAGES C)` consumer using `find_package(trtmc 0.1.0 EXACT)` — compiled, linked, and ran; output `0.1.0`.
- Exact-tree wheel build, archive validation, and installed-wheel validation — passed for 98 families and 105 shared libraries; `c_api.h` and `libtrtmc_c.so` were present.
- `npm ci && npm run test:model-support && npm run build` in `website/` — model inventory and production documentation build passed.
- `python3 tools/legal_headers.py --check` — 0 findings.
- Ruff, clang-format check mode, and `git diff --check` — passed.

### Hardware, Environment, and Revisions

- Repository head: `27620faae2f09abdc00489ba2441f60b3aa5e0dd`.
- Base: `c7473e3a9de3e76aadf6953e28f64bb03890035b`.
- Linux aarch64, Python 3.12.3, CMake 3.28.3, strict C11 consumer.
- The integration test used fake backend, text, and image-batch family DSOs; no model checkpoint was involved.

### Not Run / Remaining Gaps

- No real GPU family inference was run through the C API.
- No Multi-Device test was run.
- The complete native CTest inventory was not run; validation covered the C API and its three adjacent runtime contracts.

## Notes For Future Readers

This is a new C contract over the current Task API, not backward compatibility for the retired C++-typed entrypoints. Add another C task function only for a concrete consumer and keep each result's allocation/free ownership explicit.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: the adapter is thin and has pure-C integration coverage, but it creates a new installed public API, shared library, and ABI surface.
