### PR TITLE
test(ci): exercise unified CI policy with GPT-2

### DIFF
--- a/families/gpt2/support.py
+++ b/families/gpt2/support.py
@@ -3,6 +3,9 @@
 
 """Family-owned model and task support for gpt2."""
 
+# Comment-only live-fire payload for the ordered Community CI introduced in
+# PR #1262. This does not change GPT-2 support or runtime behavior.
+
 from tensorrt_model_connect.model_support import family_support
 
 


### PR DESCRIPTION
## Background

Live end-to-end validation of Community CI after #1268 retired the standalone CPU workflow and paused automatic GPU execution. No functional change; this PR exists only to exercise the current pull-request policy with a clean `families/` change.

## Exit Criteria

- One Community CI workflow fires automatically for the rebased head; the retired standalone Community CPU workflow does not run.
- `Community CPU / Required` succeeds before GPU authorization and impact classification.
- GPU impact selection chooses only `gpt2` and reports that automatic GPU execution is disabled.
- GPU reservation, execution, cleanup, and result publication remain skipped, with GPU validation outside the merge gate.

## Implementation

Add a comment-only annotation to `families/gpt2/support.py`. Model support, runtime behavior, validation criteria, and public interfaces are unchanged.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

- `python3 -m ruff check families/gpt2/support.py`: passed.
- `python3 -m tools.community_ci impact --base github/main`: passed; selected only `gpt2` with family scope.
- `python3 -m tools.test_impact --base github/main --head HEAD`: passed; selected only `gpt2` and requested Core tests.
- `git diff --check github/main...HEAD`: passed.

### Hardware, Environment, and Revisions

Rebased onto `github/main` at `f7c22339881f78e36ba138000e1dfa03f1943c07`. Local validation used CPU-only tooling; the live pull-request workflow is the test target.

### Not Run / Remaining Gaps

The optional manual GPU smoke is intentionally not requested. No GPU execution, model qualification, parity, or performance claim is made.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

This PR is not intended to merge. Close it after the unified CPU gate, GPU impact classification, and disabled-execution policy are observed.

### Risk level

- [x] Low

Comment-only CI live-fire payload with no functional model change.
