### PR TITLE
fix(ci): use sudo for docker on freshly reserved GPU instances

### DIFF
--- a/.github/workflows/community-gpu-ci.yml
+++ b/.github/workflows/community-gpu-ci.yml
@@ -263,7 +263,13 @@ jobs:
         run: |
           set -euo pipefail
           brev exec "$INSTANCE_NAME" "git clone --no-checkout https://github.com/$GITHUB_REPOSITORY.git /tmp/model_connect && cd /tmp/model_connect && git fetch --depth 1 origin $HEAD_SHA && git checkout $HEAD_SHA"
-          brev exec "$INSTANCE_NAME" "cd /tmp/model_connect && docker build -f Dockerfile.dev.x86-gpu -t trtmc-quickstart-gpu requirements"
+          # sudo: a freshly created instance's SSH session does not
+          # reliably have its docker-group membership propagated yet
+          # (confirmed live: "permission denied ... docker.sock" on the
+          # very first docker command right after instance creation).
+          # sudo sidesteps the group-membership timing entirely rather
+          # than depending on it.
+          brev exec "$INSTANCE_NAME" "cd /tmp/model_connect && sudo docker build -f Dockerfile.dev.x86-gpu -t trtmc-quickstart-gpu requirements"
 
           # Selective by design: 87 model families exist, and running the
           # full tests/e2e/models suite on GPU for every push is not
@@ -297,7 +303,7 @@ jobs:
             exit 0
           fi
 
-          brev exec "$INSTANCE_NAME" "docker run --rm --gpus all -v /tmp/model_connect:/src -w /src trtmc-quickstart-gpu bash -c 'python3.12 -m pip install --no-deps -e . -C py-only=true && python3.12 -m pytest $test_paths -v'" \
+          brev exec "$INSTANCE_NAME" "sudo docker run --rm --gpus all -v /tmp/model_connect:/src -w /src trtmc-quickstart-gpu bash -c 'python3.12 -m pip install --no-deps -e . -C py-only=true && python3.12 -m pytest $test_paths -v'" \
             | tee /tmp/gpu-ci-output.log
           echo "conclusion=success" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Background

The second real live trigger of community-gpu-ci.yml (PR #1260, after
#1252 and #1261 fixed two earlier parse bugs) reached provision-and-test
and actually reserved a GPU instance, but failed on the first docker
command with a permission error, confirmed via the job log.

## Exit Criteria

A live dispatch against an open PR reaches and completes the docker
build/run steps on a freshly reserved instance without a docker.sock
permission error.

## Implementation

Live run log:

\`\`\`
Cloning into '/tmp/model_connect'...
HEAD is now at 90cf7205 ...
ERROR: permission denied while trying to connect to the docker API at
unix:///var/run/docker.sock
\`\`\`

git clone succeeded on the same freshly created instance immediately
before this, so SSH access itself was fine; the instance's docker-group
membership for that SSH session had not propagated yet. The earlier
manual proof-of-concept (documented in #1249) never hit this because
there was always a natural delay between instance creation and the
first docker command (separate exec calls, manual inspection); this
workflow goes straight from reserve into docker build with no gap.

Fix: prefix both docker invocations (build and run) with sudo, which
sidesteps the group-membership timing question entirely rather than
depending on it.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

Not independently re-run in isolation; validated by re-dispatching the
full workflow against PR #1260 after this merges (see Not Run below).
sudo is available by default on the Brev instance types used here
(confirmed implicitly: brev exec runs as a sudo-capable user on the
g6e.xlarge instance from the failed run).

### Hardware, Environment, and Revisions

Same as the failed run: Brev instance type g6e.xlarge (falls back from
-g L40), NVIDIA L40S.

### Not Run / Remaining Gaps

- Not yet re-verified with a real live dispatch; that happens once this
  merges, re-triggering against PR #1260.
- If sudo itself requires a password prompt on some fallback instance
  type (unconfirmed for types other than g6e.xlarge), this would need a
  different fix; not observed in the one real run so far.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

This is the third bug found only by actually triggering the workflow
live (after #1252's failure() expression bug and #1261's impact-JSON
bug). Local shell testing cannot catch instance-provisioning timing
issues like this one; only a real dispatch can.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Adds sudo to two docker commands only; cannot regress anything that was
working, since the workflow currently fails at this exact point on
every real run.