### PR TITLE
fix(openfold3): load the selected product runtime

### DIFF
--- a/families/openfold3/tests/cpp/fake_build_identity.cpp
+++ b/families/openfold3/tests/cpp/fake_build_identity.cpp
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+extern "C" int openfold3_test_build_id() {
+    return TEST_BUILD_ID;
+}

--- a/families/openfold3/tests/cpp/fake_qualification_runtime.cpp
+++ b/families/openfold3/tests/cpp/fake_qualification_runtime.cpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/openfold3/structure_prediction.h"
+#include "trtmc/runtime/family_loader.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <stdexcept>
+
+extern "C" int openfold3_test_build_id();
+
+namespace {
+
+class Prediction final : public trtmc::openfold3::IStructurePrediction {
+  public:
+    trtmc::openfold3::StructurePredictionResult predict_structure(const std::string&) override {
+        return {"data_test\n", "{\"build_id\":" + std::to_string(TEST_BUILD_ID) + "}"};
+    }
+};
+
+} // namespace
+
+namespace trtmc {
+
+std::unique_ptr<ITask> load_task(const std::string&, const std::string& runtime_root, std::uint64_t,
+                                 const std::string&, bool) {
+    const auto backend = std::filesystem::path(runtime_root) / "libtrtmc_backend_trt.so";
+    void* library = dlopen(backend.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (library == nullptr)
+        throw std::runtime_error(dlerror());
+    const auto backend_build =
+        reinterpret_cast<int (*)()>(dlsym(library, "openfold3_test_build_id"));
+    const bool matches = backend_build != nullptr && backend_build() == TEST_BUILD_ID &&
+                         openfold3_test_build_id() == TEST_BUILD_ID;
+    dlclose(library);
+    if (!matches)
+        throw std::runtime_error("qualification runtime/core/backend product build mismatch");
+    return std::make_unique<Prediction>();
+}
+
+} // namespace trtmc

--- a/families/openfold3/tests/test_e2e.py
+++ b/families/openfold3/tests/test_e2e.py
@@ -166,6 +166,16 @@ def _run_native(
 ) -> tuple[str, dict]:
     structure = output_root / f"prediction-{index}.cif"
     metadata = output_root / f"prediction-{index}.json"
+    # The qualification executable is built separately from the selected wheel.
+    # Resolve the staged core so copied and symlinked roots both select its
+    # companion loader instead of the executable's source-build RUNPATH.
+    library_root = (runtime_root / "libtrtmc_core.so").resolve(strict=True).parent
+    loader = library_root / "libtrtmc_runtime.so"
+    assert loader.is_file(), f"OpenFold3 runtime is missing its companion loader: {loader}"
+    environment = os.environ.copy()
+    environment["LD_LIBRARY_PATH"] = os.pathsep.join(
+        path for path in (str(library_root), environment.get("LD_LIBRARY_PATH", "")) if path
+    )
     subprocess.run(
         [
             str(qualification),
@@ -177,6 +187,7 @@ def _run_native(
         ],
         check=True,
         timeout=timeout,
+        env=environment,
     )
     return structure.read_text(encoding="utf-8"), json.loads(metadata.read_text(encoding="utf-8"))
 

--- a/families/openfold3/tests/test_e2e_runtime.py
+++ b/families/openfold3/tests/test_e2e_runtime.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from . import test_e2e as e2e
+
+
+@pytest.fixture(scope="module")
+def qualification_builds(tmp_path_factory):
+    root = tmp_path_factory.mktemp("openfold3-builds")
+    repository = Path(__file__).resolve().parents[3]
+    sources = Path(__file__).with_name("cpp")
+    compiler = shutil.which("c++")
+    assert compiler, "OpenFold3 runtime regression requires a C++ compiler"
+    flags = [
+        compiler,
+        "-std=c++17",
+        f"-I{repository / 'core/runtime/include'}",
+        f"-I{repository / 'families/openfold3/include'}",
+    ]
+    native, wheel = root / "native-build", root / "wheel"
+    for build_id, directory in enumerate((native, wheel), start=1):
+        directory.mkdir()
+        for name in ("core", "backend_trt"):
+            library = f"libtrtmc_{name}.so"
+            subprocess.run(
+                [
+                    *flags,
+                    "-shared",
+                    "-fPIC",
+                    f"-DTEST_BUILD_ID={build_id}",
+                    str(sources / "fake_build_identity.cpp"),
+                    f"-Wl,-soname,{library}",
+                    "-o",
+                    str(directory / library),
+                ],
+                check=True,
+            )
+        subprocess.run(
+            [
+                *flags,
+                "-shared",
+                "-fPIC",
+                f"-DTEST_BUILD_ID={build_id}",
+                str(sources / "fake_qualification_runtime.cpp"),
+                f"-L{directory}",
+                "-ltrtmc_core",
+                "-ldl",
+                "-Wl,-soname,libtrtmc_runtime.so",
+                "-Wl,-rpath,$ORIGIN",
+                "-o",
+                str(directory / "libtrtmc_runtime.so"),
+            ],
+            check=True,
+        )
+    qualification = native / "openfold3_qualification"
+    subprocess.run(
+        [
+            *flags,
+            str(sources / "qualification.cpp"),
+            f"-L{native}",
+            "-ltrtmc_runtime",
+            f"-Wl,-rpath,{native}",
+            f"-Wl,-rpath-link,{native}",
+            "-o",
+            str(qualification),
+        ],
+        check=True,
+    )
+    return qualification, wheel
+
+
+@pytest.mark.parametrize("layout", ("copied", "symlinked"))
+def test_qualification_uses_selected_product_build(
+    qualification_builds, monkeypatch, tmp_path: Path, layout: str
+) -> None:
+    qualification, wheel = qualification_builds
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    for name in ("libtrtmc_core.so", "libtrtmc_backend_trt.so", "libtrtmc_runtime.so"):
+        if layout == "copied":
+            shutil.copy2(wheel / name, runtime_root / name)
+        elif name != "libtrtmc_runtime.so":
+            (runtime_root / name).symlink_to(wheel / name)
+    # The source-built executable's RUNPATH and the inherited environment both
+    # point at a different product build from the selected wheel libraries.
+    inherited_path = str(qualification.parent)
+    monkeypatch.setenv("LD_LIBRARY_PATH", inherited_path)
+    request = tmp_path / "query.json"
+    request.write_text("{}", encoding="utf-8")
+
+    structure, metadata = e2e._run_native(
+        qualification, runtime_root, tmp_path / "model.bundle", request, tmp_path, 0, 30
+    )
+
+    assert structure == "data_test\n"
+    assert metadata == {"build_id": 2}
+    assert os.environ["LD_LIBRARY_PATH"] == inherited_path
+
+
+def test_qualification_rejects_a_missing_companion_loader(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    (runtime_root / "libtrtmc_core.so").touch()
+
+    with pytest.raises(AssertionError, match="missing its companion loader"):
+        e2e._run_native(
+            tmp_path / "qualification",
+            runtime_root,
+            tmp_path / "model.bundle",
+            tmp_path / "query.json",
+            tmp_path,
+            0,
+            30,
+        )


### PR DESCRIPTION
## Background

OpenFold3's qualification executable is built in a separate native build tree, but its E2E test selects backend and model plugins from the installed wheel. The executable's default library search path can load the source-built runtime against those wheel plugins. Strict product-build identity checks then reject the backend before structure prediction begins.

## Exit Criteria

- Load the runtime and core paired with the selected wheel plugins.
- Support copied and symlinked staged runtime roots.
- Preserve prediction acceptance criteria and the parent process environment.
- Verify the real qualification executable across two distinct sets of runtime libraries.

## Implementation

Resolve the staged core library and prepend its companion loader directory to `LD_LIBRARY_PATH` for the qualification subprocess. Require that companion loader to exist. This keeps the runtime selection local to OpenFold3's E2E invocation.

The regression compiles the existing qualification executable and two sets of small CPU runtime/core/backend fixtures with different build identities. It tests both staging layouts with an inherited library path that points to the wrong build, plus missing-loader rejection.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

- `python -m pytest families/openfold3/tests/test_e2e_runtime.py -q`: the two cross-build layout cases failed before the fix with a runtime/core/backend build mismatch and passed after the fix.
- `python -m pytest families/openfold3/tests -q -k 'not official_checkpoint_e2e'`: 20 passed, 1 official-checkpoint E2E case deselected; includes the added missing-loader case.
- `python -m ruff check families/openfold3/tests/test_e2e.py families/openfold3/tests/test_e2e_runtime.py`: passed.
- `python -m ruff format --check families/openfold3/tests/test_e2e.py families/openfold3/tests/test_e2e_runtime.py`: passed.
- `clang-format --dry-run --Werror families/openfold3/tests/cpp/fake_build_identity.cpp families/openfold3/tests/cpp/fake_qualification_runtime.cpp`: passed.
- `python -m tools.community_ci impact --base github/main`: only `openfold3` selected.
- `python -m tools.community_ci source-quality --base github/main`: passed; 128 architecture and source-quality tests passed.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

CPU execution on Linux x86_64 with Python 3.12.3 and the system C++ compiler. The regression uses synthetic runtime fixtures, the production qualification executable, and the real OS dynamic linker; it needs no CUDA device or checkpoint. Tested change: `3de2a56e5ec820e785a66835433dd897d99aff2b`, based on `5c0bedd8549fd60eec3340a51477d83a20d91c54`.

### Not Run / Remaining Gaps

Full official-checkpoint GPU E2E has not been rerun. The CPU evidence verifies product-library selection and does not establish structure-prediction accuracy or performance. Protected premerge validation remains required.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

The qualification executable remains separately compiled against the same source interfaces. Its child environment must select the wheel's loader and core together with the wheel's plugins. This also supports the product-build identity enforcement introduced in #1190. Prediction thresholds, runtime loader guards, shared CI code, and public interfaces are unchanged.

### Risk level

- [x] Low

The change affects one family's test subprocess environment and is covered by actual compilation and dynamic loading. Official-checkpoint GPU validation is still needed.
