### PR TITLE
fix(ci): fix invalid failure() expression breaking community-gpu-ci.yml

### DIFF
--- a/.github/workflows/community-gpu-ci.yml
+++ b/.github/workflows/community-gpu-ci.yml
@@ -222,7 +222,7 @@ jobs:
     timeout-minutes: 60
     permissions: {}
     outputs:
-      conclusion: ${{ steps.result.outputs.conclusion }}
+      conclusion: ${{ steps.record_failure.outputs.conclusion || steps.record_success.outputs.conclusion }}
 
     steps:
       - name: Install the Brev CLI
@@ -296,15 +296,19 @@ jobs:
             | tee /tmp/gpu-ci-output.log
           echo "conclusion=success" >> "$GITHUB_OUTPUT"
 
-      - name: Record the step conclusion
-        if: always()
-        id: result
-        run: |
-          if [ "${{ failure() }}" = "true" ]; then
-            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-          else
-            echo "conclusion=${{ steps.test.outputs.conclusion || 'success' }}" >> "$GITHUB_OUTPUT"
-          fi
+      # success()/failure() are only valid in a step's own `if:`, not inside
+      # a run script's ${{ }} expression (that is invalid syntax and
+      # silently breaks the entire workflow file for every trigger, not
+      # just this step) so record the two outcomes as separate steps.
+      - name: Record failure
+        if: failure()
+        id: record_failure
+        run: echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+
+      - name: Record success
+        if: success()
+        id: record_success
+        run: echo "conclusion=${{ steps.test.outputs.conclusion || 'success' }}" >> "$GITHUB_OUTPUT"
 
       - name: Always tear down the GPU instance
         if: ${{ always() && steps.reserve.outputs.instance_name != '' }}


### PR DESCRIPTION
## Background

After #1249 merged, community-gpu-ci.yml never actually triggered on the
first real pull request opened against main (#1251), despite the trigger
conditions being met. Investigation traced this to an invalid GitHub
Actions expression that made the entire workflow file fail to parse for
every trigger type, not just the step it was written in.

## Exit Criteria

\`gh workflow run community-gpu-ci.yml --repo NVIDIA/TensorRT-Model-Connect
--ref main\` succeeds (does not return an expression-parse error), and the
workflow actually creates a run on the next qualifying pull-request event.

## Implementation

\`success()\`/\`failure()\` (and \`cancelled()\`/\`always()\`) are only valid
inside a step or job's own \`if:\` condition, not as a general \`\${{ }}\`
expression used elsewhere, including inside a \`run:\` script body. The
"Record the step conclusion" step used \`\${{ failure() }}\` inside its
script, which the GitHub Actions expression parser rejects, and that
single invalid expression invalidated the whole file.

Confirmed directly:

\`\`\`
gh workflow run community-gpu-ci.yml --repo NVIDIA/TensorRT-Model-Connect --ref main
-> HTTP 422: failed to parse workflow: (Line: 302, Col: 14):
   Unrecognized function: 'failure'. Located at position 1 within
   expression: failure()
\`\`\`

This also explains the three prior "failed, 0 jobs" runs recorded against
this workflow file (one on the merge to main, two earlier on the PR
branch itself) — those are GitHub's synthetic signal that a workflow file
failed to parse, not a real job execution; I had misread them as
transient artifacts.

Fix: split the single step back into two mutually exclusive steps gated
by \`if: failure()\` / \`if: success()\` (both valid, since those are real
step-level if: conditions), and update the job's \`conclusion\` output to
read from whichever of the two steps actually ran.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

\`\`\`
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/community-gpu-ci.yml'))"
# YAML OK (this alone does not catch GitHub Actions expression errors)

gh workflow run community-gpu-ci.yml --repo NVIDIA/TensorRT-Model-Connect --ref main -f pr_number=1251
# before this fix: HTTP 422 failed to parse workflow (line 302)
# this PR's content has not yet been re-verified against a live dispatch;
# see Not Run below
\`\`\`

Also re-scanned the full file for any other invalid use of
success()/failure()/cancelled()/always() outside a step/job if:; none
found (all remaining uses are legitimate if: conditions).

### Hardware, Environment, and Revisions

Not applicable: pure GitHub Actions YAML fix, no runtime/hardware
component of its own.

### Not Run / Remaining Gaps

- This PR's exact content has not yet been dispatched against main to
  confirm the parse error is actually gone; that verification happens
  once this merges, by re-triggering on a real or dispatched PR.
- The underlying Brev GPU reservation/build/test flow this workflow
  orchestrates is unaffected by this change and was already separately
  validated (see #1249, #1229).

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

If community-gpu-ci.yml (or any workflow using these functions) needs a
success/failure branch inside a script, use two steps gated by if:
success() / if: failure(), not \${{ success() }}/\${{ failure() }} inside
the script body.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Fixes a bug that currently makes the workflow a complete no-op (it cannot
run at all); cannot make things worse than the current broken state.