### PR TITLE
fix(yolov10): report integer letterbox padding

### DIFF
--- a/families/yolov10/runtime/image_preprocess_seam.cpp
+++ b/families/yolov10/runtime/image_preprocess_seam.cpp
@@ -54,8 +54,9 @@ std::vector<float> preprocess_yolov10_image(const float* pixels, std::int32_t he
     const auto scaled_h =
         static_cast<std::int32_t>(std::lround(static_cast<float>(height) * scale));
     const auto scaled_w = static_cast<std::int32_t>(std::lround(static_cast<float>(width) * scale));
-    const float pad_y = static_cast<float>(config.input_image_h - scaled_h) / 2.0F;
-    const float pad_x = static_cast<float>(config.input_image_w - scaled_w) / 2.0F;
+    // Report the integer placement used below, including when the margin is odd.
+    const float pad_y = static_cast<float>((config.input_image_h - scaled_h) / 2);
+    const float pad_x = static_cast<float>((config.input_image_w - scaled_w) / 2);
     letterbox.scale = scale;
     letterbox.pad_x = pad_x;
     letterbox.pad_y = pad_y;

--- a/families/yolov10/tests/cpp/test_image_preprocess_seam.cpp
+++ b/families/yolov10/tests/cpp/test_image_preprocess_seam.cpp
@@ -95,6 +95,41 @@ void test_letterbox_reports_a_mapping_that_inverts() {
                 "letterbox mapping inverts");
 }
 
+void check_letterbox_padding(int height, int width, int size, int top, int left) {
+    const std::vector<float> pixels(static_cast<std::size_t>(height) * width * 3U, 0.25F);
+    trtmc::Yolov10PreprocessConfig config;
+    config.input_image_h = size;
+    config.input_image_w = size;
+    config.pad_value = 0.75F;
+    trtmc::Yolov10Letterbox letterbox;
+    const auto values =
+        trtmc::preprocess_yolov10_image(pixels.data(), height, width, config, letterbox);
+
+    check_close(values[static_cast<std::size_t>(top) * size + left], 0.25F, 1e-6F,
+                "image starts at the expected integer padding");
+    if (top > 0)
+        check_close(values[static_cast<std::size_t>(top - 1) * size + left], 0.75F, 1e-6F,
+                    "row before the image is padding");
+    if (left > 0)
+        check_close(values[static_cast<std::size_t>(top) * size + left - 1], 0.75F, 1e-6F,
+                    "column before the image is padding");
+    check_close(letterbox.pad_y, static_cast<float>(top), 1e-6F,
+                "reported vertical padding matches image placement");
+    check_close(letterbox.pad_x, static_cast<float>(left), 1e-6F,
+                "reported horizontal padding matches image placement");
+}
+
+void test_letterbox_reports_actual_padding() {
+    // An odd margin puts the extra pixel below or to the right of the image.
+    check_letterbox_padding(3, 8, 8, 2, 0);
+    check_letterbox_padding(8, 3, 8, 0, 2);
+    check_letterbox_padding(125, 256, 64, 16, 0);
+    check_letterbox_padding(256, 125, 64, 0, 16);
+    check_letterbox_padding(4, 8, 8, 2, 0);
+    check_letterbox_padding(8, 4, 8, 0, 2);
+    check_letterbox_padding(8, 8, 8, 0, 0);
+}
+
 void test_preprocess_rejects_an_empty_image() {
     bool threw = false;
     try {
@@ -113,6 +148,7 @@ int main() {
     test_letterbox_keeps_aspect_and_centres_the_image();
     test_preprocess_reads_interleaved_and_writes_planar();
     test_letterbox_reports_a_mapping_that_inverts();
+    test_letterbox_reports_actual_padding();
     test_preprocess_rejects_an_empty_image();
 
     if (g_failures != 0) {


### PR DESCRIPTION
## Background

Odd total padding produces half-pixel metadata even though image placement uses an integer offset, shifting YOLOv10 boxes when mapped back to the original image.

## Exit Criteria

Reported padding matches the first image row and column for odd/even, portrait/landscape and resized inputs.

## Implementation

Use integer half-margins for the returned offsets and add seven C++ regression cases in the YOLOv10 family.

### Change categories

- [x] Model or runtime behavior

## Validation

### Commands and Results

The updated native seam test fails four padding assertions on the original code and passes with the fix. Reproduce the compile/run check with:

```sh
g++ -std=c++17 -I. families/yolov10/runtime/image_preprocess_seam.cpp families/yolov10/tests/cpp/test_image_preprocess_seam.cpp -o /tmp/yolov10-seam
/tmp/yolov10-seam
```

```sh
python -m tools.community_ci source-quality --base 296f366169a2ab9ce6674f2bd62683aac3c999b3
python -m pytest tools/tests/test_community_ci.py::test_internal_label_bridge_accepts_exact_cpu_gate_during_and_after_rollout -q -rs -p no:cacheprovider
python -m pytest families/yolov10/tests/test_model.py -q -rs -p no:cacheprovider
```

Source-quality tests: 165 passed across the full run and targeted rerun. YOLOv10 unit tests: 47 passed. Committed-file lint passed.

### Hardware, Environment, and Revisions

Base `296f366169a2ab9ce6674f2bd62683aac3c999b3`, tested commit `dd07f740ee5a70fdc289690b1b6b7df17a59b551`. Ubuntu 24.04 (WSL), GCC 13.3, Python 3.12.3, PyTorch 2.12.0+cpu. Tensor equality checks: Windows, MinGW GCC 14.2.

### Not Run / Remaining Gaps

The full Community CPU suite, native TensorRT build and YOLOv10n checkpoint inference have not run locally and remain for CI.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

Rebuild the YOLOv10 runtime to apply the corrected coordinate mapping.

### Risk level

- [x] Low

Only padding metadata changes; the nine tested preprocessing tensors are byte-for-byte identical.
