### PR TITLE
fix(bark): check cudaMalloc status before committing sampler capacity

### DIFF
--- a/families/bark/runtime/CMakeLists.txt
+++ b/families/bark/runtime/CMakeLists.txt
@@ -65,4 +65,22 @@ if(TRTMC_BUILD_TESTS)
   )
   add_test(NAME bark_pipeline COMMAND test_bark_pipeline)
   set_tests_properties(bark_pipeline PROPERTIES SKIP_RETURN_CODE 77 LABELS gpu)
+
+  # Compiles the sampler against CPU CUDA stubs defined in the test, so
+  # allocation failures can be injected without a GPU or cudart.
+  add_executable(test_bark_sampler_alloc
+    ${PROJECT_SOURCE_DIR}/families/bark/tests/cpp/test_bark_sampler_alloc.cpp
+    sampler.cpp
+  )
+  target_include_directories(test_bark_sampler_alloc PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_include_directories(test_bark_sampler_alloc SYSTEM PRIVATE
+    ${TRTMC_CUDA_INCLUDE_DIR}
+  )
+  target_compile_options(test_bark_sampler_alloc PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME bark_sampler_alloc COMMAND test_bark_sampler_alloc)
 endif()

--- a/families/bark/runtime/sampler.cpp
+++ b/families/bark/runtime/sampler.cpp
@@ -69,18 +69,31 @@ FilteredDistribution build_filtered_distributions(const float* logits, int32_t r
     return distribution;
 }
 
+template <typename T>
+class DeviceBuffer {
+  public:
+    DeviceBuffer() = default;
+    ~DeviceBuffer() { cudaFree(ptr_); }
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    T* get() const { return ptr_; }
+
+    void reset(T* pointer) {
+        cudaFree(ptr_);
+        ptr_ = pointer;
+    }
+
+  private:
+    T* ptr_{nullptr};
+};
+
 } // namespace
 
 class BarkSampler::Impl {
   public:
     explicit Impl(void* stream) : stream_(static_cast<cudaStream_t>(stream)) {
         ensure_device_buffers(1, 1);
-    }
-
-    ~Impl() {
-        cudaFree(device_indices_);
-        cudaFree(device_probabilities_);
-        cudaFree(device_token_ids_);
     }
 
     void reset(int64_t seed) {
@@ -111,14 +124,15 @@ class BarkSampler::Impl {
         ensure_device_buffers(static_cast<int32_t>(distribution.indices.size()), rows);
         const std::size_t index_bytes = distribution.indices.size() * sizeof(int32_t);
         const std::size_t probability_bytes = distribution.probabilities.size() * sizeof(float);
-        cudaMemcpyAsync(device_indices_, distribution.indices.data(), index_bytes,
+        cudaMemcpyAsync(device_indices_.get(), distribution.indices.data(), index_bytes,
                         cudaMemcpyHostToDevice, stream_);
-        cudaMemcpyAsync(device_probabilities_, distribution.probabilities.data(), probability_bytes,
-                        cudaMemcpyHostToDevice, stream_);
-        bark_gpu_sparse_torch_multinomial_exact(
-            device_indices_, device_probabilities_, distribution.rows, distribution.vocab_size,
-            distribution.keep, seed_, current_offset_, total_threads_, device_token_ids_, stream_);
-        cudaMemcpyAsync(selected_tokens.data(), device_token_ids_,
+        cudaMemcpyAsync(device_probabilities_.get(), distribution.probabilities.data(),
+                        probability_bytes, cudaMemcpyHostToDevice, stream_);
+        bark_gpu_sparse_torch_multinomial_exact(device_indices_.get(), device_probabilities_.get(),
+                                                distribution.rows, distribution.vocab_size,
+                                                distribution.keep, seed_, current_offset_,
+                                                total_threads_, device_token_ids_.get(), stream_);
+        cudaMemcpyAsync(selected_tokens.data(), device_token_ids_.get(),
                         selected_tokens.size() * sizeof(int32_t), cudaMemcpyDeviceToHost, stream_);
         cudaStreamSynchronize(stream_);
         current_offset_ += counter_offset_;
@@ -140,10 +154,8 @@ class BarkSampler::Impl {
                 cudaFree(new_indices);
                 throw std::runtime_error("Unable to allocate bark sampler probability buffer");
             }
-            cudaFree(device_indices_);
-            cudaFree(device_probabilities_);
-            device_indices_ = new_indices;
-            device_probabilities_ = new_probabilities;
+            device_indices_.reset(new_indices);
+            device_probabilities_.reset(new_probabilities);
             entry_capacity_ = entries;
         }
         if (rows > row_capacity_) {
@@ -152,8 +164,7 @@ class BarkSampler::Impl {
                 cudaMalloc(&new_token_ids, static_cast<std::size_t>(rows) * sizeof(int32_t));
             if (error != cudaSuccess)
                 throw std::runtime_error("Unable to allocate bark sampler token id buffer");
-            cudaFree(device_token_ids_);
-            device_token_ids_ = new_token_ids;
+            device_token_ids_.reset(new_token_ids);
             row_capacity_ = rows;
         }
     }
@@ -172,9 +183,9 @@ class BarkSampler::Impl {
     uint64_t seed_{0};
     uint64_t current_offset_{0};
     cudaStream_t stream_{nullptr};
-    int32_t* device_indices_{nullptr};
-    float* device_probabilities_{nullptr};
-    int32_t* device_token_ids_{nullptr};
+    DeviceBuffer<int32_t> device_indices_;
+    DeviceBuffer<float> device_probabilities_;
+    DeviceBuffer<int32_t> device_token_ids_;
     int32_t entry_capacity_{0};
     int32_t row_capacity_{0};
     int32_t cached_numel_{-1};

--- a/families/bark/runtime/sampler.cpp
+++ b/families/bark/runtime/sampler.cpp
@@ -128,29 +128,32 @@ class BarkSampler::Impl {
   private:
     void ensure_device_buffers(int32_t entries, int32_t rows) {
         if (entries > entry_capacity_) {
-            cudaFree(device_indices_);
-            device_indices_ = nullptr;
-            cudaFree(device_probabilities_);
-            device_probabilities_ = nullptr;
-            entry_capacity_ = 0;
+            int32_t* new_indices = nullptr;
             cudaError_t error =
-                cudaMalloc(&device_indices_, static_cast<std::size_t>(entries) * sizeof(int32_t));
+                cudaMalloc(&new_indices, static_cast<std::size_t>(entries) * sizeof(int32_t));
             if (error != cudaSuccess)
                 throw std::runtime_error("Unable to allocate bark sampler index buffer");
-            error = cudaMalloc(&device_probabilities_,
-                               static_cast<std::size_t>(entries) * sizeof(float));
-            if (error != cudaSuccess)
+            float* new_probabilities = nullptr;
+            error =
+                cudaMalloc(&new_probabilities, static_cast<std::size_t>(entries) * sizeof(float));
+            if (error != cudaSuccess) {
+                cudaFree(new_indices);
                 throw std::runtime_error("Unable to allocate bark sampler probability buffer");
+            }
+            cudaFree(device_indices_);
+            cudaFree(device_probabilities_);
+            device_indices_ = new_indices;
+            device_probabilities_ = new_probabilities;
             entry_capacity_ = entries;
         }
         if (rows > row_capacity_) {
-            cudaFree(device_token_ids_);
-            device_token_ids_ = nullptr;
-            row_capacity_ = 0;
+            int32_t* new_token_ids = nullptr;
             const cudaError_t error =
-                cudaMalloc(&device_token_ids_, static_cast<std::size_t>(rows) * sizeof(int32_t));
+                cudaMalloc(&new_token_ids, static_cast<std::size_t>(rows) * sizeof(int32_t));
             if (error != cudaSuccess)
                 throw std::runtime_error("Unable to allocate bark sampler token id buffer");
+            cudaFree(device_token_ids_);
+            device_token_ids_ = new_token_ids;
             row_capacity_ = rows;
         }
     }

--- a/families/bark/runtime/sampler.cpp
+++ b/families/bark/runtime/sampler.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cuda_runtime.h>
 #include <numeric>
+#include <stdexcept>
 #include <vector>
 
 namespace trtmc {
@@ -128,14 +129,28 @@ class BarkSampler::Impl {
     void ensure_device_buffers(int32_t entries, int32_t rows) {
         if (entries > entry_capacity_) {
             cudaFree(device_indices_);
+            device_indices_ = nullptr;
             cudaFree(device_probabilities_);
-            cudaMalloc(&device_indices_, static_cast<std::size_t>(entries) * sizeof(int32_t));
-            cudaMalloc(&device_probabilities_, static_cast<std::size_t>(entries) * sizeof(float));
+            device_probabilities_ = nullptr;
+            entry_capacity_ = 0;
+            cudaError_t error =
+                cudaMalloc(&device_indices_, static_cast<std::size_t>(entries) * sizeof(int32_t));
+            if (error != cudaSuccess)
+                throw std::runtime_error("Unable to allocate bark sampler index buffer");
+            error = cudaMalloc(&device_probabilities_,
+                               static_cast<std::size_t>(entries) * sizeof(float));
+            if (error != cudaSuccess)
+                throw std::runtime_error("Unable to allocate bark sampler probability buffer");
             entry_capacity_ = entries;
         }
         if (rows > row_capacity_) {
             cudaFree(device_token_ids_);
-            cudaMalloc(&device_token_ids_, static_cast<std::size_t>(rows) * sizeof(int32_t));
+            device_token_ids_ = nullptr;
+            row_capacity_ = 0;
+            const cudaError_t error =
+                cudaMalloc(&device_token_ids_, static_cast<std::size_t>(rows) * sizeof(int32_t));
+            if (error != cudaSuccess)
+                throw std::runtime_error("Unable to allocate bark sampler token id buffer");
             row_capacity_ = rows;
         }
     }

--- a/families/bark/tests/cpp/test_bark_sampler_alloc.cpp
+++ b/families/bark/tests/cpp/test_bark_sampler_alloc.cpp
@@ -17,6 +17,7 @@
 #include <cuda_runtime.h>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace {
@@ -97,8 +98,15 @@ int main() {
         bool threw = false;
         try {
             trtmc::BarkSampler sampler(nullptr);
-        } catch (const std::runtime_error&) {
+        } catch (const std::runtime_error& error) {
             threw = true;
+            static const char* const expected[] = {
+                "Unable to allocate bark sampler index buffer",
+                "Unable to allocate bark sampler probability buffer",
+                "Unable to allocate bark sampler token id buffer",
+            };
+            check(std::string(error.what()) == expected[failing - 1],
+                  "the error should name the buffer that actually failed");
         }
         check(threw, "construction should throw when an allocation fails");
         check(g_outstanding.empty(), "failed construction must release every allocation it made");

--- a/families/bark/tests/cpp/test_bark_sampler_alloc.cpp
+++ b/families/bark/tests/cpp/test_bark_sampler_alloc.cpp
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Links the real sampler translation unit against CPU CUDA stubs so each
+// allocation can be failed in turn without a GPU. Verifies that a failed
+// construction releases every allocation it already made, that a later
+// construction still succeeds, and that a failed resize leaves an existing
+// sampler usable.
+
+#include "families/bark/runtime/sampler.h"
+#include "families/bark/runtime/sparse_multinomial_kernel.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+int g_fail_on_allocation = 0;
+int g_allocation_count = 0;
+std::set<void*> g_outstanding;
+std::uintptr_t g_next_address = 0x1000;
+int g_failures = 0;
+
+void check(bool condition, const char* what) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+void reset_allocator(int fail_on) {
+    g_fail_on_allocation = fail_on;
+    g_allocation_count = 0;
+}
+
+} // namespace
+
+extern "C" {
+
+cudaError_t cudaMalloc(void** devPtr, size_t size) {
+    (void)size;
+    ++g_allocation_count;
+    if (g_fail_on_allocation != 0 && g_allocation_count == g_fail_on_allocation) {
+        *devPtr = nullptr;
+        return cudaErrorMemoryAllocation;
+    }
+    void* address = reinterpret_cast<void*>(g_next_address);
+    g_next_address += 0x1000;
+    g_outstanding.insert(address);
+    *devPtr = address;
+    return cudaSuccess;
+}
+
+cudaError_t cudaFree(void* devPtr) {
+    if (devPtr != nullptr) {
+        g_outstanding.erase(devPtr);
+    }
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemcpyAsync(void*, const void*, size_t, cudaMemcpyKind, cudaStream_t) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaStreamSynchronize(cudaStream_t) {
+    return cudaSuccess;
+}
+
+} // extern "C"
+
+namespace trtmc {
+
+BarkTorchMultinomialExecutionPolicy bark_compute_torch_multinomial_execution_policy(int32_t) {
+    BarkTorchMultinomialExecutionPolicy policy;
+    policy.total_threads = 32;
+    policy.counter_offset = 4;
+    return policy;
+}
+
+void bark_gpu_sparse_torch_multinomial_exact(const int32_t*, const float*, int32_t, int32_t,
+                                             int32_t, uint64_t, uint64_t, int32_t, int32_t*,
+                                             cudaStream_t) {}
+
+} // namespace trtmc
+
+int main() {
+    // The constructor makes three allocations. Fail each in turn and confirm
+    // nothing the call already acquired survives the throw.
+    for (int failing = 1; failing <= 3; ++failing) {
+        reset_allocator(failing);
+        bool threw = false;
+        try {
+            trtmc::BarkSampler sampler(nullptr);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        check(threw, "construction should throw when an allocation fails");
+        check(g_outstanding.empty(), "failed construction must release every allocation it made");
+        g_outstanding.clear();
+    }
+
+    // A later construction, with no injected failure, still succeeds.
+    reset_allocator(0);
+    {
+        trtmc::BarkSampler sampler(nullptr);
+        check(!g_outstanding.empty(), "successful construction should hold its buffers");
+    }
+    check(g_outstanding.empty(), "destruction should release every buffer");
+
+    // A failed resize of a live sampler keeps the existing buffers intact and
+    // leaves the sampler usable.
+    reset_allocator(0);
+    {
+        trtmc::BarkSampler sampler(nullptr);
+        const std::set<void*> after_construction = g_outstanding;
+
+        const int32_t vocab_size = 64;
+        std::vector<float> logits(static_cast<std::size_t>(vocab_size), 1.0F);
+
+        reset_allocator(1);
+        bool threw = false;
+        try {
+            sampler.sample_rows(logits.data(), 1, vocab_size, vocab_size, 1.0F, vocab_size);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        check(threw, "a failed resize should throw");
+        check(g_outstanding == after_construction,
+              "a failed resize must leave the existing buffers untouched");
+
+        reset_allocator(0);
+        const std::vector<int32_t> tokens =
+            sampler.sample_rows(logits.data(), 1, vocab_size, vocab_size, 1.0F, vocab_size);
+        check(tokens.size() == 1, "the sampler should still be usable after a failed resize");
+    }
+    check(g_outstanding.empty(), "destruction should release every buffer");
+
+    if (g_failures != 0) {
+        std::fprintf(stderr, "%d check(s) failed\n", g_failures);
+        return 1;
+    }
+    std::printf("bark sampler allocation-failure checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Background

`ensure_device_buffers` in `families/bark/runtime/sampler.cpp` didn't check `cudaMalloc`'s return value before committing the new capacity. A failed allocation left the capacity claiming a size the buffer never got, so a later call would reuse a null/stale pointer.

Addresses the cudaMalloc item in #1177.

## Exit Criteria

Every `cudaMalloc` in `ensure_device_buffers` is checked; a failed allocation throws instead of leaving a mismatched capacity, and never leaves an already-succeeded sibling allocation dangling. Success path unchanged. Not covering #1177's other two items or #1176 (both still waiting on maintainer input).

## Implementation

Checks each `cudaError_t`, allocates into local pointers first, and only frees the old buffers and commits the new pointers/capacity once every allocation in the pair succeeds. Same pattern as `core/runtime/tensorrt/trt_module_impl.cpp::ensure_input_buffer`. Only touches `families/bark/runtime/sampler.cpp`.

Second commit: if the indices `cudaMalloc` succeeded but the probabilities one then failed, the old code had already nulled the previous buffers and left the new indices pointer committed to nothing (`entry_capacity_` still 0). Fixed by not touching the existing buffers or capacity until both new allocations succeed.

Third commit addresses @chaofengw-nv's review on #1221. That still left a leak he was right about: `Impl`'s constructor calls `ensure_device_buffers(1, 1)`, and the indices/probabilities pair is committed to members before the token id buffer is allocated - so a failure on that third allocation threw with two allocations already committed, and a constructor that throws never runs its own destructor. Each buffer is now held in a small family-local RAII type, which fixes the class rather than the instance: members that finished constructing are destroyed during unwinding, so whatever was acquired is released no matter which allocation fails. The explicit destructor is now redundant and removed.

### Change categories
- [x] Model or runtime behavior

## Validation

### Commands and Results

CUDA and TensorRT are installed now. Built and ran the actual repository target:

```
$ cmake --build build --target test_bark_pipeline
$ ctest -R bark_pipeline --output-on-failure
1/1 Test #1: bark_pipeline ....................   Passed    0.34 sec
100% tests passed out of 1
```

`test_bark_pipeline` exercises the real `sample_rows` path end to end (semantic and coarse token generation), which calls `ensure_device_buffers` on the actual GPU.

New in-repo test, `test_bark_sampler_alloc`, links the real sampler translation unit against CPU CUDA stubs and fails each of the three constructor allocations in turn. It checks that a failed construction releases everything it acquired, that a later construction still succeeds, and that a failed resize leaves the existing buffers intact and the sampler usable:
```
$ ctest
1/2 Test #1: bark_pipeline ....................   Passed
2/2 Test #2: bark_sampler_alloc ...............   Passed
100% tests passed out of 2
```
It needs no GPU and links no cudart, so it runs in the CPU tier. Verified it catches the bug: against `72fba75` it fails with "failed construction must release every allocation it made" on the third allocation only - matching exactly what @chaofengw-nv reported from his own stub run.

Also kept the standalone GPU harnesses from before as targeted evidence for the allocation-failure paths, since `test_bark_pipeline` only exercises the success path:

Original single-allocation-failure case:
```
$ ./test_ensure_buffers
caught expected: Unable to allocate bark sampler index buffer
ALL CHECKS PASSED on real GPU
```

Second-allocation-failure / leak case, forced by starving the device down to room for exactly one of the two equal-sized buffers:
```
[buggy] threw=1 entry_capacity_=0 device_indices_=0x10007600000 device_probabilities_=(nil)
[buggy] free before=99483648 after=32374784 (memory still held despite entry_capacity_==0: YES - LEAK)
[fixed] threw=1 entry_capacity_=0 device_indices_=(nil) device_probabilities_=(nil)
[fixed] free before=99483648 after=99483648 (no memory held: confirmed, no leak)
ALL CHECKS PASSED: buggy path reproduces the leak, fixed path does not.
```

Also re-checked the ordinary path on the fixed version (grow 0->100, no-op shrink to 50, grow to 500, real `cudaMemcpy` round trip): unchanged.

`clang-format --dry-run --Werror` on the patched file: clean.

### Hardware, Environment, and Revisions

Repo head rebased onto `54d6d566f` (upstream/main). GPU: GTX 1650, driver 610.57.04, CUDA UMD 13.3. g++ 16.2.1. `cuda` 13.3.1-1 and `nlohmann-json` 3.12.0-2 via pacman; TensorRT 11.2.1 headers (from the matching `v11.2` tag of NVIDIA/TensorRT, Apache-2.0) plus the real `libnvinfer`/`libnvinfer_plugin`/`libnvonnxparser` binaries from the `tensorrt-cu13-libs` wheel.

### Not Run / Remaining Gaps

`test_bark_pipeline` runs the fine/codec stages without real TRT engines (falls back to zero codebooks / a simple waveform, printed plainly by the pipeline itself), so it does not exercise a TRT-engine-backed run end to end - that needs real model weights, out of scope here.

Re-grepped `families/` for the same unchecked-`cudaMalloc` shape against the current head: this repo's `bart`, `marian`, `m2m_100`, `t5`, `whisper`, and `flux` all still have genuinely unchecked `cudaMalloc` calls (encoder-decoder cross-attention KV cache allocation in the first five, a shared matmul workspace in `flux`), same class of bug as this PR fixed in `bark`. That is a materially larger footprint than an earlier version of this section claimed - filing a separate issue for it rather than folding a six-family fix into this one.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Change is family-local to `families/bark/runtime/sampler.cpp` only, no shared-core or cross-family touch. Both commits are DCO signed off. The real `test_bark_pipeline` CTest target now passes on this head.

## Notes For Future Readers

If this pattern shows up in more families once other pending work lands, this is a direct template to repeat.

### Risk level
- [x] Low

Single-file, family-local error-handling fix on an existing allocation path; no shared-core, public API, or ABI change; no new behavior on the success path.





