### PR TITLE
feat(boltz2): support protein complexes

### DIFF
--- a/families/boltz2/contracts.py
+++ b/families/boltz2/contracts.py
@@ -80,6 +80,7 @@ def validate_request(
     if not request.sequences:
         raise ValueError("Boltz-2 requires at least one polymer sequence")
     seen_chain_ids: set[str] = set()
+    entity_msas: dict[tuple[PolymerKind, str], PurePosixPath] = {}
     for item in request.sequences:
         if item.kind is not PolymerKind.PROTEIN:
             raise ValueError("only protein polymers are supported by this Boltz-2 profile")
@@ -108,9 +109,10 @@ def validate_request(
             raise ValueError(
                 "Boltz-2 A3M paths must be relative and remain inside the request root"
             )
-    if len(request.sequences) != 1 or len(request.sequences[0].chain_ids) != 1:
-        raise ValueError("the qualified Boltz-2 profile accepts exactly one protein chain")
-
+        entity = (item.kind, item.sequence)
+        previous_msa = entity_msas.setdefault(entity, item.msa_path)
+        if previous_msa != item.msa_path:
+            raise ValueError("proteins with the same sequence must share one Boltz-2 MSA")
     if not profile.min_tokens <= request.token_count <= profile.max_tokens:
         raise ValueError(
             "Boltz-2 token count is outside the qualified BF16 profile: "
@@ -167,15 +169,23 @@ def parse_request_yaml(text: str) -> Boltz2Request:
                 "unsupported Boltz-2 protein fields: "
                 + ", ".join(sorted(unknown_protein))
             )
-        chain_id = protein.get("id")
+        raw_chain_ids = protein.get("id")
         sequence = protein.get("sequence")
         msa = protein.get("msa")
-        if not all(isinstance(value, str) for value in (chain_id, sequence, msa)):
-            raise ValueError("Boltz-2 protein id, sequence, and msa must be strings")
+        if isinstance(raw_chain_ids, str):
+            chain_ids = (raw_chain_ids,)
+        elif isinstance(raw_chain_ids, list) and all(
+            isinstance(chain_id, str) for chain_id in raw_chain_ids
+        ):
+            chain_ids = tuple(raw_chain_ids)
+        else:
+            raise ValueError("Boltz-2 protein id must be a string or list of strings")
+        if not isinstance(sequence, str) or not isinstance(msa, str):
+            raise ValueError("Boltz-2 protein sequence and msa must be strings")
         sequences.append(
             SequenceInput(
                 kind=PolymerKind.PROTEIN,
-                chain_ids=(chain_id,),
+                chain_ids=chain_ids,
                 sequence=sequence,
                 msa_path=PurePosixPath(msa),
             )

--- a/families/boltz2/model.py
+++ b/families/boltz2/model.py
@@ -167,6 +167,11 @@ class Boltz2Plugin:
         except UnicodeDecodeError as error:
             raise ValueError("Boltz-2 request YAML must be UTF-8") from error
         request = parse_request_yaml(request_text)
+        if len(request.sequences) != 1 or len(request.sequences[0].chain_ids) != 1:
+            raise ValueError(
+                "Boltz-2 bundle construction requires the pinned monomer package; "
+                "prepare compatible protein-complex requests after the bundle is built"
+            )
         if request.sequences[0].msa_path != MSA:
             raise ValueError(f"Boltz-2 request must reference the packaged {MSA} file")
         msa_rows = validate_a3m(

--- a/families/boltz2/reference.py
+++ b/families/boltz2/reference.py
@@ -25,7 +25,12 @@ NATIVE_QUALIFICATION_THRESHOLDS = {
     "plddt_mean_abs_max": 0.10,
     "confidence_score_abs_max": 0.10,
     "complex_plddt_abs_max": 0.10,
+    "complex_iplddt_abs_max": 0.10,
     "ptm_abs_max": 0.10,
+    "iptm_abs_max": 0.10,
+    "protein_iptm_abs_max": 0.10,
+    "chains_ptm_max_abs_max": 0.10,
+    "pair_chains_iptm_max_abs_max": 0.10,
 }
 
 
@@ -98,7 +103,23 @@ def _as_numpy(value: Any) -> np.ndarray:
     return value.detach().float().cpu().numpy()
 
 
+def _pair_chain_arrays(prediction: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+    pairs = prediction["pair_chains_iptm"]
+    chain_ids = sorted(int(chain_id) for chain_id in pairs)
+    if any(set(int(value) for value in pairs[chain_id]) != set(chain_ids) for chain_id in pairs):
+        raise ValueError("reference pair-chain ipTM map is not square")
+    values = np.empty((len(chain_ids), len(chain_ids)), dtype=np.float32)
+    for first_index, first in enumerate(chain_ids):
+        for second_index, second in enumerate(chain_ids):
+            score = _as_numpy(pairs[first][second]).reshape(-1)
+            if score.size != 1:
+                raise ValueError("reference pair-chain ipTM score is not scalar")
+            values[first_index, second_index] = score[0]
+    return np.asarray(chain_ids, dtype=np.int32), values
+
+
 def save_reference_output(path: Path, prediction: dict[str, Any]) -> None:
+    pair_chain_ids, pair_chains_iptm = _pair_chain_arrays(prediction)
     path.parent.mkdir(parents=True, exist_ok=True)
     np.savez_compressed(
         path,
@@ -108,7 +129,12 @@ def save_reference_output(path: Path, prediction: dict[str, Any]) -> None:
         plddt=_as_numpy(prediction["plddt"]),
         confidence_score=_as_numpy(prediction["confidence_score"]),
         complex_plddt=_as_numpy(prediction["complex_plddt"]),
+        complex_iplddt=_as_numpy(prediction["complex_iplddt"]),
         ptm=_as_numpy(prediction["ptm"]),
+        iptm=_as_numpy(prediction["iptm"]),
+        protein_iptm=_as_numpy(prediction["protein_iptm"]),
+        pair_chain_ids=pair_chain_ids,
+        pair_chains_iptm=pair_chains_iptm,
     )
 
 
@@ -120,6 +146,17 @@ def _masked_coords(data: np.lib.npyio.NpzFile) -> np.ndarray:
     result = coords[mask]
     if result.size == 0 or not np.isfinite(result).all():
         raise ValueError("coordinates are empty or non-finite")
+    return result
+
+
+def _masked_tokens(data: np.lib.npyio.NpzFile, name: str) -> np.ndarray:
+    values = np.asarray(data[name], dtype=np.float64).reshape(-1)
+    mask = np.asarray(data["token_mask"], dtype=bool).reshape(-1)
+    if values.shape != mask.shape:
+        raise ValueError(f"{name} and token-mask shapes do not match")
+    result = values[mask]
+    if result.size == 0 or not np.isfinite(result).all():
+        raise ValueError(f"active {name} values are empty or non-finite")
     return result
 
 
@@ -193,7 +230,24 @@ def _qualification(
             float(metrics["complex_plddt_abs"])
             <= thresholds["complex_plddt_abs_max"]
         ),
+        "complex_iplddt_abs": (
+            float(metrics["complex_iplddt_abs"])
+            <= thresholds["complex_iplddt_abs_max"]
+        ),
         "ptm_abs": float(metrics["ptm_abs"]) <= thresholds["ptm_abs_max"],
+        "iptm_abs": float(metrics["iptm_abs"]) <= thresholds["iptm_abs_max"],
+        "protein_iptm_abs": (
+            float(metrics["protein_iptm_abs"])
+            <= thresholds["protein_iptm_abs_max"]
+        ),
+        "chains_ptm_max_abs": (
+            float(metrics["chains_ptm_max_abs"])
+            <= thresholds["chains_ptm_max_abs_max"]
+        ),
+        "pair_chains_iptm_max_abs": (
+            float(metrics["pair_chains_iptm_max_abs"])
+            <= thresholds["pair_chains_iptm_max_abs_max"]
+        ),
     }
     return {"thresholds": thresholds, "checks": checks, "passed": all(checks.values())}
 
@@ -214,10 +268,21 @@ def compare_native(
         raise ValueError("native qualification expected counts must be positive")
     with np.load(reference_npz) as reference:
         reference_coords = _masked_coords(reference)
-        reference_plddt = np.asarray(reference["plddt"], dtype=np.float64).reshape(-1)
+        reference_plddt = _masked_tokens(reference, "plddt")
         reference_confidence = float(np.asarray(reference["confidence_score"]).reshape(-1)[0])
         reference_complex_plddt = float(np.asarray(reference["complex_plddt"]).reshape(-1)[0])
+        reference_complex_iplddt = float(
+            np.asarray(reference["complex_iplddt"]).reshape(-1)[0]
+        )
         reference_ptm = float(np.asarray(reference["ptm"]).reshape(-1)[0])
+        reference_iptm = float(np.asarray(reference["iptm"]).reshape(-1)[0])
+        reference_protein_iptm = float(
+            np.asarray(reference["protein_iptm"]).reshape(-1)[0]
+        )
+        reference_chain_ids = np.asarray(reference["pair_chain_ids"], dtype=np.int32)
+        reference_pair_chains_iptm = np.asarray(
+            reference["pair_chains_iptm"], dtype=np.float64
+        )
     candidate_coords = _native_mmcif_coords(candidate_mmcif)
     metadata = json.loads(candidate_metadata.read_text(encoding="utf-8"))
     candidate_plddt = np.asarray(metadata.get("plddt", []), dtype=np.float64)
@@ -225,6 +290,29 @@ def compare_native(
         raise ValueError("reference and native coordinate shapes do not match")
     if reference_plddt.shape != candidate_plddt.shape:
         raise ValueError("reference and native pLDDT shapes do not match")
+    if reference_pair_chains_iptm.shape != (reference_chain_ids.size,) * 2:
+        raise ValueError("reference pair-chain ipTM shape does not match its chain IDs")
+    chain_keys = {str(int(chain_id)) for chain_id in reference_chain_ids}
+    candidate_chains = metadata.get("chains_ptm")
+    candidate_pairs = metadata.get("pair_chains_iptm")
+    if not isinstance(candidate_chains, dict) or set(candidate_chains) != chain_keys:
+        raise ValueError("native per-chain pTM keys do not match the reference")
+    if not isinstance(candidate_pairs, dict) or set(candidate_pairs) != chain_keys:
+        raise ValueError("native pair-chain ipTM keys do not match the reference")
+    if metadata.get("chain_pair_confidence") != []:
+        raise ValueError("native legacy chain-pair confidence field changed shape")
+    candidate_pair_chains_iptm = np.empty_like(reference_pair_chains_iptm)
+    candidate_chains_ptm = np.empty(reference_chain_ids.size, dtype=np.float64)
+    for first_index, first in enumerate(reference_chain_ids):
+        first_key = str(int(first))
+        row = candidate_pairs[first_key]
+        if not isinstance(row, dict) or set(row) != chain_keys:
+            raise ValueError("native pair-chain ipTM map is not square")
+        candidate_chains_ptm[first_index] = float(candidate_chains[first_key])
+        for second_index, second in enumerate(reference_chain_ids):
+            candidate_pair_chains_iptm[first_index, second_index] = float(
+                row[str(int(second))]
+            )
     result = {
         "schema_version": 1,
         "atom_count": int(candidate_coords.shape[0]),
@@ -234,6 +322,9 @@ def compare_native(
             and np.isfinite(candidate_coords).all()
             and np.isfinite(reference_plddt).all()
             and np.isfinite(candidate_plddt).all()
+            and np.isfinite(reference_pair_chains_iptm).all()
+            and np.isfinite(candidate_pair_chains_iptm).all()
+            and np.isfinite(candidate_chains_ptm).all()
         ),
         "lddt": _lddt(reference_coords, candidate_coords),
         "kabsch_rmsd_angstrom": _kabsch_rmsd(reference_coords, candidate_coords),
@@ -245,7 +336,20 @@ def compare_native(
         "complex_plddt_abs": abs(
             reference_complex_plddt - float(metadata["complex_plddt"])
         ),
+        "complex_iplddt_abs": abs(
+            reference_complex_iplddt - float(metadata["complex_iplddt"])
+        ),
         "ptm_abs": abs(reference_ptm - float(metadata["ptm"])),
+        "iptm_abs": abs(reference_iptm - float(metadata["iptm"])),
+        "protein_iptm_abs": abs(
+            reference_protein_iptm - float(metadata["protein_iptm"])
+        ),
+        "chains_ptm_max_abs": float(
+            np.max(np.abs(np.diag(reference_pair_chains_iptm) - candidate_chains_ptm))
+        ),
+        "pair_chains_iptm_max_abs": float(
+            np.max(np.abs(reference_pair_chains_iptm - candidate_pair_chains_iptm))
+        ),
     }
     numeric = (
         value

--- a/families/boltz2/request_preparation.py
+++ b/families/boltz2/request_preparation.py
@@ -111,7 +111,7 @@ def serialize_prepared_request(
     return header + b"".join(sections)
 
 
-def _request_inputs(request_path: Path) -> tuple[bytes, int, Path, bytes]:
+def _request_inputs(request_path: Path) -> tuple[bytes, int, tuple[tuple[Path, bytes], ...]]:
     request_bytes = request_path.read_bytes()
     try:
         request_text = request_bytes.decode("utf-8")
@@ -119,23 +119,26 @@ def _request_inputs(request_path: Path) -> tuple[bytes, int, Path, bytes]:
         raise ValueError("Boltz-2 request YAML must be UTF-8") from error
     request = parse_request_yaml(request_text)
     request_root = request_path.parent.resolve(strict=True)
-    msa_path = (request_root / request.sequences[0].msa_path).resolve(strict=True)
-    try:
-        msa_path.relative_to(request_root)
-    except ValueError as error:
-        raise ValueError("Boltz-2 A3M path must remain inside the request root") from error
-    if not msa_path.is_file():
-        raise ValueError(f"Boltz-2 A3M path is not a file: {msa_path}")
-    msa_bytes = msa_path.read_bytes()
-    try:
-        msa_text = msa_bytes.decode("utf-8")
-    except UnicodeDecodeError as error:
-        raise ValueError("Boltz-2 A3M must be UTF-8") from error
-    validate_a3m(msa_text, expected_query=request.sequences[0].sequence)
-    return request_bytes, request.token_count, msa_path, msa_bytes
+    msa_inputs: list[tuple[Path, bytes]] = []
+    for sequence in request.sequences:
+        msa_path = (request_root / sequence.msa_path).resolve(strict=True)
+        try:
+            msa_path.relative_to(request_root)
+        except ValueError as error:
+            raise ValueError("Boltz-2 A3M path must remain inside the request root") from error
+        if not msa_path.is_file():
+            raise ValueError(f"Boltz-2 A3M path is not a file: {msa_path}")
+        msa_bytes = msa_path.read_bytes()
+        try:
+            msa_text = msa_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("Boltz-2 A3M must be UTF-8") from error
+        validate_a3m(msa_text, expected_query=sequence.sequence)
+        msa_inputs.append((msa_path, msa_bytes))
+    return request_bytes, request.token_count, tuple(msa_inputs)
 
 
-def _cache_key(request: bytes, msa: bytes) -> str:
+def _cache_key(request: bytes, msa_inputs: tuple[tuple[Path, bytes], ...]) -> str:
     profile = INITIAL_BF16_PROFILE
     identity = json.dumps(
         {
@@ -148,7 +151,8 @@ def _cache_key(request: bytes, msa: bytes) -> str:
         },
         sort_keys=True,
     ).encode("utf-8")
-    return content_cache_key("boltz2-prepared-request-v2", identity, request, msa)
+    msa_payloads = tuple(payload for _, payload in msa_inputs)
+    return content_cache_key("boltz2-prepared-request-v2", identity, request, *msa_payloads)
 
 
 def _write_atomic(path: Path, payload: bytes) -> None:
@@ -171,9 +175,14 @@ def _write_atomic(path: Path, payload: bytes) -> None:
             temporary.unlink(missing_ok=True)
 
 
-def _stage_request(path: Path, request: bytes, msa_path: Path) -> None:
+def _stage_request(
+    path: Path, request: bytes, msa_inputs: tuple[tuple[Path, bytes], ...]
+) -> None:
     document = yaml.safe_load(request.decode("utf-8"))
-    document["sequences"][0]["protein"]["msa"] = str(msa_path)
+    if len(document["sequences"]) != len(msa_inputs):
+        raise ValueError("Boltz-2 request and MSA inputs are inconsistent")
+    for entry, (msa_path, _) in zip(document["sequences"], msa_inputs, strict=True):
+        entry["protein"]["msa"] = str(msa_path)
     path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
 
 
@@ -194,8 +203,8 @@ def prepare_structure_request(
     validate_artifact(root / MOLS_ARCHIVE, PINNED_BOLTZ2.molecular_archive)
     request_path = Path(request_path).resolve(strict=True)
     output_path = Path(output_path)
-    request_bytes, request_token_count, msa_path, msa_bytes = _request_inputs(request_path)
-    key = _cache_key(request_bytes, msa_bytes)
+    request_bytes, request_token_count, msa_inputs = _request_inputs(request_path)
+    key = _cache_key(request_bytes, msa_inputs)
     cache_root = (
         Path(cache_dir)
         if cache_dir is not None
@@ -224,7 +233,7 @@ def prepare_structure_request(
         work.mkdir(parents=True, exist_ok=True)
         if staged_request.is_symlink():
             raise ValueError(f"Boltz-2 staged request must not be a symlink: {staged_request}")
-        _stage_request(staged_request, request_bytes, msa_path)
+        _stage_request(staged_request, request_bytes, msa_inputs)
         process_inputs(
             data=[staged_request],
             out_dir=work,

--- a/families/boltz2/runtime/pipeline.cpp
+++ b/families/boltz2/runtime/pipeline.cpp
@@ -539,20 +539,165 @@ std::vector<float> confidenceFrameMask(const std::vector<float>& coordinates, co
 }
 
 float maximumTmScore(const std::vector<float>& expected, const std::vector<float>& frame_mask,
-                     const float* token_mask, int token_count) {
+                     const float* token_mask, const std::vector<float>& pair_mask,
+                     int token_count) {
     float maximum = 0.0F;
     for (int row = 0; row < token_count; ++row) {
         float numerator = 0.0F;
         float denominator = 0.0F;
         for (int column = 0; column < token_count; ++column) {
-            const float mask =
-                frame_mask[static_cast<std::size_t>(row)] * token_mask[column] * token_mask[row];
+            const float selection =
+                pair_mask.empty() ? 1.0F
+                                  : pair_mask[static_cast<std::size_t>(row * token_count + column)];
+            const float mask = frame_mask[static_cast<std::size_t>(row)] * token_mask[column] *
+                               token_mask[row] * selection;
             numerator += expected[static_cast<std::size_t>(row * token_count + column)] * mask;
             denominator += mask;
         }
         maximum = std::max(maximum, numerator / (denominator + 1.0e-5F));
     }
     return maximum;
+}
+
+std::vector<float> differentChainMask(const int32_t* asym_id, int token_count) {
+    std::vector<float> result(static_cast<std::size_t>(token_count * token_count));
+    for (int row = 0; row < token_count; ++row)
+        for (int column = 0; column < token_count; ++column)
+            result[static_cast<std::size_t>(row * token_count + column)] =
+                static_cast<float>(asym_id[row] != asym_id[column]);
+    return result;
+}
+
+std::vector<float> proteinInterfaceMask(const int32_t* asym_id, const int32_t* mol_type,
+                                        int token_count) {
+    constexpr int32_t kProtein = 0;
+    auto result = differentChainMask(asym_id, token_count);
+    for (int row = 0; row < token_count; ++row)
+        for (int column = 0; column < token_count; ++column)
+            result[static_cast<std::size_t>(row * token_count + column)] *=
+                static_cast<float>(mol_type[row] == kProtein && mol_type[column] == kProtein);
+    return result;
+}
+
+bool isLigandProteinPair(int32_t first, int32_t second) {
+    constexpr int32_t kProtein = 0;
+    constexpr int32_t kNonPolymer = 3;
+    return (first == kNonPolymer && second == kProtein) ||
+           (first == kProtein && second == kNonPolymer);
+}
+
+std::vector<float> ligandInterfaceMask(const int32_t* asym_id, const int32_t* mol_type,
+                                       int token_count) {
+    auto result = differentChainMask(asym_id, token_count);
+    for (int row = 0; row < token_count; ++row)
+        for (int column = 0; column < token_count; ++column)
+            result[static_cast<std::size_t>(row * token_count + column)] *=
+                static_cast<float>(isLigandProteinPair(mol_type[row], mol_type[column]));
+    return result;
+}
+
+std::vector<float> chainPairMask(const int32_t* asym_id, int token_count, int32_t first,
+                                 int32_t second) {
+    std::vector<float> result(static_cast<std::size_t>(token_count * token_count));
+    for (int row = 0; row < token_count; ++row)
+        for (int column = 0; column < token_count; ++column)
+            result[static_cast<std::size_t>(row * token_count + column)] =
+                static_cast<float>(asym_id[column] == first && asym_id[row] == second);
+    return result;
+}
+
+std::vector<int32_t> activeChainIds(const int32_t* asym_id, int active_token_count) {
+    std::vector<int32_t> result(asym_id, asym_id + active_token_count);
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+    return result;
+}
+
+float interfacePlddt(const std::vector<float>& plddt, const std::vector<float>& distances,
+                     const float* token_mask, const int32_t* asym_id, const int32_t* mol_type,
+                     int token_count) {
+    constexpr int32_t kNonPolymer = 3;
+    float weighted_sum = 0.0F;
+    float weight_sum = 0.0F;
+    for (int row = 0; row < token_count; ++row) {
+        if (token_mask[row] == 0.0F)
+            continue;
+        bool interface = false;
+        for (int column = 0; column < token_count; ++column) {
+            interface = interface ||
+                        (token_mask[column] != 0.0F && asym_id[row] != asym_id[column] &&
+                         distances[static_cast<std::size_t>(row * token_count + column)] < 8.0F);
+        }
+        const float weight = mol_type[row] == kNonPolymer ? 20.0F : (interface ? 10.0F : 1.0F);
+        weighted_sum += plddt[static_cast<std::size_t>(row)] * weight;
+        weight_sum += weight;
+    }
+    return weighted_sum / weight_sum;
+}
+
+struct ConfidenceOutputs {
+    std::vector<uint16_t> plddt_logits;
+    std::vector<uint16_t> pae_logits;
+    std::vector<float> representative_distances;
+};
+
+ConfidenceOutputs readConfidenceOutputs(ITrtModule& module, int token_count) {
+    const std::size_t tokens = static_cast<std::size_t>(token_count);
+    ConfidenceOutputs result{
+        std::vector<uint16_t>(tokens * 50U),
+        std::vector<uint16_t>(tokens * tokens * 64U),
+        std::vector<float>(tokens * tokens),
+    };
+    if (cudaMemcpy(result.plddt_logits.data(), module.device_ptr("plddt_logits"),
+                   result.plddt_logits.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(result.pae_logits.data(), module.device_ptr("pae_logits"),
+                   result.pae_logits.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(result.representative_distances.data(),
+                   module.device_ptr("representative_distance"),
+                   result.representative_distances.size() * sizeof(float),
+                   cudaMemcpyDeviceToHost) != cudaSuccess) {
+        throw std::runtime_error("Boltz-2 failed to read confidence outputs");
+    }
+    return result;
+}
+
+struct TmConfidence {
+    float ptm{0.0F};
+    float iptm{0.0F};
+    float ligand_iptm{0.0F};
+    float protein_iptm{0.0F};
+    std::vector<int32_t> chain_ids;
+    std::vector<std::vector<float>> chain_pairs;
+};
+
+TmConfidence aggregateTmConfidence(const std::vector<float>& expected,
+                                   const std::vector<float>& frame_mask, const float* token_mask,
+                                   const int32_t* asym_id, const int32_t* mol_type, int token_count,
+                                   int active_token_count) {
+    TmConfidence result;
+    result.ptm = maximumTmScore(expected, frame_mask, token_mask, {}, token_count);
+    result.iptm = maximumTmScore(expected, frame_mask, token_mask,
+                                 differentChainMask(asym_id, token_count), token_count);
+    result.ligand_iptm =
+        maximumTmScore(expected, frame_mask, token_mask,
+                       ligandInterfaceMask(asym_id, mol_type, token_count), token_count);
+    result.protein_iptm =
+        maximumTmScore(expected, frame_mask, token_mask,
+                       proteinInterfaceMask(asym_id, mol_type, token_count), token_count);
+    result.chain_ids = activeChainIds(asym_id, active_token_count);
+    result.chain_pairs.assign(result.chain_ids.size(), std::vector<float>(result.chain_ids.size()));
+    for (std::size_t first = 0; first < result.chain_ids.size(); ++first) {
+        for (std::size_t second = 0; second < result.chain_ids.size(); ++second) {
+            result.chain_pairs[first][second] =
+                maximumTmScore(expected, frame_mask, token_mask,
+                               chainPairMask(asym_id, token_count, result.chain_ids[first],
+                                             result.chain_ids[second]),
+                               token_count);
+        }
+    }
+    return result;
 }
 
 struct AtomRow {
@@ -987,23 +1132,16 @@ StructureConfidence Boltz2Pipeline::runConfidence(const std::vector<float>& coor
     engines_.confidence->forward_device_async({});
     engines_.confidence->sync();
 
-    const std::size_t plddt_elements = static_cast<std::size_t>(token_count_) * 50U;
-    const std::size_t pae_elements =
-        static_cast<std::size_t>(token_count_) * static_cast<std::size_t>(token_count_) * 64U;
-    std::vector<uint16_t> plddt_logits(plddt_elements);
-    std::vector<uint16_t> pae_logits(pae_elements);
-    if (cudaMemcpy(plddt_logits.data(), engines_.confidence->device_ptr("plddt_logits"),
-                   plddt_logits.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
-        cudaMemcpy(pae_logits.data(), engines_.confidence->device_ptr("pae_logits"),
-                   pae_logits.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
-        throw std::runtime_error("Boltz-2 failed to read confidence logits");
-    }
+    const auto outputs = readConfidenceOutputs(*engines_.confidence, token_count_);
     StructureConfidence result;
-    result.plddt =
-        softmaxExpectedBfloat16(plddt_logits, static_cast<std::size_t>(token_count_), 50, 1.0F);
+    result.plddt = softmaxExpectedBfloat16(outputs.plddt_logits,
+                                           static_cast<std::size_t>(token_count_), 50, 1.0F);
     const auto* token_mask = reinterpret_cast<const float*>(feature("token_pad_mask").data.data());
     result.complex_plddt = maskedMean(result.plddt, token_mask, token_count_);
-    result.complex_iplddt = result.complex_plddt;
+    const auto* asym_id = reinterpret_cast<const int32_t*>(feature("asym_id").data.data());
+    const auto* mol_type = reinterpret_cast<const int32_t*>(feature("mol_type").data.data());
+    result.complex_iplddt = interfacePlddt(result.plddt, outputs.representative_distances,
+                                           token_mask, asym_id, mol_type, token_count_);
 
     const auto* frames = reinterpret_cast<const int32_t*>(feature("frames_idx").data.data());
     const auto frame_mask =
@@ -1013,9 +1151,17 @@ StructureConfidence Boltz2Pipeline::runConfidence(const std::vector<float>& coor
         valid_tokens += token_mask[token];
     const float d0 = 1.24F * std::cbrt(std::max(valid_tokens, 19.0F) - 15.0F) - 1.8F;
     const auto tm_expected = softmaxExpectedTmBfloat16(
-        pae_logits, static_cast<std::size_t>(token_count_) * token_count_, 64, d0);
-    result.ptm = maximumTmScore(tm_expected, frame_mask, token_mask, token_count_);
-    result.confidence_score = (4.0F * result.complex_plddt + result.ptm) / 5.0F;
+        outputs.pae_logits, static_cast<std::size_t>(token_count_) * token_count_, 64, d0);
+    const auto tm = aggregateTmConfidence(tm_expected, frame_mask, token_mask, asym_id, mol_type,
+                                          token_count_, active_token_count_);
+    result.ptm = tm.ptm;
+    result.iptm = tm.iptm;
+    result.ligand_iptm = tm.ligand_iptm;
+    result.protein_iptm = tm.protein_iptm;
+    confidence_chain_ids_ = tm.chain_ids;
+    confidence_chain_pairs_ = tm.chain_pairs;
+    const float ranking_tm = result.iptm > 1.0e-8F ? result.iptm : result.ptm;
+    result.confidence_score = (4.0F * result.complex_plddt + ranking_tm) / 5.0F;
     result.plddt.resize(static_cast<std::size_t>(active_token_count_));
     return result;
 }
@@ -1034,6 +1180,17 @@ std::string Boltz2Pipeline::writeStructure(const std::vector<float>& coordinates
 
 std::string Boltz2Pipeline::resultMetadata(const StructurePredictionConfig& cfg,
                                            const StructureConfidence& confidence) const {
+    nlohmann::json chains_ptm = nlohmann::json::object();
+    nlohmann::json pair_chains_iptm = nlohmann::json::object();
+    for (std::size_t first = 0; first < confidence_chain_ids_.size(); ++first) {
+        const std::string first_id = std::to_string(confidence_chain_ids_[first]);
+        chains_ptm[first_id] = confidence_chain_pairs_[first][first];
+        pair_chains_iptm[first_id] = nlohmann::json::object();
+        for (std::size_t second = 0; second < confidence_chain_ids_.size(); ++second) {
+            pair_chains_iptm[first_id][std::to_string(confidence_chain_ids_[second])] =
+                confidence_chain_pairs_[first][second];
+        }
+    }
     const nlohmann::json metadata{
         {"schema_version", 1},
         {"family", "boltz2"},
@@ -1055,7 +1212,9 @@ std::string Boltz2Pipeline::resultMetadata(const StructurePredictionConfig& cfg,
         {"ligand_iptm", confidence.ligand_iptm},
         {"protein_iptm", confidence.protein_iptm},
         {"plddt", confidence.plddt},
+        {"chains_ptm", std::move(chains_ptm)},
         {"chain_pair_confidence", nlohmann::json::array()},
+        {"pair_chains_iptm", std::move(pair_chains_iptm)},
     };
     return metadata.dump(2) + "\n";
 }

--- a/families/boltz2/runtime/pipeline.h
+++ b/families/boltz2/runtime/pipeline.h
@@ -76,6 +76,8 @@ class Boltz2Pipeline final : public IStructurePrediction {
     int atom_count_{0};
     int active_token_count_{0};
     int active_atom_count_{0};
+    std::vector<int32_t> confidence_chain_ids_;
+    std::vector<std::vector<float>> confidence_chain_pairs_;
     cudaStream_t stream_{nullptr};
     std::unordered_map<std::string, DeviceTensor> device_features_;
     DeviceTensor zero_s_;

--- a/families/boltz2/tests/test_e2e.py
+++ b/families/boltz2/tests/test_e2e.py
@@ -36,6 +36,27 @@ def _cases() -> dict[str, tuple[dict, dict]]:
 CASES = _cases()
 
 
+def test_multichain_protein_request_contract() -> None:
+    from families.boltz2.contracts import parse_request_yaml
+
+    request = parse_request_yaml(
+        """version: 1
+sequences:
+  - protein:
+      id: [A, B]
+      sequence: ACDE
+      msa: shared.a3m
+  - protein:
+      id: C
+      sequence: FGHIK
+      msa: chain-c.a3m
+"""
+    )
+    assert request.token_count == 13
+    assert request.sequences[0].chain_ids == ("A", "B")
+    assert request.sequences[1].chain_ids == ("C",)
+
+
 def pytest_generate_tests(metafunc) -> None:
     if "case_name" not in metafunc.fixturenames:
         return
@@ -252,17 +273,35 @@ def test_model_e2e(case_name: str, tmp_path: Path) -> None:
         bundle_stat.st_mtime_ns,
         bundle_stat.st_ctime_ns,
     )
+    from families.boltz2.contracts import parse_request_yaml
+
     variant_request = TEST_ROOT / "data/protein_monomer_variant/protein_monomer_variant.yaml"
-    prepared = tmp_path / "protein_monomer_variant.b2rq"
+    variant = parse_request_yaml(variant_request.read_text(encoding="utf-8"))
+    complex_sequence = variant.sequences[0].sequence[:50]
+    complex_root = tmp_path / "protein-complex"
+    complex_root.mkdir()
+    complex_a3m = complex_root / "protein_complex.a3m"
+    complex_a3m.write_text(f">query\n{complex_sequence}\n", encoding="utf-8")
+    complex_request = complex_root / "protein_complex.yaml"
+    complex_request.write_text(
+        "version: 1\n"
+        "sequences:\n"
+        "  - protein:\n"
+        "      id: [A, B]\n"
+        f"      sequence: {complex_sequence}\n"
+        f"      msa: {complex_a3m.name}\n",
+        encoding="utf-8",
+    )
+    prepared = tmp_path / "protein_complex.b2rq"
     request_cache = tmp_path / "request-cache"
     preparation = prepare_structure_request(
         model_dir,
-        variant_request,
+        complex_request,
         prepared,
         cache_dir=request_cache,
     )
-    variant_structure = tmp_path / "variant.cif"
-    variant_metadata = tmp_path / "variant.json"
+    complex_structure = tmp_path / "complex.cif"
+    complex_metadata = tmp_path / "complex.json"
     completed = subprocess.run(
         [
             str(binary),
@@ -273,9 +312,9 @@ def test_model_e2e(case_name: str, tmp_path: Path) -> None:
             "--input",
             str(prepared),
             "--output",
-            str(variant_structure),
+            str(complex_structure),
             "--output-json",
-            str(variant_metadata),
+            str(complex_metadata),
         ],
         check=True,
         capture_output=True,
@@ -292,25 +331,27 @@ def test_model_e2e(case_name: str, tmp_path: Path) -> None:
         bundle_stat.st_mtime_ns,
         bundle_stat.st_ctime_ns,
     ) == bundle_identity
-    assert json.loads(variant_metadata.read_text(encoding="utf-8"))["profile"] == (
-        "tokens_117_atoms_928"
-    )
+    complex_details = json.loads(complex_metadata.read_text(encoding="utf-8"))
+    assert complex_details["profile"] == "tokens_117_atoms_928"
+    assert complex_details["active_token_count"] == 100
+    assert complex_details["active_atom_count"] == 794
+    assert complex_details["chain_pair_confidence"] == []
     _assert_live_reference_parity(
         model_dir,
         request_cache
         / str(preparation["cache_key"])[:2]
         / str(preparation["cache_key"])
         / "work/processed",
-        variant_structure,
-        variant_metadata,
-        tmp_path / "variant-reference",
-        atom_count=thresholds["atom_count"],
-        token_count=thresholds["token_count"],
+        complex_structure,
+        complex_metadata,
+        tmp_path / "complex-reference",
+        atom_count=794,
+        token_count=100,
     )
     cached = prepare_structure_request(
         model_dir,
-        variant_request,
-        tmp_path / "protein_monomer_variant-cached.b2rq",
+        complex_request,
+        tmp_path / "protein_complex-cached.b2rq",
         cache_dir=request_cache,
     )
     assert cached["cache_hit"] is True


### PR DESCRIPTION
## Background

Follow-up to #1111 and #1134. The initial Boltz-2 profile reuses one TensorRT bundle across compatible monomer requests, but rejects protein complexes and reports monomer-only confidence aggregation.

## Exit Criteria

- Accept multiple protein entries and repeated-chain `id` lists using the pinned Boltz YAML syntax.
- Validate and stage every protein entity's custom query-only A3M without allowing request-root path escapes.
- Reuse the existing 117-token, 928-padded-atom, MSA-depth-1 bundle when the complete complex fits that profile.
- Match seeded eager Boltz for complex structure, interface confidence, pTM, ipTM, protein ipTM, ranking score, and ordered per-chain pair ipTM.
- Keep deep/paired MSA, templates, ligands, affinity, constraints, and larger profiles out of this change.

## Implementation

- Generalize the family request contract from exactly one protein chain to multiple protein entities and repeated chain IDs while retaining unique-chain, uppercase-sequence, bounded-token, and query-only A3M validation.
- Resolve, validate, cache-key, and stage each entity A3M independently before invoking pinned Boltz preprocessing.
- Keep bundle construction on the pinned monomer build package because the TensorRT plans are content-independent; compatible complex requests are prepared after the bundle is built.
- Reproduce pinned Boltz multichain confidence aggregation natively, including interface-weighted pLDDT, ipTM, protein and ligand interface masks, confidence ranking, and per-chain pTM/ipTM metadata.
- Preserve the schema-version-1 `chain_pair_confidence` array and expose ordered scores under `pair_chains_iptm`.
- Save and compare eager per-chain and pair-chain scores, including exact key/shape and finite-value checks.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `pytest -q families/boltz2/tests/test_e2e.py --e2e-model boltz2`: 2 passed in 46:15, including a fresh bundle build and seeded eager parity for the embedded monomer and a reusable 100-token two-chain request.
- Two-chain, 100-token/794-atom reusable-bundle gate: all gates passed; lDDT 1.0, Kabsch RMSD 0.02369 A, mean pLDDT absolute error 0.00178, per-chain pTM maximum absolute error 0.00252, and ordered pair-chain ipTM maximum absolute error 0.00466.
- `pytest -q families/boltz2/tests/test_e2e.py`: 1 passed and 1 skipped as expected without explicit GPU selection.
- `cmake --build <build-dir> --parallel 2 --target trtmc_cli trtmc_model_boltz2 test_boltz2_sections`: passed.
- `ctest --test-dir <build-dir> -R boltz2_sections --output-on-failure`: 1 passed.
- Repository architecture and public-source suite: 128 passed.
- `ruff check families/boltz2/reference.py families/boltz2/tests/test_e2e.py`: passed.
- `clang-format --dry-run --Werror families/boltz2/runtime/pipeline.cpp`: passed.
- `python tools/check_cyclomatic_complexity.py families/boltz2/runtime --max-ccn 10 --fail-on-missing-lizard`: passed; maximum Boltz-2 runtime CCN is 9.
- `python -m tools.model_ci validate`: passed.

### Hardware, Environment, and Revisions

- Repository revision: `c7f7b18cd96c7084860b133f33e3ae4b03bd3822`.
- Boltz source and checkpoint: the public v2.2.1 revisions pinned by the existing family provenance and manifest contracts.
- Build and inference precision: BF16; bundle profile: 117 tokens, 928 padded atoms, MSA depth 1.
- GPU validation used the maintained source-build environment. Machine, driver, and container identifiers are intentionally not included in public PR text; exact-head CI is the public status source of truth.

### Not Run / Remaining Gaps

- MSA depth greater than one and taxonomy-based paired MSA remain unsupported.
- Templates, ligands, affinity prediction, constraints, modifications, cyclic polymers, nucleic acids, and larger token/atom profiles remain unsupported.
- No new warmed eager or `torch.compile` performance comparison was run because this change does not alter the TensorRT graphs; it adds request preparation and CPU-side confidence aggregation.
- Other deployment configurations and hardware targets were not qualified in this follow-up.
- Exact-head CI is rerunning after the review update and rebase.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

- Review the request contract and A3M staging first, then the native confidence helpers and the reference comparator.
- Pinned Boltz stores `pair_chains_iptm[first][second]` with `first` selected on the PAE column axis and `second` on the row axis; the native implementation intentionally preserves that asymmetric ordering.
- One bundle still serves multiple compatible requests. A rebuild is required only when the combined complex exceeds the declared token or atom profile, or when a later follow-up introduces a different MSA-depth profile.
- The legacy `chain_pair_confidence` metadata key remains an empty array under schema version 1. New consumers should use `chains_ptm` and `pair_chains_iptm`.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Medium because this expands accepted biological inputs and native confidence semantics, but it does not change TensorRT network definitions, plan shapes, dependencies, ABI, or bundle serialization. Unsupported features continue to fail closed.
