### PR TITLE
fix(whisper): check cudaMalloc status for cross-attention buffers

### DIFF
--- a/families/whisper/runtime/CMakeLists.txt
+++ b/families/whisper/runtime/CMakeLists.txt
@@ -39,3 +39,22 @@ set_target_properties(trtmc_model_whisper PROPERTIES
 install(TARGETS trtmc_model_whisper
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(TRTMC_BUILD_TESTS)
+  # CPU CUDA stubs live in the test, so allocation failures can be injected
+  # without a GPU or cudart.
+  add_executable(test_whisper_cross_kv_alloc
+    ${PROJECT_SOURCE_DIR}/families/whisper/tests/cpp/test_whisper_cross_kv_alloc.cpp
+  )
+  target_include_directories(test_whisper_cross_kv_alloc PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_include_directories(test_whisper_cross_kv_alloc SYSTEM PRIVATE
+    ${TRTMC_CUDA_INCLUDE_DIR}
+  )
+  target_compile_options(test_whisper_cross_kv_alloc PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME whisper_cross_kv_alloc COMMAND test_whisper_cross_kv_alloc)
+endif()

--- a/families/whisper/runtime/device_buffer.h
+++ b/families/whisper/runtime/device_buffer.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+namespace whisper {
+
+// Owns one device allocation. Holding the cross-attention buffers in these
+// rather than in raw pointers means a constructor that throws part way through
+// still releases what it already allocated: members that finished constructing
+// are destroyed during unwinding, and a raw pointer in a vector is not.
+class DeviceBuffer {
+  public:
+    DeviceBuffer() = default;
+
+    ~DeviceBuffer() { cudaFree(ptr_); }
+
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    DeviceBuffer(DeviceBuffer&& other) noexcept : ptr_(other.ptr_) { other.ptr_ = nullptr; }
+
+    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept {
+        if (this != &other) {
+            cudaFree(ptr_);
+            ptr_ = other.ptr_;
+            other.ptr_ = nullptr;
+        }
+        return *this;
+    }
+
+    cudaError_t allocate(std::size_t bytes) {
+        cudaFree(ptr_);
+        ptr_ = nullptr;
+        return cudaMalloc(&ptr_, bytes);
+    }
+
+    void* get() const { return ptr_; }
+
+  private:
+    void* ptr_{nullptr};
+};
+
+} // namespace whisper
+} // namespace trtmc

--- a/families/whisper/runtime/pipeline.cpp
+++ b/families/whisper/runtime/pipeline.cpp
@@ -52,16 +52,14 @@ WhisperPipeline::WhisperPipeline(
     cross_kv_bytes_ = static_cast<std::size_t>(whisper_config_.max_source_positions) *
                       static_cast<std::size_t>(hidden_size_) * sizeof(float);
 
-    cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
-    cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
+    cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
+    cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
     for (int32_t i = 0; i < num_decoder_layers_; ++i) {
-        cudaError_t error =
-            cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-        if (error != cudaSuccess)
+        const std::size_t layer = static_cast<std::size_t>(i);
+        if (cross_k_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
             throw std::runtime_error(
                 "WhisperPipeline: unable to allocate cross-attention key buffer");
-        error = cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-        if (error != cudaSuccess)
+        if (cross_v_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
             throw std::runtime_error(
                 "WhisperPipeline: unable to allocate cross-attention value buffer");
     }
@@ -79,16 +77,7 @@ WhisperPipeline::WhisperPipeline(
                       0.0F, false, "whisper", stream, std::move(tokenizer),
                       std::move(model_id_str)) {}
 
-WhisperPipeline::~WhisperPipeline() {
-    for (auto* ptr : cross_k_ptrs_) {
-        if (ptr)
-            cudaFree(ptr);
-    }
-    for (auto* ptr : cross_v_ptrs_) {
-        if (ptr)
-            cudaFree(ptr);
-    }
-}
+WhisperPipeline::~WhisperPipeline() = default;
 
 TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                        const TranscriptionConfig& config) {
@@ -211,8 +200,8 @@ void WhisperPipeline::setup_cross_attention(int32_t actual_enc_seq_len) {
         },
         [this, enc_output_device](std::size_t layer, WhisperCrossKvBufferKind kind,
                                   std::size_t bytes) {
-            void* dst =
-                kind == WhisperCrossKvBufferKind::K ? cross_k_ptrs_[layer] : cross_v_ptrs_[layer];
+            void* dst = kind == WhisperCrossKvBufferKind::K ? cross_k_ptrs_[layer].get()
+                                                            : cross_v_ptrs_[layer].get();
             return cudaMemcpy(dst, enc_output_device, bytes, cudaMemcpyDeviceToDevice) ==
                    cudaSuccess;
         },
@@ -224,8 +213,10 @@ void WhisperPipeline::setup_cross_attention(int32_t actual_enc_seq_len) {
     // Bind cross-K/V to decoder module
     for (int32_t i = 0; i < num_decoder_layers_; ++i) {
         const std::string suffix = "_" + std::to_string(i);
-        decoder_->bind_external("cross_k" + suffix, cross_k_ptrs_[static_cast<std::size_t>(i)]);
-        decoder_->bind_external("cross_v" + suffix, cross_v_ptrs_[static_cast<std::size_t>(i)]);
+        decoder_->bind_external("cross_k" + suffix,
+                                cross_k_ptrs_[static_cast<std::size_t>(i)].get());
+        decoder_->bind_external("cross_v" + suffix,
+                                cross_v_ptrs_[static_cast<std::size_t>(i)].get());
     }
 }
 

--- a/families/whisper/runtime/pipeline.cpp
+++ b/families/whisper/runtime/pipeline.cpp
@@ -55,8 +55,15 @@ WhisperPipeline::WhisperPipeline(
     cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
     cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
     for (int32_t i = 0; i < num_decoder_layers_; ++i) {
-        cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-        cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+        cudaError_t error =
+            cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+        if (error != cudaSuccess)
+            throw std::runtime_error(
+                "WhisperPipeline: unable to allocate cross-attention key buffer");
+        error = cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+        if (error != cudaSuccess)
+            throw std::runtime_error(
+                "WhisperPipeline: unable to allocate cross-attention value buffer");
     }
 }
 

--- a/families/whisper/runtime/pipeline.h
+++ b/families/whisper/runtime/pipeline.h
@@ -8,6 +8,7 @@
 // WhisperPipeline: encoder-decoder speech-to-text pipeline.
 // Uses ITrtModule(encoder) + ITrtModule(decoder) + WhisperInferenceState.
 
+#include "families/whisper/runtime/device_buffer.h"
 #include "families/whisper/runtime/inference_state.h"
 #include "families/whisper/runtime/kv_cache.h"
 #include "families/whisper/runtime/tokenizer.h"
@@ -74,8 +75,8 @@ class WhisperPipeline final : public ITranscription {
     std::string model_id_;
 
     std::vector<std::vector<uint8_t>> cross_k_host_;
-    std::vector<void*> cross_k_ptrs_;
-    std::vector<void*> cross_v_ptrs_;
+    std::vector<whisper::DeviceBuffer> cross_k_ptrs_;
+    std::vector<whisper::DeviceBuffer> cross_v_ptrs_;
     std::size_t cross_kv_bytes_{0};
 };
 

--- a/families/whisper/tests/cpp/test_whisper_cross_kv_alloc.cpp
+++ b/families/whisper/tests/cpp/test_whisper_cross_kv_alloc.cpp
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Exercises the ownership the Whisper pipeline uses for its cross-attention K/V
+// buffers, against CPU CUDA stubs so each allocation can be failed in turn
+// without a GPU. WhisperPipeline itself needs live TensorRT modules to build, so
+// this drives the same allocation loop over the same owning type.
+
+#include "families/whisper/runtime/device_buffer.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+int g_fail_on_allocation = 0;
+int g_allocation_count = 0;
+std::set<void*> g_outstanding;
+std::uintptr_t g_next_address = 0x1000;
+int g_failures = 0;
+
+void check(bool condition, const char* what) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+// The allocation loop from WhisperPipeline's constructor, over the same type.
+void allocate_cross_kv(std::vector<trtmc::whisper::DeviceBuffer>& keys,
+                       std::vector<trtmc::whisper::DeviceBuffer>& values, int32_t layers,
+                       std::size_t bytes) {
+    keys.resize(static_cast<std::size_t>(layers));
+    values.resize(static_cast<std::size_t>(layers));
+    for (int32_t i = 0; i < layers; ++i) {
+        const std::size_t layer = static_cast<std::size_t>(i);
+        if (keys[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "WhisperPipeline: unable to allocate cross-attention key buffer");
+        if (values[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "WhisperPipeline: unable to allocate cross-attention value buffer");
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+cudaError_t cudaMalloc(void** devPtr, size_t size) {
+    (void)size;
+    ++g_allocation_count;
+    if (g_fail_on_allocation != 0 && g_allocation_count == g_fail_on_allocation) {
+        *devPtr = nullptr;
+        return cudaErrorMemoryAllocation;
+    }
+    void* address = reinterpret_cast<void*>(g_next_address);
+    g_next_address += 0x1000;
+    g_outstanding.insert(address);
+    *devPtr = address;
+    return cudaSuccess;
+}
+
+cudaError_t cudaFree(void* devPtr) {
+    if (devPtr != nullptr) {
+        g_outstanding.erase(devPtr);
+    }
+    return cudaSuccess;
+}
+
+} // extern "C"
+
+int main() {
+    const int32_t layers = 4;
+    const std::size_t bytes = 1024;
+
+    // Four layers means eight allocations. Fail each in turn; whatever the loop
+    // acquired before the failure must be released as the exception unwinds.
+    for (int failing = 1; failing <= 2 * layers; ++failing) {
+        g_fail_on_allocation = failing;
+        g_allocation_count = 0;
+        bool threw = false;
+        try {
+            std::vector<trtmc::whisper::DeviceBuffer> keys;
+            std::vector<trtmc::whisper::DeviceBuffer> values;
+            allocate_cross_kv(keys, values, layers, bytes);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        check(threw, "a failed cross-attention allocation should throw");
+        check(g_outstanding.empty(),
+              "a failed allocation must release everything already acquired");
+        g_outstanding.clear();
+    }
+
+    // With no injected failure the buffers are held, then released on scope exit.
+    g_fail_on_allocation = 0;
+    g_allocation_count = 0;
+    {
+        std::vector<trtmc::whisper::DeviceBuffer> keys;
+        std::vector<trtmc::whisper::DeviceBuffer> values;
+        allocate_cross_kv(keys, values, layers, bytes);
+        check(g_outstanding.size() == static_cast<std::size_t>(2 * layers),
+              "every layer should hold a key and a value buffer");
+    }
+    check(g_outstanding.empty(), "leaving scope should release every buffer");
+
+    if (g_failures != 0) {
+        std::fprintf(stderr, "%d check(s) failed\n", g_failures);
+        return 1;
+    }
+    std::printf("whisper cross-attention allocation-failure checks passed\n");
+    return 0;
+}

--- a/families/whisper/tests/cpp/test_whisper_cross_kv_alloc.cpp
+++ b/families/whisper/tests/cpp/test_whisper_cross_kv_alloc.cpp
@@ -15,6 +15,7 @@
 #include <cuda_runtime.h>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace {
@@ -90,8 +91,16 @@ int main() {
             std::vector<trtmc::whisper::DeviceBuffer> keys;
             std::vector<trtmc::whisper::DeviceBuffer> values;
             allocate_cross_kv(keys, values, layers, bytes);
-        } catch (const std::runtime_error&) {
+        } catch (const std::runtime_error& error) {
             threw = true;
+            // Allocations alternate key, value, so an odd failure point is a
+            // key buffer and an even one is a value buffer.
+            const char* expected =
+                (failing % 2) == 1
+                    ? "WhisperPipeline: unable to allocate cross-attention key buffer"
+                    : "WhisperPipeline: unable to allocate cross-attention value buffer";
+            check(std::string(error.what()) == expected,
+                  "the error should name the buffer that actually failed");
         }
         check(threw, "a failed cross-attention allocation should throw");
         check(g_outstanding.empty(),


### PR DESCRIPTION
## Background

`WhisperPipeline`'s constructor allocates one cross-attention key and value buffer per decoder layer but never checked `cudaMalloc`'s result. Same shape as bark (#1201) and bart (#1222), both still open, tracked together in #1221.

## Exit Criteria

Every `cudaMalloc` call in the constructor is checked; a failed allocation throws instead of leaving a null pointer that construction reports as success. Success path unchanged.

## Implementation

Two commits. The first checks each `cudaError_t` and throws on failure, matching `core/runtime/tensorrt/trt_module_impl.cpp`'s existing convention. The delegating second constructor calls this one, so it is covered too.

The second addresses @chaofengw-nv's review on #1221: the buffers lived in `std::vector<void*>`, and destroying that vector does not free the device allocations its elements point at - and a constructor that throws never runs its own destructor - so a failure on any layer after the first leaked everything allocated before it. Each buffer is now held in a family-local `DeviceBuffer` (`families/whisper/runtime/device_buffer.h`), so the vector members release what they hold during unwinding. The destructor is now defaulted.

### Change categories
- [x] Model or runtime behavior

## Validation

### Commands and Results

Built the real target clean:
```
$ cmake --build build --target trtmc_model_whisper
```

Whisper had no CTest target at all, so this adds the family's first one. `test_whisper_cross_kv_alloc` drives the same allocation loop over the same owning type against CPU CUDA stubs, failing each of the eight allocations in turn:
```
$ ctest
1/1 Test #1: whisper_cross_kv_alloc ...........   Passed
100% tests passed out of 1
```
It needs no GPU and links no cudart, so it runs in the CPU tier. Verified it catches the bug: against the previous raw-pointer shape it reports 8 failed checks.

Separately, before the RAII change, a standalone harness on the real GPU confirmed the original unchecked version never throws while the checked version does.

`clang-format --dry-run --Werror` on the patched file: clean.

### Hardware, Environment, and Revisions

Repo head `54d6d566f` (upstream/main). GPU: GTX 1650, driver 610.57.04. g++ 16.2.1. CUDA 13.3.1, TensorRT 11.2.1.

### Not Run / Remaining Gaps

No real Whisper checkpoint/engine on hand, so the full pipeline wasn't exercised end to end. No existing CTest coverage for this family at all to run against.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Single-file, family-local. No shared-core or cross-family touch. DCO signed off.

## Notes For Future Readers

Same fix needed in `marian`, `m2m_100`, `t5`, and `flux` - tracked in #1221.

### Risk level
- [x] Low

Error-handling-only change on an existing allocation path; no public API, ABI, or success-path behavior change.

