### PR TITLE
fix(cosmos3): launch dual-Spark demo with MPI

### DIFF
--- a/examples/models/cosmos3/dual_spark/Dockerfile.dockerignore
+++ b/examples/models/cosmos3/dual_spark/Dockerfile.dockerignore
@@ -28,6 +28,11 @@ third_party/**
 !third_party/stb/
 !third_party/stb/**
 
+!apps/
+apps/**
+!apps/cli/
+!apps/cli/**
+
 # Guard against basename negations above matching similarly named directories
 # below unrelated source trees.
 examples/**

--- a/examples/models/cosmos3/dual_spark/README.md
+++ b/examples/models/cosmos3/dual_spark/README.md
@@ -6,28 +6,56 @@ SPDX-License-Identifier: Apache-2.0
 # Cosmos3 dual-Spark video generation example
 
 This example generates one native 1280x720 Cosmos3-Nano video with context
-parallelism across two one-GPU DGX Sparks. A host-side Python launcher prepares
-the hardware-specific TensorRT bundle, synchronizes the image and bundle
-to the peer, and starts rank 0 on the primary Spark and rank 1 on the peer.
-It does not start a server, open an application port, or require a browser.
+parallelism (CP=2) across two one-GPU DGX Sparks. Run one launcher command on
+the primary Spark. It prepares and synchronizes the image and TensorRT bundle,
+then invokes one `mpirun` command that starts an MPI worker on each Spark. Each
+worker owns one local Docker container. You do not log in to the peer to start
+rank 1.
 
 On top of the repository-pinned TensorRT base, the image adds the TRTMC CLI,
 the core and explicit runtime loader, the TensorRT backend, the Cosmos3 model
-DSO, the Python builder environment, FFmpeg, and RDMA runtime packages. It does not contain a model
-checkpoint, TensorRT bundle, generated video, SSH key, or Hugging Face token.
+DSO, the Python builder environment, FFmpeg, and RDMA runtime packages. It does
+not contain a model checkpoint, TensorRT bundle, generated video, SSH key, or
+Hugging Face token. The example does not start a server, open an application
+port, or require a browser.
 
 ## Requirements
 
 - two networked, one-GPU GB10 DGX Sparks with matching GPU architecture and
   NVIDIA driver versions;
 - Docker Engine using BuildKit and NVIDIA Container Toolkit on both Sparks;
+- matching Open MPI and `mpi4py` installations on both Sparks;
 - passwordless SSH from the primary to the peer, with the peer host key already
   present in `known_hosts` and Docker available without an interactive prompt;
 - a direct, active RoCE link between the Sparks; and
 - enough free disk, unified memory, and swap for the checkpoint and TensorRT
   build.
 
-Run all commands below on the primary Spark from the repository root.
+Install the MPI prerequisites once on both Sparks:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y openmpi-bin libopenmpi-dev python3-mpi4py
+mpirun --version
+python3 -c 'from mpi4py import MPI; print(MPI.get_vendor())'
+```
+
+The Open MPI and `mpi4py` vendor versions reported by the two Sparks must
+match. Run the remaining commands on the primary Spark from the repository
+root.
+
+## How launch and rendezvous work
+
+The launcher invokes `mpirun` on the primary with two hosts and one process per
+host. Rank 0 starts its local container, which creates and publishes the live
+NCCL unique ID. The MPI worker broadcasts the 128-byte ID with `MPI_Bcast`.
+Rank 1 receives it and starts the peer container with the ID in its environment.
+Both containers then communicate directly over NCCL/RoCE. MPI is the launch and
+bootstrap control plane; it is not the model data plane.
+
+The MPI workers remain alive and wait for their containers. This lets `mpirun`
+track the complete distributed job even though model execution stays isolated
+inside Docker. No NCCL rendezvous file is copied to the peer.
 
 ## Build the image once
 
@@ -48,7 +76,7 @@ architecture.
 
 ## Generate one video
 
-After the one-time image build, select one of the built-in scenes:
+After the one-time image build, run the complete prepare-and-generate workflow:
 
 ```bash
 python3 examples/models/cosmos3/dual_spark/run_dual_spark.py all \
@@ -59,8 +87,8 @@ python3 examples/models/cosmos3/dual_spark/run_dual_spark.py all \
 
 The first run downloads the public `nvidia/Cosmos3-Nano` checkpoint, builds a
 CP=2 TensorRT bundle on the primary Spark, and copies the image and bundle
-to the peer. That preparation can take hours. Later runs reuse the checkpoint
-cache, image, and hardware-specific bundle.
+to the peer with strict SSH. That preparation can take hours. Later runs reuse
+the checkpoint cache, image, and hardware-specific bundle.
 
 Each showcase preset produces a 189-frame, 7.875-second H.264 MP4 at 24 FPS.
 The available presets correspond to the selected showcase videos:
@@ -86,19 +114,31 @@ python3 examples/models/cosmos3/dual_spark/run_dual_spark.py run \
   --scene showcase-delivery-robot
 ```
 
+Add `--peer-user <USER>` when the peer username differs from the primary
+username. Add `--ssh-key <KEY>` and `--known-hosts <KNOWN_HOSTS>` when SSH does
+not use the defaults. The same strict SSH configuration is passed to Open MPI.
+
 Use `--dry-run` to print the mutation-free JSON execution plan. Run
 `python3 examples/models/cosmos3/dual_spark/run_dual_spark.py --help` for the
 complete CLI surface.
 
-## Network, cache, and output boundaries
+By default, the launcher prints concise workflow milestones and actionable
+errors. Set `COSMOS3_LOG_COMMANDS=1` only while troubleshooting to also print
+sanitized local and peer commands; encoded SSH transport payloads and inline
+scripts are never printed.
+
+## Operational boundaries and output locations
 
 - SSH is non-interactive and strict host-key checking remains enabled. Use
   `--ssh-key` and `--known-hosts` for non-default SSH files.
 - The default RoCE settings are HCA `rocep1s0f0:1`, network interface
   `enp1s0f0np0`, and GID index `3`. Change them only when both Sparks use the
   same alternative configuration.
+  The launcher pins Open MPI TCP traffic to the same direct-link network
+  interface, avoiding accidental use of another host interface.
 - The launcher requires NCCL RoCE (`NET/IB`) rather than socket fallback and
-  records cgroup-v2 peak memory for both ranks.
+  records cgroup-v2 peak memory for both ranks. The MPI stdout and stderr logs
+  are saved with each scene.
 - Reusable assets and run records live under
   `~/.cache/trtmc/cosmos3-physics` by default. Each run directory contains its
   MP4 files, rank logs, container records, and `run.json`. Use `--work-root`
@@ -108,3 +148,14 @@ complete CLI surface.
   model directory under the work root. No credentials are required. Generated
   motion can still contain physical or visual errors; review outputs before
   sharing them.
+
+## Common failures
+
+- `mpirun` or `mpi4py` missing: install the MPI prerequisites on both Sparks.
+- MPI version mismatch: install the same Open MPI and `mpi4py` packages on both
+  hosts.
+- SSH launch failure: verify the same key and `known_hosts` file with a
+  non-interactive `ssh` command from the primary.
+- Bundle `Permission denied` during `scp`: new bundles are built with the
+  primary user's UID and GID. The launcher also repairs ownership of a reusable
+  bundle created by an older root-running example container.

--- a/examples/models/cosmos3/dual_spark/run_dual_spark.py
+++ b/examples/models/cosmos3/dual_spark/run_dual_spark.py
@@ -6,8 +6,8 @@
 
 This host-side orchestrator uses a locally built example image to build one
 CP=2 TensorRT bundle on the primary Spark, copies the exact image and bundle to
-a peer Spark, and launches one global rank on each host. Each scene has an
-independent file rendezvous and runs only after the previous scene finishes.
+a peer Spark, and uses Open MPI to launch one Docker-owning worker per host.
+MPI broadcasts the rank-0 NCCL unique ID before rank 1 starts its container.
 """
 
 from __future__ import annotations
@@ -44,6 +44,8 @@ GUIDANCE_SCALE = 6.0
 FLOW_SHIFT = 10.0
 CP_SIZE = 2
 NCCL_ID_BYTES = 128
+NCCL_ID_ENV_TOKEN = "__TRTMC_NCCL_UNIQUE_ID_HEX__"
+NCCL_ID_LOG_PATTERN = r"\[cosmos3\.nccl\] unique_id=([0-9a-f]{256})(?:\s|$)"
 PHYSICS_NEGATIVE_PROMPT = (
     "blur, low detail, jitter, flicker, morphing, floating objects, interpenetrating "
     "objects, fused objects, teleportation, discontinuous motion, cuts, scene changes, "
@@ -118,6 +120,132 @@ for current_root, directories, filenames in os.walk(root, followlinks=False):
             raise SystemExit("remote root must not contain symbolic links")
         if child.st_uid != os.geteuid():
             raise SystemExit("remote root contents must be owned by the SSH user")
+"""
+
+MPI_FACTS_SCRIPT = """\
+import json
+from mpi4py import MPI
+
+vendor, version = MPI.get_vendor()
+print(json.dumps({"vendor": vendor, "version": list(version)}))
+"""
+
+# mpirun transports these two base64 arguments without requiring the source
+# checkout on the peer. The worker itself is the MPI application: it stays
+# alive while its node-local detached container runs and returns that
+# container's exit code to mpirun.
+MPI_WORKER_BOOTSTRAP = (
+    "import base64,sys;"
+    "exec(compile(base64.urlsafe_b64decode(sys.argv[1]),'<cosmos3-mpi-worker>','exec'))"
+)
+MPI_WORKER_SOURCE = r"""\
+import base64
+import json
+import re
+import subprocess
+import sys
+import time
+
+from mpi4py import MPI
+
+
+def abort(message):
+    print(f"cosmos3 MPI worker: {message}", file=sys.stderr, flush=True)
+    MPI.COMM_WORLD.Abort(1)
+    raise SystemExit(1)
+
+
+def run(argv):
+    return subprocess.run(
+        argv,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def launch(argv, container):
+    completed = run(argv)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        abort(f"cannot launch {container}: {detail[-2000:]}")
+
+
+def rank_zero_unique_id(config, container):
+    pattern = re.compile(config["nccl_id_log_pattern"])
+    deadline = time.monotonic() + config["bootstrap_timeout"]
+    while time.monotonic() < deadline:
+        logs = run(["docker", "logs", container])
+        combined = (logs.stdout or "") + (logs.stderr or "")
+        match = pattern.search(combined)
+        if match is not None:
+            return bytearray.fromhex(match.group(1))
+        state = run(["docker", "inspect", "--format", "{{.State.Running}}", container])
+        if state.returncode != 0 or state.stdout.strip() != "true":
+            abort(f"rank 0 exited before publishing its NCCL unique ID: {combined[-2000:]}")
+        time.sleep(0.25)
+    abort("timed out waiting for rank 0 to publish its NCCL unique ID")
+
+
+def container_exit_code(container):
+    waited = run(["docker", "wait", container])
+    if waited.returncode != 0:
+        detail = (waited.stderr or waited.stdout).strip()
+        abort(f"docker wait failed for {container}: {detail[-2000:]}")
+    lines = [line.strip() for line in waited.stdout.splitlines() if line.strip()]
+    if len(lines) != 1 or not lines[0].isdigit():
+        abort(f"docker wait returned an invalid exit code for {container}")
+    return int(lines[0])
+
+
+def main():
+    config = json.loads(base64.urlsafe_b64decode(sys.argv[2]).decode("utf-8"))
+    comm = MPI.COMM_WORLD
+    if comm.Get_size() != 2:
+        abort(f"expected two MPI ranks, got {comm.Get_size()}")
+    local = comm.Split_type(MPI.COMM_TYPE_SHARED, 0)
+    try:
+        if local.Get_size() != 1:
+            abort("expected exactly one MPI rank on each Spark")
+    finally:
+        local.Free()
+
+    rank = comm.Get_rank()
+    rank_config = config["ranks"][rank]
+    container = rank_config["container"]
+    docker_argv = list(rank_config["docker_argv"])
+    unique_id = bytearray(config["nccl_id_bytes"])
+
+    if rank == 0:
+        launch(docker_argv, container)
+        unique_id = rank_zero_unique_id(config, container)
+        if len(unique_id) != config["nccl_id_bytes"]:
+            abort("rank 0 published an invalid NCCL unique ID")
+
+    comm.Bcast([unique_id, MPI.BYTE], root=0)
+
+    if rank == 1:
+        encoded = unique_id.hex()
+        token = config["nccl_id_env_token"]
+        replacements = sum(value.count(token) for value in docker_argv)
+        if replacements != 1:
+            abort("rank 1 Docker command does not contain one NCCL ID placeholder")
+        docker_argv = [value.replace(token, encoded) for value in docker_argv]
+        launch(docker_argv, container)
+
+    exit_code = container_exit_code(container)
+    exit_codes = comm.allgather(exit_code)
+    raise SystemExit(max(exit_codes))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except BaseException as error:
+        abort(str(error))
 """
 
 
@@ -893,6 +1021,12 @@ def _scp_argv(settings: Settings) -> list[str]:
     return argv
 
 
+def _mpi_rsh_agent(settings: Settings) -> str:
+    argv = _ssh_argv(settings)[:-1]
+    argv.extend(["-l", settings.peer_user])
+    return shlex.join(argv)
+
+
 def _layout(settings: Settings) -> dict[str, Any]:
     models = settings.work_root / "models"
     run_root = settings.work_root / "runs" / settings.run_id
@@ -917,14 +1051,13 @@ def _scene_layout(settings: Settings, scene: Scene) -> dict[str, Any]:
     layout = _layout(settings)
     scene_root = Path(layout["run_root"]) / scene.slug
     remote_scene_root = f"{layout['remote_run_root']}/{scene.slug}"
-    rendezvous_name = f"{scene.slug}-seed{scene.seed}.nccl"
     return {
         "scene_root": scene_root,
         "rank0": scene_root / "rank0",
         "rank1_capture": scene_root / "rank1",
         "remote_rank1": f"{remote_scene_root}/rank1",
-        "rendezvous": scene_root / "rendezvous" / rendezvous_name,
-        "remote_rendezvous": f"{remote_scene_root}/rendezvous/{rendezvous_name}",
+        "mpi_stdout": scene_root / "mpi.stdout.log",
+        "mpi_stderr": scene_root / "mpi.stderr.log",
         "mp4": Path(layout["run_root"]) / f"{scene.slug}-720p.mp4",
         "rank0_container": f"cosmos3-{settings.run_id}-{scene.slug}-rank0",
         "rank1_container": f"cosmos3-{settings.run_id}-{scene.slug}-rank1",
@@ -983,12 +1116,11 @@ def _generation_argv(scene: Scene) -> list[str]:
 
 
 def _rank_environment(settings: Settings, scene: Scene, rank: int) -> dict[str, str]:
-    return {
+    environment = {
         "CUDA_VISIBLE_DEVICES": "0",
         "OMPI_COMM_WORLD_SIZE": str(CP_SIZE),
         "OMPI_COMM_WORLD_RANK": str(rank),
         "OMPI_COMM_WORLD_LOCAL_RANK": "0",
-        "TRTMC_NCCL_RENDEZVOUS": f"/rendezvous/{scene.slug}-seed{scene.seed}.nccl",
         "NCCL_NET": "IB",
         "NCCL_IB_DISABLE": "0",
         "NCCL_IB_HCA": f"={settings.ib_hca}",
@@ -1001,6 +1133,11 @@ def _rank_environment(settings: Settings, scene: Scene, rank: int) -> dict[str, 
         "HF_HUB_OFFLINE": "1",
         "TRANSFORMERS_OFFLINE": "1",
     }
+    if rank == 0:
+        environment["TRTMC_NCCL_UNIQUE_ID_STDOUT"] = "1"
+    elif rank == 1:
+        environment["TRTMC_NCCL_UNIQUE_ID_HEX"] = NCCL_ID_ENV_TOKEN
+    return environment
 
 
 def _rank_docker_argv(
@@ -1015,12 +1152,10 @@ def _rank_docker_argv(
     if rank == 0:
         bundle = str(layout["bundle"])
         output_dir = str(scene_paths["rank0"])
-        rendezvous_dir = str(Path(scene_paths["rendezvous"]).parent)
         container = str(scene_paths["rank0_container"])
     elif rank == 1:
         bundle = str(layout["remote_bundle"])
         output_dir = str(scene_paths["remote_rank1"])
-        rendezvous_dir = str(Path(scene_paths["remote_rendezvous"]).parent)
         container = str(scene_paths["rank1_container"])
     else:
         raise ValueError("rank must be 0 or 1")
@@ -1065,8 +1200,6 @@ def _rank_docker_argv(
             f"type=bind,src={bundle},dst=/models/cosmos3.bundle,readonly",
             "--mount",
             f"type=bind,src={output_dir},dst=/outputs",
-            "--mount",
-            f"type=bind,src={rendezvous_dir},dst=/rendezvous",
             "--entrypoint",
             "/opt/trtmc/bin/trtmc",
             settings.image,
@@ -1074,6 +1207,95 @@ def _rank_docker_argv(
         ]
     )
     return argv
+
+
+def _mpi_worker_config(
+    settings: Settings,
+    scene: Scene,
+    *,
+    primary_uverbs: str,
+    peer_uverbs: str,
+) -> dict[str, Any]:
+    paths = _scene_layout(settings, scene)
+    return {
+        "bootstrap_timeout": min(180, settings.runtime_timeout),
+        "nccl_id_bytes": NCCL_ID_BYTES,
+        "nccl_id_env_token": NCCL_ID_ENV_TOKEN,
+        "nccl_id_log_pattern": NCCL_ID_LOG_PATTERN,
+        "ranks": [
+            {
+                "container": str(paths["rank0_container"]),
+                "docker_argv": _rank_docker_argv(
+                    settings,
+                    scene,
+                    0,
+                    uverbs_device=primary_uverbs,
+                ),
+            },
+            {
+                "container": str(paths["rank1_container"]),
+                "docker_argv": _rank_docker_argv(
+                    settings,
+                    scene,
+                    1,
+                    uverbs_device=peer_uverbs,
+                ),
+            },
+        ],
+    }
+
+
+def _mpirun_argv(
+    settings: Settings,
+    scene: Scene,
+    *,
+    primary_uverbs: str,
+    peer_uverbs: str,
+    redact_payload: bool = False,
+) -> list[str]:
+    config = _mpi_worker_config(
+        settings,
+        scene,
+        primary_uverbs=primary_uverbs,
+        peer_uverbs=peer_uverbs,
+    )
+    source = base64.urlsafe_b64encode(MPI_WORKER_SOURCE.encode("utf-8")).decode("ascii")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(config, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    if redact_payload:
+        source = "<embedded-mpi-worker-source>"
+        payload = "<embedded-scene-config>"
+    return [
+        "mpirun",
+        "--host",
+        f"localhost:1,{settings.peer_host}:1",
+        "-np",
+        str(CP_SIZE),
+        "--map-by",
+        "ppr:1:node",
+        "--rank-by",
+        "slot",
+        "--mca",
+        "oob_tcp_if_include",
+        settings.net_iface,
+        "--mca",
+        "btl_tcp_if_include",
+        settings.net_iface,
+        "--mca",
+        "btl",
+        "self,tcp",
+        "--bind-to",
+        "none",
+        "--mca",
+        "plm_rsh_agent",
+        _mpi_rsh_agent(settings),
+        "python3",
+        "-c",
+        MPI_WORKER_BOOTSTRAP,
+        source,
+        payload,
+    ]
 
 
 def _checkpoint_download_argv(settings: Settings) -> list[str]:
@@ -1101,6 +1323,10 @@ def _bundle_build_argv(settings: Settings) -> list[str]:
         "docker",
         "run",
         "--rm",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
+        "-e",
+        "HOME=/tmp",
         "--gpus",
         "all",
         "--ipc",
@@ -1156,8 +1382,20 @@ def execution_plan(settings: Settings) -> dict[str, Any]:
                 "prompt": _prompt_record(scene),
                 "rendezvous": {
                     "bytes": NCCL_ID_BYTES,
-                    "primary": str(paths["rendezvous"]),
-                    "peer": str(paths["remote_rendezvous"]),
+                    "transport": "MPI_Bcast",
+                    "root": 0,
+                    "file_transfer": False,
+                },
+                "mpi": {
+                    "processes": CP_SIZE,
+                    "mapping": "one MPI worker per Spark",
+                    "argv": _mpirun_argv(
+                        settings,
+                        scene,
+                        primary_uverbs=planned_uverbs["primary"],
+                        peer_uverbs=planned_uverbs["peer"],
+                        redact_payload=True,
+                    ),
                 },
                 "ranks": [
                     {
@@ -1245,6 +1483,23 @@ def _log(message: str) -> None:
     print(f"[cosmos3-dual-spark] {message}", file=sys.stderr, flush=True)
 
 
+def _display_argv(argv: Sequence[str]) -> str:
+    values = [str(value) for value in argv]
+    displayed: list[str] = []
+    for index, value in enumerate(values):
+        if index > 0 and values[index - 1] == "-c":
+            displayed.append("<inline-code>")
+        elif len(value) > 160:
+            displayed.append(f"<argument:{len(value)}-characters>")
+        else:
+            displayed.append(value)
+    return shlex.join(displayed)
+
+
+def _command_logging_enabled() -> bool:
+    return os.environ.get("COSMOS3_LOG_COMMANDS") == "1"
+
+
 def _run(
     argv: Sequence[str],
     *,
@@ -1252,8 +1507,12 @@ def _run(
     timeout: int | float | None = None,
     input_text: str | None = None,
     capture: bool = True,
+    log_command: bool | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    _log(f"$ {shlex.join(str(value) for value in argv)}")
+    if log_command is None:
+        log_command = _command_logging_enabled()
+    if log_command:
+        _log(f"$ {_display_argv(argv)}")
     try:
         completed = subprocess.run(
             [str(value) for value in argv],
@@ -1285,7 +1544,12 @@ def _remote_run(
     *,
     check: bool = True,
     timeout: int | float | None = None,
+    log_command: bool | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    if log_command is None:
+        log_command = _command_logging_enabled()
+    if log_command:
+        _log(f"peer {settings.peer_host}: $ {_display_argv(argv)}")
     payload = base64.urlsafe_b64encode(
         json.dumps([str(value) for value in argv]).encode("utf-8")
     ).decode("ascii")
@@ -1295,6 +1559,7 @@ def _remote_run(
         check=check,
         timeout=timeout,
         input_text=REMOTE_EXEC_HELPER,
+        log_command=False,
     )
 
 
@@ -1315,10 +1580,23 @@ def _write_json(path: Path, value: Any) -> None:
     os.replace(temporary, path)
 
 
-def _image_available(settings: Settings, *, remote: bool) -> bool:
-    argv = ["docker", "image", "inspect", settings.image]
+def _image_id(settings: Settings, *, remote: bool) -> str | None:
+    argv = ["docker", "image", "inspect", "--format", "{{.Id}}", settings.image]
     completed = _remote_run(settings, argv, check=False) if remote else _run(argv, check=False)
-    return completed.returncode == 0
+    if completed.returncode == 1:
+        return None
+    if completed.returncode != 0:
+        location = "peer" if remote else "primary"
+        raise DualSparkError(f"cannot inspect the requested image on the {location}")
+    image_id = completed.stdout.strip()
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", image_id):
+        location = "peer" if remote else "primary"
+        raise DualSparkError(f"cannot parse the requested image ID on the {location}")
+    return image_id
+
+
+def _image_available(settings: Settings, *, remote: bool) -> bool:
+    return _image_id(settings, remote=remote) is not None
 
 
 def _gpu_facts(settings: Settings, *, remote: bool) -> dict[str, str]:
@@ -1411,8 +1689,36 @@ def _resolve_uverbs_device(
     return device
 
 
+def _mpi_facts(settings: Settings, *, remote: bool) -> dict[str, Any]:
+    location = "peer" if remote else "primary"
+    version_argv = ["mpirun", "--version"]
+    version = _remote_run(settings, version_argv) if remote else _run(version_argv)
+    version_lines = [line.strip() for line in version.stdout.splitlines() if line.strip()]
+    if not version_lines or "Open MPI" not in version_lines[0]:
+        raise DualSparkError(f"{location} must provide Open MPI")
+
+    facts_argv = ["python3", "-c", MPI_FACTS_SCRIPT]
+    completed = _remote_run(settings, facts_argv) if remote else _run(facts_argv)
+    try:
+        facts = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise DualSparkError(f"cannot parse {location} mpi4py runtime identity") from exc
+    if (
+        facts.get("vendor") != "Open MPI"
+        or not isinstance(facts.get("version"), list)
+        or not all(isinstance(value, int) for value in facts["version"])
+    ):
+        raise DualSparkError(f"{location} mpi4py must use Open MPI")
+    return {
+        "launcher": version_lines[0],
+        "vendor": facts["vendor"],
+        "version": facts["version"],
+    }
+
+
 def _preflight(settings: Settings) -> dict[str, Any]:
-    for executable in ("docker", "ssh", "scp", "nvidia-smi"):
+    _log(f"checking the primary and peer {settings.peer_host}")
+    for executable in ("docker", "ssh", "scp", "nvidia-smi", "mpirun", "python3"):
         if shutil.which(executable) is None:
             raise DualSparkError(f"required executable is unavailable: {executable}")
     for label, path in (
@@ -1425,6 +1731,13 @@ def _preflight(settings: Settings) -> dict[str, Any]:
     _run(["docker", "info"], timeout=60)
     _remote_run(settings, ["docker", "info"], timeout=60)
     _remote_run(settings, ["python3", "--version"], timeout=30)
+
+    local_mpi = _mpi_facts(settings, remote=False)
+    peer_mpi = _mpi_facts(settings, remote=True)
+    if local_mpi != peer_mpi:
+        raise DualSparkError(
+            "the two Sparks must use matching Open MPI and mpi4py runtime versions"
+        )
 
     local_gpu = _gpu_facts(settings, remote=False)
     peer_gpu = _gpu_facts(settings, remote=True)
@@ -1469,19 +1782,30 @@ def _preflight(settings: Settings) -> dict[str, Any]:
             "uverbs_device": uverbs_device,
         }
 
+    _log(
+        "preflight passed: matching GB10 GPUs and Open MPI, "
+        f"with active RoCE on {settings.net_iface}"
+    )
     return {
         "primary_gpu": _recorded_gpu_facts(local_gpu),
         "peer_gpu": _recorded_gpu_facts(peer_gpu),
         "host_identity": host_identity,
+        "mpi_hosts": {
+            "primary": local_mpi,
+            "peer": peer_mpi,
+        },
         "roce_hosts": roce,
     }
 
 
 def _sync_image(settings: Settings) -> None:
-    if _image_available(settings, remote=True):
-        _log("peer already has the requested image tag")
+    local_image_id = _image_id(settings, remote=False)
+    if local_image_id is None:
+        raise DualSparkError(f"primary image is unavailable: {settings.image}")
+    if _image_id(settings, remote=True) == local_image_id:
+        _log("peer already has the exact requested image")
         return
-    _log("copying the image to the peer Spark")
+    _log("copying the exact image to the peer Spark")
     with tempfile.TemporaryFile() as save_stderr_file:
         try:
             save = subprocess.Popen(
@@ -1520,8 +1844,8 @@ def _sync_image(settings: Settings) -> None:
     if save_returncode != 0 or load.returncode != 0:
         detail = (save_stderr + load_stdout + load_stderr).decode("utf-8", "replace")
         raise DualSparkError(f"image transfer failed: {detail[-2000:]}")
-    if not _image_available(settings, remote=True):
-        raise DualSparkError("peer image is unavailable after transfer")
+    if _image_id(settings, remote=True) != local_image_id:
+        raise DualSparkError("peer image ID does not match the primary after transfer")
 
 
 def _bundle_spec() -> dict[str, Any]:
@@ -1543,6 +1867,32 @@ def _prepare_checkpoint(settings: Settings) -> None:
         raise DualSparkError("checkpoint download completed without model_index.json")
 
 
+def _ensure_local_bundle_readable(settings: Settings, bundle: Path) -> None:
+    if os.access(bundle, os.R_OK):
+        return
+    if bundle.is_symlink() or not bundle.is_file():
+        raise DualSparkError(f"TensorRT bundle is not a readable regular file: {bundle}")
+
+    _log("repairing ownership of a bundle created by an older root-running container")
+    _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--mount",
+            f"type=bind,src={bundle.parent},dst=/models",
+            "--entrypoint",
+            "/bin/chown",
+            settings.image,
+            f"{os.getuid()}:{os.getgid()}",
+            f"/models/{bundle.name}",
+        ],
+        timeout=60,
+    )
+    if not os.access(bundle, os.R_OK):
+        raise DualSparkError(f"TensorRT bundle remains unreadable after ownership repair: {bundle}")
+
+
 def _prepare_bundle(settings: Settings) -> Path:
     layout = _layout(settings)
     bundle = Path(layout["bundle"])
@@ -1551,6 +1901,7 @@ def _prepare_bundle(settings: Settings) -> Path:
     if bundle.is_file() and bundle.stat().st_size > 0 and marker.is_file():
         try:
             if json.loads(marker.read_text(encoding="utf-8")) == expected:
+                _ensure_local_bundle_readable(settings, bundle)
                 _log("reusing the exact native 720p CP=2 TensorRT bundle")
                 return bundle
         except (OSError, json.JSONDecodeError):
@@ -1564,6 +1915,7 @@ def _prepare_bundle(settings: Settings) -> Path:
     if not pending.is_file() or pending.stat().st_size == 0:
         raise DualSparkError("bundle build completed without a nonempty CP=2 bundle")
     os.replace(pending, bundle)
+    _ensure_local_bundle_readable(settings, bundle)
     _write_json(marker, expected)
     return bundle
 
@@ -1594,6 +1946,8 @@ def _sync_bundle(settings: Settings, bundle: Path) -> None:
         _log("peer already has the requested CP=2 bundle configuration")
         return
 
+    bundle_gib = bundle.stat().st_size / (1024**3)
+    _log(f"copying the {bundle_gib:.1f} GiB CP=2 bundle to the peer")
     incoming = f"{remote_bundle}.incoming.{settings.run_id}"
     incoming_spec = f"{remote_spec}.incoming.{settings.run_id}"
     _remote_run(
@@ -1643,6 +1997,7 @@ def _sync_bundle(settings: Settings, bundle: Path) -> None:
             )
     if not _remote_bundle_matches(settings):
         raise DualSparkError("peer bundle is incomplete after transfer")
+    _log("peer CP=2 bundle synchronized")
 
 
 def prepare(settings: Settings) -> dict[str, Any]:
@@ -1668,7 +2023,10 @@ def prepare(settings: Settings) -> dict[str, Any]:
         "peer": settings.peer_target,
         "model": {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION},
         "profile": _profile(),
-        "image": {"name": settings.image},
+        "image": {
+            "name": settings.image,
+            "id": _image_id(settings, remote=False),
+        },
         "bundle": {
             "primary_path": str(bundle),
             "peer_path": str(layout["remote_bundle"]),
@@ -1697,14 +2055,13 @@ def _require_prepared(settings: Settings) -> dict[str, Any]:
         or preparation.get("model")
         != {"id": MODEL_ID, "revision": MODEL_REVISION, "precision": PRECISION}
         or preparation.get("profile") != _profile()
-        or preparation.get("image", {}).get("name") != settings.image
+        or preparation.get("image")
+        != {"name": settings.image, "id": _image_id(settings, remote=False)}
     ):
         raise DualSparkError("prepared assets do not match this invocation")
 
-    if not _image_available(settings, remote=False):
-        raise DualSparkError("the primary image is missing; run prepare again")
-    if not _image_available(settings, remote=True):
-        raise DualSparkError("the peer image is missing; run prepare again")
+    if _image_id(settings, remote=True) != preparation["image"]["id"]:
+        raise DualSparkError("the peer image differs from the prepared image; run prepare again")
 
     bundle = Path(layout["bundle"])
     if not bundle.is_file() or bundle.stat().st_size == 0:
@@ -1722,7 +2079,11 @@ def _require_prepared(settings: Settings) -> dict[str, Any]:
 
 def _container_exists(settings: Settings, name: str, *, remote: bool) -> bool:
     argv = ["docker", "inspect", name]
-    completed = _remote_run(settings, argv, check=False) if remote else _run(argv, check=False)
+    completed = (
+        _remote_run(settings, argv, check=False, log_command=False)
+        if remote
+        else _run(argv, check=False, log_command=False)
+    )
     if completed.returncode == 0:
         return True
     if completed.returncode == 1:
@@ -1734,7 +2095,9 @@ def _container_exists(settings: Settings, name: str, *, remote: bool) -> bool:
 
 def _container_state(settings: Settings, name: str, *, remote: bool) -> dict[str, Any]:
     argv = ["docker", "inspect", "--format", "{{json .State}}", name]
-    completed = _remote_run(settings, argv) if remote else _run(argv)
+    completed = (
+        _remote_run(settings, argv, log_command=False) if remote else _run(argv, log_command=False)
+    )
     try:
         return json.loads(completed.stdout)
     except json.JSONDecodeError as exc:
@@ -1750,7 +2113,11 @@ def _sample_memory_tracker(settings: Settings, tracker: MemoryTracker) -> None:
         f"{tracker.cgroup_path}/memory.events",
     ]
     argv = ["cat", "--", *paths]
-    completed = _remote_run(settings, argv) if tracker.remote else _run(argv)
+    completed = (
+        _remote_run(settings, argv, log_command=False)
+        if tracker.remote
+        else _run(argv, log_command=False)
+    )
     lines = [line.strip() for line in completed.stdout.splitlines()]
     values = lines[:4]
     event_lines = lines[4:]
@@ -1928,39 +2295,70 @@ def _remove_container_noexcept(settings: Settings, name: str, *, remote: bool) -
     return True
 
 
-def _wait_for_rendezvous(settings: Settings, path: Path, container: str) -> None:
+def _mpi_diagnostics(stdout_path: Path, stderr_path: Path) -> str:
+    parts = []
+    for path in (stderr_path, stdout_path):
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            continue
+        if content:
+            parts.append(content[-2000:])
+    return "\n".join(parts)[-4000:]
+
+
+def _wait_for_mpi_containers(
+    settings: Settings,
+    containers: Sequence[tuple[str, bool]],
+    process: subprocess.Popen[Any],
+    stdout_path: Path,
+    stderr_path: Path,
+) -> None:
     deadline = time.monotonic() + min(180, settings.runtime_timeout)
     while time.monotonic() < deadline:
-        if path.is_file() and path.stat().st_size == NCCL_ID_BYTES:
+        if all(_container_exists(settings, name, remote=remote) for name, remote in containers):
             return
-        state = _container_state(settings, container, remote=False)
-        if not state.get("Running", False):
-            raise DualSparkError("rank 0 exited before publishing the NCCL rendezvous")
+        returncode = process.poll()
+        if returncode is not None:
+            detail = _mpi_diagnostics(stdout_path, stderr_path)
+            suffix = f": {detail}" if detail else ""
+            raise DualSparkError(
+                f"mpirun exited with code {returncode} before both containers started{suffix}"
+            )
         time.sleep(1)
-    raise DualSparkError("timed out waiting for the NCCL rendezvous")
+    raise DualSparkError("timed out waiting for mpirun to start both rank containers")
 
 
-def _transfer_rendezvous(settings: Settings, local_path: Path, remote_path: str) -> None:
-    incoming = f"{remote_path}.incoming"
-    _remote_run(settings, ["rm", "-f", "--", incoming, remote_path], check=False)
-    copied = False
+def _wait_for_mpi_completion(
+    process: subprocess.Popen[Any],
+    stdout_path: Path,
+    stderr_path: Path,
+) -> None:
     try:
-        _run(
-            [*_scp_argv(settings), str(local_path), f"{settings.peer_target}:{incoming}"],
-            timeout=120,
-            capture=False,
-        )
-        size = _remote_run(
-            settings,
-            ["stat", "-c", "%s", "--", incoming],
-        ).stdout.strip()
-        if size != str(NCCL_ID_BYTES):
-            raise DualSparkError("peer received an invalid NCCL rendezvous file")
-        _remote_run(settings, ["mv", "-T", "--", incoming, remote_path])
-        copied = True
-    finally:
-        if not copied:
-            _remote_run(settings, ["rm", "-f", "--", incoming], check=False)
+        returncode = process.wait(timeout=30)
+    except subprocess.TimeoutExpired as exc:
+        raise DualSparkError("MPI workers did not exit after both containers stopped") from exc
+    if returncode != 0:
+        detail = _mpi_diagnostics(stdout_path, stderr_path)
+        suffix = f": {detail}" if detail else ""
+        raise DualSparkError(f"mpirun failed with exit code {returncode}{suffix}")
+
+
+def _stop_mpi_noexcept(process: subprocess.Popen[Any] | None) -> None:
+    try:
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.terminate()
+            process.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=15)
+    except Exception as exc:
+        try:
+            _log(f"WARNING: could not stop mpirun cleanly: {exc}")
+        except Exception:
+            pass
 
 
 def _wait_for_containers(
@@ -1980,7 +2378,7 @@ def _wait_for_containers(
                 continue
             try:
                 _sample_memory_tracker(settings, tracker)
-            except DualSparkError as exc:
+            except DualSparkError:
                 if tracker.samples == 0:
                     raise
                 if states[name].get("Running", False):
@@ -1991,7 +2389,9 @@ def _wait_for_containers(
                     )
                 if states[name].get("Running", False):
                     raise
-                _log(f"WARNING: final cgroup memory sample was unavailable for {name}: {exc}")
+                # Docker may remove a stopped container's cgroup between the
+                # state probe and this final sample. Earlier memory.peak
+                # samples remain authoritative for the completed rank.
                 finished_trackers.add(name)
         if all(not state.get("Running", False) for state in states.values()):
             return states
@@ -2034,6 +2434,13 @@ def _verify_rank1_has_no_frames(settings: Settings, remote_output: str) -> None:
 
 def _remove_rank1_empty_frames(settings: Settings, remote_output: str) -> None:
     frames = f"{remote_output}/frames"
+    present = _remote_run(settings, ["test", "-e", frames], check=False)
+    if present.returncode == 1:
+        return
+    if present.returncode != 0:
+        detail = (present.stderr or present.stdout or "").strip()
+        suffix = f": {detail[-500:]}" if detail else ""
+        raise DualSparkError(f"could not check rank 1's verified-empty frames directory{suffix}")
     removed = _remote_run(settings, ["rmdir", "--", frames], check=False)
     if removed.returncode != 0:
         detail = (removed.stderr or removed.stdout or "").strip()
@@ -2271,7 +2678,6 @@ def _prepare_scene_directories(settings: Settings, scene: Scene) -> None:
     paths = _scene_layout(settings, scene)
     Path(paths["rank0"]).mkdir(parents=True, exist_ok=False)
     Path(paths["rank1_capture"]).mkdir(parents=True, exist_ok=False)
-    Path(paths["rendezvous"]).parent.mkdir(parents=True, exist_ok=False)
     remote_scene_root = str(Path(paths["remote_rank1"]).parent)
     _remote_run(
         settings,
@@ -2282,7 +2688,6 @@ def _prepare_scene_directories(settings: Settings, scene: Scene) -> None:
             "0700",
             remote_scene_root,
             str(paths["remote_rank1"]),
-            str(Path(paths["remote_rendezvous"]).parent),
         ],
     )
 
@@ -2316,34 +2721,52 @@ def _run_scene(
     rank0_wall_seconds = 0.0
     trackers: dict[str, MemoryTracker] = {}
     cleanup_failures: list[str] = []
+    mpi_process: subprocess.Popen[Any] | None = None
+    mpi_stdout_path = Path(paths["mpi_stdout"])
+    mpi_stderr_path = Path(paths["mpi_stderr"])
     try:
-        _log(f"starting {scene.slug}: primary rank 0")
-        rank0_launch_attempted = True
+        _log(f"launching {scene.slug}: CP=2 across the primary and {settings.peer_host}")
+        mpi_argv = _mpirun_argv(
+            settings,
+            scene,
+            primary_uverbs=primary_uverbs,
+            peer_uverbs=peer_uverbs,
+        )
         rank0_wall_started = time.monotonic()
-        _run(_rank_docker_argv(settings, scene, 0, uverbs_device=primary_uverbs))
-        _wait_for_rendezvous(
-            settings,
-            Path(paths["rendezvous"]),
-            rank0_name,
-        )
-        _transfer_rendezvous(
-            settings,
-            Path(paths["rendezvous"]),
-            str(paths["remote_rendezvous"]),
-        )
-        _log(f"starting {scene.slug}: peer rank 1")
+        stdout_stream = mpi_stdout_path.open("w", encoding="utf-8")
+        stderr_stream = mpi_stderr_path.open("w", encoding="utf-8")
+        try:
+            mpi_process = subprocess.Popen(
+                mpi_argv,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_stream,
+                stderr=stderr_stream,
+                text=True,
+                shell=False,
+            )
+        except OSError as exc:
+            raise DualSparkError("cannot start required command: mpirun") from exc
+        finally:
+            stdout_stream.close()
+            stderr_stream.close()
+        rank0_launch_attempted = True
         rank1_launch_attempted = True
-        _remote_run(
+        containers = ((rank0_name, False), (rank1_name, True))
+        _wait_for_mpi_containers(
             settings,
-            _rank_docker_argv(settings, scene, 1, uverbs_device=peer_uverbs),
+            containers,
+            mpi_process,
+            mpi_stdout_path,
+            mpi_stderr_path,
         )
+        _log("both rank containers started; MPI rendezvous complete; NCCL/RoCE inference running")
         trackers = {
             rank0_name: _memory_tracker(settings, rank0_name, remote=False),
             rank1_name: _memory_tracker(settings, rank1_name, remote=True),
         }
         states = _wait_for_containers(
             settings,
-            ((rank0_name, False), (rank1_name, True)),
+            containers,
             trackers,
         )
         rank0_wall_seconds = time.monotonic() - rank0_wall_started
@@ -2354,7 +2777,14 @@ def _run_scene(
         }
         if failures:
             raise DualSparkError(f"Cosmos3 ranks failed for {scene.slug}: {failures}")
+        _wait_for_mpi_completion(
+            mpi_process,
+            mpi_stdout_path,
+            mpi_stderr_path,
+        )
+        _log("both ranks completed successfully; validating output and telemetry")
     finally:
+        _stop_mpi_noexcept(mpi_process)
         launched = (
             (rank0_name, False, rank0_launch_attempted, Path(paths["rank0"])),
             (rank1_name, True, rank1_launch_attempted, Path(paths["rank1_capture"])),
@@ -2420,6 +2850,7 @@ def _run_scene(
     }
     _verify_rank1_has_no_frames(settings, str(paths["remote_rank1"]))
     _remove_rank1_empty_frames(settings, str(paths["remote_rank1"]))
+    _log(f"packaging {FRAME_COUNT} frames as a native {WIDTH}x{HEIGHT} H.264 video")
     artifact = _package_video(
         settings,
         Path(paths["rank0"]) / "frames",
@@ -2431,7 +2862,13 @@ def _run_scene(
         "seed": scene.seed,
         "prompt": _prompt_record(scene),
         "rank_hosts": {"0": socket.gethostname(), "1": settings.peer_host},
-        "rendezvous_name": Path(paths["rendezvous"]).name,
+        "rendezvous": {
+            "transport": "MPI_Bcast",
+            "root": 0,
+            "bytes": NCCL_ID_BYTES,
+            "file_transfer": False,
+        },
+        "mpi_logs": {"stdout": str(mpi_stdout_path), "stderr": str(mpi_stderr_path)},
         "performance": performance,
         "memory": memory,
         "artifact": artifact,

--- a/examples/models/cosmos3/dual_spark/test_cosmos3_dual_spark_source.py
+++ b/examples/models/cosmos3/dual_spark/test_cosmos3_dual_spark_source.py
@@ -35,9 +35,7 @@ EXPECTED_SCENES = (
 
 def _clean_environment() -> dict[str, str]:
     environment = {
-        name: value
-        for name, value in os.environ.items()
-        if not name.startswith("COSMOS3_")
+        name: value for name, value in os.environ.items() if not name.startswith("COSMOS3_")
     }
     environment["PATH"] = ""
     return environment
@@ -97,6 +95,11 @@ def _generation_command(argv: Sequence[str]) -> list[str]:
     return list(argv[argv.index("generate-video") :])
 
 
+def _contains_subsequence(argv: Sequence[str], expected: Sequence[str]) -> bool:
+    width = len(expected)
+    return any(list(argv[index : index + width]) == list(expected) for index in range(len(argv)))
+
+
 def test_showcase_prompt_is_built_in_and_compact_in_dry_run(
     tmp_path: Path,
 ) -> None:
@@ -117,9 +120,9 @@ def test_showcase_prompt_is_built_in_and_compact_in_dry_run(
     assert "\n" not in compact_prompt
     assert ": " not in compact_prompt
     assert _option_value(command, "--prompt") == compact_prompt
-    assert _option_value(
-        command, "--negative-prompt"
-    ) == run_dual_spark._negative_prompt_text(scene)
+    assert _option_value(command, "--negative-prompt") == run_dual_spark._negative_prompt_text(
+        scene
+    )
 
 
 @pytest.mark.parametrize("scene_id,seed,filename", EXPECTED_SCENES)
@@ -157,9 +160,7 @@ def test_launcher_selects_one_native_720p_cp2_scene(
 
     bundle = plan["prepare"]["bundle_build_argv"]
     assert plan["prepare"]["image"] == "trtmc-cosmos3-dual-spark:local"
-    assert plan["prepare"]["image_source"] == (
-        "prebuilt locally from this example's Dockerfile"
-    )
+    assert plan["prepare"]["image_source"] == ("prebuilt locally from this example's Dockerfile")
     assert "image_build_argv" not in plan["prepare"]
     assert _option_value(bundle, "--context-parallel-size") == "2"
     assert "--family" not in bundle
@@ -167,6 +168,43 @@ def test_launcher_selects_one_native_720p_cp2_scene(
     assert _option_value(bundle, "--image-height") == "720"
     assert _option_value(bundle, "--image-width") == "1280"
     assert Path(plan["prepare"]["bundle"]).name == "cosmos3-nano-cp2-1280x720.bundle"
+    assert plan["prepare"]["image_sync"] == (
+        "docker image save on primary -> strict SSH -> docker image load"
+    )
+
+    assert scene["rendezvous"] == {
+        "bytes": 128,
+        "transport": "MPI_Bcast",
+        "root": 0,
+        "file_transfer": False,
+    }
+    assert scene["mpi"]["processes"] == 2
+    assert scene["mpi"]["mapping"] == "one MPI worker per Spark"
+    mpi_argv = scene["mpi"]["argv"]
+    assert mpi_argv[:5] == [
+        "mpirun",
+        "--host",
+        "localhost:1,peer.example:1",
+        "-np",
+        "2",
+    ]
+    assert _contains_subsequence(mpi_argv, ["--map-by", "ppr:1:node"])
+    assert _contains_subsequence(mpi_argv, ["--rank-by", "slot"])
+    assert _contains_subsequence(mpi_argv, ["--mca", "oob_tcp_if_include", "enp1s0f0np0"])
+    assert _contains_subsequence(mpi_argv, ["--mca", "btl_tcp_if_include", "enp1s0f0np0"])
+    assert _contains_subsequence(mpi_argv, ["--mca", "btl", "self,tcp"])
+    assert _contains_subsequence(mpi_argv, ["--bind-to", "none"])
+    rsh_agent = _option_value(mpi_argv, "plm_rsh_agent")
+    assert "BatchMode=yes" in rsh_agent
+    assert "StrictHostKeyChecking=yes" in rsh_agent
+    assert "-l tester" in rsh_agent
+    assert mpi_argv[-5:] == [
+        "python3",
+        "-c",
+        run_dual_spark.MPI_WORKER_BOOTSTRAP,
+        "<embedded-mpi-worker-source>",
+        "<embedded-scene-config>",
+    ]
 
     assert [(rank["host"], rank["rank"]) for rank in scene["ranks"]] == [
         ("primary", 0),
@@ -178,6 +216,13 @@ def test_launcher_selects_one_native_720p_cp2_scene(
         assert environment["OMPI_COMM_WORLD_RANK"] == str(rank_number)
         assert environment["OMPI_COMM_WORLD_LOCAL_RANK"] == "0"
         assert environment["CUDA_VISIBLE_DEVICES"] == "0"
+        assert "TRTMC_NCCL_RENDEZVOUS" not in environment
+        if rank_number == 0:
+            assert environment["TRTMC_NCCL_UNIQUE_ID_STDOUT"] == "1"
+            assert "TRTMC_NCCL_UNIQUE_ID_HEX" not in environment
+        else:
+            assert environment["TRTMC_NCCL_UNIQUE_ID_HEX"] == (run_dual_spark.NCCL_ID_ENV_TOKEN)
+            assert "TRTMC_NCCL_UNIQUE_ID_STDOUT" not in environment
         command = _generation_command(rank["docker_argv"])
         assert _option_value(command, "--runtime-root") == "/opt/trtmc/lib"
         assert _option_value(command, "--height") == "720"
@@ -216,6 +261,70 @@ def test_launcher_uses_strict_ssh_roce_and_declares_run_telemetry(
     }
 
 
+def test_mpi_worker_broadcasts_the_live_nccl_id_and_owns_container_lifecycle() -> None:
+    source = run_dual_spark.MPI_WORKER_SOURCE
+
+    assert "MPI.COMM_TYPE_SHARED" in source
+    assert "comm.Bcast([unique_id, MPI.BYTE], root=0)" in source
+    assert '["docker", "logs", container]' in source
+    assert '["docker", "wait", container]' in source
+    assert "comm.allgather(exit_code)" in source
+    assert "TRTMC_NCCL_RENDEZVOUS" not in source
+
+
+def test_command_logging_is_quiet_and_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages: list[str] = []
+    monkeypatch.delenv("COSMOS3_LOG_COMMANDS", raising=False)
+    monkeypatch.setattr(run_dual_spark, "_log", messages.append)
+
+    completed = run_dual_spark._run([sys.executable, "-c", "print('quiet')"])
+
+    assert completed.stdout.strip() == "quiet"
+    assert messages == []
+
+    monkeypatch.setenv("COSMOS3_LOG_COMMANDS", "1")
+    run_dual_spark._run([sys.executable, "-c", "print('must not be logged')"])
+
+    assert messages == [f"$ {sys.executable} -c '<inline-code>'"]
+    assert "must not be logged" not in messages[0]
+    assert "WyJ" not in messages[0]
+
+    settings = run_dual_spark.Settings(
+        action="run",
+        scene=EXPECTED_SCENES[0][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=Path("/tmp/cosmos3-contract"),
+        remote_root="/var/tmp/cosmos3-contract",
+        image="cosmos3-contract:latest",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def fake_run(argv: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append((list(argv), kwargs))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(run_dual_spark, "_run", fake_run)
+    messages.clear()
+    run_dual_spark._remote_run(settings, ["python3", "-c", "sensitive remote source"])
+
+    assert messages == ["peer peer.example: $ python3 -c '<inline-code>'"]
+    assert "sensitive remote source" not in messages[0]
+    assert "WyJ" not in messages[0]
+    assert calls[0][1]["log_command"] is False
+
+
 def test_launcher_parses_one_matching_cosmos3_performance_record(
     tmp_path: Path,
 ) -> None:
@@ -243,6 +352,35 @@ def test_launcher_parses_one_matching_cosmos3_performance_record(
     assert performance["rank0_wall_seconds"] == pytest.approx(85.25)
     assert performance["cp_size"] == 2
     assert performance["seed"] == scene.seed
+
+
+def test_stop_mpi_noexcept_swallows_timeout_after_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str | tuple[str, float]] = []
+    messages: list[str] = []
+
+    class StuckProcess:
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            events.append("terminate")
+
+        def kill(self) -> None:
+            events.append("kill")
+
+        def wait(self, timeout: float) -> int:
+            events.append(("wait", timeout))
+            raise subprocess.TimeoutExpired(cmd="mpirun", timeout=timeout)
+
+    monkeypatch.setattr(run_dual_spark, "_log", messages.append)
+
+    run_dual_spark._stop_mpi_noexcept(StuckProcess())  # type: ignore[arg-type]
+
+    assert events == ["terminate", ("wait", 15), "kill", ("wait", 15)]
+    assert len(messages) == 1
+    assert "could not stop mpirun cleanly" in messages[0]
 
 
 def test_launcher_tolerates_cgroup_teardown_after_confirmed_container_exit(
@@ -279,6 +417,7 @@ def test_launcher_tolerates_cgroup_teardown_after_confirmed_container_exit(
         )
     )
     observed_queries: list[tuple[str, bool]] = []
+    messages: list[str] = []
 
     def container_state(
         _settings: run_dual_spark.Settings,
@@ -299,6 +438,7 @@ def test_launcher_tolerates_cgroup_teardown_after_confirmed_container_exit(
         raise run_dual_spark.DualSparkError("cgroup counters disappeared")
 
     monkeypatch.setattr(run_dual_spark, "_sample_memory_tracker", missing_cgroup)
+    monkeypatch.setattr(run_dual_spark, "_log", messages.append)
 
     states = run_dual_spark._wait_for_containers(
         settings,
@@ -308,6 +448,53 @@ def test_launcher_tolerates_cgroup_teardown_after_confirmed_container_exit(
 
     assert states == {"rank1": {"Running": False, "ExitCode": 0}}
     assert observed_queries == [(tracker.container, True), (tracker.container, True)]
+    assert messages == []
+
+
+def test_launcher_rejects_missing_memory_counters_while_rank_is_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = run_dual_spark.Settings(
+        action="run",
+        scene=EXPECTED_SCENES[1][0],
+        peer_host="peer.example",
+        peer_user="tester",
+        ssh_key=None,
+        known_hosts=None,
+        work_root=Path("/tmp/cosmos3-contract"),
+        remote_root="/var/tmp/cosmos3-contract",
+        image="cosmos3-contract:latest",
+        run_id="contract-run",
+        ib_hca="rocep1s0f0:1",
+        net_iface="enp1s0f0np0",
+        gid_index=3,
+        runtime_timeout=60,
+        build_timeout=60,
+        dry_run=False,
+    )
+    tracker = run_dual_spark.MemoryTracker(
+        container="rank1",
+        remote=True,
+        cgroup_path="/sys/fs/cgroup/missing",
+        samples=1,
+    )
+    monkeypatch.setattr(
+        run_dual_spark,
+        "_container_state",
+        lambda *_args, **_kwargs: {"Running": True, "ExitCode": 0},
+    )
+
+    def missing_cgroup(*_args: Any, **_kwargs: Any) -> None:
+        raise run_dual_spark.DualSparkError("cgroup counters disappeared")
+
+    monkeypatch.setattr(run_dual_spark, "_sample_memory_tracker", missing_cgroup)
+
+    with pytest.raises(run_dual_spark.DualSparkError, match="cgroup counters disappeared"):
+        run_dual_spark._wait_for_containers(
+            settings,
+            ((tracker.container, tracker.remote),),
+            {tracker.container: tracker},
+        )
 
 
 def test_launcher_stops_sampling_a_finished_container(
@@ -387,10 +574,7 @@ def test_launcher_stops_sampling_a_finished_container(
         "rank1": {"Running": False, "ExitCode": 0},
     }
     assert sampled == [rank0.container, rank1.container, rank0.container]
-    assert messages == [
-        "WARNING: final cgroup memory sample was unavailable "
-        "for rank1: cgroup counters disappeared"
-    ]
+    assert messages == []
 
 
 def test_launcher_removes_rank1_verified_empty_frames(
@@ -436,12 +620,20 @@ def test_launcher_removes_rank1_verified_empty_frames(
     assert observed == [
         (
             [
+                "test",
+                "-e",
+                "/var/tmp/cosmos3-contract/runs/run/scene/rank1/frames",
+            ],
+            False,
+        ),
+        (
+            [
                 "rmdir",
                 "--",
                 "/var/tmp/cosmos3-contract/runs/run/scene/rank1/frames",
             ],
             False,
-        )
+        ),
     ]
 
 
@@ -546,9 +738,7 @@ def test_readme_leads_with_the_cli_and_one_time_image_build() -> None:
 
 def test_dockerfile_ships_a_pinned_isolated_cosmos3_environment() -> None:
     dockerfile = (EXAMPLE_ROOT / "Dockerfile").read_text(encoding="utf-8")
-    dockerignore = (EXAMPLE_ROOT / "Dockerfile.dockerignore").read_text(
-        encoding="utf-8"
-    )
+    dockerignore = (EXAMPLE_ROOT / "Dockerfile.dockerignore").read_text(encoding="utf-8")
 
     assert "nvcr.io/nvidia/tensorrt:26.07-py3@sha256:" in dockerfile
     assert "ARG TRTMC_CUDA_ARCHITECTURES=121-real" in dockerfile
@@ -564,6 +754,7 @@ def test_dockerfile_ships_a_pinned_isolated_cosmos3_environment() -> None:
     assert "!families/__init__.py" in dockerignore
     assert "!families/cosmos3/**" in dockerignore
     assert "!core/**" in dockerignore
+    assert "!apps/cli/**" in dockerignore
     assert "website/**" in dockerignore
     assert "nemotron_voicechat" not in dockerignore
 

--- a/families/cosmos3/runtime/distributed_runtime.cpp
+++ b/families/cosmos3/runtime/distributed_runtime.cpp
@@ -12,6 +12,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -55,6 +56,45 @@ std::filesystem::path rendezvous_path() {
     if (path == nullptr || *path == '\0')
         throw std::runtime_error("cosmos3 context parallel requires TRTMC_NCCL_RENDEZVOUS");
     return path;
+}
+
+bool env_is_one(const char* name) {
+    const char* value = std::getenv(name);
+    return value != nullptr && std::strcmp(value, "1") == 0;
+}
+
+std::string encode_unique_id(const NcclUniqueId& id) {
+    static constexpr char digits[] = "0123456789abcdef";
+    std::string encoded(sizeof(id.internal) * 2, '0');
+    for (std::size_t index = 0; index < sizeof(id.internal); ++index) {
+        const auto value = static_cast<unsigned char>(id.internal[index]);
+        encoded[index * 2] = digits[value >> 4];
+        encoded[index * 2 + 1] = digits[value & 0x0f];
+    }
+    return encoded;
+}
+
+unsigned char decode_hex_digit(char value) {
+    if (value >= '0' && value <= '9')
+        return static_cast<unsigned char>(value - '0');
+    if (value >= 'a' && value <= 'f')
+        return static_cast<unsigned char>(value - 'a' + 10);
+    if (value >= 'A' && value <= 'F')
+        return static_cast<unsigned char>(value - 'A' + 10);
+    throw std::runtime_error("TRTMC_NCCL_UNIQUE_ID_HEX contains a non-hex character");
+}
+
+NcclUniqueId decode_unique_id(const char* encoded) {
+    if (encoded == nullptr || std::strlen(encoded) != sizeof(NcclUniqueId::internal) * 2) {
+        throw std::runtime_error(
+            "cosmos3 context parallel requires a 256-character TRTMC_NCCL_UNIQUE_ID_HEX");
+    }
+    NcclUniqueId id{};
+    for (std::size_t index = 0; index < sizeof(id.internal); ++index) {
+        id.internal[index] = static_cast<char>((decode_hex_digit(encoded[index * 2]) << 4) |
+                                               decode_hex_digit(encoded[index * 2 + 1]));
+    }
+    return id;
 }
 
 class NcclRuntime {
@@ -186,13 +226,17 @@ DistributedRuntimeGroup initialize_context_parallel_group(int cp_size) {
 
     bind_cuda_device_for_local_rank();
     auto runtime = std::make_shared<NcclRuntime>();
-    const auto path = rendezvous_path();
     NcclUniqueId id{};
     if (group.rank == 0) {
         id = runtime->unique_id();
-        write_unique_id(path, id);
+        if (env_is_one("TRTMC_NCCL_UNIQUE_ID_STDOUT")) {
+            std::cout << "[cosmos3.nccl] unique_id=" << encode_unique_id(id) << std::endl;
+        } else {
+            write_unique_id(rendezvous_path(), id);
+        }
     } else {
-        id = read_unique_id(path);
+        const char* encoded = std::getenv("TRTMC_NCCL_UNIQUE_ID_HEX");
+        id = encoded != nullptr ? decode_unique_id(encoded) : read_unique_id(rendezvous_path());
     }
     runtime->init(cp_size, group.rank, id);
     group.communicator = runtime->communicator();

--- a/families/cosmos3/runtime/distributed_runtime.h
+++ b/families/cosmos3/runtime/distributed_runtime.h
@@ -21,8 +21,11 @@ struct DistributedRuntimeGroup {
 //
 // This intentionally avoids compile-time MPI/NCCL dependencies: ranks are
 // discovered from exact OpenMPI environment variables, and NCCL is loaded with
-// dlopen at runtime. TRTMC_NCCL_RENDEZVOUS must name the file shared or
-// transferred between ranks.
+// dlopen at runtime. Rank 0 can publish its unique ID to stdout for an external
+// MPI launcher by setting TRTMC_NCCL_UNIQUE_ID_STDOUT=1; rank 1 then consumes
+// the MPI-broadcast value from TRTMC_NCCL_UNIQUE_ID_HEX. The original
+// TRTMC_NCCL_RENDEZVOUS file contract remains available for callers that do not
+// use the MPI launcher.
 DistributedRuntimeGroup initialize_context_parallel_group(int cp_size);
 
 } // namespace trtmc::cosmos3


### PR DESCRIPTION
## Background

PR #926 added the Cosmos3 dual-Spark 720p example. This follow-up replaces the Python-managed file rendezvous with one host Open MPI worker per Spark while preserving Docker as the family runtime boundary. It also restores the Docker build context needed after the model-family refactor and makes normal launcher output suitable for an external demo.

## Exit Criteria

- [x] Launch CP=2 from the primary Spark with one MPI worker on each node.
- [x] Broadcast the live NCCL unique ID through MPI_Bcast instead of a shared rendezvous file.
- [x] Keep inference traffic on NCCL/RoCE while MPI provides process launch and control.
- [x] Validate matching GB10 GPUs, Open MPI vendors and versions, and active RoCE devices.
- [x] Synchronize the exact Docker image and native CP=2 TensorRT bundle to the peer.
- [x] Repair legacy root-owned bundle files before peer transfer.
- [x] Keep default logs concise and provide opt-in sanitized command logging.
- [x] Document the current prepare and run workflow.
- [x] Cover the launcher and rendezvous contracts with family-local tests.

Non-goals:

- CP values other than 2.
- Non-GB10 systems or clusters larger than two DGX Sparks.
- A model-agnostic multi-node orchestration abstraction.
- Performance comparison against single-device execution.

## Implementation

- The primary runs mpirun with one mpi4py worker on each Spark.
- Each worker owns its node-local Docker container; Docker remains the reproducible runtime and dependency boundary.
- Cosmos3 rank 0 exports the TensorRT/NCCL unique ID, MPI_Bcast delivers its 128 bytes, and rank 1 injects it before runtime initialization.
- The MPI control path is pinned to the direct-link interface; NCCL uses the configured RoCE HCA and GID index for tensor traffic.
- Preparation compares immutable image IDs, copies only when needed, and verifies matching CP=2 bundle metadata.
- Memory telemetry treats cgroup removal after a completed container as normal teardown while preserving a hard failure for an active rank with missing counters.
- The implementation remains owned by the Cosmos3 family.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [x] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

Host Open MPI and mpi4py are required on both Sparks. Container dependencies remain pinned by the example image.

## Validation

### Commands and Results

- pre-commit run on the six changed tracked files: passed.
- pytest examples/models/cosmos3/dual_spark/test_cosmos3_dual_spark_source.py: 21 passed.
- pytest tools/tests/test_architecture.py tools/tests/test_new_ci.py: 79 passed.
- python -m tools.model_ci validate: valid.
- python tools/test_impact.py --validate: valid.
- git diff --check: passed.

### Hardware, Environment, and Revisions

- Hardware: two NVIDIA DGX Spark systems with GB10 GPUs.
- Network: direct RoCE link on enp1s0f0np0 using rocep1s0f0:1 and GID index 3.
- Model: pinned nvidia/Cosmos3-Nano checkpoint.
- Engine: native TensorRT CP=2 bundle for 1280x720 generation.
- Container: trtmc-cosmos3-dual-spark:local on both nodes, verified by immutable image ID.
- prepare completed with matching GPUs, Open MPI, and active RoCE.
- A full showcase-high-speed-racing run completed all 35 denoising steps and 48 VAE decoding steps with both ranks exiting successfully.
- NCCL selected NET/IB over the direct RoCE link.
- Rank 0 produced a 1280x720 H.264 video with 189 frames at 24 FPS.
- The subsequent runtime change only suppresses an expected post-exit cgroup sampling race; dedicated tests cover both clean teardown and active-rank failure paths.

### Not Run / Remaining Gaps

- GitHub CI is pending on this PR.
- The full hardware inference was not repeated after the final log-only cgroup teardown adjustment.
- CP configurations other than 2 and systems other than dual DGX Spark were not tested.
- No performance or scaling benchmark is claimed.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

Review the family runtime rendezvous variables first, then the MPI worker launch, followed by peer artifact synchronization and the source-contract tests. The normal command log intentionally shows milestones only; set COSMOS3_LOG_COMMANDS=1 for sanitized diagnostic commands.

### Risk level

- [ ] Low
- [ ] Medium
- [x] High

Rationale: this changes the distributed runtime rendezvous and two-host launch path. The scope is family-local, preserves the existing rendezvous fallback, validates both hosts before launch, and is covered by source-contract and real dual-Spark testing.
