### PR TITLE
fix(detr): match reference resize rounding

### DIFF
--- a/families/detr/runtime/image_preprocess_seam.cpp
+++ b/families/detr/runtime/image_preprocess_seam.cpp
@@ -38,7 +38,10 @@ void validate_detr_preprocess_config(const DetrPreprocessConfig& config) {
 }
 
 int32_t hf_round(double value) {
-    return static_cast<int32_t>(std::round(value));
+    // Python's round() chooses the even integer at a half tie.
+    const auto lower = static_cast<int32_t>(std::floor(value));
+    const double fraction = value - lower;
+    return lower + (fraction > 0.5 || (fraction == 0.5 && lower % 2 != 0));
 }
 
 struct DetrResizePlan {

--- a/families/detr/tests/cpp/test_image_preprocess_seam.cpp
+++ b/families/detr/tests/cpp/test_image_preprocess_seam.cpp
@@ -48,6 +48,44 @@ void test_detr_resize_caps_longest_edge() {
     check(shape.width == 1333, "detr landscape resize width");
 }
 
+void test_detr_resize_rounds_half_ties_to_even() {
+    const trtmc::DetrPreprocessConfig config;
+    const auto landscape = trtmc::compute_detr_resize_shape(600, 1200, config);
+    check(landscape.height == 666 && landscape.width == 1333,
+          "detr landscape half tie rounds down to even");
+    const auto portrait = trtmc::compute_detr_resize_shape(1200, 600, config);
+    check(portrait.height == 1333 && portrait.width == 666,
+          "detr portrait half tie rounds down to even");
+    const auto odd_landscape = trtmc::compute_detr_resize_shape(1335, 2666, config);
+    check(odd_landscape.height == 668 && odd_landscape.width == 1333,
+          "detr landscape half tie rounds up to even");
+    const auto odd_portrait = trtmc::compute_detr_resize_shape(2666, 1335, config);
+    check(odd_portrait.height == 1333 && odd_portrait.width == 668,
+          "detr portrait half tie rounds up to even");
+}
+
+void test_detr_resize_rounds_non_ties_to_nearest() {
+    const trtmc::DetrPreprocessConfig config;
+    const auto below = trtmc::compute_detr_resize_shape(599, 1200, config);
+    check(below.height == 665 && below.width == 1333, "detr resize below half tie");
+    const auto above = trtmc::compute_detr_resize_shape(601, 1200, config);
+    check(above.height == 668 && above.width == 1333, "detr resize above half tie");
+}
+
+void test_detr_preprocess_fits_half_tie_engine_dimensions() {
+    const std::vector<float> pixels(3U * 600U * 1200U, 0.75F);
+    trtmc::DetrPreprocessConfig config;
+    config.input_image_h = 666;
+    config.input_image_w = 1333;
+    const auto landscape = trtmc::preprocess_detr_image(pixels.data(), 600, 1200, config);
+    check(landscape.size() == 3U * 666U * 1333U, "detr landscape fits reference dimensions");
+
+    config.input_image_h = 1333;
+    config.input_image_w = 666;
+    const auto portrait = trtmc::preprocess_detr_image(pixels.data(), 1200, 600, config);
+    check(portrait.size() == 3U * 1333U * 666U, "detr portrait fits reference dimensions");
+}
+
 void test_detr_preprocess_applies_normalization() {
     const std::vector<float> pixels(3U * 2U * 2U, 0.75F);
     trtmc::DetrPreprocessConfig config;
@@ -119,6 +157,9 @@ void test_detr_preprocess_rejects_invalid_config() {
 int main() {
     test_detr_resize_preserves_short_edge_for_square_image();
     test_detr_resize_caps_longest_edge();
+    test_detr_resize_rounds_half_ties_to_even();
+    test_detr_resize_rounds_non_ties_to_nearest();
+    test_detr_preprocess_fits_half_tie_engine_dimensions();
     test_detr_preprocess_applies_normalization();
     test_detr_preprocess_rejects_invalid_config();
     test_detr_preprocess_rejects_resize_larger_than_engine_input();


### PR DESCRIPTION
## Background

DETR resizes a 600x1200 image to 667x1333, while the reference produces 666x1333. This rejects inputs for an engine built at the reference dimensions.

## Exit Criteria

Landscape and portrait inputs fit their reference-sized engine inputs.

## Implementation

Round exact halves to the nearest even integer in the DETR preprocessor.

### Change categories

- [x] Model or runtime behavior

## Validation

### Commands and Results

Native regression passed (21 checks); source-quality passed (164 tests).

```sh
g++ -std=c++17 -Wall -Wextra -Wpedantic -Wno-missing-field-initializers -Wno-unused-function -I. -Ithird_party/stb families/detr/tests/cpp/test_image_preprocess_seam.cpp families/detr/runtime/image_preprocess_seam.cpp -o /tmp/trtmc-four-detr-test
/tmp/trtmc-four-detr-test
python -m tools.community_ci source-quality --base 714f1fc0d567213a7b79a488e9dcfdf405279c6a
```

### Hardware, Environment, and Revisions

`e853c2c`: Ubuntu CPU, GCC 13.3; Transformers 5.2.0 reference.

### Not Run / Remaining Gaps

Checkpoint inference and full CMake suite: TensorRT environment unavailable.

## Contributor Self-Review

- [x] I have completed a self-review of this change.

## Notes For Future Readers

Half ties follow Python's `round()`.

### Risk level

- [x] Low

Only DETR resize dimensions change.