### PR TITLE
feat(qwen): restore runtime-sized KV cache

### DIFF
--- a/apps/benchmark/performance/release.yaml
+++ b/apps/benchmark/performance/release.yaml
@@ -1203,6 +1203,10 @@ additional_profiles:
     inherit: qwen_image.generate_image
   - model: qwen-image-edit-2511
     inherit: qwen_image.generate_image
+  - model: qwen2.5-0.5b-dynamic-kv
+    inherit: qwen.generate
+    workload:
+      testcase: qwen2.5-0.5b-dynamic-kv
   - model: qwen25vl-3b
     inherit: qwen_vl.generate
   - model: qwen3-0.6b-fp8

--- a/families/qwen/dual_profile_decoder_builder.py
+++ b/families/qwen/dual_profile_decoder_builder.py
@@ -295,6 +295,7 @@ def build_dual_profile_decoder_engine(
     profile_mode: str = "dual_profile",
     full_logits_output: bool = False,
     native_kv_cache: bool = False,
+    runtime_sized_kv_cache: bool = False,
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
@@ -319,6 +320,9 @@ def build_dual_profile_decoder_engine(
     a platform-independent primitive attention graph with an explicit BOOL
     active-prefix causal mask. The dense-mask graph remains available
     for non-Qwen3 models handled by this family.
+
+    ``runtime_sized_kv_cache`` makes the standard cache row dimension dynamic
+    from one row through the bundle capacity.
     """
     _supports_config(config, weights)
     if profile_mode not in ("dual_profile", "prefill", "decode"):
@@ -328,10 +332,14 @@ def build_dual_profile_decoder_engine(
     if native_kv_cache and position_type == "alibi":
         raise NotImplementedError(
             "TensorRT native KV cache prototype does not support ALiBi")
-    # Physical KV capacity and one TensorRT enqueue's query length are
-    # separate limits. Keep the complete model context in the cache while
-    # bounding activation/workspace pressure for very long prompts; the
-    # family runtime transparently advances through multiple chunks.
+    if runtime_sized_kv_cache and position_type == "alibi":
+        raise NotImplementedError(
+            "runtime-sized Qwen KV cache does not support ALiBi")
+    if native_kv_cache and runtime_sized_kv_cache:
+        raise ValueError("native Qwen KV cache has one fixed physical capacity")
+    # Native KV bounds one enqueue's activation pressure and transparently
+    # advances through chunks. Standard runtime-sized KV has no chunk fallback,
+    # so it retains the complete requested prefill profile.
     opt_prefill_length, max_prefill_length = _resolve_prefill_lengths(
         max_cache_length,
         opt_prefill_length,
@@ -416,6 +424,8 @@ def build_dual_profile_decoder_engine(
     cache_shape: tuple[int, ...]
     if native_kv_cache:
         cache_shape = (1, num_kv_heads, max_cache_length, head_dim)
+    elif runtime_sized_kv_cache:
+        cache_shape = (-1, kv_attention_size)
     else:
         cache_shape = (max_cache_length, kv_attention_size)
     cache_k_inputs: list[trt.ITensor] = []
@@ -440,14 +450,24 @@ def build_dual_profile_decoder_engine(
     def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False):
         prof = builder.create_optimization_profile()
         min_sq = opt_sq if fixed else 1
+        opt_cache_rows = max_cache_length
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
         if not native_kv_cache:
             prof.set_shape(
                 "attention_mask",
-                (min_sq, max_cache_length + min_sq),
-                (opt_sq, max_cache_length + opt_sq),
+                (min_sq, (1 if runtime_sized_kv_cache else max_cache_length) + min_sq),
+                (opt_sq,
+                 (opt_cache_rows if runtime_sized_kv_cache else max_cache_length) + opt_sq),
                 (max_sq, max_cache_length + max_sq))
+        if runtime_sized_kv_cache:
+            for i in range(num_layers):
+                for prefix in ("cache_k", "cache_v"):
+                    prof.set_shape(
+                        graph_ops.layer_tensor_name(prefix, i),
+                        (1, kv_attention_size),
+                        (opt_cache_rows, kv_attention_size),
+                        (max_cache_length, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
     if profile_mode == "prefill":

--- a/families/qwen/model.py
+++ b/families/qwen/model.py
@@ -230,9 +230,6 @@ def _runtime_config(model_dir: Path, config: ModelConfig, model: _QwenModel, **u
 
 def build(request: "BuildRequest", writer: "BundleWriter") -> None:
     """Build one Qwen bundle through family-owned code."""
-    if request.dynamic_kv_cache:
-        raise NotImplementedError("qwen does not support dynamic_kv_cache")
-
     if request.image_height is not None:
         raise NotImplementedError("qwen does not support image_height")
 
@@ -262,6 +259,10 @@ def build(request: "BuildRequest", writer: "BundleWriter") -> None:
     )
     if unsupported_variant or not (model_type.startswith("qwen") or model_type.startswith("qwq")):
         raise ValueError(f"Qwen does not support model_type={config.model_type!r}")
+    if request.dynamic_kv_cache and model_type == "qwen3":
+        raise NotImplementedError(
+            "Qwen3 does not support dynamic_kv_cache; use its fixed-capacity native KV path"
+        )
     precision = str(request.precision).lower()
     if precision not in {"fp32", "fp16", "bf16"}:
         raise ValueError("Qwen precision must be fp32, fp16, or bf16")
@@ -281,6 +282,10 @@ def build(request: "BuildRequest", writer: "BundleWriter") -> None:
         tp_size=_positive_int(request.tensor_parallel_size, "tensor_parallel_size")
     )
     parallel.validate()
+    if request.dynamic_kv_cache and parallel.enabled:
+        raise NotImplementedError("Qwen dynamic_kv_cache does not support tensor parallelism")
+    if request.dynamic_kv_cache and quantized:
+        raise NotImplementedError("Qwen dynamic_kv_cache does not support quantization")
     if quantized:
         qualified_route = model_type == "qwen3" and (
             (not parallel.enabled and precision == "fp16")
@@ -292,6 +297,7 @@ def build(request: "BuildRequest", writer: "BundleWriter") -> None:
     config.raw["_resolved_build_precision"] = precision
     config.raw["_parallel_build_enabled"] = parallel.enabled
     config.raw["_quantized_build_requested"] = quantized
+    config.raw["dynamic_kv_cache"] = request.dynamic_kv_cache
     quant_ctx = None
     if quantized:
         from . import graph_ops
@@ -301,7 +307,21 @@ def build(request: "BuildRequest", writer: "BundleWriter") -> None:
         quant_ctx = calibrate_qwen_fp8(model_dir, config, graph_ops)
     weights = model.load_weights(str(model_dir), config, precision=precision)
     writer.set_header(family="qwen", task=request.task, backend=request.backend)
-    if quantized and parallel.enabled:
+    if request.dynamic_kv_cache:
+        config.raw["_decoder_engine_role"] = "dual_profile"
+        plan = model.build_engine(
+            config,
+            weights,
+            max_sequence_length,
+            precision=precision,
+            quant_ctx=None,
+            verbose=bool(request.verbose),
+            debug_layer_outputs=False,
+            parallel_config=parallel,
+        )
+        writer.add_bytes("engine.plan", plan)
+        layout = "dual_profile"
+    elif quantized and parallel.enabled:
         for rank in range(parallel.tp_size):
             plan = model.build_engine(
                 config,
@@ -369,19 +389,20 @@ def build(request: "BuildRequest", writer: "BundleWriter") -> None:
         writer.add_bytes("engine.plan", decode)
         writer.add_bytes("prefill.plan", prefill)
         layout = "split"
-    writer.add_json(
-        "runtime.json",
-        _runtime_config(
-            model_dir,
-            config,
-            model,
-            precision=precision,
-            max_cache_length=max_sequence_length,
-            decoder_engine_layout=layout,
-            tensor_parallel_size=parallel.tp_size,
-            tensor_parallel_mode="tensor_parallel" if parallel.enabled else "single",
-        ),
+    config.raw.pop("_decoder_engine_role", None)
+    runtime = _runtime_config(
+        model_dir,
+        config,
+        model,
+        precision=precision,
+        max_cache_length=max_sequence_length,
+        decoder_engine_layout=layout,
+        tensor_parallel_size=parallel.tp_size,
+        tensor_parallel_mode="tensor_parallel" if parallel.enabled else "single",
     )
+    if request.dynamic_kv_cache:
+        runtime["dynamic_kv_cache"] = True
+    writer.add_json("runtime.json", runtime)
     for filename in _BUNDLE_FILES:
         path = model_dir / filename
         if path.is_file():

--- a/families/qwen/runtime/CMakeLists.txt
+++ b/families/qwen/runtime/CMakeLists.txt
@@ -39,6 +39,7 @@ install(TARGETS trtmc_model_qwen
 if(TRTMC_BUILD_TESTS)
   foreach(test_name IN ITEMS
       test_qwen_native_kv_cache
+      test_qwen_plugin_helpers
       test_qwen_sampler
       test_qwen_tensor_names
   )

--- a/families/qwen/runtime/kv_cache.cpp
+++ b/families/qwen/runtime/kv_cache.cpp
@@ -258,8 +258,9 @@ void QwenKvCache::write_bidirectional_mask(TensorMap& inputs, int32_t seq_len) {
 }
 
 void QwenKvCache::write_decode_mask(TensorMap& inputs) {
-    if (bound_module_ == nullptr || bound_module_->tensor_shape(names_.attention_mask) !=
-                                        std::vector<int64_t>{1, max_length_ + 1}) {
+    if (bound_module_ == nullptr ||
+        (!dynamic_binding_enabled_ && bound_module_->tensor_shape(names_.attention_mask) !=
+                                          std::vector<int64_t>{1, max_length_ + 1})) {
         throw std::runtime_error("Qwen standard decoder has an invalid attention-mask contract");
     }
 
@@ -308,12 +309,19 @@ void QwenKvCache::bind_to(ITrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
     if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
         bind_native_cache(module);
         return;
     }
 
     ensure_standard_present_buffers();
-    if (module.tensor_shape(names_.attention_mask) != std::vector<int64_t>{1, max_length_ + 1}) {
+    dynamic_binding_enabled_ = module.input_is_dynamic(names_.cache_k.front());
+    if (dynamic_binding_enabled_ && !module.input_is_dynamic(names_.attention_mask)) {
+        throw std::runtime_error(
+            "Qwen runtime-sized KV engine must make cache and attention mask dynamic");
+    }
+    if (!dynamic_binding_enabled_ &&
+        module.tensor_shape(names_.attention_mask) != std::vector<int64_t>{1, max_length_ + 1}) {
         throw std::runtime_error("Qwen standard decoder has an invalid attention-mask contract");
     }
     const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
@@ -323,14 +331,20 @@ void QwenKvCache::bind_to(ITrtModule& module) {
         if (!module.has_input(names_.cache_k[layer]) || !module.has_input(names_.cache_v[layer]) ||
             !module.has_output(names_.present_k[layer]) ||
             !module.has_output(names_.present_v[layer]) ||
-            module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
-            module.tensor_shape(names_.cache_v[layer]) != cache_shape ||
+            (!dynamic_binding_enabled_ &&
+             (module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
+              module.tensor_shape(names_.cache_v[layer]) != cache_shape)) ||
             module.tensor_shape(names_.present_k[layer]) != present_shape ||
             module.tensor_shape(names_.present_v[layer]) != present_shape) {
             throw std::runtime_error("Qwen standard decoder has an invalid KV contract");
         }
-        module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
-        module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        if (dynamic_binding_enabled_) {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data(), cache_shape);
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data(), cache_shape);
+        } else {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        }
         module.bind_external(names_.present_k[layer], present_k_[layer].data());
         module.bind_external(names_.present_v[layer], present_v_[layer].data());
     }
@@ -340,20 +354,32 @@ void QwenKvCache::bind_cache_inputs(ITrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
     if (configure_binding_mode(module)) {
+        dynamic_binding_enabled_ = false;
         bind_native_cache(module);
         return;
     }
 
+    dynamic_binding_enabled_ = module.input_is_dynamic(names_.cache_k.front());
+    if (dynamic_binding_enabled_ && !module.input_is_dynamic(names_.attention_mask)) {
+        throw std::runtime_error(
+            "Qwen runtime-sized KV engine must make cache and attention mask dynamic");
+    }
     const std::vector<int64_t> cache_shape{max_length_, kv_dim_};
     for (int32_t i = 0; i < num_layers_; ++i) {
         const auto layer = static_cast<std::size_t>(i);
         if (!module.has_input(names_.cache_k[layer]) || !module.has_input(names_.cache_v[layer]) ||
-            module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
-            module.tensor_shape(names_.cache_v[layer]) != cache_shape) {
+            (!dynamic_binding_enabled_ &&
+             (module.tensor_shape(names_.cache_k[layer]) != cache_shape ||
+              module.tensor_shape(names_.cache_v[layer]) != cache_shape))) {
             throw std::runtime_error("Qwen standard prefill has an invalid KV contract");
         }
-        module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
-        module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        if (dynamic_binding_enabled_) {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data(), cache_shape);
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data(), cache_shape);
+        } else {
+            module.bind_external(names_.cache_k[layer], cache_k_[layer].data());
+            module.bind_external(names_.cache_v[layer], cache_v_[layer].data());
+        }
     }
 }
 

--- a/families/qwen/runtime/kv_cache.h
+++ b/families/qwen/runtime/kv_cache.h
@@ -118,6 +118,7 @@ class QwenKvCache : public QwenInferenceState {
     bool has_position_input_{false};
     bool binding_mode_initialized_{false};
     bool native_kv_update_enabled_{false};
+    bool dynamic_binding_enabled_{false};
     DType cache_dtype_{DType::kFloat32};
     std::size_t cache_element_size_{sizeof(float)};
     QwenKvCacheNames names_;

--- a/families/qwen/runtime/plugin.cpp
+++ b/families/qwen/runtime/plugin.cpp
@@ -38,6 +38,7 @@ struct RuntimeConfig {
     std::string tensor_parallel_mode;
     std::string precision;
     std::string decoder_engine_layout;
+    bool dynamic_kv_cache;
 };
 
 template <typename T>
@@ -72,13 +73,19 @@ RuntimeConfig parse_runtime_config(const BundleReader& bundle) {
     }
     if (!json.is_object())
         throw std::runtime_error("qwen runtime.json must be an object");
-    if (json.size() != 14 && json.size() != 16)
+    const bool native_kv_cache = json.contains("native_kv_cache");
+    const bool dynamic_kv_cache = json.contains("dynamic_kv_cache");
+    const std::size_t expected_fields = 14 + (native_kv_cache ? 2 : 0) + (dynamic_kv_cache ? 1 : 0);
+    if (json.size() != expected_fields)
         throw std::runtime_error("qwen runtime.json has an unexpected field set");
-    if (json.size() == 16 &&
-        (!require_value<bool>(json, "native_kv_cache") ||
-         require_value<std::int32_t>(json, "native_kv_contract_version") != 1)) {
+    if (native_kv_cache && (!require_value<bool>(json, "native_kv_cache") ||
+                            require_value<std::int32_t>(json, "native_kv_contract_version") != 1)) {
         throw std::runtime_error("qwen runtime.json has an invalid native KV contract");
     }
+    if (dynamic_kv_cache && !require_value<bool>(json, "dynamic_kv_cache"))
+        throw std::runtime_error("qwen runtime.json has an invalid dynamic KV contract");
+    if (dynamic_kv_cache && native_kv_cache)
+        throw std::runtime_error("qwen runtime.json declares incompatible KV contracts");
 
     RuntimeConfig config{
         require_value<std::int32_t>(json, "hidden_size"),
@@ -95,6 +102,7 @@ RuntimeConfig parse_runtime_config(const BundleReader& bundle) {
         require_value<std::string>(json, "tensor_parallel_mode"),
         require_value<std::string>(json, "precision"),
         require_value<std::string>(json, "decoder_engine_layout"),
+        dynamic_kv_cache,
     };
     if (config.hidden_size <= 0 || config.num_layers <= 0 || config.num_heads <= 0 ||
         config.num_key_value_heads <= 0 || config.head_dim <= 0 || config.vocab_size <= 0 ||
@@ -112,6 +120,11 @@ RuntimeConfig parse_runtime_config(const BundleReader& bundle) {
     }
     if (config.decoder_engine_layout == "split" && config.tensor_parallel_size != 1)
         throw std::runtime_error("qwen split engines require tensor_parallel_size=1");
+    if (config.dynamic_kv_cache && config.decoder_engine_layout != "dual_profile") {
+        throw std::runtime_error("runtime-sized Qwen KV cache requires a dual-profile engine");
+    }
+    if (config.dynamic_kv_cache && config.tensor_parallel_size != 1)
+        throw std::runtime_error("runtime-sized Qwen KV cache requires single-device execution");
     const std::string expected_mode =
         config.tensor_parallel_size > 1 ? "tensor_parallel" : "single";
     if (config.tensor_parallel_mode != expected_mode)
@@ -169,6 +182,14 @@ std::int32_t prefill_token_limit(const ITrtModule& module) {
     return static_cast<std::int32_t>(shape.front());
 }
 
+std::int32_t runtime_cache_rows(const FamilyContext& context, const RuntimeConfig& config) {
+    if (context.kv_cache_size_bytes == 0)
+        return config.max_cache_length;
+    return qwen::runtime_cache_rows(context.kv_cache_size_bytes, config.max_cache_length,
+                                    config.num_layers, config.num_key_value_heads, config.head_dim,
+                                    cache_dtype(config.precision));
+}
+
 DecoderModules load_modules(const FamilyContext& context, const RuntimeConfig& config) {
     DistributedRuntimeGroup group = initialize_tensor_parallel_group(config.tensor_parallel_size);
     DecoderModules modules;
@@ -204,16 +225,25 @@ DecoderModules load_modules(const FamilyContext& context, const RuntimeConfig& c
 
 ITask* create(const FamilyContext& context) {
     const RuntimeConfig config = parse_runtime_config(context.reader);
+    if (context.kv_cache_size_bytes != 0 && !config.dynamic_kv_cache) {
+        throw std::invalid_argument(
+            "--kv-cache-size requires a bundle built with --dynamic-kv-cache");
+    }
     DecoderModules modules = load_modules(context, config);
     const cudaStream_t stream = modules.decode->stream();
     const std::int32_t kv_dim =
         (config.num_key_value_heads / config.tensor_parallel_size) * config.head_dim;
-    auto state = std::make_unique<QwenKvCache>(config.num_layers, config.max_cache_length, kv_dim,
-                                               stream, cache_dtype(config.precision),
+    validate_kv_row_contract(*modules.prefill, config.dynamic_kv_cache, config.num_layers, kv_dim,
+                             config.max_cache_length, "qwen prefill");
+    validate_kv_row_contract(*modules.decode, config.dynamic_kv_cache, config.num_layers, kv_dim,
+                             config.max_cache_length, "qwen decode");
+    const std::int32_t cache_rows = runtime_cache_rows(context, config);
+    auto state = std::make_unique<QwenKvCache>(config.num_layers, cache_rows, kv_dim, stream,
+                                               cache_dtype(config.precision),
                                                make_kv_names(config.num_layers));
     if (!state->ok())
         throw std::runtime_error("qwen failed to create KV cache");
-    std::cerr << "[trtmc] KV cache rows=" << config.max_cache_length
+    std::cerr << "[trtmc] KV cache rows=" << cache_rows
               << " (bundle max=" << config.max_cache_length << ")\n";
 
     QwenTextGenConfig text_config;
@@ -234,7 +264,5 @@ ITask* create(const FamilyContext& context) {
 } // namespace trtmc::qwen
 
 extern "C" trtmc::ITask* trtmc_create_family(const trtmc::FamilyContext& context) {
-    if (context.kv_cache_size_bytes != 0)
-        throw std::invalid_argument("qwen does not support --kv-cache-size");
     return trtmc::qwen::create(context);
 }

--- a/families/qwen/runtime/plugin_helpers.cpp
+++ b/families/qwen/runtime/plugin_helpers.cpp
@@ -5,6 +5,10 @@
 
 #include "families/qwen/runtime/plugin_helpers.h"
 
+#include "families/qwen/runtime/tensor_names.h"
+
+#include <algorithm>
+#include <limits>
 #include <stdexcept>
 
 namespace trtmc::qwen {
@@ -36,6 +40,65 @@ std::shared_ptr<ITokenizer> create_tokenizer(const BundleReader& bundle) {
     if (tokenizer == nullptr)
         throw std::runtime_error("qwen BPE tokenizer construction failed");
     return std::shared_ptr<ITokenizer>(std::move(tokenizer));
+}
+
+namespace {
+
+std::uint64_t checked_multiply(std::uint64_t left, std::uint64_t right) {
+    if (left != 0 && right > std::numeric_limits<std::uint64_t>::max() / left)
+        throw std::overflow_error("qwen KV cache byte accounting overflow");
+    return left * right;
+}
+
+} // namespace
+
+void validate_kv_row_contract(const ITrtModule& module, bool runtime_sized, std::int32_t num_layers,
+                              std::int32_t kv_dim, std::int32_t bundle_max_rows,
+                              const char* label) {
+    for (std::int32_t layer = 0; layer < num_layers; ++layer) {
+        for (const char* prefix : {"cache_k", "cache_v"}) {
+            const std::string name = qwen_layer_tensor_name(prefix, layer);
+            if (!module.has_input(name) || module.input_is_dynamic(name) != runtime_sized) {
+                throw std::runtime_error(std::string(label) +
+                                         " engine does not match the dynamic KV contract");
+            }
+            if (!runtime_sized)
+                continue;
+            const auto minimum =
+                module.input_profile_shape(name, module.profile_idx(), ProfileShapeSelector::kMin);
+            const auto maximum =
+                module.input_profile_shape(name, module.profile_idx(), ProfileShapeSelector::kMax);
+            if (module.input_rank(name) != 2 || minimum != std::vector<std::int64_t>{1, kv_dim} ||
+                maximum != std::vector<std::int64_t>{bundle_max_rows, kv_dim}) {
+                throw std::runtime_error(std::string(label) +
+                                         " engine has invalid dynamic KV row dimensions");
+            }
+        }
+    }
+    if (runtime_sized &&
+        (!module.has_input("attention_mask") || !module.input_is_dynamic("attention_mask") ||
+         module.input_rank("attention_mask") != 2)) {
+        throw std::runtime_error(std::string(label) +
+                                 " engine must expose a dynamic rank-2 attention mask");
+    }
+}
+
+std::int32_t runtime_cache_rows(std::uint64_t requested_bytes, std::int32_t bundle_max_rows,
+                                std::int32_t num_layers, std::int32_t num_key_value_heads,
+                                std::int32_t head_dim, DType cache_dtype) {
+    if (requested_bytes == 0)
+        return bundle_max_rows;
+    const std::uint64_t kv_dim = checked_multiply(static_cast<std::uint64_t>(num_key_value_heads),
+                                                  static_cast<std::uint64_t>(head_dim));
+    const std::uint64_t row_bytes = checked_multiply(
+        checked_multiply(checked_multiply(static_cast<std::uint64_t>(num_layers), kv_dim),
+                         static_cast<std::uint64_t>(dtype_size(cache_dtype))),
+        2);
+    const std::uint64_t requested_rows = requested_bytes / row_bytes;
+    if (requested_rows == 0)
+        throw std::invalid_argument("--kv-cache-size is smaller than one Qwen KV cache row");
+    return static_cast<std::int32_t>(
+        std::min(requested_rows, static_cast<std::uint64_t>(bundle_max_rows)));
 }
 
 } // namespace trtmc::qwen

--- a/families/qwen/runtime/plugin_helpers.h
+++ b/families/qwen/runtime/plugin_helpers.h
@@ -9,6 +9,7 @@
 #include "trtmc/bundle.h"
 #include "trtmc/runtime/trt_backend.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -21,5 +22,10 @@ std::string require_text_section(const BundleReader& bundle, std::string_view na
 std::unique_ptr<ITrtModule> load_engine(IBackend& backend, const std::vector<char>& plan,
                                         const char* label);
 std::shared_ptr<ITokenizer> create_tokenizer(const BundleReader& bundle);
+void validate_kv_row_contract(const ITrtModule& module, bool runtime_sized, std::int32_t num_layers,
+                              std::int32_t kv_dim, std::int32_t bundle_max_rows, const char* label);
+std::int32_t runtime_cache_rows(std::uint64_t requested_bytes, std::int32_t bundle_max_rows,
+                                std::int32_t num_layers, std::int32_t num_key_value_heads,
+                                std::int32_t head_dim, DType cache_dtype);
 
 } // namespace trtmc::qwen

--- a/families/qwen/standard_decoder_builder.py
+++ b/families/qwen/standard_decoder_builder.py
@@ -117,6 +117,7 @@ def build_standard_decoder_engine(
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #
+    dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
     _dual_profile_disabled_for = (
         embed_input
         or debug_layer_outputs
@@ -126,7 +127,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    if dynamic_kv_cache and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "runtime-sized Qwen KV cache does not support specialized decoder inputs")
+    use_dynamic_sequence_builder = (
+        decoder_engine_role in ("dual_profile", "prefill")
+        or (dynamic_kv_cache and decoder_engine_role == "decode")
+    )
+    if not _dual_profile_disabled_for and use_dynamic_sequence_builder:
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -140,8 +148,9 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
-            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
+            profile_mode=decoder_engine_role,
             full_logits_output=full_logits_output,
+            runtime_sized_kv_cache=dynamic_kv_cache,
         )
 
     if full_logits_output:

--- a/families/qwen/tests/cpp/native_kv_cache_contract_test.h
+++ b/families/qwen/tests/cpp/native_kv_cache_contract_test.h
@@ -44,9 +44,11 @@ class NativeKvModuleStub final : public ITrtModule {
     NativeKvModuleStub(cudaStream_t stream, int32_t layers, int32_t capacity, int32_t kv_heads,
                        int32_t head_dim, DType dtype, bool native = true,
                        std::shared_ptr<NativeKvTrace> trace = nullptr, int32_t profile_limit = 4,
-                       int32_t vocab_size = 16, std::vector<int32_t> token_profile_max_lengths = {})
+                       int32_t vocab_size = 16, std::vector<int32_t> token_profile_max_lengths = {},
+                       bool dynamic_cache = false, bool dynamic_mask = false)
         : stream_(stream), native_(native), trace_(std::move(trace)), vocab_size_(vocab_size),
-          token_profile_max_lengths_(std::move(token_profile_max_lengths)) {
+          token_profile_max_lengths_(std::move(token_profile_max_lengths)),
+          dynamic_cache_(dynamic_cache), dynamic_mask_(dynamic_mask) {
         if (native_) {
             add("cache_write_indices", {1}, DType::kInt32, true);
             add("key_value_lengths", {1}, DType::kInt32, true);
@@ -77,6 +79,8 @@ class NativeKvModuleStub final : public ITrtModule {
         entry.shape = std::move(shape);
         entry.dtype = dtype;
     }
+
+    void set_dynamic(const std::string& name, bool value) { dynamic_overrides_[name] = value; }
 
     TensorMap forward(const TensorMap& inputs) override {
         if (!trace_)
@@ -120,6 +124,12 @@ class NativeKvModuleStub final : public ITrtModule {
                     : token_profile_max_lengths_.at(static_cast<std::size_t>(profile_idx));
             return {tokens};
         }
+        if (dynamic_cache_ && (name.rfind("cache_k_", 0) == 0 || name.rfind("cache_v_", 0) == 0)) {
+            auto shape = tensor_shape(name);
+            if (selector == ProfileShapeSelector::kMin && shape.size() == 2)
+                shape[0] = 1;
+            return shape;
+        }
         return tensor_shape(name);
     }
     int32_t optimization_profile_count() const override {
@@ -150,7 +160,14 @@ class NativeKvModuleStub final : public ITrtModule {
     int32_t input_rank(const std::string& name) const override {
         return has_input(name) ? static_cast<int32_t>(tensor_shape(name).size()) : 0;
     }
-    bool input_is_dynamic(const std::string&) const override { return false; }
+    bool input_is_dynamic(const std::string& name) const override {
+        const auto override = dynamic_overrides_.find(name);
+        if (override != dynamic_overrides_.end())
+            return override->second;
+        if (name == "attention_mask")
+            return dynamic_mask_;
+        return dynamic_cache_ && (name.rfind("cache_k_", 0) == 0 || name.rfind("cache_v_", 0) == 0);
+    }
     void reset_execution_context() override {}
     void set_timing_label(std::string) override {}
     bool ok() const override { return stream_ != nullptr; }
@@ -185,10 +202,13 @@ class NativeKvModuleStub final : public ITrtModule {
     std::shared_ptr<NativeKvTrace> trace_;
     int32_t vocab_size_;
     std::vector<int32_t> token_profile_max_lengths_;
+    bool dynamic_cache_{false};
+    bool dynamic_mask_{false};
     std::vector<float> logits_;
     std::unordered_map<std::string, Entry> tensors_;
     std::unordered_map<std::string, void*> bindings_;
     std::unordered_map<std::string, std::vector<int64_t>> binding_shapes_;
+    std::unordered_map<std::string, bool> dynamic_overrides_;
     std::vector<std::shared_ptr<void>> keep_alive_;
 };
 
@@ -287,6 +307,62 @@ int run_native_kv_contract_tests(const char* model) {
         check(cache.needs_attention_mask() && inputs.count("attention_mask") == 1 &&
                   inputs.count("cache_write_indices") == 0 && cache.position() == 1,
               "standard attention-mask cache path still advances normally");
+    }
+
+    {
+        Cache cache(1, 7, 2, stream, DType::kFloat16);
+        NativeKvModuleStub prefill(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16, {},
+                                   true, true);
+        NativeKvModuleStub decode(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16, {},
+                                  true, true);
+
+        cache.bind_cache_inputs(prefill);
+        TensorMap prefill_inputs;
+        cache.prepare_step(prefill_inputs, 3);
+        const auto* prefill_positions =
+            static_cast<const std::int32_t*>(prefill_inputs.at("position_id").data);
+        check(prefill.bound_shape("cache_k_0") == std::vector<int64_t>({7, 2}) &&
+                  prefill.bound_shape("cache_v_0") == std::vector<int64_t>({7, 2}) &&
+                  prefill_inputs.at("attention_mask").shape == std::vector<int64_t>({3, 10}) &&
+                  prefill_inputs.at("position_id").shape == std::vector<int64_t>({3}) &&
+                  prefill_positions[0] == 0 && prefill_positions[2] == 2,
+              "runtime-sized prefill binds rows, mask, and positions");
+
+        cache.bind_to(decode);
+        TensorMap decode_inputs;
+        cache.prepare_step(decode_inputs);
+        const auto* decode_position =
+            static_cast<const std::int32_t*>(decode_inputs.at("position_id").data);
+        check(decode.bound_shape("cache_k_0") == std::vector<int64_t>({7, 2}) &&
+                  decode.bound_shape("cache_v_0") == std::vector<int64_t>({7, 2}) &&
+                  decode_inputs.at("attention_mask").shape == std::vector<int64_t>({1, 8}) &&
+                  decode_inputs.at("position_id").shape == std::vector<int64_t>({1}) &&
+                  decode_position[0] == 0 && decode.device_ptr("present_k_0") != nullptr &&
+                  decode.device_ptr("present_v_0") != nullptr,
+              "runtime-sized decode binds rows, mask, positions, and present outputs");
+    }
+
+    {
+        Cache cache(1, 7, 2, stream, DType::kFloat16);
+        NativeKvModuleStub malformed(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16,
+                                     {}, true, false);
+        bool rejected = false;
+        try {
+            cache.bind_to(malformed);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        check(rejected, "runtime-sized cache rejects a static attention mask");
+    }
+
+    {
+        Cache cache(1, 11, 2, stream, DType::kFloat16);
+        NativeKvModuleStub prefill(stream, 1, 11, 1, 2, DType::kFloat16, false, nullptr, 4, 16, {},
+                                   false, true);
+        cache.bind_cache_inputs(prefill);
+        check(prefill.device_ptr("cache_k_0") == cache.cache_k(0).data() &&
+                  prefill.bound_shape("cache_k_0").empty(),
+              "static cache accepts the dynamic batched-prefill mask contract");
     }
 
     const auto make_config = [] {

--- a/families/qwen/tests/cpp/test_qwen_plugin_helpers.cpp
+++ b/families/qwen/tests/cpp/test_qwen_plugin_helpers.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/qwen/runtime/plugin_helpers.h"
+#include "families/qwen/tests/cpp/native_kv_cache_contract_test.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", name);
+        ++failures;
+    }
+}
+
+template <typename Exception, typename Function>
+bool rejects(Function function) {
+    try {
+        function();
+    } catch (const Exception&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+void test_row_math() {
+    constexpr std::int32_t max_rows = 64;
+    constexpr std::uint64_t fp16_row_bytes = 2 * 3 * 4 * 8 * 2;
+
+    check(trtmc::qwen::runtime_cache_rows(0, max_rows, 3, 4, 8, trtmc::DType::kFloat16) == max_rows,
+          "zero bytes select bundle capacity");
+    check(trtmc::qwen::runtime_cache_rows(fp16_row_bytes * 7, max_rows, 3, 4, 8,
+                                          trtmc::DType::kFloat16) == 7,
+          "FP16 byte budget selects complete rows");
+    check(trtmc::qwen::runtime_cache_rows(fp16_row_bytes * 7 + fp16_row_bytes - 1, max_rows, 3, 4,
+                                          8, trtmc::DType::kFloat16) == 7,
+          "partial row bytes are not counted");
+    check(trtmc::qwen::runtime_cache_rows(fp16_row_bytes * 5, max_rows, 3, 4, 8,
+                                          trtmc::DType::kBFloat16) == 5,
+          "BF16 uses two-byte cache elements");
+    check(trtmc::qwen::runtime_cache_rows(fp16_row_bytes * 2 * 6, max_rows, 3, 4, 8,
+                                          trtmc::DType::kFloat32) == 6,
+          "FP32 uses four-byte cache elements");
+    check(trtmc::qwen::runtime_cache_rows(fp16_row_bytes * 100, max_rows, 3, 4, 8,
+                                          trtmc::DType::kFloat16) == max_rows,
+          "byte budget clamps to bundle capacity");
+    check(rejects<std::invalid_argument>([&] {
+              (void)trtmc::qwen::runtime_cache_rows(fp16_row_bytes - 1, max_rows, 3, 4, 8,
+                                                    trtmc::DType::kFloat16);
+          }),
+          "sub-row byte budget is rejected");
+    check(rejects<std::overflow_error>([] {
+              constexpr auto maximum = std::numeric_limits<std::int32_t>::max();
+              (void)trtmc::qwen::runtime_cache_rows(std::numeric_limits<std::uint64_t>::max(), 64,
+                                                    maximum, maximum, maximum,
+                                                    trtmc::DType::kFloat32);
+          }),
+          "row byte overflow is rejected");
+}
+
+void test_engine_contract() {
+    using trtmc::test::NativeKvModuleStub;
+    const auto stream = reinterpret_cast<cudaStream_t>(static_cast<std::uintptr_t>(1));
+
+    NativeKvModuleStub prefill(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4, 16,
+                               {}, true, true);
+    NativeKvModuleStub decode(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4, 16,
+                              {}, true, true);
+    trtmc::qwen::validate_kv_row_contract(prefill, true, 2, 32, 64, "prefill");
+    trtmc::qwen::validate_kv_row_contract(decode, true, 2, 32, 64, "decode");
+
+    NativeKvModuleStub mixed_prefill(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                     16, {}, true, true);
+    mixed_prefill.set_dynamic("cache_v_1", false);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(mixed_prefill, true, 2, 32, 64, "prefill");
+          }),
+          "prefill rejects mixed dynamic and static cache inputs");
+
+    NativeKvModuleStub mixed_decode(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                    16, {}, true, true);
+    mixed_decode.set_dynamic("cache_k_1", false);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(mixed_decode, true, 2, 32, 64, "decode");
+          }),
+          "decode rejects mixed dynamic and static cache inputs");
+
+    NativeKvModuleStub wrong_rank(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                  16, {}, true, true);
+    wrong_rank.set_tensor("cache_k_0", {64, 32, 1}, trtmc::DType::kFloat16);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(wrong_rank, true, 2, 32, 64, "prefill");
+          }),
+          "dynamic cache rejects a non-rank-2 input");
+
+    NativeKvModuleStub wrong_width(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                   16, {}, true, true);
+    wrong_width.set_tensor("cache_v_0", {64, 31}, trtmc::DType::kFloat16);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(wrong_width, true, 2, 32, 64, "decode");
+          }),
+          "dynamic cache rejects the wrong KV width");
+
+    NativeKvModuleStub static_mask(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                   16, {}, true, false);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(static_mask, true, 2, 32, 64, "prefill");
+          }),
+          "dynamic cache rejects a static attention mask");
+
+    NativeKvModuleStub wrong_ceiling(stream, 2, 63, 4, 8, trtmc::DType::kFloat16, false, nullptr, 4,
+                                     16, {}, true, true);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(wrong_ceiling, true, 2, 32, 64, "decode");
+          }),
+          "dynamic cache rejects a profile below the bundle ceiling");
+
+    NativeKvModuleStub unexpected_dynamic(stream, 2, 64, 4, 8, trtmc::DType::kFloat16, false);
+    unexpected_dynamic.set_dynamic("cache_k_1", true);
+    check(rejects<std::runtime_error>([&] {
+              trtmc::qwen::validate_kv_row_contract(unexpected_dynamic, false, 2, 32, 64, "decode");
+          }),
+          "static contract rejects one dynamic cache input");
+}
+
+} // namespace
+
+int main() {
+    test_row_math();
+    test_engine_contract();
+    return failures;
+}

--- a/families/qwen/tests/manifests/qwen2.5-0.5b-dynamic-kv.json
+++ b/families/qwen/tests/manifests/qwen2.5-0.5b-dynamic-kv.json
@@ -1,0 +1,36 @@
+{
+  "name": "qwen2.5-0.5b-dynamic-kv",
+  "hf_id": "Qwen/Qwen2.5-0.5B-Instruct",
+  "hf_revision": "a338b55dd21219a5f4da42bc11a9313d1a27d4cc",
+  "bundle": "qwen2.5-0.5b-dynamic-kv.bundle",
+  "family": "qwen",
+  "task": "text_generation",
+  "precision": "fp16",
+  "trust_remote_code": false,
+  "testcases": [
+    {
+      "name": "qwen2.5-0.5b-dynamic-kv",
+      "premerge": true,
+      "reference_precision": "fp32",
+      "prompt_repeat": {
+        "text": "hello",
+        "separator": " ",
+        "count": 80,
+        "suffix": " What is the capital of France? Answer in one word."
+      },
+      "minimum_prompt_tokens": 65,
+      "max_new_tokens": 2,
+      "temperature": 0.0,
+      "top_k": 1,
+      "use_chat_template": true,
+      "kv_cache_size": "2359296",
+      "expected_runtime_kv_cache_rows": 192,
+      "expected_answers": [
+        "Paris"
+      ]
+    }
+  ],
+  "max_sequence_length": 256,
+  "tensor_parallel_size": 1,
+  "dynamic_kv_cache": true
+}

--- a/families/qwen/tests/test_dynamic_kv_contract.py
+++ b/families/qwen/tests/test_dynamic_kv_contract.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU contracts for the family-owned Qwen runtime-sized KV route."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tensorrt")
+
+from tensorrt_model_connect.build import BuildRequest  # noqa: E402
+
+from .. import model as qwen_model  # noqa: E402
+from .. import standard_decoder_builder  # noqa: E402
+from ..config import ModelConfig  # noqa: E402
+from ..dual_profile_decoder_builder import _resolve_prefill_lengths  # noqa: E402
+from .test_e2e import _assert_runtime_sized_kv_receipt  # noqa: E402
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.header: dict[str, str] = {}
+        self.bytes: dict[str, bytes] = {}
+        self.json: dict[str, dict] = {}
+
+    def set_header(self, **values: str) -> None:
+        self.header = values
+
+    def add_bytes(self, name: str, value: bytes) -> None:
+        self.bytes[name] = value
+
+    def add_json(self, name: str, value: dict) -> None:
+        self.json[name] = value
+
+
+def _request(tmp_path: Path, **updates) -> BuildRequest:
+    values = {
+        "model_dir": tmp_path,
+        "output_path": tmp_path / "model.bundle",
+        "family": "qwen",
+        "task": "text_generation",
+        "precision": "fp16",
+        "max_sequence_length": 64,
+        "dynamic_kv_cache": True,
+    }
+    values.update(updates)
+    return BuildRequest(**values)
+
+
+def _config(model_type: str) -> ModelConfig:
+    return ModelConfig.create_tiny(
+        model_type,
+        architectures=[f"{model_type.title()}ForCausalLM"],
+        hidden_act="silu",
+    )
+
+
+def test_qwen2_dynamic_kv_builds_one_dual_profile_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config("qwen2")
+    calls: list[dict] = []
+    monkeypatch.setattr(qwen_model.ModelConfig, "from_dir", lambda _path: config)
+    monkeypatch.setattr(qwen_model._QwenModel, "load_weights", lambda *_args, **_kwargs: {})
+
+    def build_engine(_self, observed_config, _weights, max_cache_length, **kwargs):
+        calls.append(
+            {
+                "raw": dict(observed_config.raw),
+                "max_cache_length": max_cache_length,
+                "kwargs": kwargs,
+            }
+        )
+        return b"dynamic-plan"
+
+    monkeypatch.setattr(qwen_model._QwenModel, "build_engine", build_engine)
+    writer = _Writer()
+
+    qwen_model.build(_request(tmp_path), writer)
+
+    assert writer.header == {"family": "qwen", "task": "text_generation", "backend": "trt"}
+    assert writer.bytes == {"engine.plan": b"dynamic-plan"}
+    assert len(calls) == 1
+    assert calls[0]["raw"]["dynamic_kv_cache"] is True
+    assert calls[0]["raw"]["_decoder_engine_role"] == "dual_profile"
+    assert calls[0]["max_cache_length"] == 64
+    assert writer.json["runtime.json"]["dynamic_kv_cache"] is True
+    assert writer.json["runtime.json"]["decoder_engine_layout"] == "dual_profile"
+
+
+@pytest.mark.parametrize(
+    ("model_type", "updates", "message"),
+    [
+        ("qwen3", {}, "fixed-capacity native KV"),
+        ("qwen2", {"tensor_parallel_size": 2}, "tensor parallelism"),
+        ("qwen2", {"quantization": "fp8"}, "quantization"),
+    ],
+)
+def test_dynamic_kv_unsupported_routes_fail_before_loading_weights(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    updates: dict,
+    message: str,
+) -> None:
+    monkeypatch.setattr(qwen_model.ModelConfig, "from_dir", lambda _path: _config(model_type))
+
+    def unexpected_load(*_args, **_kwargs):
+        raise AssertionError("weights must not load for an unsupported dynamic KV request")
+
+    monkeypatch.setattr(qwen_model._QwenModel, "load_weights", unexpected_load)
+
+    with pytest.raises(NotImplementedError, match=message):
+        qwen_model.build(_request(tmp_path, **updates), _Writer())
+
+
+@pytest.mark.parametrize("role", ["dual_profile", "decode"])
+def test_standard_decoder_routes_dynamic_kv_to_runtime_sized_profiles(
+    monkeypatch: pytest.MonkeyPatch, role: str
+) -> None:
+    config = _config("qwen2")
+    config.raw["dynamic_kv_cache"] = True
+    config.raw["_decoder_engine_role"] = role
+    calls: list[dict] = []
+
+    def build_dual(_config, _weights, _max_cache_length, **kwargs):
+        calls.append(kwargs)
+        return b"plan"
+
+    monkeypatch.setattr(
+        standard_decoder_builder,
+        "build_dual_profile_decoder_engine",
+        build_dual,
+    )
+
+    assert standard_decoder_builder.build_standard_decoder_engine(config, {}, 64) == b"plan"
+    assert len(calls) == 1
+    assert calls[0]["profile_mode"] == role
+    assert calls[0]["runtime_sized_kv_cache"] is True
+
+
+def test_dynamic_kv_prefill_profile_keeps_the_bundle_limit() -> None:
+    assert _resolve_prefill_lengths(
+        256,
+        64,
+        None,
+        native_kv_cache=False,
+        profile_mode="dual_profile",
+    ) == (64, 256)
+
+
+def test_runtime_sized_receipt_requires_selected_rows() -> None:
+    manifest = {"dynamic_kv_cache": True, "max_sequence_length": 256}
+    case = {"kv_cache_size": "2359296", "expected_runtime_kv_cache_rows": 192}
+    payload = {
+        "runtime_command": ["trtmc", "run", "model.bundle", "--kv-cache-size", "2359296"],
+        "runtime_stderr": "[trtmc] KV cache rows=192 (bundle max=256)\n",
+    }
+
+    _assert_runtime_sized_kv_receipt(payload, manifest, case)
+    with pytest.raises(AssertionError):
+        _assert_runtime_sized_kv_receipt(
+            {**payload, "runtime_stderr": "[trtmc] KV cache rows=256 (bundle max=256)\n"},
+            manifest,
+            case,
+        )

--- a/families/qwen/tests/test_e2e.py
+++ b/families/qwen/tests/test_e2e.py
@@ -152,6 +152,7 @@ def _build_bundle(manifest: dict, model_dir: Path, bundle: Path) -> None:
             tensor_parallel_size=manifest["tensor_parallel_size"],
             quantization=quantization,
             fp32_layers=fp32_layers,
+            dynamic_kv_cache=bool(manifest.get("dynamic_kv_cache", False)),
         )
     )
     assert bundle.is_file() and bundle.stat().st_size > 0, bundle
@@ -205,6 +206,8 @@ def _native_arguments(bundle: Path, runtime_root: Path, prompt: str, case: dict)
         if isinstance(value, bool):
             value = "true" if value else "false"
         arguments.extend([option, str(value)])
+    if "kv_cache_size" in case:
+        arguments.extend(["--kv-cache-size", str(case["kv_cache_size"])])
     return arguments
 
 
@@ -251,6 +254,20 @@ def _run_native(
     payload["runtime_stderr"] = completed.stderr
     payload["runtime_command"] = command
     return payload
+
+
+def _assert_runtime_sized_kv_receipt(payload: dict, manifest: dict, case: dict) -> None:
+    if "expected_runtime_kv_cache_rows" not in case:
+        return
+    expected = int(case["expected_runtime_kv_cache_rows"])
+    assert manifest.get("dynamic_kv_cache") is True
+    command = payload["runtime_command"]
+    option = command.index("--kv-cache-size")
+    assert command[option + 1] == str(case["kv_cache_size"])
+    assert (
+        f"KV cache rows={expected} (bundle max={manifest['max_sequence_length']})"
+        in payload["runtime_stderr"]
+    )
 
 
 def _raw_prompt_token_count(model_dir: Path, manifest: dict, prompt: str) -> int:
@@ -689,6 +706,10 @@ def test_e2e(case_name: str, request, tmp_path: Path) -> None:
     binary, runtime_root, torch = _required_environment(tp_size)
     model_dir = _checkpoint(manifest)
     prompt = _prompt(case)
+    if "minimum_prompt_tokens" in case:
+        assert _raw_prompt_token_count(model_dir, manifest, prompt) >= int(
+            case["minimum_prompt_tokens"]
+        )
     bundle = tmp_path / manifest["bundle"]
 
     _build_bundle(manifest, model_dir, bundle)
@@ -702,6 +723,7 @@ def test_e2e(case_name: str, request, tmp_path: Path) -> None:
         tp_size,
         tmp_path,
     )
+    _assert_runtime_sized_kv_receipt(payload, manifest, case)
     if case_name in _LOGIT_ORACLES:
         payload["logits_trace"] = _native_logits_trace(bundle, prompt, case, tp_size, tmp_path)
     reruns = int(case.get("determinism_reruns", 0))

--- a/tools/tests/test_architecture.py
+++ b/tools/tests/test_architecture.py
@@ -571,6 +571,21 @@ def test_every_builder_handles_every_family_owned_request_field() -> None:
     assert violations == []
 
 
+def _assigns_true_to_subscript(tree: ast.AST, key: str) -> bool:
+    return any(
+        isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is True
+        and any(
+            isinstance(target, ast.Subscript)
+            and isinstance(target.slice, ast.Constant)
+            and target.slice.value == key
+            for target in node.targets
+        )
+        for node in ast.walk(tree)
+    )
+
+
 def test_runtime_sized_kv_build_flag_is_direct_and_family_owned() -> None:
     build_api = REPO / "core/builder/tensorrt_model_connect/build.py"
     build_tree = ast.parse(build_api.read_text(encoding="utf-8"), filename=str(build_api))
@@ -590,6 +605,7 @@ def test_runtime_sized_kv_build_flag_is_direct_and_family_owned() -> None:
     assert isinstance(field.value, ast.Constant) and field.value.value is False
 
     owners: list[str] = []
+    implementations: list[str] = []
     for family in family_dirs():
         model = family / "model.py"
         source = model.read_text(encoding="utf-8")
@@ -602,12 +618,18 @@ def test_runtime_sized_kv_build_flag_is_direct_and_family_owned() -> None:
             for node in ast.walk(tree)
         ):
             owners.append(family.name)
-        if family.name != "llama":
-            assert (
-                f'raise NotImplementedError("{family.name} does not support dynamic_kv_cache")'
-                in source
-            )
+        rejection = (
+            f'raise NotImplementedError("{family.name} does not support dynamic_kv_cache")'
+            in source
+        )
+        implementation = _assigns_true_to_subscript(tree, "dynamic_kv_cache")
+        assert rejection != implementation, (
+            f"{family.name} must either reject dynamic_kv_cache or write its runtime contract"
+        )
+        if implementation:
+            implementations.append(family.name)
     assert owners == [family.name for family in family_dirs()]
+    assert implementations
 
 
 def test_runtime_sized_kv_budget_is_direct_and_family_owned() -> None:
@@ -619,18 +641,38 @@ def test_runtime_sized_kv_budget_is_direct_and_family_owned() -> None:
     assert "FamilyContext context{reader, configured_backend, kv_cache_size_bytes};" in loader
     assert "LoadOptions" not in factory
 
-    handlers: list[str] = []
+    implementations: list[str] = []
     for family in family_dirs():
-        plugin = family / "runtime/plugin.cpp"
-        source = plugin.read_text(encoding="utf-8")
-        if "context.kv_cache_size_bytes" in source:
-            handlers.append(family.name)
-        if family.name != "llama":
-            assert (
-                f'throw std::invalid_argument("{family.name} does not support --kv-cache-size")'
-                in source
+        source = "\n".join(
+            path.read_text(encoding="utf-8", errors="ignore")
+            for path in (family / "runtime").rglob("*")
+            if path.is_file() and path.suffix in {".h", ".hpp", ".cpp", ".cu"}
+        )
+        rejection = (
+            f'throw std::invalid_argument("{family.name} does not support --kv-cache-size")'
+            in source
+        )
+        implementation = all(
+            token in source
+            for token in (
+                'json.contains("dynamic_kv_cache")',
+                "context.kv_cache_size_bytes",
+                "input_is_dynamic",
+                "--kv-cache-size requires a bundle built with --dynamic-kv-cache",
             )
-    assert handlers == [family.name for family in family_dirs()]
+        )
+        assert rejection != implementation, (
+            f"{family.name} must either reject --kv-cache-size or implement the dynamic contract"
+        )
+        if implementation:
+            implementations.append(family.name)
+
+    build_implementations = []
+    for family in family_dirs():
+        tree = ast.parse((family / "model.py").read_text(encoding="utf-8"))
+        if _assigns_true_to_subscript(tree, "dynamic_kv_cache"):
+            build_implementations.append(family.name)
+    assert implementations == build_implementations
 
 
 def test_family_python_has_no_sibling_or_shared_model_imports() -> None:


### PR DESCRIPTION
## Background

PR #1093 retained the shared runtime-sized KV request fields but removed Qwen's implementation. Before that cutover, non-Qwen3 standard decoders could build dynamic cache-row profiles and select a smaller physical KV cache at runtime. Current Qwen bundles reject both `--dynamic-kv-cache` and `--kv-cache-size`.

## Exit Criteria

- Restore runtime-sized KV for the historically supported Qwen/Qwen2/QwQ standard-decoder path.
- Keep Qwen3 native KV, tensor parallel, and quantized dynamic requests fail closed.
- Build one dual-profile engine whose cache rows and dense attention mask accept `1..bundle max`.
- Convert the runtime byte budget into complete Qwen K/V rows and clamp it to the bundle ceiling.
- Validate every prefill/decode K/V input before binding a runtime-sized buffer.
- Keep all implementation policy in `families/qwen/**` with no Qwen-to-Llama dependency and no core extension.
- Remove the shared hardcoded family allowlist so a future family can implement the existing contract without editing shared ownership policy.

## Implementation

- Routed supported dynamic builds through Qwen's existing dual-profile decoder and wrote an explicit `dynamic_kv_cache` runtime contract.
- Added family-owned dynamic cache and attention-mask optimization profiles while preserving the full bundle prefill limit; the native-KV-only 64-token chunk limit is not applied to dense dynamic KV.
- Added Qwen-owned byte-to-row accounting for FP16, BF16, and FP32, including overflow, sub-row rejection, remainder truncation, and bundle clamping.
- Added runtime validation for every layer's cache K/V dynamic state, rank, width, and profile ceiling before allocating or binding storage.
- Bound the selected row shape to both prefill and decode modules and preserved Qwen's existing state/present-buffer lifecycle.
- Added CPU/fake contracts and a single-device Qwen2.5-0.5B dynamic premerge manifest with a prompt longer than 64 tokens and a 192-row runtime budget under a 256-row bundle ceiling.
- Added the ready dynamic case to the existing Qwen release-performance profile so catalog coverage remains complete.
- Replaced the architecture test's Llama-only allowlist with a fail-closed contract check: each family must either explicitly reject dynamic KV or implement matching build and runtime contracts.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [x] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `CI_BASE_REF=github/main PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.ci pipeline source-quality` — passed, including 117 architecture/source tests and the shared native complexity limit.
- The complete public CPU unit command (`core/builder`, benchmark, examples, and tools; excluding declared GPU/TRT markers) — 316 passed.
- In the project development image, `PYTHONPATH=core/builder:apps/benchmark:. python -m pytest families/qwen/tests -m "not gpu and not trt" -q` — 19 passed, 13 skipped by their declared environment gates.
- Built `trtmc_model_qwen`, `test_qwen_plugin_helpers`, and `test_qwen_native_kv_cache` from the exact tree — passed.
- `ctest --test-dir .ci/qwen-dynamic --output-on-failure -R "^test_qwen_plugin_helpers$"` — 1/1 CPU row/profile contract passed.
- With only GPU 0 visible, `ctest --test-dir .ci/qwen-dynamic --output-on-failure -R "^test_qwen_native_kv_cache$"` — 1/1 runtime binding/state contract passed.
- `python3 -m tools.model_ci validate` and `python3 tools/test_impact.py --validate` — valid for 99 families.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest apps/benchmark/trtmc_benchmark/tests/test_perf_matrix.py::test_release_suite_expands_profiles_and_covers_ready_catalog -q` — passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python -m tools.ci pipeline package` in the project development image — source archive, native wheel, and installed-wheel validation passed for 99 families and 105 shared libraries.
- Ruff on changed Python, clang-format check mode on changed native files, legal-header audit, and `git diff --check` — passed with 0 legal findings.

### Hardware, Environment, and Revisions

- Repository head: `b034d60368f2cf2f69d3d539f0354b8f9b6b794b`.
- Base: `d0e93c1addf12afd336ff264ad21151baa82f27b`.
- Linux aarch64, Python 3.12, CMake 3.28, CUDA 13.3; CPU tests plus one single-GPU in-memory runtime contract.
- The new E2E manifest uses public `Qwen/Qwen2.5-0.5B-Instruct` revision `a338b55dd21219a5f4da42bc11a9313d1a27d4cc`.
- No model checkpoint or generated TensorRT engine was used in completed validation.

### Not Run / Remaining Gaps

- The new Qwen2.5 dynamic manifest was not executed.
- No real Qwen/Qwen2/QwQ checkpoint was built into a dynamic TensorRT engine.
- No checkpoint inference or framework parity was run.
- No Multi-Device or NVLink test was run; this feature rejects tensor parallelism.

## Notes For Future Readers

This restores only the old standard dense-mask capability. Qwen3 continues to use its fixed-capacity native KV path. The bundle ceiling remains a build-time safety bound; `--kv-cache-size` can only reduce physical rows at runtime and is rejected for a bundle that was not built with `--dynamic-kv-cache`.

The shared changes are validation-only: one architecture test removes a hardcoded owner list, and the existing release suite covers the new ready case. Neither adds runtime configuration or a capability registry. Family source remains the contract and must either implement both sides or reject both sides.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: runtime shape, allocation, and binding contracts are covered, including one single-GPU in-memory test, but no real checkpoint engine build or inference has run yet.
