### PR TITLE
feat(runtime): restore fixed-lane task pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
 include(GNUInstallDirs)
 find_package(CUDAToolkit REQUIRED)
 find_package(nlohmann_json 3.11 REQUIRED)
+find_package(Threads REQUIRED)
 
 set(_trtmc_dependency_roots
   /usr
@@ -107,6 +108,7 @@ set_target_properties(trtmc_core PROPERTIES
 
 add_library(trtmc_runtime SHARED
   core/runtime/loader/family_loader.cpp
+  core/runtime/task_pool.cpp
 )
 target_include_directories(trtmc_runtime
   PUBLIC
@@ -119,6 +121,7 @@ target_link_libraries(trtmc_runtime
   PRIVATE
     trtmc_core
     ${CMAKE_DL_LIBS}
+    Threads::Threads
 )
 target_compile_options(trtmc_runtime PRIVATE -Wall -Wextra -Wpedantic)
 set_target_properties(trtmc_runtime PROPERTIES
@@ -393,6 +396,19 @@ if(TRTMC_BUILD_TESTS)
   )
   add_test(NAME family_loader COMMAND test_family_loader "${_trtmc_test_runtime_root}")
 
+  add_executable(test_task_pool core/runtime/tests/test_task_pool.cpp)
+  target_include_directories(test_task_pool PRIVATE
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+    ${PROJECT_SOURCE_DIR}/core
+  )
+  target_link_libraries(test_task_pool PRIVATE trtmc_runtime Threads::Threads)
+  target_compile_options(test_task_pool PRIVATE -Wall -Wextra -Wpedantic)
+  add_dependencies(test_task_pool
+    trtmc_test_backend_fake
+    trtmc_test_family_fake
+  )
+  add_test(NAME task_pool COMMAND test_task_pool "${_trtmc_test_runtime_root}")
+
   add_executable(test_trt_module_dynamic_input
     core/runtime/tests/test_trt_module_dynamic_input.cpp
   )
@@ -544,6 +560,7 @@ install(FILES
   core/runtime/include/trtmc/runtime/device_tensor.h
   core/runtime/include/trtmc/runtime/family_factory.h
   core/runtime/include/trtmc/runtime/family_loader.h
+  core/runtime/include/trtmc/runtime/task_pool.h
   core/runtime/include/trtmc/runtime/tensor.h
   core/runtime/include/trtmc/runtime/trt_backend.h
   core/runtime/include/trtmc/runtime/trt_module.h

--- a/core/runtime/include/trtmc/runtime/task_pool.h
+++ b/core/runtime/include/trtmc/runtime/task_pool.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/task.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+// Owns a fixed number of independent Task instances. One move-only lease gives
+// one caller exclusive access to one instance until the lease is destroyed.
+// The pool coordinates ownership only; it does not batch or schedule requests.
+class TaskPool {
+  private:
+    struct State;
+
+  public:
+    class Lease {
+      public:
+        Lease() = default;
+        ~Lease();
+        Lease(Lease&& other) noexcept;
+        Lease& operator=(Lease&& other) noexcept;
+        Lease(const Lease&) = delete;
+        Lease& operator=(const Lease&) = delete;
+
+        ITask* get() const;
+        ITask& operator*() const { return *get(); }
+        ITask* operator->() const { return get(); }
+        explicit operator bool() const noexcept { return state_ != nullptr; }
+
+      private:
+        friend class TaskPool;
+        Lease(std::shared_ptr<State> state, std::size_t index);
+        void release() noexcept;
+
+        std::shared_ptr<State> state_;
+        std::size_t index_{0};
+    };
+
+    explicit TaskPool(std::vector<std::unique_ptr<ITask>> tasks);
+    ~TaskPool();
+    TaskPool(TaskPool&&) noexcept;
+    TaskPool& operator=(TaskPool&&) noexcept;
+    TaskPool(const TaskPool&) = delete;
+    TaskPool& operator=(const TaskPool&) = delete;
+
+    Lease acquire();
+    std::optional<Lease> try_acquire();
+    std::size_t capacity() const;
+    std::size_t available() const;
+
+  private:
+    std::shared_ptr<State> state_;
+};
+
+// Call load_task() count times with the same direct inputs, then own those
+// independent instances in one pool.
+TaskPool load_task_pool(const std::string& bundle_path, const std::string& runtime_root,
+                        std::size_t count, std::uint64_t kv_cache_size_bytes = 0,
+                        const std::string& runtime_cache_path = {}, bool cuda_graphs = false);
+
+} // namespace trtmc

--- a/core/runtime/task_pool.cpp
+++ b/core/runtime/task_pool.cpp
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/runtime/task_pool.h"
+
+#include "trtmc/runtime/family_loader.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+
+struct TaskPool::State {
+    struct Slot {
+        std::unique_ptr<ITask> task;
+        bool leased{false};
+    };
+
+    explicit State(std::vector<std::unique_ptr<ITask>> tasks) {
+        if (tasks.empty())
+            throw std::invalid_argument("TaskPool requires at least one task");
+        slots.reserve(tasks.size());
+        for (auto& task : tasks) {
+            if (task == nullptr)
+                throw std::invalid_argument("TaskPool cannot contain a null task");
+            slots.push_back({std::move(task), false});
+        }
+        available = slots.size();
+    }
+
+    std::vector<Slot> slots;
+    std::size_t available{0};
+    mutable std::mutex mutex;
+    std::condition_variable changed;
+};
+
+TaskPool::Lease::Lease(std::shared_ptr<State> state, std::size_t index)
+    : state_(std::move(state)), index_(index) {}
+
+TaskPool::Lease::~Lease() {
+    release();
+}
+
+TaskPool::Lease::Lease(Lease&& other) noexcept
+    : state_(std::move(other.state_)), index_(other.index_) {}
+
+TaskPool::Lease& TaskPool::Lease::operator=(Lease&& other) noexcept {
+    if (this == &other)
+        return *this;
+    release();
+    state_ = std::move(other.state_);
+    index_ = other.index_;
+    return *this;
+}
+
+ITask* TaskPool::Lease::get() const {
+    if (state_ == nullptr)
+        throw std::logic_error("TaskPool lease is empty");
+    return state_->slots[index_].task.get();
+}
+
+void TaskPool::Lease::release() noexcept {
+    if (state_ == nullptr)
+        return;
+    {
+        const std::lock_guard<std::mutex> lock(state_->mutex);
+        state_->slots[index_].leased = false;
+        ++state_->available;
+    }
+    state_->changed.notify_one();
+    state_.reset();
+}
+
+TaskPool::TaskPool(std::vector<std::unique_ptr<ITask>> tasks)
+    : state_(std::make_shared<State>(std::move(tasks))) {}
+
+TaskPool::~TaskPool() = default;
+TaskPool::TaskPool(TaskPool&&) noexcept = default;
+TaskPool& TaskPool::operator=(TaskPool&&) noexcept = default;
+
+TaskPool::Lease TaskPool::acquire() {
+    if (state_ == nullptr)
+        throw std::logic_error("TaskPool is empty");
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->changed.wait(lock, [&] { return state_->available > 0; });
+    for (std::size_t index = 0; index < state_->slots.size(); ++index) {
+        auto& slot = state_->slots[index];
+        if (slot.leased)
+            continue;
+        slot.leased = true;
+        --state_->available;
+        return Lease(state_, index);
+    }
+    throw std::logic_error("TaskPool availability invariant violated");
+}
+
+std::optional<TaskPool::Lease> TaskPool::try_acquire() {
+    if (state_ == nullptr)
+        return std::nullopt;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    if (state_->available == 0)
+        return std::nullopt;
+    for (std::size_t index = 0; index < state_->slots.size(); ++index) {
+        auto& slot = state_->slots[index];
+        if (slot.leased)
+            continue;
+        slot.leased = true;
+        --state_->available;
+        return Lease(state_, index);
+    }
+    throw std::logic_error("TaskPool availability invariant violated");
+}
+
+std::size_t TaskPool::capacity() const {
+    if (state_ == nullptr)
+        return 0;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    return state_->slots.size();
+}
+
+std::size_t TaskPool::available() const {
+    if (state_ == nullptr)
+        return 0;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    return state_->available;
+}
+
+TaskPool load_task_pool(const std::string& bundle_path, const std::string& runtime_root,
+                        std::size_t count, std::uint64_t kv_cache_size_bytes,
+                        const std::string& runtime_cache_path, bool cuda_graphs) {
+    if (count == 0)
+        throw std::invalid_argument("TaskPool count must be positive");
+    std::vector<std::unique_ptr<ITask>> tasks;
+    tasks.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        tasks.push_back(load_task(bundle_path, runtime_root, kv_cache_size_bytes,
+                                  runtime_cache_path, cuda_graphs));
+    }
+    return TaskPool(std::move(tasks));
+}
+
+} // namespace trtmc

--- a/core/runtime/tests/test_task_pool.cpp
+++ b/core/runtime/tests/test_task_pool.cpp
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/bundle/bundle_format.h"
+#include "trtmc/runtime/task_pool.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+class NamedTask final : public trtmc::ITask {
+  public:
+    explicit NamedTask(std::string name) : name_(std::move(name)) {}
+    const char* task() const noexcept override { return name_.c_str(); }
+
+  private:
+    std::string name_;
+};
+
+std::vector<std::unique_ptr<trtmc::ITask>> named_tasks(std::size_t count) {
+    std::vector<std::unique_ptr<trtmc::ITask>> tasks;
+    tasks.reserve(count);
+    for (std::size_t index = 0; index < count; ++index)
+        tasks.push_back(std::make_unique<NamedTask>("task-" + std::to_string(index)));
+    return tasks;
+}
+
+bool construction_rejects(std::vector<std::unique_ptr<trtmc::ITask>> tasks) {
+    try {
+        trtmc::TaskPool pool(std::move(tasks));
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+void test_capacity_and_leases() {
+    trtmc::TaskPool pool(named_tasks(2));
+    check(pool.capacity() == 2 && pool.available() == 2, "initial capacity");
+
+    auto first = pool.acquire();
+    auto second = pool.acquire();
+    check(pool.available() == 0, "leases are exclusive");
+    check(first.get() != second.get(), "leases own distinct tasks");
+    check(!pool.try_acquire().has_value(), "try_acquire reports exhaustion");
+
+    auto moved = std::move(first);
+    check(!first && moved && pool.available() == 0, "lease move preserves ownership");
+    moved = {};
+    check(pool.available() == 1, "destroying a lease releases one task");
+    second = {};
+    check(pool.available() == 2, "all tasks return to the pool");
+}
+
+void test_blocking_acquire() {
+    trtmc::TaskPool pool(named_tasks(1));
+    auto occupied = pool.acquire();
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool started = false;
+    bool acquired = false;
+
+    std::thread waiter([&] {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            started = true;
+        }
+        changed.notify_one();
+        auto lease = pool.acquire();
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            acquired = true;
+        }
+        changed.notify_one();
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        changed.wait(lock, [&] { return started; });
+        check(!changed.wait_for(lock, std::chrono::milliseconds(20), [&] { return acquired; }),
+              "acquire blocks while the only task is leased");
+    }
+    occupied = {};
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        check(changed.wait_for(lock, std::chrono::seconds(1), [&] { return acquired; }),
+              "released task wakes one waiter");
+    }
+    waiter.join();
+    check(pool.available() == 1, "waiter returns the task after use");
+}
+
+void test_lease_outlives_pool() {
+    trtmc::TaskPool::Lease lease;
+    {
+        trtmc::TaskPool pool(named_tasks(1));
+        lease = pool.acquire();
+    }
+    check(lease && std::string(lease->task()) == "task-0", "lease keeps pool state alive");
+    lease = {};
+}
+
+void write_bundle(const std::filesystem::path& path) {
+    const std::string header =
+        R"({"format":1,"family":"fake","task":"time_series_forecast","backend":"fake","sections":{"runtime.json":{"offset":0,"length":2},"engine.plan":{"offset":2,"length":4}}})";
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(trtmc::kBundleMagic), 8);
+    const std::uint64_t length = header.size();
+    for (int shift = 0; shift < 64; shift += 8)
+        output.put(static_cast<char>((length >> shift) & 0xffU));
+    output.write(header.data(), static_cast<std::streamsize>(header.size()));
+    output.write("{}PLAN", 6);
+}
+
+void test_loader_pool(const std::filesystem::path& runtime_root) {
+    const auto bundle = runtime_root / "task-pool.bundle";
+    write_bundle(bundle);
+    bool zero_rejected = false;
+    try {
+        (void)trtmc::load_task_pool(bundle.string(), runtime_root.string(), 0);
+    } catch (const std::invalid_argument&) {
+        zero_rejected = true;
+    }
+    check(zero_rejected, "loader rejects zero capacity");
+    {
+        auto pool = trtmc::load_task_pool(bundle.string(), runtime_root.string(), 2, 4096);
+        check(pool.capacity() == 2 && pool.available() == 2, "loader creates requested capacity");
+        auto first = pool.acquire();
+        auto second = pool.acquire();
+        auto* first_forecast = dynamic_cast<trtmc::ITimeSeriesForecast*>(first.get());
+        auto* second_forecast = dynamic_cast<trtmc::ITimeSeriesForecast*>(second.get());
+        check(first_forecast != nullptr && second_forecast != nullptr,
+              "loader returns the declared Task interface");
+        check(first.get() != second.get(), "loader creates independent Task instances");
+        if (first_forecast != nullptr && second_forecast != nullptr) {
+            const float values[] = {1.0F, 2.0F};
+            const auto first_result = first_forecast->forecast({values, {}});
+            const auto second_result = second_forecast->forecast({values, {}});
+            check(first_result.shape == std::vector<std::int64_t>({4096, 2}) &&
+                      second_result.shape == first_result.shape,
+                  "loader forwards direct runtime options to every task");
+        }
+    }
+    std::filesystem::remove(bundle);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    static_assert(!std::is_copy_constructible_v<trtmc::TaskPool>);
+    static_assert(std::is_move_constructible_v<trtmc::TaskPool>);
+    static_assert(!std::is_copy_constructible_v<trtmc::TaskPool::Lease>);
+    static_assert(std::is_move_constructible_v<trtmc::TaskPool::Lease>);
+
+    check(construction_rejects({}), "empty pool is rejected");
+    auto null_tasks = named_tasks(1);
+    null_tasks.push_back(nullptr);
+    check(construction_rejects(std::move(null_tasks)), "null task is rejected");
+    test_capacity_and_leases();
+    test_blocking_acquire();
+    test_lease_outlives_pool();
+    if (argc != 2) {
+        std::cerr << "usage: test_task_pool RUNTIME_ROOT\n";
+        return 2;
+    }
+    test_loader_pool(argv[1]);
+    return failures;
+}

--- a/tools/tests/test_architecture.py
+++ b/tools/tests/test_architecture.py
@@ -297,12 +297,14 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
         "core/runtime/primitives/trt_common.cpp",
         "core/runtime/primitives/trt_common.h",
         "core/runtime/loader/family_loader.cpp",
+        "core/runtime/task_pool.cpp",
         "core/runtime/include/trtmc/byok.h",
         "core/runtime/include/trtmc/bundle.h",
         "core/runtime/include/trtmc/task.h",
         "core/runtime/include/trtmc/runtime/device_tensor.h",
         "core/runtime/include/trtmc/runtime/family_factory.h",
         "core/runtime/include/trtmc/runtime/family_loader.h",
+        "core/runtime/include/trtmc/runtime/task_pool.h",
         "core/runtime/include/trtmc/runtime/tensor.h",
         "core/runtime/include/trtmc/runtime/trt_backend.h",
         "core/runtime/include/trtmc/runtime/trt_module.h",
@@ -312,6 +314,7 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
         "core/runtime/tests/test_byok_shape_spec.cpp",
         "core/runtime/tests/test_family_loader.cpp",
         "core/runtime/tests/test_task_api.cpp",
+        "core/runtime/tests/test_task_pool.cpp",
         "core/runtime/tests/test_trt_module_dynamic_input.cpp",
     }
     expected_tools = {

--- a/website/docs/api/cpp-api.md
+++ b/website/docs/api/cpp-api.md
@@ -25,3 +25,27 @@ primitives live in `libtrtmc_core.so`. A family factory receives a
 The reader exposes immutable metadata and on-demand section reads only. The
 factory must copy the lightweight reader into its pipeline if it will read a
 section after the factory returns; it must never retain the context reference.
+
+## Independent concurrent lanes
+
+`TaskPool` creates a fixed number of independent task instances and gives one
+caller exclusive access to each instance through a move-only lease:
+
+```cpp
+#include <trtmc/runtime/task_pool.h>
+
+auto pool = trtmc::load_task_pool("gpt2.bundle", "/opt/trtmc/lib", 4);
+auto lease = pool.acquire();
+auto* text = dynamic_cast<trtmc::ITextGeneration*>(lease.get());
+if (text == nullptr) throw std::runtime_error("not a text-generation bundle");
+auto result = text->generate("Hello");
+```
+
+`acquire()` waits for a lane; `try_acquire()` returns an empty optional instead.
+Destroying or replacing the lease returns that lane to the pool. A lease keeps
+its task alive even if the pool object goes out of scope.
+
+Each lane is loaded independently, so its mutable execution context, stream,
+and model state are isolated. This also means lane memory is not shared.
+`TaskPool` is an ownership primitive, not a scheduler, batching engine, or LoRA
+adapter registry.


### PR DESCRIPTION
## Background

PR #1093 replaced the old pipeline hierarchy with typed `ITask` interfaces and removed `PipelinePool`. Applications that need concurrent requests now have no library-owned primitive for maintaining independent mutable execution lanes and leasing one lane exclusively to each caller.

## Exit Criteria

- Provide a fixed-size pool of independent `ITask` instances.
- Provide move-only leases with blocking `acquire()` and nonblocking `try_acquire()`.
- Return a lane automatically when its lease is destroyed or replaced.
- Keep an outstanding lease and task alive if the pool object is destroyed.
- Provide a loader helper that forwards the existing bundle, runtime root, KV budget, runtime cache, and CUDA graph options unchanged to every lane.
- Install the public header and implementation through the existing runtime library.
- Add no scheduler, executor, future API, continuous batching, family hook, registry, configuration layer, or compatibility alias.

## Implementation

- Added `trtmc::TaskPool` with immutable slots, one mutex-protected availability count, and a condition variable.
- Added a move-only `TaskPool::Lease` that owns shared pool state and returns exactly one lane on release.
- Added `capacity()` and `available()` inspection plus fail-closed empty/null/zero-count handling.
- Added `load_task_pool()` as a direct loop over the existing `load_task()` contract.
- Compiled the implementation into `libtrtmc_runtime.so`, installed the header, and documented the public C++ API.
- Added a fake-family C++ test covering exclusive lanes, exhaustion, move/release, blocking wakeup, pool/lease lifetime, independent task loads, and KV-budget forwarding.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [x] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `CI_BASE_REF=github/main PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.ci pipeline source-quality` — passed, including 117 architecture/source tests and the shared native complexity limit.
- Built `test_bundle_format_v1`, `test_task_api`, `test_family_loader`, and `test_task_pool` from the exact tree; their CTest selection passed 4/4.
- Repeated the TaskPool concurrency test 100 times — all passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python -m tools.ci pipeline package` in the project development image — source archive, native wheel, and installed-wheel validation passed for 99 families and 105 shared libraries.
- Symbol inspection confirmed `TaskPool`, `TaskPool::Lease`, and `load_task_pool()` are exported by `libtrtmc_runtime.so`.
- `npm ci && npm run test:model-support && npm run build` in `website/` — inventory, 34 diagram checks, and production docs build passed.
- Clang-format check mode, legal-header audit, and `git diff --check` — passed with 0 legal findings.

### Hardware, Environment, and Revisions

- Repository head: `a7d7b953b440b5aaadbdd7bfc18e0a7f3140030a`.
- Base: `d0e93c1addf12afd336ff264ad21151baa82f27b`.
- Linux aarch64, CMake 3.28, GCC 13.3; CPU/fake-family execution only.
- No checkpoint, generated TensorRT engine, or GPU was used.

### Not Run / Remaining Gaps

- No real model task or GPU inference was run through multiple lanes.
- No single-GPU memory scaling measurement was run.
- No Multi-Device or NVLink test was run; the pool does not change device placement.
- Pool-wide LoRA operations are intentionally absent. Current repeated task loads create independent Qwen-VL adapter caches and expose no side-effect-free instance capability query, so mechanically copying the old maintenance API would misrepresent registry, LRU, and rollback semantics.
- The former Qwen-VL shared-engine/shared-adapter-cache optimization is not claimed or restored by this generic pool.

## Notes For Future Readers

This is an ownership primitive: each lane is a complete, independently loaded task with its own mutable execution state and memory. It is not a batching or request-scheduling system. Add family-specific shared construction only after a concrete family proves that independent loading causes an unacceptable regression; do not add a speculative optional hook to core.

LoRA pool maintenance must remain a separate change. A faithful design needs instance-level capability and family-owned shared lane state before it can define all-lane preflight, registry consistency, and rollback.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Risk rationale: the implementation is small and CPU-tested, but it adds a public concurrent C++ API and exported ABI surface without a real model multi-lane memory or inference run.
