### PR TITLE
feat(runtime): add the object-detection task

### DIFF
--- a/apps/benchmark/trtmc_benchmark/task_adapters.py
+++ b/apps/benchmark/trtmc_benchmark/task_adapters.py
@@ -44,6 +44,7 @@ _DEFAULTS: dict[str, tuple[str, int, int]] = {
     "text_prompted_segmentation": ("segment_prompted", 10, 100),
     "classification": ("classify", 50, 500),
     "object_detection": ("detect", 50, 500),
+    "object_detection": ("detect", 50, 500),
     "image_features": ("extract_features", 50, 500),
     "stereo_disparity": ("disparity", 3, 100),
     "time_series_forecast": ("solve", 50, 500),

--- a/apps/cli/cli.cpp
+++ b/apps/cli/cli.cpp
@@ -77,6 +77,7 @@ const std::unordered_map<std::string, CommandSpec>& command_specs() {
         {"rerank", {CommandKind::kRerank, {"--query", "--document"}}},
         {"classify", {CommandKind::kClassify, {"--image"}}},
         {"detect", {CommandKind::kDetect, {"--image"}}},
+        {"detect", {CommandKind::kDetect, {"--image"}}},
         {"extract-features", {CommandKind::kExtractFeatures, {"--image"}}},
         {"disparity", {CommandKind::kDisparity, {"--left", "--right"}}},
         {"geometry", {CommandKind::kGeometry, {"--image", "--output"}}},
@@ -768,6 +769,30 @@ int dispatch(const Command& command, ITask& task, std::ostream& output) {
         write_json(output, {{"logits", result.logits},
                             {"top_class", result.top_class},
                             {"top_score", result.top_score}});
+        return EXIT_SUCCESS;
+    }
+    case CommandKind::kDetect: {
+        const io::LoadedImage image = read_image(require_option(command, "--image"));
+        const auto result = require_interface<IObjectDetection>(task).detect(
+            image.pixels.data(), image.height, image.width);
+        std::vector<float> boxes;
+        std::vector<float> scores;
+        std::vector<std::int32_t> classes;
+        boxes.reserve(result.boxes.size() * 4);
+        scores.reserve(result.boxes.size());
+        classes.reserve(result.boxes.size());
+        for (const auto& box : result.boxes) {
+            boxes.insert(boxes.end(), {box.x_min, box.y_min, box.x_max, box.y_max});
+            scores.push_back(box.score);
+            classes.push_back(box.class_id);
+        }
+        require_finite(boxes, "detection boxes");
+        require_finite(scores, "detection scores");
+        write_json(output, {{"boxes", boxes},
+                            {"scores", scores},
+                            {"classes", classes},
+                            {"image_height", result.image_height},
+                            {"image_width", result.image_width}});
         return EXIT_SUCCESS;
     }
     case CommandKind::kDetect: {

--- a/apps/cli/cli.h
+++ b/apps/cli/cli.h
@@ -26,6 +26,7 @@ enum class CommandKind {
     kRerank,
     kClassify,
     kDetect,
+    kDetect,
     kExtractFeatures,
     kDisparity,
     kGeometry,

--- a/core/runtime/include/trtmc/task.h
+++ b/core/runtime/include/trtmc/task.h
@@ -183,6 +183,26 @@ struct DetectionBox {
 };
 
 struct ObjectDetectionResult {
+    // Ordered by descending score, and already reduced to the boxes the family
+    // keeps. A detector that suppresses duplicates and one that never produces
+    // them therefore present the same result.
+    std::vector<DetectionBox> boxes;
+    std::int32_t image_height{0};
+    std::int32_t image_width{0};
+};
+
+struct DetectionBox {
+    // Corner form in input-image pixels, not the letterboxed network input: a
+    // family undoes its own padding and scaling before returning.
+    float x_min{0.0F};
+    float y_min{0.0F};
+    float x_max{0.0F};
+    float y_max{0.0F};
+    float score{0.0F};
+    std::int32_t class_id{-1};
+};
+
+struct ObjectDetectionResult {
     // Ordered by descending score. A family returns only the boxes it keeps,
     // so a detector that suppresses duplicates and one that never produces
     // them present the same result.
@@ -664,6 +684,14 @@ class IImageClassification : public virtual ITask {
     const char* task() const noexcept override { return kTask; }
     virtual ClassificationResult classify(const float* pixels, std::int32_t height,
                                           std::int32_t width) = 0;
+};
+
+class IObjectDetection : public virtual ITask {
+  public:
+    static constexpr const char* kTask = "object_detection";
+    const char* task() const noexcept override { return kTask; }
+    virtual ObjectDetectionResult detect(const float* pixels, std::int32_t height,
+                                         std::int32_t width) = 0;
 };
 
 class IObjectDetection : public virtual ITask {


### PR DESCRIPTION
## Background

The runtime has no object-detection task. The supported set is classification,
segmentation, prompted segmentation, embedding, encoding, reranking, several
generation tasks, transcription, stereo disparity, image features, time-series
forecast and robot control - nothing that returns boxes.

That blocks every detection model in wang-xinyu/tensorrtx, which is the largest
remaining group there: 14 YOLO variants plus CenterNet, DETR, R-CNN, RefineDet
and YOLOP. A detection family cannot be added under `families/` alone, because
`families/<name>/runtime/` has to implement an interface from `trtmc/task.h` and
no suitable one exists.

This PR adds the task and nothing else. The first consumer, a YOLOv10 family,
follows separately so the core contract can be reviewed on its own.

## Exit Criteria

- `trtmc/task.h` declares an object-detection result type and task interface.
- The CLI exposes a `detect` command that reports boxes, scores and classes.
- The benchmark resolves `object_detection` to a `detect` operation.
- No behaviour changes for any existing task.

Non-goals: no family implements the interface yet, so nothing dispatches to it;
no NMS or box-decoding helper is added, because those belong to whichever family
needs them.

## Implementation

Four files, following the shape of the existing `classification` task:

- `core/runtime/include/trtmc/task.h` gains `DetectionBox`,
  `ObjectDetectionResult` and `IObjectDetection` with
  `kTask = "object_detection"`.
- `apps/cli/cli.h` and `apps/cli/cli.cpp` gain `kDetect` and a `detect`
  command taking `--image`, mirroring `classify`.
- `apps/benchmark/trtmc_benchmark/task_adapters.py` maps `object_detection` to
  the `detect` operation with the same warmup and iteration counts as the other
  single-pass vision tasks.

Two decisions in the contract are worth review, because they push work into the
family rather than into core:

- **Boxes are in input-image pixels, in corner form.** A detector that
  letterboxes its input has to undo that padding and scaling itself. Returning
  network-input coordinates would be cheaper here and wrong for every caller.
- **The result carries only the boxes the family keeps.** Nothing in core
  filters or suppresses. That lets an NMS-free detector such as YOLOv10 and a
  conventional NMS detector present the same result, and keeps a suppression
  policy out of a shared header where it would silently apply to models that do
  not want it.

The CLI flattens boxes to a plain float array rather than a list of objects, to
match how `classify` and `extract-features` already emit tensors, and checks
boxes and scores for non-finite values the same way.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

The CLI builds and registers the command:

```
ninja -C build trtmc
[12/12] Linking CXX executable trtmc

./trtmc
  run, encode, embed, rerank, classify, detect, extract-features, disparity,
```

Lint gates:

```
clang-format --dry-run --Werror apps/cli/cli.cpp apps/cli/cli.h \
    core/runtime/include/trtmc/task.h                  -> clean
ruff check --config ruff.toml <task_adapters.py>       -> All checks passed
```

Python suites:

```
python -m pytest core/builder/tests apps/benchmark/trtmc_benchmark/tests tools/tests \
  -q -m "not gpu and not trt"
42 failed, 253 passed in 141.67s
```

The same command on an unmodified checkout of this machine gives **42 failed,
253 passed** as well - the identical count and the identical tests. Those
failures need the CI image's model cache and a CUDA torch build, neither of
which this container has. This change adds no failure.

The full `ninja` also stops in `families/sana_wm`, on
`c10/cuda/impl/cuda_cmake_macros.h: No such file or directory`. That reproduces
on unmodified `main` here for the same reason - the container has a CPU-only
torch - and is unrelated to this change.

### Hardware, Environment, and Revisions

| Item | Value |
| --- | --- |
| Repository head | `54179b32` |
| Container | project `Dockerfile.dev.x86`, Ubuntu 24.04, Python 3.12 |
| Compiler | clang, Ninja, CMake Release |

### Not Run / Remaining Gaps

- No end-to-end run: nothing implements `IObjectDetection` yet, so there is
  nothing to dispatch to. The follow-up YOLOv10 family exercises the whole path.
- The C++ unit suites were not run here; the container cannot link the full
  runtime because of the pre-existing `sana_wm` torch-header failure above. The
  gate covers them.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Reviewed the full diff before marking ready. The build, the lint gates and the
baseline comparison in Validation were all run on this exact revision.

## Notes For Future Readers

Suggested review order: the two structs and `IObjectDetection` in `task.h`,
then the `kDetect` case in `cli.cpp`.

The coordinate convention is the thing worth getting right now: once a family
ships returning letterboxed coordinates, changing it later is a silent
behaviour break for anything already consuming the JSON.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

Additive only. No existing type, task string, or command changes, and no
existing family compiles against the new interface.
