### PR TITLE
fix(ci): swap qwen3_8 for qwen in the GPU smoke-test family set

### DIFF
--- a/tools/community_gpu_ci.py
+++ b/tools/community_gpu_ci.py
@@ -22,7 +22,7 @@ from tools.ci.process import CiError
 
 
 FAMILY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
-SHARED_SMOKE_FAMILIES = ("bert", "gpt2", "qwen3_8", "timm_vit", "whisper")
+SHARED_SMOKE_FAMILIES = ("bert", "gpt2", "qwen", "timm_vit", "whisper")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Background

Per Yifei's investigation into Community GPU cost/latency: the
no-caching-per-run architecture is an accepted, necessary tradeoff of using
an isolated ephemeral Brev instance for every run (unlike our own
persistent internal runners), not something to fix. The actual,
addressable cost driver he identified is that \`qwen3_8\` in
\`SHARED_SMOKE_FAMILIES\` pulls the full \`Qwen/Qwen3.8-27B\` checkpoint on
every run of the shared/root-file smoke path.

## Exit Criteria

The shared/root-file GPU smoke path no longer downloads the 27B Qwen
checkpoint; it downloads a small (~0.6B) Qwen checkpoint instead, while
still exercising the same Qwen family code path.

## Implementation

Swap \`qwen3_8\` for \`qwen\` in \`tools/community_gpu_ci.py\`'s
\`SHARED_SMOKE_FAMILIES\`. \`families/qwen\`'s 4 premerge testcases (across 3
manifests) all resolve to the same \`Qwen/Qwen3-0.6B\` checkpoint, so only
one small download is needed regardless of how many of its cases run.
\`families/qwen\` has a real \`model.py\`, \`tests/test_e2e.py\`, and populated
\`tests/manifests\`, so it satisfies \`family_plan\` the same way \`qwen3_8\`
did.

### Change categories

- [x] CI or developer tooling

## Validation

### Commands and Results

\`\`\`
python3 -m pytest tools/tests/test_community_gpu_ci.py -q
# 16 passed in 0.20s
\`\`\`

\`tools/tests/test_community_gpu_ci.py\` asserts against
\`community_gpu_ci.SHARED_SMOKE_FAMILIES\` dynamically, not a hardcoded
tuple, so it adapted to this change with no test modification needed.

Also checked \`families/qwen\`'s premerge manifests directly:

\`\`\`
qwen3-0.6b-fp16.json     -> hf_id: Qwen/Qwen3-0.6B, premerge: qwen3-0.6b-fp16-native-kv-two-chunk-parity
qwen3-0.6b-native-l0.json -> hf_id: Qwen/Qwen3-0.6B, premerge: qwen3-0.6b-native-l0
qwen3-0.6b-regression-native-kv-chunked-prefill.json -> hf_id: Qwen/Qwen3-0.6B, premerge: 2 cases
\`\`\`

### Hardware, Environment, and Revisions

Not applicable: single-constant Python change, no runtime component.

### Not Run / Remaining Gaps

- Not yet exercised inside a real live GPU CI run against the shared/all
  scope path (the smoke-set fallback only fires when a shared/root file is
  touched); planned as part of an upcoming manual \`run_gpu_smoke\`
  dispatch.
- None of \`families/qwen\`'s manifests have \`hf_revision\` pinned either
  (same as \`qwen3_8\`'s manifest and ~76 other manifests repo-wide) — not a
  regression from this change, but not fixed by it either.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

This does not change what \`qwen3_8\`-specific PRs test (they still use
\`scope: "families"\` and their own real manifest); it only changes which
model downloads when a shared/root-file change triggers the generic
5-family smoke fallback.

### Risk level

- [x] Low

<!-- Risk rationale: -->
Single-constant swap to an already-valid, already-tested family; existing
test suite passes unchanged.