### PR TITLE
fix(lerobot): colocate standalone runtime libraries

### DIFF
--- a/examples/models/lerobot_act/recorded_control/CMakeLists.txt
+++ b/examples/models/lerobot_act/recorded_control/CMakeLists.txt
@@ -17,6 +17,13 @@ set(TRTMC_ENABLE_BYOK OFF CACHE BOOL "" FORCE)
 
 add_subdirectory("${TRTMC_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/trtmc")
 
+# load_task resolves the backend and family DSO from one runtime root. The
+# nested Model Connect build already writes the core/backend libraries here;
+# keep this example's family DSO beside them.
+set_target_properties(trtmc_model_lerobot_act PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/trtmc"
+)
+
 add_executable(trtmc_lerobot_act_recorded_control main.cpp)
 target_compile_features(trtmc_lerobot_act_recorded_control PRIVATE cxx_std_17)
 target_compile_options(trtmc_lerobot_act_recorded_control PRIVATE -Wall -Wextra -Wpedantic)

--- a/examples/models/lerobot_act/recorded_control/test_recorded_control_source.py
+++ b/examples/models/lerobot_act/recorded_control/test_recorded_control_source.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-only contracts for the standalone LeRobot ACT example."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[4]
+EXAMPLE = REPO / "examples/models/lerobot_act/recorded_control"
+
+
+def test_documented_runtime_root_contains_the_family_and_backend_dsos() -> None:
+    cmake = (EXAMPLE / "CMakeLists.txt").read_text(encoding="utf-8")
+    readme = (EXAMPLE / "README.md").read_text(encoding="utf-8")
+    source = (EXAMPLE / "main.cpp").read_text(encoding="utf-8")
+
+    runtime_dir = "${CMAKE_BINARY_DIR}/trtmc"
+    assert f'add_subdirectory("${{TRTMC_SOURCE_DIR}}" "{runtime_dir}")' in cmake
+    family_output = cmake.split("set_target_properties(trtmc_model_lerobot_act PROPERTIES", 1)[
+        1
+    ].split(")", 1)[0]
+    assert f'LIBRARY_OUTPUT_DIRECTORY "{runtime_dir}"' in family_output
+    dependencies = cmake.split("add_dependencies(trtmc_lerobot_act_recorded_control", 1)[1].split(
+        ")", 1
+    )[0]
+    assert "trtmc_backend_trt" in dependencies
+    assert "trtmc_model_lerobot_act" in dependencies
+
+    assert "--runtime-root /tmp/lerobot-act-example/trtmc" in readme
+    assert "load_task(options.bundle, options.runtime_root)" in source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ testpaths = [
     "apps/benchmark/trtmc_benchmark/tests",
     "examples/audio_streaming/test_audio_streaming.py",
     "examples/models/cosmos3/dual_spark/test_cosmos3_dual_spark_source.py",
+    "examples/models/lerobot_act/recorded_control/test_recorded_control_source.py",
     "examples/models/nemotron_voicechat/full_duplex/test_voicechat_full_duplex_source.py",
     "tools/tests",
 ]


### PR DESCRIPTION
## Background

The standalone LeRobot ACT example documents `/tmp/lerobot-act-example/trtmc` as its runtime root. Its nested ModelConnect build writes the core runtime and TensorRT backend there, but the LeRobot family DSO was emitted one directory higher. Because `load_task()` resolves every runtime DSO from one explicit root, the documented command could not load `libtrtmc_model_lerobot_act.so`.

## Exit Criteria

- Make the documented standalone build produce one complete runtime directory.
- Keep the fix owned by the LeRobot example; do not change the shared loader or family runtime.
- Preserve the existing command line and one-way example-to-library dependency.
- Add a source contract that prevents the README, CMake layout, and loader call from drifting apart.

## Implementation

- Set the existing `trtmc_model_lerobot_act` target's library output directory to the nested ModelConnect build directory already used by core and the backend.
- Added one example-owned source test covering the nested runtime directory, family/backend target dependencies, documented `--runtime-root`, and `load_task()` call.
- Registered that source test in the existing pytest test paths.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- Configured the standalone example in the project development image with `cmake -S examples/models/lerobot_act/recorded_control -B .ci/lerobot-example -G Ninja -DCMAKE_BUILD_TYPE=Release` — passed.
- Built `trtmc_lerobot_act_recorded_control` and asserted that `libtrtmc_core.so`, `libtrtmc_runtime.so`, `libtrtmc_backend_trt.so`, and `libtrtmc_model_lerobot_act.so` all exist under `.ci/lerobot-example/trtmc` — passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest examples/models/lerobot_act/recorded_control/test_recorded_control_source.py tools/tests/test_architecture.py tools/tests/test_new_ci.py -q` — 72 passed.
- The broader benchmark, BYOK, graph-transform, example-source, and one-way dependency audit suite — 103 passed.
- Ruff, legal-header audit, and `git diff --check` — passed with 0 legal findings.

### Hardware, Environment, and Revisions

- Repository head: `ad171f32c49d8c100b781e50bcc86b59e545dfe4`.
- Base: `c7473e3a9de3e76aadf6953e28f64bb03890035b`.
- Linux aarch64, CMake 3.28, GCC 13.3, CUDA 13.3 compiler; compile and file-layout validation only.
- No checkpoint or generated bundle was used.

### Not Run / Remaining Gaps

- The standalone executable was not run against a LeRobot checkpoint bundle.
- No GPU inference or action parity was run.
- No Multi-Device test was run; the example is single-device.

## Notes For Future Readers

The shared loader intentionally accepts one runtime root. This example therefore co-locates its one family DSO with the already co-located core and backend libraries instead of adding another search path or compatibility layer.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Risk rationale: the change only redirects one existing example target, and an actual configure/build verified the documented directory contains the complete runtime DSO set.
