### PR TITLE
fix(ci): fix impact JSON parse error breaking community-gpu-ci.yml

### DIFF
--- a/.github/workflows/community-gpu-ci.yml
+++ b/.github/workflows/community-gpu-ci.yml
@@ -154,14 +154,19 @@ jobs:
         run: |
           set -euo pipefail
           git checkout --quiet "$HEAD_SHA"
-          python3 -m tools.community_ci impact --base "$BASE_SHA" | tee /tmp/impact.json
-          # tools.community_ci already writes the "families" output; scope
-          # ("changed" vs "all", e.g. a shared/root file was touched) is not
-          # exposed as an action output, so read it from the same JSON here.
-          python3 -c "
-          import json
-          with open('/tmp/impact.json') as f:
-              summary = json.load(f)
+          IMPACT_OUTPUT="$(python3 -m tools.community_ci impact --base "$BASE_SHA")"
+          echo "$IMPACT_OUTPUT"
+          # tools.community_ci already writes the "families" output itself.
+          # scope (one of "all", "families", "docs", "none"; "all" means a
+          # shared/root file was touched) is not exposed as an action
+          # output, so read it here. The tool's own stdout is NOT pure
+          # JSON: it prints a human-readable "Community CPU base: ..."
+          # line before the JSON object, so extract from the first '{'
+          # rather than parsing the whole captured output directly.
+          IMPACT_OUTPUT="$IMPACT_OUTPUT" python3 -c "
+          import json, os
+          text = os.environ['IMPACT_OUTPUT']
+          summary = json.loads(text[text.index('{'):])
           print(f\"scope={summary['scope']}\")
           " >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Background

The first real, live pull-request trigger of community-gpu-ci.yml (PR
#1260, after the failure()-expression fix in #1252 merged) failed in the
authorize job with a JSON parse error, confirmed via the actual job log.

## Exit Criteria

Manually dispatching community-gpu-ci.yml against a real open PR reaches
the provision-and-test job (i.e. authorize succeeds and correctly resolves
scope/families) instead of failing on the impact-JSON step.

## Implementation

\`python3 -m tools.community_ci impact\` prints a human-readable
\`Community CPU base: <ref> (<sha>)\` line to stdout before its JSON
summary. The \`Resolve the changed model families\` step piped that
combined stdout through \`tee\` to \`/tmp/impact.json\` and then called
\`json.load()\` directly on the file, so it parsed the leading non-JSON
line as the start of the document:

\`\`\`
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
\`\`\`

My earlier local testing only eyeballed the printed JSON in the console;
it never actually parsed the file the workflow parses, which is how this
got past two prior PRs (#1249, #1252).

Fix: capture the tool's full stdout into a variable, and parse only the
substring from the first \`{\` onward.

Also corrects a documentation bug in the surrounding comment: real scope
values are \`all\`/\`families\`/\`docs\`/\`none\`, not \`changed\`/\`all\` as
originally written. The \`"all"\` check itself was already correct; only
the comment was wrong.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

\`\`\`
IMPACT_OUTPUT="$(python3 -m tools.community_ci impact --base upstream/main~1)"
echo "$IMPACT_OUTPUT"
IMPACT_OUTPUT="$IMPACT_OUTPUT" python3 -c "
import json, os
text = os.environ['IMPACT_OUTPUT']
summary = json.loads(text[text.index('{'):])
print(f\"scope={summary['scope']}\")
"
# scope=none  (correctly parsed despite the leading non-JSON line)
\`\`\`

Also re-tested the downstream family-name validation and test_paths
construction logic against the exact values from the failed live run
(\`FAMILIES=["bert"]\`, \`SCOPE="families"\`), and against the empty-families
case (\`SCOPE="none"\`, \`FAMILIES=[]\`) to confirm the "nothing to run on
GPU" exit path still works.

### Hardware, Environment, and Revisions

Not applicable: pure GitHub Actions YAML/shell fix.

### Not Run / Remaining Gaps

- Not yet re-verified with a real live dispatch against an open PR (that
  happens once this merges). Prior live-fire attempts: #1252 fixed the
  parse error but hit this bug; this PR fixes this bug but has not itself
  been dispatched live yet.
- Separately (not fixed here, tracked as a known follow-up): the
  automatic \`opened\` trigger races Community CPU (fires before Community
  CPU has had time to pass), so it currently always fails on a PR's first
  event and only works via a later \`synchronize\` or manual
  \`workflow_dispatch\`. Out of scope for this fix.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

Anyone touching this workflow's impact-parsing step: \`tools.community_ci
impact\`'s stdout is not pure JSON (it has a leading log line), so always
extract the JSON substring rather than parsing captured stdout directly.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Fixes a bug that currently makes the workflow's authorize job fail for
every real trigger; cannot make things worse than the current state.