### PR TITLE
feat(audio): add channel-aware streaming output

### DIFF
--- a/apps/cli/cli.cpp
+++ b/apps/cli/cli.cpp
@@ -988,34 +988,58 @@ int dispatch(const Command& command, ITask& task, std::ostream& output) {
         const std::string path = require_option(command, "--output");
         if (streaming) {
             const int32_t chunk_frames = int_option(command, "--chunk-frames", 32, 1);
+            auto* multichannel = dynamic_cast<IMultichannelStreamingAudioGeneration*>(&task);
+            auto* mono = dynamic_cast<IStreamingAudioGeneration*>(&task);
+            if (multichannel == nullptr && mono == nullptr)
+                throw std::invalid_argument("task does not support streaming audio generation");
             std::ofstream stream(path, std::ios::binary | std::ios::trunc);
             if (!stream)
                 throw std::runtime_error("unable to open streaming audio output: " + path);
             int32_t sample_rate = 0;
-            const int32_t total =
-                require_interface<IStreamingAudioGeneration>(task).generate_audio_streaming(
-                    require_option(command, "--prompt"), config,
-                    [&](const float* samples, int32_t num_samples, int32_t rate) {
-                        if (samples == nullptr || num_samples <= 0 || rate <= 0)
-                            throw std::runtime_error(
-                                "streaming audio family returned an invalid chunk");
-                        if (sample_rate != 0 && sample_rate != rate)
-                            throw std::runtime_error(
-                                "streaming audio sample rate changed mid-stream");
-                        sample_rate = rate;
-                        stream.write(reinterpret_cast<const char*>(samples),
-                                     static_cast<std::streamsize>(num_samples) * sizeof(float));
-                        if (!stream)
-                            throw std::runtime_error("failed to write streaming audio output: " +
-                                                     path);
-                    },
-                    chunk_frames);
+            int32_t num_channels = 0;
+            std::int64_t observed_samples = 0;
+            const auto write_chunk = [&](const AudioChunkView& chunk) {
+                if (chunk.samples == nullptr || chunk.num_samples <= 0 || chunk.sample_rate <= 0 ||
+                    chunk.num_channels <= 0 || chunk.num_samples % chunk.num_channels != 0)
+                    throw std::runtime_error("streaming audio family returned an invalid chunk");
+                if ((sample_rate != 0 && sample_rate != chunk.sample_rate) ||
+                    (num_channels != 0 && num_channels != chunk.num_channels))
+                    throw std::runtime_error("streaming audio format changed mid-stream");
+                for (int32_t index = 0; index < chunk.num_samples; ++index)
+                    if (!std::isfinite(chunk.samples[index]))
+                        throw std::runtime_error("streaming audio contains non-finite samples");
+                if (observed_samples > std::numeric_limits<std::int64_t>::max() - chunk.num_samples)
+                    throw std::runtime_error("streaming audio sample count overflow");
+                sample_rate = chunk.sample_rate;
+                num_channels = chunk.num_channels;
+                stream.write(reinterpret_cast<const char*>(chunk.samples),
+                             static_cast<std::streamsize>(chunk.num_samples) * sizeof(float));
+                if (!stream)
+                    throw std::runtime_error("failed to write streaming audio output: " + path);
+                observed_samples += chunk.num_samples;
+            };
+            const auto& prompt = require_option(command, "--prompt");
+            const std::int64_t total =
+                multichannel != nullptr
+                    ? multichannel->generate_audio_streaming(prompt, config, write_chunk,
+                                                             chunk_frames)
+                    : mono->generate_audio_streaming(
+                          prompt, config,
+                          [&](const float* samples, int32_t count, int32_t rate) {
+                              write_chunk({samples, count, rate, 1});
+                          },
+                          chunk_frames);
             stream.close();
-            if (total <= 0 || sample_rate <= 0)
+            if (!stream)
+                throw std::runtime_error("failed to close streaming audio output: " + path);
+            if (total <= 0 || observed_samples == 0)
                 throw std::runtime_error("streaming audio family produced no samples");
+            if (total != observed_samples)
+                throw std::runtime_error("streaming audio sample count does not match chunks");
             write_json(output, {{"output", path},
                                 {"format", "float32le"},
                                 {"sample_rate", sample_rate},
+                                {"num_channels", num_channels},
                                 {"num_samples", total}});
             return EXIT_SUCCESS;
         }

--- a/apps/cli/tests/test_cli.cpp
+++ b/apps/cli/tests/test_cli.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -122,6 +123,56 @@ class FakeStreamingAudio final : public trtmc::IAudioGeneration,
         const float samples[] = {0.25F, -0.5F, 0.75F};
         callback(samples, 3, 24000);
         return 3;
+    }
+};
+
+class FakeMultichannelAudio final : public trtmc::IAudioGeneration,
+                                    public trtmc::IStreamingAudioGeneration,
+                                    public trtmc::IMultichannelStreamingAudioGeneration {
+  public:
+    std::string fault;
+    trtmc::AudioGenerationConfig seen;
+    std::int32_t seen_chunk_frames{0};
+
+    trtmc::AudioResult generate_audio(const std::string&,
+                                      const trtmc::AudioGenerationConfig&) override {
+        throw std::logic_error("synchronous audio path was selected");
+    }
+    std::int32_t generate_audio_streaming(const std::string&, const trtmc::AudioGenerationConfig&,
+                                          trtmc::AudioChunkCallback, std::int32_t) override {
+        throw std::logic_error("mono capability was selected instead of multichannel");
+    }
+    std::int64_t generate_audio_streaming(const std::string&,
+                                          const trtmc::AudioGenerationConfig& config,
+                                          trtmc::MultichannelAudioChunkCallback callback,
+                                          std::int32_t chunk_frames) override {
+        seen = config;
+        seen_chunk_frames = chunk_frames;
+        if (fault == "empty")
+            return 0;
+        float first[] = {0.25F, -0.5F, 0.75F, -1.0F};
+        trtmc::AudioChunkView chunk{first, 4, 48000, 2};
+        if (fault == "null")
+            chunk.samples = nullptr;
+        if (fault == "partial frame")
+            chunk.num_samples = 3;
+        if (fault == "empty chunk")
+            chunk.num_samples = 0;
+        if (fault == "negative count")
+            chunk.num_samples = -2;
+        if (fault == "invalid rate")
+            chunk.sample_rate = 0;
+        if (fault == "invalid channels")
+            chunk.num_channels = 0;
+        if (fault == "nonfinite")
+            first[0] = std::numeric_limits<float>::infinity();
+        callback(chunk);
+        if (fault == "producer error")
+            throw std::runtime_error("synthetic producer failure");
+        const float last[] = {0.125F, -0.25F};
+        callback(
+            {last, 2, fault == "rate change" ? 24000 : 48000, fault == "channel change" ? 1 : 2});
+        return fault == "wrong total" ? 3 : 6;
     }
 };
 
@@ -585,6 +636,48 @@ int main() {
           "streaming audio options reach the Task API");
     check(audio_output.str().find("\"format\":\"float32le\"") != std::string::npos,
           "streaming audio output format is explicit");
+    std::filesystem::remove(audio_path);
+
+    check(audio_output.str().find("\"num_channels\":1") != std::string::npos,
+          "legacy streaming reports one channel");
+    FakeMultichannelAudio stereo_audio;
+    audio_output.str("");
+    audio_output.clear();
+    check(trtmc::cli::dispatch(audio_command, stereo_audio, audio_output) == 0,
+          "multichannel capability takes precedence over mono");
+    check(stereo_audio.seen.max_new_tokens == 9 && stereo_audio.seen.seed == 17 &&
+              stereo_audio.seen_chunk_frames == 4,
+          "multichannel options reach the Task API");
+    check(audio_output.str().find("\"num_channels\":2") != std::string::npos &&
+              audio_output.str().find("\"sample_rate\":48000") != std::string::npos &&
+              audio_output.str().find("\"num_samples\":6") != std::string::npos,
+          "streaming metadata describes interleaved stereo");
+    std::vector<float> streamed_samples(6);
+    {
+        std::ifstream input(audio_path, std::ios::binary);
+        input.read(reinterpret_cast<char*>(streamed_samples.data()), 6 * sizeof(float));
+        check(static_cast<bool>(input) && input.peek() == std::char_traits<char>::eof(),
+              "stream contains exactly the delivered samples");
+    }
+    check(streamed_samples == std::vector<float>({0.25F, -0.5F, 0.75F, -1.0F, 0.125F, -0.25F}),
+          "chunk concatenation preserves left and right sample order");
+
+    for (const std::string fault :
+         {"empty", "null", "partial frame", "empty chunk", "negative count", "invalid rate",
+          "invalid channels", "nonfinite", "producer error", "rate change", "channel change",
+          "wrong total"}) {
+        stereo_audio.fault = fault;
+        audio_output.str("");
+        audio_output.clear();
+        bool rejected = false;
+        try {
+            trtmc::cli::dispatch(audio_command, stereo_audio, audio_output);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        check(rejected, ("reject streaming fault: " + fault).c_str());
+        check(audio_output.str().empty(), "failed stream does not report successful output");
+    }
     std::filesystem::remove(audio_path);
 
     const std::filesystem::path transcription_path = "/tmp/trtmc-cli-transcription-stream.wav";

--- a/core/runtime/include/trtmc/task.h
+++ b/core/runtime/include/trtmc/task.h
@@ -404,6 +404,17 @@ struct AudioGenerationConfig {
 using AudioChunkCallback =
     std::function<void(const float* samples, std::int32_t num_samples, std::int32_t sample_rate)>;
 
+// Borrowed interleaved float PCM, valid only during the callback. num_samples
+// counts scalar samples (not frames); each nonempty chunk contains whole frames.
+struct AudioChunkView {
+    const float* samples{nullptr};
+    std::int32_t num_samples{0};
+    std::int32_t sample_rate{0};
+    std::int32_t num_channels{1};
+};
+
+using MultichannelAudioChunkCallback = std::function<void(const AudioChunkView& chunk)>;
+
 struct SpeechToSpeechConfig {
     std::int32_t max_new_tokens{128};
     std::int32_t seed{-1};
@@ -568,6 +579,21 @@ class IStreamingAudioGeneration {
     virtual std::int32_t generate_audio_streaming(const std::string& prompt,
                                                   const AudioGenerationConfig& config,
                                                   AudioChunkCallback callback,
+                                                  std::int32_t chunk_frames) = 0;
+};
+
+// Optional channel-aware capability; existing mono implementations need not
+// change. Callbacks are synchronous, ordered, and non-concurrent. Rate/channel
+// count stay fixed for a call. Return signals completion and reports the total
+// scalar samples delivered. Callback exceptions must stop generation and escape
+// the call; implementations must not retain the callback after returning.
+class IMultichannelStreamingAudioGeneration {
+  public:
+    static constexpr const char* kTask = IAudioGeneration::kTask;
+    virtual ~IMultichannelStreamingAudioGeneration() = default;
+    virtual std::int64_t generate_audio_streaming(const std::string& prompt,
+                                                  const AudioGenerationConfig& config,
+                                                  MultichannelAudioChunkCallback callback,
                                                   std::int32_t chunk_frames) = 0;
 };
 

--- a/core/runtime/tests/test_task_api.cpp
+++ b/core/runtime/tests/test_task_api.cpp
@@ -19,6 +19,7 @@ static_assert(std::is_abstract_v<trtmc::IImageBatchGeneration>);
 static_assert(std::is_abstract_v<trtmc::IWorldModelGeneration>);
 static_assert(std::is_abstract_v<trtmc::IAudioGeneration>);
 static_assert(std::is_abstract_v<trtmc::IStreamingAudioGeneration>);
+static_assert(std::is_abstract_v<trtmc::IMultichannelStreamingAudioGeneration>);
 static_assert(std::is_abstract_v<trtmc::ITranscription>);
 static_assert(std::is_abstract_v<trtmc::IBatchTranscription>);
 static_assert(std::is_abstract_v<trtmc::IStreamingTranscription>);

--- a/website/docs/architecture/runtime-lifecycle.md
+++ b/website/docs/architecture/runtime-lifecycle.md
@@ -33,6 +33,32 @@ contract. The backend owns TensorRT runtime objects, not model policy.
 returning or copy the lightweight `BundleReader` into the pipeline for deferred
 reads; it must not retain a reference to the temporary factory context.
 
+## Multichannel streaming audio
+
+Families can opt into `IMultichannelStreamingAudioGeneration` without changing
+the existing mono `IStreamingAudioGeneration` interface. A family implementing
+both is dispatched through the multichannel capability by the CLI.
+
+Each `AudioChunkView` borrows interleaved float PCM (`L0, R0, L1, R1, ...` for
+stereo), with an explicit channel count and sample rate. `num_samples` counts
+scalar samples, not frames per channel. Chunks must be nonempty whole frames;
+the sample rate and channel count stay constant within a call. Callbacks are
+synchronous, ordered, and non-concurrent. Their pointers are valid only during
+the callback. Normal return ends the stream and reports the sum of delivered
+scalar samples; callback exceptions must stop generation and propagate.
+
+`trtmc generate-audio ... --stream true --output audio.raw` writes interleaved
+float32 samples and reports `format`, `sample_rate`, `num_channels`, and
+`num_samples` in its success JSON. Playback duration is
+`num_samples / num_channels / sample_rate`. This is raw PCM, not a WAV file.
+Invalid chunks, format changes, inconsistent totals, and file-write errors fail
+the command without success JSON. A failed stream can leave a partial output
+file; callers must not treat file existence alone as success.
+
+This capability does not add HTTP transport, encoded formats, or streaming
+support to models that do not already produce incremental audio. Existing mono
+families remain unchanged and report `num_channels: 1`.
+
 ## Optional load settings
 
 Runtime-sized KV capacity is passed directly to compatible families.


### PR DESCRIPTION
## Background

Refs #1254. The existing streaming callback carries samples and sample rate but cannot describe stereo. This adds the streaming counterpart to the complete-result/WAV proposal in #1256, as an independent PR based on main.

## Exit Criteria

- Carry channel metadata with ordered interleaved PCM chunks.
- Keep existing mono family implementations working unchanged.
- Validate chunk shape, format stability, and completion counts before reporting success.

## Implementation

Add `AudioChunkView` and the optional `IMultichannelStreamingAudioGeneration` capability. The CLI prefers that capability when available, otherwise uses the existing mono capability. Raw float32 output JSON now includes `num_channels`.

Document synchronous borrowed-buffer lifetime, completion by return, and exception propagation. Existing interfaces/vtables and `AudioResult` are unchanged. No model-family, bundle-format, or dependency changes.

### Change categories

- [x] Model or runtime behavior
- [x] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [ ] CI or developer tooling

## Validation

### Commands and Results

On Linux, compiled and ran the actual CLI test with ASan/UBSan, using real loader/bundle sources and synthetic task fixtures:

```bash
g++ -std=c++17 -DTRTMC_VERSION_STRING='"0.1.0"' \
  -fsanitize=address,undefined -fno-omit-frame-pointer -g \
  -Wall -Wextra -Wpedantic -Wno-missing-field-initializers \
  -Icore/runtime/include -Icore -Iapps -Ithird_party/stb \
  -I/usr/local/lib/python3.11/site-packages/nlohmann_json/include \
  -I/usr/local/lib/python3.11/site-packages/nvidia/cuda_runtime/include \
  -I/usr/local/lib/python3.11/site-packages/nvidia/cuda_nvcc/include \
  apps/cli/tests/test_cli.cpp apps/cli/cli.cpp apps/cli/io.cpp \
  core/runtime/loader/family_loader.cpp core/runtime/bundle/bundle_format.cpp \
  -ldl -o /tmp/test_cli
/tmp/test_cli
```

Passed (`ALL PASSED`). Covers legacy mono, multichannel capability precedence, exact stereo chunk concatenation, metadata, and 12 failure modes: empty stream, null data, partial frame, empty/negative chunk count, invalid rate/channels, non-finite data, producer failure, rate/channel changes, and wrong final total.

Also passed locally:

```bash
c++ -std=c++17 -Icore/runtime/include core/runtime/tests/test_task_api.cpp \
  -o /tmp/trtmc-stream-task-api
/tmp/trtmc-stream-task-api
clang-format --dry-run --Werror apps/cli/cli.cpp apps/cli/tests/test_cli.cpp \
  core/runtime/include/trtmc/task.h core/runtime/tests/test_task_api.cpp
git diff --check
```

### Hardware, Environment, and Revisions

Tested head `7fb82240`, base `a50cf5dc`. Linux x86_64 Debian 12 CPU container, GCC 12, CUDA header packages `nvidia-cuda-runtime-cu12==12.4.127` and `nvidia-cuda-nvcc-cu12==12.4.131`, `nlohmann_json==3.12.0`. Local API/format checks used Apple Silicon macOS and clang-format 22.1.8. No GPU or TensorRT inference; synthetic float32 audio only.

### Not Run / Remaining Gaps

No real model has been migrated to the new capability in this PR, so model streaming quality/latency is not qualified. Full repository CMake/CI was not run locally. HTTP, WAV streaming, and other encoded formats remain outside scope.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

The new interface is opt-in and does not require #1256's `AudioResult` change. `num_samples` means scalar samples, with whole frames in every chunk. A failed stream can leave a partial raw file, but must not emit success JSON. This is not a cancellation/preemption API; callback exceptions must propagate and the implementation must clean up its own generation state.

### Risk level

- [ ] Low
- [x] Medium
- [ ] High

Existing ABI types are unchanged, but this is a new public capability and CLI validation now rejects malformed legacy chunks and inconsistent totals. Model-specific adoption needs its own validation.
