### PR TITLE
ci: check legal compliance in public premerge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,13 @@ CPU against GitHub's exact pull-request merge revision. Separate jobs run
 source quality, ownership and impact analysis, and the selected source-only C++
 and Python units. No comment or maintainer action is required.
 
+Source quality first checks required SPDX headers on all tracked source files
+and rejects changes to `LICENSE` or `NOTICE` relative to the tested merge's base.
+To check headers locally before pushing, run `python3 tools/legal_headers.py --check`.
+To run the full source-quality gate locally, use
+`python3 -m tools.community_ci source-quality --base upstream/main` after fetching
+the target branch and installing `requirements/community-ci.txt`.
+
 All public jobs run on GitHub-hosted `ubuntu-24.04` runners. Test jobs have
 read-only repository permission and no access to private runners, secrets, or
 GPUs. GitHub publishes native pull-request checks and public Actions logs,

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -58,10 +58,20 @@ class SourceQualityChecks:
         self.context = context
 
     def run(self) -> None:
+        self.legal_compliance()
         self.family_coverage()
         self.complexity()
         self.lint_changed_files()
         self.architecture_contracts()
+
+    def legal_compliance(self) -> None:
+        base = self.context.env.get("CI_BASE_REF", "")
+        if not base:
+            raise CiError("CI_BASE_REF is required")
+        self.context.run(["python", "tools/legal_headers.py", "--check"])
+        self.context.run(
+            ["git", "diff", "--exit-code", "--name-only", base, "--", "LICENSE", "NOTICE"]
+        )
 
     def family_coverage(self) -> None:
         self.context.run(["python", "-m", "tools.model_ci", "validate"])

--- a/tools/tests/test_community_ci.py
+++ b/tools/tests/test_community_ci.py
@@ -6,13 +6,14 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
-from tools import community_ci
+from tools import community_ci, legal_headers
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -123,6 +124,66 @@ def test_impact_publishes_only_the_public_cpu_scope(
     assert github_output.read_text(encoding="utf-8") == 'families=["qwen"]\n'
     summary = github_summary.read_text(encoding="utf-8")
     assert "families/qwen/model.py" in summary
+
+
+@pytest.mark.parametrize("change", ["valid", "missing-header", "LICENSE", "NOTICE"])
+def test_public_source_quality_enforces_legal_compliance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+    change: str,
+) -> None:
+    header = legal_headers.HASH_STYLE.render(b"\n").decode() + "\n\n"
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    shutil.copyfile(REPO_ROOT / "tools/legal_headers.py", tools_dir / "legal_headers.py")
+    (tools_dir / "legal_header_exceptions.toml").write_text(
+        header + "schema_version = 1\n", encoding="utf-8"
+    )
+    for name in ("LICENSE", "NOTICE"):
+        (tmp_path / name).write_text("Original legal document.\n", encoding="utf-8")
+
+    def git(*arguments: str) -> str:
+        return subprocess.run(
+            ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", *arguments],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "--quiet")
+    git("add", ".")
+    git("commit", "--quiet", "-m", "Base fixture")
+    base = git("rev-parse", "HEAD")
+    source = tmp_path / "families/example/support.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        ("" if change == "missing-header" else header) + '"""Example family support."""\n',
+        encoding="utf-8",
+    )
+    if change in ("LICENSE", "NOTICE"):
+        (tmp_path / change).write_text("Changed legal document.\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "--quiet", "-m", "Contribution fixture")
+
+    # Keep the real public entrypoint, header audit, and Git comparison; unrelated
+    # architecture and formatter checks need the full project and toolchain.
+    for name in ("family_coverage", "complexity", "lint_changed_files", "architecture_contracts"):
+        monkeypatch.setattr(community_ci.SourceQualityChecks, name, lambda _self: None)
+    runner = community_ci.CommunityCI(tmp_path, dict(os.environ))
+    if change == "valid":
+        runner.source_quality(base)
+        assert "findings=0" in capfd.readouterr().out
+    else:
+        with pytest.raises(community_ci.CiError):
+            runner.source_quality(base)
+        captured = capfd.readouterr()
+        output = captured.out + captured.err
+        if change == "missing-header":
+            assert "[missing] families/example/support.py: missing required hash SPDX header" in output
+        else:
+            assert change in output
 
 
 def test_public_workflow_is_an_automatic_read_only_exact_merge_gate() -> None:


### PR DESCRIPTION
## Background

A missing SPDX header in #1131 reached protected CI because public source quality did not run the repository's legal checks. Contributors should receive the filename and validation error in public PR checks before requesting protected validation.

## Exit Criteria

- Public source quality rejects tracked source files that fail the existing SPDX audit and rejects changes to `LICENSE` or `NOTICE` relative to the supplied base.
- Compliant contributions pass these checks, and failures prevent `Community CPU / Required` from passing.

## Implementation

Run legal compliance first in the source-quality entrypoint already used by Community CPU. Reuse `tools/legal_headers.py --check` and compare legal documents with the exact merge base supplied by the workflow. Add regression coverage using the public entrypoint, real Git history, and the real header checker; document the local commands.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m pytest tools/tests/test_community_ci.py tools/tests/test_new_ci.py -q -p no:cacheprovider`: passed, 50 tests, including acceptance of compliant source and rejection of a missing header and changes to each legal document.
- `python3 -m tools.community_ci source-quality --base github/main`: passed, including the legal audit, family coverage, complexity, changed-file lint, and 132 source-contract tests.
- `python3 tools/legal_headers.py --check`: passed, zero findings across 4,365 tracked files.
- `ruff check --config ruff.toml tools/ci/quality.py tools/tests/test_community_ci.py`: passed.
- `git diff --check`: passed before committing.

### Hardware, Environment, and Revisions

Local Linux CPU validation on `c1f61e49e74762819e46375547f32689246cc2c5`, based on `5c0bedd8549fd60eec3340a51477d83a20d91c54`, using Python 3.12.3, pytest 9.0.3, and Ruff 0.15.16. Public CI uses the repository's pinned requirements.

### Not Run / Remaining Gaps

GitHub Community CPU and protected premerge results are pending for this head. GPU inference, parity, and performance were not run for this CI-only change.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Manually reviewed the base-to-head diff, public workflow wiring, failure propagation, and unchanged validation criteria.

## Notes For Future Readers

The protected workflow retains its legal checks for the final tested snapshot. The existing public required check and dispatch prerequisite already propagate a source-quality failure, so this change does not require new workflow permissions or a new required-check name.

### Risk level

- [x] Low

Reuses existing validation policy in an earlier CPU gate; does not change model code, dependencies, header rules, or exception handling.
