### PR TITLE
feat(qwen): restore TensorRT Edge-LLM adapter

### DIFF
--- a/core/builder/tensorrt_model_connect/build.py
+++ b/core/builder/tensorrt_model_connect/build.py
@@ -14,6 +14,7 @@ from types import ModuleType
 
 from .bundle_writer import BundleWriter
 from .graph_transform import GraphTransform, graph_transform
+from .model_support import FamilySupport, load_model_metadata
 
 
 _ID = re.compile(r"[a-z][a-z0-9_]*\Z")
@@ -47,8 +48,8 @@ class BuildRequest:
             raise ValueError("precision must be non-empty")
         _validate_id("family", self.family)
         _validate_id("task", self.task)
-        if self.backend not in {"trt", "trt_rtx"}:
-            raise ValueError("backend must be 'trt' or 'trt_rtx'")
+        if self.backend not in {"trt", "trt_rtx", "edge_llm"}:
+            raise ValueError("backend must be 'trt', 'trt_rtx', or 'edge_llm'")
         if self.max_sequence_length is not None and self.max_sequence_length < 1:
             raise ValueError("max_sequence_length must be positive")
         for field in ("image_height", "image_width", "video_num_frames"):
@@ -102,8 +103,25 @@ def _load_family(family: str) -> ModuleType:
         raise
 
 
+def _require_supported_backend(request: BuildRequest) -> None:
+    """Require the selected family to own the requested backend."""
+
+    module = importlib.import_module(f"families.{request.family}.support")
+    describe = getattr(module, "describe", None)
+    if not callable(describe):
+        raise RuntimeError(f"family {request.family!r} does not define support.describe()")
+    support = describe(load_model_metadata(request.model_dir))
+    if not isinstance(support, FamilySupport):
+        raise ValueError(f"family {request.family!r} does not support this model")
+    if request.backend not in support.backends:
+        raise ValueError(f"family {request.family!r} does not support backend {request.backend!r}")
+
+
 def _select_backend(backend: str) -> None:
     """Bind the explicit build backend before importing a family builder."""
+
+    if backend == "edge_llm":
+        return
 
     loaded = sys.modules.get("tensorrt")
     if backend == "trt":
@@ -121,6 +139,7 @@ def build(request: BuildRequest) -> None:
     """Run one family builder and publish its bundle on success."""
 
     family = _resolve_family(request)
+    _require_supported_backend(request)
     _select_backend(request.backend)
     family_module = _load_family(family)
     writer = BundleWriter(request.output_path)

--- a/core/builder/tensorrt_model_connect/build_cli.py
+++ b/core/builder/tensorrt_model_connect/build_cli.py
@@ -22,7 +22,7 @@ def _parser() -> argparse.ArgumentParser:
     build_parser.add_argument("--task", help="Override the family-owned default task")
     build_parser.add_argument("--revision", help="Hugging Face model revision")
     build_parser.add_argument("--precision", choices=("fp16", "bf16", "fp32"), default="fp32")
-    build_parser.add_argument("--backend", choices=("trt", "trt_rtx"), default="trt")
+    build_parser.add_argument("--backend", choices=("trt", "trt_rtx", "edge_llm"), default="trt")
     build_parser.add_argument("--max-sequence-length", type=int)
     build_parser.add_argument("--image-height", type=int)
     build_parser.add_argument("--image-width", type=int)
@@ -48,6 +48,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError(
             f"family {family!r} does not support task {task!r}; "
             f"choose one of: {', '.join(support.tasks)}"
+        )
+    if args.backend not in support.backends:
+        raise ValueError(
+            f"family {family!r} does not support backend {args.backend!r}; "
+            f"choose one of: {', '.join(support.backends)}"
         )
     build(
         BuildRequest(

--- a/core/builder/tensorrt_model_connect/model_support.py
+++ b/core/builder/tensorrt_model_connect/model_support.py
@@ -55,6 +55,7 @@ class FamilySupport:
 
     tasks: tuple[str, ...]
     default_task: str
+    backends: tuple[str, ...] = ("trt", "trt_rtx")
 
     def __post_init__(self) -> None:
         if not self.tasks or len(set(self.tasks)) != len(self.tasks):
@@ -63,6 +64,10 @@ class FamilySupport:
             raise ValueError("family support tasks must be lowercase identifiers")
         if self.default_task not in self.tasks:
             raise ValueError("default_task must be one of the supported tasks")
+        if not self.backends or len(set(self.backends)) != len(self.backends):
+            raise ValueError("family support backends must be non-empty and unique")
+        if any(_ID.fullmatch(backend) is None for backend in self.backends):
+            raise ValueError("family support backends must be lowercase identifiers")
 
 
 DescribeSupport = Callable[[ModelMetadata], FamilySupport | None]
@@ -80,6 +85,7 @@ def family_support(
     required_files: tuple[str, ...] = (),
     tasks: tuple[str, ...],
     default_task: str,
+    backends: tuple[str, ...] = ("trt", "trt_rtx"),
 ) -> DescribeSupport:
     """Create one exact, family-owned support function."""
 
@@ -93,7 +99,7 @@ def family_support(
     file_keys = frozenset(value for value in required_files if value)
     if not model_type_keys and not architecture_keys and not pipeline_keys and not file_keys:
         raise ValueError("family support must declare at least one model identity")
-    support = FamilySupport(tasks=tasks, default_task=default_task)
+    support = FamilySupport(tasks=tasks, default_task=default_task, backends=backends)
 
     def describe(metadata: ModelMetadata) -> FamilySupport | None:
         if _key(metadata.model_type) in model_type_keys:

--- a/core/builder/tests/test_build.py
+++ b/core/builder/tests/test_build.py
@@ -29,6 +29,10 @@ def _request(tmp_path: Path, *, family: str = "example") -> BuildRequest:
     )
 
 
+def _accept_backend(monkeypatch) -> None:
+    monkeypatch.setattr(build_core, "_require_supported_backend", lambda _request: None)
+
+
 def test_build_request_is_a_plain_frozen_dataclass(tmp_path: Path) -> None:
     request = _request(tmp_path)
 
@@ -114,6 +118,36 @@ def test_rtx_backend_is_bound_before_family_import(monkeypatch) -> None:
     assert sys.modules["tensorrt"] is rtx
 
 
+def test_edge_llm_backend_does_not_bind_a_python_tensorrt_module(monkeypatch) -> None:
+    imported: list[str] = []
+    monkeypatch.setattr(importlib, "import_module", lambda name: imported.append(name))
+
+    build_core._select_backend("edge_llm")
+
+    assert imported == []
+
+
+def test_low_level_build_support_rejects_edge_llm_outside_qwen(tmp_path: Path) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text('{"model_type":"gpt2"}', encoding="utf-8")
+    request = BuildRequest(
+        model_dir=model,
+        output_path=tmp_path / "model.bundle",
+        family="gpt2",
+        task="text_generation",
+        precision="fp16",
+        backend="edge_llm",
+    )
+
+    with pytest.raises(ValueError, match="does not support backend 'edge_llm'"):
+        build_core._require_supported_backend(request)
+
+    (model / "config.json").write_text('{"model_type":"qwen3"}', encoding="utf-8")
+    qwen = replace(request, family="qwen")
+    assert build_core._require_supported_backend(qwen) is None
+
+
 def test_backend_cannot_switch_after_tensor_rt_is_loaded(monkeypatch) -> None:
     standard = object()
     rtx = object()
@@ -158,6 +192,7 @@ def test_family_internal_module_not_found_error_is_not_wrapped(monkeypatch) -> N
 
 
 def test_build_finishes_after_family_returns(monkeypatch, tmp_path: Path) -> None:
+    _accept_backend(monkeypatch)
     events: list[object] = []
 
     class FakeWriter:
@@ -188,6 +223,7 @@ def test_build_finishes_after_family_returns(monkeypatch, tmp_path: Path) -> Non
 def test_build_runs_graph_transform_before_family_engine_serialization(
     monkeypatch, tmp_path: Path
 ) -> None:
+    _accept_backend(monkeypatch)
     events: list[object] = []
 
     class FakeTrtBuilder:
@@ -236,6 +272,7 @@ def test_build_runs_graph_transform_before_family_engine_serialization(
 
 
 def test_build_aborts_and_preserves_family_error(monkeypatch, tmp_path: Path) -> None:
+    _accept_backend(monkeypatch)
     events: list[str] = []
     family_error = RuntimeError("family failed")
 
@@ -264,6 +301,7 @@ def test_build_aborts_and_preserves_family_error(monkeypatch, tmp_path: Path) ->
 
 
 def test_build_aborts_if_finish_fails(monkeypatch, tmp_path: Path) -> None:
+    _accept_backend(monkeypatch)
     events: list[str] = []
 
     class FakeWriter:

--- a/core/builder/tests/test_build_cli.py
+++ b/core/builder/tests/test_build_cli.py
@@ -92,6 +92,52 @@ def test_build_command_uses_the_family_owned_default_task(monkeypatch, tmp_path:
     assert captured[0].task == "text_generation"
 
 
+def test_build_command_accepts_explicit_edge_llm_backend(monkeypatch, tmp_path: Path) -> None:
+    captured = []
+    monkeypatch.setattr(build_cli, "build", captured.append)
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text('{"model_type":"qwen3"}', encoding="utf-8")
+
+    assert (
+        build_cli.main(
+            [
+                "build",
+                str(model),
+                "--output",
+                str(tmp_path / "out.bundle"),
+                "--backend",
+                "edge_llm",
+                "--precision",
+                "fp16",
+            ]
+        )
+        == 0
+    )
+
+    assert captured[0].family == "qwen"
+    assert captured[0].backend == "edge_llm"
+
+
+def test_build_command_rejects_edge_llm_for_another_family(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(build_cli, "build", lambda _request: None)
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text('{"model_type":"gpt2"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not support backend 'edge_llm'"):
+        build_cli.main(
+            [
+                "build",
+                str(model),
+                "--output",
+                str(tmp_path / "out.bundle"),
+                "--backend",
+                "edge_llm",
+            ]
+        )
+
+
 def test_hugging_face_model_id_resolves_to_a_local_snapshot(monkeypatch, tmp_path: Path) -> None:
     calls = []
 

--- a/core/builder/tests/test_model_support.py
+++ b/core/builder/tests/test_model_support.py
@@ -43,6 +43,10 @@ def test_family_support_rejects_invalid_declarations() -> None:
         FamilySupport(tasks=("generation",), default_task="editing")
     with pytest.raises(ValueError, match="lowercase identifiers"):
         FamilySupport(tasks=("not-valid",), default_task="not-valid")
+    with pytest.raises(ValueError, match="backends must be non-empty"):
+        FamilySupport(tasks=("generation",), default_task="generation", backends=())
+    with pytest.raises(ValueError, match="backends must be lowercase"):
+        FamilySupport(tasks=("generation",), default_task="generation", backends=("not-valid",))
 
 
 def test_load_model_metadata_reads_only_standard_identity_files(tmp_path: Path) -> None:
@@ -192,6 +196,15 @@ def test_qwen38_marker_has_one_owner() -> None:
     )
     assert family == "qwen3_8"
     assert support.default_task == "text_generation"
+
+
+def test_only_qwen_declares_the_edge_llm_backend() -> None:
+    family, qwen = resolve_family(ModelMetadata({"model_type": "qwen3"}, {}))
+    _, gpt2 = resolve_family(ModelMetadata({"model_type": "gpt2"}, {}))
+
+    assert family == "qwen"
+    assert qwen.backends == ("trt", "trt_rtx", "edge_llm")
+    assert gpt2.backends == ("trt", "trt_rtx")
 
 
 @pytest.mark.parametrize(

--- a/core/runtime/bundle/bundle_format.cpp
+++ b/core/runtime/bundle/bundle_format.cpp
@@ -6,6 +6,7 @@
 #include "runtime/bundle/bundle_format.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -213,6 +214,36 @@ std::vector<char> BundleReader::read_section(std::string_view name) const {
                                  "' from: " + path_);
     }
     return data;
+}
+
+void BundleReader::copy_section(std::string_view name, std::ostream& output) const {
+    const auto* section = find_section(name);
+    if (section == nullptr)
+        throw std::runtime_error("Bundle section not found: " + std::string(name));
+    const std::uint64_t file_offset =
+        checked_section_file_offset(*section, data_offset_, file_size_, path_);
+    if (file_offset > static_cast<std::uint64_t>(std::numeric_limits<std::streamoff>::max()))
+        throw std::runtime_error("Bundle section '" + section->name +
+                                 "' has an unsupported file offset: " + path_);
+
+    std::ifstream input(path_, std::ios::binary);
+    if (!input)
+        throw std::runtime_error("Failed to open bundle file: " + path_);
+    input.seekg(static_cast<std::streamoff>(file_offset));
+    std::array<char, 1024 * 1024> buffer{};
+    std::uint64_t remaining = section->length;
+    while (remaining != 0) {
+        const auto count =
+            static_cast<std::streamsize>(std::min<std::uint64_t>(remaining, buffer.size()));
+        input.read(buffer.data(), count);
+        if (input.gcount() != count)
+            throw std::runtime_error("Failed to read bundle section '" + section->name +
+                                     "' from: " + path_);
+        output.write(buffer.data(), count);
+        if (!output)
+            throw std::runtime_error("Failed to write bundle section '" + section->name + "'");
+        remaining -= static_cast<std::uint64_t>(count);
+    }
 }
 
 BundleInfo InspectBundle(const std::string& bundle_path) {

--- a/core/runtime/include/trtmc/bundle.h
+++ b/core/runtime/include/trtmc/bundle.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iosfwd>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -43,6 +44,7 @@ class BundleReader {
     const BundleInfo& info() const noexcept { return info_; }
     const BundleSectionInfo* find_section(std::string_view name) const noexcept;
     std::vector<char> read_section(std::string_view name) const;
+    void copy_section(std::string_view name, std::ostream& output) const;
 
   private:
     std::string path_;

--- a/core/runtime/include/trtmc/runtime/family_factory.h
+++ b/core/runtime/include/trtmc/runtime/family_factory.h
@@ -20,10 +20,22 @@ struct FamilyContext {
     std::uint64_t kv_cache_size_bytes{0};
 };
 
+// A family that owns a complete external runtime can use this context instead
+// of pretending that runtime implements the Engine API. Returning nullptr
+// means the bundle uses the normal Engine backend factory.
+struct FamilyOnlyContext {
+    const BundleReader& reader;
+    std::uint64_t kv_cache_size_bytes{0};
+};
+
 using CreateFamilyFn = ITask* (*)(const FamilyContext& context);
+using CreateFamilyOnlyFn = ITask* (*)(const FamilyOnlyContext& context);
 
 inline constexpr const char* kCreateFamilySymbol = "trtmc_create_family";
+inline constexpr const char* kCreateFamilyOnlySymbol = "trtmc_create_family_without_backend";
 
 } // namespace trtmc
 
 extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context);
+extern "C" trtmc::ITask*
+trtmc_create_family_without_backend(const trtmc::FamilyOnlyContext& context);

--- a/core/runtime/loader/family_loader.cpp
+++ b/core/runtime/loader/family_loader.cpp
@@ -90,6 +90,12 @@ class SharedLibrary {
         return symbol;
     }
 
+    void* find_symbol(const char* name) const noexcept {
+        dlerror();
+        void* symbol = dlsym(handle_, name);
+        return dlerror() == nullptr ? symbol : nullptr;
+    }
+
   private:
     std::string path_;
     void* handle_{nullptr};
@@ -137,16 +143,24 @@ class FamilyLibrary {
   public:
     FamilyLibrary(const fs::path& runtime_root, const std::string& family_id)
         : library_(runtime_root / ("libtrtmc_model_" + family_id + ".so")),
-          create_(reinterpret_cast<CreateFamilyFn>(library_.require_symbol(kCreateFamilySymbol))) {}
+          create_(reinterpret_cast<CreateFamilyFn>(library_.require_symbol(kCreateFamilySymbol))),
+          create_without_backend_(
+              reinterpret_cast<CreateFamilyOnlyFn>(library_.find_symbol(kCreateFamilyOnlySymbol))) {
+    }
 
     FamilyLibrary(const FamilyLibrary&) = delete;
     FamilyLibrary& operator=(const FamilyLibrary&) = delete;
 
     ITask* create(const FamilyContext& context) const { return create_(context); }
 
+    ITask* create_without_backend(const FamilyOnlyContext& context) const {
+        return create_without_backend_ != nullptr ? create_without_backend_(context) : nullptr;
+    }
+
   private:
     SharedLibrary library_;
     CreateFamilyFn create_{nullptr};
+    CreateFamilyOnlyFn create_without_backend_{nullptr};
 };
 
 class RuntimeOptionsBackend final : public IBackend {
@@ -297,8 +311,14 @@ std::unique_ptr<ITask> load_task(const std::string& bundle_path, const std::stri
     }
 
     const fs::path root = explicit_runtime_root(runtime_root);
-    IBackend& backend = cached_backend(root, info.backend);
     FamilyLibrary& family = cached_family(root, info.family);
+    if (std::unique_ptr<ITask> task(family.create_without_backend({reader, kv_cache_size_bytes}));
+        task != nullptr) {
+        require_matching_task(info, *task);
+        return task;
+    }
+
+    IBackend& backend = cached_backend(root, info.backend);
     IBackend& configured_backend =
         cached_configured_backend(backend, runtime_cache_path, cuda_graphs);
     FamilyContext context{reader, configured_backend, kv_cache_size_bytes};

--- a/core/runtime/tests/test_bundle_format_v1.cpp
+++ b/core/runtime/tests/test_bundle_format_v1.cpp
@@ -5,11 +5,13 @@
 
 #include "runtime/bundle/bundle_format.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <streambuf>
 #include <string>
 #include <unistd.h>
 
@@ -52,6 +54,21 @@ bool read_throws(const std::filesystem::path& path) {
     }
 }
 
+class BoundedSink final : public std::streambuf {
+  public:
+    std::size_t total{0};
+    std::size_t largest_write{0};
+    bool valid{true};
+
+  protected:
+    std::streamsize xsputn(const char* data, std::streamsize count) override {
+        largest_write = std::max(largest_write, static_cast<std::size_t>(count));
+        total += static_cast<std::size_t>(count);
+        valid = valid && std::all_of(data, data + count, [](char value) { return value == 'x'; });
+        return count;
+    }
+};
+
 } // namespace
 
 int main() {
@@ -82,6 +99,21 @@ int main() {
     const auto lazy_plan = reader.read_section("engine.plan");
     check(std::string(lazy_plan.begin(), lazy_plan.end()) == "PLAN",
           "file-backed reader owns an absolute path");
+
+    const auto large = directory / "large.bundle";
+    const std::string large_payload(2 * 1024 * 1024 + 17, 'x');
+    write_bundle(large,
+                 "{\"format\":1,\"family\":\"fake\",\"task\":\"time_series_forecast\","
+                 "\"backend\":\"fake\",\"sections\":{\"engine.plan\":{\"offset\":0,\"length\":" +
+                     std::to_string(large_payload.size()) + "}}}",
+                 large_payload);
+    const trtmc::BundleReader large_reader(large.string());
+    BoundedSink buffer;
+    std::ostream sink(&buffer);
+    large_reader.copy_section("engine.plan", sink);
+    check(buffer.total == large_payload.size(), "streaming copy writes the complete section");
+    check(buffer.largest_write <= 1024 * 1024, "streaming copy uses bounded chunks");
+    check(buffer.valid, "streaming copy preserves section bytes");
 
     const auto old_size = directory / "old-size.bundle";
     write_bundle(

--- a/families/qwen/edge_llm/README.md
+++ b/families/qwen/edge_llm/README.md
@@ -1,0 +1,70 @@
+# Qwen TensorRT Edge-LLM adapter
+
+This is an explicit, Qwen-owned runtime adapter. It is never selected automatically.
+Native Qwen builds remain unchanged unless `--backend edge_llm` is present.
+
+Install the family dependency and build the official TensorRT Edge-LLM native
+targets first. The `tensorrt-edgellm-export` and `llm_build` executables must be
+on `PATH`. Point `EDGELLM_PLUGIN_PATH` at the plugin produced by that same
+native build when invoking `llm_build` requires it.
+
+Configure ModelConnect with those existing source and build directories, then
+build the native CLI and Qwen Edge-LLM runtime:
+
+```bash
+python -m pip install -r families/qwen/edge_llm/dependencies.txt
+
+EDGE_LLM_SOURCE=/path/to/TensorRT-Edge-LLM
+EDGE_LLM_BUILD="$EDGE_LLM_SOURCE/build"
+export PATH="$EDGE_LLM_BUILD/examples/llm:$PATH"
+export EDGELLM_PLUGIN_PATH="$EDGE_LLM_BUILD/libNvInfer_edgellm_plugin.so.1.0"
+
+cmake -S . -B build-edge \
+  -DTRTMC_EDGE_LLM_SOURCE_DIR="$EDGE_LLM_SOURCE" \
+  -DTRTMC_EDGE_LLM_BUILD_DIR="$EDGE_LLM_BUILD"
+cmake --build build-edge --target trtmc trtmc_qwen_edge_llm_runtime
+```
+
+Build and inspect a bundle:
+
+```bash
+python -m tensorrt_model_connect build /path/to/Qwen3-0.6B \
+  --backend edge_llm \
+  --precision fp16 \
+  --max-sequence-length 4096 \
+  --output qwen3-edge.bundle
+
+build-edge/trtmc inspect qwen3-edge.bundle
+```
+
+Run through the independent runtime directory. The bundle contains the engine
+directory files, but not the Edge-LLM runtime bridge or TensorRT plugin:
+
+```bash
+build-edge/trtmc run qwen3-edge.bundle \
+  --runtime-root build-edge \
+  --prompt "What is the capital of France? Answer in one word." \
+  --max-new-tokens 16 \
+  --temperature 0 \
+  --top-k 1
+```
+
+The runtime root contains the normal ModelConnect runtime and Qwen family DSO,
+plus `libtrtmc_qwen_edge_llm.so` and `libNvInfer_edgellm_plugin.so`. Edge-LLM
+owns engine execution, so this path does not install a fake Engine API backend.
+
+The current integration is FP16, text-only, and single-device. A missing tool,
+unsupported request, export failure, engine-build failure, or runtime-library
+failure is terminal; the command does not switch to native Qwen.
+
+The real GPU entry is opt-in and is not part of the CPU contract suite:
+
+```bash
+TRTMC_QWEN_EDGE_LLM_E2E=1 \
+TRTMC_EDGE_LLM_QWEN3_0_6B_DIR=/path/to/Qwen3-0.6B \
+TRTMC_BINARY="$PWD/build-edge/trtmc" \
+TRTMC_RUNTIME_ROOT="$PWD/build-edge" \
+PYTHONPATH=core/builder:. \
+python -m pytest \
+  families/qwen/tests/test_e2e.py::test_qwen3_0_6b_edge_llm_build_inspect_and_run -q
+```

--- a/families/qwen/edge_llm/__init__.py
+++ b/families/qwen/edge_llm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-owned TensorRT Edge-LLM integration."""

--- a/families/qwen/edge_llm/build.py
+++ b/families/qwen/edge_llm/build.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a Qwen bundle with the explicitly selected TensorRT Edge-LLM backend."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tensorrt_model_connect.build import BuildRequest
+    from tensorrt_model_connect.bundle_writer import BundleWriter
+
+
+_SECTION_PREFIX = "edge_llm/"
+_REQUIRED_FILES = (
+    "config.json",
+    "llm.engine",
+    "embedding.safetensors",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "processed_chat_template.json",
+)
+
+
+def _require_executable(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise RuntimeError(
+            f"Qwen Edge-LLM requires {name!r} on PATH; install "
+            "families/qwen/edge_llm/dependencies.txt and the official native tools"
+        )
+    return executable
+
+
+def _validate_request(request: "BuildRequest") -> tuple[int, int]:
+    if request.task != "text_generation":
+        raise ValueError("Qwen Edge-LLM supports only task=text_generation")
+    if request.backend != "edge_llm":
+        raise ValueError("Qwen Edge-LLM requires backend=edge_llm")
+    if request.precision != "fp16":
+        raise ValueError("Qwen Edge-LLM currently supports only precision=fp16")
+    if request.tensor_parallel_size != 1 or request.context_parallel_size != 1:
+        raise ValueError("Qwen Edge-LLM currently supports only single-device builds")
+    if request.quantization not in (None, "none"):
+        raise ValueError("Qwen Edge-LLM currently supports only unquantized builds")
+    if request.fp32_layers:
+        raise ValueError("Qwen Edge-LLM does not support fp32 layer overrides")
+    if request.dynamic_kv_cache:
+        raise ValueError("Qwen Edge-LLM does not support dynamic_kv_cache")
+    if request.graph_transform is not None:
+        raise ValueError("Qwen Edge-LLM does not support a graph transform")
+    if any(
+        value is not None
+        for value in (request.image_height, request.image_width, request.video_num_frames)
+    ):
+        raise ValueError("Qwen Edge-LLM text generation does not accept media dimensions")
+
+    model_config = json.loads((Path(request.model_dir) / "config.json").read_text(encoding="utf-8"))
+    if model_config.get("model_type") != "qwen3":
+        raise ValueError("Qwen Edge-LLM currently supports only model_type=qwen3")
+
+    max_cache_length = request.max_sequence_length or 4096
+    max_input_length = min(max_cache_length, 1024)
+    return max_input_length, max_cache_length
+
+
+def _write_engine_sections(engine_dir: Path, writer: "BundleWriter") -> None:
+    for name in _REQUIRED_FILES:
+        path = engine_dir / name
+        if path.is_symlink() or not path.is_file() or path.stat().st_size == 0:
+            raise RuntimeError(f"TensorRT Edge-LLM engine output is missing {name}")
+    files = sorted(path for path in engine_dir.rglob("*") if path.is_file())
+    if not files:
+        raise RuntimeError("TensorRT Edge-LLM produced an empty engine directory")
+    for path in files:
+        if path.is_symlink():
+            raise RuntimeError(f"TensorRT Edge-LLM engine output contains a symlink: {path}")
+        relative = path.relative_to(engine_dir).as_posix()
+        with path.open("rb") as source, writer.open_section(_SECTION_PREFIX + relative) as section:
+            shutil.copyfileobj(source, section)
+
+
+def build(request: "BuildRequest", writer: "BundleWriter") -> None:
+    """Run the installed official exporter and engine builder once."""
+
+    max_input_length, max_cache_length = _validate_request(request)
+    exporter = _require_executable("tensorrt-edgellm-export")
+    engine_builder = _require_executable("llm_build")
+
+    output_parent = Path(request.output_path).parent
+    with tempfile.TemporaryDirectory(prefix=".trtmc-qwen-edge-", dir=output_parent) as directory:
+        workspace = Path(directory)
+        export_root = workspace / "onnx"
+        engine_dir = workspace / "engine"
+        subprocess.run(
+            [exporter, str(request.model_dir), str(export_root), "--dtype=float16"],
+            check=True,
+        )
+        onnx_dir = export_root / "llm"
+        if not onnx_dir.is_dir():
+            raise RuntimeError("TensorRT Edge-LLM exporter did not produce onnx/llm")
+        build_command = [
+            engine_builder,
+            f"--onnxDir={onnx_dir}",
+            f"--engineDir={engine_dir}",
+            f"--maxInputLen={max_input_length}",
+            f"--maxKVCacheCapacity={max_cache_length}",
+            f"--maxBatchSize={request.max_batch_size}",
+        ]
+        if request.verbose:
+            build_command.append("--debug")
+        subprocess.run(build_command, check=True)
+
+        writer.set_header(family="qwen", task=request.task, backend="edge_llm")
+        writer.add_json(
+            "edge_llm.json",
+            {
+                "max_input_length": max_input_length,
+                "max_cache_length": max_cache_length,
+                "max_batch_size": request.max_batch_size,
+            },
+        )
+        _write_engine_sections(engine_dir, writer)

--- a/families/qwen/edge_llm/dependencies.txt
+++ b/families/qwen/edge_llm/dependencies.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+tensorrt-edgellm @ git+https://github.com/NVIDIA/TensorRT-Edge-LLM.git@v0.9.0

--- a/families/qwen/edge_llm/runtime/CMakeLists.txt
+++ b/families/qwen/edge_llm/runtime/CMakeLists.txt
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(trtmc_model_qwen PRIVATE adapter.cpp)
+
+set(TRTMC_EDGE_LLM_SOURCE_DIR "" CACHE PATH
+  "Installed TensorRT Edge-LLM source directory for the optional Qwen adapter"
+)
+set(TRTMC_EDGE_LLM_BUILD_DIR "" CACHE PATH
+  "Installed TensorRT Edge-LLM build directory for the optional Qwen adapter"
+)
+if((TRTMC_EDGE_LLM_SOURCE_DIR AND NOT TRTMC_EDGE_LLM_BUILD_DIR) OR
+   (TRTMC_EDGE_LLM_BUILD_DIR AND NOT TRTMC_EDGE_LLM_SOURCE_DIR))
+  message(FATAL_ERROR
+    "Qwen Edge-LLM requires both TRTMC_EDGE_LLM_SOURCE_DIR and TRTMC_EDGE_LLM_BUILD_DIR"
+  )
+endif()
+
+set(_trtmc_qwen_edge_real_runtime OFF)
+if(TRTMC_EDGE_LLM_SOURCE_DIR AND TRTMC_EDGE_LLM_BUILD_DIR)
+  find_file(TRTMC_EDGE_LLM_CORE_LIBRARY
+    NAMES libedgellmCore.a
+    PATHS
+      "${TRTMC_EDGE_LLM_BUILD_DIR}/cpp"
+      "${TRTMC_EDGE_LLM_BUILD_DIR}/cpp/Release"
+      "${TRTMC_EDGE_LLM_BUILD_DIR}/cpp/RelWithDebInfo"
+    NO_DEFAULT_PATH
+    REQUIRED
+  )
+  find_file(TRTMC_EDGE_LLM_PLUGIN_LIBRARY
+    NAMES libNvInfer_edgellm_plugin.so.1.0 libNvInfer_edgellm_plugin.so
+    PATHS
+      "${TRTMC_EDGE_LLM_BUILD_DIR}"
+      "${TRTMC_EDGE_LLM_BUILD_DIR}/Release"
+      "${TRTMC_EDGE_LLM_BUILD_DIR}/RelWithDebInfo"
+    NO_DEFAULT_PATH
+    REQUIRED
+  )
+  if(NOT EXISTS "${TRTMC_EDGE_LLM_SOURCE_DIR}/cpp/runtime/llmInferenceRuntime.h")
+    message(FATAL_ERROR
+      "TRTMC_EDGE_LLM_SOURCE_DIR does not contain the official runtime headers"
+    )
+  endif()
+
+  add_library(trtmc_qwen_edge_llm_bridge SHARED EXCLUDE_FROM_ALL
+    bridge.cpp
+    device_link_stub.cu
+  )
+  target_include_directories(trtmc_qwen_edge_llm_bridge PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${TRTMC_EDGE_LLM_SOURCE_DIR}/cpp
+    ${TRTMC_TRT_INCLUDE_DIR}
+  )
+  target_include_directories(trtmc_qwen_edge_llm_bridge SYSTEM PRIVATE
+    ${TRTMC_CUDA_INCLUDE_DIR}
+  )
+  target_link_libraries(trtmc_qwen_edge_llm_bridge PRIVATE
+    -Wl,--whole-archive
+    ${TRTMC_EDGE_LLM_CORE_LIBRARY}
+    -Wl,--no-whole-archive
+    ${TRTMC_TRT_LIBRARY}
+    CUDA::cudart
+    CUDA::cuda_driver
+    ${CMAKE_DL_LIBS}
+  )
+  target_compile_options(trtmc_qwen_edge_llm_bridge PRIVATE -Wall -Wextra -Wpedantic)
+  set_target_properties(trtmc_qwen_edge_llm_bridge PROPERTIES
+    OUTPUT_NAME trtmc_qwen_edge_llm
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    BUILD_RPATH "\$ORIGIN"
+    LINKER_LANGUAGE CUDA
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+  )
+  add_custom_command(TARGET trtmc_qwen_edge_llm_bridge POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${TRTMC_EDGE_LLM_PLUGIN_LIBRARY}"
+      "${CMAKE_BINARY_DIR}/libNvInfer_edgellm_plugin.so"
+  )
+  add_custom_target(trtmc_qwen_edge_llm_runtime
+    DEPENDS
+      trtmc_model_qwen
+      trtmc_qwen_edge_llm_bridge
+  )
+  set(_trtmc_qwen_edge_real_runtime ON)
+endif()
+
+if(TRTMC_BUILD_TESTS AND NOT _trtmc_qwen_edge_real_runtime)
+  add_library(trtmc_qwen_edge_llm_fake_bridge SHARED EXCLUDE_FROM_ALL
+    ../tests/cpp/fake_bridge.cpp
+  )
+  target_include_directories(trtmc_qwen_edge_llm_fake_bridge PRIVATE
+    ${PROJECT_SOURCE_DIR}
+  )
+  target_compile_options(trtmc_qwen_edge_llm_fake_bridge PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  set_target_properties(trtmc_qwen_edge_llm_fake_bridge PROPERTIES
+    OUTPUT_NAME trtmc_qwen_edge_llm
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+
+  add_executable(test_qwen_edge_llm_runtime ../tests/cpp/test_runtime.cpp)
+  target_include_directories(test_qwen_edge_llm_runtime PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(test_qwen_edge_llm_runtime PRIVATE
+    trtmc_runtime
+    trtmc_core
+    nlohmann_json::nlohmann_json
+  )
+  target_compile_options(test_qwen_edge_llm_runtime PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_dependencies(test_qwen_edge_llm_runtime
+    trtmc_model_qwen
+    trtmc_qwen_edge_llm_fake_bridge
+  )
+  add_test(NAME test_qwen_edge_llm_runtime
+    COMMAND test_qwen_edge_llm_runtime "${CMAKE_BINARY_DIR}"
+  )
+endif()

--- a/families/qwen/edge_llm/runtime/adapter.cpp
+++ b/families/qwen/edge_llm/runtime/adapter.cpp
@@ -1,0 +1,253 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/qwen/edge_llm/runtime/adapter.h"
+
+#include "families/qwen/edge_llm/runtime/bridge.h"
+#include "families/qwen/runtime/plugin_helpers.h"
+#include "trtmc/runtime/family_factory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace trtmc::qwen::edge_llm {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* kSectionPrefix = "edge_llm/";
+constexpr const char* kBridgeLibrary = "libtrtmc_qwen_edge_llm.so";
+constexpr std::size_t kErrorCapacity = 1024;
+
+struct RuntimeConfig {
+    std::int32_t max_cache_length;
+};
+
+RuntimeConfig parse_config(const BundleReader& reader) {
+    const auto json = nlohmann::json::parse(require_text_section(reader, "edge_llm.json"));
+    if (!json.is_object() || json.size() != 3 || !json.contains("max_input_length") ||
+        !json.contains("max_cache_length") || !json.contains("max_batch_size")) {
+        throw std::runtime_error("qwen Edge-LLM has invalid edge_llm.json fields");
+    }
+    const auto input = json.at("max_input_length").get<std::int32_t>();
+    const auto cache = json.at("max_cache_length").get<std::int32_t>();
+    const auto batch = json.at("max_batch_size").get<std::int32_t>();
+    if (input <= 0 || cache < input || batch <= 0)
+        throw std::runtime_error("qwen Edge-LLM has invalid runtime limits");
+    return {cache};
+}
+
+bool safe_relative_path(const fs::path& path) {
+    if (path.empty() || path.is_absolute())
+        return false;
+    for (const auto& component : path) {
+        if (component.empty() || component == "." || component == "..")
+            return false;
+    }
+    return true;
+}
+
+class EngineDirectory {
+  public:
+    explicit EngineDirectory(const BundleReader& reader) {
+        fs::path pattern = fs::temp_directory_path() / "trtmc-qwen-edge-XXXXXX";
+        std::string value = pattern.string();
+        value.push_back('\0');
+        char* created = ::mkdtemp(value.data());
+        if (created == nullptr)
+            throw std::runtime_error("qwen Edge-LLM could not create its engine directory");
+        path_ = created;
+        try {
+            extract(reader);
+        } catch (...) {
+            cleanup();
+            throw;
+        }
+    }
+
+    EngineDirectory(const EngineDirectory&) = delete;
+    EngineDirectory& operator=(const EngineDirectory&) = delete;
+    ~EngineDirectory() { cleanup(); }
+
+    const fs::path& path() const noexcept { return path_; }
+
+  private:
+    void extract(const BundleReader& reader) {
+        bool found = false;
+        for (const auto& section : reader.info().sections) {
+            if (section.name.rfind(kSectionPrefix, 0) != 0)
+                continue;
+            const fs::path relative =
+                section.name.substr(std::char_traits<char>::length(kSectionPrefix));
+            if (!safe_relative_path(relative))
+                throw std::runtime_error("qwen Edge-LLM bundle has an unsafe engine path");
+            const fs::path destination = path_ / relative;
+            fs::create_directories(destination.parent_path());
+            std::ofstream output(destination, std::ios::binary | std::ios::trunc);
+            if (!output)
+                throw std::runtime_error("qwen Edge-LLM could not open an engine file");
+            reader.copy_section(section.name, output);
+            found = true;
+        }
+        if (!found)
+            throw std::runtime_error("qwen Edge-LLM bundle has no engine files");
+    }
+
+    void cleanup() noexcept {
+        if (path_.empty())
+            return;
+        std::error_code error;
+        fs::remove_all(path_, error);
+    }
+
+    fs::path path_;
+};
+
+fs::path adjacent_bridge() {
+    static const char anchor = 0;
+    Dl_info info{};
+    if (dladdr(&anchor, &info) == 0 || info.dli_fname == nullptr)
+        throw std::runtime_error("qwen Edge-LLM could not locate its family DSO");
+    return fs::path(info.dli_fname).parent_path() / kBridgeLibrary;
+}
+
+class BridgeLibrary {
+  public:
+    BridgeLibrary() {
+        const fs::path path = adjacent_bridge();
+        int flags = RTLD_NOW | RTLD_LOCAL;
+#ifdef RTLD_NODELETE
+        flags |= RTLD_NODELETE;
+#endif
+        dlerror();
+        handle_ = dlopen(path.c_str(), flags);
+        if (handle_ == nullptr) {
+            const char* error = dlerror();
+            throw std::runtime_error("qwen Edge-LLM could not load its runtime bridge: " +
+                                     std::string(error != nullptr ? error : "unknown error"));
+        }
+        dlerror();
+        auto factory =
+            reinterpret_cast<const BridgeApi* (*)() noexcept>(dlsym(handle_, kBridgeSymbol));
+        if (const char* error = dlerror(); error != nullptr || factory == nullptr) {
+            dlclose(handle_);
+            handle_ = nullptr;
+            throw std::runtime_error("qwen Edge-LLM runtime bridge has no factory");
+        }
+        api_ = factory();
+        if (api_ == nullptr || api_->abi_version != kBridgeAbiVersion ||
+            api_->struct_size < sizeof(BridgeApi) || api_->create == nullptr ||
+            api_->destroy == nullptr || api_->generate == nullptr) {
+            dlclose(handle_);
+            handle_ = nullptr;
+            throw std::runtime_error("qwen Edge-LLM runtime bridge has an incompatible ABI");
+        }
+    }
+
+    BridgeLibrary(const BridgeLibrary&) = delete;
+    BridgeLibrary& operator=(const BridgeLibrary&) = delete;
+    ~BridgeLibrary() {
+        if (handle_ != nullptr)
+            dlclose(handle_);
+    }
+
+    const BridgeApi& api() const noexcept { return *api_; }
+
+  private:
+    void* handle_{nullptr};
+    const BridgeApi* api_{nullptr};
+};
+
+void validate_config(const TextGenerationConfig& config, std::int32_t max_cache_length) {
+    if (config.max_new_tokens <= 0 || config.max_new_tokens > max_cache_length)
+        throw std::invalid_argument("qwen Edge-LLM max_new_tokens is outside the bundle limit");
+    if (!std::isfinite(config.temperature) || config.temperature < 0.0F ||
+        !std::isfinite(config.top_p) || config.top_p < 0.0F || config.top_p > 1.0F ||
+        config.top_k < 0 || config.top_k > 1024) {
+        throw std::invalid_argument("qwen Edge-LLM has invalid sampling values");
+    }
+    if (config.source_language_token_id != -1 || config.forced_bos_token_id != -1 ||
+        config.min_p != 0.0F || config.seed != -1 || config.repetition_penalty != 1.0F ||
+        config.guidance_scale >= 0.0F || config.cfg_scale >= 0.0F || config.num_steps != -1 ||
+        config.sde_gamma >= 0.0F || !config.initial_latents.empty() ||
+        !config.condition_latents.empty() || !config.condition_mask.empty() ||
+        !config.sampling_steps.empty() || !config.sde_noises.empty() || config.eos_token_id != -1 ||
+        (config.text_generation_mode != "auto" && config.text_generation_mode != "ar") ||
+        config.block_length != 0 || config.confidence_threshold >= 0.0F ||
+        config.stop_on_boxed_answer || config.stop_check_interval != 16 ||
+        !config.lora_adapter_id.empty()) {
+        throw std::invalid_argument("qwen Edge-LLM does not support a requested generation option");
+    }
+}
+
+class Pipeline final : public ITextGeneration {
+  public:
+    Pipeline(const BundleReader& reader, RuntimeConfig config)
+        : config_(config), engine_(reader), bridge_() {
+        std::vector<char> error(kErrorCapacity, '\0');
+        handle_ = bridge_.api().create(engine_.path().c_str(), error.data(), error.size());
+        if (handle_ == nullptr)
+            throw std::runtime_error("qwen Edge-LLM runtime creation failed: " +
+                                     std::string(error.data()));
+    }
+
+    ~Pipeline() override {
+        if (handle_ != nullptr)
+            bridge_.api().destroy(handle_);
+    }
+
+    std::int32_t default_max_new_tokens() const override {
+        return std::min<std::int32_t>(128, config_.max_cache_length);
+    }
+
+    TextResult generate(const std::string& prompt, const TextGenerationConfig& config) override {
+        validate_config(config, config_.max_cache_length);
+        const BridgeRequest request{
+            prompt.data(), prompt.size(), config.max_new_tokens,    config.temperature,
+            config.top_k,  config.top_p,  config.use_chat_template, config.enable_thinking};
+        BridgeResult result{};
+        std::vector<char> error(kErrorCapacity, '\0');
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!bridge_.api().generate(handle_, &request, &result, error.data(), error.size()))
+            throw std::runtime_error("qwen Edge-LLM generation failed: " +
+                                     std::string(error.data()));
+        if (result.text == nullptr || (result.token_count != 0 && result.token_ids == nullptr))
+            throw std::runtime_error("qwen Edge-LLM returned an invalid result");
+        std::vector<std::int32_t> token_ids;
+        if (result.token_count != 0)
+            token_ids.assign(result.token_ids, result.token_ids + result.token_count);
+        return {result.text, std::move(token_ids)};
+    }
+
+  private:
+    RuntimeConfig config_;
+    EngineDirectory engine_;
+    BridgeLibrary bridge_;
+    void* handle_{nullptr};
+    std::mutex mutex_;
+};
+
+} // namespace
+
+ITask* create(const FamilyOnlyContext& context) {
+    if (context.kv_cache_size_bytes != 0)
+        throw std::invalid_argument("qwen Edge-LLM does not support --kv-cache-size");
+    return new Pipeline(context.reader, parse_config(context.reader));
+}
+
+} // namespace trtmc::qwen::edge_llm

--- a/families/qwen/edge_llm/runtime/adapter.h
+++ b/families/qwen/edge_llm/runtime/adapter.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace trtmc {
+class ITask;
+struct FamilyOnlyContext;
+} // namespace trtmc
+
+namespace trtmc::qwen::edge_llm {
+
+ITask* create(const FamilyOnlyContext& context);
+
+} // namespace trtmc::qwen::edge_llm

--- a/families/qwen/edge_llm/runtime/bridge.cpp
+++ b/families/qwen/edge_llm/runtime/bridge.cpp
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/qwen/edge_llm/runtime/bridge.h"
+
+#include "common/trtUtils.h"
+#include "runtime/llmInferenceRuntime.h"
+
+#include <NvInferRuntime.h>
+#include <algorithm>
+#include <cstdio>
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <exception>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace trtmc::qwen::edge_llm {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* kPluginLibrary = "libNvInfer_edgellm_plugin.so";
+
+void set_error(char* output, std::size_t capacity, const std::string& message) noexcept {
+    if (output != nullptr && capacity != 0)
+        std::snprintf(output, capacity, "%s", message.c_str());
+}
+
+fs::path adjacent_plugin() {
+    static const char anchor = 0;
+    Dl_info info{};
+    if (dladdr(&anchor, &info) == 0 || info.dli_fname == nullptr)
+        throw std::runtime_error("could not locate the Qwen Edge-LLM runtime bridge");
+    return fs::path(info.dli_fname).parent_path() / kPluginLibrary;
+}
+
+class Plugin {
+  public:
+    Plugin() {
+        const fs::path path = adjacent_plugin();
+        int flags = RTLD_NOW | RTLD_LOCAL;
+#ifdef RTLD_NODELETE
+        flags |= RTLD_NODELETE;
+#endif
+        handle_ = dlopen(path.c_str(), flags);
+        if (handle_ == nullptr) {
+            const char* error = dlerror();
+            throw std::runtime_error("could not load the Edge-LLM TensorRT plugin: " +
+                                     std::string(error != nullptr ? error : "unknown error"));
+        }
+        dlerror();
+        auto initialize =
+            reinterpret_cast<bool (*)(void*, const char*)>(dlsym(handle_, "initEdgellmPlugins"));
+        if (const char* error = dlerror(); error != nullptr || initialize == nullptr)
+            throw std::runtime_error("Edge-LLM TensorRT plugin has no initializer");
+        if (!initialize(static_cast<nvinfer1::ILogger*>(&trt_edgellm::gLogger), ""))
+            throw std::runtime_error("Edge-LLM TensorRT plugin initialization failed");
+    }
+
+    Plugin(const Plugin&) = delete;
+    Plugin& operator=(const Plugin&) = delete;
+
+  private:
+    void* handle_{nullptr};
+};
+
+void ensure_plugin() {
+    static std::once_flag once;
+    static std::exception_ptr error;
+    static std::unique_ptr<Plugin> plugin;
+    std::call_once(once, [] {
+        try {
+            trt_edgellm::gLogger.setLevel(nvinfer1::ILogger::Severity::kWARNING);
+            plugin = std::make_unique<Plugin>();
+        } catch (...) {
+            error = std::current_exception();
+        }
+    });
+    if (error)
+        std::rethrow_exception(error);
+}
+
+class DeviceGuard {
+  public:
+    explicit DeviceGuard(int device) {
+        if (cudaGetDevice(&previous_) != cudaSuccess)
+            throw std::runtime_error("could not query the active CUDA device");
+        if (previous_ != device) {
+            if (cudaSetDevice(device) != cudaSuccess)
+                throw std::runtime_error("could not select the Edge-LLM CUDA device");
+            restore_ = true;
+        }
+    }
+
+    ~DeviceGuard() {
+        if (restore_)
+            (void)cudaSetDevice(previous_);
+    }
+
+    DeviceGuard(const DeviceGuard&) = delete;
+    DeviceGuard& operator=(const DeviceGuard&) = delete;
+
+  private:
+    int previous_{-1};
+    bool restore_{false};
+};
+
+struct Handle {
+    explicit Handle(const fs::path& engine_directory) {
+        if (cudaGetDevice(&device) != cudaSuccess)
+            throw std::runtime_error("could not query the Edge-LLM CUDA device");
+        ensure_plugin();
+        if (cudaStreamCreate(&stream) != cudaSuccess)
+            throw std::runtime_error("could not create the Edge-LLM CUDA stream");
+        try {
+            runtime = std::make_unique<trt_edgellm::rt::LLMInferenceRuntime>(
+                engine_directory.string(), std::string{},
+                std::unordered_map<std::string, std::string>{}, stream);
+            (void)runtime->captureDecodingCUDAGraph(stream);
+        } catch (...) {
+            runtime.reset();
+            (void)cudaStreamDestroy(stream);
+            stream = nullptr;
+            throw;
+        }
+    }
+
+    ~Handle() {
+        try {
+            DeviceGuard guard(device);
+            runtime.reset();
+            if (stream != nullptr)
+                (void)cudaStreamDestroy(stream);
+        } catch (...) {
+        }
+    }
+
+    int device{-1};
+    cudaStream_t stream{nullptr};
+    std::unique_ptr<trt_edgellm::rt::LLMInferenceRuntime> runtime;
+    std::string text;
+    std::vector<std::int32_t> token_ids;
+};
+
+trt_edgellm::rt::LLMGenerationRequest make_request(const BridgeRequest& request) {
+    trt_edgellm::rt::LLMGenerationRequest value;
+    trt_edgellm::rt::LLMGenerationRequest::Request item;
+    trt_edgellm::rt::Message message;
+    message.role = "user";
+    message.contents.push_back({"text", std::string(request.prompt, request.prompt_size)});
+    item.messages.push_back(std::move(message));
+    value.requests.push_back(std::move(item));
+
+    constexpr float sampling_epsilon = 1.0e-6F;
+    const bool nucleus = request.top_p > 0.0F && request.top_p < 1.0F - sampling_epsilon;
+    const bool greedy = request.temperature < sampling_epsilon || request.top_p <= 0.0F ||
+                        (request.top_k <= 1 && !nucleus);
+    if (!greedy && request.temperature < 1.0e-3F)
+        throw std::invalid_argument("Edge-LLM sampling requires temperature >= 0.001");
+
+    value.temperature = request.temperature;
+    value.topK = greedy ? 1 : request.top_k <= 1 ? 0 : request.top_k;
+    value.topP = greedy ? 1.0F : request.top_p;
+    value.maxGenerateLength = request.max_new_tokens;
+    value.applyChatTemplate = request.use_chat_template;
+    value.addGenerationPrompt = true;
+    value.enableThinking = request.enable_thinking;
+    return value;
+}
+
+void* create(const char* engine_directory, char* error, std::size_t capacity) noexcept {
+    try {
+        if (engine_directory == nullptr || engine_directory[0] == '\0')
+            throw std::invalid_argument("engine directory is required");
+        const fs::path path(engine_directory);
+        if (!fs::is_directory(path))
+            throw std::invalid_argument("engine directory does not exist");
+        return new Handle(path);
+    } catch (const std::exception& exception) {
+        set_error(error, capacity, exception.what());
+        return nullptr;
+    } catch (...) {
+        set_error(error, capacity, "unknown Edge-LLM creation failure");
+        return nullptr;
+    }
+}
+
+void destroy(void* handle) noexcept {
+    delete static_cast<Handle*>(handle);
+}
+
+bool generate(void* opaque, const BridgeRequest* request, BridgeResult* result, char* error,
+              std::size_t error_capacity) noexcept {
+    try {
+        if (opaque == nullptr || request == nullptr || result == nullptr ||
+            request->prompt == nullptr)
+            throw std::invalid_argument("invalid Edge-LLM generation request");
+        auto& handle = *static_cast<Handle*>(opaque);
+        DeviceGuard guard(handle.device);
+        auto edge_request = make_request(*request);
+        trt_edgellm::rt::LLMGenerationResponse response;
+        if (!handle.runtime->handleRequest(edge_request, response, handle.stream))
+            throw std::runtime_error("Edge-LLM handleRequest returned false");
+        if (response.outputTexts.size() != 1 || response.outputIds.size() != 1)
+            throw std::runtime_error("Edge-LLM returned an invalid response batch");
+        handle.text = std::move(response.outputTexts.front());
+        handle.token_ids = std::move(response.outputIds.front());
+        *result = {handle.text.c_str(), handle.token_ids.data(), handle.token_ids.size()};
+        return true;
+    } catch (const std::exception& exception) {
+        set_error(error, error_capacity, exception.what());
+        return false;
+    } catch (...) {
+        set_error(error, error_capacity, "unknown Edge-LLM generation failure");
+        return false;
+    }
+}
+
+const BridgeApi kApi{kBridgeAbiVersion, sizeof(BridgeApi), &create, &destroy, &generate};
+
+} // namespace
+
+} // namespace trtmc::qwen::edge_llm
+
+extern "C" const trtmc::qwen::edge_llm::BridgeApi* trtmc_qwen_edge_llm_bridge_v1() noexcept {
+    return &trtmc::qwen::edge_llm::kApi;
+}

--- a/families/qwen/edge_llm/runtime/bridge.h
+++ b/families/qwen/edge_llm/runtime/bridge.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace trtmc::qwen::edge_llm {
+
+inline constexpr std::uint32_t kBridgeAbiVersion = 1;
+inline constexpr const char* kBridgeSymbol = "trtmc_qwen_edge_llm_bridge_v1";
+
+struct BridgeRequest {
+    const char* prompt;
+    std::size_t prompt_size;
+    std::int32_t max_new_tokens;
+    float temperature;
+    std::int32_t top_k;
+    float top_p;
+    bool use_chat_template;
+    bool enable_thinking;
+};
+
+struct BridgeResult {
+    const char* text;
+    const std::int32_t* token_ids;
+    std::size_t token_count;
+};
+
+struct BridgeApi {
+    std::uint32_t abi_version;
+    std::size_t struct_size;
+    void* (*create)(const char* engine_directory, char* error, std::size_t error_capacity) noexcept;
+    void (*destroy)(void* handle) noexcept;
+    bool (*generate)(void* handle, const BridgeRequest* request, BridgeResult* result, char* error,
+                     std::size_t error_capacity) noexcept;
+};
+
+} // namespace trtmc::qwen::edge_llm
+
+extern "C" const trtmc::qwen::edge_llm::BridgeApi* trtmc_qwen_edge_llm_bridge_v1() noexcept;

--- a/families/qwen/edge_llm/runtime/device_link_stub.cu
+++ b/families/qwen/edge_llm/runtime/device_link_stub.cu
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TensorRT Edge-LLM's core is a CUDA static archive. This translation unit
+// makes CMake perform the required device-link step for the family bridge DSO.

--- a/families/qwen/edge_llm/tests/cpp/fake_bridge.cpp
+++ b/families/qwen/edge_llm/tests/cpp/fake_bridge.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/qwen/edge_llm/runtime/bridge.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc::qwen::edge_llm {
+
+namespace {
+
+struct Handle {
+    std::string text;
+    std::vector<std::int32_t> token_ids;
+};
+
+void set_error(char* output, std::size_t capacity, const char* message) noexcept {
+    if (output != nullptr && capacity != 0)
+        std::snprintf(output, capacity, "%s", message);
+}
+
+void* create(const char* engine_directory, char* error, std::size_t error_capacity) noexcept {
+    if (engine_directory == nullptr || !std::filesystem::is_directory(engine_directory)) {
+        set_error(error, error_capacity, "fake bridge requires an engine directory");
+        return nullptr;
+    }
+    return new Handle();
+}
+
+void destroy(void* handle) noexcept {
+    delete static_cast<Handle*>(handle);
+}
+
+bool generate(void* opaque, const BridgeRequest* request, BridgeResult* result, char* error,
+              std::size_t error_capacity) noexcept {
+    if (opaque == nullptr || request == nullptr || result == nullptr ||
+        request->prompt == nullptr) {
+        set_error(error, error_capacity, "invalid fake bridge request");
+        return false;
+    }
+    auto& handle = *static_cast<Handle*>(opaque);
+    const std::string prompt(request->prompt, request->prompt_size);
+    handle.text = "fake:" + prompt;
+    const std::size_t count =
+        std::min<std::size_t>(prompt.size(), static_cast<std::size_t>(request->max_new_tokens));
+    handle.token_ids.assign(prompt.begin(), prompt.begin() + static_cast<std::ptrdiff_t>(count));
+    *result = {handle.text.c_str(), handle.token_ids.data(), handle.token_ids.size()};
+    return true;
+}
+
+const BridgeApi kApi{kBridgeAbiVersion, sizeof(BridgeApi), &create, &destroy, &generate};
+
+} // namespace
+
+} // namespace trtmc::qwen::edge_llm
+
+extern "C" const trtmc::qwen::edge_llm::BridgeApi* trtmc_qwen_edge_llm_bridge_v1() noexcept {
+    return &trtmc::qwen::edge_llm::kApi;
+}

--- a/families/qwen/edge_llm/tests/cpp/test_runtime.cpp
+++ b/families/qwen/edge_llm/tests/cpp/test_runtime.cpp
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/bundle/bundle_format.h"
+#include "trtmc/runtime/family_loader.h"
+#include "trtmc/task.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+void write_bundle(const std::filesystem::path& path) {
+    const std::string runtime =
+        R"({"max_input_length":1024,"max_cache_length":4096,"max_batch_size":1})";
+    const std::string config = R"({"model":"qwen3"})";
+    const std::string engine = "ENGINE";
+    const nlohmann::json header{
+        {"format", 1},
+        {"family", "qwen"},
+        {"task", "text_generation"},
+        {"backend", "edge_llm"},
+        {"sections",
+         {{"edge_llm.json", {{"offset", 0}, {"length", runtime.size()}}},
+          {"edge_llm/config.json", {{"offset", runtime.size()}, {"length", config.size()}}},
+          {"edge_llm/llm.engine",
+           {{"offset", runtime.size() + config.size()}, {"length", engine.size()}}}}},
+    };
+    const std::string encoded = header.dump();
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(trtmc::kBundleMagic), 8);
+    const std::uint64_t length = encoded.size();
+    for (int shift = 0; shift < 64; shift += 8)
+        output.put(static_cast<char>((length >> shift) & 0xffU));
+    output.write(encoded.data(), static_cast<std::streamsize>(encoded.size()));
+    output.write(runtime.data(), static_cast<std::streamsize>(runtime.size()));
+    output.write(config.data(), static_cast<std::streamsize>(config.size()));
+    output.write(engine.data(), static_cast<std::streamsize>(engine.size()));
+}
+
+bool rejects_unsupported_sampling(trtmc::ITextGeneration& text) {
+    trtmc::TextGenerationConfig config;
+    config.min_p = 0.1F;
+    try {
+        (void)text.generate("hello", config);
+        return false;
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "usage: test_qwen_edge_llm_runtime RUNTIME_ROOT\n";
+        return 2;
+    }
+    const std::filesystem::path runtime_root(argv[1]);
+    check(!std::filesystem::exists(runtime_root / "libtrtmc_backend_edge_llm.so"),
+          "family-owned runtime does not require a fake Engine API backend");
+    const std::filesystem::path bundle =
+        runtime_root / ("qwen-edge-test-" + std::to_string(getpid()) + ".bundle");
+    write_bundle(bundle);
+
+    try {
+        const auto info = trtmc::InspectBundle(bundle.string());
+        check(info.family == "qwen", "bundle keeps Qwen family ownership");
+        check(info.task == "text_generation", "bundle selects text Task API");
+        check(info.backend == "edge_llm", "bundle explicitly selects Edge-LLM");
+
+        auto task = trtmc::load_task(bundle.string(), runtime_root.string());
+        auto* text = dynamic_cast<trtmc::ITextGeneration*>(task.get());
+        check(text != nullptr, "family returns ITextGeneration");
+        if (text != nullptr) {
+            trtmc::TextGenerationConfig config;
+            config.max_new_tokens = 8;
+            config.temperature = 0.0F;
+            config.top_k = 1;
+            const auto result = text->generate("hello", config);
+            check(result.text == "fake:hello", "request reaches family-owned bridge");
+            check(result.token_ids == std::vector<std::int32_t>({104, 101, 108, 108, 111}),
+                  "bridge token IDs reach the Task result");
+            check(rejects_unsupported_sampling(*text), "unsupported request fails closed");
+        }
+
+        auto second = trtmc::load_task(bundle.string(), runtime_root.string());
+        check(dynamic_cast<trtmc::ITextGeneration*>(second.get()) != nullptr,
+              "cached loader supports a second Edge-LLM task");
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: unexpected exception: " << error.what() << '\n';
+        ++failures;
+    }
+
+    std::error_code cleanup_error;
+    std::filesystem::remove(bundle, cleanup_error);
+    std::cerr << (failures == 0 ? "ALL PASSED\n" : "SOME FAILED\n");
+    return failures;
+}

--- a/families/qwen/model.py
+++ b/families/qwen/model.py
@@ -230,6 +230,12 @@ def _runtime_config(model_dir: Path, config: ModelConfig, model: _QwenModel, **u
 
 def build(request: "BuildRequest", writer: "BundleWriter") -> None:
     """Build one Qwen bundle through family-owned code."""
+    if request.backend == "edge_llm":
+        from .edge_llm.build import build as build_edge_llm
+
+        build_edge_llm(request, writer)
+        return
+
     if request.dynamic_kv_cache:
         raise NotImplementedError("qwen does not support dynamic_kv_cache")
 

--- a/families/qwen/runtime/CMakeLists.txt
+++ b/families/qwen/runtime/CMakeLists.txt
@@ -36,6 +36,11 @@ install(TARGETS trtmc_model_qwen
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
+add_subdirectory(
+  ${PROJECT_SOURCE_DIR}/families/qwen/edge_llm/runtime
+  ${CMAKE_CURRENT_BINARY_DIR}/edge_llm
+)
+
 if(TRTMC_BUILD_TESTS)
   foreach(test_name IN ITEMS
       test_qwen_native_kv_cache

--- a/families/qwen/runtime/plugin.cpp
+++ b/families/qwen/runtime/plugin.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "families/qwen/edge_llm/runtime/adapter.h"
 #include "families/qwen/runtime/chat_templates.h"
 #include "families/qwen/runtime/distributed_runtime.h"
 #include "families/qwen/runtime/kv_cache.h"
@@ -237,4 +238,14 @@ extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context
     if (context.kv_cache_size_bytes != 0)
         throw std::invalid_argument("qwen does not support --kv-cache-size");
     return trtmc::qwen::create(context);
+}
+
+extern "C" trtmc::ITask*
+trtmc_create_family_without_backend(const trtmc::FamilyOnlyContext& context) {
+    const std::string& backend = context.reader.info().backend;
+    if (backend == "trt" || backend == "trt_rtx")
+        return nullptr;
+    if (backend != "edge_llm")
+        throw std::invalid_argument("qwen does not support the requested external backend");
+    return trtmc::qwen::edge_llm::create(context);
 }

--- a/families/qwen/support.py
+++ b/families/qwen/support.py
@@ -10,4 +10,5 @@ describe = family_support(
     model_types=("qwen", "Qwen2", "qwen2", "qwen3", "qwq"),
     tasks=("text_generation",),
     default_task="text_generation",
+    backends=("trt", "trt_rtx", "edge_llm"),
 )

--- a/families/qwen/tests/test_e2e.py
+++ b/families/qwen/tests/test_e2e.py
@@ -11,6 +11,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from functools import cache
 from pathlib import Path
 
@@ -743,3 +744,96 @@ def test_e2e(case_name: str, request, tmp_path: Path) -> None:
         assert_native_kv_receipt(payload, case, reference[-1])
     thresholds = {} if _is_sampling(case) else _thresholds(case_name)
     _assert_correctness(payload, case, thresholds, *reference[:-1])
+
+
+def _required_edge_path(name: str, *, directory: bool = False) -> Path:
+    value = os.environ.get(name)
+    assert value, f"selected Qwen Edge-LLM E2E requires {name}"
+    path = Path(value)
+    assert path.is_dir() if directory else path.is_file(), path
+    return path
+
+
+def test_qwen3_0_6b_edge_llm_build_inspect_and_run(tmp_path: Path) -> None:
+    """Opt-in single-GPU entry; normal Qwen E2E does not select this backend."""
+
+    if os.environ.get("TRTMC_QWEN_EDGE_LLM_E2E") != "1":
+        pytest.skip("Qwen Edge-LLM E2E was not explicitly selected")
+    model_dir = _required_edge_path("TRTMC_EDGE_LLM_QWEN3_0_6B_DIR", directory=True)
+    binary = _required_edge_path("TRTMC_BINARY")
+    runtime_root = _required_edge_path("TRTMC_RUNTIME_ROOT", directory=True)
+    for name in (
+        "libtrtmc_model_qwen.so",
+        "libtrtmc_qwen_edge_llm.so",
+        "libNvInfer_edgellm_plugin.so",
+    ):
+        assert (runtime_root / name).is_file(), runtime_root / name
+
+    bundle = tmp_path / "qwen3-0.6b-edge-llm.bundle"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tensorrt_model_connect",
+            "build",
+            str(model_dir),
+            "--backend",
+            "edge_llm",
+            "--precision",
+            "fp16",
+            "--max-sequence-length",
+            "4096",
+            "--output",
+            str(bundle),
+        ],
+        check=True,
+        timeout=21600,
+    )
+
+    inspected = subprocess.run(
+        [str(binary), "inspect", str(bundle)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    info = json.loads(inspected.stdout)
+    assert info["family"] == "qwen"
+    assert info["task"] == "text_generation"
+    assert info["backend"] == "edge_llm"
+    assert "edge_llm/llm.engine" in info["sections"]
+    assert all(".so" not in name for name in info["sections"])
+
+    environment = os.environ.copy()
+    environment["LD_LIBRARY_PATH"] = ":".join(
+        value for value in (str(runtime_root), environment.get("LD_LIBRARY_PATH", "")) if value
+    )
+    completed = subprocess.run(
+        [
+            str(binary),
+            "run",
+            str(bundle),
+            "--runtime-root",
+            str(runtime_root),
+            "--prompt",
+            "What is the capital of France? Answer in one word.",
+            "--max-new-tokens",
+            "16",
+            "--temperature",
+            "0",
+            "--top-k",
+            "1",
+            "--use-chat-template",
+            "true",
+            "--enable-thinking",
+            "false",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=600,
+    )
+    result = json.loads(completed.stdout)
+    assert isinstance(result["text"], str) and "Paris" in result["text"]
+    assert isinstance(result["token_ids"], list) and result["token_ids"]

--- a/families/qwen/tests/test_edge_llm_build.py
+++ b/families/qwen/tests/test_edge_llm_build.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from families.qwen.edge_llm import build as edge_build
+from tensorrt_model_connect import BuildRequest
+from tensorrt_model_connect.bundle_writer import BUNDLE_MAGIC, BundleWriter
+
+
+def _request(tmp_path: Path, **updates) -> BuildRequest:
+    model = tmp_path / "model"
+    model.mkdir(exist_ok=True)
+    (model / "config.json").write_text('{"model_type":"qwen3"}', encoding="utf-8")
+    values = {
+        "model_dir": model,
+        "output_path": tmp_path / "qwen-edge.bundle",
+        "family": "qwen",
+        "task": "text_generation",
+        "precision": "fp16",
+        "backend": "edge_llm",
+        "max_sequence_length": 4096,
+    }
+    values.update(updates)
+    return BuildRequest(**values)
+
+
+def _read_header(path: Path) -> dict:
+    data = path.read_bytes()
+    assert data.startswith(BUNDLE_MAGIC)
+    header_size = struct.unpack_from("<Q", data, len(BUNDLE_MAGIC))[0]
+    start = len(BUNDLE_MAGIC) + 8
+    return json.loads(data[start : start + header_size])
+
+
+def test_explicit_edge_build_runs_official_tools_and_streams_engine_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        edge_build.shutil,
+        "which",
+        lambda name: f"/tools/{name}",
+    )
+
+    def run(command: list[str], *, check: bool) -> None:
+        assert check is True
+        calls.append(command)
+        if command[0].endswith("tensorrt-edgellm-export"):
+            (Path(command[2]) / "llm").mkdir(parents=True)
+            return
+        engine_argument = next(value for value in command if value.startswith("--engineDir="))
+        engine = Path(engine_argument.split("=", 1)[1])
+        engine.mkdir()
+        for name in edge_build._REQUIRED_FILES:
+            (engine / name).write_bytes(name.encode())
+
+    monkeypatch.setattr(edge_build.subprocess, "run", run)
+    request = _request(tmp_path, verbose=True)
+    writer = BundleWriter(request.output_path)
+
+    edge_build.build(request, writer)
+    writer.finish()
+
+    header = _read_header(request.output_path)
+    assert header["family"] == "qwen"
+    assert header["task"] == "text_generation"
+    assert header["backend"] == "edge_llm"
+    assert set(header["sections"]) == {
+        "edge_llm.json",
+        *(f"edge_llm/{name}" for name in edge_build._REQUIRED_FILES),
+    }
+    assert all(".so" not in name for name in header["sections"])
+    assert calls[0][0] == "/tools/tensorrt-edgellm-export"
+    assert calls[0][-1] == "--dtype=float16"
+    assert calls[1][0] == "/tools/llm_build"
+    assert "--maxInputLen=1024" in calls[1]
+    assert "--maxKVCacheCapacity=4096" in calls[1]
+    assert "--maxBatchSize=1" in calls[1]
+    assert "--debug" in calls[1]
+
+
+def test_edge_build_fails_when_an_official_tool_is_missing(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(edge_build.shutil, "which", lambda _name: None)
+    request = _request(tmp_path)
+    writer = BundleWriter(request.output_path)
+
+    with pytest.raises(RuntimeError, match="on PATH"):
+        edge_build.build(request, writer)
+    writer.abort()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("backend", "trt", "backend=edge_llm"),
+        ("precision", "bf16", "precision=fp16"),
+        ("tensor_parallel_size", 2, "single-device"),
+        ("quantization", "fp8", "unquantized"),
+        ("dynamic_kv_cache", True, "dynamic_kv_cache"),
+    ],
+)
+def test_edge_build_rejects_unsupported_requests(
+    tmp_path: Path, field: str, value: object, message: str
+) -> None:
+    request = _request(tmp_path, **{field: value})
+    writer = BundleWriter(request.output_path)
+
+    with pytest.raises(ValueError, match=message):
+        edge_build.build(request, writer)
+    writer.abort()


### PR DESCRIPTION
## Background

PR #1093 removed the Qwen adapter for NVIDIA TensorRT Edge-LLM during the family-isolation cutover. Native TensorRT remains the default Qwen backend, but users who explicitly select Edge-LLM currently have no ModelConnect build-and-run path.

## Exit Criteria

- Restore an explicit `--backend edge_llm` path for supported Qwen checkpoints.
- Keep all Edge-LLM build and runtime policy inside `families/qwen/edge_llm/`.
- Leave native Qwen builds and other families unchanged.
- Use the installed official exporter, engine builder, runtime, and plugin without cloning, downloading, caching, fallback, or digest machinery.
- Stream engine files into and out of the existing bundle format.
- Fail closed for missing tools, unsupported tasks, unsupported checkpoints, unsupported precision, and non-single-device requests.
- Do not introduce a fake Engine API backend for a runtime that owns execution itself.

## Implementation

- Added `edge_llm` to the thin family support declaration and declared it only for Qwen.
- Added a Qwen-owned builder that invokes the installed `tensorrt-edgellm-export` and `llm_build` tools, validates the produced engine directory, and writes its files into `edge_llm/` bundle sections.
- Added an opt-in family dependency declaration pinned to the public TensorRT Edge-LLM `v0.9.0` tag.
- Added a Qwen-owned `ITextGeneration` adapter plus a small C bridge to the public Edge-LLM v0.9.0 runtime API.
- Added a streaming bundle-section API and an optional family-only DSO entrypoint so an external runtime can reuse the current task interface without pretending to implement `IBackend`; these are additive C++/DSO ABI surfaces.
- Added fake-bridge native tests, Python build/dispatch tests, and an opt-in single-GPU E2E entry.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [x] ABI
- [x] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest core/builder/tests tools/tests families/qwen/tests/test_edge_llm_build.py -q` — 234 passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest families/qwen/tests/test_e2e.py -m 'not gpu and not trt' -q` — 3 passed, 13 skipped by their declared environment gates.
- `cmake --build build-edge-cpu --target test_bundle_format_v1 test_family_loader test_qwen_edge_llm_runtime -j2` followed by `ctest --test-dir build-edge-cpu --output-on-failure -R "bundle_format_v1|family_loader|qwen_edge_llm_runtime"` — 3/3 passed with the fake Edge-LLM bridge.
- `c++ -std=c++17 -Wall -Wextra -Wpedantic -fsyntax-only families/qwen/edge_llm/runtime/bridge.cpp -I. -I<TensorRT-Edge-LLM-v0.9.0>/cpp -I<TensorRT>/include -I<CUDA>/include` — passed against the public v0.9.0 headers.
- `python3 tools/legal_headers.py --check` — 0 findings.
- `PYTHONPATH=core/builder:. python3 -m tools.model_ci validate` — valid, 98 families.
- `CI_BASE_REF=github/main PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.ci pipeline source-quality` — passed, including 117 architecture/source tests and the shared native complexity limit.
- `PYTHONPATH=core/builder:apps/benchmark:. python -m tools.ci pipeline package` in the project development image — source archive, native wheel, and installed-wheel validation passed for 98 families and 104 shared libraries.
- `npm ci && npm run test:model-support && npm run build` in `website/` — model inventory, 34 diagram checks, and the production documentation build passed.
- Ruff on all changed Python files, clang-format check mode on all changed native files, and `git diff --check` — passed.

### Hardware, Environment, and Revisions

- Repository head: `304c9334bb281921d07548931895bb9e49c8d0ba`.
- Base: `c7473e3a9de3e76aadf6953e28f64bb03890035b`.
- TensorRT Edge-LLM source API: public `v0.9.0` tag.
- Linux aarch64, Python 3.12, CMake 3.28, CUDA 13.3 headers; CPU/fake-bridge execution only.
- No model checkpoint or generated engine was used in the completed validation.

### Not Run / Remaining Gaps

- The real TensorRT Edge-LLM native libraries were not built or linked.
- The official exporter and `llm_build` were not run on a Qwen checkpoint.
- Real single-GPU generation and output parity were not run.
- No Multi-Device test was run; this adapter rejects non-single-device requests.

## Notes For Future Readers

The adapter is explicit and fail closed: `trtmc build` continues to select the native TensorRT Qwen implementation unless the user passes `--backend edge_llm`. The dependency file is opt-in and family-owned. The bundle contains engine-directory data, but intentionally does not embed the Edge-LLM runtime bridge or TensorRT plugin.

Review the small shared loader/bundle additions first, then the Qwen-owned builder and runtime. Before merge, the remaining real-library link and single-GPU E2E gap should be closed on supported hardware.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: the path is opt-in and has fake-runtime coverage, but the new external runtime integration has not yet completed a real library link, checkpoint export, engine build, or GPU inference.
