### PR TITLE
feat(benchmark): restore human-readable HTML evidence

### DIFF
--- a/apps/benchmark/trtmc_benchmark/report.py
+++ b/apps/benchmark/trtmc_benchmark/report.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 import html
 import json
+import math
+import re
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
 
 from .types import BenchmarkError
 
@@ -17,45 +20,190 @@ from .types import BenchmarkError
 _RUN_SCHEMA = "trtmc.benchmark-run/v2"
 _REPORT_SCHEMA = "trtmc.benchmark-report/v2"
 
+_TASK_RATES = (
+    ("output_tokens_per_s", " token/s"),
+    ("videos_per_s", " video/s"),
+    ("images_per_s", " image/s"),
+    ("audio_seconds_per_s", " audio-s/s"),
+    ("input_audio_seconds_per_s", " input-audio-s/s"),
+    ("output_audio_seconds_per_s", " output-audio-s/s"),
+    ("documents_per_s", " document/s"),
+    ("embedding_vectors_per_s", " vector/s"),
+    ("windows_per_s", " window/s"),
+    ("action_steps_per_s", " action-step/s"),
+    ("stereo_pairs_per_s", " stereo-pair/s"),
+    ("request_throughput_per_s", " request/s"),
+)
+
+_DISPLAY_PATH = re.compile(
+    r"""(?:
+        (?P<quote>["'])
+        (?:file://|/|[A-Za-z]:[\\/]|\\\\)
+        .*?
+        (?P=quote)
+        |
+        https?://[^\s"'<>]+
+        |
+        file://[^\s"'<>]+
+        |
+        (?<![A-Za-z0-9_])[A-Za-z]:[\\/][^\s"'<>]+
+        |
+        \\\\[^\s"'<>]+
+        |
+        (?<![-A-Za-z0-9_/.<])/
+        [^\s"'<>]+
+    )""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 def write_html_report(result: Mapping[str, Any], path: Path) -> None:
     cells = result.get("cells", [])
-    rows = []
+    source_runs = _source_runs(result)
+    default_run_id = str(result.get("run_id", ""))
+    rows: list[str] = []
     for cell in cells if isinstance(cells, list) else []:
         if not isinstance(cell, Mapping):
             continue
         metrics = cell.get("metrics", {})
         latency = metrics.get("latency_ms", {}) if isinstance(metrics, Mapping) else {}
         p50 = latency.get("p50") if isinstance(latency, Mapping) else None
-        detail = (
-            f"{float(p50):.3f} ms"
-            if isinstance(p50, (int, float)) and not isinstance(p50, bool)
-            else html.escape(str(cell.get("error", "")))
-        )
+        p95 = latency.get("p95") if isinstance(latency, Mapping) else None
+        run_id = str(cell.get("run_id", default_run_id))
         rows.append(
             "<tr>"
-            f"<td>{html.escape(str(cell.get('model', '')))}</td>"
-            f"<td>{html.escape(str(cell.get('name', '')))}</td>"
-            f"<td>{html.escape(str(cell.get('operation', '')))}</td>"
-            f"<td>{html.escape(str(cell.get('status', '')))}</td>"
-            f"<td>{detail}</td>"
+            f"<td>{_escape(cell.get('model', ''))}</td>"
+            f"<td>{_escape(cell.get('name', ''))}</td>"
+            f"<td>{_escape(cell.get('operation', ''))}</td>"
+            f"<td>{_escape(_number(p50, ' ms'))}</td>"
+            f"<td>{_escape(_number(p95, ' ms'))}</td>"
+            f"<td>{_escape(_task_rate(metrics))}</td>"
+            f"<td>{_escape(cell.get('status', 'unknown'))}</td>"
+            f"<td>{_cell_evidence(cell, run_id)}</td>"
             "</tr>"
         )
+    run_rows = [
+        "<tr>"
+        f"<td><code>{_escape(run.get('run_id', 'unknown'))}</code></td>"
+        f"<td>{_escape(run.get('status', 'unknown'))}</td>"
+        f"<td>{_escape(run.get('started_at') or '—')}</td>"
+        f"<td>{_escape(run.get('finished_at') or '—')}</td>"
+        "<td><code>result.json</code></td>"
+        "</tr>"
+        for run in source_runs
+    ]
+    summary = result.get("summary", {})
+    summary = summary if isinstance(summary, Mapping) else {}
+    run_count = summary.get("runs", len(source_runs))
+    warnings = result.get("warnings", [])
+    warning_values = warnings if isinstance(warnings, list) else []
+    warning_items = "".join(f"<li>{_escape(warning)}</li>" for warning in warning_values)
+    warnings_html = f"<h2>Warnings</h2><ul>{warning_items}</ul>" if warning_items else ""
     document = f"""<!doctype html>
-<html><head><meta charset="utf-8"><title>TRTMC benchmark</title>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+<title>TRTMC benchmark report</title>
 <style>
 body {{ font: 14px system-ui, sans-serif; margin: 2rem; color: #222; }}
-table {{ border-collapse: collapse; width: 100%; }}
+table {{ border-collapse: collapse; width: 100%; margin-bottom: 2rem; }}
 th, td {{ border: 1px solid #ddd; padding: .5rem; text-align: left; }}
 th {{ background: #f3f3f3; }}
+code {{ background: #f3f3f3; padding: .1rem .25rem; overflow-wrap: anywhere; }}
+.error {{ color: #a32626; }}
 </style></head><body>
 <h1>TRTMC benchmark</h1>
-<p>Status: {html.escape(str(result.get("status", "unknown")))}</p>
-<table><thead><tr><th>Model</th><th>Case</th><th>Operation</th><th>Status</th><th>p50 / error</th></tr></thead>
-<tbody>{''.join(rows)}</tbody></table>
+<p>Status: <strong>{_escape(result.get("status", "unknown"))}</strong>.
+Source runs: <strong>{_escape(run_count)}</strong>; cases: <strong>{len(rows)}</strong>.</p>
+<h2>Models and cases</h2>
+<table><thead><tr><th>Model</th><th>Case</th><th>Operation</th><th>p50</th><th>p95</th><th>Task rate</th><th>Status</th><th>Evidence / error</th></tr></thead>
+<tbody>{"".join(rows)}</tbody></table>
+<h2>Source runs</h2>
+<table><thead><tr><th>Run</th><th>Status</th><th>Started</th><th>Finished</th><th>Result evidence</th></tr></thead>
+<tbody>{"".join(run_rows)}</tbody></table>
+{warnings_html}
+<p>Machine-readable evidence remains in <code>result.json</code> for a single run
+and <code>report.json</code> for a collection.</p>
 </body></html>
 """
     path.write_text(document, encoding="utf-8")
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _number(value: Any, suffix: str) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "—"
+    converted = float(value)
+    return "—" if not math.isfinite(converted) else f"{converted:.3f}{suffix}"
+
+
+def _task_rate(metrics: Any) -> str:
+    if not isinstance(metrics, Mapping):
+        return "—"
+    for field, unit in _TASK_RATES:
+        if field in metrics:
+            return _number(metrics[field], unit)
+    return "—"
+
+
+def _source_runs(result: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    runs = result.get("runs")
+    if isinstance(runs, list):
+        return [run for run in runs if isinstance(run, Mapping)]
+    run_id = result.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        return []
+    return [
+        {
+            "run_id": run_id,
+            "status": result.get("status", "unknown"),
+            "started_at": result.get("started_at"),
+            "finished_at": result.get("finished_at"),
+        }
+    ]
+
+
+def _is_absolute_path(value: str) -> bool:
+    if PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute():
+        return True
+    parsed = urlsplit(value)
+    return parsed.scheme.lower() == "file" and PurePosixPath(parsed.path).is_absolute()
+
+
+def _redact_absolute_paths(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        if match.group("quote"):
+            candidate = candidate[1:-1]
+        return "[absolute path]" if _is_absolute_path(candidate) else match.group(0)
+
+    return _DISPLAY_PATH.sub(replace, value)
+
+
+def _cell_evidence(cell: Mapping[str, Any], run_id: str) -> str:
+    parts: list[str] = []
+    if run_id:
+        parts.append(f"run <code>{_escape(run_id)}</code>")
+    artifact = cell.get("artifact_dir")
+    if isinstance(artifact, str) and artifact:
+        posix_path = PurePosixPath(artifact)
+        windows_path = PureWindowsPath(artifact)
+        safe_artifact = not _is_absolute_path(artifact) and all(
+            part not in {"", ".", ".."}
+            for path in (posix_path, windows_path)
+            for part in path.parts
+        )
+        label = posix_path.as_posix() if safe_artifact else "case artifacts"
+        parts.append(f"artifacts <code>{_escape(label)}</code>")
+    error = cell.get("error")
+    if isinstance(error, str) and error:
+        displayed_error = _redact_absolute_paths(error)
+        parts.append(f'<span class="error">{_escape(displayed_error)}</span>')
+    return "<br>".join(parts) or "—"
 
 
 def generate_collection_report(
@@ -69,26 +217,25 @@ def generate_collection_report(
     warnings: list[str] = []
     cells: list[dict[str, Any]] = []
     for path in result_paths:
+        result_label = _result_label(path)
         try:
             result = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as error:
-            warnings.append(f"skipped unreadable result {path}: {error}")
+            warnings.append(f"skipped unreadable result {result_label}: {_error_summary(error)}")
             continue
         if not isinstance(result, Mapping) or result.get("schema_version") != _RUN_SCHEMA:
-            warnings.append(f"skipped unsupported result {path}")
+            warnings.append(f"skipped unsupported result {result_label}")
             continue
         run_id = result.get("run_id")
         if not isinstance(run_id, str) or not run_id:
-            warnings.append(f"skipped result without run_id {path}")
+            warnings.append(f"skipped result without run_id {result_label}")
             continue
         if run_id in seen_ids:
-            raise BenchmarkError(
-                f"duplicate run_id {run_id!r}: {seen_ids[run_id]} and {path}"
-            )
+            raise BenchmarkError(f"duplicate run_id {run_id!r}: {seen_ids[run_id]} and {path}")
         seen_ids[run_id] = path
         run_cells = result.get("cells", [])
         if not isinstance(run_cells, list):
-            warnings.append(f"skipped malformed cells in {path}")
+            warnings.append(f"skipped malformed cells in {result_label}")
             continue
         source = str(path.parent)
         runs.append(
@@ -120,6 +267,8 @@ def generate_collection_report(
         "runs": runs,
         "cells": cells,
     }
+    if warnings:
+        report["warnings"] = list(warnings)
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "report.json").write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -139,3 +288,13 @@ def _result_paths(roots: Sequence[Path]) -> tuple[Path, ...]:
         elif path.is_dir():
             paths.update(path.rglob("result.json"))
     return tuple(sorted(paths))
+
+
+def _result_label(path: Path) -> str:
+    return (Path(path.parent.name) / path.name).as_posix()
+
+
+def _error_summary(error: OSError | json.JSONDecodeError) -> str:
+    if isinstance(error, json.JSONDecodeError):
+        return f"{error.msg} at line {error.lineno} column {error.colno}"
+    return error.strerror or type(error).__name__

--- a/apps/benchmark/trtmc_benchmark/tests/test_benchmark.py
+++ b/apps/benchmark/trtmc_benchmark/tests/test_benchmark.py
@@ -18,7 +18,7 @@ from trtmc_benchmark.catalog import (
 )
 from trtmc_benchmark.cli import main
 from trtmc_benchmark.metrics import reduce_metrics
-from trtmc_benchmark.report import generate_collection_report
+from trtmc_benchmark.report import generate_collection_report, write_html_report
 from trtmc_benchmark.service import BenchmarkService
 from trtmc_benchmark.types import BenchmarkError
 from trtmc_benchmark.worker import find_worker
@@ -200,6 +200,89 @@ def test_service_runs_worker_and_writes_reports(tmp_path: Path) -> None:
     assert result["cells"][0]["samples_ms"] == [2.0, 2.0]
     assert (output / "result.json").is_file()
     assert (output / "report.html").is_file()
+    report_html = (output / "report.html").read_text(encoding="utf-8")
+    assert "Source runs: <strong>1</strong>" in report_html
+    assert "<th>p95</th>" in report_html
+    assert "2.000 ms" in report_html
+    assert "1500.000 token/s" in report_html
+    assert result["cells"][0]["artifact_dir"] in report_html
+
+
+def test_html_report_snapshot_is_readable_escaped_and_self_contained(tmp_path: Path) -> None:
+    path = tmp_path / "report.html"
+    write_html_report(
+        {
+            "status": "failed",
+            "summary": {"runs": 2},
+            "runs": [
+                {
+                    "run_id": "run<&",
+                    "status": "completed",
+                    "started_at": "2026-01-02T03:04:05Z",
+                    "finished_at": "2026-01-02T03:05:06Z",
+                    "result_path": "/absolute/source<&",
+                },
+                {"run_id": "run-two", "status": "failed"},
+            ],
+            "cells": [
+                {
+                    "run_id": "run<&",
+                    "model": "model<&",
+                    "name": '"case"',
+                    "operation": "generate",
+                    "status": "completed",
+                    "artifact_dir": "artifact<&",
+                    "metrics": {
+                        "latency_ms": {"p50": 1.23456, "p95": 9.87654},
+                        "output_tokens_per_s": 42.25,
+                        "request_throughput_per_s": 1.0,
+                    },
+                },
+                {
+                    "run_id": "run-two",
+                    "model": "audio",
+                    "name": "speech",
+                    "operation": "generate_audio",
+                    "status": "completed",
+                    "metrics": {
+                        "latency_ms": {"p50": 50.0, "p95": 75.0},
+                        "audio_seconds_per_s": 2.5,
+                    },
+                },
+                {
+                    "run_id": "run-two",
+                    "model": "failed",
+                    "name": "unsafe",
+                    "operation": "generate",
+                    "status": "failed",
+                    "artifact_dir": "/absolute/case-artifacts",
+                    "error": "<script>alert('unsafe')</script>",
+                },
+            ],
+            "warnings": ["skipped <unsafe> & evidence"],
+        },
+        path,
+    )
+
+    report_html = path.read_text(encoding="utf-8")
+    row_snapshot = (
+        "<tr><td>model&lt;&amp;</td><td>&quot;case&quot;</td><td>generate</td>"
+        "<td>1.235 ms</td><td>9.877 ms</td><td>42.250 token/s</td>"
+        "<td>completed</td><td>run <code>run&lt;&amp;</code><br>"
+        "artifacts <code>artifact&lt;&amp;</code></td></tr>"
+    )
+    assert row_snapshot in report_html
+    assert "2.500 audio-s/s" in report_html
+    assert "Source runs: <strong>2</strong>; cases: <strong>3</strong>" in report_html
+    assert "<td><code>result.json</code></td>" in report_html
+    assert "/absolute" not in report_html
+    assert "artifacts <code>case artifacts</code>" in report_html
+    assert "&lt;script&gt;alert(&#x27;unsafe&#x27;)&lt;/script&gt;" in report_html
+    assert "skipped &lt;unsafe&gt; &amp; evidence" in report_html
+    assert "Content-Security-Policy" in report_html
+    assert "<script>" not in report_html
+    assert " href=" not in report_html
+    assert " src=" not in report_html
 
 
 def test_case_resolution_rejects_unknown_telemetry_override(tmp_path: Path) -> None:
@@ -246,6 +329,125 @@ def test_collection_rejects_duplicate_run_id_without_content_fingerprints(
         )
     with pytest.raises(BenchmarkError, match="duplicate run_id"):
         generate_collection_report((tmp_path,), tmp_path / "report")
+
+
+def test_collection_report_serializes_existing_warnings(tmp_path: Path) -> None:
+    valid = tmp_path / "valid"
+    valid.mkdir()
+    (valid / "result.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "trtmc.benchmark-run/v2",
+                "run_id": "run-one",
+                "status": "completed",
+                "cells": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    unreadable = tmp_path / "bad<&"
+    unreadable.mkdir()
+    (unreadable / "result.json").write_text("not JSON", encoding="utf-8")
+
+    report, warnings = generate_collection_report((tmp_path,), tmp_path / "report")
+
+    assert len(warnings) == 1
+    assert str(tmp_path) not in warnings[0]
+    assert report["warnings"] == list(warnings)
+    persisted = json.loads((tmp_path / "report/report.json").read_text(encoding="utf-8"))
+    assert persisted["warnings"] == list(warnings)
+    report_html = (tmp_path / "report/report.html").read_text(encoding="utf-8")
+    assert "<h2>Warnings</h2>" in report_html
+    assert "bad&lt;&amp;" in report_html
+    assert "bad<&" not in report_html
+    assert str(tmp_path) not in report_html
+
+
+def test_html_redacts_absolute_error_paths_without_changing_json(tmp_path: Path) -> None:
+    redacted_errors = [
+        "worker failed: /absolute/run/worker.log",
+        r"worker failed: C:\runner\work\worker.log",
+        "worker failed: file:///opt/runner/work/worker.log",
+        "worker failed: path:/opt/runner/work/worker.log",
+    ]
+    preserved_errors = [
+        "worker failed: retry limit reached",
+        "worker failed: https://example.com/public/errors",
+    ]
+    errors = [*redacted_errors, *preserved_errors]
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "result.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "trtmc.benchmark-run/v2",
+                "run_id": "failed-run",
+                "status": "failed",
+                "cells": [
+                    {
+                        "name": f"failure-{index}",
+                        "model": "model",
+                        "operation": "generate",
+                        "status": "failed",
+                        "error": error,
+                    }
+                    for index, error in enumerate(errors)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report, _ = generate_collection_report((source,), tmp_path / "report")
+
+    assert [cell["error"] for cell in report["cells"]] == errors
+    persisted = json.loads((tmp_path / "report/report.json").read_text(encoding="utf-8"))
+    assert [cell["error"] for cell in persisted["cells"]] == errors
+    report_html = (tmp_path / "report/report.html").read_text(encoding="utf-8")
+    assert report_html.count("[absolute path]") == len(redacted_errors)
+    assert all(error not in report_html for error in redacted_errors)
+    assert all(error in report_html for error in preserved_errors)
+    assert "path:[absolute path]" in report_html
+    assert "pat[absolute path]" not in report_html
+
+
+def test_html_rejects_cross_platform_absolute_artifact_labels(tmp_path: Path) -> None:
+    artifacts = [
+        r"C:\runner\work\case-artifacts",
+        "C:/runner/work/case-artifacts",
+        r"\\server\share\case-artifacts",
+    ]
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "result.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "trtmc.benchmark-run/v2",
+                "run_id": "artifact-run",
+                "status": "failed",
+                "cells": [
+                    {
+                        "name": f"failure-{index}",
+                        "model": "model",
+                        "operation": "generate",
+                        "status": "failed",
+                        "artifact_dir": artifact,
+                    }
+                    for index, artifact in enumerate(artifacts)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report, _ = generate_collection_report((source,), tmp_path / "report")
+
+    assert [cell["artifact_dir"] for cell in report["cells"]] == artifacts
+    persisted = json.loads((tmp_path / "report/report.json").read_text(encoding="utf-8"))
+    assert [cell["artifact_dir"] for cell in persisted["cells"]] == artifacts
+    report_html = (tmp_path / "report/report.html").read_text(encoding="utf-8")
+    assert report_html.count("artifacts <code>case artifacts</code>") == len(artifacts)
+    assert all(artifact not in report_html for artifact in artifacts)
 
 
 def test_cli_dry_run_uses_explicit_bundle_without_runtime(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Background

The current `trtmc-bench` HTML report only shows model, case, operation, status, and p50 latency. The same benchmark result already contains p95, task-specific rate metrics, source-run metadata, artifact evidence, and errors, but a human reviewer cannot see them without opening JSON. Collection warnings are returned to the CLI but are also absent from the persisted report.

## Exit Criteria

- Make the self-contained HTML report useful for a human audit at a glance.
- Show p50, p95, the primary task-specific rate with units, source runs, safe artifact evidence, warnings, and errors.
- Escape all untrusted values and do not render absolute host paths.
- Preserve raw machine-readable errors in `report.json`.
- Do not change benchmark execution, metrics, verdicts, thresholds, runner behavior, or schema version.

## Implementation

- Expanded the existing HTML table and added source-run and warning sections using fields the benchmark already produces.
- Added task-rate labels for the existing text, image, video, audio, embedding, forecasting, control, stereo, and request metrics.
- Kept artifact labels only when they are safe relative paths; absolute labels remain available in JSON but are not rendered.
- Redacted POSIX and Windows absolute paths only in displayed error text while preserving the original error byte-for-byte in the returned and persisted JSON report.
- Persisted the collection warning list that the existing collector already returns.
- Added adversarial HTML/CSP, path-redaction, JSON-preservation, metric, source-run, and warning tests.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [x] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest apps/benchmark/trtmc_benchmark/tests -q` — 66 passed.
- `CI_BASE_REF=github/main PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.ci pipeline source-quality` — passed, including 117 architecture/source tests and the shared native complexity limit.
- Ruff check and format-check on both changed files — passed.
- `python3 tools/legal_headers.py --check` — 0 findings.
- `git diff --check github/main...HEAD` — passed.
- Adversarial tests confirmed HTML escaping and CSP, preserved an ordinary error and an HTTPS URL, redacted POSIX and Windows absolute paths, and preserved the original raw errors in `report.json`.

### Hardware, Environment, and Revisions

- Repository head: `78fdf644883a1a3dc6f5bf66c2d92e994eb077b8`.
- Base: `d0e93c1addf12afd336ff264ad21151baa82f27b`.
- Linux aarch64, Python 3.12; CPU-only report generation and tests.
- No checkpoint, engine, GPU, or external service was used.

### Not Run / Remaining Gaps

- No real model benchmark was executed; tests use representative persisted benchmark records and the existing fake worker.
- No browser automation was run; semantic HTML, escaping, CSP, and content are asserted directly.
- No GPU or Multi-Device test was run because this change does not execute models.

## Notes For Future Readers

`report.json` remains the complete machine-readable evidence. The HTML is a safe human view over that data: it deliberately shows `[absolute path]` instead of runner-local paths. Add a new rate label only when the benchmark already emits that metric; do not infer or synthesize values in the report layer.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Risk rationale: model execution and verdicts are untouched, but the persisted collection report gains an optional warnings field and the human-visible report artifact changes substantially.
