### PR TITLE
build: Support x86_64 when using `docker compose`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM nvidia/cuda:13.3.0-devel-ubuntu24.04@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52
 
+ARG ARCH=aarch64
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TORCH_CUDA_ARCH_LIST=10.0
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
@@ -81,7 +83,7 @@ RUN python3.12 -m venv "$VIRTUAL_ENV" \
 ENV TRT_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tensorrt_libs
 ENV NCCL_LIB_DIR=/opt/venv/lib/python3.12/site-packages/nvidia/nccl/lib
 ENV TVM_FFI_LIB_DIR=/opt/venv/lib/python3.12/site-packages/tvm_ffi/lib
-ENV TRT_INC_DIR=/usr/include/aarch64-linux-gnu
+ENV TRT_INC_DIR=/usr/include/$ARCH-linux-gnu
 ENV LD_LIBRARY_PATH=$TRT_LIB_DIR:$NCCL_LIB_DIR:$TVM_FFI_LIB_DIR:/usr/local/cuda/lib64
 ENV LD_PRELOAD=/usr/local/cuda/lib64/libcublas.so.13
 
@@ -92,7 +94,7 @@ RUN python3.12 -c \
     && test -f "$TRT_LIB_DIR/libnvonnxparser.so.11" \
     && test -f "$NCCL_LIB_DIR/libnccl.so.2" \
     && test -f "$TVM_FFI_LIB_DIR/libtvm_ffi.so" \
-    && mpirun --tag-output -np 1 true
+    && HWLOC_COMPONENTS=-gl mpirun --tag-output -np 1 true
 
 WORKDIR /workspace/tensorrt-model-connect
 CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - ARCH=${ARCH:-aarch64}
     container_name: trtmc-dev
     working_dir: /workspace/tensorrt-model-connect
     tty: true


### PR DESCRIPTION
You can use a command such as the following,

```docker compose build --build-arg ARCH=$(uname -m)```

to build the CI container for x86_64 (or aarch64).

- The default CPU architecture remains `aarch64` so CI doesn't break.
- Prefix `mpirun` with `HWLOC_COMPONENTS=-gl` to avoid a hang when graphics
  are present on the GPU.

## Background

The current `docker compose` workflow doesn't support anything but `aarch64` due to hardcoding some paths. Make the CPU arch a build argument to support `x86_64` as well.

## Exit Criteria

`docker compose build --build-arg ARCH=$(uname -m)` finishes successfully on a Linux x86 host (Fedora 44 + rootless podman) with an RTX 5080 GPU.

## Implementation

N/A: Just a build improvement.

### Change categories

- [ ] Model or runtime behavior
- [ ] Public API
- [ ] ABI
- [ ] Bundle or artifact format
- [ ] Dependencies
- [ ] Documentation only
- [x] CI or developer tooling

## Validation

### Commands and Results

`docker compose build --build-arg ARCH=$(uname -m)`

### Hardware, Environment, and Revisions

- AMD Ryzen 9 5900X
- NVIDIA GeForce RTX 5080
- Fedora 44
- Podman

### Not Run / Remaining Gaps

N/A: Just a build improvement.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

N/A: Just a build improvement.

### Risk level

This is a change only to the CI/developer Docker build, so it shouldn't have any product impact. The default value for the variable being added is the same as before so it should be a transparent change if the user doesn't exercise the variable.

- [x] Low
- [ ] Medium
- [ ] High
