### PR TITLE
fix(personaplex): declare the official reference einops dependency

### DIFF
--- a/families/personaplex/requirements.txt
+++ b/families/personaplex/requirements.txt
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Match the tensor rearrangement dependency in the pinned official Moshi source.
+einops==0.7.0
 soundfile

--- a/families/personaplex/tests/test_official_reference.py
+++ b/families/personaplex/tests/test_official_reference.py
@@ -51,6 +51,27 @@ def test_audio_compat_reads_the_checked_in_float_wav() -> None:
         sphn.resample(audio, src_sample_rate=24_000, dst_sample_rate=16_000)
 
 
+def test_official_reference_imports_before_checkpoint_validation(tmp_path: Path) -> None:
+    if not os.environ.get(official_reference.SOURCE_ENVIRONMENT):
+        pytest.skip("official source checkout is required for the reference import smoke test")
+    model_dir = tmp_path / "empty_model"
+    model_dir.mkdir()
+    input_wav = tmp_path / "input.wav"
+    _write_wav(input_wav)
+
+    # Exercise the real subprocess imports without downloading weights or using a GPU.
+    # Missing dependencies must fail here instead of being mistaken for a model error.
+    with pytest.raises(RuntimeError, match="checkpoint is missing official weights"):
+        official_reference.generate(
+            model_dir,
+            input_wav,
+            tmp_path / "output",
+            max_frames=1,
+            precision="bf16",
+            timeout_s=60,
+        )
+
+
 def test_generate_runs_the_official_source_and_requires_live_outputs(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Background

PersonaPlex's pinned official reference imports `einops`, but the family requirements only declare `soundfile`. A family environment can therefore fail with `ModuleNotFoundError` before reaching checkpoint loading. The required version is declared by the [pinned upstream Moshi project](https://github.com/NVIDIA/personaplex/blob/3428dfd95309a7f3c84fd93259ded0f810d1ff91/moshi/pyproject.toml).

## Exit Criteria

Installing the family requirements provides the reference's tensor-rearrangement dependency, and the real reference subprocess completes imports before validating the checkpoint. No oracle implementation, accuracy threshold, or E2E acceptance criterion changes.

## Implementation

Declare `einops==0.7.0` in PersonaPlex's requirements, matching the pinned upstream source. Add an import smoke test using the existing reference subprocess and an empty checkpoint directory: it must reach the specific missing-checkpoint error, not fail on an import. The new smoke test requires `TRTMC_REFERENCE_SOURCE_DIR`; it explicitly skips when no source checkout is supplied. Existing E2E tests are unchanged. No API, ABI, or bundle-format changes.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

With the official source checkout supplied through `TRTMC_REFERENCE_SOURCE_DIR` and the disposable verification venv on `PATH`:

- `python -m pytest families/personaplex/tests/test_official_reference.py -q --tb=short`: **4 passed**. Before adding/installing `einops`, the same smoke test failed with `ModuleNotFoundError: No module named 'einops'` (1 failed, 3 passed).
- Family tests with `-m 'not e2e and not gpu and not trt' -q -rs`: **10 passed, 3 skipped**; the skips require explicit E2E selection.
- `ruff check families/personaplex/tests/test_official_reference.py`: passed.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

Tested tree: `3bf025c49d6179c13cbf4ab48826289c4b7d86ff`, based on `dddd2663336753c1102e47c281a925d96d899ac2`. Official source: `NVIDIA/personaplex@3428dfd95309a7f3c84fd93259ded0f810d1ff91`. Linux x86_64, Python 3.12.3, NumPy 2.4.6, torch 2.12.0+cu130, einops 0.7.0, soundfile 0.14.0, sentencepiece 0.2.2. The disposable venv reuses existing base packages; it is not a clean reproduction of the target runtime image. The import smoke test uses no model weights or GPU execution.

### Not Run / Remaining Gaps

Full GPU PersonaPlex generation/parity and target-platform dependency installation still require CI. Successful imports do not establish model correctness or compatibility with every upstream dependency. No premerge pass is claimed.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Checked the pinned upstream dependency/import closure and confirmed the test calls the real wrapper without loading weights, mocking imports, or altering the oracle.

## Notes For Future Readers

The official source is not installed as a package by this workflow, so its needed dependencies must be available through the family/base environment. Keep the source pin and dependency compatible. This PR is independent of tensor-parallel sharding fixes and does not modify global CI resource policy.

### Risk level

- [x] Low
- [ ] Medium
- [ ] High

The only production change adds one pure-Python, family-local dependency at the upstream-required version; reference behavior and E2E criteria remain unchanged.
