### PR TITLE
feat(contributing): require contributor self-review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,6 +64,35 @@ why. Use "None: <reason>" only when the recorded evidence covers every relevant
 path.
 -->
 
+## Contributor Self-Review
+
+<!--
+Review the exact current head after completing the implementation and local
+validation. `$review-trtmc-pr` is the recommended shortcut, but a documented
+manual review or another review tool is also accepted. Rerun the review after
+changes that alter the head. This section may remain incomplete while the pull
+request is a draft, but it is required before marking the pull request ready.
+-->
+
+### Method
+
+<!-- Name the skill, tool, or manual checklist used. -->
+
+### Reviewed Head
+
+<!-- Record the full Git commit SHA reviewed. -->
+
+### Result
+
+<!-- State PASS, BLOCK, or HUMAN REVIEW REQUIRED. -->
+
+### Findings and Resolution
+
+<!--
+Summarize findings that were corrected and list any remaining findings or
+decisions that require maintainer review.
+-->
+
 ## Notes For Future Readers
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,31 +67,11 @@ path.
 ## Contributor Self-Review
 
 <!--
-Review the exact current head after completing the implementation and local
-validation. `$review-trtmc-pr` is the recommended shortcut, but a documented
-manual review or another review tool is also accepted. Rerun the review after
-changes that alter the head. This section may remain incomplete while the pull
-request is a draft, but it is required before marking the pull request ready.
+Confirm that you reviewed your change before marking the pull request ready.
+`$review-trtmc-pr`, another review tool, or a manual review are all accepted.
 -->
 
-### Method
-
-<!-- Name the skill, tool, or manual checklist used. -->
-
-### Reviewed Head
-
-<!-- Record the full Git commit SHA reviewed. -->
-
-### Result
-
-<!-- State PASS, BLOCK, or HUMAN REVIEW REQUIRED. -->
-
-### Findings and Resolution
-
-<!--
-Summarize findings that were corrected and list any remaining findings or
-decisions that require maintainer review.
--->
+- [ ] I have completed a self-review of this change.
 
 ## Notes For Future Readers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,11 +134,12 @@ If you rebase a branch that you already pushed, never use an unguarded force
 push. Use `git push --force-with-lease`, and coordinate before rewriting a
 branch that other people are using.
 
-### 7. Open a pull request against upstream `main`
+### 7. Open a draft pull request against upstream `main`
 
 Open the pull request from your fork branch to
-`NVIDIA/TensorRT-Model-Connect:main`. Complete every section of the pull-request
-template; use `Not applicable: <reason>` instead of deleting a section. Include:
+`NVIDIA/TensorRT-Model-Connect:main` and keep it in draft while completing the
+self-review below. Complete every section of the pull-request template; use
+`Not applicable: <reason>` instead of deleting a section. Include:
 
 - **Background**: the problem, motivation, current behavior, and linked issue;
 - **Exit Criteria**: the conditions that define completion, including important
@@ -147,21 +148,60 @@ template; use `Not applicable: <reason>` instead of deleting a section. Include:
   API, ABI, bundle, dependency, compatibility, migration, or rollout changes;
 - **Validation**: exact commands and results, tested head and dependency/model
   revisions, environment and hardware, plus paths that were not run; and
+- **Contributor Self-Review**: method, exact reviewed head, result, resolved
+  findings, and any remaining issue that needs maintainer judgment; and
 - **Notes For Future Readers**: remaining risk, compatibility or rollout notes,
   third-party provenance, and useful follow-up context.
 
-`PR Metadata / Required` checks that these sections and the structured
-validation evidence are present. The trusted triage workflow derives model and
-component labels from the actual diff and repository ownership metadata; it
-uses the template only for declared risk and compatibility-change labels. DCO
-sign-off is enforced by the repository's DCO check rather than a self-attested
-template checkbox.
+Once the pull request is marked ready, `PR Metadata / Required` checks that
+these sections, the structured validation evidence, and the contributor
+self-review fields are present. It also verifies that the recorded self-review
+head is the current pull-request head. The trusted triage workflow derives
+model and component labels from the actual diff and repository ownership
+metadata; it uses the template only for declared risk and compatibility-change
+labels. DCO sign-off is enforced by the repository's DCO check rather than a
+self-attested template checkbox.
 
 Compilation, unit tests, inference, model parity, target-hardware execution,
 performance, and release qualification are separate evidence levels. Claim only
 what the recorded validation proves.
 
-### 8. Run contributor-visible public CPU validation
+### 8. Perform contributor self-review
+
+Review the exact current draft pull-request head after implementation and local
+validation. Codex users can run the repository-provided skill from the
+repository root:
+
+```text
+$review-trtmc-pr review this draft PR as a contributor self-review. Do not
+publish comments or change the branch. Report architecture, correctness, and
+validation findings first.
+```
+
+For an earlier pass before a draft PR exists, run:
+
+```text
+$review-trtmc-pr self-review my current branch and working tree against
+upstream/main. Do not modify files.
+```
+
+Use `/skills` or type `$` to confirm that the skill is available. If it does
+not appear, restart Codex from the repository root.
+
+Using Codex is recommended, not required. A manual review or another review
+tool is acceptable when it checks the same repository rules, architecture
+ownership boundaries, changed behavior, tests, and PR evidence. Record the
+method, full reviewed head SHA, result, corrected findings, and unresolved
+risks in **Contributor Self-Review**.
+
+Resolve blocking and high-severity findings before marking the pull request
+ready. If a finding requires an architecture or policy decision, leave the pull
+request in draft, record the question, and ask a maintainer. Any code change
+creates a new head; rerun the affected validation and self-review before
+marking that head ready. Self-review does not replace public CI, protected CI,
+or maintainer review.
+
+### 9. Run contributor-visible public CPU validation
 
 Opening a pull request or pushing a new commit automatically starts Community
 CPU against GitHub's exact pull-request merge revision. Separate jobs run
@@ -178,7 +218,7 @@ new commit automatically validates the new merge revision and cancels an older
 in-progress run for the same pull request. If `main` advances and GitHub asks
 for an update, rebase or update the branch so the new exact merge is validated.
 
-### 9. Ask a maintainer to trigger protected CI
+### 10. Ask a maintainer to trigger protected CI
 
 Opening a pull request or pushing to your fork does **not** start the protected
 premerge suite. After public CPU validation passes and the pull request is
@@ -207,7 +247,7 @@ head; finish the update, wait for automatic Community CPU validation, and
 mention `@yifeif-nv` once to request a new protected run. Private runner details,
 logs, artifacts, and URLs are not part of the public contribution interface.
 
-### 10. Respond to review and keep evidence current
+### 11. Respond to review and keep evidence current
 
 Address review feedback on the same topic branch and sign off every new commit.
 Keep the pull request current with upstream when requested. A new head requires

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,15 +148,13 @@ self-review below. Complete every section of the pull-request template; use
   API, ABI, bundle, dependency, compatibility, migration, or rollout changes;
 - **Validation**: exact commands and results, tested head and dependency/model
   revisions, environment and hardware, plus paths that were not run; and
-- **Contributor Self-Review**: method, exact reviewed head, result, resolved
-  findings, and any remaining issue that needs maintainer judgment; and
+- **Contributor Self-Review**: confirmation that you reviewed your change; and
 - **Notes For Future Readers**: remaining risk, compatibility or rollout notes,
   third-party provenance, and useful follow-up context.
 
 Once the pull request is marked ready, `PR Metadata / Required` checks that
-these sections, the structured validation evidence, and the contributor
-self-review fields are present. It also verifies that the recorded self-review
-head is the current pull-request head. The trusted triage workflow derives
+these sections and the structured validation evidence are present, including
+the contributor self-review confirmation. The trusted triage workflow derives
 model and component labels from the actual diff and repository ownership
 metadata; it uses the template only for declared risk and compatibility-change
 labels. DCO sign-off is enforced by the repository's DCO check rather than a
@@ -189,17 +187,14 @@ Use `/skills` or type `$` to confirm that the skill is available. If it does
 not appear, restart Codex from the repository root.
 
 Using Codex is recommended, not required. A manual review or another review
-tool is acceptable when it checks the same repository rules, architecture
-ownership boundaries, changed behavior, tests, and PR evidence. Record the
-method, full reviewed head SHA, result, corrected findings, and unresolved
-risks in **Contributor Self-Review**.
+tool is also acceptable. When the review is complete, select the single
+**Contributor Self-Review** checkbox in the pull-request description.
 
 Resolve blocking and high-severity findings before marking the pull request
 ready. If a finding requires an architecture or policy decision, leave the pull
-request in draft, record the question, and ask a maintainer. Any code change
-creates a new head; rerun the affected validation and self-review before
-marking that head ready. Self-review does not replace public CI, protected CI,
-or maintainer review.
+request in draft, record the question, and ask a maintainer. Rerun the affected
+validation and self-review after material changes. Self-review does not replace
+public CI, protected CI, or maintainer review.
 
 ### 9. Run contributor-visible public CPU validation
 

--- a/plugins/trtmc-agent-skills/.codex-plugin/plugin.json
+++ b/plugins/trtmc-agent-skills/.codex-plugin/plugin.json
@@ -28,6 +28,7 @@
     ],
     "defaultPrompt": [
       "Use $write-git-messages to draft a PR message from my diff.",
+      "Use $review-trtmc-pr to self-review my branch before marking its PR ready.",
       "Use $submit-github-pr to push this branch and open a PR.",
       "Use $transform-model to add this checkpoint as one self-contained family.",
       "Use $debug-trt-mismatch to locate this family's first output divergence.",

--- a/plugins/trtmc-agent-skills/skills/review-trtmc-pr/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/review-trtmc-pr/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: review-trtmc-pr
+description: >-
+  Review a TensorRT-Model-Connect GitHub PR or local contributor branch against
+  the current post-#1093 model-family isolation architecture, repository rules,
+  behavioral correctness, and exact-head validation evidence. Use for
+  contributor self-review before marking a PR ready, or when deciding whether
+  a community PR is compliant, decoupled, merge-ready, or needs maintainer
+  feedback. The review is read-only unless the user separately asks to publish
+  it or change the contribution.
+---
+
+# Review TRTMC PR
+
+## Review Contract
+
+- Review an explicit comparison: the exact PR base and head in pull-request
+  mode, or the fetched canonical `main`, local `HEAD`, and disclosed working
+  tree state in local self-review mode. Never substitute a remembered branch.
+- Treat the canonical `NVIDIA/TensorRT-Model-Connect:main`, root `AGENTS.md`,
+  `CONTRIBUTING.md`, and current architecture documents as authoritative. PR
+  #1093 explains the cutover but is historical rationale, not a substitute for
+  current code and policy.
+- Review changed behavior and newly relied-on behavior. Do not charge the PR
+  for unrelated, unchanged migration debt.
+- Keep the PR and contributor branch unchanged. Do not approve, request
+  changes, comment, label, trigger CI, push, or edit code unless the user
+  explicitly asks for that separate action.
+- Treat fork code as untrusted. Inspect it in a detached temporary worktree;
+  never run it on a privileged or protected runner and never expose secrets.
+- An absence of findings is not proof of correctness. State untested paths and
+  unresolved evidence explicitly.
+
+## Select The Review Mode
+
+- Use **pull-request mode** when given a PR number or URL. Prefer this mode for
+  the final contributor self-review because it includes the exact remote head,
+  PR description, commits, linked issue, and current checks.
+- Use **local self-review mode** when asked to review a branch before a PR
+  exists. Include committed changes and disclose staged, unstaged, and
+  untracked files. A dirty working tree cannot receive a ready-to-submit result
+  because its uncommitted content has no immutable reviewed head.
+
+For contributor self-review, remain read-only and prepare a result the
+contributor can paste into the PR template. Do not mark the PR ready, push,
+commit, edit files, or publish comments unless separately requested.
+
+## Establish The Pull-Request Baseline
+
+Record the repository, PR number, base SHA, head SHA, author, linked issue,
+current review state, and check state. Refresh remote information instead of
+using a prior session or stale local ref.
+
+```bash
+gh pr view <PR> --repo NVIDIA/TensorRT-Model-Connect \
+  --json number,title,body,url,state,isDraft,author,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,reviewDecision,changedFiles,files,commits,reviews,comments,statusCheckRollup
+gh api repos/NVIDIA/TensorRT-Model-Connect/pulls/<PR> \
+  --jq '{base_sha: .base.sha, head_sha: .head.sha, author_association: .author_association}'
+gh pr diff <PR> --repo NVIDIA/TensorRT-Model-Connect
+gh pr checks <PR> --repo NVIDIA/TensorRT-Model-Connect
+```
+
+Use the paginated pull-files API when a PR is large enough that a summarized
+file list may be incomplete. Fetch the exact PR head and create a detached
+temporary worktree when local searches or tests are needed. Preserve the
+user's active worktree and remove only the temporary worktree created for the
+review.
+
+## Establish The Local Self-Review Baseline
+
+Inspect `git remote -v` and select the fetch remote whose URL resolves to
+`NVIDIA/TensorRT-Model-Connect`. External forks normally name it `upstream`;
+maintainer clones may name it `github` or `origin`. Never use a contributor
+fork's `main` as the canonical base merely because its remote is named
+`origin`. Fetch canonical `main`, then record the base ref and SHA, merge base,
+local head SHA, branch name, and working-tree state.
+
+```bash
+git remote -v
+git fetch <canonical-remote> main
+git branch --show-current
+git rev-parse <canonical-remote>/main
+git merge-base <canonical-remote>/main HEAD
+git rev-parse HEAD
+git status --short
+git diff --stat <merge-base>
+git diff --name-status <merge-base>
+git diff <merge-base>
+git ls-files --others --exclude-standard
+git log --format=fuller <merge-base>..HEAD
+```
+
+`git diff <merge-base>` includes committed, staged, and tracked unstaged
+content. Inspect every intended untracked file separately because Git does not
+include it in that diff. If the canonical remote is ambiguous, `HEAD` is the
+canonical main branch, or intended files cannot be distinguished from unrelated
+local work, report the limitation instead of guessing.
+
+Before reading implementation details, establish whether the linked issue's
+problem still exists on current `main`. A long-lived PR may have been
+superseded, narrowed, or made unnecessary by #1093 or a later merge. A proposed
+abstraction with no current consumer does not inherit justification from an
+obsolete issue.
+
+## Load The Current Rules
+
+Always read:
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `.github/pull_request_template.md`
+- the linked issue or discussion and material maintainer comments, when one is
+  available
+
+Then read only the architecture guides relevant to the changed paths:
+
+- family or model work: `website/docs/architecture/ai-native-horizontal-scaling.md`,
+  `website/docs/architecture/validation-design.md`, and
+  `website/docs/extend/add-model-family.md`;
+- Python build or discovery: `website/docs/architecture/build-pipeline.md`;
+- native build: `website/docs/architecture/build-system.md`;
+- loader, DSO, Task, or backend work:
+  `website/docs/architecture/runtime-lifecycle.md` and
+  `website/docs/architecture/runtime-plugins.md`;
+- cross-layer ownership: `website/docs/architecture/units-and-ownership.md`.
+
+When reviewing the PR title, body, validation claims, or proposed contributor
+reply, also read and apply `../write-git-messages/SKILL.md`.
+
+## Fast Review Funnel
+
+### 1. Reconcile Intent With Current Main
+
+Summarize the problem, observable exit criteria, non-goals, affected public
+contracts, and claimed evidence. Compare these with the linked issue and the
+current base. Flag stale paths, claims about already-existing APIs, obsolete
+registries, or a solution that no longer has a concrete consumer.
+
+For a new checkpoint or model, inspect the authoritative model card, config,
+tokenizer/preprocessor configuration, license, and exact pinned revision.
+Confirm its real task and required input protocol; architectural similarity to
+an existing family does not prove that the existing reference or validation
+path exercises the checkpoint's product behavior.
+
+### 2. Classify The Diff Boundary
+
+Build a changed-path map before deep review:
+
+| Changed area | First question |
+| --- | --- |
+| `families/<family>/**` | Can this family be built, tested, changed, and reverted without a sibling edit? |
+| more than one family | Is there a real multi-owner requirement, or a cross-family dependency/bulk migration? |
+| `core/**` or public headers | Is this a narrow model-agnostic contract with concrete consumers? |
+| `apps/**` or `examples/**` | Does it consume only public APIs and keep model semantics in the family? |
+| `tools/**`, CI, or shared validation | Does it schedule generic mechanics without owning family policy or weakening evidence? |
+| root dependencies/build files | Does one family now force coordination or dependency changes for every family? |
+| media, weights, fixtures, generated files | Are source, license, attribution, and repository policy satisfied? |
+
+A normal family contribution should change only `families/<owner>/**`. A
+shared Task contract may legitimately accompany the first family whose user
+behavior cannot be represented by an existing Task API; a shared edit is a
+review trigger, not an automatic violation.
+
+### 3. Check Architecture Ownership
+
+Verify these invariants from code, build files, tests, and data flow:
+
+- The family owns checkpoint identity, tasks/default, config, weights,
+  topology, TensorRT graph, bundle-section semantics, runtime orchestration,
+  bindings, preprocessing, postprocessing, dependencies, fixtures, manifests,
+  thresholds, references, and oracles.
+- A family does not import, include, link, load, inherit from, symlink to, or
+  read implementation or validation artifacts owned by a sibling family.
+- Similar model-specific code remains family-local. Do not recommend a shared
+  helper merely to remove duplication.
+- `support.py` is dependency-free apart from the support contract, uses exact
+  identity matching, and produces exactly one owner or a clear error. It does
+  not use broad prefixes, scores, priority, repository-name guesses, or
+  first-match fallback.
+- `model.py` exposes one plain `build(request, writer)` function, explicitly
+  handles or rejects all request dimensions, and writes the selected task and
+  backend without guessing.
+- Core contains only model-agnostic discovery/loading, bounded bundle
+  mechanics, public Build/Task/Engine contracts, stable primitives, and the
+  explicit BYOK boundary. It contains no family switch, model tensor name,
+  tokenizer policy, topology, threshold, dataset, reference logic, or
+  family-specific default disguised as a generic API.
+- Core owns safe bundle framing and bounded reads; each family owns its section
+  names, schemas, and meaning. A second parser or new shared abstraction needs
+  a current independent consumer and a single clearly owned contract.
+- Runtime loads exactly the family and backend named by the bundle. Family
+  pipelines use abstract Task and Engine APIs, do not link the concrete backend
+  or loader, and do not retain references to temporary factory context.
+- Applications, examples, benchmarks, and BYOK consume public APIs. Core,
+  backend, and families never depend on application code.
+- Generic family semantics do not branch on GPU, SM, CUDA, driver, or TensorRT
+  version. A real family-local TensorRT custom plugin may be valid; expanding
+  ad hoc CUDA/cuBLAS helper execution outside TensorRT or TVM-FFI is not.
+- Shared dependencies are genuinely common. Family-only packages and versions
+  stay in the owner `requirements.txt`, and one family job does not merge
+  incompatible environments from several families.
+
+Read [references/manual-review-probes.md](references/manual-review-probes.md)
+when any model, family, runtime, bundle, benchmark, validation, dependency, or
+CI behavior changes. It covers semantic failures that path guards cannot
+detect.
+
+### 4. Trace Behavioral Correctness
+
+Follow the changed path end to end rather than reviewing isolated functions:
+
+```text
+checkpoint -> support resolution -> family build -> bundle
+           -> exact family DSO -> Task call -> family-owned oracle
+```
+
+Inspect relevant callers, consumers, configuration, tensor shapes/layouts,
+weight names, special tokens/chat templates, resize/pad/mask behavior,
+postprocessing, object lifetimes, failure propagation, and teardown. Compare
+the native path with the official reference using identical semantic inputs.
+
+Do not accept parity between two implementations that share the same wrong
+assumption. A writer-reader round trip is useful consistency evidence but is
+not an independent format validator. Likewise, a test that compares only a
+convenient subset of outputs does not validate omitted task semantics.
+
+### 5. Audit Validation Meaning
+
+- Tests must exercise the changed behavior and fail for the regression they
+  claim to prevent.
+- A requested E2E case must produce exactly one executed, non-skipped result.
+  Missing, duplicate, skipped, or unintended cases fail closed; a zero-test
+  pytest exit is not a pass.
+- Oracles must cover the task's essential outputs. Examples include boxes and
+  detection counts for detection, generated content for text, reference-relative
+  image/video evidence, and temporal behavior when the task promises it.
+- Reference and native inputs, tokenizer framing, build options, precision,
+  and aggregation levels must be aligned before drawing a parity conclusion.
+- Thresholds, expected values, oracle strength, and acceptance criteria must
+  not be weakened to obtain green CI. If a test appears wrong, require human
+  review of the evidence.
+- Benchmark sides must time equivalent regions and keep shards, batches,
+  requests, queries, samples, tokens, and artifacts as distinct accounting
+  units.
+- A family-only test does not prove a changed shared contract for all
+  consumers. Scale evidence to the actual impact classification.
+
+### 6. Audit Contributor And Repository Compliance
+
+Check that:
+
+- the PR title is focused, imperative, Conventional Commit-style, and contains
+  no banned terms;
+- every commit introduced by the PR has a valid author-owned DCO sign-off;
+- all pull-request template sections are complete, change categories match the
+  actual diff, exactly one risk level is selected, and paths/claims describe
+  the current architecture;
+- validation lists exact commands, outcomes, tested head, checkpoint and
+  dependency revisions, hardware/environment when relevant, and unrun paths;
+- contributor self-review records the method, exact reviewed head, result,
+  corrected findings, and unresolved risks; a later code push invalidates that
+  record;
+- repository documentation, code comments, user-facing messages, and PR text
+  are English except model data needed for multilingual validation;
+- SPDX headers, third-party notices, asset entries, and redistribution rights
+  are complete;
+- the change remains focused and does not add compatibility paths, fallbacks,
+  registries, speculative hooks, or unrelated cleanup.
+
+## Run Proportionate Checks
+
+In pull-request mode, run checks from the exact-head temporary worktree. In
+local mode, run them from the reviewed checkout and report whether it was
+clean. Start with the current lightweight commands from `CONTRIBUTING.md`:
+
+```bash
+git diff --check <base-sha>...<head-sha>
+PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.model_ci validate
+PYTHONPATH=core/builder:apps/benchmark:. python3 tools/test_impact.py --validate
+PYTHONPATH=core/builder:apps/benchmark:. python3 tools/test_impact.py \
+  --base <base-sha> --head <head-sha>
+PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest \
+  tools/tests/test_architecture.py tools/tests/test_family_impact.py
+```
+
+For a dirty local self-review, use `git diff --check <merge-base>` to include
+tracked working-tree changes, inspect untracked files explicitly, and state
+that impact selection covers the committed head unless explicit files were
+supplied. Do not represent uncommitted content as reviewed by the `HEAD` SHA.
+
+Then run the smallest tests that directly exercise each changed contract and
+affected family. Do not run downloaded contributor code with credentials or on
+protected hardware. If dependencies, checkpoints, or target hardware are not
+available, inspect the test logic and report the missing evidence instead of
+claiming execution.
+
+Interpret CI carefully:
+
+- Public Community CPU and protected premerge are different evidence tiers.
+- A bridge dispatch is not a protected test pass.
+- Only a passing `TRTMC Internal CI / Automated premerge gate` on the current
+  head proves protected premerge for that head.
+- A later push invalidates earlier head evidence. A base advance may also
+  require a fresh exact-merge result.
+- Green source or architecture checks do not prove TensorRT build, checkpoint
+  inference, model parity, target-platform behavior, or performance.
+
+## Report Findings First
+
+For a maintainer review, return a concise review in this order:
+
+1. `Verdict: PASS | BLOCK | HUMAN REVIEW REQUIRED`, `Merge readiness: READY |
+   NOT READY`, the recommended GitHub action (`Approve`, `Request changes`,
+   `Comment`, or `Wait`), and exact base/head.
+2. Findings ordered by severity. For each finding include:
+   - `Blocking`, `High`, or `Medium` and a short title;
+   - violated architecture rule or claimed behavior;
+   - exact changed-file line evidence and the relevant caller/consumer;
+   - affected family or shared blast radius;
+   - the smallest correction or evidence that would resolve it.
+3. A short architecture summary covering family ownership, shared neutrality,
+   one-way application dependencies, and validation ownership.
+4. Checks/evidence verified, followed by untested paths and residual risk.
+5. A contributor-facing reply only when requested. Draft it in friendly,
+   specific English; distinguish repository evolution from contributor error.
+
+For contributor self-review, use the same finding and evidence structure, but
+replace merge authority with:
+
+1. `Verdict: PASS | BLOCK | HUMAN REVIEW REQUIRED`, `Submission readiness:
+   READY TO MARK READY | READY TO OPEN DRAFT | KEEP DRAFT | NOT READY`, exact
+   base/head, and whether the worktree is clean.
+2. The next contributor action. Do not recommend `Approve` or `Request
+   changes`, because contributors do not review their own PR in that role.
+3. A ready-to-paste **Contributor Self-Review** record containing `Method`,
+   `Reviewed Head`, `Result`, and `Findings and Resolution`. Use the full
+   immutable head SHA, or state that no immutable reviewed head exists when the
+   worktree is dirty.
+
+Keep review verdict separate from merge readiness. A code/architecture `PASS`
+may still be `NOT READY` while required exact-head CI, model proof, or human
+approval is pending.
+
+Use `BLOCK` for an evidence-backed incorrect result, validation weakening,
+public-contract defect, direct cross-family dependency, model semantics in
+shared implementation, or other merge blocker. Use `HUMAN REVIEW REQUIRED`
+when a material contract, consumer need, compatibility choice, or architecture
+exception cannot be resolved from available evidence. Use `PASS` only when no
+violation was found, and preserve its limits.
+
+Do not emit style-only Low findings. Consolidate repeated symptoms under one
+root cause, distinguish facts from risks, and never invent a test result or
+claim that CI covers an unexecuted path.

--- a/plugins/trtmc-agent-skills/skills/review-trtmc-pr/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/review-trtmc-pr/SKILL.md
@@ -41,9 +41,9 @@ description: >-
   untracked files. A dirty working tree cannot receive a ready-to-submit result
   because its uncommitted content has no immutable reviewed head.
 
-For contributor self-review, remain read-only and prepare a result the
-contributor can paste into the PR template. Do not mark the PR ready, push,
-commit, edit files, or publish comments unless separately requested.
+For contributor self-review, remain read-only and tell the contributor whether
+the self-review checkbox can honestly be selected. Do not mark the PR ready,
+push, commit, edit files, or publish comments unless separately requested.
 
 ## Establish The Pull-Request Baseline
 
@@ -257,9 +257,8 @@ Check that:
   the current architecture;
 - validation lists exact commands, outcomes, tested head, checkpoint and
   dependency revisions, hardware/environment when relevant, and unrun paths;
-- contributor self-review records the method, exact reviewed head, result,
-  corrected findings, and unresolved risks; a later code push invalidates that
-  record;
+- the contributor self-review checkbox is selected only after the contributor
+  has actually reviewed the change;
 - repository documentation, code comments, user-facing messages, and PR text
   are English except model data needed for multilingual validation;
 - SPDX headers, third-party notices, asset entries, and redistribution rights
@@ -332,10 +331,9 @@ replace merge authority with:
    base/head, and whether the worktree is clean.
 2. The next contributor action. Do not recommend `Approve` or `Request
    changes`, because contributors do not review their own PR in that role.
-3. A ready-to-paste **Contributor Self-Review** record containing `Method`,
-   `Reviewed Head`, `Result`, and `Findings and Resolution`. Use the full
-   immutable head SHA, or state that no immutable reviewed head exists when the
-   worktree is dirty.
+3. Whether the contributor can honestly select the **Contributor Self-Review**
+   checkbox. Keep the detailed verdict, findings, exact head, and evidence in
+   the review response; the PR template requires only the confirmation.
 
 Keep review verdict separate from merge readiness. A code/architecture `PASS`
 may still be `NOT READY` while required exact-head CI, model proof, or human

--- a/plugins/trtmc-agent-skills/skills/review-trtmc-pr/agents/openai.yaml
+++ b/plugins/trtmc-agent-skills/skills/review-trtmc-pr/agents/openai.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 interface:
   display_name: "Review TRTMC PR"
   short_description: "Review TRTMC branches and PRs for compliance"

--- a/plugins/trtmc-agent-skills/skills/review-trtmc-pr/agents/openai.yaml
+++ b/plugins/trtmc-agent-skills/skills/review-trtmc-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review TRTMC PR"
+  short_description: "Review TRTMC branches and PRs for compliance"
+  default_prompt: "Use $review-trtmc-pr to self-review this branch or review this PR against the current TRTMC architecture and repository rules."

--- a/plugins/trtmc-agent-skills/skills/review-trtmc-pr/references/manual-review-probes.md
+++ b/plugins/trtmc-agent-skills/skills/review-trtmc-pr/references/manual-review-probes.md
@@ -1,0 +1,176 @@
+# Manual Review Probes
+
+Use these probes after the fast diff-boundary pass. They capture recurring
+semantic failures that static architecture tests and green CI can miss. Current
+repository policy and code remain authoritative.
+
+## Intent And Current Need
+
+- Does the linked issue still reproduce on the PR's current base?
+- Did #1093 or a later merge remove the original consumers or change the
+  ownership boundary?
+- Is a new abstraction used by a concrete current consumer in the same change?
+- Is the proposed shared API needed by user behavior that existing public
+  contracts cannot express, or is it only symmetry, future possibility, or
+  line-count reduction?
+- Does the PR description claim old paths, APIs, registries, or tests that no
+  longer exist?
+
+Do not equate “model-agnostic data format” with “every language needs another
+parser.” Identify the canonical owner and an independent consumer first.
+
+## Family Isolation Beyond Paths
+
+- Search family production and tests for imports, includes, CMake links,
+  `dlopen`, file reads, symlinks, fixtures, threshold files, and subprocess
+  calls that enter a sibling family.
+- Search shared code for literal family/checkpoint names, model tensor names,
+  task-specific metrics, thresholds, datasets, probes, reference adapters,
+  strategy maps, and family conditionals.
+- Check whether adding or reverting the family requires editing a root source
+  list, registry, switch, catalog exception, or another family.
+- If the PR edits an architecture allowlist or guard so its new file can pass,
+  review that as a shared-contract change. Adding a path to an expected set is
+  not evidence that the path belongs in shared code.
+- Treat a central allowlist or exclusion added only for one model as a coupling
+  smell. Determine whether it is current approved application policy or model
+  behavior that belongs in the family before reporting a violation.
+- Verify package/import isolation: discovery must not import unselected family
+  implementation or optional dependencies.
+
+Passing path guards establishes structural conformance only. It does not prove
+that configuration, runtime behavior, or validation semantics are isolated.
+
+## Shared Contract Review
+
+For every changed shared surface, list all known consumers and ask:
+
+- Is the contract expressed in task/user terms rather than the first family's
+  model terms?
+- Does a default value accidentally encode one model's calibrated policy?
+- Can specialization remain family-supplied without a family switch in core?
+- Does the shared layer validate only safe generic mechanics while leaving
+  section/output meaning with the family?
+- Are public API, ABI, bundle, CLI, compatibility, and documentation effects
+  declared and tested?
+- Does the evidence cover structurally different consumers, not only the
+  introducing family?
+
+A new model-agnostic Task interface can be valid even when its first consumer
+is one family. A new model helper, comparator, scheduler, or parser is not
+justified merely because several implementations look similar.
+
+## Runtime And Lifetime
+
+- Trace ownership after `load_task()` and after the family factory returns.
+- Look for references, pointers, spans, callbacks, or lambdas that outlive
+  stack-local loader objects or `FamilyContext`.
+- A deferred reader should own/copy the lightweight `BundleReader`; it must not
+  retain a reference to temporary context.
+- Confirm Task destruction precedes family/backend DSO unload and that streams,
+  buffers, communicators, modules, samplers, and engines have clear owners.
+- Ensure a family uses abstract `IBackend`/`IEngine`, not the concrete TRT
+  backend or runtime loader implementation.
+- Confirm distributed collectives load NCCL only when the family actually
+  creates a communicator; rank-specific replicated plans alone do not justify
+  it.
+- Reject environment, current-directory, sibling-probe, or retry fallback that
+  changes exact family/backend dispatch.
+
+## Model Semantics And External Checkpoints
+
+Inspect the pinned upstream revision rather than inferring behavior from the
+family name.
+
+- Match actual checkpoint weight keys and transformations exactly.
+- Track tensor layout across reshape, transpose, flatten, concatenation, and
+  binding boundaries.
+- Check special classes/tokens such as no-object/background IDs, EOS variants,
+  padding IDs, and ignored labels.
+- Reproduce the model card's system/user messages, chat template options,
+  preprocessing, generation settings, and task-specific control fields.
+- Check resize aspect ratio, crop behavior, padding values, masks, coordinate
+  spaces, and postprocessing scale restoration.
+- Verify task defaults and support declarations describe the real capability,
+  not only the base architecture class.
+- Do not create a new family merely because a checkpoint has a specialized
+  product use. The boundary follows mathematical topology and runtime
+  orchestration; specialized checkpoint inputs and oracles may remain owned by
+  an existing family when that family can validate them without shared policy.
+- Check the exact checkpoint and asset licenses plus any naming, attribution,
+  or redistribution conditions.
+
+Native/reference agreement under the same malformed input is not proof of the
+advertised model behavior.
+
+## Validation And Oracle Strength
+
+- Identify the bug or wrong output that each new test would reject.
+- Confirm the changed production path is reached; mock fallback must not turn a
+  build/load failure into a passing unit test.
+- Confirm an E2E selector accounts for requested, executed, passed, failed, and
+  skipped cases with one result per request.
+- Check that an oracle observes every essential result field. Top-1 label alone
+  may miss boxes/counts; mean and variance alone may accept unrelated images;
+  one generated token may miss tokenizer, stopping, or cache defects.
+- For numeric gates, inspect comparison direction, units, aggregation level,
+  worst-case behavior, sample count, and negative controls.
+- Verify reference and native sides use the same prompt framing, preprocessing,
+  initial state/latents, precision intent, generation parameters, and output
+  interpretation.
+- Treat family-local E2E as family evidence. A shared runtime/build/CI change
+  needs evidence proportional to every selected consumer class.
+- Separate compilation, unit, runtime smoke, official-checkpoint inference,
+  parity, target-hardware, performance, and release qualification.
+
+## Dependency And Build Isolation
+
+- A root requirement duplicated or contradicted by a family requirement creates
+  two owners and can force cross-family coordination.
+- A selected-family job should install only the shared base plus that family's
+  extras; a green `--no-deps` install is not dependency compatibility proof.
+- Check build files for central per-family sources, conditional names, or links
+  to another family.
+- Confirm family DSO naming and install rules are owner-local and that package
+  validation discovers the DSO without importing all family implementations.
+- Distinguish an immutable base-container pin from family-specific dependency
+  policy.
+
+## CI And Trust Boundaries
+
+- Verify status/check conclusions against the current PR head SHA.
+- Distinguish PR head tests from GitHub's exact merge-revision tests.
+- Do not treat a dispatched workflow, successful bridge, or visible source job
+  as the protected premerge result.
+- Check that fork PR code cannot execute on a privileged self-hosted host before
+  entering the intended isolated environment.
+- Third-party actions should be full-SHA pinned and permissions least-privilege.
+- Ensure changed test paths, JUnit locations, artifact names, and selectors
+  still match their workflow consumers.
+- Public contributor feedback must say which public command or phase failed
+  without leaking private logs, hosts, artifacts, or URLs.
+
+## Repository Hygiene
+
+- New source/build file extensions must be classified by the legal-header
+  checker rather than excluded merely to pass it.
+- JavaScript and other languages must use the repository-approved SPDX comment
+  form.
+- New or copied media must appear in `ASSET_LICENSES.md` with correct origin and
+  license when required.
+- Tests must fail if a native addon, DSO, or executable cannot build or load;
+  an automatic mock fallback hides the contribution's actual integration.
+- PR categories, risk, paths, API claims, validation, and unrun gaps must agree
+  with the diff and current repository layout.
+
+## Avoid False Findings
+
+- Shared-file modification alone is not coupling.
+- Intentional family-local duplication is not a maintainability defect under
+  this architecture.
+- Pre-existing unchanged debt is not introduced by the PR.
+- A family-only diff is not automatically behaviorally correct.
+- Green static or CPU CI is not GPU, model-parity, or performance evidence.
+- A passing round trip is not an independent compatibility proof.
+- Missing evidence is uncertainty; describe exactly what remains unverified
+  instead of asserting failure without evidence.

--- a/tools/pr_metadata.py
+++ b/tools/pr_metadata.py
@@ -27,13 +27,7 @@ VALIDATION_SUBSECTIONS = (
     "Hardware, Environment, and Revisions",
     "Not Run / Remaining Gaps",
 )
-SELF_REVIEW_SUBSECTIONS = (
-    "Method",
-    "Reviewed Head",
-    "Result",
-    "Findings and Resolution",
-)
-SELF_REVIEW_RESULTS = ("PASS", "BLOCK", "HUMAN REVIEW REQUIRED")
+SELF_REVIEW_CONFIRMATION = "I have completed a self-review of this change."
 CHANGE_CATEGORIES = (
     "Model or runtime behavior",
     "Public API",
@@ -47,7 +41,6 @@ RISK_LEVELS = ("Low", "Medium", "High")
 _HEADING_RE = re.compile(r"^(?P<level>#{2,3})[ \t]+(?P<title>.+?)[ \t]*$", re.MULTILINE)
 _CHECKBOX_RE = re.compile(r"^- \[(?P<mark>[ xX])\] (?P<label>.+?)[ \t]*$", re.MULTILINE)
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
-_FULL_GIT_SHA_RE = re.compile(r"(?<![0-9a-f])(?:[0-9a-f]{40}|[0-9a-f]{64})(?![0-9a-f])", re.IGNORECASE)
 
 
 class MetadataError(RuntimeError):
@@ -83,7 +76,6 @@ def checked_options(body: str, options: Sequence[str]) -> list[str]:
 def validate_body(
     body: str,
     *,
-    expected_head_sha: str | None = None,
     require_self_review: bool = True,
 ) -> list[str]:
     errors: list[str] = []
@@ -96,7 +88,7 @@ def validate_body(
         content = sections.get(title.casefold())
         if content is None:
             errors.append(f"Missing required section: {title}")
-        elif title != "Validation" and not _meaningful(content):
+        elif title not in ("Validation", "Contributor Self-Review") and not _meaningful(content):
             errors.append(f"Required section is empty: {title}")
 
     nested_requirements = {
@@ -104,8 +96,6 @@ def validate_body(
         "Validation": VALIDATION_SUBSECTIONS,
         "Notes For Future Readers": ("Risk level",),
     }
-    if require_self_review:
-        nested_requirements["Contributor Self-Review"] = SELF_REVIEW_SUBSECTIONS
     for section_title, subsection_titles in nested_requirements.items():
         content = sections.get(section_title.casefold(), "")
         subsections = _heading_blocks(content, 3)
@@ -127,20 +117,11 @@ def validate_body(
     if len(selected_risks) != 1:
         errors.append("Select exactly one Risk level option")
     if require_self_review:
-        self_review_subsections = _heading_blocks(sections.get("contributor self-review", ""), 3)
-        reviewed_head = self_review_subsections.get("reviewed head")
-        if reviewed_head is not None and _meaningful(reviewed_head):
-            match = _FULL_GIT_SHA_RE.search(_HTML_COMMENT_RE.sub("", reviewed_head))
-            if match is None:
-                errors.append("Contributor Self-Review / Reviewed Head must contain a full Git commit SHA")
-            elif expected_head_sha is not None and match.group(0).casefold() != expected_head_sha.casefold():
-                errors.append("Contributor Self-Review / Reviewed Head does not match the current PR head")
-        result = self_review_subsections.get("result")
-        if result is not None and _meaningful(result):
-            normalized_result = _HTML_COMMENT_RE.sub("", result).strip().strip("`").strip().upper()
-            if normalized_result not in SELF_REVIEW_RESULTS:
-                choices = ", ".join(SELF_REVIEW_RESULTS)
-                errors.append(f"Contributor Self-Review / Result must be exactly one of: {choices}")
+        self_review = sections.get("contributor self-review", "")
+        if SELF_REVIEW_CONFIRMATION not in checked_options(
+            self_review, (SELF_REVIEW_CONFIRMATION,)
+        ):
+            errors.append("Complete the Contributor Self-Review checkbox")
     return errors
 
 
@@ -158,18 +139,6 @@ def _pull_request_body(event: Mapping[str, object]) -> str:
     return body if isinstance(body, str) else ""
 
 
-def _pull_request_head_sha(event: Mapping[str, object]) -> str:
-    pull_request = event["pull_request"]
-    assert isinstance(pull_request, Mapping)
-    head = pull_request.get("head")
-    if not isinstance(head, Mapping):
-        raise MetadataError("GitHub event does not contain pull_request head SHA")
-    sha = head.get("sha")
-    if not isinstance(sha, str):
-        raise MetadataError("GitHub event does not contain pull_request head SHA")
-    return sha
-
-
 def _pull_request_is_draft(event: Mapping[str, object]) -> bool:
     pull_request = event["pull_request"]
     assert isinstance(pull_request, Mapping)
@@ -183,7 +152,6 @@ def _validate(event_path: Path) -> None:
     event = _load_event(event_path)
     errors = validate_body(
         _pull_request_body(event),
-        expected_head_sha=_pull_request_head_sha(event),
         require_self_review=not _pull_request_is_draft(event),
     )
     if errors:

--- a/tools/pr_metadata.py
+++ b/tools/pr_metadata.py
@@ -19,6 +19,7 @@ REQUIRED_SECTIONS = (
     "Exit Criteria",
     "Implementation",
     "Validation",
+    "Contributor Self-Review",
     "Notes For Future Readers",
 )
 VALIDATION_SUBSECTIONS = (
@@ -26,6 +27,13 @@ VALIDATION_SUBSECTIONS = (
     "Hardware, Environment, and Revisions",
     "Not Run / Remaining Gaps",
 )
+SELF_REVIEW_SUBSECTIONS = (
+    "Method",
+    "Reviewed Head",
+    "Result",
+    "Findings and Resolution",
+)
+SELF_REVIEW_RESULTS = ("PASS", "BLOCK", "HUMAN REVIEW REQUIRED")
 CHANGE_CATEGORIES = (
     "Model or runtime behavior",
     "Public API",
@@ -39,6 +47,7 @@ RISK_LEVELS = ("Low", "Medium", "High")
 _HEADING_RE = re.compile(r"^(?P<level>#{2,3})[ \t]+(?P<title>.+?)[ \t]*$", re.MULTILINE)
 _CHECKBOX_RE = re.compile(r"^- \[(?P<mark>[ xX])\] (?P<label>.+?)[ \t]*$", re.MULTILINE)
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_FULL_GIT_SHA_RE = re.compile(r"(?<![0-9a-f])(?:[0-9a-f]{40}|[0-9a-f]{64})(?![0-9a-f])", re.IGNORECASE)
 
 
 class MetadataError(RuntimeError):
@@ -71,11 +80,19 @@ def checked_options(body: str, options: Sequence[str]) -> list[str]:
     return [option for option in options if option in checked]
 
 
-def validate_body(body: str) -> list[str]:
+def validate_body(
+    body: str,
+    *,
+    expected_head_sha: str | None = None,
+    require_self_review: bool = True,
+) -> list[str]:
     errors: list[str] = []
     visible_body = _HTML_COMMENT_RE.sub("", body)
     sections = _heading_blocks(visible_body, 2)
-    for title in REQUIRED_SECTIONS:
+    required_sections = tuple(
+        title for title in REQUIRED_SECTIONS if require_self_review or title != "Contributor Self-Review"
+    )
+    for title in required_sections:
         content = sections.get(title.casefold())
         if content is None:
             errors.append(f"Missing required section: {title}")
@@ -87,6 +104,8 @@ def validate_body(body: str) -> list[str]:
         "Validation": VALIDATION_SUBSECTIONS,
         "Notes For Future Readers": ("Risk level",),
     }
+    if require_self_review:
+        nested_requirements["Contributor Self-Review"] = SELF_REVIEW_SUBSECTIONS
     for section_title, subsection_titles in nested_requirements.items():
         content = sections.get(section_title.casefold(), "")
         subsections = _heading_blocks(content, 3)
@@ -107,6 +126,21 @@ def validate_body(body: str) -> list[str]:
     selected_risks = checked_options(risk_level, RISK_LEVELS)
     if len(selected_risks) != 1:
         errors.append("Select exactly one Risk level option")
+    if require_self_review:
+        self_review_subsections = _heading_blocks(sections.get("contributor self-review", ""), 3)
+        reviewed_head = self_review_subsections.get("reviewed head")
+        if reviewed_head is not None and _meaningful(reviewed_head):
+            match = _FULL_GIT_SHA_RE.search(_HTML_COMMENT_RE.sub("", reviewed_head))
+            if match is None:
+                errors.append("Contributor Self-Review / Reviewed Head must contain a full Git commit SHA")
+            elif expected_head_sha is not None and match.group(0).casefold() != expected_head_sha.casefold():
+                errors.append("Contributor Self-Review / Reviewed Head does not match the current PR head")
+        result = self_review_subsections.get("result")
+        if result is not None and _meaningful(result):
+            normalized_result = _HTML_COMMENT_RE.sub("", result).strip().strip("`").strip().upper()
+            if normalized_result not in SELF_REVIEW_RESULTS:
+                choices = ", ".join(SELF_REVIEW_RESULTS)
+                errors.append(f"Contributor Self-Review / Result must be exactly one of: {choices}")
     return errors
 
 
@@ -124,8 +158,34 @@ def _pull_request_body(event: Mapping[str, object]) -> str:
     return body if isinstance(body, str) else ""
 
 
+def _pull_request_head_sha(event: Mapping[str, object]) -> str:
+    pull_request = event["pull_request"]
+    assert isinstance(pull_request, Mapping)
+    head = pull_request.get("head")
+    if not isinstance(head, Mapping):
+        raise MetadataError("GitHub event does not contain pull_request head SHA")
+    sha = head.get("sha")
+    if not isinstance(sha, str):
+        raise MetadataError("GitHub event does not contain pull_request head SHA")
+    return sha
+
+
+def _pull_request_is_draft(event: Mapping[str, object]) -> bool:
+    pull_request = event["pull_request"]
+    assert isinstance(pull_request, Mapping)
+    draft = pull_request.get("draft")
+    if not isinstance(draft, bool):
+        raise MetadataError("GitHub event does not contain pull_request draft state")
+    return draft
+
+
 def _validate(event_path: Path) -> None:
-    errors = validate_body(_pull_request_body(_load_event(event_path)))
+    event = _load_event(event_path)
+    errors = validate_body(
+        _pull_request_body(event),
+        expected_head_sha=_pull_request_head_sha(event),
+        require_self_review=not _pull_request_is_draft(event),
+    )
     if errors:
         for error in errors:
             print(f"::error title=PR metadata::{error}")

--- a/tools/tests/test_pr_metadata.py
+++ b/tools/tests/test_pr_metadata.py
@@ -14,7 +14,6 @@ from tools import pr_metadata
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-REVIEWED_HEAD = "d" * 40
 
 
 def _complete_body() -> str:
@@ -59,21 +58,7 @@ GPU execution was not run because runtime math is unchanged.
 
 ## Contributor Self-Review
 
-### Method
-
-`$review-trtmc-pr` on draft PR #123.
-
-### Reviewed Head
-
-`{REVIEWED_HEAD}`
-
-### Result
-
-PASS
-
-### Findings and Resolution
-
-PASS; no blocking or high-severity findings remain.
+- [x] I have completed a self-review of this change.
 
 ## Notes For Future Readers
 
@@ -89,7 +74,7 @@ ownership check before the model-owned regression.
 
 The change is isolated to model selection.
 
-""".format(REVIEWED_HEAD=REVIEWED_HEAD)
+"""
 
 
 def _without_self_review(body: str) -> str:
@@ -123,64 +108,26 @@ def test_validation_requires_commands_results_environment_revisions_and_gaps() -
     )
 
 
-def test_self_review_requires_method_head_result_and_findings() -> None:
-    evidence_by_subsection = {
-        "Method": "`$review-trtmc-pr` on draft PR #123.",
-        "Reviewed Head": f"`{REVIEWED_HEAD}`",
-        "Result": "PASS",
-        "Findings and Resolution": "PASS; no blocking or high-severity findings remain.",
-    }
-
-    for title, evidence in evidence_by_subsection.items():
-        body = _complete_body().replace(evidence, "<!-- required self-review evidence omitted -->")
-
-        assert (
-            f"Required subsection is empty: Contributor Self-Review / {title}"
-            in pr_metadata.validate_body(body)
-        )
-
-
-def test_self_review_head_must_be_full_and_match_current_pr_head() -> None:
-    short_head = _complete_body().replace(REVIEWED_HEAD, REVIEWED_HEAD[:12])
-    wrong_head = "e" * 40
-
-    assert (
-        "Contributor Self-Review / Reviewed Head must contain a full Git commit SHA"
-        in pr_metadata.validate_body(short_head)
+def test_self_review_requires_confirmation_checkbox() -> None:
+    body = _complete_body().replace(
+        "- [x] I have completed a self-review of this change.",
+        "- [ ] I have completed a self-review of this change.",
     )
-    assert (
-        "Contributor Self-Review / Reviewed Head does not match the current PR head"
-        in pr_metadata.validate_body(_complete_body(), expected_head_sha=wrong_head)
-    )
-    assert pr_metadata.validate_body(_complete_body(), expected_head_sha=REVIEWED_HEAD) == []
+
+    assert "Complete the Contributor Self-Review checkbox" in pr_metadata.validate_body(body)
 
 
-def test_self_review_result_uses_a_supported_verdict() -> None:
-    body = _complete_body().replace("\nPASS\n\n### Findings", "\nREADY\n\n### Findings")
-
-    assert (
-        "Contributor Self-Review / Result must be exactly one of: "
-        "PASS, BLOCK, HUMAN REVIEW REQUIRED"
-    ) in pr_metadata.validate_body(body)
-
-
-def test_event_validation_compares_self_review_with_current_pr_head(tmp_path: Path) -> None:
+def test_ready_event_accepts_self_review_confirmation(tmp_path: Path) -> None:
     event_path = tmp_path / "event.json"
     event = {
         "pull_request": {
             "body": _complete_body(),
             "draft": False,
-            "head": {"sha": REVIEWED_HEAD},
         }
     }
     event_path.write_text(json.dumps(event), encoding="utf-8")
 
     assert pr_metadata.main(["validate", "--event", str(event_path)]) == 0
-
-    event["pull_request"]["head"]["sha"] = "e" * 40
-    event_path.write_text(json.dumps(event), encoding="utf-8")
-
-    assert pr_metadata.main(["validate", "--event", str(event_path)]) == 1
 
 
 def test_draft_event_allows_self_review_to_remain_pending(tmp_path: Path) -> None:
@@ -189,7 +136,6 @@ def test_draft_event_allows_self_review_to_remain_pending(tmp_path: Path) -> Non
         "pull_request": {
             "body": _without_self_review(_complete_body()),
             "draft": True,
-            "head": {"sha": REVIEWED_HEAD},
         }
     }
     event_path.write_text(json.dumps(event), encoding="utf-8")
@@ -264,8 +210,7 @@ def test_template_and_validator_share_the_same_contract() -> None:
         assert f"## {title}" in template
     for title in pr_metadata.VALIDATION_SUBSECTIONS:
         assert f"### {title}" in template
-    for title in pr_metadata.SELF_REVIEW_SUBSECTIONS:
-        assert f"### {title}" in template
+    assert f"- [ ] {pr_metadata.SELF_REVIEW_CONFIRMATION}" in template
     for option in (*pr_metadata.CHANGE_CATEGORIES, *pr_metadata.RISK_LEVELS):
         assert f"- [ ] {option}" in template
 

--- a/tools/tests/test_pr_metadata.py
+++ b/tools/tests/test_pr_metadata.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import yaml
@@ -13,6 +14,7 @@ from tools import pr_metadata
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+REVIEWED_HEAD = "d" * 40
 
 
 def _complete_body() -> str:
@@ -55,6 +57,24 @@ Repository head `def456`; Qwen revision `abc123`; CPU-only Ubuntu 24.04.
 
 GPU execution was not run because runtime math is unchanged.
 
+## Contributor Self-Review
+
+### Method
+
+`$review-trtmc-pr` on draft PR #123.
+
+### Reviewed Head
+
+`{REVIEWED_HEAD}`
+
+### Result
+
+PASS
+
+### Findings and Resolution
+
+PASS; no blocking or high-severity findings remain.
+
 ## Notes For Future Readers
 
 Family-owned support resolution replaces the previous selector. Existing
@@ -69,7 +89,13 @@ ownership check before the model-owned regression.
 
 The change is isolated to model selection.
 
-"""
+""".format(REVIEWED_HEAD=REVIEWED_HEAD)
+
+
+def _without_self_review(body: str) -> str:
+    start = body.index("## Contributor Self-Review")
+    end = body.index("## Notes For Future Readers")
+    return body[:start] + body[end:]
 
 
 def test_complete_pull_request_body_passes() -> None:
@@ -95,6 +121,80 @@ def test_validation_requires_commands_results_environment_revisions_and_gaps() -
         "Required subsection is empty: Validation / Hardware, Environment, and Revisions"
         in pr_metadata.validate_body(body)
     )
+
+
+def test_self_review_requires_method_head_result_and_findings() -> None:
+    evidence_by_subsection = {
+        "Method": "`$review-trtmc-pr` on draft PR #123.",
+        "Reviewed Head": f"`{REVIEWED_HEAD}`",
+        "Result": "PASS",
+        "Findings and Resolution": "PASS; no blocking or high-severity findings remain.",
+    }
+
+    for title, evidence in evidence_by_subsection.items():
+        body = _complete_body().replace(evidence, "<!-- required self-review evidence omitted -->")
+
+        assert (
+            f"Required subsection is empty: Contributor Self-Review / {title}"
+            in pr_metadata.validate_body(body)
+        )
+
+
+def test_self_review_head_must_be_full_and_match_current_pr_head() -> None:
+    short_head = _complete_body().replace(REVIEWED_HEAD, REVIEWED_HEAD[:12])
+    wrong_head = "e" * 40
+
+    assert (
+        "Contributor Self-Review / Reviewed Head must contain a full Git commit SHA"
+        in pr_metadata.validate_body(short_head)
+    )
+    assert (
+        "Contributor Self-Review / Reviewed Head does not match the current PR head"
+        in pr_metadata.validate_body(_complete_body(), expected_head_sha=wrong_head)
+    )
+    assert pr_metadata.validate_body(_complete_body(), expected_head_sha=REVIEWED_HEAD) == []
+
+
+def test_self_review_result_uses_a_supported_verdict() -> None:
+    body = _complete_body().replace("\nPASS\n\n### Findings", "\nREADY\n\n### Findings")
+
+    assert (
+        "Contributor Self-Review / Result must be exactly one of: "
+        "PASS, BLOCK, HUMAN REVIEW REQUIRED"
+    ) in pr_metadata.validate_body(body)
+
+
+def test_event_validation_compares_self_review_with_current_pr_head(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event = {
+        "pull_request": {
+            "body": _complete_body(),
+            "draft": False,
+            "head": {"sha": REVIEWED_HEAD},
+        }
+    }
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+
+    assert pr_metadata.main(["validate", "--event", str(event_path)]) == 0
+
+    event["pull_request"]["head"]["sha"] = "e" * 40
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+
+    assert pr_metadata.main(["validate", "--event", str(event_path)]) == 1
+
+
+def test_draft_event_allows_self_review_to_remain_pending(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event = {
+        "pull_request": {
+            "body": _without_self_review(_complete_body()),
+            "draft": True,
+            "head": {"sha": REVIEWED_HEAD},
+        }
+    }
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+
+    assert pr_metadata.main(["validate", "--event", str(event_path)]) == 0
 
 
 def test_change_category_and_risk_choices_are_enforced() -> None:
@@ -163,6 +263,8 @@ def test_template_and_validator_share_the_same_contract() -> None:
     for title in pr_metadata.REQUIRED_SECTIONS:
         assert f"## {title}" in template
     for title in pr_metadata.VALIDATION_SUBSECTIONS:
+        assert f"### {title}" in template
+    for title in pr_metadata.SELF_REVIEW_SUBSECTIONS:
         assert f"### {title}" in template
     for option in (*pr_metadata.CHANGE_CATEGORIES, *pr_metadata.RISK_LEVELS):
         assert f"- [ ] {option}" in template

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -9,4 +9,17 @@ Before opening a pull request, run the ownership validator, core tests, the
 affected family tests, and the affected native target. Sign off every commit
 with `git commit --signoff`.
 
+Open the pull request as a draft and self-review its exact current head before
+marking it ready. Codex users can run:
+
+```text
+$review-trtmc-pr review this draft PR as a contributor self-review
+```
+
+A documented manual review or another tool is also accepted. Record the method,
+full reviewed head SHA, result, corrected findings, and unresolved risks in the
+pull-request template. Any new code commit requires another self-review. For an
+earlier local pass, ask `$review-trtmc-pr` to review the current branch and
+working tree against `upstream/main`.
+
 See the repository-level `CONTRIBUTING.md` for the GitHub and CI flow.

--- a/website/docs/extend/contributing.md
+++ b/website/docs/extend/contributing.md
@@ -16,10 +16,9 @@ marking it ready. Codex users can run:
 $review-trtmc-pr review this draft PR as a contributor self-review
 ```
 
-A documented manual review or another tool is also accepted. Record the method,
-full reviewed head SHA, result, corrected findings, and unresolved risks in the
-pull-request template. Any new code commit requires another self-review. For an
-earlier local pass, ask `$review-trtmc-pr` to review the current branch and
-working tree against `upstream/main`.
+A documented manual review or another tool is also accepted. When complete,
+select the single **Contributor Self-Review** checkbox in the pull-request
+template. For an earlier local pass, ask `$review-trtmc-pr` to review the
+current branch and working tree against `upstream/main`.
 
 See the repository-level `CONTRIBUTING.md` for the GitHub and CI flow.


### PR DESCRIPTION
## Background

TensorRT-Model-Connect documents architecture and validation requirements, but contributors do not have a repository-defined self-review checkpoint before maintainer review. This makes preventable ownership, evidence, and PR metadata issues more likely to reach reviewers.

## Exit Criteria

- Provide a repo-local skill that reviews local branches and exact GitHub PR heads against the post-#1093 architecture.
- Require ready-for-review PRs to confirm self-review with one checkbox.
- Keep Codex optional by accepting an equivalent documented manual or third-party review.
- Keep draft PRs usable while self-review is still in progress.

## Implementation

- Add `$review-trtmc-pr` with separate local-branch and pull-request modes, family-isolation checks, behavioral validation probes, and contributor-facing output.
- Document a draft PR → self-review → fix → ready workflow in the root contribution guide and website quickstart.
- Extend the PR template and metadata validator with one self-review confirmation; drafts may leave it unchecked.
- Add focused tests for checked, unchecked, and draft behavior.

There are no public API, ABI, bundle, dependency, model-runtime, migration, or rollout changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [x] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `git diff --check github/main...HEAD`: passed.
- `python3 -m pytest -q tools/tests/test_pr_metadata.py`: 12 passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m pytest -q tools/tests/test_architecture.py tools/tests/test_family_impact.py`: 65 passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 -m tools.model_ci validate`: passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 tools/test_impact.py --validate`: passed.
- `PYTHONPATH=core/builder:apps/benchmark:. python3 tools/test_impact.py --base github/main --head HEAD`: passed; selected repository-wide core and docs coverage.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `ruff check tools/pr_metadata.py tools/tests/test_pr_metadata.py`: passed using the repository virtual environment.
- `pre-commit run`: passed on the exact staged follow-up diff.
- `npm --prefix website run test:model-support`: 1 passed.

### Hardware, Environment, and Revisions

Repository head `216b8360f84b5b29130932479c5a2888018c000e`; current base `aefbd09639f2bf036130719554a0df1f80580f94`; CPU-only Linux environment with Python 3.12 and Node.js 22.

### Not Run / Remaining Gaps

GPU execution, TensorRT inference, model parity, and performance qualification were not run because this change affects contributor tooling, metadata validation, and documentation only. Public and protected CI must complete again on the current head.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

- Review `tools/pr_metadata.py` and its tests first, then the contributor workflow, then the skill instructions and manual probes.
- Existing open PRs will need to select the new checkbox after they update to a base containing this change and are marked ready.
- The checkbox records only that self-review happened; it does not prescribe Codex, a report format, a verdict vocabulary, or review metadata.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

This adds one required confirmation checkbox for ready contributor PRs. Draft PRs may leave it unchecked.
