### PR TITLE
fix(bert): preserve special tokens in input

### DIFF
--- a/families/bert/runtime/CMakeLists.txt
+++ b/families/bert/runtime/CMakeLists.txt
@@ -36,3 +36,22 @@ set_target_properties(trtmc_model_bert PROPERTIES
 install(TARGETS trtmc_model_bert
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(TRTMC_BUILD_TESTS)
+  add_executable(test_bert_wordpiece_tokenizer
+    ${PROJECT_SOURCE_DIR}/families/bert/tests/cpp/test_wordpiece_tokenizer.cpp
+    wordpiece_tokenizer.cpp
+  )
+  target_include_directories(test_bert_wordpiece_tokenizer PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/core/runtime/include
+  )
+  target_link_libraries(test_bert_wordpiece_tokenizer PRIVATE
+    nlohmann_json::nlohmann_json
+  )
+  target_compile_options(test_bert_wordpiece_tokenizer PRIVATE
+    -Wall -Wextra -Wpedantic
+  )
+  add_test(NAME test_bert_wordpiece_tokenizer COMMAND test_bert_wordpiece_tokenizer)
+  set_tests_properties(test_bert_wordpiece_tokenizer PROPERTIES LABELS cpu)
+endif()

--- a/families/bert/runtime/wordpiece_tokenizer.cpp
+++ b/families/bert/runtime/wordpiece_tokenizer.cpp
@@ -327,12 +327,26 @@ class WordPieceTokenizer final : public ITokenizer {
             return make_special_frame({});
         }
 
-        std::string normalized = bert_normalize(text, mNormConfig);
-        auto words = bert_pre_tokenize(normalized);
-
         std::vector<int32_t> ids;
-        for (const auto& word : words) {
-            tokenize_word(word, ids);
+        size_t start = 0;
+        while (start < text.size()) {
+            size_t next = std::string::npos;
+            int32_t special_id = -1;
+            size_t special_size = 0;
+            for (int32_t id : mRawSpecialIds) {
+                const auto& token = mIdToToken[id];
+                const auto pos = text.find(token, start);
+                if (pos < next || (pos == next && token.size() > special_size)) {
+                    next = pos;
+                    special_id = id;
+                    special_size = token.size();
+                }
+            }
+            encode_text(text.substr(start, next == std::string::npos ? next : next - start), ids);
+            if (next == std::string::npos)
+                break;
+            ids.push_back(special_id);
+            start = next + special_size;
         }
 
         if (mAddSpecialTokens) {
@@ -378,6 +392,12 @@ class WordPieceTokenizer final : public ITokenizer {
     WordPieceTokenizer() = default;
 
     // ─── Greedy longest-match WordPiece encoding ───
+
+    void encode_text(const std::string& text, std::vector<int32_t>& ids) const {
+        auto words = bert_pre_tokenize(bert_normalize(text, mNormConfig));
+        for (const auto& word : words)
+            tokenize_word(word, ids);
+    }
 
     void tokenize_word(const std::string& word, std::vector<int32_t>& ids) const {
         if (word.empty())
@@ -559,6 +579,10 @@ class WordPieceTokenizer final : public ITokenizer {
 
             if (tok.value("special", false)) {
                 mSpecialIds.insert(id);
+                // BERT's raw special tokens must bypass lowercasing and punctuation splitting.
+                if (id >= 0 && !content.empty() && !tok.value("normalized", false) &&
+                    !tok.value("single_word", false))
+                    mRawSpecialIds.push_back(id);
             }
         }
     }
@@ -634,6 +658,7 @@ class WordPieceTokenizer final : public ITokenizer {
     std::vector<std::string> mIdToToken;
     std::unordered_map<std::string, int32_t> mTokenToId;
     std::unordered_set<int32_t> mSpecialIds;
+    std::vector<int32_t> mRawSpecialIds;
     std::unordered_set<int32_t> mDecodeSkipIds; // tokens to filter during decode
 
     std::string mUnkToken = "[UNK]";

--- a/families/bert/tests/cpp/test_wordpiece_tokenizer.cpp
+++ b/families/bert/tests/cpp/test_wordpiece_tokenizer.cpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "families/bert/runtime/tokenizer.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check_ids(const std::vector<int32_t>& actual, const std::vector<int32_t>& expected,
+               const char* name) {
+    if (actual == expected)
+        return;
+    std::cerr << "FAIL: " << name << " got";
+    for (const auto id : actual)
+        std::cerr << ' ' << id;
+    std::cerr << '\n';
+    ++failures;
+}
+
+} // namespace
+
+int main() {
+    const std::string tokenizer_json = R"({
+      "model": {
+        "type": "WordPiece", "unk_token": "[UNK]",
+        "continuing_subword_prefix": "##", "max_input_chars_per_word": 100,
+        "vocab": {
+          "[PAD]": 0, "[UNK]": 1, "[CLS]": 2, "[SEP]": 3, "[MASK]": 4,
+          "hello": 5, "world": 6, "[": 7, "]": 8, "mask": 9,
+          "cls": 10, "sep": 11, "pad": 12, "unk": 13, ".": 14,
+          ",": 15, "cafe": 16, "play": 17, "##ing": 18
+        }
+      },
+      "normalizer": {"type": "BertNormalizer", "clean_text": true,
+                     "handle_chinese_chars": true, "strip_accents": null, "lowercase": true},
+      "pre_tokenizer": {"type": "BertPreTokenizer"},
+      "post_processor": {"type": "BertProcessing", "cls": ["[CLS]", 2], "sep": ["[SEP]", 3]},
+      "added_tokens": [
+        {"id": 0, "content": "[PAD]", "special": true, "normalized": false,
+         "single_word": false, "lstrip": false, "rstrip": false},
+        {"id": 1, "content": "[UNK]", "special": true, "normalized": false,
+         "single_word": false, "lstrip": false, "rstrip": false},
+        {"id": 2, "content": "[CLS]", "special": true, "normalized": false,
+         "single_word": false, "lstrip": false, "rstrip": false},
+        {"id": 3, "content": "[SEP]", "special": true, "normalized": false,
+         "single_word": false, "lstrip": false, "rstrip": false},
+        {"id": 4, "content": "[MASK]", "special": true, "normalized": false,
+         "single_word": false, "lstrip": false, "rstrip": false}
+      ]
+    })";
+
+    for (bool add_special : {false, true}) {
+        auto tokenizer = trtmc::CreateWordPieceTokenizer(tokenizer_json.data(),
+                                                         tokenizer_json.size(), add_special);
+        auto check = [&](const std::string& text, std::vector<int32_t> expected, const char* name) {
+            if (add_special) {
+                expected.insert(expected.begin(), 2);
+                expected.push_back(3);
+            }
+            check_ids(tokenizer->encode(text), expected, name);
+        };
+        check("[PAD][UNK][CLS][SEP][MASK]", {0, 1, 2, 3, 4}, "all explicit special tokens");
+        check("hello [SEP] world", {5, 3, 6}, "separator between words");
+        check("hello[MASK]world", {5, 4, 6}, "special token adjacent to words");
+        check("[MASK][MASK]", {4, 4}, "repeated special tokens");
+        check("[CLS] hello [SEP]", {2, 5, 3}, "explicit framing tokens");
+        check("[MASK], [MASK].", {4, 15, 4, 14}, "punctuation around special tokens");
+        check("[mask]", {7, 9, 8}, "special token matching is case sensitive");
+        check("HELLO, world.", {5, 15, 6, 14}, "ordinary normalization and punctuation");
+        check("CAF\xc3\x89 [MASK] playing", {16, 4, 17, 18}, "normalization on both sides");
+        check("playing", {17, 18}, "ordinary wordpieces");
+        check("unrecognized", {1}, "unknown word");
+        check("", {}, "empty input");
+        check(" \t\n ", {}, "whitespace input");
+    }
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

BERT splits `[SEP]` in `question [SEP] answer` into three ordinary tokens instead of preserving ID 102.

## Exit Criteria

Preserve explicit special tokens with automatic framing enabled or disabled.

## Implementation

Match BERT's raw special tokens before normalization and WordPiece splitting. Add a family-local native regression test.

### Change categories

- [x] Model or runtime behavior

## Validation

### Commands and Results

With `NLOHMANN_INCLUDE` pointing to the nlohmann/json include directory:

```sh
g++ -std=c++17 -Wall -Wextra -Wpedantic -I. -Icore/runtime/include -I"$NLOHMANN_INCLUDE" families/bert/tests/cpp/test_wordpiece_tokenizer.cpp families/bert/runtime/wordpiece_tokenizer.cpp -o /tmp/trtmc-bert-wordpiece-test
/tmp/trtmc-bert-wordpiece-test
```

26 checks passed. `PYTHONPATH=core/builder:apps/benchmark:. python -m pytest -q families/bert/tests/test_weights.py`: 5 passed. Another 144 token-ID comparisons against Hugging Face tokenizers passed.

`python -m tools.community_ci source-quality --base 714f1fc0d567213a7b79a488e9dcfdf405279c6a`: passed (164 tests).

### Hardware, Environment, and Revisions

Head `5f08478cd3351ad4d1af17f73afa21ab01bb2ae5`; Linux x86_64, GCC 13.3, Python 3.12.3, nlohmann/json 3.11.3, tokenizers 0.22.1; `google-bert/bert-base-uncased@86b5e0934494bd15c9632b12f734a8a67f723594`.

### Not Run / Remaining Gaps

Full-project CMake/CTest and GPU inference (TensorRT SDK unavailable).

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

### Risk level

- [x] Low

Matching is limited to declared raw special tokens.
