### PR TITLE
fix(parallel): shard SwiGLU weights in six model families

### DIFF
--- a/families/eagle_vlm/parallel.py
+++ b/families/eagle_vlm/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/eagle_vlm/tests/test_parallel_swiglu.py
+++ b/families/eagle_vlm/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""eagle_vlm SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )

--- a/families/glm/parallel.py
+++ b/families/glm/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/glm/tests/test_parallel_swiglu.py
+++ b/families/glm/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""glm SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )

--- a/families/granite/parallel.py
+++ b/families/granite/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/granite/tests/test_parallel_swiglu.py
+++ b/families/granite/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""granite SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )

--- a/families/olmo/parallel.py
+++ b/families/olmo/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/olmo/tests/test_parallel_swiglu.py
+++ b/families/olmo/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""olmo SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )

--- a/families/qwen_vl/parallel.py
+++ b/families/qwen_vl/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/qwen_vl/tests/test_parallel_swiglu.py
+++ b/families/qwen_vl/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""qwen_vl SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )

--- a/families/stablelm/parallel.py
+++ b/families/stablelm/parallel.py
@@ -82,9 +82,9 @@ def shard_standard_decoder_weights(
             sharded[key] = value
         elif key.endswith((".w_q", ".w_k", ".w_v", ".q_bias", ".k_bias", ".v_bias")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
-        elif key.endswith((".w_o", ".w_fc2")):
+        elif key.endswith((".w_o", ".w_fc2", ".w_down")):
             sharded[key] = _slice_first_dim(value, rank, tp_size)
-        elif key.endswith((".w_fc1", ".fc1_bias")):
+        elif key.endswith((".w_fc1", ".fc1_bias", ".w_gate", ".w_up")):
             sharded[key] = _slice_last_dim(value, rank, tp_size)
         else:
             sharded[key] = value

--- a/families/stablelm/tests/test_parallel_swiglu.py
+++ b/families/stablelm/tests/test_parallel_swiglu.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""stablelm SwiGLU weight shards must reconstruct the unsharded computation."""
+
+import numpy as np
+import pytest
+
+from ..checkpoint_mapper import WeightDict
+from ..config import ModelConfig
+from ..parallel import ParallelConfig, shard_standard_decoder_weights
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.float32, np.float16])
+def test_swiglu_rank_shards_reconstruct_weights_and_output(tp_size, dtype):
+    config = ModelConfig(
+        hidden_size=8,
+        intermediate_size=24,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    rng = np.random.default_rng(42)
+    weights = WeightDict(
+        {
+            "_attention_size": 8,
+            "_kv_attention_size": 8,
+            "_mlp_size": 24,
+            "embedding": rng.normal(size=(16, 8)).astype(dtype),
+            "layer.0.w_gate": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_up": rng.normal(scale=0.2, size=(8, 24)).astype(dtype),
+            "layer.0.w_down": rng.normal(scale=0.2, size=(24, 8)).astype(dtype),
+            "layer.0.post_attn_norm": np.ones(8, dtype=dtype),
+        }
+    )
+    original = {
+        key: value.copy() for key, value in weights.items() if isinstance(value, np.ndarray)
+    }
+    shards = [
+        shard_standard_decoder_weights(config, weights, ParallelConfig(tp_size, rank))
+        for rank in range(tp_size)
+    ]
+
+    for key, axis in (("w_gate", 1), ("w_up", 1), ("w_down", 0)):
+        full = weights[f"layer.0.{key}"]
+        expected_shape = list(full.shape)
+        expected_shape[axis] //= tp_size
+        for shard in shards:
+            part = shard[f"layer.0.{key}"]
+            assert part.shape == tuple(expected_shape)
+            assert part.dtype == dtype
+            assert part.flags.c_contiguous
+        np.testing.assert_array_equal(
+            np.concatenate([shard[f"layer.0.{key}"] for shard in shards], axis=axis),
+            full,
+        )
+
+    for rank, shard in enumerate(shards):
+        assert shard["_mlp_size"] == 24 // tp_size
+        assert isinstance(shard, WeightDict)
+        for key in ("embedding", "layer.0.post_attn_norm"):
+            np.testing.assert_array_equal(shard[key], weights[key])
+        if tp_size > 1:
+            assert shard["_tensor_parallel_rank"] == rank
+    for key, value in original.items():
+        np.testing.assert_array_equal(weights[key], value)
+    assert weights["_mlp_size"] == 24
+
+    inputs = rng.normal(size=(3, 8))
+
+    def evaluate(rank_weights):
+        gate = inputs @ rank_weights["layer.0.w_gate"].astype(np.float64)
+        up = inputs @ rank_weights["layer.0.w_up"].astype(np.float64)
+        return (gate / (1 + np.exp(-gate)) * up) @ rank_weights["layer.0.w_down"].astype(np.float64)
+
+    # Row-parallel down projections are summed by the runtime ALL_REDUCE.
+    np.testing.assert_allclose(
+        sum(evaluate(shard) for shard in shards),
+        evaluate(weights),
+        rtol=1e-12,
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Background

The Eagle VLM, GLM, Granite, OLMo, Qwen-VL, and StableLM tensor-parallel sharders reduce MLP width but leave SwiGLU gate/up/down weights unsharded. This passes full matrices to rank-local graph dimensions and causes reshape failures before inference. The defect is reproducible with small CPU arrays and does not require model downloads.

## Exit Criteria

- Gate/up weights are column-sharded and down weights are row-sharded for TP 2/4/8; TP 1 remains unchanged.
- Rank shards reconstruct the original weights and their summed SwiGLU outputs match the unsharded calculation.
- Existing E2E acceptance criteria and GPU resource policy remain unchanged.

## Implementation

Add the missing weight suffixes to each family's existing sharder, with one independently revertible commit per family. Each family owns its regression test; no cross-family model abstraction is introduced. There are no public API, ABI, dependency, or bundle-schema changes.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest families/eagle_vlm/tests/test_parallel_swiglu.py families/glm/tests/test_parallel_swiglu.py families/granite/tests/test_parallel_swiglu.py families/olmo/tests/test_parallel_swiglu.py families/qwen_vl/tests/test_parallel_swiglu.py families/stablelm/tests/test_parallel_swiglu.py -q --tb=short`: **48 passed** after the fix. The same regression cases produced **36 failures and 12 passes** before the production change.
- `python3 -m pytest families/eagle_vlm/tests families/glm/tests families/granite/tests families/olmo/tests families/qwen_vl/tests families/stablelm/tests -m 'not e2e and not gpu and not trt' -q --tb=short`: **101 passed, 17 skipped**; skipped tests require explicit E2E selection/checkpoints.
- `python3 -m pytest tools/tests/test_architecture.py tools/tests/test_family_impact.py tools/tests/test_community_ci.py tools/tests/test_public_source_hygiene.py tools/tests/test_new_ci.py tools/tests/test_pr_metadata.py -q -p no:cacheprovider`: **128 passed**.
- `ruff check families/{eagle_vlm,glm,granite,olmo,qwen_vl,stablelm}/parallel.py families/{eagle_vlm,glm,granite,olmo,qwen_vl,stablelm}/tests/test_parallel_swiglu.py`: passed.
- `python3 -m tools.model_ci validate`: passed.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

Tested tree: `cbbe5c24324af75038e8090b036865696fa4221e`, based on `dddd2663336753c1102e47c281a925d96d899ac2`. Linux x86_64, Python 3.12.3, NumPy 2.4.6, pytest 9.0.3; TensorRT 10.16.1.11 is available for imports. New tests use synthetic FP16/FP32 weights and CPU NumPy calculations, not GPU kernels or model checkpoints. CUDA execution was not exercised.

### Not Run / Remaining Gaps

Target TensorRT 11.1 multi-GPU engine builds, inference, and checkpoint parity still require CI validation. CPU numerical reconstruction is not evidence of GPU E2E, performance, or model qualification. No premerge pass is claimed.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Checked family mapper weight layouts, rank-local graph dimensions, down-projection all-reduce placement, dtype/contiguity preservation, TP 1 behavior, and unchanged input arrays and replicated weights.

## Notes For Future Readers

Review any family sharder together with its local regression test, then check the other family-local commits. Duplication here preserves independent family ownership and rollback. Rebuild affected TP engines to pick up the corrected weight partitioning; the serialized schema does not change. This fixes a deterministic shape defect, not every possible downstream multi-GPU failure.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The production diff is small and CPU-reproducible, but it changes rank-local model weights in six families and still needs target-hardware validation.
