### PR TITLE
fix(ci): fail closed in community GPU workflow

### DIFF
--- a/.github/workflows/community-gpu-ci.yml
+++ b/.github/workflows/community-gpu-ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Check out the base branch
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
-          ref: main
+          ref: ${{ steps.snapshot.outputs.base_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -153,17 +153,23 @@ jobs:
           BASE_SHA: ${{ steps.snapshot.outputs.base_sha }}
         run: |
           set -euo pipefail
-          git checkout --quiet "$HEAD_SHA"
-          python3 -m tools.community_ci impact --base "$BASE_SHA" | tee /tmp/impact.json
-          # tools.community_ci already writes the "families" output; scope
-          # ("changed" vs "all", e.g. a shared/root file was touched) is not
-          # exposed as an action output, so read it from the same JSON here.
-          python3 -c "
+          # Execute only the captured trusted base's classifier. The PR head
+          # is an argument to git diff, never a checkout or Python import.
+          # Families absent from the base inventory conservatively select all.
+          python3 -m tools.test_impact --base "$BASE_SHA" --head "$HEAD_SHA" \
+            | tee "$RUNNER_TEMP/trtmc-gpu-impact.json"
+          python3 - <<'PY'
           import json
-          with open('/tmp/impact.json') as f:
-              summary = json.load(f)
-          print(f\"scope={summary['scope']}\")
-          " >> "$GITHUB_OUTPUT"
+          import os
+          from pathlib import Path
+
+          summary = json.loads(
+              (Path(os.environ["RUNNER_TEMP"]) / "trtmc-gpu-impact.json").read_text()
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              print("families=" + json.dumps(summary["families"], separators=(",", ":")), file=output)
+              print("scope=" + summary["scope"], file=output)
+          PY
 
       # Security boundary, not a style choice: FAMILIES comes from directory
       # names under families/ in the pull request, which the contributor
@@ -245,8 +251,10 @@ jobs:
           instance_name="trtmc-gpu-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           # L40/L40S/L4 (Ada Lovelace, compute capability 8.9). Falls back
           # across providers/types automatically; see `brev create --help`.
-          brev create "$instance_name" -g L40 --timeout 600
+          # Publish the intended name before provisioning, so cleanup also
+          # runs when creation times out after an instance has been allocated.
           echo "instance_name=$instance_name" >> "$GITHUB_OUTPUT"
+          brev create "$instance_name" -g L40 --timeout 600
 
       - name: Build the GPU image, clone the PR head, and run the smoke test
         id: test
@@ -299,12 +307,23 @@ jobs:
       - name: Record the step conclusion
         if: always()
         id: result
+        env:
+          JOB_STATUS: ${{ job.status }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+          TEST_CONCLUSION: ${{ steps.test.outputs.conclusion }}
         run: |
-          if [ "${{ failure() }}" = "true" ]; then
-            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-          else
-            echo "conclusion=${{ steps.test.outputs.conclusion || 'success' }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # Status-check functions are only valid in if expressions. Require
+          # an explicit completed test; skipped or missing results fail closed.
+          conclusion=failure
+          if [ "$JOB_STATUS" = "cancelled" ]; then
+            conclusion=cancelled
+          elif [ "$JOB_STATUS" = "success" ] \
+            && [ "$TEST_OUTCOME" = "success" ] \
+            && [ "$TEST_CONCLUSION" = "success" ]; then
+            conclusion=success
           fi
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
 
       - name: Always tear down the GPU instance
         if: ${{ always() && steps.reserve.outputs.instance_name != '' }}
@@ -337,11 +356,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           CONCLUSION: ${{ needs.provision-and-test.outputs.conclusion }}
+          JOB_RESULT: ${{ needs.provision-and-test.result }}
         run: |
           set -euo pipefail
           state=failure
           description="GPU smoke test did not complete"
-          if [ "$CONCLUSION" = "success" ]; then
+          if [ "$JOB_RESULT" = "success" ] && [ "$CONCLUSION" = "success" ]; then
             state=success
             description="GPU smoke test passed"
           fi

--- a/tools/tests/test_community_ci.py
+++ b/tools/tests/test_community_ci.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the contributor-visible Community CPU entrypoint."""
+"""Tests for the contributor-visible Community CI entrypoints."""
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -316,3 +317,295 @@ def test_cpu_image_builds_from_the_minimal_requirements_context(
 
     assert calls[0][:3] == ["docker", "build", "--file"]
     assert calls[0][-1] == "requirements"
+
+
+@pytest.mark.parametrize(
+    ("job_status", "test_outcome", "test_conclusion", "expected"),
+    [
+        ("success", "success", "success", "success"),
+        ("failure", "skipped", "", "failure"),
+        ("failure", "failure", "", "failure"),
+        ("failure", "success", "success", "failure"),
+        ("success", "skipped", "", "failure"),
+        ("success", "success", "", "failure"),
+        ("success", "failure", "success", "failure"),
+        ("cancelled", "cancelled", "", "cancelled"),
+        ("cancelled", "success", "success", "cancelled"),
+        ("", "", "", "failure"),
+    ],
+)
+def test_gpu_step_conclusion_requires_completed_success(
+    tmp_path: Path,
+    job_status: str,
+    test_outcome: str,
+    test_conclusion: str,
+    expected: str,
+) -> None:
+    output = tmp_path / "output"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-gpu-ci.yml", "provision-and-test", "Record the step conclusion"
+            ),
+        ],
+        env={
+            **os.environ,
+            "JOB_STATUS": job_status,
+            "TEST_OUTCOME": test_outcome,
+            "TEST_CONCLUSION": test_conclusion,
+            "GITHUB_OUTPUT": str(output),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.read_text(encoding="utf-8") == f"conclusion={expected}\n"
+
+
+@pytest.mark.parametrize(
+    ("job_result", "conclusion", "expected_state"),
+    [
+        ("success", "success", "success"),
+        ("failure", "success", "failure"),
+        ("cancelled", "success", "failure"),
+        ("skipped", "", "failure"),
+        ("success", "failure", "failure"),
+        ("success", "cancelled", "failure"),
+        ("success", "", "failure"),
+    ],
+)
+def test_gpu_published_status_requires_job_and_test_success(
+    tmp_path: Path, job_result: str, conclusion: str, expected_state: str
+) -> None:
+    output = tmp_path / "status-args"
+    gh = tmp_path / "gh"
+    gh.write_text('#!/bin/bash\nprintf "%s\\n" "$@" > "$STATUS_ARGS"\n', encoding="utf-8")
+    gh.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script("community-gpu-ci.yml", "publish", "Publish the terminal status"),
+        ],
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "STATUS_ARGS": str(output),
+            "JOB_RESULT": job_result,
+            "CONCLUSION": conclusion,
+            "GITHUB_REPOSITORY": "example/model-connect",
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_RUN_ID": "123",
+            "HEAD_SHA": "a" * 40,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"state={expected_state}" in output.read_text(encoding="utf-8").splitlines()
+
+
+def test_gpu_status_contexts_and_cleanup_remain_unconditional() -> None:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/community-gpu-ci.yml").read_text(encoding="utf-8")
+    )
+    job = workflow["jobs"]["provision-and-test"]
+    steps = {step["name"]: step for step in job["steps"]}
+    result = steps["Record the step conclusion"]
+    assert result["if"] == "always()"
+    assert result["env"] == {
+        "JOB_STATUS": "${{ job.status }}",
+        "TEST_OUTCOME": "${{ steps.test.outcome }}",
+        "TEST_CONCLUSION": "${{ steps.test.outputs.conclusion }}",
+    }
+    assert "${{" not in result["run"]
+    cleanup = steps["Always tear down the GPU instance"]
+    assert cleanup["if"] == "${{ always() && steps.reserve.outputs.instance_name != '' }}"
+    assert cleanup["env"] == {"INSTANCE_NAME": "${{ steps.reserve.outputs.instance_name }}"}
+    assert cleanup["run"] == 'brev delete "$INSTANCE_NAME" || true'
+    assert job["outputs"] == {"conclusion": "${{ steps.result.outputs.conclusion }}"}
+    publish = workflow["jobs"]["publish"]["steps"][0]
+    assert publish["env"]["JOB_RESULT"] == "${{ needs.provision-and-test.result }}"
+
+
+@pytest.mark.parametrize(
+    ("changed_path", "expected_scope", "expected_families"),
+    [
+        ("families/bert/model.py", "families", ["bert"]),
+        ("families/new_family/model.py", "all", ["bert", "gpt2"]),
+        ("README.md", "docs", []),
+    ],
+)
+def test_gpu_impact_executes_only_trusted_base_code(
+    tmp_path: Path,
+    changed_path: str,
+    expected_scope: str,
+    expected_families: list[str],
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    for family in ("bert", "gpt2"):
+        root = repository / "families" / family
+        root.mkdir(parents=True)
+        (root / "model.py").write_text("# trusted base\n", encoding="utf-8")
+    tools = repository / "tools"
+    tools.mkdir()
+    (tools / "__init__.py").write_text("", encoding="utf-8")
+    (tools / "test_impact.py").write_text(
+        (REPO_ROOT / "tools/test_impact.py").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (repository / "README.md").write_text("Trusted documentation\n", encoding="utf-8")
+
+    def git(*arguments: str) -> str:
+        """Run fixture Git commands, returning stdout and raising on failure."""
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            env={
+                **os.environ,
+                "GIT_AUTHOR_NAME": "CI Test",
+                "GIT_AUTHOR_EMAIL": "test@example.invalid",
+                "GIT_COMMITTER_NAME": "CI Test",
+                "GIT_COMMITTER_EMAIL": "test@example.invalid",
+            },
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    git("init")
+    git("add", ".")
+    git("-c", "core.hooksPath=/dev/null", "commit", "-m", "trusted fixture")
+    base = git("rev-parse", "HEAD")
+    changed = repository / changed_path
+    changed.parent.mkdir(parents=True, exist_ok=True)
+    changed.write_text("# pull-request content\n", encoding="utf-8")
+    git("add", changed_path)
+    git("-c", "core.hooksPath=/dev/null", "commit", "-m", "untrusted fixture")
+    head = git("rev-parse", "HEAD")
+    # A poison import on the PR branch must never execute on the trusted runner.
+    sentinel = tmp_path / "untrusted-code-executed"
+    (tools / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(sentinel)!r}).touch()\nraise RuntimeError('untrusted')\n",
+        encoding="utf-8",
+    )
+    git("add", "tools/__init__.py")
+    git("-c", "core.hooksPath=/dev/null", "commit", "-m", "poison fixture")
+    poisoned_head = git("rev-parse", "HEAD")
+    git("checkout", "--detach", base)
+    output = tmp_path / "output"
+    script = _workflow_step_script(
+        "community-gpu-ci.yml", "authorize", "Resolve the changed model families"
+    )
+    for revision in (head, poisoned_head):
+        output.write_text("", encoding="utf-8")
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repository,
+            env={
+                **os.environ,
+                "PYTHONPATH": "",
+                "BASE_SHA": base,
+                "HEAD_SHA": revision,
+                "RUNNER_TEMP": str(tmp_path),
+                "GITHUB_OUTPUT": str(output),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert not sentinel.exists()
+        assert git("rev-parse", "HEAD") == base
+        summary = json.loads(result.stdout)
+        values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+        if revision == poisoned_head:
+            assert summary["scope"] == "all"
+            assert summary["families"] == ["bert", "gpt2"]
+        else:
+            assert summary["scope"] == expected_scope
+            assert summary["families"] == expected_families
+        assert json.loads(values["families"]) == summary["families"]
+        assert values["scope"] == summary["scope"]
+
+
+def test_gpu_authorization_uses_exact_trusted_base_and_cpu_prerequisite() -> None:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/community-gpu-ci.yml").read_text(encoding="utf-8")
+    )
+    authorize = workflow["jobs"]["authorize"]
+    steps = {step["name"]: step for step in authorize["steps"]}
+    checkout = steps["Check out the base branch"]
+    assert checkout["with"] == {
+        "ref": "${{ steps.snapshot.outputs.base_sha }}",
+        "fetch-depth": 0,
+        "persist-credentials": False,
+    }
+    snapshot = steps["Capture the exact pull-request snapshot"]["run"]
+    assert 'test "$base_repo" = "$GITHUB_REPOSITORY"' in snapshot
+    assert 'test "$base_ref" = "main"' in snapshot
+    assert "community-cpu.yml/runs?event=pull_request&head_sha=$head_sha" in snapshot
+    assert 'select(.conclusion == "success")' in snapshot
+    assert "Validate the changed family names" in steps
+
+
+@pytest.mark.parametrize("create_exitcode", [0, 1])
+def test_gpu_cleanup_can_delete_instance_after_reservation_failure(
+    tmp_path: Path, create_exitcode: int
+) -> None:
+    output = tmp_path / "output"
+    calls = tmp_path / "brev-calls"
+    brev = tmp_path / "brev"
+    brev.write_text(
+        '#!/bin/bash\nprintf "%s\\n" "$*" >> "$BREV_CALLS"\n'
+        'if [ "$1" = "create" ]; then exit "$CREATE_EXITCODE"; fi\n',
+        encoding="utf-8",
+    )
+    brev.chmod(0o755)
+    environment = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "BREV_CALLS": str(calls),
+        "CREATE_EXITCODE": str(create_exitcode),
+        "GITHUB_RUN_ID": "123",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_OUTPUT": str(output),
+    }
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-gpu-ci.yml", "provision-and-test", "Reserve a GPU instance"
+            ),
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == create_exitcode, result.stdout + result.stderr
+    instance_name = "trtmc-gpu-ci-123-2"
+    assert output.read_text(encoding="utf-8") == f"instance_name={instance_name}\n"
+    cleanup = subprocess.run(
+        [
+            "bash",
+            "-c",
+            _workflow_step_script(
+                "community-gpu-ci.yml", "provision-and-test", "Always tear down the GPU instance"
+            ),
+        ],
+        env={**environment, "INSTANCE_NAME": instance_name},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert cleanup.returncode == 0, cleanup.stdout + cleanup.stderr
+    assert calls.read_text(encoding="utf-8").splitlines() == [
+        f"create {instance_name} -g L40 --timeout 600",
+        f"delete {instance_name}",
+    ]


### PR DESCRIPTION
## Background

Community GPU CI is rejected before jobs start because its shell script interpolates `failure()` in an unsupported expression context. Review also found that impact classification checked out and executed pull-request code on the trusted orchestration runner, mixed diagnostic text with JSON, and could report incomplete tests as successful.

This isolated repair addresses workflow syntax, trusted classification, status reporting and cleanup. It deliberately does not claim to finish the separate GPU execution migration.

## Exit Criteria

- Validate workflow expressions and execute only the captured trusted base classifier on the orchestration runner.
- Publish success only after explicit test success and final provision-job success; fail closed for failure, cancellation, skips or missing results.
- Keep cleanup eligible when reservation fails after allocating an instance.
- Preserve the CPU prerequisite, family-name validation and environment protections.
- **Before ready/merge:** resolve the GPU execution blockers below and pass required exact-head checks. This PR remains draft; no GPU-execution readiness is claimed.

## Implementation

- Replace the invalid status-function interpolation with supported job/step contexts passed through environment variables. Terminal publication checks the final job result as well as the recorded test result.
- Check out the immutable captured base SHA. Invoke its existing `tools.test_impact` CLI with base/head diff operands, without checking out or importing PR code. Parse its pure JSON output separately from action outputs. New families absent from the trusted inventory conservatively select all trusted families.
- Publish the deterministic instance name before reservation so timeout/failure does not suppress best-effort cleanup.
- Add behavioral regressions for poisoned PR imports, scope classification, missing/skipped/cancelled outcomes, late job failures and reservation cleanup.
- No model code, public API, ABI, bundle format, runtime dependencies or family quality criteria change.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

- `"$TEST_PYTHON" -m pytest -q tools/tests/test_community_ci.py tools/tests/test_family_impact.py tools/tests/test_architecture.py`: **101 passed**.
- `/tmp/trtmc-actionlint-1.7.12/actionlint -shellcheck= -pyflakes=`: **passed for all workflows**. This validates workflow expressions/schema; optional ShellCheck/Pyflakes integrations were disabled because they are not installed.
- Independent `tools/tests/test_community_ci.py` run: **36 passed**, including actual shell-step execution with fake service clients and isolated Git fixtures.
- Ruff checks/formatting and `git diff --check`: **passed**.
- [Public Community CPU run34541066607](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/34541066607): **passed** on exact head `f6ec6b3aa8fad4cd973508097d08fbf7daaa040e`, including source quality, ownership, docs, hardened units and Required aggregate.
- Required protected premerge: **pending**, dispatched after public CPU success; no protected pass is claimed. No Community GPU instance was reserved or GPU inference executed during local workflow validation.

### Hardware, Environment, and Revisions

- Candidate head: `f6ec6b3aa8fad4cd973508097d08fbf7daaa040e`; base: `a50cf5dc215e84c1d9341a8ef72f7df746bde894`.
- Local x86_64 Linux, Python 3.12; no CUDA/TensorRT/GPU requirement for these workflow regression tests.
- Actionlint v1.7.12 Linux amd64 archive verified against the official release checksum manifest. It is a validation tool, not a new project runtime dependency.

### Not Run / Remaining Gaps

The existing GPU runner still needs a faithful family-owned E2E setup:

- Replace obsolete `tests/e2e/models/{family}` paths with the existing family-owned tests.
- Build the native executable, backend/family libraries and test targets; a `py-only` install is insufficient.
- Supply explicit testcase/model selection and preserve required execution checks. Merely replacing paths can produce an all-skipped false success.
- Stage exact checkpoint revisions in the untrusted GPU execution environment; some family tests require cached checkpoints.
- Resolve hardware capacity without narrowing acceptance criteria: the existing shared-change smoke set includes Qwen3.8-27B FP16, whose weights alone exceed the selected single L40 capacity. Changed-family requests may also require multiple GPUs.
- The workflow still lacks a repository-wide concurrent-resource/cost cap across distinct PRs.

No smoke-family substitution, large-test filtering, quantization workaround or threshold reduction is included. Syntax/contract validation is not evidence of a successful GPU smoke run.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

Independent review approved the bounded syntax, trust, status and cleanup repair. Actual GPU execution readiness remains unresolved and explicitly outside the validation claim.

## Notes For Future Readers

Review the trusted checkout/classifier first, then fail-closed status publication and cleanup, followed by the poison-head/outcome regressions. Do not reintroduce a PR-head checkout on the trusted runner or treat missing test output as success.

This repair is separate from the Edge adapter feature in #1253. Its workflow must enter trusted `main` through normal reviewed merge rules before it can affect the default-branch dispatcher; no direct-main push or check bypass is intended. Keep this PR draft until runner setup and resource policy are resolved.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

The diff is bounded and improves the trust boundary, but it changes orchestration that can allocate paid GPU resources. Local tests do not validate the external service or real model execution.
