### PR TITLE
perf(qwen3_omni): reduce build memory and prefill time

### DIFF
--- a/families/qwen3_omni/checkpoint_mapper.py
+++ b/families/qwen3_omni/checkpoint_mapper.py
@@ -67,4 +67,7 @@ def _get_tensor(readers: _ReaderCollection, name: str):
 
 
 def _load_tensor(readers: _ReaderCollection, name: str) -> np.ndarray:
-    return np.asarray(_get_tensor(readers, name), dtype=np.float32)
+    tensor = np.asarray(_get_tensor(readers, name))
+    if tensor.dtype == np.dtype(ml_dtypes.bfloat16):
+        return tensor
+    return np.asarray(tensor, dtype=np.float32)

--- a/families/qwen3_omni/graph_ops.py
+++ b/families/qwen3_omni/graph_ops.py
@@ -13,6 +13,16 @@ import numpy as np
 import tensorrt as trt
 
 
+class _BFloat16Weights(trt.Weights):
+    """Keep the NumPy storage alive for TensorRT's typed pointer constructor."""
+
+    def __init__(self, values: np.ndarray) -> None:
+        super().__init__(trt.bfloat16, values.ctypes.data, values.size)
+        # add_constant keeps this Weights object alive with the network. The
+        # pointer constructor itself does not retain the underlying array.
+        self._values = values
+
+
 def _cast_back_to_trt_dtype(
     network: trt.INetworkDefinition,
     tensor: trt.ITensor,
@@ -29,13 +39,12 @@ def layer_tensor_name(stem: str, layer: int) -> str:
 
 
 def _constant_carrier(values: np.ndarray, dtype: np.dtype) -> np.ndarray:
-    """Return a TensorRT-supported array with the requested storage rounding."""
+    """Return contiguous values with the requested storage rounding."""
     values_array = np.asarray(values)
     target_dtype = np.dtype(dtype)
     bf16_dtype = np.dtype(ml_dtypes.bfloat16)
     if target_dtype == bf16_dtype or values_array.dtype == bf16_dtype:
-        rounded = np.asarray(values_array, dtype=bf16_dtype)
-        return np.ascontiguousarray(rounded, dtype=np.float32)
+        return np.ascontiguousarray(values_array, dtype=bf16_dtype)
     return np.ascontiguousarray(values_array, dtype=target_dtype)
 
 
@@ -45,18 +54,21 @@ def add_constant(
     values: np.ndarray,
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Add a constant using a TensorRT-supported carrier dtype.
+    """Add a constant without expanding BF16 checkpoint storage to FP32.
 
-    NumPy BF16 uses the extension dtype ``V16``, which ``trt.Weights`` cannot
-    consume. BF16 inputs or targets are therefore rounded exactly once to
-    BF16 and promoted losslessly to an FP32 carrier. The caller must cast the
-    returned TensorRT tensor to ``trt.bfloat16`` at its strongly typed graph
-    boundary.
+    NumPy's extension BF16 dtype is not accepted by TensorRT's NumPy weights
+    constructor. Use its explicit dtype and pointer overload while retaining
+    the array for the network lifetime. BF16 inputs and targets keep the same
+    BF16 rounding as the former FP32 carrier followed by a BF16 cast.
     """
     constant_values = _constant_carrier(values, dtype)
     if constant_values.size != int(np.prod(shape, dtype=np.int64)):
         raise ValueError("Qwen3-Omni constant values do not match the declared shape")
-    weights = trt.Weights(constant_values)
+    weights = (
+        _BFloat16Weights(constant_values)
+        if constant_values.dtype == np.dtype(ml_dtypes.bfloat16)
+        else trt.Weights(constant_values)
+    )
     layer = network.add_constant(shape, weights)
     if layer is None:
         raise RuntimeError("TensorRT rejected a Qwen3-Omni constant")

--- a/families/qwen3_omni/model.py
+++ b/families/qwen3_omni/model.py
@@ -126,27 +126,20 @@ class _Qwen3OmniModel:
             expert_down = np.empty((num_experts, moe_intermediate, hidden), dtype=target_dtype)
             for expert in range(num_experts):
                 expert_source = f"{source}.mlp.experts.{expert}"
-                expected = {
-                    "gate_proj": (moe_intermediate, hidden),
-                    "up_proj": (moe_intermediate, hidden),
-                    "down_proj": (hidden, moe_intermediate),
-                }
-                mapped = {}
-                for projection in ("gate_proj", "up_proj", "down_proj"):
+                for projection, destination, expected_shape in (
+                    ("gate_proj", expert_gate, (moe_intermediate, hidden)),
+                    ("up_proj", expert_up, (moe_intermediate, hidden)),
+                    ("down_proj", expert_down, (hidden, moe_intermediate)),
+                ):
                     tensor = _load_tensor(readers, f"{expert_source}.{projection}.weight")
-                    if tensor.shape != expected[projection]:
+                    if tensor.shape != expected_shape:
                         raise ValueError(
                             f"Qwen3-Omni Thinker layer {layer} expert {expert} "
                             f"{projection} shape is invalid"
                         )
-                    mapped[projection] = _transpose_2d(
-                        tensor,
-                        f"thinker.layer.{layer}.expert.{expert}.{projection}",
-                        precision,
-                    )
-                expert_gate[expert] = mapped["gate_proj"]
-                expert_up[expert] = mapped["up_proj"]
-                expert_down[expert] = mapped["down_proj"]
+                    # Copy the transposed view directly into the packed BF16
+                    # destination, without an intermediate expert allocation.
+                    destination[expert] = tensor.T
             weights[f"{target}.experts.w_gate"] = expert_gate
             weights[f"{target}.experts.w_up"] = expert_up
             weights[f"{target}.experts.w_down"] = expert_down

--- a/families/qwen3_omni/runtime/kv_cache.cpp
+++ b/families/qwen3_omni/runtime/kv_cache.cpp
@@ -129,22 +129,23 @@ void Qwen3OmniKvCache::prepare_step(TensorMap& inputs, std::int32_t sequence_len
 void Qwen3OmniKvCache::write_prefill_kv(const std::vector<const void*>& keys,
                                         const std::vector<const void*>& values,
                                         std::int32_t sequence_length) {
-    if (position_ != 0 || sequence_length <= 0 || sequence_length > max_length_ ||
+    if (sequence_length <= 0 || sequence_length > max_length_ - position_ ||
         keys.size() != static_cast<std::size_t>(num_layers_) ||
         values.size() != static_cast<std::size_t>(num_layers_)) {
         throw std::runtime_error("Qwen3-Omni prefill KV write has invalid dimensions");
     }
     const auto bytes = static_cast<std::size_t>(sequence_length) * kv_dim_ * element_size_;
+    const auto offset = static_cast<std::size_t>(position_) * kv_dim_ * element_size_;
     for (std::int32_t layer = 0; layer < num_layers_; ++layer) {
         const auto index = static_cast<std::size_t>(layer);
         if (keys[index] == nullptr || values[index] == nullptr)
             throw std::runtime_error("Qwen3-Omni prefill KV output is null");
-        cudaMemcpyAsync(cache_k_[index].data(), keys[index], bytes, cudaMemcpyDeviceToDevice,
-                        stream_);
-        cudaMemcpyAsync(cache_v_[index].data(), values[index], bytes, cudaMemcpyDeviceToDevice,
-                        stream_);
+        cudaMemcpyAsync(static_cast<std::uint8_t*>(cache_k_[index].data()) + offset, keys[index],
+                        bytes, cudaMemcpyDeviceToDevice, stream_);
+        cudaMemcpyAsync(static_cast<std::uint8_t*>(cache_v_[index].data()) + offset, values[index],
+                        bytes, cudaMemcpyDeviceToDevice, stream_);
     }
-    position_ = sequence_length;
+    position_ += sequence_length;
 }
 
 void Qwen3OmniKvCache::advance(std::int32_t tokens) {

--- a/families/qwen3_omni/runtime/pipeline.cpp
+++ b/families/qwen3_omni/runtime/pipeline.cpp
@@ -157,22 +157,36 @@ Qwen3OmniTextPipeline::run_token_prefill(const std::vector<std::int32_t>& token_
         token_ids.size() > static_cast<std::size_t>(thinker_state_->max_length())) {
         throw std::runtime_error("Qwen3-Omni Thinker prompt exceeds its prefill profile");
     }
+    // Execute long prompts in the engine's optimized token batch while keeping
+    // its original profile and full KV capacity.
+    const auto optimal_shape = thinker_prefill_->input_profile_shape(
+        "token_id", thinker_prefill_->profile_idx(), ProfileShapeSelector::kOpt);
+    if (optimal_shape.size() != 1 || optimal_shape.front() <= 0)
+        throw std::runtime_error("Qwen3-Omni Thinker has an invalid prefill token profile");
+    const auto chunk_size = static_cast<std::size_t>(optimal_shape.front());
     thinker_state_->reset();
     thinker_state_->bind_to(*thinker_decode_);
     thinker_state_->bind_cache_inputs(*thinker_prefill_);
-    const auto sequence = static_cast<std::int32_t>(token_ids.size());
-    TensorMap inputs;
-    inputs["token_id"] =
-        Tensor{const_cast<std::int32_t*>(token_ids.data()), {sequence}, DType::kInt32};
-    thinker_state_->prepare_step(inputs, sequence);
-    const TensorMap outputs = thinker_prefill_->forward(inputs);
-    std::vector<const void*> keys;
-    std::vector<const void*> values;
-    collect_prefill_kv(*thinker_prefill_, outputs, thinker_state_->num_layers(), sequence, keys,
-                       values);
-    thinker_state_->write_prefill_kv(keys, values, sequence);
+    std::vector<float> logits;
+    for (std::size_t offset = 0; offset < token_ids.size();) {
+        const auto sequence =
+            static_cast<std::int32_t>(std::min(chunk_size, token_ids.size() - offset));
+        TensorMap inputs;
+        inputs["token_id"] =
+            Tensor{const_cast<std::int32_t*>(token_ids.data() + offset), {sequence}, DType::kInt32};
+        thinker_state_->prepare_step(inputs, sequence);
+        const TensorMap outputs = thinker_prefill_->forward(inputs);
+        std::vector<const void*> keys;
+        std::vector<const void*> values;
+        collect_prefill_kv(*thinker_prefill_, outputs, thinker_state_->num_layers(), sequence, keys,
+                           values);
+        thinker_state_->write_prefill_kv(keys, values, sequence);
+        offset += static_cast<std::size_t>(sequence);
+        if (offset == token_ids.size())
+            logits = copy_logits(outputs, config_.thinker_vocab_size);
+    }
     thinker_state_->bind_to(*thinker_decode_);
-    return copy_logits(outputs, config_.thinker_vocab_size);
+    return logits;
 }
 
 std::vector<float> Qwen3OmniTextPipeline::run_token_step(std::int32_t token_id) {

--- a/families/qwen3_omni/tests/cpp/test_qwen3_omni_pipeline.cpp
+++ b/families/qwen3_omni/tests/cpp/test_qwen3_omni_pipeline.cpp
@@ -43,12 +43,16 @@ class FixedTokenizer final : public trtmc::ITokenizer {
 struct ModuleStats {
     std::int32_t launches{0};
     std::unordered_map<std::string, std::vector<std::int64_t>> input_shapes;
+    std::vector<std::vector<std::int32_t>> token_batches;
+    std::vector<std::vector<std::int32_t>> positions;
 };
 
 class FakeThinkerModule final : public trtmc::ITrtModule {
   public:
-    FakeThinkerModule(bool prefill, std::shared_ptr<ModuleStats> stats, cudaStream_t stream)
-        : prefill_(prefill), stats_(std::move(stats)), stream_(stream),
+    FakeThinkerModule(bool prefill, std::shared_ptr<ModuleStats> stats, cudaStream_t stream,
+                      std::int32_t opt_prefill_tokens = 32)
+        : prefill_(prefill), opt_prefill_tokens_(opt_prefill_tokens), stats_(std::move(stats)),
+          stream_(stream),
           present_k_(std::vector<std::int64_t>{32, 1}, trtmc::DType::kFloat32, stream),
           present_v_(std::vector<std::int64_t>{32, 1}, trtmc::DType::kFloat32, stream),
           logits_(8, -100.0F) {
@@ -66,6 +70,10 @@ class FakeThinkerModule final : public trtmc::ITrtModule {
         for (const auto& [name, tensor] : inputs)
             stats_->input_shapes[name] = tensor.shape;
         const auto rows = inputs.at("token_id").shape.at(0);
+        const auto* tokens = static_cast<const std::int32_t*>(inputs.at("token_id").data);
+        const auto* positions = static_cast<const std::int32_t*>(inputs.at("position_id").data);
+        stats_->token_batches.emplace_back(tokens, tokens + rows);
+        stats_->positions.emplace_back(positions, positions + rows);
         present_host_.assign(static_cast<std::size_t>(rows), 0.0F);
         return {
             {"logits", trtmc::Tensor{logits_.data(), {1, 8}, trtmc::DType::kFloat32}},
@@ -113,9 +121,12 @@ class FakeThinkerModule final : public trtmc::ITrtModule {
         return {};
     }
 
-    std::vector<std::int64_t> input_profile_shape(const std::string&, std::int32_t,
-                                                  trtmc::ProfileShapeSelector) const override {
-        return {};
+    std::vector<std::int64_t>
+    input_profile_shape(const std::string& name, std::int32_t,
+                        trtmc::ProfileShapeSelector selector) const override {
+        if (name != "token_id")
+            return {};
+        return {selector == trtmc::ProfileShapeSelector::kOpt ? opt_prefill_tokens_ : 32};
     }
     std::int32_t optimization_profile_count() const override { return 1; }
 
@@ -149,6 +160,7 @@ class FakeThinkerModule final : public trtmc::ITrtModule {
 
   private:
     bool prefill_{false};
+    std::int32_t opt_prefill_tokens_{32};
     std::shared_ptr<ModuleStats> stats_;
     cudaStream_t stream_{nullptr};
     mutable std::unordered_map<std::string, void*> bindings_;
@@ -175,10 +187,13 @@ trtmc::Qwen3OmniRuntimeConfig make_config() {
     return config;
 }
 
-std::unique_ptr<trtmc::Qwen3OmniTextPipeline>
-make_pipeline(cudaStream_t stream, PipelineStats& stats, bool omit_prefill = false) {
-    auto prefill = omit_prefill ? std::unique_ptr<FakeThinkerModule>{}
-                                : std::make_unique<FakeThinkerModule>(true, stats.prefill, stream);
+std::unique_ptr<trtmc::Qwen3OmniTextPipeline> make_pipeline(cudaStream_t stream,
+                                                            PipelineStats& stats,
+                                                            bool omit_prefill = false,
+                                                            std::int32_t chunk_size = 32) {
+    auto prefill =
+        omit_prefill ? std::unique_ptr<FakeThinkerModule>{}
+                     : std::make_unique<FakeThinkerModule>(true, stats.prefill, stream, chunk_size);
     auto decode = std::make_unique<FakeThinkerModule>(false, stats.decode, stream);
     auto cache =
         std::make_unique<trtmc::Qwen3OmniKvCache>(1, 32, 1, stream, trtmc::DType::kFloat32);
@@ -234,12 +249,80 @@ void test_batched_prefill_and_argmax() {
           "Qwen3-Omni preserves batched prefill token, position, and causal-mask shapes");
 }
 
+void test_chunked_prefill_preserves_tokens_and_positions() {
+    StreamFixture fixture;
+    PipelineStats stats;
+    auto pipeline = make_pipeline(fixture.stream, stats, false, 2);
+    trtmc::TextGenerationConfig config;
+    config.max_new_tokens = 2;
+    const auto result = pipeline->generate("question", config);
+    check(result.text == "hello" && result.token_ids == std::vector<std::int32_t>({1}),
+          "Qwen3-Omni chunking preserves greedy output and EOS handling");
+    check(stats.prefill->token_batches == std::vector<std::vector<std::int32_t>>({{4, 5}, {6}}),
+          "Qwen3-Omni prefill includes every prompt token exactly once");
+    check(stats.prefill->positions == std::vector<std::vector<std::int32_t>>({{0, 1}, {2}}) &&
+              stats.decode->positions == std::vector<std::vector<std::int32_t>>({{3}}),
+          "Qwen3-Omni preserves absolute positions across prefill and decode");
+    check(stats.prefill->launches == 2 && stats.decode->launches == 1,
+          "Qwen3-Omni bounds each prefill chunk and decodes after the final chunk");
+}
+
+void test_prefill_cache_appends_rows_and_masks_previous_chunks() {
+    StreamFixture fixture;
+    trtmc::Qwen3OmniKvCache cache(1, 32, 1, fixture.stream, trtmc::DType::kFloat32);
+    trtmc::DeviceTensor source({3, 1}, trtmc::DType::kFloat32, fixture.stream);
+    const float rows[] = {11.0F, 12.0F, 13.0F};
+    cudaMemcpyAsync(source.data(), rows, sizeof(rows), cudaMemcpyHostToDevice, fixture.stream);
+    cache.write_prefill_kv({source.data()}, {source.data()}, 2);
+    try {
+        auto* last = static_cast<float*>(source.data()) + 2;
+        cache.write_prefill_kv({last}, {last}, 1);
+    } catch (const std::runtime_error&) {
+        check(false, "Qwen3-Omni appends a second prefill chunk");
+        return;
+    }
+    auto stats = std::make_shared<ModuleStats>();
+    FakeThinkerModule module(true, stats, fixture.stream);
+    cache.bind_cache_inputs(module);
+    float keys[3] = {};
+    float values[3] = {};
+    cudaMemcpyAsync(keys, module.device_ptr("cache_k_0"), sizeof(keys), cudaMemcpyDeviceToHost,
+                    fixture.stream);
+    cudaMemcpyAsync(values, module.device_ptr("cache_v_0"), sizeof(values), cudaMemcpyDeviceToHost,
+                    fixture.stream);
+    cudaStreamSynchronize(fixture.stream);
+    check(std::equal(std::begin(rows), std::end(rows), std::begin(keys)) &&
+              std::equal(std::begin(rows), std::end(rows), std::begin(values)),
+          "Qwen3-Omni appends K/V without overwriting preceding chunks");
+    trtmc::TensorMap inputs;
+    cache.prepare_step(inputs, 2);
+    const auto* mask = static_cast<const float*>(inputs.at("attention_mask").data);
+    bool correct_mask = true;
+    for (int query = 0; query < 2; ++query) {
+        for (int key = 0; key < 34; ++key) {
+            const bool visible = key < 3 || (key >= 32 && key <= 32 + query);
+            correct_mask &= mask[query * 34 + key] == (visible ? 0.0F : -1.0e4F);
+        }
+    }
+    check(cache.position() == 3 && correct_mask,
+          "Qwen3-Omni chunk masks expose preceding tokens and remain causal");
+    bool overflow = false;
+    try {
+        cache.write_prefill_kv({source.data()}, {source.data()}, 30);
+    } catch (const std::runtime_error&) {
+        overflow = true;
+    }
+    check(overflow, "Qwen3-Omni rejects chunk writes beyond the original KV capacity");
+}
+
 } // namespace
 
 int main() {
     test_pipeline_construction();
     test_validates_thinker();
     test_batched_prefill_and_argmax();
+    test_chunked_prefill_preserves_tokens_and_positions();
+    test_prefill_cache_appends_rows_and_masks_previous_chunks();
     if (failures != 0)
         std::cerr << failures << " Qwen3-Omni pipeline test(s) failed\n";
     return failures;

--- a/families/qwen3_omni/tests/test_bf16_constants.py
+++ b/families/qwen3_omni/tests/test_bf16_constants.py
@@ -15,12 +15,13 @@ trt = pytest.importorskip("tensorrt")
 from .. import graph_ops  # noqa: E402
 
 
-def test_fp32_input_with_bf16_target_uses_exact_fp32_carrier() -> None:
+def test_fp32_input_with_bf16_target_preserves_exact_rounding() -> None:
     values = np.array([1.001, -0.3333, 17.0625], dtype=np.float32)
     carrier = graph_ops._constant_carrier(values, ml_dtypes.bfloat16)
-    expected = values.astype(ml_dtypes.bfloat16).astype(np.float32)
+    expected = values.astype(ml_dtypes.bfloat16)
 
-    assert carrier.dtype == np.float32
+    assert carrier.dtype == np.dtype(ml_dtypes.bfloat16)
+    assert carrier.nbytes == values.size * 2
     assert carrier.flags.c_contiguous
     np.testing.assert_array_equal(carrier, expected)
     assert not np.array_equal(carrier, values)
@@ -51,7 +52,7 @@ def test_bf16_target_serializes_in_strongly_typed_network(values_dtype) -> None:
         np.array([1.001, -0.3333, 17.0625], dtype=values_dtype),
         dtype=ml_dtypes.bfloat16,
     )
-    assert constant.dtype == trt.float32
+    assert constant.dtype == trt.bfloat16
     constant_bf16 = network.add_cast(constant, trt.bfloat16).get_output(0)
     output = network.add_elementwise(
         input_tensor, constant_bf16, trt.ElementWiseOperation.SUM

--- a/families/qwen3_omni/tests/test_bf16_weight_storage.py
+++ b/families/qwen3_omni/tests/test_bf16_weight_storage.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""BF16 checkpoint constants retain compact storage and their original values."""
+
+from __future__ import annotations
+
+import gc
+
+import ml_dtypes
+import numpy as np
+import pytest
+import tensorrt as trt
+
+from .. import graph_ops
+
+
+@pytest.mark.gpu
+@pytest.mark.trt
+@pytest.mark.parametrize("values_dtype", [np.float32, ml_dtypes.bfloat16])
+def test_bf16_constants_keep_compact_storage_and_survive_collection(values_dtype) -> None:
+    import torch
+
+    logger = trt.Logger(trt.Logger.ERROR)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    config = builder.create_builder_config()
+    inp = network.add_input("input", trt.bfloat16, (3,))
+    values = np.array([1.001, 0.0, -0.3333, 0.0, 17.0625, 0.0], dtype=values_dtype)[::2]
+    expected = values.astype(ml_dtypes.bfloat16).astype(np.float32)
+    constant = graph_ops.add_constant(network, (3,), values, dtype=ml_dtypes.bfloat16)
+    layer = network.get_layer(0)
+
+    assert network.num_layers == 1
+    assert layer.type == trt.LayerType.CONSTANT
+    assert tuple(constant.shape) == (3,)
+    assert constant.dtype == trt.bfloat16
+
+    # Exercise the lifetime of a converted, noncontiguous temporary array.
+    del values
+    gc.collect()
+    output = network.add_elementwise(inp, constant, trt.ElementWiseOperation.SUM).get_output(0)
+    output.name = "output"
+    network.mark_output(output)
+    plan = builder.build_serialized_network(network, config)
+    assert plan is not None
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(plan)
+    assert engine is not None
+    context = engine.create_execution_context()
+    assert context is not None
+    inputs = torch.zeros(3, dtype=torch.bfloat16, device="cuda")
+    outputs = torch.empty_like(inputs)
+    stream = torch.cuda.Stream()
+    torch.cuda.synchronize()
+    assert context.set_tensor_address("input", inputs.data_ptr())
+    assert context.set_tensor_address("output", outputs.data_ptr())
+    assert context.execute_async_v3(stream.cuda_stream)
+    stream.synchronize()
+    np.testing.assert_array_equal(outputs.float().cpu().numpy(), expected)

--- a/families/qwen3_omni/tests/test_checkpoint_mapper.py
+++ b/families/qwen3_omni/tests/test_checkpoint_mapper.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint loading keeps BF16 storage until each graph boundary needs a cast."""
+
+from types import SimpleNamespace
+
+import ml_dtypes
+import numpy as np
+
+from .. import checkpoint_mapper
+
+
+def test_load_tensor_preserves_bf16_values_without_a_full_precision_copy() -> None:
+    values = np.array([[1.001, -0.3333], [17.0625, 0.0]], dtype=ml_dtypes.bfloat16)
+    reader = SimpleNamespace(get_tensor=lambda _name: values)
+    readers = checkpoint_mapper._ReaderCollection({"weight": reader})
+
+    loaded = checkpoint_mapper._load_tensor(readers, "weight")
+
+    assert loaded.dtype == values.dtype
+    assert loaded.nbytes == values.nbytes
+    assert np.shares_memory(loaded, values)
+    np.testing.assert_array_equal(loaded, values)

--- a/families/qwen3_omni/tests/test_e2e.py
+++ b/families/qwen3_omni/tests/test_e2e.py
@@ -180,6 +180,7 @@ def _native_text(binary: Path, runtime_root: Path, bundle: Path, case: dict) -> 
 
 def _official_reference(model_dir: Path, manifest: dict, case: dict) -> str:
     import torch
+    from torch.nn.attention import SDPBackend, sdpa_kernel
     from transformers import Qwen3OmniMoeForConditionalGeneration, Qwen3OmniMoeProcessor
 
     processor = Qwen3OmniMoeProcessor.from_pretrained(
@@ -217,7 +218,9 @@ def _official_reference(model_dir: Path, manifest: dict, case: dict) -> str:
         return_tensors="pt",
         padding=True,
     ).to(model.device)
-    with torch.inference_mode():
+    # Keep the correctness oracle independent of fused SDPA backend selection.
+    # The math backend retains FP32 attention intermediates for BF16 inputs.
+    with torch.inference_mode(), sdpa_kernel(SDPBackend.MATH):
         text_ids = model.generate(
             **inputs,
             thinker_max_new_tokens=int(case["max_new_tokens"]),


### PR DESCRIPTION
## Background

Qwen3-Omni's Thinker text builder expanded BF16 weights into FP32 constant buffers, increasing build memory. Long prompts also ran as one prefill batch despite the engine's smaller opt shape. This change reduces build memory and prefill time within the Qwen3-Omni family.

## Exit Criteria

- Preserve BF16, TP=1, the full 256-token cache, and the existing engine profiles.
- Preserve exact expected/native/reference text assertions and generated-token parity across prefill batches.
- Keep all source changes within `families/qwen3_omni/`.

## Implementation

- Retain BF16 storage through checkpoint loading and TensorRT constants, preserve storage ownership, and pack transposed experts directly into their destination arrays.
- Batch prefill using the engine's existing opt shape, append K/V, and preserve absolute positions and causal masks.
- Use PyTorch SDPA MATH for the family reference. Exact text assertions and native BF16 graph boundaries are unchanged.

### Change categories

- [x] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

- `ctest --test-dir "$BUILD_DIR" -R '^test_qwen3_omni_pipeline$' --output-on-failure`: 1 passed with the restored original backend.
- `python3 -m pytest families/qwen3_omni/tests -k 'not official_checkpoint_e2e' -q`: 12 passed, 1 deselected before the backend rollback; the family test and implementation sources are unchanged.
- `python3 -m pytest families/qwen3_omni/tests/test_e2e.py --e2e-model qwen3-omni-30b-a3b-instruct -s -v -p eval_phases --basetemp="$BUNDLE_DIR" --junitxml="$RESULT_DIR/junit.xml"`: Passed with constrained free GPU memory using the original shared backend, including a full engine build, native inference, and official-reference comparison. `eval_phases` is an external timing observer and does not change assertions.
- Native short- and long-prompt token parity with the original shared backend: Passed: three short-prompt runs and three runs at each of two longer prompt lengths; generated token IDs matched the baseline.

### Hardware, Environment, and Revisions

Current head: `a08e2587d62a6182a848d7da87bfe99019ed99de`. GB300, BF16, TP=1, Python 3.12.3, CUDA 13.3.33, TensorRT 11.1.0.106, PyTorch 2.12.0+cu130, Transformers 5.2.0. Checkpoint: `Qwen/Qwen3-Omni-30B-A3B-Instruct` at `26291f793822fb6be9555850f06dfe95f2d7e695`.

### Not Run / Remaining Gaps

Protected premerge has not run for this head. The automatically triggered community GPU check exited before testing because CPU validation was still running. Other hardware/software combinations and multimodal paths remain unqualified. The shared backend and admission policy are unchanged.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

Review weight storage and ownership, then K/V batching. Rebuild the Qwen3-Omni family library. Public API, ABI, bundle format, and dependencies are unchanged.

Please review the reference backend choice: default fused SDPA produced a different greedy continuation in the tested environment; MATH preserved the existing fixed expectation for both comparison variants. No expected text or tolerance was relaxed.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The family change touches K/V orchestration and constant-storage lifetimes; broader qualification remains necessary before merging.
