### PR TITLE
feat(ci): add x86_64 GPU development image for community CI

### DIFF
--- a/Dockerfile.dev.x86-gpu
+++ b/Dockerfile.dev.x86-gpu
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# x86_64 GPU development image for the community GPU CI pipeline (L4 / L40 / L40S,
+# Ada Lovelace, compute capability 8.9). The internal root Dockerfile targets
+# GB300 (aarch64, compute capability 10.0) only and cannot build on x86_64 hosts;
+# this file is the x86_64 counterpart used for CUDA-enabled testing on
+# externally reserved (Brev) GPU instances.
+ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt:26.07-py3@sha256:b82db1abc23750ab0069abc99bbe4ea29138dbdc23ea39861199e2346638b48a
+FROM ${TENSORRT_IMAGE}
+
+ARG TORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu130
+ARG TORCH_VERSION=2.12.0+cu130
+ARG TORCHVISION_VERSION=0.27.0+cu130
+ARG TORCHAUDIO_VERSION=2.11.0+cu130
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_NO_CACHE_DIR=1
+ENV TORCH_CUDA_ARCH_LIST=8.9
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      git \
+      ninja-build \
+      nlohmann-json3-dev \
+      patchelf \
+      pkg-config \
+      python3.12-dev \
+      python3.12-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.12 -m venv --system-site-packages ${VIRTUAL_ENV} && \
+    ln -s /usr/bin/cmake ${VIRTUAL_ENV}/bin/cmake
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY community-ci.txt /tmp/trtmc-community-ci.txt
+
+RUN pip install -U pip && \
+    pip install \
+      "cuda-python>=13.0.3,<14" \
+      "huggingface_hub>=0.23" \
+      "ml_dtypes>=0.4" \
+      "numpy>=1.24,<2.5" \
+      "onnx>=1.16" \
+      "PyYAML>=6.0" \
+      "safetensors>=0.4" \
+      "sentencepiece>=0.1.99" \
+      "transformers==5.2.0" && \
+    pip install \
+      "torch==${TORCH_VERSION}" \
+      "torchvision==${TORCHVISION_VERSION}" \
+      "torchaudio==${TORCHAUDIO_VERSION}" \
+      --index-url "${TORCH_CUDA_INDEX}" && \
+    pip install "setuptools>=80,<82" && \
+    pip install --requirement /tmp/trtmc-community-ci.txt && \
+    rm -f /tmp/trtmc-community-ci.txt
+
+ENV TRT_LIB_DIR=/usr/lib/x86_64-linux-gnu
+ENV TRT_INC_DIR=/usr/include/x86_64-linux-gnu
+ENV LD_LIBRARY_PATH="${TRT_LIB_DIR}:/usr/local/cuda/lib64"
+
+# Not verified here: apache-tvm-ffi / libtvm_ffi.so. It backs the native
+# C++ runtime build, which this GPU smoke-test image does not build; whether
+# it is present depends entirely on the checked-out branch's
+# requirements/community-ci.txt.
+RUN cmake --version && \
+    python3.12 -c \
+      "import onnx, tensorrt, torch; assert tensorrt.__version__ == '11.1.0.106'; assert hasattr(tensorrt, 'CausalMaskKind'); assert torch.__version__ == '${TORCH_VERSION}'; assert torch.version.cuda is not None" && \
+    test -f "${TRT_INC_DIR}/NvInferVersion.h" && \
+    test -f "${TRT_LIB_DIR}/libnvinfer.so.11"
+
+WORKDIR /workspace/tensorrt-model-connect
+
+CMD ["bash"]

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -45,6 +45,7 @@ SHARED_FILES = {
     "Dockerfile.community-cpu",
     "Dockerfile.dev.aarch64",
     "Dockerfile.dev.x86",
+    "Dockerfile.dev.x86-gpu",
     ".dockerignore",
     "conanfile.py",
     "conftest.py",


### PR DESCRIPTION
## Background

Community contributors currently only get the CPU-only `Community CPU`
workflow; the internal GB300 premerge pipeline is gated to maintainers and
runs on NVIDIA-internal infrastructure. We are adding a community-facing GPU
CI pipeline that reserves an external GPU instance (via Brev,
https://brev.nvidia.com/) on x86_64 hardware (L4/L40/L40S). The internal root
`Dockerfile` targets GB300 (aarch64, compute capability 10.0) only and fails
to build on x86_64 hosts, so this PR adds the x86_64 counterpart needed before
the GitHub Actions workflow (tracked separately) can use it.

## Exit Criteria

- `Dockerfile.dev.x86-gpu` builds successfully on an x86_64 host with an
  NVIDIA GPU (Ada Lovelace or newer).
- The resulting image has GPU-enabled PyTorch, TensorRT, and the repository's
  Python-only editable install working, and can run family unit/e2e tests
  under `tests/e2e/models/**`.
- Non-goal: this PR does not add the GitHub Actions workflow that will use
  this image, or build/verify the native C++ runtime (`tvm_ffi`/native DSOs);
  that is a separate PR.

## Implementation

Adds `Dockerfile.dev.x86-gpu`, based on the existing `Dockerfile.dev.x86` (CPU
dev image), replacing the CPU-only `torch==2.12.0+cpu` install with the
CUDA-enabled `torch==2.12.0+cu130` (+ matching torchvision/torchaudio) from
the `cu130` PyTorch index, and setting `TORCH_CUDA_ARCH_LIST=8.9` for Ada
Lovelace (L4/L40/L40S). `TRT_INC_DIR`/`TRT_LIB_DIR` continue to use the
correct `x86_64-linux-gnu` multiarch paths already used by
`Dockerfile.dev.x86`. No other files changed.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

Reserved a real L40S GPU instance via the Brev CLI and ran, on that instance:

```
docker build -f Dockerfile.dev.x86-gpu -t trtmc-quickstart-gpu requirements
# succeeds

docker run --rm --gpus all trtmc-quickstart-gpu nvidia-smi -L
# GPU 0: NVIDIA L40S (UUID: GPU-723a3adb-0cf2-ae28-e486-738a42fc56b4)

docker run --rm --gpus all -v $PWD:/src -w /src trtmc-quickstart-gpu bash -c '
  python3.12 -m pip install --no-deps -e . -C py-only=true &&
  python3.12 -m pytest tests/e2e/models/qwen3_8/test_qwen3_8_family_plugin.py -v
'
# 13 passed in 4.91s
```

The test run above was against an unmerged branch
(`zhenshanx-nv/support_qwen3_8_27B_FP8`) used only as a validation payload for
this image; that branch is not part of this PR.

### Hardware, Environment, and Revisions

- GPU: NVIDIA L40S, 46 GB VRAM (Brev instance type `g6e.xlarge`, AWS-backed)
- Driver 595.91.07, CUDA 13.3 (forward-compatibility mode), container CUDA
  runtime 13.0
- Base image: `nvcr.io/nvidia/tensorrt:26.07-py3` (pinned by digest in the
  Dockerfile)
- TensorRT 11.1.0.106, torch 2.12.0+cu130
- Repository head tested: this PR's branch tip

### Not Run / Remaining Gaps

- Native C++ runtime build (`cmake --build`) was not exercised; this image is
  currently only validated for Python-only (`py-only=true`) installs and
  Python-level family unit/e2e tests.
- `apache-tvm-ffi` / `libtvm_ffi.so` presence is not verified in this image;
  it depends on the checked-out branch's `requirements/community-ci.txt` (see
  in-file comment). Full native-runtime parity with `Dockerfile.dev.x86` is a
  follow-up if/when the GPU CI workflow needs it.
- Only tested on a single GPU (L40S); L4 not separately validated, though the
  same `TORCH_CUDA_ARCH_LIST=8.9` (Ada Lovelace) covers it.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

This is infrastructure for an upcoming community GPU CI GitHub Actions
workflow (separate PR), so that workflow can reference
`Dockerfile.dev.x86-gpu` as an already-merged dependency instead of bundling
both changes together.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Additive new file only; does not touch the root `Dockerfile` used by existing
CI, `Dockerfile.dev.x86`, or any other existing build path. No workflow wires
it up yet, so it has no effect on any current pipeline.