### PR TITLE
fix(ci): pass HF_TOKEN through to Community GPU

### DIFF
--- a/.github/workflows/community-ci.yml
+++ b/.github/workflows/community-ci.yml
@@ -563,6 +563,7 @@ jobs:
           FAMILIES: ${{ needs.gpu-authorize.outputs.families }}
           ADDED_FAMILIES: ${{ needs.gpu-authorize.outputs.added_families }}
           SCOPE: ${{ needs.gpu-authorize.outputs.scope }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -euo pipefail
           brev exec "$INSTANCE_NAME" "git init /tmp/model_connect && cd /tmp/model_connect && git remote add origin https://github.com/$GITHUB_REPOSITORY.git && git fetch --depth 2 origin refs/pull/$PR_NUMBER/merge && test \"\$(git rev-parse FETCH_HEAD)\" = $MERGE_SHA && git checkout --detach $MERGE_SHA"
@@ -575,6 +576,12 @@ jobs:
           # selected family DSOs, and configured CTest tree. It then stages
           # checkpoint revisions and uses E2ERunner's explicit premerge case
           # selection plus JUnit validation, which rejects skips and omissions.
+          # HF_TOKEN: some premerge checkpoints (e.g. sam3) are gated and
+          # fail to download without authorization. huggingface_hub reads
+          # HF_TOKEN from the environment automatically (verified directly
+          # against huggingface_hub.get_token()); no code change is needed
+          # in tools.community_gpu_ci to consume it. GitHub Actions masks
+          # the secret value everywhere it appears, including here.
           echo "Changed families: $FAMILIES; added families: $ADDED_FAMILIES (scope: $SCOPE)"
           python3 -m tools.brev_exec \
             --instance "$INSTANCE_NAME" \
@@ -585,6 +592,7 @@ jobs:
             -e "TRTMC_GPU_SCOPE=$SCOPE" \
             -e "TRTMC_GPU_FAMILIES=$FAMILIES" \
             -e "TRTMC_GPU_ADDED_FAMILIES=$ADDED_FAMILIES" \
+            -e "HF_TOKEN=$HF_TOKEN" \
             -e CMAKE_CUDA_ARCHITECTURES=89 \
             trtmc-quickstart-gpu python3.12 -m tools.community_gpu_ci
           echo "conclusion=success" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Background

Community GPU currently downloads Hugging Face checkpoints with no
authorization token, so gated models (e.g. sam3) fail to download. This is
one of the issues flagged as found-but-not-yet-fixed after the recent CI
restructuring (#1262, #1268).

## Exit Criteria

The \`provision-and-test\` job's docker invocation receives \`HF_TOKEN\` from
the \`gpu-ci-dispatch\` environment secret, and \`huggingface_hub\` inside the
container picks it up automatically for gated-checkpoint downloads.

## Implementation

\`huggingface_hub\` reads \`HF_TOKEN\` from the process environment
automatically. Verified directly:

\`\`\`
os.environ["HF_TOKEN"] = "dummy_test_value_123"
from huggingface_hub import get_token
get_token() == "dummy_test_value_123"  # True
\`\`\`

So no change is needed in \`tools.community_gpu_ci\` to consume it. This PR
only wires the \`HF_TOKEN\` secret (already added to the \`gpu-ci-dispatch\`
environment) through the trusted runner into the \`docker run\` invocation
that actually executes \`tools.community_gpu_ci\`.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

\`\`\`
python3 -c "
import os
os.environ['HF_TOKEN'] = 'dummy_test_value_123'
from huggingface_hub import get_token
print('get_token() picked up HF_TOKEN env var:', get_token() == 'dummy_test_value_123')
"
# get_token() picked up HF_TOKEN env var: True
\`\`\`

Not yet re-verified against an actual gated model download inside the real
GPU CI flow; see Not Run below.

### Hardware, Environment, and Revisions

Not applicable: environment-variable passthrough only, no runtime component
of its own.

### Not Run / Remaining Gaps

- Not yet exercised against a real gated-model download inside a live GPU
  CI run. Planned as a follow-up: swap the model in a test PR to a gated
  one and manually dispatch \`run_gpu_smoke\`, to verify both \`HF_TOKEN\` and
  the freshly rotated \`BREV_API_KEY\` in the same run.
- Deliberately **not** attempted here: making \`hf_revision\` mandatory in
  family manifests (the "no fixed revision pinning" half of the same
  complaint). Checked first: 76 of the ~85 premerge manifests have no
  \`hf_revision\` set today (including \`bert\`), so requiring it in code would
  immediately break nearly every family's GPU test rather than being a
  narrow fix. That needs a separate, family-owner-reviewed effort to
  backfill real pinned revisions across many families, not a code change
  bundled into this PR.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

If tackling the revision-pinning half of this issue later: start from the
76-manifest list this PR's investigation produced (not included here since
it's just informational, not a diff), and expect it to need per-family
owner sign-off on the exact pinned commit for each checkpoint, not a single
mechanical PR.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Purely additive environment-variable passthrough; empty/missing secret
behaves identically to today's behavior (no token).