### PR TITLE
feat(devtoolkit): restore capability API

### DIFF
--- a/apps/devtoolkit/README.md
+++ b/apps/devtoolkit/README.md
@@ -73,6 +73,44 @@ Both methods return `PreparedEnvironment`. Its `command(...)` method forms a
 command for the prepared container or local shell, while
 `execution_target(...)` connects it to the capability layer below.
 
+## Runnable build examples
+
+The examples build only the model-agnostic `trtmc` CLI and TensorRT backend,
+then execute the evidence-bound binary with `trtmc version`.
+
+Docker preparation installs the repository's generic build dependencies and
+uses the TensorRT version pinned by the development Dockerfile:
+
+```bash
+python3 apps/devtoolkit/examples/docker_build.py --gpu 0
+```
+
+The local example runs directly on the host. It can adopt a matching complete
+CUDA/TensorRT installation or materialize a digest-pinned managed toolchain:
+
+```bash
+python3 apps/devtoolkit/examples/local_build.py \
+  --python /path/to/python3.12 \
+  --tensorrt 11.0.0.114
+```
+
+Local preparation intentionally does not install generic C++ or checkout
+Python build dependencies. The host must provide CMake, a C++ compiler,
+Ninja or Make, and nlohmann-json 3.11 or newer. The current top-level CMake
+configuration also imports Torch for the SANA-WM family even when the example
+does not build that family. Select an interpreter containing Torch when needed:
+
+```bash
+python3 apps/devtoolkit/examples/local_build.py \
+  --python /usr/bin/python3 \
+  --tensorrt 11.0.0.114 \
+  --cmake-python /path/to/python-with-torch \
+  --cmake-prefix-path /path/to/nlohmann-prefix
+```
+
+Both examples accept `--state-root` for receipts and isolated build state.
+Run either script with `--help` for the complete set of options.
+
 ## Resolve, provision, build, and run
 
 The capability core has four stages:

--- a/apps/devtoolkit/README.md
+++ b/apps/devtoolkit/README.md
@@ -1,66 +1,372 @@
 # TRTMC DevToolkit
 
-`apps/devtoolkit` prepares only the TensorRT-Model-Connect checkout passed to
-it. It has no environment catalog, compatibility matrix, receipt database, or
-artifact identity layer.
+`apps/devtoolkit` is the repository-local Python API for preparing a checkout
+and composing evidence-producing development environments. It is not a workflow
+engine: Python is the composition language, and every operation remains
+independently callable.
 
-The Docker path selects the repository's existing `Dockerfile.dev.x86` or
-`Dockerfile.dev.aarch64` from `platform.machine()` and runs the same direct
-development-image build documented for source builds. Each Dockerfile pins its
-base image in the first `FROM`. An unknown host architecture fails before any
-Docker command. Repository CI continues to own the separate root `Dockerfile`.
-The app then owns the small inspect/create/start lifecycle for one explicitly
-named persistent container. It does not calculate an image, source, dependency,
-wheel, plan, or bundle digest.
+## Prepare a checkout-owned target
+
+The checkout preparation layer follows the family-owned repository layout. It selects
+`Dockerfile.dev.x86` or `Dockerfile.dev.aarch64`, owns one fail-closed persistent
+container lifecycle, and installs only the selected family's optional
+`families/<family>/requirements.txt`. The local path adopts one explicit existing
+interpreter and installs the same family-owned requirements when present.
 
 ```python
 from pathlib import Path
 import sys
 
 repo = Path.cwd()
-sys.path.insert(0, str(repo / "apps/devtoolkit"))
+sys.path.insert(0, str(repo / "apps" / "devtoolkit"))
 
 from trtmc_devtoolkit import DevToolkit, DockerTargetPolicy
 
-environment = DevToolkit.from_checkout(repo).prepare_docker(
-    family="timm_resnet",
+toolkit = DevToolkit.from_checkout(repo)
+prepared = toolkit.prepare_docker(
+    family="qwen",
     gpu="0",
     policy=DockerTargetPolicy.ENSURE,
 )
-print(" ".join(environment.command("bash")))
+print(" ".join(prepared.command("bash")))
 ```
 
-An existing name is reused only when its checkout, requested image, immutable
-image ID, command, working directory, environment, bind mounts, GPU request,
-and optional IPC mode still match. A foreign collision or configuration drift
-fails closed; the toolkit never removes or replaces a container. `ADOPT`
-requires an already-running match, performs no mutation, and reuses any family
-dependencies already present. `START` may start a stopped match without
-building an image. `ENSURE` builds the selected development image and creates a
-missing target. All policies except `ADOPT` install the selected family's
-optional requirements after the target is running.
+A prepared target can be passed directly into the capability layer without
+duplicating its container ID or workspace mapping:
 
-Requested environment values are passed to `docker create` in a mode-`0600`
-temporary `--env-file`, which is removed immediately after the command. Values
-are not placed in command arguments or toolkit error messages.
+```python
+from trtmc_devtoolkit import EnvironmentRequest
 
-When `family` is present and the policy permits mutation, the toolkit installs
-only that owner's optional `families/<family>/requirements.txt`. A family
-without that file adds nothing to the shared image. There is no central
-dependency registry.
+lock = toolkit.resolve(
+    EnvironmentRequest(
+        tensorrt="11.1.0.106",
+        target=prepared.execution_target(),
+    )
+)
+environment = toolkit.provision(lock)
+```
 
-Local preparation uses an explicit existing system or virtual-environment
+`ENSURE` builds or reuses the checkout image and creates a missing owned
+container. `START` starts an existing matching container without rebuilding.
+`ADOPT` requires an already-running match and performs no mutation. A foreign
+name collision or any image, command, mount, environment, GPU, working-directory,
+or IPC drift fails without deleting or replacing the container.
+
+Requested environment values are passed to `docker create` through a temporary
+mode-`0600` `--env-file`, removed immediately after the command. Values are
+not placed in command arguments or toolkit error messages. `ADOPT` also skips
+the selected family's dependency installation.
+
+Local preparation uses one explicit existing system or virtual-environment
 interpreter. It does not create an environment, download a toolchain, or change
 CUDA, TensorRT, headers, or the driver:
 
 ```python
-environment = DevToolkit.from_checkout(repo).prepare_local(
+prepared = toolkit.prepare_local(
     python="/opt/trtmc-venv/bin/python",
     family="timm_resnet",
 )
-print(environment.python)
+print(prepared.python)
 ```
 
 Both methods return `PreparedEnvironment`. Its `command(...)` method forms a
-command for the prepared container or the current local shell. Build, test, and
-validation behavior remains owned by the public Source CLI and `tools.ci`.
+command for the prepared container or local shell, while
+`execution_target(...)` connects it to the capability layer below.
+
+## Resolve, provision, build, and run
+
+The capability core has four stages:
+
+```text
+EnvironmentRequest -> resolve() -> EnvironmentLock
+EnvironmentLock    -> provision() -> ProvisionedEnvironment
+ProvisionedEnvironment + BuildRecipe -> build() -> BuildResult
+ProvisionedEnvironment + CommandSpec -> run() -> CommandResult
+```
+
+Attestation and receipts are automatic postconditions of these operations.
+There is no cohort admission check in this path.
+
+## Resolve and use the target's existing toolchain
+
+The TensorRT request accepts any exact four-part version. When CUDA is omitted,
+resolution first looks for a complete target CUDA toolkit: `nvcc`, headers,
+`libcudart`, `libcublas`, and `libcurand` must all be present. If no complete
+target CUDA is available, the policy falls back to managed CUDA 13.3.
+
+```python
+from pathlib import Path
+import sys
+
+repo = Path.cwd()
+sys.path.insert(0, str(repo / "apps" / "devtoolkit"))
+
+from trtmc_devtoolkit import (
+    DevToolkit,
+    EnvironmentRequest,
+    ExecutionTarget,
+    TrtmcBuildRecipe,
+)
+
+toolkit = DevToolkit.from_checkout(repo)
+lock = toolkit.resolve(
+    EnvironmentRequest(
+        tensorrt="11.1.0.106",
+        target=ExecutionTarget.local(python="python3.12", gpu="0"),
+    )
+)
+environment = toolkit.provision(lock)
+build = toolkit.build(
+    environment,
+    TrtmcBuildRecipe(
+        targets=("trtmc", "trtmc_backend_trt", "trtmc_model_qwen"),
+        outputs={"trtmc": "trtmc"},
+    ),
+)
+
+toolkit.run_trtmc(environment, ("version",), build=build)
+```
+
+`build()` itself only snapshots source, serializes identical builds, runs the
+selected recipe, hashes outputs, and writes evidence. `TrtmcBuildRecipe` is an
+optional sample recipe that configures CMake against the resolved TensorRT
+runtime and builds only the requested targets. It does not install the checkout
+into or otherwise mutate the locked toolchain Python environment. User recipes
+can replace it completely. The sample recipe pins `CMAKE_CUDA_COMPILER` and
+`CUDAToolkit_ROOT` to the resolved runtime, disables optional BYOK by default,
+queries GPU compute capability through the CUDA Driver API (with `nvidia-smi`
+as a fallback), and automatically selects Ninja when available or Unix
+Makefiles otherwise. These choices can all be overridden explicitly.
+
+For a user-owned unified CUDA/TensorRT installation, pass
+the prefix as toolchain-owned configuration. Resolution checks the prefix
+rather than ambient host locations:
+
+```python
+request = EnvironmentRequest(
+    tensorrt="11.1.0.106",
+    target=ExecutionTarget.local(),
+    toolchain="prefix",
+    toolchain_options={"prefix": "/path/to/toolchain"},
+)
+```
+
+To combine managed TensorRT artifacts with a caller-owned CUDA prefix, use
+`toolchain_options={"cuda_prefix": "/path/to/cuda"}`. Execution target options
+never carry toolchain configuration.
+
+## Adopt an existing campaign container
+
+The capability layer's built-in Docker execution provider is adoption-only. It
+does not assume an NGC image, `/opt/venv`, `--gpus device=...`, or a checked-in
+Dockerfile. It inspects a running container, records its image ID, and probes
+its actual Python, CUDA, TensorRT Python package, native library, and headers
+before producing the lock.
+Docker CLI 20.10 or newer is required so command environment values can use
+`docker exec --env-file` without appearing in process arguments.
+The lock binds the Docker daemon ID, immutable container ID, and image ID. The
+binding is rechecked before provisioning, attestation, builds, and commands, so
+a recycled container name or changed Docker context fails closed.
+
+```python
+lock = toolkit.resolve(
+    EnvironmentRequest(
+        tensorrt="11.0.2.2",
+        architecture="aarch64",
+        target=ExecutionTarget.docker(
+            container="jedha-campaign",
+            docker_context="default",  # Omit to capture `docker context show`.
+            workspace="/workspace/TensorRT-Model-Connect",
+        ),
+    )
+)
+environment = toolkit.provision(lock)
+
+toolkit.run_trtmc(
+    environment,
+    ["build", "qwen3-0.6b", "--precision", "fp8", "--output", "/tmp/q.bundle"],
+)
+```
+
+The CLI arguments are opaque to DevToolkit. Model-specific flags, validation,
+and performance policy stay with the model family or caller recipe.
+Command environment values are passed through a short-lived mode-0600 Docker
+env file and removed after execution; they are never placed in Docker argv.
+
+## Managed fallback and arbitrary TensorRT
+
+Arbitrary-version support is accept, resolve, install, and attest. Resolution
+first tries the target's installed toolchains. If none matches, the built-in
+NVIDIA catalog resolves an exact public TensorRT distribution (Python package,
+bindings, native libraries, and development headers) to immutable SHA-256
+artifacts. With no complete target CUDA, it also resolves the CUDA 13.3 native
+build component closure from NVIDIA's redistribution manifest. Provisioning
+downloads those pins into a content-addressed cache and installs them under the
+environment's isolated state prefix; it does not modify the target's system
+Python or `/usr/local/cuda`. The public lock also pins `pip`, `setuptools`, and
+`wheel`, so a minimal target whose Python lacks `ensurepip` can bootstrap its
+isolated virtual environment without an OS-package install.
+
+Versions unavailable from the public indexes, such as an internal or pre-release
+build, can be supplied through a team JSON catalog. This is still automatic
+installation—the manifest is discovery metadata, not a cohort allowlist:
+
+```python
+from trtmc_devtoolkit import DevToolkit, JsonToolchainCatalog
+from trtmc_devtoolkit.spi import ProviderRegistry
+
+registry = ProviderRegistry.with_builtins()
+registry.register_catalog(JsonToolchainCatalog((repo / "private-toolchains.json",)))
+toolkit = DevToolkit.from_checkout(repo, providers=registry.freeze())
+
+lock = toolkit.resolve(
+    EnvironmentRequest(
+        tensorrt="11.1.0.106",
+        target=ExecutionTarget.local(),
+        toolchain_options={"catalog": "json-toolchain-catalog"},
+    )
+)
+```
+
+The corresponding manifest binds the private artifacts by digest and can reuse
+the target's complete CUDA toolkit by major version:
+
+```json
+{
+  "schema_version": 1,
+  "toolchains": [
+    {
+      "id": "gb300-trt-11.1.0.106",
+      "tensorrt": "11.1.0.106",
+      "python": "3.12",
+      "architecture": "x86_64",
+      "cuda": {"source": "target", "major": "13"},
+      "artifacts": [
+        {"name": "tensorrt-bindings", "uri": "https://artifact.example/bindings.whl", "sha256": "<64 lowercase hex>"},
+        {"name": "tensorrt-libs", "uri": "https://artifact.example/libs.whl", "sha256": "<64 lowercase hex>"},
+        {"name": "tensorrt-headers", "uri": "https://artifact.example/headers.deb", "sha256": "<64 lowercase hex>"}
+      ]
+    }
+  ]
+}
+```
+
+For an entirely managed CUDA, use `{"source": "managed", "version":
+"13.3", "release": "13.3.0", "artifacts": [...]}` and list the named CUDA
+component artifacts in the record's common `artifacts` array. A private source
+distribution targeting a minimal Python can likewise list digest-pinned
+bootstrap wheels in the common array and reference their names through
+`python_bootstrap_artifacts`. Relative artifact paths are resolved relative to
+the manifest and must be reachable from the execution target. Artifact URI
+userinfo cannot contain credentials. Use
+pre-authorized URLs, target-visible local paths, or a custom catalog and
+materializer when the artifact store requires another transport or
+authentication scheme.
+
+If neither a public nor an explicitly registered catalog can supply the exact
+version, resolution raises `ArtifactUnavailable`; it never substitutes a nearby
+version. Use `CudaPolicy.exact("12.8")`, `CudaPolicy.system_only()`, or
+`CudaPolicy.managed("13.3")` to override the default policy.
+
+## Qualification is explicit and source-neutral
+
+DevToolkit does not discover repository qualification records implicitly. A
+caller may attach optional qualification evidence through a source adapter;
+this never controls which TensorRT version can be attempted.
+
+```python
+from trtmc_devtoolkit import JsonQualificationSource
+
+toolkit = DevToolkit.from_checkout(
+    repo,
+    qualifications=(JsonQualificationSource((Path("my-qualifications"),)),),
+)
+
+# Optional provenance, fail closed only because the caller explicitly asks.
+request = EnvironmentRequest(
+    tensorrt="11.2.1.2",
+    target=ExecutionTarget.local(),
+    preset="trt112-cu133",
+    require_qualification=True,
+)
+```
+
+A JSON qualification record declares generic facts rather than the historical
+cohort shape:
+
+```json
+{
+  "id": "trt112-cu133",
+  "status": "qualified",
+  "requirements": {
+    "tensorrt": "11.2.1.2",
+    "cuda": ["13.3"],
+    "architecture": ["x86_64"],
+    "execution": ["local", "container"]
+  }
+}
+```
+
+The record's content digest is stored as provenance but does not alter the
+identity of an otherwise identical environment.
+Malformed qualification metadata is ignored for unrestricted resolution; it
+fails closed when the caller requests a preset or requires qualification.
+
+## Identity and evidence
+
+| Identity | Includes | Excludes |
+|---|---|---|
+| Environment lock | resolved context, effective path mapping, exact Python/CUDA/TRT, provider versions, artifact digests | source revision, GPU SM, preset spelling, private locator |
+| Provisioned environment | lock ID, effective execution identity, normalized toolchain runtime, observed file digests | command occurrence |
+| Build request | environment ID, source snapshot, SM set, CMake/build inputs | command occurrence |
+| Build result | build request ID and output digests | unrelated later runs |
+| Command invocation | environment ID, arguments, path scopes, environment-value digest, build/artifact provenance | occurrence ID |
+
+Provisioning writes `environment-lock.json`, `provision-receipt.json`, and an
+observed attestation under `.devtoolkit/environments/<lock-id>/`. Builds and
+commands write their own v3 receipts below that environment directory. Receipts
+do not serialize provider secrets or environment variable values. JSON receipts
+are replaced atomically, and provisioning for one environment ID is serialized
+across processes to avoid partial or competing terminal state. Identical build
+requests are also serialized across processes. A completed managed prefix is
+reused after fresh attestation, and a completed build is reused only after its
+receipt identity and output digests are revalidated.
+Build failures before a build request ID can be computed are recorded below
+`builds/preflight/` with the environment ID and failed stage.
+
+## Extension points
+
+There are three provider protocols:
+
+- `ToolchainSource`: discover, materialize, and observe a CUDA/TensorRT toolchain.
+- `ToolchainCatalog`: turn version intent into immutable artifacts for a
+  registered materializer.
+- `ExecutionContext`: resolve/provision a target and execute mapped commands.
+
+Extension contracts live under `trtmc_devtoolkit.spi`. Execution contexts
+declare semantic capabilities such as `host-filesystem` or
+`container-process`; toolchain adapters select capabilities rather than
+provider names. Register adapters explicitly; there is no implicit entry-point
+discovery or workflow DAG.
+
+```python
+from trtmc_devtoolkit.spi import ProviderRegistry
+
+registry = ProviderRegistry.with_builtins()
+registry.register_context(MyRemoteContext())
+registry.register_toolchain(MyTensorRTSource())
+toolkit = DevToolkit.from_checkout(repo, providers=registry.freeze())
+```
+
+## API scope
+
+DevToolkit exposes checkout preparation through `prepare_docker()` and
+`prepare_local()`, plus the independent `resolve()`, `provision()`, `build()`,
+`run()`, and `run_trtmc()` capabilities. Higher-level development flows belong
+in user code or examples composed from those capabilities; DevToolkit does not
+define a workflow DAG or a cohort-gated preparation API.
+
+The shared capability layer is model-agnostic. Family-specific dependencies
+remain in `families/<family>/requirements.txt`; topology, runtime orchestration,
+validation, and target selection remain owned by each family or the caller's
+build recipe.

--- a/apps/devtoolkit/examples/docker_build.py
+++ b/apps/devtoolkit/examples/docker_build.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build and run TRTMC in a checkout-owned Docker environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path, PurePosixPath
+
+
+REPOSITORY = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPOSITORY / "apps/devtoolkit"))
+
+from trtmc_devtoolkit import (  # noqa: E402
+    DevToolkit,
+    DockerMount,
+    DockerTargetPolicy,
+    EnvironmentRequest,
+    TrtmcBuildRecipe,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the TRTMC CLI and TensorRT backend in a development container."
+    )
+    parser.add_argument("--gpu", default="0", help="Host GPU identifier passed to Docker.")
+    parser.add_argument(
+        "--tensorrt",
+        default="11.1.0.106",
+        help="Exact TensorRT version expected in the development image.",
+    )
+    parser.add_argument("--image", default="trtmc-dev:build-example")
+    parser.add_argument("--container", default="trtmc-devtoolkit-build-example")
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=Path(".devtoolkit/examples/docker-build"),
+        help="Receipt and build state directory; relative paths are checkout-relative.",
+    )
+    parser.add_argument("--jobs", type=int, default=None, help="Parallel build job count.")
+    return parser
+
+
+def _checkout_path(path: Path) -> Path:
+    expanded = path.expanduser()
+    return (expanded if expanded.is_absolute() else REPOSITORY / expanded).resolve()
+
+
+def main(arguments: list[str] | None = None) -> int:
+    args = _parser().parse_args(arguments)
+    state_root = _checkout_path(args.state_root)
+    state_root.mkdir(parents=True, exist_ok=True)
+
+    mounts: tuple[DockerMount, ...] = ()
+    target_state = str(state_root)
+    if not state_root.is_relative_to(REPOSITORY):
+        target_state = "/trtmc-devtoolkit-state"
+        mounts = (DockerMount(state_root, PurePosixPath(target_state)),)
+
+    toolkit = DevToolkit.from_checkout(REPOSITORY, state_root=state_root)
+    prepared = toolkit.prepare_docker(
+        family=None,
+        gpu=args.gpu,
+        image=args.image,
+        container=args.container,
+        policy=DockerTargetPolicy.ENSURE,
+        mounts=mounts,
+        ipc="host",
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt=args.tensorrt,
+            target=prepared.execution_target(state=target_state),
+        )
+    )
+    environment = toolkit.provision(lock)
+    build = toolkit.build(
+        environment,
+        TrtmcBuildRecipe(
+            targets=("trtmc", "trtmc_backend_trt"),
+            jobs=args.jobs,
+            outputs={"trtmc": "trtmc"},
+        ),
+    )
+    result = toolkit.run_trtmc(environment, ("version",), build=build, capture_output=True)
+    print(
+        json.dumps(
+            {
+                "artifact_sha256": build.artifact("trtmc").sha256,
+                "build_receipt": str(build.receipt),
+                "container_id": prepared.container_id,
+                "cuda": environment.observation.cuda_version,
+                "run_receipt": str(result.receipt),
+                "source_revision": build.source.revision,
+                "tensorrt": environment.observation.tensorrt_python_version,
+                "trtmc": result.stdout.strip(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/devtoolkit/examples/local_build.py
+++ b/apps/devtoolkit/examples/local_build.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build and run TRTMC directly in a local host environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPOSITORY / "apps/devtoolkit"))
+
+from trtmc_devtoolkit import (  # noqa: E402
+    DevToolkit,
+    EnvironmentRequest,
+    TrtmcBuildRecipe,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the TRTMC CLI and TensorRT backend directly on the host."
+    )
+    parser.add_argument(
+        "--python",
+        required=True,
+        help="Existing Python 3.12 interpreter adopted by the local execution target.",
+    )
+    parser.add_argument(
+        "--tensorrt",
+        required=True,
+        help="Exact four-part TensorRT version to adopt or provision.",
+    )
+    parser.add_argument("--gpu", default="0", help="Local GPU ordinal used by build probes.")
+    parser.add_argument(
+        "--cmake-python",
+        help="Interpreter or wrapper containing Torch for the current top-level CMake configure.",
+    )
+    parser.add_argument(
+        "--cmake-prefix-path",
+        action="append",
+        type=Path,
+        default=[],
+        help="Additional CMake package prefix; repeat this option for multiple prefixes.",
+    )
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=Path(".devtoolkit/examples/local-build"),
+        help="Receipt, managed toolchain, and build directory; relative paths are checkout-relative.",
+    )
+    parser.add_argument("--jobs", type=int, default=None, help="Parallel build job count.")
+    return parser
+
+
+def _checkout_path(path: Path) -> Path:
+    expanded = path.expanduser()
+    return (expanded if expanded.is_absolute() else REPOSITORY / expanded).resolve()
+
+
+def main(arguments: list[str] | None = None) -> int:
+    args = _parser().parse_args(arguments)
+    state_root = _checkout_path(args.state_root)
+    toolkit = DevToolkit.from_checkout(REPOSITORY, state_root=state_root)
+    prepared = toolkit.prepare_local(python=args.python, family=None)
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt=args.tensorrt,
+            target=prepared.execution_target(gpu=args.gpu),
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    cmake_defines: dict[str, str] = {
+        "Python3_EXECUTABLE": args.cmake_python or prepared.python,
+    }
+    if args.cmake_prefix_path:
+        cmake_defines["CMAKE_PREFIX_PATH"] = ";".join(
+            str(_checkout_path(path)) for path in args.cmake_prefix_path
+        )
+    build = toolkit.build(
+        environment,
+        TrtmcBuildRecipe(
+            targets=("trtmc", "trtmc_backend_trt"),
+            cmake_defines=cmake_defines,
+            jobs=args.jobs,
+            outputs={"trtmc": "trtmc"},
+        ),
+    )
+    result = toolkit.run_trtmc(environment, ("version",), build=build, capture_output=True)
+    print(
+        json.dumps(
+            {
+                "artifact_sha256": build.artifact("trtmc").sha256,
+                "build_receipt": str(build.receipt),
+                "cuda": environment.observation.cuda_version,
+                "run_receipt": str(result.receipt),
+                "source_revision": build.source.revision,
+                "tensorrt": environment.observation.tensorrt_python_version,
+                "toolchain_origin": lock.toolchain.origin,
+                "trtmc": result.stdout.strip(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/devtoolkit/trtmc_devtoolkit/__init__.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/__init__.py
@@ -1,16 +1,75 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Prepare the current TensorRT-Model-Connect checkout for development."""
+"""Composable development-environment toolkit for TensorRT-Model-Connect."""
 
 from .api import DevToolkit
+from .building import BuildArtifact, BuildResult, SourceSnapshot
+from .catalogs import JsonToolchainCatalog, NvidiaPackageIndexCatalog
+from .commands import (
+    ArtifactInput,
+    CommandArgument,
+    CommandResult,
+    CommandSpec,
+    EnvironmentPath,
+    repository_path,
+    state_path,
+    target_path,
+)
 from .docker_target import DockerMount, DockerTargetPolicy
-from .models import DevToolkitError, PreparedEnvironment
+from .models import (
+    DevToolkitError,
+    PreparedEnvironment,
+    ToolchainObservation,
+    ToolchainRuntime,
+)
+from .provisioning import AttestationFailed, ProvisionedEnvironment, ProvisionPolicy
+from .qualifications import JsonQualificationSource, QualificationRef
+from .recipes import TrtmcBuildRecipe
+from .resolution import (
+    ArtifactPin,
+    ArtifactUnavailable,
+    CudaPolicy,
+    EnvironmentLock,
+    EnvironmentRequest,
+    ExecutionTarget,
+    IncompatibleCombination,
+    ResolutionError,
+)
 
 __all__ = [
     "DevToolkit",
+    "ArtifactPin",
+    "ArtifactUnavailable",
+    "AttestationFailed",
+    "ArtifactInput",
+    "BuildArtifact",
+    "BuildResult",
+    "CommandArgument",
+    "CommandResult",
+    "CommandSpec",
+    "CudaPolicy",
     "DevToolkitError",
     "DockerMount",
     "DockerTargetPolicy",
+    "EnvironmentLock",
+    "EnvironmentPath",
+    "EnvironmentRequest",
+    "ExecutionTarget",
+    "IncompatibleCombination",
+    "JsonQualificationSource",
+    "JsonToolchainCatalog",
+    "NvidiaPackageIndexCatalog",
     "PreparedEnvironment",
+    "ProvisionedEnvironment",
+    "ProvisionPolicy",
+    "QualificationRef",
+    "ResolutionError",
+    "SourceSnapshot",
+    "ToolchainObservation",
+    "ToolchainRuntime",
+    "TrtmcBuildRecipe",
+    "repository_path",
+    "state_path",
+    "target_path",
 ]

--- a/apps/devtoolkit/trtmc_devtoolkit/api.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/api.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Prepare only the checkout that owns this toolkit."""
+"""Compose checkout preparation with evidence-producing environment capabilities."""
 
 from __future__ import annotations
 
@@ -11,6 +11,14 @@ import shutil
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from .building import BuildRecipe, BuildResult, Builder
+from .commands import (
+    ArtifactInput,
+    CommandArgument,
+    CommandExecutor,
+    CommandResult,
+    CommandSpec,
+)
 from .docker_target import (
     DockerLifecycle,
     DockerMount,
@@ -18,16 +26,33 @@ from .docker_target import (
     DockerTargetRequest,
 )
 from .models import DevToolkitError, PreparedEnvironment
-from .runner import CommandRunner
+from .providers import FrozenProviderRegistry, ProviderRegistry
+from .provisioning import EnvironmentProvisioner, ProvisionedEnvironment, ProvisionPolicy
+from .qualifications import QualificationRegistry, QualificationSource
+from .resolution import EnvironmentLock, EnvironmentRequest, EnvironmentResolver
+from .runner import CommandRunner, Runner
 
 
 _FAMILY = re.compile(r"[a-z][a-z0-9_]*\Z")
 
 
 class DevToolkit:
-    def __init__(self, repository: Path, runner: CommandRunner | None = None):
+    """Prepare a checkout or compose its resolved environment capabilities."""
+
+    def __init__(
+        self,
+        repository: Path,
+        runner: Runner | None = None,
+        *,
+        state_root: Path | None = None,
+        providers: FrozenProviderRegistry | None = None,
+        qualifications: Sequence[QualificationSource] = (),
+    ):
         self.repository = repository.resolve()
         self.runner = runner or CommandRunner()
+        self._capability_state_root = (state_root or self.repository / ".devtoolkit").resolve()
+        self._providers = providers or ProviderRegistry.with_builtins().freeze()
+        self._qualifications = QualificationRegistry(tuple(qualifications))
         if not (self.repository / "pyproject.toml").is_file():
             raise DevToolkitError(f"not a TensorRT-Model-Connect checkout: {self.repository}")
         if not (self.repository / "families").is_dir():
@@ -38,9 +63,103 @@ class DevToolkit:
         cls,
         repository: Path | None = None,
         *,
-        runner: CommandRunner | None = None,
+        state_root: Path | None = None,
+        runner: Runner | None = None,
+        providers: FrozenProviderRegistry | None = None,
+        qualifications: Sequence[QualificationSource] = (),
     ) -> "DevToolkit":
-        return cls(repository or Path.cwd(), runner=runner)
+        return cls(
+            repository or Path.cwd(),
+            runner=runner,
+            state_root=state_root,
+            providers=providers,
+            qualifications=qualifications,
+        )
+
+    def resolve(self, request: EnvironmentRequest) -> EnvironmentLock:
+        """Resolve environment intent without mutating the target or state root."""
+        return EnvironmentResolver(
+            self.repository,
+            self._providers,
+            self.runner,
+            self._qualifications,
+        ).resolve(request)
+
+    def provision(
+        self,
+        lock: EnvironmentLock,
+        *,
+        policy: ProvisionPolicy = ProvisionPolicy.ADOPT_OR_CREATE,
+    ) -> ProvisionedEnvironment:
+        """Idempotently satisfy a lock, attest it, and write a receipt."""
+        return EnvironmentProvisioner(
+            self.repository,
+            self._capability_state_root,
+            self._providers,
+            self.runner,
+        ).provision(lock, policy=policy)
+
+    def run(
+        self,
+        environment: ProvisionedEnvironment,
+        command: CommandSpec,
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+    ) -> CommandResult:
+        """Run one opaque command through the selected execution context."""
+        return CommandExecutor(self.repository, self._providers, self.runner).run(
+            environment,
+            command,
+            check=check,
+            capture_output=capture_output,
+        )
+
+    def build(
+        self,
+        environment: ProvisionedEnvironment,
+        recipe: BuildRecipe,
+    ) -> BuildResult:
+        """Execute a caller-selected source build recipe inside an environment."""
+        return Builder(self.repository, self._providers, self.runner).build(
+            environment,
+            recipe,
+        )
+
+    def run_trtmc(
+        self,
+        environment: ProvisionedEnvironment,
+        arguments: Sequence[CommandArgument],
+        *,
+        build: BuildResult | None = None,
+        artifact: str = "trtmc",
+        check: bool = True,
+        capture_output: bool = False,
+    ) -> CommandResult:
+        """Run arbitrary TRTMC CLI arguments without interpreting family semantics."""
+        executable: CommandArgument = "trtmc"
+        provenance: dict[str, str] = {}
+        artifacts: tuple[ArtifactInput, ...] = ()
+        if build is not None:
+            if build.environment_id != environment.environment_id:
+                raise DevToolkitError("Build result belongs to a different environment")
+            selected = build.artifact(artifact)
+            executable = selected.path
+            provenance = {
+                "build_id": build.build_id,
+                f"artifact:{selected.name}": selected.sha256,
+            }
+            artifacts = (ArtifactInput(selected.name, selected.path, selected.sha256),)
+        return self.run(
+            environment,
+            CommandSpec(
+                (executable, *arguments),
+                provenance=provenance,
+                artifacts=artifacts,
+            ),
+            check=check,
+            capture_output=capture_output,
+        )
 
     def prepare_docker(
         self,

--- a/apps/devtoolkit/trtmc_devtoolkit/building.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/building.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic, evidence-producing source builds driven by caller-selected recipes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MappingProxyType
+from typing import Protocol
+from uuid import uuid4
+
+from .commands import CommandSpec, EnvironmentPath, repository_path, state_path
+from .models import DevToolkitError, ToolchainRuntime
+from .providers import FrozenProviderRegistry
+from .provisioning import ProvisionedEnvironment, attest_environment
+from .receipt import exclusive_lock, write_json
+from .runner import Runner
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    revision: str
+    content_digest: str
+    dirty: bool
+
+
+@dataclass(frozen=True)
+class BuildArtifact:
+    name: str
+    path: EnvironmentPath
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    build_request_id: str
+    build_id: str
+    environment_id: str
+    recipe: str
+    source: SourceSnapshot
+    build_dir: EnvironmentPath
+    artifacts: tuple[BuildArtifact, ...]
+    receipt: Path
+
+    def artifact(self, name: str) -> BuildArtifact:
+        matches = [artifact for artifact in self.artifacts if artifact.name == name]
+        if len(matches) != 1:
+            raise DevToolkitError(f"Build has no unique artifact named {name!r}")
+        return matches[0]
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    """Stable facts and a read-only probe available to a build recipe."""
+
+    runtime: ToolchainRuntime
+    architecture: str
+    _probe: Callable[[CommandSpec], str] = field(repr=False, compare=False)
+
+    def probe(self, command: CommandSpec) -> str:
+        return self._probe(command)
+
+
+@dataclass(frozen=True)
+class BuildPlan:
+    commands: tuple[CommandSpec, ...]
+    outputs: Mapping[str, EnvironmentPath]
+
+    def __post_init__(self) -> None:
+        if not self.commands:
+            raise DevToolkitError("A build plan requires at least one command")
+        outputs = dict(self.outputs)
+        if not outputs or any(not name for name in outputs):
+            raise DevToolkitError("A build plan requires named outputs")
+        object.__setattr__(self, "commands", tuple(self.commands))
+        object.__setattr__(self, "outputs", MappingProxyType(outputs))
+
+
+class BuildRecipe(Protocol):
+    """Extension seam for user-defined source build flows."""
+
+    descriptor: str
+
+    def inputs(self, context: BuildContext) -> Mapping[str, object]: ...
+
+    def plan(
+        self,
+        context: BuildContext,
+        inputs: Mapping[str, object],
+        build_dir: EnvironmentPath,
+    ) -> BuildPlan: ...
+
+
+def _digest(payload: object, domain: bytes) -> str:
+    try:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    except (TypeError, ValueError) as error:
+        raise DevToolkitError(f"Build identity must be JSON-compatible: {error}") from error
+    return hashlib.sha256(domain + b"\0" + encoded).hexdigest()
+
+
+class Builder:
+    def __init__(
+        self,
+        repository: Path,
+        providers: FrozenProviderRegistry,
+        runner: Runner,
+    ) -> None:
+        self.repository = repository
+        self.providers = providers
+        self.runner = runner
+
+    def _execute(
+        self,
+        environment: ProvisionedEnvironment,
+        command: CommandSpec,
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+    ):
+        context = self.providers.context(environment.context.provider.name)
+        return context.execute(
+            environment.context,
+            command,
+            repository=self.repository,
+            state_dir=environment.state_dir,
+            runner=self.runner,
+            check=check,
+            capture_output=capture_output,
+        )
+
+    def _completed_result(
+        self,
+        environment: ProvisionedEnvironment,
+        recipe: BuildRecipe,
+        source: SourceSnapshot,
+        inputs: Mapping[str, object],
+        request_id: str,
+        build_dir: EnvironmentPath,
+        receipt: Path,
+        plan: BuildPlan,
+    ) -> BuildResult | None:
+        try:
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        expected_identity = {
+            "schema_version": 3,
+            "environment_id": environment.environment_id,
+            "source": asdict(source),
+            "recipe": recipe.descriptor,
+            "inputs": inputs,
+            "build_request_id": request_id,
+            "status": "completed",
+        }
+        try:
+            normalized_identity = json.loads(
+                json.dumps(expected_identity, sort_keys=True, separators=(",", ":"))
+            )
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(payload, dict) or any(
+            payload.get(name) != value for name, value in normalized_identity.items()
+        ):
+            return None
+        raw_artifacts = payload.get("artifacts")
+        if not isinstance(raw_artifacts, list) or len(raw_artifacts) != len(plan.outputs):
+            return None
+        artifacts_by_name: dict[str, object] = {}
+        for raw_artifact in raw_artifacts:
+            if not isinstance(raw_artifact, dict):
+                return None
+            name = raw_artifact.get("name")
+            if not isinstance(name, str) or name in artifacts_by_name:
+                return None
+            artifacts_by_name[name] = raw_artifact
+        artifacts: list[BuildArtifact] = []
+        for name, path in sorted(plan.outputs.items()):
+            raw_artifact = artifacts_by_name.get(name)
+            if not isinstance(raw_artifact, dict):
+                return None
+            recorded_sha256 = raw_artifact.get("sha256")
+            if (
+                raw_artifact.get("path") != str(path.path)
+                or not isinstance(recorded_sha256, str)
+                or re.fullmatch(r"[0-9a-f]{64}", recorded_sha256) is None
+            ):
+                return None
+            hash_result = self._execute(
+                environment,
+                CommandSpec(("sha256sum", path)),
+                check=False,
+                capture_output=True,
+            )
+            output = hash_result.stdout.strip()
+            observed_sha256 = output.split(None, 1)[0] if output else ""
+            if hash_result.returncode != 0 or observed_sha256 != recorded_sha256:
+                return None
+            artifacts.append(BuildArtifact(name, path, recorded_sha256))
+        artifact_payload = [
+            {"name": item.name, "path": str(item.path.path), "sha256": item.sha256}
+            for item in artifacts
+        ]
+        build_id = _digest(
+            {"build_request_id": request_id, "artifacts": artifact_payload},
+            b"trtmc-devtoolkit-build-result-v3",
+        )
+        if payload.get("build_id") != build_id:
+            return None
+        return BuildResult(
+            build_request_id=request_id,
+            build_id=build_id,
+            environment_id=environment.environment_id,
+            recipe=recipe.descriptor,
+            source=source,
+            build_dir=build_dir,
+            artifacts=tuple(artifacts),
+            receipt=receipt,
+        )
+
+    def _source_snapshot(self, environment: ProvisionedEnvironment) -> SourceSnapshot:
+        if environment.context.supports_target_operations:
+            safe_directory = environment.context.map_path(repository_path())
+        else:
+            # Third-party contexts written against the original SPI may not expose
+            # target path mapping yet. Their commands historically ran locally.
+            safe_directory = str(self.repository.resolve())
+
+        def git(*arguments: str) -> CommandSpec:
+            # Bind the exception to this invocation only. Do not mutate either the
+            # user's or the target environment's global Git configuration.
+            return CommandSpec(("git", "-c", f"safe.directory={safe_directory}", *arguments))
+
+        revision = self._execute(
+            environment,
+            git("rev-parse", "HEAD"),
+            capture_output=True,
+        ).stdout.strip()
+        diff = self._execute(
+            environment,
+            git("diff", "--binary", "HEAD"),
+            capture_output=True,
+        ).stdout
+        untracked_output = self._execute(
+            environment,
+            git("ls-files", "--others", "--exclude-standard"),
+            capture_output=True,
+        ).stdout
+        untracked: list[tuple[str, str]] = []
+        for path in sorted(line for line in untracked_output.splitlines() if line):
+            file_hash = self._execute(
+                environment,
+                git("hash-object", "--", path),
+                capture_output=True,
+            ).stdout.strip()
+            untracked.append((path, file_hash))
+        content = _digest(
+            {"revision": revision, "diff": diff, "untracked": untracked},
+            b"trtmc-devtoolkit-source-snapshot-v3",
+        )
+        return SourceSnapshot(revision, content, bool(diff or untracked))
+
+    def build(
+        self,
+        environment: ProvisionedEnvironment,
+        recipe: BuildRecipe,
+    ) -> BuildResult:
+        preflight_occurrence = uuid4().hex
+        preflight_stage = "attestation"
+        try:
+            attest_environment(
+                environment,
+                repository=self.repository,
+                providers=self.providers,
+                runner=self.runner,
+            )
+            preflight_stage = "source-snapshot"
+            source = self._source_snapshot(environment)
+            context = BuildContext(
+                runtime=environment.toolchain.runtime,
+                architecture=environment.lock.context.architecture,
+                _probe=lambda command: (
+                    self._execute(
+                        environment,
+                        command,
+                        capture_output=True,
+                    ).stdout
+                ),
+            )
+            preflight_stage = "recipe-inputs"
+            inputs = dict(recipe.inputs(context))
+            if not recipe.descriptor:
+                raise DevToolkitError("Build recipe descriptor must be non-empty")
+        except Exception as error:
+            write_json(
+                environment.state_dir / "builds" / "preflight" / f"{preflight_occurrence}.json",
+                {
+                    "schema_version": 3,
+                    "status": "failed",
+                    "failed_at": datetime.now(timezone.utc).isoformat(),
+                    "environment_id": environment.environment_id,
+                    "occurrence_id": preflight_occurrence,
+                    "stage": preflight_stage,
+                    "error_type": type(error).__name__,
+                },
+            )
+            raise
+        input_payload = {
+            "schema_version": 3,
+            "environment_id": environment.environment_id,
+            "source": asdict(source),
+            "recipe": recipe.descriptor,
+            "inputs": inputs,
+        }
+        request_id = _digest(input_payload, b"trtmc-devtoolkit-build-request-v3")
+        build_dir = state_path(f"builds/{request_id}/build")
+        receipt = environment.state_dir / "builds" / request_id / "receipt.json"
+        with exclusive_lock(receipt.parent / ".build.lock"):
+            try:
+                plan = recipe.plan(context, MappingProxyType(inputs), build_dir)
+                completed = self._completed_result(
+                    environment,
+                    recipe,
+                    source,
+                    inputs,
+                    request_id,
+                    build_dir,
+                    receipt,
+                    plan,
+                )
+                if completed is not None:
+                    return completed
+                for command in plan.commands:
+                    self._execute(environment, command)
+                artifacts: list[BuildArtifact] = []
+                for name, path in sorted(plan.outputs.items()):
+                    output = self._execute(
+                        environment,
+                        CommandSpec(("sha256sum", path)),
+                        capture_output=True,
+                    ).stdout.strip()
+                    sha256 = output.split(None, 1)[0] if output else ""
+                    if re.fullmatch(r"[0-9a-f]{64}", sha256) is None:
+                        raise DevToolkitError(f"Could not hash build output {name}: {output}")
+                    artifacts.append(BuildArtifact(name, path, sha256))
+                artifact_payload = [
+                    {"name": item.name, "path": str(item.path.path), "sha256": item.sha256}
+                    for item in artifacts
+                ]
+                build_id = _digest(
+                    {"build_request_id": request_id, "artifacts": artifact_payload},
+                    b"trtmc-devtoolkit-build-result-v3",
+                )
+                write_json(
+                    receipt,
+                    {
+                        **input_payload,
+                        "status": "completed",
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                        "build_request_id": request_id,
+                        "build_id": build_id,
+                        "artifacts": artifact_payload,
+                    },
+                )
+                return BuildResult(
+                    build_request_id=request_id,
+                    build_id=build_id,
+                    environment_id=environment.environment_id,
+                    recipe=recipe.descriptor,
+                    source=source,
+                    build_dir=build_dir,
+                    artifacts=tuple(artifacts),
+                    receipt=receipt,
+                )
+            except Exception as error:
+                write_json(
+                    receipt,
+                    {
+                        **input_payload,
+                        "status": "failed",
+                        "build_request_id": request_id,
+                        "error_type": type(error).__name__,
+                    },
+                )
+                raise

--- a/apps/devtoolkit/trtmc_devtoolkit/building.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/building.py
@@ -100,7 +100,12 @@ class BuildRecipe(Protocol):
 
 def _digest(payload: object, domain: bytes) -> str:
     try:
-        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
     except (TypeError, ValueError) as error:
         raise DevToolkitError(f"Build identity must be JSON-compatible: {error}") from error
     return hashlib.sha256(domain + b"\0" + encoded).hexdigest()
@@ -162,7 +167,12 @@ class Builder:
         }
         try:
             normalized_identity = json.loads(
-                json.dumps(expected_identity, sort_keys=True, separators=(",", ":"))
+                json.dumps(
+                    expected_identity,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
             )
         except (TypeError, ValueError):
             return None
@@ -250,11 +260,18 @@ class Builder:
         ).stdout
         untracked_output = self._execute(
             environment,
-            git("ls-files", "--others", "--exclude-standard"),
+            git(
+                "-c",
+                "core.quotePath=false",
+                "ls-files",
+                "-z",
+                "--others",
+                "--exclude-standard",
+            ),
             capture_output=True,
         ).stdout
         untracked: list[tuple[str, str]] = []
-        for path in sorted(line for line in untracked_output.splitlines() if line):
+        for path in sorted(item for item in untracked_output.split("\0") if item):
             file_hash = self._execute(
                 environment,
                 git("hash-object", "--", path),
@@ -298,6 +315,15 @@ class Builder:
             inputs = dict(recipe.inputs(context))
             if not recipe.descriptor:
                 raise DevToolkitError("Build recipe descriptor must be non-empty")
+            preflight_stage = "build-identity"
+            input_payload = {
+                "schema_version": 3,
+                "environment_id": environment.environment_id,
+                "source": asdict(source),
+                "recipe": recipe.descriptor,
+                "inputs": inputs,
+            }
+            request_id = _digest(input_payload, b"trtmc-devtoolkit-build-request-v3")
         except Exception as error:
             write_json(
                 environment.state_dir / "builds" / "preflight" / f"{preflight_occurrence}.json",
@@ -312,14 +338,6 @@ class Builder:
                 },
             )
             raise
-        input_payload = {
-            "schema_version": 3,
-            "environment_id": environment.environment_id,
-            "source": asdict(source),
-            "recipe": recipe.descriptor,
-            "inputs": inputs,
-        }
-        request_id = _digest(input_payload, b"trtmc-devtoolkit-build-request-v3")
         build_dir = state_path(f"builds/{request_id}/build")
         receipt = environment.state_dir / "builds" / request_id / "receipt.json"
         with exclusive_lock(receipt.parent / ".build.lock"):

--- a/apps/devtoolkit/trtmc_devtoolkit/builtin_providers.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/builtin_providers.py
@@ -1,0 +1,2202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in read-only providers for local system environment discovery."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import platform
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from tempfile import NamedTemporaryFile
+
+from .commands import CommandSpec, EnvironmentPath, PathScope, state_path
+from .models import DevToolkitError, ToolchainObservation, ToolchainRuntime
+from .platforms import normalize_architecture
+from .provisioning import ContextHandle, ProvisionPolicy, ToolchainHandle
+from .resolution import (
+    CudaSource,
+    ContextLock,
+    EnvironmentRequest,
+    IncompatibleCombination,
+    ProviderDescriptor,
+    ToolchainCandidate,
+)
+from .runner import Runner, command_output
+from .toolchain import (
+    CUDA_RELEASE,
+    observe_local_toolchain,
+    tensorrt_header_version,
+)
+
+
+def _parse_os_release(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        if "=" not in line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value.strip().strip('"')
+    return values
+
+
+def _os_release() -> dict[str, str]:
+    path = Path("/etc/os-release")
+    if not path.is_file():
+        return {}
+    return _parse_os_release(path.read_text(encoding="utf-8"))
+
+
+class LocalExecutionContext:
+    descriptor = ProviderDescriptor("local", "trtmc-devtoolkit-local==3", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ContextLock:
+        del repository, runner
+        actual = normalize_architecture(platform.machine())
+        if request.architecture is not None:
+            requested = normalize_architecture(request.architecture)
+            if requested != actual:
+                raise IncompatibleCombination(
+                    f"Local target architecture is {actual}; requested {requested}"
+                )
+        release = _os_release()
+        return ContextLock(
+            provider=self.descriptor,
+            operating_system=platform.system().lower(),
+            architecture=actual,
+            identity={
+                "os_id": release.get("ID", "unknown"),
+                "os_version": release.get("VERSION_ID", "unknown"),
+            },
+            execution={
+                "python": request.target.options.get("python", "python3"),
+                "gpu": request.target.options.get("gpu", "0"),
+            },
+            locator={
+                "python": request.target.options.get("python", "python3"),
+                "gpu": request.target.options.get("gpu", "0"),
+            },
+            capabilities=frozenset({"host-filesystem", "posix-process"}),
+            qualification={"execution": "local"},
+        )
+
+    def provision(
+        self,
+        context: ContextLock,
+        *,
+        inherit_system_packages: bool,
+        repository: Path,
+        state_dir: Path,
+        policy: ProvisionPolicy,
+        runner: Runner,
+    ) -> ContextHandle:
+        base_python = str(context.locator.get("python", "python3"))
+        python = base_python
+        if policy is not ProvisionPolicy.ADOPT_ONLY and inherit_system_packages:
+            venv = state_dir / "venv"
+            python_path = venv / "bin" / "python"
+            if not python_path.is_file():
+                command: list[str | Path] = [base_python, "-m", "venv"]
+                if inherit_system_packages:
+                    command.append("--system-site-packages")
+                command.append(venv)
+                runner.run(command, cwd=repository)
+            python = str(python_path)
+        environment = {
+            "PATH": f"{Path(python).parent}:{os.environ.get('PATH', '')}",
+            "CUDA_VISIBLE_DEVICES": str(context.locator.get("gpu", "0")),
+        }
+        handle = ContextHandle(
+            provider=self.descriptor,
+            identity=context.identity,
+            execution_identity={
+                "python": python,
+                "gpu": context.locator.get("gpu", "0"),
+            },
+            locator={"python": python, "gpu": context.locator.get("gpu", "0")},
+            environment=environment,
+            capabilities=context.capabilities,
+        )
+        return replace(
+            handle,
+            _executor=lambda command, check, capture_output: self.execute(
+                handle,
+                command,
+                repository=repository,
+                state_dir=state_dir,
+                runner=runner,
+                check=check,
+                capture_output=capture_output,
+            ),
+            _path_mapper=lambda value: (
+                str(repository / Path(value.path))
+                if isinstance(value, EnvironmentPath) and value.scope is PathScope.REPOSITORY
+                else str(state_dir / Path(value.path))
+                if isinstance(value, EnvironmentPath) and value.scope is PathScope.STATE
+                else str(value.path)
+                if isinstance(value, EnvironmentPath)
+                else str(value)
+            ),
+        )
+
+    def execute(
+        self,
+        context: ContextHandle,
+        command: CommandSpec,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+        check: bool,
+        capture_output: bool,
+    ):
+        def render(value: str | EnvironmentPath) -> str:
+            if not isinstance(value, EnvironmentPath):
+                return value
+            if value.scope is PathScope.REPOSITORY:
+                return str(repository / Path(value.path))
+            if value.scope is PathScope.STATE:
+                return str(state_dir / Path(value.path))
+            return str(value.path)
+
+        return runner.run(
+            [render(argument) for argument in command.arguments],
+            cwd=Path(render(command.cwd)),
+            env={**dict(context.environment), **dict(command.environment)},
+            check=check,
+            capture_output=capture_output,
+        )
+
+
+def _first_library(root: Path, name: str, architecture: str) -> Path | None:
+    triples = {
+        "aarch64": ("aarch64-linux", "aarch64-linux-gnu", "sbsa-linux"),
+        "x86_64": ("x86_64-linux", "x86_64-linux-gnu"),
+    }[architecture]
+    directories = [root / "lib64", root / "lib"]
+    directories.extend(root / "targets" / triple / "lib" for triple in triples)
+    return next(
+        (directory / name for directory in directories if (directory / name).is_file()), None
+    )
+
+
+def _toolchain_environment(
+    runtime: ToolchainRuntime,
+    architecture: str,
+    *,
+    base_environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    base = os.environ if base_environment is None else base_environment
+    cuda_root = Path(runtime.cuda_root)
+    tensorrt_library = Path(runtime.tensorrt_library)
+    library_paths = [str(tensorrt_library.parent)]
+    for directory in ("lib64", "lib"):
+        candidate = cuda_root / directory
+        if candidate.is_dir() and str(candidate) not in library_paths:
+            library_paths.append(str(candidate))
+    cudart = _first_library(cuda_root, "libcudart.so", architecture)
+    if cudart is not None and str(cudart.parent) not in library_paths:
+        library_paths.append(str(cudart.parent))
+    inherited_libraries = base.get("LD_LIBRARY_PATH", "")
+    if inherited_libraries:
+        library_paths.append(inherited_libraries)
+    return {
+        "PATH": (
+            f"{Path(runtime.python_executable).parent}:{cuda_root / 'bin'}:{base.get('PATH', '')}"
+        ),
+        "CUDA_HOME": runtime.cuda_root,
+        "CUDA_PATH": runtime.cuda_root,
+        "CUDAToolkit_ROOT": runtime.cuda_root,
+        "TRTMC_TRT_INCLUDE_DIR": runtime.tensorrt_include_dir,
+        "TRTMC_TRT_LIBRARY": runtime.tensorrt_library,
+        "TRTMC_TRT_LIBRARY_DIR": str(tensorrt_library.parent),
+        "LD_LIBRARY_PATH": ":".join(library_paths),
+    }
+
+
+def _native_version_script(library: Path) -> str:
+    return (
+        "import ctypes; "
+        f"lib=ctypes.CDLL({str(library)!r}); "
+        "names=('Major','Minor','Patch','Build'); "
+        "fs=[getattr(lib, f'getInferLib{name}Version') for name in names]; "
+        "[setattr(f, 'restype', ctypes.c_int32) for f in fs]; "
+        "print('.'.join(str(f()) for f in fs))"
+    )
+
+
+def _docker_command(docker_context: str, *arguments: str) -> list[str]:
+    return ["docker", "--context", docker_context, *arguments]
+
+
+def _docker_daemon_id(runner: Runner, repository: Path, docker_context: str) -> str:
+    daemon_id = command_output(
+        runner,
+        _docker_command(docker_context, "info", "--format", "{{.ID}}"),
+        cwd=repository,
+        timeout=30,
+    )
+    if not daemon_id:
+        raise DevToolkitError(f"Docker context {docker_context!r} has no daemon identity")
+    return daemon_id
+
+
+def _require_docker_client_version(
+    runner: Runner,
+    repository: Path,
+    docker_context: str,
+) -> None:
+    output = command_output(
+        runner,
+        _docker_command(
+            docker_context,
+            "version",
+            "--format",
+            "{{.Client.Version}}",
+        ),
+        cwd=repository,
+        timeout=30,
+    )
+    match = re.match(r"([0-9]+)\.([0-9]+)", output)
+    if match is None or tuple(int(part) for part in match.groups()) < (20, 10):
+        raise DevToolkitError(
+            f"Docker CLI 20.10 or newer is required for private exec env files; found {output}"
+        )
+
+
+def _docker_inspect(
+    runner: Runner,
+    repository: Path,
+    docker_context: str,
+    container: str,
+) -> dict[str, object]:
+    output = command_output(
+        runner,
+        _docker_command(
+            docker_context,
+            "inspect",
+            "--type",
+            "container",
+            "--format",
+            "{{json .}}",
+            container,
+        ),
+        cwd=repository,
+        timeout=30,
+    )
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise DevToolkitError(f"Could not inspect Docker container {container}: {error}") from error
+    if not isinstance(payload, dict):
+        raise DevToolkitError(f"Docker inspect returned invalid data for {container}")
+    state = payload.get("State")
+    if not isinstance(state, dict) or state.get("Running") is not True:
+        raise DevToolkitError(f"Docker container {container} must already be running")
+    return payload
+
+
+def _require_docker_binding(
+    runner: Runner,
+    repository: Path,
+    *,
+    docker_context: str,
+    daemon_id: str,
+    container_id: str,
+    image_id: str,
+) -> None:
+    _require_docker_client_version(runner, repository, docker_context)
+    observed_daemon = _docker_daemon_id(runner, repository, docker_context)
+    if observed_daemon != daemon_id:
+        raise DevToolkitError(
+            f"Docker daemon changed after resolution: expected {daemon_id}, "
+            f"observed {observed_daemon}"
+        )
+    inspected = _docker_inspect(runner, repository, docker_context, container_id)
+    if inspected.get("Id") != container_id:
+        raise DevToolkitError("Docker container identity changed after resolution")
+    if inspected.get("Image") != image_id:
+        raise DevToolkitError("Docker container image changed after resolution")
+
+
+_DOCKER_ENVIRONMENT_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+@contextmanager
+def _docker_environment_file(
+    state_dir: Path,
+    environment: Mapping[str, str],
+) -> Iterator[Path | None]:
+    if not environment:
+        yield None
+        return
+    for name, value in environment.items():
+        if _DOCKER_ENVIRONMENT_NAME.fullmatch(name) is None:
+            raise DevToolkitError(f"Invalid Docker environment name: {name!r}")
+        if not isinstance(value, str) or any(character in value for character in "\r\n\0"):
+            raise DevToolkitError(
+                f"Docker environment value for {name!r} must be a single text line"
+            )
+    secret_dir = state_dir / ".secrets"
+    secret_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(secret_dir, 0o700)
+    temporary: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=secret_dir,
+            prefix="docker-environment-",
+            suffix=".list",
+            delete=False,
+        ) as stream:
+            temporary = Path(stream.name)
+            os.chmod(temporary, 0o600)
+            for name, value in sorted(environment.items()):
+                stream.write(f"{name}={value}\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        yield temporary
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+_CONTAINER_PROBE_SCRIPT = r"""
+import ctypes
+import ctypes.util
+import hashlib
+import itertools
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import tensorrt
+
+nvcc = shutil.which("nvcc")
+if not nvcc:
+    raise RuntimeError("nvcc is not available")
+nvcc_text = subprocess.check_output([nvcc, "--version"], text=True)
+cuda_match = re.search(r"release\s+([0-9]+\.[0-9]+)", nvcc_text, re.I)
+if cuda_match is None:
+    raise RuntimeError("nvcc did not report a CUDA release")
+cuda_root = Path(nvcc).resolve().parent.parent
+cuda_libraries = []
+for name in ("libcudart.so", "libcublas.so", "libcurand.so"):
+    cuda_libraries.append(any(path.is_file() for path in cuda_root.rglob(name)))
+cuda_complete = (cuda_root / "include" / "cuda.h").is_file() and all(cuda_libraries)
+
+configured_library = os.environ.get("TRTMC_TRT_LIBRARY")
+library_name = configured_library or ctypes.util.find_library("nvinfer") or "libnvinfer.so"
+library = ctypes.CDLL(library_name)
+names = ("Major", "Minor", "Patch", "Build")
+functions = [getattr(library, f"getInferLib{name}Version") for name in names]
+for function in functions:
+    function.restype = ctypes.c_int32
+native = ".".join(str(function()) for function in functions)
+mapped = []
+maps = Path("/proc/self/maps")
+if maps.is_file():
+    mapped = [
+        line.rsplit(None, 1)[-1]
+        for line in maps.read_text().splitlines()
+        if "libnvinfer.so" in line and line.rsplit(None, 1)[-1].startswith("/")
+    ]
+library_path = str(Path(configured_library).resolve()) if configured_library else ""
+if not library_path and mapped:
+    library_path = str(Path(mapped[0]).resolve())
+
+configured_include = os.environ.get("TRTMC_TRT_INCLUDE_DIR") or os.environ.get("TRT_INC_DIR")
+configured_headers = (
+    (Path(configured_include) / "NvInferVersion.h",) if configured_include else ()
+)
+header_candidates = itertools.chain(
+    configured_headers,
+    Path("/usr/include").rglob("NvInferVersion.h"),
+    Path("/usr/local").rglob("NvInferVersion.h"),
+)
+header = next((path for path in header_candidates if path.is_file()), None)
+if header is None:
+    raise RuntimeError("NvInferVersion.h is not available")
+definitions = dict(
+    re.findall(r"^#define\s+([A-Za-z0-9_]+)\s+([A-Za-z0-9_]+)\b", header.read_text(), re.M)
+)
+parts = []
+for name in ("MAJOR", "MINOR", "PATCH", "BUILD"):
+    value = definitions.get(f"NV_TENSORRT_{name}", "")
+    parts.append(definitions.get(value, value))
+headers = ".".join(parts)
+def sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+evidence = {
+    "nvcc": sha256(nvcc),
+    "tensorrt-header": sha256(header),
+}
+if library_path:
+    evidence["tensorrt-library"] = sha256(library_path)
+print(json.dumps({
+    "architecture": platform.machine(),
+    "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+    "python_executable": sys.executable,
+    "cuda": cuda_match.group(1),
+    "cuda_root": str(cuda_root),
+    "cuda_complete": cuda_complete,
+    "tensorrt_python": tensorrt.__version__,
+    "tensorrt_native": native,
+    "tensorrt_headers": headers,
+    "tensorrt_include_dir": str(header.parent.resolve()),
+    "tensorrt_library": library_path or library_name,
+    "evidence": evidence,
+}))
+""".strip()
+
+
+def _container_observation(
+    runner: Runner,
+    repository: Path,
+    docker_context: str,
+    daemon_id: str,
+    container_id: str,
+    image_id: str,
+    python: str,
+) -> tuple[ToolchainObservation, str, bool]:
+    _require_docker_binding(
+        runner,
+        repository,
+        docker_context=docker_context,
+        daemon_id=daemon_id,
+        container_id=container_id,
+        image_id=image_id,
+    )
+    output = command_output(
+        runner,
+        _docker_command(
+            docker_context,
+            "exec",
+            container_id,
+            python,
+            "-c",
+            _CONTAINER_PROBE_SCRIPT,
+        ),
+        cwd=repository,
+        timeout=30,
+    )
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise DevToolkitError(
+            f"Container toolchain probe returned invalid JSON: {error}"
+        ) from error
+    required = (
+        "python",
+        "python_executable",
+        "cuda",
+        "cuda_root",
+        "tensorrt_python",
+        "tensorrt_native",
+        "tensorrt_headers",
+        "tensorrt_include_dir",
+        "tensorrt_library",
+        "architecture",
+        "evidence",
+    )
+    if not isinstance(payload, dict) or any(not payload.get(name) for name in required):
+        raise DevToolkitError("Container toolchain probe omitted required observations")
+    architecture = normalize_architecture(str(payload["architecture"]))
+    observation = ToolchainObservation(
+        python_version=str(payload["python"]),
+        cuda_version=str(payload["cuda"]),
+        tensorrt_python_version=str(payload["tensorrt_python"]),
+        tensorrt_native_version=str(payload["tensorrt_native"]),
+        tensorrt_header_version=str(payload["tensorrt_headers"]),
+        tensorrt_include_dir=str(payload["tensorrt_include_dir"]),
+        tensorrt_library=str(payload["tensorrt_library"]),
+        cuda_root=str(payload["cuda_root"]),
+        image_id=image_id,
+        architecture=architecture,
+        evidence={str(name): str(digest) for name, digest in dict(payload["evidence"]).items()},
+    )
+    return observation, str(payload["python_executable"]), payload.get("cuda_complete") is True
+
+
+class DockerExecutionContext:
+    """Adopt a running user container without imposing a Dockerfile or image version."""
+
+    descriptor = ProviderDescriptor("docker", "trtmc-devtoolkit-docker-adoption==6", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ContextLock:
+        container = request.target.options.get("container")
+        if not isinstance(container, str) or not container:
+            raise DevToolkitError(
+                "Docker resolution currently requires a running container for adoption"
+            )
+        docker_context = request.target.options.get("docker_context")
+        if docker_context is None:
+            docker_context = command_output(
+                runner,
+                ["docker", "context", "show"],
+                cwd=repository,
+                timeout=30,
+            )
+        if not isinstance(docker_context, str) or not docker_context:
+            raise DevToolkitError("Docker resolution requires a non-empty context name")
+        _require_docker_client_version(runner, repository, docker_context)
+        daemon_id = _docker_daemon_id(runner, repository, docker_context)
+        inspected = _docker_inspect(runner, repository, docker_context, container)
+        container_id = inspected.get("Id")
+        if not isinstance(container_id, str) or not container_id:
+            raise DevToolkitError(f"Docker container {container} has no container identity")
+        image_id = inspected.get("Image")
+        if not isinstance(image_id, str) or not image_id:
+            raise DevToolkitError(f"Docker container {container} has no image identity")
+        architecture = (
+            normalize_architecture(request.architecture)
+            if request.architecture is not None
+            else normalize_architecture(
+                command_output(
+                    runner,
+                    _docker_command(docker_context, "exec", container_id, "uname", "-m"),
+                    cwd=repository,
+                    timeout=30,
+                )
+            )
+        )
+        release = _parse_os_release(
+            command_output(
+                runner,
+                _docker_command(
+                    docker_context,
+                    "exec",
+                    container_id,
+                    "cat",
+                    "/etc/os-release",
+                ),
+                cwd=repository,
+                timeout=30,
+            )
+        )
+        _require_docker_binding(
+            runner,
+            repository,
+            docker_context=docker_context,
+            daemon_id=daemon_id,
+            container_id=container_id,
+            image_id=image_id,
+        )
+        return ContextLock(
+            provider=self.descriptor,
+            operating_system="linux",
+            architecture=architecture,
+            identity={
+                "container_id": container_id,
+                "daemon_id": daemon_id,
+                "image_id": image_id,
+                "os_id": release.get("ID", "unknown"),
+                "os_version": release.get("VERSION_ID", "unknown"),
+                "runtime": "docker",
+            },
+            execution={
+                "workspace": request.target.options.get(
+                    "workspace", "/workspace/tensorrt-model-connect"
+                ),
+                "target_state": request.target.options.get("state", "/tmp/trtmc-devtoolkit"),
+                "python": request.target.options.get("python", "python3"),
+            },
+            locator={
+                "container": container,
+                "docker_context": docker_context,
+                "workspace": request.target.options.get(
+                    "workspace", "/workspace/tensorrt-model-connect"
+                ),
+                "target_state": request.target.options.get("state", "/tmp/trtmc-devtoolkit"),
+                "python": request.target.options.get("python", "python3"),
+            },
+            capabilities=frozenset({"container-process", "posix-process"}),
+            qualification={"execution": "container"},
+        )
+
+    def provision(
+        self,
+        context: ContextLock,
+        *,
+        inherit_system_packages: bool,
+        repository: Path,
+        state_dir: Path,
+        policy: ProvisionPolicy,
+        runner: Runner,
+    ) -> ContextHandle:
+        del inherit_system_packages
+        if policy is ProvisionPolicy.CREATE:
+            raise DevToolkitError("The built-in Docker provider is adoption-only")
+        _require_docker_binding(
+            runner,
+            repository,
+            docker_context=str(context.locator["docker_context"]),
+            daemon_id=str(context.identity["daemon_id"]),
+            container_id=str(context.identity["container_id"]),
+            image_id=str(context.identity["image_id"]),
+        )
+        handle = ContextHandle(
+            provider=self.descriptor,
+            identity=context.identity,
+            execution_identity={
+                "workspace": context.locator["workspace"],
+                "target_state": context.locator["target_state"],
+                "python": context.locator["python"],
+            },
+            locator={**dict(context.locator), **dict(context.execution)},
+            capabilities=context.capabilities,
+        )
+        return replace(
+            handle,
+            _executor=lambda command, check, capture_output: self.execute(
+                handle,
+                command,
+                repository=repository,
+                state_dir=state_dir,
+                runner=runner,
+                check=check,
+                capture_output=capture_output,
+            ),
+            _path_mapper=lambda value: (
+                str(PurePosixPath(str(handle.locator["workspace"])) / value.path)
+                if isinstance(value, EnvironmentPath) and value.scope is PathScope.REPOSITORY
+                else str(PurePosixPath(str(handle.locator["target_state"])) / value.path)
+                if isinstance(value, EnvironmentPath) and value.scope is PathScope.STATE
+                else str(value.path)
+                if isinstance(value, EnvironmentPath)
+                else str(value)
+            ),
+        )
+
+    def execute(
+        self,
+        context: ContextHandle,
+        command: CommandSpec,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+        check: bool,
+        capture_output: bool,
+    ):
+        def render(value: str | EnvironmentPath) -> str:
+            if not isinstance(value, EnvironmentPath):
+                return value
+            if value.scope is PathScope.REPOSITORY:
+                return str(PurePosixPath(str(context.locator["workspace"])) / value.path)
+            if value.scope is PathScope.STATE:
+                return str(PurePosixPath(str(context.locator["target_state"])) / value.path)
+            return str(value.path)
+
+        docker_context = str(context.locator["docker_context"])
+        daemon_id = str(context.identity["daemon_id"])
+        container_id = str(context.identity["container_id"])
+        image_id = str(context.identity["image_id"])
+        _require_docker_binding(
+            runner,
+            repository,
+            docker_context=docker_context,
+            daemon_id=daemon_id,
+            container_id=container_id,
+            image_id=image_id,
+        )
+        environment = {**dict(context.environment), **dict(command.environment)}
+        with _docker_environment_file(state_dir, environment) as environment_file:
+            arguments = _docker_command(
+                docker_context,
+                "exec",
+                "--workdir",
+                render(command.cwd),
+            )
+            if environment_file is not None:
+                arguments.extend(["--env-file", str(environment_file)])
+            arguments.append(container_id)
+            arguments.extend(render(argument) for argument in command.arguments)
+            return runner.run(
+                arguments,
+                cwd=repository,
+                check=check,
+                capture_output=capture_output,
+            )
+
+
+class ContainerImageToolchainSource:
+    descriptor = ProviderDescriptor("container-image", "trtmc-devtoolkit-container-image==5", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        if "container-process" not in context.capabilities:
+            return ()
+        try:
+            observed, python_executable, complete_cuda = _container_observation(
+                runner,
+                repository,
+                str(context.locator["docker_context"]),
+                str(context.identity["daemon_id"]),
+                str(context.identity["container_id"]),
+                str(context.identity["image_id"]),
+                str(context.locator["python"]),
+            )
+        except (DevToolkitError, OSError, subprocess.TimeoutExpired):
+            return ()
+        versions = {
+            observed.tensorrt_python_version,
+            observed.tensorrt_native_version,
+            observed.tensorrt_header_version,
+        }
+        if not complete_cuda or len(versions) != 1:
+            return ()
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="image",
+                cuda_source="image",
+                tensorrt=observed.tensorrt_native_version,
+                cuda=observed.cuda_version,
+                python=observed.python_version,
+                identity={
+                    "image_id": observed.image_id,
+                },
+                runtime=ToolchainRuntime(
+                    python_executable=python_executable,
+                    cuda_root=observed.cuda_root or "",
+                    nvcc=str(PurePosixPath(observed.cuda_root or "") / "bin" / "nvcc"),
+                    tensorrt_include_dir=observed.tensorrt_include_dir,
+                    tensorrt_library=observed.tensorrt_library,
+                ),
+            ),
+        )
+
+    def provision(
+        self,
+        lock,
+        context: ContextHandle,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+    ) -> ToolchainHandle:
+        del context, repository, state_dir, runner
+        if lock.toolchain.runtime is None:
+            raise DevToolkitError("Container toolchain lock has no runtime")
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=lock.toolchain.runtime,
+        )
+
+    def observe(
+        self,
+        lock,
+        context: ContextHandle,
+        toolchain: ToolchainHandle,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ToolchainObservation:
+        del lock
+        observed, _, complete_cuda = _container_observation(
+            runner,
+            repository,
+            str(context.locator["docker_context"]),
+            str(context.identity["daemon_id"]),
+            str(context.identity["container_id"]),
+            str(context.identity["image_id"]),
+            toolchain.runtime.python_executable,
+        )
+        if not complete_cuda:
+            raise DevToolkitError("Container CUDA toolkit became incomplete after resolution")
+        return observed
+
+
+class SystemToolchainSource:
+    """Discover one complete, already-installed local CUDA/TensorRT toolchain."""
+
+    descriptor = ProviderDescriptor("system", "trtmc-devtoolkit-system==3", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        if "host-filesystem" not in context.capabilities or request.toolchain_options.get("prefix"):
+            return ()
+        discovered_cuda = self.discover_cuda(context, repository, runner)
+        if discovered_cuda is None:
+            return ()
+        cuda_root, nvcc, cuda_version = discovered_cuda
+        include_dir = Path(
+            os.environ.get("TRTMC_TRT_INCLUDE_DIR")
+            or os.environ.get("TRT_INC_DIR")
+            or f"/usr/include/{context.architecture}-linux-gnu"
+        )
+        library_dir = Path(
+            os.environ.get("TRTMC_TRT_LIBRARY_DIR")
+            or os.environ.get("TRT_LIB_DIR")
+            or f"/usr/lib/{context.architecture}-linux-gnu"
+        )
+        library = Path(os.environ.get("TRTMC_TRT_LIBRARY") or library_dir / "libnvinfer.so")
+        header = include_dir / "NvInferVersion.h"
+        if not header.is_file() or not library.is_file():
+            return ()
+        python = str(context.locator.get("python", "python3"))
+        try:
+            python_version = command_output(
+                runner,
+                [
+                    python,
+                    "-c",
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+                ],
+                cwd=repository,
+                timeout=30,
+            )
+            tensorrt_python = command_output(
+                runner,
+                [python, "-c", "import tensorrt; print(tensorrt.__version__)"],
+                cwd=repository,
+                timeout=30,
+            )
+            tensorrt_native = command_output(
+                runner,
+                [python, "-c", _native_version_script(library)],
+                cwd=repository,
+                timeout=30,
+            )
+            tensorrt_header = tensorrt_header_version(header)
+        except (DevToolkitError, OSError, subprocess.TimeoutExpired):
+            return ()
+        if len({tensorrt_python, tensorrt_native, tensorrt_header}) != 1:
+            return ()
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="system",
+                tensorrt=tensorrt_native,
+                cuda=cuda_version,
+                python=python_version,
+                identity={
+                    "cuda_root": str(cuda_root),
+                    "nvcc": str(nvcc),
+                    "tensorrt_include_dir": str(include_dir),
+                    "tensorrt_library_dir": str(library.parent),
+                    "tensorrt_library": str(library),
+                },
+                runtime=ToolchainRuntime(
+                    python_executable=python,
+                    cuda_root=str(cuda_root),
+                    nvcc=str(nvcc),
+                    tensorrt_include_dir=str(include_dir),
+                    tensorrt_library=str(library),
+                ),
+            ),
+        )
+
+    def provision(
+        self,
+        lock,
+        context: ContextHandle,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+    ) -> ToolchainHandle:
+        del repository, state_dir, runner
+        if lock.toolchain.runtime is None:
+            raise DevToolkitError("Adopted system toolchain lock has no runtime")
+        runtime = replace(
+            lock.toolchain.runtime,
+            python_executable=str(context.locator["python"]),
+        )
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=runtime,
+            environment=_toolchain_environment(runtime, lock.context.architecture),
+        )
+
+    def observe(
+        self,
+        lock,
+        context: ContextHandle,
+        toolchain: ToolchainHandle,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ToolchainObservation:
+        del lock
+        runtime = toolchain.runtime
+        return observe_local_toolchain(
+            runner,
+            repository=repository,
+            python=runtime.python_executable,
+            nvcc=runtime.nvcc,
+            tensorrt_include_dir=Path(runtime.tensorrt_include_dir),
+            tensorrt_library=Path(runtime.tensorrt_library),
+            environment=dict(context.environment),
+            cuda_root=Path(runtime.cuda_root),
+        )
+
+    @staticmethod
+    def _cuda_root() -> Path | None:
+        configured = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+        if configured:
+            return Path(configured).resolve()
+        nvcc = shutil.which("nvcc")
+        return Path(nvcc).resolve().parent.parent if nvcc else None
+
+    @staticmethod
+    def _complete_cuda(root: Path, architecture: str) -> bool:
+        required = (
+            root / "bin" / "nvcc",
+            root / "include" / "cuda.h",
+            _first_library(root, "libcudart.so", architecture),
+            _first_library(root, "libcublas.so", architecture),
+            _first_library(root, "libcurand.so", architecture),
+        )
+        return all(path is not None and path.is_file() for path in required)
+
+    @classmethod
+    def discover_cuda(
+        cls,
+        context: ContextLock,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[Path, Path, str] | None:
+        cuda_root = cls._cuda_root()
+        if cuda_root is None:
+            return None
+        return cls.discover_cuda_at(cuda_root, context, repository, runner)
+
+    @classmethod
+    def discover_cuda_at(
+        cls,
+        cuda_root: Path,
+        context: ContextLock,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[Path, Path, str] | None:
+        cuda_root = cuda_root.expanduser().resolve()
+        if not cls._complete_cuda(cuda_root, context.architecture):
+            return None
+        nvcc = cuda_root / "bin" / "nvcc"
+        try:
+            nvcc_output = command_output(
+                runner,
+                [nvcc, "--version"],
+                cwd=repository,
+                timeout=30,
+            )
+        except (DevToolkitError, OSError, subprocess.TimeoutExpired):
+            return None
+        match = CUDA_RELEASE.search(nvcc_output)
+        return (cuda_root, nvcc, match.group(1)) if match is not None else None
+
+
+@dataclass(frozen=True)
+class TargetRuntimeBaseline:
+    python: str
+    python_executable: str
+    cuda: str
+    cuda_root: str
+    nvcc: str
+    cuda_source: CudaSource
+
+
+@dataclass(frozen=True)
+class TargetPythonBaseline:
+    python: str
+    python_executable: str
+
+
+_TARGET_PYTHON_SCRIPT = (
+    "import json, sys; "
+    "print(json.dumps({'python': "
+    "f'{sys.version_info.major}.{sys.version_info.minor}', "
+    "'python_executable': sys.executable}))"
+)
+
+
+_CONTAINER_BASELINE_SCRIPT = r"""
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+nvcc = shutil.which("nvcc")
+if not nvcc:
+    raise RuntimeError("nvcc is not available")
+text = subprocess.check_output([nvcc, "--version"], text=True)
+match = re.search(r"release\s+([0-9]+\.[0-9]+)", text, re.I)
+if match is None:
+    raise RuntimeError("nvcc did not report a CUDA release")
+root = Path(nvcc).resolve().parent.parent
+required = (
+    root / "include" / "cuda.h",
+    next(root.rglob("libcudart.so"), None),
+    next(root.rglob("libcublas.so"), None),
+    next(root.rglob("libcurand.so"), None),
+)
+if not all(path is not None and path.is_file() for path in required):
+    raise RuntimeError("CUDA toolkit is incomplete")
+print(json.dumps({
+    "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+    "python_executable": sys.executable,
+    "cuda": match.group(1),
+    "cuda_root": str(root),
+    "nvcc": str(Path(nvcc).resolve()),
+}))
+""".strip()
+
+
+def target_python_baseline(
+    context: ContextLock,
+    repository: Path,
+    runner: Runner,
+) -> TargetPythonBaseline | None:
+    """Observe target Python without requiring CUDA or TensorRT."""
+
+    python = str(context.locator.get("python", "python3"))
+    try:
+        if "host-filesystem" in context.capabilities:
+            output = command_output(
+                runner,
+                [python, "-c", _TARGET_PYTHON_SCRIPT],
+                cwd=repository,
+                timeout=30,
+            )
+        elif "container-process" in context.capabilities:
+            _require_docker_binding(
+                runner,
+                repository,
+                docker_context=str(context.locator["docker_context"]),
+                daemon_id=str(context.identity["daemon_id"]),
+                container_id=str(context.identity["container_id"]),
+                image_id=str(context.identity["image_id"]),
+            )
+            output = command_output(
+                runner,
+                _docker_command(
+                    str(context.locator["docker_context"]),
+                    "exec",
+                    str(context.identity["container_id"]),
+                    python,
+                    "-c",
+                    _TARGET_PYTHON_SCRIPT,
+                ),
+                cwd=repository,
+                timeout=30,
+            )
+        else:
+            return None
+        payload = json.loads(output)
+        return TargetPythonBaseline(
+            python=str(payload["python"]),
+            python_executable=str(payload["python_executable"]),
+        )
+    except (
+        DevToolkitError,
+        json.JSONDecodeError,
+        KeyError,
+        OSError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+
+
+def target_runtime_baseline(
+    context: ContextLock,
+    repository: Path,
+    runner: Runner,
+) -> TargetRuntimeBaseline | None:
+    """Observe Python and a complete CUDA toolkit without requiring TensorRT."""
+
+    if "host-filesystem" in context.capabilities:
+        discovered = SystemToolchainSource.discover_cuda(context, repository, runner)
+        if discovered is None:
+            return None
+        cuda_root, nvcc, cuda = discovered
+        python = str(context.locator.get("python", "python3"))
+        try:
+            python_version = command_output(
+                runner,
+                [
+                    python,
+                    "-c",
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+                ],
+                cwd=repository,
+                timeout=30,
+            )
+        except (DevToolkitError, OSError, subprocess.TimeoutExpired):
+            return None
+        return TargetRuntimeBaseline(
+            python_version,
+            python,
+            cuda,
+            str(cuda_root),
+            str(nvcc),
+            "system",
+        )
+    if "container-process" not in context.capabilities:
+        return None
+    try:
+        _require_docker_binding(
+            runner,
+            repository,
+            docker_context=str(context.locator["docker_context"]),
+            daemon_id=str(context.identity["daemon_id"]),
+            container_id=str(context.identity["container_id"]),
+            image_id=str(context.identity["image_id"]),
+        )
+        output = command_output(
+            runner,
+            _docker_command(
+                str(context.locator["docker_context"]),
+                "exec",
+                str(context.identity["container_id"]),
+                str(context.locator.get("python", "python3")),
+                "-c",
+                _CONTAINER_BASELINE_SCRIPT,
+            ),
+            cwd=repository,
+            timeout=30,
+        )
+        payload = json.loads(output)
+        return TargetRuntimeBaseline(
+            str(payload["python"]),
+            str(payload["python_executable"]),
+            str(payload["cuda"]),
+            str(payload["cuda_root"]),
+            str(payload["nvcc"]),
+            "image",
+        )
+    except (
+        DevToolkitError,
+        json.JSONDecodeError,
+        KeyError,
+        OSError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+
+
+class PrefixToolchainSource(SystemToolchainSource):
+    """Adopt a complete CUDA/TensorRT toolchain rooted at a user-owned prefix."""
+
+    descriptor = ProviderDescriptor("prefix", "trtmc-devtoolkit-prefix==3", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        configured = request.toolchain_options.get("prefix")
+        if "host-filesystem" not in context.capabilities or not isinstance(configured, str):
+            return ()
+        discovered_cuda = self.discover_cuda_at(Path(configured), context, repository, runner)
+        if discovered_cuda is None:
+            return ()
+        root, nvcc, cuda_version = discovered_cuda
+        include_dir = root / "include"
+        header = include_dir / "NvInferVersion.h"
+        library = _first_library(root, "libnvinfer.so", context.architecture)
+        if not header.is_file() or library is None:
+            return ()
+        python = str(context.locator.get("python", "python3"))
+        cudart = _first_library(root, "libcudart.so", context.architecture)
+        assert cudart is not None
+        probe_environment = {
+            "PATH": f"{root / 'bin'}:{os.environ.get('PATH', '')}",
+            "CUDA_HOME": str(root),
+            "CUDA_PATH": str(root),
+            "LD_LIBRARY_PATH": (
+                f"{library.parent}:{cudart.parent}:{os.environ.get('LD_LIBRARY_PATH', '')}"
+            ),
+        }
+        try:
+            python_version = command_output(
+                runner,
+                [
+                    python,
+                    "-c",
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+                ],
+                cwd=repository,
+                env=probe_environment,
+                timeout=30,
+            )
+            tensorrt_python = command_output(
+                runner,
+                [python, "-c", "import tensorrt; print(tensorrt.__version__)"],
+                cwd=repository,
+                env=probe_environment,
+                timeout=30,
+            )
+            tensorrt_native = command_output(
+                runner,
+                [python, "-c", _native_version_script(library)],
+                cwd=repository,
+                env=probe_environment,
+                timeout=30,
+            )
+            tensorrt_header = tensorrt_header_version(header)
+        except (DevToolkitError, OSError, subprocess.TimeoutExpired):
+            return ()
+        if len({tensorrt_python, tensorrt_native, tensorrt_header}) != 1:
+            return ()
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="prefix",
+                cuda_source="prefix",
+                tensorrt=tensorrt_native,
+                cuda=cuda_version,
+                python=python_version,
+                identity={
+                    "cuda_root": str(root),
+                    "nvcc": str(nvcc),
+                    "tensorrt_include_dir": str(include_dir),
+                    "tensorrt_library_dir": str(library.parent),
+                    "tensorrt_library": str(library),
+                },
+                runtime=ToolchainRuntime(
+                    python_executable=python,
+                    cuda_root=str(root),
+                    nvcc=str(nvcc),
+                    tensorrt_include_dir=str(include_dir),
+                    tensorrt_library=str(library),
+                ),
+            ),
+        )
+
+
+class ManagedArtifactToolchainSource:
+    """Resolve caller-supplied, digest-pinned managed toolchain artifacts."""
+
+    descriptor = ProviderDescriptor("managed-artifacts", "trtmc-devtoolkit-managed-artifacts==6", 1)
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        if not ({"host-filesystem", "container-process"} & context.capabilities):
+            return ()
+        if not request.artifacts:
+            return ()
+        headers = next(
+            (artifact for artifact in request.artifacts if artifact.name == "tensorrt-headers"),
+            None,
+        )
+        if (
+            headers is None
+            or not urllib.parse.urlparse(headers.uri).path.endswith(".deb")
+            or not any(
+                urllib.parse.urlparse(artifact.uri).path.endswith(".whl")
+                for artifact in request.artifacts
+            )
+        ):
+            return ()
+        policy = request.cuda
+        configured_prefix = request.toolchain_options.get("cuda_prefix")
+        if isinstance(configured_prefix, str) and "host-filesystem" in context.capabilities:
+            system_cuda = SystemToolchainSource.discover_cuda_at(
+                Path(configured_prefix), context, repository, runner
+            )
+            existing_cuda_source: CudaSource = "prefix"
+        else:
+            baseline = target_runtime_baseline(context, repository, runner)
+            system_cuda = (
+                (Path(baseline.cuda_root), Path(baseline.nvcc), baseline.cuda)
+                if baseline is not None
+                else None
+            )
+            existing_cuda_source = baseline.cuda_source if baseline is not None else "system"
+        cuda_source = "managed"
+        system_cuda_root: str | None = None
+        system_nvcc: str | None = None
+        if policy.kind == "system-first" and system_cuda is not None:
+            cuda_root, nvcc, cuda = system_cuda
+            cuda_source = existing_cuda_source
+            system_cuda_root = str(cuda_root)
+            system_nvcc = str(nvcc)
+        elif policy.kind == "system-only":
+            if system_cuda is None or (
+                policy.version is not None and system_cuda[2] != policy.version
+            ):
+                return ()
+            cuda_root, nvcc, cuda = system_cuda
+            cuda_source = existing_cuda_source
+            system_cuda_root = str(cuda_root)
+            system_nvcc = str(nvcc)
+        elif (
+            policy.kind == "exact" and system_cuda is not None and system_cuda[2] == policy.version
+        ):
+            cuda_root, nvcc, cuda = system_cuda
+            cuda_source = existing_cuda_source
+            system_cuda_root = str(cuda_root)
+            system_nvcc = str(nvcc)
+        else:
+            cuda = policy.fallback if policy.kind == "system-first" else policy.version
+        if cuda is None:
+            return ()
+        cuda_major = cuda.split(".", 1)[0]
+        cuda_artifacts: tuple[str, ...] = ()
+        if cuda_source == "managed":
+            configured_cuda_artifacts = request.toolchain_options.get("cuda_artifacts")
+            artifact_names = {artifact.name for artifact in request.artifacts}
+            if (
+                not isinstance(configured_cuda_artifacts, tuple)
+                or not configured_cuda_artifacts
+                or any(
+                    not isinstance(name, str) or name not in artifact_names
+                    for name in configured_cuda_artifacts
+                )
+            ):
+                return ()
+            cuda_artifacts = configured_cuda_artifacts
+        configured_python_bootstrap = request.toolchain_options.get(
+            "python_bootstrap_artifacts", ()
+        )
+        artifact_names = {artifact.name for artifact in request.artifacts}
+        if (
+            not isinstance(configured_python_bootstrap, tuple)
+            or any(
+                not isinstance(name, str) or not name or name not in artifact_names
+                for name in configured_python_bootstrap
+            )
+        ):
+            return ()
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="managed",
+                cuda_source=cuda_source,
+                tensorrt=request.tensorrt,
+                cuda=cuda,
+                python=request.python,
+                identity={
+                    "layout_schema": 4,
+                    "cuda_module": f"nvidia.cu{cuda_major}",
+                    "tensorrt_lib_distribution": f"tensorrt_cu{cuda_major}_libs",
+                    "system_cuda_root": system_cuda_root,
+                    "system_nvcc": system_nvcc,
+                    "cuda_artifacts": cuda_artifacts,
+                    "python_bootstrap_artifacts": configured_python_bootstrap,
+                    "cuda_release": request.toolchain_options.get("cuda_release"),
+                },
+                artifacts=request.artifacts,
+            ),
+        )
+
+    def provision(
+        self,
+        lock,
+        context: ContextHandle,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+    ) -> ToolchainHandle:
+        if context.supports_target_operations:
+            return self._provision_target(lock, context, repository=repository, runner=runner)
+        python = Path(str(context.locator["python"]))
+        downloads = state_dir / "managed-artifacts"
+        paths = {
+            artifact.name: self._download(artifact, downloads)
+            for artifact in lock.toolchain.artifacts
+        }
+        packages = [
+            paths[artifact.name]
+            for artifact in lock.toolchain.artifacts
+            if urllib.parse.urlparse(artifact.uri).path.endswith((".whl", ".tar.gz"))
+        ]
+        if not packages:
+            raise DevToolkitError("Managed toolchain lock contains no Python packages")
+        runner.run(
+            [
+                python,
+                "-m",
+                "pip",
+                "install",
+                "--no-index",
+                "--no-deps",
+                "--no-build-isolation",
+                *packages,
+            ],
+            cwd=repository,
+        )
+        runner.run([python, "-m", "pip", "check"], cwd=repository)
+        headers_archive = paths["tensorrt-headers"]
+        headers_root = state_dir / "managed-toolchain" / "headers" / lock.lock_id
+        marker = headers_root / ".complete"
+        if not marker.is_file():
+            headers_root.mkdir(parents=True, exist_ok=True)
+            runner.run(
+                ["dpkg-deb", "--extract", headers_archive, headers_root],
+                cwd=repository,
+            )
+            marker.write_text("ready\n", encoding="utf-8")
+        matching_headers = [
+            path
+            for path in headers_root.rglob("NvInferVersion.h")
+            if tensorrt_header_version(path) == lock.toolchain.tensorrt
+        ]
+        if len(matching_headers) != 1:
+            raise DevToolkitError(
+                "Managed artifacts must provide exactly one matching NvInferVersion.h"
+            )
+        if lock.toolchain.cuda_source in {"system", "prefix", "image"}:
+            cuda_expression = (
+                f"Path({str(lock.toolchain.identity['system_cuda_root'])!r}).resolve()"
+            )
+        else:
+            cuda_root = self._materialize_local_cuda(lock, paths, state_dir, runner, repository)
+            cuda_expression = f"Path({str(cuda_root)!r}).resolve()"
+        location_script = (
+            "import importlib, importlib.metadata as m, json; from pathlib import Path; "
+            f"cuda={cuda_expression}; "
+            f"dist=m.distribution({str(lock.toolchain.identity['tensorrt_lib_distribution'])!r}); "
+            "trt=Path(dist.locate_file('tensorrt_libs')).resolve(); "
+            "libs=sorted(trt.glob('libnvinfer.so*'), key=lambda p: (p.name != 'libnvinfer.so', p.name)); "
+            "print(json.dumps({'cuda_root':str(cuda),'trt_library':str(libs[0].resolve())}))"
+        )
+        try:
+            locations = json.loads(
+                command_output(
+                    runner,
+                    [python, "-c", location_script],
+                    cwd=repository,
+                    timeout=30,
+                )
+            )
+            cuda_root = Path(locations["cuda_root"])
+            tensorrt_library = Path(locations["trt_library"])
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise DevToolkitError(f"Could not locate managed toolchain paths: {error}") from error
+        nvcc = cuda_root / "bin" / "nvcc"
+        if not SystemToolchainSource._complete_cuda(cuda_root, lock.context.architecture):
+            raise DevToolkitError("Managed artifacts produced an incomplete CUDA toolkit")
+        if not tensorrt_library.is_file():
+            raise DevToolkitError("Managed artifacts produced an incomplete TensorRT toolchain")
+        runtime = ToolchainRuntime(
+            python_executable=str(python),
+            cuda_root=str(cuda_root),
+            nvcc=str(nvcc),
+            tensorrt_include_dir=str(matching_headers[0].parent),
+            tensorrt_library=str(tensorrt_library),
+        )
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=runtime,
+            environment=_toolchain_environment(runtime, lock.context.architecture),
+        )
+
+    def _provision_target(
+        self,
+        lock,
+        context: ContextHandle,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ToolchainHandle:
+        del repository, runner
+        root_path = state_path(f"managed-toolchain/{lock.lock_id}")
+        root = context.map_path(root_path)
+        base_python = str(context.execution_identity["python"])
+        venv = str(PurePosixPath(root) / "venv")
+        venv_python = str(PurePosixPath(venv) / "bin" / "python")
+        ready_marker = str(PurePosixPath(root) / ".complete")
+        headers_root = str(PurePosixPath(root) / "headers")
+        cuda_root = (
+            str(PurePosixPath(root) / "cuda")
+            if lock.toolchain.cuda_source == "managed"
+            else None
+        )
+        context.execute(CommandSpec(("mkdir", "-p", root)))
+        complete = context.execute(
+            CommandSpec(("test", "-f", ready_marker)),
+            check=False,
+            capture_output=True,
+        )
+        newly_materialized = complete.returncode != 0
+        if newly_materialized:
+            downloads = context.map_path(state_path("artifact-cache"))
+            context.execute(CommandSpec(("mkdir", "-p", downloads)))
+            paths: dict[str, str] = {}
+            for artifact in lock.toolchain.artifacts:
+                filename = Path(urllib.parse.urlsplit(artifact.uri).path).name
+                if not filename:
+                    raise DevToolkitError(f"Artifact URI has no filename for {artifact.name}")
+                destination = str(PurePosixPath(downloads) / artifact.sha256 / filename)
+                context.execute(
+                    CommandSpec(
+                        (base_python, "-c", _TARGET_DOWNLOAD_SCRIPT, destination),
+                        environment={
+                            "TRTMC_ARTIFACT_URI": artifact.uri,
+                            "TRTMC_ARTIFACT_SHA256": artifact.sha256,
+                        },
+                    )
+                )
+                paths[artifact.name] = destination
+
+            exists = context.execute(
+                CommandSpec(("test", "-x", venv_python)),
+                check=False,
+                capture_output=True,
+            )
+            if exists.returncode != 0:
+                created = context.execute(
+                    CommandSpec((base_python, "-m", "venv", venv)),
+                    check=False,
+                    capture_output=True,
+                )
+                if created.returncode != 0:
+                    context.execute(
+                        CommandSpec((base_python, "-c", _TARGET_REMOVE_PATH_SCRIPT, venv))
+                    )
+                    context.execute(
+                        CommandSpec((base_python, "-m", "venv", "--without-pip", venv))
+                    )
+
+            bootstrap_names = self._python_bootstrap_artifact_names(lock)
+            if bootstrap_names:
+                bootstrap_paths = tuple(paths[name] for name in bootstrap_names)
+                context.execute(
+                    CommandSpec(
+                        (
+                            venv_python,
+                            "-m",
+                            "pip",
+                            "install",
+                            "--no-cache-dir",
+                            "--no-index",
+                            "--no-deps",
+                            *bootstrap_paths,
+                        ),
+                        environment={"PYTHONPATH": ":".join(bootstrap_paths)},
+                    )
+                )
+            else:
+                needs_wheel_builder = any(
+                    urllib.parse.urlsplit(artifact.uri).path.endswith(".tar.gz")
+                    for artifact in lock.toolchain.artifacts
+                )
+                python_build_ready = context.execute(
+                    CommandSpec(
+                        (
+                            venv_python,
+                            "-c",
+                            (
+                                "import pip, setuptools, wheel"
+                                if needs_wheel_builder
+                                else "import pip"
+                            ),
+                        )
+                    ),
+                    check=False,
+                    capture_output=True,
+                )
+                if python_build_ready.returncode != 0:
+                    raise DevToolkitError(
+                        "Target Python cannot build wheels; the immutable lock must include "
+                        "python_bootstrap_artifacts for pip, setuptools, and wheel"
+                    )
+
+            if cuda_root is not None:
+                context.execute(CommandSpec(("mkdir", "-p", cuda_root)))
+                for name in self._cuda_artifact_names(lock):
+                    archive = paths.get(name)
+                    if archive is None:
+                        raise DevToolkitError(f"Managed CUDA artifact {name!r} is missing")
+                    context.execute(
+                        CommandSpec(
+                            (
+                                "tar",
+                                "--extract",
+                                "--xz",
+                                "--file",
+                                archive,
+                                "--directory",
+                                cuda_root,
+                                "--strip-components=1",
+                                "--no-same-owner",
+                            )
+                        )
+                    )
+                context.execute(
+                    CommandSpec(
+                        (base_python, "-c", _TARGET_NORMALIZE_CUDA_LAYOUT_SCRIPT, cuda_root)
+                    )
+                )
+
+            bootstrap_set = set(bootstrap_names)
+            wheels = [
+                paths[artifact.name]
+                for artifact in lock.toolchain.artifacts
+                if artifact.name not in bootstrap_set
+                and urllib.parse.urlsplit(artifact.uri).path.endswith(".whl")
+            ]
+            source_packages = [
+                paths[artifact.name]
+                for artifact in lock.toolchain.artifacts
+                if urllib.parse.urlsplit(artifact.uri).path.endswith(".tar.gz")
+            ]
+            if source_packages:
+                built_wheels = str(PurePosixPath(root) / "built-wheels")
+                context.execute(CommandSpec(("mkdir", "-p", built_wheels)))
+                for source_package in source_packages:
+                    context.execute(
+                        CommandSpec(
+                            (
+                                venv_python,
+                                "-m",
+                                "pip",
+                                "wheel",
+                                "--no-cache-dir",
+                                "--no-deps",
+                                "--no-build-isolation",
+                                "--wheel-dir",
+                                built_wheels,
+                                source_package,
+                            )
+                        )
+                    )
+                wheel_result = context.execute(
+                    CommandSpec((venv_python, "-c", _TARGET_WHEELS_SCRIPT, built_wheels)),
+                    capture_output=True,
+                )
+                wheels.extend(line for line in wheel_result.stdout.splitlines() if line)
+            if not wheels:
+                raise DevToolkitError("Managed toolchain lock contains no Python packages")
+            context.execute(
+                CommandSpec(
+                    (
+                        venv_python,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--no-cache-dir",
+                        "--no-index",
+                        "--no-deps",
+                        "--no-build-isolation",
+                        *wheels,
+                    )
+                )
+            )
+            context.execute(CommandSpec((venv_python, "-m", "pip", "check")))
+
+            context.execute(CommandSpec(("mkdir", "-p", headers_root)))
+            headers_archives = [
+                paths[artifact.name]
+                for artifact in lock.toolchain.artifacts
+                if urllib.parse.urlsplit(artifact.uri).path.endswith(".deb")
+            ]
+            if not headers_archives:
+                raise DevToolkitError("Managed toolchain lock contains no TensorRT headers")
+            for archive in headers_archives:
+                context.execute(CommandSpec(("dpkg-deb", "--extract", archive, headers_root)))
+
+        header_result = context.execute(
+            CommandSpec(
+                (
+                    venv_python,
+                    "-c",
+                    _TARGET_HEADER_SCRIPT,
+                    headers_root,
+                    lock.toolchain.tensorrt,
+                )
+            ),
+            capture_output=True,
+        )
+        include_dir = header_result.stdout.strip()
+        if not include_dir:
+            raise DevToolkitError("Managed artifacts produced no matching TensorRT headers")
+
+        locations_result = context.execute(
+            CommandSpec(
+                (
+                    venv_python,
+                    "-c",
+                    _TARGET_LOCATIONS_SCRIPT,
+                    str(lock.toolchain.identity["tensorrt_lib_distribution"]),
+                    cuda_root or str(lock.toolchain.identity["system_cuda_root"]),
+                )
+            ),
+            capture_output=True,
+        )
+        try:
+            locations = json.loads(locations_result.stdout)
+            cuda_root = str(locations["cuda_root"])
+            tensorrt_library = str(locations["tensorrt_library"])
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise DevToolkitError(f"Could not locate managed toolchain paths: {error}") from error
+        runtime = ToolchainRuntime(
+            python_executable=venv_python,
+            cuda_root=cuda_root,
+            nvcc=str(PurePosixPath(cuda_root) / "bin" / "nvcc"),
+            tensorrt_include_dir=include_dir,
+            tensorrt_library=tensorrt_library,
+        )
+        base_environment_result = context.execute(
+            CommandSpec((base_python, "-c", _TARGET_ENVIRONMENT_SCRIPT)),
+            capture_output=True,
+        )
+        try:
+            raw_environment = json.loads(base_environment_result.stdout)
+            if not isinstance(raw_environment, dict) or any(
+                not isinstance(name, str) or not isinstance(value, str)
+                for name, value in raw_environment.items()
+            ):
+                raise TypeError
+            base_environment = raw_environment
+        except (json.JSONDecodeError, TypeError) as error:
+            raise DevToolkitError(
+                f"Could not observe target process environment: {error}"
+            ) from error
+        environment = _toolchain_environment(
+            runtime,
+            lock.context.architecture,
+            base_environment=base_environment,
+        )
+        if newly_materialized:
+            context.execute(CommandSpec(("touch", ready_marker)))
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=runtime,
+            environment=environment,
+        )
+
+    @staticmethod
+    def _cuda_artifact_names(lock) -> tuple[str, ...]:
+        raw = lock.toolchain.identity.get("cuda_artifacts", ())
+        if (
+            not isinstance(raw, tuple)
+            or not raw
+            or any(not isinstance(name, str) or not name for name in raw)
+        ):
+            raise DevToolkitError("Managed CUDA requires a non-empty digest-pinned component set")
+        return raw
+
+    @staticmethod
+    def _python_bootstrap_artifact_names(lock) -> tuple[str, ...]:
+        raw = lock.toolchain.identity.get("python_bootstrap_artifacts", ())
+        artifact_names = {artifact.name for artifact in lock.toolchain.artifacts}
+        if (
+            not isinstance(raw, tuple)
+            or any(
+                not isinstance(name, str) or not name or name not in artifact_names
+                for name in raw
+            )
+        ):
+            raise DevToolkitError("Managed Python bootstrap artifact set is invalid")
+        return raw
+
+    @classmethod
+    def _materialize_local_cuda(
+        cls,
+        lock,
+        paths: dict[str, Path],
+        state_dir: Path,
+        runner: Runner,
+        repository: Path,
+    ) -> Path:
+        cuda_root = state_dir / "managed-toolchain" / lock.lock_id / "cuda"
+        marker = cuda_root / ".complete"
+        if not marker.is_file():
+            cuda_root.mkdir(parents=True, exist_ok=True)
+            for name in cls._cuda_artifact_names(lock):
+                archive = paths.get(name)
+                if archive is None:
+                    raise DevToolkitError(f"Managed CUDA artifact {name!r} is missing")
+                runner.run(
+                    [
+                        "tar",
+                        "--extract",
+                        "--xz",
+                        "--file",
+                        archive,
+                        "--directory",
+                        cuda_root,
+                        "--strip-components=1",
+                        "--no-same-owner",
+                    ],
+                    cwd=repository,
+                )
+            marker.touch()
+        lib = cuda_root / "lib"
+        lib64 = cuda_root / "lib64"
+        if lib.is_dir() and not lib64.exists() and not lib64.is_symlink():
+            lib64.symlink_to("lib", target_is_directory=True)
+        if not all((lib64 / name).is_file() for name in ("libcudart_static.a", "libcudadevrt.a")):
+            raise DevToolkitError("Managed CUDA lacks static compiler runtime libraries")
+        return cuda_root
+
+    def observe(
+        self,
+        lock,
+        context: ContextHandle,
+        toolchain: ToolchainHandle,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ToolchainObservation:
+        del lock
+        runtime = toolchain.runtime
+        if "container-process" in context.capabilities:
+            result = context.execute(
+                CommandSpec(
+                    (
+                        runtime.python_executable,
+                        "-c",
+                        _TARGET_TOOLCHAIN_PROBE_SCRIPT,
+                        runtime.nvcc,
+                        runtime.tensorrt_include_dir,
+                        runtime.tensorrt_library,
+                        runtime.cuda_root,
+                    ),
+                    environment=dict(toolchain.environment),
+                ),
+                capture_output=True,
+            )
+            try:
+                payload = json.loads(result.stdout)
+                return ToolchainObservation(
+                    python_version=str(payload["python"]),
+                    cuda_version=str(payload["cuda"]),
+                    tensorrt_python_version=str(payload["tensorrt_python"]),
+                    tensorrt_native_version=str(payload["tensorrt_native"]),
+                    tensorrt_header_version=str(payload["tensorrt_headers"]),
+                    tensorrt_include_dir=str(payload["tensorrt_include_dir"]),
+                    tensorrt_library=str(payload["tensorrt_library"]),
+                    cuda_root=str(payload["cuda_root"]),
+                    image_id=str(context.identity.get("image_id", "")) or None,
+                    architecture=normalize_architecture(str(payload["architecture"])),
+                    evidence={
+                        str(name): str(digest) for name, digest in dict(payload["evidence"]).items()
+                    },
+                )
+            except (json.JSONDecodeError, KeyError, TypeError) as error:
+                raise DevToolkitError(
+                    f"Managed target toolchain probe returned invalid data: {error}"
+                ) from error
+        return observe_local_toolchain(
+            runner,
+            repository=repository,
+            python=runtime.python_executable,
+            nvcc=runtime.nvcc,
+            tensorrt_include_dir=Path(runtime.tensorrt_include_dir),
+            tensorrt_library=Path(runtime.tensorrt_library),
+            environment=dict(context.environment),
+            cuda_root=Path(runtime.cuda_root),
+        )
+
+    @staticmethod
+    def _download(artifact, root: Path) -> Path:
+        filename = Path(urllib.parse.urlparse(artifact.uri).path).name
+        if not filename:
+            raise DevToolkitError(f"Artifact URI has no filename: {artifact.uri}")
+        destination = root / artifact.sha256 / filename
+        if (
+            destination.is_file()
+            and ManagedArtifactToolchainSource._sha256(destination) == artifact.sha256
+        ):
+            return destination
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha256()
+        partial: Path | None = None
+        try:
+            with NamedTemporaryFile(
+                dir=destination.parent,
+                prefix=f".{filename}.",
+                suffix=".partial",
+                delete=False,
+            ) as stream:
+                partial = Path(stream.name)
+                with urllib.request.urlopen(artifact.uri, timeout=120) as response:
+                    while chunk := response.read(1024 * 1024):
+                        digest.update(chunk)
+                        stream.write(chunk)
+            if digest.hexdigest() != artifact.sha256:
+                raise DevToolkitError(
+                    f"Artifact checksum mismatch for {artifact.name}: {digest.hexdigest()}"
+                )
+            os.replace(partial, destination)
+        except (OSError, urllib.error.URLError) as error:
+            raise DevToolkitError(f"Could not download {artifact.name}: {error}") from error
+        finally:
+            if partial is not None:
+                partial.unlink(missing_ok=True)
+        return destination
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+
+_TARGET_WHEELS_SCRIPT = r"""
+import sys
+from pathlib import Path
+
+wheels = sorted(Path(sys.argv[1]).glob("*.whl"))
+if not wheels:
+    raise SystemExit("source package produced no wheel")
+print("\n".join(str(wheel.resolve()) for wheel in wheels))
+""".strip()
+
+
+_TARGET_REMOVE_PATH_SCRIPT = r"""
+import shutil
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if path.exists() or path.is_symlink():
+    shutil.rmtree(path)
+""".strip()
+
+
+_TARGET_ENVIRONMENT_SCRIPT = r"""
+import json
+import os
+
+print(json.dumps({
+    "PATH": os.environ.get("PATH", ""),
+    "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
+}))
+""".strip()
+
+
+_TARGET_NORMALIZE_CUDA_LAYOUT_SCRIPT = r"""
+import os
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+library = root / "lib"
+library64 = root / "lib64"
+if library.is_dir() and not os.path.lexists(library64):
+    library64.symlink_to("lib", target_is_directory=True)
+required = (library64 / "libcudart_static.a", library64 / "libcudadevrt.a")
+if not all(path.is_file() for path in required):
+    raise SystemExit("managed CUDA lacks static compiler runtime libraries")
+""".strip()
+
+
+_TARGET_DOWNLOAD_SCRIPT = r"""
+import hashlib
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+destination = Path(sys.argv[1])
+expected = os.environ["TRTMC_ARTIFACT_SHA256"]
+destination.parent.mkdir(parents=True, exist_ok=True)
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+if destination.is_file():
+    if sha256(destination) == expected:
+        raise SystemExit(0)
+digest = hashlib.sha256()
+partial = None
+try:
+    with NamedTemporaryFile(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".partial",
+        delete=False,
+    ) as stream:
+        partial = Path(stream.name)
+        with urllib.request.urlopen(os.environ["TRTMC_ARTIFACT_URI"], timeout=120) as response:
+            for chunk in iter(lambda: response.read(1024 * 1024), b""):
+                digest.update(chunk)
+                stream.write(chunk)
+except Exception as error:
+    if partial is not None:
+        partial.unlink(missing_ok=True)
+    raise SystemExit(f"artifact download failed: {type(error).__name__}")
+if digest.hexdigest() != expected:
+    if partial is not None:
+        partial.unlink(missing_ok=True)
+    raise SystemExit("artifact checksum mismatch")
+os.replace(partial, destination)
+""".strip()
+
+
+_TARGET_HEADER_SCRIPT = r"""
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+expected = sys.argv[2]
+matches = []
+for header in root.rglob("NvInferVersion.h"):
+    definitions = dict(re.findall(
+        r"^#define\s+([A-Za-z0-9_]+)\s+([A-Za-z0-9_]+)\b",
+        header.read_text(),
+        re.M,
+    ))
+    parts = []
+    for name in ("MAJOR", "MINOR", "PATCH", "BUILD"):
+        value = definitions.get(f"NV_TENSORRT_{name}", "")
+        parts.append(definitions.get(value, value))
+    if ".".join(parts) == expected:
+        matches.append(header.parent.resolve())
+if len(matches) != 1:
+    raise SystemExit(f"expected one matching TensorRT header tree, found {len(matches)}")
+print(matches[0])
+""".strip()
+
+
+_TARGET_LOCATIONS_SCRIPT = r"""
+import importlib.metadata as metadata
+import json
+import sys
+from pathlib import Path
+
+distribution = metadata.distribution(sys.argv[1])
+libraries = Path(distribution.locate_file("tensorrt_libs")).resolve()
+candidates = sorted(
+    libraries.glob("libnvinfer.so*"),
+    key=lambda path: (path.name != "libnvinfer.so", path.name),
+)
+if not candidates:
+    raise SystemExit("TensorRT library was not installed")
+cuda_root = Path(sys.argv[2]).resolve()
+required = (
+    cuda_root / "bin" / "nvcc",
+    cuda_root / "include" / "cuda.h",
+    next(cuda_root.rglob("libcudart.so"), None),
+    next(cuda_root.rglob("libcublas.so"), None),
+    next(cuda_root.rglob("libcurand.so"), None),
+)
+if not all(path is not None and path.is_file() for path in required):
+    raise SystemExit("CUDA toolkit is incomplete")
+print(json.dumps({
+    "cuda_root": str(cuda_root),
+    "tensorrt_library": str(candidates[0].resolve()),
+}))
+""".strip()
+
+
+_TARGET_TOOLCHAIN_PROBE_SCRIPT = r"""
+import ctypes
+import hashlib
+import json
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import tensorrt
+
+nvcc, include_dir, library, cuda_root = map(Path, sys.argv[1:5])
+text = subprocess.check_output([nvcc, "--version"], text=True)
+cuda = re.search(r"release\s+([0-9]+\.[0-9]+)", text, re.I)
+if cuda is None:
+    raise SystemExit("nvcc did not report a CUDA release")
+header = include_dir / "NvInferVersion.h"
+definitions = dict(re.findall(
+    r"^#define\s+([A-Za-z0-9_]+)\s+([A-Za-z0-9_]+)\b",
+    header.read_text(),
+    re.M,
+))
+parts = []
+for name in ("MAJOR", "MINOR", "PATCH", "BUILD"):
+    value = definitions.get(f"NV_TENSORRT_{name}", "")
+    parts.append(definitions.get(value, value))
+native_library = ctypes.CDLL(str(library))
+functions = [
+    getattr(native_library, f"getInferLib{name}Version")
+    for name in ("Major", "Minor", "Patch", "Build")
+]
+for function in functions:
+    function.restype = ctypes.c_int32
+def sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+print(json.dumps({
+    "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+    "cuda": cuda.group(1),
+    "tensorrt_python": tensorrt.__version__,
+    "tensorrt_native": ".".join(str(function()) for function in functions),
+    "tensorrt_headers": ".".join(parts),
+    "tensorrt_include_dir": str(include_dir),
+    "tensorrt_library": str(library),
+    "cuda_root": str(cuda_root),
+    "architecture": platform.machine(),
+    "evidence": {
+        "nvcc": sha256(nvcc),
+        "tensorrt-header": sha256(header),
+        "tensorrt-library": sha256(library),
+    },
+}))
+""".strip()

--- a/apps/devtoolkit/trtmc_devtoolkit/catalogs.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/catalogs.py
@@ -1,0 +1,707 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in catalogs that resolve toolchain intent into immutable artifacts."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from html.parser import HTMLParser
+from pathlib import Path
+
+from .builtin_providers import (
+    ManagedArtifactToolchainSource,
+    target_python_baseline,
+    target_runtime_baseline,
+)
+from .models import DevToolkitError
+from .resolution import (
+    ArtifactPin,
+    ContextLock,
+    EnvironmentRequest,
+    ProviderDescriptor,
+    ToolchainCandidate,
+)
+from .runner import Runner
+
+
+Fetch = Callable[[str], bytes | None]
+
+_CUDA_COMPONENTS = (
+    "cuda_crt",
+    "cuda_cudart",
+    "cuda_culibos",
+    "cuda_nvcc",
+    "libcublas",
+    "libcurand",
+    "libnvvm",
+)
+
+_PYTHON_BOOTSTRAP_PACKAGES = (
+    ("python-bootstrap-pip", "pip", "24.0"),
+    ("python-bootstrap-setuptools", "setuptools", "68.1.2"),
+    ("python-bootstrap-wheel", "wheel", "0.42.0"),
+)
+
+
+class _Links(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = next((value for name, value in attrs if name.lower() == "href"), None)
+        if href:
+            self.hrefs.append(href)
+
+
+def _public_fetch(url: str) -> bytes | None:
+    try:
+        with urllib.request.urlopen(url, timeout=20) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise DevToolkitError(f"NVIDIA catalog request failed with HTTP {error.code}") from error
+    except (OSError, urllib.error.URLError) as error:
+        raise DevToolkitError(f"NVIDIA catalog request failed: {type(error).__name__}") from error
+
+
+def _artifact(name: str, url: str, digest: str) -> ArtifactPin | None:
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        return None
+    return ArtifactPin(name, url, digest)
+
+
+class NvidiaPackageIndexCatalog:
+    """Resolve public NVIDIA TensorRT wheels and development headers."""
+
+    descriptor = ProviderDescriptor(
+        "nvidia-package-index",
+        "trtmc-devtoolkit-nvidia-package-index==3",
+        1,
+    )
+
+    def __init__(
+        self,
+        *,
+        pypi_json: str = "https://pypi.org/pypi",
+        nvidia_python: str = "https://pypi.nvidia.com",
+        cuda_repository: str = "https://developer.download.nvidia.com/compute/cuda/repos",
+        cuda_redist: str = "https://developer.download.nvidia.com/compute/cuda/redist",
+        fetch: Fetch | None = None,
+    ) -> None:
+        self.pypi_json = pypi_json.rstrip("/")
+        self.nvidia_python = nvidia_python.rstrip("/")
+        self.cuda_repository = cuda_repository.rstrip("/")
+        self.cuda_redist = cuda_redist.rstrip("/")
+        self._fetch = fetch or _public_fetch
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        selected_catalog = request.toolchain_options.get("catalog")
+        if (
+            request.artifacts
+            or request.toolchain not in {None, "managed-artifacts"}
+            or selected_catalog not in {None, self.descriptor.name}
+        ):
+            return ()
+        baseline = target_runtime_baseline(context, repository, runner)
+        python = baseline or target_python_baseline(context, repository, runner)
+        if python is None or python.python != request.python:
+            return ()
+        policy = request.cuda
+        use_existing = baseline is not None and (
+            policy.kind == "system-first"
+            or (policy.kind == "system-only" and policy.version in {None, baseline.cuda})
+            or (policy.kind == "exact" and policy.version == baseline.cuda)
+        )
+        if policy.kind == "system-only" and not use_existing:
+            return ()
+        if use_existing:
+            assert baseline is not None
+            cuda = baseline.cuda
+            cuda_source = baseline.cuda_source
+            cuda_root: str | None = baseline.cuda_root
+            nvcc: str | None = baseline.nvcc
+            cuda_artifacts: tuple[ArtifactPin, ...] = ()
+            cuda_release: str | None = None
+        else:
+            cuda = policy.fallback if policy.kind == "system-first" else policy.version
+            if cuda is None:
+                return ()
+            cuda_source = "managed"
+            cuda_root = None
+            nvcc = None
+            cuda_artifacts, cuda_release = self._cuda_distribution(
+                cuda,
+                context.architecture,
+            )
+            if not cuda_artifacts:
+                return ()
+        artifacts, headers_version = self._distribution(
+            request.tensorrt,
+            cuda,
+            request.python,
+            context.architecture,
+            str(context.identity.get("os_id", "unknown")),
+            str(context.identity.get("os_version", "unknown")),
+        )
+        if not artifacts:
+            return ()
+        python_bootstrap = self._python_bootstrap_distribution()
+        if not python_bootstrap:
+            return ()
+        cuda_major = cuda.split(".", 1)[0]
+        managed_names = tuple(artifact.name for artifact in cuda_artifacts)
+        bootstrap_names = tuple(artifact.name for artifact in python_bootstrap)
+        return (
+            ToolchainCandidate(
+                provider=ManagedArtifactToolchainSource.descriptor,
+                origin="managed",
+                cuda_source=cuda_source,
+                tensorrt=request.tensorrt,
+                cuda=cuda,
+                python=request.python,
+                identity={
+                    "layout_schema": 4,
+                    "catalog": {
+                        "name": self.descriptor.name,
+                        "implementation": self.descriptor.implementation,
+                        "lock_schema": self.descriptor.lock_schema,
+                    },
+                    "cuda_module": f"nvidia.cu{cuda_major}",
+                    "tensorrt_lib_distribution": f"tensorrt_cu{cuda_major}_libs",
+                    "system_cuda_root": cuda_root,
+                    "system_nvcc": nvcc,
+                    "cuda_artifacts": managed_names,
+                    "python_bootstrap_artifacts": bootstrap_names,
+                    "cuda_release": cuda_release,
+                    "headers_package_version": headers_version,
+                },
+                artifacts=(*artifacts, *cuda_artifacts, *python_bootstrap),
+            ),
+        )
+
+    def _python_bootstrap_distribution(self) -> tuple[ArtifactPin, ...]:
+        artifacts = tuple(
+            self._pypi_file(
+                package,
+                version,
+                lambda filename, expected=f"{package.replace('-', '_')}-{version}": (
+                    filename == f"{expected}-py3-none-any.whl"
+                ),
+                name,
+            )
+            for name, package, version in _PYTHON_BOOTSTRAP_PACKAGES
+        )
+        if any(artifact is None for artifact in artifacts):
+            return ()
+        return tuple(artifact for artifact in artifacts if artifact is not None)
+
+    def _cuda_distribution(
+        self,
+        version: str,
+        architecture: str,
+    ) -> tuple[tuple[ArtifactPin, ...], str]:
+        """Resolve the minimal complete native-build CUDA component closure."""
+
+        platform_name = {
+            "x86_64": "linux-x86_64",
+            "aarch64": "linux-sbsa",
+        }.get(architecture)
+        if platform_name is None:
+            return (), ""
+        release = f"{version}.0"
+        raw = self._fetch(f"{self.cuda_redist}/redistrib_{release}.json")
+        if raw is None:
+            return (), ""
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                return (), ""
+            if payload.get("release_label") != release:
+                return (), ""
+            component_names = (*_CUDA_COMPONENTS, self._cccl_component(payload))
+            artifacts: list[ArtifactPin] = []
+            for component_name in component_names:
+                component = payload[component_name]
+                platform = component[platform_name]
+                artifact = _artifact(
+                    f"cuda-component-{component_name}",
+                    urllib.parse.urljoin(
+                        f"{self.cuda_redist}/",
+                        str(platform["relative_path"]),
+                    ),
+                    str(platform["sha256"]),
+                )
+                if artifact is None:
+                    return (), ""
+                artifacts.append(artifact)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return (), ""
+        return tuple(artifacts), release
+
+    @staticmethod
+    def _cccl_component(payload: object) -> str:
+        if not isinstance(payload, dict):
+            raise TypeError
+        if "cccl" in payload:
+            return "cccl"
+        if "cuda_cccl" in payload:
+            return "cuda_cccl"
+        raise KeyError("cccl")
+
+    def _distribution(
+        self,
+        version: str,
+        cuda: str,
+        python: str,
+        architecture: str,
+        os_id: str,
+        os_version: str,
+    ) -> tuple[tuple[ArtifactPin, ...], str]:
+        cuda_major = cuda.split(".", 1)[0]
+        package = f"tensorrt-cu{cuda_major}"
+        bindings_package = f"tensorrt-cu{cuda_major}-bindings"
+        libraries_package = f"tensorrt-cu{cuda_major}-libs"
+        python_source = self._pypi_file(
+            package,
+            version,
+            lambda filename: filename.endswith(".tar.gz"),
+            "tensorrt-python",
+        )
+        python_tag = python.replace(".", "")
+        platform_tag = {"x86_64": "x86_64", "aarch64": "aarch64"}.get(architecture)
+        if platform_tag is None:
+            return (), ""
+        bindings = self._pypi_file(
+            bindings_package,
+            version,
+            lambda filename: bool(
+                re.search(
+                    rf"-cp{re.escape(python_tag)}-none-manylinux_[^-]+_{platform_tag}\.whl$",
+                    filename,
+                )
+            ),
+            "tensorrt-bindings",
+        )
+        libraries = self._nvidia_wheel(
+            libraries_package,
+            version,
+            platform_tag,
+            "tensorrt-libs",
+        )
+        headers, headers_version = self._headers(
+            version,
+            cuda,
+            os_id,
+            os_version,
+            architecture,
+        )
+        resolved = (python_source, bindings, libraries, headers)
+        if any(item is None for item in resolved):
+            return (), ""
+        return tuple(item for item in resolved if item is not None), headers_version
+
+    def _pypi_file(
+        self,
+        package: str,
+        version: str,
+        matches: Callable[[str], bool],
+        name: str,
+    ) -> ArtifactPin | None:
+        raw = self._fetch(f"{self.pypi_json}/{package}/{version}/json")
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+            files = [item for item in payload["urls"] if matches(str(item["filename"]))]
+            if len(files) != 1:
+                return None
+            item = files[0]
+            return _artifact(name, str(item["url"]), str(item["digests"]["sha256"]))
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    def _nvidia_wheel(
+        self,
+        package: str,
+        version: str,
+        platform_tag: str,
+        name: str,
+    ) -> ArtifactPin | None:
+        base = f"{self.nvidia_python}/{package}/"
+        raw = self._fetch(base)
+        if raw is None:
+            return None
+        parser = _Links()
+        parser.feed(raw.decode("utf-8", errors="replace"))
+        normalized = package.replace("-", "_")
+        pattern = re.compile(
+            rf"^{re.escape(normalized)}-{re.escape(version)}-py(?:2\.py3|3)-none-"
+            rf"manylinux_[^-]+_{platform_tag}\.whl$"
+        )
+        matches: list[tuple[str, str]] = []
+        for href in parser.hrefs:
+            resolved = urllib.parse.urljoin(base, href)
+            parsed = urllib.parse.urlsplit(resolved)
+            filename = urllib.parse.unquote(parsed.path.rsplit("/", 1)[-1])
+            digest = urllib.parse.parse_qs(parsed.fragment).get("sha256", [])
+            if pattern.fullmatch(filename) and len(digest) == 1:
+                matches.append((urllib.parse.urldefrag(resolved).url, digest[0]))
+        if len(matches) != 1:
+            return None
+        return _artifact(name, *matches[0])
+
+    def _headers(
+        self,
+        version: str,
+        cuda: str,
+        os_id: str,
+        os_version: str,
+        architecture: str,
+    ) -> tuple[ArtifactPin | None, str]:
+        distribution = self._distribution_name(os_id, os_version)
+        architecture_names = {
+            "x86_64": ("x86_64", "amd64"),
+            "aarch64": ("sbsa", "arm64"),
+        }.get(architecture)
+        if distribution is None or architecture_names is None:
+            return None, ""
+        repository_arch, deb_arch = architecture_names
+        base = f"{self.cuda_repository}/{distribution}/{repository_arch}/"
+        raw = self._fetch(f"{base}Packages.gz")
+        if raw is None:
+            return None, ""
+        try:
+            packages = gzip.decompress(raw).decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None, ""
+        cuda_major = cuda.split(".", 1)[0]
+        matches: list[dict[str, str]] = []
+        for stanza in packages.split("\n\n"):
+            fields = {
+                key: value
+                for line in stanza.splitlines()
+                if ": " in line
+                for key, value in (line.split(": ", 1),)
+            }
+            package_version = fields.get("Version", "")
+            if (
+                fields.get("Package") == "libnvinfer-headers-dev"
+                and fields.get("Architecture") in {deb_arch, "all"}
+                and package_version.startswith(f"{version}-1+cuda{cuda_major}.")
+                and fields.get("Filename")
+                and fields.get("SHA256")
+            ):
+                matches.append(fields)
+        if not matches:
+            return None, ""
+        matches.sort(
+            key=lambda item: (
+                f"+cuda{cuda}" in item["Version"],
+                item["Version"],
+            ),
+            reverse=True,
+        )
+        selected = matches[0]
+        url = urllib.parse.urljoin(base, selected["Filename"])
+        return _artifact("tensorrt-headers", url, selected["SHA256"]), selected["Version"]
+
+    @staticmethod
+    def _distribution_name(os_id: str, os_version: str) -> str | None:
+        compact = os_version.replace(".", "")
+        if os_id == "ubuntu" and compact in {"2004", "2204", "2404"}:
+            return f"ubuntu{compact}"
+        if os_id == "debian" and compact in {"11", "12", "13"}:
+            return f"debian{compact}"
+        return None
+
+
+class JsonToolchainCatalog:
+    """Resolve team/private artifacts from explicit, digest-pinned manifests."""
+
+    descriptor = ProviderDescriptor(
+        "json-toolchain-catalog",
+        "trtmc-devtoolkit-json-toolchain-catalog==1",
+        1,
+    )
+
+    def __init__(self, manifests: Sequence[Path]) -> None:
+        self.manifests = tuple(Path(path).resolve() for path in manifests)
+        if not self.manifests:
+            raise DevToolkitError("JSON toolchain catalog requires at least one manifest")
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]:
+        selected_catalog = request.toolchain_options.get("catalog")
+        if (
+            request.artifacts
+            or request.toolchain not in {None, "managed-artifacts"}
+            or selected_catalog not in {None, self.descriptor.name}
+        ):
+            return ()
+        baseline = target_runtime_baseline(context, repository, runner)
+        python = baseline or target_python_baseline(context, repository, runner)
+        if python is None or python.python != request.python:
+            return ()
+        candidates: list[ToolchainCandidate] = []
+        record_ids: set[str] = set()
+        for manifest in self.manifests:
+            raw = self._read(manifest)
+            digest = hashlib.sha256(raw).hexdigest()
+            payload = self._payload(manifest, raw)
+            for record in payload["toolchains"]:
+                if not isinstance(record, Mapping):
+                    raise DevToolkitError(f"Toolchain catalog {manifest} has a non-object record")
+                record_id = record.get("id")
+                if not isinstance(record_id, str) or not record_id:
+                    raise DevToolkitError(f"Toolchain catalog {manifest} has a record without id")
+                if record_id in record_ids:
+                    raise DevToolkitError(f"Duplicate toolchain catalog record id: {record_id}")
+                record_ids.add(record_id)
+                candidate = self._candidate(
+                    request,
+                    context,
+                    baseline,
+                    manifest,
+                    digest,
+                    record_id,
+                    record,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+        return tuple(candidates)
+
+    @staticmethod
+    def _read(manifest: Path) -> bytes:
+        try:
+            return manifest.read_bytes()
+        except OSError as error:
+            raise DevToolkitError(
+                f"Could not read toolchain catalog {manifest}: {error}"
+            ) from error
+
+    @staticmethod
+    def _payload(manifest: Path, raw: bytes) -> Mapping[str, object]:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise DevToolkitError(f"Invalid toolchain catalog JSON {manifest}: {error}") from error
+        if (
+            not isinstance(payload, Mapping)
+            or payload.get("schema_version") != 1
+            or not isinstance(payload.get("toolchains"), list)
+        ):
+            raise DevToolkitError(
+                f"Toolchain catalog {manifest} requires schema_version 1 and toolchains[]"
+            )
+        return payload
+
+    def _candidate(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        baseline,
+        manifest: Path,
+        manifest_digest: str,
+        record_id: str,
+        record: Mapping[str, object],
+    ) -> ToolchainCandidate | None:
+        if (
+            record.get("tensorrt") != request.tensorrt
+            or record.get("python") != request.python
+            or record.get("architecture") != context.architecture
+            or not self._matches_optional(record.get("os_id"), context.identity.get("os_id"))
+            or not self._matches_optional(
+                record.get("os_version"), context.identity.get("os_version")
+            )
+        ):
+            return None
+        cuda = record.get("cuda")
+        if not isinstance(cuda, Mapping):
+            raise DevToolkitError(f"Toolchain catalog record {record_id} requires cuda object")
+        source = cuda.get("source")
+        if source == "target":
+            if baseline is None or not self._target_cuda_matches(cuda, baseline.cuda):
+                return None
+            if request.cuda.kind == "managed":
+                return None
+            if request.cuda.kind in {"exact", "system-only"} and request.cuda.version not in {
+                None,
+                baseline.cuda,
+            }:
+                return None
+            resolved_cuda = baseline.cuda
+            cuda_source = baseline.cuda_source
+            cuda_root: str | None = baseline.cuda_root
+            nvcc: str | None = baseline.nvcc
+            cuda_artifact_names: tuple[str, ...] = ()
+            cuda_release: str | None = None
+        elif source == "managed":
+            resolved_cuda = cuda.get("version")
+            if not isinstance(resolved_cuda, str):
+                raise DevToolkitError(
+                    f"Toolchain catalog record {record_id} requires managed CUDA version"
+                )
+            if request.cuda.kind == "system-only":
+                return None
+            requested_cuda = (
+                request.cuda.fallback
+                if request.cuda.kind == "system-first"
+                else request.cuda.version
+            )
+            if requested_cuda != resolved_cuda:
+                return None
+            cuda_source = "managed"
+            cuda_root = None
+            nvcc = None
+            components = cuda.get("artifacts")
+            if (
+                not isinstance(components, list)
+                or not components
+                or any(not isinstance(name, str) or not name for name in components)
+            ):
+                raise DevToolkitError(
+                    f"Toolchain catalog record {record_id} requires managed CUDA artifacts[]"
+                )
+            cuda_artifact_names = tuple(components)
+            release = cuda.get("release")
+            cuda_release = str(release) if release is not None else None
+        else:
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} CUDA source must be target or managed"
+            )
+        artifacts = self._artifacts(manifest, record_id, record.get("artifacts"))
+        artifact_names = {artifact.name for artifact in artifacts}
+        if any(name not in artifact_names for name in cuda_artifact_names):
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} references an unknown CUDA artifact"
+            )
+        raw_bootstrap = record.get("python_bootstrap_artifacts", [])
+        if (
+            not isinstance(raw_bootstrap, list)
+            or any(not isinstance(name, str) or not name for name in raw_bootstrap)
+            or any(name not in artifact_names for name in raw_bootstrap)
+        ):
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} has invalid Python bootstrap artifacts"
+            )
+        python_bootstrap_artifacts = tuple(raw_bootstrap)
+        cuda_major = resolved_cuda.split(".", 1)[0]
+        distribution = record.get(
+            "tensorrt_lib_distribution",
+            f"tensorrt_cu{cuda_major}_libs",
+        )
+        if not isinstance(distribution, str) or not distribution:
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} has invalid TensorRT distribution"
+            )
+        return ToolchainCandidate(
+            provider=ManagedArtifactToolchainSource.descriptor,
+            origin="managed",
+            cuda_source=cuda_source,
+            tensorrt=request.tensorrt,
+            cuda=resolved_cuda,
+            python=request.python,
+            identity={
+                "layout_schema": 4,
+                "catalog": {
+                    "name": self.descriptor.name,
+                    "implementation": self.descriptor.implementation,
+                    "lock_schema": self.descriptor.lock_schema,
+                    "manifest_sha256": manifest_digest,
+                    "record_id": record_id,
+                },
+                "cuda_module": f"nvidia.cu{cuda_major}",
+                "tensorrt_lib_distribution": distribution,
+                "system_cuda_root": cuda_root,
+                "system_nvcc": nvcc,
+                "cuda_artifacts": cuda_artifact_names,
+                "python_bootstrap_artifacts": python_bootstrap_artifacts,
+                "cuda_release": cuda_release,
+            },
+            artifacts=artifacts,
+        )
+
+    @staticmethod
+    def _matches_optional(expected: object, actual: object) -> bool:
+        if expected is None:
+            return True
+        if isinstance(expected, str):
+            return expected == actual
+        if isinstance(expected, list) and all(isinstance(item, str) for item in expected):
+            return actual in expected
+        return False
+
+    @staticmethod
+    def _target_cuda_matches(cuda: Mapping[str, object], actual: str) -> bool:
+        version = cuda.get("version")
+        major = cuda.get("major")
+        if version is not None and version != actual:
+            return False
+        if major is not None and major != actual.split(".", 1)[0]:
+            return False
+        return version is not None or major is not None
+
+    @staticmethod
+    def _artifacts(
+        manifest: Path,
+        record_id: str,
+        raw_artifacts: object,
+    ) -> tuple[ArtifactPin, ...]:
+        if not isinstance(raw_artifacts, list) or not raw_artifacts:
+            raise DevToolkitError(f"Toolchain catalog record {record_id} requires artifacts[]")
+        artifacts: list[ArtifactPin] = []
+        for raw in raw_artifacts:
+            if not isinstance(raw, Mapping):
+                raise DevToolkitError(
+                    f"Toolchain catalog record {record_id} has a non-object artifact"
+                )
+            name, uri, digest = raw.get("name"), raw.get("uri"), raw.get("sha256")
+            if not all(isinstance(value, str) for value in (name, uri, digest)):
+                raise DevToolkitError(
+                    f"Toolchain catalog record {record_id} has an invalid artifact"
+                )
+            parsed = urllib.parse.urlsplit(uri)
+            if not parsed.scheme:
+                path = Path(uri)
+                if not path.is_absolute():
+                    path = manifest.parent / path
+                uri = path.resolve().as_uri()
+            artifacts.append(ArtifactPin(name, uri, digest))
+        names = [artifact.name for artifact in artifacts]
+        if len(names) != len(set(names)):
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} has duplicate artifact names"
+            )
+        if "tensorrt-headers" not in names or not any(
+            urllib.parse.urlsplit(artifact.uri).path.endswith((".whl", ".tar.gz"))
+            for artifact in artifacts
+        ):
+            raise DevToolkitError(
+                f"Toolchain catalog record {record_id} lacks TensorRT headers or Python packages"
+            )
+        return tuple(artifacts)

--- a/apps/devtoolkit/trtmc_devtoolkit/commands.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/commands.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opaque command execution routed through an environment's execution context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Mapping, Sequence
+from uuid import uuid4
+
+from .models import DevToolkitError
+from .providers import FrozenProviderRegistry
+from .provisioning import ProvisionedEnvironment, attest_environment
+from .receipt import write_json
+from .runner import Runner
+
+
+class PathScope(Enum):
+    REPOSITORY = "repository"
+    STATE = "state"
+    TARGET = "target"
+
+
+@dataclass(frozen=True)
+class EnvironmentPath:
+    scope: PathScope
+    path: PurePosixPath
+
+    def __post_init__(self) -> None:
+        path = PurePosixPath(self.path)
+        if self.scope is not PathScope.TARGET and (path.is_absolute() or ".." in path.parts):
+            raise DevToolkitError(
+                f"{self.scope.value} paths must be relative and cannot contain '..'"
+            )
+        if self.scope is PathScope.TARGET and not path.is_absolute():
+            raise DevToolkitError("target paths must be absolute")
+        object.__setattr__(self, "path", path)
+
+
+def repository_path(path: str | Path = ".") -> EnvironmentPath:
+    return EnvironmentPath(PathScope.REPOSITORY, PurePosixPath(path))
+
+
+def state_path(path: str | Path = ".") -> EnvironmentPath:
+    return EnvironmentPath(PathScope.STATE, PurePosixPath(path))
+
+
+def target_path(path: str | Path) -> EnvironmentPath:
+    return EnvironmentPath(PathScope.TARGET, PurePosixPath(path))
+
+
+CommandArgument = str | EnvironmentPath
+
+
+@dataclass(frozen=True)
+class ArtifactInput:
+    name: str
+    path: EnvironmentPath
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.name or re.fullmatch(r"[0-9a-f]{64}", self.sha256) is None:
+            raise DevToolkitError("Artifact inputs require a name and lowercase SHA-256")
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    arguments: tuple[CommandArgument, ...]
+    cwd: EnvironmentPath = field(default_factory=repository_path)
+    environment: Mapping[str, str] = field(default_factory=dict)
+    provenance: Mapping[str, str] = field(default_factory=dict)
+    artifacts: tuple[ArtifactInput, ...] = ()
+
+    def __init__(
+        self,
+        arguments: Sequence[CommandArgument],
+        *,
+        cwd: EnvironmentPath | None = None,
+        environment: Mapping[str, str] | None = None,
+        provenance: Mapping[str, str] | None = None,
+        artifacts: Sequence[ArtifactInput] = (),
+    ) -> None:
+        if not arguments:
+            raise DevToolkitError("A command requires at least one argument")
+        object.__setattr__(self, "arguments", tuple(arguments))
+        object.__setattr__(self, "cwd", cwd or repository_path())
+        object.__setattr__(
+            self,
+            "environment",
+            MappingProxyType(dict(environment or {})),
+        )
+        resolved_provenance = dict(provenance or {})
+        if any(not name or not value for name, value in resolved_provenance.items()):
+            raise DevToolkitError("Command provenance names and values must be non-empty")
+        object.__setattr__(
+            self,
+            "provenance",
+            MappingProxyType(resolved_provenance),
+        )
+        object.__setattr__(self, "artifacts", tuple(artifacts))
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    occurrence_id: str
+    invocation_digest: str
+    returncode: int
+    stdout: str
+    stderr: str
+    receipt: Path
+
+
+def _path_payload(path: EnvironmentPath) -> dict[str, str]:
+    return {"scope": path.scope.value, "path": str(path.path)}
+
+
+def _invocation_digest(environment: ProvisionedEnvironment, command: CommandSpec) -> str:
+    environment_digest = hashlib.sha256(
+        json.dumps(dict(command.environment), sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    payload = {
+        "schema_version": 3,
+        "environment_id": environment.environment_id,
+        "arguments": [
+            _path_payload(argument) if isinstance(argument, EnvironmentPath) else argument
+            for argument in command.arguments
+        ],
+        "cwd": _path_payload(command.cwd),
+        "environment_names": sorted(command.environment),
+        "environment_digest": environment_digest,
+        "provenance": dict(command.provenance),
+        "artifacts": [
+            {
+                "name": artifact.name,
+                "path": _path_payload(artifact.path),
+                "sha256": artifact.sha256,
+            }
+            for artifact in command.artifacts
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(b"trtmc-devtoolkit-command-v3\0" + encoded).hexdigest()
+
+
+class CommandExecutor:
+    def __init__(
+        self,
+        repository: Path,
+        providers: FrozenProviderRegistry,
+        runner: Runner,
+    ) -> None:
+        self.repository = repository
+        self.providers = providers
+        self.runner = runner
+
+    def run(
+        self,
+        environment: ProvisionedEnvironment,
+        command: CommandSpec,
+        *,
+        check: bool,
+        capture_output: bool,
+    ) -> CommandResult:
+        invocation = _invocation_digest(environment, command)
+        occurrence = uuid4().hex
+        receipt = environment.state_dir / "commands" / f"{occurrence}.json"
+        try:
+            context_provider = self.providers.context(environment.context.provider.name)
+            attest_environment(
+                environment,
+                repository=self.repository,
+                providers=self.providers,
+                runner=self.runner,
+            )
+            for artifact in command.artifacts:
+                digest_result = context_provider.execute(
+                    environment.context,
+                    CommandSpec(("sha256sum", artifact.path)),
+                    repository=self.repository,
+                    state_dir=environment.state_dir,
+                    runner=self.runner,
+                    check=True,
+                    capture_output=True,
+                )
+                output = digest_result.stdout.strip()
+                observed = output.split(None, 1)[0] if output else ""
+                if observed != artifact.sha256:
+                    raise DevToolkitError(
+                        f"Artifact {artifact.name!r} changed after build: "
+                        f"expected {artifact.sha256}, observed {observed or 'no digest'}"
+                    )
+            completed = context_provider.execute(
+                environment.context,
+                command,
+                repository=self.repository,
+                state_dir=environment.state_dir,
+                runner=self.runner,
+                check=check,
+                capture_output=capture_output,
+            )
+        except Exception as error:
+            write_json(
+                receipt,
+                {
+                    "schema_version": 3,
+                    "status": "failed",
+                    "environment_id": environment.environment_id,
+                    "occurrence_id": occurrence,
+                    "invocation_digest": invocation,
+                    "provenance": dict(command.provenance),
+                    "artifacts": [artifact.name for artifact in command.artifacts],
+                    "error_type": type(error).__name__,
+                },
+            )
+            raise
+        write_json(
+            receipt,
+            {
+                "schema_version": 3,
+                "status": "completed" if completed.returncode == 0 else "failed",
+                "completed_at": datetime.now(timezone.utc).isoformat(),
+                "environment_id": environment.environment_id,
+                "occurrence_id": occurrence,
+                "invocation_digest": invocation,
+                "provenance": dict(command.provenance),
+                "artifacts": [artifact.name for artifact in command.artifacts],
+                "returncode": completed.returncode,
+            },
+        )
+        return CommandResult(
+            occurrence_id=occurrence,
+            invocation_digest=invocation,
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            receipt=receipt,
+        )

--- a/apps/devtoolkit/trtmc_devtoolkit/docker_target.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/docker_target.py
@@ -18,7 +18,7 @@ from types import MappingProxyType
 from typing import Any, Iterator
 
 from .models import DevToolkitError
-from .runner import CommandRunner
+from .runner import Runner
 
 
 _CONTAINER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
@@ -169,7 +169,7 @@ def _environment_file(values: Mapping[str, str]) -> Iterator[Path | None]:
 class DockerLifecycle:
     """Inspect and prepare one container without deleting or replacing anything."""
 
-    def __init__(self, repository: Path, runner: CommandRunner) -> None:
+    def __init__(self, repository: Path, runner: Runner) -> None:
         self.repository = repository.resolve()
         self.runner = runner
 

--- a/apps/devtoolkit/trtmc_devtoolkit/models.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/models.py
@@ -1,17 +1,75 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Small value types returned by the checkout preparation API."""
+"""Value types shared by checkout preparation and environment capabilities."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from .resolution import ExecutionTarget
 
 
 class DevToolkitError(RuntimeError):
-    """The requested checkout environment cannot be prepared."""
+    """A user-facing development-environment error."""
+
+
+@dataclass(frozen=True)
+class ToolchainRuntime:
+    """Normalized paths required to use one resolved toolchain."""
+
+    python_executable: str
+    cuda_root: str
+    nvcc: str
+    tensorrt_include_dir: str
+    tensorrt_library: str
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not value
+            for value in (
+                self.python_executable,
+                self.cuda_root,
+                self.nvcc,
+                self.tensorrt_include_dir,
+                self.tensorrt_library,
+            )
+        ):
+            raise DevToolkitError("Toolchain runtime paths must be non-empty")
+
+
+@dataclass(frozen=True)
+class ToolchainObservation:
+    """Facts measured from the environment that will execute TRTMC."""
+
+    python_version: str
+    cuda_version: str
+    tensorrt_python_version: str
+    tensorrt_native_version: str
+    tensorrt_header_version: str
+    tensorrt_include_dir: str
+    tensorrt_library: str
+    cuda_root: str | None = None
+    image_id: str | None = None
+    architecture: str | None = None
+    evidence: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.evidence or any(
+            not isinstance(name, str)
+            or not name
+            or not isinstance(digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            for name, digest in self.evidence.items()
+        ):
+            raise DevToolkitError("Toolchain evidence requires named lowercase SHA-256 digests")
+        object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
 
 
 @dataclass(frozen=True)
@@ -25,6 +83,27 @@ class PreparedEnvironment:
     container: str | None = None
     container_id: str | None = None
     image_id: str | None = None
+
+    def execution_target(
+        self,
+        *,
+        gpu: str = "0",
+        state: str = "/tmp/trtmc-devtoolkit",
+    ) -> ExecutionTarget:
+        """Convert a prepared checkout into a capability execution target."""
+        from .resolution import ExecutionTarget
+
+        if self.kind == "docker":
+            target = self.container_id or self.container
+            if target is None:
+                raise DevToolkitError("docker environment has no container")
+            return ExecutionTarget.docker(
+                python=self.python,
+                container=target,
+                workspace=str(self.repository),
+                state=state,
+            )
+        return ExecutionTarget.local(python=self.python, gpu=gpu)
 
     def command(self, *arguments: str) -> tuple[str, ...]:
         if self.kind == "docker":

--- a/apps/devtoolkit/trtmc_devtoolkit/platforms.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/platforms.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalize platform facts used by execution-context providers."""
+
+from __future__ import annotations
+
+import platform
+
+from .models import DevToolkitError
+
+
+_ARCHITECTURE_ALIASES = {
+    "amd64": "x86_64",
+    "arm64": "aarch64",
+    "x86_64": "x86_64",
+    "aarch64": "aarch64",
+}
+
+
+def normalize_architecture(value: str | None = None) -> str:
+    raw = (value or platform.machine()).strip().lower()
+    try:
+        return _ARCHITECTURE_ALIASES[raw]
+    except KeyError as error:
+        raise DevToolkitError(f"Unsupported host architecture: {raw or '<empty>'}") from error

--- a/apps/devtoolkit/trtmc_devtoolkit/providers.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/providers.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Explicit provider registration for composable DevToolkit capabilities."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from .models import DevToolkitError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .models import ToolchainObservation
+    from .commands import CommandSpec
+    from .provisioning import ContextHandle, ProvisionPolicy, ToolchainHandle
+    from .resolution import (
+        ContextLock,
+        EnvironmentLock,
+        EnvironmentRequest,
+        ProviderDescriptor,
+        ToolchainCandidate,
+    )
+    from .runner import Runner
+
+
+class ToolchainSource(Protocol):
+    descriptor: ProviderDescriptor
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]: ...
+
+    def provision(
+        self,
+        lock: EnvironmentLock,
+        context: ContextHandle,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+    ) -> ToolchainHandle: ...
+
+    def observe(
+        self,
+        lock: EnvironmentLock,
+        context: ContextHandle,
+        toolchain: ToolchainHandle,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ToolchainObservation: ...
+
+
+class ToolchainCatalog(Protocol):
+    """Resolve version intent into immutable artifacts for a materializer."""
+
+    descriptor: ProviderDescriptor
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> tuple[ToolchainCandidate, ...]: ...
+
+
+class ExecutionContext(Protocol):
+    descriptor: ProviderDescriptor
+
+    def resolve(
+        self,
+        request: EnvironmentRequest,
+        *,
+        repository: Path,
+        runner: Runner,
+    ) -> ContextLock: ...
+
+    def provision(
+        self,
+        context: ContextLock,
+        *,
+        inherit_system_packages: bool,
+        repository: Path,
+        state_dir: Path,
+        policy: ProvisionPolicy,
+        runner: Runner,
+    ) -> ContextHandle: ...
+
+    def execute(
+        self,
+        context: ContextHandle,
+        command: CommandSpec,
+        *,
+        repository: Path,
+        state_dir: Path,
+        runner: Runner,
+        check: bool,
+        capture_output: bool,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+@dataclass(frozen=True)
+class FrozenProviderRegistry:
+    contexts: tuple[ExecutionContext, ...]
+    toolchains: tuple[ToolchainSource, ...]
+    catalogs: tuple[ToolchainCatalog, ...] = ()
+
+    def context(self, name: str) -> ExecutionContext:
+        matches = [provider for provider in self.contexts if provider.descriptor.name == name]
+        if len(matches) != 1:
+            raise DevToolkitError(f"Unknown execution context provider: {name}")
+        return matches[0]
+
+    def toolchain(self, name: str) -> ToolchainSource:
+        matches = [provider for provider in self.toolchains if provider.descriptor.name == name]
+        if len(matches) != 1:
+            raise DevToolkitError(f"Unknown toolchain source provider: {name}")
+        return matches[0]
+
+
+class ProviderRegistry:
+    """Mutable wiring object that is frozen when a toolkit is constructed."""
+
+    def __init__(self) -> None:
+        self._contexts: dict[str, ExecutionContext] = {}
+        self._toolchains: dict[str, ToolchainSource] = {}
+        self._catalogs: dict[str, ToolchainCatalog] = {}
+
+    @classmethod
+    def with_builtins(cls) -> ProviderRegistry:
+        from .builtin_providers import (
+            ContainerImageToolchainSource,
+            DockerExecutionContext,
+            LocalExecutionContext,
+            ManagedArtifactToolchainSource,
+            PrefixToolchainSource,
+            SystemToolchainSource,
+        )
+        from .catalogs import NvidiaPackageIndexCatalog
+
+        registry = cls()
+        registry.register_context(LocalExecutionContext())
+        registry.register_context(DockerExecutionContext())
+        registry.register_toolchain(SystemToolchainSource())
+        registry.register_toolchain(PrefixToolchainSource())
+        registry.register_toolchain(ContainerImageToolchainSource())
+        registry.register_toolchain(ManagedArtifactToolchainSource())
+        registry.register_catalog(NvidiaPackageIndexCatalog())
+        return registry
+
+    def register_context(self, provider: ExecutionContext) -> None:
+        self._register(self._contexts, provider, "execution context")
+
+    def register_toolchain(self, provider: ToolchainSource) -> None:
+        self._register(self._toolchains, provider, "toolchain")
+
+    def register_catalog(self, provider: ToolchainCatalog) -> None:
+        self._register(self._catalogs, provider, "toolchain catalog")
+
+    def freeze(self) -> FrozenProviderRegistry:
+        return FrozenProviderRegistry(
+            contexts=tuple(self._contexts.values()),
+            toolchains=tuple(self._toolchains.values()),
+            catalogs=tuple(self._catalogs.values()),
+        )
+
+    @staticmethod
+    def _register(registry: dict[str, object], provider: object, kind: str) -> None:
+        descriptor = getattr(provider, "descriptor", None)
+        name = getattr(descriptor, "name", None)
+        if not isinstance(name, str) or not name:
+            raise DevToolkitError(f"{kind} provider must declare a non-empty descriptor name")
+        if name in registry:
+            raise DevToolkitError(f"Duplicate {kind} provider: {name}")
+        registry[name] = provider

--- a/apps/devtoolkit/trtmc_devtoolkit/provisioning.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/provisioning.py
@@ -1,0 +1,411 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idempotent environment provisioning with core-owned attestation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Callable, Mapping, Sequence
+
+from .models import DevToolkitError, ToolchainObservation, ToolchainRuntime
+from .providers import FrozenProviderRegistry
+from .receipt import exclusive_lock, write_json
+from .resolution import EnvironmentLock, ProviderDescriptor
+from .runner import Runner
+
+
+class ProvisionPolicy(Enum):
+    ADOPT_ONLY = "adopt-only"
+    ADOPT_OR_CREATE = "adopt-or-create"
+    CREATE = "create"
+
+
+def _freeze_json(value: object) -> object:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(name): _freeze_json(item) for name, item in sorted(value.items())}
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_freeze_json(item) for item in value)
+    raise DevToolkitError(f"Provisioned identity must be JSON-compatible: {type(value).__name__}")
+
+
+def _freeze_mapping(value: Mapping[str, object]) -> Mapping[str, object]:
+    frozen = _freeze_json(value)
+    assert isinstance(frozen, Mapping)
+    return frozen
+
+
+def _plain_json(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(name): _plain_json(item) for name, item in value.items()}
+    if isinstance(value, tuple):
+        return [_plain_json(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class ContextHandle:
+    """Provider-owned runtime locator; secrets are deliberately not serialized."""
+
+    provider: ProviderDescriptor
+    identity: Mapping[str, object]
+    execution_identity: Mapping[str, object]
+    locator: Mapping[str, object] = field(default_factory=dict, compare=False)
+    environment: Mapping[str, str] = field(default_factory=dict, compare=False)
+    capabilities: frozenset[str] = frozenset()
+    _executor: Callable[[object, bool, bool], object] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _path_mapper: Callable[[object], str] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identity", _freeze_mapping(self.identity))
+        object.__setattr__(
+            self,
+            "execution_identity",
+            _freeze_mapping(self.execution_identity),
+        )
+        object.__setattr__(self, "locator", _freeze_mapping(self.locator))
+        object.__setattr__(self, "environment", MappingProxyType(dict(self.environment)))
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+
+    def execute(
+        self,
+        command: object,
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+    ) -> object:
+        if self._executor is None:
+            raise DevToolkitError(
+                f"Execution context {self.provider.name} does not expose target commands"
+            )
+        return self._executor(command, check, capture_output)
+
+    def map_path(self, path: object) -> str:
+        if self._path_mapper is None:
+            raise DevToolkitError(
+                f"Execution context {self.provider.name} does not expose target path mapping"
+            )
+        return self._path_mapper(path)
+
+    @property
+    def supports_target_operations(self) -> bool:
+        """Whether a materializer can execute commands and map paths on the target."""
+
+        return self._executor is not None and self._path_mapper is not None
+
+
+@dataclass(frozen=True)
+class ToolchainHandle:
+    """Provisioned toolchain state independent from an execution context."""
+
+    provider: ProviderDescriptor
+    identity: Mapping[str, object]
+    runtime: ToolchainRuntime
+    environment: Mapping[str, str] = field(default_factory=dict, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identity", _freeze_mapping(self.identity))
+        object.__setattr__(self, "environment", MappingProxyType(dict(self.environment)))
+
+
+@dataclass(frozen=True)
+class ProvisionedEnvironment:
+    environment_id: str
+    lock: EnvironmentLock
+    context: ContextHandle
+    toolchain: ToolchainHandle
+    observation: ToolchainObservation
+    state_dir: Path = field(compare=False)
+    receipt: Path = field(compare=False)
+
+
+class AttestationFailed(DevToolkitError):
+    """The provisioned environment does not satisfy its immutable lock."""
+
+
+def _observation_payload(observed: ToolchainObservation) -> dict[str, object]:
+    return {
+        "python_version": observed.python_version,
+        "cuda_version": observed.cuda_version,
+        "tensorrt_python_version": observed.tensorrt_python_version,
+        "tensorrt_native_version": observed.tensorrt_native_version,
+        "tensorrt_header_version": observed.tensorrt_header_version,
+        "tensorrt_include_dir": observed.tensorrt_include_dir,
+        "tensorrt_library": observed.tensorrt_library,
+        "cuda_root": observed.cuda_root,
+        "image_id": observed.image_id,
+        "architecture": observed.architecture,
+        "evidence": dict(observed.evidence),
+    }
+
+
+def _runtime_payload(runtime: ToolchainRuntime) -> dict[str, str]:
+    return asdict(runtime)
+
+
+def _environment_id(
+    lock: EnvironmentLock,
+    context: ContextHandle,
+    toolchain: ToolchainHandle,
+    observed: ToolchainObservation,
+) -> str:
+    payload = {
+        "schema_version": 3,
+        "lock_id": lock.lock_id,
+        "execution_identity": _plain_json(context.execution_identity),
+        "toolchain_provider": {
+            "name": toolchain.provider.name,
+            "implementation": toolchain.provider.implementation,
+            "lock_schema": toolchain.provider.lock_schema,
+        },
+        "toolchain_identity": _plain_json(toolchain.identity),
+        "runtime": _runtime_payload(toolchain.runtime),
+        "observed": _observation_payload(observed),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(b"trtmc-devtoolkit-environment-v3\0" + encoded).hexdigest()
+
+
+def _attest(
+    lock: EnvironmentLock,
+    toolchain: ToolchainHandle,
+    observed: ToolchainObservation,
+) -> None:
+    mismatches: list[str] = []
+    expected_trt = lock.toolchain.tensorrt
+    for name, actual in (
+        ("TensorRT Python", observed.tensorrt_python_version),
+        ("TensorRT native", observed.tensorrt_native_version),
+        ("TensorRT headers", observed.tensorrt_header_version),
+    ):
+        if actual != expected_trt:
+            mismatches.append(f"{name}: expected {expected_trt}, observed {actual}")
+    if observed.cuda_version != lock.toolchain.cuda:
+        mismatches.append(f"CUDA: expected {lock.toolchain.cuda}, observed {observed.cuda_version}")
+    if observed.python_version != lock.toolchain.python:
+        mismatches.append(
+            f"Python: expected {lock.toolchain.python}, observed {observed.python_version}"
+        )
+    if observed.architecture is not None and observed.architecture != lock.context.architecture:
+        mismatches.append(
+            f"Architecture: expected {lock.context.architecture}, observed {observed.architecture}"
+        )
+    expected_include = toolchain.runtime.tensorrt_include_dir
+    if observed.tensorrt_include_dir != expected_include:
+        mismatches.append(
+            "TensorRT include directory: "
+            f"expected {expected_include}, observed {observed.tensorrt_include_dir}"
+        )
+    expected_library = toolchain.runtime.tensorrt_library
+    if observed.tensorrt_library != expected_library:
+        mismatches.append(
+            f"TensorRT library: expected {expected_library}, observed {observed.tensorrt_library}"
+        )
+    expected_cuda_root = toolchain.runtime.cuda_root
+    if observed.cuda_root != expected_cuda_root:
+        mismatches.append(
+            f"CUDA root: expected {expected_cuda_root}, observed {observed.cuda_root}"
+        )
+    expected_image = lock.context.identity.get("image_id")
+    if expected_image is not None and observed.image_id != expected_image:
+        mismatches.append(f"Image: expected {expected_image}, observed {observed.image_id}")
+    if mismatches:
+        raise AttestationFailed("Environment attestation failed: " + "; ".join(mismatches))
+
+
+class EnvironmentProvisioner:
+    def __init__(
+        self,
+        repository: Path,
+        state_root: Path,
+        providers: FrozenProviderRegistry,
+        runner: Runner,
+    ) -> None:
+        self.repository = repository
+        self.state_root = state_root
+        self.providers = providers
+        self.runner = runner
+
+    def provision(
+        self,
+        lock: EnvironmentLock,
+        *,
+        policy: ProvisionPolicy,
+    ) -> ProvisionedEnvironment:
+        state_dir = self.state_root / "environments" / lock.lock_id
+        state_dir.mkdir(parents=True, exist_ok=True)
+        with exclusive_lock(state_dir / ".provision.lock"):
+            return self._provision_locked(lock, policy=policy, state_dir=state_dir)
+
+    def _provision_locked(
+        self,
+        lock: EnvironmentLock,
+        *,
+        policy: ProvisionPolicy,
+        state_dir: Path,
+    ) -> ProvisionedEnvironment:
+        write_json(state_dir / "environment-lock.json", lock.as_dict())
+        (state_dir / "provision-receipt.json").unlink(missing_ok=True)
+        (state_dir / "provision-failure.json").unlink(missing_ok=True)
+        try:
+            context_provider = self.providers.context(lock.context.provider.name)
+            toolchain_provider = self.providers.toolchain(lock.toolchain.provider.name)
+            if context_provider.descriptor != lock.context.provider:
+                raise AttestationFailed(
+                    "Registered execution context provider does not match the environment lock"
+                )
+            if toolchain_provider.descriptor != lock.toolchain.provider:
+                raise AttestationFailed(
+                    "Registered toolchain provider does not match the environment lock"
+                )
+            if policy is ProvisionPolicy.ADOPT_ONLY and lock.toolchain.origin == "managed":
+                raise AttestationFailed(
+                    "adopt-only provisioning cannot materialize a managed toolchain"
+                )
+            context = context_provider.provision(
+                lock.context,
+                inherit_system_packages=lock.toolchain.origin != "managed",
+                repository=self.repository,
+                state_dir=state_dir,
+                policy=policy,
+                runner=self.runner,
+            )
+            if context.provider != lock.context.provider:
+                raise AttestationFailed(
+                    "Provisioned context provider does not match the environment lock"
+                )
+            if dict(context.identity) != dict(lock.context.identity):
+                raise AttestationFailed(
+                    "Provisioned context identity does not match the environment lock"
+                )
+            toolchain = toolchain_provider.provision(
+                lock,
+                context,
+                repository=self.repository,
+                state_dir=state_dir,
+                runner=self.runner,
+            )
+            if toolchain.provider != lock.toolchain.provider:
+                raise AttestationFailed(
+                    "Provisioned toolchain provider does not match the environment lock"
+                )
+            context = replace(
+                context,
+                environment={**dict(context.environment), **dict(toolchain.environment)},
+            )
+            observed = toolchain_provider.observe(
+                lock,
+                context,
+                toolchain,
+                repository=self.repository,
+                runner=self.runner,
+            )
+            _attest(lock, toolchain, observed)
+            environment_id = _environment_id(lock, context, toolchain, observed)
+            (state_dir / "provision-failure.json").unlink(missing_ok=True)
+            receipt = write_json(
+                state_dir / "provision-receipt.json",
+                {
+                    "schema_version": 3,
+                    "status": "ready",
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "lock_id": lock.lock_id,
+                    "environment_id": environment_id,
+                    "cuda_origin": lock.cuda_origin,
+                    "toolchain_source": lock.toolchain.provider.name,
+                    "context_provider": lock.context.provider.name,
+                    "context_identity": _plain_json(context.identity),
+                    "execution_identity": _plain_json(context.execution_identity),
+                    "toolchain_identity": _plain_json(toolchain.identity),
+                    "toolchain_runtime": _runtime_payload(toolchain.runtime),
+                    "qualifications": [
+                        {
+                            "name": item.name,
+                            "digest": item.digest,
+                            "status": item.status,
+                        }
+                        for item in lock.qualifications
+                    ],
+                    "observed": _observation_payload(observed),
+                },
+            )
+            return ProvisionedEnvironment(
+                environment_id=environment_id,
+                lock=lock,
+                context=context,
+                toolchain=toolchain,
+                observation=observed,
+                state_dir=state_dir,
+                receipt=receipt,
+            )
+        except Exception as error:
+            (state_dir / "provision-receipt.json").unlink(missing_ok=True)
+            write_json(
+                state_dir / "provision-failure.json",
+                {
+                    "schema_version": 3,
+                    "status": "failed",
+                    "lock_id": lock.lock_id,
+                    "error_type": type(error).__name__,
+                },
+            )
+            raise
+
+
+def attest_environment(
+    environment: ProvisionedEnvironment,
+    *,
+    repository: Path,
+    providers: FrozenProviderRegistry,
+    runner: Runner,
+) -> ToolchainObservation:
+    """Re-observe a provisioned environment before mutable target execution."""
+    context_provider = providers.context(environment.context.provider.name)
+    toolchain_provider = providers.toolchain(environment.lock.toolchain.provider.name)
+    if context_provider.descriptor != environment.lock.context.provider:
+        raise AttestationFailed(
+            "Registered execution context provider does not match the environment lock"
+        )
+    if toolchain_provider.descriptor != environment.lock.toolchain.provider:
+        raise AttestationFailed("Registered toolchain provider does not match the environment lock")
+    if environment.context.provider != environment.lock.context.provider or dict(
+        environment.context.identity
+    ) != dict(environment.lock.context.identity):
+        raise AttestationFailed("Provisioned context does not match the environment lock")
+    observed = toolchain_provider.observe(
+        environment.lock,
+        environment.context,
+        environment.toolchain,
+        repository=repository,
+        runner=runner,
+    )
+    _attest(environment.lock, environment.toolchain, observed)
+    if observed != environment.observation:
+        raise AttestationFailed("Environment evidence changed after provisioning")
+    expected_id = _environment_id(
+        environment.lock,
+        environment.context,
+        environment.toolchain,
+        observed,
+    )
+    if expected_id != environment.environment_id:
+        raise AttestationFailed("Provisioned environment identity is inconsistent")
+    return observed

--- a/apps/devtoolkit/trtmc_devtoolkit/provisioning.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/provisioning.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
@@ -28,7 +29,11 @@ class ProvisionPolicy(Enum):
 
 
 def _freeze_json(value: object) -> object:
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise DevToolkitError("Provisioned identity requires finite JSON numbers")
+        return value
+    if value is None or isinstance(value, (str, int, bool)):
         return value
     if isinstance(value, Mapping):
         return MappingProxyType(
@@ -180,7 +185,12 @@ def _environment_id(
         "runtime": _runtime_payload(toolchain.runtime),
         "observed": _observation_payload(observed),
     }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
     return hashlib.sha256(b"trtmc-devtoolkit-environment-v3\0" + encoded).hexdigest()
 
 
@@ -307,6 +317,10 @@ class EnvironmentProvisioner:
                 raise AttestationFailed(
                     "Provisioned toolchain provider does not match the environment lock"
                 )
+            if dict(toolchain.identity) != dict(lock.toolchain.identity):
+                raise AttestationFailed(
+                    "Provisioned toolchain identity does not match the environment lock"
+                )
             context = replace(
                 context,
                 environment={**dict(context.environment), **dict(toolchain.environment)},
@@ -390,6 +404,10 @@ def attest_environment(
         environment.context.identity
     ) != dict(environment.lock.context.identity):
         raise AttestationFailed("Provisioned context does not match the environment lock")
+    if environment.toolchain.provider != environment.lock.toolchain.provider or dict(
+        environment.toolchain.identity
+    ) != dict(environment.lock.toolchain.identity):
+        raise AttestationFailed("Provisioned toolchain does not match the environment lock")
     observed = toolchain_provider.observe(
         environment.lock,
         environment.context,

--- a/apps/devtoolkit/trtmc_devtoolkit/qualifications.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/qualifications.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional, source-neutral qualification evidence for resolved environments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Protocol
+
+from .models import DevToolkitError
+
+if TYPE_CHECKING:
+    from .resolution import ContextLock, ToolchainCandidate
+
+
+@dataclass(frozen=True)
+class QualificationRef:
+    name: str
+    digest: str
+    status: str
+
+
+@dataclass(frozen=True)
+class QualificationRecord:
+    reference: QualificationRef
+    requirements: Mapping[str, tuple[str, ...]]
+    source: str = field(compare=False)
+
+    def __post_init__(self) -> None:
+        normalized = {name: tuple(values) for name, values in sorted(self.requirements.items())}
+        if any(
+            not name or not values or any(not value for value in values)
+            for name, values in normalized.items()
+        ):
+            raise DevToolkitError("Qualification requirements must be non-empty")
+        object.__setattr__(self, "requirements", MappingProxyType(normalized))
+
+    def matches(
+        self,
+        context: ContextLock,
+        candidate: ToolchainCandidate,
+    ) -> bool:
+        facts = {
+            "tensorrt": candidate.tensorrt,
+            "cuda": candidate.cuda,
+            "python": candidate.python,
+            "architecture": context.architecture,
+            **dict(context.qualification),
+        }
+        return all(facts.get(name) in accepted for name, accepted in self.requirements.items())
+
+
+class QualificationSource(Protocol):
+    def load(self) -> tuple[QualificationRecord, ...]: ...
+
+
+class JsonQualificationSource:
+    """Load generic qualification facts from caller-owned JSON directories."""
+
+    def __init__(self, roots: tuple[Path, ...]) -> None:
+        self.roots = tuple(Path(root).resolve() for root in roots)
+
+    def load(self) -> tuple[QualificationRecord, ...]:
+        paths = sorted(
+            path
+            for root in self.roots
+            if root.is_dir()
+            for path in root.glob("*.json")
+            if path.name != "schema.json"
+        )
+        return tuple(self._load(path) for path in paths)
+
+    @staticmethod
+    def _load(path: Path) -> QualificationRecord:
+        try:
+            content = path.read_bytes()
+            payload = json.loads(content)
+            name = payload["id"]
+            status = payload.get("status", "qualified")
+            raw_requirements = payload["requirements"]
+            if not isinstance(raw_requirements, dict):
+                raise TypeError("requirements must be an object")
+            requirements: dict[str, tuple[str, ...]] = {}
+            for fact, raw_values in raw_requirements.items():
+                if isinstance(raw_values, str):
+                    values = (raw_values,)
+                elif isinstance(raw_values, list):
+                    values = tuple(raw_values)
+                else:
+                    raise TypeError(f"requirement {fact} must be text or an array")
+                if not isinstance(fact, str) or any(not isinstance(value, str) for value in values):
+                    raise TypeError("requirement names and values must be text")
+                requirements[fact] = values
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as error:
+            raise DevToolkitError(f"Invalid qualification record {path}: {error}") from error
+        if not isinstance(name, str) or not name or not isinstance(status, str) or not status:
+            raise DevToolkitError(f"Invalid qualification record values in {path}")
+        return QualificationRecord(
+            reference=QualificationRef(
+                name=name,
+                digest=hashlib.sha256(content).hexdigest(),
+                status=status,
+            ),
+            requirements=requirements,
+            source=str(path),
+        )
+
+
+class QualificationRegistry:
+    def __init__(self, sources: tuple[QualificationSource, ...]) -> None:
+        self.sources = sources
+
+    def load_all(self) -> tuple[QualificationRecord, ...]:
+        records = tuple(record for source in self.sources for record in source.load())
+        names = [record.reference.name for record in records]
+        if len(set(names)) != len(names):
+            raise DevToolkitError("Duplicate qualification record names")
+        return records

--- a/apps/devtoolkit/trtmc_devtoolkit/qualifications.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/qualifications.py
@@ -47,11 +47,11 @@ class QualificationRecord:
         candidate: ToolchainCandidate,
     ) -> bool:
         facts = {
+            **dict(context.qualification),
             "tensorrt": candidate.tensorrt,
             "cuda": candidate.cuda,
             "python": candidate.python,
             "architecture": context.architecture,
-            **dict(context.qualification),
         }
         return all(facts.get(name) in accepted for name, accepted in self.requirements.items())
 

--- a/apps/devtoolkit/trtmc_devtoolkit/receipt.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/receipt.py
@@ -23,7 +23,16 @@ def _json_default(value: Any) -> str:
 
 def write_json(path: Path, payload: object) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    content = json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n"
+    content = (
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            default=_json_default,
+            allow_nan=False,
+        )
+        + "\n"
+    )
     temporary: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(

--- a/apps/devtoolkit/trtmc_devtoolkit/receipt.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/receipt.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist capability receipts safely and serialize state mutation."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"Cannot serialize {type(value).__name__}")
+
+
+def write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n"
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temporary = Path(stream.name)
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return path
+
+
+@contextmanager
+def exclusive_lock(path: Path) -> Iterator[None]:
+    """Serialize mutation associated with one state identity across processes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as stream:
+        os.chmod(path, 0o600)
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_UN)

--- a/apps/devtoolkit/trtmc_devtoolkit/recipes.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/recipes.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional build recipes composed with the generic DevToolkit builder."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from types import MappingProxyType
+
+from .building import BuildContext, BuildPlan
+from .commands import CommandSpec, EnvironmentPath, repository_path
+from .models import DevToolkitError
+
+
+def _define_value(value: str | int | bool) -> str:
+    if isinstance(value, bool):
+        return "ON" if value else "OFF"
+    return str(value)
+
+
+_CUDA_ARCHITECTURES_SCRIPT = r"""
+import ctypes
+
+driver = None
+errors = []
+for name in ("libcuda.so.1", "libcuda.so"):
+    try:
+        driver = ctypes.CDLL(name)
+        break
+    except OSError as error:
+        errors.append(str(error))
+if driver is None:
+    raise SystemExit("CUDA driver library is unavailable: " + "; ".join(errors))
+
+driver.cuInit.argtypes = [ctypes.c_uint]
+driver.cuInit.restype = ctypes.c_int
+driver.cuDeviceGetCount.argtypes = [ctypes.POINTER(ctypes.c_int)]
+driver.cuDeviceGetCount.restype = ctypes.c_int
+driver.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+driver.cuDeviceGet.restype = ctypes.c_int
+driver.cuDeviceGetAttribute.argtypes = [
+    ctypes.POINTER(ctypes.c_int),
+    ctypes.c_int,
+    ctypes.c_int,
+]
+driver.cuDeviceGetAttribute.restype = ctypes.c_int
+
+def checked(code, operation):
+    if code != 0:
+        raise SystemExit(f"{operation} failed with CUDA error {code}")
+
+checked(driver.cuInit(0), "cuInit")
+count = ctypes.c_int()
+checked(driver.cuDeviceGetCount(ctypes.byref(count)), "cuDeviceGetCount")
+architectures = set()
+for ordinal in range(count.value):
+    device = ctypes.c_int()
+    major = ctypes.c_int()
+    minor = ctypes.c_int()
+    checked(driver.cuDeviceGet(ctypes.byref(device), ordinal), "cuDeviceGet")
+    checked(
+        driver.cuDeviceGetAttribute(ctypes.byref(major), 75, device.value),
+        "cuDeviceGetAttribute(major)",
+    )
+    checked(
+        driver.cuDeviceGetAttribute(ctypes.byref(minor), 76, device.value),
+        "cuDeviceGetAttribute(minor)",
+    )
+    architectures.add(f"{major.value}{minor.value}")
+print("\n".join(sorted(architectures)))
+""".strip()
+
+
+_GENERATOR_SCRIPT = r"""
+import shutil
+
+if shutil.which("ninja"):
+    print("Ninja")
+elif shutil.which("make") or shutil.which("gmake"):
+    print("Unix Makefiles")
+else:
+    raise SystemExit("neither ninja nor make is available")
+""".strip()
+
+
+@dataclass(frozen=True)
+class TrtmcBuildRecipe:
+    """Sample recipe for the repository's native TRTMC targets."""
+
+    descriptor: str = field(default="trtmc-native==4", init=False)
+    targets: tuple[str, ...] = ("trtmc", "trtmc_backend_trt")
+    cmake_defines: Mapping[str, str | int | bool] = field(default_factory=dict)
+    cuda_architectures: tuple[str, ...] | None = None
+    build_type: str = "Release"
+    generator: str = "auto"
+    jobs: int | None = None
+    outputs: Mapping[str, str] = field(default_factory=lambda: {"trtmc": "trtmc"})
+
+    def __post_init__(self) -> None:
+        if not self.targets or any(not target for target in self.targets):
+            raise DevToolkitError("A TRTMC build requires non-empty targets")
+        if self.cuda_architectures is not None and not self.cuda_architectures:
+            raise DevToolkitError("cuda_architectures cannot be empty")
+        if self.jobs is not None and self.jobs < 1:
+            raise DevToolkitError("Build jobs must be positive")
+        if not self.generator:
+            raise DevToolkitError("Build generator must be non-empty")
+        for name, relative in self.outputs.items():
+            path = PurePosixPath(relative)
+            if not name or path.is_absolute() or ".." in path.parts:
+                raise DevToolkitError("Build output paths must be named, safe relative paths")
+        object.__setattr__(self, "targets", tuple(self.targets))
+        if self.cuda_architectures is not None:
+            object.__setattr__(self, "cuda_architectures", tuple(self.cuda_architectures))
+        object.__setattr__(self, "cmake_defines", MappingProxyType(dict(self.cmake_defines)))
+        object.__setattr__(self, "outputs", MappingProxyType(dict(self.outputs)))
+
+    def inputs(self, context: BuildContext) -> Mapping[str, object]:
+        architectures = self.cuda_architectures
+        if architectures is None:
+            try:
+                output = context.probe(
+                    CommandSpec(
+                        (
+                            context.runtime.python_executable,
+                            "-c",
+                            _CUDA_ARCHITECTURES_SCRIPT,
+                        )
+                    )
+                )
+            except (DevToolkitError, FileNotFoundError, OSError):
+                try:
+                    output = context.probe(
+                        CommandSpec(
+                            (
+                                "nvidia-smi",
+                                "--query-gpu=compute_cap",
+                                "--format=csv,noheader,nounits",
+                            )
+                        )
+                    )
+                except (DevToolkitError, FileNotFoundError, OSError) as error:
+                    raise DevToolkitError(
+                        "Could not query CUDA architecture through the driver or nvidia-smi"
+                    ) from error
+            architectures = tuple(
+                line.strip().replace(".", "") for line in output.splitlines() if line.strip()
+            )
+        if not architectures or any(not architecture.isdigit() for architecture in architectures):
+            raise DevToolkitError("Could not resolve a CUDA architecture for the TRTMC recipe")
+        generator = self.generator
+        if generator == "auto":
+            try:
+                generator = context.probe(
+                    CommandSpec(
+                        (
+                            context.runtime.python_executable,
+                            "-c",
+                            _GENERATOR_SCRIPT,
+                        )
+                    )
+                ).strip()
+            except (DevToolkitError, FileNotFoundError, OSError) as error:
+                raise DevToolkitError(
+                    "Could not resolve a CMake generator; install ninja or make, or select one"
+                ) from error
+            if generator not in {"Ninja", "Unix Makefiles"}:
+                raise DevToolkitError(f"Unsupported auto-selected CMake generator: {generator!r}")
+        return {
+            "targets": self.targets,
+            "cmake_defines": dict(self.cmake_defines),
+            "cuda_architectures": architectures,
+            "build_type": self.build_type,
+            "generator": generator,
+            "jobs": self.jobs,
+            "outputs": dict(self.outputs),
+            "cuda_root": context.runtime.cuda_root,
+            "nvcc": context.runtime.nvcc,
+        }
+
+    def plan(
+        self,
+        context: BuildContext,
+        inputs: Mapping[str, object],
+        build_dir: EnvironmentPath,
+    ) -> BuildPlan:
+        architectures = tuple(str(value) for value in inputs["cuda_architectures"])
+        commands: list[CommandSpec] = []
+        defines: dict[str, str | int | bool] = {
+            "TRTMC_BUILD_BACKEND_RTX": False,
+            "TRTMC_ENABLE_BYOK": False,
+            **dict(inputs["cmake_defines"]),
+            "CMAKE_CUDA_ARCHITECTURES": ";".join(
+                item if not item.isdigit() else f"{item}-real" for item in architectures
+            ),
+            "CMAKE_CUDA_COMPILER": str(inputs["nvcc"]),
+            "CUDAToolkit_ROOT": str(inputs["cuda_root"]),
+            "TRTMC_TRT_INCLUDE_DIR": context.runtime.tensorrt_include_dir,
+            "TRTMC_TRT_LIBRARY": context.runtime.tensorrt_library,
+        }
+        configure: list[str | EnvironmentPath] = [
+            "cmake",
+            "-S",
+            repository_path("."),
+            "-B",
+            build_dir,
+            "-G",
+            str(inputs["generator"]),
+            f"-DCMAKE_BUILD_TYPE={inputs['build_type']}",
+        ]
+        configure.extend(
+            f"-D{name}={_define_value(value)}" for name, value in sorted(defines.items())
+        )
+        commands.append(CommandSpec(configure))
+        build_command: list[str | EnvironmentPath] = [
+            "cmake",
+            "--build",
+            build_dir,
+            "--parallel",
+        ]
+        if inputs["jobs"] is not None:
+            build_command.append(str(inputs["jobs"]))
+        build_command.extend(("--target", *(str(target) for target in inputs["targets"])))
+        commands.append(CommandSpec(build_command))
+        return BuildPlan(
+            commands=tuple(commands),
+            outputs={
+                name: EnvironmentPath(build_dir.scope, build_dir.path / relative)
+                for name, relative in dict(inputs["outputs"]).items()
+            },
+        )

--- a/apps/devtoolkit/trtmc_devtoolkit/recipes.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/recipes.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
@@ -149,7 +150,10 @@ class TrtmcBuildRecipe:
             architectures = tuple(
                 line.strip().replace(".", "") for line in output.splitlines() if line.strip()
             )
-        if not architectures or any(not architecture.isdigit() for architecture in architectures):
+        if not architectures or any(
+            re.fullmatch(r"[0-9]+(?:-(?:real|virtual))?", architecture) is None
+            for architecture in architectures
+        ):
             raise DevToolkitError("Could not resolve a CUDA architecture for the TRTMC recipe")
         generator = self.generator
         if generator == "auto":

--- a/apps/devtoolkit/trtmc_devtoolkit/resolution.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/resolution.py
@@ -1,0 +1,602 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only resolution of environment intent into an immutable lock."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import urllib.parse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Literal
+
+from .models import DevToolkitError, ToolchainRuntime
+from .providers import FrozenProviderRegistry
+from .qualifications import QualificationRef, QualificationRegistry
+from .runner import Runner
+
+
+JsonScalar = str | int | float | bool | None
+FrozenJson = JsonScalar | tuple[object, ...] | Mapping[str, object]
+ToolchainOrigin = Literal["system", "managed", "image", "prefix"]
+CudaSource = Literal["system", "managed", "image", "prefix"]
+CudaOrigin = Literal["system", "managed-default", "explicit"]
+ResolutionKind = Literal["system-first", "exact", "system-only", "managed"]
+
+
+def _freeze_json(value: object) -> FrozenJson:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_json(item) for key, item in sorted(value.items())}
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_freeze_json(item) for item in value)
+    raise DevToolkitError(f"Provider state must be JSON-compatible, got {type(value).__name__}")
+
+
+def _plain_json(value: FrozenJson) -> object:
+    if isinstance(value, Mapping):
+        return {key: _plain_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_plain_json(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class ProviderDescriptor:
+    name: str
+    implementation: str
+    lock_schema: int
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.implementation or self.lock_schema < 1:
+            raise DevToolkitError("Provider descriptors require name, implementation, and schema")
+
+
+@dataclass(frozen=True)
+class CudaPolicy:
+    kind: ResolutionKind
+    version: str | None = None
+    fallback: str | None = None
+
+    @classmethod
+    def system_first(cls, *, fallback: str = "13.3") -> CudaPolicy:
+        return cls("system-first", fallback=fallback)
+
+    @classmethod
+    def exact(cls, version: str) -> CudaPolicy:
+        return cls("exact", version=version)
+
+    @classmethod
+    def system_only(cls, version: str | None = None) -> CudaPolicy:
+        return cls("system-only", version=version)
+
+    @classmethod
+    def managed(cls, version: str) -> CudaPolicy:
+        return cls("managed", version=version)
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"system-first", "exact", "system-only", "managed"}:
+            raise DevToolkitError(f"Unsupported CUDA policy kind: {self.kind}")
+        if self.kind == "system-first" and not self.fallback:
+            raise DevToolkitError("system-first CUDA policy requires a fallback version")
+        if self.kind in {"exact", "managed"} and not self.version:
+            raise DevToolkitError(f"{self.kind} CUDA policy requires an exact version")
+        for value in (self.version, self.fallback):
+            if value is not None and re.fullmatch(r"[0-9]+\.[0-9]+", value) is None:
+                raise DevToolkitError("CUDA versions must have exact major.minor form")
+
+
+@dataclass(frozen=True)
+class ExecutionTarget:
+    provider: str
+    options: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.provider:
+            raise DevToolkitError("Execution target requires a provider name")
+        object.__setattr__(self, "options", _freeze_json(self.options))
+
+    @classmethod
+    def local(
+        cls,
+        *,
+        python: str = "python3",
+        gpu: str = "0",
+    ) -> ExecutionTarget:
+        return cls("local", {"python": python, "gpu": gpu})
+
+    @classmethod
+    def docker(
+        cls,
+        *,
+        python: str = "python3",
+        docker_context: str | None = None,
+        container: str | None = None,
+        workspace: str = "/workspace/tensorrt-model-connect",
+        state: str = "/tmp/trtmc-devtoolkit",
+    ) -> ExecutionTarget:
+        options: dict[str, object] = {
+            "python": python,
+            "workspace": workspace,
+            "state": state,
+        }
+        if docker_context is not None:
+            options["docker_context"] = docker_context
+        if container is not None:
+            options["container"] = container
+        return cls("docker", options)
+
+
+@dataclass(frozen=True)
+class EnvironmentRequest:
+    tensorrt: str
+    target: ExecutionTarget
+    cuda: CudaPolicy = field(default_factory=CudaPolicy.system_first)
+    python: str = "3.12"
+    architecture: str | None = None
+    toolchain: str | None = None
+    toolchain_options: Mapping[str, object] = field(default_factory=dict)
+    preset: str | None = None
+    require_qualification: bool = False
+    artifacts: tuple[ArtifactPin, ...] = ()
+
+    def __post_init__(self) -> None:
+        value = self.tensorrt.strip()
+        if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+", value) is None:
+            raise DevToolkitError(
+                "TensorRT must be one exact four-part version, not a range or alias"
+            )
+        object.__setattr__(self, "tensorrt", value)
+        object.__setattr__(self, "artifacts", tuple(self.artifacts))
+        object.__setattr__(self, "toolchain_options", _freeze_json(self.toolchain_options))
+        names = [artifact.name for artifact in self.artifacts]
+        if len(names) != len(set(names)):
+            raise DevToolkitError("Artifact pin names must be unique")
+
+
+@dataclass(frozen=True)
+class ArtifactPin:
+    name: str
+    uri: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.uri:
+            raise DevToolkitError("Artifact pins require a name and URI")
+        parsed = urllib.parse.urlsplit(self.uri)
+        if parsed.username is not None or parsed.password is not None:
+            raise DevToolkitError(f"Artifact {self.name} URI cannot contain credentials")
+        if re.fullmatch(r"[0-9a-f]{64}", self.sha256) is None:
+            raise DevToolkitError(f"Artifact {self.name} requires a lowercase SHA-256 digest")
+
+
+@dataclass(frozen=True)
+class ContextLock:
+    """Resolved context identity, semantic execution mapping, and private locator."""
+
+    provider: ProviderDescriptor
+    operating_system: str
+    architecture: str
+    identity: Mapping[str, object]
+    execution: Mapping[str, object] = field(default_factory=dict)
+    locator: Mapping[str, object] = field(default_factory=dict, compare=False)
+    capabilities: frozenset[str] = frozenset()
+    qualification: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identity", _freeze_json(self.identity))
+        object.__setattr__(self, "execution", _freeze_json(self.execution))
+        object.__setattr__(self, "locator", _freeze_json(self.locator))
+        capabilities = frozenset(self.capabilities)
+        if any(not isinstance(value, str) or not value for value in capabilities):
+            raise DevToolkitError("Context capabilities must be non-empty strings")
+        object.__setattr__(self, "capabilities", capabilities)
+        qualification = dict(self.qualification)
+        if any(
+            not isinstance(name, str) or not name or not isinstance(value, str) or not value
+            for name, value in qualification.items()
+        ):
+            raise DevToolkitError("Context qualification facts must be non-empty strings")
+        object.__setattr__(self, "qualification", MappingProxyType(qualification))
+
+
+@dataclass(frozen=True)
+class ToolchainCandidate:
+    provider: ProviderDescriptor
+    origin: ToolchainOrigin
+    tensorrt: str
+    cuda: str
+    python: str
+    identity: Mapping[str, object]
+    runtime: ToolchainRuntime | None = None
+    artifacts: tuple[ArtifactPin, ...] = ()
+    cuda_source: CudaSource | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identity", _freeze_json(self.identity))
+        if self.cuda_source is None:
+            object.__setattr__(self, "cuda_source", self.origin)
+        if self.origin not in {"system", "managed", "image", "prefix"}:
+            raise DevToolkitError(f"Unsupported toolchain origin: {self.origin}")
+        if self.cuda_source not in {"system", "managed", "image", "prefix"}:
+            raise DevToolkitError(f"Unsupported CUDA source: {self.cuda_source}")
+        if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+", self.tensorrt) is None:
+            raise DevToolkitError("Toolchain candidates require exact four-part TensorRT")
+        if re.fullmatch(r"[0-9]+\.[0-9]+", self.cuda) is None:
+            raise DevToolkitError("Toolchain candidates require exact major.minor CUDA")
+        if re.fullmatch(r"[0-9]+\.[0-9]+", self.python) is None:
+            raise DevToolkitError("Toolchain candidates require exact major.minor Python")
+        if self.origin == "managed" and not self.artifacts:
+            raise DevToolkitError(
+                f"Managed toolchain candidate {self.provider.name} requires trusted artifacts"
+            )
+        if self.origin != "managed" and self.runtime is None:
+            raise DevToolkitError(
+                f"Adopted toolchain candidate {self.provider.name} requires a runtime"
+            )
+
+
+@dataclass(frozen=True)
+class EnvironmentLock:
+    schema_version: Literal[3]
+    lock_id: str
+    request: EnvironmentRequest
+    context: ContextLock
+    toolchain: ToolchainCandidate
+    cuda_origin: CudaOrigin
+    qualifications: tuple[QualificationRef, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 3 or self.lock_id != _environment_lock_id(
+            self.context, self.toolchain
+        ):
+            raise DevToolkitError("Environment lock ID does not match its resolved identity")
+
+    @property
+    def tensorrt(self) -> str:
+        return self.toolchain.tensorrt
+
+    @property
+    def cuda(self) -> str:
+        return self.toolchain.cuda
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            **_resolved_payload(self.context, self.toolchain),
+            "lock_id": self.lock_id,
+            "cuda_origin": self.cuda_origin,
+            "request": {
+                "tensorrt": self.request.tensorrt,
+                "cuda": {
+                    "kind": self.request.cuda.kind,
+                    "version": self.request.cuda.version,
+                    "fallback": self.request.cuda.fallback,
+                },
+                "python": self.request.python,
+                "architecture": self.request.architecture,
+                "target": {
+                    "provider": self.request.target.provider,
+                    "option_names": sorted(self.request.target.options),
+                },
+                "toolchain": self.request.toolchain,
+                "toolchain_option_names": sorted(self.request.toolchain_options),
+                "preset": self.request.preset,
+                "require_qualification": self.request.require_qualification,
+            },
+            "qualifications": [
+                {
+                    "name": item.name,
+                    "digest": item.digest,
+                    "status": item.status,
+                }
+                for item in self.qualifications
+            ],
+        }
+
+
+class ResolutionError(DevToolkitError):
+    def __init__(self, message: str, *, attempts: tuple[str, ...] = ()) -> None:
+        super().__init__(message)
+        self.attempts = attempts
+
+
+class ArtifactUnavailable(ResolutionError):
+    """No provider could supply an environment matching the request."""
+
+
+class IncompatibleCombination(ResolutionError):
+    """Providers found candidates, but none formed one unambiguous exact match."""
+
+
+class _AmbiguousCombination(IncompatibleCombination):
+    """Multiple installed/resolved candidates matched; catalogs cannot disambiguate them."""
+
+
+class EnvironmentResolver:
+    def __init__(
+        self,
+        repository: Path,
+        providers: FrozenProviderRegistry,
+        runner: Runner,
+        qualifications: QualificationRegistry | None = None,
+    ):
+        self.repository = repository
+        self.providers = providers
+        self.runner = runner
+        self.qualifications = qualifications or QualificationRegistry(())
+
+    def resolve(self, request: EnvironmentRequest) -> EnvironmentLock:
+        context_provider = self.providers.context(request.target.provider)
+        context = context_provider.resolve(
+            request,
+            repository=self.repository,
+            runner=self.runner,
+        )
+        sources = tuple(
+            source
+            for source in self.providers.toolchains
+            if request.toolchain is None or source.descriptor.name == request.toolchain
+        )
+        if not sources:
+            raise ResolutionError("No toolchain source is registered for this request")
+        candidates: list[ToolchainCandidate] = []
+        attempts: list[str] = []
+        for source in sources:
+            resolved = source.resolve(
+                request,
+                context,
+                repository=self.repository,
+                runner=self.runner,
+            )
+            candidates.extend(resolved)
+            attempts.append(f"{source.descriptor.name}: {len(resolved)} candidate(s)")
+        try:
+            selected, decision = self._select(request, tuple(candidates), tuple(attempts))
+        except _AmbiguousCombination:
+            raise
+        except ResolutionError:
+            for catalog in self.providers.catalogs:
+                resolved = catalog.resolve(
+                    request,
+                    context,
+                    repository=self.repository,
+                    runner=self.runner,
+                )
+                for candidate in resolved:
+                    materializer = self.providers.toolchain(candidate.provider.name)
+                    if materializer.descriptor != candidate.provider:
+                        raise DevToolkitError(
+                            f"Catalog {catalog.descriptor.name} selected an incompatible "
+                            f"materializer {candidate.provider.name}"
+                        )
+                candidates.extend(resolved)
+                attempts.append(f"catalog:{catalog.descriptor.name}: {len(resolved)} candidate(s)")
+            selected, decision = self._select(request, tuple(candidates), tuple(attempts))
+        qualifications = self._qualifications(request, context, selected)
+        lock_id = self._lock_id(request, context, selected)
+        return EnvironmentLock(
+            3,
+            lock_id,
+            request,
+            context,
+            selected,
+            decision,
+            qualifications,
+        )
+
+    def _qualifications(
+        self,
+        request: EnvironmentRequest,
+        context: ContextLock,
+        candidate: ToolchainCandidate,
+    ) -> tuple[QualificationRef, ...]:
+        try:
+            records = self.qualifications.load_all()
+        except DevToolkitError:
+            if request.preset is not None or request.require_qualification:
+                raise
+            return ()
+        if request.preset is not None:
+            named = [record for record in records if record.reference.name == request.preset]
+            if len(named) != 1 or not named[0].matches(context, candidate):
+                raise IncompatibleCombination(
+                    f"Requested qualification {request.preset!r} does not match the environment"
+                )
+            return (named[0].reference,)
+        matches = tuple(
+            record.reference for record in records if record.matches(context, candidate)
+        )
+        if request.require_qualification and not matches:
+            raise IncompatibleCombination(
+                "Environment resolution requires a matching qualification record"
+            )
+        return matches
+
+    @staticmethod
+    def _select(
+        request: EnvironmentRequest,
+        candidates: tuple[ToolchainCandidate, ...],
+        attempts: tuple[str, ...],
+    ) -> tuple[ToolchainCandidate, CudaOrigin]:
+        exact_trt = [
+            candidate
+            for candidate in candidates
+            if candidate.tensorrt == request.tensorrt and candidate.python == request.python
+        ]
+        policy = request.cuda
+        existing_sources = {"system", "image", "prefix"}
+        found_any = bool(candidates)
+        if policy.kind == "system-first":
+            existing = [
+                candidate for candidate in exact_trt if candidate.cuda_source in existing_sources
+            ]
+            if existing:
+                complete = [
+                    candidate for candidate in existing if candidate.origin in existing_sources
+                ]
+                return (
+                    EnvironmentResolver._one(complete or existing, attempts, found_any),
+                    "system",
+                )
+            managed = [
+                candidate
+                for candidate in exact_trt
+                if candidate.cuda_source == "managed" and candidate.cuda == policy.fallback
+            ]
+            if not managed and not found_any:
+                raise ArtifactUnavailable(
+                    "No complete target CUDA/toolchain was found, and no toolchain catalog "
+                    f"could resolve digest-pinned managed CUDA {policy.fallback} artifacts. "
+                    "Register a private ToolchainCatalog or supply a complete pinned closure.",
+                    attempts=attempts,
+                )
+            return EnvironmentResolver._one(managed, attempts, found_any), "managed-default"
+        if policy.kind == "system-only":
+            existing = [
+                candidate
+                for candidate in exact_trt
+                if candidate.cuda_source in existing_sources
+                and (policy.version is None or candidate.cuda == policy.version)
+            ]
+            complete = [candidate for candidate in existing if candidate.origin in existing_sources]
+            return (
+                EnvironmentResolver._one(complete or existing, attempts, found_any),
+                "system",
+            )
+        if policy.kind == "managed":
+            managed = [
+                candidate
+                for candidate in exact_trt
+                if candidate.cuda_source == "managed" and candidate.cuda == policy.version
+            ]
+            return EnvironmentResolver._one(managed, attempts, found_any), "explicit"
+        matches = [candidate for candidate in exact_trt if candidate.cuda == policy.version]
+        existing = [candidate for candidate in matches if candidate.cuda_source in existing_sources]
+        complete = [candidate for candidate in existing if candidate.origin in existing_sources]
+        return (
+            EnvironmentResolver._one(complete or existing or matches, attempts, found_any),
+            "explicit",
+        )
+
+    @staticmethod
+    def _one(
+        candidates: list[ToolchainCandidate],
+        attempts: tuple[str, ...],
+        found_any: bool,
+    ) -> ToolchainCandidate:
+        if len(candidates) != 1:
+            reason = "no exact candidate" if not candidates else "ambiguous exact candidates"
+            error_type = (
+                _AmbiguousCombination
+                if candidates
+                else IncompatibleCombination
+                if found_any
+                else ArtifactUnavailable
+            )
+            raise error_type(
+                f"Environment resolution failed: {reason}",
+                attempts=attempts,
+            )
+        return candidates[0]
+
+    @staticmethod
+    def _lock_id(
+        request: EnvironmentRequest,
+        context: ContextLock,
+        candidate: ToolchainCandidate,
+    ) -> str:
+        del request
+        return _environment_lock_id(context, candidate)
+
+
+def _provider_payload(provider: ProviderDescriptor) -> dict[str, object]:
+    return {
+        "name": provider.name,
+        "implementation": provider.implementation,
+        "lock_schema": provider.lock_schema,
+    }
+
+
+def _identity_payload(
+    context: ContextLock,
+    candidate: ToolchainCandidate,
+) -> dict[str, object]:
+    return {
+        "schema_version": 3,
+        "context": {
+            "provider": _provider_payload(context.provider),
+            "operating_system": context.operating_system,
+            "architecture": context.architecture,
+            "identity": _plain_json(context.identity),
+            "execution": _plain_json(context.execution),
+            "capabilities": sorted(context.capabilities),
+            "qualification": dict(context.qualification),
+        },
+        "toolchain": {
+            "provider": _provider_payload(candidate.provider),
+            "origin": candidate.origin,
+            "cuda_source": candidate.cuda_source,
+            "tensorrt": candidate.tensorrt,
+            "cuda": candidate.cuda,
+            "python": candidate.python,
+            "identity": _plain_json(candidate.identity),
+            "runtime": (
+                {
+                    "python_executable": candidate.runtime.python_executable,
+                    "cuda_root": candidate.runtime.cuda_root,
+                    "nvcc": candidate.runtime.nvcc,
+                    "tensorrt_include_dir": candidate.runtime.tensorrt_include_dir,
+                    "tensorrt_library": candidate.runtime.tensorrt_library,
+                }
+                if candidate.runtime is not None
+                else None
+            ),
+            "artifacts": [
+                {
+                    "name": artifact.name,
+                    "sha256": artifact.sha256,
+                }
+                for artifact in candidate.artifacts
+            ],
+        },
+    }
+
+
+def _environment_lock_id(
+    context: ContextLock,
+    candidate: ToolchainCandidate,
+) -> str:
+    payload = _identity_payload(context, candidate)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(b"trtmc-devtoolkit-environment-lock-v3\0" + encoded).hexdigest()
+
+
+def _resolved_payload(
+    context: ContextLock,
+    candidate: ToolchainCandidate,
+) -> dict[str, object]:
+    payload = _identity_payload(context, candidate)
+    context_payload = payload["context"]
+    toolchain_payload = payload["toolchain"]
+    assert isinstance(context_payload, dict)
+    assert isinstance(toolchain_payload, dict)
+    context_payload["locator_names"] = sorted(context.locator)
+    toolchain_payload["artifacts"] = [
+        {
+            "name": artifact.name,
+            "uri": urllib.parse.urlunsplit(
+                urllib.parse.urlsplit(artifact.uri)._replace(query="", fragment="")
+            ),
+            "sha256": artifact.sha256,
+        }
+        for artifact in candidate.artifacts
+    ]
+    return payload

--- a/apps/devtoolkit/trtmc_devtoolkit/resolution.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/resolution.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import urllib.parse
 from collections.abc import Mapping, Sequence
@@ -30,7 +31,11 @@ ResolutionKind = Literal["system-first", "exact", "system-only", "managed"]
 
 
 def _freeze_json(value: object) -> FrozenJson:
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise DevToolkitError("Provider state requires finite JSON numbers")
+        return value
+    if value is None or isinstance(value, (str, int, bool)):
         return value
     if isinstance(value, Mapping):
         return MappingProxyType(
@@ -575,7 +580,12 @@ def _environment_lock_id(
     candidate: ToolchainCandidate,
 ) -> str:
     payload = _identity_payload(context, candidate)
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
     return hashlib.sha256(b"trtmc-devtoolkit-environment-lock-v3\0" + encoded).hexdigest()
 
 

--- a/apps/devtoolkit/trtmc_devtoolkit/runner.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/runner.py
@@ -1,31 +1,85 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""External-command boundary for checkout preparation."""
+"""Subprocess execution with append-only, secret-free command logging."""
 
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Protocol
+
+from .models import DevToolkitError
 
 
-class CommandRunner:
+class Runner(Protocol):
     def run(
         self,
-        command: Sequence[str],
+        command: Sequence[str | Path],
         *,
         cwd: Path,
         env: Mapping[str, str] | None = None,
         check: bool = True,
         capture_output: bool = False,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+class CommandRunner:
+    def __init__(self, log_path: Path | None = None):
+        self.log_path = log_path
+
+    def run(
+        self,
+        command: Sequence[str | Path],
+        *,
+        cwd: Path,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        capture_output: bool = False,
+        timeout: int | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            list(command),
-            check=check,
-            capture_output=capture_output,
+        arguments = [str(item) for item in command]
+        self._log(arguments)
+        result = subprocess.run(
+            arguments,
             cwd=cwd,
-            env=dict(os.environ if env is None else env),
+            env={**os.environ, **dict(env or {})},
             text=True,
+            check=False,
+            capture_output=capture_output,
+            timeout=timeout,
         )
+        if check and result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise DevToolkitError(
+                f"Command failed ({result.returncode}): {shlex.join(arguments)}\n{detail}".rstrip()
+            )
+        return result
+
+    def _log(self, command: Sequence[str]) -> None:
+        if self.log_path is None:
+            return
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as stream:
+            stream.write(shlex.join(command) + "\n")
+
+
+def command_output(
+    runner: Runner,
+    command: Sequence[str | Path],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None = None,
+    timeout: int | None = None,
+) -> str:
+    return runner.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        timeout=timeout,
+    ).stdout.strip()

--- a/apps/devtoolkit/trtmc_devtoolkit/runner.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/runner.py
@@ -80,6 +80,7 @@ def command_output(
         command,
         cwd=cwd,
         env=env,
+        check=True,
         capture_output=True,
         timeout=timeout,
     ).stdout.strip()

--- a/apps/devtoolkit/trtmc_devtoolkit/spi.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/spi.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extension interfaces for DevToolkit adapters and build recipes."""
+
+from .building import BuildContext, BuildPlan, BuildRecipe
+from .providers import (
+    ExecutionContext,
+    FrozenProviderRegistry,
+    ProviderRegistry,
+    ToolchainCatalog,
+    ToolchainSource,
+)
+from .provisioning import ContextHandle, ToolchainHandle
+from .qualifications import (
+    QualificationRecord,
+    QualificationRegistry,
+    QualificationSource,
+)
+from .resolution import ContextLock, ProviderDescriptor, ToolchainCandidate
+
+__all__ = [
+    "BuildContext",
+    "BuildPlan",
+    "BuildRecipe",
+    "ContextHandle",
+    "ContextLock",
+    "ExecutionContext",
+    "FrozenProviderRegistry",
+    "ProviderDescriptor",
+    "ProviderRegistry",
+    "QualificationRecord",
+    "QualificationRegistry",
+    "QualificationSource",
+    "ToolchainCandidate",
+    "ToolchainCatalog",
+    "ToolchainHandle",
+    "ToolchainSource",
+]

--- a/apps/devtoolkit/trtmc_devtoolkit/toolchain.py
+++ b/apps/devtoolkit/trtmc_devtoolkit/toolchain.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Toolchain observation helpers shared by built-in providers."""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+import re
+from pathlib import Path
+
+from .models import DevToolkitError, ToolchainObservation
+from .platforms import normalize_architecture
+from .runner import Runner, command_output
+
+
+CUDA_RELEASE = re.compile(r"release\s+([0-9]+\.[0-9]+)", re.IGNORECASE)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tensorrt_header_version_text(text: str, source: str | Path) -> str:
+    definitions = dict(
+        re.findall(r"^#define\s+([A-Za-z0-9_]+)\s+([A-Za-z0-9_]+)\b", text, re.MULTILINE)
+    )
+    parts: list[str] = []
+    for name in ("MAJOR", "MINOR", "PATCH", "BUILD"):
+        value = definitions.get(f"NV_TENSORRT_{name}", "")
+        value = definitions.get(value, value)
+        if not value.isdigit():
+            raise DevToolkitError(f"Could not resolve TensorRT {name.lower()} from {source}")
+        parts.append(value)
+    return ".".join(parts)
+
+
+def tensorrt_header_version(path: Path) -> str:
+    return tensorrt_header_version_text(path.read_text(encoding="utf-8"), path)
+
+
+def observe_local_toolchain(
+    runner: Runner,
+    *,
+    repository: Path,
+    python: str | Path,
+    nvcc: str | Path,
+    tensorrt_include_dir: Path,
+    tensorrt_library: Path,
+    environment: dict[str, str],
+    cuda_root: Path | None = None,
+) -> ToolchainObservation:
+    python_version = command_output(
+        runner,
+        [python, "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+        cwd=repository,
+        env=environment,
+    )
+    nvcc_output = command_output(
+        runner,
+        [nvcc, "--version"],
+        cwd=repository,
+        env=environment,
+    )
+    match = CUDA_RELEASE.search(nvcc_output)
+    if match is None:
+        raise DevToolkitError(f"Could not resolve CUDA version from nvcc: {nvcc_output}")
+    tensorrt_python = command_output(
+        runner,
+        [python, "-c", "import tensorrt; print(tensorrt.__version__)"],
+        cwd=repository,
+        env=environment,
+    )
+    tensorrt_native = command_output(
+        runner,
+        [
+            python,
+            "-c",
+            (
+                "import ctypes; "
+                f"lib=ctypes.CDLL({str(tensorrt_library)!r}); "
+                "names=('Major','Minor','Patch','Build'); "
+                "fs=[getattr(lib, f'getInferLib{name}Version') for name in names]; "
+                "[setattr(f, 'restype', ctypes.c_int32) for f in fs]; "
+                "print('.'.join(str(f()) for f in fs))"
+            ),
+        ],
+        cwd=repository,
+        env=environment,
+    )
+    return ToolchainObservation(
+        python_version=python_version,
+        cuda_version=match.group(1),
+        tensorrt_python_version=tensorrt_python,
+        tensorrt_native_version=tensorrt_native,
+        tensorrt_header_version=tensorrt_header_version(tensorrt_include_dir / "NvInferVersion.h"),
+        tensorrt_include_dir=str(tensorrt_include_dir),
+        tensorrt_library=str(tensorrt_library),
+        cuda_root=str(cuda_root) if cuda_root is not None else None,
+        architecture=normalize_architecture(platform.machine()),
+        evidence={
+            "nvcc": _sha256(Path(nvcc)),
+            "tensorrt-header": _sha256(tensorrt_include_dir / "NvInferVersion.h"),
+            "tensorrt-library": _sha256(tensorrt_library),
+        },
+    )

--- a/tools/tests/test_architecture.py
+++ b/tools/tests/test_architecture.py
@@ -343,6 +343,7 @@ def test_shared_python_and_native_trees_are_closed_minimal_sets() -> None:
         "tools/tests/test_coderabbit_config.py",
         "tools/tests/test_community_ci.py",
         "tools/tests/test_devtoolkit.py",
+        "tools/tests/test_devtoolkit_capabilities.py",
         "tools/tests/test_family_impact.py",
         "tools/tests/test_new_ci.py",
         "tools/tests/test_pr_metadata.py",

--- a/tools/tests/test_devtoolkit.py
+++ b/tools/tests/test_devtoolkit.py
@@ -26,6 +26,19 @@ from trtmc_devtoolkit import (  # noqa: E402
 )
 
 
+@pytest.mark.parametrize("name", ("docker_build.py", "local_build.py"))
+def test_build_examples_expose_help_without_preparing_an_environment(name: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPO / "apps" / "devtoolkit" / "examples" / name), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "TRTMC CLI and TensorRT backend" in result.stdout
+
+
 class RecordingRunner:
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], Path, dict[str, str] | None]] = []

--- a/tools/tests/test_devtoolkit.py
+++ b/tools/tests/test_devtoolkit.py
@@ -687,6 +687,31 @@ def test_local_uses_only_the_explicit_existing_interpreter(tmp_path: Path) -> No
     assert result.command("python", "-V") == ("python", "-V")
 
 
+def test_prepared_environment_bridges_to_capability_execution_targets(tmp_path: Path) -> None:
+    repository = tmp_path.resolve()
+    local = PreparedEnvironment(kind="local", repository=repository, python="/venv/bin/python")
+    docker = PreparedEnvironment(
+        kind="docker",
+        repository=repository,
+        python="python3",
+        container="trtmc-dev",
+        container_id="sha256:container",
+    )
+
+    local_target = local.execution_target(gpu="2")
+    docker_target = docker.execution_target(state="/workspace/.devtoolkit")
+
+    assert local_target.provider == "local"
+    assert local_target.options == {"python": "/venv/bin/python", "gpu": "2"}
+    assert docker_target.provider == "docker"
+    assert docker_target.options == {
+        "python": "python3",
+        "workspace": str(repository),
+        "state": "/workspace/.devtoolkit",
+        "container": "sha256:container",
+    }
+
+
 @pytest.mark.parametrize("family", ("missing", "../alpha", "Alpha"))
 def test_unknown_or_invalid_family_fails_closed(tmp_path: Path, family: str) -> None:
     toolkit = DevToolkit.from_checkout(_checkout(tmp_path), runner=RecordingRunner())
@@ -710,7 +735,7 @@ def test_invalid_docker_inputs_fail_before_commands(tmp_path: Path) -> None:
     assert runner.calls == []
 
 
-def test_devtoolkit_has_no_legacy_registry_or_cohort_modules() -> None:
+def test_devtoolkit_has_no_legacy_location_or_cohort_modules() -> None:
     root = REPO / "apps/devtoolkit"
     legacy = REPO / "scripts/devToolkit"
     assert not legacy.exists() or not [path for path in legacy.rglob("*") if path.is_file()]
@@ -718,16 +743,11 @@ def test_devtoolkit_has_no_legacy_registry_or_cohort_modules() -> None:
     assert not [
         name
         for name in (
-            "builtin_providers.py",
             "builtin_registry.py",
             "cohorts.py",
             "planner.py",
-            "providers.py",
-            "receipt.py",
-            "spi.py",
             "target_contracts.py",
             "target_service.py",
-            "toolchain.py",
         )
         if (root / "trtmc_devtoolkit" / name).exists()
     ]

--- a/tools/tests/test_devtoolkit_capabilities.py
+++ b/tools/tests/test_devtoolkit_capabilities.py
@@ -1,0 +1,2701 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public capability API tests for the repository-local TRTMC DevToolkit."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import subprocess
+import sys
+import threading
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEVTOOLKIT_ROOT = REPO_ROOT / "apps" / "devtoolkit"
+sys.path.insert(0, str(DEVTOOLKIT_ROOT))
+
+from trtmc_devtoolkit import (  # noqa: E402
+    ArtifactPin,
+    ArtifactUnavailable,
+    AttestationFailed,
+    CommandSpec,
+    CudaPolicy,
+    DevToolkitError,
+    DevToolkit,
+    EnvironmentRequest,
+    ExecutionTarget,
+    IncompatibleCombination,
+    JsonQualificationSource,
+    JsonToolchainCatalog,
+    NvidiaPackageIndexCatalog,
+    ProvisionPolicy,
+    ToolchainRuntime,
+    TrtmcBuildRecipe,
+    ToolchainObservation,
+    repository_path,
+)
+from trtmc_devtoolkit.spi import (  # noqa: E402
+    ContextHandle,
+    ContextLock,
+    ExecutionContext,
+    ProviderDescriptor,
+    ProviderRegistry,
+    QualificationRegistry,
+    ToolchainCandidate,
+    ToolchainHandle,
+    ToolchainSource,
+)
+from trtmc_devtoolkit import receipt as receipt_module  # noqa: E402
+from trtmc_devtoolkit import catalogs as catalogs_module  # noqa: E402
+from trtmc_devtoolkit.building import BuildContext  # noqa: E402
+from trtmc_devtoolkit.builtin_providers import (  # noqa: E402
+    ManagedArtifactToolchainSource,
+)
+
+
+@pytest.fixture(autouse=True)
+def _valid_checkout(tmp_path: Path) -> None:
+    """Keep capability fixtures aligned with the checkout-owned apps contract."""
+    (tmp_path / "pyproject.toml").touch()
+    (tmp_path / "families").mkdir(exist_ok=True)
+
+
+def test_extension_protocols_are_isolated_in_spi() -> None:
+    assert ExecutionContext.__name__ == "ExecutionContext"
+    assert ToolchainSource.__name__ == "ToolchainSource"
+
+
+def test_nvidia_catalog_resolves_a_digest_pinned_development_toolchain() -> None:
+    version = "11.2.0.113"
+    meta = {
+        "urls": [
+            {
+                "filename": f"tensorrt_cu13-{version}.tar.gz",
+                "url": f"https://files.example/tensorrt_cu13-{version}.tar.gz",
+                "digests": {"sha256": "1" * 64},
+            }
+        ]
+    }
+    bindings = {
+        "urls": [
+            {
+                "filename": (
+                    f"tensorrt_cu13_bindings-{version}-cp312-none-manylinux_2_28_x86_64.whl"
+                ),
+                "url": f"https://files.example/bindings-{version}.whl",
+                "digests": {"sha256": "2" * 64},
+            }
+        ]
+    }
+    simple = (
+        f'<a href="tensorrt_cu13_libs-{version}-py3-none-manylinux_2_28_x86_64.whl'
+        f'#sha256={"3" * 64}">runtime</a>'
+    ).encode()
+    packages = gzip.compress(
+        "\n".join(
+            (
+                "Package: libnvinfer-headers-dev",
+                f"Version: {version}-1+cuda13.3",
+                "Architecture: amd64",
+                f"Filename: ./headers-{version}.deb",
+                f"SHA256: {'4' * 64}",
+                "",
+            )
+        ).encode()
+    )
+
+    def fetch(url: str) -> bytes | None:
+        if url.endswith(f"/tensorrt-cu13/{version}/json"):
+            return json.dumps(meta).encode()
+        if url.endswith(f"/tensorrt-cu13-bindings/{version}/json"):
+            return json.dumps(bindings).encode()
+        if url.endswith("/tensorrt-cu13-libs/"):
+            return simple
+        if url.endswith("/ubuntu2404/x86_64/Packages.gz"):
+            return packages
+        raise AssertionError(url)
+
+    catalog = NvidiaPackageIndexCatalog(fetch=fetch)
+    artifacts, headers_version = catalog._distribution(
+        version,
+        "13.0",
+        "3.12",
+        "x86_64",
+        "ubuntu",
+        "24.04",
+    )
+
+    assert [artifact.name for artifact in artifacts] == [
+        "tensorrt-python",
+        "tensorrt-bindings",
+        "tensorrt-libs",
+        "tensorrt-headers",
+    ]
+    assert [artifact.sha256 for artifact in artifacts] == [
+        "1" * 64,
+        "2" * 64,
+        "3" * 64,
+        "4" * 64,
+    ]
+    assert headers_version == f"{version}-1+cuda13.3"
+
+
+def test_nvidia_catalog_resolves_managed_cuda_when_target_has_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version = "11.2.0.113"
+    cuda_components = (
+        "cuda_crt",
+        "cuda_cudart",
+        "cuda_culibos",
+        "cuda_nvcc",
+        "libcublas",
+        "libcurand",
+        "libnvvm",
+        "cccl",
+    )
+    redistrib = {
+        "release_label": "13.3.0",
+        **{
+            component: {
+                "linux-x86_64": {
+                    "relative_path": f"{component}/{component}.tar.xz",
+                    "sha256": str(index) * 64,
+                }
+            }
+            for index, component in enumerate(cuda_components, start=1)
+        },
+    }
+    meta = {
+        "urls": [
+            {
+                "filename": f"tensorrt_cu13-{version}.tar.gz",
+                "url": f"https://files.example/tensorrt_cu13-{version}.tar.gz",
+                "digests": {"sha256": "a" * 64},
+            }
+        ]
+    }
+    bindings = {
+        "urls": [
+            {
+                "filename": (
+                    f"tensorrt_cu13_bindings-{version}-cp312-none-manylinux_2_28_x86_64.whl"
+                ),
+                "url": f"https://files.example/bindings-{version}.whl",
+                "digests": {"sha256": "b" * 64},
+            }
+        ]
+    }
+    simple = (
+        f'<a href="tensorrt_cu13_libs-{version}-py3-none-manylinux_2_28_x86_64.whl'
+        f'#sha256={"c" * 64}">runtime</a>'
+    ).encode()
+    packages = gzip.compress(
+        "\n".join(
+            (
+                "Package: libnvinfer-headers-dev",
+                f"Version: {version}-1+cuda13.3",
+                "Architecture: amd64",
+                f"Filename: ./headers-{version}.deb",
+                f"SHA256: {'d' * 64}",
+                "",
+            )
+        ).encode()
+    )
+    bootstrap = {
+        "pip": ("24.0", "pip-24.0-py3-none-any.whl", "e" * 64),
+        "setuptools": (
+            "68.1.2",
+            "setuptools-68.1.2-py3-none-any.whl",
+            "f" * 64,
+        ),
+        "wheel": ("0.42.0", "wheel-0.42.0-py3-none-any.whl", "0" * 64),
+    }
+
+    def fetch(url: str) -> bytes | None:
+        if url.endswith("/redistrib_13.3.0.json"):
+            return json.dumps(redistrib).encode()
+        if url.endswith(f"/tensorrt-cu13/{version}/json"):
+            return json.dumps(meta).encode()
+        if url.endswith(f"/tensorrt-cu13-bindings/{version}/json"):
+            return json.dumps(bindings).encode()
+        if url.endswith("/tensorrt-cu13-libs/"):
+            return simple
+        if url.endswith("/ubuntu2404/x86_64/Packages.gz"):
+            return packages
+        for package, (package_version, filename, digest) in bootstrap.items():
+            if url.endswith(f"/{package}/{package_version}/json"):
+                return json.dumps(
+                    {
+                        "urls": [
+                            {
+                                "filename": filename,
+                                "url": f"https://files.example/{filename}",
+                                "digests": {"sha256": digest},
+                            }
+                        ]
+                    }
+                ).encode()
+        raise AssertionError(url)
+
+    monkeypatch.setattr(catalogs_module, "target_runtime_baseline", lambda *args: None)
+    monkeypatch.setattr(
+        catalogs_module,
+        "target_python_baseline",
+        lambda *args: type(
+            "PythonBaseline",
+            (),
+            {"python": "3.12", "python_executable": "/usr/bin/python3"},
+        )(),
+    )
+    context = ContextLock(
+        provider=ProviderDescriptor("test", "tests==1", 1),
+        operating_system="linux",
+        architecture="x86_64",
+        identity={"os_id": "ubuntu", "os_version": "24.04"},
+        capabilities=frozenset({"container-process"}),
+    )
+    candidate = NvidiaPackageIndexCatalog(fetch=fetch).resolve(
+        EnvironmentRequest(
+            tensorrt=version,
+            target=ExecutionTarget("test"),
+        ),
+        context,
+        repository=tmp_path,
+        runner=CommandRecordingRunner(),
+    )[0]
+
+    assert candidate.cuda == "13.3"
+    assert candidate.cuda_source == "managed"
+    assert candidate.identity["cuda_release"] == "13.3.0"
+    assert candidate.identity["cuda_artifacts"] == tuple(
+        f"cuda-component-{component}" for component in cuda_components
+    )
+    assert candidate.identity["python_bootstrap_artifacts"] == (
+        "python-bootstrap-pip",
+        "python-bootstrap-setuptools",
+        "python-bootstrap-wheel",
+    )
+    assert [artifact.name for artifact in candidate.artifacts[-3:]] == list(
+        candidate.identity["python_bootstrap_artifacts"]
+    )
+    assert len(candidate.artifacts) == 15
+
+
+def test_nvidia_catalog_ignores_a_malformed_cuda_manifest() -> None:
+    catalog = NvidiaPackageIndexCatalog(fetch=lambda _url: json.dumps([]).encode())
+
+    artifacts, release = catalog._cuda_distribution("13.3", "x86_64")
+
+    assert artifacts == ()
+    assert release == ""
+
+
+def test_json_catalog_supplies_a_private_exact_version_from_target_cuda(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version = "11.2.0.113"
+    manifest = tmp_path / "private-toolchains.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "toolchains": [
+                    {
+                        "id": "gb300-trt-1120113",
+                        "tensorrt": version,
+                        "python": "3.12",
+                        "architecture": "x86_64",
+                        "cuda": {"source": "target", "major": "13"},
+                        "artifacts": [
+                            {
+                                "name": "tensorrt-bindings",
+                                "uri": "artifacts/bindings.whl",
+                                "sha256": "1" * 64,
+                            },
+                            {
+                                "name": "tensorrt-libs",
+                                "uri": "https://artifacts.example/libs.whl",
+                                "sha256": "2" * 64,
+                            },
+                            {
+                                "name": "tensorrt-headers",
+                                "uri": "https://artifacts.example/headers.deb",
+                                "sha256": "3" * 64,
+                            },
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        catalogs_module,
+        "target_runtime_baseline",
+        lambda *args: type(
+            "RuntimeBaseline",
+            (),
+            {
+                "python": "3.12",
+                "python_executable": "/usr/bin/python3",
+                "cuda": "13.0",
+                "cuda_root": "/usr/local/cuda-13.0",
+                "nvcc": "/usr/local/cuda-13.0/bin/nvcc",
+                "cuda_source": "image",
+            },
+        )(),
+    )
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(EmptySystemToolchainSource())
+    registry.register_toolchain(ManagedArtifactToolchainSource())
+    registry.register_catalog(JsonToolchainCatalog((manifest,)))
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt=version,
+            target=ExecutionTarget("test-local"),
+            architecture="x86_64",
+            toolchain_options={"catalog": "json-toolchain-catalog"},
+        )
+    )
+
+    assert lock.tensorrt == version
+    assert lock.cuda == "13.0"
+    assert lock.toolchain.cuda_source == "image"
+    assert lock.toolchain.identity["catalog"]["record_id"] == "gb300-trt-1120113"
+    assert lock.toolchain.artifacts[0].uri == (tmp_path / "artifacts/bindings.whl").as_uri()
+
+
+def test_public_api_exposes_capabilities_without_plan_or_apply(tmp_path: Path) -> None:
+    toolkit = DevToolkit.from_checkout(tmp_path)
+
+    assert not hasattr(toolkit, "plan")
+    assert not hasattr(toolkit, "apply")
+
+
+def test_generic_qualification_source_is_explicit(tmp_path: Path) -> None:
+    root = tmp_path / "qualifications"
+    root.mkdir()
+    (root / "qualified.json").write_text(
+        json.dumps(
+            {
+                "id": "qualified",
+                "status": "supported",
+                "requirements": {"tensorrt": "11.2.0.113", "execution": ["local"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    records = QualificationRegistry((JsonQualificationSource((root,)),)).load_all()
+
+    assert records
+    assert all(record.reference.digest for record in records)
+
+
+class BuiltinProbeRunner:
+    def run(
+        self,
+        command,
+        *,
+        cwd,
+        env=None,
+        check=True,
+        capture_output=False,
+        timeout=None,
+    ):
+        del cwd, env, check, capture_output, timeout
+        arguments = [str(item) for item in command]
+        if arguments[-1] == "--version":
+            output = "Cuda compilation tools, release 12.8, V12.8.0\n"
+        elif "sys.version_info" in arguments[-1]:
+            output = "3.12\n"
+        elif "tensorrt.__version__" in arguments[-1]:
+            output = "11.2.0.113\n"
+        elif "getInferLib" in arguments[-1]:
+            output = "11.2.0.113\n"
+        else:
+            raise AssertionError(arguments)
+        return subprocess.CompletedProcess(arguments, 0, output, "")
+
+
+class DockerAdoptionRunner:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.environments: list[dict[str, str] | None] = []
+        self.environment_files: list[tuple[Path, str, int]] = []
+        self.client_version = "28.0.0"
+        self.daemon_id = "daemon-789"
+        self.container_id = "container-123"
+        self.tensorrt_version = "11.0.2.2"
+
+    def run(
+        self,
+        command,
+        *,
+        cwd,
+        env=None,
+        check=True,
+        capture_output=False,
+        timeout=None,
+    ):
+        del cwd, check, capture_output, timeout
+        arguments = [str(item) for item in command]
+        self.commands.append(arguments)
+        self.environments.append(dict(env) if env is not None else None)
+        if arguments == ["docker", "context", "show"]:
+            output = "test-context\n"
+        elif arguments[:4] == ["docker", "--context", "test-context", "version"]:
+            output = self.client_version + "\n"
+        elif arguments[:4] == ["docker", "--context", "test-context", "info"]:
+            output = self.daemon_id + "\n"
+        elif arguments[:4] == ["docker", "--context", "test-context", "inspect"]:
+            output = json.dumps(
+                {
+                    "Id": self.container_id,
+                    "Image": "sha256:image-456",
+                    "State": {"Running": True},
+                    "Config": {"Image": "campaign:latest"},
+                }
+            )
+        elif arguments[:4] == ["docker", "--context", "test-context", "exec"]:
+            if "--env-file" in arguments:
+                environment_file = Path(arguments[arguments.index("--env-file") + 1])
+                self.environment_files.append(
+                    (
+                        environment_file,
+                        environment_file.read_text(encoding="utf-8"),
+                        environment_file.stat().st_mode & 0o777,
+                    )
+                )
+            if arguments[-2:] == ["cat", "/etc/os-release"]:
+                output = 'ID="ubuntu"\nVERSION_ID="24.04"\n'
+            elif "uname" in arguments:
+                output = "aarch64\n"
+            else:
+                output = json.dumps(
+                    {
+                        "python": "3.12",
+                        "python_executable": "/usr/bin/python3",
+                        "cuda": "12.8",
+                        "cuda_root": "/usr/local/cuda-12.8",
+                        "tensorrt_python": self.tensorrt_version,
+                        "tensorrt_native": self.tensorrt_version,
+                        "tensorrt_headers": self.tensorrt_version,
+                        "tensorrt_include_dir": "/usr/include/aarch64-linux-gnu",
+                        "tensorrt_library": ("/usr/lib/aarch64-linux-gnu/libnvinfer.so.11"),
+                        "cuda_complete": True,
+                        "architecture": "aarch64",
+                        "evidence": {
+                            "nvcc": "1" * 64,
+                            "tensorrt-header": "2" * 64,
+                            "tensorrt-library": "3" * 64,
+                        },
+                    }
+                )
+        else:
+            raise AssertionError(arguments)
+        return subprocess.CompletedProcess(arguments, 0, output, "")
+
+
+class ManagedProvisionRunner:
+    def __init__(self, root: Path) -> None:
+        self.header_include: Path | None = None
+        self.cuda = root / "managed-cuda"
+        self.trt = root / "managed-trt"
+        for directory in (self.cuda / "bin", self.cuda / "include", self.cuda / "lib"):
+            directory.mkdir(parents=True)
+        for relative in (
+            "bin/nvcc",
+            "include/cuda.h",
+            "lib/libcudart.so",
+            "lib/libcublas.so",
+            "lib/libcurand.so",
+        ):
+            (self.cuda / relative).touch()
+        self.trt.mkdir()
+        (self.trt / "libnvinfer.so").touch()
+
+    def run(self, command, **kwargs):
+        check = kwargs.get("check", True)
+        arguments = [str(item) for item in command]
+        output = ""
+        returncode = 0
+        script = arguments[2] if len(arguments) > 2 and arguments[1] == "-c" else ""
+        if arguments[0] == "test":
+            path = Path(arguments[-1])
+            returncode = 0 if path.is_file() else 1
+        elif arguments[:2] == ["mkdir", "-p"]:
+            Path(arguments[-1]).mkdir(parents=True, exist_ok=True)
+        elif arguments[0] == "touch":
+            Path(arguments[-1]).touch()
+        elif arguments[:2] == ["dpkg-deb", "--extract"]:
+            include = Path(arguments[3]) / "usr" / "include" / "x86_64-linux-gnu"
+            self.header_include = include
+            include.mkdir(parents=True)
+            (include / "NvInferVersion.h").write_text(
+                "\n".join(
+                    (
+                        "#define NV_TENSORRT_MAJOR 11",
+                        "#define NV_TENSORRT_MINOR 2",
+                        "#define NV_TENSORRT_PATCH 0",
+                        "#define NV_TENSORRT_BUILD 113",
+                    )
+                ),
+                encoding="utf-8",
+            )
+        elif "expected one matching TensorRT header tree" in script:
+            assert self.header_include is not None
+            output = str(self.header_include) + "\n"
+        elif "metadata.distribution" in script or "m.distribution" in arguments[-1]:
+            if not (self.cuda / "lib" / "libcurand.so").is_file():
+                raise DevToolkitError("Managed artifacts produced an incomplete CUDA toolkit")
+            output = json.dumps(
+                {
+                    "cuda_root": str(self.cuda),
+                    "tensorrt_library": str(self.trt / "libnvinfer.so"),
+                }
+            )
+        elif "os.environ.get" in script and '"LD_LIBRARY_PATH"' in script:
+            output = json.dumps(
+                {
+                    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
+                    "LD_LIBRARY_PATH": "",
+                }
+            )
+        elif arguments[-1] == "--version":
+            output = "Cuda compilation tools, release 13.3, V13.3.0\n"
+        elif "sys.version_info" in arguments[-1]:
+            output = "3.12\n"
+        elif "tensorrt.__version__" in arguments[-1]:
+            output = "11.2.0.113\n"
+        elif "getInferLib" in arguments[-1]:
+            output = "11.2.0.113\n"
+        result = subprocess.CompletedProcess(arguments, returncode, output, "")
+        if check and returncode != 0:
+            raise DevToolkitError(f"simulated target command failure: {arguments}")
+        return result
+
+
+class CommandRecordingRunner:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.artifact_digest = "c" * 64
+
+    def run(self, command, **kwargs):
+        del kwargs
+        arguments = [str(item) for item in command]
+        self.commands.append(arguments)
+        output = "trtmc 0.1\n"
+        if arguments[-2:] == ["rev-parse", "HEAD"]:
+            output = "b" * 40 + "\n"
+        elif arguments[-3:-1] == ["diff", "--binary"]:
+            output = ""
+        elif arguments[-3:-1] == ["ls-files", "--others"]:
+            output = ""
+        elif arguments[0] == "sha256sum":
+            output = f"{self.artifact_digest}  {arguments[1]}\n"
+        elif "CUDA runtime headers are missing" in arguments[-2]:
+            output = json.dumps(
+                {
+                    "include": "/cuda/include",
+                    "cudart": "/cuda/lib64/libcudart.so",
+                    "cublas": "/cuda/lib64/libcublas.so",
+                }
+            )
+        elif "shutil.which" in arguments[-1]:
+            output = "Ninja\n"
+        return subprocess.CompletedProcess(arguments, 0, output, "")
+
+
+class BlockingBuildRunner(CommandRecordingRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_configure_entered = threading.Event()
+        self.release_first_configure = threading.Event()
+        self.second_configure_entered = threading.Event()
+        self._configure_calls = 0
+        self._guard = threading.Lock()
+
+    def run(self, command, **kwargs):
+        arguments = [str(item) for item in command]
+        if arguments[:2] == ["cmake", "-S"]:
+            with self._guard:
+                self._configure_calls += 1
+                call = self._configure_calls
+            if call == 1:
+                self.first_configure_entered.set()
+                assert self.release_first_configure.wait(timeout=5)
+            else:
+                self.second_configure_entered.set()
+        return super().run(command, **kwargs)
+
+
+class NonzeroCommandRunner:
+    def __init__(self) -> None:
+        self.checks: list[bool] = []
+
+    def run(
+        self,
+        command,
+        *,
+        cwd,
+        env=None,
+        check=True,
+        capture_output=False,
+        timeout=None,
+    ):
+        del cwd, env, capture_output, timeout
+        arguments = [str(item) for item in command]
+        self.checks.append(check)
+        return subprocess.CompletedProcess(arguments, 7, "", "expected failure")
+
+
+class SecretEchoFailureRunner:
+    def run(self, command, *, env=None, **kwargs):
+        del command, kwargs
+        raise RuntimeError(f"runner leaked environment: {env}")
+
+
+class StaticLocalContext:
+    descriptor = ProviderDescriptor("test-local", "tests==1", 1)
+
+    def resolve(self, request, *, repository, runner):
+        del repository, runner
+        return ContextLock(
+            provider=self.descriptor,
+            operating_system="linux",
+            architecture=request.architecture or "aarch64",
+            identity={"kind": "local"},
+            execution={"gpu": "0", "python": "python3"},
+            locator={"gpu": "0"},
+            capabilities=frozenset({"host-filesystem", "posix-process"}),
+            qualification={"execution": "local"},
+        )
+
+    def provision(
+        self,
+        context,
+        *,
+        inherit_system_packages,
+        repository,
+        state_dir,
+        policy,
+        runner,
+    ):
+        del repository, runner
+        del inherit_system_packages
+        assert policy is ProvisionPolicy.ADOPT_OR_CREATE
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return ContextHandle(
+            provider=self.descriptor,
+            identity=context.identity,
+            execution_identity={"root": str(state_dir), "gpu": "0"},
+            locator={"root": str(state_dir)},
+            environment={"CUDA_VISIBLE_DEVICES": "0"},
+        )
+
+    def execute(
+        self,
+        context,
+        command,
+        *,
+        repository,
+        state_dir,
+        runner,
+        check,
+        capture_output,
+    ):
+        del context
+        arguments = [
+            str(repository / argument.path)
+            if hasattr(argument, "scope") and argument.scope.value == "repository"
+            else str(state_dir / argument.path)
+            if hasattr(argument, "scope") and argument.scope.value == "state"
+            else str(argument)
+            for argument in command.arguments
+        ]
+        cwd = repository / command.cwd.path
+        return runner.run(
+            arguments,
+            cwd=cwd,
+            env=command.environment,
+            check=check,
+            capture_output=capture_output,
+        )
+
+
+class BlockingLocalContext(StaticLocalContext):
+    def __init__(self) -> None:
+        self.first_entered = threading.Event()
+        self.release_first = threading.Event()
+        self.second_entered = threading.Event()
+        self._guard = threading.Lock()
+        self._calls = 0
+
+    def provision(
+        self,
+        context,
+        *,
+        inherit_system_packages,
+        repository,
+        state_dir,
+        policy,
+        runner,
+    ):
+        with self._guard:
+            self._calls += 1
+            call = self._calls
+        if call == 1:
+            self.first_entered.set()
+            assert self.release_first.wait(timeout=5)
+        else:
+            self.second_entered.set()
+        return super().provision(
+            context,
+            inherit_system_packages=inherit_system_packages,
+            repository=repository,
+            state_dir=state_dir,
+            policy=policy,
+            runner=runner,
+        )
+
+
+class ExistingToolchainSource:
+    descriptor = ProviderDescriptor("test-system", "tests==1", 1)
+
+    def __init__(self) -> None:
+        self.requested_versions: list[str] = []
+
+    def resolve(self, request, context, *, repository, runner):
+        del context, repository, runner
+        self.requested_versions.append(request.tensorrt)
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="system",
+                tensorrt=request.tensorrt,
+                cuda="12.8",
+                python=request.python,
+                identity={"prefix": "/opt/nvidia"},
+                runtime=ToolchainRuntime(
+                    python_executable="python3",
+                    cuda_root="/opt/nvidia/cuda",
+                    nvcc="/opt/nvidia/cuda/bin/nvcc",
+                    tensorrt_include_dir="/opt/nvidia/include",
+                    tensorrt_library="/opt/nvidia/lib/libnvinfer.so",
+                ),
+            ),
+        )
+
+    def provision(self, lock, context, *, repository, state_dir, runner):
+        del repository, state_dir, runner
+        assert lock.toolchain.runtime is not None
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=replace(
+                lock.toolchain.runtime,
+                python_executable=str(context.locator.get("python", "python3")),
+            ),
+        )
+
+    def observe(self, lock, context, toolchain, *, repository, runner):
+        del context, repository, runner
+        return ToolchainObservation(
+            python_version=lock.toolchain.python,
+            cuda_version=lock.toolchain.cuda,
+            tensorrt_python_version=lock.toolchain.tensorrt,
+            tensorrt_native_version=lock.toolchain.tensorrt,
+            tensorrt_header_version=lock.toolchain.tensorrt,
+            tensorrt_include_dir=toolchain.runtime.tensorrt_include_dir,
+            tensorrt_library=toolchain.runtime.tensorrt_library,
+            cuda_root=toolchain.runtime.cuda_root,
+            evidence={"toolchain": "a" * 64},
+        )
+
+
+class ReplacementToolchainSource(ExistingToolchainSource):
+    descriptor = ProviderDescriptor("test-system", "tests==2", 1)
+
+
+class AlternateExistingToolchainSource(ExistingToolchainSource):
+    descriptor = ProviderDescriptor("alternate-system", "tests==1", 1)
+
+
+class FailingReattestationSource(ExistingToolchainSource):
+    def __init__(self) -> None:
+        super().__init__()
+        self.observations = 0
+
+    def observe(self, lock, context, toolchain, *, repository, runner):
+        self.observations += 1
+        if self.observations > 1:
+            raise RuntimeError("preflight contained super-secret")
+        return super().observe(
+            lock,
+            context,
+            toolchain,
+            repository=repository,
+            runner=runner,
+        )
+
+
+class MutableEvidenceSource(ExistingToolchainSource):
+    def __init__(self) -> None:
+        super().__init__()
+        self.digest = "a" * 64
+
+    def observe(self, lock, context, toolchain, *, repository, runner):
+        observed = super().observe(
+            lock,
+            context,
+            toolchain,
+            repository=repository,
+            runner=runner,
+        )
+        return replace(observed, evidence={"toolchain": self.digest})
+
+
+class EmptySystemToolchainSource:
+    descriptor = ProviderDescriptor("empty-system", "tests==1", 1)
+
+    def resolve(self, request, context, *, repository, runner):
+        del request, context, repository, runner
+        return ()
+
+
+class RecordingToolchainCatalog:
+    descriptor = ProviderDescriptor("test-catalog", "tests==1", 1)
+
+    def __init__(self, materializer: ProviderDescriptor) -> None:
+        self.materializer = materializer
+        self.requests: list[str] = []
+
+    def resolve(self, request, context, *, repository, runner):
+        del context, repository, runner
+        self.requests.append(request.tensorrt)
+        return (
+            ToolchainCandidate(
+                provider=self.materializer,
+                origin="managed",
+                cuda_source="managed",
+                tensorrt=request.tensorrt,
+                cuda="13.3",
+                python=request.python,
+                identity={"catalog": self.descriptor.name},
+                artifacts=(
+                    ArtifactPin(
+                        "toolchain",
+                        "https://example.invalid/toolchain.tar.xz",
+                        "f" * 64,
+                    ),
+                ),
+            ),
+        )
+
+
+class ManagedContainerCatalog:
+    descriptor = ProviderDescriptor("container-catalog", "tests==1", 1)
+
+    def __init__(self, materializer: ProviderDescriptor) -> None:
+        self.materializer = materializer
+
+    def resolve(self, request, context, *, repository, runner):
+        del context, repository, runner
+        suffixes = ("module.tar.gz", "bindings.whl", "libs.whl", "headers.deb")
+        names = (
+            "tensorrt-python",
+            "tensorrt-bindings",
+            "tensorrt-libs",
+            "tensorrt-headers",
+        )
+        return (
+            ToolchainCandidate(
+                provider=self.materializer,
+                origin="managed",
+                cuda_source="image",
+                tensorrt=request.tensorrt,
+                cuda="13.0",
+                python=request.python,
+                identity={
+                    "layout_schema": 2,
+                    "tensorrt_lib_distribution": "tensorrt_cu13_libs",
+                    "system_cuda_root": "/usr/local/cuda",
+                    "system_nvcc": "/usr/local/cuda/bin/nvcc",
+                },
+                artifacts=tuple(
+                    ArtifactPin(name, f"https://example.invalid/{suffix}", str(index) * 64)
+                    for index, (name, suffix) in enumerate(zip(names, suffixes), start=1)
+                ),
+            ),
+        )
+
+
+class BootstrapManagedContainerCatalog(ManagedContainerCatalog):
+    descriptor = ProviderDescriptor("bootstrap-container-catalog", "tests==1", 1)
+
+    def resolve(self, request, context, *, repository, runner):
+        candidate = super().resolve(
+            request,
+            context,
+            repository=repository,
+            runner=runner,
+        )[0]
+        names = (
+            "python-bootstrap-pip",
+            "python-bootstrap-setuptools",
+            "python-bootstrap-wheel",
+        )
+        artifacts = tuple(
+            ArtifactPin(name, f"https://example.invalid/{name}.whl", str(index) * 64)
+            for index, name in enumerate(names, start=5)
+        )
+        return (
+            replace(
+                candidate,
+                identity={
+                    **dict(candidate.identity),
+                    "python_bootstrap_artifacts": names,
+                },
+                artifacts=(*candidate.artifacts, *artifacts),
+            ),
+        )
+
+
+class ManagedCudaContainerCatalog(ManagedContainerCatalog):
+    descriptor = ProviderDescriptor("managed-cuda-container-catalog", "tests==1", 1)
+
+    def resolve(self, request, context, *, repository, runner):
+        candidate = super().resolve(
+            request,
+            context,
+            repository=repository,
+            runner=runner,
+        )[0]
+        cuda_artifact = ArtifactPin(
+            "cuda-component-cuda-nvcc",
+            "https://example.invalid/cuda-nvcc.tar.xz",
+            "5" * 64,
+        )
+        return (
+            replace(
+                candidate,
+                cuda="13.3",
+                cuda_source="managed",
+                identity={
+                    **dict(candidate.identity),
+                    "system_cuda_root": None,
+                    "system_nvcc": None,
+                    "cuda_artifacts": (cuda_artifact.name,),
+                    "cuda_release": "13.3.0",
+                },
+                artifacts=(*candidate.artifacts, cuda_artifact),
+            ),
+        )
+
+
+class ManagedContainerContext:
+    descriptor = ProviderDescriptor("test-container", "tests==1", 1)
+
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.command_environments: list[dict[str, str]] = []
+        self.cuda_version = "13.0"
+        self.venv_requires_bootstrap = False
+        self.target_files: set[str] = set()
+
+    def resolve(self, request, *, repository, runner):
+        del request, repository, runner
+        return ContextLock(
+            provider=self.descriptor,
+            operating_system="linux",
+            architecture="x86_64",
+            identity={"image_id": "sha256:test-image"},
+            execution={"python": "/usr/bin/python3", "target_state": "/target/state"},
+            locator={"python": "/usr/bin/python3", "target_state": "/target/state"},
+            capabilities=frozenset({"container-process", "posix-process"}),
+            qualification={"execution": "container"},
+        )
+
+    def provision(self, context, **kwargs):
+        del kwargs
+
+        def execute(command, check, capture_output):
+            del capture_output
+            arguments = [str(item) for item in command.arguments]
+            self.commands.append(arguments)
+            self.command_environments.append(dict(command.environment))
+            returncode = 0
+            if arguments[0] == "test":
+                returncode = 0 if arguments[-1] in self.target_files else 1
+            elif (
+                self.venv_requires_bootstrap
+                and arguments[:3] == ["/usr/bin/python3", "-m", "venv"]
+                and "--without-pip" not in arguments
+            ):
+                returncode = 1
+            elif arguments[0] == "touch":
+                self.target_files.add(arguments[-1])
+            output = ""
+            script = arguments[2] if len(arguments) > 2 and arguments[1] == "-c" else ""
+            if "os.environ.get" in script and '"LD_LIBRARY_PATH"' in script:
+                output = json.dumps(
+                    {
+                        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
+                        "LD_LIBRARY_PATH": "/image/lib",
+                    }
+                )
+            elif "expected one matching TensorRT header tree" in script:
+                output = (
+                    "/target/state/managed-toolchain/lock/headers/usr/include/x86_64-linux-gnu\n"
+                )
+            elif "metadata.distribution" in script:
+                output = json.dumps(
+                    {
+                        "cuda_root": arguments[-1],
+                        "tensorrt_library": "/target/state/venv/tensorrt_libs/libnvinfer.so",
+                    }
+                )
+            elif "source package produced no wheel" in script:
+                output = "/target/state/managed-toolchain/lock/built-wheels/tensorrt.whl\n"
+            elif '"tensorrt_python"' in script:
+                output = json.dumps(
+                    {
+                        "python": "3.12",
+                        "cuda": self.cuda_version,
+                        "tensorrt_python": "11.2.0.113",
+                        "tensorrt_native": "11.2.0.113",
+                        "tensorrt_headers": "11.2.0.113",
+                        "tensorrt_include_dir": (
+                            "/target/state/managed-toolchain/lock/headers/usr/include/"
+                            "x86_64-linux-gnu"
+                        ),
+                        "tensorrt_library": ("/target/state/venv/tensorrt_libs/libnvinfer.so"),
+                        "cuda_root": arguments[-1],
+                        "architecture": "x86_64",
+                        "evidence": {
+                            "nvcc": "a" * 64,
+                            "tensorrt-header": "b" * 64,
+                            "tensorrt-library": "c" * 64,
+                        },
+                    }
+                )
+            result = subprocess.CompletedProcess(arguments, returncode, output, "")
+            if check and returncode != 0:
+                raise DevToolkitError(f"simulated target command failure: {arguments}")
+            return result
+
+        return ContextHandle(
+            provider=self.descriptor,
+            identity=context.identity,
+            execution_identity={"python": "/usr/bin/python3"},
+            locator=context.locator,
+            capabilities=context.capabilities,
+            _executor=execute,
+            _path_mapper=lambda path: f"/target/state/{path.path}",
+        )
+
+    def execute(self, context, command, **kwargs):
+        del kwargs
+        return context.execute(command)
+
+
+class ManagedCudaToolchainSource:
+    descriptor = ProviderDescriptor("test-managed", "tests==1", 1)
+
+    def __init__(self) -> None:
+        self.provisioned = False
+
+    def resolve(self, request, context, *, repository, runner):
+        del context, repository, runner
+        return (
+            ToolchainCandidate(
+                provider=self.descriptor,
+                origin="managed",
+                tensorrt=request.tensorrt,
+                cuda="13.3",
+                python=request.python,
+                identity={"distribution": "test"},
+                artifacts=(
+                    ArtifactPin(
+                        name="cuda-toolkit",
+                        uri="https://example.invalid/cuda-13.3.tar.xz",
+                        sha256="a" * 64,
+                    ),
+                ),
+            ),
+        )
+
+    def provision(self, lock, context, *, repository, state_dir, runner):
+        del context, repository, state_dir, runner
+        self.provisioned = True
+        return ToolchainHandle(
+            provider=self.descriptor,
+            identity=lock.toolchain.identity,
+            runtime=ToolchainRuntime(
+                python_executable="python3",
+                cuda_root="/managed/cuda",
+                nvcc="/managed/cuda/bin/nvcc",
+                tensorrt_include_dir="/managed/include",
+                tensorrt_library="/managed/lib/libnvinfer.so",
+            ),
+        )
+
+    def observe(self, lock, context, toolchain, *, repository, runner):
+        del context, repository, runner
+        return ToolchainObservation(
+            python_version=lock.toolchain.python,
+            cuda_version=lock.toolchain.cuda,
+            tensorrt_python_version=lock.toolchain.tensorrt,
+            tensorrt_native_version=lock.toolchain.tensorrt,
+            tensorrt_header_version=lock.toolchain.tensorrt,
+            tensorrt_include_dir=toolchain.runtime.tensorrt_include_dir,
+            tensorrt_library=toolchain.runtime.tensorrt_library,
+            cuda_root=toolchain.runtime.cuda_root,
+            evidence={"toolchain": "b" * 64},
+        )
+
+
+class CatalogMaterializer(ManagedCudaToolchainSource):
+    descriptor = ProviderDescriptor("test-catalog-materializer", "tests==1", 1)
+
+    def resolve(self, request, context, *, repository, runner):
+        del request, context, repository, runner
+        return ()
+
+
+def test_arbitrary_tensorrt_reaches_provider_without_a_cohort(tmp_path: Path) -> None:
+    source = ExistingToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(source)
+    state_root = tmp_path / "state"
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=state_root,
+        providers=registry.freeze(),
+    )
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            cuda=CudaPolicy.system_first(fallback="13.3"),
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+
+    assert source.requested_versions == ["11.2.0.113"]
+    assert lock.tensorrt == "11.2.0.113"
+    assert lock.cuda == "12.8"
+    assert lock.cuda_origin == "system"
+    assert len(lock.lock_id) == 64
+    assert not state_root.exists()
+
+
+def test_missing_version_falls_through_to_a_toolchain_catalog(tmp_path: Path) -> None:
+    materializer = CatalogMaterializer()
+    catalog = RecordingToolchainCatalog(materializer.descriptor)
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(EmptySystemToolchainSource())
+    registry.register_toolchain(materializer)
+    registry.register_catalog(catalog)
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+        )
+    )
+
+    assert catalog.requests == ["11.2.0.113"]
+    assert lock.toolchain.provider == materializer.descriptor
+    assert lock.toolchain.origin == "managed"
+    assert lock.toolchain.artifacts[0].sha256 == "f" * 64
+
+
+def test_exact_installed_toolchain_does_not_query_catalog(tmp_path: Path) -> None:
+    installed = ExistingToolchainSource()
+    catalog = RecordingToolchainCatalog(installed.descriptor)
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(installed)
+    registry.register_catalog(catalog)
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+        )
+    )
+
+    assert lock.toolchain.origin == "system"
+    assert catalog.requests == []
+
+
+def test_ambiguous_installed_toolchains_do_not_query_a_catalog(tmp_path: Path) -> None:
+    installed = ExistingToolchainSource()
+    alternate = AlternateExistingToolchainSource()
+    catalog = RecordingToolchainCatalog(installed.descriptor)
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(installed)
+    registry.register_toolchain(alternate)
+    registry.register_catalog(catalog)
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    with pytest.raises(IncompatibleCombination, match="ambiguous exact candidates"):
+        toolkit.resolve(
+            EnvironmentRequest(
+                tensorrt="11.2.0.113",
+                target=ExecutionTarget("test-local"),
+            )
+        )
+
+    assert catalog.requests == []
+
+
+def test_managed_catalog_installs_into_an_isolated_container_prefix(tmp_path: Path) -> None:
+    context = ManagedContainerContext()
+    materializer = ManagedArtifactToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(context)
+    registry.register_toolchain(materializer)
+    registry.register_catalog(ManagedContainerCatalog(materializer.descriptor))
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-container"),
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    assert environment.observation.tensorrt_native_version == "11.2.0.113"
+    pip_install = next(
+        command for command in context.commands if command[1:4] == ["-m", "pip", "install"]
+    )
+    assert pip_install[0].startswith(f"/target/state/managed-toolchain/{lock.lock_id}/venv/")
+    assert pip_install[0] != "/usr/bin/python3"
+    assert "--no-index" in pip_install
+    assert environment.context.environment["PATH"].endswith(
+        ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+    )
+    assert environment.context.environment["LD_LIBRARY_PATH"].endswith(":/image/lib")
+
+
+def test_managed_target_bootstraps_python_without_ensurepip(tmp_path: Path) -> None:
+    context = ManagedContainerContext()
+    context.venv_requires_bootstrap = True
+    materializer = ManagedArtifactToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(context)
+    registry.register_toolchain(materializer)
+    registry.register_catalog(BootstrapManagedContainerCatalog(materializer.descriptor))
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-container"),
+        )
+    )
+    toolkit.provision(lock)
+
+    venv_commands = [command for command in context.commands if command[1:3] == ["-m", "venv"]]
+    assert any("--without-pip" in command for command in venv_commands)
+    bootstrap_install_index = next(
+        index
+        for index, command in enumerate(context.commands)
+        if command[1:4] == ["-m", "pip", "install"]
+        and "python-bootstrap-pip.whl" in " ".join(command)
+    )
+    bootstrap_environment = context.command_environments[bootstrap_install_index]
+    assert "python-bootstrap-pip.whl" in bootstrap_environment["PYTHONPATH"]
+    wheel_build = next(
+        command for command in context.commands if command[1:3] == ["-m", "pip"] and "wheel" in command
+    )
+    assert wheel_build[0].endswith("/venv/bin/python")
+    assert all(
+        "--no-cache-dir" in command
+        for command in context.commands
+        if command[1:3] == ["-m", "pip"] and command[3] in {"install", "wheel"}
+    )
+
+
+def test_managed_target_reuses_a_completed_toolchain_prefix(tmp_path: Path) -> None:
+    context = ManagedContainerContext()
+    materializer = ManagedArtifactToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(context)
+    registry.register_toolchain(materializer)
+    registry.register_catalog(ManagedContainerCatalog(materializer.descriptor))
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-container"),
+        )
+    )
+
+    first = toolkit.provision(lock)
+    first_wheel_builds = sum(
+        command[1:3] == ["-m", "pip"] and "wheel" in command for command in context.commands
+    )
+    first_downloads = sum(
+        "artifact download failed" in command[2]
+        for command in context.commands
+        if len(command) > 2 and command[1] == "-c"
+    )
+    second = toolkit.provision(lock)
+
+    assert second.environment_id == first.environment_id
+    assert sum(
+        command[1:3] == ["-m", "pip"] and "wheel" in command for command in context.commands
+    ) == first_wheel_builds
+    assert sum(
+        "artifact download failed" in command[2]
+        for command in context.commands
+        if len(command) > 2 and command[1] == "-c"
+    ) == first_downloads
+
+
+def test_managed_cuda_components_are_extracted_into_the_target_prefix(
+    tmp_path: Path,
+) -> None:
+    context = ManagedContainerContext()
+    context.cuda_version = "13.3"
+    materializer = ManagedArtifactToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(context)
+    registry.register_toolchain(materializer)
+    registry.register_catalog(ManagedCudaContainerCatalog(materializer.descriptor))
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-container"),
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    extraction = next(command for command in context.commands if command[0] == "tar")
+    assert "--strip-components=1" in extraction
+    assert environment.toolchain.runtime.cuda_root.endswith(f"/{lock.lock_id}/cuda")
+    assert environment.observation.cuda_version == "13.3"
+
+
+def test_system_first_falls_back_to_managed_cuda_13_3(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(EmptySystemToolchainSource())
+    registry.register_toolchain(ManagedCudaToolchainSource())
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.0.114",
+            target=ExecutionTarget("test-local"),
+        )
+    )
+
+    assert lock.cuda == "13.3"
+    assert lock.cuda_origin == "managed-default"
+    assert lock.toolchain.artifacts[0].sha256 == "a" * 64
+
+
+def test_adopt_only_never_materializes_a_managed_toolchain(tmp_path: Path) -> None:
+    source = ManagedCudaToolchainSource()
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(source)
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.0.114",
+            target=ExecutionTarget("test-local"),
+        )
+    )
+
+    with pytest.raises(AttestationFailed, match="adopt-only"):
+        toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+
+    assert source.provisioned is False
+
+
+@pytest.mark.parametrize("version", ["latest", "11.2", ">=11.1", "11.2.*"])
+def test_environment_request_requires_an_exact_four_part_tensorrt_version(
+    version: str,
+) -> None:
+    with pytest.raises(DevToolkitError, match="exact four-part"):
+        EnvironmentRequest(tensorrt=version, target=ExecutionTarget.local())
+
+
+def test_cuda_policy_rejects_an_unknown_runtime_kind() -> None:
+    with pytest.raises(DevToolkitError, match="CUDA policy kind"):
+        CudaPolicy("unknown")  # type: ignore[arg-type]
+
+
+def test_environment_lock_rejects_a_tampered_identity(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    lock = DevToolkit.from_checkout(tmp_path, providers=registry.freeze()).resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+
+    with pytest.raises(DevToolkitError, match="lock ID"):
+        replace(lock, lock_id="../outside")
+
+
+def test_builtin_local_provider_discovers_complete_system_toolchain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cuda = tmp_path / "cuda"
+    (cuda / "bin").mkdir(parents=True)
+    (cuda / "include").mkdir()
+    (cuda / "lib64").mkdir()
+    for relative in (
+        "bin/nvcc",
+        "include/cuda.h",
+        "lib64/libcudart.so",
+        "lib64/libcublas.so",
+        "lib64/libcurand.so",
+    ):
+        (cuda / relative).touch()
+    trt_include = tmp_path / "trt" / "include"
+    trt_library_dir = tmp_path / "trt" / "lib"
+    trt_include.mkdir(parents=True)
+    trt_library_dir.mkdir(parents=True)
+    (trt_library_dir / "libnvinfer.so").touch()
+    major, minor, patch, build = "11.2.0.113".split(".")
+    (trt_include / "NvInferVersion.h").write_text(
+        "\n".join(
+            (
+                f"#define NV_TENSORRT_MAJOR {major}",
+                f"#define NV_TENSORRT_MINOR {minor}",
+                f"#define NV_TENSORRT_PATCH {patch}",
+                f"#define NV_TENSORRT_BUILD {build}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CUDA_HOME", str(cuda))
+    monkeypatch.setenv("TRTMC_TRT_INCLUDE_DIR", str(trt_include))
+    monkeypatch.setenv("TRTMC_TRT_LIBRARY_DIR", str(trt_library_dir))
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=BuiltinProbeRunner())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(python="python3.12"),
+        )
+    )
+
+    assert lock.toolchain.provider.name == "system"
+    assert lock.toolchain.identity["cuda_root"] == str(cuda)
+    assert lock.toolchain.identity["tensorrt_include_dir"] == str(trt_include)
+
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+
+    assert environment.observation.cuda_version == "12.8"
+    assert environment.observation.tensorrt_header_version == "11.2.0.113"
+
+
+def test_resolution_distinguishes_unavailable_from_incompatible(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(EmptySystemToolchainSource())
+    unavailable = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    with pytest.raises(ArtifactUnavailable):
+        unavailable.resolve(
+            EnvironmentRequest(
+                tensorrt="11.2.0.113",
+                target=ExecutionTarget("test-local"),
+            )
+        )
+
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    incompatible = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+
+    with pytest.raises(IncompatibleCombination):
+        incompatible.resolve(
+            EnvironmentRequest(
+                tensorrt="11.2.0.113",
+                cuda=CudaPolicy.exact("13.3"),
+                target=ExecutionTarget("test-local"),
+            )
+        )
+
+
+def test_provision_attests_and_writes_a_v3_receipt(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    state_root = tmp_path / "state"
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=state_root,
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+
+    environment = toolkit.provision(lock)
+
+    assert environment.environment_id != lock.lock_id
+    assert environment.observation.tensorrt_header_version == "11.2.0.113"
+    receipt = json.loads(environment.receipt.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 3
+    assert receipt["lock_id"] == lock.lock_id
+    assert receipt["cuda_origin"] == "system"
+    assert receipt["observed"]["tensorrt_native_version"] == "11.2.0.113"
+
+
+def test_provision_rejects_a_different_toolchain_provider_implementation(
+    tmp_path: Path,
+) -> None:
+    original = ProviderRegistry()
+    original.register_context(StaticLocalContext())
+    original.register_toolchain(ExistingToolchainSource())
+    lock = DevToolkit.from_checkout(tmp_path, providers=original.freeze()).resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    replacement = ProviderRegistry()
+    replacement.register_context(StaticLocalContext())
+    replacement.register_toolchain(ReplacementToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=replacement.freeze(),
+    )
+
+    with pytest.raises(AttestationFailed, match="toolchain provider"):
+        toolkit.provision(lock)
+
+
+def test_provision_records_failure_when_locked_provider_is_not_registered(
+    tmp_path: Path,
+) -> None:
+    original = ProviderRegistry()
+    original.register_context(StaticLocalContext())
+    original.register_toolchain(ExistingToolchainSource())
+    lock = DevToolkit.from_checkout(tmp_path, providers=original.freeze()).resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    missing_toolchain = ProviderRegistry()
+    missing_toolchain.register_context(StaticLocalContext())
+    state_root = tmp_path / "state"
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=state_root,
+        providers=missing_toolchain.freeze(),
+    )
+
+    with pytest.raises(DevToolkitError, match="Unknown toolchain source provider"):
+        toolkit.provision(lock)
+
+    state_dir = state_root / "environments" / lock.lock_id
+    failure = json.loads((state_dir / "provision-failure.json").read_text(encoding="utf-8"))
+    assert failure["error_type"] == "DevToolkitError"
+    assert not (state_dir / "provision-receipt.json").exists()
+
+
+def test_provision_serializes_mutation_for_the_same_environment(tmp_path: Path) -> None:
+    context = BlockingLocalContext()
+    registry = ProviderRegistry()
+    registry.register_context(context)
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    failures: list[BaseException] = []
+
+    def provision() -> None:
+        try:
+            toolkit.provision(lock)
+        except BaseException as error:
+            failures.append(error)
+
+    first = threading.Thread(target=provision)
+    second = threading.Thread(target=provision)
+    first.start()
+    assert context.first_entered.wait(timeout=5)
+    second.start()
+    assert not context.second_entered.wait(timeout=0.2)
+    context.release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert context.second_entered.is_set()
+    assert failures == []
+
+
+def test_json_receipt_replace_failure_preserves_previous_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    receipt_module.write_json(receipt, {"status": "previous"})
+
+    def fail_replace(source, destination) -> None:
+        del source, destination
+        raise OSError("simulated interrupted replace")
+
+    monkeypatch.setattr(receipt_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="interrupted replace"):
+        receipt_module.write_json(receipt, {"status": "new"})
+
+    assert json.loads(receipt.read_text(encoding="utf-8")) == {"status": "previous"}
+    assert list(tmp_path.glob(".receipt.json.*.tmp")) == []
+
+
+def test_builtin_docker_provider_adopts_a_probed_campaign_container(
+    tmp_path: Path,
+) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(container="jedha-campaign"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+
+    assert lock.toolchain.provider.name == "container-image"
+    assert lock.context.identity["daemon_id"] == "daemon-789"
+    assert lock.context.identity["container_id"] == "container-123"
+    assert lock.context.identity["image_id"] == "sha256:image-456"
+    assert environment.context.locator["container"] == "jedha-campaign"
+    assert environment.observation.tensorrt_native_version == "11.0.2.2"
+    assert not any("run" in command[:5] for command in runner.commands)
+
+
+def test_docker_provider_rejects_cli_without_private_exec_env_files(
+    tmp_path: Path,
+) -> None:
+    runner = DockerAdoptionRunner()
+    runner.client_version = "19.03.15"
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=runner)
+
+    with pytest.raises(DevToolkitError, match="Docker CLI 20.10 or newer"):
+        toolkit.resolve(
+            EnvironmentRequest(
+                tensorrt="11.0.2.2",
+                target=ExecutionTarget.docker(container="jedha-campaign"),
+                architecture="aarch64",
+            )
+        )
+
+
+def test_docker_environment_identity_distinguishes_container_instances(
+    tmp_path: Path,
+) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=runner)
+    request = EnvironmentRequest(
+        tensorrt="11.0.2.2",
+        target=ExecutionTarget.docker(container="campaign"),
+        architecture="aarch64",
+    )
+
+    first = toolkit.resolve(request)
+    runner.container_id = "container-456"
+    second = toolkit.resolve(request)
+
+    assert first.context.identity["image_id"] == second.context.identity["image_id"]
+    assert first.context.identity["container_id"] != second.context.identity["container_id"]
+    assert first.lock_id != second.lock_id
+
+
+def test_docker_environment_identity_includes_effective_path_mapping(
+    tmp_path: Path,
+) -> None:
+    runner = DockerAdoptionRunner()
+    first_toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "first-state",
+        runner=runner,
+    )
+    second_toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "second-state",
+        runner=runner,
+    )
+    first_lock = first_toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(
+                container="jedha-campaign",
+                workspace="/workspace/first",
+            ),
+            architecture="aarch64",
+        )
+    )
+    second_lock = second_toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(
+                container="jedha-campaign",
+                workspace="/workspace/second",
+            ),
+            architecture="aarch64",
+        )
+    )
+
+    first = first_toolkit.provision(first_lock, policy=ProvisionPolicy.ADOPT_ONLY)
+    second = second_toolkit.provision(second_lock, policy=ProvisionPolicy.ADOPT_ONLY)
+
+    assert first_lock.lock_id != second_lock.lock_id
+    assert first.environment_id != second.environment_id
+
+
+def test_changed_toolchain_evidence_blocks_execution(tmp_path: Path) -> None:
+    source = MutableEvidenceSource()
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(source)
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+    source.digest = "b" * 64
+
+    with pytest.raises(AttestationFailed, match="evidence changed"):
+        toolkit.run(environment, CommandSpec(("trtmc", "version")))
+
+
+def test_docker_command_forwards_environment_without_values_in_argv(tmp_path: Path) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(container="jedha-campaign"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+
+    toolkit.run(
+        environment,
+        CommandSpec(("trtmc", "version"), environment={"TOKEN": "super-secret"}),
+    )
+
+    assert "super-secret" not in " ".join(runner.commands[-1])
+    assert "--env-file" in runner.commands[-1]
+    assert "container-123" in runner.commands[-1]
+    assert "jedha-campaign" not in runner.commands[-1]
+    environment_path, content, mode = runner.environment_files[-1]
+    assert content == "TOKEN=super-secret\n"
+    assert mode == 0o600
+    assert not environment_path.exists()
+    assert runner.environments[-1] is None
+
+
+def test_docker_command_rejects_a_changed_daemon_after_attestation(tmp_path: Path) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(container="jedha-campaign"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+    command_count = len(runner.commands)
+    runner.daemon_id = "different-daemon"
+
+    with pytest.raises(DevToolkitError, match="Docker daemon changed"):
+        toolkit.run(environment, CommandSpec(("trtmc", "version")))
+
+    new_commands = runner.commands[command_count:]
+    assert len(new_commands) == 2
+    assert new_commands[1][:4] == ["docker", "--context", "test-context", "info"]
+
+
+def test_docker_command_rejects_a_replaced_container_after_attestation(
+    tmp_path: Path,
+) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(container="jedha-campaign"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+    command_count = len(runner.commands)
+    runner.container_id = "replacement-container"
+
+    with pytest.raises(DevToolkitError, match="container identity changed"):
+        toolkit.run(environment, CommandSpec(("trtmc", "version")))
+
+    new_commands = runner.commands[command_count:]
+    assert len(new_commands) == 3
+    assert not any("trtmc" in command for command in new_commands)
+
+
+def test_docker_command_reattests_mutable_toolchain_before_execution(tmp_path: Path) -> None:
+    runner = DockerAdoptionRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.0.2.2",
+            target=ExecutionTarget.docker(container="jedha-campaign"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock, policy=ProvisionPolicy.ADOPT_ONLY)
+    command_count = len(runner.commands)
+    runner.tensorrt_version = "11.0.0.114"
+
+    with pytest.raises(AttestationFailed, match="expected 11.0.2.2"):
+        toolkit.run(environment, CommandSpec(("trtmc", "version")))
+
+    new_commands = runner.commands[command_count:]
+    assert not any("trtmc" in command for command in new_commands)
+
+
+def test_generic_command_is_routed_by_the_execution_context(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    runner = CommandRecordingRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    result = toolkit.run(
+        environment,
+        CommandSpec(
+            ("trtmc", "inspect", repository_path("example.bundle")),
+            cwd=repository_path("."),
+        ),
+        capture_output=True,
+    )
+
+    assert runner.commands[-1] == ["trtmc", "inspect", str(tmp_path / "example.bundle")]
+    assert result.stdout == "trtmc 0.1\n"
+    receipt = json.loads(result.receipt.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == 3
+    assert receipt["environment_id"] == environment.environment_id
+    assert receipt["occurrence_id"] != receipt["invocation_digest"]
+
+
+def test_run_trtmc_forwards_check_policy(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    runner = NonzeroCommandRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    result = toolkit.run_trtmc(environment, ("version",), check=False)
+
+    assert result.returncode == 7
+    assert runner.checks == [False]
+
+
+def test_command_failure_receipt_does_not_serialize_environment_values(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    state_root = tmp_path / "state"
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=state_root,
+        providers=registry.freeze(),
+        runner=SecretEchoFailureRunner(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    with pytest.raises(RuntimeError, match="super-secret"):
+        toolkit.run(
+            environment,
+            CommandSpec(("false",), environment={"TOKEN": "super-secret"}),
+        )
+
+    receipt = next((environment.state_dir / "commands").glob("*.json"))
+    assert "super-secret" not in receipt.read_text(encoding="utf-8")
+
+
+def test_native_build_identity_includes_source_sm_options_and_outputs(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    runner = CommandRecordingRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    build = toolkit.build(
+        environment,
+        TrtmcBuildRecipe(
+            targets=("trtmc",),
+            cmake_defines={"TRTMC_BUILD_TESTS": False},
+            cuda_architectures=("100",),
+        ),
+    )
+
+    assert len(build.build_request_id) == 64
+    assert len(build.build_id) == 64
+    assert build.build_id != build.build_request_id
+    assert build.artifacts[0].sha256 == "c" * 64
+    configure = next(command for command in runner.commands if command[:2] == ["cmake", "-S"])
+    assert "-DCMAKE_CUDA_ARCHITECTURES=100-real" in configure
+    assert "-DCMAKE_CUDA_COMPILER=/opt/nvidia/cuda/bin/nvcc" in configure
+    assert "-DCUDAToolkit_ROOT=/opt/nvidia/cuda" in configure
+    assert "-DTRTMC_BUILD_TESTS=OFF" in configure
+    assert "-DTRTMC_ENABLE_BYOK=OFF" in configure
+    assert "-DTRTMC_TRT_INCLUDE_DIR=/opt/nvidia/include" in configure
+    assert "-DTRTMC_TRT_LIBRARY=/opt/nvidia/lib/libnvinfer.so" in configure
+    assert not any(command[1:4] == ["-m", "pip", "install"] for command in runner.commands)
+    receipt = json.loads(build.receipt.read_text(encoding="utf-8"))
+    assert receipt["environment_id"] == environment.environment_id
+    assert receipt["source"]["revision"] == "b" * 40
+    assert receipt["artifacts"][0]["sha256"] == "c" * 64
+    source_git = next(command for command in runner.commands if "rev-parse" in command)
+    assert source_git[:3] == [
+        "git",
+        "-c",
+        f"safe.directory={tmp_path.resolve()}",
+    ]
+
+    command = toolkit.run_trtmc(environment, ("version",), build=build)
+    command_receipt = json.loads(command.receipt.read_text(encoding="utf-8"))
+    assert command_receipt["provenance"] == {
+        "build_id": build.build_id,
+        "artifact:trtmc": "c" * 64,
+    }
+    assert runner.commands[-1][0].endswith(f"builds/{build.build_request_id}/build/trtmc")
+
+    runner.artifact_digest = "d" * 64
+    with pytest.raises(DevToolkitError, match="changed after build"):
+        toolkit.run_trtmc(environment, ("version",), build=build)
+    assert runner.commands[-1][0] == "sha256sum"
+
+
+def test_native_recipe_resolves_thor_architecture_through_cuda_driver() -> None:
+    runtime = ToolchainRuntime(
+        python_executable="/managed/venv/bin/python",
+        cuda_root="/managed/cuda",
+        nvcc="/managed/cuda/bin/nvcc",
+        tensorrt_include_dir="/managed/include",
+        tensorrt_library="/managed/lib/libnvinfer.so",
+    )
+
+    def probe(command: CommandSpec) -> str:
+        arguments = [str(argument) for argument in command.arguments]
+        script = arguments[2] if len(arguments) > 2 and arguments[1] == "-c" else ""
+        if "cuDeviceGetAttribute" in script:
+            return "110\n"
+        if "shutil.which" in script:
+            return "Unix Makefiles\n"
+        if arguments[0] == "nvidia-smi":
+            raise FileNotFoundError("nvidia-smi")
+        raise AssertionError(arguments)
+
+    inputs = TrtmcBuildRecipe().inputs(
+        BuildContext(runtime=runtime, architecture="aarch64", _probe=probe)
+    )
+
+    assert inputs["cuda_architectures"] == ("110",)
+    assert inputs["generator"] == "Unix Makefiles"
+
+
+def test_native_recipe_auto_generator_prefers_ninja_when_available() -> None:
+    runtime = ToolchainRuntime(
+        python_executable="python3",
+        cuda_root="/cuda",
+        nvcc="/cuda/bin/nvcc",
+        tensorrt_include_dir="/trt/include",
+        tensorrt_library="/trt/lib/libnvinfer.so",
+    )
+
+    generator_probes: list[list[str]] = []
+
+    def probe(command: CommandSpec) -> str:
+        script = str(command.arguments[2])
+        if "shutil.which" in script:
+            generator_probes.append([str(argument) for argument in command.arguments])
+            return "Ninja\n"
+        raise AssertionError(command.arguments)
+
+    inputs = TrtmcBuildRecipe(cuda_architectures=("110",)).inputs(
+        BuildContext(runtime=runtime, architecture="aarch64", _probe=probe)
+    )
+
+    assert inputs["generator"] == "Ninja"
+    assert len(generator_probes) == 1
+
+
+def test_native_build_records_attestation_preflight_failure(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(FailingReattestationSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    with pytest.raises(RuntimeError, match="super-secret"):
+        toolkit.build(environment, TrtmcBuildRecipe(cuda_architectures=("100",)))
+
+    receipts = list((environment.state_dir / "builds" / "preflight").glob("*.json"))
+    assert len(receipts) == 1
+    payload = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["stage"] == "attestation"
+    assert payload["environment_id"] == environment.environment_id
+    assert payload["error_type"] == "RuntimeError"
+    assert "super-secret" not in receipts[0].read_text(encoding="utf-8")
+
+
+def test_identical_builds_are_serialized(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    runner = BlockingBuildRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+    recipe = TrtmcBuildRecipe(cuda_architectures=("100",))
+    results = []
+
+    first = threading.Thread(target=lambda: results.append(toolkit.build(environment, recipe)))
+    second = threading.Thread(target=lambda: results.append(toolkit.build(environment, recipe)))
+    first.start()
+    assert runner.first_configure_entered.wait(timeout=5)
+    second.start()
+    assert not runner.second_configure_entered.wait(timeout=0.2)
+    runner.release_first_configure.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not runner.second_configure_entered.is_set()
+    assert len(results) == 2
+    assert results[0].build_request_id == results[1].build_request_id
+
+
+def test_completed_build_receipt_skips_reexecution(tmp_path: Path) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    runner = CommandRecordingRunner()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+    recipe = TrtmcBuildRecipe(cuda_architectures=("100",), generator="Ninja")
+
+    first = toolkit.build(environment, recipe)
+    first_configures = sum(command[:2] == ["cmake", "-S"] for command in runner.commands)
+    first_builds = sum(command[:2] == ["cmake", "--build"] for command in runner.commands)
+    second = toolkit.build(environment, recipe)
+
+    assert second.build_id == first.build_id
+    assert sum(command[:2] == ["cmake", "-S"] for command in runner.commands) == first_configures
+    assert sum(command[:2] == ["cmake", "--build"] for command in runner.commands) == first_builds
+
+
+def test_qualification_is_optional_provenance_not_an_allowlist(
+    tmp_path: Path,
+) -> None:
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    (presets / "qualified.json").write_text(
+        json.dumps(
+            {
+                "id": "qualified-trt",
+                "status": "supported",
+                "requirements": {
+                    "execution": ["local"],
+                    "tensorrt": "11.2.0.113",
+                    "cuda": "12.8",
+                    "python": ["3.12"],
+                    "architecture": ["aarch64"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        providers=registry.freeze(),
+        qualifications=(JsonQualificationSource((presets,)),),
+    )
+
+    qualified = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+            preset="qualified-trt",
+            require_qualification=True,
+        )
+    )
+    unrestricted = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+
+    assert qualified.qualifications[0].name == "qualified-trt"
+    assert len(qualified.qualifications[0].digest) == 64
+    assert qualified.lock_id == unrestricted.lock_id
+
+
+def test_required_qualification_fails_without_restricting_default_resolution(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(tmp_path, providers=registry.freeze())
+    request = EnvironmentRequest(
+        tensorrt="11.2.0.113",
+        target=ExecutionTarget("test-local"),
+        architecture="aarch64",
+    )
+
+    assert toolkit.resolve(request).qualifications == ()
+    with pytest.raises(IncompatibleCombination, match="qualification"):
+        toolkit.resolve(
+            EnvironmentRequest(
+                tensorrt=request.tensorrt,
+                target=request.target,
+                architecture=request.architecture,
+                require_qualification=True,
+            )
+        )
+
+
+def test_invalid_optional_qualification_metadata_does_not_gate_resolution(
+    tmp_path: Path,
+) -> None:
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    (presets / "broken.json").write_text("{not-json", encoding="utf-8")
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        providers=registry.freeze(),
+        qualifications=(JsonQualificationSource((presets,)),),
+    )
+    request = EnvironmentRequest(
+        tensorrt="11.2.0.113",
+        target=ExecutionTarget("test-local"),
+        architecture="aarch64",
+    )
+
+    assert toolkit.resolve(request).qualifications == ()
+    with pytest.raises(DevToolkitError, match="Invalid qualification"):
+        toolkit.resolve(replace(request, require_qualification=True))
+
+
+@pytest.mark.parametrize("invalid", ([], {"python": 3.12}, {"python": [3.12]}))
+def test_qualification_rejects_invalid_requirement_shapes(
+    tmp_path: Path,
+    invalid: object,
+) -> None:
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    payload = {
+        "id": "malformed",
+        "status": "supported",
+        "requirements": invalid,
+    }
+    (presets / "malformed.json").write_text(json.dumps(payload), encoding="utf-8")
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        providers=registry.freeze(),
+        qualifications=(JsonQualificationSource((presets,)),),
+    )
+
+    with pytest.raises(DevToolkitError, match="Invalid qualification"):
+        toolkit.resolve(
+            EnvironmentRequest(
+                tensorrt="11.2.0.113",
+                target=ExecutionTarget("test-local"),
+                architecture="aarch64",
+                require_qualification=True,
+            )
+        )
+
+
+def test_builtin_managed_source_accepts_arbitrary_trt_with_pinned_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_HOME", str(tmp_path / "missing-cuda"))
+    artifacts = (
+        ArtifactPin(
+            name="tensorrt-headers",
+            uri="https://example.invalid/libnvinfer-headers.deb",
+            sha256="d" * 64,
+        ),
+        ArtifactPin(
+            name="tensorrt-wheel",
+            uri="https://example.invalid/tensorrt-11.2.0.113.whl?token=super-secret",
+            sha256="e" * 64,
+        ),
+        ArtifactPin(
+            name="cuda-component-nvcc",
+            uri="https://example.invalid/cuda-nvcc.tar.xz",
+            sha256="f" * 64,
+        ),
+    )
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=BuiltinProbeRunner())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            artifacts=artifacts,
+            toolchain_options={"cuda_artifacts": ["cuda-component-nvcc"]},
+        )
+    )
+
+    assert lock.toolchain.provider.name == "managed-artifacts"
+    assert lock.toolchain.cuda == "13.3"
+    assert lock.cuda_origin == "managed-default"
+    assert lock.toolchain.artifacts == artifacts
+    assert "super-secret" not in json.dumps(lock.as_dict())
+
+
+def test_builtin_managed_source_materializes_and_attests_pinned_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_HOME", str(tmp_path / "missing-cuda"))
+    headers = tmp_path / "libnvinfer-headers.deb"
+    wheel = tmp_path / "tensorrt-11.2.0.113-py3-none-any.whl"
+    cuda = tmp_path / "cuda-nvcc.tar.xz"
+    headers.write_bytes(b"pinned headers")
+    wheel.write_bytes(b"pinned wheel")
+    cuda.write_bytes(b"pinned CUDA")
+
+    def pin(name: str, path: Path) -> ArtifactPin:
+        return ArtifactPin(
+            name,
+            path.as_uri(),
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=ManagedProvisionRunner(tmp_path),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            artifacts=(
+                pin("tensorrt-headers", headers),
+                pin("tensorrt-wheel", wheel),
+                pin("cuda-component-nvcc", cuda),
+            ),
+            toolchain_options={"cuda_artifacts": ["cuda-component-nvcc"]},
+        )
+    )
+
+    environment = toolkit.provision(lock)
+
+    assert environment.observation.cuda_version == "13.3"
+    assert environment.observation.tensorrt_native_version == "11.2.0.113"
+    assert environment.context.environment["CUDA_HOME"] == str(tmp_path / "managed-cuda")
+    receipt = json.loads(environment.receipt.read_text(encoding="utf-8"))
+    assert receipt["observed"]["tensorrt_header_version"] == "11.2.0.113"
+
+
+def test_builtin_managed_source_rejects_an_incomplete_cuda_toolkit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_HOME", str(tmp_path / "missing-cuda"))
+    headers = tmp_path / "headers.deb"
+    wheel = tmp_path / "tensorrt.whl"
+    cuda = tmp_path / "cuda-nvcc.tar.xz"
+    headers.write_bytes(b"headers")
+    wheel.write_bytes(b"wheel")
+    cuda.write_bytes(b"CUDA")
+    artifacts = tuple(
+        ArtifactPin(
+            name,
+            path.as_uri(),
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+        for name, path in (
+            ("tensorrt-headers", headers),
+            ("tensorrt-wheel", wheel),
+            ("cuda-component-nvcc", cuda),
+        )
+    )
+    runner = ManagedProvisionRunner(tmp_path)
+    (runner.cuda / "lib" / "libcurand.so").unlink()
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            artifacts=artifacts,
+            toolchain_options={"cuda_artifacts": ["cuda-component-nvcc"]},
+        )
+    )
+
+    with pytest.raises(DevToolkitError, match="incomplete CUDA"):
+        toolkit.provision(lock)
+
+
+def test_managed_tensorrt_uses_complete_system_cuda_before_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cuda = tmp_path / "cuda"
+    for directory in (cuda / "bin", cuda / "include", cuda / "lib64"):
+        directory.mkdir(parents=True)
+    for relative in (
+        "bin/nvcc",
+        "include/cuda.h",
+        "lib64/libcudart.so",
+        "lib64/libcublas.so",
+        "lib64/libcurand.so",
+    ):
+        (cuda / relative).touch()
+    monkeypatch.setenv("CUDA_HOME", str(cuda))
+    monkeypatch.setenv("TRTMC_TRT_INCLUDE_DIR", str(tmp_path / "missing-trt"))
+    artifacts = (
+        ArtifactPin(
+            "tensorrt-headers",
+            "https://example.invalid/headers.deb",
+            "1" * 64,
+        ),
+        ArtifactPin(
+            "tensorrt-wheel",
+            "https://example.invalid/tensorrt.whl",
+            "2" * 64,
+        ),
+    )
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=BuiltinProbeRunner())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            artifacts=artifacts,
+        )
+    )
+
+    assert lock.toolchain.origin == "managed"
+    assert lock.toolchain.cuda_source == "system"
+    assert lock.cuda == "12.8"
+    assert lock.cuda_origin == "system"
+
+
+def test_environment_identity_depends_on_resolution_not_request_spelling(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    providers = registry.freeze()
+    toolkit_a = DevToolkit.from_checkout(tmp_path, providers=providers)
+    toolkit_b = DevToolkit.from_checkout(tmp_path, providers=providers)
+    common = {
+        "tensorrt": "11.2.0.113",
+        "target": ExecutionTarget("test-local"),
+        "architecture": "aarch64",
+    }
+
+    default_lock = toolkit_a.resolve(EnvironmentRequest(**common))
+    explicit_lock = toolkit_b.resolve(EnvironmentRequest(**common, cuda=CudaPolicy.exact("12.8")))
+
+    assert default_lock.lock_id == explicit_lock.lock_id
+    assert default_lock.cuda_origin == "system"
+    assert explicit_lock.cuda_origin == "explicit"
+
+
+def test_builtin_prefix_provider_uses_user_owned_toolchain_root(
+    tmp_path: Path,
+) -> None:
+    prefix = tmp_path / "toolchain"
+    for directory in (prefix / "bin", prefix / "include", prefix / "lib"):
+        directory.mkdir(parents=True)
+    for relative in (
+        "bin/nvcc",
+        "include/cuda.h",
+        "lib/libcudart.so",
+        "lib/libcublas.so",
+        "lib/libcurand.so",
+        "lib/libnvinfer.so",
+    ):
+        (prefix / relative).touch()
+    major, minor, patch, build = "11.2.0.113".split(".")
+    (prefix / "include" / "NvInferVersion.h").write_text(
+        "\n".join(
+            (
+                f"#define NV_TENSORRT_MAJOR {major}",
+                f"#define NV_TENSORRT_MINOR {minor}",
+                f"#define NV_TENSORRT_PATCH {patch}",
+                f"#define NV_TENSORRT_BUILD {build}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=BuiltinProbeRunner())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            toolchain="prefix",
+            toolchain_options={"prefix": str(prefix)},
+        )
+    )
+
+    assert lock.toolchain.provider.name == "prefix"
+    assert lock.toolchain.origin == "prefix"
+    assert lock.toolchain.identity["cuda_root"] == str(prefix)
+
+
+def test_managed_tensorrt_follows_cuda_from_explicit_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prefix = tmp_path / "cuda"
+    for directory in (prefix / "bin", prefix / "include", prefix / "lib"):
+        directory.mkdir(parents=True)
+    for relative in (
+        "bin/nvcc",
+        "include/cuda.h",
+        "lib/libcudart.so",
+        "lib/libcublas.so",
+        "lib/libcurand.so",
+    ):
+        (prefix / relative).touch()
+    monkeypatch.setenv("CUDA_HOME", str(tmp_path / "missing-cuda"))
+    artifacts = (
+        ArtifactPin(
+            "tensorrt-headers",
+            "https://example.invalid/headers.deb",
+            "3" * 64,
+        ),
+        ArtifactPin(
+            "tensorrt-wheel",
+            "https://example.invalid/tensorrt.whl",
+            "4" * 64,
+        ),
+    )
+    toolkit = DevToolkit.from_checkout(tmp_path, runner=BuiltinProbeRunner())
+
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget.local(),
+            toolchain_options={"cuda_prefix": str(prefix)},
+            artifacts=artifacts,
+        )
+    )
+
+    assert lock.toolchain.provider.name == "managed-artifacts"
+    assert lock.toolchain.cuda_source == "prefix"
+    assert lock.toolchain.cuda == "12.8"
+    assert lock.cuda_origin == "system"

--- a/tools/tests/test_devtoolkit_capabilities.py
+++ b/tools/tests/test_devtoolkit_capabilities.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import gzip
 import hashlib
 import json
+import math
 import subprocess
 import sys
 import threading
@@ -54,10 +55,11 @@ from trtmc_devtoolkit.spi import (  # noqa: E402
 )
 from trtmc_devtoolkit import receipt as receipt_module  # noqa: E402
 from trtmc_devtoolkit import catalogs as catalogs_module  # noqa: E402
-from trtmc_devtoolkit.building import BuildContext  # noqa: E402
+from trtmc_devtoolkit.building import BuildContext, Builder  # noqa: E402
 from trtmc_devtoolkit.builtin_providers import (  # noqa: E402
     ManagedArtifactToolchainSource,
 )
+from trtmc_devtoolkit.runner import CommandRunner, command_output  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -602,7 +604,7 @@ class CommandRecordingRunner:
             output = "b" * 40 + "\n"
         elif arguments[-3:-1] == ["diff", "--binary"]:
             output = ""
-        elif arguments[-3:-1] == ["ls-files", "--others"]:
+        elif "ls-files" in arguments and "--others" in arguments:
             output = ""
         elif arguments[0] == "sha256sum":
             output = f"{self.artifact_digest}  {arguments[1]}\n"
@@ -828,6 +830,18 @@ class ExistingToolchainSource:
 
 class ReplacementToolchainSource(ExistingToolchainSource):
     descriptor = ProviderDescriptor("test-system", "tests==2", 1)
+
+
+class MismatchedIdentityToolchainSource(ExistingToolchainSource):
+    def provision(self, lock, context, *, repository, state_dir, runner):
+        toolchain = super().provision(
+            lock,
+            context,
+            repository=repository,
+            state_dir=state_dir,
+            runner=runner,
+        )
+        return replace(toolchain, identity={"prefix": "/different"})
 
 
 class AlternateExistingToolchainSource(ExistingToolchainSource):
@@ -1473,6 +1487,25 @@ def test_cuda_policy_rejects_an_unknown_runtime_kind() -> None:
         CudaPolicy("unknown")  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize("value", (math.nan, math.inf, -math.inf))
+def test_capability_identities_reject_nonfinite_numbers(value: float) -> None:
+    with pytest.raises(DevToolkitError, match="finite JSON numbers"):
+        ExecutionTarget("test-local", {"weight": value})
+
+    with pytest.raises(DevToolkitError, match="finite JSON numbers"):
+        ToolchainHandle(
+            provider=ExistingToolchainSource.descriptor,
+            identity={"weight": value},
+            runtime=ToolchainRuntime(
+                python_executable="python3",
+                cuda_root="/cuda",
+                nvcc="/cuda/bin/nvcc",
+                tensorrt_include_dir="/tensorrt/include",
+                tensorrt_library="/tensorrt/lib/libnvinfer.so",
+            ),
+        )
+
+
 def test_environment_lock_rejects_a_tampered_identity(tmp_path: Path) -> None:
     registry = ProviderRegistry()
     registry.register_context(StaticLocalContext())
@@ -1628,6 +1661,34 @@ def test_provision_rejects_a_different_toolchain_provider_implementation(
         toolkit.provision(lock)
 
 
+def test_provision_rejects_a_toolchain_identity_that_differs_from_the_lock(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(MismatchedIdentityToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+
+    with pytest.raises(AttestationFailed, match="toolchain identity"):
+        toolkit.provision(lock)
+
+    state_dir = tmp_path / "state" / "environments" / lock.lock_id
+    failure = json.loads((state_dir / "provision-failure.json").read_text(encoding="utf-8"))
+    assert failure["error_type"] == "AttestationFailed"
+    assert not (state_dir / "provision-receipt.json").exists()
+
+
 def test_provision_records_failure_when_locked_provider_is_not_registered(
     tmp_path: Path,
 ) -> None:
@@ -1718,6 +1779,15 @@ def test_json_receipt_replace_failure_preserves_previous_state(
 
     assert json.loads(receipt.read_text(encoding="utf-8")) == {"status": "previous"}
     assert list(tmp_path.glob(".receipt.json.*.tmp")) == []
+
+
+def test_json_receipt_rejects_nonfinite_numbers(tmp_path: Path) -> None:
+    receipt = tmp_path / "receipt.json"
+
+    with pytest.raises(ValueError, match="JSON compliant"):
+        receipt_module.write_json(receipt, {"weight": math.nan})
+
+    assert not receipt.exists()
 
 
 def test_builtin_docker_provider_adopts_a_probed_campaign_container(
@@ -2025,6 +2095,30 @@ def test_run_trtmc_forwards_check_policy(tmp_path: Path) -> None:
     assert runner.checks == [False]
 
 
+def test_command_output_explicitly_requests_checked_execution(tmp_path: Path) -> None:
+    checks: list[bool] = []
+
+    class DefaultUncheckedRunner:
+        def run(
+            self,
+            command,
+            *,
+            cwd,
+            env=None,
+            check=False,
+            capture_output=False,
+            timeout=None,
+        ):
+            del cwd, env, capture_output, timeout
+            checks.append(check)
+            return subprocess.CompletedProcess(command, 0, "observed\n", "")
+
+    output = command_output(DefaultUncheckedRunner(), ("probe",), cwd=tmp_path)
+
+    assert output == "observed"
+    assert checks == [True]
+
+
 def test_command_failure_receipt_does_not_serialize_environment_values(
     tmp_path: Path,
 ) -> None:
@@ -2055,6 +2149,50 @@ def test_command_failure_receipt_does_not_serialize_environment_values(
 
     receipt = next((environment.state_dir / "commands").glob("*.json"))
     assert "super-secret" not in receipt.read_text(encoding="utf-8")
+
+
+def test_source_snapshot_handles_untracked_unicode_and_newline_names(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "checkout"
+    repository.mkdir()
+    (repository / "pyproject.toml").touch()
+    (repository / "families").mkdir()
+    (repository / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    for command in (
+        ("git", "init", "--quiet"),
+        ("git", "config", "user.name", "DevToolkit Test"),
+        ("git", "config", "user.email", "devtoolkit@example.invalid"),
+        ("git", "add", "pyproject.toml", "tracked.txt"),
+        ("git", "commit", "--quiet", "-m", "initial"),
+    ):
+        subprocess.run(command, cwd=repository, check=True, capture_output=True, text=True)
+    (repository / "模型\nsource.cpp").write_text("untracked\n", encoding="utf-8")
+
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    providers = registry.freeze()
+    runner = CommandRunner()
+    toolkit = DevToolkit.from_checkout(
+        repository,
+        state_root=tmp_path / "state",
+        providers=providers,
+        runner=runner,
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    snapshot = Builder(repository, providers, runner)._source_snapshot(environment)
+
+    assert snapshot.dirty is True
+    assert len(snapshot.content_digest) == 64
 
 
 def test_native_build_identity_includes_source_sm_options_and_outputs(
@@ -2154,6 +2292,48 @@ def test_native_recipe_resolves_thor_architecture_through_cuda_driver() -> None:
     assert inputs["generator"] == "Unix Makefiles"
 
 
+@pytest.mark.parametrize("architecture", ("100-real", "89-virtual"))
+def test_native_recipe_accepts_cmake_cuda_architecture_suffixes(
+    architecture: str,
+) -> None:
+    runtime = ToolchainRuntime(
+        python_executable="python3",
+        cuda_root="/cuda",
+        nvcc="/cuda/bin/nvcc",
+        tensorrt_include_dir="/tensorrt/include",
+        tensorrt_library="/tensorrt/lib/libnvinfer.so",
+    )
+
+    inputs = TrtmcBuildRecipe(
+        cuda_architectures=(architecture,),
+        generator="Ninja",
+    ).inputs(BuildContext(runtime=runtime, architecture="x86_64", _probe=lambda _: ""))
+
+    assert inputs["cuda_architectures"] == (architecture,)
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    ("90a", "100f", "100-real-real", "real", "100-"),
+)
+def test_native_recipe_rejects_invalid_cuda_architecture_forms(
+    architecture: str,
+) -> None:
+    runtime = ToolchainRuntime(
+        python_executable="python3",
+        cuda_root="/cuda",
+        nvcc="/cuda/bin/nvcc",
+        tensorrt_include_dir="/tensorrt/include",
+        tensorrt_library="/tensorrt/lib/libnvinfer.so",
+    )
+
+    with pytest.raises(DevToolkitError, match="CUDA architecture"):
+        TrtmcBuildRecipe(
+            cuda_architectures=(architecture,),
+            generator="Ninja",
+        ).inputs(BuildContext(runtime=runtime, architecture="x86_64", _probe=lambda _: ""))
+
+
 def test_native_recipe_auto_generator_prefers_ninja_when_available() -> None:
     runtime = ToolchainRuntime(
         python_executable="python3",
@@ -2209,6 +2389,49 @@ def test_native_build_records_attestation_preflight_failure(tmp_path: Path) -> N
     assert payload["environment_id"] == environment.environment_id
     assert payload["error_type"] == "RuntimeError"
     assert "super-secret" not in receipts[0].read_text(encoding="utf-8")
+
+
+def test_native_build_records_identity_serialization_preflight_failure(
+    tmp_path: Path,
+) -> None:
+    class NonfiniteIdentityRecipe:
+        descriptor = "nonfinite-identity==1"
+
+        def inputs(self, context):
+            del context
+            return {"weight": math.nan}
+
+        def plan(self, context, inputs, build_dir):
+            del context, inputs, build_dir
+            raise AssertionError("invalid build identity must fail before planning")
+
+    registry = ProviderRegistry()
+    registry.register_context(StaticLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        state_root=tmp_path / "state",
+        providers=registry.freeze(),
+        runner=CommandRecordingRunner(),
+    )
+    lock = toolkit.resolve(
+        EnvironmentRequest(
+            tensorrt="11.2.0.113",
+            target=ExecutionTarget("test-local"),
+            architecture="aarch64",
+        )
+    )
+    environment = toolkit.provision(lock)
+
+    with pytest.raises(DevToolkitError, match="JSON-compatible"):
+        toolkit.build(environment, NonfiniteIdentityRecipe())
+
+    receipts = list((environment.state_dir / "builds" / "preflight").glob("*.json"))
+    assert len(receipts) == 1
+    payload = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["stage"] == "build-identity"
+    assert payload["error_type"] == "DevToolkitError"
 
 
 def test_identical_builds_are_serialized(tmp_path: Path) -> None:
@@ -2331,6 +2554,61 @@ def test_qualification_is_optional_provenance_not_an_allowlist(
     assert qualified.qualifications[0].name == "qualified-trt"
     assert len(qualified.qualifications[0].digest) == 64
     assert qualified.lock_id == unrestricted.lock_id
+
+
+def test_context_qualification_cannot_override_resolved_environment_facts(
+    tmp_path: Path,
+) -> None:
+    class SpoofingLocalContext(StaticLocalContext):
+        def resolve(self, request, *, repository, runner):
+            context = super().resolve(request, repository=repository, runner=runner)
+            return replace(
+                context,
+                qualification={
+                    "execution": "local",
+                    "tensorrt": "0.0.0.0",
+                    "cuda": "13.3",
+                    "python": "2.7",
+                    "architecture": "x86_64",
+                },
+            )
+
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    (presets / "spoofed.json").write_text(
+        json.dumps(
+            {
+                "id": "spoofed",
+                "status": "supported",
+                "requirements": {
+                    "tensorrt": "0.0.0.0",
+                    "cuda": "13.3",
+                    "python": "2.7",
+                    "architecture": "x86_64",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = ProviderRegistry()
+    registry.register_context(SpoofingLocalContext())
+    registry.register_toolchain(ExistingToolchainSource())
+    toolkit = DevToolkit.from_checkout(
+        tmp_path,
+        providers=registry.freeze(),
+        qualifications=(JsonQualificationSource((presets,)),),
+    )
+
+    with pytest.raises(IncompatibleCombination, match="does not match"):
+        toolkit.resolve(
+            EnvironmentRequest(
+                tensorrt="11.2.0.113",
+                target=ExecutionTarget("test-local"),
+                architecture="aarch64",
+                preset="spoofed",
+                require_qualification=True,
+            )
+        )
 
 
 def test_required_qualification_fails_without_restricting_default_resolution(

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -50,11 +50,15 @@ print(" ".join(environment.command("bash")))
 The toolkit reuses a container only when its checkout-owned configuration still
 matches. A foreign name collision or configuration drift fails without removing
 or replacing the container. Unknown host architectures fail before Docker is
-invoked. The toolkit has no environment catalog or secondary artifact identity.
-Each development Dockerfile's first `FROM` is its base-image pin; repository CI
-continues to use the root `Dockerfile`. Optional Python dependencies remain in
-`families/<family>/requirements.txt`. See `apps/devtoolkit/README.md` for
-lifecycle policies and the explicit existing-interpreter local path.
+invoked. This preparation call remains separate from the toolkit's optional
+`resolve`, `provision`, `build`, and `run` capabilities; use
+`environment.execution_target()` to pass the prepared container into that
+evidence-producing path. Each development Dockerfile's first `FROM` is its
+base-image pin; repository CI continues to use the root `Dockerfile`. Optional
+Python dependencies remain in `families/<family>/requirements.txt`. See
+`apps/devtoolkit/README.md` for lifecycle policies, immutable environment
+identity and receipts, managed toolchain catalogs, and the explicit
+existing-interpreter local path.
 
 The manual commands below remain the direct source-build path and show the
 operations performed by development mode.

--- a/website/docs/getting-started/source-build.md
+++ b/website/docs/getting-started/source-build.md
@@ -47,6 +47,23 @@ environment = toolkit.prepare_docker(
 print(" ".join(environment.command("bash")))
 ```
 
+Runnable end-to-end examples are available for both supported execution paths:
+
+```bash
+# Build in a checkout-owned development container.
+python3 apps/devtoolkit/examples/docker_build.py --gpu 0
+
+# Build directly on a prepared host interpreter/toolchain.
+python3 apps/devtoolkit/examples/local_build.py \
+  --python /path/to/python3.12 \
+  --tensorrt 11.0.0.114
+```
+
+The local path expects the generic native build prerequisites documented in
+`apps/devtoolkit/README.md`; use its `--cmake-python` and
+`--cmake-prefix-path` options when those dependencies live in isolated
+prefixes.
+
 The toolkit reuses a container only when its checkout-owned configuration still
 matches. A foreign name collision or configuration drift fails without removing
 or replacing the container. Unknown host architectures fail before Docker is


### PR DESCRIPTION
## Background

PR #1093 kept a small checkout preparation app but removed the composable
DevToolkit capability layer. Restore that design under the current
`apps/devtoolkit` location without undoing the family-owned repository layout
or the fail-closed Docker lifecycle added after the cutover.

## Exit Criteria

- Preserve `prepare_docker()` and `prepare_local()`, including family-local
  dependency installation and non-destructive container ownership checks.
- Restore independent `resolve()`, `provision()`, `build()`, `run()`, and
  `run_trtmc()` capabilities with immutable identity, attestation, and receipts.
- Provide runnable Docker and bare-metal local build examples using those
  capabilities end to end.
- Keep cohort admission, workflow DAGs, model semantics, and family-specific
  dependency registries out of the shared app.

## Implementation

- Reintroduced explicit execution-context, toolchain-source, catalog, and
  qualification extension contracts, including exact TensorRT/CUDA resolution
  and digest-pinned managed artifact fallback.
- Restored serialized provisioning, source/build identities, artifact
  revalidation, secret-free command receipts, and mutable-target re-attestation.
- Added `PreparedEnvironment.execution_target()` so the current checkout-owned
  Docker/local preparation path feeds the capability layer without duplicating
  container or workspace identity.
- Adapted the sample native recipe to the current CMake topology by binding
  `CMAKE_CUDA_COMPILER` and `CUDAToolkit_ROOT`, retaining caller-selected
  targets, and leaving family dependencies in
  `families/<family>/requirements.txt`.
- Added `docker_build.py` and `local_build.py` examples that compose preparation,
  resolution, provisioning, native CLI/TRT-backend compilation, and
  evidence-bound `trtmc version` execution. The local example exposes explicit
  CMake Python and package-prefix inputs for isolated host dependencies.
- Hardened the restored contracts after review: provisioned toolchain identity
  must exactly match its lock, context qualification metadata cannot override
  resolved environment facts, source snapshots use NUL-delimited Git paths,
  build/receipt identities reject non-finite JSON numbers, CMake
  `-real`/`-virtual` architecture forms are accepted, and read-only probes
  explicitly request checked execution.

### Change categories

- [ ] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `pre-commit run --files apps/devtoolkit/trtmc_devtoolkit/building.py apps/devtoolkit/trtmc_devtoolkit/provisioning.py apps/devtoolkit/trtmc_devtoolkit/qualifications.py apps/devtoolkit/trtmc_devtoolkit/receipt.py apps/devtoolkit/trtmc_devtoolkit/recipes.py apps/devtoolkit/trtmc_devtoolkit/resolution.py apps/devtoolkit/trtmc_devtoolkit/runner.py tools/tests/test_devtoolkit_capabilities.py`:
  passed all applicable end-of-file, whitespace, and Ruff checks.
- `python3 -m compileall -q apps/devtoolkit/trtmc_devtoolkit apps/devtoolkit/examples`:
  passed.
- `python3 apps/devtoolkit/examples/docker_build.py --help` and
  `python3 apps/devtoolkit/examples/local_build.py --help`: passed without
  preparing an environment.
- `python3 -m pytest -q tools/tests/test_devtoolkit.py tools/tests/test_devtoolkit_capabilities.py`:
  111 passed.
- `python3 -m pytest -q tools/tests`: 239 passed.
- `python3 -m tools.model_ci validate`: passed.
- `python3 -m tools.test_impact --validate`: passed.
- `git diff --check`: passed.
- On GB300, `docker_build.py --gpu 1 --jobs 8` with isolated image,
  container, and state names: passed; built `trtmc` and
  `trtmc_backend_trt`, then returned `trtmc 0.1.0`.
- On ThorX-2 bare metal, `local_build.py` with `--python /usr/bin/python3`,
  `--tensorrt 11.0.0.114`, `--jobs 4`, isolated CMake Python,
  nlohmann-json prefix, and state options: passed; built `trtmc` and
  `trtmc_backend_trt`, then returned `trtmc 0.1.0`.

### Hardware, Environment, and Revisions

Exact repository head `774d8df618d9b243126492c80cbb2088ba86c4be` was used
for both hardware builds, and both source snapshots recorded `dirty=false`.

- GB300 aarch64 Docker target: CUDA 13.3, TensorRT 11.1.0.106, SM103,
  Ninja generator. The final `trtmc` artifact SHA-256 was
  `3a1ab984e9f613428830b7c0ed660d65148db5d08c8904ca561a6c5a1ab3a3c2`.
- ThorX-2 aarch64 bare-metal local target: digest-pinned managed CUDA 13.3,
  TensorRT 11.0.0.114, SM110, Unix Makefiles generator. The exact-head run
  re-attested the previously materialized toolchain. The final `trtmc` artifact
  SHA-256 was
  `ba95f505e3386e784f252fe34a04eb4437a6d0d7feaf2a63c832f125a7e671a0`.

Both builds produced completed build receipts and successful command receipts.

### Not Run / Remaining Gaps

No model-family DSO, checkpoint conversion, model parity, performance, or
production deployment qualification was run. The examples intentionally stop
at the shared CLI and TensorRT backend boundary.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

- Review the public composition in `api.py` and `models.py` first, then the
  resolution/provider/provisioning path, followed by the runnable examples,
  migrated regression tests, and documentation.
- `TrtmcBuildRecipe` disables optional BYOK by default because the generic
  toolchain capability does not install checkout Python dependencies; callers
  with the required dependency may override that CMake definition.
- Local preparation manages CUDA/TensorRT, not generic C++ or checkout Python
  build dependencies. The current top-level CMake configure requires
  nlohmann-json and a Python interpreter containing Torch; the local example
  accepts isolated paths for both.
- This intentionally restores provider, catalog, receipt, and SPI modules but
  does not restore cohort manifests, planner APIs, or shared family policy.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The change restores a large developer-facing provisioning surface. It is
isolated to `apps/devtoolkit`, preserves the existing non-destructive checkout
preparation behavior, and has deterministic unit coverage plus exact-head
aarch64 Docker and bare-metal native build evidence.
