### PR TITLE
fix(wan_t2v): restore reference initialization

### DIFF
--- a/families/wan_t2v/requirements.txt
+++ b/families/wan_t2v/requirements.txt
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Pillow
+accelerate>=1.1.1
 diffusers

--- a/families/wan_t2v/tests/test_e2e.py
+++ b/families/wan_t2v/tests/test_e2e.py
@@ -255,7 +255,6 @@ def _tie_wan_text_encoder(pipeline) -> None:
     tie_weights = getattr(text_encoder, "tie_weights", None)
     if not callable(tie_weights):
         raise RuntimeError("Wan reference text encoder does not expose tie_weights()")
-    tie_weights()
     shared = getattr(text_encoder, "shared", None)
     encoder = getattr(text_encoder, "encoder", None)
     embedded = getattr(encoder, "embed_tokens", None)
@@ -263,6 +262,12 @@ def _tie_wan_text_encoder(pipeline) -> None:
         raise RuntimeError("Wan reference text encoder has no shared embedding binding")
     if shared.weight.shape != embedded.weight.shape:
         raise RuntimeError("Wan reference text encoder embedding shapes do not match")
+    # Wan stores the input embedding as shared.weight. Transformers 5 can load
+    # encoder.embed_tokens separately when tie_word_embeddings is false; its
+    # tie_weights() then leaves that newly initialized embedding untouched.
+    text_encoder.set_input_embeddings(shared)
+    tie_weights()
+    embedded = text_encoder.encoder.embed_tokens
     if shared.weight.data_ptr() != embedded.weight.data_ptr():
         raise RuntimeError("Wan reference text encoder tie_weights() did not bind embeddings")
 

--- a/families/wan_t2v/tests/test_reference_contract.py
+++ b/families/wan_t2v/tests/test_reference_contract.py
@@ -67,6 +67,10 @@ def _framework(monkeypatch) -> tuple[dict, object]:
         def tie_weights(self):
             self.tied = True
 
+        def set_input_embeddings(self, shared):
+            self.shared = shared
+            self.encoder.embed_tokens = shared
+
     class Pipeline:
         def __init__(self):
             self.text_encoder = TextEncoder()
@@ -158,6 +162,59 @@ def test_reference_rejects_an_untied_text_encoder() -> None:
         shared=SimpleNamespace(weight=_Weight(1)),
         encoder=SimpleNamespace(embed_tokens=SimpleNamespace(weight=_Weight(2))),
         tie_weights=lambda: None,
+        set_input_embeddings=lambda shared: None,
     )
     with pytest.raises(RuntimeError, match=r"tie_weights\(\) did not bind embeddings"):
         e2e._tie_wan_text_encoder(SimpleNamespace(text_encoder=text_encoder))
+
+
+def test_reference_rejects_mismatched_embedding_shapes() -> None:
+    embedded = _Weight(2)
+    embedded.shape = (16, 4)
+    text_encoder = SimpleNamespace(
+        shared=SimpleNamespace(weight=_Weight(1)),
+        encoder=SimpleNamespace(embed_tokens=SimpleNamespace(weight=embedded)),
+        tie_weights=lambda: None,
+    )
+    with pytest.raises(RuntimeError, match="embedding shapes do not match"):
+        e2e._tie_wan_text_encoder(SimpleNamespace(text_encoder=text_encoder))
+
+
+def test_reference_restores_checkpoint_shared_embedding(tmp_path: Path) -> None:
+    import torch
+    from safetensors.torch import save_file
+    from transformers import UMT5Config, UMT5EncoderModel
+
+    config = UMT5Config(
+        vocab_size=16,
+        d_model=8,
+        d_kv=4,
+        d_ff=16,
+        num_layers=1,
+        num_heads=2,
+        dropout_rate=0.0,
+        tie_word_embeddings=False,
+    )
+    reference = UMT5EncoderModel(config).eval()
+    # Wan checkpoints store the shared input embedding only, even though the
+    # config disables input/output word embedding tying.
+    reference.encoder.embed_tokens = reference.shared
+    state = {
+        name: tensor.clone()
+        for name, tensor in reference.state_dict().items()
+        if name != "encoder.embed_tokens.weight"
+    }
+    config.save_pretrained(tmp_path)
+    save_file(state, tmp_path / "model.safetensors", metadata={"format": "pt"})
+
+    loaded = UMT5EncoderModel.from_pretrained(tmp_path, local_files_only=True).eval()
+    e2e._tie_wan_text_encoder(SimpleNamespace(text_encoder=loaded))
+
+    assert loaded.config.tie_word_embeddings is False
+    assert loaded.encoder.embed_tokens.weight.data_ptr() == loaded.shared.weight.data_ptr()
+    torch.testing.assert_close(loaded.shared.weight, state["shared.weight"], rtol=0, atol=0)
+    tokens = torch.tensor([[1, 2, 3]])
+    with torch.no_grad():
+        expected = reference(tokens).last_hidden_state
+        actual = loaded(tokens).last_hidden_state
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/families/wan_t2v/tests/test_reference_contract.py
+++ b/families/wan_t2v/tests/test_reference_contract.py
@@ -110,6 +110,32 @@ def test_every_wan_reference_is_fp32() -> None:
     assert {case["reference_precision"] for _, _, case in e2e.CASES.values()} == {"fp32"}
 
 
+def test_reference_transformer_loads_checkpoint_with_fp32_modules(tmp_path: Path) -> None:
+    import torch
+
+    diffusers = pytest.importorskip("diffusers")
+    model = diffusers.WanTransformer3DModel(
+        num_attention_heads=2,
+        attention_head_dim=8,
+        in_channels=4,
+        out_channels=4,
+        text_dim=8,
+        freq_dim=8,
+        ffn_dim=16,
+        num_layers=1,
+    )
+    model.save_pretrained(tmp_path)
+    # This is the submodel loader used by WanPipeline.from_pretrained. It must
+    # retain the reference's FP32 modules instead of falling back when the
+    # family's accelerate dependency is missing.
+    restored = diffusers.WanTransformer3DModel.from_pretrained(
+        tmp_path, torch_dtype=torch.float32, local_files_only=True, low_cpu_mem_usage=True
+    )
+    assert not any(parameter.is_meta for parameter in restored.parameters())
+    for name, expected in model.state_dict().items():
+        torch.testing.assert_close(restored.state_dict()[name], expected, rtol=0, atol=0)
+
+
 def test_native_receives_the_exact_raw_latents(monkeypatch, tmp_path: Path) -> None:
     _, manifest, case = e2e.CASES["wan21-t2v-1.3b-l0"]
     latents = e2e._initial_latents(manifest, case)


### PR DESCRIPTION
## Background

Wan reference initialization needs its low-memory loader dependency and an explicit input embedding binding. Without `accelerate`, Diffusers 0.40.0 falls back to a loading path that rejects Wan modules retained in FP32. With the loader available, initialization fails with Transformers 5.2.0 because the checkpoint stores `shared.weight` without a duplicate `encoder.embed_tokens.weight`, while its configuration has `tie_word_embeddings=false`. Calling `tie_weights()` alone leaves a separately initialized encoder embedding and trips the reference binding guard.

## Exit Criteria

- Load the Wan reference with its declared low-memory dependency and retain FP32 modules.
- Restore the checkpoint's shared input embedding before reference inference.
- Preserve the checkpoint configuration, loaded weights, shape checks, and shared-storage check.
- Reproduce the failure with a real local UMT5 checkpoint and verify the repaired encoder's forward output.

## Implementation

Declare `accelerate>=1.1.1` in the Wan family requirements and test a real tiny Diffusers Wan Transformer checkpoint load with exact FP32 weight comparison. Call UMT5's `set_input_embeddings()` with the loaded shared embedding before `tie_weights()` and the existing pointer check. Add a tiny checkpoint regression that omits the duplicate embedding, checks unchanged weights and configuration, and compares encoder outputs exactly. Keep failure coverage for mismatched shapes and a binding operation that does nothing.

### Change categories

- [x] Dependencies
- [x] CI or developer tooling

## Validation

### Commands and Results

- A real tiny Wan Transformer checkpoint reproduces the Diffusers 0.40.0 loader error with Accelerate availability disabled; with Accelerate 1.15.0, loading succeeds and every FP32 weight matches exactly.
- `python -m pytest families/wan_t2v/tests -q -k 'not official_checkpoint_e2e' -p no:cacheprovider`: 33 passed, 4 GPU E2E cases deselected, using Transformers 5.2.0, Diffusers 0.40.0, and Accelerate 1.15.0.
- `ruff check families/wan_t2v/tests/test_reference_contract.py`: passed.
- `ruff format --check families/wan_t2v/tests/test_reference_contract.py`: passed.
- `python -m tools.community_ci source-quality --base github/main`: 128 architecture and source-quality tests passed.
- `git diff --check`: passed.

### Hardware, Environment, and Revisions

CPU validation on Linux x86_64, Python 3.12, PyTorch 2.12.0; isolated Transformers 5.2.0, Diffusers 0.40.0, Accelerate 1.15.0. Fixtures are generated tiny UMT5 and Wan Transformer checkpoints with FP32 weights. The tests load real checkpoints without a GPU. Tested head: `09544b988b7ca8c9d97f032ede3f1105647fd698`, based on `5c0bedd8549fd60eec3340a51477d83a20d91c54`.

### Not Run / Remaining Gaps

Full official-checkpoint GPU E2E and video parity remain unverified at this head. Protected premerge validation is still required. The CPU environment without Diffusers skips the optional transformer load regression; family CI installs the declared dependencies and runs it.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

The input embedding must remain shared even when the checkpoint disables input/output word embedding tying. The explicit binding is local to Wan's reference loader. This change preserves validation thresholds and adds the required family-local loader dependency without altering native runtime code or bundle formats.

### Risk level

- [x] Low

The change is limited to reference initialization and has real checkpoint load and forward regressions. Full model parity still requires GPU validation.
