### PR TITLE
fix(m2m_100): check cudaMalloc status for cross-attention buffers

### DIFF
--- a/families/m2m_100/runtime/CMakeLists.txt
+++ b/families/m2m_100/runtime/CMakeLists.txt
@@ -57,4 +57,21 @@ if(TRTMC_BUILD_TESTS)
   target_link_libraries(test_m2m_100_tokenizer_schema PRIVATE trtmc_model_m2m_100)
   target_compile_options(test_m2m_100_tokenizer_schema PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME m2m_100_tokenizer_schema COMMAND test_m2m_100_tokenizer_schema)
+
+  # CPU CUDA stubs live in the test, so allocation failures can be injected
+  # without a GPU or cudart.
+  add_executable(test_m2m_100_cross_kv_alloc
+    ${PROJECT_SOURCE_DIR}/families/m2m_100/tests/cpp/test_m2m_100_cross_kv_alloc.cpp
+  )
+  target_include_directories(test_m2m_100_cross_kv_alloc PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_include_directories(test_m2m_100_cross_kv_alloc SYSTEM PRIVATE
+    ${TRTMC_CUDA_INCLUDE_DIR}
+  )
+  target_compile_options(test_m2m_100_cross_kv_alloc PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME m2m_100_cross_kv_alloc COMMAND test_m2m_100_cross_kv_alloc)
 endif()

--- a/families/m2m_100/runtime/device_buffer.h
+++ b/families/m2m_100/runtime/device_buffer.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+namespace m2m_100 {
+
+// Owns one device allocation. Holding the cross-attention buffers in these
+// rather than in raw pointers means a constructor that throws part way through
+// still releases what it already allocated: members that finished constructing
+// are destroyed during unwinding, and a raw pointer in a vector is not.
+class DeviceBuffer {
+  public:
+    DeviceBuffer() = default;
+
+    ~DeviceBuffer() { cudaFree(ptr_); }
+
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    DeviceBuffer(DeviceBuffer&& other) noexcept : ptr_(other.ptr_) { other.ptr_ = nullptr; }
+
+    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept {
+        if (this != &other) {
+            cudaFree(ptr_);
+            ptr_ = other.ptr_;
+            other.ptr_ = nullptr;
+        }
+        return *this;
+    }
+
+    cudaError_t allocate(std::size_t bytes) {
+        cudaFree(ptr_);
+        ptr_ = nullptr;
+        return cudaMalloc(&ptr_, bytes);
+    }
+
+    void* get() const { return ptr_; }
+
+  private:
+    void* ptr_{nullptr};
+};
+
+} // namespace m2m_100
+} // namespace trtmc

--- a/families/m2m_100/runtime/device_buffer.h
+++ b/families/m2m_100/runtime/device_buffer.h
@@ -6,7 +6,10 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <cuda_runtime_api.h>
+#include <stdexcept>
+#include <vector>
 
 namespace trtmc {
 namespace m2m_100 {
@@ -46,6 +49,23 @@ class DeviceBuffer {
   private:
     void* ptr_{nullptr};
 };
+
+// The pipeline's own allocation loop, kept here so the test can drive the
+// same code the constructor runs.
+inline void allocate_cross_kv(std::vector<DeviceBuffer>& keys, std::vector<DeviceBuffer>& values,
+                              int32_t layers, std::size_t bytes) {
+    keys.resize(static_cast<std::size_t>(layers));
+    values.resize(static_cast<std::size_t>(layers));
+    for (int32_t i = 0; i < layers; ++i) {
+        const std::size_t layer = static_cast<std::size_t>(i);
+        if (keys[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "M2M100Pipeline: unable to allocate cross-attention key buffer");
+        if (values[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "M2M100Pipeline: unable to allocate cross-attention value buffer");
+    }
+}
 
 } // namespace m2m_100
 } // namespace trtmc

--- a/families/m2m_100/runtime/plugin.cpp
+++ b/families/m2m_100/runtime/plugin.cpp
@@ -169,8 +169,15 @@ class M2M100Pipeline final : public ITextGeneration {
         cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
         cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
         for (int32_t i = 0; i < num_decoder_layers_; ++i) {
-            cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-            cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+            cudaError_t error =
+                cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+            if (error != cudaSuccess)
+                throw std::runtime_error(
+                    "M2M100Pipeline: unable to allocate cross-attention key buffer");
+            error = cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
+            if (error != cudaSuccess)
+                throw std::runtime_error(
+                    "M2M100Pipeline: unable to allocate cross-attention value buffer");
         }
     }
 

--- a/families/m2m_100/runtime/plugin.cpp
+++ b/families/m2m_100/runtime/plugin.cpp
@@ -7,6 +7,7 @@
 // Encoder-decoder text-to-text pipeline for M2M-100 and NLLB models.
 
 #include "families/m2m_100/runtime/decode_runtime.h"
+#include "families/m2m_100/runtime/device_buffer.h"
 #include "families/m2m_100/runtime/kv_cache.h"
 #include "families/m2m_100/runtime/plugin_helpers.h"
 #include "families/m2m_100/runtime/request_tokens.h"
@@ -166,29 +167,16 @@ class M2M100Pipeline final : public ITextGeneration {
 
         cross_kv_bytes_ = static_cast<std::size_t>(max_source_length_) *
                           static_cast<std::size_t>(hidden_size_) * sizeof(float);
-        cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
-        cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_), nullptr);
+        cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
+        cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
         for (int32_t i = 0; i < num_decoder_layers_; ++i) {
-            cudaError_t error =
-                cudaMalloc(&cross_k_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-            if (error != cudaSuccess)
+            const std::size_t layer = static_cast<std::size_t>(i);
+            if (cross_k_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
                 throw std::runtime_error(
                     "M2M100Pipeline: unable to allocate cross-attention key buffer");
-            error = cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
-            if (error != cudaSuccess)
+            if (cross_v_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
                 throw std::runtime_error(
                     "M2M100Pipeline: unable to allocate cross-attention value buffer");
-        }
-    }
-
-    ~M2M100Pipeline() override {
-        for (auto* ptr : cross_k_ptrs_) {
-            if (ptr)
-                cudaFree(ptr);
-        }
-        for (auto* ptr : cross_v_ptrs_) {
-            if (ptr)
-                cudaFree(ptr);
         }
     }
 
@@ -275,13 +263,17 @@ class M2M100Pipeline final : public ITextGeneration {
             throw std::runtime_error("M2M100Pipeline: no encoder_output");
         for (int32_t i = 0; i < num_decoder_layers_; ++i) {
             auto idx = static_cast<std::size_t>(i);
-            cudaMemcpy(cross_k_ptrs_[idx], enc_out, cross_kv_bytes_, cudaMemcpyDeviceToDevice);
-            cudaMemcpy(cross_v_ptrs_[idx], enc_out, cross_kv_bytes_, cudaMemcpyDeviceToDevice);
+            cudaMemcpy(cross_k_ptrs_[idx].get(), enc_out, cross_kv_bytes_,
+                       cudaMemcpyDeviceToDevice);
+            cudaMemcpy(cross_v_ptrs_[idx].get(), enc_out, cross_kv_bytes_,
+                       cudaMemcpyDeviceToDevice);
         }
         for (int32_t i = 0; i < num_decoder_layers_; ++i) {
             std::string s = "_" + std::to_string(i);
-            decoder_->bind_external("cross_k" + s, cross_k_ptrs_[static_cast<std::size_t>(i)]);
-            decoder_->bind_external("cross_v" + s, cross_v_ptrs_[static_cast<std::size_t>(i)]);
+            decoder_->bind_external("cross_k" + s,
+                                    cross_k_ptrs_[static_cast<std::size_t>(i)].get());
+            decoder_->bind_external("cross_v" + s,
+                                    cross_v_ptrs_[static_cast<std::size_t>(i)].get());
         }
     }
 
@@ -342,8 +334,8 @@ class M2M100Pipeline final : public ITextGeneration {
     cudaStream_t stream_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
-    std::vector<void*> cross_k_ptrs_;
-    std::vector<void*> cross_v_ptrs_;
+    std::vector<m2m_100::DeviceBuffer> cross_k_ptrs_;
+    std::vector<m2m_100::DeviceBuffer> cross_v_ptrs_;
     std::vector<float> encoder_attention_mask_;
     std::size_t cross_kv_bytes_{0};
 };

--- a/families/m2m_100/runtime/plugin.cpp
+++ b/families/m2m_100/runtime/plugin.cpp
@@ -167,17 +167,8 @@ class M2M100Pipeline final : public ITextGeneration {
 
         cross_kv_bytes_ = static_cast<std::size_t>(max_source_length_) *
                           static_cast<std::size_t>(hidden_size_) * sizeof(float);
-        cross_k_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
-        cross_v_ptrs_.resize(static_cast<std::size_t>(num_decoder_layers_));
-        for (int32_t i = 0; i < num_decoder_layers_; ++i) {
-            const std::size_t layer = static_cast<std::size_t>(i);
-            if (cross_k_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
-                throw std::runtime_error(
-                    "M2M100Pipeline: unable to allocate cross-attention key buffer");
-            if (cross_v_ptrs_[layer].allocate(cross_kv_bytes_) != cudaSuccess)
-                throw std::runtime_error(
-                    "M2M100Pipeline: unable to allocate cross-attention value buffer");
-        }
+        m2m_100::allocate_cross_kv(cross_k_ptrs_, cross_v_ptrs_, num_decoder_layers_,
+                                   cross_kv_bytes_);
     }
 
     TextResult generate(const std::string& prompt, const TextGenerationConfig& cfg) override {

--- a/families/m2m_100/tests/cpp/test_m2m_100_cross_kv_alloc.cpp
+++ b/families/m2m_100/tests/cpp/test_m2m_100_cross_kv_alloc.cpp
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Exercises the ownership the M2M-100 pipeline uses for its cross-attention K/V
+// buffers, against CPU CUDA stubs so each allocation can be failed in turn
+// without a GPU. M2M100Pipeline itself needs live TensorRT modules to build, so
+// this drives the same allocation loop over the same owning type.
+
+#include "families/m2m_100/runtime/device_buffer.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_fail_on_allocation = 0;
+int g_allocation_count = 0;
+std::set<void*> g_outstanding;
+std::uintptr_t g_next_address = 0x1000;
+int g_failures = 0;
+
+void check(bool condition, const char* what) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+// The allocation loop from M2M100Pipeline's constructor, over the same type.
+void allocate_cross_kv(std::vector<trtmc::m2m_100::DeviceBuffer>& keys,
+                       std::vector<trtmc::m2m_100::DeviceBuffer>& values, int32_t layers,
+                       std::size_t bytes) {
+    keys.resize(static_cast<std::size_t>(layers));
+    values.resize(static_cast<std::size_t>(layers));
+    for (int32_t i = 0; i < layers; ++i) {
+        const std::size_t layer = static_cast<std::size_t>(i);
+        if (keys[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "M2M100Pipeline: unable to allocate cross-attention key buffer");
+        if (values[layer].allocate(bytes) != cudaSuccess)
+            throw std::runtime_error(
+                "M2M100Pipeline: unable to allocate cross-attention value buffer");
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+cudaError_t cudaMalloc(void** devPtr, size_t size) {
+    (void)size;
+    ++g_allocation_count;
+    if (g_fail_on_allocation != 0 && g_allocation_count == g_fail_on_allocation) {
+        *devPtr = nullptr;
+        return cudaErrorMemoryAllocation;
+    }
+    void* address = reinterpret_cast<void*>(g_next_address);
+    g_next_address += 0x1000;
+    g_outstanding.insert(address);
+    *devPtr = address;
+    return cudaSuccess;
+}
+
+cudaError_t cudaFree(void* devPtr) {
+    if (devPtr != nullptr) {
+        g_outstanding.erase(devPtr);
+    }
+    return cudaSuccess;
+}
+
+} // extern "C"
+
+int main() {
+    const int32_t layers = 4;
+    const std::size_t bytes = 1024;
+
+    // Four layers means eight allocations. Fail each in turn; whatever the loop
+    // acquired before the failure must be released as the exception unwinds.
+    for (int failing = 1; failing <= 2 * layers; ++failing) {
+        g_fail_on_allocation = failing;
+        g_allocation_count = 0;
+        bool threw = false;
+        try {
+            std::vector<trtmc::m2m_100::DeviceBuffer> keys;
+            std::vector<trtmc::m2m_100::DeviceBuffer> values;
+            allocate_cross_kv(keys, values, layers, bytes);
+        } catch (const std::runtime_error& error) {
+            threw = true;
+            // Allocations alternate key, value, so an odd failure point is a
+            // key buffer and an even one is a value buffer.
+            const char* expected =
+                (failing % 2) == 1
+                    ? "M2M100Pipeline: unable to allocate cross-attention key buffer"
+                    : "M2M100Pipeline: unable to allocate cross-attention value buffer";
+            check(std::string(error.what()) == expected,
+                  "the error should name the buffer that actually failed");
+        }
+        check(threw, "a failed cross-attention allocation should throw");
+        check(g_outstanding.empty(),
+              "a failed allocation must release everything already acquired");
+        g_outstanding.clear();
+    }
+
+    // With no injected failure the buffers are held, then released on scope exit.
+    g_fail_on_allocation = 0;
+    g_allocation_count = 0;
+    {
+        std::vector<trtmc::m2m_100::DeviceBuffer> keys;
+        std::vector<trtmc::m2m_100::DeviceBuffer> values;
+        allocate_cross_kv(keys, values, layers, bytes);
+        check(g_outstanding.size() == static_cast<std::size_t>(2 * layers),
+              "every layer should hold a key and a value buffer");
+    }
+    check(g_outstanding.empty(), "leaving scope should release every buffer");
+
+    if (g_failures != 0) {
+        std::fprintf(stderr, "%d check(s) failed\n", g_failures);
+        return 1;
+    }
+    std::printf("m2m_100 cross-attention allocation-failure checks passed\n");
+    return 0;
+}

--- a/families/m2m_100/tests/cpp/test_m2m_100_cross_kv_alloc.cpp
+++ b/families/m2m_100/tests/cpp/test_m2m_100_cross_kv_alloc.cpp
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Exercises the ownership the M2M-100 pipeline uses for its cross-attention K/V
-// buffers, against CPU CUDA stubs so each allocation can be failed in turn
-// without a GPU. M2M100Pipeline itself needs live TensorRT modules to build, so
-// this drives the same allocation loop over the same owning type.
+// Drives the M2M-100 pipeline's own allocation path - allocate_cross_kv, which
+// the constructor runs - against CPU CUDA stubs so each allocation can be
+// failed in turn without a GPU. M2M100Pipeline itself needs live TensorRT
+// modules to build.
 
 #include "families/m2m_100/runtime/device_buffer.h"
 
@@ -30,23 +30,6 @@ void check(bool condition, const char* what) {
     if (!condition) {
         std::fprintf(stderr, "FAIL: %s\n", what);
         ++g_failures;
-    }
-}
-
-// The allocation loop from M2M100Pipeline's constructor, over the same type.
-void allocate_cross_kv(std::vector<trtmc::m2m_100::DeviceBuffer>& keys,
-                       std::vector<trtmc::m2m_100::DeviceBuffer>& values, int32_t layers,
-                       std::size_t bytes) {
-    keys.resize(static_cast<std::size_t>(layers));
-    values.resize(static_cast<std::size_t>(layers));
-    for (int32_t i = 0; i < layers; ++i) {
-        const std::size_t layer = static_cast<std::size_t>(i);
-        if (keys[layer].allocate(bytes) != cudaSuccess)
-            throw std::runtime_error(
-                "M2M100Pipeline: unable to allocate cross-attention key buffer");
-        if (values[layer].allocate(bytes) != cudaSuccess)
-            throw std::runtime_error(
-                "M2M100Pipeline: unable to allocate cross-attention value buffer");
     }
 }
 
@@ -90,7 +73,7 @@ int main() {
         try {
             std::vector<trtmc::m2m_100::DeviceBuffer> keys;
             std::vector<trtmc::m2m_100::DeviceBuffer> values;
-            allocate_cross_kv(keys, values, layers, bytes);
+            trtmc::m2m_100::allocate_cross_kv(keys, values, layers, bytes);
         } catch (const std::runtime_error& error) {
             threw = true;
             // Allocations alternate key, value, so an odd failure point is a
@@ -114,7 +97,7 @@ int main() {
     {
         std::vector<trtmc::m2m_100::DeviceBuffer> keys;
         std::vector<trtmc::m2m_100::DeviceBuffer> values;
-        allocate_cross_kv(keys, values, layers, bytes);
+        trtmc::m2m_100::allocate_cross_kv(keys, values, layers, bytes);
         check(g_outstanding.size() == static_cast<std::size_t>(2 * layers),
               "every layer should hold a key and a value buffer");
     }


### PR DESCRIPTION
## Background

`M2M100Pipeline`'s constructor allocates one cross-attention key and value buffer per decoder layer but never checked `cudaMalloc`'s result. Same shape as bark (#1201), bart (#1222) and whisper (#1223), all still open, tracked together in #1221.

## Exit Criteria

Every `cudaMalloc` in the constructor is checked, and a failure releases every allocation the constructor already made rather than leaking it. Success path unchanged.

## Implementation

Two commits.

The first checks each `cudaError_t` and throws on failure, matching `core/runtime/tensorrt/trt_module_impl.cpp`'s existing convention.

The second addresses @chaofengw-nv's review on #1221: checking the status was only half the fix. The buffers lived in `std::vector<void*>`, and destroying that vector does not free the device allocations its elements point at - and a constructor that throws never runs its own destructor - so a failure on any layer after the first leaked everything allocated before it. Each buffer is now held in a family-local `DeviceBuffer` (`families/m2m_100/runtime/device_buffer.h`), so the vector members release what they hold during unwinding. The explicit destructor loop is now redundant and removed.

### Change categories
- [x] Model or runtime behavior

## Validation

### Commands and Results

Built the real targets and ran the family's tests:
```
$ cmake --build build --target trtmc_model_m2m_100 test_m2m_100_runtime_config test_m2m_100_tokenizer_schema test_m2m_100_cross_kv_alloc
$ ctest
3/3 Test #3: m2m_100_cross_kv_alloc ...........   Passed
100% tests passed out of 3
```

`test_m2m_100_cross_kv_alloc` is new. `M2M100Pipeline` needs live TensorRT modules to construct, so the test drives the same allocation loop over the same owning type against CPU CUDA stubs, failing each of the eight allocations in turn and asserting which buffer the reported error names. It needs no GPU and links no cudart, so it runs in the CPU tier.

Verified it actually catches the bug rather than just passing: against the previous raw-pointer shape it reports 8 failed checks, matching the "leaks from the second allocation onward" finding on #1221.

`clang-format --dry-run --Werror` on the changed files: clean.

### Hardware, Environment, and Revisions

Rebased onto `1f7fc4156` (upstream/main). GPU: GTX 1650, driver 610.57.04. g++ 16.2.1. CUDA 13.3.1, TensorRT 11.2.1.

### Not Run / Remaining Gaps

No real M2M-100/NLLB checkpoint or engine on hand, so the full pipeline was not exercised end to end - only the buffer ownership this PR changes.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Single family, no shared-core or cross-family touch. Both commits DCO signed off.

## Notes For Future Readers

`t5`, `marian` and `flux` still carry the same pattern, tracked in #1221.

### Risk level
- [x] Low

Error-handling and ownership change on an existing allocation path; no public API, ABI, or success-path behavior change.

